### PR TITLE
Suggestion: add directus version info to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -39,4 +39,7 @@ For security issues, please email support@directus.io directly.
 - Web Server: [eg: Apache 2.4.37]
 - PHP Version: [eg: 7.2.0]
 - Database: [eg: MySQL 8.0.12]
+- Directus Release Version: [eg: v8.0.0-rc.1]
+  - App Version: [eg: 7.11.0] (include if Directus Release Version <=`190927A`)
+  - API Version: [eg: 2.6.0] (include if Directus Release Version <=`190927A`)
 - Install Method: [eg: cloned `master` branch]


### PR DESCRIPTION
Including info about directus versions in each bug report could help tackling and solving the issue faster.
Moreover, info about App and API versions must be included if the release version is below v8.0.0-rc.1.

Recreated from #2469.