### PR TITLE
Add read_only option to (most) interfaces

### DIFF
--- a/app/core/interfaces/checkboxes/component.js
+++ b/app/core/interfaces/checkboxes/component.js
@@ -4,6 +4,13 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
     dataTypes: ['VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'options',
         ui: 'json',
         type: 'Object',

--- a/app/core/interfaces/checkboxes/input.html
+++ b/app/core/interfaces/checkboxes/input.html
@@ -26,7 +26,7 @@
 		cursor: pointer;
 	}
 
-	.multi_selectlist-interface input[type=checkbox]:checked + label {
+	.multi_selectlist-interface input[type=checkbox]:checked:not(:disabled) + label {
 		font-weight: 700;
 		color: #3498DB;
 	}
@@ -45,10 +45,14 @@
 		transition: color 200ms ease-in-out;
 	}
 
-	.multi_selectlist-interface input[type=checkbox]:checked + label::before,
-	.multi_selectlist-interface input[type=checkbox]:hover + label::before,
-	.multi_selectlist-interface input[type=checkbox]:focus + label::before {
+	.multi_selectlist-interface input[type=checkbox]:checked:not(:disabled) + label::before,
+	.multi_selectlist-interface input[type=checkbox]:hover:not(:disabled) + label::before,
+	.multi_selectlist-interface input[type=checkbox]:focus:not(:disabled) + label::before {
 		color: #3498DB;
+	}
+
+	.multi_selectlist-interface input[type=checkbox]:disabled + label {
+		opacity: 0.6;
 	}
 
 	.multi_selectlist-interface input[type=checkbox] + label::before {
@@ -64,7 +68,7 @@
 	<ul class="gridlist">
 	{{#options}}
 		<li>
-			<input id="multi_select_{{../name}}_{{key}}" name="{{../name}}_{{key}}" value="{{key}}" type="checkbox" {{#if selected}}checked{{/if}}/>
+			<input id="multi_select_{{../name}}_{{key}}" name="{{../name}}_{{key}}" value="{{key}}" type="checkbox" {{#if ../readOnly}} disabled {{/if}} {{#if selected}}checked{{/if}}/>
 			<label for="multi_select_{{../name}}_{{key}}">{{value}}</label>
 		</li>
 	{{/options}}

--- a/app/core/interfaces/checkboxes/input.html
+++ b/app/core/interfaces/checkboxes/input.html
@@ -69,7 +69,7 @@
 	<ul class="gridlist">
 	{{#options}}
 		<li>
-			<input id="multi_select_{{../name}}_{{key}}" name="{{../name}}_{{key}}" value="{{key}}" type="checkbox" {{#if ../readOnly}} disabled {{/if}} {{#if selected}}checked{{/if}}/>
+			<input id="multi_select_{{../name}}_{{key}}" name="{{../name}}_{{key}}" value="{{key}}" type="checkbox" {{#if ../readOnly}} readonly {{/if}} {{#if selected}}checked{{/if}}/>
 			<label for="multi_select_{{../name}}_{{key}}">{{value}}</label>
 		</li>
 	{{/options}}

--- a/app/core/interfaces/checkboxes/input.html
+++ b/app/core/interfaces/checkboxes/input.html
@@ -53,6 +53,7 @@
 
 	.multi_selectlist-interface input[type=checkbox]:disabled + label {
 		opacity: 0.6;
+		cursor: not-allowed;
 	}
 
 	.multi_selectlist-interface input[type=checkbox] + label::before {

--- a/app/core/interfaces/checkboxes/interface.js
+++ b/app/core/interfaces/checkboxes/interface.js
@@ -53,7 +53,7 @@ define(['core/UIView'], function (UIView) {
         options: optionsArray,
         name: this.options.name,
         comment: this.options.schema.get('comment'),
-        readonly: !this.options.canWrite,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         value: value
       };
     }

--- a/app/core/interfaces/color/component.js
+++ b/app/core/interfaces/color/component.js
@@ -12,12 +12,18 @@ define([
     dataTypes: ['VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'input',
         ui: 'radio_buttons',
         type: 'String',
         comment: 'The unit in which the user will enter the data',
         default_value: 'hex',
-        required: true,
         options: {
           options: {
             hex: 'Hex',
@@ -57,7 +63,8 @@ define([
         id: 'palette',
         ui: 'tags',
         type: 'String',
-        comment: 'Add color options as hex values'
+        comment: 'Add color options as hex values',
+        default_value: ''
       },
       {
         id: 'palette_only',

--- a/app/core/interfaces/color/component.js
+++ b/app/core/interfaces/color/component.js
@@ -72,8 +72,7 @@ define([
         type: 'Boolean',
         comment: 'Allow values with an alpha channel',
         default_value: false
-      },
-      {id: 'readonly', type: 'Boolean', default_value: false, ui: 'toggle'}
+      }
     ],
     Input: Input,
     validate: function (value, options) {

--- a/app/core/interfaces/color/input.html
+++ b/app/core/interfaces/color/input.html
@@ -136,28 +136,28 @@
 
 	{{#if hex}}
 	{{#unless alpha}}
-	<input type="text" class="color-text" placeholder="000000" pattern="[0-9a-fA-F]{3,6}" maxlength="6" value="{{value}}" {{#if readOnly}} disabled {{/if}}>
+	<input type="text" class="color-text" placeholder="000000" pattern="[0-9a-fA-F]{3,6}" maxlength="6" value="{{value}}" {{#if readOnly}} readonly {{/if}}>
 	{{/unless}}
 	{{#if alpha}}
-	<input type="text" class="color-text alpha" placeholder="00000000" pattern="[0-9a-fA-F]{3,8}" maxlength="8" value="{{value}}" {{#if readOnly}} disabled {{/if}}>
+	<input type="text" class="color-text alpha" placeholder="00000000" pattern="[0-9a-fA-F]{3,8}" maxlength="8" value="{{value}}" {{#if readOnly}} readonly {{/if}}>
 	{{/if}}
 	{{/if}}
 
 	{{#if rgb}}
-	<label><span>Red: </span><input type="number" class="color-text red" placeholder="0" value="{{value.[0]}}" min="0" max="255" step="1" {{#if readOnly}} disabled {{/if}} /></label>
-	<label><span>Green: </span><input type="number" class="color-text green" placeholder="0" value="{{value.[1]}}" min="0" max="255" step="1" {{#if readOnly}} disabled {{/if}} /></label>
-	<label><span>Blue: </span><input type="number" class="color-text blue" placeholder="0" value="{{value.[2]}}" min="0" max="255" step="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Red: </span><input type="number" class="color-text red" placeholder="0" value="{{value.[0]}}" min="0" max="255" step="1" {{#if readOnly}} readonly {{/if}} /></label>
+	<label><span>Green: </span><input type="number" class="color-text green" placeholder="0" value="{{value.[1]}}" min="0" max="255" step="1" {{#if readOnly}} readonly {{/if}} /></label>
+	<label><span>Blue: </span><input type="number" class="color-text blue" placeholder="0" value="{{value.[2]}}" min="0" max="255" step="1" {{#if readOnly}} readonly {{/if}} /></label>
 	{{#if alpha}}
-	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readOnly}} readonly {{/if}} /></label>
 	{{/if}}
 	{{/if}}
 
 	{{#if hsl}}
-	<label><span>Hue: </span><input type="number" class="color-text hue" placeholder="0" value="{{value.[0]}}" min="0" max="360" step="1" {{#if readOnly}} disabled {{/if}} /></label>
-	<label><span>Saturation: </span><input type="number" class="color-text saturation" placeholder="0" value="{{value.[1]}}" min="0" max="100" step="1" {{#if readOnly}} disabled {{/if}} /></label>
-	<label><span>Lightness: </span><input type="number" class="color-text lightness" placeholder="0" value="{{value.[2]}}" min="0" max="100" step="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Hue: </span><input type="number" class="color-text hue" placeholder="0" value="{{value.[0]}}" min="0" max="360" step="1" {{#if readOnly}} readonly {{/if}} /></label>
+	<label><span>Saturation: </span><input type="number" class="color-text saturation" placeholder="0" value="{{value.[1]}}" min="0" max="100" step="1" {{#if readOnly}} readonly {{/if}} /></label>
+	<label><span>Lightness: </span><input type="number" class="color-text lightness" placeholder="0" value="{{value.[2]}}" min="0" max="100" step="1" {{#if readOnly}} readonly {{/if}} /></label>
 	{{#if alpha}}
-	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readOnly}} readonly {{/if}} /></label>
 	{{/if}}
 	{{/if}}
 

--- a/app/core/interfaces/color/input.html
+++ b/app/core/interfaces/color/input.html
@@ -136,35 +136,35 @@
 
 	{{#if hex}}
 	{{#unless alpha}}
-	<input type="text" class="color-text" placeholder="000000" pattern="[0-9a-fA-F]{3,6}" maxlength="6" value="{{value}}" {{#if readonly}} disabled {{/if}}>
+	<input type="text" class="color-text" placeholder="000000" pattern="[0-9a-fA-F]{3,6}" maxlength="6" value="{{value}}" {{#if readOnly}} disabled {{/if}}>
 	{{/unless}}
 	{{#if alpha}}
-	<input type="text" class="color-text alpha" placeholder="00000000" pattern="[0-9a-fA-F]{3,8}" maxlength="8" value="{{value}}" {{#if readonly}} disabled {{/if}}>
+	<input type="text" class="color-text alpha" placeholder="00000000" pattern="[0-9a-fA-F]{3,8}" maxlength="8" value="{{value}}" {{#if readOnly}} disabled {{/if}}>
 	{{/if}}
 	{{/if}}
 
 	{{#if rgb}}
-	<label><span>Red: </span><input type="number" class="color-text red" placeholder="0" value="{{value.[0]}}" min="0" max="255" step="1" {{#if readonly}} disabled {{/if}} /></label>
-	<label><span>Green: </span><input type="number" class="color-text green" placeholder="0" value="{{value.[1]}}" min="0" max="255" step="1" {{#if readonly}} disabled {{/if}} /></label>
-	<label><span>Blue: </span><input type="number" class="color-text blue" placeholder="0" value="{{value.[2]}}" min="0" max="255" step="1" {{#if readonly}} disabled {{/if}} /></label>
+	<label><span>Red: </span><input type="number" class="color-text red" placeholder="0" value="{{value.[0]}}" min="0" max="255" step="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Green: </span><input type="number" class="color-text green" placeholder="0" value="{{value.[1]}}" min="0" max="255" step="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Blue: </span><input type="number" class="color-text blue" placeholder="0" value="{{value.[2]}}" min="0" max="255" step="1" {{#if readOnly}} disabled {{/if}} /></label>
 	{{#if alpha}}
-	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readonly}} disabled {{/if}} /></label>
+	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readOnly}} disabled {{/if}} /></label>
 	{{/if}}
 	{{/if}}
 
 	{{#if hsl}}
-	<label><span>Hue: </span><input type="number" class="color-text hue" placeholder="0" value="{{value.[0]}}" min="0" max="360" step="1" {{#if readonly}} disabled {{/if}} /></label>
-	<label><span>Saturation: </span><input type="number" class="color-text saturation" placeholder="0" value="{{value.[1]}}" min="0" max="100" step="1" {{#if readonly}} disabled {{/if}} /></label>
-	<label><span>Lightness: </span><input type="number" class="color-text lightness" placeholder="0" value="{{value.[2]}}" min="0" max="100" step="1" {{#if readonly}} disabled {{/if}} /></label>
+	<label><span>Hue: </span><input type="number" class="color-text hue" placeholder="0" value="{{value.[0]}}" min="0" max="360" step="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Saturation: </span><input type="number" class="color-text saturation" placeholder="0" value="{{value.[1]}}" min="0" max="100" step="1" {{#if readOnly}} disabled {{/if}} /></label>
+	<label><span>Lightness: </span><input type="number" class="color-text lightness" placeholder="0" value="{{value.[2]}}" min="0" max="100" step="1" {{#if readOnly}} disabled {{/if}} /></label>
 	{{#if alpha}}
-	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readonly}} disabled {{/if}} /></label>
+	<label><span>Alpha: </span><input type="number" class="color-text alpha" placeholder="0" value="{{value.[3]}}" min="0" max="1" {{#if readOnly}} disabled {{/if}} /></label>
 	{{/if}}
 	{{/if}}
 
-	<span class="color-preview" style="box-shadow: inset 0 0 0 30px {{preview}}, 1px 1px 2px 0px rgba(0,0,0,0.4)">{{#unless readonly}}<i class="material-icons">close</i>{{/unless}}</span>
+	<span class="color-preview" style="box-shadow: inset 0 0 0 30px {{preview}}, 1px 1px 2px 0px rgba(0,0,0,0.4)">{{#unless readOnly}}<i class="material-icons">close</i>{{/unless}}</span>
 
 	{{/unless}}
-	{{#unless readonly}}
+	{{#unless readOnly}}
 	{{#if palette}}
 	<div class="palette">
 	{{#each palette}}

--- a/app/core/interfaces/color/interface.js
+++ b/app/core/interfaces/color/interface.js
@@ -196,7 +196,7 @@ define(['core/UIView', 'core/t', 'core/interfaces/color/lib/color'], function(UI
         name: this.options.name,
         comment: this.options.schema.get('comment'),
         palette: userPalette.length ? userPalette.split(',') : false,
-        readonly: this.options.settings.get('readonly'),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         input: input,
         output: this.options.settings.get('output'),
         hex: input === 'hex',

--- a/app/core/interfaces/datetime/date.js
+++ b/app/core/interfaces/datetime/date.js
@@ -86,7 +86,13 @@ define(['app', 'core/UIComponent', 'core/UIView', 'moment', 'helpers/ui', 'core/
     id: 'date',
     dataTypes: ['DATE'],
     variables: [
-      {id: 'readonly', type: 'Boolean', default_value: false, ui: 'toggle'},
+      {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
       {
         id: 'format',
         ui: 'text_input',

--- a/app/core/interfaces/datetime/datetime.js
+++ b/app/core/interfaces/datetime/datetime.js
@@ -62,7 +62,7 @@ define(['app', 'underscore', 'core/interfaces/datetime/date', 'moment'], functio
         dateValue: date.format(this.getDateFormat()),
         value: date.format(format),
         name: this.name,
-        readonly: this.options.canWrite === false || (settings && settings.has('readonly')) ? settings.get('readonly') === true : false
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       });
     },
   });

--- a/app/core/interfaces/datetime/input.html
+++ b/app/core/interfaces/datetime/input.html
@@ -16,7 +16,7 @@
 	}
 </style>
 
-{{#if useDate}}<input type="date" {{#if readonly}}disabled{{/if}} class="date" {{#if hasValue}}value="{{dateValue}}"{{/if}}>{{/if}}
-{{#if useTime}}<input type="time" step="1" {{#if readonly}}disabled{{/if}} class="time" {{#if hasValue}}value="{{timeValue}}"{{/if}}>{{/if}}
-{{#unless readonly}}<a class="now text-button">{{t "date_now"}}</a>{{/unless}}
+{{#if useDate}}<input type="date" {{#if readOnly}}disabled{{/if}} class="date" {{#if hasValue}}value="{{dateValue}}"{{/if}}>{{/if}}
+{{#if useTime}}<input type="time" step="1" {{#if readOnly}}disabled{{/if}} class="time" {{#if hasValue}}value="{{timeValue}}"{{/if}}>{{/if}}
+{{#unless readOnly}}<a class="now text-button">{{t "date_now"}}</a>{{/unless}}
 <input class="merged" type="hidden" {{#if hasValue}}value="{{value}}"{{/if}} name="{{name}}" id="{{name}}">

--- a/app/core/interfaces/datetime/input.html
+++ b/app/core/interfaces/datetime/input.html
@@ -16,7 +16,7 @@
 	}
 </style>
 
-{{#if useDate}}<input type="date" {{#if readOnly}}disabled{{/if}} class="date" {{#if hasValue}}value="{{dateValue}}"{{/if}}>{{/if}}
-{{#if useTime}}<input type="time" step="1" {{#if readOnly}}disabled{{/if}} class="time" {{#if hasValue}}value="{{timeValue}}"{{/if}}>{{/if}}
+{{#if useDate}}<input type="date" {{#if readOnly}}readonly{{/if}} class="date" {{#if hasValue}}value="{{dateValue}}"{{/if}}>{{/if}}
+{{#if useTime}}<input type="time" step="1" {{#if readOnly}}readonly{{/if}} class="time" {{#if hasValue}}value="{{timeValue}}"{{/if}}>{{/if}}
 {{#unless readOnly}}<a class="now text-button">{{t "date_now"}}</a>{{/unless}}
 <input class="merged" type="hidden" {{#if hasValue}}value="{{value}}"{{/if}} name="{{name}}" id="{{name}}">

--- a/app/core/interfaces/datetime/time.js
+++ b/app/core/interfaces/datetime/time.js
@@ -115,7 +115,7 @@ define(['app', 'moment', 'core/UIComponent', 'core/UIView', 'core/t'], function(
         hasValue: true,
         timeValue: timeValue,
         value: timeValue,
-        readonly: !this.options.canWrite || (settings && settings.has('readonly')) ? settings.get('readonly')!=0 : false
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     },
 
@@ -128,8 +128,13 @@ define(['app', 'moment', 'core/UIComponent', 'core/UIView', 'core/t'], function(
     id: 'time',
     dataTypes: ['TIME'],
     variables: [
-      // @TODO: add time step setting
-      {id: 'readonly', type: 'Boolean', default_value: false, ui: 'toggle'},
+      {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
       {
         id: 'include_seconds',
         ui: 'toggle',

--- a/app/core/interfaces/dropdown/component.js
+++ b/app/core/interfaces/dropdown/component.js
@@ -4,6 +4,13 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
     dataTypes: ['VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'options',
         ui: 'json',
         type: 'Object',
@@ -25,11 +32,6 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
         type: 'String',
         comment: 'Enter Placeholder Text',
         default_value: ''
-      },
-      {
-        id: 'read_only',
-        default_value: false,
-        ui: 'toggle'
       },
       {
         id: 'use_native_input',

--- a/app/core/interfaces/dropdown/interface.js
+++ b/app/core/interfaces/dropdown/interface.js
@@ -36,7 +36,7 @@ define(['core/UIView', 'select2'], function (UIView) {
         comment: this.options.schema.get('comment'),
         readonly: !this.options.canWrite,
         placeholder: this.options.schema.get('placeholder'),
-        readOnly: Boolean(Number(this.options.settings.get('read_only'))),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         native: Boolean(Number(this.options.settings.get('use_native_input'))),
         value: value
       };

--- a/app/core/interfaces/dropdown_enum/component.js
+++ b/app/core/interfaces/dropdown_enum/component.js
@@ -4,13 +4,19 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
     dataTypes: ['ENUM'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'placeholder',
         ui: 'text_input',
         type: 'String',
         comment: 'Enter Placeholder Text',
         default_value: ''
       },
-      {id: 'read_only', default_value: false, ui: 'toggle'},
       {
         id: 'use_native_input',
         ui: 'toggle',

--- a/app/core/interfaces/dropdown_enum/interface.js
+++ b/app/core/interfaces/dropdown_enum/interface.js
@@ -40,7 +40,7 @@ define(['core/UIView', 'select2'], function (UIView) {
         comment: this.options.schema.get('comment'),
         readonly: !this.options.canWrite,
         placeholder: this.options.schema.get('placeholder'),
-        readOnly: Boolean(Number(this.options.settings.get('read_only'))),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         native: Boolean(Number(this.options.settings.get('use_native_input'))),
         value: value
       };

--- a/app/core/interfaces/dropdown_multiselect/component.js
+++ b/app/core/interfaces/dropdown_multiselect/component.js
@@ -4,6 +4,13 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
     dataTypes: ['VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'options',
         ui: 'json',
         type: 'Object',
@@ -26,7 +33,6 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
         comment: 'Enter Placeholder Text',
         default_value: ''
       },
-      {id: 'read_only', default_value: false, ui: 'toggle'},
       {
         id: 'use_native_input',
         ui: 'toggle',

--- a/app/core/interfaces/dropdown_multiselect/interface.js
+++ b/app/core/interfaces/dropdown_multiselect/interface.js
@@ -36,7 +36,7 @@ define(['core/UIView', 'select2'], function (UIView) {
         comment: this.options.schema.get('comment'),
         readonly: !this.options.canWrite,
         placeholder: this.options.schema.get('placeholder'),
-        readOnly: Boolean(Number(this.options.settings.get('read_only'))),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         native: Boolean(Number(this.options.settings.get('use_native_input'))),
         value: value
       };

--- a/app/core/interfaces/json/component.js
+++ b/app/core/interfaces/json/component.js
@@ -5,6 +5,13 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
     Input: Input,
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'indent',
         ui: 'text_input',
         type: 'String',

--- a/app/core/interfaces/json/input.html
+++ b/app/core/interfaces/json/input.html
@@ -4,4 +4,4 @@
 	}
 </style>
 
-<textarea rows="{{rows}}" class="interface_json" name="{{name}}" id="{{name}}" placeholder="{{placeholder}}" {{#if readOnly}}disabled{{/if}}>{{value}}</textarea>
+<textarea rows="{{rows}}" class="interface_json" name="{{name}}" id="{{name}}" placeholder="{{placeholder}}" {{#if readOnly}}readonly{{/if}}>{{value}}</textarea>

--- a/app/core/interfaces/json/input.html
+++ b/app/core/interfaces/json/input.html
@@ -4,4 +4,4 @@
 	}
 </style>
 
-<textarea rows="{{rows}}" class="interface_json" name="{{name}}" id="{{name}}" placeholder="{{placeholder}}" {{#if readonly}}readonly{{/if}}>{{value}}</textarea>
+<textarea rows="{{rows}}" class="interface_json" name="{{name}}" id="{{name}}" placeholder="{{placeholder}}" {{#if readOnly}}disabled{{/if}}>{{value}}</textarea>

--- a/app/core/interfaces/json/interface.js
+++ b/app/core/interfaces/json/interface.js
@@ -140,7 +140,7 @@ define(['core/UIView'], function (UIView) {
         name: this.options.name,
         rows: this.options.settings.get('rows'),
         placeholder: this.options.settings.get('placeholder'),
-        readonly: !this.options.canWrite
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     }
   });

--- a/app/core/interfaces/many_to_one/component.js
+++ b/app/core/interfaces/many_to_one/component.js
@@ -5,7 +5,13 @@ define(['./interface', 'backbone', 'handlebars', 'core/UIComponent', 'core/t'], 
     id: 'many_to_one',
     dataTypes: ['INT', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT'],
     variables: [
-      {id: 'readonly', type: 'Boolean', default_value: false, ui: 'toggle'},
+      {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
       {
         id: 'visible_column',
         ui: 'text_input',

--- a/app/core/interfaces/many_to_one/input.html
+++ b/app/core/interfaces/many_to_one/input.html
@@ -1,5 +1,5 @@
 <div class="select-container">
-	<select name="{{name}}" {{#unless canEdit}}disabled{{/unless}}>
+	<select name="{{name}}" {{#if readOnly}}disabled{{/if}}>
 		{{#if allowNull}}
 		<option value="">{{placeholder}}</option>
 		{{/if}}

--- a/app/core/interfaces/many_to_one/input.html
+++ b/app/core/interfaces/many_to_one/input.html
@@ -1,5 +1,5 @@
 <div class="select-container">
-	<select name="{{name}}" {{#if readOnly}}disabled{{/if}}>
+	<select name="{{name}}" {{#if readOnly}}readonly{{/if}}>
 		{{#if allowNull}}
 		<option value="">{{placeholder}}</option>
 		{{/if}}

--- a/app/core/interfaces/many_to_one/interface.js
+++ b/app/core/interfaces/many_to_one/interface.js
@@ -76,14 +76,14 @@ define([
       }
 
       return {
-        canEdit: this.canEdit,
         name: this.options.name,
         data: data,
         handleBarString: this.options.settings.get('value_template'),
         comment: this.options.schema.get('comment'),
         use_radio_buttons: this.options.settings.get('use_radio_buttons') === true,
         allowNull: this.options.settings.get('allow_null') === true,
-        placeholder: (this.options.settings.get('placeholder')) ? this.options.settings.get('placeholder') : __t('select_from_below')
+        placeholder: (this.options.settings.get('placeholder')) ? this.options.settings.get('placeholder') : __t('select_from_below'),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     },
 

--- a/app/core/interfaces/many_to_one_typeahead/component.js
+++ b/app/core/interfaces/many_to_one_typeahead/component.js
@@ -19,6 +19,13 @@ define(['./interface', 'app', 'backbone', 'core/UIComponent', 'core/t'], functio
     dataTypes: ['INT', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'visible_column',
         ui: 'text_input',
         type: 'String',

--- a/app/core/interfaces/many_to_one_typeahead/input.html
+++ b/app/core/interfaces/many_to_one_typeahead/input.html
@@ -64,7 +64,7 @@
 	}
 </style>
 
-<input type="text" value="" class="for_display_only {{size}}{{#if disabled}} disabled{{/if}}" placeholder="{{t "m2o_typeahead_placeholder"}}" {{#if readOnly}}disabled{{/if}}/>
+<input type="text" value="" class="for_display_only {{size}}{{#if disabled}} disabled{{/if}}" placeholder="{{t "m2o_typeahead_placeholder"}}" {{#if readOnly}}readonly{{/if}}/>
 {{#if disabled}}
 	<div class="disabled-input"></div>
 	<em>There aren't any visible columns selected</em>

--- a/app/core/interfaces/many_to_one_typeahead/input.html
+++ b/app/core/interfaces/many_to_one_typeahead/input.html
@@ -64,7 +64,7 @@
 	}
 </style>
 
-<input type="text" value="" class="for_display_only {{size}}{{#if disabled}} disabled{{/if}}" placeholder="{{t "m2o_typeahead_placeholder"}}" {{#if readonly}}readonly{{/if}}/>
+<input type="text" value="" class="for_display_only {{size}}{{#if disabled}} disabled{{/if}}" placeholder="{{t "m2o_typeahead_placeholder"}}" {{#if readOnly}}disabled{{/if}}/>
 {{#if disabled}}
 	<div class="disabled-input"></div>
 	<em>There aren't any visible columns selected</em>

--- a/app/core/interfaces/many_to_one_typeahead/interface.js
+++ b/app/core/interfaces/many_to_one_typeahead/interface.js
@@ -30,7 +30,7 @@ define(['app', 'handlebars', 'core/UIView', 'utils'], function (app, Handlebars,
       return {
         name: this.options.name,
         size: this.columnSchema.options.get('size'),
-        readonly: false,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         disabled: !this.visibleColumn,
         selectedItem: relatedModel,
         hasSelectedItem: !relatedModel.isNew(),

--- a/app/core/interfaces/map/component.js
+++ b/app/core/interfaces/map/component.js
@@ -5,6 +5,13 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
     id: 'map',
     dataTypes: ['VARCHAR', 'ALIAS'],
     variables: [
+      {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
       // Google API Key (Provided by Google)
       {
         id: 'google_api_key',

--- a/app/core/interfaces/map/input.html
+++ b/app/core/interfaces/map/input.html
@@ -27,5 +27,5 @@
 		width: 401px;
 	}
 </style>
-<input id="pac-input" class="controls" type="text" placeholder="Search Box"><div style="height: 400px" id="map-canvas"/>
+<input id="pac-input" class="controls" type="text" placeholder="Search Box" {{#if readOnly}}readonly{{/if}}><div style="height: 400px" id="map-canvas"/>
 <input type="text" value="{{value}}" name="{{name}}" id="{{name}}" class="medium" readonly/>

--- a/app/core/interfaces/map/interface.js
+++ b/app/core/interfaces/map/interface.js
@@ -31,7 +31,8 @@ define([
 
       var mapOptions = {
         center: center,
-        zoom: 12
+        zoom: 12,
+        disableDefaultUI: this.options.settings.get('read_only') || !this.options.canWrite
       };
 
       var map = new google.maps.Map(this.$el.find('#map-canvas').get(0), mapOptions);
@@ -150,7 +151,8 @@ define([
 
       var data = {
         value: value,
-        name: this.options.name
+        name: this.options.name,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
 
       if (this.options.schema.get('type') === 'ALIAS') {

--- a/app/core/interfaces/markdown/component.js
+++ b/app/core/interfaces/markdown/component.js
@@ -20,6 +20,13 @@ define([
     dataTypes: ['TEXT', 'VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'rows',
         ui: 'numeric',
         type: 'Number',

--- a/app/core/interfaces/markdown/input.html
+++ b/app/core/interfaces/markdown/input.html
@@ -58,6 +58,6 @@
 	<button class="toggle-pane" type="button" data-action="md-preview">Preview</button>
 </div>
 <div class="md-interface">
-	<textarea rows="{{rows}}" class="md-editor" name="{{name}}" id="{{name}}" {{#if readonly}}readonly{{/if}}>{{rawValue}}</textarea>
+	<textarea rows="{{rows}}" class="md-editor" name="{{name}}" id="{{name}}" {{#if readOnly}}readonly{{/if}}>{{rawValue}}</textarea>
 	<div class="md-editor-preview">{{{value}}}</div>
 </div>

--- a/app/core/interfaces/markdown/interface.js
+++ b/app/core/interfaces/markdown/interface.js
@@ -63,7 +63,7 @@ define([
         name: this.options.name,
         rows: this.options.settings.get('rows'),
         comment: this.options.schema.get('comment'),
-        readonly: !this.options.canWrite
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     }
   });

--- a/app/core/interfaces/numeric/component.js
+++ b/app/core/interfaces/numeric/component.js
@@ -9,6 +9,13 @@ define([
     dataTypes: SchemaHelper.getNumericInterfaceTypes(),
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'size',
         ui: 'dropdown',
         type: 'String',

--- a/app/core/interfaces/numeric/input.html
+++ b/app/core/interfaces/numeric/input.html
@@ -1,1 +1,1 @@
-<input type="number" value="{{value}}" placeholder="{{placeholder}}" name="{{name}}" id="{{name}}" class="{{size}}" step="{{step}}" {{#if readonly}}readonly{{/if}} />
+<input type="number" value="{{value}}" placeholder="{{placeholder}}" name="{{name}}" id="{{name}}" class="{{size}}" step="{{step}}" {{#if readOnly}}readonly{{/if}} />

--- a/app/core/interfaces/numeric/interface.js
+++ b/app/core/interfaces/numeric/interface.js
@@ -64,7 +64,7 @@ define([
         size: this.options.settings.get('size'),
         placeholder: (this.options.settings) ? this.options.settings.get('placeholder') : '',
         comment: this.options.schema.get('comment'),
-        readonly: !this.options.canWrite,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         step: step
       };
     }

--- a/app/core/interfaces/password/component.js
+++ b/app/core/interfaces/password/component.js
@@ -11,6 +11,13 @@ define(['core/interfaces/password/interface', 'underscore', 'core/UIComponent', 
 
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'require_confirmation',
         ui: 'toggle',
         type: 'Boolean',

--- a/app/core/interfaces/password/input.html
+++ b/app/core/interfaces/password/input.html
@@ -1,14 +1,16 @@
-<input type="password" value="{{value}}" name="{{name}}" class="medium password-primary" style="display:block;margin-bottom:10px;" placeholder="{{t "password_placeholder"}}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"/>
-<input type="password" id="password_fake" class="hidden" autocomplete="off" style="display: none;">
+<input type="password" value="{{value}}" name="{{name}}" class="medium password-primary" style="display:block;margin-bottom:10px;" placeholder="{{t "password_placeholder"}}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" {{#if readOnly}}readonly{{/if}}/>
+<input type="password" id="password_fake" class="hidden" autocomplete="off" style="display: none;" {{#if readOnly}}readonly{{/if}}>
 
 <span class="password-text"></span>
 
 {{#if require_confirmation}}
-<input type="password" value="{{value}}" class="medium password-confirm" style="display:block;margin-bottom:10px;" placeholder="{{t "password_confirm_placeholder"}}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"/>
+<input type="password" value="{{value}}" class="medium password-confirm" style="display:block;margin-bottom:10px;" placeholder="{{t "password_confirm_placeholder"}}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" {{#if readOnly}}readonly{{/if}}/>
 {{/if}}
 
+{{#unless readOnly}}
 <div style="display:block;">
 	<button class="button password-generate" style="margin-right:10px;" type="button">{{t "generate_new"}}</button>
 	<button class="button password-toggle" style="display:none;" type="button">{{t "reveal_password"}}</button>
 	<span class="encrypted hidden">{{t "password_encrypted"}}</span>
 </div>
+{{/if}}

--- a/app/core/interfaces/password/interface.js
+++ b/app/core/interfaces/password/interface.js
@@ -120,7 +120,8 @@ define(['underscore', 'core/UIView', 'core/t', 'core/notification'], function (_
         name: this.options.name,
         value: this.options.value,
         comment: this.options.schema.get('comment'),
-        require_confirmation: (this.options.settings.get('require_confirmation') === true)
+        require_confirmation: (this.options.settings.get('require_confirmation') === true),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     },
 

--- a/app/core/interfaces/radio_buttons/component.js
+++ b/app/core/interfaces/radio_buttons/component.js
@@ -4,6 +4,13 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
     dataTypes: ['VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'options',
         ui: 'json',
         type: 'Object',
@@ -18,7 +25,8 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
             value3: 'Option 3'
           }, null, '  ')
         }
-      }, {
+      },
+      {
         id: 'list_view_formatting',
         ui: 'radio_buttons',
         type: 'String',

--- a/app/core/interfaces/radio_buttons/input.html
+++ b/app/core/interfaces/radio_buttons/input.html
@@ -30,7 +30,7 @@
 		cursor: pointer;
 	}
 
-	.select_list-interface input[type=radio]:checked + label {
+	.select_list-interface input[type=radio]:checked:not(:disabled) + label {
 		font-weight: 700;
 		color: #3498DB;
 	}
@@ -49,10 +49,15 @@
 		transition: color 200ms ease-in-out;
 	}
 
-	.select_list-interface input[type=radio]:checked + label::before,
-	.select_list-interface input[type=radio]:hover + label::before,
-	.select_list-interface input[type=radio]:focus + label::before {
+	.select_list-interface input[type=radio]:checked:not(:disabled) + label::before,
+	.select_list-interface input[type=radio]:hover:not(:disabled) + label::before,
+	.select_list-interface input[type=radio]:focus:not(:disabled) + label::before {
 		color: #3498DB;
+	}
+
+	.select_list-interface input[type=radio]:disabled + label {
+		cursor: not-allowed;
+		opacity: 0.6;
 	}
 
 	.select_list-interface input[type=radio] + label::before {
@@ -68,7 +73,7 @@
 	<ul class="gridlist">
 	{{#options}}
 		<li>
-			<input type="radio" name="{{../name}}" value="{{key}}" id="radio-{{../name}}-{{key}}" {{#if selected}}checked{{/if}}>
+			<input type="radio" name="{{../name}}" value="{{key}}" id="radio-{{../name}}-{{key}}" {{#if selected}}checked{{/if}} {{#if readOnly}}readonly{{/if}}>
 			<label class="radiobuttons" for="radio-{{../name}}-{{key}}">{{value}}</label>
 		</li>
 	{{/options}}

--- a/app/core/interfaces/radio_buttons/interface.js
+++ b/app/core/interfaces/radio_buttons/interface.js
@@ -40,7 +40,7 @@ define([
         options: optionsArray,
         name: this.options.name,
         comment: this.options.schema.get('comment'),
-        readonly: !this.options.canWrite,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         value: value
       };
     }

--- a/app/core/interfaces/random/component.js
+++ b/app/core/interfaces/random/component.js
@@ -10,6 +10,13 @@ define([
     dataTypes: ['VARCHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'string_length',
         ui: 'numeric',
         type: 'Number',

--- a/app/core/interfaces/random/interface.html
+++ b/app/core/interfaces/random/interface.html
@@ -1,4 +1,4 @@
-<input type="text" value="{{value}}" name="{{name}}" class="medium password-primary" style="display:block;margin-bottom:10px;" placeholder="{{ placeholder }}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" {{#if readonly}}readonly{{/if}}/>
+<input type="text" value="{{value}}" name="{{name}}" class="medium password-primary" style="display:block;margin-bottom:10px;" placeholder="{{ placeholder }}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" {{#if readOnly}}readonly{{/if}}/>
 <div>
 	<button class="btn btn-primary margin-left string-generate" style="margin-right:10px;" type="button">{{t "generate_new"}}</button>
 	<span class="placard generated hide add-color margin-left-small bold">{{t "generated"}}</span>

--- a/app/core/interfaces/random/interface.js
+++ b/app/core/interfaces/random/interface.js
@@ -65,7 +65,7 @@ define([
       return {
         name: this.options.name,
         value: this.options.value,
-        readonly: !this.options.canWrite || this.options.settings.get('allow_any_value') !== true,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         comment: this.options.schema.get('comment'),
         placeholder: this.options.settings.get('placeholder')
       };

--- a/app/core/interfaces/slider/component.js
+++ b/app/core/interfaces/slider/component.js
@@ -6,6 +6,13 @@ define(['core/interfaces/slider/interface', 'core/UIComponent', 'core/t'], funct
     dataTypes: ['INT'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'minimum',
         ui: 'numeric',
         type: 'Number',

--- a/app/core/interfaces/slider/input.html
+++ b/app/core/interfaces/slider/input.html
@@ -5,9 +5,13 @@
 		background-color: transparent;
 	}
 
+	input[type=range]:disabled {
+		opacity: 0.6 !important;
+	}
+
 	span.slider-value {
 		margin-left: 10px;
 		width: auto !important;
 	}
 </style>
-<input type="range" value="{{value}}" name="{{name}}" id="{{name}}" min="{{min}}" max="{{max}}" step="{{step}}"><span class="slider-value">{{value}} {{unit}}</span>
+<input type="range" value="{{value}}" name="{{name}}" id="{{name}}" min="{{min}}" max="{{max}}" step="{{step}}" {{#if readOnly}}readonly{{/if}}><span class="slider-value">{{value}} {{unit}}</span>

--- a/app/core/interfaces/slider/interface.js
+++ b/app/core/interfaces/slider/interface.js
@@ -23,6 +23,7 @@ define(['core/UIView'], function (UIView) {
       return {
         value: this.options.value || 0,
         name: this.options.name,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         min: this.options.settings.get('minimum'),
         max: this.options.settings.get('maximum'),
         step: this.options.settings.get('step'),

--- a/app/core/interfaces/slug/component.js
+++ b/app/core/interfaces/slug/component.js
@@ -6,10 +6,11 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
     dataTypes: ['VARCHAR'],
     variables: [
       {
-        id: 'readonly',
+        id: 'read_only',
+        ui: 'toggle',
         type: 'Boolean',
-        default_value: true,
-        ui: 'toggle'
+        comment: 'Force this interface to be read only',
+        default_value: false
       },
       {
         id: 'size',

--- a/app/core/interfaces/slug/input.html
+++ b/app/core/interfaces/slug/input.html
@@ -1,3 +1,2 @@
-<input type="text" value="{{value}}" name="{{name}}" id="{{name}}" maxLength="{{maxLength}}" class="{{size}}" {{#if readonly}}readonly{{/if}}/>
+<input type="text" value="{{value}}" name="{{name}}" id="{{name}}" maxLength="{{maxLength}}" class="{{size}}" {{#if readOnly}}readonly{{/if}}/>
 <span class="char-count hide">{{characters}}</span>
-

--- a/app/core/interfaces/slug/interface.js
+++ b/app/core/interfaces/slug/interface.js
@@ -87,7 +87,7 @@ define(['underscore', 'core/UIView'], function (_, UIView) {
       var mirroredField = this.getMirroredFieldName();
       var model = this.options.model;
 
-      if (this.options.settings.get('readonly') === true) {
+      if (this.options.settings.get('read_only') === true) {
         $slugInput.prop('readonly', true);
       }
 
@@ -111,7 +111,7 @@ define(['underscore', 'core/UIView'], function (_, UIView) {
         name: this.options.name,
         maxLength: length,
         comment: this.options.schema.get('comment'),
-        readonly: this.options.settings.get('readonly') === true
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     }
   });

--- a/app/core/interfaces/tags/component.js
+++ b/app/core/interfaces/tags/component.js
@@ -11,6 +11,13 @@ define([
     dataTypes: ['TEXT','VARCHAR','CHAR'],
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'force_lowercase',
         ui: 'toggle',
         type: 'Boolean',

--- a/app/core/interfaces/tags/input.html
+++ b/app/core/interfaces/tags/input.html
@@ -1,4 +1,4 @@
-<input type="text" id="tag-input" placeholder="{{t "tags_placeholder"}}">
+<input type="text" id="tag-input" placeholder="{{t "tags_placeholder"}}" {{#if readOnly}}readonly{{/if}}>
 <div class="tag-container">
 	{{#tags}}<div class="tag">{{this}}</div>{{/tags}}
 </div>

--- a/app/core/interfaces/tags/interface.js
+++ b/app/core/interfaces/tags/interface.js
@@ -72,6 +72,7 @@ define([
       return {
         value: this.getTagsValue(),
         name: this.options.name,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         tags: this.tags,
         comment: this.options.schema.get('comment')
       };

--- a/app/core/interfaces/text_input/component.js
+++ b/app/core/interfaces/text_input/component.js
@@ -10,10 +10,11 @@ define([
     dataTypes: ['VARCHAR', 'CHAR', 'DATE', 'TIME', 'ENUM'],
     variables: [
       {
-        id: 'readonly',
+        id: 'read_only',
+        ui: 'toggle',
         type: 'Boolean',
-        default_value: false,
-        ui: 'toggle'
+        comment: 'Force this interface to be read only',
+        default_value: false
       },
       {
         id: 'size',

--- a/app/core/interfaces/text_input/input.html
+++ b/app/core/interfaces/text_input/input.html
@@ -10,7 +10,7 @@
 </style>
 
 <div class="char-count-container {{size}}">
-	<input type="text" placeholder="{{placeholder}}" value="{{value}}" name="{{name}}" id="{{name}}" maxLength="{{maxLength}}" class="{{size}}" {{#if readonly}}readonly{{/if}}/>
+	<input type="text" placeholder="{{placeholder}}" value="{{value}}" name="{{name}}" id="{{name}}" maxLength="{{maxLength}}" class="{{size}}" {{#if readOnly}}readonly{{/if}}/>
 	{{#if length}}
 		<span class="char-count hide">{{characters}}</span>
 	{{/if}}

--- a/app/core/interfaces/text_input/interface.js
+++ b/app/core/interfaces/text_input/interface.js
@@ -77,7 +77,7 @@ define([
         maxLength: length,
         characters: length - value.toString().length,
         comment: this.options.schema.get('comment'),
-        readonly: ((this.options.settings && this.options.settings.get('readonly') === true) || !this.options.canWrite),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         placeholder: (this.options.settings) ? this.options.settings.get('placeholder') : ''
       };
     },

--- a/app/core/interfaces/textarea/component.js
+++ b/app/core/interfaces/textarea/component.js
@@ -18,6 +18,13 @@ define([
     id: 'textarea',
     dataTypes: ['TEXT', 'VARCHAR'],
     variables: [
+      {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
       // The number of text rows available for the input before scrolling
       {
         id: 'rows',

--- a/app/core/interfaces/textarea/input.html
+++ b/app/core/interfaces/textarea/input.html
@@ -1,1 +1,1 @@
-<textarea rows="{{rows}}" name="{{name}}" id="{{name}}" placeholder="{{placeholder}}" {{#if readonly}}readonly{{/if}}>{{value}}</textarea>
+<textarea rows="{{rows}}" name="{{name}}" id="{{name}}" placeholder="{{placeholder}}" {{#if readOnly}}readonly{{/if}}>{{value}}</textarea>

--- a/app/core/interfaces/textarea/interface.js
+++ b/app/core/interfaces/textarea/interface.js
@@ -41,7 +41,7 @@ define([
         rows: this.options.settings.get('rows'),
         placeholder: this.options.settings.get('placeholder'),
         comment: this.options.schema.get('comment'),
-        readonly: !this.options.canWrite
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     }
   });

--- a/app/core/interfaces/toggle/component.js
+++ b/app/core/interfaces/toggle/component.js
@@ -6,6 +6,8 @@ define(['./interface', 'core/UIComponent', 'core/t'], function(Input, UIComponen
       {
         id: 'read_only',
         ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
         default_value: false
       },
       {

--- a/app/core/interfaces/toggle/input.html
+++ b/app/core/interfaces/toggle/input.html
@@ -72,7 +72,7 @@
 </style>
 
 <div class="interface-toggle {{#unless showAsCheckbox}}toggle{{/unless}}">
-	<input id="toggle_{{name}}" class="{{#if showAsCheckbox}}custom-checkbox{{/if}}" type="checkbox" {{#if readOnly}}disabled{{/if}} {{#if selected}}checked{{/if}} />
+	<input id="toggle_{{name}}" class="{{#if showAsCheckbox}}custom-checkbox{{/if}}" type="checkbox" {{#if readOnly}}readonly{{/if}} {{#if selected}}checked{{/if}} />
 	<label for="toggle_{{name}}"><span></span>{{label}}</label>
 
 	<input type="hidden" name="{{name}}" value="{{#if selected}}1{{else}}0{{/if}}">

--- a/app/core/interfaces/toggle/interface.js
+++ b/app/core/interfaces/toggle/interface.js
@@ -26,7 +26,7 @@ define(['underscore', 'utils', 'core/UIView'], function (_, Utils, UIView) {
         selected: (value === true),
         label: this.options.settings.get('label'),
         showAsCheckbox: Number(this.options.settings.get('show_as_checkbox')) === 1,
-        readOnly: this.options.settings.get('read_only')
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
       };
     }
   });

--- a/app/core/interfaces/wysiwyg/component.js
+++ b/app/core/interfaces/wysiwyg/component.js
@@ -6,43 +6,52 @@ define(['core/interfaces/wysiwyg/interface', 'core/UIComponent', 'core/t'], func
     id: 'wysiwyg',
     dataTypes: ['VARCHAR', 'TEXT', 'MEDIUMTEXT', 'LONGTEXT'],
     Input: Input,
-    variables: [{
-      id: 'buttons',
-      ui: 'checkboxes',
-      type: 'String',
-      comment: 'Buttons that will be shown when selecting text',
-      default_value: 'bold,italic,underline,anchor,h2,h3,quote',
-      nullable: true,
-      options: {
+    variables: [
+      {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
+        id: 'buttons',
+        ui: 'checkboxes',
+        type: 'String',
+        comment: 'Buttons that will be shown when selecting text',
+        default_value: 'bold,italic,underline,anchor,h2,h3,quote',
+        nullable: true,
         options: {
-          bold: 'Bold',
-          italic: 'Italic',
-          underline: 'Underline',
-          strikethrough: 'Strikethrough',
-          subscript: 'Subscript',
-          superscript: 'Superscript',
-          anchor: 'Link',
-          quote: 'Quote',
-          pre: 'Pre',
-          orderedlist: 'Ordered List',
-          unorderedlist: 'Unordered List',
-          h1: 'H1',
-          h2: 'H2',
-          h3: 'H3',
-          h4: 'H4',
-          h5: 'H5',
-          h6: 'H6',
-          removeFormat: 'Remove all formatting'
+          options: {
+            bold: 'Bold',
+            italic: 'Italic',
+            underline: 'Underline',
+            strikethrough: 'Strikethrough',
+            subscript: 'Subscript',
+            superscript: 'Superscript',
+            anchor: 'Link',
+            quote: 'Quote',
+            pre: 'Pre',
+            orderedlist: 'Ordered List',
+            unorderedlist: 'Unordered List',
+            h1: 'H1',
+            h2: 'H2',
+            h3: 'H3',
+            h4: 'H4',
+            h5: 'H5',
+            h6: 'H6',
+            removeFormat: 'Remove all formatting'
+          }
         }
+      },
+      {
+        id: 'simple_editor',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Simplify styling of the interface input',
+        default_value: false
       }
-    },
-    {
-      id: 'simple_editor',
-      ui: 'toggle',
-      type: 'Boolean',
-      comment: 'Simplify styling of the interface input',
-      default_value: false
-    }],
+    ],
     validate: function (value, options) {
       if (options.view.isRequired() && !value) {
         return __t('this_field_is_required');

--- a/app/core/interfaces/wysiwyg/input.html
+++ b/app/core/interfaces/wysiwyg/input.html
@@ -319,4 +319,4 @@
 	}
 </style>
 <div style="position: absolute; width: 100%;" id="medium-editor-{{name}}" class="{{widthClass}}"></div>
-<textarea id="wysiwyg-interface_{{name}}" name="{{name}}" {{#if simple_editor}}class="simple-editor"{{/if}}>{{value}}</textarea>
+<textarea id="wysiwyg-interface_{{name}}" name="{{name}}" {{#if simple_editor}}class="simple-editor"{{/if}} {{#if readOnly}}readonly{{/if}}>{{value}}</textarea>

--- a/app/core/interfaces/wysiwyg/interface.js
+++ b/app/core/interfaces/wysiwyg/interface.js
@@ -81,6 +81,7 @@ define(['core/UIView', 'core/interfaces/wysiwyg/vendor/medium-editor.min'], func
         value: value,
         name: this.name,
         widthClass: getWidthClass(buttonsLength),
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         simple_editor: (this.options.settings && this.options.settings.get('simple_editor') === true),
       };
 

--- a/app/core/interfaces/wysiwyg_full/component.js
+++ b/app/core/interfaces/wysiwyg_full/component.js
@@ -8,6 +8,13 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
     Input: Input,
     variables: [
       {
+        id: 'read_only',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'Force this interface to be read only',
+        default_value: false
+      },
+      {
         id: 'show_element_path',
         ui: 'toggle',
         type: 'Boolean',

--- a/app/core/interfaces/wysiwyg_full/input.html
+++ b/app/core/interfaces/wysiwyg_full/input.html
@@ -33,4 +33,4 @@
 		min-width: 0 !important;
 	}
 </style>
-<textarea name="{{name}}" id="wysiwyg_{{name}}">{{value}}</textarea>
+<textarea name="{{name}}" id="wysiwyg_{{name}}" {{#if readOnly}}readonly{{/if}}>{{value}}</textarea>

--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -14,6 +14,7 @@ define([
 
       return {
         value: value,
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         name: this.options.name
       };
     },
@@ -129,6 +130,7 @@ define([
         autoresize_max_height: this.options.settings.get('max_height'),
         elementpath: elementpath,
         menubar: false,
+        readonly: this.options.settings.get('read_only') || !this.options.canWrite,
         toolbar: toolbar,
         content_style: 'body.mce-content-body {font-family: \'Roboto\', sans-serif;line-height: 22px;font-size: 14px;color: #333;}',
         style_formats: styleFormats,


### PR DESCRIPTION
There are a view remaining which don't support `read_only` at the moment, like the relational ones. These need a little more attention to get read_only to work properly. These ones can be merged already 👍 