### PR TITLE
Fix empty saved page after change

### DIFF
--- a/app/src/composables/use-items/use-items.ts
+++ b/app/src/composables/use-items/use-items.ts
@@ -95,7 +95,7 @@ export function useItems(collection: Ref<string>, query: Query) {
 		if (!before || isEqual(after, before)) {
 			return;
 		}
-
+		page.value = 1;
 		await Vue.nextTick();
 		if (loading.value === false) {
 			getItems();
@@ -178,6 +178,10 @@ export function useItems(collection: Ref<string>, query: Query) {
 
 			items.value = fetchedItems;
 			itemCount.value = response.data.data.length;
+
+			if (fetchedItems.length === 0 && page.value !== 1) {
+				page.value = 1;
+			}
 
 			if (response.data.data.length === limit.value || page.value > 1) {
 				getItemCount();


### PR DESCRIPTION
There could be two cases when the loaded page no longer exists

- there are less items compared to when the page was saved
- the search or filters were changed

In both cases the page should be reset  to 1

Relates to #3644