### PR TITLE
Remove /custom subpath for endpoints and add a way to customize the endpoint subpath

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -184,7 +184,8 @@ export default async function createApp(): Promise<express.Application> {
 	app.use('/users', usersRouter);
 	app.use('/utils', utilsRouter);
 	app.use('/webhooks', webhooksRouter);
-	app.use('/custom', customRouter);
+
+	app.use(customRouter);
 
 	// Register custom hooks / endpoints
 	await emitAsyncSafe('routes.custom.init.before', { app });

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -21,7 +21,7 @@ import emitter from './emitter';
 import env from './env';
 import * as exceptions from './exceptions';
 import logger from './logger';
-import { HookRegisterFunction, EndpointRegisterFunction } from './types';
+import { HookConfig, EndpointConfig } from './types';
 import fse from 'fs-extra';
 import { getSchema } from './utils/get-schema';
 
@@ -33,6 +33,7 @@ import { rollup } from 'rollup';
 import virtual from '@rollup/plugin-virtual';
 import alias from '@rollup/plugin-alias';
 import { Url } from './utils/url';
+import getModuleDefault from './utils/get-module-default';
 
 let extensions: Extension[] = [];
 let extensionBundles: Partial<Record<AppExtensionType, string>> = {};
@@ -150,14 +151,9 @@ function registerHooks(hooks: Extension[]) {
 
 	function registerHook(hook: Extension) {
 		const hookPath = path.resolve(hook.path, hook.entrypoint || '');
-		const hookInstance: HookRegisterFunction | { default?: HookRegisterFunction } = require(hookPath);
+		const hookInstance: HookConfig | { default: HookConfig } = require(hookPath);
 
-		let register: HookRegisterFunction = hookInstance as HookRegisterFunction;
-		if (typeof hookInstance !== 'function') {
-			if (hookInstance.default) {
-				register = hookInstance.default;
-			}
-		}
+		const register = getModuleDefault(hookInstance);
 
 		const events = register({ services, exceptions, env, database: getDatabase(), getSchema });
 
@@ -189,17 +185,15 @@ function registerEndpoints(endpoints: Extension[], router: Router) {
 
 	function registerEndpoint(endpoint: Extension) {
 		const endpointPath = path.resolve(endpoint.path, endpoint.entrypoint || '');
-		const endpointInstance: EndpointRegisterFunction | { default?: EndpointRegisterFunction } = require(endpointPath);
+		const endpointInstance: EndpointConfig | { default: EndpointConfig } = require(endpointPath);
 
-		let register: EndpointRegisterFunction = endpointInstance as EndpointRegisterFunction;
-		if (typeof endpointInstance !== 'function') {
-			if (endpointInstance.default) {
-				register = endpointInstance.default;
-			}
-		}
+		const mod = getModuleDefault(endpointInstance);
+
+		const register = typeof mod === 'function' ? mod : mod.handler;
+		const pathName = typeof mod === 'function' ? endpoint.name : mod.id;
 
 		const scopedRouter = express.Router();
-		router.use(`/${endpoint.name}/`, scopedRouter);
+		router.use(`/${pathName}`, scopedRouter);
 
 		register(scopedRouter, { services, exceptions, env, database: getDatabase(), getSchema });
 	}

--- a/api/src/types/extensions.ts
+++ b/api/src/types/extensions.ts
@@ -14,5 +14,14 @@ export type ExtensionContext = {
 	getSchema: typeof getSchema;
 };
 
-export type HookRegisterFunction = (context: ExtensionContext) => Record<string, ListenerFn>;
-export type EndpointRegisterFunction = (router: Router, context: ExtensionContext) => void;
+type HookHandlerFunction = (context: ExtensionContext) => Record<string, ListenerFn>;
+
+export type HookConfig = HookHandlerFunction;
+
+type EndpointHandlerFunction = (router: Router, context: ExtensionContext) => void;
+interface EndpointAdvancedConfig {
+	id: string;
+	handler: EndpointHandlerFunction;
+}
+
+export type EndpointConfig = EndpointHandlerFunction | EndpointAdvancedConfig;

--- a/api/src/utils/get-module-default.ts
+++ b/api/src/utils/get-module-default.ts
@@ -1,0 +1,6 @@
+export default function getModuleDefault<T>(mod: T | { default: T }): T {
+	if ('default' in mod) {
+		return mod.default;
+	}
+	return mod;
+}

--- a/docs/guides/api-endpoints.md
+++ b/docs/guides/api-endpoints.md
@@ -9,7 +9,7 @@ Custom endpoints are dynamically loaded from within your project's `/extensions/
 extensions directory is configurable within your env file, and may be located elsewhere.
 
 Each endpoint is registered using a registration function within a scoped directory. For example, to create a custom
-`/custom/my-endpoint/` endpoint, you would add the following function to `/extensions/endpoints/my-endpoint/index.js`.
+`/my-endpoint/` endpoint, you would add the following function to `/extensions/endpoints/my-endpoint/index.js`.
 
 ```js
 module.exports = function registerEndpoint(router) {
@@ -20,9 +20,9 @@ module.exports = function registerEndpoint(router) {
 You can also create several scoped endpoints within a single function:
 
 ```js
-// /custom/my-endpoint/
-// /custom/my-endpoint/intro
-// /custom/my-endpoint/goodbye
+// /my-endpoint/
+// /my-endpoint/intro
+// /my-endpoint/goodbye
 module.exports = function registerEndpoint(router) {
 	router.get('/', (req, res) => res.send('Hello, World!'));
 	router.get('/intro', (req, res) => res.send('Nice to meet you.'));
@@ -33,7 +33,7 @@ module.exports = function registerEndpoint(router) {
 ## 2. Develop your Custom Endpoint
 
 The `registerEndpoint` function receives two parameters: `router` and `context`. Router is an express Router instance
-that is scoped to `/custom/<extension-name>`, while `context` holds the following properties:
+that is scoped to `/<extension-name>`, while `context` holds the following properties:
 
 - `services` — All API internal services.
 - `exceptions` — API exception objects that can be used to throw "proper" errors.

--- a/packages/shared/src/types/endpoints.ts
+++ b/packages/shared/src/types/endpoints.ts
@@ -1,4 +1,10 @@
 import { Router } from 'express';
 import { ApiExtensionContext } from './extensions';
 
-export type EndpointRegisterFunction = (router: Router, context: ApiExtensionContext) => void;
+type EndpointHandlerFunction = (router: Router, context: ApiExtensionContext) => void;
+interface EndpointAdvancedConfig {
+	id: string;
+	handler: EndpointHandlerFunction;
+}
+
+export type EndpointConfig = EndpointHandlerFunction | EndpointAdvancedConfig;

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -1,3 +1,5 @@
 import { ApiExtensionContext } from './extensions';
 
-export type HookRegisterFunction = (context: ApiExtensionContext) => Record<string, (...values: any[]) => void>;
+type HookHandlerFunction = (context: ApiExtensionContext) => Record<string, (...values: any[]) => void>;
+
+export type HookConfig = HookHandlerFunction;

--- a/packages/shared/src/utils/define-extension.ts
+++ b/packages/shared/src/utils/define-extension.ts
@@ -1,11 +1,4 @@
-import {
-	InterfaceConfig,
-	DisplayConfig,
-	LayoutConfig,
-	ModuleConfig,
-	HookRegisterFunction,
-	EndpointRegisterFunction,
-} from '../types';
+import { InterfaceConfig, DisplayConfig, LayoutConfig, ModuleConfig, HookConfig, EndpointConfig } from '../types';
 
 export function defineInterface(config: InterfaceConfig): InterfaceConfig {
 	return config;
@@ -25,10 +18,10 @@ export function defineModule(config: ModuleConfig): ModuleConfig {
 	return config;
 }
 
-export function defineHook(config: HookRegisterFunction): HookRegisterFunction {
+export function defineHook(config: HookConfig): HookConfig {
 	return config;
 }
 
-export function defineEndpoint(config: EndpointRegisterFunction): EndpointRegisterFunction {
+export function defineEndpoint(config: EndpointConfig): EndpointConfig {
 	return config;
 }


### PR DESCRIPTION
**Notice**: This drops the `/custom/` prefix for custom endpoint modules. Please update your projects logic if you rely on custom endpoints.

---

When using

```js
export default router => {
  ...
};
```

to register a custom endpoint, it will now be registered at `/<extension-name>`.

This adds another way to register an endpoint:

```js
export default {
  id: 'some-id',
  handler: router => {
    ...
  }
};
```

This endpoint will be registered at `/some-id`.