### PR TITLE
remove auto-open feature for info sidebar

### DIFF
--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -54,23 +54,6 @@ export default defineComponent({
 			setFavicon(serverStore.info?.project?.project_color || '#00C897', hasCustomLogo);
 		});
 
-		const { width } = useWindowSize();
-
-		watch(
-			width,
-			(newWidth, oldWidth) => {
-				if (newWidth === null || newWidth === 0) return;
-				if (newWidth === oldWidth) return;
-
-				if (newWidth >= 1424) {
-					if (sidebarOpen.value === false) sidebarOpen.value = true;
-				} else {
-					if (sidebarOpen.value === true) sidebarOpen.value = false;
-				}
-			},
-			{ immediate: true }
-		);
-
 		watch(
 			() => userStore.currentUser,
 			(newUser) => {

--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -27,7 +27,6 @@ import { useAppStore, useUserStore, useServerStore } from '@/stores';
 import { startIdleTracking, stopIdleTracking } from './idle';
 import useSystem from '@/composables/use-system';
 
-import useWindowSize from '@/composables/use-window-size';
 import setFavicon from '@/utils/set-favicon';
 
 export default defineComponent({
@@ -38,7 +37,7 @@ export default defineComponent({
 		const userStore = useUserStore();
 		const serverStore = useServerStore();
 
-		const { hydrating, sidebarOpen } = toRefs(appStore);
+		const { hydrating } = toRefs(appStore);
 
 		const brandStyle = computed(() => {
 			return {


### PR DESCRIPTION
Closes #7899 

Basically removes the watcher for window width which opens/closes sidebar on the 1424 width breakpoint.

## Before removal

![DTzhI9p9xN](https://user-images.githubusercontent.com/42867097/132427705-c07513ff-923e-465f-ab7d-9530ad7430c3.gif)

## After removal

![OUWXEE4Nzb](https://user-images.githubusercontent.com/42867097/132427719-9befeb4b-4913-4ff0-840a-e8c2a1d4acb7.gif)
