### PR TITLE
Don't sort filters alphabetical

### DIFF
--- a/app/src/composables/use-field-tree/use-field-tree.ts
+++ b/app/src/composables/use-field-tree/use-field-tree.ts
@@ -29,7 +29,7 @@ export default function useFieldTree(
 	function parseLevel(collection: string, parentPath: string | null, level = 0) {
 		const fieldsInLevel = orderBy(
 			[
-				...cloneDeep(fieldsStore.getFieldsForCollectionAlphabetical(collection)),
+				...cloneDeep(fieldsStore.getFieldsForCollection(collection)),
 				...(inject?.value?.fields.filter((field) => field.collection === collection) || []),
 			]
 				.filter((field: Field) => {


### PR DESCRIPTION
closes #7491
As far as I can see, the fields are in correct order in layout options, only the filter had them alphabetical.