### PR TITLE
Fixed ambiguous column when field name exists in some join table

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -169,7 +169,10 @@ export function applyFilter(
 				const pkField = `${collection}.${o2mRelation.one_primary}`;
 
 				dbQuery[logical].whereIn(pkField, (subQueryKnex) => {
-					subQueryKnex.select([o2mRelation.many_field]).from(o2mRelation.many_collection);
+					const field = o2mRelation.many_field
+					const collection = o2mRelation.many_collection
+					const column = `${collection}.${field}`
+					subQueryKnex.select({[field]: column}).from(collection);
 
 					applyQuery(
 						o2mRelation.many_collection,


### PR DESCRIPTION
Version: v9.0.0-rc.51
Database: PostgreSQL 13.2

---

When you try to filter on the same table with an intermediate table, the query throws a database error when it detects that the column is ambiguous.

---

Example: When you have an intermediate user group table and you want a user to be able to see the users that belong to their group.

```sql
select
  "directus_users"."id" 
from "directus_users" 
where (
  (
    "directus_users"."id" = $1 or 
    "directus_users"."id" in (
      select 
        "user" 
      from "users_groups" 
      left join "groups" as "vnevl" on "users_groups"."group" = "vnevl"."id" 
      left join "users_groups" as "zigah" on "vnevl"."id" = "zigah"."group" 
      left join "directus_users" as "vcolc" on "zigah"."user" = "vcolc"."id" 
      where "zigah"."user" = $2
    )
  )
) limit $3 - column reference "user" is ambiguous
```