### PR TITLE
wysiwyg: set the default link protocol to https

### DIFF
--- a/app/src/interfaces/wysiwyg/wysiwyg.vue
+++ b/app/src/interfaces/wysiwyg/wysiwyg.vue
@@ -155,6 +155,7 @@ export default defineComponent({
 				file_picker_types: 'image media',
 				file_picker_callback: setImageUploadHandler,
 				urlconverter_callback: urlConverter,
+				link_default_protocol: 'https',
 				...(props.tinymceOverrides || {}),
 			};
 		});


### PR DESCRIPTION
See https://www.tiny.cloud/docs/plugins/opensource/link/#link_default_protocol

when you don't enter a protocol, and tinyemc thinks you entered an external link, it will prompt you to add https

![image](https://user-images.githubusercontent.com/2185527/109187729-795cfd80-7792-11eb-83ce-5e623fb7d4cd.png)

closes https://github.com/directus/directus/discussions/4288