### PR TITLE
fix(app): ignore certain tags from firing keyboard shortcuts

### DIFF
--- a/app/src/composables/use-shortcut/use-shortcut.ts
+++ b/app/src/composables/use-shortcut/use-shortcut.ts
@@ -4,6 +4,7 @@ type ShortcutHandler = (event: KeyboardEvent, cancelNext: () => void) => void | 
 
 const keysdown: Set<string> = new Set([]);
 const handlers: Record<string, ShortcutHandler[]> = {};
+const ignoredTags: string[] = ['INPUT', 'TEXTAREA'];
 
 document.body.addEventListener('keydown', (event: KeyboardEvent) => {
 	if (event.repeat || !event.key) return;
@@ -24,6 +25,7 @@ export default function useShortcut(
 ): void {
 	const callback: ShortcutHandler = (event, cancelNext) => {
 		if (!reference.value) return;
+		if (document.activeElement && ignoredTags.includes(document.activeElement.tagName)) return;
 		const ref = reference.value instanceof HTMLElement ? reference.value : (reference.value.$el as HTMLElement);
 
 		if (


### PR DESCRIPTION
In the PR #7560, we can use SHIFT+number keyboard shortcuts to navigate to modules. However this will also fire whenever we are typing `!@#$%^` etc in inputs/textarea, thus preventing us from actually being able to type these symbols.

For reference, this scenario is also addressed by ["Conditionally Disable" section of useMagicKeys in VueUse](https://vueuse.org/core/useMagicKeys/#conditionally-disable) which was what I referred when I thought of keyboard shortcuts and the reason why my solution involved `INPUT` and `TEXTAREA` tags.

## Test performed before & after fix

- Navigate to Adding User page
- Select the email input, attempt to type `@` (SHIFT-2)
- Select the description textarea, attempt to type `@` (SHIFT-2)
- Unselect any input, attempt to use `SHIFT-2`

## Before Fix

Step 2 and 3 of the test fails here. Step 4 works as expected.

https://user-images.githubusercontent.com/42867097/131111930-9244f61e-92d3-4716-8aee-ff8b3310def9.mp4

## After Fix

All steps now works as expected.

https://user-images.githubusercontent.com/42867097/131111979-832f2494-487e-4241-9b03-2bbb8ee2b8ff.mp4

## Additional Test

Tested in rich text markdown editor & everything seems to be in order, though in hindsight they aren't the exact same combinations so this could be an invalid test.

https://user-images.githubusercontent.com/42867097/131112951-fc887927-e91e-48d6-a19e-fc7829dc5c5c.mp4

## Possible Alternatives / Additional Thoughts

Maybe adding tags to ignore within `useShortcuts()` like how useMagicKeys does in VueUse will be a better way to avoid unintended side effects, such as maybe some INPUT or TEXTAREA still wants the keyboard shortcuts to fire, but I also personally can't think of any instance where this is needed. 

Maybe when the input is just a numeric number? but that might also end up being confusing if some type of input does fire the shortcut while some don't.

Since I have some doubts on whether the current approach is elegant, or maybe acceptable just as a temp fix, I'll leave it as a draft for now.


