### PR TITLE
Stall login/pw reset to prevent email leaking

### DIFF
--- a/api/src/utils/stall.ts
+++ b/api/src/utils/stall.ts
@@ -1,0 +1,36 @@
+import { performance } from 'perf_hooks';
+
+/**
+ * Wait a specific time to meet the stall ms. Useful in cases where you need to make sure that every
+ * path in a function takes at least X ms (for example authenticate).
+ *
+ * @param {number} ms - Stall time to wait until
+ * @param {number} start - Current start time of the function
+ *
+ * @example
+ *
+ * ```js
+ * const STALL_TIME = 100;
+ *
+ * // Function will always take (at least) 100ms
+ * async function doSomething() {
+ *   const timeStart = performance.now();
+ *
+ *   if (something === true) {
+ *     await heavy();
+ *   }
+ *
+ *   stall(STALL_TIME, timeStart);
+ *   return 'result';
+ * }
+ * ```
+ */
+export async function stall(ms: number, start: number) {
+	const now = performance.now();
+	const timeElapsed = now - start;
+	const timeRemaining = ms - timeElapsed;
+
+	if (timeRemaining <= 0) return;
+
+	return new Promise((resolve) => setTimeout(resolve, timeRemaining));
+}


### PR DESCRIPTION
Artificially stalls the login and pw-reset flows to ensure there's no timing difference in logging in with a existing or non-existing email address