### PR TITLE
Don't initialize mailer on startup

### DIFF
--- a/api/src/mailer.ts
+++ b/api/src/mailer.ts
@@ -2,54 +2,47 @@ import nodemailer, { Transporter } from 'nodemailer';
 import env from './env';
 import logger from './logger';
 
-let transporter: Transporter | null = null;
+let transporter: Transporter;
 
-if (env.EMAIL_TRANSPORT === 'sendmail') {
-	transporter = nodemailer.createTransport({
-		sendmail: true,
-		newline: env.EMAIL_SENDMAIL_NEW_LINE || 'unix',
-		path: env.EMAIL_SENDMAIL_PATH || '/usr/sbin/sendmail',
-	});
-} else if (env.EMAIL_TRANSPORT.toLowerCase() === 'smtp') {
-	let auth: boolean | { user?: string; pass?: string } = false;
+export default function getMailer(): Transporter {
+	if (transporter) return transporter;
 
-	if (env.EMAIL_SMTP_USER || env.EMAIL_SMTP_PASSWORD) {
-		auth = {
-			user: env.EMAIL_SMTP_USER,
-			pass: env.EMAIL_SMTP_PASSWORD,
-		};
+	if (env.EMAIL_TRANSPORT === 'sendmail') {
+		transporter = nodemailer.createTransport({
+			sendmail: true,
+			newline: env.EMAIL_SENDMAIL_NEW_LINE || 'unix',
+			path: env.EMAIL_SENDMAIL_PATH || '/usr/sbin/sendmail',
+		});
+	} else if (env.EMAIL_TRANSPORT.toLowerCase() === 'smtp') {
+		let auth: boolean | { user?: string; pass?: string } = false;
+
+		if (env.EMAIL_SMTP_USER || env.EMAIL_SMTP_PASSWORD) {
+			auth = {
+				user: env.EMAIL_SMTP_USER,
+				pass: env.EMAIL_SMTP_PASSWORD,
+			};
+		}
+
+		transporter = nodemailer.createTransport({
+			pool: env.EMAIL_SMTP_POOL,
+			host: env.EMAIL_SMTP_HOST,
+			port: env.EMAIL_SMTP_PORT,
+			secure: env.EMAIL_SMTP_SECURE,
+			auth: auth,
+		} as Record<string, unknown>);
+	} else if (env.EMAIL_TRANSPORT.toLowerCase() === 'mailgun') {
+		const mg = require('nodemailer-mailgun-transport');
+		transporter = nodemailer.createTransport(
+			mg({
+				auth: {
+					api_key: env.EMAIL_MAILGUN_API_KEY,
+					domain: env.EMAIL_MAILGUN_DOMAIN,
+				},
+			}) as any
+		);
+	} else {
+		logger.warn('Illegal transport given for email. Check the EMAIL_TRANSPORT env var.');
 	}
 
-	transporter = nodemailer.createTransport({
-		pool: env.EMAIL_SMTP_POOL,
-		host: env.EMAIL_SMTP_HOST,
-		port: env.EMAIL_SMTP_PORT,
-		secure: env.EMAIL_SMTP_SECURE,
-		auth: auth,
-	} as Record<string, unknown>);
-} else if (env.EMAIL_TRANSPORT.toLowerCase() === 'mailgun') {
-	const mg = require('nodemailer-mailgun-transport');
-	transporter = nodemailer.createTransport(
-		mg({
-			auth: {
-				api_key: env.EMAIL_MAILGUN_API_KEY,
-				domain: env.EMAIL_MAILGUN_DOMAIN,
-			},
-		}) as any
-	);
-} else {
-	logger.warn('Illegal transport given for email. Check the EMAIL_TRANSPORT env var.');
+	return transporter;
 }
-
-if (transporter) {
-	transporter.verify((error) => {
-		if (error) {
-			logger.warn(`Couldn't connect to email server.`);
-			logger.warn(`Email verification error: ${error}`);
-		} else {
-			logger.info(`Email connection established`);
-		}
-	});
-}
-
-export default transporter;

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -14,7 +14,7 @@ import { rateLimiter } from '../middleware/rate-limiter';
 import storage from '../storage';
 import { AbstractServiceOptions, Accountability, SchemaOverview } from '../types';
 import { toArray } from '../utils/to-array';
-import mailer from '../mailer';
+import getMailer from '../mailer';
 import { SettingsService } from './settings';
 
 export class ServerService {
@@ -316,8 +316,10 @@ export class ServerService {
 				],
 			};
 
+			const mailer = getMailer();
+
 			try {
-				await mailer?.verify();
+				await mailer.verify();
 			} catch (err) {
 				checks['email:connection'][0].status = 'error';
 				checks['email:connection'][0].output = err;

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
@@ -3,7 +3,7 @@
 		<div class="grid">
 			<div class="field">
 				<div class="type-label">{{ t('this_collection') }}</div>
-				<v-input disabled :value="relations[0].related_collection" />
+				<v-input disabled :model-value="relations[0].related_collection" />
 			</div>
 			<div class="field">
 				<div class="type-label">{{ t('junction_collection') }}</div>
@@ -126,7 +126,7 @@
 					</template>
 				</v-input>
 			</div>
-			<v-input disabled :value="currentPrimaryKeyField" />
+			<v-input disabled :model-value="currentPrimaryKeyField" />
 			<v-input
 				:class="{ matches: junctionFieldExists(relations[0].field) }"
 				v-model="relations[0].field"


### PR DESCRIPTION
Makes sure we don't have any side effects on file imports, another important step to serverless :)

Verify call is moved to instances where the mailer is about to be used.
