### PR TITLE
Improve `disabled` state on the file interface

### DIFF
--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -1,17 +1,10 @@
 <template>
 	<div class="file">
-		<v-menu attached :disabled="disabled || loading">
+		<v-menu attached :disabled="loading">
 			<template #activator="{ toggle }">
 				<div>
 					<v-skeleton-loader type="input" v-if="loading" />
-					<v-input
-						v-else
-						@click="toggle"
-						readonly
-						:placeholder="$t('no_file_selected')"
-						:disabled="disabled"
-						:value="file && file.title"
-					>
+					<v-input v-else @click="toggle" readonly :placeholder="$t('no_file_selected')" :value="file && file.title">
 						<template #prepend>
 							<div
 								class="preview"
@@ -30,7 +23,13 @@
 						<template #append>
 							<template v-if="file">
 								<v-icon name="open_in_new" class="edit" v-tooltip="$t('edit')" @click.stop="editDrawerActive = true" />
-								<v-icon class="deselect" name="close" @click.stop="$emit('input', null)" v-tooltip="$t('deselect')" />
+								<v-icon
+									v-if="!disabled"
+									class="deselect"
+									name="close"
+									@click.stop="$emit('input', null)"
+									v-tooltip="$t('deselect')"
+								/>
 							</template>
 							<v-icon v-else name="attach_file" />
 						</template>
@@ -45,33 +44,35 @@
 						<v-list-item-content>{{ $t('download_file') }}</v-list-item-content>
 					</v-list-item>
 
-					<v-divider />
+					<v-divider v-if="!disabled" />
 				</template>
-				<v-list-item @click="activeDialog = 'upload'">
-					<v-list-item-icon><v-icon name="phonelink" /></v-list-item-icon>
-					<v-list-item-content>
-						{{ $t(file ? 'replace_from_device' : 'upload_from_device') }}
-					</v-list-item-content>
-				</v-list-item>
+				<template v-if="!disabled">
+					<v-list-item @click="activeDialog = 'upload'">
+						<v-list-item-icon><v-icon name="phonelink" /></v-list-item-icon>
+						<v-list-item-content>
+							{{ $t(file ? 'replace_from_device' : 'upload_from_device') }}
+						</v-list-item-content>
+					</v-list-item>
 
-				<v-list-item @click="activeDialog = 'choose'">
-					<v-list-item-icon><v-icon name="folder_open" /></v-list-item-icon>
-					<v-list-item-content>
-						{{ $t(file ? 'replace_from_library' : 'choose_from_library') }}
-					</v-list-item-content>
-				</v-list-item>
+					<v-list-item @click="activeDialog = 'choose'">
+						<v-list-item-icon><v-icon name="folder_open" /></v-list-item-icon>
+						<v-list-item-content>
+							{{ $t(file ? 'replace_from_library' : 'choose_from_library') }}
+						</v-list-item-content>
+					</v-list-item>
 
-				<v-list-item @click="activeDialog = 'url'">
-					<v-list-item-icon><v-icon name="link" /></v-list-item-icon>
-					<v-list-item-content>
-						{{ $t(file ? 'replace_from_url' : 'import_from_url') }}
-					</v-list-item-content>
-				</v-list-item>
+					<v-list-item @click="activeDialog = 'url'">
+						<v-list-item-icon><v-icon name="link" /></v-list-item-icon>
+						<v-list-item-content>
+							{{ $t(file ? 'replace_from_url' : 'import_from_url') }}
+						</v-list-item-content>
+					</v-list-item>
+				</template>
 			</v-list>
 		</v-menu>
 
 		<drawer-item
-			v-if="!disabled && file"
+			v-if="file"
 			:active.sync="editDrawerActive"
 			collection="directus_files"
 			:primary-key="file.id"


### PR DESCRIPTION
* See discussion: https://github.com/directus/directus/discussions/5105

* Still allow downloading the file if the file interface is disabled.

* Allow editing the underlying file (as this is possible anyway via the
  files collection), but do not allow disassociating the current file
  or setting another file, which is the actual semantic meaning of
  `disabled` in this context.