### PR TITLE
Prevent v-input append slot from shrinking

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -379,6 +379,7 @@ body {
 		}
 
 		.append {
+			flex-shrink: 0;
 			margin-left: 8px;
 		}
 	}


### PR DESCRIPTION
## Bug

Currently the input in `<v-input>` component has CSS property `flex-grow: 1`, so it will push/squish the append section:

![chrome_Cdpj0n7hsu](https://user-images.githubusercontent.com/42867097/132927418-611e7ffe-3056-435e-b39d-9a379cdab1c3.png)

## Solution

Add `flex-shrink: 0` to `.append` to prevent them from shrinking.

## After fix

![chrome_XESt2ndYE4](https://user-images.githubusercontent.com/42867097/132927547-d2a787cb-3f7d-47d0-89f7-7b300f2492b7.png)

