### PR TITLE
Fix item.read hook not firing for readByQuery

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -279,6 +279,17 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			throw new ForbiddenException();
 		}
 
+		emitAsyncSafe(`${this.eventScope}.read`, {
+			event: `${this.eventScope}.read`,
+			accountability: this.accountability,
+			collection: this.collection,
+			// item: ,
+			action: 'read',
+			payload: records,
+			schema: this.schema,
+			database: getDatabase(),
+		});
+
 		return records as Item[];
 	}
 
@@ -306,17 +317,6 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			throw new ForbiddenException();
 		}
 
-		emitAsyncSafe(`${this.eventScope}.read`, {
-			event: `${this.eventScope}.read`,
-			accountability: this.accountability,
-			collection: this.collection,
-			item: key,
-			action: 'read',
-			payload: results,
-			schema: this.schema,
-			database: getDatabase(),
-		});
-
 		return results[0];
 	}
 
@@ -343,17 +343,6 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		};
 
 		const results = await this.readByQuery(queryWithKeys, opts);
-
-		emitAsyncSafe(`${this.eventScope}.read`, {
-			event: `${this.eventScope}.read`,
-			accountability: this.accountability,
-			collection: this.collection,
-			item: keys,
-			action: 'read',
-			payload: results,
-			schema: this.schema,
-			database: getDatabase(),
-		});
 
 		return results;
 	}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -283,7 +283,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			event: `${this.eventScope}.read`,
 			accountability: this.accountability,
 			collection: this.collection,
-			// item: ,
+			query,
 			action: 'read',
 			payload: records,
 			schema: this.schema,

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -170,6 +170,20 @@ properties:
 - `schema` - The current API schema in use
 - `database` - Current database transaction
 
+#### Items read
+
+In contrast to the other `items` events (`items.create`, `items.update`, `items.delete`) the `items.read` doesn't
+receive the primary key(s) of the items but the query used:
+
+- `event` — Full event string
+- `accountability` — Information about the current user
+- `collection` — Collection that is being modified
+- `query` — The query used to get the data
+- `action` — Action that is performed
+- `payload` — Payload of the request
+- `schema` - The current API schema in use
+- `database` - Current database transaction
+
 #### Auth
 
 The `auth` and `oauth` hooks have the following context properties:


### PR DESCRIPTION
As reported by @lluishi93 in #6622  the current implementation of the `item.read` hook is flawed, as it doesn't get called with certain read actions.

I've moved the calling of the hook to the `readByQuery` method (which gets called by `readOne` and `readMany`), but there is still a problem. Normally, the hook gets called as follows:

```js
emitAsyncSafe(`${this.eventScope}.eventType`, {
  event: `${this.eventScope}.eventType`,
  accountability: this.accountability,
  collection: this.collection,
  item: keys, // notice this
  action: 'eventType',
  payload: records,
  schema: this.schema,
  database: getDatabase(),
});
```

In `readByQuery`, however, the `keys` array is not available, as it consumes a query, already with the keys implemented.

I see several options:

1. Make an exception and don't return `item` here
2. Pass keys as an additional parameter to `readByQuery`; The significant drawback here is that `readByQuery` is called from a lot of places in the codebase, and I feel like this would provide some 'code smell'
3. Retrieve from the query as follows:
    ```js
    const primaryKeyField = this.schema.collections[this.collection].primary;
    
    const keys = query.filter?.[primaryKeyField]?._eq || query.filter?.[primaryKeyField]?._in || null;
    ```

    To be fair, this feels like a hack to me.
4. Return to state before #6341, as there's no proper fix at the moment.

Would love to hear your opinions.

Fixes #6622 