### PR TITLE
Clarify SQLite setup when running Directus locally

### DIFF
--- a/api/example.env
+++ b/api/example.env
@@ -9,6 +9,7 @@ LOG_STYLE="pretty"
 ####################################################################################################
 # Database
 
+## PostgreSQL Example
 DB_CLIENT="pg"
 DB_HOST="localhost"
 DB_PORT=5432
@@ -17,6 +18,7 @@ DB_USER="postgres"
 DB_PASSWORD="psql1234"
 
 ## SQLite Example
+# DB_CLIENT="sqlite3"
 # DB_FILENAME="./data.db"
 
 ####################################################################################################

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -38,19 +38,31 @@ npm run build
 
 ## 5. Create a `.env` file
 
-Create a `.env` file under the `api` folder the API to use. You can use the `example.env` file provided under `api` as a
-starting point.
-
-## 6. Setup the Database
-
-For this step, you'll need to already have a SQL database up-and-running, otherwise you can only use the SQLite driver,
-which will create the database for you. Run the following command from within root of the project:
+Create a `.env` file under the `api` folder. You can use the `example.env` file provided under `api` as a starting
+point.
 
 ```bash
+# To use the example file
+cp api/example.env api/.env
+```
+
+## 6. Initialize the database
+
+For this step, you'll need to already have a SQL database up-and-running, except if you're using the SQLite driver,
+which will create the database (file) for you.
+
+To start the initialization run the following command:
+
+```bash
+# From within the root of the project
+npm run cli bootstrap
+
+# For SQLite you need to be in the 'api' folder to initialize the database
+cd api
 npm run cli bootstrap
 ```
 
-This will install Directus, and make sure all the migrations have run.
+This will set-up the required tables for Directus and make sure all the migrations have run.
 
 ## 7. Start the development server
 


### PR DESCRIPTION
For the SQLite setup you need to run the bootstrap command from within the 'api' folder (at least if .env is configured with `DB_FILENAME="./data.db"`) as the database file will be created relative to the current folder and the API will look up the file relative to the 'api' folder.
This pull request will clarify those things.