### PR TITLE
Updating one-to-many relationship fields form

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-o2m.vue
@@ -97,7 +97,13 @@
 		<div class="corresponding" v-if="!isExisting">
 			<div class="field">
 				<div class="type-label">{{ $t('create_field') }}</div>
-				<v-checkbox block :label="correspondingLabel" v-model="hasCorresponding" />
+				<v-checkbox
+					block
+					:disabled="isExisting"
+					:checked="isExisting"
+					:label="correspondingLabel"
+					v-model="hasCorresponding"
+				/>
 			</div>
 			<div class="field">
 				<div class="type-label">{{ $t('field_name') }}</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-o2m.vue
@@ -100,7 +100,6 @@
 				<v-checkbox
 					block
 					:disabled="isExisting"
-					:checked="isExisting"
 					:label="correspondingLabel"
 					v-model="hasCorresponding"
 				/>


### PR DESCRIPTION
From @juancarlosjr97:

---

If the relationship exists, the tickbox "Create Field" would be disabled to avoid ticking the box and creating an unnecessary error, creating the O2M relationship.

If the fields if not existing, the "Create Field" is ticked automatically that a field needs to be created.