### PR TITLE
Create event emitter take out transaction scope.

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -159,20 +159,20 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				await cache.clear();
 			}
 
-			emitter
-				.emitAsync(`${this.eventScope}.create`, {
-					event: `${this.eventScope}.create`,
-					accountability: this.accountability,
-					collection: this.collection,
-					item: primaryKeys,
-					action: 'create',
-					payload: payloads,
-					schema: this.schema,
-				})
-				.catch((err) => logger.warn(err));
-
 			return primaryKeys;
 		});
+
+		emitter
+			.emitAsync(`${this.eventScope}.create`, {
+				event: `${this.eventScope}.create`,
+				accountability: this.accountability,
+				collection: this.collection,
+				item: savedPrimaryKeys,
+				action: 'create',
+				payload: payloads,
+				schema: this.schema,
+			})
+			.catch((err) => logger.warn(err));
 
 		return Array.isArray(data) ? savedPrimaryKeys : savedPrimaryKeys[0];
 	}
@@ -381,7 +381,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			const payloads = toArray(data);
 
 			for (const single of payloads as Partial<Item>[]) {
-				let payload = clone(single);
+				const payload = clone(single);
 				const key = payload[primaryKeyField];
 
 				if (!key) {


### PR DESCRIPTION
Fix #3635.

```js
module.exports = function registerHook({ exceptions, database }) {
	const { InvalidPayloadException } = exceptions;

	return {
		'items.create': async function (input) {
			const collection = input.collection;
			const primaryKeyField = input.schema[collection].primary;
			const firstItemId = input.item[0];

			const result = await database
				.select('*')
				.from(collection)
				.where({ [primaryKeyField]: firstItemId })
				.first();

			console.log(result);

			return input;
		},
	};
};
```

Result
`{ id: 'a752ba80-757d-4c15-93a7-1ce1c4f045a6', name: 'test' }`