### PR TITLE
Fix absolute URL in Image Editor, closes #5482

### DIFF
--- a/app/src/views/private/components/image-editor/image-editor.vue
+++ b/app/src/views/private/components/image-editor/image-editor.vue
@@ -110,6 +110,7 @@ import { nanoid } from 'nanoid';
 import throttle from 'lodash/throttle';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { addTokenToURL } from '@/api';
+import { getRootPath } from '@/utils/get-root-path';
 
 type Image = {
 	type: string;
@@ -176,7 +177,7 @@ export default defineComponent({
 		});
 
 		const imageURL = computed(() => {
-			return addTokenToURL(`/assets/${props.id}?${nanoid()}`);
+			return addTokenToURL(`${getRootPath()}assets/${props.id}?${nanoid()}`);
 		});
 
 		return {


### PR DESCRIPTION
use this as reference https://github.com/directus/directus/blob/main/app/src/displays/file/file.vue#L48

a quick search showed that this is the only missed case like this https://github.com/directus/directus/search?p=2&q=addTokenToURL
altho wysiwyg uses public url method instead:
https://github.com/directus/directus/blob/801e86855452bd32d49475d8b07ce151c11e962a/app/src/interfaces/wysiwyg/useImage.ts#L63
https://github.com/directus/directus/blob/801e86855452bd32d49475d8b07ce151c11e962a/app/src/interfaces/wysiwyg/useMedia.ts#L132