### PR TITLE
Improve recursive filtering

### DIFF
--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -213,7 +213,9 @@ router.delete(
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
 		await service.delete(req.body as PrimaryKey[]);
+
 		return next();
 	}),
 	respond
@@ -229,7 +231,9 @@ router.delete(
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
 		const pk = req.params.pk.includes(',') ? req.params.pk.split(',') : req.params.pk;
+
 		await service.delete(pk as any);
 		return next();
 	}),

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -334,21 +334,13 @@ export class AuthorizationService {
 			schema: this.schema,
 		});
 
-		try {
-			const query: Query = {
-				fields: ['*'],
-			};
+		const query: Query = {
+			fields: ['*'],
+		};
 
-			const result = await itemsService.readByKey(pk as any, query, action);
+		const result = await itemsService.readByKey(pk as any, query, action);
 
-			if (!result) throw '';
-			if (Array.isArray(pk) && pk.length > 1 && result.length !== pk.length) throw '';
-		} catch {
-			throw new ForbiddenException(`You're not allowed to ${action} item "${pk}" in collection "${collection}".`, {
-				collection,
-				item: pk,
-				action,
-			});
-		}
+		if (!result) throw new ForbiddenException();
+		if (Array.isArray(pk) && pk.length > 1 && result.length !== pk.length) throw new ForbiddenException();
 	}
 }

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -217,6 +217,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		action: PermissionsAction = 'read'
 	): Promise<null | Partial<Item> | Partial<Item>[]> {
 		query = clone(query);
+
 		const primaryKeyField = this.schema.tables[this.collection].primary;
 		const keys = toArray(key);
 
@@ -474,7 +475,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				schema: this.schema,
 			});
 
-			await authorizationService.checkAccess('delete', this.collection, key);
+			await authorizationService.checkAccess('delete', this.collection, keys);
 		}
 
 		await emitter.emitAsync(`${this.eventScope}.delete.before`, {

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -2,9 +2,11 @@ import { Knex } from 'knex';
 import { Query, Filter, Relation, SchemaOverview } from '../types';
 import { clone, isPlainObject } from 'lodash';
 import { systemRelationRows } from '../database/system-data/relations';
-import { nanoid } from 'nanoid';
+import { nanoid, customAlphabet } from 'nanoid';
 import getLocalType from './get-local-type';
 import validate from 'uuid-validate';
+
+const generateAlias = customAlphabet('abcdefghijklmnopqrstuvwxyz', 5);
 
 export default function applyQuery(
 	collection: string,
@@ -100,7 +102,7 @@ export function applyFilter(
 
 				const isM2O = relation.many_collection === parentCollection && relation.many_field === pathParts[0];
 
-				const alias = nanoid(8);
+				const alias = generateAlias();
 				aliasMap[pathParts.join('+')] = alias;
 
 				if (isM2O) {
@@ -293,6 +295,8 @@ export function applyFilter(
 
 				const isM2O = relation.many_collection === parentCollection && relation.many_field === pathParts[0];
 				const alias = aliasMap[pathParts.join('+')];
+
+				console.log(alias);
 
 				pathParts.shift();
 


### PR DESCRIPTION
The join alias mapping would get confused once you started doing recursive relational filtering


- Use lowercase chars only
- Fix join alias mapping
- Pass keys as array in delete
- Cleanup delete controller
- Don't catch unexpected errors
