### PR TITLE
fix WYSIWYG field focus event

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -6,8 +6,8 @@
 			:init="editorOptions"
 			:disabled="disabled"
 			model-events="change keydown blur focus paste ExecCommand SetContent"
-			@onFocusIn="setFocus(true)"
-			@onFocusOut="setFocus(false)"
+			@focusin="setFocus(true)"
+			@focusout="setFocus(false)"
 		/>
 
 		<v-dialog v-model="linkDrawerOpen">


### PR DESCRIPTION
## Bug

The focus event for WYSIWYG field aren't working. Here are the relevant code (`@onFocusIn` and `@onFocusOut`):

https://github.com/directus/directus/blob/39c617c8639a44b9b97a87f85fb36769ceef6b79/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue#L3-L11

https://github.com/directus/directus/blob/39c617c8639a44b9b97a87f85fb36769ceef6b79/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue#L392-L403

## Before Fix

The border aren't turning green here, which is what the class `.focus` should do.

![fE7lh196vI](https://user-images.githubusercontent.com/42867097/131696735-ebbc6117-a3b7-47c1-91e3-8a6450acfa46.gif)

## Investigation

The original code (`@onFocusIn` and `@onFocusOut`) does seem to follow the official tinymce documentation over here: https://www.tiny.cloud/docs/integrations/vue/#eventbinding

However there was a recent issue mentioning `@onChange` does not work for them, which I have also tested on Directus and got the same issue. This was the reply from the maintainer: https://github.com/tinymce/tinymce-vue/issues/265#issuecomment-888777786

thus if we follow the syntax advised by the maintainer as shown here: https://www.tiny.cloud/docs/advanced/events/#supportedbrowser-nativeevents

the focus events now works properly. 

## After Fix

![NKfPDh8pEe](https://user-images.githubusercontent.com/42867097/131696916-83e8f279-9ed3-4f8c-a506-49d70252b5ca.gif)

