### PR TITLE
Fix hooks config

### DIFF
--- a/api/configuration_sample.php
+++ b/api/configuration_sample.php
@@ -50,7 +50,7 @@ return array(
   // ),
 
   // Use these hooks to extend the base Directus functionality
-  'dbHooks' => array(
+  'hooks' => array(
     'postInsert' => function ($TableGateway, $record, $db, $acl) {
       // ...
     },

--- a/installation/config_setup.php
+++ b/installation/config_setup.php
@@ -132,7 +132,7 @@ return array(
     //   'password' => ''
     // ),
 
-    'dbHooks' => array(
+    'hooks' => array(
         'postInsert' => function (".'$TableGateway, $record, $db, $acl'.") {
 
         },


### PR DESCRIPTION
When using the sample `configuration.php` file, hooks are never run.

This is because `api.php` is looking for a hooks config key called `hooks` but `configuration.php` is using `dbHooks`: 
[configuration_sample.php](https://github.com/directus/directus/blob/080b2da187989b62e0510af61e5b6f07479eae28/api/configuration_sample.php#L53)
[api.php](https://github.com/directus/directus/blob/080b2da187989b62e0510af61e5b6f07479eae28/api/api.php#L76)
