### PR TITLE
Improve e2e test watch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist
 /.idea/
 app/public/img/docs/*
 *.tsbuildinfo
+.e2e-containers.json

--- a/e2e-tests/config.ts
+++ b/e2e-tests/config.ts
@@ -20,6 +20,8 @@ export type Config = {
 
 export const processID = generateID();
 
+export const CONTAINER_PERSISTENCE_FILE = '.e2e-containers.json';
+
 const config: Config = {
 	containerConfig: {
 		postgres: {

--- a/e2e-tests/setup/setup.ts
+++ b/e2e-tests/setup/setup.ts
@@ -3,9 +3,11 @@ import knex, { Knex } from 'knex';
 import { awaitDatabaseConnection, awaitDirectusConnection } from './utils/await-connection';
 import Listr, { ListrTask } from 'listr';
 import { getDBsToTest } from '../get-dbs-to-test';
-import config from '../config';
+import config, { CONTAINER_PERSISTENCE_FILE } from '../config';
 import globby from 'globby';
 import path from 'path';
+import { GlobalConfigTsJest } from 'ts-jest/dist/types';
+import { writeFileSync } from 'fs';
 
 declare module global {
 	let databaseContainers: { vendor: string; container: Dockerode.Container }[];
@@ -16,7 +18,7 @@ declare module global {
 const docker = new Dockerode();
 let started = false;
 
-export default async () => {
+export default async (jestConfig: GlobalConfigTsJest) => {
 	if (started) return;
 	started = true;
 
@@ -257,6 +259,21 @@ export default async () => {
 					}),
 					{ concurrent: true }
 				);
+			},
+		},
+		{
+			skip: () => !jestConfig.watch,
+			title: 'Persist container info',
+			task: () => {
+				const persistContainer = ({ container, vendor }: { container: Dockerode.Container; vendor: string }) => ({
+					id: container.id,
+					vendor,
+				});
+				const containers = {
+					db: global.databaseContainers.map(persistContainer),
+					directus: global.directusContainers.map(persistContainer),
+				};
+				writeFileSync(CONTAINER_PERSISTENCE_FILE, JSON.stringify(containers));
 			},
 		},
 	]).run();

--- a/e2e-tests/setup/setup.ts
+++ b/e2e-tests/setup/setup.ts
@@ -14,8 +14,12 @@ declare module global {
 }
 
 const docker = new Dockerode();
+let started = false;
 
 export default async () => {
+	if (started) return;
+	started = true;
+
 	console.log('\n\n');
 
 	console.log(`👮‍♀️ Starting tests!\n`);

--- a/e2e-tests/setup/teardown.ts
+++ b/e2e-tests/setup/teardown.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 import Dockerode from 'dockerode';
 import { getDBsToTest } from '../get-dbs-to-test';
 import config from '../config';
+import { GlobalConfigTsJest } from 'ts-jest/dist/types';
 
 declare module global {
 	let databaseContainers: { vendor: string; container: Dockerode.Container }[];
@@ -10,7 +11,9 @@ declare module global {
 	let knexInstances: { vendor: string; knex: Knex }[];
 }
 
-export default async () => {
+export default async (jestConfig: GlobalConfigTsJest) => {
+	if (jestConfig.watch || jestConfig.watchAll) return;
+
 	const vendors = getDBsToTest();
 
 	console.log('\n');

--- a/e2e-tests/setup/teardown.ts
+++ b/e2e-tests/setup/teardown.ts
@@ -13,8 +13,12 @@ declare module global {
 }
 const docker = new Dockerode();
 
-export default async (jestConfig: GlobalConfigTsJest, isAfterWatch = false) => {
-	if (jestConfig.watch || jestConfig.watchAll) return;
+if (require.main === module) {
+	teardown(undefined, true);
+}
+
+export default async function teardown(jestConfig?: GlobalConfigTsJest, isAfterWatch = false) {
+	if (jestConfig?.watch || jestConfig?.watchAll) return;
 
 	const vendors = getDBsToTest();
 
@@ -111,4 +115,4 @@ export default async (jestConfig: GlobalConfigTsJest, isAfterWatch = false) => {
 	console.log('\n');
 
 	console.log(`👮‍♀️ Tests complete!\n`);
-};
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 		"build": "lerna run build",
 		"release": "lerna publish --force-publish --exact",
 		"test": "lerna run test",
-		"test:e2e": "jest e2e-tests -c e2e-tests/jest.config.js",
+    "test:e2e": "jest e2e-tests -c e2e-tests/jest.config.js",
+    "test:e2e:watch": "npm run test:e2e -- --watch",
+    "posttest:e2e:watch": "ts-node --project ./e2e-tests/tsconfig.json --transpile-only -e 'require(\"./e2e-tests/setup/teardown.ts\").default({}, true)'",
 		"cli": "cross-env DIRECTUS_DEV=true NODE_ENV=development DOTENV_CONFIG_PATH=api/.env ts-node -r dotenv/config --script-mode --transpile-only api/src/cli/index.ts"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
 		"build": "lerna run build",
 		"release": "lerna publish --force-publish --exact",
 		"test": "lerna run test",
-    "test:e2e": "jest e2e-tests -c e2e-tests/jest.config.js",
-    "test:e2e:watch": "npm run test:e2e -- --watch",
-    "posttest:e2e:watch": "ts-node --project ./e2e-tests/tsconfig.json --transpile-only -e 'require(\"./e2e-tests/setup/teardown.ts\").default({}, true)'",
+		"test:e2e": "jest e2e-tests -c e2e-tests/jest.config.js",
+		"test:e2e:watch": "npm run test:e2e -- --watch",
+		"posttest:e2e:watch": "ts-node --project ./e2e-tests/tsconfig.json --transpile-only ./e2e-tests/setup/teardown.ts",
 		"cli": "cross-env DIRECTUS_DEV=true NODE_ENV=development DOTENV_CONFIG_PATH=api/.env ts-node -r dotenv/config --script-mode --transpile-only api/src/cli/index.ts"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Just some small improvements to make the e2e tests easier to run in watch mode.
There is one remaining problem though:
There is no way to run something when watch mode exits (at least I couldn't figure out a way to archieve it)
There is a lot of discussion about this on the jest repo, but the proposed workarounds for listening on SIGINT do not work on the latest versions.
So I would propose to just leave this point out of scope for now and require the containers to be stopped manually after exiting watch mode.

If you have any ideas how we could make this work in a better way I would be very happy 🙂 