### PR TITLE
style: add sans-serif for monospace

### DIFF
--- a/app/src/styles/_type-styles.scss
+++ b/app/src/styles/_type-styles.scss
@@ -1,7 +1,7 @@
 @import './mixins/type-styles.scss';
 
 :root {
-	--family-monospace: 'Fira Mono', monospace;
+	--family-monospace: 'Fira Mono', monospace, sans-serif;
 	--family-serif: 'Merriweather', serif;
 	--family-sans-serif: 'Inter', -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial',
 		sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';


### PR DESCRIPTION
For handle Cyrillic like texts in monospace styles

![screen](https://user-images.githubusercontent.com/17751886/113943687-d5905400-980b-11eb-86d9-714db16c055f.png)

After add `sans-serif` compatibility:

![screen](https://user-images.githubusercontent.com/17751886/113943896-45064380-980c-11eb-9489-720cb5f9c004.png)
