### PR TITLE
Fix watcher loop and filters not being applied.

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1413,3 +1413,5 @@ layouts:
     invalid_geometry: Invalid geometry
     auto_location_filter: Always filter data to view bounds
     search_this_area: Search this area
+    clear_data_filter: Clear Data Filter
+    clear_location_filter: Clear Location Filter

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -67,6 +67,12 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			},
 		});
 
+		const geometryFieldData = computed(() => {
+			return fieldsInCollection.value.find((f: Field) => f.field == geometryField.value);
+		});
+
+		const isGeometryFieldNative = computed(() => geometryFieldData.value?.type == 'geometry');
+
 		const geometryFields = computed(() => {
 			return (fieldsInCollection.value as Field[]).filter(
 				({ type, meta }) => type == 'geometry' || meta?.interface == 'map'
@@ -84,9 +90,9 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		);
 
 		const geometryOptions = computed<GeometryOptions | undefined>(() => {
-			const field = fieldsInCollection.value.filter((field: Field) => field.field == geometryField.value)[0];
+			const field = geometryFieldData.value;
 			if (!field) return undefined;
-			if (field.type == 'geometry') {
+			if (isGeometryFieldNative.value) {
 				return {
 					geometryField: field.field,
 					geometryFormat: 'native',
@@ -103,15 +109,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			return undefined;
 		});
 
-		watch(
-			() => geometryOptions.value,
-			(options, _) => {
-				if (options?.geometryFormat !== 'native') {
-					autoLocationFilter.value = false;
-				}
-			}
-		);
-
 		const template = computed(() => {
 			if (info.value?.meta?.display_template) return info.value?.meta?.display_template;
 			return `{{ ${primaryKeyField.value?.field} }}`;
@@ -123,18 +120,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				.filter((e) => !!e) as string[];
 		});
 
-		const _filters = ref(filters.value);
-
 		const locationFilterOutdated = ref(false);
 
 		function getLocationFilter(): Filter | undefined {
-			if (geometryOptions.value?.geometryFormat !== 'native') {
+			if (!isGeometryFieldNative.value || !cameraOptions.value) {
 				return;
 			}
-			if (!geometryField.value || !cameraOptions.value) {
-				return;
-			}
-			const bbox = cameraOptions.value?.bbox;
+			const bbox = cameraOptions.value.bbox;
 			const bboxPolygon = [
 				[bbox[0], bbox[1]],
 				[bbox[2], bbox[1]],
@@ -156,12 +148,21 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		function updateLocationFilter() {
 			const locationFilter = getLocationFilter();
 			locationFilterOutdated.value = false;
-			_filters.value = filters.value.filter((filter) => filter.key !== 'location-filter').concat(locationFilter ?? []);
+			filters.value = filters.value.filter((filter) => filter.key !== 'location-filter').concat(locationFilter ?? []);
 		}
 
-		function removeLocationFilter() {
+		function clearLocationFilter() {
 			shouldUpdateCamera.value = true;
-			_filters.value = filters.value.filter((filter) => filter.key !== 'location-filter');
+			locationFilterOutdated.value = false;
+			filters.value = filters.value.filter((filter) => filter.key !== 'location-filter');
+			if (geojson.value) {
+				geojsonBounds.value = geojson.value.bbox;
+			}
+		}
+
+		function clearDataFilters() {
+			filters.value = filters.value.filter((filter) => filter.key === 'location-filter');
+			searchQuery.value = null;
 		}
 
 		const shouldUpdateCamera = ref(false);
@@ -177,13 +178,20 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			}
 		);
 
+		watch(
+			() => autoLocationFilter.value,
+			(value) => {
+				if (value) updateLocationFilter();
+			}
+		);
+
 		const { items, loading, error, totalPages, itemCount, totalCount, getItems } = useItems(collection, {
 			sort,
 			limit,
 			page,
 			searchQuery,
 			fields: queryFields,
-			filters: _filters,
+			filters: filters,
 		});
 
 		const geojson = ref<GeoJSON.FeatureCollection>({ type: 'FeatureCollection', features: [] });
@@ -324,6 +332,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			handleSelect,
 			geometryFormat,
 			geometryField,
+			isGeometryFieldNative,
 			cameraOptions,
 			autoLocationFilter,
 			clusterData,
@@ -336,6 +345,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			itemCount,
 			fieldsInCollection,
 			limit,
+			filters,
 			primaryKeyField,
 			sort,
 			info,
@@ -347,7 +357,8 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			customLayerDrawerOpen,
 			locationFilterOutdated,
 			updateLocationFilter,
-			removeLocationFilter,
+			clearLocationFilter,
+			clearDataFilters,
 		};
 
 		async function resetPresetAndRefresh() {

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -189,9 +189,9 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			sort,
 			limit,
 			page,
+			filters,
 			searchQuery,
 			fields: queryFields,
-			filters: filters,
 		});
 
 		const geojson = ref<GeoJSON.FeatureCollection>({ type: 'FeatureCollection', features: [] });


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/7832, and also filters not being applied after the new layout structure change.

For the loop, the problem was that when the camera position changed, `cameraOptions` was updated. For some reason, this led the computed `geometryOptions` to be re-computed, which triggered this watcher:
https://github.com/directus/directus/blob/013d5f6819ce7e9ba9eca93bcdecf555908ff26e/app/src/layouts/map/index.ts#L106-L113
Which in turn re-triggered the computation of `geometryOptions`, etc. Loop. 

To fix this, I just removed that watcher. Another working solution was to check if `autoLocationFilter.value == false` before doing the assignment, preventing the loop. But this wouldn't solve the underlying issue.

Is there a way to prevent `geometryOptions` to be re-computed any time any property of `layoutOptions` is updated ?