### PR TITLE
Fix: M2M File Interface: Missing deselect / delete button for non-admin users

### DIFF
--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -25,9 +25,9 @@
 				/>
 			</template>
 
-			<template #item-append="{ item }" v-if="!disabled">
-				<v-icon name="save_alt" v-tooltip="$t('download')" class="download" @click.stop="downloadItem(item)" />
-				<v-icon name="close" v-tooltip="$t('deselect')" class="deselect" @click.stop="deleteItem(item)" />
+			<template #item-append="{ item }">
+				<v-icon name="save_alt" v-show="!disabled" v-tooltip="$t('download')" class="download" @click.stop="downloadItem(item)" />
+				<v-icon name="close" v-show="!disabled" v-tooltip="$t('deselect')" class="deselect" @click.stop="deleteItem(item)" />
 			</template>
 		</v-table>
 


### PR DESCRIPTION
This was recently addressed and fixed for o2m and m2m interfaces (https://github.com/directus/directus/pull/4748) but not for the files interface.