### PR TITLE
make csv imports try to parse values to json

### DIFF
--- a/api/src/services/import.ts
+++ b/api/src/services/import.ts
@@ -104,8 +104,16 @@ export class ImportService {
 					.pipe(csv())
 					.on('data', (value: Record<string, string>) => {
 						const obj = transform(value, (result: Record<string, string>, value, key) => {
-							if (value.length === 0) delete result[key];
-							else set(result, key, value);
+							if (value.length === 0) {
+								delete result[key];
+							} else {
+								try {
+									const parsedJson = JSON.parse(value);
+									set(result, key, parsedJson);
+								} catch {
+									set(result, key, value);
+								}
+							}
 						});
 
 						saveQueue.push(obj);


### PR DESCRIPTION
Fixes #7434 

## Context

Currently when we export a collection as CSV, fields with type `CSV` are exported in a JSON array format, which is correct as to reflect the output if we were to retrieve it via API.

However if we directly use the exported CSV and import it again, the fields with type `CSV` ends up broken.

### Sample CSV which mimics the CSV provided in the issue

```csv
"id","name","tags"
1,"Item 1","[""mobile"",""desktop""]"
2,"Item 2","[""tablet"",""desktop""]"
3,"Item 3","[""mobile""]"
```
_This exact CSV will be used in the tests/videos below._

## Investigation

In the current code for importing CSV seen here:

https://github.com/directus/directus/blob/9200b88db4779d273c48504943ba58b25a5d9437/api/src/services/import.ts#L103-L112

It just checks if a particular value is empty (likely due to `csv-parser` returning empty string `''` for empty columns). If it is empty i.e. `length === 0`, the key is deleted, else the value is set back as is, which then causes the faulty imports. 

## Before Fix

https://user-images.githubusercontent.com/42867097/132064407-c9299906-39a4-461c-8a9e-63b2ca06fb68.mp4

## After Fix

https://user-images.githubusercontent.com/42867097/132064466-cd4df838-6d3e-4a18-928d-38b6f7aedbbb.mp4