### PR TITLE
test(sdk-js): fix failing test

### DIFF
--- a/packages/sdk-js/tests/index.ts
+++ b/packages/sdk-js/tests/index.ts
@@ -46,7 +46,7 @@ describe('DirectusSDK', () => {
 	});
 
 	it('Defaults to the correct auth options', () => {
-		expect(directus['authOptions'].autoRefresh).to.be.true;
+		expect(directus['authOptions'].autoRefresh).to.be.false;
 		expect(directus['authOptions'].mode).to.equal('cookie');
 		expect(directus['authOptions'].storage).to.be.instanceOf(MemoryStore);
 	});


### PR DESCRIPTION
## Issue
The `sdk-js` test suite is failing due to an incorrect assert.

The default behavior of `authOptions.autoRefresh` is expected to be `false` when `undefined`.

See L35 https://github.com/directus/directus/blob/2b64449f6cdc3c8024793f7b3b78d856aaf98b2b/packages/sdk-js/src/index.ts#L32-L36