### PR TITLE
Text input size fix

### DIFF
--- a/api/locales/en.json
+++ b/api/locales/en.json
@@ -232,6 +232,7 @@
     "size_large": "Large",
     "size_medium": "Medium",
     "size_small": "Small",
+    "size_auto": "Automatic",
 
     "select_ui_show_options_value": "Value",
     "select_ui_show_options_text": "Text",

--- a/app/core/interfaces/text_input/component.js
+++ b/app/core/interfaces/text_input/component.js
@@ -37,7 +37,8 @@ define([
           options: {
             large: __t('size_large'),
             medium: __t('size_medium'),
-            small: __t('size_small')
+            small: __t('size_small'),
+            auto: __t('size_auto')
           }
         }
       },

--- a/app/core/interfaces/text_input/input.html
+++ b/app/core/interfaces/text_input/input.html
@@ -10,7 +10,7 @@
 </style>
 
 <div class="char-count-container {{size}}">
-	<input type="text" placeholder="{{placeholder}}" value="{{value}}" name="{{name}}" id="{{name}}" maxLength="{{maxLength}}" class="{{size}}" {{#if readOnly}}readonly{{/if}}/>
+	<input {{#if autoSize}}style="width: {{length}}ch;"{{/if}} type="text" placeholder="{{placeholder}}" value="{{value}}" name="{{name}}" id="{{name}}" maxLength="{{maxLength}}" class="{{size}}" {{#if readOnly}}readonly{{/if}}/>
 	{{#if length}}
 		<span class="char-count hide">{{characters}}</span>
 	{{/if}}

--- a/app/core/interfaces/text_input/interface.js
+++ b/app/core/interfaces/text_input/interface.js
@@ -53,6 +53,7 @@ define(['core/UIView'], function (UIView) {
         characters: length - value.toString().length,
         comment: this.options.schema.get('comment'),
         readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
+        autoSize: this.options.settings.get('size') === 'auto',
         placeholder: (this.options.settings) ? this.options.settings.get('placeholder') : ''
       };
     },

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3535,9 +3535,9 @@ body.loading .header .logo {
                 -o-transition: all 200ms ease-in-out 0ms;
                 -ms-transition: all 200ms ease-in-out 0ms;
                 transition: all 200ms ease-in-out 0ms;
-                -webkit-box-shadow: 0px 0px 0px 0px transparent;
-                -moz-box-shadow: 0px 0px 0px 0px transparent;
-                box-shadow: 0px 0px 0px 0px transparent;
+                -webkit-box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
+                -moz-box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
+                box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
                 display: block;
                 padding: 16px;
                 width: 100%;
@@ -5077,9 +5077,9 @@ body.help .discover-spotlight {
       line-height: 30px;
       background-color: #f6f6f6; }
       .message .reply textarea:focus {
-        -webkit-box-shadow: 0px 0px 0px 0px transparent;
-        -moz-box-shadow: 0px 0px 0px 0px transparent;
-        box-shadow: 0px 0px 0px 0px transparent; }
+        -webkit-box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
+        -moz-box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
+        box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0); }
     .message .reply .button {
       -webkit-transition: all 400ms ease-in-out 0ms;
       -moz-transition: all 400ms ease-in-out 0ms;
@@ -5448,28 +5448,31 @@ body.help .discover-spotlight {
       line-height: 14px;
       width: auto; }
     .fields .field .interface input {
-      min-width: 400px; }
+      width: 100%;
+      max-width: 400px; }
       .fields .field .interface input.small {
-        width: 150px; }
+        max-width: 150px; }
       .fields .field .interface input.medium {
-        width: 300px; }
+        max-width: 300px; }
     .fields .field .interface textarea {
       position: relative;
-      min-width: 400px;
+      width: 100%;
+      max-width: 400px;
       min-height: 140px;
       line-height: 18px;
       height: auto; }
     .fields .field .interface select {
       padding-right: 36px;
-      min-width: 200px; }
+      width: 100%;
+      max-width: 200px; }
     .fields .field .interface input[type="checkbox"].custom-checkbox + label {
       display: inline-block; }
     .fields .field .interface input[type="checkbox"],
     .fields .field .interface input[type="radio"] {
-      min-width: auto;
+      max-width: auto;
       width: auto; }
     .fields .field .interface input[type="date"] {
-      min-width: auto;
+      max-width: auto;
       width: 170px;
       margin-right: 20px; }
     .fields .field .interface input[type="time"] {
@@ -5477,7 +5480,7 @@ body.help .discover-spotlight {
       min-width: auto; }
     .fields .field .interface input[type="range"] {
       padding: 0;
-      min-width: 340px;
+      max-width: 340px;
       -webkit-appearance: none;
       border: none;
       margin-right: 10px;
@@ -5825,9 +5828,9 @@ body.help .discover-spotlight {
           margin: 80px auto 40px;
           color: #CCCCCC; }
       .fields .field .interface .wysiwyg textarea {
-        -webkit-box-shadow: 0px 1px 4px 0px transparent;
-        -moz-box-shadow: 0px 1px 4px 0px transparent;
-        box-shadow: 0px 1px 4px 0px transparent;
+        -webkit-box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0);
+        -moz-box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0);
+        box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0);
         padding: 0;
         border: none;
         resize: none;

--- a/assets/sass/_item.scss
+++ b/assets/sass/_item.scss
@@ -185,12 +185,13 @@
 				width: auto;
 			}
 			input {
-				min-width: 400px;
+				width: 100%;
+				max-width: 400px;
 				&.small {
-					width: 150px;
+					max-width: 150px;
 				}
 				&.medium {
-					width: 300px;
+					max-width: 300px;
 				}
 			}
 			textarea {
@@ -202,18 +203,19 @@
 			}
 			select {
 				padding-right: 36px; // So the right side isn't cropped
-				min-width: 200px;
+				width: 100%;
+				max-width: 200px;
 			}
 			input[type="checkbox"].custom-checkbox + label {
 				display: inline-block;
 			}
 			input[type="checkbox"],
 			input[type="radio"] {
-				min-width: auto;
+				max-width: auto;
 				width: auto;
 			}
 			input[type="date"] {
-				min-width: auto;
+				max-width: auto;
 				width: 170px;
 				margin-right: 20px;
 			}

--- a/assets/sass/_item.scss
+++ b/assets/sass/_item.scss
@@ -196,7 +196,8 @@
 			}
 			textarea {
 				position: relative;
-				min-width: 400px;
+				width: 100%;
+				max-width: 400px;
 				min-height: 140px;
 				line-height: 18px;
 				height: auto;
@@ -225,7 +226,7 @@
 			}
 			input[type="range"] {
 				padding: 0;
-				min-width: 340px;
+				max-width: 340px;
 				-webkit-appearance: none;
 				border: none;
 				margin-right: 10px;


### PR DESCRIPTION
This PR fixes the input width issue mentioned in https://github.com/directus/directus/issues/1760 and adds a 'Automatic' option to the `size` option, which will set the width of the `text_input` to fit exactly the amount of characters that's set in the `length` option.

I converted the global input style which set the inputs to a min-width value to utilize a max-width instead. I haven't been able to find any new glitches due to this change, but since it's a global style change, I'd like some extra eyes on this before we merge to develop. ✌🏻