### PR TITLE
fixes invalid date - safari

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -119,7 +119,9 @@ define(function(require, exports, module) {
 
       //Parse response date
       responseData = _.map(responseData, function(item) {
-        item.date_uploaded = new Date(item.date_uploaded);
+        // Safari hates dashes apparently
+        // http://stackoverflow.com/a/5646753/1772076
+        item.date_uploaded = new Date(item.date_uploaded.replace(/-/g, '/'));
         return item;
       });
 
@@ -159,7 +161,9 @@ define(function(require, exports, module) {
     var success = function(responseData) {
       //Parse response date
       responseData = _.map(responseData, function(item) {
-        item.date_uploaded = new Date(item.date_uploaded);
+        // Safari hates dashes apparently
+        // http://stackoverflow.com/a/5646753/1772076
+        item.date_uploaded = new Date(item.date_uploaded.replace(/-/g, '/'));
         return item;
       });
 

--- a/app/router.js
+++ b/app/router.js
@@ -259,7 +259,6 @@ define(function(require, exports, module) {
     },
 
     files: function(pref) {
-      console.log("HERE");
       if (_.contains(this.tabBlacklist,'files'))
         return this.notFound();
 


### PR DESCRIPTION
After several testing it seems that the only solution to this problem it's to use slashes instead of dashes on dates. it's seems that safari does not like dashes, but slashes are well supported by browsers.
