### PR TITLE
Setting the default date to today is a bad idea

### DIFF
--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -161,7 +161,7 @@ export default defineComponent({
 					return _value.value.getMonth();
 				},
 				set(newMonth: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date();
+					const newValue = _value.value ? new Date(_value.value) : new Date(0);
 					newValue.setMonth(newMonth || 0);
 					_value.value = newValue;
 				},
@@ -173,7 +173,7 @@ export default defineComponent({
 					return _value.value.getDate();
 				},
 				set(newDate: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date();
+					const newValue = _value.value ? new Date(_value.value) : new Date(0);
 					newValue.setDate(newDate || 1);
 					_value.value = newValue;
 				},
@@ -191,7 +191,7 @@ export default defineComponent({
 					return hours;
 				},
 				set(newHours: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date();
+					const newValue = _value.value ? new Date(_value.value) : new Date(0);
 					newValue.setHours(newHours || 0);
 					_value.value = newValue;
 				},
@@ -203,7 +203,7 @@ export default defineComponent({
 					return _value.value.getMinutes();
 				},
 				set(newMinutes: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date();
+					const newValue = _value.value ? new Date(_value.value) : new Date(0);
 					newValue.setMinutes(newMinutes || 0);
 					_value.value = newValue;
 				},
@@ -215,7 +215,7 @@ export default defineComponent({
 					return _value.value.getSeconds();
 				},
 				set(newSeconds: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date();
+					const newValue = _value.value ? new Date(_value.value) : new Date(0);
 					newValue.setSeconds(newSeconds || 0);
 					_value.value = newValue;
 				},


### PR DESCRIPTION
If a user selects a year, the day and month are set to today's day and month. This is a very bad idea since people want to sort entries by date. Most of the time only the year is of interest. The entries will be sorted then by the time and day when the were created...
This commit should set the values to the same by default.