### PR TITLE
Remove migration error

### DIFF
--- a/api/migrations/upgrades/20170630231929_UsersTokenNullable.php
+++ b/api/migrations/upgrades/20170630231929_UsersTokenNullable.php
@@ -6,6 +6,7 @@ class UsersTokenNullable extends Ruckusing_Migration_Base
     public function up()
     {
         $this->change_column('directus_users', 'token', 'string', [
+            'limit' => 128,
             'null' => true
         ]);
     }//up()


### PR DESCRIPTION
db:migrate - UsersTokenNullable - Error executing 'query' with:
ALTER TABLE `directus_users` CHANGE `token` `token` varchar(255)

Reason: Specified key was too long; max key length is 767 bytes