### PR TITLE
Add reference to relational data section to create item API docs

### DIFF
--- a/docs/reference/api/items.md
+++ b/docs/reference/api/items.md
@@ -197,6 +197,13 @@ Supports all [global query parameters](/reference/api/query).
 
 An array of partial [item objects](#the-item-object).
 
+::: tip Nested Data (Relations)
+
+Relational data needs to be correctly nested to add new items successfully. Check out the
+[relational data section](/reference/api/introduction/#relational-data) for more information
+
+:::
+
 ### Returns
 
 Returns the [item objects](#the-item-object) of the item that were created.


### PR DESCRIPTION
This PR adds a reference for easier retrieval of the requirements for sending successful requests containing relational data.

This is based on the discussion I had with @rijkvanzanten on the help channel. 

If there is additional changes required, please let me know and I'll get to work :) 

