### PR TITLE
Fix extra dots being added on uploaded files

### DIFF
--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -46,9 +46,9 @@ export class FilesService extends ItemsService {
 			primaryKey = await this.createOne(payload, { emitEvents: false });
 		}
 
-		const fileExtension = path.extname(payload.filename_download) || (payload.type && extension(payload.type));
+		const fileExtension = path.extname(payload.filename_download) || (payload.type && '.' + extension(payload.type));
 
-		payload.filename_disk = primaryKey + '.' + fileExtension;
+		payload.filename_disk = primaryKey + fileExtension;
 
 		if (!payload.type) {
 			payload.type = 'application/octet-stream';


### PR DESCRIPTION
resolves #6573 

Fixes a bug where extra dots `.` were added between the filename and extension on disk when a file was uploaded or imported.

Ex: `c8242f4f-0b55-478b-9bf2-0b5af64eac56..md`