### PR TITLE
Fixed migrations for fresh Oracle install

### DIFF
--- a/api/src/database/migrations/20201105B-change-webhook-url-type.ts
+++ b/api/src/database/migrations/20201105B-change-webhook-url-type.ts
@@ -1,4 +1,6 @@
 import { Knex } from 'knex';
+// @ts-ignore
+import Client_Oracledb from 'knex/lib/dialects/oracledb';
 import env from '../../env';
 
 async function oracleAlterUrl(knex: Knex, type: string): Promise<void> {
@@ -10,7 +12,7 @@ async function oracleAlterUrl(knex: Knex, type: string): Promise<void> {
 }
 
 export async function up(knex: Knex): Promise<void> {
-	if (env.DB_CLIENT === 'oracledb') {
+	if (knex.client instanceof Client_Oracledb) {
 		await oracleAlterUrl(knex, 'CLOB');
 		return;
 	}

--- a/api/src/database/migrations/20210312A-webhooks-collections-text.ts
+++ b/api/src/database/migrations/20210312A-webhooks-collections-text.ts
@@ -1,4 +1,6 @@
 import { Knex } from 'knex';
+// @ts-ignore
+import Client_Oracledb from 'knex/lib/dialects/oracledb';
 import env from '../../env';
 
 async function oracleAlterCollections(knex: Knex, type: string): Promise<void> {
@@ -10,7 +12,7 @@ async function oracleAlterCollections(knex: Knex, type: string): Promise<void> {
 }
 
 export async function up(knex: Knex): Promise<void> {
-	if (env.DB_CLIENT === 'oracledb') {
+	if (knex.client instanceof Client_Oracledb) {
 		await oracleAlterCollections(knex, 'CLOB');
 		return;
 	}


### PR DESCRIPTION
Now the migrations should work even when .env isn't defined, such as during first time setup.