### PR TITLE
Right icon hides for numeric input

### DIFF
--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -27,11 +27,7 @@
 			>
 				{{ charsRemaining }}
 			</span>
-			<v-icon
-				v-if="iconRight"
-				:class="{ hide: percentageRemaining !== false && percentageRemaining <= 20 }"
-				:name="iconRight"
-			/>
+			<v-icon v-if="iconRight" :class="{ hide: percentageRemaining && percentageRemaining <= 20 }" :name="iconRight" />
 		</template>
 	</v-input>
 </template>
@@ -124,8 +120,8 @@ export default defineComponent({
 		const percentageRemaining = computed(() => {
 			if (typeof props.value === 'number') return null;
 
-			if (!props.length) return false;
-			if (!props.value) return false;
+			if (!props.length) return null;
+			if (!props.value) return null;
 			return 100 - (props.value.length / +props.length) * 100;
 		});
 


### PR DESCRIPTION
Before, a numeric input with appened icon was hiding that icon on data entry.

![Incorrect_number_icon_right](https://user-images.githubusercontent.com/1660347/132824851-acaaf4cc-2372-4c84-a6e3-23eb9bf34ba1.gif)


Now, it works as expected:

![Correct_number_icon_right](https://user-images.githubusercontent.com/1660347/132824482-4d896aa4-9260-451c-bf0e-3af923b47678.gif)
