### PR TITLE
Fix "Duplicate environment variable" error message never showing up

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -181,14 +181,14 @@ function processValues(env: Record<string, any>) {
 		// and store it in the variable with the same name but without '_FILE' at the end
 		let newKey;
 		if (key.length > 5 && key.endsWith('_FILE')) {
+			newKey = key.slice(0, -5);
+			if (newKey in env) {
+				throw new Error(
+					`Duplicate environment variable encountered: you can't use "${newKey}" and "${key}" simultaneously.`
+				);
+			}
 			try {
 				value = fs.readFileSync(value, { encoding: 'utf8' });
-				newKey = key.slice(0, -5);
-				if (newKey in env) {
-					throw new Error(
-						`Duplicate environment variable encountered: you can't use "${key}" and "${newKey}" simultaneously.`
-					);
-				}
 				key = newKey;
 			} catch {
 				throw new Error(`Failed to read value from file "${value}", defined in environment variable "${key}".`);


### PR DESCRIPTION
Move check for "duplicate environment variable" outside of try...catch statement, as otherwise the follwing (confusing) message will be shown instead:
```
Error: Failed to read value from file "<value from KEY variable>", defined in environment variable "KEY_FILE".
```