### PR TITLE
Update the required Node version to 12.20.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -60,7 +60,7 @@
 		"prepublishOnly": "npm run build"
 	},
 	"engines": {
-		"node": ">=12.0.0"
+		"node": ">=12.20.0"
 	},
 	"files": [
 		"dist",

--- a/docs/guides/installation/cli.md
+++ b/docs/guides/installation/cli.md
@@ -5,7 +5,7 @@
 Directus requires two things to run: [Node.js](https://nodejs.dev) and a Database. For both these system requirements,
 we aim to support the current LTS release (and newer).
 
-To run Directus, you currently need Node 12.12 or newer, and one of the following databases:
+To run Directus, you currently need Node 12.20 or newer, and one of the following databases:
 
 | Database      | Version |
 | ------------- | ------- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,18 +58,18 @@
 		},
 		"api": {
 			"name": "directus",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/app": "9.0.0-rc.82",
-				"@directus/drive": "9.0.0-rc.82",
-				"@directus/drive-azure": "9.0.0-rc.82",
-				"@directus/drive-gcs": "9.0.0-rc.82",
-				"@directus/drive-s3": "9.0.0-rc.82",
-				"@directus/format-title": "9.0.0-rc.82",
-				"@directus/schema": "9.0.0-rc.82",
-				"@directus/shared": "9.0.0-rc.82",
-				"@directus/specs": "9.0.0-rc.82",
+				"@directus/app": "9.0.0-rc.83",
+				"@directus/drive": "9.0.0-rc.83",
+				"@directus/drive-azure": "9.0.0-rc.83",
+				"@directus/drive-gcs": "9.0.0-rc.83",
+				"@directus/drive-s3": "9.0.0-rc.83",
+				"@directus/format-title": "9.0.0-rc.83",
+				"@directus/schema": "9.0.0-rc.83",
+				"@directus/shared": "9.0.0-rc.83",
+				"@directus/specs": "9.0.0-rc.83",
 				"@godaddy/terminus": "^4.9.0",
 				"@rollup/plugin-alias": "^3.1.2",
 				"@rollup/plugin-virtual": "^2.0.3",
@@ -170,7 +170,7 @@
 				"typescript": "4.3.4"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=12.20.0"
 			},
 			"optionalDependencies": {
 				"@keyv/redis": "^2.1.2",
@@ -292,12 +292,12 @@
 		},
 		"app": {
 			"name": "@directus/app",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"devDependencies": {
-				"@directus/docs": "9.0.0-rc.82",
-				"@directus/extension-sdk": "9.0.0-rc.82",
-				"@directus/format-title": "9.0.0-rc.82",
-				"@directus/shared": "9.0.0-rc.82",
+				"@directus/docs": "9.0.0-rc.83",
+				"@directus/extension-sdk": "9.0.0-rc.83",
+				"@directus/format-title": "9.0.0-rc.83",
+				"@directus/shared": "9.0.0-rc.83",
 				"@fullcalendar/core": "5.8.0",
 				"@fullcalendar/daygrid": "5.8.0",
 				"@fullcalendar/interaction": "5.8.0",
@@ -384,7 +384,7 @@
 		},
 		"docs": {
 			"name": "@directus/docs",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "ISC",
 			"devDependencies": {
 				"directory-tree": "2.2.9",
@@ -53332,11 +53332,11 @@
 		},
 		"packages/cli": {
 			"name": "@directus/cli",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/format-title": "9.0.0-rc.82",
-				"@directus/sdk": "9.0.0-rc.82",
+				"@directus/format-title": "9.0.0-rc.83",
+				"@directus/sdk": "9.0.0-rc.83",
 				"@types/yargs": "^17.0.0",
 				"app-module-path": "^2.2.0",
 				"chalk": "^4.1.0",
@@ -53518,7 +53518,7 @@
 			}
 		},
 		"packages/create-directus-project": {
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"chalk": "^4.1.1",
@@ -53554,7 +53554,7 @@
 		},
 		"packages/drive": {
 			"name": "@directus/drive",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.0.0",
@@ -53573,11 +53573,11 @@
 		},
 		"packages/drive-azure": {
 			"name": "@directus/drive-azure",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.0.0-rc.82",
+				"@directus/drive": "9.0.0-rc.83",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -53609,10 +53609,10 @@
 		},
 		"packages/drive-gcs": {
 			"name": "@directus/drive-gcs",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.0.0-rc.82",
+				"@directus/drive": "9.0.0-rc.83",
 				"@google-cloud/storage": "^5.8.5",
 				"normalize-path": "^3.0.0"
 			},
@@ -53631,10 +53631,10 @@
 		},
 		"packages/drive-s3": {
 			"name": "@directus/drive-s3",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.0.0-rc.82",
+				"@directus/drive": "9.0.0-rc.83",
 				"aws-sdk": "^2.928.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -53681,9 +53681,9 @@
 		},
 		"packages/extension-sdk": {
 			"name": "@directus/extension-sdk",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"dependencies": {
-				"@directus/shared": "9.0.0-rc.82",
+				"@directus/shared": "9.0.0-rc.83",
 				"@rollup/plugin-commonjs": "^19.0.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
 				"@vue/compiler-sfc": "^3.1.1",
@@ -53700,6 +53700,9 @@
 				"npm-run-all": "4.1.5",
 				"rimraf": "3.0.2",
 				"typescript": "4.3.4"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"packages/extension-sdk/node_modules/commander": {
@@ -53712,7 +53715,7 @@
 		},
 		"packages/format-title": {
 			"name": "@directus/format-title",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "19.0.0",
@@ -53731,7 +53734,7 @@
 		},
 		"packages/gatsby-source-directus": {
 			"name": "@directus/gatsby-source-directus",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
 				"@directus/sdk-js": "9.0.0-rc.53",
@@ -57453,7 +57456,7 @@
 		},
 		"packages/schema": {
 			"name": "@directus/schema",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"knex-schema-inspector": "^1.3.0",
@@ -57466,7 +57469,7 @@
 		},
 		"packages/sdk": {
 			"name": "@directus/sdk",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.21.1"
@@ -57668,7 +57671,7 @@
 		},
 		"packages/shared": {
 			"name": "@directus/shared",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"dependencies": {
 				"fs-extra": "10.0.0",
 				"vue": "3.1.2"
@@ -57694,7 +57697,7 @@
 		},
 		"packages/specs": {
 			"name": "@directus/specs",
-			"version": "9.0.0-rc.82",
+			"version": "9.0.0-rc.83",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"openapi3-ts": "^2.0.1"
@@ -59458,10 +59461,10 @@
 		"@directus/app": {
 			"version": "file:app",
 			"requires": {
-				"@directus/docs": "9.0.0-rc.82",
-				"@directus/extension-sdk": "9.0.0-rc.82",
-				"@directus/format-title": "9.0.0-rc.82",
-				"@directus/shared": "9.0.0-rc.82",
+				"@directus/docs": "9.0.0-rc.83",
+				"@directus/extension-sdk": "9.0.0-rc.83",
+				"@directus/format-title": "9.0.0-rc.83",
+				"@directus/shared": "9.0.0-rc.83",
 				"@fullcalendar/core": "5.8.0",
 				"@fullcalendar/daygrid": "5.8.0",
 				"@fullcalendar/interaction": "5.8.0",
@@ -59538,8 +59541,8 @@
 		"@directus/cli": {
 			"version": "file:packages/cli",
 			"requires": {
-				"@directus/format-title": "9.0.0-rc.82",
-				"@directus/sdk": "9.0.0-rc.82",
+				"@directus/format-title": "9.0.0-rc.83",
+				"@directus/sdk": "9.0.0-rc.83",
 				"@types/figlet": "1.5.1",
 				"@types/fs-extra": "9.0.11",
 				"@types/jest": "26.0.23",
@@ -59815,7 +59818,7 @@
 			"version": "file:packages/drive-azure",
 			"requires": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.0.0-rc.82",
+				"@directus/drive": "9.0.0-rc.83",
 				"@types/fs-extra": "9.0.11",
 				"@types/jest": "26.0.23",
 				"@types/node": "15.12.2",
@@ -59845,7 +59848,7 @@
 		"@directus/drive-gcs": {
 			"version": "file:packages/drive-gcs",
 			"requires": {
-				"@directus/drive": "9.0.0-rc.82",
+				"@directus/drive": "9.0.0-rc.83",
 				"@google-cloud/storage": "^5.8.5",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.11",
@@ -59863,7 +59866,7 @@
 		"@directus/drive-s3": {
 			"version": "file:packages/drive-s3",
 			"requires": {
-				"@directus/drive": "9.0.0-rc.82",
+				"@directus/drive": "9.0.0-rc.83",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.11",
 				"@types/jest": "26.0.23",
@@ -59895,7 +59898,7 @@
 		"@directus/extension-sdk": {
 			"version": "file:packages/extension-sdk",
 			"requires": {
-				"@directus/shared": "9.0.0-rc.82",
+				"@directus/shared": "9.0.0-rc.83",
 				"@rollup/plugin-commonjs": "^19.0.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
 				"@vue/compiler-sfc": "^3.1.1",
@@ -75119,15 +75122,15 @@
 		"directus": {
 			"version": "file:api",
 			"requires": {
-				"@directus/app": "9.0.0-rc.82",
-				"@directus/drive": "9.0.0-rc.82",
-				"@directus/drive-azure": "9.0.0-rc.82",
-				"@directus/drive-gcs": "9.0.0-rc.82",
-				"@directus/drive-s3": "9.0.0-rc.82",
-				"@directus/format-title": "9.0.0-rc.82",
-				"@directus/schema": "9.0.0-rc.82",
-				"@directus/shared": "9.0.0-rc.82",
-				"@directus/specs": "9.0.0-rc.82",
+				"@directus/app": "9.0.0-rc.83",
+				"@directus/drive": "9.0.0-rc.83",
+				"@directus/drive-azure": "9.0.0-rc.83",
+				"@directus/drive-gcs": "9.0.0-rc.83",
+				"@directus/drive-s3": "9.0.0-rc.83",
+				"@directus/format-title": "9.0.0-rc.83",
+				"@directus/schema": "9.0.0-rc.83",
+				"@directus/shared": "9.0.0-rc.83",
+				"@directus/specs": "9.0.0-rc.83",
 				"@godaddy/terminus": "^4.9.0",
 				"@keyv/redis": "^2.1.2",
 				"@rollup/plugin-alias": "^3.1.2",

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -18,6 +18,9 @@
 		"dev": "npm run build -- -- -w --preserveWatchOutput --incremental",
 		"prepublishOnly": "npm run cleanup && npm run build"
 	},
+	"engines": {
+		"node": ">=12.20.0"
+	},
 	"author": "Nicola Krumschmidt",
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd",
 	"dependencies": {


### PR DESCRIPTION
This is needed as lower versions do not fully support the package "exports" field used by shared and extension-sdk.