### PR TITLE
Fix WYSIWYG field not being cleared after "Save and Create New"

### DIFF
--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -133,6 +133,7 @@ export default defineComponent({
 		const internalValue = computed(() => {
 			if (props.modelValue !== undefined) return props.modelValue;
 			if (props.initialValue !== undefined) return props.initialValue;
+			if (props.field.meta?.interface === 'input-rich-text-html') return '';
 			return defaultValue.value;
 		});
 

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -133,7 +133,6 @@ export default defineComponent({
 		const internalValue = computed(() => {
 			if (props.modelValue !== undefined) return props.modelValue;
 			if (props.initialValue !== undefined) return props.initialValue;
-			if (props.field.meta?.interface === 'input-rich-text-html') return '';
 			return defaultValue.value;
 		});
 

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -289,11 +289,8 @@ export default defineComponent({
 
 		const internalValue = computed({
 			get() {
-				if (props.value) {
-					return replaceTokens(props.value, getToken());
-				}
-
-				return props.value;
+				if (!props.value) return '';
+				return replaceTokens(props.value, getToken());
 			},
 			set(newValue: string) {
 				if (newValue !== props.value && (props.value === null && newValue === '') === false) {


### PR DESCRIPTION
Fixes #7730

## Investigation

https://user-images.githubusercontent.com/42867097/131691368-4961c357-0025-4553-9ed9-28fc767e6e93.mp4

In the above video, we can see that "Title" and "Content" are both set as `null` in the beginning. After entering values to the fields, particularly "Content" the WYSIWYG field, we can observe the value does indeed turn into the HTML string on the current fields value. After clicking "Save and Create New", both fields are set as `null` again, even the "Content" field as shown in the end. 

This proves that the current code does indeed nulls/clears the WYSIWYG field, so this should be an issue with tinymce-vue itself, which is used over here:

https://github.com/directus/directus/blob/39c617c8639a44b9b97a87f85fb36769ceef6b79/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue#L3-L11

When we inspect the watcher of this 3rd party component, we can find the following code:

```js
  watch(modelValue, (val: string, prevVal: string) => {
    if (editor && typeof val === 'string' && val !== prevVal && val !== editor.getContent({ format: props.outputFormat })) {
      editor.setContent(val);
    }
  });
 ```
 
 Link to above code: https://github.com/tinymce/tinymce-vue/blob/540b4bf78c16bbe5335a5f1cc9c16f0b381e9117/src/main/ts/Utils.ts#L99-L103
 
 We can now see the issue is with `typeof val === 'string'`. Since we are resetting it as `null`, the if statement fails, thus not setting the content as "null" or empty.
 
 ## Solution
 
 This is why I added a check in internalValue to return an empty string if the interface is `input-rich-text-html`. Here's what it looks like after the fix:
 
https://user-images.githubusercontent.com/42867097/131694410-c0ac0b88-51dd-4164-86ae-1444a7afdc71.mp4

Do let me know if there's a better way to add this check if the if statement there seems hacky.

