### PR TITLE
Fix input-code component lint style

### DIFF
--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -289,8 +289,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-@import 'codemirror/addon/lint/lint.css';
-
 .input-code {
 	position: relative;
 	width: 100%;

--- a/app/src/styles/lib/_codemirror.scss
+++ b/app/src/styles/lib/_codemirror.scss
@@ -273,6 +273,54 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 	background: #e8f2ff;
 }
 
+/* Default styles for linting */
+.CodeMirror-gutter-elt {
+	left: 4px;
+}
+.CodeMirror-lint-markers {
+	width: 16px;
+}
+.CodeMirror-lint-tooltip {
+	position: absolute;
+	z-index: 850;
+	max-width: 600px;
+	padding: 4px 8px;
+	color: var(--foreground-inverted);
+	background-color: var(--background-inverted);
+	border-radius: var(--border-radius);
+	font-family: var(--family-monospace);
+	white-space: pre-wrap;
+	overflow: hidden;
+	opacity: 0;
+	transition: opacity var(--fast) var(--transition);
+}
+.CodeMirror-lint-mark-warning {
+	border-bottom: 2px dashed var(--warning);
+}
+
+.CodeMirror-lint-mark-error {
+	border-bottom: 2px dashed var(--danger);
+}
+.CodeMirror-lint-marker {
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	cursor: pointer;
+	left: 4px;
+	height: 16px;
+	width: 16px;
+}
+.CodeMirror-lint-marker-warning {
+	background-color: var(--warning);
+	-webkit-mask-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23000000'%3E%3Cg%3E%3Cg%3E%3Cg%3E%3Cpath d='M12,5.99L19.53,19H4.47L12,5.99 M12,2L1,21h22L12,2L12,2z'/%3E%3Cpolygon points='13,16 11,16 11,18 13,18'/%3E%3Cpolygon points='13,10 11,10 11,15 13,15'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+	mask-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23000000'%3E%3Cg%3E%3Cg%3E%3Cg%3E%3Cpath d='M12,5.99L19.53,19H4.47L12,5.99 M12,2L1,21h22L12,2L12,2z'/%3E%3Cpolygon points='13,16 11,16 11,18 13,18'/%3E%3Cpolygon points='13,10 11,10 11,15 13,15'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+}
+.CodeMirror-lint-marker-error {
+	background-color: var(--danger);
+	-webkit-mask-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23000000'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z'/%3E%3C/svg%3E");
+	mask-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23000000'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z'/%3E%3C/svg%3E");
+}
+
 /* STOP */
 
 /* ============================================================================================== */


### PR DESCRIPTION
## Bug

Currently when we are editing the Filter rules for permisions, there doesn't seem to be any linting. However upon inspection, there is indeed linting for JSON, presumably was intended for filter rules, as seen here:

https://github.com/directus/directus/blob/4bde1d7455162408debe9ed2a2b4ccf408726be8/app/src/interfaces/input-code/input-code.vue#L138-L167

We can also verify it's linting/firing since if we hover on the "invisible errors", we can see the codemirror lint tooltip appear at the end of the DOM in the devtools as shown here:

![luiYYDHRho](https://user-images.githubusercontent.com/42867097/131496609-e3932ca9-a9b5-40da-910c-fc3f8305d764.gif)

## Diagnosis

Seems like since the `lint.css` imported here is inside a scoped style:

https://github.com/directus/directus/blob/4bde1d7455162408debe9ed2a2b4ccf408726be8/app/src/interfaces/input-code/input-code.vue#L291-L292

the error markers, red underlines, and the tooltip aren't being applied anymore. If we remove the "scoped" attribute, we can see things are appearing again, albeit imperfect because the tooltip still has a lower z-index than the side panel.

![Ad4hxme7F6](https://user-images.githubusercontent.com/42867097/131497815-0fda315d-1ee3-4460-a266-8864fa10ff7b.gif)

## Fix applied

Since there is already an existing scss file for Codemirror, I opt to remove the out-of-the-box `lint.css` file, and add the modified version of it into the Codemirror scss file. 

Notable differences:

- originally Codemirror uses base64 png background-image to show the error/warning markers, but I went with svg (material icon named Error Outline) + mask-image so that we can retain the styling customization of danger & warning css variables. The `mask-image` css property is supported in all modern browsers except Internet Explorer, but I believe Directus doesn't support IE anymore, so hopefully this is acceptable. Reference: https://caniuse.com/?search=mask-image

- originally Codemirror uses base64 png to show the red underline, but I opt to use `border-bottom` + existing css variables instead.

## Result

### Dark Mode

![IGB4ech2wm](https://user-images.githubusercontent.com/42867097/131499323-f4a0c62c-4744-461c-8b85-547eb5ef4f30.gif)

### Light Mode

![mOpWVDDDUI](https://user-images.githubusercontent.com/42867097/131499343-0d4a3e61-e77d-488b-b25f-2e9655a8feb7.gif)



