### PR TITLE
fix: getLocalType 'data_type' is undefined

### DIFF
--- a/api/src/utils/get-local-type.ts
+++ b/api/src/utils/get-local-type.ts
@@ -91,6 +91,8 @@ export default function getLocalType(
 	column: SchemaOverview[string]['columns'][string] | Column,
 	field?: { special?: FieldMeta['special'] }
 ): typeof types[number] | 'unknown' {
+	if (column === undefined) return 'unknown';
+
 	const type = localTypeMap[column.data_type.toLowerCase().split('(')[0]];
 
 	const special = field?.special;


### PR DESCRIPTION
From the last updates property `column` is `undefined` and the app is going to crash

In logs I see:

```
🔥 LOGGER ~ getLocalType ~ column: undefined

18:16:09 🚨 Cannot read property 'data_type' of undefined
TypeError: Cannot read property 'data_type' of undefined
    at Object.getLocalType [as default] (/directus/node_modules/directus/dist/utils/get-local-type.js:85:38)
    at getDatabaseSchema (/directus/node_modules/directus/dist/utils/get-schema.js:128:43)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async Object.getSchema (/directus/node_modules/directus/dist/utils/get-schema.js:33:22)
    at async /directus/node_modules/directus/dist/middleware/schema.js:9:18
18:16:09 ✨ request errored GET 500 /server/info?limit=-1 132ms
```

Actually, I have `directus@9.0.0-rc.82`, `node@v14.16.1`, and `postgresql@12.6`

That fix solved the problem.