### PR TITLE
M2O create / update error fix

### DIFF
--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -25,9 +25,10 @@ router.post(
 			schema: req.schema,
 		});
 
-		const primaryKey = await service.create(req.body);
-
+		
 		try {
+			const primaryKey = await service.create(req.body);
+
 			const result = await service.readByKey(primaryKey, req.sanitizedQuery);
 			res.locals.payload = { data: result || null };
 		} catch (error) {
@@ -120,9 +121,10 @@ router.patch(
 		}
 
 		if (Array.isArray(req.body)) {
-			const primaryKeys = await service.update(req.body);
-
+			
 			try {
+				const primaryKeys = await service.update(req.body);
+
 				const result = await service.readByKey(primaryKeys, req.sanitizedQuery);
 				res.locals.payload = { data: result || null };
 			} catch (error) {
@@ -147,9 +149,10 @@ router.patch(
 			throw new FailedValidationException(error.details[0]);
 		}
 
-		const primaryKeys = await service.update(req.body.data, req.body.keys);
-
+		
 		try {
+			const primaryKeys = await service.update(req.body.data, req.body.keys);
+
 			const result = await service.readByKey(primaryKeys, req.sanitizedQuery);
 			res.locals.payload = { data: result || null };
 		} catch (error) {
@@ -180,9 +183,10 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const updatedPrimaryKey = await service.update(req.body, req.params.pk);
-
+		
 		try {
+			const updatedPrimaryKey = await service.update(req.body, req.params.pk);
+			
 			const result = await service.readByKey(updatedPrimaryKey, req.sanitizedQuery);
 			res.locals.payload = { data: result || null };
 		} catch (error) {


### PR DESCRIPTION
PR based on #5070 (Only for error with M2O create / update)

I ran the latest rc (59) source code locally in debug. With breakpoints I found out that code on line [189 (api/services/items.ts)](https://github.com/Thomasparsley/directus/blob/3de49c373e70cd34e752c4d58bc7b16386740469/api/src/services/items.ts#L189) return 400 for no reason. So I moved service on line [28 (api/controllers/items.ts)](https://github.com/Thomasparsley/directus/blob/3de49c373e70cd34e752c4d58bc7b16386740469/api/src/controllers/items.ts#L28) inside try block. I hoped, when service is inside try block I get more details with `console.error` with error from catch block. But when i moved service inside try block and I wanted to create new record with m2o suddenly it works.

I have no idea why it works now. I have no idea if it's correct solution. But its works now, :D

If you guys know why it is works now, please tell me.