### PR TITLE
Fix addComment when id attribute is not "id"

### DIFF
--- a/app/core/widgets/timeline/TimelineWidget.js
+++ b/app/core/widgets/timeline/TimelineWidget.js
@@ -114,7 +114,7 @@ function(app, Backbone, $, _, __t, Directus, Utils, moment) {
         datetime: date,
         subject: subject,
         message: message,
-        comment_metadata: this.model.collection.table.id + ":" + this.model.get('id')
+        comment_metadata: this.model.collection.table.id + ":" + this.model.get(this.model.idAttribute)
       });
       model.unset('responses');
       model.url = app.API_URL + 'comments/';


### PR DESCRIPTION
If primary key is not "id" but "id_tableName" or anything else, add a comment does not work.
