### PR TITLE
Fixed bug in randomString

### DIFF
--- a/api/core/Directus/Util/StringUtils.php
+++ b/api/core/Directus/Util/StringUtils.php
@@ -135,7 +135,7 @@ class StringUtils
             case 'numeric':
                 $min = str_repeat('9', $length-1);
                 $max = str_repeat('9', $length);
-                return (string) random_int($min, $max);
+                return (string) mt_rand($min, $max);
             break;
             case 'loweralpha': $pool = $loweralpha; break;
             case 'upperalpha': $pool = $upperalpha; break;

--- a/api/core/Directus/Util/StringUtils.php
+++ b/api/core/Directus/Util/StringUtils.php
@@ -133,7 +133,7 @@ class StringUtils
 
         switch ($type) {
             case 'numeric':
-                $min = str_repeat('9', $length-1);
+                $min = str_repeat('9', $length-1) + 1;
                 $max = str_repeat('9', $length);
                 return (string) mt_rand($min, $max);
             break;

--- a/api/core/Directus/Util/StringUtils.php
+++ b/api/core/Directus/Util/StringUtils.php
@@ -132,7 +132,11 @@ class StringUtils
         $pool = '';
 
         switch ($type) {
-            case 'numeric': $pool = $numeric; break;
+            case 'numeric':
+                $min = str_repeat('9', $length-1);
+                $max = str_repeat('9', $length);
+                return (string) random_int($min, $max);
+            break;
             case 'loweralpha': $pool = $loweralpha; break;
             case 'upperalpha': $pool = $upperalpha; break;
             case 'loweralphanumeric': $pool = $numeric . $loweralpha; break;


### PR DESCRIPTION
Fixed bug in randomString, where numeric value starting with 0 looses the 0 as soon as the value is parsed as INT somewhere else in the code.
Also updated to use mt_rand which is safer and faster for numbers.