### PR TITLE
Temporarily remove process env usage in docs

### DIFF
--- a/docs/guides/displays.md
+++ b/docs/guides/displays.md
@@ -121,7 +121,6 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		replace({
-			'process.env.NODE_ENV': JSON.stringify('production'),
 			preventAssignment: true,
 		}),
 		terser(),

--- a/docs/guides/interfaces.md
+++ b/docs/guides/interfaces.md
@@ -112,7 +112,6 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		replace({
-			'process.env.NODE_ENV': JSON.stringify('production'),
 			preventAssignment: true,
 		}),
 		terser(),

--- a/docs/guides/layouts.md
+++ b/docs/guides/layouts.md
@@ -154,7 +154,6 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		replace({
-			'process.env.NODE_ENV': JSON.stringify('production'),
 			preventAssignment: true,
 		}),
 		terser(),

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -154,7 +154,6 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		replace({
-			'process.env.NODE_ENV': JSON.stringify('production'),
 			preventAssignment: true,
 		}),
 		terser(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11699,7 +11699,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -11733,7 +11733,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": ">=0.8"
 			}
@@ -11998,7 +11998,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -12007,7 +12007,7 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/axe-core": {
 			"version": "4.2.2",
@@ -12611,7 +12611,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -12733,6 +12733,7 @@
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"inherits": "~2.0.0"
@@ -13620,7 +13621,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/ccount": {
 			"version": "1.1.0",
@@ -16260,7 +16261,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"assert-plus": "^1.0.0"
 			},
@@ -17333,7 +17334,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -19566,7 +19567,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"devOptional": true,
+			"dev": true,
 			"engines": [
 				"node >=0.6.0"
 			]
@@ -20070,7 +20071,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -20557,6 +20558,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
 			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
@@ -20572,6 +20574,7 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -23899,7 +23902,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"assert-plus": "^1.0.0"
 			}
@@ -25070,7 +25073,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -25080,7 +25083,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
 			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"deprecated": "this library is no longer supported",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
@@ -25741,7 +25744,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -27095,7 +27098,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -29397,7 +29400,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/jsdom": {
 			"version": "16.6.0",
@@ -29538,7 +29541,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -29709,7 +29712,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"devOptional": true,
+			"dev": true,
 			"engines": [
 				"node >=0.6.0"
 			],
@@ -29776,6 +29779,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
 			"integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
+			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -36677,7 +36681,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/pg": {
 			"version": "8.6.0",
@@ -40356,7 +40360,7 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -40416,7 +40420,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -40430,7 +40434,7 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -40439,7 +40443,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -42260,6 +42264,7 @@
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"fstream": "^1.0.0",
@@ -42286,6 +42291,7 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"abbrev": "1"
@@ -42298,6 +42304,7 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -42310,6 +42317,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+			"dev": true,
 			"optional": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -42319,6 +42327,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
 			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"block-stream": "*",
@@ -42330,6 +42339,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -42377,7 +42387,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"devOptional": true,
+			"dev": true,
 			"dependencies": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -46323,7 +46333,7 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/type": {
 			"version": "1.2.0",
@@ -47327,7 +47337,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"devOptional": true,
+			"dev": true,
 			"engines": [
 				"node >=0.6.0"
 			],
@@ -64040,6 +64050,7 @@
 			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
 			"integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
 			"requires": {
+				"@oclif/config": "^1.15.1",
 				"@oclif/errors": "^1.3.3",
 				"@oclif/parser": "^3.8.3",
 				"@oclif/plugin-help": "^3",
@@ -65979,6 +65990,7 @@
 			"integrity": "sha512-pM7CR3yXB6L8Gfn6EmX7FLNE3+V/15I3o33GkSNsWvgsMp6HVGXKkXgojrcfUUauyL1LZOdvTmu4enU2RePGHw==",
 			"dev": true,
 			"requires": {
+				"@babel/core": "^7.11.0",
 				"@babel/helper-compilation-targets": "^7.9.6",
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -65991,6 +66003,7 @@
 				"@vue/babel-plugin-jsx": "^1.0.3",
 				"@vue/babel-preset-jsx": "^1.2.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3",
+				"core-js": "^3.6.5",
 				"core-js-compat": "^3.6.5",
 				"semver": "^6.1.0"
 			},
@@ -68368,7 +68381,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -68419,7 +68432,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"devOptional": true
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -68633,13 +68646,13 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"devOptional": true
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-			"devOptional": true
+			"dev": true
 		},
 		"axe-core": {
 			"version": "4.2.2",
@@ -69100,7 +69113,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -69203,6 +69216,7 @@
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"inherits": "~2.0.0"
@@ -69920,7 +69934,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"devOptional": true
+			"dev": true
 		},
 		"ccount": {
 			"version": "1.1.0",
@@ -72144,7 +72158,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -73316,7 +73330,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -75042,7 +75056,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"devOptional": true
+			"dev": true
 		},
 		"fast-copy": {
 			"version": "2.1.1",
@@ -75449,7 +75463,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"devOptional": true
+			"dev": true
 		},
 		"fork-ts-checker-webpack-plugin": {
 			"version": "3.1.1",
@@ -75836,6 +75850,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
 			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -75848,6 +75863,7 @@
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -78420,7 +78436,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -79320,13 +79336,13 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"devOptional": true
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
 			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
@@ -79857,7 +79873,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -80825,7 +80841,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"devOptional": true
+			"dev": true
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -82573,7 +82589,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"devOptional": true
+			"dev": true
 		},
 		"jsdom": {
 			"version": "16.6.0",
@@ -82686,7 +82702,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"devOptional": true
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -82820,7 +82836,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -82878,6 +82894,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
 			"integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"node-addon-api": "^3.0.0",
@@ -88402,7 +88419,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"devOptional": true
+			"dev": true
 		},
 		"pg": {
 			"version": "8.6.0",
@@ -91396,7 +91413,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -91424,7 +91441,7 @@
 					"version": "2.3.3",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-					"devOptional": true,
+					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.6",
@@ -91435,13 +91452,13 @@
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"devOptional": true
+					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"devOptional": true,
+					"dev": true,
 					"requires": {
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
@@ -92946,6 +92963,7 @@
 					"version": "3.8.0",
 					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 					"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "^1.0.0",
@@ -92966,6 +92984,7 @@
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1"
@@ -92975,6 +92994,7 @@
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -92984,12 +93004,14 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
 					"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"block-stream": "*",
@@ -93001,6 +93023,7 @@
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -93038,7 +93061,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -96138,7 +96161,7 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"devOptional": true
+			"dev": true
 		},
 		"type": {
 			"version": "1.2.0",
@@ -96931,7 +96954,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",


### PR DESCRIPTION
@nickrum The usage of process.env (for whatever reason) made the build of the app fail:

```
[rollup-plugin-dynamic-import-variables] Unexpected token (1:3395)
file: /home/runner/work/directus/directus/docs/guides/displays.md?raw:1:3395
error during build:
SyntaxError: Unexpected token (1:3395)
    at Parser.pp$4.raise (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:16749:13)
    at Parser.pp.unexpected (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:14259:8)
    at Parser.pp.semicolon (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:14236:64)
    at Parser.pp$1.parseExport (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:15148:12)
    at Parser.pp$1.parseStatement (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:14433:72)
    at Parser.pp$1.parseTopLevel (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:14316:21)
    at Parser.parse (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:14108:15)
    at Function.parse (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:14139:35)
    at Graph.contextParse (/home/runner/work/directus/directus/node_modules/rollup/dist/shared/rollup.js:20084:38)
    at Object.transform (/home/runner/work/directus/directus/node_modules/vite/dist/node/chunks/dep-bc228bbb.js:31970:27)
``` 

I believe Vite/rollup might be parsing the JS inside the doc blocks and replacing the `process.env.NODE_ENV` usage, causing invalid JS?