### PR TITLE
Move geojson from devDeps to deps of shared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25038,7 +25038,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/geojson/-/geojson-0.5.0.tgz",
 			"integrity": "sha1-PNbJY5m+ZbVu5VWWEW/pGRznAcA=",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -58686,6 +58685,7 @@
 				"date-fns": "1.30.1",
 				"express": "4.17.1",
 				"fs-extra": "10.0.0",
+				"geojson": "0.5.0",
 				"joi": "17.4.2",
 				"knex-schema-inspector": "1.5.13",
 				"lodash": "4.17.21",
@@ -58693,7 +58693,6 @@
 				"vue-router": "4.0.11"
 			},
 			"devDependencies": {
-				"geojson": "0.5.0",
 				"npm-run-all": "4.1.5",
 				"rimraf": "3.0.2",
 				"typescript": "4.3.5"
@@ -81898,8 +81897,7 @@
 		"geojson": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/geojson/-/geojson-0.5.0.tgz",
-			"integrity": "sha1-PNbJY5m+ZbVu5VWWEW/pGRznAcA=",
-			"dev": true
+			"integrity": "sha1-PNbJY5m+ZbVu5VWWEW/pGRznAcA="
 		},
 		"geojson-flatten": {
 			"version": "1.0.4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -48,6 +48,7 @@
 		"date-fns": "1.30.1",
 		"express": "4.17.1",
 		"fs-extra": "10.0.0",
+		"geojson": "0.5.0",
 		"joi": "17.4.2",
 		"knex-schema-inspector": "1.5.13",
 		"lodash": "4.17.21",
@@ -55,7 +56,6 @@
 		"vue-router": "4.0.11"
 	},
 	"devDependencies": {
-		"geojson": "0.5.0",
 		"npm-run-all": "4.1.5",
 		"rimraf": "3.0.2",
 		"typescript": "4.3.5"


### PR DESCRIPTION
Geojson has to be a regular dependency in order for the imported types to be available when installing shared.
Ideally, we should bundle type definitions to a single file.