### PR TITLE
Fix list-selection branch mode unselect bug

### DIFF
--- a/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
@@ -258,15 +258,20 @@ export default defineComponent({
 		function emitBranch(rawValue: (string | number)[], { added, removed }: Delta) {
 			const allChildrenRecursive = getRecursiveChildrenValues('all');
 
+			// Note: Added/removed is a tad confusing here, as an item that gets added to the array of
+			// selected items can immediately be negated by the logic below, as it's potentially
+			// replaced by the parent item's value
+
 			// When clicking on an individual item in the enabled group
 			if (
 				(props.modelValue.includes(props.value) || props.checked === true) &&
 				added &&
-				childrenValues.value.includes(added?.[0])
+				added.length === 1 &&
+				childrenValues.value.includes(added[0])
 			) {
 				const newValue = [
-					...rawValue.filter((val) => val !== props.value && val !== added?.[0]),
-					...childrenValues.value.filter((childVal) => childVal !== added?.[0]),
+					...rawValue.filter((val) => val !== props.value && val !== added[0]),
+					...childrenValues.value.filter((childVal) => childVal !== added[0]),
 				];
 
 				return emitValue(newValue);
@@ -446,6 +451,6 @@ export default defineComponent({
 
 <style scoped>
 .item {
-	padding-left: 32px;
+	padding-left: 32px !important;
 }
 </style>

--- a/app/src/components/v-list/v-list-group.vue
+++ b/app/src/components/v-list/v-list-group.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="v-list-group">
+	<li class="v-list-group">
 		<v-list-item
 			class="activator"
 			:active="active"
@@ -29,10 +29,10 @@
 			</v-list-item-icon>
 		</v-list-item>
 
-		<div v-if="groupActive" class="items">
+		<ul v-if="groupActive" class="items">
 			<slot />
-		</div>
-	</div>
+		</ul>
+	</li>
 </template>
 
 <script lang="ts">
@@ -134,6 +134,7 @@ export default defineComponent({
 
 	.items {
 		padding-left: 16px;
+		list-style: none;
 	}
 }
 </style>

--- a/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue
+++ b/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue
@@ -1,28 +1,25 @@
 <template>
-	<div>
-		<div class="select-multiple-checkbox-tree">
-			<div class="search">
-				<v-input v-model="search" class="input" type="text" :placeholder="t('search')">
-					<template #prepend>
-						<v-icon name="search" />
-					</template>
+	<div class="select-multiple-checkbox-tree">
+		<div class="search">
+			<v-input v-model="search" class="input" type="text" :placeholder="t('search')">
+				<template #prepend>
+					<v-icon name="search" />
+				</template>
 
-					<template v-if="search" #append>
-						<v-icon name="clear" clickable @click="search = ''" />
-					</template>
-				</v-input>
-			</div>
-
-			<v-checkbox-tree
-				:model-value="value"
-				:search="searchDebounced"
-				:disabled="disabled"
-				:choices="choices"
-				:value-combining="valueCombining"
-				@update:model-value="$emit('input', $event)"
-			/>
+				<template v-if="search" #append>
+					<v-icon name="clear" clickable @click="search = ''" />
+				</template>
+			</v-input>
 		</div>
-		<pre>{{ value }}</pre>
+
+		<v-checkbox-tree
+			:model-value="value"
+			:search="searchDebounced"
+			:disabled="disabled"
+			:choices="choices"
+			:value-combining="valueCombining"
+			@update:model-value="$emit('input', $event)"
+		/>
 	</div>
 </template>
 

--- a/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue
+++ b/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue
@@ -1,25 +1,28 @@
 <template>
-	<div class="select-multiple-checkbox-tree">
-		<div class="search">
-			<v-input v-model="search" class="input" type="text" :placeholder="t('search')">
-				<template #prepend>
-					<v-icon name="search" />
-				</template>
+	<div>
+		<div class="select-multiple-checkbox-tree">
+			<div class="search">
+				<v-input v-model="search" class="input" type="text" :placeholder="t('search')">
+					<template #prepend>
+						<v-icon name="search" />
+					</template>
 
-				<template v-if="search" #append>
-					<v-icon name="clear" clickable @click="search = ''" />
-				</template>
-			</v-input>
+					<template v-if="search" #append>
+						<v-icon name="clear" clickable @click="search = ''" />
+					</template>
+				</v-input>
+			</div>
+
+			<v-checkbox-tree
+				:model-value="value"
+				:search="searchDebounced"
+				:disabled="disabled"
+				:choices="choices"
+				:value-combining="valueCombining"
+				@update:model-value="$emit('input', $event)"
+			/>
 		</div>
-
-		<v-checkbox-tree
-			:model-value="value"
-			:search="searchDebounced"
-			:disabled="disabled"
-			:choices="choices"
-			:value-combining="valueCombining"
-			@update:model-value="$emit('input', $event)"
-		/>
+		<pre>{{ value }}</pre>
 	</div>
 </template>
 


### PR DESCRIPTION
The `v-tree-select` component would deselect sibling items, instead of just children items on branch mode deselect of a single child item.