### PR TITLE
Pass on errors thrown in MailService

### DIFF
--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -67,12 +67,7 @@ export class MailService {
 			html = prettier.format(html as string, { parser: 'html', printWidth: 70, tabWidth: 0 });
 		}
 
-		try {
-			await this.mailer.sendMail({ ...emailOptions, from, html });
-		} catch (error) {
-			logger.warn('[Email] Unexpected error while sending an email:');
-			logger.warn(error);
-		}
+		await this.mailer.sendMail({ ...emailOptions, from, html });
 	}
 
 	private async renderTemplate(template: string, variables: Record<string, any>) {


### PR DESCRIPTION
As discussed in #6537, I am opening this PR to make MailService throw errors when something occurs at the "send" method (so we can catch it in the caller to ensure mail was really sent).