### PR TITLE
Docs: Close open ports in docker-compose for security improvement

### DIFF
--- a/docs/guides/installation/docker.md
+++ b/docs/guides/installation/docker.md
@@ -57,6 +57,7 @@ services:
       - directus
 
   directus:
+    container_name: directus
     image: directus/directus:v9.0.0-rc.24
     ports:
       - 8055:8055

--- a/docs/guides/installation/docker.md
+++ b/docs/guides/installation/docker.md
@@ -39,24 +39,22 @@ When using Docker compose, you can use the following setup to get you started:
 version: '3.2'
 services:
   database:
+    container_name: database
     image: postgres:12
     volumes:
       - ./data/database:/var/lib/postgresql/data
     networks:
       - directus
-    ports:
-      - 5432:5432
     environment:
       POSTGRES_USER: 'directus'
       POSTGRES_PASSWORD: 'directus'
       POSTGRES_DB: 'directus'
 
   cache:
+    container_name: cache
     image: redis:6
     networks:
       - directus
-    ports:
-      - 6379:6379
 
   directus:
     image: directus/directus:v9.0.0-rc.24
@@ -64,6 +62,9 @@ services:
       - 8055:8055
     networks:
       - directus
+    depends_on:
+      - cache
+      - database
     environment:
       KEY: '255d861b-5ea1-5996-9aa3-922530ec40b1'
       SECRET: '6116487b-cda1-52c2-b5b5-c8022c45e263'


### PR DESCRIPTION
- Ports are not required here, as all three containers share the same 'directus' network. They can communicate with each other internally. Opening the ports only exposes the database and cache to the world (the internet) unnecessarily, posing more of a security issue. 

- 'Container name:' ensures that the container adopts that specific name. While by default the container will start with the name specified at the top of each container section (i.e. directus, cache, database), if one of those names is occupied it risks reverting to an alternative, which will have networking implications as those specific hostnames are sought from the other containers. With 'container name:' set, it will return an error that the container name is in use. Adopting here the 'explicit is better than implicit' approach. 

- 'Depends on:' as the name suggests, ensures that the database and cache are up and running before Directus starts.