### PR TITLE
Fix youtube embeds (Fixes #1095)

### DIFF
--- a/api/core/Directus/Db/TableGateway/DirectusSettingsTableGateway.php
+++ b/api/core/Directus/Db/TableGateway/DirectusSettingsTableGateway.php
@@ -37,7 +37,8 @@ class DirectusSettingsTableGateway extends AclAwareTableGateway {
             'thumbnail_size' => 200,
             'file_naming' => 'file_id',
             'thumbnail_crop_enabled' => 1,
-            'thumbnail_storage_adapter' => 'FileSystemAdapter'
+            'thumbnail_storage_adapter' => 'FileSystemAdapter',
+            'youtube_api_key' => ''
         );
     }
 
@@ -97,7 +98,8 @@ class DirectusSettingsTableGateway extends AclAwareTableGateway {
             'files' => array(
                     'file_naming',
                     'thumbnail_quality',
-                    'thumbnail_crop_enabled'
+                    'thumbnail_crop_enabled',
+                    'youtube_api_key'
                 ),
             'global' => array(
                     'project_name',

--- a/api/core/Directus/Util/Installation/Console.php
+++ b/api/core/Directus/Util/Installation/Console.php
@@ -224,7 +224,8 @@ class Console
                       (12,'files','thumbnail_size','200'),
                       (13,'global','cms_thumbnail_url',''),
                       (14,'files','file_naming','file_id'),
-                      (15,'files','thumbnail_crop_enabled','1');";
+                      (15,'files','thumbnail_crop_enabled','1'),
+                      (16,'files','youtube_api_key','');";
 
         $statement = $this->dbh->prepare($insert);
         $statement->execute();

--- a/api/schema.sql
+++ b/api/schema.sql
@@ -271,7 +271,8 @@ VALUES
   (12,'files','thumbnail_size','200'),
   (13,'global','cms_thumbnail_url',''),
   (14,'files','file_naming','file_id'),
-  (15,'files','thumbnail_crop_enabled','1');
+  (15,'files','thumbnail_crop_enabled','1'),
+  (16,'files','youtube_api_key','');
 
 /*!40000 ALTER TABLE `directus_settings` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/app/schema/fixed/settings.files.js
+++ b/app/schema/fixed/settings.files.js
@@ -12,7 +12,8 @@ define(function(require, exports, module) {
       }'}, comment: "The file-system naming convention for uploads"
     },
     {id: 'thumbnail_quality', ui: 'numeric', char_length: 255, options: {options: 'small'}, comment: "The quality percentage for Directus thumbnails"},
-    {id: 'thumbnail_crop_enabled', ui: 'checkbox', comment: 'Uncheck if your project requires seeing uncropped Directus Thumbnails'}
+    {id: 'thumbnail_crop_enabled', ui: 'checkbox', comment: 'Uncheck if your project requires seeing uncropped Directus Thumbnails'},
+    {id: 'youtube_api_key', ui: 'textinput', char_length: 255, comment: 'Youtube Api Key for retrieving Youtube embed info. <a target="_blank" href="https://developers.google.com/youtube/v3/getting-started">Get Key</a>'}
   ];
 
   return SettingsFilesSchema;


### PR DESCRIPTION
As per #1095, Updated the code to use the new youtube api (V2 was deprecated)

Requires an API key so I added it to file settings. Existing installation will need to open file settings and save again to add the entry. Added to install so should not affect new installations.
