### PR TITLE
Install exact version of Directus

### DIFF
--- a/.github/actions/build-images/rootfs/directus/images/main/Dockerfile
+++ b/.github/actions/build-images/rootfs/directus/images/main/Dockerfile
@@ -81,7 +81,7 @@ COPY --from=builder --chown=node:node /directus/package.json .
 RUN \
   # Install Directus and runtime dependencies
   # (retry if it fails for some reason, e.g. release not published yet)
-  for i in $(seq 15); do npm install "directus@${VERSION}" && break || if [ $i -eq 15 ]; then exit 1; else sleep 30; fi; done && \
+  for i in $(seq 15); do npm install --save-exact "directus@${VERSION}" && break || if [ $i -eq 15 ]; then exit 1; else sleep 30; fi; done && \
   npm install \
   # Create data directories
   && mkdir -p \


### PR DESCRIPTION
See #6633

~To ensure that the exact version of the `directus` package is installed, if there's already a newer version.~

Edit: As @t7tran stated in #6633 this doesn't add real value, but I still would prefer using '--save-exact'. For example this ensures that the `directus` package doesn't get updated if a user runs `npm update` inside the container and thus this ensures that the `directus` version still matches the Docker image version.