### PR TITLE
remove undefined fitBounds

### DIFF
--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -110,7 +110,6 @@ export default defineComponent({
 			GEOMETRY_TYPES,
 			geometryType,
 			mapContainer,
-			fitBounds,
 		};
 	},
 });


### PR DESCRIPTION
An undefined `fitBounds` variable (method?) is returned by setup() in map interface options which leads to the following error when setting up the interface:

![image](https://user-images.githubusercontent.com/16208594/130338424-40ca56e8-2da8-4d35-b541-f81da3ce5cb2.png)

`fitBounds` is not itself referenced further in either `options.vue` or `map.vue`. `map.vue` uses `maplibre-gl`'s `fitBounds`method and the field's value for the bounding box.