### PR TITLE
Export Collection button now shows collection name not table name

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
@@ -80,9 +80,7 @@ export default defineComponent({
 			}
 		});
 
-		const visibleStore = collections.visibleCollections;
-
-		return { t, format, useFilters, exportData, collections, visibleStore, collectionName };
+		return { t, format, useFilters, exportData, collections, collectionName };
 
 		function exportData() {
 			const endpoint = props.collection.startsWith('directus_')

--- a/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
@@ -25,7 +25,7 @@
 
 			<div class="field full">
 				<v-button full-width @click="exportData">
-					{{ t('Export ' + collectionName) }}
+					{{ t('export_collection', { collection: collectionName }) }}
 				</v-button>
 			</div>
 		</div>
@@ -72,15 +72,10 @@ export default defineComponent({
 
 		const format = ref('csv');
 		const useFilters = ref(true);
-		const collections = useCollectionsStore();
-		let collectionName;
-		collections.visibleCollections.forEach((collection) => {
-			if (collection.collection === props.collection) {
-				collectionName = collection.name;
-			}
-		});
+		const collectionsStore = useCollectionsStore();
+		let collectionName = collectionsStore.getCollection(props.collection).name;
 
-		return { t, format, useFilters, exportData, collections, collectionName };
+		return { t, format, useFilters, exportData, collectionName };
 
 		function exportData() {
 			const endpoint = props.collection.startsWith('directus_')

--- a/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
@@ -25,7 +25,7 @@
 
 			<div class="field full">
 				<v-button full-width @click="exportData">
-					{{ t('export_collection', { collection }) }}
+					{{ t('Export ' + collectionName) }}
 				</v-button>
 			</div>
 		</div>
@@ -39,6 +39,7 @@ import { Filter } from '@directus/shared/types';
 import api from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
 import filtersToQuery from '@/utils/filters-to-query';
+import { useCollectionsStore } from '@/stores/';
 
 type LayoutQuery = {
 	fields?: string[];
@@ -65,13 +66,23 @@ export default defineComponent({
 			required: true,
 		},
 	},
+
 	setup(props) {
 		const { t } = useI18n();
 
 		const format = ref('csv');
 		const useFilters = ref(true);
+		const collections = useCollectionsStore();
+		let collectionName;
+		collections.visibleCollections.forEach((collection) => {
+			if (collection.collection === props.collection) {
+				collectionName = collection.name;
+			}
+		});
 
-		return { t, format, useFilters, exportData };
+		const visibleStore = collections.visibleCollections;
+
+		return { t, format, useFilters, exportData, collections, visibleStore, collectionName };
 
 		function exportData() {
 			const endpoint = props.collection.startsWith('directus_')

--- a/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
@@ -34,7 +34,7 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, PropType } from 'vue';
+import { defineComponent, ref, PropType, computed } from 'vue';
 import { Filter } from '@directus/shared/types';
 import api from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
@@ -73,7 +73,7 @@ export default defineComponent({
 		const format = ref('csv');
 		const useFilters = ref(true);
 		const collectionsStore = useCollectionsStore();
-		let collectionName = collectionsStore.getCollection(props.collection).name;
+		const collectionName = computed(() => collectionsStore.getCollection(props.collection).name);
 
 		return { t, format, useFilters, exportData, collectionName };
 


### PR DESCRIPTION
Changed export collection button to use collection.name instead of collection.collection.
Fixes #7361 