### PR TITLE
Add support for account creation through SSO provider

### DIFF
--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -175,4 +175,9 @@ export class UsersService extends ItemsService {
 	async disableTFA(pk: string) {
 		await this.knex('directus_users').update({ tfa_secret: null }).where({ id: pk });
 	}
+
+	async emailHasAccount(email: string) {
+		const user = await this.knex('directus_users').where({ email }).first();
+		return !!user;
+	}
 }

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -430,7 +430,7 @@ divider: Divider
 color: Color
 circle: Circle
 empty_item: Empty Item
-log_in_with: 'Log In with {provider}'
+continue_with: 'Continue with {provider}'
 advanced_filter: Advanced Filter
 delete_advanced_filter: Delete Filter
 change_advanced_filter_operator: Change Operator

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -4,7 +4,7 @@
 			<v-divider />
 
 			<a class="sso-link" v-for="provider in providers" :key="provider.name" :href="provider.link">
-				{{ $t('log_in_with', { provider: provider.name }) }}
+				{{ $t('continue_with', { provider: provider.name }) }}
 			</a>
 		</template>
 	</div>


### PR DESCRIPTION
Basically exactly what @benhaynes mentioned [here](https://github.com/directus/v8-archive/issues/664#issuecomment-445570679).

If a user tries to authenticate through an SSO provider for the first time, directus will create a new account for them if both of the following are true...
1. There isn't already a record in the `dierctus_users` table with matching email
2. Their email address is on a domain whitelist that is configurable through the `OAUTH_USER_CREATION_DOMAIN_WHITELIST ` environment variable

I haven't added any tests or docs yet, but I'm happy to if ya'll think this approach works and are open to accepting the PR. This would be a super helpful feature for a relatively large company like ours that wants to use Directus 🙏