### PR TITLE
Fix session memcache variable name

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -193,9 +193,9 @@ Alternatively, you can provide the individual connection parameters:
 
 ### Memcache
 
-| Variable           | Description                        | Default Value |
-| ------------------ | ---------------------------------- | ------------- |
-| `SESSION_MEMCACHE` | Location of your memcache instance | ---           |
+| Variable                 | Description                        | Default Value |
+| ------------------------ | ---------------------------------- | ------------- |
+| `SESSION_MEMCACHE_HOSTS` | Location of your memcache instance | ---           |
 
 ### Database
 


### PR DESCRIPTION
The memcache session store is constructed with`getConfigFromEnv('SESSION_MEMCACHE_')`.

Checking the docs of [`connect-memcached`](https://github.com/balor/connect-memcached#options) the correct variable name should be `SESSION_MEMCACHE_HOSTS`.
