### PR TITLE
lint-staged: Reintroduce Prettier for md files

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -118,6 +118,7 @@ export default defineComponent({
 					return i;
 				}
 			}
+			return null;
 		});
 
 		/**

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
 		"pre-commit": "npx lint-staged"
 	},
 	"lint-staged": {
-		"*.{js,ts,vue,md}": "eslint --fix",
+		"*.{js,ts,vue}": "eslint --fix",
+		"*.md": "prettier --write",
 		"*.{css,scss,vue}": "stylelint --fix"
 	}
 }


### PR DESCRIPTION
Since ESLint doesn't process md files, we still need to run Prettier directly against those in the pre-commit hook.

Also contains a small syntax fix 😃