### PR TITLE
Support global installation and add update check

### DIFF
--- a/packages/create-directus-project/lib/index.js
+++ b/packages/create-directus-project/lib/index.js
@@ -10,6 +10,7 @@ const ora = require('ora');
 
 const pkg = require('../package.json');
 const checkRequirements = require('./check-requirements');
+const checkForUpdate = require('update-check');
 
 const program = new commander.Command(pkg.name);
 
@@ -92,6 +93,26 @@ async function create(directory) {
 		// eslint-disable-next-line no-console
 		console.log(`Error: ${err.stderr}`);
 		process.exit(1);
+	}
+
+	let update;
+
+	try {
+		update = await checkForUpdate(pkg);
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.log(`Error: ${err.stderr}`);
+	}
+
+	if (update) {
+		// eslint-disable-next-line no-console
+		console.log();
+		// eslint-disable-next-line no-console
+		console.log(chalk.yellow.bold(`A new version of \`${pkg.name}\` is available!`));
+		// eslint-disable-next-line no-console
+		console.log('You can update by running: ' + chalk.cyan(`npm i -g ${pkg.name}@latest`));
+		// eslint-disable-next-line no-console
+		console.log();
 	}
 
 	process.exit(0);

--- a/packages/create-directus-project/package.json
+++ b/packages/create-directus-project/package.json
@@ -3,7 +3,10 @@
 	"version": "9.0.0-rc.83",
 	"description": "A small installer util that will create a directory, add boilerplate folders, and install Directus through npm.",
 	"main": "lib/index.js",
-	"bin": "./lib/index.js",
+	"bin": {
+		"create-directus-project": "./lib/index.js",
+		"cdp": "./lib/index.js"
+	},
 	"keywords": [
 		"directus",
 		"installer"
@@ -15,7 +18,8 @@
 		"commander": "^8.0.0",
 		"execa": "^5.1.1",
 		"fs-extra": "^10.0.0",
-		"ora": "^5.4.0"
+		"ora": "^5.4.0",
+		"update-check": "^1.5.4"
 	},
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd"
 }


### PR DESCRIPTION
In this PR, I have addressed #6794. The user will now be able to globally install the CLI and use it. Also, if there is an update available, they will get notified when they run the CLI.

P.S. I have not updated the version.