### PR TITLE
fix occasional typeerror in payload service

### DIFF
--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -376,10 +376,10 @@ export class PayloadService {
 			});
 
 			const relatedRecord: Partial<Item> = payload[relation.many_field];
-			const hasPrimaryKey = relation.one_primary in relatedRecord;
 
 			if (['string', 'number'].includes(typeof relatedRecord)) continue;
 
+			const hasPrimaryKey = relation.one_primary in relatedRecord;
 			let relatedPrimaryKey: PrimaryKey = relatedRecord[relation.one_primary];
 
 			const exists =


### PR DESCRIPTION
Not entirely sure why this is onyl triggered sometimes, but even logic wise this seemed odd, you clearly expect relatedRecord sometimes to be a string or number, so in should only be used after those cases have been skipped.

this surfaced to a user like this on save in the "seite" collection:
```
PATCH https://my.directus.tld/app/mydirectus/items/seite/44 
{"absatz":[145,{"absatz_id":{"name":"Bühne HVK (Krems 10.015)","elemente":[{"collection":"bildelement","item":{"global":false,"imagemobile":"c7faca22-7f3c-41ba-b09b-da543cb8ea89","imagetablet":"c7faca22-7f3c-41ba-b09b-da543cb8ea89","imagedesktop":"979349bd-648a-4346-85f2-14164e3fbb8c"}}]}}]}

{"errors":[{"message":"Cannot use 'in' operator to search for 'id' in 138","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}
```

![image](https://user-images.githubusercontent.com/2185527/118833165-88e77080-b8c1-11eb-952b-88aaff7f0f2a.png)
