### PR TITLE
Missing closing / on v-icon documentation

### DIFF
--- a/docs/reference/app/components/v-icon.md
+++ b/docs/reference/app/components/v-icon.md
@@ -37,7 +37,7 @@ Oftentimes, you'll use the icon next to some text, for example in a button. When
 
 ```html
 <v-button>
-	<v-icon name="add" left> Add new
+	<v-icon name="add" left /> Add new
 </v-button>
 ```
 


### PR DESCRIPTION
Added the missing closing `/` on the v-icon inside the v-button in the Left/Right example of the v-icon documentation.