### PR TITLE
Fixed wrong letter case for module core/notification causing error

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -12,7 +12,7 @@ define(function(require, exports, module) {
 
   var app              = require('app'),
       _                = require('underscore'),
-      Notification     = require('core/Notification'),
+      Notification     = require('core/notification'),
       //Directus       = require('core/directus'),
       Tabs             = require('core/tabs'),
       Bookmarks        = require('core/bookmarks'),


### PR DESCRIPTION
Fixed wrong letter case for module core/notification causing the load of a HTML file insteard of notification.js and throwing a parsing error.
