### PR TITLE
Handle autocomplete empty path configurations

### DIFF
--- a/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
+++ b/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-notice v-if="!url || !resultsPath || !valuePath" type="warning">
+	<v-notice v-if="!url" type="warning">
 		{{ t('one_or_more_options_are_missing') }}
 	</v-notice>
 	<div v-else>
@@ -98,15 +98,15 @@ export default defineComponent({
 
 			try {
 				const result = await axios.get(url);
-				const resultsArray = get(result.data, props.resultsPath);
+				const resultsArray = props.resultsPath ? get(result.data, props.resultsPath) : result.data;
 
 				if (Array.isArray(resultsArray) === false) {
 					// eslint-disable-next-line no-console
-					console.warn(`Expected results type of array, "${typeof resultsArray}" recieved`);
+					console.warn(`Expected results type of array, "${typeof resultsArray}" received`);
 					return;
 				} else {
 					results.value = resultsArray
-						.map((result: Record<string, unknown>) => get(result, props.valuePath))
+						.map((result: Record<string, unknown>) => (props.valuePath ? get(result, props.valuePath) : result))
 						.filter((val: unknown) => val);
 				}
 			} catch (err) {


### PR DESCRIPTION
PR opened as discussed in #7016. With this changes, one can configure Autocomplete Input to get results from any kind of API format, even a simple as:

```json
[
  "option 1",
  "option 2",
  "option 3"
]
```

This is the case when the field interface would be configured with empty "resultsPath" and "valuePath" options. So the field now can handle all use cases, from the simplest ones to more complex JSON structures.

Hope the code is clean enough (otherwise, feel free to state, so I can adjust).

Best regards!