### PR TITLE
Make Temporary token TTL configurable

### DIFF
--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -742,6 +742,7 @@ class CoreServicesProvider
                 [
                     'secret_key' => $container->get('config')->get('auth.secret_key'),
                     'public_key' => $container->get('config')->get('auth.public_key'),
+                    'ttl' => $container->get('config')->get('auth.ttl'),
                 ]
             );
         };

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -122,6 +122,7 @@ class Schema
             new Group('auth', [
                 new Value('secret_key', Types::STRING, '<type-a-secret-authentication-key-string>'),
                 new Value('public_key', Types::STRING, '<type-a-public-authentication-key-string>'),
+                new Value('ttl', Types::INTEGER, 20),
                 new Group('social_providers', [
                     new Group('okta?', [
                         new Value('client_id', Types::STRING, ''),


### PR DESCRIPTION
Hi,

I'd like the temporary token expiration to be configurable ([currently defaults to 20 minutes](https://docs.directus.io/api/authentication.html#tokens)). I don't know much of Directus, but I gave a look around and it seems that it is not currently configurable. 

This patch keeps the old behaviour, but allows the config PHP file to have a new entry to configure the TTL token expiration, example:

```
    'auth' => [
        'secret_key' => 'XXX',
        'public_key' => '12345678-1234-1234-1234-123456789012',
        'ttl' => 60,
       .....
```

I would be happy to have suggestions on how to improve this little PR.

Thanks for reviewing this!

cc: @herrfinke