### PR TITLE
adding join handling code

### DIFF
--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -954,6 +954,26 @@ class RelationalTableGateway extends BaseTableGateway
     }
 
     /**
+     * Process column joins
+     *
+     * @param Builder $query            
+     * @param array $joins            
+     */
+    protected function processJoins(Builder $query, array $joins = [])
+    {
+        $columns = ['*'];
+        foreach ($joins as $table => $params) {
+            if (! isset($params['type'])) {
+                $params['type'] = 'INNER';
+            }
+            
+            $params['on'] = implode("=", $params['on']);
+            
+            $query->join($table, $params['on'], $columns, $params['type']);
+        }
+    }
+
+    /**
      * Process Query search
      *
      * @param Builder $query


### PR DESCRIPTION
Adding code to allow join queries, syntax as follows. I'll submit an additional pull request to add these docs to the api-docs repo

# Join Queries

Compare multiple tables to create a result set.

```
SELECT [columns] FROM `candidates` INNER JOIN `jobs` ON `jobs`.`id`=`candidates`.`job` WHERE `jobs`.`user_id` = '11' 
```


## Basic use
```
'joins' => [
	'jobs' => [
        'on' => [
            'jobs.id',
            'candidates.job'
        ],
        'type' => 'INNER'
    ]
]
```

## More advanced with filters
```
[
    'filters' => [
        'jobs.user_id' => [
            '=' => 27
        ]
    ],
    'joins' => [
        'jobs' => [
            'on' => [
                'jobs.id',
                'candidates.job'
            ],
            'type' => 'INNER'
        ]
    ]
]
```