### PR TITLE
Read the config with the ArrayUtils correctly

### DIFF
--- a/src/core/Directus/Util/ArrayUtils.php
+++ b/src/core/Directus/Util/ArrayUtils.php
@@ -50,6 +50,13 @@ class ArrayUtils
             }
         }
 
+        if(static::deepLevel($array) > 0) {
+            $k = array_search($key, array_column($array, 'key'));
+            if(static::exists($array, $k)) {
+                return $array[$k]['value'];
+            }
+        }
+
         return $default;
     }
 


### PR DESCRIPTION
This will fix the ArrayUtils to read out the config from the database.

The problem was:

In Thumbnailer the '$this->getConfig' return a multidimensional array like this

`config[0] => ['id' => 1, 'key' => 'thumbnail_dimensions', 'value' => '100x100, 200x200']`

And the ArrayUtils try to find in the firstlevel the key 'thumbnail_dimensions' but it will return null while all keys are integer.

So I add a deeplevel check to the ArrayUtils::get method. This will find the key in in the second level and if it find this it will return the integer key of the search key. If this exists it will return the value from the second level.