### PR TITLE
Fixed oracle healthcheck url

### DIFF
--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -148,7 +148,7 @@ export class ServerService {
 			const startTime = performance.now();
 
 			try {
-				await database.raw('SELECT 1');
+				await database.select(1).from('directus_settings').where(1, 0);
 				checks[`${client}:responseTime`][0].status = 'ok';
 			} catch (err) {
 				checks[`${client}:responseTime`][0].status = 'error';


### PR DESCRIPTION
Configurations using oracle would throw the error `Error: SELECT 1 - ORA-00923: FROM keyword not found where expected
` when performing a healthcheck.

This change should work for all supported database clients.