### PR TITLE
Fixed double root on storage.get

### DIFF
--- a/packages/drive-azure/src/AzureBlobWebServices.ts
+++ b/packages/drive-azure/src/AzureBlobWebServices.ts
@@ -101,8 +101,6 @@ export class AzureBlobWebServicesStorage extends Storage {
 	}
 
 	public async get(location: string, encoding: BufferEncoding = 'utf-8'): Promise<ContentResponse<string>> {
-		location = this._fullPath(location);
-
 		try {
 			const bufferResult = await this.getBuffer(location);
 			return {

--- a/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
@@ -129,8 +129,6 @@ export class AmazonWebServicesS3Storage extends Storage {
 	 * Returns the file contents.
 	 */
 	public async get(location: string, encoding: BufferEncoding = 'utf-8'): Promise<ContentResponse<string>> {
-		location = this._fullPath(location);
-
 		const bufferResult = await this.getBuffer(location);
 
 		return {


### PR DESCRIPTION
The root directory gets set twice for S3 and Azure instances when calling `get`.