### PR TITLE
Feature/markdown shortcuts

### DIFF
--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -273,7 +273,6 @@ export default defineComponent({
 		useShortcut('meta+alt+4', () => edit('heading', { level: 4 }));
 		useShortcut('meta+alt+5', () => edit('heading', { level: 5 }));
 		useShortcut('meta+alt+6', () => edit('heading', { level: 6 }));
-		//  TODO Heading, paragraph and div to follow
 
 		return { codemirrorEl, edit, view, html, table, onImageUpload, imageDialogOpen, useShortcut, translateShortcut };
 

--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -9,7 +9,7 @@
 				</template>
 				<v-list>
 					<v-list-item v-for="n in 6" :key="n" @click="edit('heading', { level: n })">
-						<v-text-overflow :text="$t(`wysiwyg_options.h${n}`)" />
+						<v-list-item-content><v-text-overflow :text="$t(`wysiwyg_options.h${n}`)" /></v-list-item-content>
 						<v-list-item-hint>{{ translateShortcut(['meta', 'alt']) }} {{ n }}</v-list-item-hint>
 					</v-list-item>
 				</v-list>

--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -10,7 +10,7 @@
 				<v-list>
 					<v-list-item v-for="n in 6" :key="n" @click="edit('heading', { level: n })">
 						<v-text-overflow :text="$t(`wysiwyg_options.h${n}`)" />
-						<v-list-item-hint>{{ translateShortcut(['control', 'alt']) }} {{ n }}</v-list-item-hint>
+						<v-list-item-hint>{{ translateShortcut(['meta', 'alt']) }} {{ n }}</v-list-item-hint>
 					</v-list-item>
 				</v-list>
 			</v-menu>
@@ -35,7 +35,7 @@
 				small
 				icon
 				@click="edit('strikethrough')"
-				v-tooltip="$t('wysiwyg_options.strikethrough') + ' - ' + translateShortcut(['control', 'alt', 'd'])"
+				v-tooltip="$t('wysiwyg_options.strikethrough') + ' - ' + translateShortcut(['meta', 'alt', 'd'])"
 			>
 				<v-icon name="format_strikethrough" />
 			</v-button>
@@ -49,7 +49,7 @@
 				small
 				icon
 				@click="edit('blockquote')"
-				v-tooltip="$t('wysiwyg_options.blockquote') + ' - ' + translateShortcut(['control', 'alt', 'q'])"
+				v-tooltip="$t('wysiwyg_options.blockquote') + ' - ' + translateShortcut(['meta', 'alt', 'q'])"
 			>
 				<v-icon name="format_quote" />
 			</v-button>
@@ -57,7 +57,7 @@
 				small
 				icon
 				@click="edit('code')"
-				v-tooltip="$t('wysiwyg_options.codeblock') + ' - ' + translateShortcut(['control', 'alt', 'c'])"
+				v-tooltip="$t('wysiwyg_options.codeblock') + ' - ' + translateShortcut(['meta', 'alt', 'c'])"
 			>
 				<v-icon name="code" />
 			</v-button>

--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -8,19 +8,35 @@
 					</v-button>
 				</template>
 				<v-list>
-					<v-list-item v-for="n in 5" :key="n" @click="edit('heading', { level: n })">
+					<v-list-item v-for="n in 6" :key="n" @click="edit('heading', { level: n })">
 						<v-text-overflow :text="$t(`wysiwyg_options.h${n}`)" />
+						<v-list-item-hint>{{ translateShortcut(['control', 'alt']) }} {{ n }}</v-list-item-hint>
 					</v-list-item>
 				</v-list>
 			</v-menu>
 
-			<v-button small icon @click="edit('bold')" v-tooltip="$t('wysiwyg_options.bold')">
+			<v-button
+				small
+				icon
+				@click="edit('bold')"
+				v-tooltip="$t('wysiwyg_options.bold') + ' - ' + translateShortcut(['meta', 'b'])"
+			>
 				<v-icon name="format_bold" />
 			</v-button>
-			<v-button small icon @click="edit('italic')" v-tooltip="$t('wysiwyg_options.italic')">
+			<v-button
+				small
+				icon
+				@click="edit('italic')"
+				v-tooltip="$t('wysiwyg_options.italic') + ' - ' + translateShortcut(['meta', 'i'])"
+			>
 				<v-icon name="format_italic" />
 			</v-button>
-			<v-button small icon @click="edit('strikethrough')" v-tooltip="$t('wysiwyg_options.strikethrough')">
+			<v-button
+				small
+				icon
+				@click="edit('strikethrough')"
+				v-tooltip="$t('wysiwyg_options.strikethrough') + ' - ' + translateShortcut(['control', 'alt', 'd'])"
+			>
 				<v-icon name="format_strikethrough" />
 			</v-button>
 			<v-button small icon @click="edit('listBulleted')" v-tooltip="$t('wysiwyg_options.bullist')">
@@ -29,13 +45,28 @@
 			<v-button small icon @click="edit('listNumbered')" v-tooltip="$t('wysiwyg_options.numlist')">
 				<v-icon name="format_list_numbered" />
 			</v-button>
-			<v-button small icon @click="edit('blockquote')" v-tooltip="$t('wysiwyg_options.blockquote')">
+			<v-button
+				small
+				icon
+				@click="edit('blockquote')"
+				v-tooltip="$t('wysiwyg_options.blockquote') + ' - ' + translateShortcut(['control', 'alt', 'q'])"
+			>
 				<v-icon name="format_quote" />
 			</v-button>
-			<v-button small icon @click="edit('code')" v-tooltip="$t('wysiwyg_options.codeblock')">
+			<v-button
+				small
+				icon
+				@click="edit('code')"
+				v-tooltip="$t('wysiwyg_options.codeblock') + ' - ' + translateShortcut(['control', 'alt', 'c'])"
+			>
 				<v-icon name="code" />
 			</v-button>
-			<v-button small icon @click="edit('link')" v-tooltip="$t('wysiwyg_options.link')">
+			<v-button
+				small
+				icon
+				@click="edit('link')"
+				v-tooltip="$t('wysiwyg_options.link') + ' - ' + translateShortcut(['meta', 'k'])"
+			>
 				<v-icon name="insert_link" />
 			</v-button>
 
@@ -137,6 +168,7 @@ import { getPublicURL } from '@/utils/get-root-path';
 import { addTokenToURL } from '@/api';
 import escapeStringRegexp from 'escape-string-regexp';
 import useShortcut from '@/composables/use-shortcut';
+import translateShortcut from '@/utils/translate-shortcut';
 
 export default defineComponent({
 	props: {
@@ -235,7 +267,6 @@ export default defineComponent({
 		useShortcut('meta+alt+d', () => edit('strikethrough'));
 		useShortcut('meta+alt+q', () => edit('blockquote'));
 		useShortcut('meta+alt+c', () => edit('code'));
-		useShortcut('meta+alt+t', () => edit('table'));
 		useShortcut('meta+alt+1', () => edit('heading', { level: 1 }));
 		useShortcut('meta+alt+2', () => edit('heading', { level: 2 }));
 		useShortcut('meta+alt+3', () => edit('heading', { level: 3 }));
@@ -244,7 +275,7 @@ export default defineComponent({
 		useShortcut('meta+alt+6', () => edit('heading', { level: 6 }));
 		//  TODO Heading, paragraph and div to follow
 
-		return { codemirrorEl, edit, view, html, table, onImageUpload, imageDialogOpen };
+		return { codemirrorEl, edit, view, html, table, onImageUpload, imageDialogOpen, useShortcut, translateShortcut };
 
 		function onImageUpload(image: any) {
 			if (!codemirror.value) return;

--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="interface-markdown" :class="view[0]">
+	<div class="interface-markdown" :class="view[0]" ref="markdownInterface">
 		<div class="toolbar">
 			<v-menu show-arrow placement="bottom-start">
 				<template #activator="{ toggle }">
@@ -194,7 +194,8 @@ export default defineComponent({
 		},
 	},
 	setup(props, { emit }) {
-		const codemirrorEl = ref<HTMLTextAreaElement | null>(null);
+		const markdownInterface = ref<HTMLElement>();
+		const codemirrorEl = ref<HTMLTextAreaElement>();
 		const codemirror = ref<CodeMirror.EditorFromTextArea | null>(null);
 
 		const view = ref(['editor']);
@@ -261,20 +262,31 @@ export default defineComponent({
 			columns: 4,
 		});
 
-		useShortcut('meta+b', () => edit('bold'));
-		useShortcut('meta+i', () => edit('italic'));
-		useShortcut('meta+k', () => edit('link'));
-		useShortcut('meta+alt+d', () => edit('strikethrough'));
-		useShortcut('meta+alt+q', () => edit('blockquote'));
-		useShortcut('meta+alt+c', () => edit('code'));
-		useShortcut('meta+alt+1', () => edit('heading', { level: 1 }));
-		useShortcut('meta+alt+2', () => edit('heading', { level: 2 }));
-		useShortcut('meta+alt+3', () => edit('heading', { level: 3 }));
-		useShortcut('meta+alt+4', () => edit('heading', { level: 4 }));
-		useShortcut('meta+alt+5', () => edit('heading', { level: 5 }));
-		useShortcut('meta+alt+6', () => edit('heading', { level: 6 }));
+		useShortcut('meta+b', () => edit('bold'), markdownInterface);
+		useShortcut('meta+i', () => edit('italic'), markdownInterface);
+		useShortcut('meta+k', () => edit('link'), markdownInterface);
+		useShortcut('meta+alt+d', () => edit('strikethrough'), markdownInterface);
+		useShortcut('meta+alt+q', () => edit('blockquote'), markdownInterface);
+		useShortcut('meta+alt+c', () => edit('code'), markdownInterface);
+		useShortcut('meta+alt+1', () => edit('heading', { level: 1 }), markdownInterface);
+		useShortcut('meta+alt+2', () => edit('heading', { level: 2 }), markdownInterface);
+		useShortcut('meta+alt+3', () => edit('heading', { level: 3 }), markdownInterface);
+		useShortcut('meta+alt+4', () => edit('heading', { level: 4 }), markdownInterface);
+		useShortcut('meta+alt+5', () => edit('heading', { level: 5 }), markdownInterface);
+		useShortcut('meta+alt+6', () => edit('heading', { level: 6 }), markdownInterface);
 
-		return { codemirrorEl, edit, view, html, table, onImageUpload, imageDialogOpen, useShortcut, translateShortcut };
+		return {
+			codemirrorEl,
+			edit,
+			view,
+			html,
+			table,
+			onImageUpload,
+			imageDialogOpen,
+			useShortcut,
+			translateShortcut,
+			markdownInterface,
+		};
 
 		function onImageUpload(image: any) {
 			if (!codemirror.value) return;

--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -136,6 +136,7 @@ import { useEdit, CustomSyntax } from './composables/use-edit';
 import { getPublicURL } from '@/utils/get-root-path';
 import { addTokenToURL } from '@/api';
 import escapeStringRegexp from 'escape-string-regexp';
+import useShortcut from '@/composables/use-shortcut';
 
 export default defineComponent({
 	props: {
@@ -227,6 +228,21 @@ export default defineComponent({
 			rows: 4,
 			columns: 4,
 		});
+
+		useShortcut('meta+b', () => edit('bold'));
+		useShortcut('meta+i', () => edit('italic'));
+		useShortcut('meta+k', () => edit('link'));
+		useShortcut('meta+alt+d', () => edit('strikethrough'));
+		useShortcut('meta+alt+q', () => edit('blockquote'));
+		useShortcut('meta+alt+c', () => edit('code'));
+		useShortcut('meta+alt+t', () => edit('table'));
+		useShortcut('meta+alt+1', () => edit('heading', { level: 1 }));
+		useShortcut('meta+alt+2', () => edit('heading', { level: 2 }));
+		useShortcut('meta+alt+3', () => edit('heading', { level: 3 }));
+		useShortcut('meta+alt+4', () => edit('heading', { level: 4 }));
+		useShortcut('meta+alt+5', () => edit('heading', { level: 5 }));
+		useShortcut('meta+alt+6', () => edit('heading', { level: 6 }));
+		//  TODO Heading, paragraph and div to follow
 
 		return { codemirrorEl, edit, view, html, table, onImageUpload, imageDialogOpen };
 

--- a/app/src/utils/translate-shortcut/translate-shortcut.ts
+++ b/app/src/utils/translate-shortcut/translate-shortcut.ts
@@ -9,6 +9,7 @@ export default function translateShortcut(keys: string[]) {
 				if (key === 'meta') return '⌘';
 				if (key === 'option') return '⌥';
 				if (key === 'shift') return '⇧';
+				if (key === 'alt') return '⌥';
 				return capitalizeFirst(key);
 			})
 			.join('');


### PR DESCRIPTION
adds #4235 + h6 to the md-editor

NOTE:
At least in Europe `command+alt` is already in use for some of the shortcuts (e.g `command+alt+q` will ask to quit the browser). **BUT** for international support  (#4123)  I've used the `meta+alt` version over the `control+alt` - hoping this will support other countries / keyboards (unfortunately I don't have a Russian keyboard to test it 😆 ) 

