### PR TITLE
Make type-only dependency versions of shared package less strict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51415,17 +51415,18 @@
 			"name": "@directus/shared",
 			"version": "9.0.0-rc.92",
 			"dependencies": {
+				"axios": "*",
 				"date-fns": "2.23.0",
-				"express": "4.17.1",
+				"express": "*",
 				"fs-extra": "10.0.0",
-				"geojson": "0.5.0",
+				"geojson": "*",
 				"joi": "17.4.2",
-				"knex": "0.95.11",
-				"knex-schema-inspector": "1.6.0",
+				"knex": "*",
+				"knex-schema-inspector": "*",
 				"lodash": "4.17.21",
-				"pino": "6.13.2",
-				"vue": "3.2.11",
-				"vue-router": "4.0.11"
+				"pino": "*",
+				"vue": "3",
+				"vue-router": "4"
 			},
 			"devDependencies": {
 				"npm-run-all": "4.1.5",
@@ -53647,20 +53648,21 @@
 		"@directus/shared": {
 			"version": "file:packages/shared",
 			"requires": {
+				"axios": "*",
 				"date-fns": "2.23.0",
-				"express": "4.17.1",
+				"express": "*",
 				"fs-extra": "10.0.0",
-				"geojson": "0.5.0",
+				"geojson": "*",
 				"joi": "17.4.2",
-				"knex": "0.95.11",
-				"knex-schema-inspector": "1.6.0",
+				"knex": "*",
+				"knex-schema-inspector": "*",
 				"lodash": "4.17.21",
 				"npm-run-all": "4.1.5",
-				"pino": "6.13.2",
+				"pino": "*",
 				"rimraf": "3.0.2",
 				"typescript": "4.4.3",
-				"vue": "3.2.11",
-				"vue-router": "4.0.11"
+				"vue": "3",
+				"vue-router": "4"
 			},
 			"dependencies": {
 				"typescript": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,17 +46,18 @@
 	],
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd",
 	"dependencies": {
+		"axios": "*",
 		"date-fns": "2.23.0",
-		"express": "4.17.1",
+		"express": "*",
 		"fs-extra": "10.0.0",
-		"geojson": "0.5.0",
+		"geojson": "*",
 		"joi": "17.4.2",
-		"knex": "0.95.11",
-		"knex-schema-inspector": "1.6.0",
+		"knex": "*",
+		"knex-schema-inspector": "*",
 		"lodash": "4.17.21",
-		"pino": "6.13.2",
-		"vue": "3.2.11",
-		"vue-router": "4.0.11"
+		"pino": "*",
+		"vue": "3",
+		"vue-router": "4"
 	},
 	"devDependencies": {
 		"npm-run-all": "4.1.5",


### PR DESCRIPTION
Strictly depending on a specific vue version caused multiple versions to be installed when scaffolding a typescript extension.
This broke building the typescript extension.