### PR TITLE
Prevent admin check to be bypassed

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -23,7 +23,7 @@ export class CollectionsService {
 	create(data: Partial<Collection>[]): Promise<string[]>;
 	create(data: Partial<Collection>): Promise<string>;
 	async create(data: Partial<Collection> | Partial<Collection>[]): Promise<string | string[]> {
-		if (this.accountability && this.accountability.admin !== true) {
+		if (!this.accountability || this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action.');
 		}
 
@@ -256,7 +256,7 @@ export class CollectionsService {
 	delete(collections: string[]): Promise<string[]>;
 	delete(collection: string): Promise<string>;
 	async delete(collection: string[] | string): Promise<string[] | string> {
-		if (this.accountability && this.accountability.admin !== true) {
+		if (!this.accountability || this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action.');
 		}
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -197,7 +197,7 @@ export class FieldsService {
 		field: Partial<Field> & { field: string; type: typeof types[number] },
 		table?: CreateTableBuilder // allows collection creation to
 	) {
-		if (this.accountability && this.accountability.admin !== true) {
+		if (!this.accountability || this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action.');
 		}
 
@@ -234,7 +234,7 @@ export class FieldsService {
 	}
 
 	async updateField(collection: string, field: RawField) {
-		if (this.accountability && this.accountability.admin !== true) {
+		if (!this.accountability || this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action');
 		}
 
@@ -279,7 +279,7 @@ export class FieldsService {
 
 	/** @todo save accountability */
 	async deleteField(collection: string, field: string) {
-		if (this.accountability && this.accountability.admin !== true) {
+		if (!this.accountability || this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action.');
 		}
 


### PR DESCRIPTION
It seems CollectionService and FieldsService have a somewhat weak admin role check. That check can be bypassed by not passing accountability object at all.