### PR TITLE
WIP Add types to every class that extends Items

### DIFF
--- a/packages/sdk-js/src/handlers/activity.ts
+++ b/packages/sdk-js/src/handlers/activity.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { ItemsHandler } from './items';
-import { Query, PrimaryKey, Item, ItemsResponse } from '../types';
+import { Query, PrimaryKey, Item, Response } from '../types';
 
 export type ActivityItem = {
 	action: string;
@@ -27,16 +27,16 @@ export class ActivityHandler {
 		this.itemsHandler = new ItemsHandler<ActivityItem>('directus_activity', axios);
 	}
 
-	async read(query?: Query): Promise<ItemsResponse<ActivityItem>>;
-	async read(key: PrimaryKey, query?: Query): Promise<ItemsResponse<ActivityItem>>;
+	async read(query?: Query): Promise<Response<Partial<ActivityItem>>>;
+	async read(key: PrimaryKey, query?: Query): Promise<Response<Partial<ActivityItem>>>;
 	async read(
 		keys: PrimaryKey[],
 		query?: Query
-	): Promise<ItemsResponse<ActivityItem | ActivityItem[]>>;
+	): Promise<Response<Partial<ActivityItem> | Partial<ActivityItem>[]>>;
 	async read(
 		keysOrQuery?: PrimaryKey | PrimaryKey[] | Query,
 		query?: Query & { single: boolean }
-	): Promise<ItemsResponse<ActivityItem | ActivityItem[]>> {
+	): Promise<Response<Partial<ActivityItem> | Partial<ActivityItem>[]>> {
 		const result = await this.itemsHandler.read(keysOrQuery as any, query as any);
 		return result;
 	}
@@ -46,7 +46,7 @@ export class ActivityHandler {
 			collection: string;
 			item: string;
 			comment: string;
-		}): Promise<ItemsResponse<Item>> => {
+		}): Promise<Response<Item>> => {
 			const response = await this.axios.post('/activity/comments', payload);
 			return response.data;
 		},

--- a/packages/sdk-js/src/handlers/activity.ts
+++ b/packages/sdk-js/src/handlers/activity.ts
@@ -1,24 +1,43 @@
 import { AxiosInstance } from 'axios';
 import { ItemsHandler } from './items';
-import { Query, PrimaryKey, Item, Response } from '../types';
+import { Query, PrimaryKey, Item, ItemsResponse } from '../types';
 
+export type ActivityItem = {
+	action: string;
+	ip: string;
+	item: PrimaryKey;
+	user_agent: string;
+	timestamp: string;
+	id: number;
+	user: string;
+	comment: string | null;
+	collection: string;
+	revisions: [number] | null;
+};
+
+/**
+ * @TODO I'm not sure why revisions return [number], but it's what api returns
+ */
 export class ActivityHandler {
 	private axios: AxiosInstance;
-	private itemsHandler: ItemsHandler;
+	private itemsHandler: ItemsHandler<ActivityItem>;
 
 	constructor(axios: AxiosInstance) {
 		this.axios = axios;
-		this.itemsHandler = new ItemsHandler('directus_activity', axios);
+		this.itemsHandler = new ItemsHandler<ActivityItem>('directus_activity', axios);
 	}
 
-	async read<T extends Item>(query?: Query): Promise<Response<T | T[]>>;
-	async read<T extends Item>(key: PrimaryKey, query?: Query): Promise<Response<T>>;
-	async read<T extends Item>(keys: PrimaryKey[], query?: Query): Promise<Response<T | T[]>>;
-	async read<T extends Item>(
+	async read(query?: Query): Promise<ItemsResponse<ActivityItem>>;
+	async read(key: PrimaryKey, query?: Query): Promise<ItemsResponse<ActivityItem>>;
+	async read(
+		keys: PrimaryKey[],
+		query?: Query
+	): Promise<ItemsResponse<ActivityItem | ActivityItem[]>>;
+	async read(
 		keysOrQuery?: PrimaryKey | PrimaryKey[] | Query,
 		query?: Query & { single: boolean }
-	): Promise<Response<T | T[]>> {
-		const result = await this.itemsHandler.read<T>(keysOrQuery as any, query as any);
+	): Promise<ItemsResponse<ActivityItem | ActivityItem[]>> {
+		const result = await this.itemsHandler.read(keysOrQuery as any, query as any);
 		return result;
 	}
 
@@ -27,7 +46,7 @@ export class ActivityHandler {
 			collection: string;
 			item: string;
 			comment: string;
-		}): Promise<Response<Item>> => {
+		}): Promise<ItemsResponse<Item>> => {
 			const response = await this.axios.post('/activity/comments', payload);
 			return response.data;
 		},

--- a/packages/sdk-js/src/handlers/items.ts
+++ b/packages/sdk-js/src/handlers/items.ts
@@ -1,7 +1,7 @@
-import { Query, Item, Payload, Response, PrimaryKey } from '../types';
+import { Query, Item, Payload, ItemsResponse, PrimaryKey } from '../types';
 import { AxiosInstance } from 'axios';
 
-export class ItemsHandler {
+export class ItemsHandler<T extends Item = Item> {
 	axios: AxiosInstance;
 	private endpoint: string;
 
@@ -12,12 +12,9 @@ export class ItemsHandler {
 			: `/items/${collection}/`;
 	}
 
-	async create<T extends Item>(payload: Payload, query?: Query): Promise<Response<T>>;
-	async create<T extends Item>(payloads: Payload[], query?: Query): Promise<Response<T[]>>;
-	async create<T extends Item>(
-		payloads: Payload | Payload[],
-		query?: Query
-	): Promise<Response<T | T[]>> {
+	async create(payload: Payload, query?: Query): Promise<ItemsResponse<T>>;
+	async create(payloads: Payload[], query?: Query): Promise<ItemsResponse<T[]>>;
+	async create(payloads: Payload | Payload[], query?: Query): Promise<ItemsResponse<T | T[]>> {
 		const result = await this.axios.post(this.endpoint, payloads, {
 			params: query,
 		});
@@ -25,17 +22,15 @@ export class ItemsHandler {
 		return result.data;
 	}
 
-	async read<T extends Item>(): Promise<Response<T | T[]>>;
-	async read<T extends Item>(query: Query & { single: true }): Promise<Response<T>>;
-	async read<T extends Item>(
-		query: Query & { single: false | undefined }
-	): Promise<Response<T[]>>;
-	async read<T extends Item>(key: PrimaryKey, query?: Query): Promise<Response<T>>;
-	async read<T extends Item>(keys: PrimaryKey[], query?: Query): Promise<Response<T | T[]>>;
-	async read<T extends Item>(
+	async read(): Promise<ItemsResponse<T | T[]>>;
+	async read(query: Query & { single: true }): Promise<ItemsResponse<T>>;
+	async read(query: Query & { single: false | undefined }): Promise<ItemsResponse<T[]>>;
+	async read(key: PrimaryKey, query?: Query): Promise<ItemsResponse<T>>;
+	async read(keys: PrimaryKey[], query?: Query): Promise<ItemsResponse<T | T[]>>;
+	async read(
 		keysOrQuery?: PrimaryKey | PrimaryKey[] | Query,
 		query?: Query & { single: boolean }
-	): Promise<Response<T | T[]>> {
+	): Promise<ItemsResponse<T | T[]>> {
 		let keys: PrimaryKey | PrimaryKey[] | null = null;
 
 		if (
@@ -70,23 +65,15 @@ export class ItemsHandler {
 		return result.data;
 	}
 
-	async update<T extends Item>(
-		key: PrimaryKey,
-		payload: Payload,
-		query?: Query
-	): Promise<Response<T>>;
-	async update<T extends Item>(
-		keys: PrimaryKey[],
-		payload: Payload,
-		query?: Query
-	): Promise<Response<T[]>>;
-	async update<T extends Item>(payload: Payload[], query?: Query): Promise<Response<T[]>>;
-	async update<T extends Item>(payload: Payload, query: Query): Promise<Response<T[]>>;
-	async update<T extends Item>(
+	async update(key: PrimaryKey, payload: Payload, query?: Query): Promise<ItemsResponse<T>>;
+	async update(keys: PrimaryKey[], payload: Payload, query?: Query): Promise<ItemsResponse<T[]>>;
+	async update(payload: Payload[], query?: Query): Promise<ItemsResponse<T[]>>;
+	async update(payload: Payload, query: Query): Promise<ItemsResponse<T[]>>;
+	async update(
 		keyOrPayload: PrimaryKey | PrimaryKey[] | Payload | Payload[],
 		payloadOrQuery?: Payload | Query,
 		query?: Query
-	): Promise<Response<T | T[]>> {
+	): Promise<ItemsResponse<T | T[]>> {
 		if (
 			typeof keyOrPayload === 'string' ||
 			typeof keyOrPayload === 'number' ||

--- a/packages/sdk-js/src/handlers/items.ts
+++ b/packages/sdk-js/src/handlers/items.ts
@@ -1,7 +1,7 @@
-import { Query, Item, Payload, ItemsResponse, PrimaryKey } from '../types';
+import { Query, Item as BaseItem, Payload, Response, PrimaryKey } from '../types';
 import { AxiosInstance } from 'axios';
 
-export class ItemsHandler<T extends Item = Item> {
+export class ItemsHandler<Item extends BaseItem = BaseItem> {
 	axios: AxiosInstance;
 	private endpoint: string;
 
@@ -12,9 +12,12 @@ export class ItemsHandler<T extends Item = Item> {
 			: `/items/${collection}/`;
 	}
 
-	async create(payload: Payload, query?: Query): Promise<ItemsResponse<T>>;
-	async create(payloads: Payload[], query?: Query): Promise<ItemsResponse<T[]>>;
-	async create(payloads: Payload | Payload[], query?: Query): Promise<ItemsResponse<T | T[]>> {
+	async create<T = Partial<Item>>(payload: Payload, query?: Query): Promise<Response<T>>;
+	async create<T = Partial<Item>>(payloads: Payload[], query?: Query): Promise<Response<T[]>>;
+	async create<T = Partial<Item>>(
+		payloads: Payload | Payload[],
+		query?: Query
+	): Promise<Response<T | T[]>> {
 		const result = await this.axios.post(this.endpoint, payloads, {
 			params: query,
 		});
@@ -22,15 +25,23 @@ export class ItemsHandler<T extends Item = Item> {
 		return result.data;
 	}
 
-	async read(): Promise<ItemsResponse<T | T[]>>;
-	async read(query: Query & { single: true }): Promise<ItemsResponse<T>>;
-	async read(query: Query & { single: false | undefined }): Promise<ItemsResponse<T[]>>;
-	async read(key: PrimaryKey, query?: Query): Promise<ItemsResponse<T>>;
-	async read(keys: PrimaryKey[], query?: Query): Promise<ItemsResponse<T | T[]>>;
-	async read(
+	async read<T extends BaseItem = Partial<Item>>(): Promise<Response<T | T[]>>;
+	async read<T extends BaseItem = Partial<Item>>(
+		query: Query & { single: true }
+	): Promise<Response<T>>;
+	async read<T extends BaseItem = Partial<Item>>(query: Query): Promise<Response<T | T[]>>;
+	async read<T extends BaseItem = Partial<Item>>(
+		key: PrimaryKey,
+		query?: Query
+	): Promise<Response<T>>;
+	async read<T extends BaseItem = Partial<Item>>(
+		keys: PrimaryKey[],
+		query?: Query
+	): Promise<Response<T | T[]>>;
+	async read<T extends BaseItem = Partial<Item>>(
 		keysOrQuery?: PrimaryKey | PrimaryKey[] | Query,
 		query?: Query & { single: boolean }
-	): Promise<ItemsResponse<T | T[]>> {
+	): Promise<Response<T | T[]>> {
 		let keys: PrimaryKey | PrimaryKey[] | null = null;
 
 		if (
@@ -65,15 +76,26 @@ export class ItemsHandler<T extends Item = Item> {
 		return result.data;
 	}
 
-	async update(key: PrimaryKey, payload: Payload, query?: Query): Promise<ItemsResponse<T>>;
-	async update(keys: PrimaryKey[], payload: Payload, query?: Query): Promise<ItemsResponse<T[]>>;
-	async update(payload: Payload[], query?: Query): Promise<ItemsResponse<T[]>>;
-	async update(payload: Payload, query: Query): Promise<ItemsResponse<T[]>>;
-	async update(
+	async update<T extends BaseItem = Item>(
+		key: PrimaryKey,
+		payload: Payload,
+		query?: Query
+	): Promise<Response<T>>;
+	async update<T extends BaseItem = Item>(
+		keys: PrimaryKey[],
+		payload: Payload,
+		query?: Query
+	): Promise<Response<T[]>>;
+	async update<T extends BaseItem = Item>(
+		payload: Payload[],
+		query?: Query
+	): Promise<Response<T[]>>;
+	async update<T extends BaseItem = Item>(payload: Payload, query: Query): Promise<Response<T[]>>;
+	async update<T extends BaseItem = Item>(
 		keyOrPayload: PrimaryKey | PrimaryKey[] | Payload | Payload[],
 		payloadOrQuery?: Payload | Query,
 		query?: Query
-	): Promise<ItemsResponse<T | T[]>> {
+	): Promise<Response<T | T[]>> {
 		if (
 			typeof keyOrPayload === 'string' ||
 			typeof keyOrPayload === 'number' ||

--- a/packages/sdk-js/src/handlers/settings.ts
+++ b/packages/sdk-js/src/handlers/settings.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance } from 'axios';
+import { Item } from '../types';
 import { ItemsHandler } from './items';
 
 export type DirectusSettigns = {
@@ -26,7 +27,7 @@ export type DirectusSettigns = {
 	storage_asset_transform: 'none' | 'all' | 'presets';
 };
 
-export class SettingsHandler extends ItemsHandler<DirectusSettigns> {
+export class SettingsHandler<T extends Item> extends ItemsHandler<DirectusSettigns & T> {
 	constructor(axios: AxiosInstance) {
 		super('directus_settings', axios);
 	}

--- a/packages/sdk-js/src/handlers/settings.ts
+++ b/packages/sdk-js/src/handlers/settings.ts
@@ -1,7 +1,32 @@
 import { AxiosInstance } from 'axios';
 import { ItemsHandler } from './items';
 
-export class SettingsHandler extends ItemsHandler {
+export type DirectusSettigns = {
+	auth_login_attempts: number;
+	auth_password_policy: string | null;
+	custom_css: string | null;
+	id: 1;
+	project_color: string | null;
+	project_logo: string | null;
+	project_name: string;
+	project_url: string;
+	public_background: string | null;
+	public_foreground: string | null;
+	public_note: string | null;
+	storage_asset_presets:
+		| {
+				fit: string;
+				height: number;
+				width: number;
+				quality: number;
+				key: string;
+				withoutEnlargement: boolean;
+		  }[]
+		| null;
+	storage_asset_transform: 'none' | 'all' | 'presets';
+};
+
+export class SettingsHandler extends ItemsHandler<DirectusSettigns> {
 	constructor(axios: AxiosInstance) {
 		super('directus_settings', axios);
 	}

--- a/packages/sdk-js/src/types.ts
+++ b/packages/sdk-js/src/types.ts
@@ -8,7 +8,11 @@ export enum Meta {
 }
 
 export type Response<T> = {
-	data: T | null;
+	data: T;
+};
+
+export type ItemsResponse<T> = {
+	data: T;
 	meta?: Record<Meta, number>;
 };
 

--- a/packages/sdk-js/src/types.ts
+++ b/packages/sdk-js/src/types.ts
@@ -8,11 +8,7 @@ export enum Meta {
 }
 
 export type Response<T> = {
-	data: T;
-};
-
-export type ItemsResponse<T> = {
-	data: T;
+	data: T | null;
 	meta?: Record<Meta, number>;
 };
 


### PR DESCRIPTION
I wanted to try to bring full types support to all handlers. This is the easiest, simplest and cleanest way to do it. I had to change generics in `ItemsHandler`. Example of new usage is in `SettingsHandler`. I first wanted to see if you are okay with api changes before adding types to all handlers.
Also, i think that `Response.data` never returns null. If user does not have permission or item does not exist, it will throw error. If fetching array, it will return empty array.

What do you think?