### PR TITLE
Add permission check for sqlite, upload and extensions directories

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -41,6 +41,7 @@ import sanitizeQuery from './middleware/sanitize-query';
 import schema from './middleware/schema';
 import { track } from './utils/track';
 import { validateEnv } from './utils/validate-env';
+import { validateStorage } from './utils/validate-storage';
 import { register as registerWebhooks } from './webhooks';
 import { session } from './middleware/session';
 import { flushCaches } from './cache';
@@ -53,6 +54,8 @@ export default async function createApp(): Promise<express.Application> {
 	} catch {
 		logger.warn('PUBLIC_URL is not a valid URL');
 	}
+
+	await validateStorage();
 
 	await validateDBConnection();
 

--- a/api/src/utils/validate-storage.ts
+++ b/api/src/utils/validate-storage.ts
@@ -1,0 +1,31 @@
+import env from '../env';
+import logger from '../logger';
+import { access } from 'fs/promises';
+import { constants } from 'fs';
+import path from 'path';
+
+export async function validateStorage(): Promise<void> {
+	if (env.DB_CLIENT === 'sqlite3') {
+		try {
+			await access(path.dirname(env.DB_FILENAME), constants.R_OK | constants.W_OK);
+		} catch {
+			logger.warn(
+				`Directory for SQLite database file (${path.resolve(path.dirname(env.DB_FILENAME))}) is not read/writeable!`
+			);
+		}
+	}
+
+	if (env.STORAGE_LOCATIONS.split(',').includes('local')) {
+		try {
+			await access(env.STORAGE_LOCAL_ROOT, constants.R_OK | constants.W_OK);
+		} catch {
+			logger.warn(`Upload directory (${path.resolve(env.STORAGE_LOCAL_ROOT)}) is not read/writeable!`);
+		}
+	}
+
+	try {
+		await access(env.EXTENSIONS_PATH, constants.R_OK);
+	} catch {
+		logger.warn(`Extensions directory (${path.resolve(env.EXTENSIONS_PATH)}) is not readable!`);
+	}
+}


### PR DESCRIPTION
As discussed in #7111

Warnings will be thrown in logs, like this:
```
directus: 15:19:12 ⚠️  Directory for SQLite database file (/Users/<redacted>/Development/directus/api) is not read/writeable!
directus: 15:19:12 ⚠️  Upload directory (/Users/<redacted>/Development/directus/api/uploads) is not read/writeable!
directus: 15:19:12 ⚠️  Extensions directory (/Users/<redacted>/Development/directus/api/extensions) is not readable!
```