### PR TITLE
Fix configuration stub

### DIFF
--- a/api/core/Directus/Util/Installation/stubs/configuration.stub
+++ b/api/core/Directus/Util/Installation/stubs/configuration.stub
@@ -69,7 +69,7 @@ return [
 
     'feedback' => [
         'token' => '{{feedback_token}}',
-        'login' => {{feedback_login}}
+        'login' => '{{feedback_login}}',
     ],
 
     // These tables will not be loaded in the directus schema


### PR DESCRIPTION
Without this fix, a fresh install results in
`18/Jan/2017:18:07:24 +0000 [ERROR 0 /index.php] PHP message: PHP Parse error:  syntax error, unexpected '{' in /var/www/directus/api/configuration.php online 72`