### PR TITLE
Handle difference between `pg` and `postgres` as db client in geometry helper

### DIFF
--- a/api/src/database/helpers/geometry.ts
+++ b/api/src/database/helpers/geometry.ts
@@ -14,6 +14,7 @@ export function getGeometryHelper(): KnexSpatial {
 			mariadb: KnexSpatial_MySQL,
 			sqlite3: KnexSpatial,
 			pg: KnexSpatial_PG,
+			postgres: KnexSpatial_PG,
 			redshift: KnexSpatial_Redshift,
 			mssql: KnexSpatial_MSSQL,
 			oracledb: KnexSpatial_Oracle,


### PR DESCRIPTION
Should fix #7559

@rijkvanzanten Should we use another parameter to find out which database is being used ?