### PR TITLE
Storage asset transform Presets Only value fix

### DIFF
--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -82,9 +82,9 @@ router.get(
 			if (transformation.key && allKeys.includes(transformation.key as string) === false)
 				throw new InvalidQueryException(`Key "${transformation.key}" isn't configured.`);
 			return next();
-		} else if (assetSettings.storage_asset_transform === 'shortcut') {
+		} else if (assetSettings.storage_asset_transform === 'presets') {
 			if (allKeys.includes(transformation.key as string)) return next();
-			throw new InvalidQueryException(`Only configured shortcuts can be used in asset generation.`);
+			throw new InvalidQueryException(`Only configured presets can be used in asset generation.`);
 		} else {
 			if (transformation.key && systemKeys.includes(transformation.key as string)) return next();
 			throw new InvalidQueryException(`Dynamic asset generation has been disabled for this project.`);


### PR DESCRIPTION
Presets Only value has been set as "presets" but this value is checking as "shortcut" in the assets controller.

https://github.com/directus/directus/blob/9666cf44fe113b0a11c0d91662ac9b31907f35b0/api/src/database/system-data/fields/settings.yaml#L182-L192