### PR TITLE
fix: mode not correctly set in refresh handler

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -99,7 +99,7 @@ router.post(
 			throw new InvalidPayloadException(`"refresh_token" is required in either the JSON payload or Cookie`);
 		}
 
-		const mode: 'json' | 'cookie' = req.body.mode || req.body.refresh_token ? 'json' : 'cookie';
+		const mode: 'json' | 'cookie' = req.body.mode || (req.body.refresh_token ? 'json' : 'cookie');
 
 		const { accessToken, refreshToken, expires } = await authenticationService.refresh(currentRefreshToken);
 


### PR DESCRIPTION
When a refresh request with `mode: 'cookie'` is handled, the current logic checks if either `req.body.mode` or `req.body.refresh_token` is defined in the request body and sets the mode to 'json', even if it's defined as 'cookie' in the request body.
This is a bug that causes refresh responses not to set the new refresh token via set-cookie header.
Adding simple parenthesis fixes this problem.