### PR TITLE
Pass onUploadProgress function through to the axios request

### DIFF
--- a/packages/sdk/src/base/transport/axios-transport.ts
+++ b/packages/sdk/src/base/transport/axios-transport.ts
@@ -48,6 +48,7 @@ export class AxiosTransport implements ITransport {
 			options.sendAuthorizationHeaders = options.sendAuthorizationHeaders ?? true;
 			options.refreshTokenIfNeeded = options.refreshTokenIfNeeded ?? true;
 			options.headers = options.headers ?? {};
+			options.onUploadProgress = options.onUploadProgress ?? undefined;
 
 			if (options.refreshTokenIfNeeded) {
 				await this._refresh();
@@ -59,6 +60,7 @@ export class AxiosTransport implements ITransport {
 				data: data,
 				params: options.params,
 				headers: options.headers,
+				onUploadProgress: options.onUploadProgress,
 			};
 
 			const token = this._storage.auth_token;

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -24,6 +24,7 @@ export type TransportOptions = {
 	headers?: any;
 	refreshTokenIfNeeded?: boolean;
 	sendAuthorizationHeaders?: boolean;
+	onUploadProgress?: ((progressEvent: any) => void) | undefined;
 };
 
 export interface ITransport {


### PR DESCRIPTION
The AxiosRequest config allows for an onUploadProgress function to be passed in. This is useful, if we want to give users some kind of feedback about the progress of a potential file transfer. Currently, the sdk is only supporting this via direct access to the transport method, hence we are adding this extra param there. 

I actually looked into writing a test for this in the existing framework. However, from what I understood this is all running in a node environment. As progress events are something that only happens in a browser context, I didn't know of a good way of asserting the function assignment happens as expected. 

If someone sees a possibility, I'd be happy to pair up on it or get pointed in the right direction of how to achieve a test for this!

