### PR TITLE
Adding 'OR' capable code for filters

### DIFF
--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -897,6 +897,11 @@ class RelationalTableGateway extends BaseTableGateway
     protected function processFilters(Builder $query, array $filters = [])
     {
         foreach($filters as $column => $condition) {
+			$logical = null;
+			if (is_array($condition) && isset($condition['logical'])) {
+                $logical = $condition['logical'];
+                unset($condition['logical']);
+            }
             $operator = is_array($condition) ? key($condition) : '=';
             $value = is_array($condition) ? current($condition) : $condition;
             $not = false;
@@ -920,6 +925,10 @@ class RelationalTableGateway extends BaseTableGateway
             }
 
             $arguments = [$column, $value];
+			if (isset($logical)) {
+				$arguments[] = null;
+                $arguments[] = $logical;
+            }
             $relationship = TableSchema::getColumnRelationship($this->getTable(), $column);
             if (in_array($operator, ['all', 'has']) && in_array($relationship->getType(), ['ONETOMANY', 'MANYTOMANY'])) {
                 if ($operator == 'all' && is_string($value)) {

--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -954,6 +954,26 @@ class RelationalTableGateway extends BaseTableGateway
     }
 
     /**
+     * Process column joins
+     *
+     * @param Builder $query            
+     * @param array $joins            
+     */
+    protected function processJoins(Builder $query, array $joins = [])
+    {
+        $columns = ['*'];
+        foreach ($joins as $table => $params) {
+            if (! isset($params['type'])) {
+                $params['type'] = 'INNER';
+            }
+            
+            $params['on'] = implode("=", $params['on']);
+            
+            $query->join($table, $params['on'], $columns, $params['type']);
+        }
+    }
+
+    /**
      * Process Query search
      *
      * @param Builder $query

--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -974,6 +974,18 @@ class RelationalTableGateway extends BaseTableGateway
         }
     }
 
+
+    /**
+     * Process group-by
+     *
+     * @param Builder $query
+     * @param array $groupBy
+     */
+    protected function processGroups(Builder $query, array $columns = [])
+    {
+        $query->groupBy($columns);
+    }
+
     /**
      * Process Query search
      *


### PR DESCRIPTION
#1388 allow a parameter 'logical' to be specified per-column when querying on multiple columns

usage:  (this will make more sense on querying multiple columns)
```
 filters => ['column' => [ 'logical' => 'or' , 'eq' => 17]]
```
