### PR TITLE
Adding syntax prefix parsing to specific types instead of only string var

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -155,7 +155,7 @@ function processValues(env: Record<string, any>) {
 	for (const [key, value] of Object.entries(env)) {
 		if (acceptableEnvTypes.some((envType) => value.includes(`${envType}:`))) {
 			env[key] = getEnvironmentValueByType(value);
-			break;
+			continue;
 		}
 
 		if (typeMap[key]) {

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -153,7 +153,7 @@ function processValues(env: Record<string, any>) {
 	env = clone(env);
 
 	for (const [key, value] of Object.entries(env)) {
-		if (acceptableEnvTypes.some((envType) => value.includes(`${envType}:`))) {
+		if (typeof value === 'string' && acceptableEnvTypes.some((envType) => value.includes(`${envType}:`))) {
 			env[key] = getEnvironmentValueByType(value);
 			continue;
 		}

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -12,6 +12,8 @@ import { clone, toString, toNumber } from 'lodash';
 import { toArray } from './utils/to-array';
 import logger from './logger';
 
+const acceptableEnvTypes = ['string', 'number', 'regex', 'array'];
+
 const defaults: Record<string, any> = {
 	CONFIG_PATH: path.resolve(process.cwd(), '.env'),
 	PORT: 8055,
@@ -123,10 +125,39 @@ function getEnv() {
 	return dotenv.parse(fs.readFileSync(configPath).toString());
 }
 
+function getVariableType(variable: string) {
+	return variable.split(':').slice(0, -1)[0];
+}
+
+function getEnvVariableValue(variableValue: string, variableType: string) {
+	return variableValue.split(`${variableType}:`)[1];
+}
+
+function getEnvironmentValueByType(envVariableString: string) {
+	const variableType = getVariableType(envVariableString);
+	const envVariableValue = getEnvVariableValue(envVariableString, variableType);
+
+	switch (variableType) {
+		case 'number':
+			return toNumber(envVariableValue);
+		case 'array':
+			return toArray(envVariableValue);
+		case 'regex':
+			return new RegExp(envVariableValue);
+		case 'string':
+			return envVariableValue;
+	}
+}
+
 function processValues(env: Record<string, any>) {
 	env = clone(env);
 
 	for (const [key, value] of Object.entries(env)) {
+		if (acceptableEnvTypes.some((envType) => value.includes(`${envType}:`))) {
+			env[key] = getEnvironmentValueByType(value);
+			break;
+		}
+
 		if (typeMap[key]) {
 			switch (typeMap[key]) {
 				case 'number':

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -310,7 +310,7 @@ Directus will attempt to automatically type cast environment variables based on 
 
 | Syntax Prefix | Example                                          | Output                                           |
 | ------------- | ------------------------------------------------ | ------------------------------------------------ |
-| `string`      | `string:value`                                   | `value`                                          |
+| `string`      | `string:value`                                   | `"value"`                                          |
 | `number`      | `number:3306`                                    | `3306`                                           |
 | `regex`       | `regex:/\.example\.com$/`                        | `/\.example\.com$/`                              |
 | `array`       | `array:https://example.com,https://example2.com` | `["https://example.com","https://example2.com"]` |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -303,3 +303,15 @@ DB_SSL__REJECT_UNAUTHORIZED="false"
 	}
 }
 ```
+
+## Environment Syntax Prefix
+
+Environment variables are by default treated as string, however if a syntax prefix is specified the string value will be
+converted to a certain type
+
+| Syntax Prefix | Example                                          | Output                                           |
+| ------------- | ------------------------------------------------ | ------------------------------------------------ |
+| `string`      | `string:value`                                   | `value`                                          |
+| `number`      | `number:3306`                                    | `3306`                                           |
+| `regex`       | `regex:/\.example\.com$/`                        | `/\.example\.com$/`                              |
+| `array`       | `array:https://example.com,https://example2.com` | `["https://example.com","https://example2.com"]` |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -306,8 +306,7 @@ DB_SSL__REJECT_UNAUTHORIZED="false"
 
 ## Environment Syntax Prefix
 
-Environment variables are by default treated as string, however if a syntax prefix is specified the string value will be
-converted to a certain type
+Directus will attempt to automatically type cast environment variables based on context clues ([see above](#type-casting-and-nesting)). If you have a specific need for a given type, you can tell Directus what type to use for the given value by prefixing the value with `{type}:`. The following types are available:
 
 | Syntax Prefix | Example                                          | Output                                           |
 | ------------- | ------------------------------------------------ | ------------------------------------------------ |


### PR DESCRIPTION
### Adding syntax prefix parsing to specific types instead of only string var

Original PR: #3865

Updated:

1. Obtaining the value based on a prefix from environment variables
2. Updated documentation to show how to add the prefix syntax