### PR TITLE
Prevent from deleting the last admin user

### DIFF
--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -6,7 +6,7 @@ import { clone, cloneDeep, isObject, isPlainObject, omit } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import getDatabase from '../database';
 import { ForbiddenException, InvalidPayloadException } from '../exceptions';
-import { AbstractServiceOptions, Accountability, Item, PrimaryKey, Query, SchemaOverview } from '../types';
+import { AbstractServiceOptions, Accountability, Item, PrimaryKey, Query, SchemaOverview, Alterations } from '../types';
 import { toArray } from '../utils/to-array';
 import { ItemsService } from './items';
 
@@ -19,16 +19,6 @@ type Transformers = {
 		payload: Partial<Item>;
 		accountability: Accountability | null;
 	}) => Promise<any>;
-};
-
-type Alterations = {
-	create: {
-		[key: string]: any;
-	}[];
-	update: {
-		[key: string]: any;
-	}[];
-	delete: (number | string)[];
 };
 
 /**

--- a/api/src/services/roles.ts
+++ b/api/src/services/roles.ts
@@ -10,7 +10,7 @@ export class RolesService extends ItemsService {
 		super('directus_roles', options);
 	}
 
-	private async checkForOtherAdminRoles(excludeKeys: PrimaryKey[]) {
+	private async checkForOtherAdminRoles(excludeKeys: PrimaryKey[]): Promise<void> {
 		// Make sure there's at least one admin role left after this deletion is done
 		const otherAdminRoles = await this.knex
 			.count('*', { as: 'count' })
@@ -23,7 +23,7 @@ export class RolesService extends ItemsService {
 		if (otherAdminRolesCount === 0) throw new UnprocessableEntityException(`You can't delete the last admin role.`);
 	}
 
-	private async checkForOtherAdminUsers(key: PrimaryKey, users: Alterations | Item[]) {
+	private async checkForOtherAdminUsers(key: PrimaryKey, users: Alterations | Item[]): Promise<void> {
 		const role = await this.knex.select('admin_access').from('directus_roles').where('id', '=', key).first();
 
 		if (!role) throw new ForbiddenException();
@@ -62,6 +62,8 @@ export class RolesService extends ItemsService {
 		if (otherAdminUsersCount === 0) {
 			throw new UnprocessableEntityException(`You can't remove the last admin user from the admin role.`);
 		}
+
+		return;
 	}
 
 	async updateOne(key: PrimaryKey, data: Record<string, any>, opts?: MutationOptions) {

--- a/api/src/services/roles.ts
+++ b/api/src/services/roles.ts
@@ -1,6 +1,6 @@
-import { UnprocessableEntityException } from '../exceptions';
-import { AbstractServiceOptions, PrimaryKey } from '../types';
-import { ItemsService } from './items';
+import { ForbiddenException, UnprocessableEntityException } from '../exceptions';
+import { AbstractServiceOptions, PrimaryKey, Query, Alterations, Item } from '../types';
+import { ItemsService, MutationOptions } from './items';
 import { PermissionsService } from './permissions';
 import { PresetsService } from './presets';
 import { UsersService } from './users';
@@ -10,21 +10,87 @@ export class RolesService extends ItemsService {
 		super('directus_roles', options);
 	}
 
+	private async checkForOtherAdminRoles(excludeKeys: PrimaryKey[]) {
+		// Make sure there's at least one admin role left after this deletion is done
+		const otherAdminRoles = await this.knex
+			.count('*', { as: 'count' })
+			.from('directus_roles')
+			.whereNotIn('id', excludeKeys)
+			.andWhere({ admin_access: true })
+			.first();
+
+		const otherAdminRolesCount = +(otherAdminRoles?.count || 0);
+		if (otherAdminRolesCount === 0) throw new UnprocessableEntityException(`You can't delete the last admin role.`);
+	}
+
+	private async checkForOtherAdminUsers(key: PrimaryKey, users: Alterations | Item[]) {
+		const role = await this.knex.select('admin_access').from('directus_roles').where('id', '=', key).first();
+
+		if (!role) throw new ForbiddenException();
+
+		// The users that will now be in this new non-admin role
+		let userKeys: PrimaryKey[] = [];
+
+		if (Array.isArray(users)) {
+			userKeys = users.map((user) => (typeof user === 'string' ? user : user.id)).filter((id) => id);
+		} else {
+			userKeys = users.update.map((user) => user.id).filter((id) => id);
+		}
+
+		const usersThatWereInRoleBefore = (await this.knex.select('id').from('directus_users').where('role', '=', key)).map(
+			(user) => user.id
+		);
+		const usersThatAreRemoved = usersThatWereInRoleBefore.filter((id) => userKeys.includes(id) === false);
+
+		const usersThatAreAdded = Array.isArray(users) ? users : users.create;
+
+		// If the role the users are moved to is an admin-role, and there's at least 1 (new) admin
+		// user, we don't have to check for other admin
+		// users
+		if ((role.admin_access === true || role.admin_access === 1) && usersThatAreAdded.length > 0) return;
+
+		const otherAdminUsers = await this.knex
+			.count('*', { as: 'count' })
+			.from('directus_users')
+			.whereNotIn('directus_users.id', [...userKeys, ...usersThatAreRemoved])
+			.andWhere({ 'directus_roles.admin_access': true })
+			.leftJoin('directus_roles', 'directus_users.role', 'directus_roles.id')
+			.first();
+
+		const otherAdminUsersCount = +(otherAdminUsers?.count || 0);
+
+		if (otherAdminUsersCount === 0) {
+			throw new UnprocessableEntityException(`You can't remove the last admin user from the admin role.`);
+		}
+	}
+
+	async updateOne(key: PrimaryKey, data: Record<string, any>, opts?: MutationOptions) {
+		if ('admin_access' in data && data.admin_access === false) {
+			await this.checkForOtherAdminRoles([key]);
+		}
+
+		if ('users' in data) {
+			await this.checkForOtherAdminUsers(key, data.users);
+		}
+
+		return super.updateOne(key, data, opts);
+	}
+
+	async updateMany(keys: PrimaryKey[], data: Record<string, any>, opts?: MutationOptions) {
+		if ('admin_access' in data && data.admin_access === false) {
+			await this.checkForOtherAdminRoles(keys);
+		}
+
+		return super.updateMany(keys, data, opts);
+	}
+
 	async deleteOne(key: PrimaryKey): Promise<PrimaryKey> {
 		await this.deleteMany([key]);
 		return key;
 	}
 
 	async deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]> {
-		// Make sure there's at least one admin role left after this deletion is done
-		const otherAdminRoles = await this.knex
-			.count('*', { as: 'count' })
-			.from('directus_roles')
-			.whereNotIn('id', keys)
-			.andWhere({ admin_access: true })
-			.first();
-		const otherAdminRolesCount = +(otherAdminRoles?.count || 0);
-		if (otherAdminRolesCount === 0) throw new UnprocessableEntityException(`You can't delete the last admin role.`);
+		await this.checkForOtherAdminRoles(keys);
 
 		await this.knex.transaction(async (trx) => {
 			const itemsService = new ItemsService('directus_roles', {
@@ -75,6 +141,10 @@ export class RolesService extends ItemsService {
 		});
 
 		return keys;
+	}
+
+	deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		return super.deleteByQuery(query, opts);
 	}
 
 	/**

--- a/api/src/types/items.ts
+++ b/api/src/types/items.ts
@@ -6,3 +6,13 @@
 export type Item = Record<string, any>;
 
 export type PrimaryKey = string | number;
+
+export type Alterations = {
+	create: {
+		[key: string]: any;
+	}[];
+	update: {
+		[key: string]: any;
+	}[];
+	delete: (number | string)[];
+};

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -423,6 +423,7 @@ errors:
   USER_SUSPENDED: User Suspended
   CONTAINS_NULL_VALUES: Field contains null values
   UNKNOWN: Unexpected Error
+  UNPROCESSABLE_ENTITY: Unprocessable entity
   INTERNAL_SERVER_ERROR: Unexpected Error
 value_hashed: Value Securely Hashed
 bookmark_name: Bookmark name...


### PR DESCRIPTION
Will check if there's at least a single admin role/user remaining after updates are applied. This prevents the user from accidentally removing the last admin role/user, which would lock them out of the system completely.

Fixes #6990