### PR TITLE
Authorization token is null in gatsby plugin

### DIFF
--- a/packages/gatsby-source-directus/gatsby-node.js
+++ b/packages/gatsby-source-directus/gatsby-node.js
@@ -144,7 +144,7 @@ exports.sourceNodes = async (gatsby, options) => {
 		}
 
 		return Object.assign(obj, {
-			Authorization: `Bearer ${directus.auth.token}`,
+			Authorization: `Bearer ${auth?.token}`,
 		});
 	};
 


### PR DESCRIPTION
It creates a 401 unauthorized when trying to use a token :)

Fixes https://github.com/directus/directus/issues/5270