### PR TITLE
Added support for PostgreSQL identity column

### DIFF
--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -14,7 +14,8 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
           c.column_name,
           c.column_default as default_value,
           c.is_nullable,
-          c.data_type
+          c.data_type,
+          c.is_identity
         FROM
           information_schema.columns c
         LEFT JOIN information_schema.tables t
@@ -64,9 +65,10 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
 
 			overview[column.table_name].columns[column.column_name] = {
 				...column,
-				default_value: column.default_value?.startsWith('nextval(')
-					? 'AUTO_INCREMENT'
-					: this.parseDefaultValue(column.default_value),
+				default_value:
+					column.is_identity === 'YES' || column.default_value?.startsWith('nextval(')
+						? 'AUTO_INCREMENT'
+						: this.parseDefaultValue(column.default_value),
 				is_nullable: column.is_nullable === 'YES',
 			};
 		}


### PR DESCRIPTION
PostgreSQL identity columns were introduced in version 10. They aim to replace the commonly used SERIAL type, as it not compliant with the SQL standard - and is error prone, as you have to manage the sequence associated to. An identity column is basically a generated integer type with a sequence built-in it knows everything about (it won't pick nextval if nextval already exists).

Solves https://github.com/directus/directus/issues/5501.
Potentially breaking on PostgreSQL < 10, but 9 is [EOL](https://www.postgresql.org/about/news/postgresql-132-126-1111-1016-9621-and-9525-released-2165/) anyway.