### PR TITLE
Fix discard not closing on singleton

### DIFF
--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -469,6 +469,7 @@ export default defineComponent({
 		function discardAndLeave() {
 			if (!leaveTo.value) return;
 			edits.value = {};
+			confirmLeave.value = false;
 			router.push(leaveTo.value);
 		}
 


### PR DESCRIPTION
When editing a singleton collection, then clicking on a different singleton collection, the modal wouldn't get closed.