### PR TITLE
Fix nullable property of Postgres schema overview

### DIFF
--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -148,10 +148,11 @@ export default class Postgres implements Schema {
 					columns: {},
 				};
 
-			overview[column.table_name].columns[column.column_name] = column;
-			overview[column.table_name].columns[
-				column.column_name
-			].default_value = this.parseDefaultValue(column.default_value);
+			overview[column.table_name].columns[column.column_name] = {
+				...column,
+				default_value: this.parseDefaultValue(column.default_value),
+				is_nullable: column.is_nullable === 'YES',
+			};
 		}
 
 		return overview;


### PR DESCRIPTION
I don't know whether this fixes any issues, but I noticed this while debugging #3186 so might as well fix it.