### PR TITLE
Fix header icon for revisions drawer

### DIFF
--- a/app/src/views/private/components/revisions-drawer-detail/revisions-drawer.vue
+++ b/app/src/views/private/components/revisions-drawer-detail/revisions-drawer.vue
@@ -3,6 +3,7 @@
 		<v-drawer
 			v-model="internalActive"
 			:title="t('item_revision')"
+			icon="change_history"
 			:sidebar-label="t(currentTab[0])"
 			@cancel="internalActive = false"
 		>


### PR DESCRIPTION
## Context

Suggested from https://github.com/directus/directus/issues/7924#issuecomment-915517865, which is to make the icon in revision drawer the same as the one for revision detail.

## Before

![chrome_kU9HUEOuM5](https://user-images.githubusercontent.com/42867097/132798637-35cfefd1-39c3-4648-b4d0-7f4297f2e03d.png)

## After

![chrome_2jferaVf36](https://user-images.githubusercontent.com/42867097/132798651-16944ebf-8423-4420-9a5a-526529563e1a.png)
