### PR TITLE
Add a hash (associative array works hasing internally) for camelCase …

### DIFF
--- a/api/core/Directus/Application/Application.php
+++ b/api/core/Directus/Application/Application.php
@@ -28,7 +28,7 @@ class Application extends Slim
      *
      * @var string
      */
-    const DIRECTUS_VERSION = '6.4.9-dev';
+    const DIRECTUS_VERSION = '6.4.9';
 
     /**
      * @var bool

--- a/api/core/Directus/Util/StringUtils.php
+++ b/api/core/Directus/Util/StringUtils.php
@@ -143,6 +143,8 @@ class StringUtils
         return substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
     }
 
+    protected static $camelHash = array();
+
     /**
      * Convert a string separated by $separator to camel case.
      *
@@ -154,18 +156,29 @@ class StringUtils
      */
     public static function toCamelCase($string, $first = false, $separator = '_')
     {
+
+        $key = $string.($first ? 'T' : 'F').$separator;
+        if ( array_key_exists($key,static::$camelHash) ){
+            return static::$camelHash[ $key ];
+        }
+
         $parts = explode($separator, $string);
         $newParts = array_map(function ($string) {
             return ucwords($string);
         }, $parts);
 
-        $newString = implode('', $newParts);
+        $camelCased = implode('', $newParts);
 
         if ($first === false) {
-            $newString[0] = strtolower($newString[0]);
+            $camelCased[0] = strtolower($camelCased[0]);
         }
 
-        return $newString;
+        if ( count(static::$camelHash) < 200 ){
+            static::$camelHash[ $key ] = $camelCased;
+        }
+        
+        return $camelCased;
+
     }
 
     /**

--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -137,7 +137,7 @@ define([
         menubar: false,
         readonly: this.options.settings.get('read_only') || !this.options.canWrite,
         toolbar: toolbar,
-        content_style: 'body.mce-content-body {font-family: \'Roboto\', sans-serif;line-height:24px;letter-spacing:0.2px;font-size:14px;color:#333;margin:0;padding: 10px 30px !important;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}body.mce-content-body p{line-height:inherit !important;}',
+        content_style: 'body.mce-content-body {font-family: \'Roboto\', sans-serif;line-height:24px;letter-spacing:0.2px;font-size:14px;color:#333;margin:0;padding: 10px 30px !important;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}body.mce-content-body p{line-height:inherit !important;}body.mce-content-body img{max-width:100% !important;}',
         style_formats: styleFormats,
         setup: function (editor) {
           /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Directus",
-  "version": "6.4.9-dev",
+  "version": "6.4.9",
   "description": "API-driven content management framework for custom databases",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -120,5 +120,5 @@ Sponsors: Bas Jansen
 
 ## Copyright, License, and Trademarks
 * Directus Core codebase released under the [GPLv3](http://www.gnu.org/copyleft/gpl.html) license.
-* Example Code, Design Previews, Demonstration Apps, Custom Extensions, Custom interfaces, and Documentation copyright 2017 [RANGER Studio LLC](http://rngr.org/).
+* Example Code, Design Previews, Demonstration Apps, Custom Extensions, Custom interfaces, and Documentation copyright 2018 [RANGER Studio LLC](http://rngr.org/).
 * RANGER Studio owns all Directus trademarks, service marks, and graphic logos on behalf of our project's community. The names of all Directus projects are trademarks of [RANGER Studio LLC](http://rngr.org/).

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Download the latest pre-built version from [our releases page](https://github.co
 NGINX or Apache Server, MySQL 5.2+, PHP 5.5+ (curl, gd, finfo, pdo_mysql)
 
 ### Database types
-While Directus has been abstracted to allow for different database adapters in the future, currently only MySQL is supported. PostgreSQL, SQLite, and MongoDB support is under development – and we hope to expand support for additional database types as we gain contributors.
+While Directus has been abstracted to allow for different database adapters in the future, currently only MySQL is supported. PostgreSQL, SQLite, and MongoDB support are under development – and we hope to expand support for additional database types as we gain contributors.
 
 
 ## Documentation
@@ -46,7 +46,7 @@ You can find the source of this documentation in [our API docs repo](https://git
 Think you've discovered a bug? First, read through our [docs](https://docs.getdirectus.com) to be sure – then submit a ticket to our [GitHub Issues](https://github.com/directus/directus/issues/new). And if you already know a good solution, we love [Pull Requests](https://github.com/directus/directus/pulls)! **For all security related issues, please chat with us directly through [getdirectus.com](https://getdirectus.com/).**
 
 ### Requesting Features or Enhancements
-Use our [Feature Request Tool](https://request.getdirectus.com/) to request new features or vote on existing commmunity suggestions.
+Use our [Feature Request Tool](https://request.getdirectus.com/) to request new features or vote on existing community suggestions.
 
 ### Technical Support
 For support using Directus, please post questions with the `directus` tag on [Stack Overflow](https://stackoverflow.com/questions/tagged/directus).
@@ -96,8 +96,8 @@ _This is what we want to get done next:_
 ### Q1 2018
 - Begin work on Directus v7.0 (moving from Backbone to Vue)
 - CMS App Decoupled from API
-- API 2.0 - Speed improvements, better relational filtering / querying and increased i18n support
-- [Support for multiple database (multitenant)](https://request.getdirectus.com/r/1)
+- API 2.0 - Speed improvements, better relational filtering / querying, and increased i18n support
+- [Support for multiple databases (multitenant)](https://request.getdirectus.com/r/1)
 - [Digital Asset Management improvements](https://request.getdirectus.com/r/2)
 - [Web Hooks](https://request.getdirectus.com/r/9)
 


### PR DESCRIPTION
…function

Knwoing that is used to transform a limited range of names (data modeling  names) and that it seems is one bottleneck slowling the API (https://github.com/directus/directus/issues/2020) I've added a little hash to the function.

It saved from 100ms to 150ms to each API call regardless of the amount of data to be parsed. In a small collection from 450ms to 350ms.