### PR TITLE
Support arrays in formatted-json-value display

### DIFF
--- a/app/src/displays/formatted-json-value/formatted-json-value.vue
+++ b/app/src/displays/formatted-json-value/formatted-json-value.vue
@@ -5,7 +5,6 @@
 			<span @click.stop="toggle" class="toggle">
 				<span class="label">
 					{{ displayValue.length }}
-					<template v-if="displayValue.length >= 100">+</template>
 					{{ t('items') }}
 				</span>
 			</span>

--- a/app/src/displays/formatted-json-value/formatted-json-value.vue
+++ b/app/src/displays/formatted-json-value/formatted-json-value.vue
@@ -1,19 +1,38 @@
 <template>
 	<value-null v-if="!displayValue" />
+	<v-menu v-else-if="displayValue.length > 1" show-arrow>
+		<template #activator="{ toggle }">
+			<span @click.stop="toggle" class="toggle">
+				<span class="label">
+					{{ displayValue.length }}
+					<template v-if="displayValue.length >= 100">+</template>
+					{{ t('items') }}
+				</span>
+			</span>
+		</template>
 
+		<v-list class="links">
+			<v-list-item v-for="(item, index) in displayValue" :key="index">
+				<v-list-item-content>
+					{{ item }}
+				</v-list-item-content>
+			</v-list-item>
+		</v-list>
+	</v-menu>
 	<span v-else>
-		{{ displayValue }}
+		{{ displayValue[0] }}
 	</span>
 </template>
 
 <script lang="ts">
 import { render } from 'micromustache';
 import { defineComponent, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
 	props: {
 		value: {
-			type: Object,
+			type: [Object, Array],
 			default: null,
 		},
 		format: {
@@ -22,16 +41,22 @@ export default defineComponent({
 		},
 	},
 	setup(props) {
+		const { t } = useI18n();
 		const displayValue = computed(() => {
 			if (!props.value) return null;
+
 			try {
-				return render(props.format || '', props.value);
+				if (Array.isArray(props.value)) {
+					return props.value.map((item: any) => render(props.format || '', item));
+				} else {
+					return [render(props.format || '', props.value)];
+				}
 			} catch (error) {
 				return null;
 			}
 		});
 
-		return { displayValue };
+		return { displayValue, t };
 	},
 });
 </script>


### PR DESCRIPTION
I've opened this one already, but I had to close it because the branch was a bit messy. I've refactored it for vue3/directus-rc73>, and I'd like to check in again to see if it could be an addition for core? PR should be good to go.

This is how it looks like, similar to `related-values` display:

![image](https://user-images.githubusercontent.com/17851386/124382340-36beab00-dcc7-11eb-9958-e05a719fddd9.png)
