### PR TITLE
harddelete possible when no active

### DIFF
--- a/api/core/Directus/Db/TableGateway/AclAwareTableGateway.php
+++ b/api/core/Directus/Db/TableGateway/AclAwareTableGateway.php
@@ -536,6 +536,14 @@ class AclAwareTableGateway extends \Zend\Db\TableGateway\TableGateway {
         $canHardDelete = $this->acl->hasTablePrivilege($deleteTable, 'harddelete');
         $aclErrorPrefix = $this->acl->getErrorMessagePrefix();
         
+        if (!TableSchema::hasTableColumn($deleteTable, STATUS_COLUMN_NAME)) {
+          if ($this->acl->hasTablePrivilege($deleteTable, 'bigdelete')) {
+            $canBigHardDelete = true;
+          } else if ($this->acl->hasTablePrivilege($deleteTable, 'delete')) {
+            $canHardDelete = true;
+          }
+        }
+        
         /**
          * ACL Enforcement
          */
@@ -548,7 +556,7 @@ class AclAwareTableGateway extends \Zend\Db\TableGateway\TableGateway {
           // cannot delete if there's no magic owner column and can't big delete
           if (!$canBigHardDelete) {
             // All deletes are "big" deletes if there is no magic owner column.
-            throw new UnauthorizedTableBigDeleteException($aclErrorPrefix . "The table `$deleteTable` is missing the `user_create_column` within `directus_tables` (BigEdit Permission Forbidden)");
+            throw new UnauthorizedTableBigDeleteException($aclErrorPrefix . "The table `$deleteTable` is missing the `user_create_column` within `directus_tables` (BigHardDelete Permission Forbidden)");
           }
         } else {
           if(!$canBigHardDelete){

--- a/api/core/Directus/Db/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Db/TableGateway/RelationalTableGateway.php
@@ -361,13 +361,13 @@ class RelationalTableGateway extends AclAwareTableGateway {
                         foreach($foreignDataSet as $junctionRow) {
                             /** This association is designated for removal */
                             if (isset($junctionRow[STATUS_COLUMN_NAME]) && $junctionRow[STATUS_COLUMN_NAME] == STATUS_DELETED_NUM) {
-                                $Where = new Where;
-                                $Where->equalTo('id', $junctionRow['id']);
-                                $JunctionTable->delete($Where);
-                                // Flag the top-level record as having been altered.
-                                // (disassociating w/ existing M2M collection entry)
-                                $parentCollectionRelationshipsChanged = true;
-                                continue;
+                              $Where = new Where;
+                              $Where->equalTo('id', $junctionRow['id']);
+                              $JunctionTable->delete($Where);
+                              // Flag the top-level record as having been altered.
+                              // (disassociating w/ existing M2M collection entry)
+                              $parentCollectionRelationshipsChanged = true;
+                              continue;
                             } else if (isset($junctionRow['data']['id'])) {
                               // Is this a new element?
                               // if the element `id` exists it's because is not a new element

--- a/api/core/Directus/Db/TableSchema.php
+++ b/api/core/Directus/Db/TableSchema.php
@@ -171,6 +171,16 @@ class TableSchema {
         }
         return $columns;
     }
+    
+    public static function hasTableColumn($table, $column) {
+      $columns = self::getTableColumns($table);
+      
+      if (array_key_exists($column, array_flip($columns))) {
+        return true;
+      }
+      
+      return false;
+    }
 
     public static function getUniqueColumnName($tbl_name) {
         // @todo for safe joins w/o name collision


### PR DESCRIPTION
Issue #563 

This PR would let user with `delete/bigdelete` permission to has `harddelete/bigharddelete` when trying to delete on table that does not has status column. This would solve the delete permission on many to many, as right now it does not work with status column.

There also a new method on TableSchema class to verify wether a specific table has a specific column.
