### PR TITLE
Reorganize checkbox interface

### DIFF
--- a/app/core/UIManager.js
+++ b/app/core/UIManager.js
@@ -13,7 +13,7 @@ define(function(require, exports, module) {
     require('core/interfaces/_internals/file_preview/interface'),
     require('core/interfaces/textinput/index'),
     require('core/interfaces/section_break/section_break'),
-    require('core/interfaces/checkbox/checkbox'),
+    require('core/interfaces/checkbox/component'),
     require('core/interfaces/color/index'),
     require('core/interfaces/numeric/index'),
     require('core/interfaces/slider'),

--- a/app/core/interfaces/checkbox/component.js
+++ b/app/core/interfaces/checkbox/component.js
@@ -1,0 +1,23 @@
+define(['core/interfaces/checkbox/interface', 'core/UIComponent', 'core/t'], function(Input, UIComponent, __t) {
+  return UIComponent.extend({
+    id: 'checkbox',
+    dataTypes: ['TINYINT'],
+    variables: [
+      {id: 'mandatory', type: 'Boolean', default_value: false, ui: 'checkbox', comment: 'if this field should always be checked by the user.'}
+    ],
+    Input: Input,
+    validate: function(value, options) {
+      // If a checkbox is mandatory, it MUST be checked to save
+      // similar to "agree to terms" functionality
+      var required = options.view ? options.view.isRequired() : false;
+      if (required && value === 0) {
+        return __t('this_field_is_required');
+      }
+    },
+    list: function(options) {
+      var listTemplateSource = '<input type="checkbox" class="custom-checkbox" {{#if selected}}checked="true"{{/if}} disabled><label><span></span></label>';
+
+      return this.compileView(listTemplateSource, {selected: parseInt(options.value, 10) === 1});
+    }
+  });
+});

--- a/app/core/interfaces/checkbox/interface.js
+++ b/app/core/interfaces/checkbox/interface.js
@@ -7,10 +7,10 @@
 //  http://www.getdirectus.com
 /*jshint multistr: true */
 
-define(['app', 'underscore', 'utils', 'core/UIComponent', 'core/UIView', 'core/t'], function(app, _, Utils, UIComponent, UIView, __t) {
+define(['underscore', 'utils', 'core/UIView', 'core/t'], function(_, Utils, UIView, __t) {
   'use strict';
 
-  var Input = UIView.extend({
+  return UIView.extend({
     template: 'checkbox/input',
 
     events: {
@@ -48,28 +48,4 @@ define(['app', 'underscore', 'utils', 'core/UIComponent', 'core/UIView', 'core/t
       };
     }
   });
-
-  var Component = UIComponent.extend({
-    id: 'checkbox',
-    dataTypes: ['TINYINT'],
-    variables: [
-      {id: 'mandatory', type: 'Boolean', default_value: false, ui: 'checkbox', comment: 'if this field should always be checked by the user.'}
-    ],
-    Input: Input,
-    validate: function(value, options) {
-      // If a checkbox is mandatory, it MUST be checked to save
-      // similar to "agree to terms" functionality
-      var required = options.view ? options.view.isRequired() : false;
-      if (required && value === 0) {
-        return __t('this_field_is_required');
-      }
-    },
-    list: function(options) {
-      var listTemplateSource = '<input type="checkbox" class="custom-checkbox" {{#if selected}}checked="true"{{/if}} disabled><label><span></span></label>';
-
-      return this.compileView(listTemplateSource, {selected: parseInt(options.value, 10) === 1});
-    }
-  });
-
-  return Component;
 });


### PR DESCRIPTION
Splits the component and view into two separate files.

New file structure:
```
app/core/interfaces/checkbox
├── component.js
├── input.html
└── interface.js
```

No further changes