### PR TITLE
Set Map interface to cooperative mode

### DIFF
--- a/app/core/interfaces/map/interface.js
+++ b/app/core/interfaces/map/interface.js
@@ -32,7 +32,8 @@ define([
       var mapOptions = {
         center: center,
         zoom: 12,
-        disableDefaultUI: this.options.settings.get('read_only') || !this.options.canWrite
+        disableDefaultUI: this.options.settings.get('read_only') || !this.options.canWrite,
+        gestureHandling: 'cooperative',
       };
 
       var map = new google.maps.Map(this.$el.find('#map-canvas').get(0), mapOptions);


### PR DESCRIPTION
This prevents accidentally zooming the map instead of scrolling the page when using mousewheel of 1-finger swipe.
See https://developers.google.com/maps/documentation/javascript/interaction#demos for examples & details.