### PR TITLE
custom db migration

### DIFF
--- a/api/ruckusing.conf.php
+++ b/api/ruckusing.conf.php
@@ -59,7 +59,7 @@ Valid types (adapters) are Postgres & MySQL:
 
 */
 return [
-    'migrations_dir' => ['default' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'migrations'],
+    'migrations_dir' => ['default' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'migrations', 'customs' => dirname(__FILE__,2) . DIRECTORY_SEPARATOR . 'customs' . DIRECTORY_SEPARATOR. 'migrations'],
     'db_dir' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'logs' . DIRECTORY_SEPARATOR . 'db',
     'log_dir' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'logs',
     'ruckusing_base' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'vendor/ruckusing/ruckusing-migrations'


### PR DESCRIPTION
Allows migration script to access migration files in customs folder.
While creating custom extensions or hooks for specific clients developers may need database schema changes, now they can put those schema changes and upgrade SQL in migrations folder under customs. So custom migrations will be isolated from core migrations folder.