### PR TITLE
Filter O2M collections with a subquery instead of joins to prevent cartesian products

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,8 +1,9 @@
-import express from 'express';
-import bodyParser from 'body-parser';
-import logger from './logger';
 import expressLogger from 'express-pino-logger';
+import bodyParser from 'body-parser';
+import express from 'express';
+import logger from './logger';
 import path from 'path';
+import qs from 'qs';
 
 import { validateDBConnection, isInstalled } from './database';
 
@@ -69,6 +70,7 @@ export default async function createApp() {
 
 	app.disable('x-powered-by');
 	app.set('trust proxy', true);
+	app.set('query parser', (str: string) => qs.parse(str, { depth: 10 }));
 
 	await emitAsyncSafe('init.before', { app });
 

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -157,7 +157,7 @@ function getDBQuery(
 
 	query.sort = query.sort || [{ column: primaryKeyField, order: 'asc' }];
 
-	applyQuery(knex, table, dbQuery, queryCopy, schema);
+	applyQuery(table, dbQuery, queryCopy, schema, nested);
 
 	return dbQuery;
 }

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -157,12 +157,7 @@ function getDBQuery(
 
 	query.sort = query.sort || [{ column: primaryKeyField, order: 'asc' }];
 
-	applyQuery(table, dbQuery, queryCopy, schema);
-
-	// Nested filters use joins to filter on the parent level, to prevent duplicate
-	// parents, we group the query by the current tables primary key (which is unique)
-	// ref #3798
-	dbQuery.groupBy(`${table}.${primaryKeyField}`);
+	applyQuery(knex, table, dbQuery, queryCopy, schema);
 
 	return dbQuery;
 }

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -261,7 +261,7 @@ function mergeWithParentItems(
 				itemChildren = itemChildren.slice(0, nestedNode.query.limit ?? 100);
 			}
 
-			parentItem[nestedNode.fieldKey] = itemChildren.length > 0 ? itemChildren : null;
+			parentItem[nestedNode.fieldKey] = itemChildren.length > 0 ? itemChildren : [];
 		}
 	} else if (nestedNode.type === 'm2a') {
 		for (const parentItem of parentItems) {

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -157,7 +157,7 @@ function getDBQuery(
 
 	query.sort = query.sort || [{ column: primaryKeyField, order: 'asc' }];
 
-	applyQuery(table, dbQuery, queryCopy, schema, nested);
+	applyQuery(table, dbQuery, queryCopy, schema);
 
 	return dbQuery;
 }

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -7,11 +7,11 @@ import getLocalType from './get-local-type';
 import validate from 'uuid-validate';
 
 export default function applyQuery(
-	knex: Knex,
 	collection: string,
 	dbQuery: Knex.QueryBuilder,
 	query: Query,
-	schema: SchemaOverview
+	schema: SchemaOverview,
+	nested: boolean = false
 ) {
 	if (query.sort) {
 		dbQuery.orderBy(
@@ -39,7 +39,7 @@ export default function applyQuery(
 	}
 
 	if (query.filter) {
-		applyFilter(knex, schema, dbQuery, query.filter, collection);
+		applyFilter(schema, dbQuery, query.filter, collection, nested);
 	}
 
 	if (query.search) {
@@ -48,11 +48,11 @@ export default function applyQuery(
 }
 
 export function applyFilter(
-	knex: Knex,
 	schema: SchemaOverview,
 	rootQuery: Knex.QueryBuilder,
 	rootFilter: Filter,
-	collection: string
+	collection: string,
+	nested: boolean = false
 ) {
 	const relations: Relation[] = [...schema.relations, ...systemRelationRows];
 
@@ -89,28 +89,44 @@ export function applyFilter(
 			followRelation(path);
 
 			function followRelation(pathParts: string[], parentCollection: string = collection, parentAlias?: string) {
-				// Only follow M2O relations when adding joins. O2M relations are resolved with a subquery.
-				const m2oRelation = relations.find((relation) => {
-					return relation.many_collection === parentCollection && relation.many_field === pathParts[0];
+				const relation = relations.find((relation) => {
+					return (
+						(relation.many_collection === parentCollection && relation.many_field === pathParts[0]) ||
+						(relation.one_collection === parentCollection && relation.one_field === pathParts[0])
+					);
 				});
 
-				if (!m2oRelation) return;
+				if (!relation) return;
+
+				const isM2O = relation.many_collection === parentCollection && relation.many_field === pathParts[0];
 
 				const alias = nanoid(8);
 				aliasMap[pathParts.join('+')] = alias;
 
-				dbQuery.leftJoin(
-					{ [alias]: m2oRelation.one_collection! },
-					`${parentAlias || parentCollection}.${m2oRelation.many_field}`,
-					`${alias}.${m2oRelation.one_primary}`
-				);
+				if (isM2O) {
+					dbQuery.leftJoin(
+						{ [alias]: relation.one_collection! },
+						`${parentAlias || parentCollection}.${relation.many_field}`,
+						`${alias}.${relation.one_primary}`
+					);
+				}
 
-				pathParts.shift();
+				if (nested === true && isM2O === false) {
+					dbQuery.leftJoin(
+						{ [alias]: relation.many_collection },
+						`${parentAlias || parentCollection}.${relation.one_primary}`,
+						`${alias}.${relation.many_field}`
+					);
+				}
 
-				const parent = m2oRelation.one_collection!;
+				if (isM2O || nested === true) {
+					pathParts.shift();
 
-				if (pathParts.length) {
-					followRelation(pathParts, parent, alias);
+					const parent = isM2O ? relation.one_collection! : relation.many_collection;
+
+					if (pathParts.length) {
+						followRelation(pathParts, parent, alias);
+					}
 				}
 			}
 		}
@@ -142,27 +158,33 @@ export function applyFilter(
 			const filterPath = getFilterPath(key, value);
 			const { operator: filterOperator, value: filterValue } = getOperation(key, value);
 
-			if (filterPath.length > 1) {
-				// Determine if we're filtering on a o2m relation. In that case, a subquery
-				// needs to be constructed instead of just applying the filter to the query
-				const o2mRelation = relations.find((relation) => {
-					return relation.one_collection === collection && relation.one_field === filterPath[0];
+			const o2mRelation = relations.find((relation) => {
+				return relation.one_collection === collection && relation.one_field === filterPath[0];
+			});
+
+			if (!!o2mRelation && nested === false) {
+				const pkField = `${collection}.${o2mRelation.one_primary}`;
+
+				dbQuery[logical].whereIn(pkField, (subQuery) => {
+					subQuery.select([o2mRelation.many_field]).from(o2mRelation.many_collection);
+
+					applyQuery(
+						o2mRelation.many_collection,
+						subQuery,
+						{
+							filter: value,
+						},
+						schema,
+						true
+					);
 				});
-				if (o2mRelation) {
-					// Generate subquery
-					const subQuery = knex.select([o2mRelation.many_field]).from(o2mRelation.many_collection);
-					const query: Query = {
-						filter: value,
-					};
-					applyQuery(knex, o2mRelation.many_collection, subQuery, query, schema);
-					const pkField = `${collection}.${o2mRelation.one_primary || 'id'}`;
-					dbQuery[logical].whereIn(pkField, subQuery);
-				} else {
+			} else {
+				if (filterPath.length > 1) {
 					const columnName = getWhereColumn(filterPath, collection);
 					applyFilterToQuery(columnName, filterOperator, filterValue, logical);
+				} else {
+					applyFilterToQuery(`${collection}.${filterPath[0]}`, filterOperator, filterValue, logical);
 				}
-			} else {
-				applyFilterToQuery(`${collection}.${filterPath[0]}`, filterOperator, filterValue, logical);
 			}
 		}
 


### PR DESCRIPTION
This PR fixes #4078. A group by clause is not required anymore because filtering on O2M relations now generates a WHERE item.id IN (SELECT o2m_item.fk_id FROM o2m_collection WHERE...) subquery.

Tested locally with mssql, so testing with other RDMBSes still needs to be done.