### PR TITLE
Add custom JWTs support for static token

### DIFF
--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -27,7 +27,7 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 		let payload: { id: string };
 
 		try {
-			payload = jwt.verify(req.token, env.SECRET as string) as { id: string };
+			payload = jwt.verify(req.token, env.SECRET as string, { issuer: 'directus' }) as { id: string };
 		} catch (err: any) {
 			if (err instanceof TokenExpiredError) {
 				throw new InvalidCredentialsException('Token expired.');

--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -4,7 +4,7 @@ import getDatabase from '../database';
 import env from '../env';
 import { InvalidCredentialsException } from '../exceptions';
 import asyncHandler from '../utils/async-handler';
-import isJWT from '../utils/is-jwt';
+import isDirectusJWT from '../utils/is-directus-jwt';
 
 /**
  * Verify the passed JWT and assign the user ID and role to `req`
@@ -23,7 +23,7 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 
 	const database = getDatabase();
 
-	if (isJWT(req.token)) {
+	if (isDirectusJWT(req.token)) {
 		let payload: { id: string };
 
 		try {

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -171,6 +171,7 @@ export class AuthenticationService {
 		 */
 		const accessToken = jwt.sign(payload, env.SECRET as string, {
 			expiresIn: env.ACCESS_TOKEN_TTL,
+			issuer: 'directus',
 		});
 
 		const refreshToken = nanoid(64);
@@ -237,6 +238,7 @@ export class AuthenticationService {
 
 		const accessToken = jwt.sign({ id: record.id }, env.SECRET as string, {
 			expiresIn: env.ACCESS_TOKEN_TTL,
+			issuer: 'directus',
 		});
 
 		const newRefreshToken = nanoid(64);

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -305,7 +305,7 @@ export class UsersService extends ItemsService {
 				await service.createOne({ email, role, status: 'invited' });
 
 				const payload = { email, scope: 'invite' };
-				const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '7d' });
+				const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '7d', issuer: 'directus' });
 				const subjectLine = subject ?? "You've been invited";
 				const inviteURL = url ? new Url(url) : new Url(env.PUBLIC_URL).addPath('admin', 'accept-invite');
 				inviteURL.setQuery('token', token);
@@ -326,7 +326,7 @@ export class UsersService extends ItemsService {
 	}
 
 	async acceptInvite(token: string, password: string): Promise<void> {
-		const { email, scope } = jwt.verify(token, env.SECRET as string) as {
+		const { email, scope } = jwt.verify(token, env.SECRET as string, { issuer: 'directus' }) as {
 			email: string;
 			scope: string;
 		};
@@ -365,7 +365,7 @@ export class UsersService extends ItemsService {
 		});
 
 		const payload = { email, scope: 'password-reset' };
-		const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '1d' });
+		const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '1d', issuer: 'directus' });
 
 		if (url && isUrlAllowed(url, env.PASSWORD_RESET_URL_ALLOW_LIST) === false) {
 			throw new InvalidPayloadException(`Url "${url}" can't be used to reset passwords.`);
@@ -390,7 +390,7 @@ export class UsersService extends ItemsService {
 	}
 
 	async resetPassword(token: string, password: string): Promise<void> {
-		const { email, scope } = jwt.verify(token, env.SECRET as string) as {
+		const { email, scope } = jwt.verify(token, env.SECRET as string, { issuer: 'directus' }) as {
 			email: string;
 			scope: string;
 		};

--- a/api/src/utils/is-directus-jwt.ts
+++ b/api/src/utils/is-directus-jwt.ts
@@ -2,9 +2,10 @@ import atob from 'atob';
 import logger from '../logger';
 
 /**
- * Check if a given string conforms to the structure of a JWT.
+ * Check if a given string conforms to the structure of a JWT
+ * and whether it is issued by Directus.
  */
-export default function isJWT(string: string): boolean {
+export default function isDirectusJWT(string: string): boolean {
 	const parts = string.split('.');
 
 	// JWTs have the structure header.payload.signature
@@ -23,7 +24,8 @@ export default function isJWT(string: string): boolean {
 	// Check if the header and payload are valid JSON
 	try {
 		JSON.parse(atob(parts[0]));
-		JSON.parse(atob(parts[1]));
+		const payload = JSON.parse(atob(parts[1]));
+		if (payload.iss !== 'directus') return false;
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
**Notice**: This adds an issuer flag to every generated JWT. This means that existing JWTs will be invalid once the update is applied. For authentication sessions, this shouldn't matter as the refresh token is unaffected. However, it does mean that user-invite and password-reset emails will be invalided and will have to be regenerated.

---

Fixes #5598

## Context

Currently the `authenticate` middleware checks whether the token is in JWT format (`isJWT(req.token)`). If it is, then proceed to check it like a user access token, else it will then try to search for the static token for this user, as seen here:

https://github.com/directus/directus/blob/698580a6611207c26973da8b4795deb360ba4521/api/src/middleware/authenticate.ts#L26-L79

The `isJWT()` utility function currently only checks if a string conforms to the structure of a JWT. Line 26 in particular is where the payload is parsed, but not really inspected for it's content:

https://github.com/directus/directus/blob/698580a6611207c26973da8b4795deb360ba4521/api/src/utils/is-jwt.ts#L7-L32
 
## Solution

Previously the suggested solution in the reply of the above issue was to add a dedicated directus scope. However [JWT spec already has the Issuer claim](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) which is used to identify who issued the token. Since that aligns perfectly to the purpose/direction of the suggested solution, this PR opts to use the Issuer claim. Plus it's supported out-of-the-box by the `jsonwebtoken` package currently used in Directus.

The `isJWT()` utility is modified to check whether the payload includes `iss: 'directus'` (Issuer claim) property. It is then promptly renamed to `isDirectusJWT()` to be more appropriate.

## Test performed in the before/after depiction

I used the following custom made JWT token using the site https://jwt.io/ in both cases. It is set as the static token for the admin user.

![chrome_aJ8sdTzlkt](https://user-images.githubusercontent.com/42867097/132095958-460a581d-24a4-4ce0-aa2f-2e7f225bf12e.png)

## Before fix

### The payload in the token

![chrome_bKZ3bkFN9q](https://user-images.githubusercontent.com/42867097/132095779-8b593b8d-4581-4950-bfe2-5963032669cf.png)

### Failed attempt to call collections API using the custom token

![chrome_mCSbSkYyN8](https://user-images.githubusercontent.com/42867097/132096051-dd8ca773-ea1e-41fd-bdd5-32c9f44ea00c.png)

## After fix

### The payload in the token

Now the payload includes `iss` property which is the Issuer claim.

![chrome_qZ5l6O5aUm](https://user-images.githubusercontent.com/42867097/132095820-604e8455-7e42-4ad8-9d6b-3dc4fe9efccd.png)

### Successful attempt to call collections API using the custom token

![chrome_MMimUvYI0V](https://user-images.githubusercontent.com/42867097/132096034-8898f10e-c910-49dd-8056-2bbc39273b96.png)

## Pending Discussion

Currently there are still 2 places where JWT signing occurs that **DOES NOT** add issuer to the payload, which are

- Invite User

    - Where JWT signing occurs & the scope `invite` is added to the payload
    
        https://github.com/directus/directus/blob/698580a6611207c26973da8b4795deb360ba4521/api/src/services/users.ts#L307-L308

    - Where the token is checked to see whether the scope `invite` is present
    
        https://github.com/directus/directus/blob/698580a6611207c26973da8b4795deb360ba4521/api/src/services/users.ts#L329-L334
        
- Request Password Reset

    - Where JWT signing occurs & the scope `password-reset` is added to the payload
  
        https://github.com/directus/directus/blob/698580a6611207c26973da8b4795deb360ba4521/api/src/services/users.ts#L367-L368

    - Where the token is checked to see whether the scope `password-reset` is present
    
        https://github.com/directus/directus/blob/698580a6611207c26973da8b4795deb360ba4521/api/src/services/users.ts#L393-L398

Current thoughts on the above 2 features involving JWT tokens:

- If we were to add the issuer here, it may break existing pending user invites & password resets, right? so we might need to note this as a breaking change if we do indeed add issuer to them.

- It may not even be necessary to add issuer for them since there are the scope check already.

- However in terms of completeness or uniformity perspective, adding issuer to them also sort of makes sense.