### PR TITLE
Fix Boolean Conversion

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -118,7 +118,7 @@ define(function() {
   };
 
   Utils.convertToBoolean = function(value) {
-    return value != false;
+    return value == null ? false : value != false;
   };
 
   Utils.isEmpty = function(value) {


### PR DESCRIPTION
Catches attempts to convert “undefined” and “null” to boolean values
and returns false.  Since both “undefined” and “null” both return true
when checking if they do not equal “false”