### PR TITLE
Use minimum value as default if set

### DIFF
--- a/app/core/interfaces/slider/interface.js
+++ b/app/core/interfaces/slider/interface.js
@@ -21,7 +21,7 @@ define(['core/UIView'], function (UIView) {
       }
 
       return {
-        value: this.options.value || 0,
+        value: this.options.value || this.options.settings.get('minimum') || 0,
         name: this.options.name,
         readOnly: this.options.settings.get('read_only') || !this.options.canWrite,
         min: this.options.settings.get('minimum'),


### PR DESCRIPTION
Closed #2131 and moved commit to correct branch. If the minimum value is set, use it instead of zero for the slider’s default value.