### PR TITLE
Fix input padding

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -281,7 +281,7 @@ body {
 		flex-grow: 1;
 		align-items: center;
 		height: 100%;
-		padding: var(--input-padding);
+		padding: 0 var(--input-padding);
 		color: var(--v-input-color);
 		font-family: var(--v-input-font-family);
 		background-color: var(--background-page);
@@ -361,6 +361,7 @@ body {
 		flex-grow: 1;
 		width: 20px; // allows flex to grow/shrink to allow for slots
 		height: 100%;
+		padding: var(--input-padding) 0;
 		font-family: var(--v-input-font-family);
 		background-color: transparent;
 		border: none;


### PR DESCRIPTION
Small tweak to the input padding to make the "selection area" a little bigger when clicking on the inputs.

#### Before: 
![before](https://user-images.githubusercontent.com/14101189/107731494-211ef980-6cc4-11eb-8eb6-db012b20ed20.gif)

#### After: 
![after](https://user-images.githubusercontent.com/14101189/107731502-27ad7100-6cc4-11eb-9364-7a2c8f3f2c89.gif)
