### PR TITLE
[WYSIWYG] Custom element wrappers

### DIFF
--- a/app/core/interfaces/wysiwyg_full/component.js
+++ b/app/core/interfaces/wysiwyg_full/component.js
@@ -97,7 +97,7 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
             openlink: 'Open Link',
             image: 'Image',
             pagebreak: 'Page Break',
-            code: 'Inline Code',
+            code: 'View Source',
             insertdatetime: 'Time and Date',
             media: 'Insert Media'
           }

--- a/app/core/interfaces/wysiwyg_full/component.js
+++ b/app/core/interfaces/wysiwyg_full/component.js
@@ -111,6 +111,15 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
           placeholder: 'undo redo | table'
         },
         comment: 'Space separated list of <a href="https://www.tinymce.com/docs/configure/editor-appearance/#toolbar" target="_blank" rel="noopener">TinyMCE toolbar controls</a>'
+      },
+      {
+        id: 'custom_wrapper',
+        ui: 'textarea',
+        default_value: '',
+        options: {
+          rows: 25,
+          placeholder_text: '{\n    "highlight": {\n        "name": "Add Highlight",\n        "template": "<div class=\'highlight\'>{{text}}</div>",\n        "selector": "div.highlight",\n        "preview_style": "border: 2px dashed grey;"\n   }\n}'
+        }
       }
     ],
     validate: function (value, options) {

--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -157,7 +157,7 @@ define([
               // Add button to editor
               editor.addButton(identifier, {
                 title: customWrapperSettings[identifier].name,
-                text: customWrapperSettings[identifier].name.match(/\b(\w)/g).join('').toUpperCase(),
+                text: customWrapperSettings[identifier].label || customWrapperSettings[identifier].name.match(/\b(\w)/g).join('').toUpperCase(),
                 onclick: function () {
                   var text = editor.selection.getContent({format: 'text'});
                   if (text && text.length > 0) {

--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -87,19 +87,24 @@ define([
       toolbar = (styleFormats.length > 0 ? 'styleselect | ' : '');
 
       if (toolbarOptions.length > 0) {
-        toolbar += toolbarOptions.reduce(function (str, option) {
-          if (str === 'inline') {
-            return str = inline.reduce(function (inlineStr, option) {
-              return inlineStr += ' ' + option;
-            });
-          } else if (option === 'alignment') {
-            return str += alignment.reduce(function (alignmentStr, option) {
-              return alignmentStr += ' ' + option;
-            });
-          } else {
+        // Convert inline / alignment to appropriate options & add to toolbar
+        toolbar = toolbarOptions
+          .map(function (option) {
+            if (option === 'inline') {
+              return inline.reduce(function (inlineStr, inlineOption) {
+                return inlineStr += ' ' + inlineOption;
+              });
+            } else if (option === 'alignment') {
+              return alignment.reduce(function (alignmentStr, alignmentOption) {
+                return alignmentStr += ' ' + alignmentOption;
+              });
+            } else {
+              return option;
+            }
+          })
+          .reduce(function (str, option) {
             return str += ' ' + option;
-          }
-        });
+          });
       }
 
       toolbar += settings.get('custom_toolbar_options');


### PR DESCRIPTION
Adds the ability to add custom element wrappers w/ buttons into the editor. 

For example: the following setting
```json
{
  "highlight": {
    "name": "Add Highlight",
    "template": "<div class='highlight'>{{text}}</div>",
    "selector": "div.highlight",
    "preview_style": "border: 2px dashed grey;"
  }
}
```
results in the editor adding a `AH` button which will wrap the selected text with the provided template.  

<img width="183" alt="screen shot 2017-06-09 at 22 22 33" src="https://user-images.githubusercontent.com/9141017/26993311-d3bfd224-4d62-11e7-8cb1-9b476a47d152.png">

The optional `selector` and `preview_style` properties allow the user to provide custom preview-styling inside the editor:

<img width="271" alt="screen shot 2017-06-09 at 22 26 42" src="https://user-images.githubusercontent.com/9141017/26993307-d0a24220-4d62-11e7-8767-b39cbc0502be.png">


Next to that, this PR fixes some small bugs:
- Rename 'Inline Code' toolbar option to 'View Source'
- Fix 'inline' / 'alignment' toolbar option not being honored when it's the only one selected

_Update 1:_
The optional `label` property allows the user to override the default initial-based label of the button with a custom string