### PR TITLE
Adding `PROJECT_NAME` as an environment variable

### DIFF
--- a/api/example.env
+++ b/api/example.env
@@ -1,6 +1,7 @@
 ####################################################################################################
 # General
 
+PROJECT_NAME="Directus"
 PORT=8055
 PUBLIC_URL="http://localhost:8055"
 LOG_LEVEL="info"

--- a/api/src/mail/index.ts
+++ b/api/src/mail/index.ts
@@ -53,7 +53,7 @@ async function getDefaultTemplateOptions() {
 		.first();
 
 	return {
-		projectName: projectInfo?.project_name || 'Directus',
+		projectName: env.PROJECT_NAME || projectInfo?.project_name || 'Directus',
 		projectColor: projectInfo?.project_color || '#546e7a',
 		projectLogo: projectInfo?.project_logo
 			? getProjectLogoURL(projectInfo.project_logo)

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -6,6 +6,7 @@ import os from 'os';
 import { version } from '../../package.json';
 import macosRelease from 'macos-release';
 import { SettingsService } from './settings';
+import env from '../env';
 
 export class ServerService {
 	knex: Knex;
@@ -36,6 +37,10 @@ export class ServerService {
 		});
 
 		info.project = projectInfo;
+
+		if (env.PROJECT_NAME) {
+			info.project.project_name = env.PROJECT_NAME;
+		}
 
 		if (this.accountability?.admin === true) {
 			const osType = os.type() === 'Darwin' ? 'macOS' : os.type();

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -5,6 +5,12 @@
 
 ## General
 
+### `PROJECT_NAME`
+
+What is the name of the project.<br>**Default: empty value**
+
+If the `PROJECT_NAME` is set, it will be set automatically as the project name.
+
 ### `PORT`
 
 What port to run the API under.<br>**Default: `8055`**


### PR DESCRIPTION
### Description

Adding `PROJECT_NAME` as an environment variable

### Reason

I was looking to describe the environment easily moving the database, but as the name is always the same. As an environment variable, I could pass a fixed name and the environment to easily identified