### PR TITLE
Enable Dependabot to keep track of package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will enable [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically) which will keep track of package updates (and create pull requests).
According to the docs it should work with Lerna.
If Directus is not ready for an update it can be [ignored](https://docs.github.com/en/code-security/supply-chain-security/managing-pull-requests-for-dependency-updates), but in general I think this would be a good addition to the project, especially since it has some vulnerable packages at the moment (see `npm audit`).