### PR TITLE
Add system collections to GraphQL schema

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -255,6 +255,14 @@ export class GraphQLService {
 			},
 		};
 
+		if (Object.keys(schemaWithLists).length > 0) {
+			for (const key of Object.keys(schemaWithLists)) {
+				if (key !== 'items') {
+					queryBase.fields[key] = schemaWithLists[key];
+				}
+			}
+		}
+
 		if (Object.keys(schemaWithLists.items).length > 0) {
 			queryBase.fields.items = {
 				type: new GraphQLObjectType({


### PR DESCRIPTION
Follow-up to #3849

I scrapped my previous changes and added some bits that add system collections to the base of the schema.

So far, this works for the schema, but now I am facing this error when I query one of the system collections:
```
Cannot destructure property 'collection' of 'collectionsRequested.find(...)' as it is undefined.
```