### PR TITLE
Fix sorting items with drag and drop

### DIFF
--- a/app/core/table/table.bodyview.js
+++ b/app/core/table/table.bodyview.js
@@ -162,7 +162,7 @@ function(app, Backbone, _, Sortable, Notification) {
         var $el = $(this);
 
         attributes[sortColumnName] = i;
-        collection.get($el.data('cid')).set(attributes, {silent: true});
+        collection.get($el.data('id')).set(attributes, {silent: true});
       });
 
       success = function () {


### PR DESCRIPTION
Sorting items has an issue because getting the item by `cid` returns null.