### PR TITLE
fix default of env var EMAIL_MAILGUN_HOST

### DIFF
--- a/api/src/mailer.ts
+++ b/api/src/mailer.ts
@@ -43,7 +43,7 @@ export default function getMailer(): Transporter {
 					api_key: env.EMAIL_MAILGUN_API_KEY,
 					domain: env.EMAIL_MAILGUN_DOMAIN,
 				},
-				host: env.EMAIL_MAILGUN_HOST || 'https://api.mailgun.net',
+				host: env.EMAIL_MAILGUN_HOST || 'api.mailgun.net',
 			}) as any
 		);
 	} else {


### PR DESCRIPTION
# Issue addressed
Trying to send an email without setting env variable `EMAIL_MAILGUN_HOST` fails with error:

`FetchError: request to https://https/api.mailgun.net/v3/MY_DOMAIN_NAME/messages failed, reason: getaddrinfo ENOTFOUND https`

Note the incorrect scheme at the beginning of the url.

# Background
nodemailer uses `dns.resolve()` for dns resolution (as described [here](https://nodemailer.com/smtp/)). Hence, `host` should not include a scheme.

# Workaround
Anyone currently facing this issue can set `EMAIL_MAILGUN_HOST` to `api.mailgun.net`.

# Documentation
Maybe mention that env variables `EMAIL_*_HOST` should **not** include a scheme?