### PR TITLE
prevent error on new M2M item

### DIFF
--- a/api/core/Directus/Db/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Db/TableGateway/RelationalTableGateway.php
@@ -420,13 +420,18 @@ class RelationalTableGateway extends AclAwareTableGateway {
                         $JunctionTable = new RelationalTableGateway($this->acl, $junctionTableName, $this->adapter);
                         $ForeignTable = new RelationalTableGateway($this->acl, $foreignTableName, $this->adapter);
                         foreach($foreignDataSet as $junctionRow) {
-                            /** This association is designated for removal */
-                            $Where = new Where;
-                            $Where->equalTo($junctionKeyLeft, $parentRow['id'])
-                                    ->equalTo($junctionKeyRight, $junctionRow['data']['id']);
-                            if ($JunctionTable->select($Where)->count()) {
-                                continue;
+                            // Is this a new element?
+                            // if the element `id` exists it's because is not a new element
+                            // and already had its id given.
+                            if (isset($junctionRow['data']['id'])) {
+                              $Where = new Where;
+                              $Where->equalTo($junctionKeyLeft, $parentRow['id'])
+                                      ->equalTo($junctionKeyRight, $junctionRow['data']['id']);
+                              if ($JunctionTable->select($Where)->count()) {
+                                  continue;
+                              }
                             }
+                            /** This association is designated for removal */
                             if (isset($junctionRow[STATUS_COLUMN_NAME]) && $junctionRow[STATUS_COLUMN_NAME] == STATUS_DELETED_NUM) {
                                 $Where = new Where;
                                 $Where->equalTo('id', $junctionRow['id']);


### PR DESCRIPTION
This prevent the error commented on this issue :#470 (**Adding item through many-to-many UI throws error**)

The problem with this issue was in fact: ee3ed41b1b953cf5fc45939676b9b19e8d7a921e commit.

I did not keep in mind that new item from M2M can be new items without any id, so if there's not id, not need to compare whether exists or not.
