### PR TITLE
Clarify extension folders and Rollup configuration tip

### DIFF
--- a/docs/guides/displays.md
+++ b/docs/guides/displays.md
@@ -115,6 +115,13 @@ export default {
 };
 ```
 
+::: tip Building multiple extensions
+
+You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
+See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
+
+:::
+
 ## 3. Develop Your Custom Display
 
 The display itself is simply a function or a Vue component, providing a blank canvas for creating anything you need.
@@ -127,5 +134,5 @@ To build the display for use within Directus, run:
 npx rollup -c
 ```
 
-Finally, move the output from your display's `dist` folder into your project's `/extensions/displays` folder. Keep in
-mind that the extensions directory is configurable within your env file, and may be located elsewhere.
+Finally, move the output from your display's `dist` folder into your project's `/extensions/displays/my-custom-display`
+folder. Keep in mind that the extensions directory is configurable within your env file, and may be located elsewhere.

--- a/docs/guides/interfaces.md
+++ b/docs/guides/interfaces.md
@@ -111,6 +111,13 @@ export default {
 };
 ```
 
+::: tip Building multiple extensions
+
+You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
+See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
+
+:::
+
 ## 3. Develop your Custom Interface
 
 The interface itself is simply a Vue component, which provides an blank canvas for creating anything you need.

--- a/docs/guides/layouts.md
+++ b/docs/guides/layouts.md
@@ -92,6 +92,13 @@ export default {
 };
 ```
 
+::: tip Building multiple extensions
+
+You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
+See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
+
+:::
+
 ## 3. Develop Your Custom Layout
 
 The layout itself is simply a Vue component, which provides an blank canvas for creating anything you need.
@@ -104,5 +111,5 @@ To build the layout for use within Directus, run:
 npx rollup -c
 ```
 
-Finally, move the output from your layout's `dist` folder into your project's `/extensions/layouts` folder. Keep in mind
-that the extensions directory is configurable within your env file, and may be located elsewhere.
+Finally, move the output from your layout's `dist` folder into your project's `/extensions/layouts/my-custom-layout`
+folder. Keep in mind that the extensions directory is configurable within your env file, and may be located elsewhere.

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -94,6 +94,13 @@ export default {
 };
 ```
 
+::: tip Building multiple extensions
+
+You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
+See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
+
+:::
+
 ## 3. Develop Your Custom Module
 
 The module itself is simply a Vue component, which provides an blank canvas for creating anything you need.
@@ -106,5 +113,5 @@ To build the module for use within Directus, run:
 npx rollup -c
 ```
 
-Finally, move the output from your module's `dist` folder into your project's `/extensions/modules` folder. Keep in mind
-that the extensions directory is configurable within your env file, and may be located elsewhere.
+Finally, move the output from your module's `dist` folder into your project's `/extensions/modules/my-custom-module`
+folder. Keep in mind that the extensions directory is configurable within your env file, and may be located elsewhere.


### PR DESCRIPTION
This PR tries to clarify the use of the extension folders as discussed with @benhaynes in #2646. This was already done in the `interfaces.md` file, so I kept the same format for consistency.

It also adds a Rollup configuration file tip, so developers get a hint on how to use a single Rollup configuration file to build (or watch) multiple extensions.

Hope this is useful.