### PR TITLE
Allow for filtering by false booleans

### DIFF
--- a/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
+++ b/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
@@ -26,7 +26,7 @@ export default function getAvailableOperatorsForType(type: string): OperatorType
 		case 'boolean':
 			return {
 				type: 'checkbox',
-				operators: ['eq', 'empty', 'nempty'],
+				operators: ['eq', 'neq', 'empty', 'nempty'],
 			};
 		// Numbers
 		case 'integer':


### PR DESCRIPTION
Is there a reason this operator wasn't made available?