### PR TITLE
Enable "Format JSON Value" to display 'geometry'

### DIFF
--- a/app/src/displays/formatted-json-value/index.ts
+++ b/app/src/displays/formatted-json-value/index.ts
@@ -5,7 +5,7 @@ export default defineDisplay({
 	id: 'formatted-json-value',
 	name: '$t:displays.formatted-json-value.formatted-json-value',
 	description: '$t:displays.formatted-json-value.description',
-	types: ['json'],
+	types: ['json', 'geometry'],
 	icon: 'settings_ethernet',
 	handler: DisplayJsonValue,
 	options: [


### PR DESCRIPTION
This addresses #7879 - enabling "Formatted JSON value" as a Display for geometry types.

The geometry type returns [GeoJSON](https://geojson.org/) as the raw value. Because GeoJSON is a well documented standard, it can then be reliably formatted.

`{"coordinates":[10.72791,59.91699],"type":"Point"}` => `{{ type }}: {{ coordinates[0] }}° east, {{ coordinates[1] }}° north.`