### PR TITLE
Render href attributes on router-link

### DIFF
--- a/app/src/components/v-button/v-button.vue
+++ b/app/src/components/v-button/v-button.vue
@@ -3,7 +3,7 @@
 		<slot name="prepend-outer" />
 		<component
 			:is="component"
-			:ref="component === 'a' ? 'noopener noreferer' : null"
+			:ref="component === 'a' ? 'noopener noreferer' : undefined"
 			v-focus="autofocus"
 			:download="download"
 			class="button"
@@ -23,9 +23,9 @@
 			]"
 			:type="type"
 			:disabled="disabled"
-			:to="to"
+			:to="to !== '' ? to : undefined"
 			:href="href"
-			:target="component === 'a' ? '_blank' : null"
+			:target="component === 'a' ? '_blank' : undefined"
 			@click="onClick"
 		>
 			<span class="content" :class="{ invisible: loading }">
@@ -89,7 +89,7 @@ export default defineComponent({
 		},
 		href: {
 			type: String,
-			default: null,
+			default: undefined,
 		},
 		active: {
 			type: Boolean,
@@ -109,7 +109,7 @@ export default defineComponent({
 		},
 		value: {
 			type: [Number, String],
-			default: null,
+			default: undefined,
 		},
 		dashed: {
 			type: Boolean,
@@ -126,7 +126,7 @@ export default defineComponent({
 		},
 		download: {
 			type: String,
-			default: null,
+			default: undefined,
 		},
 		...sizeProps,
 	},
@@ -137,7 +137,7 @@ export default defineComponent({
 		const { route: linkRoute, isActive, isExactActive } = useLink(props);
 		const sizeClass = useSizeClass(props);
 
-		const component = computed<'a' | 'router-link' | 'button'>(() => {
+		const component = computed(() => {
 			if (props.disabled) return 'button';
 			if (notEmpty(props.href)) return 'a';
 			if (props.to) return 'router-link';

--- a/app/src/components/v-list/v-list-item.vue
+++ b/app/src/components/v-list/v-list-item.vue
@@ -2,7 +2,7 @@
 	<component
 		:is="component"
 		class="v-list-item"
-		:to="to"
+		:to="to !== '' ? to : undefined"
 		:class="{
 			active: isActiveRoute,
 			dense,
@@ -14,7 +14,7 @@
 		}"
 		:href="href"
 		:download="download"
-		:target="component === 'a' ? '_blank' : null"
+		:target="component === 'a' ? '_blank' : undefined"
 		@click="onClick"
 	>
 		<slot />
@@ -43,7 +43,7 @@ export default defineComponent({
 		},
 		href: {
 			type: String,
-			default: null,
+			default: undefined,
 		},
 		disabled: {
 			type: Boolean,
@@ -71,7 +71,7 @@ export default defineComponent({
 		},
 		download: {
 			type: String,
-			default: null,
+			default: undefined,
 		},
 		value: {
 			type: [String, Number],
@@ -88,7 +88,7 @@ export default defineComponent({
 
 		const { route: linkRoute, isActive, isExactActive } = useLink(props);
 
-		const component = computed<string>(() => {
+		const component = computed(() => {
 			if (props.to) return 'router-link';
 			if (props.href) return 'a';
 			return 'li';

--- a/app/src/views/private/components/module-bar/module-bar.vue
+++ b/app/src/views/private/components/module-bar/module-bar.vue
@@ -52,8 +52,8 @@ export default defineComponent({
 				modules.value
 					.map((module: ModuleConfig) => ({
 						...module,
-						href: module.link || null,
-						to: module.link === undefined ? `/${module.id}` : null,
+						href: module.link,
+						to: module.link === undefined ? `/${module.id}` : '',
 					}))
 					.filter((module: ModuleConfig) => {
 						if (module.hidden !== undefined && unref(module.hidden) === true) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,7 @@
 				"@types/express-session": "1.17.4",
 				"@types/fs-extra": "9.0.12",
 				"@types/inquirer": "7.3.3",
+				"@types/jest": "27.0.1",
 				"@types/js-yaml": "4.0.2",
 				"@types/json2csv": "5.0.3",
 				"@types/jsonwebtoken": "8.5.4",
@@ -169,6 +170,8 @@
 				"@types/wellknown": "0.5.1",
 				"copyfiles": "2.4.1",
 				"cross-env": "7.0.3",
+				"jest": "27.0.6",
+				"ts-jest": "27.0.4",
 				"ts-node-dev": "1.1.8",
 				"typescript": "4.3.5"
 			},
@@ -188,6 +191,28 @@
 				"pg": "^8.6.0",
 				"sqlite3": "^5.0.2",
 				"tedious": "^11.0.8"
+			}
+		},
+		"api/node_modules/@types/jest": {
+			"version": "27.0.1",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
+			"integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+			"dev": true,
+			"dependencies": {
+				"jest-diff": "^27.0.0",
+				"pretty-format": "^27.0.0"
+			}
+		},
+		"api/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"api/node_modules/argparse": {
@@ -231,6 +256,15 @@
 				"url": "https://opencollective.com/date-fns"
 			}
 		},
+		"api/node_modules/diff-sequences": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+			"integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+			"dev": true,
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
 		"api/node_modules/fs-extra": {
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -268,6 +302,21 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"api/node_modules/jest-diff": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+			"integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^27.0.6",
+				"jest-get-type": "^27.0.6",
+				"pretty-format": "^27.0.6"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
 		"api/node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -290,6 +339,21 @@
 			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"api/node_modules/pretty-format": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+			"integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^27.0.6",
+				"ansi-regex": "^5.0.0",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"api/node_modules/rxjs": {
@@ -76686,6 +76750,7 @@
 				"@types/express-session": "1.17.4",
 				"@types/fs-extra": "9.0.12",
 				"@types/inquirer": "7.3.3",
+				"@types/jest": "27.0.1",
 				"@types/js-yaml": "4.0.2",
 				"@types/json2csv": "5.0.3",
 				"@types/jsonwebtoken": "8.5.4",
@@ -76735,6 +76800,7 @@
 				"graphql-compose": "^9.0.1",
 				"inquirer": "^8.1.1",
 				"ioredis": "^4.27.6",
+				"jest": "27.0.6",
 				"joi": "^17.3.0",
 				"js-yaml": "^4.1.0",
 				"js2xmlparser": "^4.0.1",
@@ -76773,6 +76839,7 @@
 				"sqlite3": "^5.0.2",
 				"stream-json": "^1.7.1",
 				"tedious": "^11.0.8",
+				"ts-jest": "27.0.4",
 				"ts-node-dev": "1.1.8",
 				"typescript": "4.3.5",
 				"update-check": "^1.5.4",
@@ -76781,6 +76848,22 @@
 				"wellknown": "^0.5.0"
 			},
 			"dependencies": {
+				"@types/jest": {
+					"version": "27.0.1",
+					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
+					"integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+					"dev": true,
+					"requires": {
+						"jest-diff": "^27.0.0",
+						"pretty-format": "^27.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -76805,6 +76888,12 @@
 					"version": "2.22.1",
 					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
 					"integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg=="
+				},
+				"diff-sequences": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+					"integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+					"dev": true
 				},
 				"fs-extra": {
 					"version": "10.0.0",
@@ -76837,6 +76926,18 @@
 						"through": "^2.3.6"
 					}
 				},
+				"jest-diff": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+					"integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.0.0",
+						"diff-sequences": "^27.0.6",
+						"jest-get-type": "^27.0.6",
+						"pretty-format": "^27.0.6"
+					}
+				},
 				"js-yaml": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -76854,6 +76955,18 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
 					"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+				},
+				"pretty-format": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+					"integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^27.0.6",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^17.0.1"
+					}
 				},
 				"rxjs": {
 					"version": "7.2.0",


### PR DESCRIPTION
While props set to null aren't rendered to the DOM, they are passed to other components as attributes if not defined as props.
This prevents vue-router from setting the attribute itself.