### PR TITLE
Decline to send expired token

### DIFF
--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -43,6 +43,12 @@ export class Auth implements IAuth {
 		this.storage.auth_token = response.data!.access_token;
 		this.storage.auth_refresh_token = response.data?.refresh_token || null;
 		this.storage.auth_expires = response.data?.expires || null;
+		if (response.data?.expires) {
+			const now = new Date();
+			const expiry = now.setTime(now.getTime() + response.data?.expires)
+			this.storage.auth_valid_until = expiry;
+		}
+
 
 		return {
 			access_token: response.data!.access_token,
@@ -86,6 +92,11 @@ export class Auth implements IAuth {
 		this.storage.auth_token = response.data!.access_token;
 		this.storage.auth_refresh_token = response.data?.refresh_token || null;
 		this.storage.auth_expires = response.data?.expires || null;
+		if (response.data?.expires) {
+			const now = new Date();
+			const expiry = now.setTime(now.getTime() + response.data?.expires)
+			this.storage.auth_valid_until = expiry;
+		}
 
 		return {
 			access_token: response.data!.access_token,

--- a/packages/sdk/src/base/storage/base.ts
+++ b/packages/sdk/src/base/storage/base.ts
@@ -41,6 +41,22 @@ export abstract class BaseStorage implements IStorage {
 		}
 	}
 
+	get auth_valid_until(): number | null {
+		const value = this.get('auth_valid_until');
+		if (value === null) {
+			return null;
+		}
+		return parseInt(value);
+	}
+
+	set auth_valid_until(value: number | null) {
+		if (value === null) {
+			this.delete('auth_valid_until');
+		} else {
+			this.set('auth_valid_until', value!.toString());
+		}
+	}
+
 	abstract get(key: string): string | null;
 	abstract set(key: string, value: string): string;
 	abstract delete(key: string): string | null;

--- a/packages/sdk/src/base/transport/axios-transport.ts
+++ b/packages/sdk/src/base/transport/axios-transport.ts
@@ -143,7 +143,9 @@ export class AxiosTransport implements ITransport {
 
 	private createRequestConfig(config: AxiosRequestConfig): AxiosRequestConfig {
 		let token = this._storage.auth_token;
-		if (!token) {
+		let validUntil = this._storage.auth_valid_until;
+		const now = new Date();
+		if (!token || validUntil && validUntil < now.getTime()) {
 			return config;
 		}
 

--- a/packages/sdk/src/storage.ts
+++ b/packages/sdk/src/storage.ts
@@ -2,6 +2,7 @@ export interface IStorage {
 	auth_token: string | null;
 	auth_expires: number | null;
 	auth_refresh_token: string | null;
+	auth_valid_until: number | null;
 
 	get(key: string): string | null;
 	set(key: string, value: string): string;


### PR DESCRIPTION
This PR will change the default behaviour to attach all  `auth_token`s to Axios requests.

This partially addresses a concern that Directus will return 401 for all endpoints if an invalid access token is passed, regardless of which endpoint is being requested, and whether an access token should be needed in the first place (eg: login, refresh), by making the client responsible for ensuring the access token is valid.

This PR also allows one to attach a custom interceptor to axios, handling expired access tokens transparently by refreshing on 401 errors and retrying the request (eg:

```
import {
  Directus,
} from "directus/packages/sdk/src";

const url = process.env.NEXT_PUBLIC_API_URL;

const directusInstance = new Directus(url);

const successHandler = (res) => res;
const errorHandler = async (err) => {
  const originalReq = err.config;
  const status = err.response?.status;
  const code = err.response?.data?.errors?.[0]?.extensions?.code;

  if (
    status === 401 &&
    code === "INVALID_CREDENTIALS" &&
    err.request.responseURL.includes("refresh") === false &&
    err.request.responseURL.includes("login") === false &&
    err.request.responseURL.includes("tfa") === false &&
    !originalReq._retry
  ) {
    originalReq._retry = true;
    try {
      await directusInstance.auth.refresh();
      return directusInstance.transport.axios(originalReq);
    } catch (e) {
      return Promise.reject(err);
    }
  } else if (err.response.status === 401 && originalReq._retry) {
    return Promise.reject(err);
  } else {
    return Promise.reject(err);
  }
};

directusInstance.transport.axios.interceptors.response.use(
  successHandler,
  errorHandler
);

export const directus = directusInstance;
```

I posted about this [here on Discord](https://discord.com/channels/725371605378924594/819637968259907628/830812897554202664), but have not discussed this specific implementation with the core team (I am open to do so if there are changes needed or suggested)