### PR TITLE
Update Docker image to execute as a non-root user

### DIFF
--- a/.github/actions/build-images/rootfs/directus/images/main/Dockerfile
+++ b/.github/actions/build-images/rootfs/directus/images/main/Dockerfile
@@ -69,16 +69,19 @@ WORKDIR /directus
 # Global requirements
 RUN npm install -g yargs pino pino-colada
 
+# Copy files
+COPY ./rootfs /
+
+RUN chmod +x /usr/bin/entrypoint && chmod +x /usr/bin/print && \
+    chown node:node /directus
+
 # Install Directus
+USER node
 COPY --from=builder /directus/package.json .
 RUN npm install
 
-# Copy files
-COPY ./rootfs /
 # Keep the updated package.json
 COPY --from=builder /directus/package.json .
-
-RUN chmod +x /usr/bin/entrypoint && chmod +x /usr/bin/print
 
 # Create directories
 RUN \


### PR DESCRIPTION
Just a minor update to Docker image build to allow its container to run as a non-root user following container best practices.