### PR TITLE
Fix group interface start

### DIFF
--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-detail class="group-detail">
+	<v-detail :start-open="start === 'open'" class="group-detail">
 		<template #activator="{ toggle, active }">
 			<v-divider
 				:style="{
@@ -7,7 +7,6 @@
 				}"
 				:class="{ active }"
 				:inline-title="false"
-				:start-open="start === 'open'"
 				large
 				@click="toggle"
 			>


### PR DESCRIPTION
Fix issue with group interface where specifying "Start Open" did not actually initialize the form with the group open.

Related issue: #7385 

<img width="928" alt="Screen Shot 2021-08-13 at 3 37 13 PM" src="https://user-images.githubusercontent.com/12628251/129416340-4738b34d-1ecb-42d6-bdf2-215bff2c7183.png">
