### PR TITLE
Add unit-option to slider interface

### DIFF
--- a/app/core/interfaces/slider/component.js
+++ b/app/core/interfaces/slider/component.js
@@ -7,7 +7,8 @@ define(['core/interfaces/slider/interface', 'core/UIComponent', 'core/t'], funct
     variables: [
       {id: 'minimum', type: 'Number', default_value: 0, ui: 'numeric'},
       {id: 'maximum', type: 'Number', default_value: 100, ui: 'numeric'},
-      {id: 'step', type: 'Number', default_value: 1, ui: 'numeric', comment: __t('slider_step_comment')}
+      {id: 'step', type: 'Number', default_value: 1, ui: 'numeric', comment: __t('slider_step_comment')},
+      {id: 'unit', default_value: '', ui: 'textinput', comment: 'Show unit next to slider value, e.g.: 15 Pounds'}
     ],
     Input: Input,
     validate: function (value, options) {

--- a/app/core/interfaces/slider/input.html
+++ b/app/core/interfaces/slider/input.html
@@ -7,6 +7,7 @@
 
 	span.slider-value {
 		margin-left: 10px;
+		width: auto !important;
 	}
 </style>
-<input type="range" value="{{value}}" name="{{name}}" id="{{name}}" min="{{min}}" max="{{max}}" step="{{step}}"><span class="slider-value">{{value}}</span>
+<input type="range" value="{{value}}" name="{{name}}" id="{{name}}" min="{{min}}" max="{{max}}" step="{{step}}"><span class="slider-value">{{value}} {{unit}}</span>

--- a/app/core/interfaces/slider/interface.js
+++ b/app/core/interfaces/slider/interface.js
@@ -7,7 +7,7 @@ define(['core/UIView'], function (UIView) {
     events: {
       'input input[type=range]': function (e) {
         var value = e.target.value;
-        this.$el.find('span.slider-value').html(value);
+        this.$el.find('span.slider-value').html(value + ' ' + this.options.settings.get('unit'));
       }
     },
     serialize: function () {
@@ -21,7 +21,8 @@ define(['core/UIView'], function (UIView) {
         min: this.options.settings.get('minimum'),
         max: this.options.settings.get('maximum'),
         step: this.options.settings.get('step'),
-        comment: this.options.schema.get('comment')
+        comment: this.options.schema.get('comment'),
+        unit: this.options.settings.get('unit')
       };
     }
   });


### PR DESCRIPTION
Adds textinput to options to allow user to provide unit for the slider interface. Doesn't get saved to database, is only for display purposes.

<img width="528" alt="screen shot 2017-05-27 at 19 18 36" src="https://cloud.githubusercontent.com/assets/9141017/26523141/6521352a-4311-11e7-97df-fac36216e729.png">
