### PR TITLE
Add new /utils/cache/clear endpoint

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -44,9 +44,10 @@ import {
 import { Knex } from 'knex';
 import { flatten, get, mapKeys, merge, set, uniq } from 'lodash';
 import ms from 'ms';
+import { getCache } from '../cache';
 import getDatabase from '../database';
 import env from '../env';
-import { BaseException, GraphQLValidationException, InvalidPayloadException } from '../exceptions';
+import { BaseException, ForbiddenException, GraphQLValidationException, InvalidPayloadException } from '../exceptions';
 import { listExtensions } from '../extensions';
 import { AbstractServiceOptions, Accountability, Action, GraphQLParams, Item, Query, SchemaOverview } from '../types';
 import { getGraphQLType } from '../utils/get-graphql-type';
@@ -1607,6 +1608,21 @@ export class GraphQLService {
 					});
 					await service.revert(args.revision);
 					return true;
+				},
+			},
+			utils_cache_clear: {
+				type: GraphQLVoid,
+				resolve: async () => {
+					if (this.accountability?.admin !== true) {
+						throw new ForbiddenException();
+					}
+
+					const { cache, schemaCache } = getCache();
+
+					await cache?.clear();
+					await schemaCache?.clear();
+
+					return;
 				},
 			},
 			users_invite_accept: {

--- a/docs/reference/api/system/utilities.md
+++ b/docs/reference/api/system/utilities.md
@@ -269,3 +269,38 @@ n/a
 </div>
 
 ---
+
+## Clear the Internal Cache
+
+Resets both the data and schema cache of Directus. This endpoint is only available to admin users.
+
+<div class="two-up">
+<div class="left">
+
+### Request Body
+
+n/a
+
+### Returns
+
+Empty body
+
+</div>
+<div class="right">
+
+### REST API
+
+```
+POST /utils/cache/clear
+```
+
+### GraphQL
+
+```graphql
+mutation {
+	utils_cache_clear
+}
+```
+
+</div>
+</div>


### PR DESCRIPTION
Allows admin users to force-reset the internal cache, useful if you're doing direct-to-db updates with (schema-)caching enabled