### PR TITLE
Undefined index: junction_key_left when using advance search both in api and ui

### DIFF
--- a/api/core/Directus/Db/TableGateway/RelationalTableGatewayWithConditions.php
+++ b/api/core/Directus/Db/TableGateway/RelationalTableGatewayWithConditions.php
@@ -232,8 +232,8 @@ class RelationalTableGatewayWithConditions extends RelationalTableGateway {
               }
             } elseif (isset($target['relationship']) && $target['relationship']['type'] == "MANYTOONE") {
               $relatedTable = $target['relationship']['table_related'];
-              $keyLeft = $this->getTable() . "." . $target['relationship']['junction_key_right'];
-              $keyRight = $relatedTable . ".id";
+              $keyRight = $this->getTable() . "." . $target['relationship']['junction_key_right'];
+              $keyLeft = $relatedTable . ".id";
               $filterColumn = $target['options']['visible_column'];
               $joinedFilterColumn = $relatedTable . "." . $filterColumn;
 

--- a/api/core/Directus/Db/TableGateway/RelationalTableGatewayWithConditions.php
+++ b/api/core/Directus/Db/TableGateway/RelationalTableGatewayWithConditions.php
@@ -232,9 +232,9 @@ class RelationalTableGatewayWithConditions extends RelationalTableGateway {
               }
             } elseif (isset($target['relationship']) && $target['relationship']['type'] == "MANYTOONE") {
               $relatedTable = $target['relationship']['table_related'];
-              $keyLeft = $this->getTable() . "." . $target['relationship']['junction_key_left'];
+              $keyLeft = $this->getTable() . "." . $target['relationship']['junction_key_right'];
               $keyRight = $relatedTable . ".id";
-              $filterColumn = $target['options']['filter_column'];
+              $filterColumn = $target['options']['visible_column'];
               $joinedFilterColumn = $relatedTable . "." . $filterColumn;
 
               // do not let join this table twice


### PR DESCRIPTION
On tables that have  a manny to one relation and an advance filter is applied the RelationTabelGatewayWithConditions file will throw an error on junction_key_left. I've applied a fix on it and it seems to work. I've tested this issue even with the example gallery table on the 'user' column and it gives me the same error.

Error message:

```
ErrorException
Undefined index: junction_key_left
 /var/www/html/directus/api/core/Directus/Db/TableGateway/RelationalTableGatewayWithConditions.php
on line 235
```

Api request url:
http://192.168.33.6/api/1/tables/tabel/rows?access_token=<<Removed>>&adv_search[0][id]=pin_number&adv_search[0][type]=like&adv_search[0][value]=123456
