### PR TITLE
Fix wrong number casting in query

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -51,7 +51,8 @@ export default async function applyQuery(
 					if (['text', 'string'].includes(column.localType)) {
 						this.orWhereRaw(`LOWER(??) LIKE ?`, [column.column_name, `%${query.search!.toLowerCase()}%`]);
 					} else if (['bigInteger', 'integer', 'decimal', 'float'].includes(column.localType)) {
-						this.orWhere({ [column.column_name]: Number(query.search!) });
+						const number = Number(query.search!);
+						if (!isNaN(number)) this.orWhere({ [column.column_name]: number });
 					} else if (column.localType === 'uuid' && validate(query.search!)) {
 						this.orWhere({ [column.column_name]: query.search! });
 					}


### PR DESCRIPTION
The search broke with that commit, due to an invalid cast: https://github.com/directus/directus/commit/8e3151d34feeb4e7bbeb270683d9400bd570b139

I just added a check to validate that the search query can indeed be casted to a number.
Fixes https://github.com/directus/directus/issues/3731.