### PR TITLE
fix readme filename in sync-dockerhub-readme.yml

### DIFF
--- a/.github/workflows/sync-dockerhub-readme.yml
+++ b/.github/workflows/sync-dockerhub-readme.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          readme-filepath: ./readme.md


### PR DESCRIPTION
just noticed workflow fails because the default is looking for `./README.md` (all uppercase) whereas directus current one is `./readme.md`. Sorry for missing that detail in my previous PR #7889