### PR TITLE
Translation Select Bug Fix

### DIFF
--- a/app/modules/tables/views/TranslationView.js
+++ b/app/modules/tables/views/TranslationView.js
@@ -107,7 +107,7 @@ function(app, Backbone, Handlebars, Directus, EntriesManager) {
 
       if(this.languageCollection) {
         data.languages = this.languageCollection.map(function(item) {
-          return {val: item.id, name: item.get(that.translateSettings.languages_name_column), active: (item.id === that.activeLanguageId)};
+          return {val: item.id, name: item.get(that.translateSettings.languages_name_column), active: (item.id == that.activeLanguageId)};
         });
       }
 


### PR DESCRIPTION
Fixed the comparison that sets the selected language for translation
fields.

Previous comparison would always return false, since the value types
being compared were different.
