### PR TITLE
S3 option passthrough

### DIFF
--- a/api/core/Directus/Filesystem/FilesystemFactory.php
+++ b/api/core/Directus/Filesystem/FilesystemFactory.php
@@ -50,7 +50,7 @@ class FilesystemFactory
         }
 
         $client = S3Client::factory($options);
-        $adapter = new S3Adapter($client, $config['bucket'], $config['root'] ?: null, $config['option'] ?: array());
+        $adapter = new S3Adapter($client, $config['bucket'], $config['root'] ?: null, isset($config['s3-option']) ? $config['s3-option'] : array());
 
         return new Flysystem($adapter, [
             'visibility' => ArrayUtils::get($config, 'visibility', AdapterInterface::VISIBILITY_PUBLIC)

--- a/api/core/Directus/Filesystem/FilesystemFactory.php
+++ b/api/core/Directus/Filesystem/FilesystemFactory.php
@@ -50,7 +50,7 @@ class FilesystemFactory
         }
 
         $client = S3Client::factory($options);
-        $adapter = new S3Adapter($client, $config['bucket'], $config['root'] ?: null);
+        $adapter = new S3Adapter($client, $config['bucket'], $config['root'] ?: null, $config['option'] ?: array());
 
         return new Flysystem($adapter, [
             'visibility' => ArrayUtils::get($config, 'visibility', AdapterInterface::VISIBILITY_PUBLIC)


### PR DESCRIPTION
… defined to allow better control over content uploaded to S3.

We are using Directus to upload content to S3 that we would like to provide a Cache-Control header for by default. We're hoping to pass a value from the configuration file through to the S3Adapter to set default headers. S3Adapter provides this functionality via an optional $option argument but the FilesystemFactory doesn't pass anything to it by default.