### PR TITLE
fix(sdk-js): target es2015 for better support

### DIFF
--- a/packages/sdk-js/rollup.config.js
+++ b/packages/sdk-js/rollup.config.js
@@ -28,7 +28,7 @@ const configs = {
 	bundler: {
 		file: pkg.module,
 		format: 'es',
-		target: 'esnext',
+		target: 'es2015',
 		mode: 'development',
 	},
 	cjs: {


### PR DESCRIPTION
## Issue
Using `@directus/sdk-js` in `create-react-app` results in a syntax error due to optional-chaining. It cannot be fixed without a `cra` override lib.

![image](https://user-images.githubusercontent.com/7349258/102651528-b07fb480-413a-11eb-966f-f76710ca4c31.png)


Steps to reproduce:

1. Create a react-app `yarn create react-app directus-test`
2. Install `@directus/sdk-js` (currently 9.0.0-rc.24)
3. Import DirectusSDK `import DirectusSDK from "@directus/sdk-js"`
4. Syntax error occurs

## Fix
Target a more widely used syntax, `es2015` for use with bundlers.

Tested locally with `yarn link`.

Line in question now is transpiled to:
![image](https://user-images.githubusercontent.com/7349258/102651752-0ce2d400-413b-11eb-862e-b94d53cacdb6.png)

