### PR TITLE
use zend db 2.2 to fix bug

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -2,7 +2,7 @@
   "require": {
     "slim/slim": "2.3.2",
     "slim/extras": "dev-develop",
-    "zendframework/zend-db": "2.1.*@dev",
+    "zendframework/zend-db": "2.2.*@dev",
     "directus/migrations": "dev-master",
     "phpmailer/phpmailer": "~5.2"
   },


### PR DESCRIPTION
There is a bug in Zend DB 2.1 which would throw this error:

```
Strict standards: Declaration of Zend\Db\Metadata\Source\MysqlMetadata::loadConstraintReferences()
 should be compatible with Zend\Db\Metadata\Source\AbstractSource::loadConstraintReferences($table, 
$schema) in /zendframework/zend-db/src/Metadata/Source/MysqlMetadata.php on line 15
```

Which was fixed in 2.2.

[fixed signature of loadConstraintReferences](https://github.com/zendframework/zend-db/commit/56bad74caad91536df271f5f3783dc31638ad744)
