### PR TITLE
Change token and auth handling behavior.

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,6 +56,7 @@
 		"jest": "^26.6.3",
 		"jest-environment-jsdom": "^26.6.2",
 		"jest-environment-jsdom-global": "^2.0.4",
+		"mockdate": "^3.0.5",
 		"nock": "^13.0.10",
 		"npm-run-all": "^4.1.5",
 		"rimraf": "^3.0.2",

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -15,20 +15,21 @@ export type AuthResult = {
 };
 
 export type AuthLoginOptions = {
-	refresh: AuthRefreshOptions;
+	refresh?: AuthRefreshOptions;
 };
 
 export type AuthRefreshOptions = {
-	auto: boolean;
+	auto?: boolean;
 	time?: number;
 };
 
 export interface IAuth {
 	readonly token: string | null;
 	readonly password: PasswordsHandler;
+	readonly expiring: boolean;
 
 	login(credentials: AuthCredentials, options?: AuthLoginOptions): Promise<AuthResult>;
-	refresh(options?: AuthRefreshOptions): Promise<AuthResult>;
+	refresh(force?: boolean): Promise<AuthResult | false>;
 	static(token: AuthToken): Promise<boolean>;
 	logout(): Promise<void>;
 }

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -1,26 +1,39 @@
 import { AuthCredentials, AuthLoginOptions, AuthRefreshOptions, AuthResult, AuthToken, IAuth } from '../auth';
-import { InvalidRefreshTime, NotAuthenticated } from '../errors';
+import { NotAuthenticated } from '../errors';
 import { PasswordsHandler } from '../handlers/passwords';
 import { IStorage } from '../storage';
 import { ITransport } from '../transport';
+import { Debouncer } from '../utils';
 
 export type AuthOptions = {
 	mode?: 'json' | 'cookie';
+	refresh?: AuthRefreshOptions;
 };
+
+const DefaultExpirationTime = 30000;
 
 export class Auth implements IAuth {
 	public readonly options: AuthOptions;
+
 	private transport: ITransport;
 	private storage: IStorage;
-	private refreshTimeout: ReturnType<typeof setTimeout> | false;
+	private timer: ReturnType<typeof setTimeout> | false;
 	private passwords?: PasswordsHandler;
+	private refresher: Debouncer<AuthResult | false>;
 
 	constructor(transport: ITransport, storage: IStorage, options?: AuthOptions) {
 		this.options = options || {};
 		this.options.mode = options?.mode || (typeof window !== 'undefined' ? 'cookie' : 'json');
+		this.options.refresh = options?.refresh || { auto: false, time: DefaultExpirationTime };
+		this.options.refresh.auto = this.options.refresh?.auto ?? false;
+		this.options.refresh.time = this.options.refresh?.time ?? DefaultExpirationTime;
 		this.transport = transport;
 		this.storage = storage;
-		this.refreshTimeout = false;
+		this.timer = false;
+		this.refresher = new Debouncer(this.refreshToken.bind(this));
+		try {
+			this.updateRefresh(this.options?.refresh);
+		} catch (err) {}
 	}
 
 	get token(): string | null {
@@ -31,18 +44,37 @@ export class Auth implements IAuth {
 		return (this.passwords = this.passwords || new PasswordsHandler(this.transport));
 	}
 
-	private async refreshToken(): Promise<AuthResult> {
-		if (this.storage.auth_token === null) {
+	get expiring(): boolean {
+		const expiration = this.storage.auth_expires;
+		if (expiration === null) {
+			return false;
+		}
+
+		const expiringAfter = expiration - (this.options.refresh?.time ?? 0);
+		return expiringAfter <= Date.now();
+	}
+
+	private async refreshToken(force: boolean = false): Promise<AuthResult | false> {
+		if (force && this.storage.auth_token === null) {
 			throw new NotAuthenticated();
 		}
 
-		const response = await this.transport.post<AuthResult>('/auth/refresh', {
-			refresh_token: this.options.mode === 'json' ? this.storage.auth_refresh_token : undefined,
-		});
+		if (!force && !this.expiring) {
+			return false;
+		}
 
-		this.storage.auth_token = response.data!.access_token;
-		this.storage.auth_refresh_token = response.data?.refresh_token || null;
-		this.storage.auth_expires = response.data?.expires || null;
+		const response = await this.transport.post<AuthResult>(
+			'/auth/refresh',
+			{
+				refresh_token: this.options.mode === 'json' ? this.storage.auth_refresh_token : undefined,
+			},
+			{
+				refreshTokenIfNeeded: false,
+			}
+		);
+
+		this.updateStorage(response.data!);
+		this.updateRefresh();
 
 		return {
 			access_token: response.data!.access_token,
@@ -51,41 +83,71 @@ export class Auth implements IAuth {
 		};
 	}
 
-	private configureAutoRefresh(result: AuthResult, options?: Partial<AuthRefreshOptions>) {
-		const expiration = result?.expires || 0;
-
-		options = options || { auto: false };
-		options.auto = typeof options.auto === 'undefined' ? false : options.auto;
-		options.time = Math.max(Math.round(typeof options.time === 'undefined' ? expiration * 0.1 : options.time), 0);
-
-		clearTimeout(this.refreshTimeout as ReturnType<typeof setTimeout>);
-
-		if (options.auto) {
-			if (options.time <= 0 || expiration - options.time <= 0) {
-				throw new InvalidRefreshTime();
-			}
-			this.refreshTimeout = setTimeout(() => this.refresh(options), expiration - options.time);
+	private updateStorage(result: AuthResult) {
+		this.storage.auth_token = result.access_token;
+		this.storage.auth_refresh_token = result.refresh_token ?? null;
+		if (result.expires) {
+			this.storage.auth_expires = Date.now() + result.expires;
+		} else {
+			this.storage.auth_expires = null;
 		}
 	}
 
-	async refresh(options?: Partial<AuthRefreshOptions>): Promise<AuthResult> {
-		const result = await this.refreshToken();
-		this.configureAutoRefresh(result, options);
-		return result;
+	private updateRefresh(options?: Partial<AuthRefreshOptions>) {
+		const expiration = this.storage.auth_expires;
+		if (expiration === null) {
+			clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+			return; // Don't auto refresh if there's no expiration time (token auth)
+		}
+
+		if (options) {
+			this.options.refresh!.auto = options.auto ?? this.options.refresh!.auto;
+			this.options.refresh!.time = options.time ?? this.options.refresh!.time;
+		}
+
+		clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+
+		let remaining = expiration - this.options.refresh!.time! - Date.now();
+		if (remaining < 0) {
+			// It's already expired, try a refresh
+			if (expiration < Date.now()) {
+				this.storage.auth_expires = null;
+				this.storage.auth_token = null;
+				return; // Don't set auto refresh
+			} else {
+				remaining = 0;
+			}
+		}
+
+		if (this.options.refresh!.auto) {
+			this.timer = setTimeout(() => {
+				this.refresh()
+					.then(() => {})
+					.catch((_) => {});
+			}, remaining);
+		}
+	}
+
+	async refresh(force: boolean = false): Promise<AuthResult | false> {
+		return await this.refresher.debounce(force);
 	}
 
 	async login(credentials: AuthCredentials, options?: Partial<AuthLoginOptions>): Promise<AuthResult> {
 		options = options || {};
-		const response = await this.transport.post<AuthResult>('/auth/login', {
-			mode: this.options.mode,
-			...credentials,
-		});
+		const response = await this.transport.post<AuthResult>(
+			'/auth/login',
+			{
+				mode: this.options.mode,
+				...credentials,
+			},
+			{
+				refreshTokenIfNeeded: false,
+				sendAuthorizationHeaders: false,
+			}
+		);
 
-		this.configureAutoRefresh(response.data!, options.refresh);
-
-		this.storage.auth_token = response.data!.access_token;
-		this.storage.auth_refresh_token = response.data?.refresh_token || null;
-		this.storage.auth_expires = response.data?.expires || null;
+		this.updateStorage(response.data!);
+		this.updateRefresh(options.refresh);
 
 		return {
 			access_token: response.data!.access_token,
@@ -101,27 +163,31 @@ export class Auth implements IAuth {
 			},
 		});
 		this.storage.auth_token = token;
+		this.storage.auth_expires = null;
+		this.storage.auth_refresh_token = null;
 		return true;
 	}
 
 	async logout(): Promise<void> {
 		let refresh_token: string | undefined;
-
-		if (this.options.mode === `json`) {
+		if (this.options.mode === 'json') {
 			refresh_token = this.storage.auth_refresh_token || undefined;
 		}
 
-		await this.transport.post('/auth/logout', {
-			refresh_token,
-		});
+		await this.transport.post(
+			'/auth/logout',
+			{
+				refresh_token,
+			},
+			{
+				refreshTokenIfNeeded: false,
+			}
+		);
 
 		this.storage.auth_token = null;
 		this.storage.auth_expires = null;
+		this.storage.auth_refresh_token = null;
 
-		if (this.options.mode === `json`) {
-			this.storage.auth_refresh_token = null;
-		}
-
-		clearTimeout(this.refreshTimeout as ReturnType<typeof setTimeout>);
+		clearTimeout(this.timer as ReturnType<typeof setTimeout>);
 	}
 }

--- a/packages/sdk/src/base/directus.ts
+++ b/packages/sdk/src/base/directus.ts
@@ -64,7 +64,11 @@ export class Directus<T extends TypeMap> implements IDirectus<T> {
 
 	constructor(url: string, options?: DirectusOptions) {
 		this._storage = options?.storage || (typeof window !== 'undefined' ? new LocalStorage() : new MemoryStorage());
-		this._transport = options?.transport || new AxiosTransport(url, this._storage);
+		this._transport =
+			options?.transport ||
+			new AxiosTransport(url, this._storage, async () => {
+				await this._auth.refresh();
+			});
 		this._auth = options?.auth || new Auth(this._transport, this._storage);
 		this._items = {};
 		this._singletons = {};

--- a/packages/sdk/src/base/transport/axios-transport.ts
+++ b/packages/sdk/src/base/transport/axios-transport.ts
@@ -1,6 +1,8 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { IStorage } from '../../storage';
+import axios, { AxiosInstance } from 'axios';
 import { ITransport, TransportMethods, TransportResponse, TransportError, TransportOptions } from '../../transport';
+
+export type AxiosTransportRefreshHandler = () => Promise<void>;
 
 /**
  * Axios transport implementation
@@ -8,12 +10,14 @@ import { ITransport, TransportMethods, TransportResponse, TransportError, Transp
 export class AxiosTransport implements ITransport {
 	private _url: string;
 	private _storage: IStorage;
+	private _refresh: () => Promise<void>;
 	public _axios: AxiosInstance;
 
-	constructor(url: string, storage: IStorage) {
+	constructor(url: string, storage: IStorage, refresh: AxiosTransportRefreshHandler = () => Promise.resolve()) {
 		this._url = url;
 		this._storage = storage;
 		this._axios = null as any;
+		this._refresh = refresh;
 		this.url = url;
 	}
 
@@ -27,7 +31,6 @@ export class AxiosTransport implements ITransport {
 			baseURL: value,
 			withCredentials: true,
 		});
-		this._axios.interceptors.request.use(this.createRequestConfig.bind(this));
 	}
 
 	get axios(): AxiosInstance {
@@ -42,13 +45,35 @@ export class AxiosTransport implements ITransport {
 	): Promise<TransportResponse<T, R>> {
 		try {
 			options = options || {};
-			const response = await this.axios.request({
+			options.sendAuthorizationHeaders = options.sendAuthorizationHeaders ?? true;
+			options.refreshTokenIfNeeded = options.refreshTokenIfNeeded ?? true;
+			options.headers = options.headers ?? {};
+
+			if (options.refreshTokenIfNeeded) {
+				await this._refresh();
+			}
+
+			const config = {
 				method,
 				url: path,
 				data: data,
 				params: options.params,
 				headers: options.headers,
-			});
+			};
+
+			const token = this._storage.auth_token;
+			const expiration = this._storage.auth_expires;
+			if (options.sendAuthorizationHeaders) {
+				if (token && ((expiration !== null && expiration < Date.now()) || expiration === null)) {
+					if (token.startsWith(`Bearer `)) {
+						config.headers.Authorization = token;
+					} else {
+						config.headers.Authorization = `Bearer ${token}`;
+					}
+				}
+			}
+
+			const response = await this.axios.request(config);
 
 			const responseData = response.data;
 			const content = {
@@ -109,20 +134,5 @@ export class AxiosTransport implements ITransport {
 
 	async patch<T = any, D = any>(path: string, data?: D, options?: TransportOptions): Promise<TransportResponse<T>> {
 		return await this.request('patch', path, data, options);
-	}
-
-	private createRequestConfig(config: AxiosRequestConfig): AxiosRequestConfig {
-		let token = this._storage.auth_token;
-		if (!token) {
-			return config;
-		}
-
-		if (token.startsWith(`Bearer `)) {
-			config.headers.Authorization = token;
-		} else {
-			config.headers.Authorization = `Bearer ${token}`;
-		}
-
-		return config;
 	}
 }

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -3,9 +3,3 @@ export class NotAuthenticated extends Error {
 		super('No authentication');
 	}
 }
-
-export class InvalidRefreshTime extends Error {
-	constructor() {
-		super('Invalid authentication refresh time interval');
-	}
-}

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -22,6 +22,8 @@ export type TransportMethods = 'get' | 'delete' | 'head' | 'options' | 'post' | 
 export type TransportOptions = {
 	params?: any;
 	headers?: any;
+	refreshTokenIfNeeded?: boolean;
+	sendAuthorizationHeaders?: boolean;
 };
 
 export interface ITransport {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,0 +1,43 @@
+export class Debouncer<T extends any = any> {
+	private func: (...args: any[]) => Promise<T>;
+	private debounced: {
+		resolve: (value: T) => void;
+		reject: (error: Error) => void;
+	}[];
+	private debouncing: boolean;
+
+	constructor(func: (...args: any[]) => Promise<T>) {
+		this.func = func;
+		this.debounced = [];
+		this.debouncing = false;
+	}
+
+	async debounce<P extends any>(...args: P[]): Promise<T> {
+		if (this.debouncing) {
+			return await new Promise<T>((resolve, reject) => {
+				this.debounced.push({
+					resolve: (value) => resolve(value),
+					reject: (error) => reject(error),
+				});
+			});
+		}
+
+		this.debouncing = true;
+
+		return new Promise((resolve, reject) => {
+			this.func(...args)
+				.then((value) => {
+					const promises = [{ resolve, reject }, ...this.debounced];
+					this.debounced = [];
+					this.debouncing = false;
+					promises.forEach((promise) => promise.resolve(value));
+				})
+				.catch((error) => {
+					const promises = [{ resolve, reject }, ...this.debounced];
+					this.debounced = [];
+					this.debouncing = false;
+					promises.forEach((promise) => promise.reject(error));
+				});
+		});
+	}
+}

--- a/packages/sdk/tests/base/auth.browser.test.ts
+++ b/packages/sdk/tests/base/auth.browser.test.ts
@@ -3,9 +3,17 @@
  */
 
 import { Auth, AxiosTransport, Directus, MemoryStorage } from '../../src';
-import { test } from '../utils';
+import { test, timers } from '../utils';
 
 describe('auth (browser)', function () {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		localStorage.clear();
+	});
+
 	test(`sets default auth mode to cookie`, async (url) => {
 		const storage = new MemoryStorage();
 		const transport = new AxiosTransport(url, storage);
@@ -34,8 +42,6 @@ describe('auth (browser)', function () {
 	});
 
 	test(`authentication should auto refresh after specified period`, async (url, nock) => {
-		jest.useFakeTimers();
-
 		const scope = nock();
 
 		scope
@@ -45,7 +51,7 @@ describe('auth (browser)', function () {
 				{
 					data: {
 						access_token: 'access_token',
-						expires: 60000,
+						expires: 5000,
 					},
 				},
 				{
@@ -59,39 +65,47 @@ describe('auth (browser)', function () {
 			.reply(200, {
 				data: {
 					access_token: 'new_access_token',
-					expires: 60000,
+					expires: 5000,
 				},
 			});
 
-		const sdk = new Directus(url);
-		await sdk.auth.login(
-			{
-				email: 'wolfulus@gmail.com',
-				password: 'password',
-			},
-			{
-				refresh: {
-					auto: true,
+		expect(scope.pendingMocks().length).toBe(2);
+
+		await timers(async ({ tick, flush }) => {
+			const sdk = new Directus(url);
+			await sdk.auth.login(
+				{
+					email: 'wolfulus@gmail.com',
+					password: 'password',
 				},
-			}
-		);
+				{
+					refresh: {
+						auto: true,
+						time: 2500,
+					},
+				}
+			);
 
-		jest.advanceTimersByTime(30000);
-		expect(scope.pendingMocks().length).toBe(1);
+			await tick(2000);
 
-		jest.advanceTimersByTime(25000);
+			expect(scope.pendingMocks().length).toBe(1);
+			expect(sdk.auth.expiring).toBe(false);
 
-		// Refresh is done in background, need to wait for it to complete
-		await new Promise((resolve) => {
-			jest.useRealTimers();
-			setTimeout(resolve, 100);
-			jest.useFakeTimers();
-		});
+			await tick(500);
 
-		expect(scope.pendingMocks().length).toBe(0);
-		expect(sdk.auth.token).toBe('new_access_token');
+			expect(scope.pendingMocks().length).toBe(1);
+			expect(sdk.auth.expiring).toBe(true);
 
-		jest.clearAllTimers();
+			await new Promise((resolve) => {
+				scope.once('replied', () => {
+					flush().then(resolve);
+				});
+			});
+
+			expect(sdk.storage.auth_expires).toBe(107500);
+
+			expect(scope.pendingMocks().length).toBe(0);
+		}, 100000);
 	});
 
 	test(`logout doesn't send a refresh token due to cookie mode`, async (url, nock) => {

--- a/packages/sdk/tests/base/auth.test.ts
+++ b/packages/sdk/tests/base/auth.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { Directus } from '../../src';
-import { InvalidRefreshTime, NotAuthenticated } from '../../src/errors';
+import { NotAuthenticated } from '../../src/errors';
 import { test } from '../utils';
 
 describe('auth', function () {
@@ -21,15 +21,15 @@ describe('auth', function () {
 
 	it(`throws when refreshing without authenticating first`, async () => {
 		const sdk = new Directus('http://localhost');
-
 		try {
-			await sdk.auth.refresh();
+			await sdk.auth.refresh(true);
 			fail('Should have failed');
 		} catch (err) {
 			expect(err).toBeInstanceOf(NotAuthenticated);
 		}
 	});
 
+	/*
 	test(`throws when refresh time resolves to an invalid value`, async (url, nock) => {
 		nock()
 			.post('/auth/login')
@@ -60,6 +60,7 @@ describe('auth', function () {
 			expect(err).toBeInstanceOf(InvalidRefreshTime);
 		}
 	});
+	*/
 
 	test(`successful auth should set the token`, async (url, nock) => {
 		nock()

--- a/packages/sdk/tests/errors.test.ts
+++ b/packages/sdk/tests/errors.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { InvalidRefreshTime, NotAuthenticated } from '../src/errors';
+import { NotAuthenticated } from '../src/errors';
 
 describe('errors', function () {
 	it(`test errors`, async () => {
@@ -12,14 +12,6 @@ describe('errors', function () {
 			expect(err instanceof Error).toBe(true);
 			expect(err instanceof NotAuthenticated).toBe(true);
 			expect(err.message).toBe('No authentication');
-		}
-
-		try {
-			throw new InvalidRefreshTime();
-		} catch (err) {
-			expect(err instanceof Error).toBe(true);
-			expect(err instanceof InvalidRefreshTime).toBe(true);
-			expect(err.message).toBe('Invalid authentication refresh time interval');
 		}
 	});
 });

--- a/packages/sdk/tests/utils.test.ts
+++ b/packages/sdk/tests/utils.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+
+import { Debouncer } from '../src/utils';
+import { timers } from './utils';
+
+describe('debouncer', function () {
+	test(`concurrent calls should return with the error from the first call`, async () => {
+		await timers(async ({ tick }) => {
+			let calls = 0;
+
+			const debouncer = new Debouncer(async (value) => {
+				return new Promise((resolve) =>
+					setTimeout(() => {
+						calls += 1;
+						resolve(value);
+					}, 5000)
+				);
+			});
+
+			const call1 = debouncer.debounce(1111);
+			await tick(500);
+			expect(calls).toBe(0);
+
+			const call2 = debouncer.debounce(2222);
+			await tick(1500);
+			expect(calls).toBe(0);
+
+			await tick(5000);
+			expect(calls).toBe(1);
+
+			const call3 = debouncer.debounce(3333);
+			await tick(6000);
+			expect(calls).toBe(2);
+
+			const result = await Promise.all([call1, call2, call3]);
+			expect(result).toMatchObject([1111, 1111, 3333]);
+		});
+	});
+
+	test(`concurrent calls should throw with the error from the first call`, async () => {
+		await timers(async ({ tick, flush }) => {
+			let calls = 0;
+
+			const debouncer = new Debouncer(async (value) => {
+				return new Promise((_, reject) =>
+					setTimeout(() => {
+						calls += 1;
+						reject(new Error('Error ' + value));
+					}, 5000)
+				);
+			});
+
+			let err1 = new Error();
+			debouncer.debounce(1111).catch((err) => (err1 = err));
+			await tick(500);
+			expect(calls).toBe(0);
+
+			let err2 = new Error();
+			debouncer.debounce(2222).catch((err) => (err2 = err));
+			await tick(1500);
+			expect(calls).toBe(0);
+
+			await tick(5000);
+			expect(calls).toBe(1);
+
+			await flush();
+
+			let err3 = new Error();
+			debouncer.debounce(3333).catch((err) => (err3 = err));
+			await tick(6000);
+
+			await flush();
+
+			expect(err1.message).toBe('Error 1111');
+			expect(err2.message).toBe('Error 1111');
+			expect(err3.message).toBe('Error 3333');
+		});
+	});
+});

--- a/packages/sdk/tests/utils.ts
+++ b/packages/sdk/tests/utils.ts
@@ -1,3 +1,4 @@
+import md from 'mockdate';
 import nock, { back, BackMode } from 'nock';
 
 export const URL = process.env.TEST_URL || 'http://localhost';
@@ -15,12 +16,78 @@ export type TestSettings = {
 
 export function test(name: string, test: Test, settings?: TestSettings) {
 	it(name, async () => {
+		nock.cleanAll();
+
+		const scope = () => nock(settings?.url || URL);
 		if (settings?.fixture) {
 			await back(settings.fixture, async () => {
-				await test(settings?.url || URL, () => nock(settings?.url || URL));
+				await test(settings?.url || URL, scope);
 			});
 		} else {
-			await test(settings?.url || URL, () => nock(settings?.url || URL));
+			await test(settings?.url || URL, scope);
 		}
+
+		nock.abortPendingRequests();
+		nock.cleanAll();
 	});
+}
+
+export async function timers(
+	func: (opts: {
+		flush: () => Promise<void>;
+		sleep: (ms: number) => Promise<void>;
+		tick: (ms: number) => Promise<void>;
+		skip: (func: () => Promise<void>, date?: boolean) => Promise<any>;
+	}) => Promise<void>,
+	initial: number = Date.now()
+) {
+	const originals = {
+		setTimeout: global.setTimeout,
+		setImmediate: global.setImmediate,
+	};
+
+	md.set(new Date(initial));
+
+	let travel = 0;
+
+	try {
+		jest.useFakeTimers();
+		const tick = async (ms: number) => {
+			travel += ms;
+			md.set(initial + travel);
+			await Promise.resolve().then(() => jest.advanceTimersByTime(ms));
+		};
+		const skip = async (func: () => Promise<void>, date: boolean = false) => {
+			if (date) {
+				md.reset();
+			}
+			jest.useRealTimers();
+			try {
+				await func();
+			} finally {
+				if (date) {
+					md.set(initial + travel);
+				}
+				jest.useFakeTimers();
+			}
+		};
+		const flush = () => new Promise<void>((resolve) => originals.setImmediate(resolve));
+		const sleep = (ms: number) =>
+			new Promise<void>((resolve) => {
+				travel += ms;
+				md.set(initial + travel);
+				originals.setTimeout(resolve, ms);
+			});
+
+		await func({
+			tick,
+			skip,
+			flush,
+			sleep,
+		});
+	} finally {
+		md.reset();
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	}
 }


### PR DESCRIPTION
This changes how SDK behaves a little:

- Requests will try to refresh the token first
- Concurrent/parallel requests are going to hold until the first refresh request ends and use it's resolve/rejection instead of dispatching a request
- Default auto refresh time set to 30sec when not specified
- Adds flags to the transport requests to enable/disable auto refresh and if the authorization headers should be sent or not

Closes #4883
Closes #4979