### PR TITLE
Resolve relative CONFIG_PATH

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -87,7 +87,7 @@ env = processValues(env);
 export default env;
 
 function getEnv() {
-	const configPath = process.env.CONFIG_PATH || defaults.CONFIG_PATH;
+	const configPath = path.resolve(process.env.CONFIG_PATH || defaults.CONFIG_PATH);
 
 	if (fs.existsSync(configPath) === false) return {};
 


### PR DESCRIPTION
See #4451 

This PR adds a `path.resolve()` call to resolve relative paths passed with the `CONFIG_PATH` env variable.

As opposed to the example given in the issue mentioned above, `process.env.CONFIG_PATH || defaults.CONFIG_PATH` is wrapped entirely, as opposed to only the environment variable, as `path.resolve()` will return `process.cwd()` if no path can be resolved.