### PR TITLE
Fix the i18n key for the show_lat_lng parameter

### DIFF
--- a/app/core/interfaces/map/component.js
+++ b/app/core/interfaces/map/component.js
@@ -99,7 +99,7 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
         id: 'show_lat_lng',
         ui: 'toggle',
         type: 'Boolean',
-        comment: __t('map_showLatLng_comment'),
+        comment: __t('map_mapLatLng_comment'),
         default_value: false
       }
     ],


### PR DESCRIPTION
There is wrong i18n key used in the map interface. This results to 

![image](https://user-images.githubusercontent.com/35192116/38929950-5d139b04-430e-11e8-9320-e4ae6289a523.png)

This commit fixes it