### PR TITLE
Fix time fields that was not updated

### DIFF
--- a/app/core/uis/datetime/time.js
+++ b/app/core/uis/datetime/time.js
@@ -48,6 +48,8 @@ define(['app', 'moment', 'core/UIComponent', 'core/UIView', 'core/t'], function(
     template: 'datetime/input',
 
     events: {
+      'blur  input.time':   'updateValue',
+      'change  input.time': 'updateValue',
       'click .now': 'makeNow'
     },
 
@@ -59,6 +61,32 @@ define(['app', 'moment', 'core/UIComponent', 'core/UIView', 'core/t'], function(
 
       this.value = moment().format(timeFormat);
       this.render();
+    },
+
+    getTime: function() {
+
+      var format = 'HH:mm';
+
+      if (this.options.settings.get('include_seconds') == 1) {
+        format += ':ss';
+      }
+
+      return {
+        value: this.$('input[type=time]').val(),
+        format: format
+      }
+    },
+
+    updateValue: function() {
+      var time = this.getTime();
+      var val = time.value;
+      var format = time.format;
+
+      if (moment(val, format).isValid()) {
+        this.$('#'+this.name).val(val);
+      } else {
+        this.$('#'+this.name).val('');
+      }
     },
 
     serialize: function() {


### PR DESCRIPTION
Changes in time fields were not taken into account – only “Now” button was actually editing the value.
It turns out that events on change were missing, I added them based on what's there in [date.js](https://github.com/directus/directus/blob/master/app/core/uis/datetime/date.js)

<img width="407" alt="screen shot 2016-09-08 at 14 21 30" src="https://cloud.githubusercontent.com/assets/1294203/18346532/46a07990-75de-11e6-9375-4f285535d999.png">
