### PR TITLE
Respect & show correct icon/color for collection drawers

### DIFF
--- a/app/src/components/v-drawer/v-drawer.vue
+++ b/app/src/components/v-drawer/v-drawer.vue
@@ -32,9 +32,11 @@
 						</template>
 
 						<template #title-outer:prepend>
-							<v-button class="header-icon" rounded icon secondary disabled>
-								<v-icon :name="icon" />
-							</v-button>
+							<slot name="title-outer:prepend">
+								<v-button class="header-icon" rounded icon secondary disabled>
+									<v-icon :name="icon" />
+								</v-button>
+							</slot>
 						</template>
 
 						<template #actions:prepend><slot name="actions:prepend" /></template>

--- a/app/src/views/private/components/drawer-collection/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection/drawer-collection.vue
@@ -15,6 +15,12 @@
 				<v-breadcrumb :items="[{ name: collectionInfo.name, disabled: true }]" />
 			</template>
 
+			<template #title-outer:prepend>
+				<v-button class="header-icon" rounded icon secondary disabled>
+					<v-icon :name="collectionInfo.icon" :color="collectionInfo.color" />
+				</v-button>
+			</template>
+
 			<template #actions:prepend><component :is="`layout-actions-${localLayout}`" v-bind="layoutState" /></template>
 
 			<template #actions>


### PR DESCRIPTION
Fixes #7924

## Reported Bug

When we select related collections in o2m/m2o/m2m collections, the drawer for the related collection doesn't show the configured icon & color, but just shows the generic box icon instead.

Here the Shelves collection has a custom icon with blue color, but the drawer doesn't reflect that:

![C7MW4dwI4r](https://user-images.githubusercontent.com/42867097/132798310-4d1e3319-3ae1-4170-90ed-e268207495db.gif)

## Solution

Actually most of the groundwork of passing collection information is already done in the current codebase, so this PR just does the following:

- add slot in `<v-drawer>` so the title-outer:prepend (where the icon is) can be overridden
- add named slot in `<drawer-collection>` and use the existing `collectionInfo` for icon & color

## After Fix

![c0gFb5Ih3G](https://user-images.githubusercontent.com/42867097/132798407-380a6a15-828b-40bb-afee-8ae6620f42bf.gif)
