### PR TITLE
Fix datetime when timestamp field type

### DIFF
--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -136,7 +136,7 @@ export default defineComponent({
 					if (newValue === null) return emit('input', null);
 
 					if (props.type === 'timestamp') {
-						emit('input', formatISO(newValue));
+						emit('input', format(newValue, 'yyyy-MM-dd HH:mm:ss'));
 					} else if (props.type === 'dateTime') {
 						emit('input', format(newValue, "yyyy-MM-dd'T'HH:mm:ss"));
 					} else if (props.type === 'date') {


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/3655

According to the mysql docs (https://dev.mysql.com/doc/refman/5.7/en/datetime.html) the format should be  'YYYY-MM-DD hh:mm:ss[.fraction]'

