### PR TITLE
Fix custom tags arrow vertical alignment

### DIFF
--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -24,7 +24,7 @@
 				</v-chip>
 			</span>
 			<span v-if="customVals.length > 0 && allowCustom" class="custom tag-container">
-				<v-icon v-if="presetVals.length > 0" name="chevron_right" />
+				<v-icon class="custom-tags-delimeter" v-if="presetVals.length > 0" name="chevron_right" />
 				<v-chip
 					v-for="val in customVals"
 					:key="val"
@@ -200,6 +200,7 @@ export default defineComponent({
 		display: contents;
 	}
 
+	.custom-tags-delimeter,
 	.tag {
 		margin-top: 8px;
 		margin-right: 8px;


### PR DESCRIPTION
Fix arrow position in tags
<img width="521" alt="Screenshot 2020-11-23 at 13 57 19" src="https://user-images.githubusercontent.com/1009639/99974291-63adf580-2da9-11eb-961b-6c26c59af11d.png">
