### PR TITLE
Add basic support for a config file to extension building

### DIFF
--- a/packages/extension-sdk/src/cli/commands/build.ts
+++ b/packages/extension-sdk/src/cli/commands/build.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import chalk from 'chalk';
 import fse from 'fs-extra';
 import ora from 'ora';
-import { OutputOptions as RollupOutputOptions, rollup, RollupOptions } from 'rollup';
+import { OutputOptions as RollupOutputOptions, rollup, RollupOptions, Plugin } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
@@ -12,6 +12,7 @@ import { EXTENSION_PKG_KEY, EXTENSION_TYPES, APP_SHARED_DEPS, API_SHARED_DEPS } 
 import { isAppExtension, isExtension, validateExtensionManifest } from '@directus/shared/utils';
 import { ExtensionManifestRaw } from '@directus/shared/types';
 import log from '../utils/logger';
+import loadConfig from '../utils/load-config';
 
 type BuildOptions = { type: string; input: string; output: string; force: boolean };
 
@@ -55,11 +56,13 @@ export default async function build(options: BuildOptions): Promise<void> {
 		process.exit(1);
 	}
 
+	const config = await loadConfig();
+
 	const isApp = isAppExtension(type);
 
 	const spinner = ora('Building Directus extension...').start();
 
-	const rollupOptions = getRollupOptions(isApp, input);
+	const rollupOptions = getRollupOptions(isApp, input, config.plugins);
 	const rollupOutputOptions = getRollupOutputOptions(isApp, output);
 
 	const bundle = await rollup(rollupOptions);
@@ -71,7 +74,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 	spinner.succeed('Done');
 }
 
-function getRollupOptions(isApp: boolean, input: string): RollupOptions {
+function getRollupOptions(isApp: boolean, input: string, plugins: Plugin[] = []): RollupOptions {
 	if (isApp) {
 		return {
 			input,
@@ -79,6 +82,7 @@ function getRollupOptions(isApp: boolean, input: string): RollupOptions {
 			plugins: [
 				vue({ preprocessStyles: true }),
 				styles(),
+				...plugins,
 				nodeResolve(),
 				commonjs({ esmExternals: true, sourceMap: false }),
 				terser(),
@@ -88,7 +92,7 @@ function getRollupOptions(isApp: boolean, input: string): RollupOptions {
 		return {
 			input,
 			external: API_SHARED_DEPS,
-			plugins: [nodeResolve(), commonjs({ sourceMap: false }), terser()],
+			plugins: [...plugins, nodeResolve(), commonjs({ sourceMap: false }), terser()],
 		};
 	}
 }

--- a/packages/extension-sdk/src/cli/utils/load-config.ts
+++ b/packages/extension-sdk/src/cli/utils/load-config.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import fse from 'fs-extra';
+
+const CONFIG_FILE_NAMES = ['extension.config.js', 'extension.config.mjs', 'extension.config.cjs'];
+
+// This is needed to work around Typescript always transpiling import() to require() for CommonJS targets.
+const _import = new Function('url', 'return import(url)');
+
+export default async function loadConfig(): Promise<Record<string, any>> {
+	for (const fileName of CONFIG_FILE_NAMES) {
+		if (await fse.pathExists(fileName)) {
+			const configFile = await _import(path.join(process.cwd(), fileName));
+
+			return configFile.default;
+		}
+	}
+
+	return {};
+}


### PR DESCRIPTION
The config file has to be a file inside the cwd. It should be named "extension.config.(m|c)?js". Right now it only supports specifying a plugins array.

Let's see if a single injection point into rollup's plugin loading order is sufficient. We can extend this later on.

Edit: By using the `type` field in `package.json` or using the appropriate file extension (`.mjs` or `.cjs`), the config file can be loaded as a CommonJS or ESM file.