### PR TITLE
fix minor typo in api-hooks.md

### DIFF
--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -141,7 +141,7 @@ module.exports = function registerHook() {
 ## 4. Develop your Custom Hook
 
 > Hooks can impact performance when not carefully implemented. This is especially true for `before` hooks (as these are
-> blocking) and hooks on `read` actions, as a single request can result in a large ammount of database reads.
+> blocking) and hooks on `read` actions, as a single request can result in a large amount of database reads.
 
 ### Register Function
 


### PR DESCRIPTION
Corrected `ammount` to `amount`.