### PR TITLE
Create instead of triggers for mssql for foreign key actions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"fs-extra": "^9.0.1",
 		"highlight.js": "^10.3.2",
 		"html-loader": "^1.1.0",
-		"husky": "^4.2.5",
+		"husky": "^4.3.8",
 		"joi": "^17.3.0",
 		"jsonlint": "^1.6.3",
 		"jsonlint-mod": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"fs-extra": "^9.0.1",
 		"highlight.js": "^10.3.2",
 		"html-loader": "^1.1.0",
-		"husky": "^4.3.8",
+		"husky": "^4.2.5",
 		"joi": "^17.3.0",
 		"jsonlint": "^1.6.3",
 		"jsonlint-mod": "^1.7.6",


### PR DESCRIPTION
MS SQL Server is very restrictive when applying ON UPDATE ... an ON DELETE ... actions on foreign keys. In many cases, it complains that these actions cause cycles or multiple cascade paths. This happened when running the directus cli with mssql.

This PR is a continuation of the work done in PR #3498 but specifically focused on fixing the multiple cascade paths issue by implementing instead of delete triggers and setting ON UPDATE NO ACTION and ON DELETE NO ACTION.

The PR fixes issue #3158.

Note: I did not create a trigger to replace update actions (ON UPDATE CASCADE) because I think directus doesn't update primary key values of exisiting records, right?