### PR TITLE
Allow using regular input interface on TEXT type fields

### DIFF
--- a/app/src/interfaces/input/index.ts
+++ b/app/src/interfaces/input/index.ts
@@ -8,6 +8,6 @@ export default defineInterface({
 	description: '$t:interfaces.input.description',
 	icon: 'text_fields',
 	component: InterfaceInput,
-	types: ['string', 'uuid', 'bigInteger', 'integer', 'float', 'decimal', 'geometry'],
+	types: ['string', 'uuid', 'bigInteger', 'integer', 'float', 'decimal', 'geometry', 'text'],
 	options: Options,
 });


### PR DESCRIPTION
This commit will add additional support for connecting to an existing database PostgreSQL.
The only difference between TEXT and VARCHAR(n) is that you can limit the maximum length of a VARCHAR column.