### PR TITLE
Use `/` as default value for public_url

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -16,7 +16,7 @@ const defaults: Record<string, any> = {
 	CONFIG_PATH: path.resolve(process.cwd(), '.env'),
 
 	PORT: 8055,
-	PUBLIC_URL: 'http://localhost:8055',
+	PUBLIC_URL: '/',
 	MAX_PAYLOAD_SIZE: '100kb',
 
 	STORAGE_LOCATIONS: 'local',

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -7,15 +7,15 @@
 
 ## General
 
-| Variable                   | Description                                                                                                | Default Value           |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `CONFIG_PATH`              | Where your config file is located. See [Config Files](/reference/config-files/)                            | `.env`                  |
-| `PORT`                     | What port to run the API under.                                                                            | `8055`                  |
-| `PUBLIC_URL`<sup>[1]</sup> | URL where your API can be reached on the web.                                                              | `http://localhost:8055` |
-| `LOG_LEVEL`                | What level of detail to log. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`.        | `info`                  |
-| `LOG_STYLE`                | Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.                                | `pretty`                |
-| `MAX_PAYLOAD_SIZE`         | Controls the maximum request body size. Accepts number of bytes, or human readable string.                 | `100kb`                 |
-| `ROOT_REDIRECT`            | Where to redirect to when navigating to `/`. Accepts a relative path, absolute URL, or `false` to disable. | `./admin`               |
+| Variable                   | Description                                                                                                | Default Value |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------- |
+| `CONFIG_PATH`              | Where your config file is located. See [Config Files](/reference/config-files/)                            | `.env`        |
+| `PORT`                     | What port to run the API under.                                                                            | `8055`        |
+| `PUBLIC_URL`<sup>[1]</sup> | URL where your API can be reached on the web.                                                              | `/`           |
+| `LOG_LEVEL`                | What level of detail to log. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`.        | `info`        |
+| `LOG_STYLE`                | Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.                                | `pretty`      |
+| `MAX_PAYLOAD_SIZE`         | Controls the maximum request body size. Accepts number of bytes, or human readable string.                 | `100kb`       |
+| `ROOT_REDIRECT`            | Where to redirect to when navigating to `/`. Accepts a relative path, absolute URL, or `false` to disable. | `./admin`     |
 
 <sup>[1]</sup> The PUBLIC_URL value is used for things like oAuth redirects, forgot-password emails, and logos that
 needs to be publicly available on the internet.


### PR DESCRIPTION
Makes sure that the API will show warnings about the missing env var, while the app will still function across ports. 