### PR TITLE
Fix validation of required fields

### DIFF
--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -89,8 +89,8 @@ export async function getSchema(options?: {
 			sortField: collectionMeta?.sort_field || null,
 			fields: mapValues(schemaOverview[collection].columns, (column) => ({
 				field: column.column_name,
-				defaultValue: getDefaultValue(column) || null,
-				nullable: column.is_nullable || true,
+				defaultValue: getDefaultValue(column) ?? null,
+				nullable: column.is_nullable ?? true,
 				type: getLocalType(column) || 'alias',
 				precision: column.numeric_precision || null,
 				scale: column.numeric_scale || null,
@@ -121,8 +121,8 @@ export async function getSchema(options?: {
 
 		result.collections[field.collection].fields[field.field] = {
 			field: field.field,
-			defaultValue: existing?.defaultValue || null,
-			nullable: existing?.nullable || true,
+			defaultValue: existing?.defaultValue ?? null,
+			nullable: existing?.nullable ?? true,
 			type: existing
 				? getLocalType(schemaOverview[field.collection].columns[field.field], {
 						special: field.special ? toArray(field.special) : [],


### PR DESCRIPTION
Use nullish coalescing operator for setting `nullable` and `defaultValue` properties in the `getSchema` function instead of the `||`(or) logical operator which always causes assigning `true` to the `nullable` property and ignores `0` and `false` values in the `defaultValue` property.

Due to this problem required fields aren't now validated neither on create nor on update.

I assume that `precision` and `scale` properties can have the same problem if assign to them `0` and probably should be investigated as well.