### PR TITLE
Fix v-fancy-select icon stretching

### DIFF
--- a/app/src/components/v-fancy-select/v-fancy-select.vue
+++ b/app/src/components/v-fancy-select/v-fancy-select.vue
@@ -115,7 +115,7 @@ export default defineComponent({
 	}
 
 	.content {
-		flex-grow: 1;
+		flex: 1;
 
 		.description {
 			opacity: 0.6;


### PR DESCRIPTION
Fixing this

<img width="833" alt="Screenshot 2020-12-06 at 12 39 53" src="https://user-images.githubusercontent.com/1009639/101277929-81735580-37c0-11eb-8073-88d17649263f.png">
