### PR TITLE
fix: fetch relational fields' properties

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -7,7 +7,11 @@ import { APIError } from '@/types';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 
-export function useItem(collection: Ref<string>, primaryKey: Ref<string | number | null>) {
+export function useItem(
+	collection: Ref<string>,
+	primaryKey: Ref<string | number | null>,
+	fieldsToFetch?: Ref<string[] | null>
+) {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 
 	const item = ref<Record<string, any> | null>(null);
@@ -73,7 +77,11 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 		error.value = null;
 
 		try {
-			const response = await api.get(itemEndpoint.value);
+			const response = await api.get(itemEndpoint.value, {
+				params: {
+					fields: fieldsToFetch?.value || ['*'],
+				},
+			});
 			setItemValueToResponse(response);
 		} catch (err) {
 			error.value = err;

--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -241,7 +241,21 @@ export default defineComponent({
 
 		const revisionsDrawerDetail = ref<Vue | null>(null);
 
-		const { info: collectionInfo, defaults, primaryKeyField, isSingleton } = useCollection(collection);
+		const { info: collectionInfo, defaults, fields: fieldsInCollection, primaryKeyField, isSingleton } = useCollection(
+			collection
+		);
+
+		const fieldsToFetch = computed(() =>
+			fieldsInCollection.value.map((field) => {
+				const relationalFieldTypes = ['m2o', 'o2m', 'm2m', 'm2a'];
+
+				if (relationalFieldTypes.includes(field.type)) {
+					return `${field.field}.*`;
+				}
+
+				return field.field;
+			})
+		);
 
 		const {
 			isNew,
@@ -259,7 +273,7 @@ export default defineComponent({
 			saveAsCopy,
 			refresh,
 			validationErrors,
-		} = useItem(collection, primaryKey);
+		} = useItem(collection, primaryKey, fieldsToFetch);
 
 		const hasEdits = computed(() => Object.keys(edits.value).length > 0);
 

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -94,6 +94,7 @@ import SettingsNavigation from '../../../components/navigation.vue';
 import router from '@/router';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail';
 import useItem from '@/composables/use-item';
+import { usePermissions } from '@/composables/use-permissions';
 import { useUserStore, usePermissionsStore } from '@/stores/';
 import RoleInfoSidebarDetail from './components/role-info-sidebar-detail.vue';
 import PermissionsOverview from './components/permissions-overview.vue';
@@ -117,10 +118,23 @@ export default defineComponent({
 		const permissionsStore = usePermissionsStore();
 		const userInviteModalActive = ref(false);
 		const { primaryKey } = toRefs(props);
+		const { fields } = usePermissions(ref('directus_roles'), primaryKey, ref(false));
+		const fieldsToFetch = computed(() =>
+			fields.value.map((field) => {
+				const relationalFieldTypes = ['m2o', 'o2m', 'm2m', 'm2a'];
+
+				if (relationalFieldTypes.includes(field.type)) {
+					return `${field.field}.*`;
+				}
+
+				return field.field;
+			})
+		);
 
 		const { edits, item, saving, loading, error, save, remove, deleting, isBatch } = useItem(
 			ref('directus_roles'),
-			primaryKey
+			primaryKey,
+			fieldsToFetch
 		);
 
 		const hasEdits = computed<boolean>(() => Object.keys(edits.value).length > 0);


### PR DESCRIPTION
The problem: item details page (route: /items/:collection/:pk) won't display o2m field's values.
Solution: Specifying fields to `/items/:collection/:pk` endpoint on the admin app.