### PR TITLE
Storage: S3 ACL & Content Type

### DIFF
--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -66,7 +66,7 @@ export class AssetsService {
 				transformer.toFormat(type.substring(6), { quality: Number(transformation.quality) });
 			}
 
-			await storage.disk(file.storage).put(assetFilename, readStream.pipe(transformer));
+			await storage.disk(file.storage).put(assetFilename, readStream.pipe(transformer), type);
 
 			return {
 				stream: storage.disk(file.storage).getStream(assetFilename, range),

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -49,7 +49,7 @@ export class FilesService extends ItemsService {
 		}
 
 		try {
-			await storage.disk(data.storage).put(payload.filename_disk, stream);
+			await storage.disk(data.storage).put(payload.filename_disk, stream, payload.type);
 		} catch (err) {
 			logger.warn(`Couldn't save file ${payload.filename_disk}`);
 			logger.warn(err);

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -189,6 +189,7 @@ Based on your configured driver, you must also provide the following configurati
 | `STORAGE_<LOCATION>_BUCKET`   | S3 Bucket   | --                 |
 | `STORAGE_<LOCATION>_REGION`   | S3 Region   | --                 |
 | `STORAGE_<LOCATION>_ENDPOINT` | S3 Endpoint | "s3.amazonaws.com" |
+| `STORAGE_<LOCATION>_ACL`      | S3 ACL      | --                 |
 
 ### Azure (`azure`)
 

--- a/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
@@ -35,6 +35,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 	protected $driver: S3;
 	protected $bucket: string;
 	protected $root: string;
+	protected $acl: string;
 
 	constructor(config: AmazonWebServicesS3StorageConfig) {
 		super();
@@ -49,6 +50,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 
 		this.$bucket = config.bucket;
 		this.$root = config.root ? normalize(config.root).replace(/^\//, '') : '';
+		this.$acl = config.acl ? config.acl : '';
 	}
 
 	/**
@@ -69,6 +71,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 			Key: dest,
 			Bucket: this.$bucket,
 			CopySource: `/${this.$bucket}/${src}`,
+			ACL: this.$acl,
 		};
 
 		try {
@@ -247,10 +250,20 @@ export class AmazonWebServicesS3Storage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
+	public async put(
+		location: string,
+		content: Buffer | NodeJS.ReadableStream | string,
+		type?: string
+	): Promise<Response> {
 		location = this._fullPath(location);
 
-		const params = { Key: location, Body: content, Bucket: this.$bucket };
+		const params = {
+			Key: location,
+			Body: content,
+			Bucket: this.$bucket,
+			ACL: this.$acl,
+			ContentType: type ? type : '',
+		};
 
 		try {
 			const result = await this.$driver.upload(params).promise();
@@ -301,4 +314,5 @@ export interface AmazonWebServicesS3StorageConfig extends ClientConfiguration {
 	secret: string;
 	bucket: string;
 	root?: string;
+	acl?: string;
 }

--- a/packages/drive/src/Storage.ts
+++ b/packages/drive/src/Storage.ts
@@ -131,7 +131,7 @@ export default abstract class Storage {
 	 *
 	 * Supported drivers: "local", "s3", "gcs", "azure"
 	 */
-	put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
+	put(location: string, content: Buffer | NodeJS.ReadableStream | string, type?: string): Promise<Response> {
 		throw new MethodNotSupported('put', this.constructor.name);
 	}
 


### PR DESCRIPTION
For discussion here: https://github.com/directus/directus/discussions/4681

- Adds support for `STORAGE_<LOCATION>_ACL` env variable to set the ACL value on S3 file upload: [AWSJavaScriptSDK#putObject-property](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property) (If not set AWS will currently default to `private`. Empty string default in Directus codebase lets AWS continue to be the default authority).
- Additionally passes the mime type to `ContentType` property for S3 upload to correctly set file content type in S3 (will default to `application/octet-stream` in S3 otherwise).