### PR TITLE
Refresh token after idle period/background tab

### DIFF
--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -22,10 +22,11 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, toRefs, watch, computed, provide } from 'vue';
+import { defineComponent, toRefs, watch, computed, provide, onMounted, onUnmounted } from 'vue';
 import * as stores from '@/stores';
 import api, { addTokenToURL } from '@/api';
 import axios from 'axios';
+import { startIdleTracking, stopIdleTracking, idleTracker } from './idle';
 
 import useWindowSize from '@/composables/use-window-size';
 import setFavicon from '@/utils/set-favicon';
@@ -47,6 +48,9 @@ export default defineComponent({
 				'--brand': serverStore.info?.project?.project_color || 'var(--primary)',
 			};
 		});
+
+		onMounted(() => startIdleTracking());
+		onUnmounted(() => stopIdleTracking());
 
 		watch([() => serverStore.info?.project?.project_color, () => serverStore.info?.project?.project_logo], () => {
 			const hasCustomLogo = !!serverStore.info?.project?.project_logo;

--- a/app/src/idle.ts
+++ b/app/src/idle.ts
@@ -1,0 +1,61 @@
+import mitt from 'mitt';
+
+const events = ['pointermove', 'pointerdown', 'keydown'];
+const time = 5 * 60 * 1000; // 5 min in ms
+
+let timeout: NodeJS.Timeout;
+
+let visible = true;
+let idle = false;
+
+export const idleTracker = mitt();
+
+export function startIdleTracking() {
+	document.addEventListener('visibilitychange', onVisibilityChange);
+
+	for (const event of events) {
+		document.addEventListener(event, onIdleEvents);
+	}
+
+	resetTimeout();
+}
+
+export function stopIdleTracking() {
+	document.removeEventListener('visibilitychange', onVisibilityChange);
+
+	for (const event of events) {
+		document.removeEventListener(event, onIdleEvents);
+	}
+}
+
+function onIdleEvents() {
+	if (idle === true) {
+		idle = false;
+		idleTracker.emit('active');
+	}
+
+	resetTimeout();
+}
+
+function onVisibilityChange() {
+	if (document.visibilityState === 'hidden' && visible === true) {
+		visible = false;
+		idleTracker.emit('hide');
+	}
+
+	if (document.visibilityState === 'visible' && visible === false) {
+		visible = true;
+		idleTracker.emit('show');
+	}
+}
+
+function resetTimeout() {
+	if (timeout) {
+		clearTimeout(timeout);
+	}
+
+	timeout = setTimeout(() => {
+		idle = true;
+		idleTracker.emit('idle');
+	}, time);
+}


### PR DESCRIPTION
This will stop the token auto-refresh once the user is idle (for 5+ minutes), or if the browser tab is hidden (using visibility change). Once the user is active again/opened the tab, the token will be refreshed. This should prevent the issue where the app had trouble persisting the user session while running in the background.

This will however increase the amount of refreshes made from the app, as we now have to do a refresh as soon as you change the tab and change back. It remains to be seen how much impact this has in real life, but it's something to be aware of.

Fixes #3940