### PR TITLE
api: ignore singleton on validate-batch

### DIFF
--- a/api/src/middleware/validate-batch.ts
+++ b/api/src/middleware/validate-batch.ts
@@ -13,6 +13,8 @@ export const validateBatch = (scope: 'read' | 'update' | 'delete'): RequestHandl
 
 		if (!req.body) throw new InvalidPayloadException('Payload in body is required');
 
+		if (req.singleton) return next();
+
 		// Every cRUD action has either keys or query
 		let batchSchema = Joi.object().keys({
 			keys: Joi.array().items(Joi.alternatives(Joi.string(), Joi.number())),


### PR DESCRIPTION
Currently it's not possible to update singletons, because the API
expects to receive an object with `data` property. But this is false,
when is a singleton