### PR TITLE
Update Discussions link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ channels:
 
 - [Discord](https://directus.chat) (Live Discussions)
 - [GitHub Issues](https://github.com/directus/directus/issues) (Report Bugs)
-- [GitHub Discussions](https://github.com/directus/directus/discussions/category_choices) (Questions, Feature Requests)
+- [GitHub Discussions](https://github.com/directus/directus/discussions) (Questions, Feature Requests)
 - [Twitter](https://twitter.com/directus) (Latest News)
 - [YouTube](https://www.youtube.com/c/DirectusVideos/featured) (Video Tutorials)
 


### PR DESCRIPTION
👋🏻 Hello! The `.../discussions/category_choices` URLs for GitHub Discussions is going to stop working in a day or so. We noticed that you're linking there from your README, so I thought I'd send you a PR to update it so your link doesn't go dead.