### PR TITLE
Add `TELEMETRY` env var description in env vars reference

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -350,10 +350,12 @@ variables to automatically configure the first user:
 
 ## Telemetry
 
-Directus collects little and anonymized data about your environment. You can easily opt-out with the following environment variable:
+To more accurately gauge the frequency of installation, version fragmentation, and general size of the userbase,
+Directus collects little and anonymized data about your environment. You can easily opt-out with the following
+environment variable:
 
 | Variable    | Description                                                       | Default Value |
-| ------------| ----------------------------------------------------------------- | ------------- |
+| ----------- | ----------------------------------------------------------------- | ------------- |
 | `TELEMETRY` | Allow Directus to collect anonymized data about your environment. | true          |
 
 ---

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -338,7 +338,7 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 | `EMAIL_MAILGUN_DOMAIN`  | A domain from [your Mailgun account](https://app.mailgun.com/app/sending/domains) | --                |
 | `EMAIL_MAILGUN_HOST`    | Allows you to specify a custom host.                                              | 'api.mailgun.net' |
 
-## Misc.
+## Admin Account
 
 If you're relying on Docker and/or the `directus bootstrap` CLI command, you can pass the following two environment
 variables to automatically configure the first user:
@@ -347,6 +347,14 @@ variables to automatically configure the first user:
 | ---------------- | ------------------------------------------------------------------------------------------------- | ------------- |
 | `ADMIN_EMAIL`    | The email address of the first user that's automatically created when using `directus bootstrap`. | --            |
 | `ADMIN_PASSWORD` | The password of the first user that's automatically created when using `directus bootstrap`.      | --            |
+
+## Telemetry
+
+Directus collects little and anonymized data about your environment. You can easily opt-out with the following environment variable:
+
+| Variable    | Description                                                       | Default Value |
+| ------------| ----------------------------------------------------------------- | ------------- |
+| `TELEMETRY` | Allow Directus to collect anonymized data about your environment. | true          |
 
 ---
 


### PR DESCRIPTION
I stumbled upon the TELEMETRY environment variable and was a little bit surprised that it is not mentioned in the documentation.
While I'm totally okay with it (as only little / harmless data is collected) I think it's better to mention it somewhere and give users who don't want this the possibility to opt-out.
Feel free to close this PR if you don't like it.