### PR TITLE
Removed background-color from m2a-builder class

### DIFF
--- a/app/src/interfaces/m2a-builder/m2a-builder.vue
+++ b/app/src/interfaces/m2a-builder/m2a-builder.vue
@@ -576,9 +576,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.m2a-builder {
-	background-color: white;
-}
+// .m2a-builder {
+// background-color: white;
+// }
 
 .m2a-row {
 	display: flex;

--- a/app/src/interfaces/m2a-builder/m2a-builder.vue
+++ b/app/src/interfaces/m2a-builder/m2a-builder.vue
@@ -576,10 +576,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-// .m2a-builder {
-// background-color: white;
-// }
-
 .m2a-row {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Seems to fix #3247.

I removed the `background-color: white` from the m2a-builder class so it now uses the background-color from the form itself, which seems to fix the issue.

![image](https://user-images.githubusercontent.com/4715129/100925217-79fe3480-34c0-11eb-9fff-ecae0f671114.png)

![image](https://user-images.githubusercontent.com/4715129/100925268-8bdfd780-34c0-11eb-9b47-637819d8fc7b.png)
