### PR TITLE
Add a query and an sql error to an exception string

### DIFF
--- a/src/core/Directus/Database/Exception/InvalidQueryException.php
+++ b/src/core/Directus/Database/Exception/InvalidQueryException.php
@@ -21,7 +21,8 @@ class InvalidQueryException extends ErrorException
      */
     public function __construct($query, $previous = null)
     {
-        parent::__construct('Failed generating the SQL query.', static::ERROR_CODE, $previous);
+        $error = $previous !== null ? '; error: '.$previous->getMessage() : '';
+        parent::__construct("Failed generating the SQL query: $query$error", static::ERROR_CODE, $previous);
         $this->query = $query;
     }
 


### PR DESCRIPTION
This commit extends the exception string with a query and an SQL error:  
```Failed generating the SQL query: ...; error ...```