### PR TITLE
Add Thumbnailer fallback option to configuration_sample

### DIFF
--- a/api/configuration_sample.php
+++ b/api/configuration_sample.php
@@ -204,9 +204,15 @@ return [
 
     // This is the configuration for the Directus Dynamic Thumbnailer
     // It creates image thumbnails on the fly, simply by requesting them. For example:
-    // http://directus.example.com/thumbnail/100/100/crop/best/original-image-name.jpg
+    // http://directus.example.com/thumbnail/100/100/crop/best/original-image-name.jpg 
     'thumbnailer' => [
         '404imageLocation' => __DIR__ . '/../thumbnail/img-not-found.png',
+        /*
+            By default the 404imageLocation is served if dimension is not supported
+            Adding the fallback would send the nearest availble size back instead
+            For example: using below, /200/200/... will fallback to /300/200/...
+        */
+        'fallback' => true, 
         'supportedThumbnailDimensions' => [
             // width x height
             // '100x100',


### PR DESCRIPTION
Updated thumbnailer script to fall back on an allowed size rather than return a 404 img.
Controlled via a fallback option within the thumbnailer config in "/api/configuration.php"