### PR TITLE
Fix use custom selection init value

### DIFF
--- a/app/src/composables/use-custom-selection/use-custom-selection.ts
+++ b/app/src/composables/use-custom-selection/use-custom-selection.ts
@@ -8,7 +8,7 @@ export function useCustomSelection(currentValue: Ref<string>, items: Ref<any[]>,
 
 	const otherValue = computed({
 		get() {
-			return localOtherValue.value;
+			return localOtherValue.value || (usesOtherValue.value ? currentValue.value : '');
 		},
 		set(newValue: string | null) {
 			if (newValue === null) {


### PR DESCRIPTION
Radio buttons doesn't remember and display the "other value". It seem to be because the initial value of useCustomSelection()