### PR TITLE
Fix project name setting when installing

### DIFF
--- a/api/core/Directus/Util/Installation/InstallerUtils.php
+++ b/api/core/Directus/Util/Installation/InstallerUtils.php
@@ -235,7 +235,7 @@ class InstallerUtils
             ],
             [
                 'collection' => 'global',
-                'name' => 'project',
+                'name' => 'project_name',
                 'value' => $data['directus_name']
             ],
             [


### PR DESCRIPTION
It seems this should be `project_name` instead of `project`. I could be wrong, but it seems that the UI correctly displays what I put under `project_name`.
