### PR TITLE
fixed an infinite scroll bug when some of the visible states had no i…

### DIFF
--- a/app/core/collection.js
+++ b/app/core/collection.js
@@ -63,7 +63,7 @@ function(app, Backbone, StatusHelper, _) {
       visibleStates.forEach(function (state) {
         var status = StatusHelper.getStatus(this.table.id, state);
         if (status) {
-          totalCount += this.table.get(status.get('name'));
+          totalCount += this.table.get(status.get('name')) || 0;
         }
       }, this);
 


### PR DESCRIPTION
The infinite scroll was not working when some of the visible states had no items.
F.E: All the items of a table are in "Publish" and there are 0 "Draft" items.

The problem is that this.table.get(status.get('name')) returns undefined, so when trying to sum it to the totalCount the value of this changed to NaN.