### PR TITLE
Fix before hook items transaction

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -70,7 +70,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					action: 'create',
 					payload: payloads[i],
 					schema: this.schema,
-					database: this.knex,
+					database: trx,
 				});
 
 				if (customProcessed && customProcessed.length > 0) {


### PR DESCRIPTION
Since we might need information from database, we must provide the
current transaction, instead of the connection.
Otherwise, databases like SQLite which only accepts a single connection
will throw an error of knex timeout.