### PR TITLE
Update admin to use `no-store`

### DIFF
--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -8,7 +8,7 @@ const api = axios.create({
 	baseURL: getRootPath(),
 	withCredentials: true,
 	headers: {
-		'Cache-Control': 'no-cache',
+		'Cache-Control': 'no-store',
 	},
 });
 


### PR DESCRIPTION
Directus was updated to use `no-store` to skip caching with #6355, but the admin wasn't updated to reflect this. This meant that changes would not show in the UI due to using a cached value 

fixes #6420.