### PR TITLE
Solve tag removal while it is read only

### DIFF
--- a/app/core/interfaces/tags/interface.js
+++ b/app/core/interfaces/tags/interface.js
@@ -28,6 +28,11 @@ define([
       'click .tag': function (event) {
         var $target = $(event.currentTarget);
         var index = this.$('.tag').index($target);
+        
+        //return if the widget is read only ( Do not remove tag )
+        if (this.$('#tag-input').is('[readonly]')) {
+            return;
+        }
 
         this.tags.splice(index, 1);
         this.model.set(this.name, this.getTagsValue());


### PR DESCRIPTION
If we make the "tags" interface 'read only', input becomes read only. But we can remove the tags by clicking on the tags given below the input.