### PR TITLE
Setup CI for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,57 @@
+name: Run e2e tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: ['mssql', 'mysql', 'postgres', 'maria', 'sqlite3']
+        node-version: [ '12-alpine', '14-alpine', '15-alpine' ]
+    env:
+      CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull cached directus image
+        run: |
+          docker pull $CACHED_IMAGE || true
+          docker tag $CACHED_IMAGE directus-test-image || true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+      - name: restore node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Install dependencies
+        run: |
+          npm install
+      - name: Build
+        run: |
+          npm run build
+      - name: Run tests
+        env:
+          TEST_NODE_VERSION: ${{ matrix.node-version }}
+          TEST_DB: ${{ matrix.db }}
+        run: npm run test:e2e
+      - name: Push cached image
+        # only push the new cache image on the main branch once per node version
+        if: github.ref == 'refs/heads/main' && github.repository == 'directus/directus' && matrix.db == 'sqlite3'
+        run: |
+          docker tag directus-test-image $CACHED_IMAGE
+          docker push $CACHED_IMAGE || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,32 +4,34 @@ ARG NODE_VERSION=15-alpine
 
 FROM node:${NODE_VERSION}
 
-WORKDIR /tmp
-
 # Required to run OracleDB
 # Technically not required for the others, but I'd rather have 1 image that works for all, instead of building n images
 # per test
-RUN apk --no-cache add libaio libnsl libc6-compat curl && \
-    curl -o instantclient-basiclite.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip -SL && \
-    unzip instantclient-basiclite.zip && \
-    mv instantclient*/ /usr/lib/instantclient && \
-    rm instantclient-basiclite.zip && \
-    ln -s /usr/lib/instantclient/libclntsh.so.19.1 /usr/lib/libclntsh.so && \
-    ln -s /usr/lib/instantclient/libocci.so.19.1 /usr/lib/libocci.so && \
-    ln -s /usr/lib/instantclient/libociicus.so /usr/lib/libociicus.so && \
-    ln -s /usr/lib/instantclient/libnnz19.so /usr/lib/libnnz19.so && \
-    ln -s /usr/lib/libnsl.so.2 /usr/lib/libnsl.so.1 && \
-    ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2 && \
-    ln -s /lib64/ld-linux-x86-64.so.2 /usr/lib/ld-linux-x86-64.so.2
+#WORKDIR /tmp
+#RUN apk --no-cache add libaio libnsl libc6-compat curl && \
+#    curl -o instantclient-basiclite.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip -SL && \
+#    unzip instantclient-basiclite.zip && \
+#    mv instantclient*/ /usr/lib/instantclient && \
+#    rm instantclient-basiclite.zip && \
+#    ln -s /usr/lib/instantclient/libclntsh.so.19.1 /usr/lib/libclntsh.so && \
+#    ln -s /usr/lib/instantclient/libocci.so.19.1 /usr/lib/libocci.so && \
+#    ln -s /usr/lib/instantclient/libociicus.so /usr/lib/libociicus.so && \
+#    ln -s /usr/lib/instantclient/libnnz19.so /usr/lib/libnnz19.so && \
+#    ln -s /usr/lib/libnsl.so.2 /usr/lib/libnsl.so.1 && \
+#    ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2 && \
+#    ln -s /lib64/ld-linux-x86-64.so.2 /usr/lib/ld-linux-x86-64.so.2
+#
+#ENV ORACLE_BASE /usr/lib/instantclient
+#ENV LD_LIBRARY_PATH /usr/lib/instantclient
+#ENV TNS_ADMIN /usr/lib/instantclient
+#ENV ORACLE_HOME /usr/lib/instantclient
 
-ENV ORACLE_BASE /usr/lib/instantclient
-ENV LD_LIBRARY_PATH /usr/lib/instantclient
-ENV TNS_ADMIN /usr/lib/instantclient
-ENV ORACLE_HOME /usr/lib/instantclient
+RUN npm i -g lerna
 
 WORKDIR /directus
 
 COPY package*.json ./
+COPY lerna.json ./
 COPY api/package.json api/
 COPY api/cli.js api/
 COPY app/package.json app/
@@ -46,15 +48,11 @@ COPY packages/schema/package.json packages/schema/
 COPY packages/sdk/package.json packages/sdk/
 COPY packages/specs/package.json packages/specs/
 
-RUN npm ci
+RUN npx lerna bootstrap
 
 COPY . .
-
-# Required for Node < 15 (no native workspaces)
-RUN npx lerna link
 
 WORKDIR /directus/api
 
 CMD ["sh", "-c", "node ./dist/cli/index.js bootstrap; node ./dist/start.js;"]
-
 EXPOSE 8055/tcp

--- a/e2e-tests/setup/setup.ts
+++ b/e2e-tests/setup/setup.ts
@@ -32,16 +32,19 @@ export default async () => {
 		{
 			title: 'Create Directus Docker Image',
 			task: async (_, task) => {
-				const result = await globby(['**/*', '!node_modules', '!**/node_modules', '!**/src'], {
-					cwd: path.resolve(__dirname, '..', '..'),
-				});
+				const result = await globby(
+					['**/*', '!node_modules', '!**/node_modules', '!**/src', '!e2e-tests', '!**/tests'],
+					{
+						cwd: path.resolve(__dirname, '..', '..'),
+					}
+				);
 
 				const stream = await docker.buildImage(
 					{
 						context: path.resolve(__dirname, '..', '..'),
 						src: ['Dockerfile', ...result],
 					},
-					{ t: 'directus-test-image', buildargs: { NODE_VERSION } }
+					{ t: 'directus-test-image', buildargs: { NODE_VERSION }, cachefrom: '["directus-test-image"]' }
 				);
 
 				await new Promise((resolve, reject) => {

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,8 @@
 	"command": {
 		"bootstrap": {
 			"npmClientArgs": [
-				"--no-package-lock"
+				"--no-package-lock",
+				"--legacy-peer-deps"
 			]
 		}
 	}


### PR DESCRIPTION
A short recap about the discussion I had with @rijkvanzanten about this:

- Using ghcr as a cache for the builds seems like the best solution
- The image is pulled at the start to reuse it as cache for the next build
- after the build the image is pushed again to ghcr (only when not running on a forks and on the main branch)


- The tests are executed for every db vendor and every node version (12,14,15) in parallel
- node_modules outside the docker build are cached via the cache action


