### PR TITLE
"Generated!" message for the API key generator isn't hidden correctly.

### DIFF
--- a/app/core/interfaces/random/interface.html
+++ b/app/core/interfaces/random/interface.html
@@ -1,5 +1,5 @@
 <input type="text" value="{{value}}" name="{{name}}" class="medium password-primary" style="display:block;margin-bottom:10px;" placeholder="{{ placeholder }}" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" {{#if readOnly}}readonly{{/if}}/>
 <div>
-	<button class="btn btn-primary margin-left string-generate" style="margin-right:10px;" type="button">{{t "generate_new"}}</button>
-	<span class="placard generated hide add-color margin-left-small bold">{{t "generated"}}</span>
+	<button class="button btn-primary margin-left string-generate" style="margin-right:10px;" type="button">{{t "generate_new"}}</button>
+	<span class="placard generated hidden add-color margin-left-small bold">{{t "generated"}}</span>
 </div>

--- a/app/core/interfaces/random/interface.js
+++ b/app/core/interfaces/random/interface.js
@@ -35,7 +35,7 @@ define([
         if (!_.isEmpty(resp) && !_.isEmpty(resp.data.random)) {
           randomString = resp.data.random;
           this.$('input.password-primary').val(randomString);
-          this.$('.generated').removeClass('hide');
+          this.$('.generated').removeClass('hidden');
           this.model.set(this.name, randomString);
         } else {
           Notification.error('Random', __t('error_generating_a_random_string'));


### PR DESCRIPTION
It was still using .hide , instead of .hidden. I've also changed "Generate New!" to be a button, to match the one for passwords.

<img width="331" alt="screen shot 2017-08-30 at 12 30 40" src="https://user-images.githubusercontent.com/152811/29868437-2daa6680-8d7f-11e7-8970-9d6a8a154af1.png">
