### PR TITLE
M2O filtered dropdown

### DIFF
--- a/app/src/interfaces/many-to-one-dropdown/index.ts
+++ b/app/src/interfaces/many-to-one-dropdown/index.ts
@@ -1,0 +1,16 @@
+import { defineInterface } from '../define';
+import InterfaceManyToOneDropdown from './many-to-one-dropdown.vue';
+import Options from './options.vue';
+
+export default defineInterface(({ i18n }) => ({
+	id: 'many-to-one-dropdown',
+	name: 'Many to one - Filtered dropdown',
+	description: 'Filtered selection of related table values',
+	icon: 'arrow_right_alt',
+	component: InterfaceManyToOneDropdown,
+	types: ['uuid', 'string', 'text', 'integer', 'bigInteger'],
+	relational: true,
+	groups: ['m2o'],
+	recommendedDisplays: ['related-values'],
+	options: Options,
+}));

--- a/app/src/interfaces/many-to-one-dropdown/many-to-one-dropdown.vue
+++ b/app/src/interfaces/many-to-one-dropdown/many-to-one-dropdown.vue
@@ -1,0 +1,97 @@
+<template>
+	<div>
+		<p v-if="loading || !items.length">{{ loadingText }}</p>
+		<v-select v-else :value="value" @input="$listeners.input" :items="items">
+			<template #prepend v-if="icon">
+				<v-icon :name="icon" />
+			</template>
+		</v-select>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@vue/composition-api';
+import { useRelationsStore } from '@/stores';
+import getFieldsFromTemplate from '@/utils/get-fields-from-template';
+import api from '@/api';
+import { Field, Relation } from '@/types';
+import { i18n } from '@/lang/';
+
+export default defineComponent({
+	props: {
+		value: {
+			type: [Number, String, Object],
+			default: null,
+		},
+		collection: {
+			type: String,
+			required: true,
+		},
+		field: {
+			type: String,
+			required: true,
+		},
+		template: {
+			type: String,
+			default: null,
+		},
+		column: {
+			type: String,
+			//required: true,
+		},
+		relation: {
+			type: String,
+			default: '_eq',
+		},
+		related_value: {
+			type: String,
+			default: false,
+		},
+	},
+	setup(props, { emit }) {
+		const field_rel: Relation = useRelationsStore().getRelationsForField(props.collection, props.field)[0];
+		const one_table = field_rel.one_collection;
+
+		const items = ref<Record<string, any>[] | null>(null);
+		const loading = ref(false);
+		const loadingText = i18n.t('no_items');
+
+		async function fetchItems() {
+			if (one_table) {
+				loading.value = true;
+				const params: any = {};
+				let qs = '';
+				if (props.column && props.relation && props.related_value) {
+					// Right now I don't get the filter as an object given to
+					// api.get to work.
+					/*params.filter = {
+						[props.column]: {
+							[props.relation]: props.related_value,
+						},
+					};*/
+					qs = `?filter[${props.column}][${props.relation}]=${props.related_value}`;
+				}
+				try {
+					const response = await api.get('/items/' + one_table + qs, params);
+					const values: any[] = [];
+					const one_fields = getFieldsFromTemplate(props.template);
+					response.data.data.forEach((item: Record<string, string | number | boolean>) => {
+						values.push({
+							text: one_fields.map((field) => item[field]).join(' - '),
+							value: item[field_rel.one_primary],
+						});
+					});
+					items.value = values;
+				} catch (err) {
+					console.log('m2o-dropdown - setup:fetchItems - err: ' + err);
+				}
+			} else {
+				console.log('m2o-dropdown - setup:fetchItems - skipping, no one_table');
+			}
+			loading.value = false;
+		}
+		fetchItems();
+		return { items, loading, loadingText };
+	},
+});
+</script>

--- a/app/src/interfaces/many-to-one-dropdown/many-to-one-dropdown.vue
+++ b/app/src/interfaces/many-to-one-dropdown/many-to-one-dropdown.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<p v-if="loading || !items || !items.length">{{ loadingText }}</p>
+		<p v-if="loading || !items.length">{{ loadingText }}</p>
 		<v-select v-else :value="value" @input="$listeners.input" :items="items">
 			<template #prepend v-if="icon">
 				<v-icon :name="icon" />
@@ -52,7 +52,7 @@ export default defineComponent({
 		const field_rel: Relation = useRelationsStore().getRelationsForField(props.collection, props.field)[0];
 		const one_table = field_rel.one_collection;
 
-		const items = ref<Record<string, any>[] | null>(null);
+		const items = ref<Record<string, any>[] | null>([]);
 		const loading = ref(false);
 		const loadingText = i18n.t('no_items');
 

--- a/app/src/interfaces/many-to-one-dropdown/many-to-one-dropdown.vue
+++ b/app/src/interfaces/many-to-one-dropdown/many-to-one-dropdown.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<p v-if="loading || !items.length">{{ loadingText }}</p>
+		<p v-if="loading || !items || !items.length">{{ loadingText }}</p>
 		<v-select v-else :value="value" @input="$listeners.input" :items="items">
 			<template #prepend v-if="icon">
 				<v-icon :name="icon" />

--- a/app/src/interfaces/many-to-one-dropdown/options.vue
+++ b/app/src/interfaces/many-to-one-dropdown/options.vue
@@ -1,0 +1,115 @@
+<template>
+	<div>
+		<v-divider>Display fields (in dropdown)</v-divider>
+		<!-- Some space is needed in the layout - don't know better way now -->
+		<!-- Vue compiler clears out &nbsp; - so use a trick -->
+		<p>&nbsp;{{ '\xa0' }}</p>
+		<v-field-template :collection="relatedCollection" v-model="template" :depth="1" />
+		<p>&nbsp;{{ '\xa0' }}</p>
+		<v-divider>Filter (optional)</v-divider>
+		<p>&nbsp;{{ '\xa0' }}</p>
+		<v-form :fields="options" primary-key="+" v-model="fieldData.meta.options" />
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType, computed } from '@vue/composition-api';
+import { useFieldsStore } from '@/stores';
+import { Field } from '@/types';
+import { Relation } from '@/types/relations';
+
+export default defineComponent({
+	name: 'm2o-interface-filtered-dropdown',
+	props: {
+		collection: String,
+		fieldData: Object as PropType<Field>,
+		relations: Array as PropType<Relation[]>,
+		value: Object as PropType<any>,
+	},
+	setup(props, { emit }) {
+		if (!props.relations) return;
+		const relation: Relation = props.relations[0];
+		const template = computed({
+			get() {
+				return props.value?.template;
+			},
+			set(newTemplate: string) {
+				emit('input', {
+					...(props.value || {}),
+					template: newTemplate,
+				});
+			},
+		});
+		return {
+			relation,
+			relatedCollection: relation.one_collection,
+			relatedColumns: useFieldsStore().getFieldsForCollection(relation.one_collection),
+			options: getOptionsFor(relation),
+			template,
+		};
+	},
+});
+
+function getOptionsFor(relation: Relation) {
+	return [
+		{
+			field: 'column',
+			name: 'Related column',
+			type: 'string',
+			meta: {
+				width: 'half',
+				interface: 'dropdown',
+				options: {
+					choices: useFieldsStore()
+						.getFieldsForCollectionAlphabetical(relation.one_collection)
+						.map((field: Field) => ({
+							text: field.field,
+							value: field.field,
+							disabled: !field.schema,
+						})),
+				},
+			},
+		},
+		{
+			field: 'relation',
+			name: 'Relation',
+			type: 'string',
+			meta: {
+				width: 'half',
+				interface: 'dropdown',
+				options: {
+					choices: [
+						{ text: 'equals', value: '_eq' },
+						{ text: 'differs', value: '_neq' },
+						{ text: 'greater than', value: '_gt' },
+						{ text: 'less than', value: '_lt' },
+						{ text: 'in (values)', value: '_in' },
+						{ text: 'not in (values)', value: '_nin' },
+						{ text: 'containing', value: '_contains' },
+						{ text: 'not containing', value: '_ncontains' },
+						{ text: 'empty/false', value: '_empty' },
+						{ text: 'not empty/false', value: '_nempty' },
+						{ text: 'greater or equal', value: '_gte' },
+						{ text: 'less or equal', value: '_lte' },
+					],
+				},
+			},
+			schema: {
+				default_value: '_eq',
+			},
+		},
+		{
+			field: 'related_value',
+			name: 'Related value',
+			type: 'string',
+			meta: {
+				width: 'half',
+				interface: 'text-input',
+				options: {
+					placeholder: 'Enter value to be filtered against',
+				},
+			},
+		},
+	];
+}
+</script>

--- a/app/src/interfaces/many-to-one-dropdown/options.vue
+++ b/app/src/interfaces/many-to-one-dropdown/options.vue
@@ -51,6 +51,16 @@ export default defineComponent({
 });
 
 function getOptionsFor(relation: Relation) {
+	let choices = [{ text: '<none>', value: '' }];
+	choices = choices.concat(
+		useFieldsStore()
+			.getFieldsForCollectionAlphabetical(relation.one_collection)
+			.map((field: Field) => ({
+				text: field.field,
+				value: field.field,
+				disabled: !field.schema,
+			}))
+	);
 	return [
 		{
 			field: 'column',
@@ -60,13 +70,7 @@ function getOptionsFor(relation: Relation) {
 				width: 'half',
 				interface: 'dropdown',
 				options: {
-					choices: useFieldsStore()
-						.getFieldsForCollectionAlphabetical(relation.one_collection)
-						.map((field: Field) => ({
-							text: field.field,
-							value: field.field,
-							disabled: !field.schema,
-						})),
+					choices,
 				},
 			},
 		},


### PR DESCRIPTION
I implemented an (optionally) filtered dropdown interface for many-to-one relationships.  I think it's quite useful, for more quickly and precisely editing values referring to other tables. 

Since I don't know how you do with pull requests (interfaces, displays,...) atm. I did not go through effort of adding items in translation files and so on. Maybe there is a better way to build the filter - but this achieves the basics. 

As feedback, I found it a bit difficult to get a nice layout, on the interface customization (I wanted two parts: _Display fields_, _Filter_).  Particularly getting some vertical space, after the divider was hard.

I developed against RC 0.44. When pulling/merging w RC 0.46 - I hit a new Api / Db error - it looks unrelated to my new interface. (I report on it separately). 

