### PR TITLE
Fix field update for data types with length or boolean as default value

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -417,13 +417,6 @@ export class FieldsService {
 
 		if (field.schema?.has_auto_increment) {
 			column = table.increments(field.field);
-		} else if (field.schema?.data_type) {
-			// Append length to data type if it's stored in schema
-			const data_type =
-				field.schema?.max_length && field.schema.data_type !== 'longtext'
-					? `${field.schema.data_type}(${field.schema.max_length})`
-					: field.schema.data_type;
-			column = table.specificType(field.field, data_type);
 		} else if (field.type === 'string') {
 			column = table.string(field.field, field.schema?.max_length ?? undefined);
 		} else if (['float', 'decimal'].includes(field.type)) {
@@ -445,10 +438,6 @@ export class FieldsService {
 				['"null"', 'null'].includes(field.schema.default_value.toLowerCase())
 			) {
 				column.defaultTo(null);
-			} else if (typeof field.schema.default_value === 'boolean') {
-				// Convert boolean values to number (required for MySQL)
-				const default_value = field.schema.default_value === true ? 1 : 0;
-				column.defaultTo(default_value);
 			} else {
 				column.defaultTo(field.schema.default_value);
 			}

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -418,7 +418,12 @@ export class FieldsService {
 		if (field.schema?.has_auto_increment) {
 			column = table.increments(field.field);
 		} else if (field.schema?.data_type) {
-			column = table.specificType(field.field, field.schema.data_type);
+			// Append length to data type if it's stored in schema
+			const data_type =
+				field.schema?.max_length && field.schema.data_type !== 'longtext'
+					? `${field.schema.data_type}(${field.schema.max_length})`
+					: field.schema.data_type;
+			column = table.specificType(field.field, data_type);
 		} else if (field.type === 'string') {
 			column = table.string(field.field, field.schema?.max_length ?? undefined);
 		} else if (['float', 'decimal'].includes(field.type)) {
@@ -440,6 +445,10 @@ export class FieldsService {
 				['"null"', 'null'].includes(field.schema.default_value.toLowerCase())
 			) {
 				column.defaultTo(null);
+			} else if (typeof field.schema.default_value === 'boolean') {
+				// Convert boolean values to number (required for MySQL)
+				const default_value = field.schema.default_value === true ? 1 : 0;
+				column.defaultTo(default_value);
 			} else {
 				column.defaultTo(field.schema.default_value);
 			}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
-dist
+dist/
+index.json


### PR DESCRIPTION
Fixes #6130 

Tested with most field types in MySQL, PostgreSQL and SQLite.
I had to exclude `longtext` (used for JSON in MySQL) from this new behavior as it doesn't support the length property but Directus has it stored in the field schema.