### PR TITLE
Add github action for syncing readme to Docker Hub

### DIFF
--- a/.github/workflows/sync-dockerhub-readme.yml
+++ b/.github/workflows/sync-dockerhub-readme.yml
@@ -1,0 +1,23 @@
+name: Sync Readme to Docker Hub
+
+on:
+  push:
+    branches:
+      - main
+    paths: # ensures this workflow only runs when the readme.md or this file changes.
+      - 'readme.md'
+      - '.github/workflows/sync-dockerhub-readme.yml'
+  workflow_dispatch:
+
+jobs:
+  sync-dockerhub-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Sync Readme to Docker Hub
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
## Context

Currently the readme for Directus on Docker Hub seems to be outdated: https://hub.docker.com/r/directus/directus

Notable differences would be things like

| Docker Hub readme | Current GitHub readme |
|---|---|
| - | Has the Release Candidate section |
| Directus only requires Node.js (or PHP) | Directus only requires Node.js |
| Node.js 10+ | Node.js 12+ |
| MySQL 5.6+ | MySQL 5.7.8+ (8.* with mysql_native_password here) |

Arguably most people would look at the GitHub readme more so compared to the DockerHub one, but there's still the slightest chance someone reads the outdated one & get misled. So I figured adding a github action to automate this should help make this easier to manage.

## Solution

- GitHub Action used: Docker Hub Description
    - Marketplace link: https://github.com/marketplace/actions/docker-hub-description
    - GitHub link: https://github.com/peter-evans/dockerhub-description
- It uses the `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` secrets which are already being used in other workflows like `release.yml`, so no further action needed by the maintainers
- Currently set to only run when `readme.md` or this workflow file is updated/changed
- Added `on_dispatch` as a form of manual trigger so that it'll be easier to perform this gh action if this PR get merged, and also in case any edge cases in the future
