### PR TITLE
Rename the nullable text input interface option

### DIFF
--- a/app/src/interfaces/text-input/index.ts
+++ b/app/src/interfaces/text-input/index.ts
@@ -88,18 +88,18 @@ export default defineInterface({
 			},
 		},
 		{
-			field: 'nullable',
-			name: '$t:interfaces.text-input.nullable',
+			field: 'clear',
+			name: '$t:interfaces.text-input.clear',
 			type: 'boolean',
 			meta: {
 				width: 'half',
 				interface: 'toggle',
 				options: {
-					label: '$t:interfaces.text-input.nullable_label',
+					label: '$t:interfaces.text-input.clear_label',
 				},
 			},
 			schema: {
-				default_value: true,
+				default_value: false,
 			},
 		},
 	],

--- a/app/src/interfaces/text-input/text-input.vue
+++ b/app/src/interfaces/text-input/text-input.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-input
 		:value="value"
-		:nullable="nullable"
+		:nullable="!clear"
 		:placeholder="placeholder"
 		:disabled="disabled"
 		:trim="trim"
@@ -40,9 +40,9 @@ export default defineComponent({
 			type: String,
 			default: null,
 		},
-		nullable: {
+		clear: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		disabled: {
 			type: Boolean,

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -995,7 +995,7 @@ interfaces:
     mask: Masked
     mask_label: Hide the real value
     clear: Cleared Value
-    clear_label: Save cleared value as empty string
+    clear_label: Save as empty string
   textarea:
     textarea: Textarea
     description: Enter multiline plain-text

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -994,8 +994,8 @@ interfaces:
     trim_label: Trim the start and end
     mask: Masked
     mask_label: Hide the real value
-    nullable: Nullable
-    nullable_label: Save empty value as NULL
+    clear: Clear
+    clear_label: Save cleared value as empty string
   textarea:
     textarea: Textarea
     description: Enter multiline plain-text

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -994,7 +994,7 @@ interfaces:
     trim_label: Trim the start and end
     mask: Masked
     mask_label: Hide the real value
-    clear: Clear
+    clear: Cleared Value
     clear_label: Save cleared value as empty string
   textarea:
     textarea: Textarea


### PR DESCRIPTION
The "nullable" option is kind of confusing because the phrase "Save empty value as NULL" implies that an empty value is _always_ saved as `NULL`, although the option only affects the value of a text field if it's content has been removed manually. Also, it is not clear, that the alternative to `NULL` is in fact the empty string.

I am not too happy with the new wording either, so I would love to hear your thoughts/ideas.