### PR TITLE
Improvement/add volta js tool manager

### DIFF
--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -9,6 +9,9 @@
 You will need to have [the latest version of Node](https://nodejs.org/en/download/current/) to _build_ a Development
 version of Directus.
 
+You can use the JavaScript tool manager [volta](https://volta.sh/) to automatically install the current node and npm
+versions.
+
 :::
 
 ## 1. Fork the Directus repository

--- a/package.json
+++ b/package.json
@@ -73,5 +73,9 @@
 		"*.{js,ts,vue}": "eslint --fix",
 		"*.{md,yaml}": "prettier --write",
 		"*.{css,scss,vue}": "stylelint --fix"
+	},
+	"volta": {
+		"node": "16.5.0",
+		"npm": "7.20.0"
 	}
 }


### PR DESCRIPTION
#6910 

Define node and npm version for volta in package.json

I thought lerna could also be defined, but it's just possible to define node, npm and yarn.
But lerna is already defined in the devDependencies.

Moreover I added a hint for volta in the contributing docs.