### PR TITLE
Add upload event for file imports

### DIFF
--- a/app/src/components/v-upload/v-upload.vue
+++ b/app/src/components/v-upload/v-upload.vue
@@ -92,6 +92,7 @@ import uploadFiles from '@/utils/upload-files';
 import uploadFile from '@/utils/upload-file';
 import DrawerCollection from '@/views/private/components/drawer-collection';
 import api from '@/api';
+import emitter, { Events } from '@/events';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 export default defineComponent({
@@ -292,6 +293,8 @@ export default defineComponent({
 							folder: props.folder,
 						},
 					});
+
+					emitter.emit(Events.upload);
 
 					if (props.multiple) {
 						emit('input', [response.data.data]);


### PR DESCRIPTION
## Context

Currently when we add a file either by drag & drop or browsing a file, the view will refresh to show the latest uploaded file.

However when we use the `Import File from URL` feature, the dialog will close but **does not** refresh the current view to show the uploaded file.

## Before fix

https://user-images.githubusercontent.com/42867097/131363455-6c3c4531-1755-4817-a7a4-a02f70c95892.mp4

## After fix

https://user-images.githubusercontent.com/42867097/131363482-fe9364c6-8f70-4a35-81d1-dc84cc9eff1c.mp4

## Reasoning for Solution used

Currently the `uploadFile()` and `uploadFiles()` are called before finally emitting the input via `emit('input', ...)` as seen here:

https://github.com/directus/directus/blob/36f796a5f2455f44258457d613aad2416a4efd98/app/src/components/v-upload/v-upload.vue#L175-L202

Then within `uploadFile()` and `uploadFiles()`, the event `Events.upload` is emitted before the response is returned as seen here:

https://github.com/directus/directus/blob/36f796a5f2455f44258457d613aad2416a4efd98/app/src/utils/upload-file/upload-file.ts#L47-L49

 Which explains why they worked. This is then leads to why I put the `emitter.emit(Events.upload);` before the `emit('input', ...)` within `importFromURL()` is called to mirror the existing logic.