### PR TITLE
Additional improvements to extension loading (properly closes #4733)

### DIFF
--- a/app/src/displays/register.ts
+++ b/app/src/displays/register.ts
@@ -17,7 +17,7 @@ export async function registerDisplays() {
 		.filter((m) => m);
 
 	try {
-		const customResponse = await api.get('/extensions/displays');
+		const customResponse = await api.get('/extensions/displays/');
 		const displays: string[] = customResponse.data.data || [];
 
 		await asyncPool(5, displays, async (displayName) => {

--- a/app/src/displays/register.ts
+++ b/app/src/displays/register.ts
@@ -27,7 +27,7 @@ export async function registerDisplays() {
 				);
 				modules.push(result.default);
 			} catch (err) {
-				console.warn(`Couldn't load custom displays "${displayName}"`);
+				console.warn(`Couldn't load custom displays "${displayName}":`, err);
 			}
 		});
 	} catch {

--- a/app/src/interfaces/register.ts
+++ b/app/src/interfaces/register.ts
@@ -17,7 +17,7 @@ export async function registerInterfaces() {
 		.filter((m) => m);
 
 	try {
-		const customResponse = await api.get('/extensions/interfaces');
+		const customResponse = await api.get('/extensions/interfaces/');
 		const interfaces: string[] = customResponse.data.data || [];
 
 		await asyncPool(5, interfaces, async (interfaceName) => {

--- a/app/src/interfaces/register.ts
+++ b/app/src/interfaces/register.ts
@@ -27,7 +27,7 @@ export async function registerInterfaces() {
 				);
 				modules.push(result.default);
 			} catch (err) {
-				console.warn(`Couldn't load custom interface "${interfaceName}"`);
+				console.warn(`Couldn't load custom interface "${interfaceName}":`, err);
 			}
 		});
 	} catch {

--- a/app/src/layouts/register.ts
+++ b/app/src/layouts/register.ts
@@ -26,7 +26,7 @@ export async function registerLayouts() {
 				);
 				modules.push(result.default);
 			} catch (err) {
-				console.warn(`Couldn't load custom layout "${layoutName}"`);
+				console.warn(`Couldn't load custom layout "${layoutName}":`, err);
 			}
 		});
 	} catch {

--- a/app/src/layouts/register.ts
+++ b/app/src/layouts/register.ts
@@ -16,7 +16,7 @@ export async function registerLayouts() {
 		.filter((m) => m);
 
 	try {
-		const customResponse = await api.get('/extensions/layouts');
+		const customResponse = await api.get('/extensions/layouts/');
 		const layouts: string[] = customResponse.data.data || [];
 
 		await asyncPool(5, layouts, async (layoutName) => {

--- a/app/src/modules/register.ts
+++ b/app/src/modules/register.ts
@@ -19,7 +19,7 @@ export async function loadModules() {
 		.filter((m) => m);
 
 	try {
-		const customResponse = await api.get('/extensions/modules');
+		const customResponse = await api.get('/extensions/modules/');
 		const modules: string[] = customResponse.data.data || [];
 
 		await asyncPool(5, modules, async (moduleName) => {

--- a/app/src/modules/register.ts
+++ b/app/src/modules/register.ts
@@ -36,7 +36,7 @@ export async function loadModules() {
 				});
 				queuedModules.push(result.default);
 			} catch (err) {
-				console.warn(`Couldn't load custom module "${moduleName}"`);
+				console.warn(`Couldn't load custom module "${moduleName}":`, err);
 			}
 		});
 	} catch {


### PR DESCRIPTION
the first commit restores https://github.com/directus/directus/pull/4911, which was reverted by https://github.com/directus/directus/pull/4859/files (on accident I assume, seems like it was missed in a rebase?)

the second commits prints out more helpful errors to extension devs when their stuff broke, not sure if you wan't to lock that behind an option or smth to not expose it to users? 