### PR TITLE
Namespace system collections in GraphQL queries

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -90,7 +90,7 @@ export class GraphQLService {
 
 	getGraphQLSchema(collections: Collection[], fields: Field[], relations: Relation[]) {
 		const filterTypes = this.getFilterArgs(collections, fields, relations);
-		const schema: any = { items: {} };
+		const schema: any = { items: {}, directus: {} };
 
 		for (const collection of collections) {
 			const systemCollection = collection.collection.startsWith('directus_');
@@ -122,7 +122,7 @@ export class GraphQLService {
 									const relatedIsSystem = relationForField.one_collection!.startsWith('directus_');
 
 									const relatedType = relatedIsSystem
-										? schema[relationForField.one_collection!.substring(9)].type
+										? schema.directus[relationForField.one_collection!.substring(9)].type
 										: schema.items[relationForField.one_collection!].type;
 
 									fieldsObject[field.field] = {
@@ -132,7 +132,7 @@ export class GraphQLService {
 									const relatedIsSystem = relationForField.many_collection.startsWith('directus_');
 
 									const relatedType = relatedIsSystem
-										? schema[relationForField.many_collection.substring(9)].type
+										? schema.directus[relationForField.many_collection.substring(9)].type
 										: schema.items[relationForField.many_collection].type;
 
 									fieldsObject[field.field] = {
@@ -151,7 +151,7 @@ export class GraphQLService {
 
 									for (const relatedCollection of relatedCollections) {
 										const relatedType = relatedCollection.startsWith('directus_')
-											? schema[relatedCollection.substring(9)].type
+											? schema.directus[relatedCollection.substring(9)].type
 											: schema.items[relatedCollection].type;
 
 										types.push(relatedType);
@@ -196,7 +196,7 @@ export class GraphQLService {
 			};
 
 			if (systemCollection) {
-				schema[collection.collection.substring(9)] = schemaSection;
+				schema.directus[collection.collection.substring(9)] = schemaSection;
 			} else {
 				schema.items[collection.collection] = schemaSection;
 			}
@@ -209,8 +209,8 @@ export class GraphQLService {
 				const systemCollection = collection.collection.startsWith('directus_');
 
 				if (systemCollection) {
-					schemaWithLists[collection.collection.substring(9)].type = new GraphQLList(
-						schemaWithLists[collection.collection.substring(9)].type
+					schemaWithLists.directus[collection.collection.substring(9)].type = new GraphQLList(
+						schemaWithLists.directus[collection.collection.substring(9)].type
 					);
 				} else {
 					schemaWithLists.items[collection.collection].type = new GraphQLList(
@@ -243,6 +243,16 @@ export class GraphQLService {
 				type: new GraphQLObjectType({
 					name: 'items',
 					fields: schemaWithLists.items,
+				}),
+				resolve: () => ({}),
+			};
+		}
+
+		if (Object.keys(schemaWithLists.directus).length > 0) {
+			queryBase.fields.items = {
+				type: new GraphQLObjectType({
+					name: 'directus',
+					fields: schemaWithLists.directus,
 				}),
 				resolve: () => ({}),
 			};


### PR DESCRIPTION
I wasn't able to access `directus_*` collections (or "system collections") in a GraphQL query like this:
```gql
{
  items {
    directus_files {
      id,
      filename_disk,
      tags
    }
  }
}
```
I looked in the code, finding in [`api/src/services/graphql.ts`](https://github.com/juniorRubyist/directus/blob/main/api/src/services/graphql.ts#L198-L203) that they were namespaced in the root of the query (i.e. not under `items` or etc.), without the `directus_*` prefix. After learning that, I tried a query similar to this, but to no avail:
```gql
{
  # Querying directus_files
  files {
    id,
    filename_disk,
    tags
  }
}
```
This change will move all of the `directus_*` collections to be namespaced under `directus` in GraphQL queries (like custom collections are under `items`) so a query like this will be possible:
```gql
{
  # Querying directus_files
  directus {
    files {
      id,
      filename_disk,
      tags
    }
  }
}
```
I brought up this issue on the [Discord](https://discord.com/channels/725371605378924594/725817819882586132/804407589563662356), and didn't really get a solution so I figured it out myself, and I would appreciate any feedback on this. Also, I have tested this on my own local installation as well, and it did work as intended.