### PR TITLE
Fix extension loading on windows

### DIFF
--- a/packages/shared/src/utils/generate-extensions-entry.ts
+++ b/packages/shared/src/utils/generate-extensions-entry.ts
@@ -1,10 +1,13 @@
-import path from 'path';
+import path from 'path/posix';
 import { AppExtensionType, Extension } from '../types';
 
 export function generateExtensionsEntry(type: AppExtensionType, extensions: Extension[]): string {
 	const filteredExtensions = extensions.filter((extension) => extension.type === type);
 
 	return `${filteredExtensions
-		.map((extension, i) => `import e${i} from '${path.resolve(extension.path, extension.entrypoint || '')}';\n`)
+		.map(
+			(extension, i) =>
+				`import e${i} from './${path.relative('.', path.resolve(extension.path, extension.entrypoint || ''))}';\n`
+		)
 		.join('')}export default [${filteredExtensions.map((_, i) => `e${i}`).join(',')}];`;
 }


### PR DESCRIPTION
Javascript import syntax uses URLs instead of paths, so we have to normalize the extension paths to forward slashes when importing them inside the virtual entrypoints.

Fixes #6550