### PR TITLE
Filter for image files before adding to the basic images list in tinyMCE

### DIFF
--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -224,10 +224,12 @@ define([
           collection.once('sync', function(collection) {
             var images = [];
             collection.each(function(model) {
-              images.push({
-                'text': model.get('title'),
-                'value': model.get('url')
-              });
+              if (model.get('type').match(/image/g)) {
+                images.push({
+                  'text': model.get('title'),
+                  'value': model.get('url')
+                });
+              }
             });
             success(images)
           })


### PR DESCRIPTION
The variable name image_list and the button in the UI of tinyMCE suggest that there should only be images in the list. 