### PR TITLE
Application initialization events

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -43,12 +43,7 @@ import sanitizeQuery from './middleware/sanitize-query';
 import { checkIP } from './middleware/check-ip';
 import { InvalidPayloadException } from './exceptions';
 
-import {
-	initializeExtensions,
-	registerExtensionEndpoints,
-	registerExtensionHooks,
-	registerExtensions,
-} from './extensions';
+import { initializeExtensions, registerExtensionEndpoints, registerExtensionHooks } from './extensions';
 import { register as registerWebhooks } from './webhooks';
 import emitter, { emitAsyncSafe } from './emitter';
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -72,7 +72,7 @@ export default async function createApp() {
 
 	await emitAsyncSafe('init.before', { app });
 
-	await emitAsyncSafe('app.middlewares.before', { app });
+	await emitAsyncSafe('middlewares.init.before', { app });
 
 	app.use(expressLogger({ logger }));
 
@@ -126,9 +126,9 @@ export default async function createApp() {
 
 	app.use(sanitizeQuery);
 
-	await emitAsyncSafe('app.middlewares.after', { app });
+	await emitAsyncSafe('middlewares.init.after', { app });
 
-	await emitAsyncSafe('app.routes.before', { app });
+	await emitAsyncSafe('routes.init.before', { app });
 
 	app.use(cache);
 
@@ -159,14 +159,14 @@ export default async function createApp() {
 	app.use('/custom', customRouter);
 
 	// Register custom hooks / endpoints
-	await emitAsyncSafe('app.custom.before', { app });
+	await emitAsyncSafe('routes.custom.init.before', { app });
 	await registerExtensionEndpoints(customRouter);
-	await emitAsyncSafe('app.custom.after', { app });
+	await emitAsyncSafe('routes.custom.init.after', { app });
 
 	app.use(notFoundHandler);
 	app.use(errorHandler);
 
-	await emitAsyncSafe('app.routes.after', { app });
+	await emitAsyncSafe('routes.init.after', { app });
 
 	// Register all webhooks
 	await registerWebhooks();

--- a/api/src/controllers/not-found.ts
+++ b/api/src/controllers/not-found.ts
@@ -16,7 +16,7 @@ import emitter from '../emitter';
  */
 const notFound: RequestHandler = async (req, res, next) => {
 	try {
-		const ret = await emitter.emitAsync('app.not_found', req, res);
+		const ret = await emitter.emitAsync('request.not_found', req, res);
 		if (ret.reduce((prev, current) => current || prev, false)) {
 			return next();
 		}

--- a/api/src/controllers/not-found.ts
+++ b/api/src/controllers/not-found.ts
@@ -1,8 +1,29 @@
 import { RequestHandler } from 'express';
 import { RouteNotFoundException } from '../exceptions';
 
-const notFound: RequestHandler = (req, res, next) => {
-	throw new RouteNotFoundException(req.path);
+import emitter from '../emitter';
+
+/**
+ * Handles not found routes.
+ *
+ * - If a hook throws an error, the error gets forwarded to the error handler.
+ * - If a hook returns true, the handler assumes the response has been
+ *   processed and won't generate a response.
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+const notFound: RequestHandler = async (req, res, next) => {
+	try {
+		const ret = await emitter.emitAsync('app.not_found', req, res);
+		if (ret.reduce((prev, current) => current || prev, false)) {
+			return next();
+		}
+		next(new RouteNotFoundException(req.path));
+	} catch (err) {
+		next(err);
+	}
 };
 
 export default notFound;

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -1,5 +1,21 @@
 import { EventEmitter2 } from 'eventemitter2';
+import logger from './logger';
 
 const emitter = new EventEmitter2({ wildcard: true, verboseMemoryLeak: true, delimiter: '.' });
+
+/**
+ * Emit async events without throwing errors. Just log them out as warnings.
+ * @param name
+ * @param args
+ */
+export async function emitAsyncSafe(name: string, ...args: any[]) {
+	try {
+		return await emitter.emitAsync(name, ...args);
+	} catch (err) {
+		logger.warn(`An error was thrown while executing hook "${name}"`);
+		logger.warn(err);
+	}
+	return [];
+}
 
 export default emitter;

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -25,6 +25,10 @@ export async function ensureFoldersExist() {
 	}
 }
 
+export async function initializeExtensions() {
+	await ensureFoldersExist();
+}
+
 export async function listExtensions(type: string) {
 	const extensionsPath = env.EXTENSIONS_PATH as string;
 	const location = path.join(extensionsPath, type);
@@ -42,20 +46,25 @@ export async function listExtensions(type: string) {
 }
 
 export async function registerExtensions(router: Router) {
-	await ensureFoldersExist();
-	let hooks: string[] = [];
+	await registerExtensionHooks();
+	await registerExtensionEndpoints(router);
+}
+
+export async function registerExtensionEndpoints(router: Router) {
 	let endpoints: string[] = [];
-
-	try {
-		hooks = await listExtensions('hooks');
-		registerHooks(hooks);
-	} catch (err) {
-		logger.warn(err);
-	}
-
 	try {
 		endpoints = await listExtensions('endpoints');
 		registerEndpoints(endpoints, router);
+	} catch (err) {
+		logger.warn(err);
+	}
+}
+
+export async function registerExtensionHooks() {
+	let hooks: string[] = [];
+	try {
+		hooks = await listExtensions('hooks');
+		registerHooks(hooks);
 	} catch (err) {
 		logger.warn(err);
 	}

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,7 +5,7 @@ import { URL } from 'url';
 import { createTerminus, TerminusOptions } from '@godaddy/terminus';
 import { Request } from 'express';
 import logger from './logger';
-import emitter from './emitter';
+import { emitAsyncSafe } from './emitter';
 import database from './database';
 import createApp from './app';
 import { once } from 'lodash';
@@ -63,7 +63,7 @@ export default async function createServer() {
 				duration: elapsedMilliseconds.toFixed(),
 			};
 
-			emitter.emitAsync('response', info).catch((err) => logger.warn(err));
+			emitAsyncSafe('response', info);
 		});
 
 		res.once('finish', complete.bind(null, true));
@@ -83,7 +83,7 @@ export default async function createServer() {
 	return server;
 
 	async function beforeShutdown() {
-		await emitter.emitAsync('server.stop.before', { server });
+		emitAsyncSafe('server.stop.before', { server });
 
 		if ('DIRECTUS_DEV' in process.env) {
 			logger.info('Restarting...');
@@ -98,7 +98,7 @@ export default async function createServer() {
 	}
 
 	async function onShutdown() {
-		emitter.emitAsync('server.stop').catch((err) => logger.warn(err));
+		emitAsyncSafe('server.stop');
 
 		if (!('DIRECTUS_DEV' in process.env)) {
 			logger.info('Directus shut down OK. Bye bye!');

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -14,8 +14,7 @@ import {
 } from '../types';
 import Knex from 'knex';
 import cache from '../cache';
-import emitter from '../emitter';
-import logger from '../logger';
+import emitter, { emitAsyncSafe } from '../emitter';
 import { toArray } from '../utils/to-array';
 import env from '../env';
 
@@ -164,17 +163,15 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			return primaryKeys;
 		});
 
-		emitter
-			.emitAsync(`${this.eventScope}.create`, {
-				event: `${this.eventScope}.create`,
-				accountability: this.accountability,
-				collection: this.collection,
-				item: savedPrimaryKeys,
-				action: 'create',
-				payload: payloads,
-				schema: this.schema,
-			})
-			.catch((err) => logger.warn(err));
+		emitAsyncSafe(`${this.eventScope}.create`, {
+			event: `${this.eventScope}.create`,
+			accountability: this.accountability,
+			collection: this.collection,
+			item: savedPrimaryKeys,
+			action: 'create',
+			payload: payloads,
+			schema: this.schema,
+		});
 
 		return Array.isArray(data) ? savedPrimaryKeys : savedPrimaryKeys[0];
 	}
@@ -362,17 +359,15 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				await cache.clear();
 			}
 
-			emitter
-				.emitAsync(`${this.eventScope}.update`, {
-					event: `${this.eventScope}.update`,
-					accountability: this.accountability,
-					collection: this.collection,
-					item: key,
-					action: 'update',
-					payload,
-					schema: this.schema,
-				})
-				.catch((err) => logger.warn(err));
+			emitAsyncSafe(`${this.eventScope}.update`, {
+				event: `${this.eventScope}.update`,
+				accountability: this.accountability,
+				collection: this.collection,
+				item: key,
+				action: 'update',
+				payload,
+				schema: this.schema,
+			});
 
 			return key;
 		}
@@ -499,17 +494,15 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			await cache.clear();
 		}
 
-		emitter
-			.emitAsync(`${this.eventScope}.delete`, {
-				event: `${this.eventScope}.delete`,
-				accountability: this.accountability,
-				collection: this.collection,
-				item: keys,
-				action: 'delete',
-				payload: null,
-				schema: this.schema,
-			})
-			.catch((err) => logger.warn(err));
+		emitAsyncSafe(`${this.eventScope}.delete`, {
+			event: `${this.eventScope}.delete`,
+			accountability: this.accountability,
+			collection: this.collection,
+			item: keys,
+			action: 'delete',
+			payload: null,
+			schema: this.schema,
+		});
 
 		return key;
 	}

--- a/api/src/start.ts
+++ b/api/src/start.ts
@@ -1,4 +1,4 @@
-import emitter from './emitter';
+import emitter, { emitAsyncSafe } from './emitter';
 import env from './env';
 import logger from './logger';
 
@@ -19,7 +19,7 @@ export default async function start() {
 	server
 		.listen(port, () => {
 			logger.info(`Server started at port ${port}`);
-			emitter.emitAsync('server.start').catch((err) => logger.warn(err));
+			emitAsyncSafe('server.start');
 		})
 		.once('error', (err: any) => {
 			if (err?.code === 'EADDRINUSE') {

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -1,6 +1,7 @@
 # Custom API Hooks <small></small>
 
-> Custom API Hooks allow running custom logic when a specified event occurs within your project. They can be registered as either "blocking" or immediate.
+> Custom API Hooks allow running custom logic when a specified event occurs within your project. They can be registered
+> as either "blocking" or immediate.
 
 ## 1. Create a Hook File
 
@@ -71,26 +72,30 @@ module.exports = function registerHook({ exceptions }) {
 
 ### Event Format Options
 
-| Scope         | Actions                            | Before   |
-| ------------- | ---------------------------------- | -------- |
-| `items`       | `create`, `update` and `delete`    | Optional |
-| `activity`    | `create`, `update` and `delete`    | Optional |
-| `collections` | `create`, `update` and `delete`    | Optional |
-| `fields`      | `create`, `update` and `delete`    | Optional |
-| `files`       | `create`, `update` and `delete`    | Optional |
-| `folders`     | `create`, `update` and `delete`    | Optional |
-| `permissions` | `create`, `update` and `delete`    | Optional |
-| `presets`     | `create`, `update` and `delete`    | Optional |
-| `relations`   | `create`, `update` and `delete`    | Optional |
-| `revisions`   | `create`, `update` and `delete`    | Optional |
-| `roles`       | `create`, `update` and `delete`    | Optional |
-| `settings`    | `create`, `update` and `delete`    | Optional |
-| `users`       | `create`, `update` and `delete`    | Optional |
-| `webhooks`    | `create`, `update` and `delete`    | Optional |
-| `response`    |                                    | No†      |
-| `auth`        | `success`†, `fail`† and `refresh`† | No       |
-| `init`        |                                    | Optional |
-| `server`      | `start` and `stop`                 | Optional |
+| Scope                | Actions                            | Before   |
+| -------------------- | ---------------------------------- | -------- |
+| `server`             | `start` and `stop`                 | Optional |
+| `init`               |                                    | Optional |
+| `routes.init`        | `before` and `after`               | No       |
+| `routes.custom.init` | `before` and `after`               | No       |
+| `middlewares.init`   | `before` and `after`               | No       |
+| `request`            | `not_found`                        | No       |
+| `response`           |                                    | No†      |
+| `items`              | `create`, `update` and `delete`    | Optional |
+| `auth`               | `success`†, `fail`† and `refresh`† | No       |
+| `activity`           | `create`, `update` and `delete`    | Optional |
+| `collections`        | `create`, `update` and `delete`    | Optional |
+| `fields`             | `create`, `update` and `delete`    | Optional |
+| `files`              | `create`, `update` and `delete`    | Optional |
+| `folders`            | `create`, `update` and `delete`    | Optional |
+| `permissions`        | `create`, `update` and `delete`    | Optional |
+| `presets`            | `create`, `update` and `delete`    | Optional |
+| `relations`          | `create`, `update` and `delete`    | Optional |
+| `revisions`          | `create`, `update` and `delete`    | Optional |
+| `roles`              | `create`, `update` and `delete`    | Optional |
+| `settings`           | `create`, `update` and `delete`    | Optional |
+| `users`              | `create`, `update` and `delete`    | Optional |
+| `webhooks`           | `create`, `update` and `delete`    | Optional |
 
 † TBD
 


### PR DESCRIPTION
This allows for better control over the application lifecycle, also fixes some issues with the initialization process like `init.before` triggering after app has been initialized.

## Old initialization process

- Validate database connection
- Create express application
- Register Directus middlewares
- Register Directus routes
- Ensure extension folders
- Register extension hooks
- Register all extension routes
- Emit `init.before`
- Emit `init`

## New initialization process

- Validate database connection
- Ensure extension folders
- Register extension hooks
- Create express application
- Emit `init.before`
- Emit `middlewares.init.before`
- Register Directus middlewares
- Emit `middlewares.init.after`
- Emit `routes.init.before`
- Register Directus routes
- Emit `routes.custom.init.before`
- Register all extension routes
- Emit `routes.custom.init.after`
- Emit `routes.init.after`
- Emit `init`
