### PR TITLE
remove list-style for v-list

### DIFF
--- a/app/src/components/v-list/v-list.vue
+++ b/app/src/components/v-list/v-list.vue
@@ -65,6 +65,7 @@ export default defineComponent({
 .v-list {
 	position: static;
 	display: block;
+	list-style: none;
 	min-width: var(--v-list-min-width);
 	max-width: var(--v-list-max-width);
 	min-height: var(--v-list-min-height);


### PR DESCRIPTION
## Reason for PR
To fix list style or bullet points for items in `v-list` component in navigation.
![image](https://user-images.githubusercontent.com/42867097/129616783-aa79e718-6aad-473f-8f65-7555534d3bc0.png)
_Source image from report in Discord: [Message link](https://discord.com/channels/725371605378924594/741327526240059483/876892769631744020)_

## Solution
Here's a gif to illustrate the before & after adding this CSS property to hide the bullets.

![XLtY6XCdNr](https://user-images.githubusercontent.com/42867097/129616589-7749e43c-9e68-4873-9c64-e626c661c31c.gif)

I have also checked other UI components such as checkboxes and checkboxes (trees) to avoid regressions, but do let me know if it affected other components not readily apparent.