### PR TITLE
Adding group by on queries

### DIFF
--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -954,6 +954,26 @@ class RelationalTableGateway extends BaseTableGateway
     }
 
     /**
+     * Process column joins
+     *
+     * @param Builder $query            
+     * @param array $joins            
+     */
+    protected function processJoins(Builder $query, array $joins = [])
+    {
+        $columns = ['*'];
+        foreach ($joins as $table => $params) {
+            if (! isset($params['type'])) {
+                $params['type'] = 'INNER';
+            }
+            
+            $params['on'] = implode("=", $params['on']);
+            
+            $query->join($table, $params['on'], $columns, $params['type']);
+        }
+    }
+
+    /**
      * Process Query search
      *
      * @param Builder $query

--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -974,6 +974,18 @@ class RelationalTableGateway extends BaseTableGateway
         }
     }
 
+
+    /**
+     * Process group-by
+     *
+     * @param Builder $query
+     * @param array $groupBy
+     */
+    protected function processGroups(Builder $query, array $columns = [])
+    {
+        $query->groupBy($columns);
+    }
+
     /**
      * Process Query search
      *


### PR DESCRIPTION
Adding group by capability to api query builder, users can send an array of column names, supporting dot-notation. Would normally only be used with "joins" but can also be used alone.
```
'groups' => [
    'jobs.id'
]
```