### PR TITLE
Make data-model collection options persistent

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -106,11 +106,11 @@ import CollectionOptions from './components/collection-options.vue';
 import CollectionsFilter from './components/collections-filter.vue';
 import marked from 'marked';
 
+const activeTypes = ref(['visible', 'hidden', 'unmanaged']);
+
 export default defineComponent({
 	components: { SettingsNavigation, CollectionOptions, CollectionsFilter },
 	setup() {
-		const activeTypes = ref(['visible', 'hidden', 'unmanaged']);
-
 		const collectionsStore = useCollectionsStore();
 
 		const tableHeaders = ref<HeaderRaw[]>([


### PR DESCRIPTION
I'm now storing the settings globaly in the component so it only resets when the page reloads.
![grafik](https://user-images.githubusercontent.com/22577866/113417946-cdc45000-93c4-11eb-82ee-427e720bf091.png)

closes #4818
