### PR TITLE
Don't allow `empty` filter for non-string types. Add `null` filter where appropriate.

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -300,15 +300,13 @@ export function applyFilter(
 
 			if (operator === '_empty' || (operator === '_nempty' && compareValue === false)) {
 				dbQuery[logical].andWhere((query) => {
-					query.whereNull(key);
-					query.orWhere(key, '=', '');
+					query.where(key, '=', '');
 				});
 			}
 
 			if (operator === '_nempty' || (operator === '_empty' && compareValue === false)) {
 				dbQuery[logical].andWhere((query) => {
-					query.whereNotNull(key);
-					query.orWhere(key, '!=', '');
+					query.where(key, '!=', '');
 				});
 			}
 

--- a/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
+++ b/app/src/views/private/components/filter-sidebar-detail/get-available-operators-for-type.ts
@@ -11,7 +11,6 @@ export default function getAvailableOperatorsForType(type: Type): OperatorType {
 	switch (type) {
 		// Text
 		case 'binary':
-		case 'json':
 		case 'hash':
 		case 'string':
 			return {
@@ -27,27 +26,36 @@ export default function getAvailableOperatorsForType(type: Type): OperatorType {
 					'neq',
 					'empty',
 					'nempty',
+					'null',
+					'nnull',
 					'in',
 					'nin',
 				],
 			};
+		// JSON
+		case 'json':
+			return {
+				type,
+				operators: ['eq', 'neq', 'null', 'nnull', 'in', 'nin'],
+			};
+		// UUID
 		case 'uuid':
 			return {
 				type,
-				operators: ['eq', 'neq', 'empty', 'nempty', 'in', 'nin'],
+				operators: ['eq', 'neq', 'null', 'nnull', 'in', 'nin'],
 			};
 		// Boolean
 		case 'boolean':
 			return {
 				type,
-				operators: ['eq', 'neq', 'empty', 'nempty'],
+				operators: ['eq', 'neq', 'null', 'nnull'],
 			};
 		// Numbers
 		case 'integer':
 		case 'decimal':
 			return {
 				type,
-				operators: ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'empty', 'nempty', 'in', 'nin'],
+				operators: ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'null', 'nnull', 'in', 'nin'],
 			};
 		// Datetime
 		case 'dateTime':
@@ -55,13 +63,13 @@ export default function getAvailableOperatorsForType(type: Type): OperatorType {
 		case 'time':
 			return {
 				type,
-				operators: ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'empty', 'nempty', 'in', 'nin'],
+				operators: ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'null', 'nnull', 'in', 'nin'],
 			};
 		// Geometry
 		case 'geometry':
 			return {
 				type,
-				operators: ['eq', 'neq', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'],
+				operators: ['eq', 'neq', 'null', 'nnull', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'],
 			};
 		default:
 			return {
@@ -79,6 +87,8 @@ export default function getAvailableOperatorsForType(type: Type): OperatorType {
 					'nbetween',
 					'empty',
 					'nempty',
+					'null',
+					'nnull',
 					'in',
 					'nin',
 				],

--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -4,7 +4,6 @@ export function getFilterOperatorsForType(type: Type): ClientFilterOperator[] {
 	switch (type) {
 		// Text
 		case 'binary':
-		case 'json':
 		case 'hash':
 		case 'string':
 		case 'csv':
@@ -22,23 +21,44 @@ export function getFilterOperatorsForType(type: Type): ClientFilterOperator[] {
 				'in',
 				'nin',
 			];
+
+		// JSON
+		case 'json':
+			return ['eq', 'neq', 'null', 'nnull', 'in', 'nin'];
+
+		// UUID
 		case 'uuid':
-			return ['eq', 'neq', 'empty', 'nempty', 'in', 'nin'];
+			return ['eq', 'neq', 'null', 'nnull', 'in', 'nin'];
 
 		// Boolean
 		case 'boolean':
-			return ['eq', 'neq', 'empty', 'nempty'];
+			return ['eq', 'neq', 'null', 'nnull'];
 
 		// Numbers
 		case 'integer':
 		case 'decimal':
-			return ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'empty', 'nempty', 'in', 'nin'];
+			return ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'null', 'nnull', 'in', 'nin'];
 
 		// Datetime
 		case 'dateTime':
 		case 'date':
 		case 'time':
-			return ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'empty', 'nempty', 'in', 'nin'];
+			return [
+				'eq',
+				'neq',
+				'null',
+				'nnull',
+				'lt',
+				'lte',
+				'gt',
+				'gte',
+				'between',
+				'nbetween',
+				'null',
+				'nnull',
+				'in',
+				'nin',
+			];
 
 		case 'geometry':
 			return ['eq', 'neq', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'];
@@ -57,6 +77,8 @@ export function getFilterOperatorsForType(type: Type): ClientFilterOperator[] {
 				'nbetween',
 				'empty',
 				'nempty',
+				'null',
+				'nnull',
 				'in',
 				'nin',
 			];


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/7500