### PR TITLE
Add directus-extension CLI to extension-sdk

### DIFF
--- a/api/cli.js
+++ b/api/cli.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-return require('./dist/cli/index.js');
+require('./dist/cli/index.js');

--- a/docs/guides/displays.md
+++ b/docs/guides/displays.md
@@ -86,7 +86,7 @@ export default {
 };
 ```
 
-## 2. Install Dependencies and Configure the Buildchain
+## 2. Install Dependencies
 
 Set up a package.json file by running:
 
@@ -95,37 +95,13 @@ npm init -y
 ```
 
 To be read by the Admin App, your custom display's Vue component must first be bundled into a single `index.js` file. We
-recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
+recommend bundling your code using the directus-extension CLI from our `@directus/extension-sdk` package. The CLI
+internally uses a Rollup configuration tailored specifically to bundling Directus extensions. To install the Extension
+SDK, run this command:
 
 ```bash
-npm i -D rollup @rollup/plugin-node-resolve @rollup/plugin-commonjs rollup-plugin-terser rollup-plugin-vue @vue/compiler-sfc
+npm i -D @directus/extension-sdk
 ```
-
-You can then use the following Rollup configuration within `rollup.config.js`:
-
-```js
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
-import vue from 'rollup-plugin-vue';
-
-export default {
-	input: 'src/index.js',
-	output: {
-		format: 'es',
-		file: 'dist/index.js',
-	},
-	external: ['vue', '@directus/extension-sdk'],
-	plugins: [vue(), nodeResolve(), commonjs(), terser()],
-};
-```
-
-::: tip Building multiple extensions
-
-You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
-See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
-
-:::
 
 ## 3. Develop Your Custom Display
 
@@ -136,7 +112,7 @@ The display itself is simply a function or a Vue component, providing a blank ca
 To build the display for use within Directus, run:
 
 ```bash
-npx rollup -c
+npx directus-extension build
 ```
 
 Finally, move the output from your display's `dist` folder into your project's `/extensions/displays/my-custom-display`

--- a/docs/guides/interfaces.md
+++ b/docs/guides/interfaces.md
@@ -77,7 +77,7 @@ export default {
 - `field` — The key of the field.
 - `primaryKey` — The current item's primary key.
 
-## 2. Install Dependencies and Configure the Buildchain
+## 2. Install Dependencies
 
 Set up a package.json file by running:
 
@@ -86,37 +86,13 @@ npm init -y
 ```
 
 To be read by the Admin App, your custom interface's Vue component must first be bundled into a single `index.js` file.
-We recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
+We recommend bundling your code using the directus-extension CLI from our `@directus/extension-sdk` package. The CLI
+internally uses a Rollup configuration tailored specifically to bundling Directus extensions. To install the Extension
+SDK, run this command:
 
 ```bash
-npm i -D rollup @rollup/plugin-node-resolve @rollup/plugin-commonjs rollup-plugin-terser rollup-plugin-vue @vue/compiler-sfc
+npm i -D @directus/extension-sdk
 ```
-
-You can then use the following Rollup configuration within `rollup.config.js`:
-
-```js
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
-import vue from 'rollup-plugin-vue';
-
-export default {
-	input: 'src/index.js',
-	output: {
-		format: 'es',
-		file: 'dist/index.js',
-	},
-	external: ['vue', '@directus/extension-sdk'],
-	plugins: [vue(), nodeResolve(), commonjs(), terser()],
-};
-```
-
-::: tip Building multiple extensions
-
-You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
-See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
-
-:::
 
 ## 3. Develop your Custom Interface
 
@@ -127,7 +103,7 @@ The interface itself is simply a Vue component, which provides an blank canvas f
 To build the interface for use within Directus, run:
 
 ```bash
-npx rollup -c
+npx directus-extension build
 ```
 
 Finally, move the output from your interface's `dist` folder into your project's

--- a/docs/guides/layouts.md
+++ b/docs/guides/layouts.md
@@ -82,7 +82,7 @@ The props you can use in an layout are:
 - `filters` (sync) - The user's currently active filters.
 - `search-query` (sync) - The user's current search query.
 
-## 2. Install Dependencies and Configure the Buildchain
+## 2. Install Dependencies
 
 Set up a package.json file by running:
 
@@ -91,37 +91,13 @@ npm init -y
 ```
 
 To be read by the Admin App, your custom layouts's Vue component must first be bundled into a single `index.js` file. We
-recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
+recommend bundling your code using the directus-extension CLI from our `@directus/extension-sdk` package. The CLI
+internally uses a Rollup configuration tailored specifically to bundling Directus extensions. To install the Extension
+SDK, run this command:
 
 ```bash
-npm i -D rollup @rollup/plugin-node-resolve @rollup/plugin-commonjs rollup-plugin-terser rollup-plugin-vue @vue/compiler-sfc
+npm i -D @directus/extension-sdk
 ```
-
-You can then use the following Rollup configuration within `rollup.config.js`:
-
-```js
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
-import vue from 'rollup-plugin-vue';
-
-export default {
-	input: 'src/index.js',
-	output: {
-		format: 'es',
-		file: 'dist/index.js',
-	},
-	external: ['vue', '@directus/extension-sdk'],
-	plugins: [vue(), nodeResolve(), commonjs(), terser()],
-};
-```
-
-::: tip Building multiple extensions
-
-You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
-See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
-
-:::
 
 ## 3. Develop Your Custom Layout
 
@@ -132,7 +108,7 @@ The layout itself is simply a Vue component, which provides an blank canvas for 
 To build the layout for use within Directus, run:
 
 ```bash
-npx rollup -c
+npx directus-extension build
 ```
 
 Finally, move the output from your layout's `dist` folder into your project's `/extensions/layouts/my-custom-layout`

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -119,7 +119,7 @@ instance of the `collectionsStore` using `system.useCollectionsStore()`, but tha
 
 If you setup a route with a parameter, you can pass it in as a prop.
 
-## 2. Install Dependencies and Configure the Buildchain
+## 2. Install Dependencies
 
 Set up a package.json file by running:
 
@@ -128,37 +128,13 @@ npm init -y
 ```
 
 To be read by the Admin App, your custom module's Vue component must first be bundled into a single `index.js` file. We
-recommend bundling your code using Rollup. To install this and the other development dependencies, run this command:
+recommend bundling your code using the directus-extension CLI from our `@directus/extension-sdk` package. The CLI
+internally uses a Rollup configuration tailored specifically to bundling Directus extensions. To install the Extension
+SDK, run this command:
 
 ```bash
-npm i -D rollup @rollup/plugin-node-resolve @rollup/plugin-commonjs rollup-plugin-terser rollup-plugin-vue @vue/compiler-sfc
+npm i -D @directus/extension-sdk
 ```
-
-You can then use the following Rollup configuration within `rollup.config.js`:
-
-```js
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
-import vue from 'rollup-plugin-vue';
-
-export default {
-	input: 'src/index.js',
-	output: {
-		format: 'es',
-		file: 'dist/index.js',
-	},
-	external: ['vue', '@directus/extension-sdk'],
-	plugins: [vue(), nodeResolve(), commonjs(), terser()],
-};
-```
-
-::: tip Building multiple extensions
-
-You can export an array of build configurations, so you can bundle (or even watch) multiple extensions at the same time.
-See the [Rollup configuration file documentation](https://rollupjs.org/guide/en/#configuration-files) for more info.
-
-:::
 
 ## 3. Develop Your Custom Module
 
@@ -169,7 +145,7 @@ The module itself is simply a Vue component, which provides an blank canvas for 
 To build the module for use within Directus, run:
 
 ```bash
-npx rollup -c
+npx directus-extension build
 ```
 
 Finally, move the output from your module's `dist` folder into your project's `/extensions/modules/my-custom-module`

--- a/package-lock.json
+++ b/package-lock.json
@@ -6250,7 +6250,6 @@
 			"version": "19.0.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.0.tgz",
 			"integrity": "sha512-adTpD6ATGbehdaQoZQ6ipDFhdjqsTgpOAhFiPwl+dzre4pPshsecptDPyEFb61JMJ1+mGljktaC4jI8ARMSNyw==",
-			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
 				"commondir": "^1.0.1",
@@ -6283,7 +6282,6 @@
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
 			"integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
-			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
 				"@types/resolve": "1.17.1",
@@ -6328,7 +6326,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
 			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "0.0.39",
 				"estree-walker": "^1.0.1",
@@ -6344,14 +6341,12 @@
 		"node_modules/@rollup/pluginutils/node_modules/@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-			"dev": true
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
 		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-			"dev": true
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 		},
 		"node_modules/@samverschueren/stream-to-observable": {
 			"version": "0.3.1",
@@ -7530,7 +7525,6 @@
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
 			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -9393,7 +9387,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.1.2.tgz",
 			"integrity": "sha512-SeG/2+DvwejQ7oAiSx8BrDh5qOdqCYHGClPiTvVIHTfSIHiS2JjMbCANdDCjHkTOh/O7WZzo2JhdKm98bRBxTw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.13.9",
 				"@babel/types": "^7.13.0",
@@ -9421,7 +9414,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.1.2.tgz",
 			"integrity": "sha512-BwXo9LFk5OSWdMyZQ4bX1ELHX0Z/9F+ld/OaVnpUPzAZCHslBYLvyKUVDwv2C/lpLjRffpC2DOUEdl1+RP1aGg==",
-			"dev": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.1.2",
 				"@vue/shared": "3.1.2"
@@ -13525,7 +13517,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
 			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			},
@@ -15227,7 +15218,6 @@
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
 			"integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
-			"dev": true,
 			"dependencies": {
 				"bluebird": "^3.7.2"
 			},
@@ -17350,7 +17340,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -24065,7 +24054,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
 			"integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
-			"dev": true,
 			"dependencies": {
 				"loader-utils": "^1.1.0"
 			}
@@ -25646,8 +25634,7 @@
 		"node_modules/hash-sum": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-			"dev": true
+			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
 		},
 		"node_modules/hash.js": {
 			"version": "1.1.7",
@@ -27086,8 +27073,7 @@
 		"node_modules/is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-			"dev": true
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
 		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.1",
@@ -27230,7 +27216,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
 			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -30763,7 +30748,6 @@
 			"version": "0.25.7",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
 			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-			"dev": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.4"
 			}
@@ -31561,7 +31545,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
 			"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-			"dev": true,
 			"dependencies": {
 				"source-map": "^0.6.1"
 			}
@@ -38362,7 +38345,6 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.1.3.tgz",
 			"integrity": "sha512-dBT39hrXe4OAVYJe/2ZuIZ9BzYhOe7t+IhedYeQ2OxKwDpAGlkEN/fR0fGnrbx4BvgbMReRX4hCubYK9cE/pJQ==",
-			"dev": true,
 			"dependencies": {
 				"generic-names": "^2.0.1",
 				"icss-replace-symbols": "^1.1.0",
@@ -43247,7 +43229,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
 			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"jest-worker": "^26.2.1",
@@ -43262,7 +43243,6 @@
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
 			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -43342,6 +43322,32 @@
 			"engines": {
 				"node": ">= 4.0.0"
 			}
+		},
+		"node_modules/rollup-plugin-vue": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
+			"integrity": "sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"hash-sum": "^2.0.0",
+				"rollup-pluginutils": "^2.8.2"
+			},
+			"peerDependencies": {
+				"@vue/compiler-sfc": "*"
+			}
+		},
+		"node_modules/rollup-pluginutils": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+			"dependencies": {
+				"estree-walker": "^0.6.1"
+			}
+		},
+		"node_modules/rollup-pluginutils/node_modules/estree-walker": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
@@ -44508,8 +44514,7 @@
 		"node_modules/sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"dev": true
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
@@ -45183,8 +45188,7 @@
 		"node_modules/string-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-			"dev": true
+			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -53942,12 +53946,31 @@
 			"name": "@directus/extension-sdk",
 			"version": "9.0.0-rc.81",
 			"dependencies": {
-				"@directus/shared": "9.0.0-rc.81"
+				"@directus/shared": "9.0.0-rc.81",
+				"@rollup/plugin-commonjs": "^19.0.0",
+				"@rollup/plugin-node-resolve": "^13.0.0",
+				"@vue/compiler-sfc": "^3.1.1",
+				"commander": "^8.0.0",
+				"ora": "^5.4.0",
+				"rollup": "^2.51.2",
+				"rollup-plugin-terser": "^7.0.2",
+				"rollup-plugin-vue": "^6.0.0"
+			},
+			"bin": {
+				"directus-extension": "cli.js"
 			},
 			"devDependencies": {
 				"npm-run-all": "4.1.5",
 				"rimraf": "3.0.2",
 				"typescript": "4.3.4"
+			}
+		},
+		"packages/extension-sdk/node_modules/commander": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+			"integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"packages/format-title": {
@@ -60136,9 +60159,24 @@
 			"version": "file:packages/extension-sdk",
 			"requires": {
 				"@directus/shared": "9.0.0-rc.81",
+				"@rollup/plugin-commonjs": "^19.0.0",
+				"@rollup/plugin-node-resolve": "^13.0.0",
+				"@vue/compiler-sfc": "^3.1.1",
+				"commander": "^8.0.0",
 				"npm-run-all": "4.1.5",
+				"ora": "^5.4.0",
 				"rimraf": "3.0.2",
+				"rollup": "^2.51.2",
+				"rollup-plugin-terser": "^7.0.2",
+				"rollup-plugin-vue": "^6.0.0",
 				"typescript": "4.3.4"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+					"integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
+				}
 			}
 		},
 		"@directus/format-title": {
@@ -65837,7 +65875,6 @@
 			"version": "19.0.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.0.tgz",
 			"integrity": "sha512-adTpD6ATGbehdaQoZQ6ipDFhdjqsTgpOAhFiPwl+dzre4pPshsecptDPyEFb61JMJ1+mGljktaC4jI8ARMSNyw==",
-			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
 				"commondir": "^1.0.1",
@@ -65861,7 +65898,6 @@
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
 			"integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
-			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
 				"@types/resolve": "1.17.1",
@@ -65892,7 +65928,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
 			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
 				"estree-walker": "^1.0.1",
@@ -65902,14 +65937,12 @@
 				"@types/estree": {
 					"version": "0.0.39",
 					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-					"dev": true
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 				},
 				"estree-walker": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-					"dev": true
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 				}
 			}
 		},
@@ -66990,7 +67023,6 @@
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
 			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -68492,7 +68524,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.1.2.tgz",
 			"integrity": "sha512-SeG/2+DvwejQ7oAiSx8BrDh5qOdqCYHGClPiTvVIHTfSIHiS2JjMbCANdDCjHkTOh/O7WZzo2JhdKm98bRBxTw==",
-			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.13.9",
 				"@babel/types": "^7.13.0",
@@ -68517,7 +68548,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.1.2.tgz",
 			"integrity": "sha512-BwXo9LFk5OSWdMyZQ4bX1ELHX0Z/9F+ld/OaVnpUPzAZCHslBYLvyKUVDwv2C/lpLjRffpC2DOUEdl1+RP1aGg==",
-			"dev": true,
 			"requires": {
 				"@vue/compiler-dom": "3.1.2",
 				"@vue/shared": "3.1.2"
@@ -71895,8 +71925,7 @@
 		"builtin-modules": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
-			"dev": true
+			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
@@ -73240,7 +73269,6 @@
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
 			"integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
-			"dev": true,
 			"requires": {
 				"bluebird": "^3.7.2"
 			}
@@ -74938,8 +74966,7 @@
 		"deepmerge": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
 		"default-gateway": {
 			"version": "5.0.5",
@@ -80439,7 +80466,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
 			"integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0"
 			}
@@ -81654,8 +81680,7 @@
 		"hash-sum": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-			"dev": true
+			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -82746,8 +82771,7 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-			"dev": true
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
 		},
 		"is-negative-zero": {
 			"version": "2.0.1",
@@ -82844,7 +82868,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
 			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "*"
 			}
@@ -85650,7 +85673,6 @@
 			"version": "0.25.7",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
 			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-			"dev": true,
 			"requires": {
 				"sourcemap-codec": "^1.4.4"
 			}
@@ -86285,7 +86307,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
 			"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.6.1"
 			}
@@ -91593,7 +91614,6 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.1.3.tgz",
 			"integrity": "sha512-dBT39hrXe4OAVYJe/2ZuIZ9BzYhOe7t+IhedYeQ2OxKwDpAGlkEN/fR0fGnrbx4BvgbMReRX4hCubYK9cE/pJQ==",
-			"dev": true,
 			"requires": {
 				"generic-names": "^2.0.1",
 				"icss-replace-symbols": "^1.1.0",
@@ -95424,7 +95444,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
 			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
 				"jest-worker": "^26.2.1",
@@ -95436,7 +95455,6 @@
 					"version": "26.6.2",
 					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
 					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-					"dev": true,
 					"requires": {
 						"@types/node": "*",
 						"merge-stream": "^2.0.0",
@@ -95499,6 +95517,31 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 					"dev": true
+				}
+			}
+		},
+		"rollup-plugin-vue": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
+			"integrity": "sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==",
+			"requires": {
+				"debug": "^4.1.1",
+				"hash-sum": "^2.0.0",
+				"rollup-pluginutils": "^2.8.2"
+			}
+		},
+		"rollup-pluginutils": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+			"requires": {
+				"estree-walker": "^0.6.1"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 				}
 			}
 		},
@@ -96464,8 +96507,7 @@
 		"sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"dev": true
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
@@ -97016,8 +97058,7 @@
 		"string-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-			"dev": true
+			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
 		},
 		"string-length": {
 			"version": "4.0.2",

--- a/packages/extension-sdk/cli.js
+++ b/packages/extension-sdk/cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./dist/cjs/cli/index.js');

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -7,6 +7,9 @@
 		"import": "./dist/esm/index.js",
 		"require": "./dist/cjs/index.js"
 	},
+	"bin": {
+		"directus-extension": "cli.js"
+	},
 	"scripts": {
 		"build": "npm run cleanup && run-p build:*",
 		"build:esm": "tsc --project ./tsconfig.json --module ES2015 --outDir ./dist/esm",
@@ -18,7 +21,15 @@
 	"author": "Nicola Krumschmidt",
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd",
 	"dependencies": {
-		"@directus/shared": "9.0.0-rc.81"
+		"@directus/shared": "9.0.0-rc.81",
+		"@rollup/plugin-commonjs": "^19.0.0",
+		"@rollup/plugin-node-resolve": "^13.0.0",
+		"@vue/compiler-sfc": "^3.1.1",
+		"commander": "^8.0.0",
+		"ora": "^5.4.0",
+		"rollup": "^2.51.2",
+		"rollup-plugin-terser": "^7.0.2",
+		"rollup-plugin-vue": "^6.0.0"
 	},
 	"devDependencies": {
 		"npm-run-all": "4.1.5",

--- a/packages/extension-sdk/src/cli/commands/build.ts
+++ b/packages/extension-sdk/src/cli/commands/build.ts
@@ -1,0 +1,28 @@
+/* eslint-disable no-console */
+
+import ora from 'ora';
+import { rollup } from 'rollup';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import { terser } from 'rollup-plugin-terser';
+import vue from 'rollup-plugin-vue';
+import { SHARED_DEPS } from '@directus/shared/constants';
+
+export default async function build(options: { input: string; output: string }): Promise<void> {
+	const spinner = ora('Building Directus extension...').start();
+
+	const bundle = await rollup({
+		input: options.input,
+		external: SHARED_DEPS,
+		plugins: [vue(), nodeResolve(), commonjs(), terser()],
+	});
+
+	await bundle.write({
+		format: 'es',
+		file: options.output,
+	});
+
+	await bundle.close();
+
+	spinner.succeed('Done');
+}

--- a/packages/extension-sdk/src/cli/index.ts
+++ b/packages/extension-sdk/src/cli/index.ts
@@ -1,0 +1,18 @@
+import { Command } from 'commander';
+import build from './commands/build';
+
+const pkg = require('../../../package.json');
+
+const program = new Command();
+
+program.name('directus-extension').usage('[command] [options]');
+program.version(pkg.version, '-v, --version');
+
+program
+	.command('build')
+	.description('Bundle a Directus extension to a single entrypoint')
+	.option('-i, --input <file>', 'change the default entrypoint', 'src/index.js')
+	.option('-o, --output <file>', 'change the default output file', 'dist/index.js')
+	.action(build);
+
+program.parse(process.argv);


### PR DESCRIPTION
The initial version only implements the `build` command.
Executing `build` in the root of an extension package bundles the extension to a single distributable and loadable entrypoint.