### PR TITLE
Fix publishing packages without changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: '16.x'
 
-      - run: npx lerna publish --no-verify-access --force-publish --exact from-git --yes
+      - run: npx lerna publish from-git --no-verify-access --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"dev": "lerna run dev --stream --parallel",
 		"build": "lerna run build",
 		"pack": "node docker/pack",
-		"release": "lerna version --exact",
+		"release": "lerna version --force-publish --exact",
 		"test": "lerna run test",
 		"test:e2e": "jest tests -c tests/jest.config.js",
 		"test:e2e:watch": "npm run test:e2e -- --watch",


### PR DESCRIPTION
Despite the name, `--force-publish` is actually an option for `lerna version`.

When using `lerna publish from-git`, lerna won't run "lerna version" beforehand, so we can savely remove the `lerna version`-specific options.