### PR TITLE
Replace system provide with composables

### DIFF
--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -22,11 +22,10 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, toRefs, watch, computed, provide, onMounted, onUnmounted } from 'vue';
-import * as stores from '@/stores';
-import api, { addTokenToURL } from '@/api';
-import axios from 'axios';
+import { defineComponent, toRefs, watch, computed, onMounted, onUnmounted } from 'vue';
+import { useAppStore, useUserStore, useServerStore } from '@/stores';
 import { startIdleTracking, stopIdleTracking } from './idle';
+import useSystem from '@/composables/use-system';
 
 import useWindowSize from '@/composables/use-window-size';
 import setFavicon from '@/utils/set-favicon';
@@ -34,8 +33,6 @@ import setFavicon from '@/utils/set-favicon';
 export default defineComponent({
 	setup() {
 		const { t } = useI18n();
-
-		const { useAppStore, useUserStore, useServerStore } = stores;
 
 		const appStore = useAppStore();
 		const userStore = useUserStore();
@@ -106,15 +103,7 @@ export default defineComponent({
 
 		const error = computed(() => appStore.error);
 
-		/**
-		 * This allows custom extensions to use the apps internals
-		 */
-		provide('system', {
-			...stores,
-			api,
-			axios,
-			addTokenToURL,
-		});
+		useSystem();
 
 		return { t, hydrating, brandStyle, error, customCSS };
 	},

--- a/app/src/composables/use-system.ts
+++ b/app/src/composables/use-system.ts
@@ -1,0 +1,9 @@
+import { provide } from 'vue';
+import api from '@/api';
+import * as stores from '@/stores';
+import { API_INJECT, STORES_INJECT } from '@directus/shared/constants';
+
+export default function useSystem(): void {
+	provide(STORES_INJECT, stores);
+	provide(API_INJECT, api);
+}

--- a/packages/extension-sdk/src/index.ts
+++ b/packages/extension-sdk/src/index.ts
@@ -6,4 +6,4 @@ export {
 	defineHook,
 	defineEndpoint,
 } from '@directus/shared/utils';
-export { useLayoutState } from '@directus/shared/composables';
+export { useLayoutState, useStores, useApi } from '@directus/shared/composables';

--- a/packages/shared/src/composables/index.ts
+++ b/packages/shared/src/composables/index.ts
@@ -1,1 +1,2 @@
 export * from './use-layout-state';
+export * from './use-system';

--- a/packages/shared/src/composables/use-system.ts
+++ b/packages/shared/src/composables/use-system.ts
@@ -1,0 +1,19 @@
+import { inject } from 'vue';
+import { AxiosInstance } from 'axios';
+import { API_INJECT, STORES_INJECT } from '../constants';
+
+export function useStores(): Record<string, any> {
+	const stores = inject<Record<string, any>>(STORES_INJECT);
+
+	if (!stores) throw new Error('[useStores]: This function has to be used inside a Directus extension.');
+
+	return stores;
+}
+
+export function useApi(): AxiosInstance {
+	const api = inject<AxiosInstance>(API_INJECT);
+
+	if (!api) throw new Error('[useApi]: This function has to be used inside a Directus extension.');
+
+	return api;
+}

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './extensions';
 export * from './fields';
+export * from './injection';
 export * from './symbols';

--- a/packages/shared/src/constants/injection.ts
+++ b/packages/shared/src/constants/injection.ts
@@ -1,0 +1,2 @@
+export const STORES_INJECT = 'stores';
+export const API_INJECT = 'api';


### PR DESCRIPTION
For now only stores and the api are provided this way. Axios can just be imported within extensions (we can discuss sharing it in the future). The `addTokenToURL` util should rather be exposed through the sdk or added to the `api` object.