### PR TITLE
Add support for aliasing fields

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -263,8 +263,6 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			knex: this.knex,
 		});
 
-		// console.dir(ast, { depth: null });
-
 		if (this.accountability && this.accountability.admin !== true) {
 			ast = await authorizationService.processAST(ast, opts?.permissionsAction);
 		}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -263,6 +263,8 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			knex: this.knex,
 		});
 
+		// console.dir(ast, { depth: null });
+
 		if (this.accountability && this.accountability.admin !== true) {
 			ast = await authorizationService.processAST(ast, opts?.permissionsAction);
 		}

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -112,7 +112,7 @@ export class PayloadService {
 			return value;
 		},
 		async csv({ action, value }) {
-			if (!value) return;
+			if (!value || Array.isArray(value)) return;
 			if (action === 'read') return value.split(',');
 
 			if (Array.isArray(value)) return value.join(',');

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -112,9 +112,8 @@ export class PayloadService {
 			return value;
 		},
 		async csv({ action, value }) {
-			if (!value || Array.isArray(value)) return;
-			if (action === 'read') return value.split(',');
-
+			if (!value) return;
+			if (action === 'read' && Array.isArray(value) === false) return value.split(',');
 			if (Array.isArray(value)) return value.join(',');
 			return value;
 		},

--- a/api/src/types/ast.ts
+++ b/api/src/types/ast.ts
@@ -45,6 +45,7 @@ export type NestedCollectionNode = M2ONode | O2MNode | M2ANode;
 export type FieldNode = {
 	type: 'field';
 	name: string;
+	fieldKey: string;
 };
 
 export type AST = {

--- a/api/src/types/query.ts
+++ b/api/src/types/query.ts
@@ -13,6 +13,7 @@ export type Query = {
 	group?: string[];
 	aggregate?: Aggregate;
 	deep?: Record<string, Query>;
+	alias?: Record<string, string>;
 };
 
 export type Sort = {

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -65,17 +65,6 @@ export default async function getASTFromQuery(
 		fields = query.group;
 	}
 
-	/**
-	 * When we're requesting field duplicates through aliases, we have to explicitly ask for the
-	 * the alias name, otherwise they're ignored as non-existing fields
-	 */
-
-	if (query.alias) {
-		for (const aliasName of Object.keys(query.alias)) {
-			fields.push(aliasName);
-		}
-	}
-
 	fields = uniq(fields);
 
 	const deep = query.deep || {};
@@ -122,34 +111,42 @@ export default async function getASTFromQuery(
 
 		const relationalStructure: Record<string, string[] | anyNested> = {};
 
-		for (const field of fields) {
+		for (const fieldKey of fields) {
+			let name = fieldKey;
+
+			const isAlias = (query.alias && name in query.alias) ?? false;
+
+			if (isAlias) {
+				name = query.alias![fieldKey];
+			}
+
 			const isRelational =
-				field.includes('.') ||
+				name.includes('.') ||
 				// We'll always treat top level o2m fields as a related item. This is an alias field, otherwise it won't return
 				// anything
 				!!schema.relations.find(
-					(relation) => relation.related_collection === parentCollection && relation.meta?.one_field === field
+					(relation) => relation.related_collection === parentCollection && relation.meta?.one_field === name
 				);
 
 			if (isRelational) {
 				// field is relational
-				const parts = field.split('.');
+				const parts = name.split('.');
 
-				let fieldKey = parts[0];
+				let rootField = parts[0];
 				let collectionScope: string | null = null;
 
 				// m2a related collection scoped field selector `fields=sections.section_id:headings.title`
-				if (fieldKey.includes(':')) {
-					const [key, scope] = fieldKey.split(':');
-					fieldKey = key;
+				if (rootField.includes(':')) {
+					const [key, scope] = rootField.split(':');
+					rootField = key;
 					collectionScope = scope;
 				}
 
-				if (fieldKey in relationalStructure === false) {
+				if (rootField in relationalStructure === false) {
 					if (collectionScope) {
-						relationalStructure[fieldKey] = { [collectionScope]: [] };
+						relationalStructure[rootField] = { [collectionScope]: [] };
 					} else {
-						relationalStructure[fieldKey] = [];
+						relationalStructure[rootField] = [];
 					}
 				}
 
@@ -157,34 +154,36 @@ export default async function getASTFromQuery(
 					const childKey = parts.slice(1).join('.');
 
 					if (collectionScope) {
-						if (collectionScope in relationalStructure[fieldKey] === false) {
-							(relationalStructure[fieldKey] as anyNested)[collectionScope] = [];
+						if (collectionScope in relationalStructure[rootField] === false) {
+							(relationalStructure[rootField] as anyNested)[collectionScope] = [];
 						}
 
-						(relationalStructure[fieldKey] as anyNested)[collectionScope].push(childKey);
+						(relationalStructure[rootField] as anyNested)[collectionScope].push(childKey);
 					} else {
-						(relationalStructure[fieldKey] as string[]).push(childKey);
+						(relationalStructure[rootField] as string[]).push(childKey);
 					}
 				}
 			} else {
-				if (query.alias && field in query.alias) {
-					children.push({ type: 'field', name: query.alias[field], fieldKey: field });
-				} else {
-					children.push({ type: 'field', name: field, fieldKey: field });
-				}
+				children.push({ type: 'field', name, fieldKey });
 			}
 		}
 
-		for (const [relationalField, nestedFields] of Object.entries(relationalStructure)) {
-			const relatedCollection = getRelatedCollection(parentCollection, relationalField);
-			const relation = getRelation(parentCollection, relationalField);
+		for (const [fieldKey, nestedFields] of Object.entries(relationalStructure)) {
+			let fieldName = fieldKey;
+
+			if (query.alias && fieldKey in query.alias) {
+				fieldName = query.alias[fieldKey];
+			}
+
+			const relatedCollection = getRelatedCollection(parentCollection, fieldName);
+			const relation = getRelation(parentCollection, fieldName);
 
 			if (!relation) continue;
 
 			const relationType = getRelationType({
 				relation,
 				collection: parentCollection,
-				field: relationalField,
+				field: fieldName,
 			});
 
 			if (!relationType) continue;
@@ -204,7 +203,7 @@ export default async function getASTFromQuery(
 					query: {},
 					relatedKey: {},
 					parentKey: schema.collections[parentCollection].primary,
-					fieldKey: relationalField,
+					fieldKey: fieldKey,
 					relation: relation,
 				};
 
@@ -212,10 +211,10 @@ export default async function getASTFromQuery(
 					child.children[relatedCollection] = await parseFields(
 						relatedCollection,
 						Array.isArray(nestedFields) ? nestedFields : (nestedFields as anyNested)[relatedCollection] || ['*'],
-						deep?.[`${relationalField}:${relatedCollection}`]
+						deep?.[`${fieldKey}:${relatedCollection}`]
 					);
 
-					child.query[relatedCollection] = getDeepQuery(deep?.[`${relationalField}:${relatedCollection}`] || {});
+					child.query[relatedCollection] = getDeepQuery(deep?.[`${fieldKey}:${relatedCollection}`] || {});
 
 					child.relatedKey[relatedCollection] = schema.collections[relatedCollection].primary;
 				}
@@ -227,12 +226,12 @@ export default async function getASTFromQuery(
 				child = {
 					type: relationType,
 					name: relatedCollection,
-					fieldKey: relationalField,
+					fieldKey: fieldKey,
 					parentKey: schema.collections[parentCollection].primary,
 					relatedKey: schema.collections[relatedCollection].primary,
 					relation: relation,
-					query: getDeepQuery(deep?.[relationalField] || {}),
-					children: await parseFields(relatedCollection, nestedFields as string[], deep?.[relationalField] || {}),
+					query: getDeepQuery(deep?.[fieldKey] || {}),
+					children: await parseFields(relatedCollection, nestedFields as string[], deep?.[fieldKey] || {}),
 				};
 
 				if (relationType === 'o2m' && !child!.query.sort) {
@@ -247,7 +246,18 @@ export default async function getASTFromQuery(
 			}
 		}
 
-		return children;
+		// Deduplicate any children fields that are included both as a regular field, and as a nested m2o field
+		const nestedCollectionNodes = children.filter((childNode) => childNode.type !== 'field');
+
+		return children.filter((childNode) => {
+			const existsAsNestedRelational = !!nestedCollectionNodes.find(
+				(nestedCollectionNode) => childNode.fieldKey === nestedCollectionNode.fieldKey
+			);
+
+			if (childNode.type === 'field' && existsAsNestedRelational) return false;
+
+			return true;
+		});
 	}
 
 	async function convertWildcards(parentCollection: string, fields: string[]) {
@@ -273,12 +283,18 @@ export default async function getASTFromQuery(
 			if (fieldKey.includes('*') === false) continue;
 
 			if (fieldKey === '*') {
+				const aliases = Object.keys(query.alias ?? {});
 				// Set to all fields in collection
 				if (allowedFields.includes('*')) {
-					fields.splice(index, 1, ...fieldsInCollection);
+					fields.splice(index, 1, ...fieldsInCollection, ...aliases);
 				} else {
 					// Set to all allowed fields
-					fields.splice(index, 1, ...allowedFields);
+					const allowedAliases = aliases.filter((fieldKey) => {
+						const name = query.alias![fieldKey];
+						return allowedFields!.includes(name);
+					});
+
+					fields.splice(index, 1, ...allowedFields, ...allowedAliases);
 				}
 			}
 
@@ -300,6 +316,16 @@ export default async function getASTFromQuery(
 
 				const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
 
+				const aliasFields = Object.keys(query.alias ?? {}).map((fieldKey) => {
+					const name = query.alias![fieldKey];
+
+					if (relationalFields.includes(name)) {
+						return `${fieldKey}.${parts.slice(1).join('.')}`;
+					}
+
+					return fieldKey;
+				});
+
 				fields.splice(
 					index,
 					1,
@@ -308,6 +334,7 @@ export default async function getASTFromQuery(
 							return `${relationalField}.${parts.slice(1).join('.')}`;
 						}),
 						...nonRelationalFields,
+						...aliasFields,
 					]
 				);
 			}

--- a/api/src/utils/get-column.ts
+++ b/api/src/utils/get-column.ts
@@ -28,15 +28,15 @@ export function getColumn(
 		if (functionName in fn) {
 			const result = fn[functionName as keyof typeof fn](table, columnName);
 
-			if (alias) {
-				return knex.raw(result + ' AS ??', [alias]);
-			}
-
-			return result;
+			return knex.raw(result + ' AS ??', [alias]);
 		} else {
 			throw new Error(`Invalid function specified "${functionName}"`);
 		}
 	}
 
-	return knex.raw('??.??', [table, column]);
+	if (column !== alias) {
+		return knex.ref(`${table}.${column}`).as(alias);
+	}
+
+	return knex.ref(`${table}.${column}`);
 }

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -61,6 +61,10 @@ export function sanitizeQuery(rawQuery: Record<string, any>, accountability?: Ac
 		query.deep = sanitizeDeep(rawQuery.deep, accountability);
 	}
 
+	if (rawQuery.alias) {
+		query.alias = sanitizeAlias(rawQuery.alias);
+	}
+
 	return query;
 }
 
@@ -201,4 +205,18 @@ function sanitizeDeep(deep: Record<string, any>, accountability?: Accountability
 			set(result, path, merge({}, get(result, path, {}), parsedLevel));
 		}
 	}
+}
+
+function sanitizeAlias(rawAlias: any) {
+	let alias: Record<string, string> = rawAlias;
+
+	if (typeof rawAlias === 'string') {
+		try {
+			alias = JSON.parse(rawAlias);
+		} catch (err) {
+			logger.warn('Invalid value passed for alias query parameter.');
+		}
+	}
+
+	return alias;
 }

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -22,6 +22,7 @@ const querySchema = Joi.object({
 	export: Joi.string().valid('json', 'csv', 'xml'),
 	aggregate: Joi.object(),
 	deep: Joi.object(),
+	alias: Joi.object(),
 }).id('query');
 
 export function validateQuery(query: Query): Query {
@@ -29,6 +30,10 @@ export function validateQuery(query: Query): Query {
 
 	if (query.filter && Object.keys(query.filter).length > 0) {
 		validateFilter(query.filter);
+	}
+
+	if (query.alias) {
+		validateAlias(query.alias);
 	}
 
 	if (error) {
@@ -140,4 +145,20 @@ function validateGeometry(value: any, key: string) {
 	}
 
 	return true;
+}
+
+function validateAlias(alias: any) {
+	if (isPlainObject(alias) === false) {
+		throw new InvalidQueryException(`"alias" has to be an object`);
+	}
+
+	for (const [key, value] of Object.entries(alias)) {
+		if (typeof key !== 'string') {
+			throw new InvalidQueryException(`"alias" key has to be a string. "${typeof key}" given.`);
+		}
+
+		if (typeof value !== 'string') {
+			throw new InvalidQueryException(`"alias" value has to be a string. "${typeof key}" given.`);
+		}
+	}
 }

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -160,5 +160,9 @@ function validateAlias(alias: any) {
 		if (typeof value !== 'string') {
 			throw new InvalidQueryException(`"alias" value has to be a string. "${typeof key}" given.`);
 		}
+
+		if (key.includes('.') || value.includes('.')) {
+			throw new InvalidQueryException(`"alias" key/value can't contain a period character \`.\``);
+		}
 	}
 }


### PR DESCRIPTION
Allows for fetching any field under a different name. This allows for things like fetching the same o2m nested collection set twice, using different filters/sort.

Example:

```
fields=*.*
alias[english_translations]=translations
deep[english_translations][_filter][language_code][_eq]=en-US
```