### PR TITLE
Add click event for user tooltip & navigate to the user's page

### DIFF
--- a/app/src/views/private/components/user-popover/user-popover.vue
+++ b/app/src/views/private/components/user-popover/user-popover.vue
@@ -15,7 +15,7 @@
 			{{ error }}
 		</div>
 
-		<div v-else-if="data" class="user-box">
+		<div v-else-if="data" class="user-box" @click.stop="navigateToUser">
 			<v-avatar x-large class="avatar">
 				<img v-if="avatarSrc" :src="avatarSrc" :alt="data.first_name" />
 				<v-icon v-else name="person" outline />
@@ -36,15 +36,8 @@ import api from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
 import { userName } from '@/utils/user-name';
 import { addTokenToURL } from '@/api';
-
-type User = {
-	first_name: string;
-	last_name: string;
-	email: string;
-	avatar: {
-		id: string;
-	};
-};
+import { useRouter } from 'vue-router';
+import { User } from '@directus/shared/types';
 
 export default defineComponent({
 	props: {
@@ -55,6 +48,8 @@ export default defineComponent({
 	},
 	setup(props) {
 		const { t } = useI18n();
+
+		const router = useRouter();
 
 		const loading = ref(false);
 		const error = ref(null);
@@ -83,7 +78,7 @@ export default defineComponent({
 			data.value = null;
 		});
 
-		return { t, loading, error, data, active, avatarSrc, userName };
+		return { t, loading, error, data, active, avatarSrc, userName, navigateToUser };
 
 		async function fetchUser() {
 			loading.value = true;
@@ -92,7 +87,7 @@ export default defineComponent({
 			try {
 				const response = await api.get(`/users/${props.user}`, {
 					params: {
-						fields: ['email', 'first_name', 'last_name', 'avatar.id', 'role.name', 'status', 'email'],
+						fields: ['id', 'first_name', 'last_name', 'avatar.id', 'role.name', 'status', 'email'],
 					},
 				});
 				data.value = response.data.data;
@@ -101,6 +96,10 @@ export default defineComponent({
 			} finally {
 				loading.value = false;
 			}
+		}
+
+		function navigateToUser() {
+			if (data.value) router.push(`/users/${data.value.id}`);
 		}
 	},
 });
@@ -114,8 +113,8 @@ export default defineComponent({
 .user-box {
 	display: flex;
 	min-width: 300px;
-	height: 80px;
-	margin: 8px 4px;
+	padding: 8px 4px;
+	cursor: pointer;
 
 	.v-avatar {
 		margin-right: 16px;


### PR DESCRIPTION
## Context

Related to #7926 where there's a request to make user tooltips clickable and bring us to the user page.

Currently it only closes on click, as that is the existing click event so that menus will close when the user click an action:

![8U8SUi1fCf](https://user-images.githubusercontent.com/42867097/132746236-1e99ced2-eb42-45b0-919d-259da93d3b6e.gif)

## Solution

I thought we had to replace/override that specific click event, but on second thought we can just use `@click.stop` for the div `.user-box` so we can capture that click event without propagating to the click event that closes it. That's what I ended up doing.

### Summary of things in this PR

- add click event to navigate to user page
- there is a `type User`, but seems like it's outdated over a year ago and there's new shared types, so I swapped it out for the new one. (also the template was complaining some user property not adding up anyways)
- oddly there's 2 email fields in the params, but I just changed one to `id` since we need it to form the router.push url
- turned `.user-box` margin to padding for proper hitbox and add `cursor: pointer` for UX.

## After Fix

### In table view

![LkgBlDqXWG](https://user-images.githubusercontent.com/42867097/132747330-1b455a98-f9f9-4522-ad7f-37216fe139f4.gif)

### In revisions

![rReF63agUK](https://user-images.githubusercontent.com/42867097/132747378-a8ecaa6e-288c-4142-af68-992b8f527ad2.gif)
