### PR TITLE
Fix space key event issue with Japanese, Chinese (etc) IMEs in Chrome and Safari

### DIFF
--- a/assets/js/libs/wysihtml5.js
+++ b/assets/js/libs/wysihtml5.js
@@ -8542,7 +8542,7 @@ wysihtml5.views.View = Base.extend(
     });
 
     // --------- neword event ---------
-    dom.observe(element, "keyup", function(event) {
+    dom.observe(element, "keydown", function(event) {
       var keyCode = event.keyCode;
       if (keyCode === wysihtml5.SPACE_KEY || keyCode === wysihtml5.ENTER_KEY) {
         that.parent.fire("newword:composer");


### PR DESCRIPTION
Reference:
https://github.com/xing/wysihtml5/pull/382