### PR TITLE
Fix default value for refresh and access token

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -40,8 +40,8 @@ database instance.
 | -------------------------------- | ------------------------------------------------------------------------------------------------ | ------------- |
 | `KEY`                            | Unique identifier for the project.                                                               | --            |
 | `SECRET`                         | Secret string for the project.                                                                   | --            |
-| `ACCESS_TOKEN_TTL`               | The duration that the access token is valid.                                                     | 7d            |
-| `REFRESH_TOKEN_TTL`              | The duration that the refresh token is valid, and also how long users stay logged-in to the App. | 15m           |
+| `ACCESS_TOKEN_TTL`               | The duration that the access token is valid.                                                     | 15m           |
+| `REFRESH_TOKEN_TTL`              | The duration that the refresh token is valid, and also how long users stay logged-in to the App. | 7d            |
 | `REFRESH_TOKEN_COOKIE_SECURE`    | Whether or not to use a secure cookie for the refresh token in cookie mode.                      | `false`       |
 | `REFRESH_TOKEN_COOKIE_SAME_SITE` | Value for `sameSite` in the refresh token cookie when in cookie mode.                            | `lax`         |
 


### PR DESCRIPTION
The default values for refresh token TTL and access token TTL were swapped. This PR fixes the issue 