### PR TITLE
Fixed migration changing filesize failing on Oracle

### DIFF
--- a/api/src/database/migrations/20201105B-change-webhook-url-type.ts
+++ b/api/src/database/migrations/20201105B-change-webhook-url-type.ts
@@ -1,7 +1,6 @@
 import { Knex } from 'knex';
 // @ts-ignore
 import Client_Oracledb from 'knex/lib/dialects/oracledb';
-import env from '../../env';
 
 async function oracleAlterUrl(knex: Knex, type: string): Promise<void> {
 	await knex.raw('ALTER TABLE "directus_webhooks" ADD "url__temp" ?', [knex.raw(type)]);
@@ -23,7 +22,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-	if (env.DB_CLIENT === 'oracledb') {
+	if (knex.client instanceof Client_Oracledb) {
 		await oracleAlterUrl(knex, 'VARCHAR2(255)');
 		return;
 	}

--- a/api/src/database/migrations/20210312A-webhooks-collections-text.ts
+++ b/api/src/database/migrations/20210312A-webhooks-collections-text.ts
@@ -1,7 +1,6 @@
 import { Knex } from 'knex';
 // @ts-ignore
 import Client_Oracledb from 'knex/lib/dialects/oracledb';
-import env from '../../env';
 
 async function oracleAlterCollections(knex: Knex, type: string): Promise<void> {
 	await knex.raw('ALTER TABLE "directus_webhooks" ADD "collections__temp" ?', [knex.raw(type)]);
@@ -23,7 +22,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-	if (env.DB_CLIENT === 'oracledb') {
+	if (knex.client instanceof Client_Oracledb) {
 		await oracleAlterCollections(knex, 'VARCHAR2(255)');
 		return;
 	}

--- a/api/src/database/migrations/20210626A-change-filesize-bigint.ts
+++ b/api/src/database/migrations/20210626A-change-filesize-bigint.ts
@@ -1,12 +1,22 @@
 import { Knex } from 'knex';
+// @ts-ignore
+import Client_Oracledb from 'knex/lib/dialects/oracledb';
 
 export async function up(knex: Knex): Promise<void> {
+	if (knex.client instanceof Client_Oracledb) {
+		return;
+	}
+
 	await knex.schema.alterTable('directus_files', (table) => {
 		table.bigInteger('filesize').nullable().defaultTo(null).alter();
 	});
 }
 
 export async function down(knex: Knex): Promise<void> {
+	if (knex.client instanceof Client_Oracledb) {
+		return;
+	}
+
 	await knex.schema.alterTable('directus_files', (table) => {
 		table.integer('filesize').nullable().defaultTo(null).alter();
 	});


### PR DESCRIPTION
Fix for #6721.

The default assignment for Integer types from Knex creates `NUMBER(38)` columns. Altering to BigInt actually reduces the column size to `NUMBER(20)`. I think we can safely skip this migration for Oracle, since it wouldn't actually affect the column type.