### PR TITLE
Fixed config file creation validation

### DIFF
--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -470,7 +470,7 @@ class InstallerUtils
         $input = ArrayUtils::omit($data, ['private']);
         $configPath = static::createConfigPathFromData($path, $input);
 
-        static::ensureDirectoryIsWritable($path);
+        static::ensureDirectoryIsWritable($path . '/config');
         if ($force !== true) {
             static::ensureFileDoesNotExists($configPath);
         }


### PR DESCRIPTION
`InstallerUtils::ensureCanCreateConfig` was checking if `/var/directus` is writable instead of `/var/directus/config`. This was breaking project creation via the api.