### PR TITLE
Fixed bug with saving "User" UI input

### DIFF
--- a/app/core/uis/user.js
+++ b/app/core/uis/user.js
@@ -23,7 +23,8 @@ define(['app', 'core/UIComponent', 'core/UIView', 'core/t'], function(app, UICom
 
       if(user) {
         var avatar = user.getAvatar();
-        this.$el.append('<img src="' + avatar + '" class="big-avatar"><span class="big-avatar-name">' + user.get('first_name') + ' ' + user.get('last_name') + '</span>');
+        //Added input with the value of the current user so that the field will save correctly.
+        this.$el.append('<img src="' + avatar + '" class="big-avatar"><span class="big-avatar-name">' + user.get('first_name') + ' ' + user.get('last_name') + '</span><input type="hidden" placeholder="" value="'+user.get('id')+'" name="'+options.name+'" id="'+options.name+'" readonly maxlength="11">');
       } else {
         this.$el.append('<span class="avatar-name medium-grey-color">'+__t('no_user')+'</span>');
       }


### PR DESCRIPTION
The “User” UI input type was failing to save due to missing input
field. Resulting in the UI always saving as “A missing or removed user”.

Fixed bug by adding hidden input with the field name for the UI and the
user id as the value.