### PR TITLE
Fix related-values display not working on translations

### DIFF
--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -1,7 +1,7 @@
 <template>
 	<value-null v-if="!relatedCollection" />
 	<v-menu
-		v-else-if="type.toLowerCase() === 'o2m' || type.toLowerCase() === 'm2m' || type.toLowerCase() === 'm2a'"
+		v-else-if="['o2m', 'm2m', 'm2a', 'translations'].includes(type.toLowerCase())"
 		show-arrow
 		:disabled="value.length === 0"
 	>


### PR DESCRIPTION
closes #3350 
The reason why I didn't add a placeholder too is that we are not using a standard input for the display-template component and it would have been extremly complicated to add that when I wrote the display-template.