### PR TITLE
Setup GitHub Actions for E2E Tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,52 @@
+name: Run e2e tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: ['mssql', 'mysql', 'postgres', 'maria', 'sqlite3']
+        node-version: [ '12-alpine', '14-alpine', '15-alpine']
+    env:
+      CACHE_IMAGE_NAME: ghcr.io/directus/directus/e2e-test-cache:${{ matrix.node_version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.REGISTRY_PASSWORD }}
+          password: ${{ secrets.REGISTRY_USERNAME }}
+      - name: Restore docker cache
+        run: |
+          docker pull $CACHE_IMAGE_NAME || true
+          docker tag $CACHE_IMAGE_NAME directus-test-image || true
+      - name: Install dependencies & Build
+        run: |
+          npm ci
+          npm run build
+      - name: Run tests
+        env:
+          TEST_NODE_VERSION: ${{ matrix.node-version }}
+          TEST_DB: ${{ matrix.db }}
+        run: npm run test:e2e
+      - name: Save docker cache
+        run: |
+          docker tag directus-test-image $CACHE_IMAGE_NAME
+          docker push $CACHE_IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,12 @@ ENV LD_LIBRARY_PATH /usr/lib/instantclient
 ENV TNS_ADMIN /usr/lib/instantclient
 ENV ORACLE_HOME /usr/lib/instantclient
 
+RUN npm i -g lerna
+
 WORKDIR /directus
 
 COPY package*.json ./
+COPY lerna.json ./
 COPY api/package.json api/
 COPY api/cli.js api/
 COPY app/package.json app/
@@ -46,15 +49,11 @@ COPY packages/schema/package.json packages/schema/
 COPY packages/sdk/package.json packages/sdk/
 COPY packages/specs/package.json packages/specs/
 
-RUN npm ci
+RUN npx lerna bootstrap
 
 COPY . .
 
-# Required for Node < 15 (no native workspaces)
-RUN npx lerna link
-
 WORKDIR /directus/api
-
 CMD ["sh", "-c", "node ./dist/cli/index.js bootstrap; node ./dist/start.js;"]
 
 EXPOSE 8055/tcp

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,8 @@
 	"command": {
 		"bootstrap": {
 			"npmClientArgs": [
-				"--no-package-lock"
+				"--no-package-lock",
+				"--legacy-peer-deps"
 			]
 		}
 	}


### PR DESCRIPTION
## Workflow
The e2e tests are executed after every commit to the main branch and for every opened pull request.

## Build
I had to adjust the Dockerfile and the build options slightly to make the build work without any prior steps.

## Performance
Currently the tests take roughly `6 minutes` to run (including installing dependencies and building the image).
Maybe we can improve some steps in the future to speed things up, but for now this should be enough.

## Node versions
I am not sure about this one. I setup the workflow to accept an array of node versions (docker tags) to target.
I tried to build the docker image with node v14 but I got a few errors because of some missing dependencies.
Maybe you have an idea why that's not working?


You can find the running Workflow here: https://github.com/Jakob-em/directus/actions/runs/738728333

Relates to #4921