### PR TITLE
Fix validation of when dropdown field is required

### DIFF
--- a/app/core/interfaces/dropdown/component.js
+++ b/app/core/interfaces/dropdown/component.js
@@ -59,7 +59,7 @@ define(['./interface', 'core/UIComponent', 'core/t', 'utils'], function (Input, 
       var nullable = options.schema.isNullable();
       var defaultValue = options.schema.getDefaultValue();
 
-      if ((defaultValue || !nullable) && options.schema.isRequired() && Utils.isEmpty(value)) {
+      if (((!defaultValue && !nullable) || options.schema.isRequired()) && Utils.isEmpty(value)) {
         return __t('this_field_is_required');
       }
     },


### PR DESCRIPTION
Validation was failing when the dropdown field was empty and set as required (it would save without error). I fixed the validation, and hopefully have taken into account when the field might be nullable/have a default value/required