### PR TITLE
Fix extension path wildcard

### DIFF
--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -12,7 +12,7 @@ const extensionsPath = env.EXTENSIONS_PATH as string;
 const appExtensions = ['interfaces', 'layouts', 'displays', 'modules'];
 
 router.get(
-	'/:type/*',
+	['/:type', '/:type/*'],
 	asyncHandler(async (req, res, next) => {
 		if (appExtensions.includes(req.params.type) === false) {
 			throw new RouteNotFoundException(req.path);


### PR DESCRIPTION
I adjusted the wildcard that was introduced by the changes in https://github.com/directus/directus/commit/cdbd6e820b87943e596f225df724ad5a1cd7818f so the extension list can be loaded again.

fixes #4902 
