### PR TITLE
Allow nodemailer SMTP configuration with no authentication

### DIFF
--- a/api/src/services/mailer.ts
+++ b/api/src/services/mailer.ts
@@ -11,15 +11,19 @@ if (env.EMAIL_TRANSPORT === 'sendmail') {
 		path: env.EMAIL_SENDMAIL_PATH || '/usr/sbin/sendmail',
 	});
 } else if (env.EMAIL_TRANSPORT.toLowerCase() === 'smtp') {
+	let auth: boolean | Object = false;
+	if (env.EMAIL_SMTP_USER && env.EMAIL_SMTP_PASSWORD) {
+		auth = {
+			user: env.EMAIL_SMTP_USER,
+			pass: env.EMAIL_SMTP_PASSWORD,
+		}
+	}
 	transporter = nodemailer.createTransport({
 		pool: env.EMAIL_SMTP_POOL,
 		host: env.EMAIL_SMTP_HOST,
 		port: env.EMAIL_SMTP_PORT,
 		secure: env.EMAIL_SMTP_SECURE,
-		auth: {
-			user: env.EMAIL_SMTP_USER,
-			pass: env.EMAIL_SMTP_PASSWORD,
-		},
+		auth: auth,
 	} as any);
 } else {
 	logger.warn('Illegal transport given for email. Check the EMAIL_TRANSPORT env var.');

--- a/api/src/services/mailer.ts
+++ b/api/src/services/mailer.ts
@@ -11,20 +11,22 @@ if (env.EMAIL_TRANSPORT === 'sendmail') {
 		path: env.EMAIL_SENDMAIL_PATH || '/usr/sbin/sendmail',
 	});
 } else if (env.EMAIL_TRANSPORT.toLowerCase() === 'smtp') {
-	let auth: boolean | Object = false;
-	if (env.EMAIL_SMTP_USER && env.EMAIL_SMTP_PASSWORD) {
+	let auth: boolean | { user?: string; pass?: string } = false;
+
+	if (env.EMAIL_SMTP_USER || env.EMAIL_SMTP_PASSWORD) {
 		auth = {
 			user: env.EMAIL_SMTP_USER,
 			pass: env.EMAIL_SMTP_PASSWORD,
-		}
+		};
 	}
+
 	transporter = nodemailer.createTransport({
 		pool: env.EMAIL_SMTP_POOL,
 		host: env.EMAIL_SMTP_HOST,
 		port: env.EMAIL_SMTP_PORT,
 		secure: env.EMAIL_SMTP_SECURE,
 		auth: auth,
-	} as any);
+	} as Record<string, unknown>);
 } else {
 	logger.warn('Illegal transport given for email. Check the EMAIL_TRANSPORT env var.');
 }


### PR DESCRIPTION
Fixes: https://github.com/directus/directus/issues/5652

This allows the use of tools like MailHog with SMTP to be used during development to test emails.