### PR TITLE
fix(api): merge original user object into payload from auth hook

### DIFF
--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -65,13 +65,13 @@ export class AuthenticationService {
 
 		const { email, password, ip, userAgent, otp } = options;
 
-		let user = await this.knex
+		const user = await this.knex
 			.select('id', 'password', 'role', 'tfa_secret', 'status')
 			.from('directus_users')
 			.whereRaw('LOWER(??) = ?', ['email', email.toLowerCase()])
 			.first();
 
-		const updatedUser = await emitter.emitAsync('auth.login.before', options, {
+		const updatedOptions = await emitter.emitAsync('auth.login.before', options, {
 			event: 'auth.login.before',
 			action: 'login',
 			schema: this.schema,
@@ -82,14 +82,8 @@ export class AuthenticationService {
 			database: this.knex,
 		});
 
-		if (updatedUser) {
-			user =
-				updatedUser.length > 0
-					? merge(
-							updatedUser.reduce((acc, val) => merge(acc, val), {}),
-							user
-					  )
-					: user;
+		if (updatedOptions) {
+			options = updatedOptions.length > 0 ? updatedOptions.reduce((acc, val) => merge(acc, val), {}) : options;
 		}
 
 		const emitStatus = (status: 'fail' | 'success') => {

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -86,7 +86,7 @@ export class AuthenticationService {
 			user =
 				updatedUser.length > 0
 					? merge(
-							updatedUser.reduce((val, acc) => merge(acc, val)),
+							updatedUser.reduce((acc, val) => merge(acc, val), {}),
 							user
 					  )
 					: user;

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -83,7 +83,13 @@ export class AuthenticationService {
 		});
 
 		if (updatedUser) {
-			user = updatedUser.length > 0 ? updatedUser.reduce((val, acc) => merge(acc, val)) : user;
+			user =
+				updatedUser.length > 0
+					? merge(
+							updatedUser.reduce((val, acc) => merge(acc, val)),
+							user
+					  )
+					: user;
 		}
 
 		const emitStatus = (status: 'fail' | 'success') => {


### PR DESCRIPTION
Fixes #7564

## Reproduction steps

Create a custom hook at `/extensions/hooks/before-login/index.js` with the following code:

```js
module.exports = function registerHook() {
	return {
		'auth.login.before': async function (payload) {
			return payload;
		},
	};
};
```

User is then unable to login as it says Invalid Credentials. Though this is weird since we're basically returning the exact same payload without any modification.

## Investigation

Judging from the relevant source code here:

https://github.com/directus/directus/blob/e10eba3692eb650daa1c002d19f12f64027141ac/api/src/services/authentication.ts#L68-L87

If there is `updatedUser` (which is true when there's an `auth.login.before` hook), `user` variable will become `updatedUser`.

If we check the resulting `user` object before & after the merge, we will see the following:

| Before | After |
|---|---|
|  ![Code_2mS8ZPtc6g](https://user-images.githubusercontent.com/42867097/130616784-53385843-c5dc-49a7-9f1a-94b11288f266.png) | ![Code_8LB1nXKImR](https://user-images.githubusercontent.com/42867097/130616817-40347e0f-f7c4-495c-bae0-90e4386d97f0.png) |

This then indicates that the payload actually entirely replaced the user object, rather than "merging" into it. Then since the crucial `status` property that existed in `user` is now gone, the following logic will be true (`user.status !== 'active'`) and return Invalid Credential error to the user:

![Code_8WFUGq8dEY](https://user-images.githubusercontent.com/42867097/130617160-7bca32e0-189a-4533-938b-0b8fb19fce95.png)

## Original fix

So I added `merge()` wrapping the `updatedUser.reduce()` in the ternary logic to ensure the `status` property in the original user object persists before going forward. I also assume that this was the original intention of the ternary logic & the merge was missed in the past. This results in the following:

| Before | After |
|---|---|
|  ![Code_4EWXPPqFgD](https://user-images.githubusercontent.com/42867097/130617766-a2dfd5ce-4cdd-4381-bc9e-4712703de2c1.png) | ![Code_3lKwNERiV6](https://user-images.githubusercontent.com/42867097/130617815-1def4dfa-6143-410f-9cbb-453f4d4a3613.png) |

Now we can see that `status` remains in the user object, while we also have the payload such as `ip` and `mode`.

However since the payload has `password` property, it overridden the argon2 password property of the original user object, thus making it fail again when we reach the following code:

![Code_jNEEydEgSl](https://user-images.githubusercontent.com/42867097/130617945-d42d52c0-7385-4e13-b5bb-9ce6f9a2c738.png)

## Current fix

Hence the current fix is to flip them within the `merge()` function and ensure the argon2 password overrides the plain login password during the auth process.

## Possible alternatives

When I was looking at past PRs, I noticed that there used to be a step where you used lodash `omit()` function to remove `password` & `otp` properties from the hook payload as seen here: https://github.com/joselcvarela/directus/blob/207eda1d2dd35a6d96721f32c511a01bb6e37030/api/src/services/authentication.ts#L61

If we were to add this, we then won't have to flip the merge as I did in the end. However the flip may be justifiable in the sense that those original user properties like `id`, `password` (argon2), `role` shouldn't be able to be overridden by the payload.

Ultimately this is a draft now since I'm not sure if the merge I did was the actual intention of the ternary code as it was my own assumption, so I wanted to get confirmations first before proceeding to make it an active PR.