### PR TITLE
Add 'skipAuthChecks' param to 'authenticate' method

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -258,9 +258,12 @@ router.get(
 
 		req.session?.destroy(() => {});
 
-		const { accessToken, refreshToken, expires } = await authenticationService.authenticate({
-			email,
-		});
+		const { accessToken, refreshToken, expires } = await authenticationService.authenticate(
+			{
+				email,
+			},
+			true
+		);
 
 		if (redirect) {
 			res.cookie('directus_refresh_token', refreshToken, {


### PR DESCRIPTION
This PR adds a `skipAuthChecks` parameter to the `authenticate` method of the `AuthenticationService` class, this helps when developing custom endpoints and fixes a probable issue on the `/oauth/:provider/callback` endpoint.

I added this parameter (which defaults to `false`) because reading the previous comment on the `authenticate` method it seemed to be possibile to pass an `undefined` value for the `password` field and still have tokens returned but trying to do so from a custom endpoint yielded an `InvalidCredentialsException` error.

The original comment for the `authenticate` method:

>  Retrieve the tokens for a given user email.
>  
>  Password is optional to allow usage of this function within the SSO flow and extensions. Make sure
> to handle password existence checks elsewhere

but because of the following lines it wasn't working as expected

```ts
if (!password || !user.password) {
  throw new InvalidCredentialsException();
}

if (password !== undefined && (await argon2.verify(user.password, password)) === false) {
  throw new InvalidCredentialsException();
}
```