### PR TITLE
Run migrations before adding the admin user

### DIFF
--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -23,6 +23,9 @@ export default async function bootstrap() {
 
 		await installDatabase(database);
 
+		logger.info('Running migrations...');
+		await runMigrations(database, 'latest');
+
 		const schema = await getSchema();
 
 		logger.info('Setting up first admin role...');
@@ -54,10 +57,9 @@ export default async function bootstrap() {
 		}
 	} else {
 		logger.info('Database already initialized, skipping install');
+		logger.info('Running migrations...');
+		await runMigrations(database, 'latest');
 	}
-
-	logger.info('Running migrations...');
-	await runMigrations(database, 'latest');
 
 	logger.info('Done');
 	process.exit(0);


### PR DESCRIPTION
When the migrations don't run before the admin user is added the following error is thrown when creating a new project with a fresh database:
```
select `collection`, `singleton`, `note`, `sort_field`, `accountability` from `directus_collections` - ER_BAD_FIELD_ERROR: Unknown column 'accountability' in 'field list'
```
This is because the column `accountability` is added by the migrations, but the column is already being used in the getSchema call after the db installation. By running the migrations directly after the installation of the db this problem is fixed.

PS: This caused the e2e tests to fail 🙂 