### PR TITLE
Autoload Order Change for Login

### DIFF
--- a/login.php
+++ b/login.php
@@ -5,16 +5,16 @@ if(!file_exists('api/config.php') || filesize('api/config.php') == 0) {
   header('Location: installation/index.php');
 }
 
+// Composer Autoloader
+$loader = require 'api/vendor/autoload.php';
+$loader->add("Directus", dirname(__FILE__) . "/api/core/");
+
 require "api/config.php";
 require "api/globals.php";
 
 /**
  * Temporary solution for disabling this page for logged in users.
  */
-
-// Composer Autoloader
-$loader = require 'api/vendor/autoload.php';
-$loader->add("Directus", dirname(__FILE__) . "/api/core/");
 
 if(\Directus\Auth\Provider::loggedIn()) {
     header('Location: ' . DIRECTUS_PATH );


### PR DESCRIPTION
If there are any composer dependencies in api/config.php (I was using vlucas/phpdotenv to manage my environments), it would crash. Changed so the autoloader would run before the config file.
