### PR TITLE
Capitalization Issue for Extension Example

### DIFF
--- a/app/core/extensions.js
+++ b/app/core/extensions.js
@@ -1,4 +1,4 @@
-define(['backbone', 'core/directus', 'core/basePageView'], function(Backbone, Directus, BasePageView) {
+define(['backbone', 'core/directus', 'core/BasePageView'], function(Backbone, Directus, BasePageView) {
   return {
     Router: Directus.SubRoute,
     View: Backbone.Layout.extend({


### PR DESCRIPTION
The other week I submitted a PR that renamed the BasePageView.js to be basePageView.js to resolve an issue with this file and that change likely broke everything! Upon globally searching the code base, looks like it was more appropriate to change the capitalization in this particular file instead. I see there was already a PR to fix the previous issue I caused! 

Sorry I didn't dig into it a little more before submitting.