### PR TITLE
Fix form field sort order

### DIFF
--- a/app/src/composables/use-form-fields/use-form-fields.ts
+++ b/app/src/composables/use-form-fields/use-form-fields.ts
@@ -45,7 +45,7 @@ export default function useFormFields(fields: Ref<Field[]>): { formFields: Compu
 			}
 
 			if (field.meta?.sort && field.meta?.system !== true) {
-				field.meta.sort = field.meta.sort + systemFieldsCount.value;
+				field.meta.sort = Number(field.meta.sort) + Number(systemFieldsCount.value);
 			}
 
 			return field;


### PR DESCRIPTION
Tweak sort order generation.

In case the DB driver returns the sort order as a string, coming from a bigInt instead of an int field