### PR TITLE
Use https for openmaptiles fonts.

### DIFF
--- a/app/src/utils/geometry/basemap.ts
+++ b/app/src/utils/geometry/basemap.ts
@@ -17,7 +17,7 @@ const defaultBasemap: BasemapSource = {
 
 const baseStyle: Style = {
 	version: 8,
-	glyphs: 'http://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
+	glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
 };
 
 export function getBasemapSources(): BasemapSource[] {


### PR DESCRIPTION
Fixes mixed active content error in some environments.