### PR TITLE
Add CLI bootstrap command

### DIFF
--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -1,0 +1,84 @@
+import env from '../../../env';
+import logger from '../../../logger';
+import installDatabase from '../../../database/seeds/run';
+import runMigrations from '../../../database/migrations/run';
+import { nanoid } from 'nanoid';
+
+export default async function bootstrap() {
+	logger.info('Initializing bootstrap...');
+
+	if (!('KEY' in env) || env.KEY == '') {
+		logger.error('Missing KEY environment variable.');
+		process.exit(1);
+	}
+
+	if (!('SECRET' in env) || env.SECRET == '') {
+		logger.error('Missing SECRET environment variable.');
+		process.exit(1);
+	}
+
+	if ((await isDatabaseAvailable()) === false) {
+		logger.error(`Can't connect to the database`);
+		process.exit(1);
+	}
+
+	const { isInstalled, default: database, schemaInspector } = require('../../../database');
+	const { RolesService } = require('../../../services/roles');
+	const { UsersService } = require('../../../services/users');
+
+	if ((await isInstalled()) === false) {
+		logger.info('Installing Directus system tables...');
+
+		await installDatabase(database);
+
+		const schema = await schemaInspector.overview();
+
+		logger.info('Setting up first admin role...');
+		const rolesService = new RolesService({ schema });
+		const role = await rolesService.create({ name: 'Admin', admin_access: true });
+
+		logger.info('Adding first admin user...');
+		const usersService = new UsersService({ schema });
+
+		let adminEmail = env.ADMIN_EMAIL;
+
+		if (!adminEmail) {
+			logger.info('No admin email provided. Defaulting to "admin@example.com"');
+			adminEmail = 'admin@example.com';
+		}
+
+		let adminPassword = env.ADMIN_PASSWORD;
+
+		if (!adminPassword) {
+			adminPassword = nanoid(12);
+			logger.info(`No admin password provided. Defaulting to "${adminPassword}"`);
+		}
+
+		await usersService.create({ email: adminEmail, password: adminPassword, role });
+	} else {
+		logger.info('Database already initialized, skipping install');
+	}
+
+	logger.info('Running migrations...');
+	await runMigrations(database, 'latest');
+
+	logger.info('Done');
+	process.exit(0);
+}
+
+async function isDatabaseAvailable() {
+	const { hasDatabaseConnection } = require('../../../database');
+
+	const tries = 5;
+	const secondsBetweenTries = 5;
+
+	for (var i = 0; i < tries; i++) {
+		if (await hasDatabaseConnection()) {
+			return true;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, secondsBetweenTries * 1000));
+	}
+
+	return false;
+}

--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -7,16 +7,6 @@ import { nanoid } from 'nanoid';
 export default async function bootstrap() {
 	logger.info('Initializing bootstrap...');
 
-	if (!('KEY' in env) || env.KEY == '') {
-		logger.error('Missing KEY environment variable.');
-		process.exit(1);
-	}
-
-	if (!('SECRET' in env) || env.SECRET == '') {
-		logger.error('Missing SECRET environment variable.');
-		process.exit(1);
-	}
-
 	if ((await isDatabaseAvailable()) === false) {
 		logger.error(`Can't connect to the database`);
 		process.exit(1);

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -11,6 +11,7 @@ import dbMigrate from './commands/database/migrate';
 import usersCreate from './commands/users/create';
 import rolesCreate from './commands/roles/create';
 import count from './commands/count';
+import bootstrap from './commands/bootstrap';
 
 program.name('directus').usage('[command] [options]');
 program.version(pkg.version, '-v, --version');
@@ -56,6 +57,8 @@ program
 	.command('count <collection>')
 	.description('Count the amount of items in a given collection')
 	.action(count);
+
+program.command('bootstrap').description('Initialize or update the database').action(bootstrap);
 
 program.parseAsync(process.argv).catch((err) => {
 	console.error(err);

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -46,9 +46,18 @@ database
 		logger.trace(`[${delta.toFixed(3)}ms] ${queryInfo.sql} [${queryInfo.bindings.join(', ')}]`);
 	});
 
+export async function hasDatabaseConnection() {
+	try {
+		await database.raw('select 1 + 1 as result');
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export async function validateDBConnection() {
 	try {
-		await database.raw('select 1+1 as result');
+		await hasDatabaseConnection();
 	} catch (error) {
 		logger.fatal(`Can't connect to the database.`);
 		logger.fatal(error);

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -260,3 +260,18 @@ provide the following configurations.<br>**Default: `sendmail`**
     -   **`EMAIL_SMTP_PASSWORD`** — SMTP Password
     -   **`EMAIL_SMTP_POOL`** — Use SMTP pooling
     -   **`EMAIL_SMTP_SECURE`** — Enable TLS
+
+## Misc.
+
+If you're relying on Docker and/or the `directus bootstrap` CLI command, you can pass the following
+two environment variables to automatically configure the first user:
+
+### `ADMIN_EMAIL`
+
+The email address of the first user that's automatically created when using `directus bootstrap`.
+Defaults to `admin@example.com`
+
+### `ADMIN_PASSWORD`
+
+The password of the first user that's automatically created when using `directus bootstrap`.
+Defaults to a random string of 12 characters.


### PR DESCRIPTION
Adds a `directus bootstrap` command that will install the database, and setup the first role and user if they don't exist yet.

If the database already exists, it'll just run the migrations. 

Meant to be used in automatic deploys / docker / etc