### PR TITLE
Always remove the primary key field from the update payload

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -315,6 +315,12 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				payloadWithoutAliases = await payloadService.processValues('update', payloadWithoutAliases);
 
 				if (Object.keys(payloadWithoutAliases).length > 0) {
+					// Always delete primaryKeyField from payload to prevent issues with updating in databases
+					// that do not allow updating primary key columns (for example mssql identity columns).
+					if (payloadWithoutAliases.hasOwnProperty(primaryKeyField)) {
+						delete payloadWithoutAliases[primaryKeyField];
+					}
+
 					try {
 						await trx(this.collection).update(payloadWithoutAliases).whereIn(primaryKeyField, keys);
 					} catch (err) {


### PR DESCRIPTION
Always remove the primary key field from the update payload to prevent issues with databases that don't allow certain primary key columns (e.g. mssql identity columns).

Note that this PR affects updating all items, not only fields.

fixes #4495