### PR TITLE
Remove refresh token cookie on logout

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -144,6 +144,13 @@ router.post(
 		}
 
 		await authenticationService.logout(currentRefreshToken);
+
+		if (req.cookies.directus_refresh_token) {
+			res.clearCookie('directus_refresh_token', {
+				domain: env.REFRESH_TOKEN_COOKIE_DOMAIN,
+			});
+		}
+
 		return next();
 	}),
 	respond

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,17 +52,17 @@
 		},
 		"api": {
 			"name": "directus",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/app": "^9.0.0-rc.57",
-				"@directus/drive": "^9.0.0-rc.57",
-				"@directus/drive-azure": "^9.0.0-rc.57",
-				"@directus/drive-gcs": "^9.0.0-rc.57",
-				"@directus/drive-s3": "^9.0.0-rc.57",
-				"@directus/format-title": "^9.0.0-rc.57",
-				"@directus/schema": "^9.0.0-rc.57",
-				"@directus/specs": "^9.0.0-rc.57",
+				"@directus/app": "9.0.0-rc.59",
+				"@directus/drive": "9.0.0-rc.59",
+				"@directus/drive-azure": "9.0.0-rc.59",
+				"@directus/drive-gcs": "9.0.0-rc.59",
+				"@directus/drive-s3": "9.0.0-rc.59",
+				"@directus/format-title": "9.0.0-rc.59",
+				"@directus/schema": "9.0.0-rc.59",
+				"@directus/specs": "9.0.0-rc.59",
 				"@godaddy/terminus": "^4.4.1",
 				"argon2": "^0.27.0",
 				"atob": "^2.1.2",
@@ -212,10 +212,10 @@
 		},
 		"app": {
 			"name": "@directus/app",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"devDependencies": {
-				"@directus/docs": "^9.0.0-rc.57",
-				"@directus/format-title": "^9.0.0-rc.57",
+				"@directus/docs": "9.0.0-rc.59",
+				"@directus/format-title": "9.0.0-rc.59",
 				"@popperjs/core": "^2.9.1",
 				"@sindresorhus/slugify": "^1.1.0",
 				"@tinymce/tinymce-vue": "^3.2.8",
@@ -317,7 +317,7 @@
 		},
 		"docs": {
 			"name": "@directus/docs",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "ISC",
 			"devDependencies": {
 				"directory-tree": "^2.2.6",
@@ -45660,7 +45660,7 @@
 			}
 		},
 		"packages/create-directus-project": {
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"chalk": "^4.1.0",
@@ -45683,7 +45683,7 @@
 		},
 		"packages/drive": {
 			"name": "@directus/drive",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^9.1.0",
@@ -45702,11 +45702,11 @@
 		},
 		"packages/drive-azure": {
 			"name": "@directus/drive-azure",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/storage-blob": "^12.2.1",
-				"@directus/drive": "^9.0.0-rc.57",
+				"@directus/drive": "9.0.0-rc.59",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -45725,10 +45725,10 @@
 		},
 		"packages/drive-gcs": {
 			"name": "@directus/drive-gcs",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "^9.0.0-rc.57",
+				"@directus/drive": "9.0.0-rc.59",
 				"@google-cloud/storage": "^5.0.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -45747,10 +45747,10 @@
 		},
 		"packages/drive-s3": {
 			"name": "@directus/drive-s3",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "^9.0.0-rc.57",
+				"@directus/drive": "9.0.0-rc.59",
 				"aws-sdk": "^2.680.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -45771,7 +45771,7 @@
 		},
 		"packages/format-title": {
 			"name": "@directus/format-title",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^17.1.0",
@@ -45790,7 +45790,7 @@
 		},
 		"packages/gatsby-source-directus": {
 			"name": "@directus/gatsby-source-directus",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"dependencies": {
 				"@directus/sdk-js": "^9.0.0-rc.53",
@@ -48445,7 +48445,7 @@
 		},
 		"packages/schema": {
 			"name": "@directus/schema",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"knex-schema-inspector": "^1.2.0",
@@ -48458,7 +48458,7 @@
 		},
 		"packages/sdk": {
 			"name": "@directus/sdk",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.21.1"
@@ -48488,7 +48488,7 @@
 		},
 		"packages/specs": {
 			"name": "@directus/specs",
-			"version": "9.0.0-rc.57",
+			"version": "9.0.0-rc.59",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"openapi3-ts": "^2.0.1"
@@ -50130,8 +50130,8 @@
 		"@directus/app": {
 			"version": "file:app",
 			"requires": {
-				"@directus/docs": "^9.0.0-rc.57",
-				"@directus/format-title": "^9.0.0-rc.57",
+				"@directus/docs": "9.0.0-rc.59",
+				"@directus/format-title": "9.0.0-rc.59",
 				"@popperjs/core": "^2.9.1",
 				"@sindresorhus/slugify": "^1.1.0",
 				"@tinymce/tinymce-vue": "^3.2.8",
@@ -50249,7 +50249,7 @@
 			"version": "file:packages/drive-azure",
 			"requires": {
 				"@azure/storage-blob": "^12.2.1",
-				"@directus/drive": "^9.0.0-rc.57",
+				"@directus/drive": "9.0.0-rc.59",
 				"@types/fs-extra": "^9.0.9",
 				"@types/jest": "^26.0.22",
 				"@types/node": "^14.14.37",
@@ -50266,7 +50266,7 @@
 		"@directus/drive-gcs": {
 			"version": "file:packages/drive-gcs",
 			"requires": {
-				"@directus/drive": "^9.0.0-rc.57",
+				"@directus/drive": "9.0.0-rc.59",
 				"@google-cloud/storage": "^5.0.0",
 				"@lukeed/uuid": "^1.0.1",
 				"@types/fs-extra": "^9.0.9",
@@ -50284,7 +50284,7 @@
 		"@directus/drive-s3": {
 			"version": "file:packages/drive-s3",
 			"requires": {
-				"@directus/drive": "^9.0.0-rc.57",
+				"@directus/drive": "9.0.0-rc.59",
 				"@lukeed/uuid": "^1.0.1",
 				"@types/fs-extra": "^9.0.9",
 				"@types/jest": "^26.0.22",
@@ -63203,14 +63203,14 @@
 		"directus": {
 			"version": "file:api",
 			"requires": {
-				"@directus/app": "^9.0.0-rc.57",
-				"@directus/drive": "^9.0.0-rc.57",
-				"@directus/drive-azure": "^9.0.0-rc.57",
-				"@directus/drive-gcs": "^9.0.0-rc.57",
-				"@directus/drive-s3": "^9.0.0-rc.57",
-				"@directus/format-title": "^9.0.0-rc.57",
-				"@directus/schema": "^9.0.0-rc.57",
-				"@directus/specs": "^9.0.0-rc.57",
+				"@directus/app": "9.0.0-rc.59",
+				"@directus/drive": "9.0.0-rc.59",
+				"@directus/drive-azure": "9.0.0-rc.59",
+				"@directus/drive-gcs": "9.0.0-rc.59",
+				"@directus/drive-s3": "9.0.0-rc.59",
+				"@directus/format-title": "9.0.0-rc.59",
+				"@directus/schema": "9.0.0-rc.59",
+				"@directus/specs": "9.0.0-rc.59",
 				"@godaddy/terminus": "^4.4.1",
 				"@keyv/redis": "^2.1.2",
 				"@types/atob": "^2.1.2",


### PR DESCRIPTION
While it is not something which is absolutely necessary, I still think it would be good to remove the refresh token cookie when calling the logout endpoint.