### PR TITLE
Remove dotenv preloading from api dev script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -53,7 +53,7 @@
 	"scripts": {
 		"start": "npx directus start",
 		"build": "rimraf dist && tsc --build && copyfiles \"src/**/*.*\" -e \"src/**/*.ts\" -u 1 dist",
-		"dev": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect --require dotenv/config src/start.ts",
+		"dev": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect -- src/start.ts",
 		"cli": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node --script-mode --transpile-only src/cli/index.ts",
 		"lint": "eslint \"src/**/*.ts\" cli.js index.js",
 		"prepublishOnly": "npm run build",


### PR DESCRIPTION
Now that there is a native way to specify the config path by using the `CONFIG_PATH` env var, this is not needed anymore and even prevents that env var from working correctly because the preloaded dotenv overwrites the specified config file.