### PR TITLE
Resolves an issue when loading the application when there are no options.extensions set

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -557,10 +557,11 @@ define(function(require, exports, module) {
 
       _.each(options.extensions, function(item) {
         try {
-          this.extensions[item] = ExtensionManager.getInstance(item);
+          if (typeof item != 'undefined') {
+            this.extensions[item] = ExtensionManager.getInstance(item);
+          }
         } catch (e) {
-          console.log(item + ' failed to load:', e.stack);
-          this.tabs.get(item).set({'error': e});
+          console.log('failed to load:', e.stack);
           return;
         }
         //this.extensions[item.id].bind('all', logRoute);


### PR DESCRIPTION
After a fresh installation,using an empty database, I am alerted with:

Error: TypeError: undefined is not an object (evaluating 'this.tabs.get(item).set') File: http://redacted/Directus/app/router.js?bust=5968259023e9bd2962aeef90f00fef0754a2f458 Line:563

and was unable to use the application.

This fix seems to resolve the issue
