### PR TITLE
Expose package.json from shared and extensions-sdk

### DIFF
--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -11,7 +11,8 @@
 		"./cli": {
 			"import": "./dist/esm/cli/index.js",
 			"require": "./dist/cjs/cli/index.js"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"types": "dist/esm/index.d.ts",
 	"bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,10 @@
 			"import": "./dist/esm/constants/index.js",
 			"require": "./dist/cjs/constants/index.js"
 		},
+		"./exceptions": {
+			"import": "./dist/esm/exceptions/index.js",
+			"require": "./dist/cjs/exceptions/index.js"
+		},
 		"./types": {
 			"import": "./dist/esm/types/index.js",
 			"require": "./dist/cjs/types/index.js"
@@ -27,10 +31,7 @@
 			"import": "./dist/esm/utils/node/index.js",
 			"require": "./dist/cjs/utils/node/index.js"
 		},
-		"./exceptions": {
-			"import": "./dist/esm/exceptions/index.js",
-			"require": "./dist/cjs/exceptions/index.js"
-		}
+		"./package.json": "./package.json"
 	},
 	"scripts": {
 		"build": "run-p \"build:* -- {@}\" --",


### PR DESCRIPTION
I'd consider it good style to expose the `package.json` file.