### PR TITLE
Fix user-popover location when hovered in revisions

### DIFF
--- a/app/src/views/private/components/revisions-drawer-detail/revision-item.vue
+++ b/app/src/views/private/components/revisions-drawer-detail/revision-item.vue
@@ -163,6 +163,11 @@ export default defineComponent({
 	}
 
 	.user {
+		span {
+			margin: -6px;
+			padding: 6px;
+		}
+
 		&:hover {
 			color: var(--foreground-normal);
 		}

--- a/app/src/views/private/components/revisions-drawer-detail/revision-item.vue
+++ b/app/src/views/private/components/revisions-drawer-detail/revision-item.vue
@@ -8,7 +8,7 @@
 			<span class="time">{{ time }}</span>
 			–
 			<user-popover v-if="revision.activity.user" class="user" :user="revision.activity.user.id">
-				{{ user }}
+				<span>{{ user }}</span>
 			</user-popover>
 
 			<span v-else>{{ t('private_user') }}</span>


### PR DESCRIPTION
Fixes #7926

## Bug reported in the issue

The user tooltip **for revisions** are wrongly shown on the top left corner:

![orZOLhGpxp](https://user-images.githubusercontent.com/42867097/132675722-6ffdb743-10ed-4efb-9447-2e2cb98920b0.gif)

There is an emphasis on "for revisions" because if we observe the same user tooltip in the table view, it is working as expected:

![QjWgVVtdK9](https://user-images.githubusercontent.com/42867097/132675750-07c6093e-7ee0-49d9-82f6-4e63303551bb.png)

## Investigation

If we look at the `v-menu` component which is used for this user tooltip `user-popover`, we can see there are `activator` and `reference` to target HTML element, with `virtualReference` technically a point in the top left corner because of everything is 0 as observed here:

https://github.com/directus/directus/blob/640368a21b4743689c1df5568eb20ddd564ec8c0/app/src/components/v-menu/v-menu.vue#L103-L117

Then when we look at the watcher for `isActive`, which dictates whether the tooltip appears or not, we can see the logic for `reference` being either the first child of the `activator` (i.e. the first child of the element we hover at) or just the virtual reference which is the top left corner:

https://github.com/directus/directus/blob/640368a21b4743689c1df5568eb20ddd564ec8c0/app/src/components/v-menu/v-menu.vue#L140-L148

This is why the tooltip works in table view because there's a div (with class `user both`) inside the activator element (the one with class `v-menu-activator`) as shown here:

![vivaldi_vm88o8xK4v](https://user-images.githubusercontent.com/42867097/132676304-94d015da-0510-460d-80ae-471e89bd2fc1.png)

Whereas the user-popover in revisions directly inserts the user email without any wrapping element as the child:

https://github.com/directus/directus/blob/640368a21b4743689c1df5568eb20ddd564ec8c0/app/src/views/private/components/revisions-drawer-detail/revision-item.vue#L10-L12

![vivaldi_jxFiD10QZV](https://user-images.githubusercontent.com/42867097/132676527-73b757a2-7fd6-45b6-8828-3298b1a255c9.png)

## Solution

Add a wrapping element, specifically `<span>` tag on the user email, then it'll work as expected:

![OaG0lbvGA3](https://user-images.githubusercontent.com/42867097/132676331-0929b5b9-ad06-42e8-94d2-dae82bd5055e.gif)

![S5StsW3inG](https://user-images.githubusercontent.com/42867097/132676816-572bf4c2-daa8-4390-902b-3c8a85aa620f.png)
