### PR TITLE
Add env for cookie domain

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -62,6 +62,7 @@ router.post(
 		if (mode === 'cookie') {
 			res.cookie('directus_refresh_token', refreshToken, {
 				httpOnly: true,
+				domain: env.REFRESH_TOKEN_COOKIE_DOMAIN,
 				maxAge: ms(env.REFRESH_TOKEN_TTL as string),
 				secure: env.REFRESH_TOKEN_COOKIE_SECURE ?? false,
 				sameSite: (env.REFRESH_TOKEN_COOKIE_SAME_SITE as 'lax' | 'strict' | 'none') || 'strict',

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -53,6 +53,7 @@ All the `DB_POOL_` prefixed options are passed [to `tarn.js`](https://github.com
 | `SECRET`                         | Secret string for the project.                                                                                                  | --            |
 | `ACCESS_TOKEN_TTL`               | The duration that the access token is valid.                                                                                    | 15m           |
 | `REFRESH_TOKEN_TTL`              | The duration that the refresh token is valid, and also how long users stay logged-in to the App.                                | 7d            |
+| `REFRESH_TOKEN_COOKIE_DOMAIN`    | Which domain to use for the refresh cookie. Usefull for development mode.                                                       | --            |
 | `REFRESH_TOKEN_COOKIE_SECURE`    | Whether or not to use a secure cookie for the refresh token in cookie mode.                                                     | `false`       |
 | `REFRESH_TOKEN_COOKIE_SAME_SITE` | Value for `sameSite` in the refresh token cookie when in cookie mode.                                                           | `lax`         |
 | `PASSWORD_RESET_URL_ALLOW_LIST`  | List of URLs that can be used [as `reset_url` in /password/request](/reference/api/rest/authentication/#request-password-reset) | --            |
@@ -180,13 +181,13 @@ Based on your configured driver, you must also provide the following configurati
 
 ### S3 (`s3`)
 
-| Variable                      	| Description                                 	| Default Value 	|
-|-------------------------------	|---------------------------------------------	|---------------	|
-| `STORAGE_<LOCATION>_KEY`      	| User key                                    	| --            	|
-| `STORAGE_<LOCATION>_SECRET`   	| User secret                                 	| --            	|
-| `STORAGE_<LOCATION>_BUCKET`   	| S3 Bucket                                   	| --            	|
-| `STORAGE_<LOCATION>_REGION`   	| S3 Region                                   	| --            	|
-| `STORAGE_<LOCATION>_ENDPOINT` 	| S3 Endpoint 	| "s3.amazonaws.com"            	|
+| Variable                      | Description | Default Value      |
+| ----------------------------- | ----------- | ------------------ |
+| `STORAGE_<LOCATION>_KEY`      | User key    | --                 |
+| `STORAGE_<LOCATION>_SECRET`   | User secret | --                 |
+| `STORAGE_<LOCATION>_BUCKET`   | S3 Bucket   | --                 |
+| `STORAGE_<LOCATION>_REGION`   | S3 Region   | --                 |
+| `STORAGE_<LOCATION>_ENDPOINT` | S3 Endpoint | "s3.amazonaws.com" |
 
 ### Azure (`azure`)
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -53,7 +53,7 @@ All the `DB_POOL_` prefixed options are passed [to `tarn.js`](https://github.com
 | `SECRET`                         | Secret string for the project.                                                                                                  | --            |
 | `ACCESS_TOKEN_TTL`               | The duration that the access token is valid.                                                                                    | 15m           |
 | `REFRESH_TOKEN_TTL`              | The duration that the refresh token is valid, and also how long users stay logged-in to the App.                                | 7d            |
-| `REFRESH_TOKEN_COOKIE_DOMAIN`    | Which domain to use for the refresh cookie. Usefull for development mode.                                                       | --            |
+| `REFRESH_TOKEN_COOKIE_DOMAIN`    | Which domain to use for the refresh cookie. Useful for development mode.                                                        | --            |
 | `REFRESH_TOKEN_COOKIE_SECURE`    | Whether or not to use a secure cookie for the refresh token in cookie mode.                                                     | `false`       |
 | `REFRESH_TOKEN_COOKIE_SAME_SITE` | Value for `sameSite` in the refresh token cookie when in cookie mode.                                                           | `lax`         |
 | `PASSWORD_RESET_URL_ALLOW_LIST`  | List of URLs that can be used [as `reset_url` in /password/request](/reference/api/rest/authentication/#request-password-reset) | --            |


### PR DESCRIPTION
Hey 👋 
I have next situation:

My Admin app on host: `https://foo.bar/directus/`  
My Frontend app on host: `https://foo.bar/`

Also I have oauth to Admin app via SSO provider

I need to authorize users in the Frontend app, because they would like to send likes, comments, etc to my articles.

In the Frontend app I can authorize users as though they authorized be in the Admin app, because I have refresh token on the same domain `foo.bar`

But when I running Frontend app in development mode on localhost I can't log in to my app, therefore I need to rewrite cookie's domain to something like `.foo.bar` (with leading dot) so it helps me to log in to my app if I change `http://localhost:8080/` to some local domain like `https://local.foo.bar/`

This changes would help to development while anyone has auth via SSO provider

I'm sure this changes should not to break something, because if env would be `undefined` they would pass to argument `options` in `res.cookie()` [method](https://github.com/expressjs/express/blob/master/lib/response.js#L831) and then that option would be skipped by [serialize function](https://github.com/jshttp/cookie/blob/master/index.js#L131)