### PR TITLE
Use SEARCH instead of GET to fetch filtered data in frontend

### DIFF
--- a/app/src/composables/use-items/use-items.ts
+++ b/app/src/composables/use-items/use-items.ts
@@ -181,14 +181,18 @@ export function useItems(collection: Ref<string | null>, query: Query, fetchOnIn
 		fieldsToFetch = fieldsToFetch.filter((field) => field.startsWith('$') === false);
 
 		try {
-			const response = await api.get(endpoint.value, {
-				params: {
-					limit: limit.value,
-					fields: fieldsToFetch,
-					sort: sort.value,
-					page: page.value,
-					search: searchQuery.value,
-					...filtersToQuery(filters.value),
+			const response = await api.request({
+				url: endpoint.value,
+				method: 'search',
+				data: {
+					query: {
+						limit: limit.value,
+						fields: fieldsToFetch,
+						sort: sort.value,
+						page: page.value,
+						search: searchQuery.value,
+						...filtersToQuery(filters.value),
+					},
 				},
 			});
 
@@ -231,13 +235,17 @@ export function useItems(collection: Ref<string | null>, query: Query, fetchOnIn
 	async function getItemCount() {
 		if (!primaryKeyField.value || !endpoint.value) return;
 
-		const response = await api.get(endpoint.value, {
-			params: {
-				limit: 0,
-				fields: primaryKeyField.value.field,
-				meta: ['filter_count', 'total_count'],
-				search: searchQuery.value,
-				...filtersToQuery(filters.value),
+		const response = await api.request({
+			url: endpoint.value,
+			method: 'search',
+			data: {
+				query: {
+					limit: 0,
+					fields: primaryKeyField.value.field,
+					meta: ['filter_count', 'total_count'],
+					search: searchQuery.value,
+					...filtersToQuery(filters.value),
+				},
 			},
 		});
 

--- a/app/src/interfaces/list-m2m/use-preview.ts
+++ b/app/src/interfaces/list-m2m/use-preview.ts
@@ -195,12 +195,21 @@ export default function usePreview(
 
 		const fieldsToFetch = addRelatedPrimaryKeyToFields(collection, fields);
 
-		const response = await api.get(endpoint, {
-			params: {
-				fields: fieldsToFetch,
-				[`filter[${filteredField}][_in]`]: primaryKeys.join(','),
+		const response = await api.request({
+			url: endpoint,
+			method: 'search',
+			data: {
+				query: {
+					fields: fieldsToFetch,
+					filter: {
+						[filteredField]: {
+							_in: primaryKeys,
+						},
+					},
+				},
 			},
 		});
+
 		return response?.data.data as Record<string, any>[];
 	}
 

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -302,12 +302,16 @@ export default defineComponent({
 					}
 				}
 
-				const response = await api.get(`/items/${props.collection}`, {
-					params: {
-						fields: [...fields, ...result],
-						filter: {
-							[primaryKeyField.value.field]: {
-								_in: selection,
+				const response = await api.request({
+					url: `/items/${props.collection}`,
+					method: 'search',
+					data: {
+						query: {
+							fields: [...fields, ...result],
+							filter: {
+								[primaryKeyField.value.field]: {
+									_in: selection,
+								},
 							},
 						},
 					},

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -322,10 +322,18 @@ export default defineComponent({
 						let existingItems: any[] = [];
 
 						if (primaryKeys && primaryKeys.length > 0) {
-							const response = await api.get(endpoint, {
-								params: {
-									fields: fieldsToFetch,
-									[`filter[${pkField}][_in]`]: primaryKeys.join(','),
+							const response = await api.request({
+								url: endpoint,
+								method: 'search',
+								data: {
+									query: {
+										fields: fieldsToFetch,
+										filter: {
+											[pkField]: {
+												_in: primaryKeys,
+											},
+										},
+									},
 								},
 							});
 

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -285,12 +285,16 @@ export default defineComponent({
 				loading.value = true;
 
 				try {
-					const response = await api.get(`/items/${collection}`, {
-						params: {
-							fields,
-							filter: {
-								[translationsPrimaryKeyField.value]: {
-									_in: existingPrimaryKeys.value,
+					const response = await api.request({
+						url: `/items/${collection}`,
+						method: 'search',
+						data: {
+							query: {
+								fields,
+								filter: {
+									[translationsPrimaryKeyField.value]: {
+										_in: existingPrimaryKeys.value,
+									},
 								},
 							},
 						},
@@ -389,12 +393,16 @@ export default defineComponent({
 						fields.push(languagesRelation.value.field);
 					}
 
-					const existing = await api.get(`/items/${translationsCollection.value}`, {
-						params: {
-							fields,
-							filter: {
-								[translationsRelation.value.field]: {
-									_eq: props.primaryKey,
+					const existing = await api.request({
+						url: `/items/${translationsCollection.value}`,
+						method: 'search',
+						data: {
+							query: {
+								fields,
+								filter: {
+									[translationsRelation.value.field]: {
+										_eq: props.primaryKey,
+									},
 								},
 							},
 						},


### PR DESCRIPTION
Closes #5540

Tested on Firefox, works like a charm.

Note: There is an open pull request from @rijkvanzanten for axios to accept method 'search' (string to be exact), however it is already working (just a TS warning) - see https://github.com/axios/axios/pull/3802