### PR TITLE
Fix calendar layout not opening detail pages for system collections

### DIFF
--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -201,9 +201,9 @@ export default defineLayout<LayoutOptions>({
 
 						const endpoint = collection.value.startsWith('directus')
 							? collection.value.substring(9)
-							: `/collections/${collection.value}`;
+							: `collections/${collection.value}`;
 
-						router.push(`${endpoint}/${primaryKey}`);
+						router.push(`/${endpoint}/${primaryKey}`);
 					}
 				},
 				async eventChange(info) {


### PR DESCRIPTION
### Before

The `endpoint` variable correctly adds a starting slash to collections to ensure absolute path, but not for files (or any directus-specific tables), so it'll route us to the wrong url for Files + Calendar View.

https://user-images.githubusercontent.com/42867097/130588388-469f9665-d004-4b43-bb92-de9763b8e724.mp4

### After

Enforced starting slash for both cases. Now `/files` is added to the URL correctly.

https://user-images.githubusercontent.com/42867097/130588519-a2b1c8b2-543c-4b3a-b683-9bd3fa116442.mp4

