### PR TITLE
Fix requiring vue from a cjs/umd dependency in a extension

### DIFF
--- a/packages/extension-sdk/src/cli/commands/build.ts
+++ b/packages/extension-sdk/src/cli/commands/build.ts
@@ -15,7 +15,13 @@ export default async function build(options: { input: string; output: string }):
 	const bundle = await rollup({
 		input: options.input,
 		external: SHARED_DEPS,
-		plugins: [vue(), styles(), nodeResolve(), commonjs({ esmExternals: true, sourceMap: false }), terser()],
+		plugins: [
+			vue({ preprocessStyles: true }),
+			styles(),
+			nodeResolve(),
+			commonjs({ esmExternals: true, sourceMap: false }),
+			terser(),
+		],
 	});
 
 	await bundle.write({

--- a/packages/extension-sdk/src/cli/commands/build.ts
+++ b/packages/extension-sdk/src/cli/commands/build.ts
@@ -15,7 +15,7 @@ export default async function build(options: { input: string; output: string }):
 	const bundle = await rollup({
 		input: options.input,
 		external: SHARED_DEPS,
-		plugins: [vue(), styles(), nodeResolve(), commonjs({ esmExternals: true }), terser()],
+		plugins: [vue(), styles(), nodeResolve(), commonjs({ esmExternals: true, sourceMap: false }), terser()],
 	});
 
 	await bundle.write({

--- a/packages/extension-sdk/src/cli/commands/build.ts
+++ b/packages/extension-sdk/src/cli/commands/build.ts
@@ -15,7 +15,7 @@ export default async function build(options: { input: string; output: string }):
 	const bundle = await rollup({
 		input: options.input,
 		external: SHARED_DEPS,
-		plugins: [vue(), styles(), nodeResolve(), commonjs(), terser()],
+		plugins: [vue(), styles(), nodeResolve(), commonjs({ esmExternals: true }), terser()],
 	});
 
 	await bundle.write({


### PR DESCRIPTION
This ensures that shared dependencies are treated as esm by rollup.