### PR TITLE
Reorganize textinput & textarea interface

### DIFF
--- a/app/core/UIManager.js
+++ b/app/core/UIManager.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
     require('core/interfaces/slider'),
     require('core/interfaces/single_file/component'),
     require('core/interfaces/slug'),
-    require('core/interfaces/textarea'),
+    require('core/interfaces/textarea/component'),
     require('core/interfaces/user/interface'),
     require('core/interfaces/directus_activity'),
     require('core/interfaces/datetime/datetime'),

--- a/app/core/UIManager.js
+++ b/app/core/UIManager.js
@@ -11,7 +11,7 @@ define(function(require, exports, module) {
     require('core/interfaces/_internals/permissions/interface'),
     require('core/interfaces/_internals/views/interface'),
     require('core/interfaces/_internals/file_preview/interface'),
-    require('core/interfaces/textinput/index'),
+    require('core/interfaces/textinput/component'),
     require('core/interfaces/section_break/section_break'),
     require('core/interfaces/checkbox/checkbox'),
     require('core/interfaces/color/index'),

--- a/app/core/interfaces/textarea/component.js
+++ b/app/core/interfaces/textarea/component.js
@@ -6,28 +6,15 @@
 //  For all details and documentation:
 //  http://www.getdirectus.com
 
-define(['app', 'core/UIComponent', 'core/UIView', 'core/t'],function(app, UIComponent, UIView, __t) {
+define([
+  'core/interfaces/textarea/interface',
+  'core/UIComponent',
+  'core/t'
+],function(Input, UIComponent, __t) {
 
   'use strict';
 
-  var template = '<textarea rows="{{rows}}" name="{{name}}" id="{{name}}" placeholder="{{placeholder_text}}" {{#if readonly}}readonly{{/if}}>{{value}}</textarea>';
-
-  var Input = UIView.extend({
-    templateSource: template,
-
-    serialize: function() {
-      return {
-        value: this.options.value,
-        name: this.options.name,
-        rows: this.options.settings.get('rows'),
-        placeholder_text: this.options.settings.get('placeholder_text'),
-        comment: this.options.schema.get('comment'),
-        readonly: !this.options.canWrite
-      };
-    }
-  });
-
-  var Component = UIComponent.extend({
+  return UIComponent.extend({
     id: 'textarea',
     dataTypes: ['TEXT', 'VARCHAR'],
     variables: [
@@ -47,6 +34,4 @@ define(['app', 'core/UIComponent', 'core/UIView', 'core/t'],function(app, UIComp
       return _.isString(options.value) ? options.value.replace(/<(?:.|\n)*?>/gm, '').substr(0,100) : '<span class="silver">--</span>';
     }
   });
-
-  return Component;
 });

--- a/app/core/interfaces/textarea/input.html
+++ b/app/core/interfaces/textarea/input.html
@@ -1,0 +1,1 @@
+<textarea rows="{{rows}}" name="{{name}}" id="{{name}}" placeholder="{{placeholder_text}}" {{#if readonly}}readonly{{/if}}>{{value}}</textarea>

--- a/app/core/interfaces/textarea/interface.js
+++ b/app/core/interfaces/textarea/interface.js
@@ -1,0 +1,29 @@
+//  Textarea Core UI component
+//  Directus 6.0
+
+//  (c) RANGER
+//  Directus may be freely distributed under the GNU license.
+//  For all details and documentation:
+//  http://www.getdirectus.com
+
+define([
+  'core/UIView'
+],function(UIView) {
+
+  'use strict';
+
+  return UIView.extend({
+    template: 'textarea/input',
+
+    serialize: function() {
+      return {
+        value: this.options.value,
+        name: this.options.name,
+        rows: this.options.settings.get('rows'),
+        placeholder_text: this.options.settings.get('placeholder_text'),
+        comment: this.options.schema.get('comment'),
+        readonly: !this.options.canWrite
+      };
+    }
+  });
+});

--- a/app/core/interfaces/textinput/component.js
+++ b/app/core/interfaces/textinput/component.js
@@ -1,0 +1,65 @@
+define([
+  'core/interfaces/textinput/interface',
+  'core/UIComponent',
+  'core/t'
+], function(Input, UIComponent, __t) {
+  'use strict';
+
+  return UIComponent.extend({
+    id: 'textinput',
+    dataTypes: ['VARCHAR', 'CHAR', 'DATE', 'TIME', 'ENUM'],
+    variables: [
+      // Disables editing of the field while still letting users see the value (true = readonly)
+      {id: 'readonly', type: 'Boolean', default_value: false, ui: 'checkbox'},
+      // Adjusts the max width of the input (Small, Medium, Large)
+      {id: 'size', type: 'String', default_value: 'large', ui: 'select', options: {options: {'large': __t('size_large'), 'medium': __t('size_medium'), 'small': __t('size_small')}}},
+      // Grayed out default placeholder text in the input when it's empty
+      {id: 'placeholder_text', type: 'String', default_value: '', ui: 'textinput', char_length: 200},
+      // Chooses the type of validation used on this field
+      // * Character Blacklist: Choose the specific characters **not** allowed in the input
+      // * Character Whitelist: Choose the specific characters allowed in the input
+      // * RegEx: Create a regular expression to validate the value. Useful for emails, phone number formatting, or almost anything
+      {id: 'validation_type', type: 'String', ui: 'select', options: {options: {'bl': __t('character_blacklist'), 'wl': __t('character_whitelist'), 'rgx': __t('regex')} }, default_value: 'rgx'},
+      // Holds the CSV list of Whitelist/Blacklist characters or the RegEx value (based on the above option)
+      {id: 'validation_string', type: 'String', default_value: '', ui: 'textinput', char_length: 200, comment: __t('textinput_validation_string_comment')},
+      // A message that is shown to the user if the validation fails
+      {id: 'validation_message', type: 'String', default_value: '', ui: 'textinput', char_length: 200}
+    ],
+    Input: Input,
+    validate: function(value, options) {
+      var validationMessage = options.settings.get('validation_message') || __t('confirm_invalid_value');
+
+      if (_.isEmpty(value)) {
+        if (options.schema.get('required') === true) {
+          return __t('this_field_is_required');
+        }
+
+        return;
+      }
+
+      switch(options.settings.get('validation_type')) {
+        case ('wl') :
+          var Regex = new RegExp('^[' + options.settings.get('validation_string') + ']+$');
+          if(!value.match(Regex)) {
+            return validationMessage;
+          }
+          break;
+        case ('bl') :
+          var chars = options.settings.get('validation_string').split('');
+          if(chars.length > 0 && value.match(chars.join('|'))) {
+            return validationMessage;
+          }
+          break;
+        case ('rgx'):
+          var regex = new RegExp(options.settings.get('validation_string'));
+          if (!regex.test(value)) {
+            return validationMessage;
+          }
+          break;
+      }
+    },
+    list: function(options) {
+      return (options.value) ? options.value.toString().replace(/<(?:.|\n)*?>/gm, '').substr(0, 100) : '';
+    }
+  });
+});

--- a/app/core/interfaces/textinput/interface.js
+++ b/app/core/interfaces/textinput/interface.js
@@ -15,11 +15,14 @@
 // options.name       String            Field name
 /*jshint multistr: true */
 
-define(['app', 'core/UIComponent', 'core/UIView', 'core/t'], function(app, UIComponent, UIView, __t) {
+define([
+  'core/UIView',
+  'core/t'
+], function(UIView, __t) {
 
   'use strict';
 
-  var Input = UIView.extend({
+  return UIView.extend({
     template: 'textinput/input',
 
     // Event Declarations
@@ -89,64 +92,4 @@ define(['app', 'core/UIComponent', 'core/UIView', 'core/t'], function(app, UICom
       this.maxCharLength = this.options.schema.get('length');
     }
   });
-
-  var Component = UIComponent.extend({
-    id: 'textinput',
-    dataTypes: ['VARCHAR', 'CHAR', 'DATE', 'TIME', 'ENUM'],
-    variables: [
-      // Disables editing of the field while still letting users see the value (true = readonly)
-      {id: 'readonly', type: 'Boolean', default_value: false, ui: 'checkbox'},
-      // Adjusts the max width of the input (Small, Medium, Large)
-      {id: 'size', type: 'String', default_value: 'large', ui: 'select', options: {options: {'large': __t('size_large'), 'medium': __t('size_medium'), 'small': __t('size_small')}}},
-      // Grayed out default placeholder text in the input when it's empty
-      {id: 'placeholder_text', type: 'String', default_value: '', ui: 'textinput', char_length: 200},
-      // Chooses the type of validation used on this field
-      // * Character Blacklist: Choose the specific characters **not** allowed in the input
-      // * Character Whitelist: Choose the specific characters allowed in the input
-      // * RegEx: Create a regular expression to validate the value. Useful for emails, phone number formatting, or almost anything
-      {id: 'validation_type', type: 'String', ui: 'select', options: {options: {'bl': __t('character_blacklist'), 'wl': __t('character_whitelist'), 'rgx': __t('regex')} }, default_value: 'rgx'},
-      // Holds the CSV list of Whitelist/Blacklist characters or the RegEx value (based on the above option)
-      {id: 'validation_string', type: 'String', default_value: '', ui: 'textinput', char_length: 200, comment: __t('textinput_validation_string_comment')},
-      // A message that is shown to the user if the validation fails
-      {id: 'validation_message', type: 'String', default_value: '', ui: 'textinput', char_length: 200}
-    ],
-    Input: Input,
-    validate: function(value, options) {
-      var validationMessage = options.settings.get('validation_message') || __t('confirm_invalid_value');
-
-      if (_.isEmpty(value)) {
-        if (options.schema.get('required') === true) {
-          return __t('this_field_is_required');
-        }
-
-        return;
-      }
-
-      switch(options.settings.get('validation_type')) {
-        case ('wl') :
-          var Regex = new RegExp('^[' + options.settings.get('validation_string') + ']+$');
-          if(!value.match(Regex)) {
-            return validationMessage;
-          }
-          break;
-        case ('bl') :
-          var chars = options.settings.get('validation_string').split('');
-          if(chars.length > 0 && value.match(chars.join('|'))) {
-            return validationMessage;
-          }
-          break;
-        case ('rgx'):
-          var regex = new RegExp(options.settings.get('validation_string'));
-          if (!regex.test(value)) {
-            return validationMessage;
-          }
-          break;
-      }
-    },
-    list: function(options) {
-      return (options.value) ? options.value.toString().replace(/<(?:.|\n)*?>/gm, '').substr(0, 100) : '';
-    }
-  });
-
-  return Component;
 });


### PR DESCRIPTION
Splits the component and view of the two interfaces into two separate files.

New file structure:
```
app/core/interfaces/textinput
├── component.js
├── input.html
└── interface.js

app/core/interfaces/textarea
├── component.js
├── input.html
└── interface.js
```

No further changes