### PR TITLE
Fix for batch edit status changes

### DIFF
--- a/app/core/interfaces/_system/status/input.handlebars
+++ b/app/core/interfaces/_system/status/input.handlebars
@@ -69,5 +69,5 @@
 	<label for={{identifier}}>{{name}}</label>
 	{{/statuses}}
 
-	<input type="hidden" name="{{name}}" value="{{value}}">
+	<input type="radio" name="{{name}}" value="{{value}}" style="display:none;">
 </div>


### PR DESCRIPTION
This fixes #1924 . The jquery serializeArray function was serializing the input of type="hidden" for the status field as an empty string, causing it to be concatenated with the draft/published status flag from the radio buttons. This created instances where the edit view data had status set to "1," or "2,", because it thought status was a multivalued field and was joining the actual value and an empty string by a comma. Switching the input a type of "radio" and hiding it via styling fixes the issue, so that only one "status" value gets serialized.