### PR TITLE
Log localhost url on startup so it's clickable in terminals

### DIFF
--- a/api/src/start.ts
+++ b/api/src/start.ts
@@ -30,7 +30,7 @@ export default async function start(): Promise<void> {
 					// No need to log/warn here. The update message is only an informative nice-to-have
 				});
 
-			logger.info(`Server started at port ${port}`);
+			logger.info(`Server started at http://localhost:${port}`);
 			emitAsyncSafe('server.start');
 		})
 		.once('error', (err: any) => {


### PR DESCRIPTION
This is a little DX enhancement so folks don't have to go to through browser, make a new tab, type out the URL. Instead they can ctrl+click the url in their terminal. Maybe there's a reason this isn't originally this way, but I want to suggest it. 