### PR TITLE
Change the entrypoint for API extensions from index.js to index.cjs

### DIFF
--- a/docs/guides/api-endpoints.md
+++ b/docs/guides/api-endpoints.md
@@ -9,7 +9,7 @@ Custom endpoints are dynamically loaded from within your project's `/extensions/
 extensions directory is configurable within your env file, and may be located elsewhere.
 
 Each endpoint is registered using a registration function within a scoped directory. For example, to create a custom
-`/my-endpoint/` endpoint, you would add the following function to `/extensions/endpoints/my-endpoint/index.js`.
+`/my-endpoint/` endpoint, you would add the following function to `/extensions/endpoints/my-endpoint/index.cjs`.
 
 ```js
 module.exports = function registerEndpoint(router) {
@@ -52,7 +52,7 @@ npx directus start
 ## Full Example:
 
 ```js
-// extensions/endpoints/recipes/index.js
+// extensions/endpoints/recipes/index.cjs
 
 module.exports = function registerEndpoint(router, { services, exceptions }) {
 	const { ItemsService } = services;

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -11,7 +11,7 @@ Custom hooks are dynamically loaded from within your extensions folder. By defau
 ### Default Standalone Hook Location
 
 ```
-/extensions/hooks/<hook-id>/index.js
+/extensions/hooks/<hook-id>/index.cjs
 ```
 
 ## 2. Define the Event
@@ -215,7 +215,7 @@ npx directus start
 
 ## Full Example
 
-`extensions/hooks/sync-with-external/index.js`:
+`extensions/hooks/sync-with-external/index.cjs`:
 
 ```js
 const axios = require('axios');

--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -71,7 +71,7 @@ export default async function create(type: string, name: string, options: Create
 		keywords: ['directus', 'directus-extension', `directus-custom-${type}`],
 		[EXTENSION_PKG_KEY]: {
 			type,
-			path: 'dist/index.js',
+			path: `dist/index.${isAppExtension(type) ? '.js' : '.cjs'}`,
 			source: `src/index.${languageToShort(options.language)}`,
 			host: `^${pkg.version}`,
 			hidden: false,

--- a/packages/shared/src/utils/node/get-extensions.ts
+++ b/packages/shared/src/utils/node/get-extensions.ts
@@ -86,7 +86,7 @@ export async function getLocalExtensions(root: string, types: readonly Extension
 					path: extensionPath,
 					name: extensionName,
 					type: extensionType,
-					entrypoint: 'index.js',
+					entrypoint: 'index.cjs',
 					local: true,
 					root: true,
 				});


### PR DESCRIPTION
This doesn't feel nice at all.