### PR TITLE
Check if array is empty before inserting into database

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -152,7 +152,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					delta: JSON.stringify(payloads[index]),
 				}));
 
-				await trx.insert(revisionRecords).into('directus_revisions');
+				if (revisionRecords.length > 0) {
+					await trx.insert(revisionRecords).into('directus_revisions');
+				}
 			}
 
 			if (cache && env.CACHE_AUTO_PURGE) {
@@ -350,7 +352,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 						delta: JSON.stringify(payloadWithoutAliases),
 					}));
 
-					await trx.insert(revisionRecords).into('directus_revisions');
+					if (revisionRecords.length > 0) {
+						await trx.insert(revisionRecords).into('directus_revisions');
+					}
 				}
 			});
 
@@ -485,7 +489,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					item: key,
 				}));
 
-				await trx.insert(activityRecords).into('directus_activity');
+				if (activityRecords.length > 0) {
+					await trx.insert(activityRecords).into('directus_activity');
+				}
 			}
 		});
 


### PR DESCRIPTION
In the process of creating a m2m entry, `updateByQuery()` gets called with a query that has no results. As a result, `trx.insert(revisionRecords)` gets called with `revisionRecords` being an empty array, which fails for some of the database vendors like SQLite and presumably also OracleDB but doesn't for the others.
I will harmonize this in Knex, but the check shouldn't hurt anyway.

Edit: I am not sure if `update()` should do anything with the payload even if the query result is empty, though.

Fixes #2945, fixes #2949