### PR TITLE
Fix display labels translations

### DIFF
--- a/api/src/database/system-data/fields/activity.yaml
+++ b/api/src/database/system-data/fields/activity.yaml
@@ -13,19 +13,19 @@ fields:
       defaultForeground: 'var(--foreground-normal)'
       defaultBackground: 'var(--background-normal-alt)'
       choices:
-        - text: $t:field_options.directus_activity.Create
+        - text: $t:field_options.directus_activity.create
           value: create
           foreground: 'var(--primary)'
           background: 'var(--primary-25)'
-        - text: $t:field_options.directus_activity.Update
+        - text: $t:field_options.directus_activity.update
           value: update
           foreground: 'var(--blue)'
           background: 'var(--blue-25)'
-        - text: $t:field_options.directus_activity.Delete
+        - text: $t:field_options.directus_activity.delete
           value: delete
           foreground: 'var(--danger)'
           background: 'var(--danger-25)'
-        - text: $t:field_options.directus_activity.Login
+        - text: $t:field_options.directus_activity.login
           value: authenticate
           foreground: 'var(--purple)'
           background: 'var(--purple-25)'

--- a/app/src/displays/labels/labels.vue
+++ b/app/src/displays/labels/labels.vue
@@ -30,6 +30,7 @@
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue';
 import formatTitle from '@directus/format-title';
+import { translate } from '@/utils/translate-object-values';
 
 type Choice = {
 	value: string;
@@ -101,12 +102,12 @@ export default defineComponent({
 						background: props.defaultBackground,
 					};
 				} else {
-					return {
+					return translate({
 						value: item,
 						text: choice.text || itemStringValue,
 						foreground: choice.foreground || props.defaultForeground,
 						background: choice.background || props.defaultBackground,
-					};
+					});
 				}
 			});
 		});

--- a/app/src/lang/translations/af-ZA.yaml
+++ b/app/src/lang/translations/af-ZA.yaml
@@ -83,6 +83,8 @@ fields:
   directus_webhooks:
     status: Status
 field_options:
+  directus_activity:
+    create: Skep
   directus_collections:
     language: Taal
   directus_webhooks:

--- a/app/src/lang/translations/ar-SA.yaml
+++ b/app/src/lang/translations/ar-SA.yaml
@@ -768,6 +768,11 @@ fields:
 field_options:
   directus_settings:
     security_divider_title: الأمان
+  directus_activity:
+    login: تسجيل الدخول
+    create: انشاء
+    update: تحديث
+    delete: حذف
   directus_collections:
     track_activity_revisions: تتبع النشاط والتنقيحات
     only_track_activity: تتبع النشاط فقط

--- a/app/src/lang/translations/bg-BG.yaml
+++ b/app/src/lang/translations/bg-BG.yaml
@@ -868,7 +868,7 @@ field_options:
     auth_password_policy:
       none_text: Без - не се препоръчва
       weak_text: Слаба - минимум от 8 символа
-      strong_text: Силна - главни, малки, числа и специални символи 
+      strong_text: Силна - главни, малки, числа и специални символи
     storage_asset_presets:
       fit:
         contain_text: Напасване (запазване на съотношението)
@@ -882,6 +882,11 @@ field_options:
     basemaps_style: Стил на географската карта
     files_divider_title: Файлове и картинки
     overrides_divider_title: Отмяна
+  directus_activity:
+    login: Вход
+    create: Създаване
+    update: Обновяване
+    delete: Изтриване
   directus_collections:
     track_activity_revisions: Проследяване на активността и ревизиите
     only_track_activity: Проследяване само на активността

--- a/app/src/lang/translations/ca-ES.yaml
+++ b/app/src/lang/translations/ca-ES.yaml
@@ -620,7 +620,7 @@ wysiwyg_options:
   superscript: Superíndex
   codeblock: Codi
   blockquote: Bloc de cita
-  bullist: Llista amb vinyetes 
+  bullist: Llista amb vinyetes
   numlist: Llista ordenada
   hr: Regle horitzontal
   link: Afegeix / Edita l'enllaç
@@ -853,6 +853,11 @@ field_options:
     security_divider_title: Seguretat
     files_divider_title: Fitxers i miniatures
     overrides_divider_title: Substitucións de l'aplicació
+  directus_activity:
+    login: Entra
+    create: Crear
+    update: Actualitzar
+    delete: Elimina
   directus_collections:
     track_activity_revisions: Traça l'activitat i revisions
     only_track_activity: Només traça l'activitat

--- a/app/src/lang/translations/cs-CZ.yaml
+++ b/app/src/lang/translations/cs-CZ.yaml
@@ -351,6 +351,11 @@ fields:
     name: Jméno
     status: Stav
 field_options:
+  directus_activity:
+    login: Login
+    create: Vytořit
+    update: Úpravy
+    delete: Smazat
   directus_collections:
     language: Jazyk
     archive_divider: Archivovat

--- a/app/src/lang/translations/da-DK.yaml
+++ b/app/src/lang/translations/da-DK.yaml
@@ -344,6 +344,11 @@ fields:
     name: Navn
     status: Status
 field_options:
+  directus_activity:
+    login: Log ind
+    create: Opret
+    update: Opdater
+    delete: Slet
   directus_collections:
     language: Sprog
     archive_divider: Arkiver

--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -887,6 +887,11 @@ field_options:
     basemaps_style: Mapbox-Stil
     files_divider_title: Dateien & Vorschaubilder
     overrides_divider_title: App-Überschreibungen
+  directus_activity:
+    login: Login
+    create: Erstellen
+    update: Aktualisieren
+    delete: Löschen
   directus_collections:
     track_activity_revisions: Verfolge Aktivitäten und Änderungen
     only_track_activity: Nur Aktivitäten verfolgen

--- a/app/src/lang/translations/el-GR.yaml
+++ b/app/src/lang/translations/el-GR.yaml
@@ -226,6 +226,10 @@ fields:
     name: Όνομα
     status: Κατάσταση
 field_options:
+  directus_activity:
+    create: Δημιουργία
+    update: Ενημέρωση
+    delete: Διαγραφή
   directus_collections:
     archive_divider: Αρχειοθέτηση
   directus_roles:

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -900,6 +900,11 @@ field_options:
     basemaps_style: Mapbox Style
     files_divider_title: Files & Thumbnails
     overrides_divider_title: App Overrides
+  directus_activity:
+    login: Login
+    create: Create
+    update: Update
+    delete: Delete
   directus_collections:
     track_activity_revisions: Track Activity & Revisions
     only_track_activity: Only Track Activity

--- a/app/src/lang/translations/es-419.yaml
+++ b/app/src/lang/translations/es-419.yaml
@@ -824,6 +824,11 @@ field_options:
     language: Idioma
     archive_divider: Archivar
     divider: Ordenar
+  directus_activity:
+    login: Iniciar Sesión
+    create: Crear
+    update: Actualización
+    delete: Eliminar
   directus_roles:
     fields:
       icon_name: Ícono

--- a/app/src/lang/translations/es-CL.yaml
+++ b/app/src/lang/translations/es-CL.yaml
@@ -815,6 +815,11 @@ fields:
     name: Nombre
     status: Estado
 field_options:
+  directus_activity:
+    login: Iniciar sesión
+    create: Crear
+    update: Actualizar
+    delete: Eliminar
   directus_collections:
     track_activity_revisions: Rastrear actividad y revisiones
     only_track_activity: Sólo seguimiento de actividad

--- a/app/src/lang/translations/es-ES.yaml
+++ b/app/src/lang/translations/es-ES.yaml
@@ -814,6 +814,11 @@ fields:
     name: Nombre
     status: Estado
 field_options:
+  directus_activity:
+    login: Iniciar Sesión
+    create: Crear
+    update: Actualización
+    delete: Eliminar
   directus_collections:
     track_activity_revisions: Rastrear actividad y revisiones
     only_track_activity: Sólo seguimiento de actividad

--- a/app/src/lang/translations/et-EE.yaml
+++ b/app/src/lang/translations/et-EE.yaml
@@ -662,7 +662,7 @@ page_help_docs_global: >-
 page_help_files_collection: >-
   **Failikogu* - Näitab kõiki faile ja pilte selles projektis. Muuta saab vaateid, filtreid jm ning lisada järjehoidjaid
 page_help_files_item: >-
-  **Faili detailid* - Vorm, milles saab muuta faili metaandmeid, ligipääse jm 
+  **Faili detailid* - Vorm, milles saab muuta faili metaandmeid, ligipääse jm
 page_help_settings_project: "**Projekti seaded** - Sinu projekti üldised seaded"
 page_help_settings_datamodel_collections: >-
   **Andmekogud** - Näitab kõiki andmekogusid (sh süsteemseid)
@@ -797,6 +797,11 @@ fields:
     name: Nimi
     status: Staatus
 field_options:
+  directus_activity:
+    login: Logi sisse
+    create: Loo
+    update: Uuenda
+    delete: Kustuta
   directus_collections:
     track_activity_revisions: Salvesta muudatuste statistika
     only_track_activity: Jälgi ainult aktiivsust

--- a/app/src/lang/translations/fi-FI.yaml
+++ b/app/src/lang/translations/fi-FI.yaml
@@ -794,6 +794,11 @@ fields:
     name: Nimi
     status: Tila
 field_options:
+  directus_activity:
+    login: Kirjaudu sisään
+    create: Luo
+    update: Päivitä
+    delete: Poista
   directus_collections:
     track_activity_revisions: Seuraa tapahtumia ja versioita
     only_track_activity: Seuraa vain tapahtumia

--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -873,6 +873,11 @@ field_options:
     basemaps_style: Style de Mapbox
     files_divider_title: Fichiers et miniatures
     overrides_divider_title: Remplacer les applications
+  directus_activity:
+    login: Se connecter
+    create: Créer
+    update: Mettre à jour
+    delete: Supprimer
   directus_collections:
     track_activity_revisions: Enregistrer les activités et l'historique
     only_track_activity: Enregistrer seulement l'activité

--- a/app/src/lang/translations/hi-IN.yaml
+++ b/app/src/lang/translations/hi-IN.yaml
@@ -241,6 +241,8 @@ fields:
   directus_webhooks:
     name: नाम
 field_options:
+  directus_activity:
+    delete: डिलीट
   directus_collections:
     language: भाषा
     archive_divider: आर्काइव

--- a/app/src/lang/translations/hu-HU.yaml
+++ b/app/src/lang/translations/hu-HU.yaml
@@ -882,6 +882,11 @@ field_options:
     basemaps_style: Mapbox stílus
     files_divider_title: Fájlok és miniatűrök
     overrides_divider_title: Alkalmazás felülbírálások
+  directus_activity:
+    login: Belépés
+    create: Létrehozás
+    update: Frissítés
+    delete: Törlés
   directus_collections:
     track_activity_revisions: Tevékenységek és módosítások nyomon követése
     only_track_activity: Csak a tevékenység nyomon követése

--- a/app/src/lang/translations/id-ID.yaml
+++ b/app/src/lang/translations/id-ID.yaml
@@ -540,6 +540,11 @@ fields:
     name: Nama
     status: Status
 field_options:
+  directus_activity:
+    login: Masuk
+    create: Buat
+    update: Perbarui
+    delete: Hapus
   directus_collections:
     language: Bahasa
     archive_divider: Arsip

--- a/app/src/lang/translations/it-IT.yaml
+++ b/app/src/lang/translations/it-IT.yaml
@@ -887,6 +887,11 @@ field_options:
     basemaps_style: Stile Mapbox
     files_divider_title: File e miniature
     overrides_divider_title: Personalizzazioni App
+  directus_activity:
+    login: Accesso
+    create: Creare
+    update: Aggiornare
+    delete: Elimina
   directus_collections:
     track_activity_revisions: Traccia Attività e Revisioni
     only_track_activity: Traccia solo Attività

--- a/app/src/lang/translations/ja-JP.yaml
+++ b/app/src/lang/translations/ja-JP.yaml
@@ -383,6 +383,11 @@ fields:
     name: 名前
     status: ステータス
 field_options:
+  directus_activity:
+    login: ログイン
+    create: 作成
+    update: 更新
+    delete: 削除
   directus_collections:
     collection_setup: コレクションの作成
     singleton: シングルオブジェクトに設定する

--- a/app/src/lang/translations/ka-GE.yaml
+++ b/app/src/lang/translations/ka-GE.yaml
@@ -57,6 +57,8 @@ fields:
   directus_webhooks:
     status: სტატუსი
 field_options:
+  directus_activity:
+    create: შექმნა
   directus_webhooks:
     actions_create: შექმნა
 comment: კომენტარი

--- a/app/src/lang/translations/lt-LT.yaml
+++ b/app/src/lang/translations/lt-LT.yaml
@@ -738,6 +738,10 @@ fields:
     name: Pavadinimas
     status: Būsena
 field_options:
+  directus_activity:
+    login: Prisijungti
+    create: Kurti
+    update: Atnaujinti
   directus_collections:
     collection_setup: Kolekcijos konfigūracija
     singleton: Laikyti vienu objektu

--- a/app/src/lang/translations/ms-MY.yaml
+++ b/app/src/lang/translations/ms-MY.yaml
@@ -151,6 +151,11 @@ fields:
     name: Nama
     status: Status
 field_options:
+  directus_activity:
+    login: Log masuk
+    create: Cipta
+    update: Kemaskini
+    delete: Padam
   directus_roles:
     fields:
       name_name: Nama

--- a/app/src/lang/translations/nl-NL.yaml
+++ b/app/src/lang/translations/nl-NL.yaml
@@ -815,6 +815,11 @@ fields:
     name: Naam
     status: Status
 field_options:
+  directus_activity:
+    login: Login
+    create: Maak
+    update: Updaten
+    delete: Verwijder
   directus_collections:
     track_activity_revisions: Track Activiteiten & Revisies
     only_track_activity: Track alleen activiteiten

--- a/app/src/lang/translations/no-NO.yaml
+++ b/app/src/lang/translations/no-NO.yaml
@@ -439,6 +439,11 @@ fields:
     name: Navn
     status: Status
 field_options:
+  directus_activity:
+    login: Logg inn
+    create: Opprett
+    update: Oppdater
+    delete: Slett
   directus_collections:
     language: Språk
     archive_divider: Arkiv

--- a/app/src/lang/translations/pl-PL.yaml
+++ b/app/src/lang/translations/pl-PL.yaml
@@ -822,6 +822,11 @@ fields:
     name: Nazwa
     status: Status
 field_options:
+  directus_activity:
+    login: Zaloguj się
+    create: Stwórz
+    update: Zaktualizuj
+    delete: Usuń
   directus_collections:
     track_activity_revisions: Śledź aktywność i rewizje
     only_track_activity: Tylko Śledź Aktywność

--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -849,7 +849,7 @@ fields:
     collection_list: Navegação da Coleção
   directus_webhooks:
     name: Nome
-    method: Método 
+    method: Método
     status: Status
     data: Dados
     data_label: Enviar Dados do Evento
@@ -863,6 +863,11 @@ field_options:
     additional_transforms: Transformações Adicionais
     files_divider_title: Arquivos e Miniaturas
     overrides_divider_title: Substituições de Aplicativos
+  directus_activity:
+    login: Entrar
+    create: Criar
+    update: Alteração
+    delete: Excluir
   directus_collections:
     track_activity_revisions: Rastrear Atividades e Revisões
     only_track_activity: Acompanhar apenas Atividade

--- a/app/src/lang/translations/pt-PT.yaml
+++ b/app/src/lang/translations/pt-PT.yaml
@@ -637,6 +637,10 @@ fields:
     name: Nome
     status: Estado
 field_options:
+  directus_activity:
+    create: Criar
+    update: Atualizar
+    delete: Remover
   directus_collections:
     track_activity_revisions: Rastrear Atividades e Revisões
     only_track_activity: Apenas rastrear Atividade

--- a/app/src/lang/translations/ro-RO.yaml
+++ b/app/src/lang/translations/ro-RO.yaml
@@ -163,6 +163,8 @@ fields:
   directus_webhooks:
     status: Stare
 field_options:
+  directus_activity:
+    create: Creează
   directus_collections:
     archive_divider: Arhivează
   directus_roles:

--- a/app/src/lang/translations/ru-RU.yaml
+++ b/app/src/lang/translations/ru-RU.yaml
@@ -845,6 +845,11 @@ field_options:
     security_divider_title: Безопасность
     files_divider_title: Файлы и миниатюры
     overrides_divider_title: Переопределить заводские настройки
+  directus_activity:
+    login: Войти
+    create: Создать
+    update: Обновить
+    delete: Удалить
   directus_collections:
     track_activity_revisions: Отслеживание активности и изменений
     only_track_activity: Отслеживать только активность

--- a/app/src/lang/translations/sl-SI.yaml
+++ b/app/src/lang/translations/sl-SI.yaml
@@ -853,6 +853,11 @@ field_options:
     security_divider_title: Varnost
     files_divider_title: Datoteke & sličice
     overrides_divider_title: Aplikacijske preglasitve
+  directus_activity:
+    login: Prijava
+    create: Ustvari
+    update: Posodobi
+    delete: Izbriši
   directus_collections:
     track_activity_revisions: Sledi aktivnosti in revizije
     only_track_activity: Sledi samo aktivnosti

--- a/app/src/lang/translations/sr-CS.yaml
+++ b/app/src/lang/translations/sr-CS.yaml
@@ -797,6 +797,11 @@ fields:
     name: Ime
     status: Status
 field_options:
+  directus_activity:
+    login: Prijavi se
+    create: Kreiraj
+    update: Ažuriranje
+    delete: Obriši
   directus_collections:
     track_activity_revisions: Prati Aktivnost & Revizije
     only_track_activity: Samo Prati Aktivnost

--- a/app/src/lang/translations/sr-SP.yaml
+++ b/app/src/lang/translations/sr-SP.yaml
@@ -140,6 +140,8 @@ fields:
     name: Име
     status: Стање
 field_options:
+  directus_activity:
+    create: Креирај
   directus_collections:
     language: Језик
     archive_divider: Архивирај

--- a/app/src/lang/translations/sv-SE.yaml
+++ b/app/src/lang/translations/sv-SE.yaml
@@ -773,6 +773,11 @@ fields:
     name: Namn
     status: Status
 field_options:
+  directus_activity:
+    login: Logga in
+    create: Skapa
+    update: Uppdatera
+    delete: Radera
   directus_collections:
     collection_setup: Konfiguration av kollektion
     singleton: Behandla som ett enskilt objekt

--- a/app/src/lang/translations/th-TH.yaml
+++ b/app/src/lang/translations/th-TH.yaml
@@ -817,6 +817,10 @@ fields:
     name: ชื่อ
     status: สถานะ
 field_options:
+  directus_activity:
+    login: ลงชื่อเข้าใช้
+    create: สร้าง
+    update: แก้ไข
   directus_collections:
     track_activity_revisions: ติดตามกิจกรรมและการแก้ไข
     only_track_activity: ติดตามกิจกรรมเท่านั้น

--- a/app/src/lang/translations/tr-TR.yaml
+++ b/app/src/lang/translations/tr-TR.yaml
@@ -631,6 +631,11 @@ fields:
     name: İsim
     status: Durum
 field_options:
+  directus_activity:
+    login: Oturum Aç
+    create: Oluştur
+    update: Güncelle
+    delete: Sil
   directus_collections:
     language: Dil
     archive_divider: Arşiv

--- a/app/src/lang/translations/uk-UA.yaml
+++ b/app/src/lang/translations/uk-UA.yaml
@@ -276,6 +276,11 @@ fields:
     name: Назва
     status: Статус
 field_options:
+  directus_activity:
+    login: Вхід
+    create: Створити
+    update: Оновити
+    delete: Видалити
   directus_collections:
     language: Мова
     archive_divider: Архів

--- a/app/src/lang/translations/vi-VN.yaml
+++ b/app/src/lang/translations/vi-VN.yaml
@@ -553,6 +553,10 @@ fields:
     name: Tên
     status: Trạng thái
 field_options:
+  directus_activity:
+    login: Đăng nhập
+    create: Tạo
+    update: Cập nhật
   directus_collections:
     language: Ngôn ngữ
     archive_divider: Lưu trữ

--- a/app/src/lang/translations/zh-CN.yaml
+++ b/app/src/lang/translations/zh-CN.yaml
@@ -853,6 +853,11 @@ field_options:
     security_divider_title: 安全
     files_divider_title: 文件和缩略图
     overrides_divider_title: 应用设置覆盖
+  directus_activity:
+    login: 登录
+    create: 创建
+    update: 更新
+    delete: 删除
   directus_collections:
     track_activity_revisions: 跟踪活动和历史修改版本
     only_track_activity: 仅跟踪活动

--- a/app/src/lang/translations/zh-TW.yaml
+++ b/app/src/lang/translations/zh-TW.yaml
@@ -545,6 +545,11 @@ fields:
     name: 名稱
     status: 狀態
 field_options:
+  directus_activity:
+    login: 登入
+    create: 新建
+    update: 更新
+    delete: 刪除
   directus_collections:
     language: 語言
     archive_divider: 封存


### PR DESCRIPTION
## Bug

When we view the Activity page, all the Action labels are showing the raw `$t:` strings and not the translated strings as seen here:

![chrome_gmkJ2vdSW1](https://user-images.githubusercontent.com/42867097/132229909-a96d2344-3e74-43d0-8780-f7b695fcce16.png)

## Investigation

Seems like these `$t:field_options.directus_activity.<action-name>` keys were added in this recent PR over here: https://github.com/directus/directus/pull/7554/files#diff-f93103f324fcfbbfe7139309a131a9ba24995ff1fc031bf528bccf4006f64ff0, but it looks like their counterpart in the `en-US.yaml` file were missing: https://github.com/directus/directus/pull/7554/files#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6a, which would explain why they are not being translated properly. The solution would then be adding the keys in `en-US.yaml` (and other languages).

However after adding them, the labels are still showing up as the raw `$t:` strings. I got curious and thought `$t:` prefix is one of the features of Vue i18n, but apparently it's being processed by this utility function: 

https://github.com/directus/directus/blob/013d5f6819ce7e9ba9eca93bcdecf555908ff26e/app/src/utils/translate-object-values.ts#L9-L10

Which in turn is used by the `useFormFields` composable function over here: 

https://github.com/directus/directus/blob/013d5f6819ce7e9ba9eca93bcdecf555908ff26e/app/src/composables/use-form-fields/use-form-fields.ts#L61

Thus explaining why forms/interfaces are translated without any issue, whereas it was not implemented for `labels`.

An extra proof would be the webhooks page which uses `$t:create` for example, where the key already exist for a long time, and it is still not translated properly as seen here:

![chrome_pocLW9rWyA](https://user-images.githubusercontent.com/42867097/132230100-0118becb-8d64-44f6-ad1f-2753230c03c6.png)

## Solution

Since the `translate-object-values` utility function accepts an object as the name implies, I wrapped it around the return statement for the `items` computed field in labels component, only if the choice is not undefined. Link to this particular change in this PR: https://github.com/directus/directus/pull/7858/files#diff-181b8e2efbb3c17aae847b26cee4868395bfa4af0adc5d8146ea4cd5d792ff05

I have also added the `field_options.directus_activity.<action-name>` keys to the translation files, and referred them in their respective language files since `login`, `create`, `update` and `delete` are usually present elsewhere, especially `field_options.directus_webhooks.action_create` for `create` and so on.

## After Fix

### Activity page

![chrome_zF7LDa6Gez](https://user-images.githubusercontent.com/42867097/132230309-c1239e33-692e-44a9-ae7a-cb593a081508.png)

### Webhooks page

![chrome_PV1flGkIst](https://user-images.githubusercontent.com/42867097/132230346-b5c9c2c6-7b99-4775-b0a9-e3812bef5c70.png)

---

### Side question

As I was referring to the `field_options.directus_webhooks` section to translate the `field_options.directus_activity` section, it seems like the ones in directus_webhooks are not really used at the moment, as seen here: 

https://github.com/directus/directus/blob/013d5f6819ce7e9ba9eca93bcdecf555908ff26e/app/src/lang/translations/en-US.yaml#L961-L969

Whereas the yaml defined here are still using the global/highest level of keys such as `$t:create` instead of `$t:field_options:directus_webhooks.action_create` as one of the example, as seen here:

https://github.com/directus/directus/blob/013d5f6819ce7e9ba9eca93bcdecf555908ff26e/api/src/database/system-data/fields/webhooks.yaml#L91-L107

Hence I'm wondering is there any concensus on which to use? If the original intent was to actually use the new ones under `field_options`, I'll add them in a separate PR.


