### PR TITLE
Exclude vendors, include composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ package-lock.json
 
 # Don't track composer phar/vendors
 composer.phar
-composer.lock
+/vendor
 
 # Ignore configuration files
 /config/*


### PR DESCRIPTION
If there is a specific reason why vendors are stored in this repo, plz ignore this PR or just close.

My local test of removing the vendors and reinstall them went fine. Why not just put the lock file in the repo to ensure the updated versions?

https://stackoverflow.com/questions/12896780/should-composer-lock-be-committed-to-version-control