### PR TITLE
fix url format for Azure storage endpoint

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -246,7 +246,7 @@ Based on your configured driver, you must also provide the following configurati
 | `STORAGE_<LOCATION>_CONTAINER_NAME` | Azure Storage container    | --                                    |
 | `STORAGE_<LOCATION>_ACCOUNT_NAME`   | Azure Storage account name | --                                    |
 | `STORAGE_<LOCATION>_ACCOUNT_KEY`    | Azure Storage key          | --                                    |
-| `STORAGE_<LOCATION>_ENDPOINT`       | Azure URL                  | "{ACCOUNT_KEY}.blob.core.windows.net" |
+| `STORAGE_<LOCATION>_ENDPOINT`       | Azure URL                  | "https://{ACCOUNT_KEY}.blob.core.windows.net" |
 
 ### Google Cloud Storage (`gcs`)
 


### PR DESCRIPTION
Based on 

- this comment: https://github.com/directus/directus/issues/7788#issuecomment-912172438 with a working setup
- personally have a similar working Azure storage setup with `https://` in the URL
- there was another user in the Discord server having issue with Azure storage, end up being they didn't add `https://` for their setup. It worked after they add it.

Seems like this is a necessary update for it in the docs. 