### PR TITLE
Use `no-store` instead of `no-cache` for skipping the cache

### DIFF
--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -10,7 +10,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 	if (env.CACHE_ENABLED !== true) return next();
 	if (!cache) return next();
 
-	if (req.headers['cache-control']?.includes('no-cache') || req.headers['Cache-Control']?.includes('no-cache')) {
+	if (req.headers['cache-control']?.includes('no-store') || req.headers['Cache-Control']?.includes('no-store')) {
 		return next();
 	}
 

--- a/api/src/utils/get-cache-headers.ts
+++ b/api/src/utils/get-cache-headers.ts
@@ -15,10 +15,10 @@ export function getCacheControlHeader(req: Request, ttl: number | null): string 
 	if (env.CACHE_AUTO_PURGE === true) return 'no-cache';
 
 	const noCacheRequested =
-		req.headers['cache-control']?.includes('no-cache') || req.headers['Cache-Control']?.includes('no-cache');
+		req.headers['cache-control']?.includes('no-store') || req.headers['Cache-Control']?.includes('no-store');
 
 	// When the user explicitly asked to skip the cache
-	if (noCacheRequested) return 'no-cache';
+	if (noCacheRequested) return 'no-store';
 
 	// Cache control header uses seconds for everything
 	const ttlSeconds = Math.round(ttl / 1000);


### PR DESCRIPTION
⚠️ If you were using `no-cache` before to skip the cache, make sure to update it to `no-store`

---

Closes https://github.com/directus/directus/issues/6354