### PR TITLE
Add missing keys to translations

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -978,6 +978,8 @@ interfaces:
     inline_title_label: Show title inside line
     margin_top: Margin Top
     margin_top_label: Increase Top Margin
+    default_active: Default open
+    default_active_label: Open the drawer automatically as default state
   select-dropdown:
     description: Select a value from a dropdown
     choices_placeholder: Add a new choice


### PR DESCRIPTION
It seems like those keys were added in #7059 and removed by accident in #7075.