### PR TITLE
Remove misleading return statement and add a note how the final payload is created

### DIFF
--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -63,11 +63,19 @@ module.exports = function registerHook({ exceptions }) {
 			if (LOGIC_TO_CANCEL_EVENT) {
 				throw new InvalidPayloadException(WHAT_IS_WRONG);
 			}
-
-			return input;
 		},
 	};
 };
+```
+
+**Note on `items.create.before`**
+
+Do only return a result from your `items.create.before` hook if it changes the payload. The `ItemsService` reduces
+the final payload from all return values before writing it into the database.
+
+```js
+// api/src/services/items.ts#L120
+const payloadAfterHooks = hooksResult.length > 0 ? hooksResult.reduce((val, acc) => merge(acc, val)) : payload;
 ```
 
 ### Event Format Options


### PR DESCRIPTION
… payload is created

I've run into the issue that changes I did inside a `items.create.before` hook were overridden by other `items.create.before` hooks which returned the initial payload if the targeted collection was not affected. After digging into it and understanding how the final payload is produced. I tried to explain it as compact as possible to not add any bloat to the documentation. Also I removed the generic return statement from the example, because this was what made me think it is required. 
(Might have something to do that I did a lot with redux reducers in the past and hooks are somewhat similar)

Hooks are one of the best Directus feature and I believe we can explain them in more detail with extensive examples.