### PR TITLE
Update interfaces.md

### DIFF
--- a/docs/guides/displays.md
+++ b/docs/guides/displays.md
@@ -1,6 +1,7 @@
 # Custom Displays <small></small>
 
-> Displays are small inline components that allow you to create new ways of viewing field values throughout the App. [Learn more about Displays](/concepts/displays/).
+> Displays are small inline components that allow you to create new ways of viewing field values throughout the App.
+> [Learn more about Displays](/concepts/displays/).
 
 ## 1. Setup the Boilerplate
 
@@ -93,7 +94,7 @@ To be read by the Admin App, your custom display's Vue component must first be b
 recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
 
 ```bash
-npm i -D rollup rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-terser rollup-plugin-vue@5.0.0 @vue/compiler-sfc vue-template-compiler
+npm i -D rollup rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-terser rollup-plugin-vue@5.0.0 @vue/compiler-sfc rollup-plugin-vue@next
 ```
 
 You can then use the following Rollup configuration within `rollup.config.js`:

--- a/docs/guides/interfaces.md
+++ b/docs/guides/interfaces.md
@@ -79,7 +79,7 @@ To be read by the Admin App, your custom interface's Vue component must first be
 We recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
 
 ```bash
-npm i -D rollup rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-terser rollup-plugin-vue@5.0.0 @vue/compiler-sfc vue-template-compiler
+npm i -D rollup rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-terser rollup-plugin-vue@5.0.0 @vue/compiler-sfc rollup-plugin-vue@next
 ```
 
 You can then use the following Rollup configuration within `rollup.config.js`:

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -1,6 +1,7 @@
 # Custom Modules <small></small>
 
-> Custom Modules are completely open-ended components that allow you to create new experiences within the Directus platform. [Learn more about Modules](/concepts/modules/).
+> Custom Modules are completely open-ended components that allow you to create new experiences within the Directus
+> platform. [Learn more about Modules](/concepts/modules/).
 
 ## 1. Setup the Boilerplate
 
@@ -72,7 +73,7 @@ To be read by the Admin App, your custom module's Vue component must first be bu
 recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
 
 ```bash
-npm i -D rollup rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-terser rollup-plugin-vue@5.0.0 @vue/compiler-sfc vue-template-compiler
+npm i -D rollup rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-terser rollup-plugin-vue@5.0.0 @vue/compiler-sfc rollup-plugin-vue@next
 ```
 
 You can then use the following Rollup configuration within `rollup.config.js`:


### PR DESCRIPTION
vue-template-compiler => rollup-plugin-vue@next 
It resolves rollup halting with error

It is same/similar change in all guides for extension creation.

(I looked for way to merge suggestion to one branch - in GitHub UI - but did not find). 