### PR TITLE
Auth patch to @directus/gatsby-source-directus

### DIFF
--- a/packages/gatsby-source-directus/gatsby-node.js
+++ b/packages/gatsby-source-directus/gatsby-node.js
@@ -169,7 +169,7 @@ exports.sourceNodes = async (gatsby, options) => {
 exports.createResolvers = async ({ actions, cache, createNodeId, createResolvers, store, reporter }, options) => {
 	const { createNode } = actions;
 
-	const { url } = options;
+	const { url, auth } = options;
 
 	let endpoints = normalizeEndpoint(url);
 
@@ -187,6 +187,7 @@ exports.createResolvers = async ({ actions, cache, createNodeId, createResolvers
 						cache,
 						createNode,
 						createNodeId,
+						httpHeaders: { Authorization: `Bearer ${auth.token}` },
 						reporter,
 					});
 				},


### PR DESCRIPTION
Gatsby needs one-time access to the images at build time with the secure access token. With this security patch it is now no longer needed to have all Directus files continuously exposed to the public.