### PR TITLE
Fix extension loading on Windows

### DIFF
--- a/packages/shared/src/utils/generate-extensions-entry.ts
+++ b/packages/shared/src/utils/generate-extensions-entry.ts
@@ -7,10 +7,10 @@ export function generateExtensionsEntry(type: AppExtensionType, extensions: Exte
 	return `${filteredExtensions
 		.map(
 			(extension, i) =>
-				`import e${i} from './${path.posix.relative(
-					'.',
-					path.posix.resolve(extension.path, extension.entrypoint || '')
-				)}';\n`
+				`import e${i} from './${path
+					.relative('.', path.resolve(extension.path, extension.entrypoint || ''))
+					.split(path.sep)
+					.join(path.posix.sep)}';\n`
 		)
 		.join('')}export default [${filteredExtensions.map((_, i) => `e${i}`).join(',')}];`;
 }


### PR DESCRIPTION
Extension path and entrypoint are win32 paths, so they have to be converted to posix last.