### PR TITLE
Also join o2m relations when not in subquery but at non-root level

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -109,7 +109,8 @@ export function applyFilter(
 					);
 				}
 
-				if (subQuery === true && isM2O === false) {
+				// Still join o2m relations when in subquery OR when the o2m relation is not at the root level
+				if ((subQuery === true || parentAlias !== undefined) && isM2O === false) {
 					dbQuery.leftJoin(
 						{ [alias]: relation.many_collection },
 						`${parentAlias || parentCollection}.${relation.one_primary}`,


### PR DESCRIPTION
Here's a PR that fixes the query error when a filter contains an o2m relation that is not at the root level. It's fixed by not only joining o2m relations when in a subquery, but also when the o2m relation is 'deeper' in the filter (by checking if the parentAlias is set). 

Possibly this could introduce cartesian products again, but I couldn't figure out a better way that uses a subquery. At least, it's better than an Exception ;-).

Fixes https://github.com/directus/directus/issues/4485