### PR TITLE
Reduced chunk vendor build size ( Parsed size from 3.48MB to 1.19MB )

### DIFF
--- a/app/src/interfaces/types.ts
+++ b/app/src/interfaces/types.ts
@@ -1,5 +1,5 @@
 import VueI18n from 'vue-i18n';
-import { Component } from 'vue';
+import { Component, AsyncComponent } from 'vue';
 import { Field, types, localTypes } from '@/types';
 
 export type InterfaceConfig = {
@@ -7,8 +7,8 @@ export type InterfaceConfig = {
 	icon: string;
 	name: string | VueI18n.TranslateResult;
 	description?: string | VueI18n.TranslateResult;
-	component: Component;
-	options: DeepPartial<Field>[] | Component;
+	component: Component | AsyncComponent;
+	options: DeepPartial<Field>[] | Component | AsyncComponent;
 	types: typeof types[number][];
 	groups?: readonly typeof localTypes[number][];
 	relational?: boolean;

--- a/app/src/interfaces/wysiwyg/index.ts
+++ b/app/src/interfaces/wysiwyg/index.ts
@@ -1,12 +1,15 @@
-import InterfaceWYSIWYG from './wysiwyg.vue';
+import { AsyncComponent } from 'vue';
 import { defineInterface } from '@/interfaces/define';
+
+const InterfaceWYSIWYG = () =>
+	import(/* webpackChunkName: 'interface-wysiwyg', webpackPrefetch: true */ './wysiwyg.vue');
 
 export default defineInterface(({ i18n }) => ({
 	id: 'wysiwyg',
 	name: i18n.t('interfaces.wysiwyg.wysiwyg'),
 	description: i18n.t('interfaces.wysiwyg.description'),
 	icon: 'format_quote',
-	component: InterfaceWYSIWYG,
+	component: InterfaceWYSIWYG as AsyncComponent,
 	types: ['text'],
 	options: [
 		{

--- a/app/src/modules/docs/routes/static.vue
+++ b/app/src/modules/docs/routes/static.vue
@@ -27,10 +27,12 @@
 </template>
 
 <script lang="ts">
+import { AsyncComponent } from 'vue';
 import { defineComponent, ref, computed } from '@vue/composition-api';
 import DocsNavigation from '../components/navigation.vue';
-import Markdown from '../components/markdown.vue';
 import marked from 'marked';
+
+const Markdown = () => import(/* webpackChunkName: 'markdown', webpackPrefetch: true */ '../components/markdown.vue');
 
 async function getMarkdownForPath(path: string) {
 	const pathParts = path.split('/');
@@ -52,7 +54,7 @@ async function getMarkdownForPath(path: string) {
 
 export default defineComponent({
 	name: 'StaticDocs',
-	components: { DocsNavigation, Markdown },
+	components: { DocsNavigation, Markdown: Markdown as AsyncComponent },
 	async beforeRouteEnter(to, from, next) {
 		const md = await getMarkdownForPath(to.path);
 

--- a/app/src/utils/register-component/register-component.ts
+++ b/app/src/utils/register-component/register-component.ts
@@ -1,6 +1,6 @@
-import Vue, { Component } from 'vue';
+import Vue, { Component, AsyncComponent } from 'vue';
 
-function registerComponent(id: string, component: Component): void;
+function registerComponent(id: string, component: Component | AsyncComponent): void;
 function registerComponent(id: string, component: Parameters<typeof Vue.component>[1]): void;
 
 function registerComponent(id: string, component: any) {


### PR DESCRIPTION
Hi, dear directus team

My name is kamwing and I'm from China. recently I use directus to build my project website. It's really easy to use and very flexible. Thank you very much for build this amazing project!

I found the Wysiwyg and markdown bundle size is too large, and not necessarily build into chunk-vendors, so I split out **Wysiwyg** and **markdown** code into a separate chunk. 

Before code split

![1](https://user-images.githubusercontent.com/183904/112270671-f194e100-8cb4-11eb-89ca-81adec165673.png)

After code split

![2](https://user-images.githubusercontent.com/183904/112270687-f78ac200-8cb4-11eb-89db-c1d6dfc2f5a2.png)
