### PR TITLE
In mysql, select only tables

### DIFF
--- a/packages/schema/src/dialects/mysql.ts
+++ b/packages/schema/src/dialects/mysql.ts
@@ -7,17 +7,20 @@ export default class MySQL extends KnexMySQL implements SchemaInspector {
 		const columns = await this.knex.raw(
 			`
 			SELECT
-				TABLE_NAME as table_name,
-				COLUMN_NAME as column_name,
-				COLUMN_DEFAULT as default_value,
-				IS_NULLABLE as is_nullable,
-				DATA_TYPE as data_type,
-				COLUMN_KEY as column_key,
-				EXTRA as extra
+				C.TABLE_NAME as table_name,
+				C.COLUMN_NAME as column_name,
+				C.COLUMN_DEFAULT as default_value,
+				C.IS_NULLABLE as is_nullable,
+				C.DATA_TYPE as data_type,
+				C.COLUMN_KEY as column_key,
+				C.EXTRA as extra
 			FROM
-				INFORMATION_SCHEMA.COLUMNS
+				INFORMATION_SCHEMA.COLUMNS AS C
+			LEFT JOIN
+				INFORMATION_SCHEMA.TABLES AS T ON C.TABLE_NAME = T.TABLE_NAME
 			WHERE
-				table_schema = ?;
+				T.TABLE_TYPE = 'BASE TABLE' AND
+				T.TABLE_SCHEMA = ?;
 			`,
 			[this.knex.client.database()]
 		);


### PR DESCRIPTION
Fix warnings like

```
directus: 07:00:11 ⚠️  Collection "_gallery_agr_totals" doesn't have a primary key column and will be ignored
directus: 07:00:11 ✨ request completed GET 200 /server/info 102ms
directus: 07:00:12 ⚠️  Collection "_gallery_agr_totals" doesn't have a primary key column and will be ignored
directus: 07:00:12 ✨ request completed PATCH 200 /users/me/track/page 112ms
directus: 07:00:12 ⚠️  Collection "_gallery_agr_totals" doesn't have a primary key column and will be ignored
directus: 07:00:12 ⚠️  Collection "_gallery_agr_totals" doesn't have a primary key column and will be ignored
```