### PR TITLE
Add related-values as the default display for relational fields

### DIFF
--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -215,17 +215,11 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 						if (Array.isArray(layoutQuery.value.fields)) return layoutQuery.value.fields;
 					}
 
-					const fields =
-						layoutQuery.value?.fields ||
-						fieldsInCollection.value
-							.filter((field: Field) => !!field.meta?.hidden === false)
-							.slice(0, 4)
-							.sort((a: Field, b: Field) => {
-								if (a.field < b.field) return -1;
-								else if (a.field > b.field) return 1;
-								else return 1;
-							})
-							.map(({ field }: Field) => field);
+					const fields = fieldsInCollection.value
+						.filter((field: Field) => !!field.meta?.hidden === false)
+						.slice(0, 4)
+						.map((field) => field.field)
+						.sort();
 
 					return fields;
 				},
@@ -288,7 +282,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 						value: field.field,
 						width: localWidths.value[field.field] || layoutOptions.value?.widths?.[field.field] || null,
 						field: {
-							display: field.meta?.display || getDefaultDisplayForType(field.type),
+							display: field.meta?.display || getDefaultDisplayForType(field.type, field.collection, field.field),
 							displayOptions: field.meta?.display_options,
 							interface: field.meta?.interface,
 							interfaceOptions: field.meta?.options,

--- a/app/src/utils/get-default-display-for-type.ts
+++ b/app/src/utils/get-default-display-for-type.ts
@@ -1,3 +1,4 @@
+import { useRelationsStore } from '@/stores';
 import { Type } from '@directus/shared/types';
 
 const defaultDisplayMap: Record<Type, string> = {
@@ -22,6 +23,11 @@ const defaultDisplayMap: Record<Type, string> = {
 	geometry: 'map',
 };
 
-export function getDefaultDisplayForType(type: Type): string {
+export function getDefaultDisplayForType(type: Type, collection?: string, field?: string): string {
+	if (collection !== undefined && field !== undefined) {
+		const store = useRelationsStore();
+		const relations = store.getRelationsForField(collection, field);
+		if (relations.length > 0) return 'related-values';
+	}
 	return defaultDisplayMap[type] || 'raw';
 }


### PR DESCRIPTION
closes #7081 
I'm not sure if this is the best way to implement this but doing this even deeper inside the getField method of the store seemed to out of place.