### PR TITLE
fix(cli): Migrations name should be schemas on cli db install

### DIFF
--- a/src/core/Directus/Console/Modules/DatabaseModule.php
+++ b/src/core/Directus/Console/Modules/DatabaseModule.php
@@ -36,7 +36,7 @@ class DatabaseModule extends ModuleBase
 
     public function cmdInstall($args, $extra)
     {
-        $this->runMigration('schema');
+        $this->runMigration('schemas');
     }
 
     public function cmdUpgrade($args, $extra)


### PR DESCRIPTION
The install command for database schema creation has calls schema but it's defined as schemas.