### PR TITLE
Fixes bug when trying to edit geometry in code interface.

### DIFF
--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -111,7 +111,7 @@ export default defineComponent({
 		const stringValue = computed<string>(() => {
 			if (props.value === null) return '';
 
-			if (props.type === 'json') {
+			if (typeof props.value === 'object') {
 				return JSON.stringify(props.value, null, 4);
 			}
 

--- a/app/src/interfaces/input/index.ts
+++ b/app/src/interfaces/input/index.ts
@@ -8,6 +8,6 @@ export default defineInterface({
 	description: '$t:interfaces.input.description',
 	icon: 'text_fields',
 	component: InterfaceInput,
-	types: ['string', 'uuid', 'bigInteger', 'integer', 'float', 'decimal', 'geometry', 'text'],
+	types: ['string', 'uuid', 'bigInteger', 'integer', 'float', 'decimal', 'text'],
 	options: Options,
 });


### PR DESCRIPTION
Removed `geometry` from `interface-input` as it doesn't handle editing object.
Make sure that objects are stringified in `interface-input-code`.

Fixes app crash when editing a geometry with the code interface.