### PR TITLE
Add missing translations

### DIFF
--- a/api/src/database/system-data/fields/settings.yaml
+++ b/api/src/database/system-data/fields/settings.yaml
@@ -44,7 +44,7 @@ fields:
     interface: presentation-divider
     options:
       icon: public
-      title: Public Pages
+      title: $t:fields.directus_settings.public_pages
     special:
       - alias
       - no-data
@@ -74,7 +74,7 @@ fields:
     interface: presentation-divider
     options:
       icon: security
-      title: Security
+      title: $t:security
     special:
       - alias
       - no-data
@@ -104,7 +104,7 @@ fields:
     interface: presentation-divider
     options:
       icon: storage
-      title: Files & Thumbnails
+      title: $t:fields.directus_settings.files_and_thumbnails
     special:
       - alias
       - no-data
@@ -115,7 +115,7 @@ fields:
     options:
       fields:
         - field: key
-          name: Key
+          name: $t:key
           type: string
           schema:
             is_nullable: false
@@ -144,7 +144,7 @@ fields:
                   text: Fit outside
             width: half
         - field: width
-          name: Width
+          name: $t:width
           type: integer
           schema:
             is_nullable: false
@@ -152,7 +152,7 @@ fields:
             interface: input
             width: half
         - field: height
-          name: Height
+          name: $t:height
           type: integer
           schema:
             is_nullable: false
@@ -161,7 +161,7 @@ fields:
             width: half
         - field: quality
           type: integer
-          name: Quality
+          name: $t:quality
           schema:
             default_value: 80
             is_nullable: false
@@ -236,23 +236,23 @@ fields:
     options:
       choices:
         - value: all
-          text: All
+          text: $t:all
         - value: none
-          text: None
+          text: $t:none
         - value: presets
-          text: Presets Only
+          text: $t:presets_only
     width: half
 
   - field: storage_default_folder
     interface: system-folder
     width: half
-    note: Default folder where new files are uploaded
+    note: $t:interfaces.system-folder.field_hint
 
   - field: overrides_divider
     interface: presentation-divider
     options:
       icon: brush
-      title: App Overrides
+      title: $t:fields.directus_settings.overrides
     special:
       - alias
       - no-data

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -64,7 +64,7 @@ fields:
     interface: presentation-divider
     options:
       icon: face
-      title: User Preferences
+      title: $t:fields.directus_users.user_preferences
     special:
       - alias
       - no-data
@@ -79,11 +79,11 @@ fields:
     options:
       choices:
         - value: auto
-          text: Automatic (Based on System)
+          text: $t:fields.directus_users.theme_auto
         - value: light
-          text: Light Mode
+          text: $t:fields.directus_users.theme_light
         - value: dark
-          text: Dark Mode
+          text: $t:fields.directus_users.theme_dark
     width: half
 
   - field: tfa_secret
@@ -95,7 +95,7 @@ fields:
     interface: presentation-divider
     options:
       icon: verified_user
-      title: Admin Options
+      title: $t:fields.directus_users.admin_options
       color: '#E35169'
     special:
       - alias
@@ -106,15 +106,15 @@ fields:
     interface: select-dropdown
     options:
       choices:
-        - text: Draft
+        - text: $t:fields.directus_users.status_draft
           value: draft
-        - text: Invited
+        - text: $t:fields.directus_users.status_invited
           value: invited
-        - text: Active
+        - text: $t:fields.directus_users.status_active
           value: active
-        - text: Suspended
+        - text: $t:fields.directus_users.status_suspended
           value: suspended
-        - text: Archived
+        - text: $t:fields.directus_users.status_archived
           value: archived
     width: half
 
@@ -132,7 +132,7 @@ fields:
     interface: token
     options:
       iconRight: vpn_key
-      placeholder: Enter a secure access token...
+      placeholder: $t:fields.directus_users.token_placeholder
     width: full
 
   - field: id

--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -38,26 +38,26 @@ fields:
       defaultBackground: 'var(--background-normal-alt)'
       showAsDot: true
       choices:
-        - text: Active
+        - text: $t:active
           value: active
           foreground: 'var(--primary-10)'
           background: 'var(--primary)'
-        - text: Inactive
+        - text: $t:inactive
           value: inactive
           foreground: 'var(--foreground-normal)'
           background: 'var(--background-normal-alt)'
     options:
       choices:
-        - text: Active
+        - text: $t:active
           value: active
-        - text: Inactive
+        - text: $t:inactive
           value: inactive
     width: half
 
   - field: data
     interface: boolean
     options:
-      label: Send Event Data
+      label: $t:fields.directus_webhooks.data_label
     special: boolean
     width: half
     display: boolean
@@ -66,7 +66,7 @@ fields:
     interface: presentation-divider
     options:
       icon: api
-      title: Triggers
+      title: $t:fields.directus_webhooks.triggers
     special:
       - alias
       - no-data
@@ -76,11 +76,11 @@ fields:
     interface: select-multiple-checkbox
     options:
       choices:
-        - text: Create
+        - text: $t:create
           value: create
-        - text: Update
+        - text: $t:update
           value: update
-        - text: Delete
+        - text: $t:delete_label
           value: delete
     special: csv
     width: full
@@ -89,19 +89,19 @@ fields:
       defaultForeground: 'var(--foreground-normal)'
       defaultBackground: 'var(--background-normal-alt)'
       choices:
-        - text: Create
+        - text: $t:create
           value: create
           foreground: 'var(--primary)'
           background: 'var(--primary-25)'
-        - text: Update
+        - text: $t:update
           value: update
           foreground: 'var(--blue)'
           background: 'var(--blue-25)'
-        - text: Delete
+        - text: $t:delete_label
           value: delete
           foreground: 'var(--danger)'
           background: 'var(--danger-25)'
-        - text: Login
+        - text: $t:login
           value: authenticate
           foreground: 'var(--purple)'
           background: 'var(--purple-25)'

--- a/app/src/lang/translations/bg-BG.yaml
+++ b/app/src/lang/translations/bg-BG.yaml
@@ -390,6 +390,7 @@ display_template_not_setup: Опциите за показване на шабл
 collection_field_not_setup: Опциите на полето от колекцията са неправилно конфигурирани
 select_a_collection: Избор на колекция
 active: Активен
+inactive: Неактивен
 users: Потребители
 activity: Активности
 webhooks: Уеб-куки
@@ -443,6 +444,7 @@ errors:
   UNPROCESSABLE_ENTITY: Необработен обект
   INTERNAL_SERVER_ERROR: Неочаквана грешка
   NOT_NULL_VIOLATION: Стойността не трябва да е null
+security: Сигурност
 value_hashed: Хеширана стойност
 bookmark_name: Име на отметка...
 create_bookmark: Създаване на отметка
@@ -563,6 +565,7 @@ user: Потребител
 no_presets: Няма заготовки
 no_presets_copy: Все още няма запазени заготовки или отметки.
 no_presets_cta: Добавяне на заготовка
+presets_only: Само заготовки
 create: Създаване
 on_create: При създаване
 on_update: При промяна
@@ -578,6 +581,7 @@ label: Етикет
 image_url: URL на изображение
 alt_text: Алтернативен текст
 media: Медия
+quality: Качество
 width: Ширина
 height: Височина
 source: Източник
@@ -772,12 +776,23 @@ fields:
     title: Заглавие
     description: Описание
     tags: Тагове
+    user_preferences: Потребителски настройки
     language: Език
     theme: Тема
+    theme_auto: Автоматичен (според системата)
+    theme_light: Светъл режим
+    theme_dark: Тъмен режим
     tfa_secret: Двуфакторна автентикация
+    admin_options: Административни настройки
     status: Статус
+    status_draft: Чернова
+    status_invited: Поканен
+    status_active: Активен
+    status_suspended: Замразен
+    status_archived: Архивиран
     role: Роля
     token: Токен
+    token_placeholder: Въвеждане на сигурен ключ за достъп...
     last_page: Последна страница
     last_access: Последно посещение
   directus_settings:
@@ -785,13 +800,17 @@ fields:
     project_url: URL на проекта
     project_color: Цвят на проекта
     project_logo: Лого на проекта
+    public_pages: Публични Страници
     public_foreground: Публично изображение
     public_background: Публичен фон
     public_note: Публично съобщение
     auth_password_policy: Политика за пароли
     auth_login_attempts: Брой за опити за вход
+    files_and_thumbnails: Файлове и картинки
+    storage_default_folder: Папка по подразбиране
     storage_asset_presets: Заготовки за съхранените файлове
     storage_asset_transform: Трансформации на съхранените файлове
+    overrides: Отмяна
     custom_css: Потребителски CSS
   directus_fields:
     collection: Име на колекцията
@@ -812,6 +831,15 @@ fields:
     users: Потребители към роля
     module_list: Модули
     collection_list: Навигация в колекции
+  directus_webhooks:
+    name: Име
+    method: Метод
+    status: Статус
+    data: Данни
+    data_label: Изпращане и на данните
+    triggers: Тригер
+    actions: Действия
+    collections: Колекции
 field_options:
   directus_collections:
     track_activity_revisions: Проследяване на активността и ревизиите

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -396,6 +396,7 @@ display_template_not_setup: The display template option is misconfigured
 collection_field_not_setup: The collection field option is misconfigured
 select_a_collection: Select a Collection
 active: Active
+inactive: Inactive
 users: Users
 activity: Activity
 webhooks: Webhooks
@@ -450,6 +451,7 @@ errors:
   UNPROCESSABLE_ENTITY: Unprocessable entity
   INTERNAL_SERVER_ERROR: Unexpected Error
   NOT_NULL_VIOLATION: Value can't be null
+security: Security
 value_hashed: Value Securely Hashed
 bookmark_name: Bookmark name...
 create_bookmark: Create Bookmark
@@ -571,6 +573,7 @@ user: User
 no_presets: No Presets
 no_presets_copy: No presets or bookmarks have been saved yet.
 no_presets_cta: Add Preset
+presets_only: Presets Only
 create: Create
 on_create: On Create
 on_update: On Update
@@ -586,6 +589,7 @@ label: Label
 image_url: Image Url
 alt_text: Alternative Text
 media: Media
+quality: Quality
 width: Width
 height: Height
 source: Source
@@ -786,12 +790,23 @@ fields:
     title: Title
     description: Description
     tags: Tags
+    user_preferences: User Preferences
     language: Language
     theme: Theme
+    theme_auto: Automatic (Based on System)
+    theme_light: Light Mode
+    theme_dark: Dark Mode
     tfa_secret: Two-Factor Authentication
+    admin_options: Admin Options
     status: Status
+    status_draft: Draft
+    status_invited: Inactive
+    status_active: Активен
+    status_suspended: Suspended
+    status_archived: Archived
     role: Role
     token: Token
+    token_placeholder: Enter a secure access token...
     last_page: Last Page
     last_access: Last Access
   directus_settings:
@@ -799,13 +814,17 @@ fields:
     project_url: Project URL
     project_color: Project Color
     project_logo: Project Logo
+    public_pages: Public Pages
     public_foreground: Public Foreground
     public_background: Public Background
     public_note: Public Note
     auth_password_policy: Auth Password Policy
     auth_login_attempts: Auth Login Attempts
+    files_and_thumbnails: Files & Thumbnails
+    storage_default_folder: Storage Default Folder
     storage_asset_presets: Storage Asset Presets
     storage_asset_transform: Storage Asset Transform
+    overrides: App Overrides
     custom_css: Custom CSS
   directus_fields:
     collection: Collection Name
@@ -826,6 +845,14 @@ fields:
     users: Users in Role
     module_list: Module Navigation
     collection_list: Collection Navigation
+  directus_webhooks:
+    name: Name
+    method: Method
+    status: Status
+    data: Data
+    data_label: Send Event Data
+    triggers: Triggers
+    actions: Actions
 field_options:
   directus_collections:
     track_activity_revisions: Track Activity & Revisions


### PR DESCRIPTION
Fix some missing translations in webhooks, user profile and settings.

I notice that fields object in translation yaml files is nice place to encapsulate translations, but was quite unsure where to put for example the select options translations and placeholders, so I had put them together and just suffix with _placeholder or prefix with the field name.
