### PR TITLE
Disable attribute inheritance for all layout components

### DIFF
--- a/app/src/layouts/calendar/actions.vue
+++ b/app/src/layouts/calendar/actions.vue
@@ -10,6 +10,7 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		itemCount: {
 			type: Number,

--- a/app/src/layouts/calendar/calendar.vue
+++ b/app/src/layouts/calendar/calendar.vue
@@ -10,6 +10,7 @@ import { defineComponent, onMounted, onUnmounted, PropType, ref } from 'vue';
 import '@fullcalendar/core/vdom';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		createCalendar: {
 			type: Function as PropType<(calendarElement: HTMLElement) => void>,

--- a/app/src/layouts/cards/actions.vue
+++ b/app/src/layouts/cards/actions.vue
@@ -10,6 +10,7 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		itemCount: {
 			type: Number,

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -91,6 +91,7 @@ import { Collection } from '@/types';
 
 export default defineComponent({
 	components: { Card, CardsHeader },
+	inheritAttrs: false,
 	props: {
 		collection: {
 			type: String,

--- a/app/src/layouts/map/actions.vue
+++ b/app/src/layouts/map/actions.vue
@@ -10,6 +10,7 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		itemCount: {
 			type: Number,

--- a/app/src/layouts/map/map.vue
+++ b/app/src/layouts/map/map.vue
@@ -105,6 +105,7 @@ import { GeometryOptions, Item } from '@directus/shared/types';
 
 export default defineComponent({
 	components: { MapComponent },
+	inheritAttrs: false,
 	props: {
 		selection: {
 			type: Array as PropType<Item[]>,

--- a/app/src/layouts/tabular/actions.vue
+++ b/app/src/layouts/tabular/actions.vue
@@ -10,6 +10,7 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		itemCount: {
 			type: Number,

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -89,6 +89,7 @@ import { HeaderRaw } from '@/components/v-table/types';
 import { Collection } from '@/types';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		collection: {
 			type: String,

--- a/packages/extensions-sdk/templates/layout/javascript/src/layout.vue
+++ b/packages/extensions-sdk/templates/layout/javascript/src/layout.vue
@@ -7,6 +7,7 @@
 
 <script>
 export default {
+	inheritAttrs: false,
 	props: {
 		collection: {
 			type: String,

--- a/packages/extensions-sdk/templates/layout/typescript/src/layout.vue
+++ b/packages/extensions-sdk/templates/layout/typescript/src/layout.vue
@@ -9,6 +9,7 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		collection: {
 			type: String,


### PR DESCRIPTION
This prevents vue from polluting the DOM with unused state props.