### PR TITLE
Add ability to customise database errors

### DIFF
--- a/api/src/exceptions/database/translate.ts
+++ b/api/src/exceptions/database/translate.ts
@@ -1,4 +1,5 @@
-import getDatabase from '../../database';
+import { getDatabaseClient } from '../../database';
+import emitter from '../../emitter';
 import { extractError as mssql } from './dialects/mssql';
 import { extractError as mysql } from './dialects/mysql';
 import { extractError as oracle } from './dialects/oracle';
@@ -16,22 +17,28 @@ import { SQLError } from './dialects/types';
  * - Value Too Long
  */
 export async function translateDatabaseError(error: SQLError): Promise<any> {
-	const database = getDatabase();
+	const client = getDatabaseClient();
+	let defaultError: any;
 
-	switch (database.client.constructor.name) {
-		case 'Client_MySQL':
-			return mysql(error);
-		case 'Client_PG':
-			return postgres(error);
-		case 'Client_SQLite3':
-			return sqlite(error);
-		case 'Client_Oracledb':
-		case 'Client_Oracle':
-			return oracle(error);
-		case 'Client_MSSQL':
-			return await mssql(error);
-
-		default:
-			return error;
+	switch (client) {
+		case 'mysql':
+			defaultError = mysql(error);
+			break;
+		case 'postgres':
+			defaultError = postgres(error);
+			break;
+		case 'sqlite':
+			defaultError = sqlite(error);
+			break;
+		case 'oracle':
+			defaultError = oracle(error);
+			break;
+		case 'mssql':
+			defaultError = await mssql(error);
+			break;
 	}
+
+	const hookError = await emitter.emitAsync('database.error', defaultError, { client });
+
+	return hookError || defaultError;
 }

--- a/api/src/exceptions/database/translate.ts
+++ b/api/src/exceptions/database/translate.ts
@@ -1,3 +1,4 @@
+import { compact, last } from 'lodash';
 import { getDatabaseClient } from '../../database';
 import emitter from '../../emitter';
 import { extractError as mssql } from './dialects/mssql';
@@ -38,7 +39,8 @@ export async function translateDatabaseError(error: SQLError): Promise<any> {
 			break;
 	}
 
-	const hookError = await emitter.emitAsync('database.error', defaultError, { client });
+	const hookResult = await emitter.emitAsync('database.error', defaultError, { client });
+	const hookError = Array.isArray(hookResult) ? last(compact(hookResult)) : hookResult;
 
 	return hookError || defaultError;
 }

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -82,6 +82,7 @@ module.exports = function registerHook({ exceptions }) {
 | `middlewares.init`              | `before` and `after`                                        | No               |
 | `request`                       | `not_found`                                                 | No               |
 | `response`                      |                                                             | No<sup>[1]</sup> |
+| `database.error`                | When a database error is thrown                             | No               |
 | `error`                         |                                                             | No               |
 | `auth`                          | `login`, `logout`<sup>[1]</sup> and `refresh`<sup>[1]</sup> | Optional         |
 | `oauth.:provider`<sup>[2]</sup> | `login` and `redirect`                                      | Optional         |


### PR DESCRIPTION
Added a `database.error` hook that can be used to customise database errors. Some error messages (for example check constraint violations) are currently meaningless to non-developers.

**Example usage:**
```javascript
module.exports = function registerHook({ exceptions }) {
	const { UnprocessableEntityException } = exceptions;

	return {
		'database.error': (error) => {
			switch (error.constraint) {
				case 'pages_path_valid':
					return new UnprocessableEntityException('Invalid page path...');
				default:
					return error;
			}
		},
	};
};

```

**Before:**
![check-violation-before](https://user-images.githubusercontent.com/1536407/132119901-67e64625-4cbe-4687-af18-ecef7b2ed249.png)

**After:**
![check-violation-after](https://user-images.githubusercontent.com/1536407/132119905-6f9d402c-deba-44ed-9609-78ecab790e37.png)