### PR TITLE
Updating SDK 2FA endpoints

### DIFF
--- a/packages/sdk-js/src/handlers/users.ts
+++ b/packages/sdk-js/src/handlers/users.ts
@@ -41,7 +41,7 @@ export class UsersHandler extends ItemsHandler {
 			await this.axios.post('/users/me/tfa/enable', { password });
 		},
 		disable: async (otp: string): Promise<void> => {
-			await this.axios.post('/users/tfa/disable', { otp });
+			await this.axios.post('/users/me/tfa/disable', { otp });
 		},
 	};
 

--- a/packages/sdk-js/src/handlers/users.ts
+++ b/packages/sdk-js/src/handlers/users.ts
@@ -38,7 +38,7 @@ export class UsersHandler extends ItemsHandler {
 
 	tfa = {
 		enable: async (password: string): Promise<void> => {
-			await this.axios.post('/users/tfa/enable', { password });
+			await this.axios.post('/users/me/tfa/enable', { password });
 		},
 		disable: async (otp: string): Promise<void> => {
 			await this.axios.post('/users/tfa/disable', { otp });

--- a/packages/sdk-js/tests/handlers/users.ts
+++ b/packages/sdk-js/tests/handlers/users.ts
@@ -57,12 +57,12 @@ describe('UsersHandler', () => {
 	});
 
 	describe('tfa.enable', () => {
-		it('Calls the /users/tfa/enable endpoint', async () => {
+		it('Calls the /users/me/tfa/enable endpoint', async () => {
 			const stub = sandbox.stub(handler.axios, 'post').resolves(Promise.resolve());
 
 			await handler.tfa.enable('p455w0rd');
 
-			expect(stub).to.have.been.calledWith('/users/tfa/enable', {
+			expect(stub).to.have.been.calledWith('/users/me/tfa/enable', {
 				password: 'p455w0rd',
 			});
 		});

--- a/packages/sdk-js/tests/handlers/users.ts
+++ b/packages/sdk-js/tests/handlers/users.ts
@@ -69,12 +69,12 @@ describe('UsersHandler', () => {
 	});
 
 	describe('tfa.disable', () => {
-		it('Calls the /users/tfa/disable endpoint', async () => {
+		it('Calls the /users/me/tfa/disable endpoint', async () => {
 			const stub = sandbox.stub(handler.axios, 'post').resolves(Promise.resolve());
 
 			await handler.tfa.disable('351851');
 
-			expect(stub).to.have.been.calledWith('/users/tfa/disable', {
+			expect(stub).to.have.been.calledWith('/users/me/tfa/disable', {
 				otp: '351851',
 			});
 		});


### PR DESCRIPTION
# Updating SDK 2FA endpoint

Currently, the SDK fails as the endpoint to enable/disable 2FA.