### PR TITLE
Set bundler and cjs targets of sdk-js and format-title to es2018

### DIFF
--- a/packages/format-title/rollup.config.js
+++ b/packages/format-title/rollup.config.js
@@ -27,13 +27,13 @@ const configs = {
 	bundler: {
 		file: pkg.module,
 		format: 'es',
-		target: 'esnext',
+		target: 'es2018',
 		mode: 'development',
 	},
 	cjs: {
 		file: pkg.main,
 		format: 'cjs',
-		target: 'esnext',
+		target: 'es2018',
 		mode: 'development',
 	},
 };

--- a/packages/sdk-js/rollup.config.js
+++ b/packages/sdk-js/rollup.config.js
@@ -28,13 +28,13 @@ const configs = {
 	bundler: {
 		file: pkg.module,
 		format: 'es',
-		target: 'es2015',
+		target: 'es2018',
 		mode: 'development',
 	},
 	cjs: {
 		file: pkg.main,
 		format: 'cjs',
-		target: 'esnext',
+		target: 'es2018',
 		mode: 'development',
 	},
 };


### PR DESCRIPTION
There was a case mentioned on Discord, where next.js/webpack would import sdk-js from the `main` entrypoint instead of the `module` entrypoint. While I couldn't reproduce this on my end, it is a good idea to be consistent between the cjs and the bundler target anyway.

I think `es2018` is a good compromise between `es2015` (introduced in #3471) and `esnext`, as it is supported by all current Node LTS versions while having a much smaller impact on bundle size.

I also changed the target versions of format-title. This has zero impact on the bundle size and was just done for consistency.