### PR TITLE
fix readme emoji

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ important to keep your projects up-to-date.
 
 <br>
 
-## :rocket: One-Click Deployments
+## 🚀 One-Click Deployments
 
 If you would like to completely avoid the manual installation process, the following self-hosted one-click apps will
 handle the heavy-lifting for you. While Directus is always completely free, you will likely need to pay for these


### PR DESCRIPTION
Just a minor tweak since currently every headers uses emoji symbols directly except One-Click Deployments which uses `:rocket:`. It works on GitHub but not on DockerHub as seen here:

![chrome_TglU9ZuOK3](https://user-images.githubusercontent.com/42867097/132377110-11c9c455-95a2-468b-9acd-3bb0888185ce.png)
