### PR TITLE
Fix & enhance linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,32 +1,66 @@
+const defaultRules = {
+	// No console statements in production
+	'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+	// No debugger statements in production
+	'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+	// Enforce prettier formating
+	'prettier/prettier': 'error',
+};
+
 module.exports = {
+	// Stop looking for ESLint configurations in parent folders
 	root: true,
+	// Global variables: Browser and Node.js
 	env: {
+		browser: true,
 		node: true,
 	},
-	extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier-vue/recommended', 'plugin:vue/essential'],
+	// Basic configuration for js files
 	plugins: ['@typescript-eslint', 'prettier'],
-	rules: {
-		'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-		'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-		'@typescript-eslint/camelcase': 0,
-		'@typescript-eslint/no-use-before-define': 0,
-		'@typescript-eslint/ban-ts-ignore': 0,
-		'@typescript-eslint/no-explicit-any': 0,
-		'@typescript-eslint/no-var-requires': 0,
-		'prettier/prettier': ['error', { singleQuote: true }],
-		'vue/valid-v-slot': 0,
-		'comma-dangle': [
-			'error',
-			{
-				arrays: 'always-multiline',
-				exports: 'always-multiline',
-				functions: 'never',
-				imports: 'always-multiline',
-				objects: 'always-multiline',
-			},
-		],
-	},
+	extends: ['eslint:recommended', 'prettier'],
+	rules: defaultRules,
 	parserOptions: {
-		parser: '@typescript-eslint/parser',
+		ecmaVersion: 2020,
 	},
+	overrides: [
+		// Parse rollup configration as module
+		{
+			files: ['rollup.config.js'],
+			parserOptions: {
+				sourceType: 'module',
+			},
+		},
+		// Configuration for ts/vue files
+		{
+			files: ['*.ts', '*.vue'],
+			parser: 'vue-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser',
+			},
+			extends: [
+				'plugin:vue/essential',
+				'eslint:recommended',
+				'plugin:@typescript-eslint/recommended',
+				'plugin:prettier-vue/recommended',
+				'prettier',
+			],
+			rules: {
+				...defaultRules,
+				// It's recommended to turn off this rule on TypeScript projects
+				'no-undef': 'off',
+				// Allow ts-directive comments (used to suppress TypeScript compiler errors)
+				'@typescript-eslint/ban-ts-comment': 0,
+				// Allow usage of the any type (consider to enable this rule later on)
+				'@typescript-eslint/no-explicit-any': 0,
+				// Allow usage of require statements (consider to enable this rule later on)
+				'@typescript-eslint/no-var-requires': 0,
+				// Allow non-null assertions for now (consider to enable this rule later on)
+				'@typescript-eslint/no-non-null-assertion': 0,
+				// Allow unused variables when they begin with an underscore
+				'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+				// Disable validity checks on v-slot directive (consider to enable this rule later on)
+				'vue/valid-v-slot': 0,
+			},
+		},
+	],
 };

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+dist
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"eslint": "^7.22.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-prettier": "^3.4.0",
-				"eslint-plugin-prettier-vue": "^2.1.1",
+				"eslint-plugin-prettier-vue": "^3.0.0",
 				"eslint-plugin-vue": "^7.8.0",
 				"globby": "^11.0.3",
 				"jest": "^26.6.3",
@@ -8013,6 +8013,39 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true
 		},
+		"node_modules/@vue/compiler-core": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.11.tgz",
+			"integrity": "sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.12.0",
+				"@babel/types": "^7.12.0",
+				"@vue/shared": "3.0.11",
+				"estree-walker": "^2.0.1",
+				"source-map": "^0.6.1"
+			}
+		},
+		"node_modules/@vue/compiler-dom": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz",
+			"integrity": "sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==",
+			"dev": true,
+			"dependencies": {
+				"@vue/compiler-core": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"node_modules/@vue/compiler-ssr": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.11.tgz",
+			"integrity": "sha512-66yUGI8SGOpNvOcrQybRIhl2M03PJ+OrDPm78i7tvVln86MHTKhM3ERbALK26F7tXl0RkjX4sZpucCpiKs3MnA==",
+			"dev": true,
+			"dependencies": {
+				"@vue/compiler-dom": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
 		"node_modules/@vue/component-compiler-utils": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.2.0.tgz",
@@ -8075,6 +8108,52 @@
 				"html-webpack-plugin": ">=2.26.0",
 				"webpack": ">=4.0.0"
 			}
+		},
+		"node_modules/@vue/reactivity": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
+			"integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"node_modules/@vue/runtime-core": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
+			"integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@vue/reactivity": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"node_modules/@vue/runtime-dom": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
+			"integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@vue/runtime-core": "3.0.11",
+				"@vue/shared": "3.0.11",
+				"csstype": "^2.6.8"
+			}
+		},
+		"node_modules/@vue/runtime-dom/node_modules/csstype": {
+			"version": "2.6.17",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+			"integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/@vue/shared": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+			"integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA==",
+			"dev": true
 		},
 		"node_modules/@vue/test-utils": {
 			"version": "1.1.3",
@@ -11301,6 +11380,7 @@
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"inherits": "~2.0.0"
@@ -16257,9 +16337,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
-			"integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+			"integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
 			"dependencies": {
 				"@babel/code-frame": "7.12.11",
 				"@eslint/eslintrc": "^0.4.0",
@@ -16766,17 +16846,196 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier-vue": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier-vue/-/eslint-plugin-prettier-vue-2.1.1.tgz",
-			"integrity": "sha512-B9nYJCwf6508tc36fBU6a7QRwmp688Z8q6BPDvHLftR5KccqVNRkCUwPYjHXouw1m6NzdcRZraJ0A0jXwtNCTQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier-vue/-/eslint-plugin-prettier-vue-3.0.0.tgz",
+			"integrity": "sha512-fRjvHSu7aLjS+rJp/Asrualum/6uThr1Swf5ExlieAT8EeY3Z1kegmNinN2t2UTEi3lOtRvhV6b6iRVWjVtpqA==",
 			"dev": true,
 			"dependencies": {
-				"@vue/component-compiler-utils": "^3.1.2",
+				"@vue/compiler-sfc": "^3.0.0",
 				"chalk": "^4.0.0",
-				"prettier": "^1.18.2 || ^2.0.0",
-				"prettier-linter-helpers": "^1.0.0",
-				"vue-template-compiler": "^2.0.0"
+				"prettier": "^2.0.0",
+				"prettier-linter-helpers": "^1.0.0"
 			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/@vue/compiler-sfc": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.11.tgz",
+			"integrity": "sha512-7fNiZuCecRleiyVGUWNa6pn8fB2fnuJU+3AGjbjl7r1P5wBivfl02H4pG+2aJP5gh2u+0wXov1W38tfWOphsXw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.13.9",
+				"@babel/types": "^7.13.0",
+				"@vue/compiler-core": "3.0.11",
+				"@vue/compiler-dom": "3.0.11",
+				"@vue/compiler-ssr": "3.0.11",
+				"@vue/shared": "3.0.11",
+				"consolidate": "^0.16.0",
+				"estree-walker": "^2.0.1",
+				"hash-sum": "^2.0.0",
+				"lru-cache": "^5.1.1",
+				"magic-string": "^0.25.7",
+				"merge-source-map": "^1.1.0",
+				"postcss": "^8.1.10",
+				"postcss-modules": "^4.0.0",
+				"postcss-selector-parser": "^6.0.4",
+				"source-map": "^0.6.1"
+			},
+			"peerDependencies": {
+				"vue": "3.0.11"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/consolidate": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+			"integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+			"dev": true,
+			"dependencies": {
+				"bluebird": "^3.7.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/hash-sum": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+			"dev": true
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/icss-utils": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >= 14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/postcss": {
+			"version": "8.2.13",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+			"integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
+			"dev": true,
+			"dependencies": {
+				"colorette": "^1.2.2",
+				"nanoid": "^3.1.22",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/postcss-modules": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.0.0.tgz",
+			"integrity": "sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==",
+			"dev": true,
+			"dependencies": {
+				"generic-names": "^2.0.1",
+				"icss-replace-symbols": "^1.1.0",
+				"lodash.camelcase": "^4.3.0",
+				"postcss-modules-extract-imports": "^3.0.0",
+				"postcss-modules-local-by-default": "^4.0.0",
+				"postcss-modules-scope": "^3.0.0",
+				"postcss-modules-values": "^4.0.0",
+				"string-hash": "^1.1.1"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/postcss-modules-extract-imports": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >= 14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/postcss-modules-local-by-default": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+			"integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+			"dev": true,
+			"dependencies": {
+				"icss-utils": "^5.0.0",
+				"postcss-selector-parser": "^6.0.2",
+				"postcss-value-parser": "^4.1.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >= 14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/postcss-modules-scope": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+			"integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.4"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >= 14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/postcss-modules-values": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+			"integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+			"dev": true,
+			"dependencies": {
+				"icss-utils": "^5.0.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >= 14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/vue": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
+			"integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@vue/compiler-dom": "3.0.11",
+				"@vue/runtime-dom": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"node_modules/eslint-plugin-prettier-vue/node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
 		},
 		"node_modules/eslint-plugin-react": {
 			"version": "7.23.2",
@@ -16842,9 +17101,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-vue": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.8.0.tgz",
-			"integrity": "sha512-OGrnPz+PuYL2HmVyBHxm4mRjxW2kfFCQE6Hw9G6qOHs/Pcu0srOlCCW0FMa8SLzIEqxl8WuKoBSPcMnrjUG2vw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.9.0.tgz",
+			"integrity": "sha512-2Q0qQp5+5h+pZvJKCbG1/jCRUYrdgAz5BYKGyTlp2NU8mx09u3Hp7PsH6d5qef6ojuPoCXMnrbbDxeoplihrSw==",
 			"dev": true,
 			"dependencies": {
 				"eslint-utils": "^2.1.0",
@@ -18464,6 +18723,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
 			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
@@ -18479,6 +18739,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -18491,6 +18752,7 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -20981,6 +21243,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/generic-names": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+			"integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+			"dev": true,
+			"dependencies": {
+				"loader-utils": "^1.1.0"
 			}
 		},
 		"node_modules/gensync": {
@@ -26462,6 +26733,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"node_modules/lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
 			"dev": true
 		},
 		"node_modules/lodash.clonedeep": {
@@ -36966,6 +37243,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -36978,6 +37256,7 @@
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"fstream": "^1.0.0",
@@ -37004,6 +37283,7 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"abbrev": "1"
@@ -37016,6 +37296,7 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -37028,6 +37309,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+			"dev": true,
 			"optional": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -37037,6 +37319,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
 			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"block-stream": "*",
@@ -37048,6 +37331,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -37485,6 +37769,12 @@
 			"resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
 			"integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
 			"peer": true
+		},
+		"node_modules/string-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+			"dev": true
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -57088,6 +57378,39 @@
 				}
 			}
 		},
+		"@vue/compiler-core": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.11.tgz",
+			"integrity": "sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.12.0",
+				"@babel/types": "^7.12.0",
+				"@vue/shared": "3.0.11",
+				"estree-walker": "^2.0.1",
+				"source-map": "^0.6.1"
+			}
+		},
+		"@vue/compiler-dom": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz",
+			"integrity": "sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==",
+			"dev": true,
+			"requires": {
+				"@vue/compiler-core": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"@vue/compiler-ssr": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.11.tgz",
+			"integrity": "sha512-66yUGI8SGOpNvOcrQybRIhl2M03PJ+OrDPm78i7tvVln86MHTKhM3ERbALK26F7tXl0RkjX4sZpucCpiKs3MnA==",
+			"dev": true,
+			"requires": {
+				"@vue/compiler-dom": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
 		"@vue/component-compiler-utils": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.2.0.tgz",
@@ -57137,6 +57460,54 @@
 			"integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==",
 			"dev": true,
 			"requires": {}
+		},
+		"@vue/reactivity": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
+			"integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"@vue/runtime-core": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
+			"integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@vue/reactivity": "3.0.11",
+				"@vue/shared": "3.0.11"
+			}
+		},
+		"@vue/runtime-dom": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
+			"integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@vue/runtime-core": "3.0.11",
+				"@vue/shared": "3.0.11",
+				"csstype": "^2.6.8"
+			},
+			"dependencies": {
+				"csstype": {
+					"version": "2.6.17",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+					"integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
+		"@vue/shared": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
+			"integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA==",
+			"dev": true
 		},
 		"@vue/test-utils": {
 			"version": "1.1.3",
@@ -59793,6 +60164,7 @@
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"inherits": "~2.0.0"
@@ -63945,9 +64317,9 @@
 			}
 		},
 		"eslint": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
-			"integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+			"integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
 			"requires": {
 				"@babel/code-frame": "7.12.11",
 				"@eslint/eslintrc": "^0.4.0",
@@ -64343,16 +64715,153 @@
 			}
 		},
 		"eslint-plugin-prettier-vue": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier-vue/-/eslint-plugin-prettier-vue-2.1.1.tgz",
-			"integrity": "sha512-B9nYJCwf6508tc36fBU6a7QRwmp688Z8q6BPDvHLftR5KccqVNRkCUwPYjHXouw1m6NzdcRZraJ0A0jXwtNCTQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier-vue/-/eslint-plugin-prettier-vue-3.0.0.tgz",
+			"integrity": "sha512-fRjvHSu7aLjS+rJp/Asrualum/6uThr1Swf5ExlieAT8EeY3Z1kegmNinN2t2UTEi3lOtRvhV6b6iRVWjVtpqA==",
 			"dev": true,
 			"requires": {
-				"@vue/component-compiler-utils": "^3.1.2",
+				"@vue/compiler-sfc": "^3.0.0",
 				"chalk": "^4.0.0",
-				"prettier": "^1.18.2 || ^2.0.0",
-				"prettier-linter-helpers": "^1.0.0",
-				"vue-template-compiler": "^2.0.0"
+				"prettier": "^2.0.0",
+				"prettier-linter-helpers": "^1.0.0"
+			},
+			"dependencies": {
+				"@vue/compiler-sfc": {
+					"version": "3.0.11",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.11.tgz",
+					"integrity": "sha512-7fNiZuCecRleiyVGUWNa6pn8fB2fnuJU+3AGjbjl7r1P5wBivfl02H4pG+2aJP5gh2u+0wXov1W38tfWOphsXw==",
+					"dev": true,
+					"requires": {
+						"@babel/parser": "^7.13.9",
+						"@babel/types": "^7.13.0",
+						"@vue/compiler-core": "3.0.11",
+						"@vue/compiler-dom": "3.0.11",
+						"@vue/compiler-ssr": "3.0.11",
+						"@vue/shared": "3.0.11",
+						"consolidate": "^0.16.0",
+						"estree-walker": "^2.0.1",
+						"hash-sum": "^2.0.0",
+						"lru-cache": "^5.1.1",
+						"magic-string": "^0.25.7",
+						"merge-source-map": "^1.1.0",
+						"postcss": "^8.1.10",
+						"postcss-modules": "^4.0.0",
+						"postcss-selector-parser": "^6.0.4",
+						"source-map": "^0.6.1"
+					}
+				},
+				"consolidate": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+					"integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.7.2"
+					}
+				},
+				"hash-sum": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+					"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+					"dev": true
+				},
+				"icss-utils": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+					"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+					"dev": true,
+					"requires": {}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"postcss": {
+					"version": "8.2.13",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+					"integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
+					"dev": true,
+					"requires": {
+						"colorette": "^1.2.2",
+						"nanoid": "^3.1.22",
+						"source-map": "^0.6.1"
+					}
+				},
+				"postcss-modules": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.0.0.tgz",
+					"integrity": "sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==",
+					"dev": true,
+					"requires": {
+						"generic-names": "^2.0.1",
+						"icss-replace-symbols": "^1.1.0",
+						"lodash.camelcase": "^4.3.0",
+						"postcss-modules-extract-imports": "^3.0.0",
+						"postcss-modules-local-by-default": "^4.0.0",
+						"postcss-modules-scope": "^3.0.0",
+						"postcss-modules-values": "^4.0.0",
+						"string-hash": "^1.1.1"
+					}
+				},
+				"postcss-modules-extract-imports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+					"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+					"dev": true,
+					"requires": {}
+				},
+				"postcss-modules-local-by-default": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+					"integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+					"dev": true,
+					"requires": {
+						"icss-utils": "^5.0.0",
+						"postcss-selector-parser": "^6.0.2",
+						"postcss-value-parser": "^4.1.0"
+					}
+				},
+				"postcss-modules-scope": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+					"integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+					"dev": true,
+					"requires": {
+						"postcss-selector-parser": "^6.0.4"
+					}
+				},
+				"postcss-modules-values": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+					"integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+					"dev": true,
+					"requires": {
+						"icss-utils": "^5.0.0"
+					}
+				},
+				"vue": {
+					"version": "3.0.11",
+					"resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
+					"integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"@vue/compiler-dom": "3.0.11",
+						"@vue/runtime-dom": "3.0.11",
+						"@vue/shared": "3.0.11"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-plugin-react": {
@@ -64404,9 +64913,9 @@
 			"requires": {}
 		},
 		"eslint-plugin-vue": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.8.0.tgz",
-			"integrity": "sha512-OGrnPz+PuYL2HmVyBHxm4mRjxW2kfFCQE6Hw9G6qOHs/Pcu0srOlCCW0FMa8SLzIEqxl8WuKoBSPcMnrjUG2vw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.9.0.tgz",
+			"integrity": "sha512-2Q0qQp5+5h+pZvJKCbG1/jCRUYrdgAz5BYKGyTlp2NU8mx09u3Hp7PsH6d5qef6ojuPoCXMnrbbDxeoplihrSw==",
 			"dev": true,
 			"requires": {
 				"eslint-utils": "^2.1.0",
@@ -65716,6 +66225,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
 			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -65728,6 +66238,7 @@
 					"version": "0.5.5",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimist": "^1.2.5"
@@ -65737,6 +66248,7 @@
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -67686,6 +68198,15 @@
 				"google-auth-library": "^7.0.0",
 				"pumpify": "^2.0.0",
 				"stream-events": "^1.0.4"
+			}
+		},
+		"generic-names": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+			"integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^1.1.0"
 			}
 		},
 		"gensync": {
@@ -71940,6 +72461,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
 			"dev": true
 		},
 		"lodash.clonedeep": {
@@ -80423,6 +80950,7 @@
 					"version": "0.5.5",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimist": "^1.2.5"
@@ -80432,6 +80960,7 @@
 					"version": "3.8.0",
 					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 					"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "^1.0.0",
@@ -80452,6 +80981,7 @@
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1"
@@ -80461,6 +80991,7 @@
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -80470,12 +81001,14 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
 					"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"block-stream": "*",
@@ -80487,6 +81020,7 @@
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -80844,6 +81378,12 @@
 			"resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
 			"integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
 			"peer": true
+		},
+		"string-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+			"dev": true
 		},
 		"string-length": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"eslint": "^7.22.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-prettier": "^3.4.0",
-		"eslint-plugin-prettier-vue": "^2.1.1",
+		"eslint-plugin-prettier-vue": "^3.0.0",
 		"eslint-plugin-vue": "^7.8.0",
 		"globby": "^11.0.3",
 		"jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"./packages/*"
 	],
 	"scripts": {
-		"lint": "npm-run-all -p lint:*",
+		"lint": "npm-run-all --parallel --continue-on-error lint:*",
 		"lint:eslint": "eslint .",
 		"lint:stylelint": "stylelint \"**/*.{css,scss,vue}\"",
 		"format": "prettier --write \"**/*.{js,ts,vue,md}\"",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"pre-commit": "npx lint-staged"
 	},
 	"lint-staged": {
-		"*.{js,ts,vue,md}": "prettier --write",
+		"*.{js,ts,vue,md}": "eslint . --fix",
 		"*.{css,scss,vue}": "stylelint --fix"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 	"scripts": {
 		"lint": "npm-run-all -p lint:*",
 		"lint:eslint": "eslint .",
-		"lint:stylelint": "stylelint .",
-		"format": "prettier --write \"**/*.{js,vue,ts,md}\"",
+		"lint:stylelint": "stylelint \"**/*.{css,scss,vue}\"",
+		"format": "prettier --write \"**/*.{js,ts,vue,md}\"",
 		"dev": "lerna run dev --stream --parallel",
 		"build": "lerna run build",
 		"release": "lerna publish --force-publish --exact",
@@ -62,7 +62,7 @@
 		"pre-commit": "npx lint-staged"
 	},
 	"lint-staged": {
-		"*.{js,ts,md,vue}": "prettier --write",
+		"*.{js,ts,vue,md}": "prettier --write",
 		"*.{css,scss,vue}": "stylelint --fix"
 	}
 }


### PR DESCRIPTION
As discussed in #5254 this pull request contains only the config part.

With this pull request you can now run `npm run lint` (and will see quite a few errors/warnings 😉🙊)
You are also able to run something like `npx eslint --fix .; npx stylelint "**/*.{css,scss,vue}"` to fix problems which are automatically fixable.

@rijkvanzanten Please let me know weather I should include https://github.com/directus/directus/pull/5254/commits/d70487198570d69a346864ae9e7590a21d44091a in this pull request. This would mean that linting would already take place on files which are part of new commits.

Two more things:
* The eslint configuration could possibly be improved, but I think "it does its job for now"
* Maybe it would make sense to split it up into different eslint config files per package (e.g. one it 'app', one in 'api', ...) later on 