### PR TITLE
Changed PORT type from number to string

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -71,7 +71,7 @@ const defaults: Record<string, any> = {
 // Allows us to force certain environment variable into a type, instead of relying
 // on the auto-parsed type in processValues. ref #3705
 const typeMap: Record<string, string> = {
-	PORT: 'number',
+	PORT: 'string',
 
 	DB_NAME: 'string',
 	DB_USER: 'string',


### PR DESCRIPTION
Allows Directus to start when PORT is a named pipe or numbered port. 

Closes https://github.com/directus/directus/issues/5977