### PR TITLE
Display formatted-json-value

### DIFF
--- a/app/src/displays/formatted-json-value/formatted-json-value.vue
+++ b/app/src/displays/formatted-json-value/formatted-json-value.vue
@@ -1,0 +1,37 @@
+<template>
+	<value-null v-if="!displayValue" />
+
+	<span v-else>
+		{{ displayValue }}
+	</span>
+</template>
+
+<script lang="ts">
+import { render } from 'micromustache';
+import { defineComponent, computed } from '@vue/composition-api';
+
+export default defineComponent({
+	props: {
+		value: {
+			type: Object,
+			default: null,
+		},
+		format: {
+			type: String,
+			default: false,
+		},
+	},
+	setup(props) {
+		const displayValue = computed(() => {
+			if (!props.value) return null;
+			try {
+				return render(props.format, props.value);
+			} catch (error) {
+				return null;
+			}
+		});
+
+		return { displayValue };
+	},
+});
+</script>

--- a/app/src/displays/formatted-json-value/index.ts
+++ b/app/src/displays/formatted-json-value/index.ts
@@ -1,0 +1,25 @@
+import { defineDisplay } from '@/displays/define';
+import DisplayJsonValue from './formatted-json-value.vue';
+
+export default defineDisplay(({ i18n }) => ({
+	id: 'formatted-json-value',
+	name: i18n.t('displays.formatted-json-value.formatted-json-value'),
+	description: i18n.t('displays.formatted-json-value.description'),
+	types: ['json'],
+	icon: 'settings_ethernet',
+	handler: DisplayJsonValue,
+	options: [
+		{
+			field: 'format',
+			name: i18n.t('display_template'),
+			type: 'string',
+			meta: {
+				width: 'full',
+				interface: 'text-input',
+				options: {
+					placeholder: '{{ field }}',
+				},
+			},
+		},
+	],
+}));

--- a/app/src/lang/en-US/displays.json
+++ b/app/src/lang/en-US/displays.json
@@ -48,6 +48,10 @@
 			"format_title_label": "Auto-format casing",
 			"bold_label": "Use bold style"
 		},
+		"formatted-json-value": {
+			"formatted-json-value": "Formatted JSON value",
+			"description": "Display a formatted version of the object"
+		},
 		"icon": {
 			"icon": "Icon",
 			"description": "Display an icon",


### PR DESCRIPTION
Displaying JSON values in layouts is bit annoying in some cases, and for example like this

<img width="841" alt="Screenshot 2020-11-29 at 15 59 59" src="https://user-images.githubusercontent.com/1009639/100544089-0f4cbf00-325c-11eb-9d86-a6a2b1746b58.png">

There is text formatter but no for objects, so this PR should solve such cases.

Display UI

<img width="847" alt="Screenshot 2020-11-29 at 15 50 55" src="https://user-images.githubusercontent.com/1009639/100544114-32776e80-325c-11eb-99bd-9e4a3fafab19.png">
