### PR TITLE
Add Platform.sh deploy button.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,16 @@ Simply follow the setup prompts and the CLI will create your new project directo
 
 <br>
 
+## :rocket: Deploy on Platform.sh
+
+An empty [Directus project](https://github.com/platformsh-templates/directus) repository is maintained by [Platform.sh](https://platform.sh) that you can quickly deploy using the button below.
+
+<p align="center">
+<a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/directus/.platform.template.yaml&utm_content=directus&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+</p>
+
 ## 📌 Requirements
 
 Directus only requires Node.js (or [PHP](https://github.com/directus/api-next)), and supports most operating systems and SQL database vendors.


### PR DESCRIPTION
Hey all, here's the result of our PoC work with Platform.sh. 

I tried for a bit to get our configuration files into this repo itself, deploying from a `package` at first, but that would have either created a situation where users would not have `package.json/lock` committed on their projects, or otherwise create another task for your team to keep this file up to date on your end. 

In the end, it didn't seem to me that adding our configuration here would have resulted in the best experience for those who used it and would have created more work for you. So we elected to create a template in our organization the button actually points to [platformsh-templates/directus](https://github.com/platformsh-templates/directus). We've subscribed to the main `directus/directus` feed to keep it up to date within our current workflow as well. 

So then the contents of this PR are just the new README section and the button itself, feel free to adjust as needed and play with the template in the meantime. 

Hope you're all well!