### PR TITLE
Replace DIRECTUS_DEV env var with NODE_ENV and SERVE_APP

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -55,8 +55,8 @@
 		"prebuild": "npm run cleanup",
 		"build": "tsc --build && copyfiles \"src/**/*.*\" -e \"src/**/*.ts\" -u 1 dist",
 		"cleanup": "rimraf dist",
-		"dev": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect --exit-child -- src/start.ts",
-		"cli": "cross-env DIRECTUS_DEV=true NODE_ENV=development ts-node --script-mode --transpile-only src/cli/index.ts"
+		"dev": "cross-env NODE_ENV=development SERVE_APP=false ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect --exit-child -- src/start.ts",
+		"cli": "cross-env NODE_ENV=development SERVE_APP=false ts-node --script-mode --transpile-only src/cli/index.ts"
 	},
 	"engines": {
 		"node": ">=12.20.0"

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -105,7 +105,7 @@ export default async function createApp(): Promise<express.Application> {
 		app.use(cors);
 	}
 
-	if (!('DIRECTUS_DEV' in process.env)) {
+	if (env.SERVE_APP ?? env.NODE_ENV !== 'development') {
 		const adminPath = require.resolve('@directus/app/dist/index.html');
 		const publicUrl = env.PUBLIC_URL.endsWith('/') ? env.PUBLIC_URL : env.PUBLIC_URL + '/';
 

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -38,7 +38,7 @@ export async function initializeExtensions(): Promise<void> {
 		logger.warn(err);
 	}
 
-	if (!('DIRECTUS_DEV' in process.env)) {
+	if (env.SERVE_APP ?? env.NODE_ENV !== 'development') {
 		extensionBundles = await generateExtensionBundles();
 	}
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -8,6 +8,7 @@ import url from 'url';
 import createApp from './app';
 import getDatabase from './database';
 import { emitAsyncSafe } from './emitter';
+import env from './env';
 import logger from './logger';
 
 export default async function createServer(): Promise<http.Server> {
@@ -86,9 +87,7 @@ export default async function createServer(): Promise<http.Server> {
 	async function beforeShutdown() {
 		emitAsyncSafe('server.stop.before', { server });
 
-		if ('DIRECTUS_DEV' in process.env) {
-			logger.info('Restarting...');
-		} else {
+		if (env.NODE_ENV !== 'development') {
 			logger.info('Shutting down...');
 		}
 	}
@@ -102,7 +101,7 @@ export default async function createServer(): Promise<http.Server> {
 	async function onShutdown() {
 		emitAsyncSafe('server.stop');
 
-		if (!('DIRECTUS_DEV' in process.env)) {
+		if (env.NODE_ENV !== 'development') {
 			logger.info('Directus shut down OK. Bye bye!');
 		}
 	}

--- a/api/src/utils/track.ts
+++ b/api/src/utils/track.ts
@@ -14,7 +14,7 @@ export async function track(event: string): Promise<void> {
 		try {
 			await axios.post('https://telemetry.directus.io/', info);
 		} catch (err) {
-			if ('DIRECTUS_DEV' in process.env) {
+			if (env.NODE_ENV === 'development') {
 				logger.error(err);
 			}
 		}
@@ -27,7 +27,7 @@ async function getEnvInfo(event: string) {
 		event: event,
 		project_id: env.KEY,
 		machine_id: await machineId(),
-		environment: process.env.NODE_ENV,
+		environment: env.NODE_ENV,
 		stack: 'node',
 		os: {
 			arch: os.arch(),

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -16,6 +16,7 @@
 | `LOG_STYLE`                | Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.                                | `pretty`      |
 | `MAX_PAYLOAD_SIZE`         | Controls the maximum request body size. Accepts number of bytes, or human readable string.                 | `100kb`       |
 | `ROOT_REDIRECT`            | Where to redirect to when navigating to `/`. Accepts a relative path, absolute URL, or `false` to disable. | `./admin`     |
+| `SERVE_APP`                | Overwrites the default behavior of serving the app in production mode.                                     | --            |
 
 <sup>[1]</sup> The PUBLIC_URL value is used for things like oAuth redirects, forgot-password emails, and logos that
 needs to be publicly available on the internet.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -16,7 +16,7 @@
 | `LOG_STYLE`                | Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.                                | `pretty`      |
 | `MAX_PAYLOAD_SIZE`         | Controls the maximum request body size. Accepts number of bytes, or human readable string.                 | `100kb`       |
 | `ROOT_REDIRECT`            | Where to redirect to when navigating to `/`. Accepts a relative path, absolute URL, or `false` to disable. | `./admin`     |
-| `SERVE_APP`                | Overwrites the default behavior of serving the app in production mode.                                     | --            |
+| `SERVE_APP`                | Whether or not to serve the Admin App under `/admin`.                                     | true            |
 
 <sup>[1]</sup> The PUBLIC_URL value is used for things like oAuth redirects, forgot-password emails, and logos that
 needs to be publicly available on the internet.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"test:e2e": "jest tests -c tests/jest.config.js",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"posttest:e2e:watch": "ts-node --project ./tests/tsconfig.json --transpile-only ./tests/setup/teardown.ts",
-		"cli": "cross-env DIRECTUS_DEV=true NODE_ENV=development DOTENV_CONFIG_PATH=api/.env ts-node -r dotenv/config --script-mode --transpile-only api/src/cli/index.ts"
+		"cli": "cross-env NODE_ENV=development SERVE_APP=false DOTENV_CONFIG_PATH=api/.env ts-node -r dotenv/config --script-mode --transpile-only api/src/cli/index.ts"
 	},
 	"engines": {
 		"node": ">=16.0.0",


### PR DESCRIPTION
If `SERVE_APP` hasn't been set, the App will be served if `NODE_ENV` is not set to `development`.

I also removed the `Restarting...` log message as the API is usually not restarted automatically when receiving a signal, even in development.

Should this be something that is mentioned in the docs? I could see this being useful for users as well.