### PR TITLE
Update *.vue import type shim

### DIFF
--- a/app/src/shims.d.ts
+++ b/app/src/shims.d.ts
@@ -2,9 +2,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 declare module '*.vue' {
-	import { ComponentOptions } from 'vue';
-	const Component: ComponentOptions;
-	export default Component;
+	import { DefineComponent } from 'vue';
+	const component: DefineComponent<{}, {}, any>;
+	export default component;
 }
 
 declare module '*.md' {


### PR DESCRIPTION
Vue router started complaining about the old shim.
This is the shim used by vite's vue-ts template.