### PR TITLE
Add translations labels

### DIFF
--- a/api/locales/de.json
+++ b/api/locales/de.json
@@ -268,6 +268,8 @@
   "regex": "Regex",
   "textinput_validation_string_comment": "All characters below will be enforced",
 
+  "translation_title": "Übersetzungen",
+  "translations_x": "%{field}",
   "translation_languages_table_comment": "Enter Table that contains all languages supported",
   "translation_languages_name_column_comment": "Language Title Field",
   "translation_default_language_id_comment": "Default language ID in language table",

--- a/api/locales/en.json
+++ b/api/locales/en.json
@@ -270,6 +270,8 @@
     "regex": "Regex",
     "textinput_validation_string_comment": "All characters below will be enforced",
 
+    "translation_title": "Translations",
+    "translations_x": "%{field}",
     "translation_languages_table_comment": "Enter Table that contains all languages supported",
     "translation_languages_name_column_comment": "Language Title Field",
     "translation_default_language_id_comment": "Default language ID in language table",

--- a/api/locales/es.json
+++ b/api/locales/es.json
@@ -258,6 +258,8 @@
     "regex": "Regex",
     "textinput_validation_string_comment": "Todos los caracteres siguiente seran forzados",
 
+    "translation_title": "Traducciones",
+    "translations_x": "%{field}",
     "translation_languages_table_comment": "Ingresa la table que contiene todos los idiomas soportado",
     "translation_languages_name_column_comment": "Campo del titulo de idioma",
     "translation_default_language_id_comment": "ID por defecto del idioma in la tabla de languajes",

--- a/api/locales/fr.json
+++ b/api/locales/fr.json
@@ -258,6 +258,8 @@
     "regex": "Regex",
     "textinput_validation_string_comment": "Tous les caractères ci-dessous seront appliqués",
 
+    "translation_title": "Traductions",
+    "translations_x": "%{field}",
     "translation_languages_table_comment": "Rajoutez un tableau qui contient toutes les langues supportées",
     "translation_languages_name_column_comment": "Titre de la langue",
     "translation_default_language_id_comment": "ID de la langue par défaut dans le tableau de langues",

--- a/api/locales/zh-hans.json
+++ b/api/locales/zh-hans.json
@@ -259,6 +259,8 @@
     "regex": "正则表达式",
     "textinput_validation_string_comment": "所有以下字符将被强制验证",
 
+    "translation_title": "译文",
+    "translations_x": "%{field}",
     "translation_languages_table_comment": "输入语言表格的名称",
     "translation_languages_name_column_comment": "语言标题字段",
     "translation_default_language_id_comment": "默认语言在语言表格中的 ID",


### PR DESCRIPTION
Two labels are missing in the translation UI:

<img width="570" alt="screen shot 2016-09-02 at 15 12 18" src="https://cloud.githubusercontent.com/assets/1294203/18199826/ba533cb0-711f-11e6-9825-e2608859b53c.png">

`translation_title` and `translations_x` are used in [app/templates/modules/tables/translation.html](https://github.com/directus/directus/commit/00d7291b1071ef2a7ec0dc2f459ac1d97571c04c) but have disappeared from translation files.

``` html
<span class="big-label-text" title="{{t "translation_title"}}">{{t "translations_x" field=translateField}}</span>
```
