### PR TITLE
Fix asset transformation `withEnlargement` type

### DIFF
--- a/api/src/utils/transformations.ts
+++ b/api/src/utils/transformations.ts
@@ -16,14 +16,22 @@ export function resolvePreset(input: TransformationParams | TransformationPreset
 	);
 }
 
-function extractOptions<T extends Record<string, any>>(keys: (keyof T)[], numberKeys: (keyof T)[] = []) {
+function extractOptions<T extends Record<string, any>>(
+	keys: (keyof T)[],
+	numberKeys: (keyof T)[] = [],
+	booleanKeys: (keyof T)[] = []
+) {
 	return function (input: TransformationParams | TransformationPreset): T {
 		return Object.entries(input).reduce(
 			(config, [key, value]) =>
 				keys.includes(key as any) && isNil(value) === false
 					? {
 							...config,
-							[key]: numberKeys.includes(key as any) ? +value : value,
+							[key]: numberKeys.includes(key as any)
+								? +value
+								: booleanKeys.includes(key as any)
+								? Boolean(value)
+								: value,
 					  }
 					: config,
 			{} as T
@@ -53,7 +61,8 @@ function extractResize(input: TransformationParams | TransformationPreset): Tran
 		'resize',
 		extractOptions<TransformationPresetResize>(
 			['width', 'height', 'fit', 'withoutEnlargement'],
-			['width', 'height']
+			['width', 'height'],
+			['withoutEnlargement']
 		)(input),
 	];
 }


### PR DESCRIPTION
Fixes #7544

### Before fix applied

Gets `Expected boolean for withoutEnlargement but received true of type string`

Screenshot:
![chrome_BFzjIsJvXi](https://user-images.githubusercontent.com/42867097/130512876-f89062a4-02ea-4ca5-aafc-a2ccede33a27.png)

### After fix applied

Using `withoutEnlargement=true`:
![chrome_LAYnk2tp38](https://user-images.githubusercontent.com/42867097/130512945-74fcffa2-3cee-4b55-9d8f-43b221ef1982.png)

other values such as `withoutEnlargement=1` and `withoutEnlargement=t` as mentioned in the issue still evaluates to true due to nature of JS boolean, but doing `withoutEnlargement` only results in false since empty string is evaluated as false by default. Though I think that's fine as in it basically means it wasn't fully defined and Sharp does defaults `withoutEnlargement` to false, so not sure if there's intention to make that scenario true instead.

Also basically just mimics/extends the previous PR like how they used numberKeys, not sure if there's a better approach here.