### PR TITLE
Fix display of non-image files

### DIFF
--- a/app/core/uis/single_file.js
+++ b/app/core/uis/single_file.js
@@ -303,11 +303,11 @@ define([
       var url, link;
       if (this.fileModel.has('name')) {
         if (this.fileModel.isNew()) {
-          url = this.fileModel.get('thumbnailData') || this.fileModel.get('url');
           link = '#';
+          url = this.fileModel.get('thumbnailData') || this.fileModel.get('url');
         } else {
-          url = this.fileModel.makeFileUrl(true);
           link = this.fileModel.makeFileUrl();
+          url = this.fileModel.makeFileUrl(true) || link;
         }
       }
 


### PR DESCRIPTION
Non-image files are always shown as empty on detail pages:
<img width="361" alt="screen shot 2016-09-08 at 20 32 25" src="https://cloud.githubusercontent.com/assets/1294203/18356206/6bf676ba-7609-11e6-9313-bc7c5c99ea5c.png">

The [template](https://github.com/directus/directus/blob/fa66ae3274e01fe94591b19c38cd66cf65b9dd21/app/core/uis/single_file.js#L135) is using `url` to know whether there’s a file or not:

``` javascript
{{#if url}} \
                    <div class="single-image-thumbnail has-file"> \
```

`url` is [populated](https://github.com/directus/directus/blob/fa66ae3274e01fe94591b19c38cd66cf65b9dd21/app/core/uis/single_file.js#L309) by [`makeFileUrl(true)`](https://github.com/directus/directus/blob/fa66ae3274e01fe94591b19c38cd66cf65b9dd21/app/modules/files/FilesModel.js#L18):

``` javascript
link = this.fileModel.makeFileUrl();
url = this.fileModel.makeFileUrl(true)
```

…which returns an empty string, as non-image files do not have a thumbnail.

``` javascript
makeFileUrl: function(thumbnail) {
      var url;

      if (thumbnail) {
        url = this.get('thumbnail_url');
      } else {
        url = this.get('url');
      }

      return url;
    },
```
