### PR TITLE
Added support for nodemailer ignoreTLS option

### DIFF
--- a/api/example.env
+++ b/api/example.env
@@ -143,6 +143,7 @@ EMAIL_SENDMAIL_PATH="/usr/sbin/sendmail"
 # EMAIL_SMTP_HOST="localhost"
 # EMAIL_SMTP_PORT=465
 # EMAIL_SMTP_SECURE=false # Use TLS
+# EMAIL_SMTP_IGNORE_TLS=false
 # EMAIL_SMTP_USER="username"
 # EMAIL_SMTP_PASSWORD="password"
 

--- a/api/src/mailer.ts
+++ b/api/src/mailer.ts
@@ -28,6 +28,7 @@ export default function getMailer(): Transporter {
 			host: env.EMAIL_SMTP_HOST,
 			port: env.EMAIL_SMTP_PORT,
 			secure: env.EMAIL_SMTP_SECURE,
+			ignoreTLS: env.EMAIL_SMTP_IGNORE_TLS,
 			auth: auth,
 		} as Record<string, unknown>);
 	} else if (env.EMAIL_TRANSPORT.toLowerCase() === 'mailgun') {

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -318,7 +318,7 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 | `EMAIL_SMTP_PASSWORD`   | SMTP Password    | --            |
 | `EMAIL_SMTP_POOL`       | Use SMTP pooling | --            |
 | `EMAIL_SMTP_SECURE`     | Enable TLS       | --            |
-| `EMAIL_SMTP_IGNORE_TLS` | Ignore TLS       | false         |
+| `EMAIL_SMTP_IGNORE_TLS` | Ignore TLS       | --            |
 
 ### Mailgun (`mailgun`)
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -310,14 +310,15 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 
 ### SMTP (`smtp`)
 
-| Variable              | Description      | Default Value |
-| --------------------- | ---------------- | ------------- |
-| `EMAIL_SMTP_HOST`     | SMTP Host        | --            |
-| `EMAIL_SMTP_PORT`     | SMTP Port        | --            |
-| `EMAIL_SMTP_USER`     | SMTP User        | --            |
-| `EMAIL_SMTP_PASSWORD` | SMTP Password    | --            |
-| `EMAIL_SMTP_POOL`     | Use SMTP pooling | --            |
-| `EMAIL_SMTP_SECURE`   | Enable TLS       | --            |
+| Variable                | Description      | Default Value |
+| ----------------------- | ---------------- | ------------- |
+| `EMAIL_SMTP_HOST`       | SMTP Host        | --            |
+| `EMAIL_SMTP_PORT`       | SMTP Port        | --            |
+| `EMAIL_SMTP_USER`       | SMTP User        | --            |
+| `EMAIL_SMTP_PASSWORD`   | SMTP Password    | --            |
+| `EMAIL_SMTP_POOL`       | Use SMTP pooling | --            |
+| `EMAIL_SMTP_SECURE`     | Enable TLS       | --            |
+| `EMAIL_SMTP_IGNORE_TLS` | Ignore TLS       | false         |
 
 ### Mailgun (`mailgun`)
 


### PR DESCRIPTION
The directus environment doesn't allow for the `ignoreTLS` option in nodemailer. Setting `secure` to `false`  will cause nodemailer to not use TLS _unless_ the mail server supports the `STARTTLS` extension. In order to avoid using TLS entirely, it's necessary to set both `secure` to `false`, and `ignoreTLS` to `true`.

See [TLS options](https://nodemailer.com/smtp/#tls-options) section of the nodemailer docs for reference. 