### PR TITLE
m2o fix corresponding type not set

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
@@ -163,6 +163,7 @@ export default defineComponent({
 		function useCorresponding() {
 			const hasCorresponding = computed({
 				get() {
+					console.log(state);
 					return state.newFields.length > 0;
 				},
 				set(enabled: boolean) {
@@ -171,6 +172,7 @@ export default defineComponent({
 
 						state.newFields.push({
 							$type: 'corresponding',
+							type: null,
 							field: state.relations[0].one_field,
 							collection: state.relations[0].one_collection,
 							meta: {

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
@@ -163,7 +163,6 @@ export default defineComponent({
 		function useCorresponding() {
 			const hasCorresponding = computed({
 				get() {
-					console.log(state);
 					return state.newFields.length > 0;
 				},
 				set(enabled: boolean) {


### PR DESCRIPTION
The server threw an error because the type of a field wasn't set when creating a corresponding field of a m2o relation.