### PR TITLE
Allow setting primary key in o2m

### DIFF
--- a/app/src/interfaces/one-to-many/one-to-many.vue
+++ b/app/src/interfaces/one-to-many/one-to-many.vue
@@ -403,7 +403,7 @@ export default defineComponent({
 					return item;
 				});
 
-				if (hasPrimaryKey === false && newValue.includes(edits) === false) {
+				if (newValue.includes(edits) === false) {
 					newValue.push(edits);
 				}
 


### PR DESCRIPTION
closes #3908
I could swear that there was a thought why I only allowed new items without setting the primaryKey, do you remember that Rijk?
Was it because the Api didn't support it? Removing the check seems to work totally fine.