### PR TITLE
Add info to reamde about mysql 8 setting up

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Directus only requires Node.js and supports most operating systems and SQL datab
 #### Supported Databases
 
 - PostgreSQL 10+
-- MySQL 5.7.8+
+- MySQL 5.7.8+ (8.* with mysql_native_password [here](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password-compatible-connectors))
 - MariaDB 10.2+
 - SQLite 3+
 - MS-SQL X.X+


### PR DESCRIPTION
Currently it's not possible to connect to mysql with default password algorithm, more info here https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password-compatible-connectors