### PR TITLE
default sort column

### DIFF
--- a/api/core/Directus/Db/TableGateway/DirectusPreferencesTableGateway.php
+++ b/api/core/Directus/Db/TableGateway/DirectusPreferencesTableGateway.php
@@ -54,6 +54,12 @@ class DirectusPreferencesTableGateway extends AclAwareTableGateway {
                 }
             }
         }
+        if(isset($preferences['sort'])) {
+            $sortColumn = $preferences['sort'];
+            if (!TableSchema::hasTableColumn($table, $sortColumn)) {
+                $preferences['sort'] = 'id';
+            }
+        }
         return $preferences;
     }
 


### PR DESCRIPTION
This would prevent to use a sort column that does not exists on the table. this doble prevent the issue #597 
