### PR TITLE
Revert "Fix building on Node v10"

### DIFF
--- a/packages/format-title/rollup.config.js
+++ b/packages/format-title/rollup.config.js
@@ -44,7 +44,7 @@ function createConfig({
 	target,
 	mode,
 	browser = false,
-	external = Object.assign(...Object.keys(pkg.dependencies || {}).map((k) => ({ [k]: k }))),
+	external = Object.fromEntries(Object.keys(pkg.dependencies || {}).map((x) => [x, x])),
 }) {
 	const isProduction = mode === 'production';
 

--- a/packages/sdk-js/rollup.config.js
+++ b/packages/sdk-js/rollup.config.js
@@ -45,7 +45,7 @@ function createConfig({
 	target,
 	mode,
 	browser = false,
-	external = Object.assign(...Object.keys(pkg.dependencies || {}).map((k) => ({ [k]: k }))),
+	external = Object.fromEntries(Object.keys(pkg.dependencies || {}).map((x) => [x, x])),
 }) {
 	const isProduction = mode === 'production';
 


### PR DESCRIPTION
Reverts directus/directus#3697

It broke the build:

```
!] TypeError: Cannot convert undefined or null to object
TypeError: Cannot convert undefined or null to object
    at Function.assign (<anonymous>)
    at createConfig (/Users/Rijk/Sites/directus/next/packages/format-title/rollup.config.js:59:20)
```