### PR TITLE
fix type for deep query with underscore prefix

### DIFF
--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -30,7 +30,7 @@ export enum Meta {
 export type QueryOne<T> = {
 	fields?: keyof T | (keyof T)[] | '*' | '*.*' | '*.*.*' | string | string[];
 	search?: string;
-	deep?: Record<string, QueryMany<T>>;
+	deep?: Record<string, DeepQueryMany<T>>;
 	export?: 'json' | 'csv' | 'xml';
 	filter?: Filter<T>;
 };
@@ -41,6 +41,10 @@ export type QueryMany<T> = QueryOne<T> & {
 	offset?: number;
 	page?: number;
 	meta?: keyof ItemMetadata | '*';
+};
+
+export type DeepQueryMany<T> = {
+	[K in keyof QueryMany<T> as `_${string & K}`]: QueryMany<T>[K];
 };
 
 export type Sort<T> = (`${Extract<keyof T, string>}` | `-${Extract<keyof T, string>}`)[];


### PR DESCRIPTION
Fixes #7541 

## Context

Currently in the SDK, the following types are defined:

https://github.com/directus/directus/blob/689ac586a114534bb9d2305a157394ad6cdd829e/packages/sdk/src/items.ts#L30-L44

As `deep` is a Record that uses `QueryMany<T>`, this leads to the keys in `deep` property remains the same as `sort`, `filter` etc without any underscore prefix.

Whereas in the api application, it checks for keys starting with an underscore and removes it over here:

https://github.com/directus/directus/blob/689ac586a114534bb9d2305a157394ad6cdd829e/api/src/utils/sanitize-query.ts#L156-L171

## Before

Here we can see the suggestions within `deep` doesn't have underscore prefix, so it causes error despite underscore prefix is actually the correct code.

https://user-images.githubusercontent.com/42867097/132029083-abe4a73a-d4be-4228-b321-44bbcb4c909a.mp4

## After

Now the parameters within are prefixed with underscore, while the outer most level still doesn't have prefix as expected.

https://user-images.githubusercontent.com/42867097/132029248-738482ae-5217-40bf-8ac2-1e68c216209f.mp4

---

With that said, admittedly I am not super sure on my implementation as I just referred here to come out with what I did: https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as, but at the very least I hope this helps to get the ball rolling.


