### PR TITLE
Fix map interface controls not showing

### DIFF
--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -239,6 +239,16 @@ export default defineComponent({
 					loadValueFromProps();
 				}
 			);
+
+			watch(
+				() => props.disabled,
+				() => {
+					map.removeControl(controls.draw);
+					controls.draw = new MapboxDraw(getDrawOptions(geometryType));
+					map.addControl(controls.draw as IControl, 'top-left');
+					loadValueFromProps();
+				}
+			);
 		}
 
 		function resetValue(hard: boolean) {


### PR DESCRIPTION
Fixes https://github.com/directus/directus/pull/7505#issuecomment-912509464

> @Oreilles
> 
> _Not sure if it's related to this but..._
> 
> When I load an item with a field that has a map interface I don't have these anymore:
> 
> ![image](https://user-images.githubusercontent.com/10562635/132006631-5d2420c3-a91c-49a6-8c13-cbc8c58fd537.png)
> 
> (they appear when I first create an item)
> 
> But this way I cannot edit a map that doesn't already have a marker defined (e.g. the field is `NULL`), nor can I change the type of marker (e.g. going from a `point` to a `polygon`)

