### PR TITLE
Map interface now supports filling of latitude and longitude row fields

### DIFF
--- a/api/core/Directus/Application/Application.php
+++ b/api/core/Directus/Application/Application.php
@@ -28,7 +28,7 @@ class Application extends Slim
      *
      * @var string
      */
-    const DIRECTUS_VERSION = '6.4.9-dev';
+    const DIRECTUS_VERSION = '6.4.9';
 
     /**
      * @var bool

--- a/app/core/interfaces/map/component.js
+++ b/app/core/interfaces/map/component.js
@@ -24,6 +24,24 @@ define(['./interface', 'core/UIComponent', 'core/t'], function (Input, UICompone
       },
       // Column names to fill with respective item
       {
+        id: 'lat_field',
+        ui: 'text_input',
+        type: 'String',
+        comment: 'Latitude column to fill',
+        default_value: '',
+        required: false,
+        char_length: 200
+      },
+      {
+        id: 'lng_field',
+        ui: 'text_input',
+        type: 'String',
+        comment: 'Longitude column to fill',
+        default_value: '',
+        required: false,
+        char_length: 200
+      },
+      {
         id: 'street_number_field',
         ui: 'text_input',
         type: 'String',

--- a/app/core/interfaces/map/interface.js
+++ b/app/core/interfaces/map/interface.js
@@ -94,8 +94,9 @@ define([
             map: map
           });
         }
-
-        var latlngVal = event.latLng.lat() + ',' + event.latLng.lng();
+        var lat = event.latLng.lat();
+        var lng = event.latLng.lng();
+        var latlngVal = lat + ',' + lng;
         that.$el.find('input').val(latlngVal);
         that.model.set(that.name, latlngVal);
 
@@ -105,6 +106,8 @@ define([
           if (data.results && data.results.length > 0) {
             data = data.results[0].address_components;
             var address = {};
+            address.lat = Math.round(lat * 100000000) / 100000000;
+            address.lng = Math.round(lng * 100000000) / 100000000;
             data.forEach(function (part) {
               switch (part.types[0]) {
                 case 'street_number':

--- a/app/core/interfaces/wysiwyg_full/interface.js
+++ b/app/core/interfaces/wysiwyg_full/interface.js
@@ -137,7 +137,7 @@ define([
         menubar: false,
         readonly: this.options.settings.get('read_only') || !this.options.canWrite,
         toolbar: toolbar,
-        content_style: 'body.mce-content-body {font-family: \'Roboto\', sans-serif;line-height:24px;letter-spacing:0.2px;font-size:14px;color:#333;margin:0;padding: 10px 30px !important;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}body.mce-content-body p{line-height:inherit !important;}',
+        content_style: 'body.mce-content-body {font-family: \'Roboto\', sans-serif;line-height:24px;letter-spacing:0.2px;font-size:14px;color:#333;margin:0;padding: 10px 30px !important;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}body.mce-content-body p{line-height:inherit !important;}body.mce-content-body img{max-width:100% !important;}',
         style_formats: styleFormats,
         setup: function (editor) {
           /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Directus",
-  "version": "6.4.9-dev",
+  "version": "6.4.9",
   "description": "API-driven content management framework for custom databases",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -120,5 +120,5 @@ Sponsors: Bas Jansen
 
 ## Copyright, License, and Trademarks
 * Directus Core codebase released under the [GPLv3](http://www.gnu.org/copyleft/gpl.html) license.
-* Example Code, Design Previews, Demonstration Apps, Custom Extensions, Custom interfaces, and Documentation copyright 2017 [RANGER Studio LLC](http://rngr.org/).
+* Example Code, Design Previews, Demonstration Apps, Custom Extensions, Custom interfaces, and Documentation copyright 2018 [RANGER Studio LLC](http://rngr.org/).
 * RANGER Studio owns all Directus trademarks, service marks, and graphic logos on behalf of our project's community. The names of all Directus projects are trademarks of [RANGER Studio LLC](http://rngr.org/).

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Download the latest pre-built version from [our releases page](https://github.co
 NGINX or Apache Server, MySQL 5.2+, PHP 5.5+ (curl, gd, finfo, pdo_mysql)
 
 ### Database types
-While Directus has been abstracted to allow for different database adapters in the future, currently only MySQL is supported. PostgreSQL, SQLite, and MongoDB support is under development – and we hope to expand support for additional database types as we gain contributors.
+While Directus has been abstracted to allow for different database adapters in the future, currently only MySQL is supported. PostgreSQL, SQLite, and MongoDB support are under development – and we hope to expand support for additional database types as we gain contributors.
 
 
 ## Documentation
@@ -46,7 +46,7 @@ You can find the source of this documentation in [our API docs repo](https://git
 Think you've discovered a bug? First, read through our [docs](https://docs.getdirectus.com) to be sure – then submit a ticket to our [GitHub Issues](https://github.com/directus/directus/issues/new). And if you already know a good solution, we love [Pull Requests](https://github.com/directus/directus/pulls)! **For all security related issues, please chat with us directly through [getdirectus.com](https://getdirectus.com/).**
 
 ### Requesting Features or Enhancements
-Use our [Feature Request Tool](https://request.getdirectus.com/) to request new features or vote on existing commmunity suggestions.
+Use our [Feature Request Tool](https://request.getdirectus.com/) to request new features or vote on existing community suggestions.
 
 ### Technical Support
 For support using Directus, please post questions with the `directus` tag on [Stack Overflow](https://stackoverflow.com/questions/tagged/directus).
@@ -96,8 +96,8 @@ _This is what we want to get done next:_
 ### Q1 2018
 - Begin work on Directus v7.0 (moving from Backbone to Vue)
 - CMS App Decoupled from API
-- API 2.0 - Speed improvements, better relational filtering / querying and increased i18n support
-- [Support for multiple database (multitenant)](https://request.getdirectus.com/r/1)
+- API 2.0 - Speed improvements, better relational filtering / querying, and increased i18n support
+- [Support for multiple databases (multitenant)](https://request.getdirectus.com/r/1)
 - [Digital Asset Management improvements](https://request.getdirectus.com/r/2)
 - [Web Hooks](https://request.getdirectus.com/r/9)
 


### PR DESCRIPTION
It's not optimal, for querying purposes, storing latitude and longitude comma-separated in a text field.

Now you can specify in the "Map" interface options if you want to store latitude and longitude in different columns. (e.g. lat DECIMAL 10,8 / lng DECIMAL 11,8)
