### PR TITLE
Update example for endpoints to pass error to next

### DIFF
--- a/docs/guides/api-endpoints.md
+++ b/docs/guides/api-endpoints.md
@@ -57,14 +57,14 @@ module.exports = function registerEndpoint(router, { services, exceptions }) {
 	const { ItemsService } = services;
 	const { ServiceUnavailableException } = exceptions;
 
-	router.get('/', (req, res) => {
+	router.get('/', (req, res, next) => {
 		const recipeService = new ItemsService('recipes', { schema: req.schema, accountability: req.accountability });
 
 		recipeService
 			.readByQuery({ sort: 'name', fields: ['*'] })
 			.then((results) => res.json(results))
 			.catch((error) => {
-				throw new ServiceUnavailableException(error.message);
+				return next(new ServiceUnavailableException(error.message));
 			});
 	});
 };


### PR DESCRIPTION
As per discussion [here](https://github.com/directus/directus/discussions/4096), current example doesn't pass error to `next`.