### PR TITLE
Add option to specify .env filename in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 .vscode
 .env
+.env.*
 .secrets
 npm-debug.log
 lerna-debug.log

--- a/api/package.json
+++ b/api/package.json
@@ -53,7 +53,7 @@
 	"scripts": {
 		"start": "npx directus start",
 		"build": "rimraf dist && tsc --build && copyfiles \"src/**/*.*\" -e \"src/**/*.ts\" -u 1 dist",
-		"dev": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node-dev --inspect --files --transpile-only --respawn --watch \".env\" src/start.ts",
+		"dev": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect --require dotenv/config src/start.ts",
 		"cli": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node --script-mode --transpile-only src/cli/index.ts",
 		"lint": "eslint \"src/**/*.ts\" cli.js index.js",
 		"prepublishOnly": "npm run build",


### PR DESCRIPTION
When required from the command line, dotenv loads the .env file specified by the DOTENV_CONFIG_PATH env var.

Files with a filename pattern of the form .env.* are ignored by git to make it easier to work with multiple different database vendors.