### PR TITLE
Adding skip_activity_log param to bulk row updates

### DIFF
--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -2,6 +2,7 @@
 
 namespace Directus\Database\TableGateway;
 
+use Directus\API\Routes\A1\Traits;
 use Directus\Database\Exception;
 use Directus\Database\Filters\Filter;
 use Directus\Database\Filters\In;
@@ -22,6 +23,8 @@ use Zend\Db\TableGateway\TableGateway;
 
 class RelationalTableGateway extends BaseTableGateway
 {
+    use Traits\ActivityMode;
+    
     const ACTIVITY_ENTRY_MODE_DISABLED = 0;
     const ACTIVITY_ENTRY_MODE_PARENT = 1;
     const ACTIVITY_ENTRY_MODE_CHILD = 2;
@@ -2018,6 +2021,7 @@ class RelationalTableGateway extends BaseTableGateway
     public function updateCollection($entries)
     {
         $entries = ArrayUtils::isNumericKeys($entries) ? $entries : [$entries];
+        $activityMode = $this->getActivityMode();
         foreach ($entries as $entry) {
             $entry = $this->updateRecord($entry);
             $entry->save();

--- a/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/api/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -2023,7 +2023,7 @@ class RelationalTableGateway extends BaseTableGateway
         $entries = ArrayUtils::isNumericKeys($entries) ? $entries : [$entries];
         $activityMode = $this->getActivityMode();
         foreach ($entries as $entry) {
-            $entry = $this->updateRecord($entry);
+            $entry = $this->updateRecord($entry, $activityMode);
             $entry->save();
         }
     }


### PR DESCRIPTION
Really simple change to address #2175. Everything appears to be working when I run it in my Docker environment; the directus_activity table is not growing anymore. I haven't had time to become intimately familiar with the codebase so I'm not sure if there are other considerations, but it works for `tables/[table]/rows/bulk` and solves my problem.