### PR TITLE
Added logic/config for basic image listing

### DIFF
--- a/app/core/interfaces/wysiwyg_full/component.js
+++ b/app/core/interfaces/wysiwyg_full/component.js
@@ -164,6 +164,13 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
         type: 'Boolean',
         comment: 'Have the editor remove potentially unsafe tags like iframe and script',
         default_value: true
+      },
+      {
+        id: 'basic_image_list',
+        ui: 'toggle',
+        type: 'Boolean',
+        comment: 'use basic image listing in ui (potentially slow with high number of images)',
+        default_value: true
       }
     ],
     validate: function (value, interfaceOptions) {

--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -1,10 +1,11 @@
 /* global $ */
 define([
+  'app',
   'utils',
   'underscore',
   'core/UIView',
   'tinyMCE'
-], function (Utils, _, UIView, tinyMCE) {
+], function (app, Utils, _, UIView, tinyMCE) {
   'use strict';
 
   return UIView.extend({
@@ -213,6 +214,23 @@ define([
       if (this.options.settings.get('remove_unsafe_tags') === false) {
         options.valid_elements = '*[*]';
         options.extended_valid_elements = '*[*]';
+      }
+
+      if (settings.get('basic_image_list')) {
+        options.image_list = function(success) {
+          var collection = app.files;
+          collection.once('sync', function(collection) {
+            var images = [];
+            collection.each(function(model) {
+              images.push({
+                'text': model.get('title'),
+                'value': model.get('url')
+              });
+            });
+            success(images)
+          })
+          collection.fetch();
+        }
       }
 
       tinyMCE.init(options);


### PR DESCRIPTION
In lieu of having a decent image selector for the wysiwyg component, I've added one using TinyMCE's image_list functionality.  Super basic, but better than nothing.

Adds new configuration to the interface options for wysiwyg_full:
![image](https://user-images.githubusercontent.com/5734286/34075776-0e2f9446-e30c-11e7-95c8-6597afc646d2.png)

and pulls in all images into the dialog like so:
![image](https://user-images.githubusercontent.com/5734286/34075782-34e7af2e-e30c-11e7-81ea-aa5fbb36706c.png)

Figured it would be good to disable as performance may be sluggish with high number of images, but it's enabled by default.