### PR TITLE
Show dropdown groupable

### DIFF
--- a/app/src/composables/groupable/groupable.ts
+++ b/app/src/composables/groupable/groupable.ts
@@ -71,13 +71,16 @@ export function useGroupable(options?: GroupableOptions) {
 	return {
 		active,
 		toggle: () => {
+			active.value = !active.value;
 			toggle(item);
 		},
 		activate: () => {
 			if (active.value === false) toggle(item);
+			active.value = true;
 		},
 		deactivate: () => {
 			if (active.value === true) toggle(item);
+			active.value = false;
 		},
 	};
 }


### PR DESCRIPTION
Fixes #4193. @rijkvanzanten, these three lines were deleted in v9.0.0-rc.41, but killed the dropdown in the sidebar. I have re-entered them, but let me know if this does any harm.