### PR TITLE
Use existing file extension as default

### DIFF
--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -47,7 +47,7 @@ export class FilesService extends ItemsService {
 			primaryKey = await this.createOne(payload, { emitEvents: false });
 		}
 
-		const fileExtension = (payload.type && extension(payload.type)) || path.extname(payload.filename_download);
+		const fileExtension = path.extname(payload.filename_download) || (payload.type && extension(payload.type));
 
 		payload.filename_disk = primaryKey + '.' + fileExtension;
 


### PR DESCRIPTION
When uploading a new file, the extension of the saved name on disk would be determined based on the mime type. This could cause some issues with types that later changed to a different extension (like `.gt` -> `.mov`). 

This reverses that logic, so it will default to whatever the extension was of the uploaded file