### PR TITLE
Fix 401 error for public API when no token is provided @directus/gatsby-source-directus

### DIFF
--- a/packages/gatsby-source-directus/gatsby-node.js
+++ b/packages/gatsby-source-directus/gatsby-node.js
@@ -137,7 +137,7 @@ exports.sourceNodes = async (gatsby, options) => {
 			Object.assign(obj, (await graphql?.headers()) || {});
 		}
 
-		if (hasToken) {
+		if (!hasToken) {
 			return obj;
 		}
 


### PR DESCRIPTION
## Issue

Fixes https://github.com/directus/directus/issues/4997

## Package 
@directus/gatsby-source-directus

## Description
For public Graphql API, the plugin is still sending the auth token, which is throwing `401` error.  The following changes fix the issue for public APIs. Haven't verified for an authenticated one.


## Screen shots:
<img width="846" alt="Screen Shot 2021-04-12 at 5 25 32 PM" src="https://user-images.githubusercontent.com/27361350/114390238-b7cd4100-9bb5-11eb-8352-74a6412d3759.png">
