### PR TITLE
Fixed missing quotes

### DIFF
--- a/api/core/Directus/Util/Installation/stubs/configuration.stub
+++ b/api/core/Directus/Util/Installation/stubs/configuration.stub
@@ -69,7 +69,7 @@ return [
 
     'feedback' => [
         'token' => '{{feedback_token}}',
-        'login' => {{feedback_login}}
+        'login' => '{{feedback_login}}'
     ],
 
     // These tables will not be loaded in the directus schema


### PR DESCRIPTION
These are causing the following error on runtime:
01/Feb/2017:17:33:22 +0000 [ERROR 0 /index.php] PHP message: PHP Parse error:  syntax error, unexpected '{' in /var/www/directus/api/configuration.php on line 72

Signed-off-by: Juan C. Méndez <jcmendez@alum.mit.edu>