### PR TITLE
Fix SDK request URL when updating fields

### DIFF
--- a/packages/sdk/src/handlers/fields.ts
+++ b/packages/sdk/src/handlers/fields.ts
@@ -34,7 +34,7 @@ export class FieldsHandler<T = FieldItem> {
 	}
 
 	async updateOne(collection: string, field: string, item: PartialItem<T>): Promise<OneItem<T>> {
-		return (await this.transport.patch<PartialItem<T>>(`/fields/${collection}/${field}}`, item)).data;
+		return (await this.transport.patch<PartialItem<T>>(`/fields/${collection}/${field}`, item)).data;
 	}
 
 	async deleteOne(collection: string, field: string): Promise<void> {

--- a/packages/sdk/tests/handlers/fields.test.ts
+++ b/packages/sdk/tests/handlers/fields.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+
+import { Directus } from '../../src';
+import { test } from '../utils';
+
+describe('fields', function () {
+	test(`update one`, async (url, nock) => {
+		const scope = nock()
+			.patch('/fields/posts/title', { meta: { required: true } })
+			.reply(200, {});
+
+		const sdk = new Directus(url);
+		await sdk.fields.updateOne('posts', 'title', {
+			meta: {
+				required: true,
+			},
+		});
+
+		expect(scope.pendingMocks().length).toBe(0);
+	});
+});

--- a/packages/sdk/tests/utils.ts
+++ b/packages/sdk/tests/utils.ts
@@ -28,9 +28,10 @@ export function test(name: string, test: Test, settings?: TestSettings): void {
 		}
 
 		// `clearImmediate` doesn't exist in the jsdom environment and nock throws ReferenceError
-		if (global.clearImmediate !== typeof 'function') {
+		if (typeof global.clearImmediate !== 'function') {
 			global.clearImmediate = clearImmediate;
 		}
+
 		nock.abortPendingRequests();
 		nock.cleanAll();
 	});


### PR DESCRIPTION
- Removed an extra `}` in the update field request url
- Added a tests for updating a field using the SDK
- Fix the check for `window.clearImmediate` in tests (was always returning `true`)