### PR TITLE
Add support for `read` hooks on `items`

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -309,7 +309,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			collection: this.collection,
 			item: key,
 			action: 'read',
-			payload: query,
+			payload: results,
 			schema: this.schema,
 			database: getDatabase(),
 		});
@@ -347,7 +347,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			collection: this.collection,
 			item: keys,
 			action: 'read',
-			payload: query,
+			payload: results,
 			schema: this.schema,
 			database: getDatabase(),
 		});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -303,6 +303,17 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			throw new ForbiddenException();
 		}
 
+		emitAsyncSafe(`${this.eventScope}.read`, {
+			event: `${this.eventScope}.read`,
+			accountability: this.accountability,
+			collection: this.collection,
+			item: key,
+			action: 'read',
+			payload: query,
+			schema: this.schema,
+			database: getDatabase(),
+		});
+
 		return results[0];
 	}
 
@@ -329,6 +340,18 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		};
 
 		const results = await this.readByQuery(queryWithKeys, opts);
+
+		emitAsyncSafe(`${this.eventScope}.read`, {
+			event: `${this.eventScope}.read`,
+			accountability: this.accountability,
+			collection: this.collection,
+			item: keys,
+			action: 'read',
+			payload: query,
+			schema: this.schema,
+			database: getDatabase(),
+		});
+
 		return results;
 	}
 

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -85,7 +85,7 @@ module.exports = function registerHook({ exceptions }) {
 | `error`                         |                                                             | No               |
 | `auth`                          | `login`, `logout`<sup>[1]</sup> and `refresh`<sup>[1]</sup> | Optional         |
 | `oauth.:provider`<sup>[2]</sup> | `login` and `redirect`                                      | Optional         |
-| `items`                         | `create`, `update` and `delete`                             | Optional         |
+| `items`                         | `read`<sup>[3]</sup>, `create`, `update` and `delete`       | Optional         |
 | `activity`                      | `create`, `update` and `delete`                             | Optional         |
 | `collections`                   | `create`, `update` and `delete`                             | Optional         |
 | `fields`                        | `create`, `update` and `delete`                             | Optional         |
@@ -114,7 +114,7 @@ on day-of-month 1) or `cron(5 4 * * sun)` (at 04:05 on Sunday). See example belo
 module.exports = function registerHook() {
 	return {
 		'cron(*/15 * * * *)': async function () {
-			await axios.post('http://example.com/webhook', { message: "Another 15 minutes passed..." });
+			await axios.post('http://example.com/webhook', { message: 'Another 15 minutes passed...' });
 		},
 	};
 };
@@ -135,6 +135,9 @@ module.exports = function registerHook() {
 ```
 
 ## 4. Develop your Custom Hook
+
+> Hooks can impact performance when not carefully implemented. This is especially true for `before` hooks (as these are
+> blocking) and hooks on `read` actions, as a single request can result in a large ammount of database reads.
 
 ### Register Function
 


### PR DESCRIPTION
As discussed in #3736, this PR adds an event emitter on a `read` action of items. A `before` event has not been added, due to the greatly increased performance implications of such a hook.

**Use case**
As @jocstech mentioned in #3736, a possible use case is incrementing a `view` field on blog posts, for example. This would be even better in combination with #3147.

The documentation has been updated accordingly, with the addition of a warning about the performance implications of hooks, especially this one, as this was the main argument brought forwards against `read` hooks.