### PR TITLE
Fix many to one placeholder/default_value issue (Closes #1737)

### DIFF
--- a/api/locales/en.json
+++ b/api/locales/en.json
@@ -256,7 +256,7 @@
     "m2o_visible_column_comment": "Visible Column Name",
     "m2o_visible_column_template_comment": "Twig Template String",
     "m2o_visible_status_ids_comment": "A CSV of visible statuses (eg: '1,2' shows Published and Draft)",
-    "m2o_placeholder_text_comment": "Placeholder Text",
+    "m2o_placeholder_text_comment": "The first value will be saved for new items if no default or placeholder is used",
     "m2o_filter_column_comment": "Column thats value is used for filter search",
 
     "m2o_typeahead_placeholder": "Search for an item...",

--- a/app/core/interfaces/many_to_one/component.js
+++ b/app/core/interfaces/many_to_one/component.js
@@ -52,7 +52,7 @@ define([
         ui: 'text_input',
         type: 'String',
         comment: __t('m2o_placeholder_text_comment'),
-        default_value: '',
+        default_value: 'Please select an option',
         char_length: 255,
         required: false
       },

--- a/app/core/interfaces/many_to_one/input.html
+++ b/app/core/interfaces/many_to_one/input.html
@@ -1,8 +1,6 @@
 <div class="select-container">
 	<select name="{{name}}" {{#if readOnly}}readonly disabled{{/if}}>
-		{{#if allowNull}}
-		<option value="">{{placeholder}}</option>
-		{{/if}}
+		<option value="" {{#unless allowNull}}disabled{{/unless}} {{#unless value}}selected{{/unless}}>{{placeholder}}</option>
 		{{#data}}
 		<option value="{{id}}" {{#if selected}}selected{{/if}}>{{{name}}}</option>
 		{{/data}}

--- a/app/core/interfaces/many_to_one/input.html
+++ b/app/core/interfaces/many_to_one/input.html
@@ -1,6 +1,8 @@
 <div class="select-container">
 	<select name="{{name}}" {{#if readOnly}}readonly disabled{{/if}}>
-		<option value="" {{#unless allowNull}}disabled{{/unless}} {{#unless value}}selected{{/unless}}>{{placeholder}}</option>
+		{{#if placeholderAvailable}}
+		<option value="" {{#unless value}}selected{{/unless}} {{#if required}}disabled{{/if}}>{{placeholder}}</option>
+		{{/if}}
 		{{#data}}
 		<option value="{{id}}" {{#if selected}}selected{{/if}}>{{{name}}}</option>
 		{{/data}}

--- a/app/core/interfaces/many_to_one/interface.js
+++ b/app/core/interfaces/many_to_one/interface.js
@@ -58,12 +58,17 @@ define([
 
     serialize: function () {
       var optionTemplate = Handlebars.compile(this.options.settings.get('visible_column_template'));
-      var value = this.options.value;
+      var defaultValue = +this.options.schema.get('default_value');
 
-      // Set the first value to the column when the record is new
-      // This prevent assigning the incorrect (null/empty) value to the column
-      if (this.collection.length > 0 && !this.options.settings.get('allow_null') && this.model.isNew()) {
-        value = this.collection.first().id;
+      var value = this.options.value || defaultValue;
+
+      if (value instanceof Backbone.Model) {
+        value = value.id;
+      }
+
+      // If we don't set this, user gets "nothing changed, nothing saved"
+      if (defaultValue && defaultValue === value) {
+        this.model.set(this.name, defaultValue);
       }
 
       if (this.options.settings.get('readonly') === true) {
@@ -72,10 +77,6 @@ define([
 
       var data = this.collection.map(function (model) {
         var data = model.toJSON();
-
-        if (value instanceof Backbone.Model) {
-          value = value.id;
-        }
 
         return {
           id: model.id,
@@ -105,7 +106,8 @@ define([
         use_radio_buttons: this.options.settings.get('use_radio_buttons') === true,
         allowNull: this.options.settings.get('allow_null') === true,
         placeholder: (this.options.settings.get('placeholder')) ? this.options.settings.get('placeholder') : __t('select_from_below'),
-        readOnly: this.options.settings.get('read_only') || !this.options.canWrite
+        readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
+        value: this.value
       };
     },
 

--- a/app/core/interfaces/many_to_one/interface.js
+++ b/app/core/interfaces/many_to_one/interface.js
@@ -59,6 +59,7 @@ define([
     serialize: function () {
       var optionTemplate = Handlebars.compile(this.options.settings.get('visible_column_template'));
       var defaultValue = +this.options.schema.get('default_value');
+      var placeholderAvailable = !!this.options.settings.get('placeholder') && this.options.settings.get('placeholder').length > 0;
 
       var value = this.options.value || defaultValue;
 
@@ -66,7 +67,8 @@ define([
         value = value.id;
       }
 
-      // If we don't set this, user gets "nothing changed, nothing saved"
+      // Save value when the defaultValue is used
+      // (prevents nothing changed nothing saved error)
       if (defaultValue && defaultValue === value) {
         this.model.set(this.name, defaultValue);
       }
@@ -105,9 +107,11 @@ define([
         comment: this.options.schema.get('comment'),
         use_radio_buttons: this.options.settings.get('use_radio_buttons') === true,
         allowNull: this.options.settings.get('allow_null') === true,
-        placeholder: (this.options.settings.get('placeholder')) ? this.options.settings.get('placeholder') : __t('select_from_below'),
+        placeholder: this.options.settings.get('placeholder'),
+        placeholderAvailable: placeholderAvailable,
         readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
-        value: this.value
+        value: this.value,
+        required: this.options.schema.isRequired()
       };
     },
 

--- a/app/core/interfaces/many_to_one/interface.js
+++ b/app/core/interfaces/many_to_one/interface.js
@@ -67,12 +67,6 @@ define([
         value = value.id;
       }
 
-      // Save value when the defaultValue is used
-      // (prevents nothing changed nothing saved error)
-      if (defaultValue && defaultValue === value) {
-        this.model.set(this.name, defaultValue);
-      }
-
       if (this.options.settings.get('readonly') === true) {
         this.canEdit = false;
       }
@@ -97,12 +91,6 @@ define([
       }
 
       data = _.sortBy(data, 'name');
-
-      // Save value when there's no placeholder and the first item is auto-selected
-      // (prevents nothing changed nothing saved error)
-      if (data.length > 0 && !placeholderAvailable && !value) {
-        this.model.set(this.name, data[0].id);
-      }
 
       this.value = value;
 

--- a/app/core/interfaces/many_to_one/interface.js
+++ b/app/core/interfaces/many_to_one/interface.js
@@ -98,6 +98,12 @@ define([
 
       data = _.sortBy(data, 'name');
 
+      // Save value when there's no placeholder and the first item is auto-selected
+      // (prevents nothing changed nothing saved error)
+      if (data.length > 0 && !placeholderAvailable && !value) {
+        this.model.set(this.name, data[0].id);
+      }
+
       this.value = value;
 
       return {


### PR DESCRIPTION
Sets the models value on load if the default value is used to prevent directus throwing the "nothing changed nothing saved" error. It also allows the user to set the interface to allow_null once again, by providing a placeholder which can be selected and has a null value.