### PR TITLE
Fix translation keys for system collections

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -743,6 +743,22 @@ collections: Collections
 singleton: Singleton
 singleton_label: Treat as single object
 system_fields_locked: System fields are locked and can't be edited
+directus_collection:
+  directus_activity: Accountability logs for all events
+  directus_collections: Additional collection configuration and metadata
+  directus_fields: Additional field configuration and metadata
+  directus_files: Metadata for all managed file assets
+  directus_folders: Provides virtual directories for files
+  directus_migrations: What version of the database you're using
+  directus_permissions: Access permissions for each role
+  directus_presets: Presets for collection defaults and bookmarks
+  directus_relations: Relationship configuration and metadata
+  directus_revisions: Data snapshots for all activity
+  directus_roles: Permission groups for system users
+  directus_sessions: User session information
+  directus_settings: Project configuration options
+  directus_users: System users for the platform
+  directus_webhooks: Configuration for event-based HTTP requests
 fields:
   directus_activity:
     item: Item Primary Key

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -105,6 +105,7 @@ import { useRouter } from 'vue-router';
 import { sortBy } from 'lodash';
 import CollectionOptions from './components/collection-options.vue';
 import CollectionsFilter from './components/collections-filter.vue';
+import { translate } from '@/utils/translate-object-values';
 
 const activeTypes = ref(['visible', 'hidden', 'unmanaged']);
 
@@ -201,7 +202,7 @@ export default defineComponent({
 				}
 
 				if (activeTypes.value.includes('system')) {
-					items.push(system.value);
+					items.push(translate(system.value));
 				}
 
 				return items.flat();


### PR DESCRIPTION
## Context

Following up https://github.com/directus/directus/pull/7858#issuecomment-914361325, this PR adds the missing translation keys (`directus.collection.<collection-name>`) and ensure the notes for **System Collections** in System Data Model page are translated.

## Before

![chrome_jfHU9Gp97i](https://user-images.githubusercontent.com/42867097/132515558-bb8ba1ac-21cd-4ddf-a963-2705fa23ded7.jpg)

## After

![chrome_BZMuMg3Pt3](https://user-images.githubusercontent.com/42867097/132515814-b40c405e-3019-4029-a6ec-fbfa76b9a6d9.jpg)
