### PR TITLE
Allow v-menu tooltip to stay active on hover

### DIFF
--- a/app/src/components/v-menu/v-menu.vue
+++ b/app/src/components/v-menu/v-menu.vue
@@ -4,8 +4,8 @@
 			ref="activator"
 			class="v-menu-activator"
 			:class="{ attached }"
-			@pointerenter="onPointerEnter"
-			@pointerleave="onPointerLeave"
+			@pointerenter.stop="onPointerEnter"
+			@pointerleave.stop="onPointerLeave"
 		>
 			<slot
 				name="activator"
@@ -36,7 +36,12 @@
 					:style="styles"
 				>
 					<div class="arrow" :class="{ active: showArrow && isActive }" :style="arrowStyles" data-popper-arrow />
-					<div class="v-menu-content" @click.stop="onContentClick">
+					<div
+						class="v-menu-content"
+						@click.stop="onContentClick"
+						@pointerenter.stop="onPointerEnter"
+						@pointerleave.stop="onPointerLeave"
+					>
 						<slot
 							v-bind="{
 								toggle: toggle,
@@ -57,6 +62,7 @@ import { defineComponent, ref, PropType, computed, watch, nextTick } from 'vue';
 import { usePopper } from './use-popper';
 import { Placement } from '@popperjs/core';
 import { nanoid } from 'nanoid';
+import { debounce } from 'lodash';
 
 export default defineComponent({
 	props: {
@@ -98,7 +104,7 @@ export default defineComponent({
 			default: 0,
 		},
 	},
-	emits: ['update:modelValue'],
+	emits: ['update:modelValue', 'something'],
 	setup(props, { emit }) {
 		const activator = ref<HTMLElement | null>(null);
 		const reference = ref<HTMLElement | null>(null);
@@ -241,7 +247,18 @@ export default defineComponent({
 		}
 
 		function useEvents() {
-			let timeout: ReturnType<typeof setTimeout> | null = null;
+			const isHovered = ref(false);
+
+			watch(
+				isHovered,
+				debounce((newHoveredState) => {
+					if (newHoveredState) {
+						if (!isActive.value) activate();
+					} else {
+						deactivate();
+					}
+				}, props.delay)
+			);
 
 			return { onClick, onPointerLeave, onPointerEnter };
 
@@ -253,20 +270,12 @@ export default defineComponent({
 
 			function onPointerEnter() {
 				if (props.trigger !== 'hover') return;
-				if (timeout) return;
-				timeout = setTimeout(() => {
-					activate();
-				}, props.delay);
+				isHovered.value = true;
 			}
 
 			function onPointerLeave() {
-				if (hoveringOnPopperContent.value === true) return;
-
 				if (props.trigger !== 'hover') return;
-				if (timeout === null) return;
-				clearTimeout(timeout);
-				deactivate();
-				timeout = null;
+				isHovered.value = false;
 			}
 		}
 	},

--- a/app/src/components/v-menu/v-menu.vue
+++ b/app/src/components/v-menu/v-menu.vue
@@ -104,7 +104,7 @@ export default defineComponent({
 			default: 0,
 		},
 	},
-	emits: ['update:modelValue', 'something'],
+	emits: ['update:modelValue'],
 	setup(props, { emit }) {
 		const activator = ref<HTMLElement | null>(null);
 		const reference = ref<HTMLElement | null>(null);


### PR DESCRIPTION
## Context

Related to #7926, but this PR isn't aimed at bug mentioned there which is addressed by #7947. 

Currently the user tooltip closes immediately when we try to hover on the tooltip itself.

## Before

![6lkQeFFY7x](https://user-images.githubusercontent.com/42867097/132678299-e2af6391-7e5a-4288-be20-c2c81913580e.gif)

## Solution

Added a watcher to check if the user is either hovering on the activator element or the tooltip, the tooltip will stay open until the user's pointer leave either of them.

## After

![KFQHoJwrVF](https://user-images.githubusercontent.com/42867097/132678446-99a5faef-4de3-450d-8eaf-f369aa33ba74.gif)
