### PR TITLE
Fixes for "Save and X" button

### DIFF
--- a/app/modules/tables/views/EditView.js
+++ b/app/modules/tables/views/EditView.js
@@ -210,8 +210,9 @@ define([
 
         if (action === 'save-form-add') {
           goToNewItem();
-        } else {
+        } else if (action !== 'save-form-stay') {
           notifyParent();
+          // Go back to the table view unless we are supposed to stay on this page
           // Write this as a helper function
           var route = Backbone.history.fragment.split('/');
           route.pop();

--- a/app/templates/core/widgets/save-widget.handlebars
+++ b/app/templates/core/widgets/save-widget.handlebars
@@ -1,4 +1,4 @@
-<button id="save_button" class="action primary help{{#unless state.enabled}} disabled{{/unless}}"{{#unless state.enabled}} disabled{{/unless}} data-help="This button saves the current item. You can also click the 'three dots' at the top for more save options.">
+<div id="save_button" class="action primary help{{#unless state.enabled}} disabled{{/unless}}"{{#unless state.enabled}} disabled{{/unless}} data-help="This button saves the current item. You can also click the 'three dots' at the top for more save options.">
 	<i class="material-icons center">check</i>
 	<div class="action-text">Save</div>
 	{{#unless basicSave}}
@@ -16,7 +16,7 @@
 		<i class="material-icons">more_horiz</i>
 	</div>
 	{{/unless}}
-</button>
+</div>
 {{!--
 <span class="select-and-circle {{#unless isUpToDate}}saved-success{{/unless}}">
   <button type="button" id="save" class="tool-item btn btn-header" title="Save">


### PR DESCRIPTION
This fixes #1980 where the Save and X button is not clickable in Firefox. This was an issue because interactive content was displayed inside a button, which Firefox doesn't allow. I switched to a div instead of a button.

I also fixed a bug where clicking "Save and Stay" after not making any changes to an item routed you back to the table view. Fixed that so it keeps you on the same item editing view, but still displays the "nothing saved" warning.