### PR TITLE
Syntax fixes

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -51,7 +51,7 @@ import { emitAsyncSafe } from './emitter';
 
 import fse from 'fs-extra';
 
-export default async function createApp() {
+export default async function createApp(): Promise<express.Application> {
 	validateEnv(['KEY', 'SECRET']);
 
 	await validateDBConnection();

--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -5,7 +5,7 @@ import runMigrations from '../../../database/migrations/run';
 import { getSchema } from '../../../utils/get-schema';
 import { nanoid } from 'nanoid';
 
-export default async function bootstrap() {
+export default async function bootstrap(): Promise<void> {
 	logger.info('Initializing bootstrap...');
 
 	if ((await isDatabaseAvailable()) === false) {

--- a/api/src/cli/commands/count/index.ts
+++ b/api/src/cli/commands/count/index.ts
@@ -1,4 +1,4 @@
-export default async function count(collection: string) {
+export default async function count(collection: string): Promise<void> {
 	const database = require('../../../database/index').default;
 
 	if (!collection) {

--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import installSeeds from '../../../database/seeds/run';
 import runMigrations from '../../../database/migrations/run';
 
-export default async function start() {
+export default async function start(): Promise<void> {
 	const database = require('../../../database/index').default as Knex;
 
 	try {

--- a/api/src/cli/commands/database/migrate.ts
+++ b/api/src/cli/commands/database/migrate.ts
@@ -1,6 +1,6 @@
 import run from '../../../database/migrations/run';
 
-export default async function migrate(direction: 'latest' | 'up' | 'down') {
+export default async function migrate(direction: 'latest' | 'up' | 'down'): Promise<void> {
 	const database = require('../../../database').default;
 
 	try {

--- a/api/src/cli/commands/init/index.ts
+++ b/api/src/cli/commands/init/index.ts
@@ -15,7 +15,7 @@ import runMigrations from '../../../database/migrations/run';
 import createDBConnection, { Credentials } from '../../utils/create-db-connection';
 import { Knex } from 'knex';
 
-export default async function init(options: Record<string, any>) {
+export default async function init(): Promise<void> {
 	const rootPath = process.cwd();
 
 	let { client } = await inquirer.prompt([
@@ -39,7 +39,7 @@ export default async function init(options: Record<string, any>) {
 
 	async function trySeed(): Promise<{ credentials: Credentials; db: Knex }> {
 		const credentials: Credentials = await inquirer.prompt(
-			(databaseQuestions[dbClient] as any[]).map((question: Function) =>
+			(databaseQuestions[dbClient] as any[]).map((question: ({ client, filepath }: any) => any) =>
 				question({ client: dbClient, filepath: rootPath })
 			)
 		);

--- a/api/src/cli/commands/init/questions.ts
+++ b/api/src/cli/commands/init/questions.ts
@@ -1,20 +1,20 @@
 import path from 'path';
 
-const filename = ({ filepath }: { filepath: string }) => ({
+const filename = ({ filepath }: { filepath: string }): Record<string, string> => ({
 	type: 'input',
 	name: 'filename',
 	message: 'Database File Path:',
 	default: path.join(filepath, 'data.db'),
 });
 
-const host = () => ({
+const host = (): Record<string, string> => ({
 	type: 'input',
 	name: 'host',
 	message: 'Database Host:',
 	default: '127.0.0.1',
 });
 
-const port = ({ client }: { client: string }) => ({
+const port = ({ client }: { client: string }): Record<string, any> => ({
 	type: 'input',
 	name: 'port',
 	message: 'Port:',
@@ -30,27 +30,27 @@ const port = ({ client }: { client: string }) => ({
 	},
 });
 
-const database = () => ({
+const database = (): Record<string, string> => ({
 	type: 'input',
 	name: 'database',
 	message: 'Database Name:',
 	default: 'directus',
 });
 
-const user = () => ({
+const user = (): Record<string, string> => ({
 	type: 'input',
 	name: 'user',
 	message: 'Database User:',
 });
 
-const password = () => ({
+const password = (): Record<string, string> => ({
 	type: 'password',
 	name: 'password',
 	message: 'Database Password:',
 	mask: '*',
 });
 
-const ssl = () => ({
+const ssl = (): Record<string, string | boolean> => ({
 	type: 'confirm',
 	name: 'ssl',
 	message: 'Enable SSL:',

--- a/api/src/cli/commands/roles/create.ts
+++ b/api/src/cli/commands/roles/create.ts
@@ -1,6 +1,6 @@
 import { getSchema } from '../../../utils/get-schema';
 
-export default async function rolesCreate({ name, admin }: any) {
+export default async function rolesCreate({ name, admin }: any): Promise<void> {
 	const { default: database } = require('../../../database/index');
 	const { RolesService } = require('../../../services/roles');
 

--- a/api/src/cli/commands/users/create.ts
+++ b/api/src/cli/commands/users/create.ts
@@ -1,6 +1,6 @@
 import { getSchema } from '../../../utils/get-schema';
 
-export default async function usersCreate({ email, password, role }: any) {
+export default async function usersCreate({ email, password, role }: any): Promise<void> {
 	const { default: database, schemaInspector } = require('../../../database/index');
 	const { UsersService } = require('../../../services/users');
 

--- a/api/src/cli/commands/users/passwd.ts
+++ b/api/src/cli/commands/users/passwd.ts
@@ -1,7 +1,7 @@
 import argon2 from 'argon2';
 import { getSchema } from '../../../utils/get-schema';
 
-export default async function usersPasswd({ email, password }: any) {
+export default async function usersPasswd({ email, password }: any): Promise<void> {
 	const { default: database } = require('../../../database/index');
 	const { UsersService } = require('../../../services/users');
 

--- a/api/src/cli/utils/create-db-connection.ts
+++ b/api/src/cli/utils/create-db-connection.ts
@@ -13,7 +13,7 @@ export type Credentials = {
 export default function createDBConnection(
 	client: 'sqlite3' | 'mysql' | 'pg' | 'oracledb' | 'mssql',
 	credentials: Credentials
-) {
+): Knex<any, unknown[]> {
 	let connection: Knex.Config['connection'] = {};
 
 	if (client === 'sqlite3') {

--- a/api/src/cli/utils/create-env/index.ts
+++ b/api/src/cli/utils/create-env/index.ts
@@ -23,7 +23,11 @@ const defaults = {
 	},
 };
 
-export default async function createEnv(client: keyof typeof drivers, credentials: Credentials, directory: string) {
+export default async function createEnv(
+	client: keyof typeof drivers,
+	credentials: Credentials,
+	directory: string
+): Promise<void> {
 	const config: Record<string, any> = {
 		...defaults,
 		database: {

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -311,7 +311,9 @@ router.get(
 		try {
 			const email = getEmailFromProfile(req.params.provider, req.session.grant.response?.profile);
 
-			req.session?.destroy(() => {});
+			req.session?.destroy(() => {
+				// Do nothing
+			});
 
 			authResponse = await authenticationService.authenticate({
 				email,

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -55,7 +55,7 @@ database
 		logger.trace(`[${delta.toFixed(3)}ms] ${queryInfo.sql} [${queryInfo.bindings.join(', ')}]`);
 	});
 
-export async function hasDatabaseConnection() {
+export async function hasDatabaseConnection(): Promise<boolean> {
 	try {
 		if (env.DB_CLIENT === 'oracledb') {
 			await database.raw('select 1 from DUAL');
@@ -68,7 +68,7 @@ export async function hasDatabaseConnection() {
 	}
 }
 
-export async function validateDBConnection() {
+export async function validateDBConnection(): Promise<void> {
 	try {
 		await hasDatabaseConnection();
 	} catch (error) {
@@ -80,7 +80,7 @@ export async function validateDBConnection() {
 
 export const schemaInspector = SchemaInspector(database);
 
-export async function isInstalled() {
+export async function isInstalled(): Promise<boolean> {
 	// The existence of a directus_collections table alone isn't a "proper" check to see if everything
 	// is installed correctly of course, but it's safe enough to assume that this collection only
 	// exists when using the installer CLI.

--- a/api/src/database/migrations/20201028A-remove-collection-foreign-keys.ts
+++ b/api/src/database/migrations/20201028A-remove-collection-foreign-keys.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_fields', (table) => {
 		table.dropForeign(['collection']);
 	});
@@ -27,7 +27,7 @@ export async function up(knex: Knex) {
 	});
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_fields', (table) => {
 		table.foreign('collection').references('directus_collections.collection');
 	});

--- a/api/src/database/migrations/20201029A-remove-system-relations.ts
+++ b/api/src/database/migrations/20201029A-remove-system-relations.ts
@@ -1,14 +1,14 @@
 import { Knex } from 'knex';
 import { merge } from 'lodash';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex('directus_relations')
 		.delete()
 		.where('many_collection', 'like', 'directus_%')
 		.andWhere('one_collection', 'like', 'directus_%');
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	const defaults = {
 		many_collection: 'directus_users',
 		many_field: null,

--- a/api/src/database/migrations/20201029B-remove-system-collections.ts
+++ b/api/src/database/migrations/20201029B-remove-system-collections.ts
@@ -1,11 +1,11 @@
 import { Knex } from 'knex';
 import { merge } from 'lodash';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex('directus_collections').delete().where('collection', 'like', 'directus_%');
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	const defaults = {
 		collection: null,
 		hidden: false,

--- a/api/src/database/migrations/20201029C-remove-system-fields.ts
+++ b/api/src/database/migrations/20201029C-remove-system-fields.ts
@@ -1639,12 +1639,12 @@ const systemFields = [
 	return merge({}, defaults, row);
 });
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	const fieldKeys = uniq(systemFields.map((field: any) => field.field));
 
 	await knex('directus_fields').delete().where('collection', 'like', 'directus_%').whereIn('field', fieldKeys);
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.insert(systemFields).into('directus_fields');
 }

--- a/api/src/database/migrations/20201105A-add-cascade-system-relations.ts
+++ b/api/src/database/migrations/20201105A-add-cascade-system-relations.ts
@@ -114,7 +114,7 @@ const updates = [
  * Postgres behaves erratic on those triggers, not sure if MySQL / Maria plays nice either.
  */
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	for (const update of updates) {
 		await knex.schema.alterTable(update.table, (table) => {
 			for (const constraint of update.constraints) {
@@ -125,7 +125,7 @@ export async function up(knex: Knex) {
 	}
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	for (const update of updates) {
 		await knex.schema.alterTable(update.table, (table) => {
 			for (const constraint of update.constraints) {

--- a/api/src/database/migrations/20201105B-change-webhook-url-type.ts
+++ b/api/src/database/migrations/20201105B-change-webhook-url-type.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_webhooks', (table) => {
 		table.text('url').alter();
 	});
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_webhooks', (table) => {
 		table.string('url').alter();
 	});

--- a/api/src/database/migrations/20210225A-add-relations-sort-field.ts
+++ b/api/src/database/migrations/20210225A-add-relations-sort-field.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_relations', (table) => {
 		table.string('sort_field');
 	});
@@ -26,7 +26,7 @@ export async function up(knex: Knex) {
 	}
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_relations', (table) => {
 		table.dropColumn('sort_field');
 	});

--- a/api/src/database/migrations/20210304A-remove-locked-fields.ts
+++ b/api/src/database/migrations/20210304A-remove-locked-fields.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_fields', (table) => {
 		table.dropColumn('locked');
 	});
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_fields', (table) => {
 		table.boolean('locked').defaultTo(false).notNullable();
 	});

--- a/api/src/database/migrations/20210312A-webhooks-collections-text.ts
+++ b/api/src/database/migrations/20210312A-webhooks-collections-text.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_webhooks', (table) => {
 		table.text('collections').alter();
 	});
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_webhooks', (table) => {
 		table.string('collections').alter();
 	});

--- a/api/src/database/migrations/20210331A-add-refresh-interval.ts
+++ b/api/src/database/migrations/20210331A-add-refresh-interval.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_presets', (table) => {
 		table.integer('refresh_interval');
 	});
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_presets', (table) => {
 		table.dropColumn('refresh_interval');
 	});

--- a/api/src/database/migrations/20210415A-make-filesize-nullable.ts
+++ b/api/src/database/migrations/20210415A-make-filesize-nullable.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_files', (table) => {
 		table.integer('filesize').nullable().defaultTo(null).alter();
 	});
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_files', (table) => {
 		table.integer('filesize').notNullable().defaultTo(0).alter();
 	});

--- a/api/src/database/migrations/20210416A-add-collections-accountability.ts
+++ b/api/src/database/migrations/20210416A-add-collections-accountability.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_collections', (table) => {
 		table.string('accountability').defaultTo('all');
 	});
@@ -8,7 +8,7 @@ export async function up(knex: Knex) {
 	await knex('directus_collections').update({ accountability: 'all' });
 }
 
-export async function down(knex: Knex) {
+export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_collections', (table) => {
 		table.dropColumn('accountability');
 	});

--- a/api/src/database/migrations/20210422A-remove-files-interface.ts
+++ b/api/src/database/migrations/20210422A-remove-files-interface.ts
@@ -1,7 +1,9 @@
 import { Knex } from 'knex';
 
-export async function up(knex: Knex) {
+export async function up(knex: Knex): Promise<void> {
 	await knex('directus_fields').update({ interface: 'many-to-many' }).where({ interface: 'files' });
 }
 
-export async function down(knex: Knex) {}
+export async function down(_knex: Knex): Promise<void> {
+	// Do nothing
+}

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -10,7 +10,7 @@ type Migration = {
 	timestamp: Date;
 };
 
-export default async function run(database: Knex, direction: 'up' | 'down' | 'latest') {
+export default async function run(database: Knex, direction: 'up' | 'down' | 'latest'): Promise<void> {
 	let migrationFiles = await fse.readdir(__dirname);
 
 	const customMigrationsPath = path.resolve(env.EXTENSIONS_PATH, 'migrations');

--- a/api/src/database/seeds/run.ts
+++ b/api/src/database/seeds/run.ts
@@ -25,7 +25,7 @@ type TableSeed = {
 	};
 };
 
-export default async function runSeed(database: Knex) {
+export default async function runSeed(database: Knex): Promise<void> {
 	const exists = await database.schema.hasTable('directus_collections');
 
 	if (exists) {

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -15,7 +15,7 @@ const emitter = new EventEmitter2({
  * @param name
  * @param args
  */
-export async function emitAsyncSafe(name: string, ...args: any[]) {
+export async function emitAsyncSafe(name: string, ...args: any[]): Promise<any> {
 	try {
 		return await emitter.emitAsync(name, ...args);
 	} catch (err) {

--- a/api/src/exceptions/database/dialects/mssql.ts
+++ b/api/src/exceptions/database/dialects/mssql.ts
@@ -46,8 +46,8 @@ async function uniqueViolation(error: MSSQLError) {
 	 * information_schema when this happens
 	 */
 
-	const betweenQuotes = /\'([^\']+)\'/;
-	const betweenParens = /\(([^\)]+)\)/g;
+	const betweenQuotes = /'([^']+)'/;
+	const betweenParens = /\(([^)]+)\)/g;
 
 	const quoteMatches = error.message.match(betweenQuotes);
 	const parenMatches = error.message.match(betweenParens);
@@ -107,7 +107,7 @@ function numericValueOutOfRange(error: MSSQLError) {
 
 function valueLimitViolation(error: MSSQLError) {
 	const betweenBrackets = /\[([^\]]+)\]/g;
-	const betweenQuotes = /\'([^\']+)\'/g;
+	const betweenQuotes = /'([^']+)'/g;
 
 	const bracketMatches = error.message.match(betweenBrackets);
 	const quoteMatches = error.message.match(betweenQuotes);
@@ -125,7 +125,7 @@ function valueLimitViolation(error: MSSQLError) {
 
 function notNullViolation(error: MSSQLError) {
 	const betweenBrackets = /\[([^\]]+)\]/g;
-	const betweenQuotes = /\'([^\']+)\'/g;
+	const betweenQuotes = /'([^']+)'/g;
 
 	const bracketMatches = error.message.match(betweenBrackets);
 	const quoteMatches = error.message.match(betweenQuotes);
@@ -142,8 +142,8 @@ function notNullViolation(error: MSSQLError) {
 }
 
 function foreignKeyViolation(error: MSSQLError) {
-	const betweenUnderscores = /\_\_(.+)\_\_/g;
-	const betweenParens = /\(([^\)]+)\)/g;
+	const betweenUnderscores = /__(.+)__/g;
+	const betweenParens = /\(([^)]+)\)/g;
 
 	// NOTE:
 	// Seeing that MS SQL doesn't return the offending column name, we have to extract it from the

--- a/api/src/exceptions/database/dialects/mssql.ts
+++ b/api/src/exceptions/database/dialects/mssql.ts
@@ -5,17 +5,7 @@ import { ValueTooLongException } from '../value-too-long';
 import { ValueOutOfRangeException } from '../value-out-of-range';
 
 import database from '../../../database';
-
-type MSSQLError = {
-	message: string;
-	code: 'EREQUEST';
-	number: number;
-	state: number;
-	class: number;
-	serverName: string;
-	procName: string;
-	lineNumber: number;
-};
+import { MSSQLError } from './types';
 
 enum MSSQLErrorCodes {
 	FOREIGN_KEY_VIOLATION = 547,
@@ -25,7 +15,7 @@ enum MSSQLErrorCodes {
 	VALUE_LIMIT_VIOLATION = 2628,
 }
 
-export async function extractError(error: MSSQLError) {
+export async function extractError(error: MSSQLError): Promise<MSSQLError | Error> {
 	switch (error.number) {
 		case MSSQLErrorCodes.UNIQUE_VIOLATION:
 		case 2627:

--- a/api/src/exceptions/database/dialects/mysql.ts
+++ b/api/src/exceptions/database/dialects/mysql.ts
@@ -30,7 +30,7 @@ export function extractError(error: MySQLError): MySQLError | Error {
 }
 
 function uniqueViolation(error: MySQLError) {
-	const betweenQuotes = /\'([^\']+)\'/g;
+	const betweenQuotes = /'([^']+)'/g;
 	const matches = error.sqlMessage.match(betweenQuotes);
 
 	if (!matches) return error;
@@ -60,8 +60,8 @@ function uniqueViolation(error: MySQLError) {
 }
 
 function numericValueOutOfRange(error: MySQLError) {
-	const betweenTicks = /\`([^\`]+)\`/g;
-	const betweenQuotes = /\'([^\']+)\'/g;
+	const betweenTicks = /`([^`]+)`/g;
+	const betweenQuotes = /'([^']+)'/g;
 
 	const tickMatches = error.sql.match(betweenTicks);
 	const quoteMatches = error.sqlMessage.match(betweenQuotes);
@@ -78,8 +78,8 @@ function numericValueOutOfRange(error: MySQLError) {
 }
 
 function valueLimitViolation(error: MySQLError) {
-	const betweenTicks = /\`([^\`]+)\`/g;
-	const betweenQuotes = /\'([^\']+)\'/g;
+	const betweenTicks = /`([^`]+)`/g;
+	const betweenQuotes = /'([^']+)'/g;
 
 	const tickMatches = error.sql.match(betweenTicks);
 	const quoteMatches = error.sqlMessage.match(betweenQuotes);
@@ -96,8 +96,8 @@ function valueLimitViolation(error: MySQLError) {
 }
 
 function notNullViolation(error: MySQLError) {
-	const betweenTicks = /\`([^\`]+)\`/g;
-	const betweenQuotes = /\'([^\']+)\'/g;
+	const betweenTicks = /`([^`]+)`/g;
+	const betweenQuotes = /'([^']+)'/g;
 
 	const tickMatches = error.sql.match(betweenTicks);
 	const quoteMatches = error.sqlMessage.match(betweenQuotes);
@@ -114,8 +114,8 @@ function notNullViolation(error: MySQLError) {
 }
 
 function foreignKeyViolation(error: MySQLError) {
-	const betweenTicks = /\`([^\`]+)\`/g;
-	const betweenParens = /\(([^\)]+)\)/g;
+	const betweenTicks = /`([^`]+)`/g;
+	const betweenParens = /\(([^)]+)\)/g;
 
 	const tickMatches = error.sqlMessage.match(betweenTicks);
 	const parenMatches = error.sql.match(betweenParens);

--- a/api/src/exceptions/database/dialects/mysql.ts
+++ b/api/src/exceptions/database/dialects/mysql.ts
@@ -3,16 +3,7 @@ import { NotNullViolationException } from '../not-null-violation';
 import { RecordNotUniqueException } from '../record-not-unique';
 import { ValueTooLongException } from '../value-too-long';
 import { ValueOutOfRangeException } from '../value-out-of-range';
-
-type MySQLError = {
-	message: string;
-	code: string;
-	errno: number;
-	sqlMessage: string;
-	sqlState: string;
-	index: number;
-	sql: string;
-};
+import { MySQLError } from './types';
 
 enum MySQLErrorCodes {
 	UNIQUE_VIOLATION = 'ER_DUP_ENTRY',
@@ -22,7 +13,7 @@ enum MySQLErrorCodes {
 	FOREIGN_KEY_VIOLATION = 'ER_NO_REFERENCED_ROW_2',
 }
 
-export function extractError(error: MySQLError) {
+export function extractError(error: MySQLError): MySQLError | Error {
 	switch (error.code) {
 		case MySQLErrorCodes.UNIQUE_VIOLATION:
 			return uniqueViolation(error);

--- a/api/src/exceptions/database/dialects/oracle.ts
+++ b/api/src/exceptions/database/dialects/oracle.ts
@@ -1,3 +1,3 @@
-export function extractError(error: any) {
+export function extractError(error: Error): Error {
 	return error;
 }

--- a/api/src/exceptions/database/dialects/postgres.ts
+++ b/api/src/exceptions/database/dialects/postgres.ts
@@ -33,7 +33,7 @@ export function extractError(error: PostgresError): PostgresError | Error {
 function uniqueViolation(error: PostgresError) {
 	const { table, detail } = error;
 
-	const betweenParens = /\(([^\)]+)\)/g;
+	const betweenParens = /\(([^)]+)\)/g;
 	const matches = detail.match(betweenParens);
 
 	if (!matches) return error;
@@ -100,7 +100,7 @@ function notNullViolation(error: PostgresError) {
 function foreignKeyViolation(error: PostgresError) {
 	const { table, detail } = error;
 
-	const betweenParens = /\(([^\)]+)\)/g;
+	const betweenParens = /\(([^)]+)\)/g;
 	const matches = detail.match(betweenParens);
 
 	if (!matches) return error;

--- a/api/src/exceptions/database/dialects/postgres.ts
+++ b/api/src/exceptions/database/dialects/postgres.ts
@@ -3,18 +3,7 @@ import { NotNullViolationException } from '../not-null-violation';
 import { RecordNotUniqueException } from '../record-not-unique';
 import { ValueTooLongException } from '../value-too-long';
 import { ValueOutOfRangeException } from '../value-out-of-range';
-
-type PostgresError = {
-	message: string;
-	length: number;
-	code: string;
-	detail: string;
-	schema: string;
-	table: string;
-	column?: string;
-	dataType?: string;
-	constraint?: string;
-};
+import { PostgresError } from './types';
 
 enum PostgresErrorCodes {
 	FOREIGN_KEY_VIOLATION = '23503',
@@ -24,7 +13,7 @@ enum PostgresErrorCodes {
 	VALUE_LIMIT_VIOLATION = '22001',
 }
 
-export function extractError(error: PostgresError) {
+export function extractError(error: PostgresError): PostgresError | Error {
 	switch (error.code) {
 		case PostgresErrorCodes.UNIQUE_VIOLATION:
 			return uniqueViolation(error);

--- a/api/src/exceptions/database/dialects/sqlite.ts
+++ b/api/src/exceptions/database/dialects/sqlite.ts
@@ -1,18 +1,13 @@
 import { InvalidForeignKeyException } from '../invalid-foreign-key';
 import { RecordNotUniqueException } from '../record-not-unique';
 import { NotNullViolationException } from '../not-null-violation';
-
-type SQLiteError = {
-	message: string;
-	errno: number;
-	code: string;
-};
+import { SQLiteError } from './types';
 
 // NOTE:
 // - Sqlite doesn't have varchar with length support, so no ValueTooLongException
 // - Sqlite doesn't have a max range for numbers, so no ValueOutOfRangeException
 
-export function extractError(error: SQLiteError) {
+export function extractError(error: SQLiteError): SQLiteError | Error {
 	if (error.message.includes('SQLITE_CONSTRAINT: NOT NULL')) {
 		return notNullConstraint(error);
 	}

--- a/api/src/exceptions/database/dialects/types.ts
+++ b/api/src/exceptions/database/dialects/types.ts
@@ -1,0 +1,40 @@
+export type MSSQLError = {
+	message: string;
+	code: 'EREQUEST';
+	number: number;
+	state: number;
+	class: number;
+	serverName: string;
+	procName: string;
+	lineNumber: number;
+};
+
+export type MySQLError = {
+	message: string;
+	code: string;
+	errno: number;
+	sqlMessage: string;
+	sqlState: string;
+	index: number;
+	sql: string;
+};
+
+export type PostgresError = {
+	message: string;
+	length: number;
+	code: string;
+	detail: string;
+	schema: string;
+	table: string;
+	column?: string;
+	dataType?: string;
+	constraint?: string;
+};
+
+export type SQLiteError = {
+	message: string;
+	errno: number;
+	code: string;
+};
+
+export type SQLError = MSSQLError & MySQLError & PostgresError & SQLiteError & Error;

--- a/api/src/exceptions/database/translate.ts
+++ b/api/src/exceptions/database/translate.ts
@@ -4,6 +4,7 @@ import { extractError as mysql } from './dialects/mysql';
 import { extractError as mssql } from './dialects/mssql';
 import { extractError as sqlite } from './dialects/sqlite';
 import { extractError as oracle } from './dialects/oracle';
+import { SQLError } from './dialects/types';
 
 /**
  * Translates an error thrown by any of the databases into a pre-defined Exception. Currently
@@ -14,7 +15,7 @@ import { extractError as oracle } from './dialects/oracle';
  * - Value Out of Range
  * - Value Too Long
  */
-export async function translateDatabaseError(error: any) {
+export async function translateDatabaseError(error: SQLError): Promise<any> {
 	switch (database.client.constructor.name) {
 		case 'Client_MySQL':
 			return await mysql(error);

--- a/api/src/exceptions/database/translate.ts
+++ b/api/src/exceptions/database/translate.ts
@@ -18,14 +18,14 @@ import { SQLError } from './dialects/types';
 export async function translateDatabaseError(error: SQLError): Promise<any> {
 	switch (database.client.constructor.name) {
 		case 'Client_MySQL':
-			return await mysql(error);
+			return mysql(error);
 		case 'Client_PG':
-			return await postgres(error);
+			return postgres(error);
 		case 'Client_SQLite3':
-			return await sqlite(error);
+			return sqlite(error);
 		case 'Client_Oracledb':
 		case 'Client_Oracle':
-			return await oracle(error);
+			return oracle(error);
 		case 'Client_MSSQL':
 			return await mssql(error);
 

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -13,7 +13,7 @@ import * as exceptions from './exceptions';
 import * as services from './services';
 import database from './database';
 
-export async function ensureFoldersExist() {
+export async function ensureFoldersExist(): Promise<void> {
 	const folders = ['endpoints', 'hooks', 'interfaces', 'modules', 'layouts', 'displays'];
 
 	for (const folder of folders) {
@@ -26,11 +26,11 @@ export async function ensureFoldersExist() {
 	}
 }
 
-export async function initializeExtensions() {
+export async function initializeExtensions(): Promise<void> {
 	await ensureFoldersExist();
 }
 
-export async function listExtensions(type: string) {
+export async function listExtensions(type: string): Promise<string[]> {
 	const extensionsPath = env.EXTENSIONS_PATH as string;
 	const location = path.join(extensionsPath, type);
 
@@ -46,12 +46,12 @@ export async function listExtensions(type: string) {
 	}
 }
 
-export async function registerExtensions(router: Router) {
+export async function registerExtensions(router: Router): Promise<void> {
 	await registerExtensionHooks();
 	await registerExtensionEndpoints(router);
 }
 
-export async function registerExtensionEndpoints(router: Router) {
+export async function registerExtensionEndpoints(router: Router): Promise<void> {
 	let endpoints: string[] = [];
 	try {
 		endpoints = await listExtensions('endpoints');
@@ -61,7 +61,7 @@ export async function registerExtensionEndpoints(router: Router) {
 	}
 }
 
-export async function registerExtensionHooks() {
+export async function registerExtensionHooks(): Promise<void> {
 	let hooks: string[] = [];
 	try {
 		hooks = await listExtensions('hooks');

--- a/api/src/middleware/use-collection.ts
+++ b/api/src/middleware/use-collection.ts
@@ -2,9 +2,10 @@
  * Set req.collection for use in other middleware. Used as an alternative on validate-collection for
  * system collections
  */
+import { RequestHandler } from 'express';
 import asyncHandler from '../utils/async-handler';
 
-const useCollection = (collection: string) =>
+const useCollection = (collection: string): RequestHandler =>
 	asyncHandler(async (req, res, next) => {
 		req.collection = collection;
 		next();

--- a/api/src/rate-limiter.ts
+++ b/api/src/rate-limiter.ts
@@ -4,6 +4,7 @@ import {
 	RateLimiterMemcache,
 	IRateLimiterOptions,
 	IRateLimiterStoreOptions,
+	RateLimiterAbstract,
 } from 'rate-limiter-flexible';
 
 import { merge } from 'lodash';
@@ -13,7 +14,7 @@ import { getConfigFromEnv } from './utils/get-config-from-env';
 
 type IRateLimiterOptionsOverrides = Partial<IRateLimiterOptions> | Partial<IRateLimiterStoreOptions>;
 
-export function createRateLimiter(configOverrides?: IRateLimiterOptionsOverrides) {
+export function createRateLimiter(configOverrides?: IRateLimiterOptionsOverrides): RateLimiterAbstract {
 	switch (env.RATE_LIMITER_STORE) {
 		case 'redis':
 			return new RateLimiterRedis(getConfig('redis', configOverrides));

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -21,22 +21,24 @@ export default async function createServer(): Promise<http.Server> {
 			const elapsedNanoseconds = elapsedTime[0] * 1e9 + elapsedTime[1];
 			const elapsedMilliseconds = elapsedNanoseconds / 1e6;
 
-			const previousIn = (req.connection as any)._metrics?.in || 0;
-			const previousOut = (req.connection as any)._metrics?.out || 0;
+			const previousIn = (req.socket as any)._metrics?.in || 0;
+			const previousOut = (req.socket as any)._metrics?.out || 0;
 
 			const metrics = {
-				in: req.connection.bytesRead - previousIn,
-				out: req.connection.bytesWritten - previousOut,
+				in: req.socket.bytesRead - previousIn,
+				out: req.socket.bytesWritten - previousOut,
 			};
 
-			(req.connection as any)._metrics = {
-				in: req.connection.bytesRead,
-				out: req.connection.bytesWritten,
+			(req.socket as any)._metrics = {
+				in: req.socket.bytesRead,
+				out: req.socket.bytesWritten,
 			};
 
 			// Compatibility when supporting serving with certificates
 			const protocol = server instanceof https.Server ? 'https' : 'http';
 
+			// Rely on url.parse for path extraction
+			// Doesn't break on illegal URLs
 			const urlInfo = url.parse(req.originalUrl || req.url);
 
 			const info = {
@@ -58,7 +60,7 @@ export default async function createServer(): Promise<http.Server> {
 					size: metrics.out,
 					headers: res.getHeaders(),
 				},
-				ip: req.headers['x-forwarded-for'] || req.connection?.remoteAddress || req.socket?.remoteAddress,
+				ip: req.headers['x-forwarded-for'] || req.socket?.remoteAddress,
 				duration: elapsedMilliseconds.toFixed(),
 			};
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -10,7 +10,7 @@ import database from './database';
 import createApp from './app';
 import { once } from 'lodash';
 
-export default async function createServer() {
+export default async function createServer(): Promise<http.Server> {
 	const server = http.createServer(await createApp());
 
 	server.on('request', function (req: http.IncomingMessage & Request, res: http.ServerResponse) {

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { Knex } from 'knex';
 import { Accountability, AbstractServiceOptions, Transformation } from '../types';
 import { AuthorizationService } from './authorization';
-import { Range } from '@directus/drive';
+import { Range, StatResponse } from '@directus/drive';
 import { RangeNotSatisfiableException } from '../exceptions';
 
 export class AssetsService {
@@ -19,7 +19,11 @@ export class AssetsService {
 		this.authorizationService = new AuthorizationService(options);
 	}
 
-	async getAsset(id: string, transformation: Transformation, range?: Range) {
+	async getAsset(
+		id: string,
+		transformation: Transformation,
+		range?: Range
+	): Promise<{ stream: NodeJS.ReadableStream; file: any; stat: StatResponse }> {
 		const publicSettings = await this.knex
 			.select('project_logo', 'public_background', 'public_foreground')
 			.from('directus_settings')

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -50,7 +50,9 @@ export class AuthenticationService {
 	 * Password is optional to allow usage of this function within the SSO flow and extensions. Make sure
 	 * to handle password existence checks elsewhere
 	 */
-	async authenticate(options: AuthenticateOptions) {
+	async authenticate(
+		options: AuthenticateOptions
+	): Promise<{ accessToken: any; refreshToken: any; expires: any; id?: any }> {
 		const settingsService = new SettingsService({
 			knex: this.knex,
 			schema: this.schema,
@@ -196,7 +198,7 @@ export class AuthenticationService {
 		};
 	}
 
-	async refresh(refreshToken: string) {
+	async refresh(refreshToken: string): Promise<Record<string, any>> {
 		if (!refreshToken) {
 			throw new InvalidCredentialsException();
 		}
@@ -235,16 +237,16 @@ export class AuthenticationService {
 		};
 	}
 
-	async logout(refreshToken: string) {
+	async logout(refreshToken: string): Promise<void> {
 		await this.knex.delete().from('directus_sessions').where({ token: refreshToken });
 	}
 
-	generateTFASecret() {
+	generateTFASecret(): string {
 		const secret = authenticator.generateSecret();
 		return secret;
 	}
 
-	async generateOTPAuthURL(pk: string, secret: string) {
+	async generateOTPAuthURL(pk: string, secret: string): Promise<string> {
 		const user = await this.knex.select('first_name', 'last_name').from('directus_users').where({ id: pk }).first();
 		const name = `${user.first_name} ${user.last_name}`;
 		return authenticator.keyuri(name, 'Directus', secret);
@@ -261,7 +263,7 @@ export class AuthenticationService {
 		return authenticator.check(otp, secret);
 	}
 
-	async verifyPassword(pk: string, password: string) {
+	async verifyPassword(pk: string, password: string): Promise<boolean> {
 		const userRecord = await this.knex.select('password').from('directus_users').where({ id: pk }).first();
 
 		if (!userRecord || !userRecord.password) {

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -304,7 +304,7 @@ export class AuthorizationService {
 		return errors;
 	}
 
-	async checkAccess(action: PermissionsAction, collection: string, pk: PrimaryKey | PrimaryKey[]) {
+	async checkAccess(action: PermissionsAction, collection: string, pk: PrimaryKey | PrimaryKey[]): Promise<void> {
 		if (this.accountability?.admin === true) return;
 
 		const itemsService = new ItemsService(collection, {

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -111,7 +111,10 @@ export class CollectionsService {
 	/**
 	 * Create multiple new collections
 	 */
-	async createMany(payloads: Partial<Collection> & { collection: string }[], opts?: MutationOptions) {
+	async createMany(
+		payloads: Partial<Collection> & { collection: string }[],
+		opts?: MutationOptions
+	): Promise<string[]> {
 		const collections = await this.knex.transaction(async (trx) => {
 			const service = new CollectionsService({
 				schema: this.schema,

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -157,7 +157,7 @@ export class FieldsService {
 		return result;
 	}
 
-	async readOne(collection: string, field: string) {
+	async readOne(collection: string, field: string): Promise<Record<string, any>> {
 		if (this.accountability && this.accountability.admin !== true) {
 			if (this.hasReadAccess === false) {
 				throw new ForbiddenException();
@@ -205,7 +205,7 @@ export class FieldsService {
 		collection: string,
 		field: Partial<Field> & { field: string; type: typeof types[number] },
 		table?: Knex.CreateTableBuilder // allows collection creation to
-	) {
+	): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action.');
 		}
@@ -246,7 +246,7 @@ export class FieldsService {
 		}
 	}
 
-	async updateField(collection: string, field: RawField) {
+	async updateField(collection: string, field: RawField): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action');
 		}
@@ -289,7 +289,7 @@ export class FieldsService {
 	}
 
 	/** @todo save accountability */
-	async deleteField(collection: string, field: string) {
+	async deleteField(collection: string, field: string): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException('Only admins can perform this action.');
 		}
@@ -375,7 +375,7 @@ export class FieldsService {
 		});
 	}
 
-	public addColumnToTable(table: Knex.CreateTableBuilder, field: RawField | Field, alter: Column | null = null) {
+	public addColumnToTable(table: Knex.CreateTableBuilder, field: RawField | Field, alter: Column | null = null): void {
 		let column: Knex.ColumnBuilder;
 
 		if (field.schema?.has_auto_increment) {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -188,7 +188,9 @@ export class FieldsService {
 		try {
 			column = await this.schemaInspector.columnInfo(collection, field);
 			column.default_value = getDefaultValue(column);
-		} catch {}
+		} finally {
+			// Do nothing
+		}
 
 		const data = {
 			collection,

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -30,7 +30,7 @@ export class FilesService extends ItemsService {
 		stream: NodeJS.ReadableStream,
 		data: Partial<File> & { filename_download: string; storage: string },
 		primaryKey?: PrimaryKey
-	) {
+	): Promise<PrimaryKey> {
 		const payload = clone(data);
 
 		if (primaryKey !== undefined) {
@@ -140,7 +140,7 @@ export class FilesService extends ItemsService {
 	/**
 	 * Import a single file from an external URL
 	 */
-	async importOne(importURL: string, body: Partial<File>) {
+	async importOne(importURL: string, body: Partial<File>): Promise<PrimaryKey> {
 		const fileCreatePermissions = this.schema.permissions.find(
 			(permission) => permission.collection === 'directus_files' && permission.action === 'create'
 		);
@@ -220,7 +220,7 @@ export class FilesService extends ItemsService {
 		stream: NodeJS.ReadableStream,
 		data: Partial<File> & { filename_download: string; storage: string },
 		primaryKey?: PrimaryKey
-	) {
+	): Promise<PrimaryKey> {
 		logger.warn('FilesService.upload is deprecated and will be removed before v9.0.0. Use uploadOne instead.');
 
 		return await this.uploadOne(stream, data, primaryKey);
@@ -229,7 +229,7 @@ export class FilesService extends ItemsService {
 	/**
 	 * @deprecated Use `importOne` instead
 	 */
-	async import(importURL: string, body: Partial<File>) {
+	async import(importURL: string, body: Partial<File>): Promise<PrimaryKey> {
 		return await this.importOne(importURL, body);
 	}
 

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -174,7 +174,7 @@ export class FilesService extends ItemsService {
 			...(body || {}),
 		};
 
-		return await this.upload(fileResponse.data, payload);
+		return await this.uploadOne(fileResponse.data, payload);
 	}
 
 	/**

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -527,7 +527,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	/**
 	 * Upsert a single item
 	 */
-	async upsertOne(payload: Partial<Item>, opts?: MutationOptions) {
+	async upsertOne(payload: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const primaryKeyField = this.schema.collections[this.collection].primary;
 		const primaryKey: PrimaryKey | undefined = payload[primaryKeyField];
 
@@ -549,7 +549,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	/**
 	 * Upsert many items
 	 */
-	async upsertMany(payloads: Partial<Item>[], opts?: MutationOptions) {
+	async upsertMany(payloads: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const primaryKeys = await this.knex.transaction(async (trx) => {
 			const service = new ItemsService(this.collection, {
 				accountability: this.accountability,
@@ -702,7 +702,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	/**
 	 * Upsert/treat collection as singleton
 	 */
-	async upsertSingleton(data: Partial<Item>, opts?: MutationOptions) {
+	async upsertSingleton(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const primaryKeyField = this.schema.collections[this.collection].primary;
 		const record = await this.knex.select(primaryKeyField).from(this.collection).limit(1).first();
 

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -17,7 +17,7 @@ export class MetaService {
 		this.schema = options.schema;
 	}
 
-	async getMetaForQuery(collection: string, query: Query) {
+	async getMetaForQuery(collection: string, query: Query): Promise<Record<string, any> | undefined> {
 		if (!query || !query.meta) return;
 
 		const results = await Promise.all(
@@ -35,7 +35,7 @@ export class MetaService {
 		}, {});
 	}
 
-	async totalCount(collection: string) {
+	async totalCount(collection: string): Promise<number> {
 		const dbQuery = this.knex(collection).count('*', { as: 'count' }).first();
 
 		if (this.accountability?.admin !== true) {
@@ -55,7 +55,7 @@ export class MetaService {
 		return Number(result?.count ?? 0);
 	}
 
-	async filterCount(collection: string, query: Query) {
+	async filterCount(collection: string, query: Query): Promise<number> {
 		const dbQuery = this.knex(collection).count('*', { as: 'count' });
 
 		let filter = query.filter || {};

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -191,7 +191,7 @@ export class PayloadService {
 		payload: Partial<Item>,
 		action: Action,
 		accountability: Accountability | null
-	) {
+	): Promise<any> {
 		if (!field.special) return payload[field.field];
 		const fieldSpecials = field.special ? toArray(field.special) : [];
 
@@ -215,7 +215,10 @@ export class PayloadService {
 	 * Knex returns `datetime` and `date` columns as Date.. This is wrong for date / datetime, as those
 	 * shouldn't return with time / timezone info respectively
 	 */
-	async processDates(payloads: Partial<Record<string, any>>[], action: Action) {
+	async processDates(
+		payloads: Partial<Record<string, any>>[],
+		action: Action
+	): Promise<Partial<Record<string, any>>[]> {
 		const fieldsInCollection = Object.entries(this.schema.collections[this.collection].fields);
 
 		const dateColumns = fieldsInCollection.filter(([name, field]) =>

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -10,7 +10,7 @@ export class PermissionsService extends ItemsService {
 		super('directus_permissions', options);
 	}
 
-	getAllowedFields(action: PermissionsAction, collection?: string) {
+	getAllowedFields(action: PermissionsAction, collection?: string): Record<string, string[]> {
 		const results = this.schema.permissions.filter((permission) => {
 			let matchesCollection = true;
 

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -7,7 +7,7 @@ export class RevisionsService extends ItemsService {
 		super('directus_revisions', options);
 	}
 
-	async revert(pk: PrimaryKey) {
+	async revert(pk: PrimaryKey): Promise<void> {
 		const revision = await super.readOne(pk);
 
 		if (!revision) throw new ForbiddenException();

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -30,7 +30,7 @@ export class ServerService {
 		this.settingsService = new SettingsService({ knex: this.knex, schema: this.schema });
 	}
 
-	async serverInfo() {
+	async serverInfo(): Promise<Record<string, any>> {
 		const info: Record<string, any> = {};
 
 		const projectInfo = await this.settingsService.readSingleton({
@@ -70,7 +70,7 @@ export class ServerService {
 		return info;
 	}
 
-	async health() {
+	async health(): Promise<Record<string, any>> {
 		const checkID = nanoid(5);
 
 		// Based on https://tools.ietf.org/id/draft-inadarei-api-health-check-05.html#name-componenttype

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -217,7 +217,7 @@ export class UsersService extends ItemsService {
 		return keys;
 	}
 
-	async inviteUser(email: string | string[], role: string, url: string | null) {
+	async inviteUser(email: string | string[], role: string, url: string | null): Promise<void> {
 		const emails = toArray(email);
 
 		const urlWhitelist = toArray(env.USER_INVITE_URL_ALLOW_LIST);
@@ -263,7 +263,7 @@ export class UsersService extends ItemsService {
 		});
 	}
 
-	async acceptInvite(token: string, password: string) {
+	async acceptInvite(token: string, password: string): Promise<void> {
 		const { email, scope } = jwt.verify(token, env.SECRET as string) as {
 			email: string;
 			scope: string;
@@ -286,7 +286,7 @@ export class UsersService extends ItemsService {
 		}
 	}
 
-	async requestPasswordReset(email: string, url: string | null) {
+	async requestPasswordReset(email: string, url: string | null): Promise<void> {
 		const user = await this.knex.select('id').from('directus_users').where({ email }).first();
 		if (!user) throw new ForbiddenException();
 
@@ -321,7 +321,7 @@ export class UsersService extends ItemsService {
 		});
 	}
 
-	async resetPassword(token: string, password: string) {
+	async resetPassword(token: string, password: string): Promise<void> {
 		const { email, scope } = jwt.verify(token, env.SECRET as string) as {
 			email: string;
 			scope: string;
@@ -344,7 +344,7 @@ export class UsersService extends ItemsService {
 		}
 	}
 
-	async enableTFA(pk: string) {
+	async enableTFA(pk: string): Promise<Record<string, string>> {
 		const user = await this.knex.select('tfa_secret').from('directus_users').where({ id: pk }).first();
 
 		if (user?.tfa_secret !== null) {
@@ -366,7 +366,7 @@ export class UsersService extends ItemsService {
 		};
 	}
 
-	async disableTFA(pk: string) {
+	async disableTFA(pk: string): Promise<void> {
 		await this.knex('directus_users').update({ tfa_secret: null }).where({ id: pk });
 	}
 

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -15,7 +15,7 @@ export class UtilsService {
 		this.schema = options.schema;
 	}
 
-	async sort(collection: string, { item, to }: { item: PrimaryKey; to: PrimaryKey }) {
+	async sort(collection: string, { item, to }: { item: PrimaryKey; to: PrimaryKey }): Promise<void> {
 		const sortFieldResponse =
 			(await this.knex.select('sort_field').from('directus_collections').where({ collection }).first()) ||
 			systemCollectionRows;

--- a/api/src/start.ts
+++ b/api/src/start.ts
@@ -7,7 +7,7 @@ if (require.main === module) {
 	start();
 }
 
-export default async function start() {
+export default async function start(): Promise<void> {
 	const createServer = require('./server').default;
 
 	const server = await createServer();

--- a/api/src/types/deep-partial.d.ts
+++ b/api/src/types/deep-partial.d.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/ban-types */
+
 type Primitive = string | number | boolean | bigint | symbol | undefined | null;
 type Builtin = Primitive | Function | Date | Error | RegExp;
 type IsTuple<T> = T extends [infer A]

--- a/api/src/types/express-session.d.ts
+++ b/api/src/types/express-session.d.ts
@@ -1,4 +1,6 @@
-import * as expressSession from 'express-session';
+import { SessionData } from 'express-session';
+
+export = SessionData;
 
 declare module 'express-session' {
 	interface SessionData {

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -13,7 +13,7 @@ export default function applyQuery(
 	query: Query,
 	schema: SchemaOverview,
 	subQuery: boolean = false
-) {
+): void {
 	if (query.sort) {
 		dbQuery.orderBy(
 			query.sort.map((sort) => ({
@@ -50,7 +50,7 @@ export function applyFilter(
 	rootFilter: Filter,
 	collection: string,
 	subQuery: boolean = false
-) {
+): void {
 	const relations: Relation[] = [...schema.relations, ...systemRelationRows];
 
 	const aliasMap: Record<string, string> = {};
@@ -332,7 +332,7 @@ export async function applySearch(
 	dbQuery: Knex.QueryBuilder,
 	searchQuery: string,
 	collection: string
-) {
+): Promise<void> {
 	const fields = Object.entries(schema.collections[collection].fields);
 
 	dbQuery.andWhere(function () {

--- a/api/src/utils/deep-map.ts
+++ b/api/src/utils/deep-map.ts
@@ -1,6 +1,7 @@
 export function deepMap(
 	object: Record<string, any>,
 	iterator: (value: any, key: string | number) => any,
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	context?: any
 ): any {
 	if (Array.isArray(object)) {

--- a/api/src/utils/filter-items.ts
+++ b/api/src/utils/filter-items.ts
@@ -6,7 +6,7 @@ import generateJoi from './generate-joi';
  existing array of items has to be filtered using the same filter syntax as used in the ast-to-sql flow
  */
 
-export function filterItems(items: Record<string, any>[], filter: Query['filter']) {
+export function filterItems(items: Record<string, any>[], filter: Query['filter']): Record<string, any>[] {
 	if (!filter) return items;
 
 	return items.filter((item) => {

--- a/api/src/utils/get-cache-key.ts
+++ b/api/src/utils/get-cache-key.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 import url from 'url';
 
-export function getCacheKey(req: Request) {
+export function getCacheKey(req: Request): string {
 	const path = url.parse(req.originalUrl).pathname;
 
 	let key: string;

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -2,7 +2,7 @@ import camelcase from 'camelcase';
 import env from '../env';
 import { set } from 'lodash';
 
-export function getConfigFromEnv(prefix: string, omitPrefix?: string | string[]) {
+export function getConfigFromEnv(prefix: string, omitPrefix?: string | string[]): any {
 	const config: any = {};
 
 	for (const [key, value] of Object.entries(env)) {

--- a/api/src/utils/get-default-value.ts
+++ b/api/src/utils/get-default-value.ts
@@ -2,7 +2,9 @@ import getLocalType from './get-local-type';
 import { Column } from 'knex-schema-inspector/dist/types/column';
 import { SchemaOverview } from '@directus/schema/dist/types/overview';
 
-export default function getDefaultValue(column: SchemaOverview[string]['columns'][string] | Column) {
+export default function getDefaultValue(
+	column: SchemaOverview[string]['columns'][string] | Column
+): string | boolean | null {
 	const type = getLocalType(column);
 
 	let defaultValue = column.default_value ?? null;

--- a/api/src/utils/get-email-from-profile.ts
+++ b/api/src/utils/get-email-from-profile.ts
@@ -15,7 +15,7 @@ const profileMap: Record<string, string> = {};
  *
  * This is used in the SSO flow to extract the users
  */
-export default function getEmailFromProfile(provider: string, profile: Record<string, any>) {
+export default function getEmailFromProfile(provider: string, profile: Record<string, any>): string {
 	const path = profileMap[provider] || env[`OAUTH_${provider.toUpperCase()}_PROFILE_EMAIL`] || 'email';
 
 	const email = get(profile, path);

--- a/api/src/utils/get-graphql-type.ts
+++ b/api/src/utils/get-graphql-type.ts
@@ -1,9 +1,9 @@
-import { GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLScalarType, GraphQLString } from 'graphql';
 import { GraphQLJSON } from 'graphql-compose';
 import { GraphQLDate } from '../services/graphql';
 import { types } from '../types';
 
-export function getGraphQLType(localType: typeof types[number] | 'alias' | 'unknown') {
+export function getGraphQLType(localType: typeof types[number] | 'alias' | 'unknown'): GraphQLScalarType {
 	switch (localType) {
 		case 'boolean':
 			return GraphQLBoolean;

--- a/api/src/utils/is-jwt.ts
+++ b/api/src/utils/is-jwt.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 /**
  * Check if a given string conforms to the structure of a JWT.
  */
-export default function isJWT(string: string) {
+export default function isJWT(string: string): boolean {
 	const parts = string.split('.');
 
 	// JWTs have the structure header.payload.signature

--- a/api/src/utils/list-folders.ts
+++ b/api/src/utils/list-folders.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 
-export default async function listFolders(location: string) {
+export default async function listFolders(location: string): Promise<string[]> {
 	const fullPath = path.resolve(location);
 	const files = await readdir(fullPath);
 

--- a/api/src/utils/parse-filter.ts
+++ b/api/src/utils/parse-filter.ts
@@ -2,7 +2,7 @@ import { Filter, Accountability } from '../types';
 import { deepMap } from './deep-map';
 import { toArray } from '../utils/to-array';
 
-export function parseFilter(filter: Filter, accountability: Accountability | null) {
+export function parseFilter(filter: Filter, accountability: Accountability | null): any {
 	return deepMap(filter, (val, key) => {
 		if (val === 'true') return true;
 		if (val === 'false') return false;

--- a/api/src/utils/parse-iptc.ts
+++ b/api/src/utils/parse-iptc.ts
@@ -13,7 +13,7 @@ const IPTC_ENTRY_TYPES = new Map([
 
 const IPTC_ENTRY_MARKER = Buffer.from([0x1c, 0x02]);
 
-export default function parseIPTC(buffer: Buffer) {
+export default function parseIPTC(buffer: Buffer): Record<string, any> {
 	if (!Buffer.isBuffer(buffer)) return {};
 
 	let iptc: Record<string, any> = {};

--- a/api/src/utils/reduce-schema.ts
+++ b/api/src/utils/reduce-schema.ts
@@ -11,7 +11,7 @@ import { uniq } from 'lodash';
 export function reduceSchema(
 	schema: SchemaOverview,
 	actions: PermissionsAction[] = ['create', 'read', 'update', 'delete']
-) {
+): SchemaOverview {
 	const reduced: SchemaOverview = {
 		collections: {},
 		relations: [],

--- a/api/src/utils/require-yaml.ts
+++ b/api/src/utils/require-yaml.ts
@@ -1,7 +1,7 @@
 import fse from 'fs-extra';
 import yaml from 'js-yaml';
 
-export function requireYAML(filepath: string) {
+export function requireYAML(filepath: string): Record<string, any> {
 	const yamlRaw = fse.readFileSync(filepath, 'utf8');
 
 	return yaml.load(yamlRaw) as Record<string, any>;

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -3,7 +3,7 @@ import logger from '../logger';
 import { parseFilter } from '../utils/parse-filter';
 import { flatten, set, merge, get } from 'lodash';
 
-export function sanitizeQuery(rawQuery: Record<string, any>, accountability?: Accountability | null) {
+export function sanitizeQuery(rawQuery: Record<string, any>, accountability?: Accountability | null): Query {
 	const query: Query = {};
 
 	if (rawQuery.limit !== undefined) {

--- a/api/src/utils/track.ts
+++ b/api/src/utils/track.ts
@@ -9,7 +9,7 @@ import env from '../env';
 // @ts-ignore
 import { version } from '../../package.json';
 
-export async function track(event: string) {
+export async function track(event: string): Promise<void> {
 	if (env.TELEMETRY !== false) {
 		const info = await getEnvInfo(event);
 

--- a/api/src/utils/validate-env.ts
+++ b/api/src/utils/validate-env.ts
@@ -1,7 +1,7 @@
 import logger from '../logger';
 import env from '../env';
 
-export function validateEnv(requiredKeys: string[]) {
+export function validateEnv(requiredKeys: string[]): void {
 	if (env.DB_CLIENT && env.DB_CLIENT === 'sqlite3') {
 		requiredKeys.push('DB_FILENAME');
 	} else if (env.DB_CLIENT && env.DB_CLIENT === 'oracledb') {

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -22,7 +22,7 @@ const querySchema = Joi.object({
 	deep: Joi.object(),
 }).id('query');
 
-export function validateQuery(query: Query) {
+export function validateQuery(query: Query): Query {
 	const { error } = querySchema.validate(query);
 
 	if (query.filter && Object.keys(query.filter).length > 0) {

--- a/api/src/webhooks.ts
+++ b/api/src/webhooks.ts
@@ -7,7 +7,7 @@ import logger from './logger';
 
 let registered: { event: string; handler: ListenerFn }[] = [];
 
-export async function register() {
+export async function register(): Promise<void> {
 	unregister();
 
 	const webhooks = await database.select<Webhook[]>('*').from('directus_webhooks').where({ status: 'active' });
@@ -29,7 +29,7 @@ export async function register() {
 	}
 }
 
-export function unregister() {
+export function unregister(): void {
 	for (const { event, handler } of registered) {
 		emitter.off(event, handler);
 	}

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -24,7 +24,7 @@ export interface RequestError extends AxiosError {
 	response: Response;
 }
 
-export const onRequest = (config: AxiosRequestConfig) => {
+export const onRequest = (config: AxiosRequestConfig): RequestConfig => {
 	const requestsStore = useRequestsStore();
 	const id = requestsStore.startRequest();
 
@@ -36,14 +36,14 @@ export const onRequest = (config: AxiosRequestConfig) => {
 	return requestConfig;
 };
 
-export const onResponse = (response: AxiosResponse | Response) => {
+export const onResponse = (response: AxiosResponse | Response): AxiosResponse | Response => {
 	const requestsStore = useRequestsStore();
 	const id = (response.config as RequestConfig).id;
 	requestsStore.endRequest(id);
 	return response;
 };
 
-export const onError = async (error: RequestError) => {
+export const onError = async (error: RequestError): Promise<RequestError> => {
 	const requestsStore = useRequestsStore();
 	const id = (error.response.config as RequestConfig).id;
 	requestsStore.endRequest(id);
@@ -64,7 +64,7 @@ export const onError = async (error: RequestError) => {
 		error.request.responseURL.includes('login') === false &&
 		error.request.responseURL.includes('tfa') === false
 	) {
-		let newToken: string;
+		let newToken: string | undefined;
 
 		try {
 			newToken = await refresh();
@@ -95,7 +95,7 @@ function getToken() {
 	return api.defaults.headers?.['Authorization']?.split(' ')[1] || null;
 }
 
-export function addTokenToURL(url: string, token?: string) {
+export function addTokenToURL(url: string, token?: string): string {
 	token = token || getToken();
 	if (!token) return url;
 

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -9,7 +9,7 @@ export type LoginCredentials = {
 	password: string;
 };
 
-export async function login(credentials: LoginCredentials) {
+export async function login(credentials: LoginCredentials): Promise<void> {
 	const appStore = useAppStore();
 
 	const response = await api.post(`/auth/login`, {
@@ -38,7 +38,7 @@ export async function login(credentials: LoginCredentials) {
 
 let refreshTimeout: any;
 
-export async function refresh({ navigate }: LogoutOptions = { navigate: true }) {
+export async function refresh({ navigate }: LogoutOptions = { navigate: true }): Promise<string | undefined> {
 	const appStore = useAppStore();
 
 	try {
@@ -79,7 +79,7 @@ export type LogoutOptions = {
 /**
  * Everything that should happen when someone logs out, or is logged out through an external factor
  */
-export async function logout(optionsRaw: LogoutOptions = {}) {
+export async function logout(optionsRaw: LogoutOptions = {}): Promise<void> {
 	const appStore = useAppStore();
 
 	const defaultOptions: Required<LogoutOptions> = {

--- a/app/src/components/transition/expand/transition-expand-methods.ts
+++ b/app/src/components/transition/expand/transition-expand-methods.ts
@@ -11,7 +11,7 @@ interface HTMLExpandElement extends HTMLElement {
 	};
 }
 
-export default function (expandedParentClass = '', xAxis = false) {
+export default function (expandedParentClass = '', xAxis = false): Record<string, any> {
 	const sizeProperty = xAxis ? 'width' : ('height' as 'width' | 'height');
 	const offsetProperty = `offset${capitalizeFirst(sizeProperty)}` as 'offsetHeight' | 'offsetWidth';
 

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -38,6 +38,7 @@ import { defineComponent, PropType, computed, ref } from '@vue/composition-api';
 import { Field } from '@/types';
 import { getInterfaces } from '@/interfaces';
 import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
+import { InterfaceConfig } from '@/interfaces/types';
 
 export default defineComponent({
 	props: {
@@ -74,7 +75,9 @@ export default defineComponent({
 		const { interfaces } = getInterfaces();
 
 		const interfaceExists = computed(() => {
-			return !!interfaces.value.find((inter) => inter.id === props.field?.meta?.interface || 'text-input');
+			return !!interfaces.value.find(
+				(inter: InterfaceConfig) => inter.id === props.field?.meta?.interface || 'text-input'
+			);
 		});
 
 		return { interfaceExists, getDefaultInterfaceForType };

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -39,7 +39,7 @@
 <script lang="ts">
 import { defineComponent, PropType, computed, ref, provide } from '@vue/composition-api';
 import { useFieldsStore } from '@/stores/';
-import { Field } from '@/types';
+import { Field, FieldRaw } from '@/types';
 import { useElementSize } from '@/composables/use-element-size';
 import { clone, cloneDeep } from 'lodash';
 import marked from 'marked';
@@ -113,7 +113,7 @@ export default defineComponent({
 		 * admin can be made aware
 		 */
 		const unknownValidationErrors = computed(() => {
-			const fieldKeys = formFields.value.map((field) => field.field);
+			const fieldKeys = formFields.value.map((field: FieldRaw) => field.field);
 			return props.validationErrors.filter((error) => fieldKeys.includes(error.field) === false);
 		});
 

--- a/app/src/components/v-menu/use-popper.ts
+++ b/app/src/components/v-menu/use-popper.ts
@@ -14,7 +14,7 @@ export function usePopper(
 	reference: Ref<HTMLElement | null>,
 	popper: Ref<HTMLElement | null>,
 	options: Readonly<Ref<Readonly<{ placement: Placement; attached: boolean; arrow: boolean }>>>
-) {
+): Record<string, any> {
 	const popperInstance = ref<Instance | null>(null);
 	const styles = ref({});
 	const arrowStyles = ref({});

--- a/app/src/components/v-slider/v-slider.vue
+++ b/app/src/components/v-slider/v-slider.vue
@@ -75,7 +75,7 @@ export default defineComponent({
 			if (props.value === null) return { '--_v-slider-percentage': 50 };
 
 			let percentage = ((props.value - props.min) / (props.max - props.min)) * 100;
-			if (percentage === NaN) percentage = 0;
+			if (isNaN(percentage)) percentage = 0;
 			return { '--_v-slider-percentage': percentage };
 		});
 

--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -265,7 +265,7 @@ export default defineComponent({
 				if (_sort.value.desc === true) return itemsSorted.reverse();
 				return itemsSorted;
 			},
-			set: (value: object[]) => {
+			set: (value: Record<string, any>) => {
 				emit('update:items', value);
 			},
 		});

--- a/app/src/composables/groupable/groupable.ts
+++ b/app/src/composables/groupable/groupable.ts
@@ -19,7 +19,7 @@ type GroupableOptions = {
 	watch?: boolean;
 };
 
-export function useGroupable(options?: GroupableOptions) {
+export function useGroupable(options?: GroupableOptions): Record<string, any> {
 	// Injects the registration / toggle functions from the parent scope
 	const parentFunctions = inject(options?.group || 'item-group', null);
 
@@ -104,7 +104,7 @@ export function useGroupableParent(
 	state: GroupableParentState = {},
 	options: GroupableParentOptions = {},
 	group = 'item-group'
-) {
+): Record<string, any> {
 	// References to the active state and value of the individual child items
 	const items = ref<GroupableInstance[]>([]);
 

--- a/app/src/composables/groupable/groupable.ts
+++ b/app/src/composables/groupable/groupable.ts
@@ -26,12 +26,15 @@ export function useGroupable(options?: GroupableOptions): Record<string, any> {
 	if (isEmpty(parentFunctions)) {
 		return {
 			active: ref(false),
-			// eslint-disable-next-line @typescript-eslint/no-empty-function
-			toggle: () => {},
-			// eslint-disable-next-line @typescript-eslint/no-empty-function
-			activate: () => {},
-			// eslint-disable-next-line @typescript-eslint/no-empty-function
-			deactivate: () => {},
+			toggle: () => {
+				// Do nothing
+			},
+			activate: () => {
+				// Do nothing
+			},
+			deactivate: () => {
+				// Do nothing
+			},
 		};
 	}
 

--- a/app/src/composables/size-class/size-class.ts
+++ b/app/src/composables/size-class/size-class.ts
@@ -1,4 +1,4 @@
-import { computed } from '@vue/composition-api';
+import { computed, ComputedRef } from '@vue/composition-api';
 
 export const sizeProps = {
 	xSmall: {
@@ -26,7 +26,7 @@ interface RequiredProps {
 	xLarge: boolean;
 }
 
-export default function useSizeClass<T>(props: T & RequiredProps) {
+export default function useSizeClass<T>(props: T & RequiredProps): ComputedRef<string | null> {
 	const sizeClass = computed<string | null>(() => {
 		if (props.xSmall) return 'x-small';
 		if (props.small) return 'small';

--- a/app/src/composables/unsaved-changes/unsaved-changes.ts
+++ b/app/src/composables/unsaved-changes/unsaved-changes.ts
@@ -1,6 +1,6 @@
 import { onBeforeMount, onBeforeUnmount, Ref } from '@vue/composition-api';
 
-export default function unsavedChanges(isSavable: Ref<boolean>) {
+export default function unsavedChanges(isSavable: Ref<boolean>): void {
 	onBeforeMount(() => {
 		window.addEventListener('beforeunload', beforeUnload);
 	});

--- a/app/src/composables/use-collection/use-collection.ts
+++ b/app/src/composables/use-collection/use-collection.ts
@@ -1,8 +1,8 @@
-import { computed, Ref, ref } from '@vue/composition-api';
+import { computed, ComputedRef, Ref, ref } from '@vue/composition-api';
 import { useCollectionsStore, useFieldsStore } from '@/stores/';
 import { Field } from '@/types';
 
-export function useCollection(collectionKey: string | Ref<string>) {
+export function useCollection(collectionKey: string | Ref<string>): Record<string, ComputedRef> {
 	const collectionsStore = useCollectionsStore();
 	const fieldsStore = useFieldsStore();
 

--- a/app/src/composables/use-collection/use-collection.ts
+++ b/app/src/composables/use-collection/use-collection.ts
@@ -32,8 +32,7 @@ export function useCollection(collectionKey: string | Ref<string>): Record<strin
 
 	const primaryKeyField = computed(() => {
 		// Every collection has a primary key; rules of the land
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return fields.value?.find(
+		return fields.value.find(
 			(field) => field.collection === collection.value && field.schema?.is_primary_key === true
 		)!;
 	});

--- a/app/src/composables/use-custom-selection/use-custom-selection.ts
+++ b/app/src/composables/use-custom-selection/use-custom-selection.ts
@@ -1,9 +1,13 @@
-import { Ref, ref, computed, watch } from '@vue/composition-api';
+import { Ref, ref, computed, watch, ComputedRef } from '@vue/composition-api';
 import { nanoid } from 'nanoid';
 
 type EmitFunction = (event: string, ...args: any[]) => void;
 
-export function useCustomSelection(currentValue: Ref<string>, items: Ref<any[]>, emit: EmitFunction) {
+export function useCustomSelection(
+	currentValue: Ref<string>,
+	items: Ref<any[]>,
+	emit: EmitFunction
+): Record<string, ComputedRef> {
 	const localOtherValue = ref('');
 
 	const otherValue = computed({
@@ -34,7 +38,11 @@ export function useCustomSelection(currentValue: Ref<string>, items: Ref<any[]>,
 	return { otherValue, usesOtherValue };
 }
 
-export function useCustomSelectionMultiple(currentValues: Ref<string[]>, items: Ref<any[]>, emit: EmitFunction) {
+export function useCustomSelectionMultiple(
+	currentValues: Ref<string[]>,
+	items: Ref<any[]>,
+	emit: EmitFunction
+): Record<string, any> {
 	type OtherValue = {
 		key: string;
 		value: string;

--- a/app/src/composables/use-element-size/use-element-size.ts
+++ b/app/src/composables/use-element-size/use-element-size.ts
@@ -8,7 +8,9 @@ declare global {
 	}
 }
 
-export default function useElementSize<T extends Element>(target: T | Ref<T> | Ref<undefined>) {
+export default function useElementSize<T extends Element>(
+	target: T | Ref<T> | Ref<undefined>
+): Record<string, Ref<number>> {
 	const width = ref(0);
 	const height = ref(0);
 

--- a/app/src/composables/use-event-listener/use-event-listener.ts
+++ b/app/src/composables/use-event-listener/use-event-listener.ts
@@ -5,7 +5,7 @@ export default function useEventListener<T extends EventTarget, E extends Event>
 	type: string,
 	handler: (this: T, evt: E) => void,
 	options?: AddEventListenerOptions
-) {
+): void {
 	onMounted(() => {
 		const t = isRef(target) ? target.value : target;
 		t.addEventListener(type, handler as (evt: Event) => void, options);

--- a/app/src/composables/use-field-tree/use-field-tree.ts
+++ b/app/src/composables/use-field-tree/use-field-tree.ts
@@ -1,4 +1,4 @@
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, computed, ComputedRef } from '@vue/composition-api';
 import { useFieldsStore, useRelationsStore } from '@/stores/';
 import { Field, Relation } from '@/types';
 import { cloneDeep } from 'lodash';
@@ -12,7 +12,7 @@ export default function useFieldTree(
 	strict: boolean = false,
 	inject?: Ref<{ fields: Field[]; relations: Relation[] } | null>,
 	filter: (field: Field) => boolean = () => true
-) {
+): Record<string, ComputedRef> {
 	const fieldsStore = useFieldsStore();
 	const relationsStore = useRelationsStore();
 

--- a/app/src/composables/use-form-fields/use-form-fields.ts
+++ b/app/src/composables/use-form-fields/use-form-fields.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { computed, Ref } from '@vue/composition-api';
+import { computed, ComputedRef, Ref } from '@vue/composition-api';
 import getDefaultInterfaceForType from '@/utils/get-default-interface-for-type';
 import { getInterfaces } from '@/interfaces';
 import { FormField } from '@/components/v-form/types';
 import { Field } from '@/types';
 import { clone } from 'lodash';
+import { InterfaceConfig } from '@/interfaces/types';
 
-export default function useFormFields(fields: Ref<Field[]>) {
+export default function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef } {
 	const { interfaces } = getInterfaces();
 
 	const formFields = computed(() => {
@@ -16,14 +17,14 @@ export default function useFormFields(fields: Ref<Field[]>) {
 		formFields = formFields.map((field, index) => {
 			if (!field.meta) return field;
 
-			let interfaceUsed = interfaces.value.find((int) => int.id === field.meta?.interface);
+			let interfaceUsed = interfaces.value.find((int: InterfaceConfig) => int.id === field.meta?.interface);
 			const interfaceExists = interfaceUsed !== undefined;
 
 			if (interfaceExists === false) {
 				field.meta.interface = getDefaultInterfaceForType(field.type);
 			}
 
-			interfaceUsed = interfaces.value.find((int) => int.id === field.meta?.interface);
+			interfaceUsed = interfaces.value.find((int: InterfaceConfig) => int.id === field.meta?.interface);
 
 			if (interfaceUsed?.hideLabel === true) {
 				(field as FormField).hideLabel = true;

--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -8,7 +8,7 @@ import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { VALIDATION_TYPES } from '@/constants';
 
-export function useItem(collection: Ref<string>, primaryKey: Ref<string | number | null>) {
+export function useItem(collection: Ref<string>, primaryKey: Ref<string | number | null>): Record<string, any> {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 
 	const item = ref<Record<string, any> | null>(null);

--- a/app/src/composables/use-items/use-items.ts
+++ b/app/src/composables/use-items/use-items.ts
@@ -17,7 +17,7 @@ type Query = {
 	searchQuery: Ref<string | null>;
 };
 
-export function useItems(collection: Ref<string>, query: Query) {
+export function useItems(collection: Ref<string>, query: Query): Record<string, any> {
 	const { primaryKeyField, sortField } = useCollection(collection);
 
 	let loadingTimeout: any = null;

--- a/app/src/composables/use-permissions.ts
+++ b/app/src/composables/use-permissions.ts
@@ -1,11 +1,15 @@
-import { computed, Ref } from '@vue/composition-api';
+import { computed, ComputedRef, Ref } from '@vue/composition-api';
 import { isAllowed } from '../utils/is-allowed';
 import { useCollection } from './use-collection';
 import { useUserStore, usePermissionsStore } from '@/stores';
 import { cloneDeep } from 'lodash';
 import { Field } from '@/types';
 
-export function usePermissions(collection: Ref<string>, item: Ref<any>, isNew: Ref<boolean>) {
+export function usePermissions(
+	collection: Ref<string>,
+	item: Ref<any>,
+	isNew: Ref<boolean>
+): Record<string, ComputedRef> {
 	const userStore = useUserStore();
 	const permissionsStore = usePermissionsStore();
 

--- a/app/src/composables/use-preset/use-preset.ts
+++ b/app/src/composables/use-preset/use-preset.ts
@@ -273,7 +273,6 @@ export function usePreset(
 
 		if (data.id) delete data.id;
 
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		data.user = userStore.state.currentUser!.id;
 
 		return await savePreset(data);

--- a/app/src/composables/use-preset/use-preset.ts
+++ b/app/src/composables/use-preset/use-preset.ts
@@ -5,7 +5,11 @@ import { useCollection } from '@/composables/use-collection';
 
 import { Filter, Preset } from '@/types/';
 
-export function usePreset(collection: Ref<string>, bookmark: Ref<number | null> = ref(null), temporary = false) {
+export function usePreset(
+	collection: Ref<string>,
+	bookmark: Ref<number | null> = ref(null),
+	temporary = false
+): Record<string, any> {
 	const presetsStore = usePresetsStore();
 	const userStore = useUserStore();
 

--- a/app/src/composables/use-scroll-distance/use-scroll-distance.ts
+++ b/app/src/composables/use-scroll-distance/use-scroll-distance.ts
@@ -1,7 +1,7 @@
 import { ref, onMounted, onUnmounted, Ref, isRef, computed } from '@vue/composition-api';
 import { throttle } from 'lodash';
 
-export default function useScrollDistance<T extends Element>(t: T | Ref<T | null | Vue>) {
+export default function useScrollDistance<T extends Element>(t: T | Ref<T | null | Vue>): Record<string, Ref> {
 	const top = ref<number>();
 	const left = ref<number>();
 

--- a/app/src/composables/use-shortcut/use-shortcut.ts
+++ b/app/src/composables/use-shortcut/use-shortcut.ts
@@ -92,14 +92,12 @@ function callHandlers(event: KeyboardEvent) {
 		for (let i = 0; i < value.length; i++) {
 			let cancel = false;
 
-			value[i](event, cancelNext);
+			value[i](event, () => {
+				cancel = true;
+			});
 
 			// if cancelNext is called, discontinue going through the queue.
 			if (typeof cancel === 'boolean' && cancel) break;
-
-			function cancelNext() {
-				cancel = true;
-			}
 		}
 	});
 }

--- a/app/src/composables/use-shortcut/use-shortcut.ts
+++ b/app/src/composables/use-shortcut/use-shortcut.ts
@@ -22,7 +22,7 @@ export default function useShortcut(
 	shortcuts: string | string[],
 	handler: ShortcutHandler,
 	reference: Ref<HTMLElement | undefined> | Ref<Vue | undefined> = ref(document.body)
-) {
+): void {
 	const callback: ShortcutHandler = (event, cancelNext) => {
 		if (!reference.value) return;
 		const ref = reference.value instanceof HTMLElement ? reference.value : (reference.value.$el as HTMLElement);

--- a/app/src/composables/use-template-data.ts
+++ b/app/src/composables/use-template-data.ts
@@ -4,7 +4,10 @@ import { computed, Ref, ref, watch } from '@vue/composition-api';
 import { ComputedRef } from '@vue/composition-api';
 import { Collection } from '@/types';
 
-export default function useTemplateData(collection: ComputedRef<Collection | undefined>, primaryKey: Ref<string>) {
+export default function useTemplateData(
+	collection: ComputedRef<Collection | undefined>,
+	primaryKey: Ref<string>
+): Record<string, any> {
 	const templateData = ref<Record<string, any>>();
 	const loading = ref(false);
 	const error = ref(null);

--- a/app/src/composables/use-time-from-now/use-time-from-now.ts
+++ b/app/src/composables/use-time-from-now/use-time-from-now.ts
@@ -1,7 +1,7 @@
-import { onMounted, onUnmounted, ref } from '@vue/composition-api';
+import { onMounted, onUnmounted, Ref, ref } from '@vue/composition-api';
 import localizedFormatDistance from '@/utils/localized-format-distance/';
 
-export async function useTimeFromNow(date: Date | number, autoUpdate = 60000) {
+export async function useTimeFromNow(date: Date | number, autoUpdate = 60000): Promise<Ref<string>> {
 	let interval: number;
 
 	const formatOptions = {

--- a/app/src/composables/use-title/use-title.ts
+++ b/app/src/composables/use-title/use-title.ts
@@ -1,7 +1,7 @@
 import { ref, Ref, watch } from '@vue/composition-api';
 import { TranslateResult } from 'vue-i18n';
 
-export function useTitle(newTitle: string | Ref<string>) {
+export function useTitle(newTitle: string | Ref<string>): Ref | undefined {
 	if (newTitle === undefined || newTitle === null) return;
 
 	const titleRef = typeof newTitle === 'string' ? ref(newTitle) : newTitle;

--- a/app/src/composables/use-window-size/use-window-size.ts
+++ b/app/src/composables/use-window-size/use-window-size.ts
@@ -1,11 +1,11 @@
-import { onMounted, onUnmounted, ref, onBeforeMount } from '@vue/composition-api';
+import { onMounted, onUnmounted, ref, onBeforeMount, Ref } from '@vue/composition-api';
 import { throttle } from 'lodash';
 
 type WindowSizeOptions = {
 	throttle: number;
 };
 
-export default function useWindowSize(options: WindowSizeOptions = { throttle: 100 }) {
+export default function useWindowSize(options: WindowSizeOptions = { throttle: 100 }): Record<string, Ref> {
 	const width = ref(0);
 	const height = ref(0);
 

--- a/app/src/directives/click-outside/click-outside.ts
+++ b/app/src/directives/click-outside/click-outside.ts
@@ -24,7 +24,7 @@ interface ClickOutsideElement extends HTMLElement {
 	}[];
 }
 
-const bind = (el: HTMLElement, { value }: Partial<DirectiveBinding>) => {
+const bind = (el: HTMLElement, { value }: Partial<DirectiveBinding>): void => {
 	const { handler, middleware, events, disabled } = processValue(value);
 
 	watch(
@@ -51,7 +51,7 @@ const bind = (el: HTMLElement, { value }: Partial<DirectiveBinding>) => {
 	});
 };
 
-const unbind = (el: HTMLElement) => {
+const unbind = (el: HTMLElement): void => {
 	const handlers = (el as ClickOutsideElement).$clickOutsideHandlers || [];
 
 	handlers.forEach(({ event, handler }) => {
@@ -59,7 +59,7 @@ const unbind = (el: HTMLElement) => {
 	});
 };
 
-const update = (el: HTMLElement, { value, oldValue }: Partial<DirectiveBinding>) => {
+const update = (el: HTMLElement, { value, oldValue }: Partial<DirectiveBinding>): void => {
 	if (JSON.stringify(value) === JSON.stringify(oldValue)) {
 		return;
 	}
@@ -113,7 +113,7 @@ export function onEvent({
 	event: Event;
 	handler: Handler;
 	middleware: Middleware;
-}) {
+}): void {
 	event.stopPropagation();
 	const path = event.composedPath();
 	const isClickOutside = path ? path.indexOf(el) < 0 : el.contains(event.target as Element) === false;

--- a/app/src/directives/tooltip/tooltip.ts
+++ b/app/src/directives/tooltip/tooltip.ts
@@ -6,7 +6,7 @@ const tooltipDelay = 300;
 
 const handlers: Record<string, () => void> = {};
 
-function bind(element: HTMLElement, binding: DirectiveBinding) {
+function bind(element: HTMLElement, binding: DirectiveBinding): void {
 	if (binding.value) {
 		element.dataset.tooltip = nanoid();
 		handlers[element.dataset.tooltip] = createEnterHandler(element, binding);
@@ -15,7 +15,7 @@ function bind(element: HTMLElement, binding: DirectiveBinding) {
 	}
 }
 
-function unbind(element: HTMLElement) {
+function unbind(element: HTMLElement): void {
 	element.removeEventListener('mouseenter', handlers[element.dataset.tooltip as string]);
 	element.removeEventListener('mouseleave', onLeaveTooltip);
 	clearTimeout(tooltipTimer);
@@ -44,7 +44,7 @@ export default Tooltip;
 let tooltipTimer: number;
 
 export function createEnterHandler(element: HTMLElement, binding: DirectiveBinding) {
-	return () => {
+	return (): void => {
 		const tooltip = getTooltip();
 
 		if (binding.modifiers.instant) {
@@ -60,14 +60,14 @@ export function createEnterHandler(element: HTMLElement, binding: DirectiveBindi
 	};
 }
 
-export function onLeaveTooltip() {
+export function onLeaveTooltip(): void {
 	const tooltip = getTooltip();
 
 	clearTimeout(tooltipTimer);
 	animateOut(tooltip);
 }
 
-export function updateTooltip(element: HTMLElement, binding: DirectiveBinding, tooltip: HTMLElement) {
+export function updateTooltip(element: HTMLElement, binding: DirectiveBinding, tooltip: HTMLElement): void {
 	const offset = 10;
 	const arrowAlign = 20;
 
@@ -156,7 +156,7 @@ export function updateTooltip(element: HTMLElement, binding: DirectiveBinding, t
 	}
 }
 
-export function animateIn(tooltip: HTMLElement) {
+export function animateIn(tooltip: HTMLElement): void {
 	tooltip.classList.add('visible', 'enter');
 	tooltip.classList.remove('leave', 'leave-active');
 
@@ -171,7 +171,7 @@ export function animateIn(tooltip: HTMLElement) {
 	}, 200);
 }
 
-export function animateOut(tooltip: HTMLElement) {
+export function animateOut(tooltip: HTMLElement): void {
 	if (tooltip.classList.contains('visible') === false) return;
 
 	tooltip.classList.add('visible', 'leave');

--- a/app/src/displays/filesize/handler.ts
+++ b/app/src/displays/filesize/handler.ts
@@ -1,5 +1,5 @@
 import bytes from 'bytes';
 
-export default function handler(value: number) {
+export default function handler(value: number): string {
 	return bytes(value, { decimalPlaces: 0 });
 }

--- a/app/src/displays/index.ts
+++ b/app/src/displays/index.ts
@@ -4,7 +4,7 @@ import { DisplayConfig } from './types';
 let displaysRaw: Ref<DisplayConfig[]>;
 let displays: Ref<DisplayConfig[]>;
 
-export function getDisplays() {
+export function getDisplays(): Record<string, Ref> {
 	if (!displaysRaw) {
 		displaysRaw = ref([]);
 	}

--- a/app/src/displays/register.ts
+++ b/app/src/displays/register.ts
@@ -4,10 +4,11 @@ import { Component } from 'vue';
 import api from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
 import asyncPool from 'tiny-async-pool';
+import { DisplayConfig } from './types';
 
 const { displaysRaw } = getDisplays();
 
-export async function registerDisplays() {
+export async function registerDisplays(): Promise<void> {
 	const context = require.context('.', true, /^.*index\.ts$/);
 
 	const modules = context
@@ -36,7 +37,7 @@ export async function registerDisplays() {
 
 	displaysRaw.value = modules;
 
-	displaysRaw.value.forEach((display) => {
+	displaysRaw.value.forEach((display: DisplayConfig) => {
 		if (typeof display.handler !== 'function') {
 			registerComponent('display-' + display.id, display.handler as Component);
 		}

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -22,12 +22,12 @@ export default defineDisplay(() => ({
 	groups: ['m2m', 'm2o', 'o2m'],
 	fields: (options: Options | null, { field, collection }) => {
 		const relatedCollection = getRelatedCollection(collection, field);
-		const { primaryKeyField } = useCollection(ref(relatedCollection as string));
+		const { primaryKeyField } = useCollection(ref((relatedCollection as unknown) as string));
 
 		if (!relatedCollection) return [];
 
 		const fields = options?.template
-			? adjustFieldsForDisplays(getFieldsFromTemplate(options.template), relatedCollection)
+			? adjustFieldsForDisplays(getFieldsFromTemplate(options.template), (relatedCollection as unknown) as string)
 			: [];
 
 		if (primaryKeyField.value && !fields.includes(primaryKeyField.value.field)) {

--- a/app/src/displays/related-values/options.vue
+++ b/app/src/displays/related-values/options.vue
@@ -66,6 +66,8 @@ export default defineComponent({
 			if (o2m !== undefined) {
 				return o2m?.many_collection || null;
 			}
+
+			return null;
 		});
 
 		return { template, relatedCollection };

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -67,7 +67,7 @@ export default defineComponent({
 
 		const primaryKeyField = computed(() => {
 			if (relatedCollection.value !== null) {
-				return useCollection(relatedCollection as Ref<string>).primaryKeyField.value;
+				return useCollection((relatedCollection as unknown) as Ref<string>).primaryKeyField.value;
 			}
 		});
 

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -69,6 +69,7 @@ export default defineComponent({
 			if (relatedCollection.value !== null) {
 				return useCollection((relatedCollection as unknown) as Ref<string>).primaryKeyField.value;
 			}
+			return null;
 		});
 
 		const _template = computed(() => {

--- a/app/src/displays/types.ts
+++ b/app/src/displays/types.ts
@@ -8,7 +8,7 @@ export type DisplayHandlerFunctionContext = {
 export type DisplayHandlerFunction = (
 	value: any,
 	options: any,
-	context: DisplayHandlerFunctionContext
+	context?: DisplayHandlerFunctionContext
 ) => string | null;
 
 export type DisplayFieldsFunction = (
@@ -26,7 +26,8 @@ export interface DisplayConfig {
 	icon: string;
 	description?: string;
 
-	handler: DisplayHandlerFunction | Component;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	handler: DisplayHandlerFunction | Component | Function;
 	options: null | DeepPartial<Field>[] | Component;
 	types: readonly typeof types[number][];
 	groups?: readonly typeof localTypes[number][];

--- a/app/src/hydrate.ts
+++ b/app/src/hydrate.ts
@@ -37,12 +37,12 @@ export function useStores(
 		useRelationsStore,
 		usePermissionsStore,
 	]
-) {
+): GenericStore[] {
 	return stores.map((useStore) => useStore()) as GenericStore[];
 }
 
 /* istanbul ignore next: useStores has a test already */
-export async function hydrate(stores = useStores()) {
+export async function hydrate(stores = useStores()): Promise<void> {
 	const appStore = useAppStore();
 	const userStore = useUserStore();
 
@@ -75,7 +75,7 @@ export async function hydrate(stores = useStores()) {
 }
 
 /* istanbul ignore next: useStores has a test already */
-export async function dehydrate(stores = useStores()) {
+export async function dehydrate(stores = useStores()): Promise<void> {
 	const appStore = useAppStore();
 
 	if (appStore.state.hydrated === false) return;

--- a/app/src/interfaces/_system/interface-options/interface-options.vue
+++ b/app/src/interfaces/_system/interface-options/interface-options.vue
@@ -29,6 +29,7 @@
 <script lang="ts">
 import { defineComponent, computed, inject, ref } from '@vue/composition-api';
 import { getInterfaces } from '@/interfaces';
+import { InterfaceConfig } from '@/interfaces/types';
 
 export default defineComponent({
 	props: {
@@ -49,7 +50,7 @@ export default defineComponent({
 		const selectedInterface = computed(() => {
 			if (!values.value[props.interfaceField]) return;
 
-			return interfaces.value.find((inter) => inter.id === values.value[props.interfaceField]);
+			return interfaces.value.find((inter: InterfaceConfig) => inter.id === values.value[props.interfaceField]);
 		});
 
 		return { selectedInterface, values };

--- a/app/src/interfaces/_system/interface/interface.vue
+++ b/app/src/interfaces/_system/interface/interface.vue
@@ -15,7 +15,7 @@
 import { defineComponent, computed, PropType, inject, ref, watch } from '@vue/composition-api';
 import i18n from '@/lang';
 import { getInterfaces } from '@/interfaces';
-import { types } from '@/types';
+import { InterfaceConfig } from '@/interfaces/types';
 
 export default defineComponent({
 	props: {
@@ -47,9 +47,11 @@ export default defineComponent({
 
 		const items = computed(() => {
 			return interfaces.value
-				.filter((inter) => inter.relational !== true && inter.system !== true)
-				.filter((inter) => selectedType.value === undefined || inter.types.includes(selectedType.value))
-				.map((inter) => {
+				.filter((inter: InterfaceConfig) => inter.relational !== true && inter.system !== true)
+				.filter(
+					(inter: InterfaceConfig) => selectedType.value === undefined || inter.types.includes(selectedType.value)
+				)
+				.map((inter: InterfaceConfig) => {
 					return {
 						text: inter.name,
 						value: inter.id,

--- a/app/src/interfaces/code/code.vue
+++ b/app/src/interfaces/code/code.vue
@@ -136,7 +136,7 @@ export default defineComponent({
 					codemirror.value.setOption('mode', { name: 'javascript', json: true });
 
 					CodeMirror.registerHelper('lint', 'json', (text: string) => {
-						const found: {}[] = [];
+						const found: Record<string, any> = [];
 						const parser = jsonlint.parser;
 
 						parser.parseError = (str: string, hash: any) => {

--- a/app/src/interfaces/code/code.vue
+++ b/app/src/interfaces/code/code.vue
@@ -150,7 +150,9 @@ export default defineComponent({
 						if (text.length > 0) {
 							try {
 								jsonlint.parse(text);
-							} catch (e) {}
+							} finally {
+								// Do nothing
+							}
 						}
 						return found;
 					});
@@ -273,7 +275,9 @@ export default defineComponent({
 			if (props.type === 'json') {
 				try {
 					emit('input', JSON.parse(props.template));
-				} catch {}
+				} finally {
+					// Do nothing
+				}
 			} else {
 				emit('input', props.template);
 			}

--- a/app/src/interfaces/image/image.vue
+++ b/app/src/interfaces/image/image.vue
@@ -113,7 +113,7 @@ export default defineComponent({
 			if (!image.value) return null;
 			const { filesize, width, height, type } = image.value;
 
-			return `${i18n.n(width)}x${i18n.n(height)} • ${formatFilesize(filesize)} • ${type}`;
+			return `${i18n.n(width)}x${i18n.n(height)} • ${formatFilesize(filesize)} • ${type}`;
 		});
 
 		watch(

--- a/app/src/interfaces/index.ts
+++ b/app/src/interfaces/index.ts
@@ -4,7 +4,7 @@ import { InterfaceConfig } from './types';
 let interfacesRaw: Ref<InterfaceConfig[]>;
 let interfaces: Ref<InterfaceConfig[]>;
 
-export function getInterfaces() {
+export function getInterfaces(): Record<string, Ref> {
 	if (!interfacesRaw) {
 		interfacesRaw = ref([]);
 	}

--- a/app/src/interfaces/m2a-builder/m2a-builder.vue
+++ b/app/src/interfaces/m2a-builder/m2a-builder.vue
@@ -329,7 +329,6 @@ export default defineComponent({
 							} else {
 								val[anyRelation.value.many_field] = cloneDeep(item);
 							}
-						} else {
 						}
 
 						return val;

--- a/app/src/interfaces/many-to-many/many-to-many.vue
+++ b/app/src/interfaces/many-to-many/many-to-many.vue
@@ -86,6 +86,7 @@ import useSort from './use-sort';
 import { getFieldsFromTemplate } from '@/utils/get-fields-from-template';
 import adjustFieldsForDisplays from '@/utils/adjust-fields-for-displays';
 import { usePermissionsStore, useUserStore } from '@/stores';
+import { DisplayConfig } from '@/displays/types';
 
 export default defineComponent({
 	components: { DrawerItem, DrawerCollection, Draggable },
@@ -138,7 +139,7 @@ export default defineComponent({
 			let relatedDisplayTemplate = relationCollection.value.meta?.display_template;
 			if (relatedDisplayTemplate) {
 				const regex = /({{.*?}})/g;
-				const parts = relatedDisplayTemplate.split(regex).filter((p) => p);
+				const parts = relatedDisplayTemplate.split(regex).filter((p: DisplayConfig) => p);
 
 				for (const part of parts) {
 					if (part.startsWith('{{') === false) continue;

--- a/app/src/interfaces/many-to-many/use-actions.ts
+++ b/app/src/interfaces/many-to-many/use-actions.ts
@@ -6,7 +6,7 @@ export default function useActions(
 	value: Ref<(string | number | Record<string, any>)[] | null>,
 	relation: Ref<RelationInfo>,
 	emit: (newValue: any[] | null) => void
-) {
+): Record<string, any> {
 	// Returns the junction item with the given Id.
 	function getJunctionItem(id: string | number) {
 		const { junctionPkField } = relation.value;

--- a/app/src/interfaces/many-to-many/use-edit.ts
+++ b/app/src/interfaces/many-to-many/use-edit.ts
@@ -6,7 +6,7 @@ export default function useEdit(
 	value: Ref<(string | number | Record<string, any>)[] | null>,
 	relation: Ref<RelationInfo>,
 	emit: (newVal: any[] | null) => void
-) {
+): Record<string, any> {
 	const editModalActive = ref(false);
 	const currentlyEditing = ref<string | number | null>(null);
 	const relatedPrimaryKey = ref<string | number | null>(null);

--- a/app/src/interfaces/many-to-many/use-preview.ts
+++ b/app/src/interfaces/many-to-many/use-preview.ts
@@ -14,7 +14,7 @@ export default function usePreview(
 	getUpdatedItems: () => Record<string, any>[],
 	getNewItems: () => Record<string, any>[],
 	getPrimaryKeys: () => (string | number)[]
-) {
+): Record<string, Ref> {
 	// Using a ref for the table headers here means that the table itself can update the
 	// values if it needs to. This allows the user to manually resize the columns for example
 

--- a/app/src/interfaces/many-to-many/use-relation.ts
+++ b/app/src/interfaces/many-to-many/use-relation.ts
@@ -12,7 +12,7 @@ export type RelationInfo = {
 	relationCollection: string;
 };
 
-export default function useRelation(collection: Ref<string>, field: Ref<string>) {
+export default function useRelation(collection: Ref<string>, field: Ref<string>): Record<string, any> {
 	const relationsStore = useRelationsStore();
 	const collectionsStore = useCollectionsStore();
 

--- a/app/src/interfaces/many-to-many/use-selection.ts
+++ b/app/src/interfaces/many-to-many/use-selection.ts
@@ -8,7 +8,7 @@ export default function useSelection(
 	items: Ref<Record<string, any>[]>,
 	relation: Ref<RelationInfo>,
 	emit: (newVal: any[] | null) => void
-) {
+): Record<string, any> {
 	const selectModalActive = ref(false);
 
 	const selectedPrimaryKeys = computed(() => {

--- a/app/src/interfaces/many-to-many/use-sort.ts
+++ b/app/src/interfaces/many-to-many/use-sort.ts
@@ -8,7 +8,7 @@ export default function useSort(
 	fields: Ref<string[]>,
 	items: Ref<Record<string, any>[]>,
 	emit: (newVal: any[] | null) => void
-) {
+): Record<string, any> {
 	const sort = ref<Sort>({ by: relation.value.sortField || fields.value[0], desc: false });
 
 	const sortedItems = computed(() => {

--- a/app/src/interfaces/markdown/composables/use-edit.ts
+++ b/app/src/interfaces/markdown/composables/use-edit.ts
@@ -32,7 +32,7 @@ export type CustomSyntax = {
 	box: 'inline' | 'block';
 };
 
-export function useEdit(codemirror: Ref<CodeMirror.EditorFromTextArea | null>, customSyntaxBlocks: CustomSyntax[]) {
+export function useEdit(codemirror: Ref<CodeMirror.EditorFromTextArea | null>): Record<string, any> {
 	const alterations: AlterationFunctions = {
 		heading(selection, { cursorTo }, options) {
 			const level = options?.level || 3;

--- a/app/src/interfaces/markdown/markdown.vue
+++ b/app/src/interfaces/markdown/markdown.vue
@@ -235,7 +235,7 @@ export default defineComponent({
 			}
 		);
 
-		const { edit } = useEdit(codemirror, props.customSyntax);
+		const { edit } = useEdit(codemirror);
 
 		const html = computed(() => {
 			let md = props.value || '';

--- a/app/src/interfaces/register.ts
+++ b/app/src/interfaces/register.ts
@@ -4,10 +4,11 @@ import { Component } from 'vue';
 import api from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
 import asyncPool from 'tiny-async-pool';
+import { InterfaceConfig } from './types';
 
 const { interfacesRaw } = getInterfaces();
 
-export async function registerInterfaces() {
+export async function registerInterfaces(): Promise<void> {
 	const context = require.context('.', true, /^.*index\.ts$/);
 
 	const modules = context
@@ -36,7 +37,7 @@ export async function registerInterfaces() {
 
 	interfacesRaw.value = modules;
 
-	interfacesRaw.value.forEach((inter) => {
+	interfacesRaw.value.forEach((inter: InterfaceConfig) => {
 		registerComponent('interface-' + inter.id, inter.component);
 
 		if (typeof inter.options !== 'function' && Array.isArray(inter.options) === false) {

--- a/app/src/interfaces/repeater/options.vue
+++ b/app/src/interfaces/repeater/options.vue
@@ -12,7 +12,7 @@
 
 		<div class="grid-element full">
 			<p class="type-label">{{ $t('interfaces.repeater.edit_fields') }}</p>
-			<repeater v-model="repeaterValue" :template="`{{ field }} — {{ interface }}`" :fields="repeaterFields" />
+			<repeater v-model="repeaterValue" :template="`{{ field }} — {{ interface }}`" :fields="repeaterFields" />
 		</div>
 	</div>
 </template>

--- a/app/src/interfaces/wysiwyg/get-editor-styles.ts
+++ b/app/src/interfaces/wysiwyg/get-editor-styles.ts
@@ -2,7 +2,7 @@ function cssVar(name: string) {
 	return getComputedStyle(document.body).getPropertyValue(name);
 }
 
-export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospace') {
+export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospace'): string {
 	return `
 body {
 	color: ${cssVar('--foreground-normal')};

--- a/app/src/interfaces/wysiwyg/useImage.ts
+++ b/app/src/interfaces/wysiwyg/useImage.ts
@@ -10,7 +10,7 @@ type ImageSelection = {
 	height?: number;
 };
 
-export default function useImage(editor: Ref<any>, imageToken: Ref<string>) {
+export default function useImage(editor: Ref<any>, imageToken: Ref<string>): Record<string, any> {
 	const imageDrawerOpen = ref(false);
 	const imageSelection = ref<ImageSelection | null>(null);
 

--- a/app/src/interfaces/wysiwyg/useLink.ts
+++ b/app/src/interfaces/wysiwyg/useLink.ts
@@ -8,7 +8,7 @@ type LinkSelection = {
 	newTab: boolean;
 };
 
-export default function useLink(editor: Ref<any>) {
+export default function useLink(editor: Ref<any>): Record<string, any> {
 	const linkDrawerOpen = ref(false);
 	const linkSelection = ref<LinkSelection>({
 		url: null,

--- a/app/src/interfaces/wysiwyg/useMedia.ts
+++ b/app/src/interfaces/wysiwyg/useMedia.ts
@@ -9,7 +9,7 @@ type MediaSelection = {
 	height?: number;
 };
 
-export default function useMedia(editor: Ref<any>, imageToken: Ref<string>) {
+export default function useMedia(editor: Ref<any>, imageToken: Ref<string>): Record<string, any> {
 	const mediaDrawerOpen = ref(false);
 	const mediaSelection = ref<MediaSelection | null>(null);
 	const openMediaTab = ref(['video']);

--- a/app/src/interfaces/wysiwyg/useSourceCode.ts
+++ b/app/src/interfaces/wysiwyg/useSourceCode.ts
@@ -1,7 +1,7 @@
 import { Ref, ref } from '@vue/composition-api';
 import i18n from '@/lang';
 
-export default function useSourceCode(editor: Ref<any>) {
+export default function useSourceCode(editor: Ref<any>): Record<string, any> {
 	const codeDrawerOpen = ref(false);
 	const code = ref<string>();
 

--- a/app/src/lang/index.ts
+++ b/app/src/lang/index.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import VueI18n from 'vue-i18n';
+import VueI18n, { TranslateResult } from 'vue-i18n';
 import { RequestError } from '@/api';
 
 import availableLanguages from './available-languages.yaml';
@@ -25,7 +25,7 @@ export const loadedLanguages: Language[] = ['en-US'];
 
 export default i18n;
 
-export function translateAPIError(error: RequestError | string) {
+export function translateAPIError(error: RequestError | string): TranslateResult {
 	const defaultMsg = i18n.t('unexpected_error');
 
 	let code = error;

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -136,7 +136,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType, toRefs, inject, computed, ref } from '@vue/composition-api';
-import { Filter } from '@/types';
+import { FieldMeta, Filter } from '@/types';
 import useSync from '@/composables/use-sync/';
 import useCollection from '@/composables/use-collection/';
 import useItems from '@/composables/use-items';
@@ -228,7 +228,7 @@ export default defineComponent({
 		const { info, primaryKeyField, fields: fieldsInCollection } = useCollection(collection);
 
 		const fileFields = computed(() => {
-			return fieldsInCollection.value.filter((field) => {
+			return fieldsInCollection.value.filter((field: FieldMeta) => {
 				if (field.field === '$thumbnail') return true;
 
 				const relation = relationsStore.state.relations.find((relation) => {

--- a/app/src/layouts/index.ts
+++ b/app/src/layouts/index.ts
@@ -4,7 +4,7 @@ import { LayoutConfig } from './types';
 let layoutsRaw: Ref<LayoutConfig[]>;
 let layouts: Ref<LayoutConfig[]>;
 
-export function getLayouts() {
+export function getLayouts(): Record<string, Ref<LayoutConfig[]>> {
 	if (!layoutsRaw) {
 		layoutsRaw = ref([]);
 	}

--- a/app/src/layouts/register.ts
+++ b/app/src/layouts/register.ts
@@ -6,7 +6,7 @@ import asyncPool from 'tiny-async-pool';
 
 const { layoutsRaw } = getLayouts();
 
-export async function registerLayouts() {
+export async function registerLayouts(): Promise<void> {
 	const context = require.context('.', true, /^.*index\.ts$/);
 
 	const modules = context

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -278,7 +278,7 @@ export default defineComponent({
 		});
 
 		const availableFields = computed(() => {
-			return fieldsInCollection.value.filter((field) => field.meta?.special?.includes('no-data') !== true);
+			return fieldsInCollection.value.filter((field: Field) => field.meta?.special?.includes('no-data') !== true);
 		});
 
 		useShortcut(
@@ -394,14 +394,14 @@ export default defineComponent({
 					const fields =
 						_layoutQuery.value?.fields ||
 						fieldsInCollection.value
-							.filter((field) => !!field.meta?.hidden === false)
+							.filter((field: Field) => !!field.meta?.hidden === false)
 							.slice(0, 4)
-							.sort((a?: Field, b?: Field) => {
-								if (a!.field < b!.field) return -1;
-								else if (a!.field > b!.field) return 1;
+							.sort((a: Field, b: Field) => {
+								if (a.field < b.field) return -1;
+								else if (a.field > b.field) return 1;
 								else return 1;
 							})
-							.map(({ field }) => field);
+							.map(({ field }: Field) => field);
 
 					return fields;
 				},
@@ -446,7 +446,7 @@ export default defineComponent({
 			const activeFields = computed<Field[]>({
 				get() {
 					return fields.value
-						.map((key) => fieldsInCollection.value.find((field) => field.field === key))
+						.map((key) => fieldsInCollection.value.find((field: Field) => field.field === key))
 						.filter((f) => f) as Field[];
 				},
 				set(val) {
@@ -549,7 +549,7 @@ export default defineComponent({
 			}
 
 			function getFieldDisplay(fieldKey: string) {
-				const field = fieldsInCollection.value.find((field) => field.field === fieldKey);
+				const field = fieldsInCollection.value.find((field: Field) => field.field === fieldKey);
 
 				if (field === undefined) return null;
 				if (!field.meta?.display) return null;

--- a/app/src/layouts/types.ts
+++ b/app/src/layouts/types.ts
@@ -8,7 +8,7 @@ export interface LayoutConfig {
 	component: Component;
 }
 
-export type LayoutContext = {};
+export type LayoutContext = Record<string, any>;
 
 export type LayoutDefineParam = LayoutConfig | ((context: LayoutContext) => LayoutConfig);
 

--- a/app/src/modules/collections/composables/use-navigation.ts
+++ b/app/src/modules/collections/composables/use-navigation.ts
@@ -21,7 +21,7 @@ export type NavItemGroup = {
 let activeGroups: Ref<string[]>;
 let hiddenShown: Ref<boolean>;
 
-export default function useNavigation(searchQuery?: Ref<string | null>) {
+export default function useNavigation(searchQuery?: Ref<string | null>): Record<string, any> {
 	const collectionsStore = useCollectionsStore();
 	const userStore = useUserStore();
 

--- a/app/src/modules/collections/composables/use-search.ts
+++ b/app/src/modules/collections/composables/use-search.ts
@@ -1,8 +1,8 @@
-import { ref, watch } from '@vue/composition-api';
+import { Ref, ref } from '@vue/composition-api';
 
 const searchQuery = ref<string | null>(null);
 const visible = ref<number | null>(null);
 
-export function useSearch() {
+export function useSearch(): Record<string, Ref> {
 	return { visible, searchQuery };
 }

--- a/app/src/modules/docs/components/markdown.vue
+++ b/app/src/modules/docs/components/markdown.vue
@@ -75,7 +75,7 @@ export default defineComponent({
 
 			let markdown = body;
 
-			const rawImages = body.matchAll(/!\[[^\]]*\]\((?<filename>.*?)(?=\"|\))(?<optionalpart>\".*\")?\)/g) ?? [];
+			const rawImages = body.matchAll(/!\[[^\]]*\]\((?<filename>.*?)(?="|\))(?<optionalpart>".*")?\)/g) ?? [];
 			const rootPath = getRootPath();
 
 			for (const rawImage of rawImages) {

--- a/app/src/modules/docs/routes/static.vue
+++ b/app/src/modules/docs/routes/static.vue
@@ -80,6 +80,8 @@ export default defineComponent({
 					return lines[i].substring(2).trim();
 				}
 			}
+
+			return null;
 		});
 
 		const markdownWithoutTitle = computed(() => {

--- a/app/src/modules/files/components/navigation.vue
+++ b/app/src/modules/files/components/navigation.vue
@@ -55,7 +55,7 @@
 
 <script lang="ts">
 import { defineComponent, watch } from '@vue/composition-api';
-import useFolders from '../composables/use-folders';
+import useFolders, { Folder } from '../composables/use-folders';
 import NavigationFolder from './navigation-folder.vue';
 import arraysAreEqual from '@/utils/arrays-are-equal';
 
@@ -85,7 +85,7 @@ export default defineComponent({
 			if (!openFolders?.value) return [];
 
 			const shouldBeOpen: string[] = [];
-			const folder = folders.value.find((folder) => folder.id === props.currentFolder);
+			const folder = folders.value.find((folder: Folder) => folder.id === props.currentFolder);
 
 			if (folder && folder.parent) parseFolder(folder.parent);
 
@@ -105,7 +105,7 @@ export default defineComponent({
 				if (!folders.value) return;
 				shouldBeOpen.push(id);
 
-				const folder = folders.value.find((folder) => folder.id === id);
+				const folder = folders.value.find((folder: Folder) => folder.id === id);
 
 				if (folder && folder.parent) {
 					parseFolder(folder.parent);

--- a/app/src/modules/files/composables/use-folders.ts
+++ b/app/src/modules/files/composables/use-folders.ts
@@ -22,7 +22,7 @@ let openFolders: Ref<string[] | null> | null = null;
 
 let error: Ref<any> | null = null;
 
-export default function useFolders() {
+export default function useFolders(): Record<string, any> {
 	if (loading === null) loading = ref(false);
 	if (folders === null) folders = ref<Folder[] | null>(null);
 	if (nestedFolders === null) nestedFolders = ref<Folder[] | null>(null);
@@ -61,11 +61,11 @@ export default function useFolders() {
 	}
 }
 
-export function nestFolders(rawFolders: FolderRaw[]) {
+export function nestFolders(rawFolders: FolderRaw[]): FolderRaw[] {
 	return rawFolders.map((rawFolder) => nestChildren(rawFolder, rawFolders)).filter((folder) => folder.parent === null);
 }
 
-export function nestChildren(rawFolder: FolderRaw, rawFolders: FolderRaw[]) {
+export function nestChildren(rawFolder: FolderRaw, rawFolders: FolderRaw[]): FolderRaw & Folder {
 	const folder: FolderRaw & Folder = { ...rawFolder };
 
 	const children = rawFolders

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -178,7 +178,7 @@ import router from '@/router';
 import Vue from 'vue';
 import { useNotificationsStore, useUserStore, usePermissionsStore } from '@/stores';
 import { subDays } from 'date-fns';
-import useFolders from '../composables/use-folders';
+import useFolders, { Folder } from '../composables/use-folders';
 import useEventListener from '@/composables/use-event-listener';
 import uploadFiles from '@/utils/upload-files';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -371,7 +371,7 @@ export default defineComponent({
 				}
 
 				if (props.queryFilters?.folder) {
-					const folder = folders.value?.find((folder) => folder.id === props.queryFilters.folder);
+					const folder = folders.value?.find((folder: Folder) => folder.id === props.queryFilters.folder);
 
 					if (folder) {
 						return folder.name;

--- a/app/src/modules/index.ts
+++ b/app/src/modules/index.ts
@@ -4,7 +4,7 @@ import { ModuleConfig } from './types';
 let modulesRaw: Ref<ModuleConfig[]>;
 let modules: Ref<ModuleConfig[]>;
 
-export function getModules() {
+export function getModules(): Record<string, any> {
 	if (!modulesRaw) {
 		modulesRaw = ref([]);
 	}

--- a/app/src/modules/register.ts
+++ b/app/src/modules/register.ts
@@ -10,7 +10,7 @@ const { modulesRaw } = getModules();
 
 let queuedModules: any = [];
 
-export async function loadModules() {
+export async function loadModules(): Promise<void> {
 	const context = require.context('.', true, /^.*index\.ts$/);
 
 	queuedModules = context
@@ -45,7 +45,7 @@ export async function loadModules() {
 	}
 }
 
-export async function register() {
+export async function register(): Promise<void> {
 	const userStore = useUserStore();
 	const permissionsStore = usePermissionsStore();
 
@@ -75,7 +75,7 @@ export async function register() {
 	}
 }
 
-export function unregister() {
+export function unregister(): void {
 	replaceRoutes((routes) => routes);
 	modulesRaw.value = [];
 }

--- a/app/src/modules/settings/composables/use-project-info.ts
+++ b/app/src/modules/settings/composables/use-project-info.ts
@@ -1,4 +1,4 @@
-import { ref, computed } from '@vue/composition-api';
+import { ref, computed, Ref } from '@vue/composition-api';
 import prettyMS from 'pretty-ms';
 import bytes from 'bytes';
 import api from '@/api';
@@ -19,7 +19,7 @@ type ServerInfo = {
 	};
 };
 
-export function useProjectInfo() {
+export function useProjectInfo(): Record<string, Ref> {
 	const info = ref<ServerInfo>();
 	const loading = ref(false);
 	const error = ref<any>();

--- a/app/src/modules/settings/routes/data-model/field-detail/components/display.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/display.vue
@@ -42,6 +42,8 @@ import { FancySelectItem } from '@/components/v-fancy-select/types';
 import { clone } from 'lodash';
 
 import { state, availableDisplays } from '../store';
+import { InterfaceConfig } from '@/interfaces/types';
+import { DisplayConfig } from '@/displays/types';
 
 export default defineComponent({
 	props: {
@@ -59,7 +61,7 @@ export default defineComponent({
 		const { interfaces } = getInterfaces();
 
 		const selectedInterface = computed(() => {
-			return interfaces.value.find((inter) => inter.id === state.fieldData.meta.interface);
+			return interfaces.value.find((inter: InterfaceConfig) => inter.id === state.fieldData.meta.interface);
 		});
 
 		const selectItems = computed(() => {
@@ -85,9 +87,9 @@ export default defineComponent({
 
 			const recommendedItems: (FancySelectItem | { divider: boolean } | undefined)[] = [];
 
-			const recommendedList = recommended.map((key) => displayItems.find((item) => item.value === key));
+			const recommendedList = recommended.map((key: any) => displayItems.find((item) => item.value === key));
 			if (recommendedList !== undefined) {
-				recommendedItems.push(...recommendedList.filter((i) => i));
+				recommendedItems.push(...recommendedList.filter((i: any) => i));
 			}
 
 			if (displayItems.length >= 5 && recommended.length > 0) {
@@ -103,7 +105,7 @@ export default defineComponent({
 		});
 
 		const selectedDisplay = computed(() => {
-			return displays.value.find((display) => display.id === state.fieldData.meta.display);
+			return displays.value.find((display: DisplayConfig) => display.id === state.fieldData.meta.display);
 		});
 
 		const { fieldData, relations, newCollections, newFields } = toRefs(state);

--- a/app/src/modules/settings/routes/data-model/field-detail/components/interface.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/interface.vue
@@ -40,6 +40,7 @@ import { getInterfaces } from '@/interfaces';
 import { FancySelectItem } from '@/components/v-fancy-select/types';
 
 import { state, availableInterfaces } from '../store';
+import { InterfaceConfig } from '@/interfaces/types';
 
 export default defineComponent({
 	props: {
@@ -112,7 +113,7 @@ export default defineComponent({
 		});
 
 		const selectedInterface = computed(() => {
-			return interfaces.value.find((inter) => inter.id === state.fieldData.meta.interface);
+			return interfaces.value.find((inter: InterfaceConfig) => inter.id === state.fieldData.meta.interface);
 		});
 
 		const { fieldData, relations, newCollections, newFields } = toRefs(state);

--- a/app/src/modules/settings/routes/data-model/field-detail/components/tabs.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/tabs.vue
@@ -18,7 +18,7 @@ export default defineComponent({
 		},
 		current: {
 			type: Array as PropType<string[]>,
-			default: 'schema',
+			default: () => ['schema'],
 		},
 		type: {
 			type: String,

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -31,7 +31,7 @@ let generationInfo: ComputedRef<GenerationInfo[]>;
 
 export { state, availableInterfaces, availableDisplays, generationInfo, initLocalStore, clearLocalStore };
 
-function initLocalStore(collection: string, field: string, type: typeof localTypes[number]) {
+function initLocalStore(collection: string, field: string, type: typeof localTypes[number]): void {
 	const { interfaces } = getInterfaces();
 	const { displays } = getDisplays();
 
@@ -69,7 +69,7 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 
 	availableInterfaces = computed<InterfaceConfig[]>(() => {
 		return interfaces.value
-			.filter((inter) => {
+			.filter((inter: InterfaceConfig) => {
 				// Filter out all system interfaces
 				if (inter.system === true) return false;
 
@@ -78,18 +78,18 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 
 				return matchesType && matchesLocalType;
 			})
-			.sort((a, b) => (a.name > b.name ? 1 : -1));
+			.sort((a: InterfaceConfig, b: InterfaceConfig) => (a.name > b.name ? 1 : -1));
 	});
 
 	availableDisplays = computed(() => {
 		return displays.value
-			.filter((inter) => {
+			.filter((inter: InterfaceConfig) => {
 				const matchesType = inter.types.includes(state.fieldData?.type || 'alias');
 				const matchesLocalType = (inter.groups || ['standard']).includes(type) || true;
 
 				return matchesType && matchesLocalType;
 			})
-			.sort((a, b) => (a.name > b.name ? 1 : -1));
+			.sort((a: InterfaceConfig, b: InterfaceConfig) => (a.name > b.name ? 1 : -1));
 	});
 
 	generationInfo = computed(() => {
@@ -978,6 +978,6 @@ function initLocalStore(collection: string, field: string, type: typeof localTyp
 	}
 }
 
-function clearLocalStore() {
+function clearLocalStore(): void {
 	state = null;
 }

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -202,6 +202,7 @@ import { cloneDeep } from 'lodash';
 import { getLocalTypeForField } from '../../get-local-type';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { InterfaceConfig } from '@/interfaces/types';
 
 export default defineComponent({
 	props: {
@@ -234,7 +235,7 @@ export default defineComponent({
 		} = useDuplicate();
 
 		const interfaceName = computed(() => {
-			return interfaces.value.find((inter) => inter.id === props.field.meta?.interface)?.name;
+			return interfaces.value.find((inter: InterfaceConfig) => inter.id === props.field.meta?.interface)?.name;
 		});
 
 		const hidden = computed(() => props.field.meta?.hidden === true);

--- a/app/src/modules/settings/routes/roles/item/composables/use-permissions.ts
+++ b/app/src/modules/settings/routes/roles/item/composables/use-permissions.ts
@@ -1,22 +1,8 @@
 import { ref, Ref, watch } from '@vue/composition-api';
 import api from '@/api';
+import { Permission } from '@/types';
 
-export type Permission = {
-	id?: number;
-	collection: string;
-	role: number;
-	status: null | string;
-	create: 'none' | 'full';
-	read: 'none' | 'mine' | 'role' | 'full';
-	update: 'none' | 'mine' | 'role' | 'full';
-	delete: 'none' | 'mine' | 'role' | 'full';
-	comment: 'none' | 'read' | 'create' | 'update' | 'full';
-	read_field_blacklist: null | string[];
-	write_field_blacklist: null | string[];
-	status_blacklist: null | string[];
-};
-
-export default function usePermissions(role: Ref<number>) {
+export default function usePermissions(role: Ref<number>): Record<string, any> {
 	const loading = ref(false);
 	const error = ref(null);
 	const permissions = ref<Permission[] | null>(null);

--- a/app/src/modules/settings/routes/roles/item/composables/use-update-permissions.ts
+++ b/app/src/modules/settings/routes/roles/item/composables/use-update-permissions.ts
@@ -7,7 +7,7 @@ export default function useUpdatePermissions(
 	collection: Ref<Collection>,
 	permissions: Ref<Permission[]>,
 	role: Ref<string>
-) {
+): Record<string, any> {
 	const saving = ref(false);
 	const refresh = inject<() => Promise<void>>('refresh-permissions');
 

--- a/app/src/modules/users/composables/use-navigation.ts
+++ b/app/src/modules/users/composables/use-navigation.ts
@@ -6,7 +6,7 @@ import { Role } from '@/types';
 let roles: Ref<Role[] | null> | null = null;
 let loading: Ref<boolean> | null = null;
 
-export default function useNavigation() {
+export default function useNavigation(): Record<string, Ref> {
 	if (roles === null) {
 		roles = ref<Role[] | null>(null);
 	}

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -151,6 +151,7 @@ import { useUserStore, usePermissionsStore } from '@/stores';
 import marked from 'marked';
 import useNavigation from '../composables/use-navigation';
 import DrawerBatch from '@/views/private/components/drawer-batch';
+import { Role } from '@/types';
 
 type Item = {
 	[field: string]: any;
@@ -303,7 +304,7 @@ export default defineComponent({
 
 			const title = computed(() => {
 				if (!props.queryFilters?.role) return i18n.t('user_directory');
-				return roles.value?.find((role) => role.id === props.queryFilters.role)?.name;
+				return roles.value?.find((role: Role) => role.id === props.queryFilters.role)?.name;
 			});
 
 			return { breadcrumb, title };

--- a/app/src/router.ts
+++ b/app/src/router.ts
@@ -97,7 +97,9 @@ export const onBeforeEach: NavigationGuard = async (to, from, next) => {
 		// Try retrieving a fresh access token on first load
 		try {
 			await refresh({ navigate: false });
-		} catch {}
+		} catch {
+			// Ignore error
+		}
 	}
 
 	if (serverStore.state.info === null) {

--- a/app/src/router.ts
+++ b/app/src/router.ts
@@ -119,7 +119,7 @@ export const onBeforeEach: NavigationGuard = async (to, from, next) => {
 
 let trackTimeout: number | null = null;
 
-export const onAfterEach = (to: Route) => {
+export const onAfterEach = (to: Route): void => {
 	const userStore = useUserStore();
 
 	if (to.meta.public !== true) {

--- a/app/src/routes/accept-invite/accept-invite.vue
+++ b/app/src/routes/accept-invite/accept-invite.vue
@@ -87,10 +87,6 @@ export default defineComponent({
 				creating.value = false;
 			}
 		}
-
-		return {
-			acceptToken,
-		};
 	},
 });
 </script>

--- a/app/src/shims.d.ts
+++ b/app/src/shims.d.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/ban-types */
+
 declare module '*.vue' {
 	import Vue from 'vue';
 	export default Vue;

--- a/app/src/utils/abbreviate-number.ts
+++ b/app/src/utils/abbreviate-number.ts
@@ -1,4 +1,4 @@
-export function abbreviateNumber(value: number) {
+export function abbreviateNumber(value: number): number | string {
 	if (value >= 1000) {
 		const suffixes = ['', 'K', 'M', 'B', 'T'];
 		const suffixNum = Math.floor(('' + value).length / 3);

--- a/app/src/utils/add-query-to-path.ts
+++ b/app/src/utils/add-query-to-path.ts
@@ -1,4 +1,4 @@
-export function addQueryToPath(path: string, query: Record<string, string>) {
+export function addQueryToPath(path: string, query: Record<string, string>): string {
 	const queryParams = [];
 
 	for (const [key, value] of Object.entries(query)) {

--- a/app/src/utils/adjust-fields-for-displays/adjust-fields-for-displays.ts
+++ b/app/src/utils/adjust-fields-for-displays/adjust-fields-for-displays.ts
@@ -1,8 +1,9 @@
 import { useFieldsStore } from '@/stores/';
 import { Field } from '@/types/';
 import { getDisplays } from '@/displays';
+import { DisplayConfig } from '@/displays/types';
 
-export default function adjustFieldsForDisplays(fields: readonly string[], parentCollection: string) {
+export default function adjustFieldsForDisplays(fields: readonly string[], parentCollection: string): string[] {
 	const fieldsStore = useFieldsStore();
 	const { displays } = getDisplays();
 
@@ -13,7 +14,7 @@ export default function adjustFieldsForDisplays(fields: readonly string[], paren
 			if (!field) return fieldKey;
 			if (field.meta?.display === null) return fieldKey;
 
-			const display = displays.value.find((d) => d.id === field.meta?.display);
+			const display = displays.value.find((d: DisplayConfig) => d.id === field.meta?.display);
 
 			if (!display) return fieldKey;
 			if (!display?.fields) return fieldKey;

--- a/app/src/utils/arrays-are-equal/arrays-are-equal.ts
+++ b/app/src/utils/arrays-are-equal/arrays-are-equal.ts
@@ -1,4 +1,4 @@
-export default function arraysAreEqual(a1: readonly (string | number)[], a2: readonly (string | number)[]) {
+export default function arraysAreEqual(a1: readonly (string | number)[], a2: readonly (string | number)[]): boolean {
 	const superSet: {
 		[key: string]: number;
 	} = {};

--- a/app/src/utils/deep-map.ts
+++ b/app/src/utils/deep-map.ts
@@ -1,6 +1,7 @@
 import { transform, isPlainObject } from 'lodash';
 
-export function deepMap(obj: Record<string, any>, iterator: Function, context?: Function) {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function deepMap(obj: Record<string, any>, iterator: Function, context?: Function): any {
 	return transform(obj, function (result: any, val, key) {
 		result[key] = isPlainObject(val) ? deepMap(val, iterator, context) : iterator.call(context, val, key, obj);
 	});

--- a/app/src/utils/filters-to-query/filters-to-query.ts
+++ b/app/src/utils/filters-to-query/filters-to-query.ts
@@ -1,7 +1,7 @@
 import { Filter } from '@/types/';
 import { clone } from 'lodash';
 
-export default function filtersToQuery(filters: readonly Filter[]) {
+export default function filtersToQuery(filters: readonly Filter[]): any {
 	const filterList: Record<string, any>[] = [];
 
 	for (const filter of filters) {

--- a/app/src/utils/format-filesize/format-filesize.ts
+++ b/app/src/utils/format-filesize/format-filesize.ts
@@ -1,4 +1,4 @@
-export default function formatFilesize(bytes = 0, decimal = true) {
+export default function formatFilesize(bytes = 0, decimal = true): string {
 	const threshold = decimal ? 1000 : 1024;
 
 	if (Boolean(bytes) === false) {

--- a/app/src/utils/generate-joi/index.ts
+++ b/app/src/utils/generate-joi/index.ts
@@ -64,7 +64,7 @@ const defaults: JoiOptions = {
 	allowUnknown: true,
 };
 
-export default function generateJoi(filter: Record<string, any> | null, options?: JoiOptions) {
+export default function generateJoi(filter: Record<string, any> | null, options?: JoiOptions): any {
 	filter = filter || {};
 
 	options = {

--- a/app/src/utils/get-date-fns-locale/get-date-fns-locale.ts
+++ b/app/src/utils/get-date-fns-locale/get-date-fns-locale.ts
@@ -1,6 +1,6 @@
 import { i18n } from '@/lang';
 
-export async function getDateFNSLocale() {
+export async function getDateFNSLocale(): Promise<Locale> {
 	const lang = i18n.locale;
 
 	const localesToTry = [lang, lang.split('-')[0], 'en-US'];

--- a/app/src/utils/get-default-interface-for-type/get-default-interface-for-type.ts
+++ b/app/src/utils/get-default-interface-for-type/get-default-interface-for-type.ts
@@ -25,6 +25,6 @@ const defaultInterfaceMap: Record<typeof types[number], string> = {
  * @todo default to correct interfaces for uuid / enum
  */
 
-export default function getDefaultInterfaceForType(type: typeof types[number]) {
+export default function getDefaultInterfaceForType(type: typeof types[number]): string {
 	return defaultInterfaceMap[type] || 'text-input';
 }

--- a/app/src/utils/get-endpoint.ts
+++ b/app/src/utils/get-endpoint.ts
@@ -1,4 +1,4 @@
-export function getEndpoint(collection: string) {
+export function getEndpoint(collection: string): string {
 	if (collection.startsWith('directus_')) {
 		return `/${collection.substring(9)}`;
 	}

--- a/app/src/utils/get-fields-from-template.ts
+++ b/app/src/utils/get-fields-from-template.ts
@@ -1,4 +1,4 @@
-export function getFieldsFromTemplate(template: string | null) {
+export function getFieldsFromTemplate(template: string | null): string[] {
 	if (template === null) return [];
 
 	const regex = /{{(.*?)}}/g;

--- a/app/src/utils/get-js-type.ts
+++ b/app/src/utils/get-js-type.ts
@@ -1,6 +1,6 @@
 import { types } from '@/types';
 
-export function getJSType(type: typeof types[number]) {
+export function getJSType(type: typeof types[number]): string {
 	if (['bigInteger', 'integer', 'float', 'decimal'].includes(type)) return 'number';
 	if (['string', 'text', 'uuid', 'hash'].includes(type)) return 'string';
 	if (['boolean'].includes(type)) return 'boolean';

--- a/app/src/utils/get-related-collection/get-related-collection.ts
+++ b/app/src/utils/get-related-collection/get-related-collection.ts
@@ -1,6 +1,7 @@
 import { useFieldsStore, useRelationsStore } from '@/stores/';
+import { Collection } from '@/types';
 
-export default function getRelatedCollection(collection: string, field: string) {
+export default function getRelatedCollection(collection: string, field: string): Collection {
 	const relationsStore = useRelationsStore();
 	const fieldsStore = useFieldsStore();
 

--- a/app/src/utils/get-root-path.ts
+++ b/app/src/utils/get-root-path.ts
@@ -6,7 +6,7 @@ export function getRootPath(): string {
 	return rootPath;
 }
 
-export function getPublicURL() {
+export function getPublicURL(): string {
 	const path = window.location.href;
 	const parts = path.split('/');
 	const adminIndex = parts.indexOf('admin');

--- a/app/src/utils/hide-drag-image/hide-drag-image.ts
+++ b/app/src/utils/hide-drag-image/hide-drag-image.ts
@@ -1,4 +1,4 @@
-export default function hideDragImage(dataTransfer: DataTransfer) {
+export default function hideDragImage(dataTransfer: DataTransfer): void {
 	const emptyImg = new Image();
 	dataTransfer.setDragImage(emptyImg, 0, 0);
 }

--- a/app/src/utils/hljs-graphql.ts
+++ b/app/src/utils/hljs-graphql.ts
@@ -1,6 +1,6 @@
 import { HASH_COMMENT_MODE, QUOTE_STRING_MODE, NUMBER_MODE } from 'highlight.js';
 
-export default () => ({
+export default (): LanguageDetail & ModeDetails => ({
 	aliases: ['gql'],
 	keywords: {
 		keyword:

--- a/app/src/utils/is-allowed.ts
+++ b/app/src/utils/is-allowed.ts
@@ -7,7 +7,7 @@ export function isAllowed(
 	action: Permission['action'],
 	value: Record<string, any> | null,
 	strict = false
-) {
+): boolean {
 	const permissionsStore = usePermissionsStore();
 	const userStore = useUserStore();
 

--- a/app/src/utils/jwt-payload/jwt-payload.ts
+++ b/app/src/utils/jwt-payload/jwt-payload.ts
@@ -1,6 +1,6 @@
 import { decode } from 'base-64';
 
-export default function jwtPayload(token: string) {
+export default function jwtPayload(token: string): any {
 	const payloadBase64 = token.split('.')[1].replace('-', '+').replace('_', '/');
 	const payloadDecoded = decode(payloadBase64);
 	const payloadObject = JSON.parse(payloadDecoded);

--- a/app/src/utils/move-in-array/move-in-array.ts
+++ b/app/src/utils/move-in-array/move-in-array.ts
@@ -1,4 +1,4 @@
-export default function moveInArray(array: readonly any[], fromIndex: number, toIndex: number) {
+export default function moveInArray(array: readonly any[], fromIndex: number, toIndex: number): readonly any[] | any[] {
 	const item = array[fromIndex];
 	const length = array.length;
 	const diff = fromIndex - toIndex;

--- a/app/src/utils/notify.ts
+++ b/app/src/utils/notify.ts
@@ -3,7 +3,7 @@ import { NotificationRaw } from '@/types';
 
 let store: any;
 
-export function notify(notification: NotificationRaw) {
+export function notify(notification: NotificationRaw): void {
 	if (!store) store = useNotificationsStore();
 	store.add(notification);
 }

--- a/app/src/utils/parse-filter.ts
+++ b/app/src/utils/parse-filter.ts
@@ -1,7 +1,7 @@
 import { deepMap } from './deep-map';
 import { useUserStore } from '@/stores';
 
-export function parseFilter(filter: Record<string, any>) {
+export function parseFilter(filter: Record<string, any>): Record<string, any> {
 	const userStore = useUserStore();
 
 	return deepMap(filter, (val: any, key: string) => {

--- a/app/src/utils/readable-mime-type/readable-mime-type.ts
+++ b/app/src/utils/readable-mime-type/readable-mime-type.ts
@@ -1,7 +1,7 @@
 import types from './types.json';
 import extensions from './extensions.json';
 
-export default function readableMimeType(type: string, extension = false) {
+export default function readableMimeType(type: string, extension = false): string | null {
 	if (extension) {
 		return (extensions as any)[type] || null;
 	}

--- a/app/src/utils/register-component/register-component.ts
+++ b/app/src/utils/register-component/register-component.ts
@@ -3,7 +3,8 @@ import Vue, { Component, AsyncComponent } from 'vue';
 function registerComponent(id: string, component: Component | AsyncComponent): void;
 function registerComponent(id: string, component: Parameters<typeof Vue.component>[1]): void;
 
-function registerComponent(id: string, component: any) {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+function registerComponent(id: string, component: any): void {
 	Vue.component(id, component);
 }
 

--- a/app/src/utils/render-string-template.ts
+++ b/app/src/utils/render-string-template.ts
@@ -1,21 +1,28 @@
-import { computed, Ref } from '@vue/composition-api';
+import { computed, ComputedRef, Ref } from '@vue/composition-api';
 import { render } from 'micromustache';
 import { getFieldsFromTemplate } from './get-fields-from-template';
+
+type StringTemplate = {
+	fieldsInTemplate: ComputedRef<string[]>;
+	displayValue: ComputedRef<string | false>;
+};
 
 export function renderStringTemplate(
 	template: Ref<string | null> | string,
 	item: Ref<Record<string, any> | undefined | null>
-) {
+): StringTemplate {
 	const templateString = computed(() => (typeof template === 'string' ? template : template.value));
 
 	const fieldsInTemplate = computed(() => getFieldsFromTemplate(templateString.value));
 
 	const displayValue = computed(() => {
-		if (!item.value || !templateString.value || !fieldsInTemplate.value) return;
+		if (!item.value || !templateString.value || !fieldsInTemplate.value) return false;
 
 		try {
 			return render(templateString.value, item.value, { propsExist: true });
-		} catch {}
+		} catch {
+			return false;
+		}
 	});
 
 	return { fieldsInTemplate, displayValue };

--- a/app/src/utils/set-favicon/set-favicon.ts
+++ b/app/src/utils/set-favicon/set-favicon.ts
@@ -20,14 +20,15 @@ export default function setFavicon(color = '#00C897', hide = false): void {
 	const wrapper = document.createElement('div');
 	wrapper.innerHTML = icon.trim();
 
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const iconSerialized = new XMLSerializer().serializeToString(wrapper.firstChild!);
+	if (wrapper.firstChild) {
+		const iconSerialized = new XMLSerializer().serializeToString(wrapper.firstChild);
 
-	const string = 'data:image/svg+xml;base64,' + window.btoa(iconSerialized);
+		const string = 'data:image/svg+xml;base64,' + window.btoa(iconSerialized);
 
-	const link: HTMLLinkElement = document.querySelector("link[rel*='icon']") || document.createElement('link');
-	link.type = 'image/x-icon';
-	link.rel = 'icon';
-	link.href = string;
-	document.getElementsByTagName('head')[0].appendChild(link);
+		const link: HTMLLinkElement = document.querySelector("link[rel*='icon']") || document.createElement('link');
+		link.type = 'image/x-icon';
+		link.rel = 'icon';
+		link.href = string;
+		document.getElementsByTagName('head')[0].appendChild(link);
+	}
 }

--- a/app/src/utils/set-favicon/set-favicon.ts
+++ b/app/src/utils/set-favicon/set-favicon.ts
@@ -15,7 +15,7 @@ const svg = (color: string, hide: boolean) => `
 	}
 </svg>`;
 
-export default function setFavicon(color = '#00C897', hide = false) {
+export default function setFavicon(color = '#00C897', hide = false): void {
 	const icon = svg(color, hide);
 	const wrapper = document.createElement('div');
 	wrapper.innerHTML = icon.trim();

--- a/app/src/utils/translate-object-values.ts
+++ b/app/src/utils/translate-object-values.ts
@@ -1,7 +1,7 @@
 import i18n from '@/lang';
 import { cloneDeep } from 'lodash';
 
-export function translate<T extends Record<string, any>>(obj: T) {
+export function translate<T extends Record<string, any>>(obj: T): any {
 	obj = cloneDeep(obj);
 
 	Object.entries(obj).forEach(([key, val]) => {

--- a/app/src/utils/translate-shortcut/translate-shortcut.ts
+++ b/app/src/utils/translate-shortcut/translate-shortcut.ts
@@ -1,6 +1,6 @@
 import capitalizeFirst from '@/utils/capitalize-first';
 
-export default function translateShortcut(keys: string[]) {
+export default function translateShortcut(keys: string[]): string {
 	const isMac = navigator.platform.toLowerCase().startsWith('mac') || navigator.platform.startsWith('iP');
 
 	if (isMac) {

--- a/app/src/utils/unexpected-error.ts
+++ b/app/src/utils/unexpected-error.ts
@@ -5,7 +5,7 @@ import { APIError } from '@/types';
 
 let store: any;
 
-export function unexpectedError(error: Error | RequestError | APIError) {
+export function unexpectedError(error: Error | RequestError | APIError): void {
 	if (!store) store = useNotificationsStore();
 
 	const code =

--- a/app/src/utils/upload-file/upload-file.ts
+++ b/app/src/utils/upload-file/upload-file.ts
@@ -13,7 +13,7 @@ export default async function uploadFile(
 		preset?: Record<string, any>;
 		fileId?: string;
 	}
-) {
+): Promise<any> {
 	const progressHandler = options?.onProgressChange || (() => undefined);
 	const formData = new FormData();
 

--- a/app/src/utils/upload-files/upload-files.ts
+++ b/app/src/utils/upload-files/upload-files.ts
@@ -10,7 +10,7 @@ export default async function uploadFiles(
 		notifications?: boolean;
 		preset?: Record<string, any>;
 	}
-) {
+): Promise<File[] | undefined> {
 	const progressHandler = options?.onProgressChange || (() => undefined);
 	const progressForFiles = files.map(() => 0);
 

--- a/app/src/views/private/components/drawer-item/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item/drawer-item.vue
@@ -157,7 +157,7 @@ export default defineComponent({
 
 		const fields = computed(() => {
 			if (props.circularField) {
-				return fieldsWithPermissions.value.filter((field) => {
+				return fieldsWithPermissions.value.filter((field: Field) => {
 					return field.field !== props.circularField;
 				});
 			} else {

--- a/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
+++ b/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
@@ -17,7 +17,6 @@ export default function getAvailableOperatorsForType(type: string): OperatorType
 		case 'lang':
 		case 'uuid':
 		case 'hash':
-		case 'array':
 		case 'string':
 			return {
 				type: 'text',

--- a/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
+++ b/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
@@ -1,4 +1,6 @@
-export default function getAvailableOperatorsForType(type: string) {
+import { OperatorType } from './types';
+
+export default function getAvailableOperatorsForType(type: string): OperatorType {
 	/**
 	 * @NOTE
 	 * In the filter, you can't filter on the relational field itself, so we don't have to account

--- a/app/src/views/private/components/filter-sidebar-detail/types.ts
+++ b/app/src/views/private/components/filter-sidebar-detail/types.ts
@@ -5,3 +5,8 @@ export type FieldTree = {
 	name: string | TranslateResult;
 	children?: FieldTree[];
 };
+
+export type OperatorType = {
+	type: string;
+	operators: string[];
+};

--- a/app/src/views/private/components/image-editor/image-editor.vue
+++ b/app/src/views/private/components/image-editor/image-editor.vue
@@ -312,7 +312,6 @@ export default defineComponent({
 						return 'crop_square';
 					case imageData.value.width / imageData.value.height:
 						return 'crop_original';
-					case NaN:
 					default:
 						return 'crop_free';
 				}

--- a/app/src/views/private/components/latency-indicator/latency-indicator.vue
+++ b/app/src/views/private/components/latency-indicator/latency-indicator.vue
@@ -51,10 +51,12 @@ export default defineComponent({
 					return `${i18n.t('connection_fair')}\n(${ms(avgLatency.value)} ${i18n.t('latency')})`;
 				case 1:
 					return `${i18n.t('connection_poor')}\n(${ms(avgLatency.value)} ${i18n.t('latency')})`;
+				default:
+					return null;
 			}
 		});
 
-		const icon = computed<string>(() => {
+		const icon = computed(() => {
 			switch (connectionStrength.value) {
 				case 4:
 					return 'signal_wifi_4_bar';
@@ -64,6 +66,8 @@ export default defineComponent({
 					return 'signal_wifi_2_bar';
 				case 1:
 					return 'signal_wifi_1_bar';
+				default:
+					return null;
 			}
 		});
 

--- a/app/src/views/private/components/module-bar/module-bar.vue
+++ b/app/src/views/private/components/module-bar/module-bar.vue
@@ -34,6 +34,7 @@ import ModuleBarLogo from '../module-bar-logo/';
 import ModuleBarAvatar from '../module-bar-avatar/';
 import { useUserStore } from '@/stores/';
 import { orderBy } from 'lodash';
+import { ModuleConfig } from '@/modules/types';
 
 export default defineComponent({
 	components: {
@@ -49,12 +50,12 @@ export default defineComponent({
 
 			const registeredModules = orderBy(
 				modules.value
-					.map((module) => ({
+					.map((module: ModuleConfig) => ({
 						...module,
 						href: module.link || null,
 						to: module.link === undefined ? `/${module.id}/` : null,
 					}))
-					.filter((module) => {
+					.filter((module: ModuleConfig) => {
 						if (module.hidden !== undefined) {
 							if ((module.hidden as boolean) === true || (module.hidden as Ref<boolean>).value === true) {
 								return false;

--- a/app/src/views/private/components/render-display/render-display.vue
+++ b/app/src/views/private/components/render-display/render-display.vue
@@ -23,6 +23,7 @@
 import { defineComponent, computed } from '@vue/composition-api';
 import { getDisplays } from '@/displays';
 import ValueNull from '@/views/private/components/value-null';
+import { DisplayConfig } from '@/displays/types';
 
 export default defineComponent({
 	components: { ValueNull },
@@ -62,7 +63,9 @@ export default defineComponent({
 	},
 	setup(props) {
 		const { displays } = getDisplays();
-		const displayInfo = computed(() => displays.value.find((display) => display.id === props.display) || null);
+		const displayInfo = computed(
+			() => displays.value.find((display: DisplayConfig) => display.id === props.display) || null
+		);
 		return { displayInfo };
 	},
 });

--- a/app/src/views/private/components/render-template/render-template.vue
+++ b/app/src/views/private/components/render-template/render-template.vue
@@ -27,6 +27,7 @@ import { get } from 'lodash';
 import { Field } from '@/types';
 import { getDisplays } from '@/displays';
 import ValueNull from '@/views/private/components/value-null';
+import { DisplayConfig, DisplayHandlerFunction } from '@/displays/types';
 
 export default defineComponent({
 	components: { ValueNull },
@@ -89,14 +90,14 @@ export default defineComponent({
 					// If no display is configured, we can render the raw value
 					if (!field || !field.meta?.display) return value;
 
-					const displayInfo = displays.value.find((display) => display.id === field.meta?.display);
+					const displayInfo = displays.value.find((display: DisplayConfig) => display.id === field.meta?.display);
 
 					// If used display doesn't exist in the current project, return raw value
 					if (!displayInfo) return value;
 
 					// If the display handler is a function, we parse the value and return the result
 					if (typeof displayInfo.handler === 'function') {
-						const handler = displayInfo.handler as Function;
+						const handler = displayInfo.handler as DisplayHandlerFunction;
 						return handler(value, field.meta?.display_options);
 					}
 

--- a/app/src/views/private/components/user-popover/user-popover.vue
+++ b/app/src/views/private/components/user-popover/user-popover.vue
@@ -63,6 +63,7 @@ export default defineComponent({
 			if (data.value.avatar?.id) {
 				return addTokenToURL(`${getRootPath()}assets/${data.value.avatar.id}?key=system-medium-cover`);
 			}
+			return null;
 		});
 
 		const active = ref(false);

--- a/app/vue.config.js
+++ b/app/vue.config.js
@@ -1,6 +1,3 @@
-/* @tslint:disable */
-/* eslint-disable */
-
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
 module.exports = {

--- a/packages/drive-azure/src/AzureBlobWebServices.ts
+++ b/packages/drive-azure/src/AzureBlobWebServices.ts
@@ -53,7 +53,7 @@ export class AzureBlobWebServicesStorage extends Storage {
 	/**
 	 * Prefixes the given filePath with the storage root location
 	 */
-	protected _fullPath(filePath: string) {
+	protected _fullPath(filePath: string): string {
 		return normalize(path.join(this.$root, filePath));
 	}
 

--- a/packages/drive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/drive-gcs/src/GoogleCloudStorage.ts
@@ -63,7 +63,7 @@ export class GoogleCloudStorage extends Storage {
 	/**
 	 * Prefixes the given filePath with the storage root location
 	 */
-	protected _fullPath(filePath: string) {
+	protected _fullPath(filePath: string): string {
 		return normalize(path.join(this.$root, filePath));
 	}
 

--- a/packages/drive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/drive-gcs/src/GoogleCloudStorage.ts
@@ -94,13 +94,13 @@ export class GoogleCloudStorage extends Storage {
 			const result = await this._file(location).delete();
 			return { raw: result, wasDeleted: true };
 		} catch (e) {
-			e = handleError(e, location);
+			const error = handleError(e, location);
 
-			if (e instanceof FileNotFound) {
+			if (error instanceof FileNotFound) {
 				return { raw: undefined, wasDeleted: false };
 			}
 
-			throw e;
+			throw error;
 		}
 	}
 

--- a/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
@@ -39,7 +39,6 @@ export class AmazonWebServicesS3Storage extends Storage {
 
 	constructor(config: AmazonWebServicesS3StorageConfig) {
 		super();
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const S3 = require('aws-sdk/clients/s3');
 
 		this.$driver = new S3({

--- a/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
@@ -56,7 +56,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 	/**
 	 * Prefixes the given filePath with the storage root location
 	 */
-	protected _fullPath(filePath: string) {
+	protected _fullPath(filePath: string): string {
 		return normalize(path.join(this.$root, filePath));
 	}
 

--- a/packages/drive/src/LocalFileSystemStorage.ts
+++ b/packages/drive/src/LocalFileSystemStorage.ts
@@ -72,13 +72,13 @@ export class LocalFileSystemStorage extends Storage {
 			const result = await fse.unlink(this._fullPath(location));
 			return { raw: result, wasDeleted: true };
 		} catch (e) {
-			e = handleError(e, location);
+			const error = handleError(e, location);
 
-			if (e instanceof FileNotFound) {
+			if (error instanceof FileNotFound) {
 				return { raw: undefined, wasDeleted: false };
 			}
 
-			throw e;
+			throw error;
 		}
 	}
 

--- a/packages/drive/src/utils.ts
+++ b/packages/drive/src/utils.ts
@@ -6,7 +6,7 @@ import Storage from './Storage';
  * Returns a boolean indication if stream param
  * is a readable stream or not.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function isReadableStream(stream: any): stream is NodeJS.ReadableStream {
 	return (
 		stream !== null &&

--- a/packages/drive/tests/LocalFileSystemStorage.test.ts
+++ b/packages/drive/tests/LocalFileSystemStorage.test.ts
@@ -39,8 +39,6 @@ jest.mock('fs-extra', () => {
 				errors.map = map;
 				try {
 					await handler();
-				} catch (e) {
-					throw e;
 				} finally {
 					errors.map = {};
 				}

--- a/packages/drive/tests/StorageManager.test.ts
+++ b/packages/drive/tests/StorageManager.test.ts
@@ -29,7 +29,7 @@ describe('Storage Manager', () => {
 		const storageManager = new StorageManager({
 			default: 'local',
 			disks: {
-				// @ts-expect-error
+				// @ts-expect-error No driver
 				local: {},
 			},
 		});

--- a/packages/schema/src/dialects/mysql.ts
+++ b/packages/schema/src/dialects/mysql.ts
@@ -3,7 +3,7 @@ import { SchemaOverview } from '../types/overview';
 import { SchemaInspector } from '../types/schema';
 
 export default class MySQL extends KnexMySQL implements SchemaInspector {
-	async overview() {
+	async overview(): Promise<SchemaOverview> {
 		const columns = await this.knex.raw(
 			`
 			SELECT

--- a/packages/schema/src/dialects/oracledb.ts
+++ b/packages/schema/src/dialects/oracledb.ts
@@ -4,7 +4,7 @@ import { SchemaInspector } from '../types/schema';
 import { mapKeys } from 'lodash';
 
 export default class Oracle extends KnexOracle implements SchemaInspector {
-	async overview() {
+	async overview(): Promise<SchemaOverview> {
 		type RawColumn = {
 			TABLE_NAME: string;
 			COLUMN_NAME: string;

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -3,7 +3,7 @@ import { SchemaOverview } from '../types/overview';
 import { SchemaInspector } from '../types/schema';
 
 export default class Postgres extends KnexPostgres implements SchemaInspector {
-	async overview() {
+	async overview(): Promise<SchemaOverview> {
 		const [columnsResult, primaryKeysResult] = await Promise.all([
 			// Only select columns from BASE TABLEs to exclude views (Postgres views
 			// cannot have primary keys so they cannot be used)

--- a/packages/schema/src/dialects/sqlite.ts
+++ b/packages/schema/src/dialects/sqlite.ts
@@ -12,7 +12,7 @@ type RawColumn = {
 };
 
 export default class SQLite extends KnexSQLite implements SchemaInspector {
-	async overview() {
+	async overview(): Promise<SchemaOverview> {
 		const tablesWithAutoIncrementPrimaryKeys = (
 			await this.knex.select('name').from('sqlite_master').whereRaw(`sql LIKE "%AUTOINCREMENT%"`)
 		).map(({ name }) => name);

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -33,7 +33,9 @@ export class Auth implements IAuth {
 		this.refresher = new Debouncer(this.refreshToken.bind(this));
 		try {
 			this.updateRefresh(this.options?.refresh);
-		} catch (err) {}
+		} catch {
+			// Ignore error
+		}
 	}
 
 	get token(): string | null {
@@ -122,8 +124,12 @@ export class Auth implements IAuth {
 		if (this.options.refresh!.auto) {
 			this.timer = setTimeout(() => {
 				this.refresh()
-					.then(() => {})
-					.catch((_) => {});
+					.then(() => {
+						// Do nothing
+					})
+					.catch(() => {
+						// Do nothing
+					});
 			}, remaining);
 		}
 	}

--- a/packages/sdk/src/handlers/activity.ts
+++ b/packages/sdk/src/handlers/activity.ts
@@ -17,7 +17,7 @@ export class ActivityHandler<T = DefaultType> extends ItemsHandler<ActivityItem<
 		this._comments = new CommentsHandler(this.transport);
 	}
 
-	get comments() {
+	get comments(): CommentsHandler<T> {
 		return this._comments;
 	}
 }

--- a/packages/sdk/src/handlers/extensions.ts
+++ b/packages/sdk/src/handlers/extensions.ts
@@ -64,7 +64,7 @@ export class ExtensionHandler {
 		this.transport = transport;
 	}
 
-	endpoint(name: string) {
+	endpoint(name: string): ExtensionEndpoint {
 		return new ExtensionEndpoint(this.transport, name);
 	}
 }

--- a/packages/sdk/src/handlers/graphql.ts
+++ b/packages/sdk/src/handlers/graphql.ts
@@ -14,10 +14,12 @@ export class GraphQLHandler {
 		});
 	}
 
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	async items<T>(query: string, variables?: any): Promise<TransportResponse<T>> {
 		return await this.request('/graphql', query, variables);
 	}
 
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	async system<T>(query: string, variables?: any): Promise<TransportResponse<T>> {
 		return await this.request('/graphql/system', query, variables);
 	}

--- a/packages/sdk/tests/base/storage/tests.ts
+++ b/packages/sdk/tests/base/storage/tests.ts
@@ -1,7 +1,7 @@
 import { IStorage } from '../../../src/storage';
 
 export function createStorageTests(createStorage: () => IStorage) {
-	return function () {
+	return function (): void {
 		beforeEach(() => {
 			// These run both in node and browser mode
 			if (typeof localStorage !== 'undefined') {

--- a/packages/sdk/tests/base/transport/axios.test.ts
+++ b/packages/sdk/tests/base/transport/axios.test.ts
@@ -77,11 +77,11 @@ describe('axios transport', function () {
 			} catch (err) {
 				const terr = err as TransportError;
 				expect(terr).toBeInstanceOf(TransportError);
-				expect(terr.response!.status).toBe(403);
+				expect(terr.response?.status).toBe(403);
 				expect(terr.message).toBe('You don\'t have permission access to "contacts" collection.');
 				expect(terr.errors.length).toBe(1);
-				expect(terr.errors[0]!.message).toBe('You don\'t have permission access to "contacts" collection.');
-				expect(terr.errors[0]!.extensions?.code).toBe('FORBIDDEN');
+				expect(terr.errors[0]?.message).toBe('You don\'t have permission access to "contacts" collection.');
+				expect(terr.errors[0]?.extensions?.code).toBe('FORBIDDEN');
 			}
 		});
 
@@ -101,7 +101,7 @@ describe('axios transport', function () {
 				expect(terr.response).toBeUndefined();
 				expect(terr.message).toBe('Random error');
 				expect(terr.parent).not.toBeUndefined();
-				expect(terr.parent!.message).toBe('Random error');
+				expect(terr.parent?.message).toBe('Random error');
 			}
 		});
 	});
@@ -129,7 +129,7 @@ describe('axios transport', function () {
 			expect(terr.response).toBeUndefined();
 			expect(terr.message).toBe('this is not an axios error');
 			expect(terr.parent).not.toBeUndefined();
-			expect(terr.parent!.message).toBe('this is not an axios error');
+			expect(terr.parent?.message).toBe('this is not an axios error');
 		}
 	});
 

--- a/packages/sdk/tests/handlers/utils.test.ts
+++ b/packages/sdk/tests/handlers/utils.test.ts
@@ -37,7 +37,7 @@ describe('utils', function () {
 		const sdk = new Directus(url);
 		const hash = await sdk.utils.hash.generate('wolfulus');
 
-		expect(hash.substr(0, 7)).toBe('$argon2');
+		expect(hash?.substr(0, 7)).toBe('$argon2');
 	});
 
 	test(`hash verify`, async (url, nock) => {
@@ -54,7 +54,7 @@ describe('utils', function () {
 		const sdk = new Directus(url);
 		const hash = await sdk.utils.hash.generate('wolfulus');
 
-		expect(hash.substr(0, 7)).toBe('$argon2');
+		expect(hash?.substr(0, 7)).toBe('$argon2');
 
 		nock()
 			.post('/utils/hash/verify')
@@ -64,7 +64,7 @@ describe('utils', function () {
 				};
 			});
 
-		const result = await sdk.utils.hash.verify('wolfulus', hash);
+		const result = await sdk.utils.hash.verify('wolfulus', hash || '');
 
 		expect(result).toBe(true);
 	});

--- a/packages/sdk/tests/items.test.ts
+++ b/packages/sdk/tests/items.test.ts
@@ -23,9 +23,9 @@ describe('items', function () {
 
 		expect(item).not.toBeNull();
 		expect(item).not.toBeUndefined();
-		expect(item!.id).toBe(1);
-		expect(item!.title).toBe(`My first post`);
-		expect(item!.body).toBe('<h1>Hey there!</h1>');
+		expect(item?.id).toBe(1);
+		expect(item?.title).toBe(`My first post`);
+		expect(item?.body).toBe('<h1>Hey there!</h1>');
 	});
 
 	test(`should encode ids`, async (url, nock) => {
@@ -43,8 +43,8 @@ describe('items', function () {
 
 		expect(item).not.toBeNull();
 		expect(item).not.toBeUndefined();
-		expect(item!.slug).toBe('double slash');
-		expect(item!.name).toBe('Double Slash');
+		expect(item?.slug).toBe('double slash');
+		expect(item?.name).toBe('Double Slash');
 	});
 
 	test(`can get multiple items by id`, async (url, nock) => {
@@ -70,14 +70,14 @@ describe('items', function () {
 		const sdk = new Directus<Blog>(url);
 		const items = await sdk.items('posts').readMany();
 
-		expect(items.data![0]).toMatchObject({
+		expect(items.data?.[0]).toMatchObject({
 			id: 1,
 			title: 'My first post',
 			body: '<h1>Hey there!</h1>',
 			published: false,
 		});
 
-		expect(items.data![1]).toMatchObject({
+		expect(items.data?.[1]).toMatchObject({
 			id: 2,
 			title: 'My second post',
 			body: '<h1>Hey there!</h1>',
@@ -109,13 +109,13 @@ describe('items', function () {
 			fields: ['id', 'title'],
 		});
 
-		expect(items.data![0]!.id).toBe(1);
-		expect(items.data![0]!.title).toBe(`My first post`);
-		expect(items.data![0]!.body).toBeUndefined();
+		expect(items.data?.[0]?.id).toBe(1);
+		expect(items.data?.[0]?.title).toBe(`My first post`);
+		expect(items.data?.[0]?.body).toBeUndefined();
 
-		expect(items.data![1]!.id).toBe(2);
-		expect(items.data![1]!.title).toBe(`My second post`);
-		expect(items.data![1]!.body).toBeUndefined();
+		expect(items.data?.[1]?.id).toBe(2);
+		expect(items.data?.[1]?.title).toBe(`My second post`);
+		expect(items.data?.[1]?.body).toBeUndefined();
 	});
 
 	test(`create one item`, async (url, nock) => {
@@ -179,14 +179,14 @@ describe('items', function () {
 			},
 		]);
 
-		expect(items.data![0]).toMatchObject({
+		expect(items.data?.[0]).toMatchObject({
 			id: 4,
 			title: 'New post 2',
 			body: 'This is a new post 2',
 			published: false,
 		});
 
-		expect(items.data![1]).toMatchObject({
+		expect(items.data?.[1]).toMatchObject({
 			id: 5,
 			title: 'New post 3',
 			body: 'This is a new post 3',
@@ -256,14 +256,14 @@ describe('items', function () {
 			},
 		]);
 
-		expect(item.data![0]).toMatchObject({
+		expect(item.data?.[0]).toMatchObject({
 			id: 1,
 			title: 'Updated post',
 			body: 'Updated post content',
 			published: true,
 		});
 
-		expect(item.data![1]).toMatchObject({
+		expect(item.data?.[1]).toMatchObject({
 			id: 2,
 			title: 'Updated post 2',
 			body: 'Updated post content 2',

--- a/packages/sdk/tests/singleton.test.ts
+++ b/packages/sdk/tests/singleton.test.ts
@@ -36,9 +36,9 @@ describe('singleton', function () {
 
 		expect(settings).not.toBeNull();
 		expect(settings).not.toBeUndefined();
-		expect(settings!.url).toBe('http://website.com');
-		expect(settings!.title).toBe(`Website Title`);
-		expect(settings!.show_menu).toBe(true);
+		expect(settings?.url).toBe('http://website.com');
+		expect(settings?.title).toBe(`Website Title`);
+		expect(settings?.show_menu).toBe(true);
 	});
 
 	test(`can update an item`, async (url, nock) => {
@@ -63,8 +63,8 @@ describe('singleton', function () {
 
 		expect(settings).not.toBeNull();
 		expect(settings).not.toBeUndefined();
-		expect(settings!.url).toBe('http://website.com');
-		expect(settings!.title).toBe(`New Website Title`);
-		expect(settings!.show_menu).toBe(true);
+		expect(settings?.url).toBe('http://website.com');
+		expect(settings?.title).toBe(`New Website Title`);
+		expect(settings?.show_menu).toBe(true);
 	});
 });

--- a/packages/sdk/tests/utils.ts
+++ b/packages/sdk/tests/utils.ts
@@ -14,7 +14,7 @@ export type TestSettings = {
 	fixture?: string;
 };
 
-export function test(name: string, test: Test, settings?: TestSettings) {
+export function test(name: string, test: Test, settings?: TestSettings): void {
 	it(name, async () => {
 		nock.cleanAll();
 
@@ -40,7 +40,7 @@ export async function timers(
 		skip: (func: () => Promise<void>, date?: boolean) => Promise<any>;
 	}) => Promise<void>,
 	initial: number = Date.now()
-) {
+): Promise<void> {
 	const originals = {
 		setTimeout: global.setTimeout,
 		setImmediate: global.setImmediate,

--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -1,0 +1,16 @@
+import Dockerode from 'dockerode';
+import { Knex } from 'knex';
+
+type Global = {
+	databaseContainers: { vendor: string; container: Dockerode.Container }[];
+	directusContainers: { vendor: string; container: Dockerode.Container }[];
+	knexInstances: { vendor: string; knex: Knex }[];
+};
+
+const global: Global = {
+	databaseContainers: [],
+	directusContainers: [],
+	knexInstances: [],
+};
+
+export default global;

--- a/tests/setup/setup.ts
+++ b/tests/setup/setup.ts
@@ -1,5 +1,5 @@
 import Dockerode, { ContainerSpec } from 'dockerode';
-import knex, { Knex } from 'knex';
+import knex from 'knex';
 import { awaitDatabaseConnection, awaitDirectusConnection } from './utils/await-connection';
 import Listr, { ListrTask } from 'listr';
 import { getDBsToTest } from '../get-dbs-to-test';
@@ -8,27 +8,18 @@ import globby from 'globby';
 import path from 'path';
 import { GlobalConfigTsJest } from 'ts-jest/dist/types';
 import { writeFileSync } from 'fs';
-
-declare module global {
-	let databaseContainers: { vendor: string; container: Dockerode.Container }[];
-	let directusContainers: { vendor: string; container: Dockerode.Container }[];
-	let knexInstances: { vendor: string; knex: Knex }[];
-}
+import global from './global';
 
 const docker = new Dockerode();
 let started = false;
 
-export default async (jestConfig: GlobalConfigTsJest) => {
+export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 	if (started) return;
 	started = true;
 
 	console.log('\n\n');
 
 	console.log(`👮‍♀️ Starting tests!\n`);
-
-	global.databaseContainers = [];
-	global.directusContainers = [];
-	global.knexInstances = [];
 
 	const vendors = getDBsToTest();
 

--- a/tests/setup/teardown.ts
+++ b/tests/setup/teardown.ts
@@ -1,23 +1,18 @@
 import Listr from 'listr';
-import { Knex } from 'knex';
 import Dockerode from 'dockerode';
 import { getDBsToTest } from '../get-dbs-to-test';
 import config, { CONTAINER_PERSISTENCE_FILE } from '../config';
 import { GlobalConfigTsJest } from 'ts-jest/dist/types';
 import { readFileSync, rmSync } from 'fs';
+import global from './global';
 
-declare module global {
-	let databaseContainers: { vendor: string; container: Dockerode.Container }[];
-	let directusContainers: { vendor: string; container: Dockerode.Container }[];
-	let knexInstances: { vendor: string; knex: Knex }[];
-}
 const docker = new Dockerode();
 
 if (require.main === module) {
 	teardown(undefined, true);
 }
 
-export default async function teardown(jestConfig?: GlobalConfigTsJest, isAfterWatch = false) {
+export default async function teardown(jestConfig?: GlobalConfigTsJest, isAfterWatch = false): Promise<void> {
 	if (jestConfig?.watch || jestConfig?.watchAll) return;
 
 	const vendors = getDBsToTest();

--- a/tests/setup/utils/await-connection.ts
+++ b/tests/setup/utils/await-connection.ts
@@ -1,7 +1,11 @@
 import { Knex } from 'knex';
 import axios from 'axios';
 
-export async function awaitDatabaseConnection(database: Knex, checkSQL: string, currentAttempt: number = 0) {
+export async function awaitDatabaseConnection(
+	database: Knex,
+	checkSQL: string,
+	currentAttempt = 0
+): Promise<void | null> {
 	try {
 		await database.raw(checkSQL);
 	} catch {
@@ -18,7 +22,7 @@ export async function awaitDatabaseConnection(database: Knex, checkSQL: string, 
 	}
 }
 
-export async function awaitDirectusConnection(port: number = 6100, currentAttempt: number = 0) {
+export async function awaitDirectusConnection(port = 6100, currentAttempt = 0): Promise<void | null> {
 	try {
 		await axios.get(`http://localhost:${port}/server/ping`);
 	} catch {


### PR DESCRIPTION
As discussed in #5254 this pull request contains only a slimmed down version of the "syntax fixes" part.

There are still many changes, but it is much clearer now and the changes should be safer and easier to be reviewed.
It is now split into two commits:
* One which declares return types on TypeScript functions (https://github.com/directus/directus/commit/65032f288c8888a54af7ef1b4b686a3c1e76182d)
* One which contains minor fixes, mostly based on warnings from eslint (see https://github.com/directus/directus/commit/b70de1b8679a0a947cf808479eb50e659fd2f8ec for detailed explanation)

Many changes from the original pull request have been omitted:
* All the changes which were done automatically by eslint or stylelint, for obvious reasons
* All the changes which are "easily" reproducible, like:
  * Changes related to `hasOwnProperty`: @rijkvanzanten IMHO I still think those should be changed to `Object.prototype.hasOwnProperty.call` or otherwise the corresponding eslint rule should be disabled - I don't see any advantage in changing it into `'key' in transformation` and didn't want to waste my time on this
  * Removal of unused imports, variables and types
* I left out almost all changes to non-null assertions because those vary from case to case and cannot easily be changed (as @rijkvanzanten already stated)

I've checked all the changes again to make sure everything is alright and rebased it on latest state from main branch. 

I really hope you can use this pull request as I've now put quite a lot of effort into it 😃 Thanks!

