### PR TITLE
Feature: don't expose admin url (optional)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -99,7 +99,9 @@ export default async function createApp() {
 		html = html.replace(/href="\//g, `href="${publicUrl}`);
 		html = html.replace(/src="\//g, `src="${publicUrl}`);
 
-		app.get('/', (req, res) => res.redirect(`./admin/`));
+    app.get('/', (req, res) =>
+			env.REDIRECT_TO_ADMIN ? res.redirect(`./admin/`) : res.status(403).send('Access denied')
+		);
 		app.get('/admin', (req, res) => res.send(html));
 		app.use('/admin', express.static(path.join(adminPath, '..')));
 		app.use('/admin/*', (req, res) => {

--- a/api/src/cli/utils/create-env/env-stub.liquid
+++ b/api/src/cli/utils/create-env/env-stub.liquid
@@ -39,6 +39,7 @@ ACCESS_TOKEN_TTL="15m"
 REFRESH_TOKEN_TTL="7d"
 REFRESH_TOKEN_COOKIE_SECURE=false
 REFRESH_TOKEN_COOKIE_SAME_SITE="lax"
+REDIRECT_TO_ADMIN=true
 
 ####################################################################################################
 ## SSO (OAuth) Providers

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -26,6 +26,7 @@ const defaults: Record<string, any> = {
 	REFRESH_TOKEN_TTL: '7d',
 	REFRESH_TOKEN_COOKIE_SECURE: false,
 	REFRESH_TOKEN_COOKIE_SAME_SITE: 'lax',
+	REDIRECT_TO_ADMIN: true,
 
 	CORS_ENABLED: true,
 


### PR DESCRIPTION
While building a project I found out that Directus 9 is exposing `/admin` path so here's a quick fix I tried locally. Would be happy to discuss & contribute.