### PR TITLE
Fix check for status=0 parameter in the api

### DIFF
--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -1481,7 +1481,7 @@ class RelationalTableGateway extends BaseTableGateway
         }
 
         $skipAcl = $this->acl === null;
-        if (ArrayUtils::get($params, 'status') && TableSchema::hasStatusColumn($this->getTable(), $skipAcl)) {
+        if (ArrayUtils::has($params, 'status') && TableSchema::hasStatusColumn($this->getTable(), $skipAcl)) {
             $statuses = $params['status'];
             if (!is_array($statuses)) {
                 $statuses = array_map(function($item) {
@@ -1489,7 +1489,7 @@ class RelationalTableGateway extends BaseTableGateway
                 }, explode(',', $params['status']));
             }
 
-            $statuses = array_filter($statuses);
+            $statuses = array_filter($statuses, "is_numeric");
             if ($statuses) {
                 $query->whereIn(TableSchema::getStatusColumn(
                     $this->getTable(),


### PR DESCRIPTION
If one used the `status = 0` parameter to retrieve all rows with e.g. status DELETED, the response still contained all rows instead. The reason was wrong handling for the 0 vs. NULL / False / ...
This is the fox for this.