### PR TITLE
Only loads app extensions if SERVE_APP is true

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -171,7 +171,7 @@ export default async function createApp(): Promise<express.Application> {
 	app.use('/relations', relationsRouter);
 	app.use('/revisions', revisionsRouter);
 	app.use('/roles', rolesRouter);
-	app.use('/server/', serverRouter);
+	app.use('/server', serverRouter);
 	app.use('/settings', settingsRouter);
 	app.use('/users', usersRouter);
 	app.use('/utils', utilsRouter);

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -8,7 +8,14 @@ import {
 	getPackageExtensions,
 	resolvePackage,
 } from '@directus/shared/utils/node';
-import { APP_EXTENSION_TYPES, APP_SHARED_DEPS } from '@directus/shared/constants';
+import {
+	API_EXTENSION_PACKAGE_TYPES,
+	API_EXTENSION_TYPES,
+	APP_EXTENSION_TYPES,
+	APP_SHARED_DEPS,
+	EXTENSION_PACKAGE_TYPES,
+	EXTENSION_TYPES,
+} from '@directus/shared/constants';
 import getDatabase from './database';
 import emitter from './emitter';
 import env from './env';
@@ -31,14 +38,14 @@ let extensionBundles: Partial<Record<AppExtensionType, string>> = {};
 
 export async function initializeExtensions(): Promise<void> {
 	try {
-		await ensureExtensionDirs(env.EXTENSIONS_PATH);
+		await ensureExtensionDirs(env.EXTENSIONS_PATH, env.SERVE_APP ? EXTENSION_TYPES : API_EXTENSION_TYPES);
 		extensions = await getExtensions();
 	} catch (err) {
 		logger.warn(`Couldn't load extensions`);
 		logger.warn(err);
 	}
 
-	if (env.SERVE_APP ?? env.NODE_ENV !== 'development') {
+	if (env.SERVE_APP) {
 		extensionBundles = await generateExtensionBundles();
 	}
 
@@ -71,8 +78,14 @@ export function registerExtensionHooks(): void {
 }
 
 async function getExtensions(): Promise<Extension[]> {
-	const packageExtensions = await getPackageExtensions('.');
-	const localExtensions = await getLocalExtensions(env.EXTENSIONS_PATH);
+	const packageExtensions = await getPackageExtensions(
+		'.',
+		env.SERVE_APP ? EXTENSION_PACKAGE_TYPES : API_EXTENSION_PACKAGE_TYPES
+	);
+	const localExtensions = await getLocalExtensions(
+		env.EXTENSIONS_PATH,
+		env.SERVE_APP ? EXTENSION_TYPES : API_EXTENSION_TYPES
+	);
 
 	return [...packageExtensions, ...localExtensions];
 }

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -8,7 +8,7 @@ import {
 	getLocalExtensions,
 	generateExtensionsEntry,
 } from '@directus/shared/utils/node';
-import { APP_SHARED_DEPS, APP_EXTENSION_TYPES } from '@directus/shared/constants';
+import { APP_SHARED_DEPS, APP_EXTENSION_TYPES, APP_EXTENSION_PACKAGE_TYPES } from '@directus/shared/constants';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -94,9 +94,9 @@ function directusExtensions() {
 		const apiPath = path.join('..', 'api');
 		const extensionsPath = path.join(apiPath, 'extensions');
 
-		await ensureExtensionDirs(extensionsPath);
-		const packageExtensions = await getPackageExtensions(apiPath);
-		const localExtensions = await getLocalExtensions(extensionsPath);
+		await ensureExtensionDirs(extensionsPath, APP_EXTENSION_TYPES);
+		const packageExtensions = await getPackageExtensions(apiPath, APP_EXTENSION_PACKAGE_TYPES);
+		const localExtensions = await getLocalExtensions(extensionsPath, APP_EXTENSION_TYPES);
 
 		const extensions = [...packageExtensions, ...localExtensions];
 

--- a/packages/shared/src/constants/extensions.ts
+++ b/packages/shared/src/constants/extensions.ts
@@ -4,7 +4,11 @@ export const API_SHARED_DEPS = ['axios'];
 export const APP_EXTENSION_TYPES = ['interface', 'display', 'layout', 'module'] as const;
 export const API_EXTENSION_TYPES = ['hook', 'endpoint'] as const;
 export const EXTENSION_TYPES = [...APP_EXTENSION_TYPES, ...API_EXTENSION_TYPES] as const;
-export const EXTENSION_PACKAGE_TYPES = [...EXTENSION_TYPES, 'pack'] as const;
+
+export const EXTENSION_PACK_TYPE = 'pack';
+export const APP_EXTENSION_PACKAGE_TYPES = [...APP_EXTENSION_TYPES, EXTENSION_PACK_TYPE] as const;
+export const API_EXTENSION_PACKAGE_TYPES = [...API_EXTENSION_TYPES, EXTENSION_PACK_TYPE] as const;
+export const EXTENSION_PACKAGE_TYPES = [...EXTENSION_TYPES, EXTENSION_PACK_TYPE] as const;
 
 export const EXTENSION_NAME_REGEX = /^(?:(?:@[^/]+\/)?directus-extension-|@directus\/extension-).+$/;
 

--- a/packages/shared/src/types/extensions.ts
+++ b/packages/shared/src/types/extensions.ts
@@ -1,14 +1,19 @@
 import {
+	API_EXTENSION_PACKAGE_TYPES,
 	API_EXTENSION_TYPES,
+	APP_EXTENSION_PACKAGE_TYPES,
 	APP_EXTENSION_TYPES,
 	EXTENSION_PACKAGE_TYPES,
 	EXTENSION_PKG_KEY,
 	EXTENSION_TYPES,
 } from '../constants';
 
-export type ApiExtensionType = typeof API_EXTENSION_TYPES[number];
 export type AppExtensionType = typeof APP_EXTENSION_TYPES[number];
+export type ApiExtensionType = typeof API_EXTENSION_TYPES[number];
 export type ExtensionType = typeof EXTENSION_TYPES[number];
+
+export type AppExtensionPackageType = typeof APP_EXTENSION_PACKAGE_TYPES[number];
+export type ApiExtensionPackageType = typeof API_EXTENSION_PACKAGE_TYPES[number];
 export type ExtensionPackageType = typeof EXTENSION_PACKAGE_TYPES[number];
 
 export type Extension = {

--- a/packages/shared/src/utils/node/ensure-extension-dirs.ts
+++ b/packages/shared/src/utils/node/ensure-extension-dirs.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import fse from 'fs-extra';
 import { pluralize } from '../pluralize';
-import { EXTENSION_TYPES } from '../../constants';
+import { ExtensionType } from '../../types';
 
-export async function ensureExtensionDirs(extensionsPath: string): Promise<void> {
-	for (const extensionType of EXTENSION_TYPES) {
+export async function ensureExtensionDirs(extensionsPath: string, types: readonly ExtensionType[]): Promise<void> {
+	for (const extensionType of types) {
 		const dirPath = path.resolve(extensionsPath, pluralize(extensionType));
 		try {
 			await fse.ensureDir(dirPath);


### PR DESCRIPTION
This also ensures API/App only load their respective extensions in dev.

Unfortunately, the whole `*_EXTENSION_*_TYPES`-thing is getting a little verbose, but at least typescript is very happy.