### PR TITLE
sdk-js: Upgrade axios from 0.19.2 to 0.21.1

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -30,7 +30,7 @@
   "author": "Rijk van Zanten <rijkvanzanten@me.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "openapi3-ts": "^2.0.0"
   },
   "nyc": {


### PR DESCRIPTION
Projects with the sdk-js dependency get a high severity vulnerability displayed because of:
https://www.npmjs.com/advisories/1594

PR upgrades sdk-js to 0.21.1 in the sdk-js project.