### PR TITLE
Replace `path.normalize` with `normalize-path`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 			}
 		},
 		"api": {
+			"name": "directus",
 			"version": "9.0.0-rc.51",
 			"license": "GPL-3.0-only",
 			"dependencies": {
@@ -220,6 +221,7 @@
 			}
 		},
 		"app": {
+			"name": "@directus/app",
 			"version": "9.0.0-rc.51",
 			"devDependencies": {
 				"@directus/docs": "9.0.0-rc.51",
@@ -309,6 +311,7 @@
 			}
 		},
 		"docs": {
+			"name": "@directus/docs",
 			"version": "9.0.0-rc.51",
 			"license": "ISC",
 			"devDependencies": {
@@ -5421,6 +5424,12 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"dev": true
+		},
+		"node_modules/@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -42273,6 +42282,7 @@
 			}
 		},
 		"packages/drive": {
+			"name": "@directus/drive",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
@@ -42285,14 +42295,17 @@
 			}
 		},
 		"packages/drive-azure": {
+			"name": "@directus/drive-azure",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
-				"@azure/storage-blob": "^12.2.1"
+				"@azure/storage-blob": "^12.2.1",
+				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@types/fs-extra": "^9.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"fs-extra": "^9.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
@@ -42315,14 +42328,17 @@
 			}
 		},
 		"packages/drive-gcs": {
+			"name": "@directus/drive-gcs",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
-				"@google-cloud/storage": "^5.0.0"
+				"@google-cloud/storage": "^5.0.0",
+				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@lukeed/uuid": "^1.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
 			},
@@ -42344,14 +42360,17 @@
 			}
 		},
 		"packages/drive-s3": {
+			"name": "@directus/drive-s3",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
-				"aws-sdk": "^2.680.0"
+				"aws-sdk": "^2.680.0",
+				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@types/fs-extra": "^9.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"fs-extra": "^9.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
@@ -42387,6 +42406,7 @@
 			}
 		},
 		"packages/format-title": {
+			"name": "@directus/format-title",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"devDependencies": {
@@ -42405,6 +42425,7 @@
 			}
 		},
 		"packages/gatsby-source-directus": {
+			"name": "@directus/gatsby-source-directus",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
@@ -42421,6 +42442,7 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"packages/schema": {
+			"name": "@directus/schema",
 			"version": "9.0.0-rc.51",
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -42432,6 +42454,7 @@
 			}
 		},
 		"packages/sdk-js": {
+			"name": "@directus/sdk-js",
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
@@ -42440,6 +42463,7 @@
 			}
 		},
 		"packages/specs": {
+			"name": "@directus/specs",
 			"version": "9.0.0-rc.51",
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -44205,7 +44229,9 @@
 				"@azure/storage-blob": "^12.2.1",
 				"@directus/drive": "9.0.0-rc.51",
 				"@types/fs-extra": "^9.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"fs-extra": "^9.0.0",
+				"normalize-path": "^3.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
 			},
@@ -44228,6 +44254,8 @@
 				"@directus/drive": "9.0.0-rc.51",
 				"@google-cloud/storage": "^5.0.0",
 				"@lukeed/uuid": "^1.0.1",
+				"@types/normalize-path": "^3.0.0",
+				"normalize-path": "^3.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
 			},
@@ -44249,8 +44277,10 @@
 			"requires": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@types/fs-extra": "^9.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"aws-sdk": "^2.680.0",
 				"fs-extra": "^9.0.0",
+				"normalize-path": "^3.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
 			},
@@ -46958,6 +46988,12 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"dev": true
+		},
+		"@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
 			"dev": true
 		},
 		"@types/parse-json": {

--- a/packages/drive-azure/package-lock.json
+++ b/packages/drive-azure/package-lock.json
@@ -9,11 +9,13 @@
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
-				"@azure/storage-blob": "^12.2.1"
+				"@azure/storage-blob": "^12.2.1",
+				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@types/fs-extra": "^9.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"fs-extra": "^9.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
@@ -216,6 +218,12 @@
 				"form-data": "^3.0.0"
 			}
 		},
+		"node_modules/@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
+			"dev": true
+		},
 		"node_modules/@types/tunnel": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
@@ -342,6 +350,14 @@
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 			"engines": {
 				"node": "4.x || >=6.0.0"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/npm-watch": {
@@ -636,6 +652,12 @@
 				"form-data": "^3.0.0"
 			}
 		},
+		"@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
+			"dev": true
+		},
 		"@types/tunnel": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
@@ -735,8 +757,14 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+		},
 		"npm-watch": {
 			"version": "0.9.0",
+			"integrity": "sha512-C5Rgh5+jvY33K1EH8Qjr1hfpH9Nhasc90QJ0W+JyKg2ogE0LOCZI4xirC8QmywW7XinyBpynwxlrN6aPfjc3Hw==",
 			"dev": true,
 			"requires": {
 				"nodemon": "^2.0.7",
@@ -765,6 +793,7 @@
 		},
 		"through2": {
 			"version": "4.0.2",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "3"

--- a/packages/drive-azure/package.json
+++ b/packages/drive-azure/package.json
@@ -40,7 +40,8 @@
 		"dist"
 	],
 	"dependencies": {
-		"@azure/storage-blob": "^12.2.1"
+		"@azure/storage-blob": "^12.2.1",
+		"normalize-path": "^3.0.0"
 	},
 	"peerDependencies": {
 		"@directus/drive": "9.0.0-rc.51"
@@ -48,6 +49,7 @@
 	"devDependencies": {
 		"@directus/drive": "9.0.0-rc.51",
 		"@types/fs-extra": "^9.0.1",
+		"@types/normalize-path": "^3.0.0",
 		"fs-extra": "^9.0.0",
 		"npm-watch": "^0.9.0",
 		"typescript": "^4.2.3"

--- a/packages/drive-azure/src/AzureBlobWebServices.ts
+++ b/packages/drive-azure/src/AzureBlobWebServices.ts
@@ -26,6 +26,8 @@ import path from 'path';
 
 import { PassThrough, Readable } from 'stream';
 
+import normalize from 'normalize-path';
+
 function handleError(err: Error, path: string): Error {
 	return new UnknownException(err, err.name, path);
 }
@@ -45,7 +47,7 @@ export class AzureBlobWebServicesStorage extends Storage {
 			this.$signedCredentials
 		);
 		this.$containerClient = this.$client.getContainerClient(config.containerName);
-		this.$root = config.root ? path.normalize(config.root) : '';
+		this.$root = config.root ? normalize(config.root).replace(/^\//, '') : '';
 	}
 
 	/**

--- a/packages/drive-gcs/package-lock.json
+++ b/packages/drive-gcs/package-lock.json
@@ -9,11 +9,13 @@
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
-				"@google-cloud/storage": "^5.0.0"
+				"@google-cloud/storage": "^5.0.0",
+				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@lukeed/uuid": "^1.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
 			},
@@ -125,6 +127,12 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
+			"dev": true
 		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
@@ -639,6 +647,14 @@
 				"node": ">= 6.0.0"
 			}
 		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/npm-watch": {
 			"version": "0.9.0",
 			"integrity": "sha512-C5Rgh5+jvY33K1EH8Qjr1hfpH9Nhasc90QJ0W+JyKg2ogE0LOCZI4xirC8QmywW7XinyBpynwxlrN6aPfjc3Hw==",
@@ -1003,6 +1019,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+		},
+		"@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
+			"dev": true
 		},
 		"abort-controller": {
 			"version": "3.0.0",
@@ -1385,8 +1407,14 @@
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
 			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
 		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+		},
 		"npm-watch": {
 			"version": "0.9.0",
+			"integrity": "sha512-C5Rgh5+jvY33K1EH8Qjr1hfpH9Nhasc90QJ0W+JyKg2ogE0LOCZI4xirC8QmywW7XinyBpynwxlrN6aPfjc3Hw==",
 			"dev": true,
 			"requires": {
 				"nodemon": "^2.0.7",
@@ -1519,6 +1547,7 @@
 		},
 		"through2": {
 			"version": "4.0.2",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "3"

--- a/packages/drive-gcs/package.json
+++ b/packages/drive-gcs/package.json
@@ -39,7 +39,8 @@
 		}
 	},
 	"dependencies": {
-		"@google-cloud/storage": "^5.0.0"
+		"@google-cloud/storage": "^5.0.0",
+		"normalize-path": "^3.0.0"
 	},
 	"peerDependencies": {
 		"@directus/drive": "9.0.0-rc.51"
@@ -47,6 +48,7 @@
 	"devDependencies": {
 		"@directus/drive": "9.0.0-rc.51",
 		"@lukeed/uuid": "^1.0.1",
+		"@types/normalize-path": "^3.0.0",
 		"npm-watch": "^0.9.0",
 		"typescript": "^4.2.3"
 	},

--- a/packages/drive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/drive-gcs/src/GoogleCloudStorage.ts
@@ -28,6 +28,8 @@ import {
 
 import path from 'path';
 
+import normalize from 'normalize-path';
+
 function handleError(err: Error & { code?: number | string }, path: string): Error {
 	switch (err.code) {
 		case 401:
@@ -55,7 +57,7 @@ export class GoogleCloudStorage extends Storage {
 		const GCSStorage = require('@google-cloud/storage').Storage;
 		this.$driver = new GCSStorage(config);
 		this.$bucket = this.$driver.bucket(config.bucket);
-		this.$root = config.root ? path.normalize(config.root) : '';
+		this.$root = config.root ? normalize(config.root).replace(/^\//, '') : '';
 	}
 
 	/**

--- a/packages/drive-s3/package-lock.json
+++ b/packages/drive-s3/package-lock.json
@@ -9,11 +9,13 @@
 			"version": "9.0.0-rc.51",
 			"license": "MIT",
 			"dependencies": {
-				"aws-sdk": "^2.680.0"
+				"aws-sdk": "^2.680.0",
+				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
 				"@directus/drive": "9.0.0-rc.51",
 				"@types/fs-extra": "^9.0.1",
+				"@types/normalize-path": "^3.0.0",
 				"fs-extra": "^9.0.0",
 				"npm-watch": "^0.9.0",
 				"typescript": "^4.2.3"
@@ -33,18 +35,24 @@
 			}
 		},
 		"node_modules/@types/fs-extra": {
-			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
-			"integrity": "sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.9.tgz",
+			"integrity": "sha512-5TqDycCl0oMzwzd1cIjSJWMKMvLCDVErle4ZTjU4EmHDURR/+yZghe6GDHMCpHtcVfq0x0gMoOM546/5TbYHrg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "14.14.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-			"integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+			"version": "14.14.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+			"integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==",
+			"dev": true
+		},
+		"node_modules/@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
 			"dev": true
 		},
 		"node_modules/at-least-node": {
@@ -57,9 +65,9 @@
 			}
 		},
 		"node_modules/aws-sdk": {
-			"version": "2.871.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.871.0.tgz",
-			"integrity": "sha512-rFd2shGgYfCzQQQeqqgZRiLuPFUm3uUlHqM40nMtbqM1y7abuOUyuOMxTHsKsbY+Bu7gRESngPTf7Iknxq9/uQ==",
+			"version": "2.872.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.872.0.tgz",
+			"integrity": "sha512-hI1/iwR1uPbuulvWZmCCmLKN1Oiv+Beutwcn+7ZOsWAEtsgsXiHmuRDS/ZdWiBRNQkfZgUhcCwLz7nOrWKpb8w==",
 			"dependencies": {
 				"buffer": "4.9.2",
 				"events": "1.1.1",
@@ -169,6 +177,14 @@
 			"integrity": "sha512-KJI+FawYOv74x60H6+zrBPfO2vvp9m0pHZi6SH8BBBuc67Irv11DsqY4Le4EBFq1/T5aXFU3hkLrMgtW7RNXxA==",
 			"dev": true
 		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/npm-watch": {
 			"version": "0.9.0",
 			"integrity": "sha512-C5Rgh5+jvY33K1EH8Qjr1hfpH9Nhasc90QJ0W+JyKg2ogE0LOCZI4xirC8QmywW7XinyBpynwxlrN6aPfjc3Hw==",
@@ -276,18 +292,24 @@
 			}
 		},
 		"@types/fs-extra": {
-			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
-			"integrity": "sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.9.tgz",
+			"integrity": "sha512-5TqDycCl0oMzwzd1cIjSJWMKMvLCDVErle4ZTjU4EmHDURR/+yZghe6GDHMCpHtcVfq0x0gMoOM546/5TbYHrg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/node": {
-			"version": "14.14.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-			"integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+			"version": "14.14.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+			"integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==",
+			"dev": true
+		},
+		"@types/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
 			"dev": true
 		},
 		"at-least-node": {
@@ -297,9 +319,9 @@
 			"dev": true
 		},
 		"aws-sdk": {
-			"version": "2.871.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.871.0.tgz",
-			"integrity": "sha512-rFd2shGgYfCzQQQeqqgZRiLuPFUm3uUlHqM40nMtbqM1y7abuOUyuOMxTHsKsbY+Bu7gRESngPTf7Iknxq9/uQ==",
+			"version": "2.872.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.872.0.tgz",
+			"integrity": "sha512-hI1/iwR1uPbuulvWZmCCmLKN1Oiv+Beutwcn+7ZOsWAEtsgsXiHmuRDS/ZdWiBRNQkfZgUhcCwLz7nOrWKpb8w==",
 			"requires": {
 				"buffer": "4.9.2",
 				"events": "1.1.1",
@@ -380,6 +402,11 @@
 			"resolved": "https://registry.npmjs.org/node-exceptions/-/node-exceptions-4.0.1.tgz",
 			"integrity": "sha512-KJI+FawYOv74x60H6+zrBPfO2vvp9m0pHZi6SH8BBBuc67Irv11DsqY4Le4EBFq1/T5aXFU3hkLrMgtW7RNXxA==",
 			"dev": true
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"npm-watch": {
 			"version": "0.9.0",

--- a/packages/drive-s3/package.json
+++ b/packages/drive-s3/package.json
@@ -40,7 +40,8 @@
 		}
 	},
 	"dependencies": {
-		"aws-sdk": "^2.680.0"
+		"aws-sdk": "^2.680.0",
+		"normalize-path": "^3.0.0"
 	},
 	"peerDependencies": {
 		"@directus/drive": "9.0.0-rc.51"
@@ -48,6 +49,7 @@
 	"devDependencies": {
 		"@directus/drive": "9.0.0-rc.51",
 		"@types/fs-extra": "^9.0.1",
+		"@types/normalize-path": "^3.0.0",
 		"fs-extra": "^9.0.0",
 		"npm-watch": "^0.9.0",
 		"typescript": "^4.2.3"

--- a/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
@@ -16,6 +16,7 @@ import {
 	Range,
 } from '@directus/drive';
 import path from 'path';
+import normalize from 'normalize-path';
 
 function handleError(err: Error, path: string, bucket: string): Error {
 	switch (err.name) {
@@ -47,7 +48,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 		});
 
 		this.$bucket = config.bucket;
-		this.$root = config.root ? path.normalize(config.root) : '';
+		this.$root = config.root ? normalize(config.root).replace(/^\//, '') : '';
 	}
 
 	/**


### PR DESCRIPTION
This PR tries to solve #4628, where a change is proposed to replace `path.normalize` with the `normalize-path` package for Azure, GCS and S3.

I'm not sure how to test this change, so any help or guidance is appreciated.