### PR TITLE
Revert "update dependency macos-release to v3"

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -116,7 +116,7 @@
 		"knex-schema-inspector": "1.5.13",
 		"liquidjs": "^9.25.0",
 		"lodash": "^4.17.21",
-		"macos-release": "^3.0.0",
+		"macos-release": "^2.4.1",
 		"mime-types": "^2.1.31",
 		"ms": "^2.1.3",
 		"nanoid": "^3.1.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
 				"knex-schema-inspector": "1.5.13",
 				"liquidjs": "^9.25.0",
 				"lodash": "^4.17.21",
-				"macos-release": "^3.0.0",
+				"macos-release": "^2.4.1",
 				"mime-types": "^2.1.31",
 				"ms": "^2.1.3",
 				"nanoid": "^3.1.23",
@@ -31638,11 +31638,11 @@
 			}
 		},
 		"node_modules/macos-release": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.0.0.tgz",
-			"integrity": "sha512-y+uUjBt2D1YK0w8k0D19r6O8BYrCkSokWMaTJPvE68RjUOVYQmPXUD7Y4wGphM+/DEJNU+e46hl1lXOzPpvo+w==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+			"integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -76724,7 +76724,7 @@
 				"knex-schema-inspector": "1.5.13",
 				"liquidjs": "^9.25.0",
 				"lodash": "^4.17.21",
-				"macos-release": "^3.0.0",
+				"macos-release": "^2.4.1",
 				"memcached": "^2.2.2",
 				"mime-types": "^2.1.31",
 				"ms": "^2.1.3",
@@ -87043,9 +87043,9 @@
 			}
 		},
 		"macos-release": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.0.0.tgz",
-			"integrity": "sha512-y+uUjBt2D1YK0w8k0D19r6O8BYrCkSokWMaTJPvE68RjUOVYQmPXUD7Y4wGphM+/DEJNU+e46hl1lXOzPpvo+w=="
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+			"integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g=="
 		},
 		"magic-string": {
 			"version": "0.25.7",


### PR DESCRIPTION
Reverts directus/directus#7381

TypeScript isn't ready for ESM primetime yet.. Until it is, we'll have to wait with Sindre's push ahead