### PR TITLE
Share vue-router between App and extensions

### DIFF
--- a/packages/shared/src/constants/extensions.ts
+++ b/packages/shared/src/constants/extensions.ts
@@ -1,4 +1,4 @@
-export const APP_SHARED_DEPS = ['@directus/extension-sdk', 'vue'];
+export const APP_SHARED_DEPS = ['@directus/extension-sdk', 'vue', 'vue-router'];
 export const API_SHARED_DEPS = ['axios'];
 
 export const APP_EXTENSION_TYPES = ['interface', 'display', 'layout', 'module'] as const;


### PR DESCRIPTION
It is very unlikely that we will ever stop using vue-router. Without this it is not possible to use `useRouter()` in extensions.