### PR TITLE
Update oracledb.ts

### DIFF
--- a/packages/schema/src/dialects/oracledb.ts
+++ b/packages/schema/src/dialects/oracledb.ts
@@ -60,10 +60,18 @@ export default class Oracle extends KnexOracle implements SchemaInspector {
 					columns: {},
 				};
 			}
+			
+			/**
+			* Oracle doesn't return AUTO_INCREMENT. Incrementing is done using triggers, and there is no
+			* nice way to detect if a trigger is an increment trigger. For compatibility sake, assume all
+			* numeric primary keys AUTO_INCREMENT to prevent authorization throwing a "required value" error.
+			*/
+			const isNumericPrimary = column.data_type === 'NUMBER' && overview[column.table_name].primary;
 
 			overview[column.table_name].columns[column.column_name] = {
 				...column,
 				is_nullable: column.is_nullable === 'Y',
+				default_value: !column.default_value && isNumericPrimary ? 'AUTO_INCREMENT' : column.default_value,
 			};
 		}
 


### PR DESCRIPTION
As explained in the code comment, Oracle doesn't return AUTO_INCREMENT, causing `authorization.ts` to throw a error because it doesn't know primary keys are AUTO_INCREMENT.

This was the last fix required to get things running with Oracle 19c (with a few minor issues).