### PR TITLE
Use OpenMapTiles font instead of ArcGIS

### DIFF
--- a/app/src/layouts/map/style.ts
+++ b/app/src/layouts/map/style.ts
@@ -73,8 +73,7 @@ export const layers: AnyLayer[] = [
 		filter: ['has', 'point_count'],
 		layout: {
 			'text-field': '{point_count_abbreviated}',
-			// 'text-font': ['Open Sans Semibold'],
-			'text-font': ['Noto Sans Regular'],
+			'text-font': ['Open Sans Semibold'],
 			'text-size': ['step', ['get', 'point_count'], 15, 100, 17, 750, 19],
 		},
 	},

--- a/app/src/utils/geometry/basemap.ts
+++ b/app/src/utils/geometry/basemap.ts
@@ -17,8 +17,7 @@ const defaultBasemap: BasemapSource = {
 
 const baseStyle: Style = {
 	version: 8,
-	glyphs:
-		'https://basemaps.arcgis.com/arcgis/rest/services/OpenStreetMap_GCS_v2/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf',
+	glyphs: 'http://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
 };
 
 export function getBasemapSources(): BasemapSource[] {


### PR DESCRIPTION
Fixes clusters not rendering when using mapbox styles.