### PR TITLE
Resolve event hook name inconsistencies

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -155,7 +155,7 @@ export default async function createApp(): Promise<express.Application> {
 
 	app.use(sanitizeQuery);
 
-	await emitAsyncSafe('middlewares.init.after', { app });
+	await emitAsyncSafe('middlewares.init', { app });
 
 	await emitAsyncSafe('routes.init.before', { app });
 
@@ -191,12 +191,12 @@ export default async function createApp(): Promise<express.Application> {
 	// Register custom hooks / endpoints
 	await emitAsyncSafe('routes.custom.init.before', { app });
 	registerExtensionEndpoints(customRouter);
-	await emitAsyncSafe('routes.custom.init.after', { app });
+	await emitAsyncSafe('routes.custom.init', { app });
 
 	app.use(notFoundHandler);
 	app.use(errorHandler);
 
-	await emitAsyncSafe('routes.init.after', { app });
+	await emitAsyncSafe('routes.init', { app });
 
 	// Register all webhooks
 	await registerWebhooks();

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -82,7 +82,7 @@ export default async function createApp(): Promise<express.Application> {
 	app.set('trust proxy', true);
 	app.set('query parser', (str: string) => qs.parse(str, { depth: 10 }));
 
-	await emitAsyncSafe('init.before', { app });
+	await emitAsyncSafe('app.init.before', { app });
 
 	await emitAsyncSafe('middlewares.init.before', { app });
 
@@ -203,7 +203,7 @@ export default async function createApp(): Promise<express.Application> {
 
 	track('serverStarted');
 
-	emitAsyncSafe('init');
+	emitAsyncSafe('app.init');
 
 	return app;
 }

--- a/api/src/cli/index.test.ts
+++ b/api/src/cli/index.test.ts
@@ -28,7 +28,7 @@ const customCliExtension: Extension = {
 const beforeHook = jest.fn();
 const afterAction = jest.fn();
 const afterHook = jest.fn(({ program }: { program: Command }) => program.command('custom').action(afterAction));
-const customCliHook = { 'cli.init.before': beforeHook, 'cli.init.after': afterHook };
+const customCliHook = { 'cli.init.before': beforeHook, 'cli.init': afterHook };
 
 const writeOut = jest.fn();
 const writeErr = jest.fn();

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -88,7 +88,7 @@ export async function createCli(): Promise<Command> {
 		.option('--skipAdminInit', 'Skips the creation of the default Admin Role and User')
 		.action(bootstrap);
 
-	await emitAsyncSafe('cli.init.after', { program });
+	await emitAsyncSafe('cli.init', { program });
 
 	return program;
 }

--- a/api/src/middleware/error-handler.ts
+++ b/api/src/middleware/error-handler.ts
@@ -87,7 +87,7 @@ const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
 		}
 	}
 
-	emitAsyncSafe('error', payload.errors).then(() => {
+	emitAsyncSafe('request.error', payload.errors).then(() => {
 		return res.json(payload);
 	});
 };

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -76,7 +76,7 @@ module.exports = function registerHook({ exceptions }) {
 | ------------------------------- | ----------------------------------------------------------- | ---------------- |
 | `cron()`                        | [See below for configuration](#interval-cron)               | No               |
 | `server`                        | `start` and `stop`                                          | Optional         |
-| `init`                          |                                                             | Optional         |
+| `app`                           | `init`                                                      | Optional         |
 | `cli`                           | `init`                                                      | Optional         |
 | `routes`                        | `init`                                                      | Optional         |
 | `routes.custom`                 | `init`                                                      | Optional         |

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -81,9 +81,9 @@ module.exports = function registerHook({ exceptions }) {
 | `routes`                        | `init`                                                      | Optional         |
 | `routes.custom`                 | `init`                                                      | Optional         |
 | `middlewares`                   | `init`                                                      | Optional         |
+| `database`                      | `error`                                                     | No               |
 | `request`                       | `error` and `not_found`                                     | No               |
 | `response`                      |                                                             | No<sup>[1]</sup> |
-| `database.error`                | When a database error is thrown                             | No               |
 | `auth`                          | `login`, `logout`<sup>[1]</sup> and `refresh`<sup>[1]</sup> | Optional         |
 | `oauth.:provider`<sup>[2]</sup> | `login` and `redirect`                                      | Optional         |
 | `items`                         | `read`<sup>[3]</sup>, `create`, `update` and `delete`       | Optional         |

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -75,12 +75,12 @@ module.exports = function registerHook({ exceptions }) {
 | Scope                           | Actions                                                     | Before           |
 | ------------------------------- | ----------------------------------------------------------- | ---------------- |
 | `cron()`                        | [See below for configuration](#interval-cron)               | No               |
-| `cli.init`                      | `before` and `after`                                        | No               |
 | `server`                        | `start` and `stop`                                          | Optional         |
 | `init`                          |                                                             | Optional         |
-| `routes.init`                   | `before` and `after`                                        | No               |
-| `routes.custom.init`            | `before` and `after`                                        | No               |
-| `middlewares.init`              | `before` and `after`                                        | No               |
+| `cli`                           | `init`                                                      | Optional         |
+| `routes`                        | `init`                                                      | Optional         |
+| `routes.custom`                 | `init`                                                      | Optional         |
+| `middlewares`                   | `init`                                                      | Optional         |
 | `request`                       | `not_found`                                                 | No               |
 | `response`                      |                                                             | No<sup>[1]</sup> |
 | `database.error`                | When a database error is thrown                             | No               |

--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -81,10 +81,9 @@ module.exports = function registerHook({ exceptions }) {
 | `routes`                        | `init`                                                      | Optional         |
 | `routes.custom`                 | `init`                                                      | Optional         |
 | `middlewares`                   | `init`                                                      | Optional         |
-| `request`                       | `not_found`                                                 | No               |
+| `request`                       | `error` and `not_found`                                     | No               |
 | `response`                      |                                                             | No<sup>[1]</sup> |
 | `database.error`                | When a database error is thrown                             | No               |
-| `error`                         |                                                             | No               |
 | `auth`                          | `login`, `logout`<sup>[1]</sup> and `refresh`<sup>[1]</sup> | Optional         |
 | `oauth.:provider`<sup>[2]</sup> | `login` and `redirect`                                      | Optional         |
 | `items`                         | `read`<sup>[3]</sup>, `create`, `update` and `delete`       | Optional         |


### PR DESCRIPTION
This addresses the inconsistencies discussed in #7744.

The third commit moves `error` to `request.error`. I added this to distinguish request and database errors in case #7833 lands.