### PR TITLE
Update Auth docs details about SSO/OAuth endpoints

### DIFF
--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -89,10 +89,10 @@ paths:
     $ref: "./paths/auth/password-request.yaml"
   /auth/password/reset:
     $ref: "./paths/auth/password-reset.yaml"
-  /auth/sso:
-    $ref: "./paths/auth/sso.yaml"
-  /auth/sso/{provider}:
-    $ref: "./paths/auth/sso-provider.yaml"
+  /auth/oauth:
+    $ref: "./paths/auth/oauth.yaml"
+  /auth/oauth/{provider}:
+    $ref: "./paths/auth/oauth-provider.yaml"
 
   # Items
   /items/{collection}:

--- a/packages/specs/src/paths/auth/oauth-provider.yaml
+++ b/packages/specs/src/paths/auth/oauth-provider.yaml
@@ -1,21 +1,20 @@
 get:
-  summary: List SSO providers
-  description: List the SSO providers.
+  summary: Authenticated using an OAuth provider
+  description: Start OAuth flow using the specified provider
   tags:
     - Authentication
-  operationId: ssoProvider
+  operationId: oauthProvider
   parameters:
     - name: provider
       in: path
-      description: Key of the activated SSO provider.
+      description: Key of the activated OAuth provider.
       required: true
       schema:
         type: string
-    - $ref: "../../openapi.yaml#/components/parameters/Mode"
-    - name: redirect_url
+    - name: redirect
       in: query
-      required: true
-      description: Where to redirect on successful login.
+      required: false
+      description: Where to redirect on successful login.<br/>If set the authentication details are set inside cookies otherwise a JSON is returned.
       schema:
         type: string
   responses:

--- a/packages/specs/src/paths/auth/oauth.yaml
+++ b/packages/specs/src/paths/auth/oauth.yaml
@@ -1,9 +1,9 @@
 get:
   tags:
     - Authentication
-  operationId: sso
-  summary: List SSO Providers
-  description: List the SSO providers.
+  operationId: oauth
+  summary: List OAuth Providers
+  description: List configured OAuth providers.
   responses:
     "200":
       description: Successful request


### PR DESCRIPTION
This PR updates the docs related to the old `SSO`endpoints (now migrated to the `oauth` ones) as reported by @metalmarco on Discord

> Metalmarco 01/29/2021
> Is the GET /auth/sso/{provider} endpoint working?
> Metalmarco 01/29/2021
> nevermind, the docs was outdated. The correct endpoint is /auth/oauth

[Discord message](https://discord.com/channels/725371605378924594/741330910594465823/804666679908368405)