### PR TITLE
Add environment variable to force-exclude tables from Directus

### DIFF
--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -22,6 +22,7 @@ export default function getDatabase(): Knex {
 		'DB_SEARCH_PATH',
 		'DB_CONNECTION_STRING',
 		'DB_POOL',
+		'DB_EXCLUDE_TABLES',
 	]);
 
 	const poolConfig = getConfigFromEnv('DB_POOL');

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -19,6 +19,8 @@ const defaults: Record<string, any> = {
 	PUBLIC_URL: '/',
 	MAX_PAYLOAD_SIZE: '100kb',
 
+	DB_EXCLUDE_TABLES: [],
+
 	STORAGE_LOCATIONS: 'local',
 	STORAGE_LOCAL_DRIVER: 'local',
 	STORAGE_LOCAL_ROOT: './uploads',

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -116,6 +116,11 @@ async function getDatabaseSchema(
 	];
 
 	for (const [collection, info] of Object.entries(schemaOverview)) {
+		if (toArray(env.DB_EXCLUDE_TABLES).includes(collection)) {
+			logger.trace(`Collection "${collection}" is configured to be excluded and will be ignored`);
+			continue;
+		}
+
 		if (!info.primary) {
 			logger.warn(`Collection "${collection}" doesn't have a primary key column and will be ignored`);
 			continue;

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -34,6 +34,7 @@ needs to be publicly available on the internet.
 | `DB_FILENAME`          | Where to read/write the SQLite database. **Required** when using `sqlite3`.                                                                        | --            |
 | `DB_CONNECTION_STRING` | When using `pg`, you can submit a connection string instead of individual properties. Using this will ignore any of the other connection settings. | --            |
 | `DB_POOL_*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --            |
+| `DB_IGNORE_TABLES`     | CSV of tables you want Directus to ignore completely                                                                                               | --            |
 
 ::: tip Additional Database Variables
 


### PR DESCRIPTION
Useful for external/pre-existing tables you don't ever want to manage or interact with from within Directus. For example `spatial_ref_sys`