### PR TITLE
Docs: update actions for file event

### DIFF
--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -91,7 +91,7 @@ module.exports = function registerHook({ exceptions }) {
 | `activity`                      | `create`, `update` and `delete`                             | Optional         |
 | `collections`                   | `create`, `update` and `delete`                             | Optional         |
 | `fields`                        | `create`, `update` and `delete`                             | Optional         |
-| `files`                         | `upload`<sup>[3]</sup>, `create`, `update` and `delete`     | Optional         |
+| `files`                         | `upload`<sup>[3]</sup>                                      | No               |
 | `folders`                       | `create`, `update` and `delete`                             | Optional         |
 | `permissions`                   | `create`, `update` and `delete`                             | Optional         |
 | `presets`                       | `create`, `update` and `delete`                             | Optional         |


### PR DESCRIPTION
According to this PR https://github.com/directus/directus/pull/5334 create, update and delete actions won't trigger the file hook anymore. This PR is an update for the docs