### PR TITLE
Fix 'Inactive' to 'Invited' translations on user status

### DIFF
--- a/app/src/lang/translations/ar-SA.yaml
+++ b/app/src/lang/translations/ar-SA.yaml
@@ -741,7 +741,7 @@ fields:
     theme: السمة
     tfa_secret: التحقق بخطوتين
     status: حالة
-    status_invited: غير نشط
+    status_invited: مدعو
     status_active: مفعل
     role: الدور
     last_page: آخر صفحة

--- a/app/src/lang/translations/bg-BG.yaml
+++ b/app/src/lang/translations/bg-BG.yaml
@@ -797,7 +797,7 @@ fields:
     admin_options: Административни настройки
     status: Статус
     status_draft: Чернова
-    status_invited: Неактивен
+    status_invited: Поканен
     status_active: Активен
     status_suspended: Замразен
     status_archived: Архивиран

--- a/app/src/lang/translations/ca-ES.yaml
+++ b/app/src/lang/translations/ca-ES.yaml
@@ -796,7 +796,7 @@ fields:
     admin_options: Opcions d'administrador
     status: Estat
     status_draft: Esborrany
-    status_invited: Inactiva
+    status_invited: Convidat
     status_active: Activa
     status_suspended: Suspès
     status_archived: Arxivat

--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -795,7 +795,7 @@ fields:
     admin_options: Admin-Optionen
     status: Status
     status_draft: Entwurf
-    status_invited: Inaktiv
+    status_invited: Eingeladen
     status_active: Aktiv
     status_suspended: Angehalten
     status_archived: Archiviert

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -811,7 +811,7 @@ fields:
     admin_options: Admin Options
     status: Status
     status_draft: Draft
-    status_invited: Inactive
+    status_invited: Invited
     status_active: Active
     status_suspended: Suspended
     status_archived: Archived

--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -796,7 +796,7 @@ fields:
     admin_options: Options d'Administration
     status: État
     status_draft: Brouillon
-    status_invited: Inactif
+    status_invited: Invité
     status_active: Actif
     status_suspended: Suspendu
     status_archived: Archivé

--- a/app/src/lang/translations/hu-HU.yaml
+++ b/app/src/lang/translations/hu-HU.yaml
@@ -726,7 +726,7 @@ fields:
     theme: Téma
     tfa_secret: Kétlépcsős hitelesítés
     status: Állapot
-    status_invited: Inaktív
+    status_invited: Meghívott
     status_active: aktív
     role: Szerepkör
     token: Token

--- a/app/src/lang/translations/it-IT.yaml
+++ b/app/src/lang/translations/it-IT.yaml
@@ -798,7 +798,7 @@ fields:
     admin_options: Opzioni Amministratore
     status: Stato
     status_draft: Bozza
-    status_invited: Disattivato
+    status_invited: Invitato
     status_active: Attivo
     status_suspended: Sospeso
     status_archived: Archiviato

--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -797,7 +797,7 @@ fields:
     admin_options: Opções do Admin
     status: Status
     status_draft: Rascunho
-    status_invited: Inativo
+    status_invited: Convidado
     status_active: Ativo
     status_suspended: Suspenso
     status_archived: Arquivado

--- a/app/src/lang/translations/ru-RU.yaml
+++ b/app/src/lang/translations/ru-RU.yaml
@@ -779,7 +779,7 @@ fields:
     admin_options: Настройки администратора
     status: Статус
     status_draft: Черновик
-    status_invited: Неактивный
+    status_invited: Приглашен
     status_active: Активный
     status_suspended: Приостановлен
     status_archived: В архиве

--- a/app/src/lang/translations/sl-SI.yaml
+++ b/app/src/lang/translations/sl-SI.yaml
@@ -796,7 +796,7 @@ fields:
     admin_options: Administracijske opcije
     status: Stanje
     status_draft: Osnutek
-    status_invited: Neaktivno
+    status_invited: Vabljeni
     status_active: Aktivno
     status_suspended: Zaustavljeno
     status_archived: Arhivirano

--- a/app/src/lang/translations/zh-CN.yaml
+++ b/app/src/lang/translations/zh-CN.yaml
@@ -796,7 +796,7 @@ fields:
     admin_options: 管理员设置
     status: 状态
     status_draft: 草稿
-    status_invited: 非活跃
+    status_invited: 受邀
     status_active: 激活
     status_suspended: 已停用
     status_archived: 已存档


### PR DESCRIPTION
Fixes #7729 

I have used translator to put on other languages, so I am not sure if they are correct or not.
The ones I can tell are OK are: English, 