### PR TITLE
Remove dependency on one_primary and many_primary

### DIFF
--- a/api/src/database/seeds/10-relations.yaml
+++ b/api/src/database/seeds/10-relations.yaml
@@ -14,10 +14,6 @@ columns:
     type: string
     length: 64
     nullable: false
-  many_primary:
-    type: string
-    length: 64
-    nullable: false
   one_collection:
     type: string
     length: 64
@@ -25,9 +21,6 @@ columns:
       table: directus_collections
       column: collection
   one_field:
-    type: string
-    length: 64
-  one_primary:
     type: string
     length: 64
   one_collection_field:

--- a/api/src/database/system-data/fields/relations.yaml
+++ b/api/src/database/system-data/fields/relations.yaml
@@ -10,16 +10,10 @@ fields:
   - field: many_field
     width: half
 
-  - field: many_primary
-    width: half
-
   - field: one_collection
     width: half
 
   - field: one_field
-    width: half
-
-  - field: one_primary
     width: half
 
   - field: one_collection_field

--- a/api/src/database/system-data/relations/relations.yaml
+++ b/api/src/database/system-data/relations/relations.yaml
@@ -3,78 +3,50 @@ table: directus_relations
 defaults:
   many_collection: directus_users
   many_field: null
-  many_primary: null
   one_collection: null
   one_field: null
-  one_primary: null
   junction_field: null
 
 data:
   - many_collection: directus_users
     many_field: role
-    many_primary: id
     one_collection: directus_roles
     one_field: users
-    one_primary: id
   - many_collection: directus_users
     many_field: avatar
-    many_primary: id
     one_collection: directus_files
-    one_primary: id
   - many_collection: directus_revisions
     many_field: activity
-    many_primary: id
     one_collection: directus_activity
     one_field: revisions
-    one_primary: id
   - many_collection: directus_presets
     many_field: user
-    many_primary: id
     one_collection: directus_users
-    one_primary: id
   - many_collection: directus_presets
     many_field: role
-    many_primary: id
     one_collection: directus_roles
-    one_primary: id
   - many_collection: directus_folders
     many_field: parent
-    many_primary: id
     one_collection: directus_folders
-    one_primary: id
   - many_collection: directus_files
     many_field: folder
-    many_primary: id
     one_collection: directus_folders
-    one_primary: id
   - many_collection: directus_files
     many_field: uploaded_by
-    many_primary: id
     one_collection: directus_users
-    one_primary: id
   - many_collection: directus_fields
     many_field: collection
-    many_primary: id
     one_collection: directus_collections
     one_field: fields
-    one_primary: collection
   - many_collection: directus_activity
     many_field: user
-    many_primary: id
     one_collection: directus_users
-    one_primary: id
   - many_collection: directus_settings
     many_field: project_logo
-    many_primary: id
     one_collection: directus_files
-    one_primary: id
   - many_collection: directus_settings
     many_field: public_foreground
-    many_primary: id
     one_collection: directus_files
-    one_primary: id
   - many_collection: directus_settings
     many_field: public_background
-    many_primary: id
     one_collection: directus_files
-    one_primary: id

--- a/api/src/types/relation.ts
+++ b/api/src/types/relation.ts
@@ -3,11 +3,9 @@ export type Relation = {
 
 	many_collection: string;
 	many_field: string;
-	many_primary: string;
 
 	one_collection: string | null;
 	one_field: string | null;
-	one_primary: string | null;
 
 	one_collection_field: string | null;
 	one_allowed_collections: string | null;

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -90,12 +90,12 @@ export function applyFilter(schema: SchemaOverview, rootQuery: QueryBuilder, roo
 					dbQuery.leftJoin(
 						{ [alias]: relation.one_collection! },
 						`${parentAlias || parentCollection}.${relation.many_field}`,
-						`${alias}.${relation.one_primary}`
+						`${alias}.${schema.tables[relation.one_collection!].primary}`
 					);
 				} else {
 					dbQuery.leftJoin(
 						{ [alias]: relation.many_collection },
-						`${parentAlias || parentCollection}.${relation.one_primary}`,
+						`${parentAlias || parentCollection}.${schema.tables[relation.one_collection!].primary}`,
 						`${alias}.${relation.many_field}`
 					);
 				}

--- a/app/src/interfaces/m2a-builder/m2a-builder.vue
+++ b/app/src/interfaces/m2a-builder/m2a-builder.vue
@@ -253,10 +253,14 @@ export default defineComponent({
 				// related values
 				const values = cloneDeep(props.value || [])
 					.map((val, index) => {
-						const junctionKey = isPlainObject(val) ? val[o2mRelation.value.many_primary] : val;
+						const junctionKey = isPlainObject(val)
+							? val[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)]
+							: val;
 
 						const savedValues = junctionRowMap.value.find(
-							(junctionRow) => junctionRow[o2mRelation.value.many_primary] === junctionKey
+							(junctionRow) =>
+								junctionRow[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)] ===
+								junctionKey
 						);
 
 						if (isPlainObject(val)) {
@@ -348,7 +352,9 @@ export default defineComponent({
 						// There's a case where you sort with no other changes where the one_collection_field doesn't exist
 						// and there's no further changes nested in the many field
 						else if (anyRelation.value.one_collection_field! in stagedValue === false) {
-							junctionRowsToInspect.push(stagedValue[o2mRelation.value.many_primary]);
+							junctionRowsToInspect.push(
+								stagedValue[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)]
+							);
 						}
 
 						// Otherwise, it's an object with the edits on an existing item, or a newly added item
@@ -377,12 +383,12 @@ export default defineComponent({
 						const junctionInfoResponse = await api.get(`/items/${o2mRelation.value.many_collection}`, {
 							params: {
 								filter: {
-									[o2mRelation.value.many_primary]: {
+									[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)]: {
 										_in: junctionRowsToInspect,
 									},
 								},
 								fields: [
-									o2mRelation.value.many_primary,
+									fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection),
 									anyRelation.value.many_field,
 									anyRelation.value.one_collection_field!,
 									props.sortField,
@@ -512,7 +518,7 @@ export default defineComponent({
 			function editExisting(item: Record<string, any>) {
 				if (typeof item === 'string' || typeof item === 'number') {
 					const junctionRow = junctionRowMap.value.find((row) => {
-						return row[o2mRelation.value.many_primary] == item;
+						return row[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)] == item;
 					});
 
 					const collection = junctionRow[anyRelation.value.one_collection_field!];
@@ -521,7 +527,7 @@ export default defineComponent({
 						: junctionRow[anyRelation.value.many_field];
 
 					editsAtStart.value = {
-						[o2mRelation.value.many_primary]: item,
+						[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)]: item,
 						[anyRelation.value.one_collection_field!]: collection,
 						[anyRelation.value.many_field]: {
 							[primaryKeys.value[collection]]: relatedKey,
@@ -533,7 +539,7 @@ export default defineComponent({
 					return;
 				}
 
-				const junctionPrimaryKey = item[o2mRelation.value.many_primary];
+				const junctionPrimaryKey = item[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)];
 				const relatedCollectiom = item[anyRelation.value.one_collection_field!];
 				let relatedKey = item[anyRelation.value.many_field];
 
@@ -576,7 +582,7 @@ export default defineComponent({
 							};
 						} else {
 							return {
-								[o2mRelation.value.many_primary]: rawValue,
+								[fieldsStore.getPrimaryKeyFieldForCollection(o2mRelation.value.many_collection)]: rawValue,
 								[props.sortField]: sortedItemIndex + 1,
 							};
 						}

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType, computed, ref, watch } from '@vue/composition-api';
-import { useRelationsStore } from '@/stores/';
+import { useFieldsStore, useRelationsStore } from '@/stores/';
 import api from '@/api';
 import { Relation } from '@/types';
 import getFieldsFromTemplate from '@/utils/get-fields-from-template';
@@ -64,6 +64,7 @@ export default defineComponent({
 	},
 	setup(props, { emit }) {
 		const relationsStore = useRelationsStore();
+		const fieldsStore = useFieldsStore();
 
 		const {
 			relationsForField,
@@ -76,7 +77,7 @@ export default defineComponent({
 			translationsLanguageField,
 		} = useRelations();
 
-		const { languages, loading: languagesLoading, error: languagesError, template: languagesTemplate } = useLanguages();
+		const { languages, loading: languagesLoading, template: languagesTemplate } = useLanguages();
 
 		const { startEditing, editing, edits, stageEdits, cancelEdit } = useEdits();
 
@@ -119,7 +120,7 @@ export default defineComponent({
 
 			const translationsPrimaryKeyField = computed(() => {
 				if (!translationsRelation.value) return null;
-				return translationsRelation.value.many_primary;
+				return fieldsStore.getPrimaryKeyForCollection(translationsRelation.value.many_collection);
 			});
 
 			const languagesRelation = computed(() => {
@@ -134,7 +135,7 @@ export default defineComponent({
 
 			const languagesPrimaryKeyField = computed(() => {
 				if (!languagesRelation.value) return null;
-				return languagesRelation.value.one_primary;
+				return fieldsStore.getPrimaryKeyForCollection(translationsRelation.value.one_collection);
 			});
 
 			const translationsLanguageField = computed(() => {

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -286,8 +286,7 @@ export default defineComponent({
 						state.relations.length === 0 ||
 						isEmpty(state.relations[0].many_collection) ||
 						isEmpty(state.relations[0].many_field) ||
-						isEmpty(state.relations[0].one_collection) ||
-						isEmpty(state.relations[0].one_primary)
+						isEmpty(state.relations[0].one_collection)
 					);
 				}
 
@@ -299,8 +298,7 @@ export default defineComponent({
 						isEmpty(state.relations[0].one_field) ||
 						isEmpty(state.relations[1].many_collection) ||
 						isEmpty(state.relations[1].many_field) ||
-						isEmpty(state.relations[1].one_collection) ||
-						isEmpty(state.relations[1].one_primary)
+						isEmpty(state.relations[1].one_collection)
 					);
 				}
 

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -137,9 +137,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				{
 					many_collection: collection,
 					many_field: '',
-					many_primary: fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field,
 					one_collection: 'directus_files',
-					one_primary: fieldsStore.getPrimaryKeyFieldForCollection('directus_files')?.field,
 				},
 			];
 		}
@@ -164,7 +162,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 						collection: collectionName,
 						fields: [
 							{
-								field: state.relations[0].one_primary,
+								field: 'id',
 								type: 'integer',
 								schema: {
 									has_auto_increment: true,
@@ -185,9 +183,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				{
 					many_collection: collection,
 					many_field: '',
-					many_primary: fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field,
 					one_collection: '',
-					one_primary: '',
 				},
 			];
 		}
@@ -207,7 +203,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				if (collectionExists(state.relations[0].one_collection)) {
 					const field = fieldsStore.getPrimaryKeyFieldForCollection(state.relations[0].one_collection);
 					state.fieldData.type = field.type;
-					state.relations[0].one_primary = field.field;
 				} else {
 					state.fieldData.type = 'integer';
 				}
@@ -224,7 +219,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 			}
 		);
 
-		watch([() => state.relations[0].one_collection, () => state.relations[0].one_primary], syncNewCollectionsM2O);
+		watch([() => state.relations[0].one_collection], syncNewCollectionsM2O);
 	}
 
 	function useO2M() {
@@ -256,8 +251,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 						],
 					},
 				];
-
-				state.relations[0].many_primary = 'id';
 			}
 
 			if (collectionExists(collectionName)) {
@@ -294,11 +287,9 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				{
 					many_collection: '',
 					many_field: '',
-					many_primary: '',
 
 					one_collection: collection,
 					one_field: state.fieldData.field,
-					one_primary: fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field,
 				},
 			];
 		}
@@ -307,17 +298,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 			() => state.fieldData.field,
 			() => {
 				state.relations[0].one_field = state.fieldData.field;
-			}
-		);
-
-		watch(
-			() => state.relations[0].many_collection,
-			() => {
-				if (collectionExists(state.relations[0].many_collection)) {
-					state.relations[0].many_primary = fieldsStore.getPrimaryKeyFieldForCollection(
-						state.relations[0].many_collection
-					).field;
-				}
 			}
 		);
 
@@ -357,9 +337,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 						},
 					],
 				});
-
-				state.relations[0].many_primary = 'id';
-				state.relations[1].many_primary = 'id';
 			}
 
 			if (fieldExists(junctionCollection, manyCurrent) === false) {
@@ -415,7 +392,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 						},
 						fields: [
 							{
-								field: state.relations[1].one_primary,
+								field: 'id',
 								type: 'string',
 								schema: {
 									is_primary_key: true,
@@ -448,7 +425,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 						collection: relatedCollection,
 						fields: [
 							{
-								field: state.relations[1].one_primary,
+								field: 'id',
 								type: 'integer',
 								schema: {
 									has_auto_increment: true,
@@ -509,32 +486,17 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				{
 					many_collection: '',
 					many_field: '',
-					many_primary: '',
 					one_collection: collection,
 					one_field: state.fieldData.field,
-					one_primary: fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field,
 				},
 				{
 					many_collection: '',
 					many_field: '',
-					many_primary: '',
 					one_collection: '',
 					one_field: null,
-					one_primary: '',
 				},
 			];
 		}
-
-		watch(
-			() => state.relations[0].many_collection,
-			() => {
-				if (collectionExists(state.relations[0].many_collection)) {
-					const pkField = fieldsStore.getPrimaryKeyFieldForCollection(state.relations[0].many_collection)?.field;
-					state.relations[0].many_primary = pkField;
-					state.relations[1].many_primary = pkField;
-				}
-			}
-		);
 
 		watch(
 			() => state.relations[0].many_field,
@@ -547,17 +509,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 			() => state.relations[1].many_field,
 			() => {
 				state.relations[0].junction_field = state.relations[1].many_field;
-			}
-		);
-
-		watch(
-			() => state.relations[1].one_collection,
-			() => {
-				if (collectionExists(state.relations[1].one_collection)) {
-					state.relations[1].one_primary = fieldsStore.getPrimaryKeyFieldForCollection(
-						state.relations[1].one_collection
-					)?.field;
-				}
 			}
 		);
 
@@ -584,7 +535,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 					state.relations[0].many_field = `${state.relations[0].one_collection}_${state.relations[0].one_primary}`;
 					state.relations[1].one_collection = state.fieldData.field;
 
-					state.relations[1].one_primary = fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field;
 					state.relations[1].many_collection = `${state.relations[0].one_collection}_${state.relations[1].one_collection}`;
 					state.relations[1].many_field = `${state.relations[1].one_collection}_${state.relations[1].one_primary}`;
 
@@ -598,7 +548,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 		if (type === 'files') {
 			Vue.nextTick(() => {
 				state.relations[1].one_collection = 'directus_files';
-				state.relations[1].one_primary = 'id';
 			});
 		}
 
@@ -610,7 +559,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				(startWatching) => {
 					if (startWatching) {
 						stop = watch(
-							[() => state.relations[1].one_collection, () => state.relations[1].one_primary],
+							[() => state.relations[1].one_collection],
 							([newRelatedCollection, newRelatedPrimary]: string[]) => {
 								if (newRelatedCollection) {
 									state.relations[0].many_collection = getAutomaticJunctionCollectionName(
@@ -651,19 +600,9 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 			);
 
 			state.relations[0].many_collection = `${collection}_translations`;
-
 			state.relations[0].many_field = `${collection}_${fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field}`;
-
 			state.relations[1].one_collection = 'languages';
-
-			if (collectionExists('languages')) {
-				state.relations[1].one_primary = fieldsStore.getPrimaryKeyFieldForCollection('languages')?.field;
-			} else {
-				state.relations[1].one_primary = 'code';
-			}
-
 			state.relations[1].many_field = `${state.relations[1].one_collection}_${state.relations[1].one_primary}`;
-
 			state.fieldData.field = 'translations';
 			state.relations[0].one_field = 'translations';
 		}
@@ -722,9 +661,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 						},
 					],
 				});
-
-				state.relations[0].many_primary = 'id';
-				state.relations[1].many_primary = 'id';
 			}
 
 			if (fieldExists(junctionCollection, manyCurrent) === false) {
@@ -776,34 +712,19 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 				{
 					many_collection: '',
 					many_field: '',
-					many_primary: '',
 					one_collection: collection,
 					one_field: state.fieldData.field,
-					one_primary: fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field,
 				},
 				{
 					many_collection: '',
 					many_field: '',
-					many_primary: '',
 					one_collection: null,
 					one_field: null,
-					one_primary: null,
 					one_allowed_collections: [],
 					one_collection_field: '',
 				},
 			];
 		}
-
-		watch(
-			() => state.relations[0].many_collection,
-			() => {
-				if (collectionExists(state.relations[0].many_collection)) {
-					const pkField = fieldsStore.getPrimaryKeyFieldForCollection(state.relations[0].many_collection)?.field;
-					state.relations[0].many_primary = pkField;
-					state.relations[1].many_primary = pkField;
-				}
-			}
-		);
 
 		watch(
 			() => state.relations[0].many_field,

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -447,9 +447,7 @@ export default defineComponent({
 				relations.push({
 					many_collection: collectionName.value!,
 					many_field: systemFields.userCreated.name,
-					many_primary: primaryKeyFieldName.value,
 					one_collection: 'directus_users',
-					one_primary: 'id',
 				});
 			}
 
@@ -457,9 +455,7 @@ export default defineComponent({
 				relations.push({
 					many_collection: collectionName.value!,
 					many_field: systemFields.userUpdated.name,
-					many_primary: primaryKeyFieldName.value,
 					one_collection: 'directus_users',
-					one_primary: 'id',
 				});
 			}
 

--- a/app/src/types/relations.ts
+++ b/app/src/types/relations.ts
@@ -2,10 +2,10 @@ export type Relation = {
 	id: number;
 	many_collection: string;
 	many_field: string;
-	many_primary: string;
+
 	one_collection: string;
 	one_field: null | string;
-	one_primary: string;
+
 	junction_field: null | string;
 	one_collection_field: null | string;
 	one_allowed_collections: null | string[];


### PR DESCRIPTION
This can be fetched from the schema info instead, reducing duplicate data in the database and potential desyncing issues.

Closes #3311