### PR TITLE
Align memcached configurations for multiple hosts

### DIFF
--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -57,7 +57,12 @@ function getConfig(store: 'memory' | 'redis' | 'memcache' = 'memory', ttl: numbe
 
 	if (store === 'memcache') {
 		const KeyvMemcache = require('keyv-memcache');
-		config.store = new KeyvMemcache(env.CACHE_MEMCACHE);
+
+		// keyv-memcache uses memjs which only accepts a comma separated string instead of an array,
+		// so we need to join array into a string when applicable. See #9999
+		const cacheMemcache = Array.isArray(env.CACHE_MEMCACHE) ? env.CACHE_MEMCACHE.join(',') : env.CACHE_MEMCACHE;
+
+		config.store = new KeyvMemcache(cacheMemcache);
 	}
 
 	return config;

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -59,7 +59,7 @@ function getConfig(store: 'memory' | 'redis' | 'memcache' = 'memory', ttl: numbe
 		const KeyvMemcache = require('keyv-memcache');
 
 		// keyv-memcache uses memjs which only accepts a comma separated string instead of an array,
-		// so we need to join array into a string when applicable. See #9999
+		// so we need to join array into a string when applicable. See #7986
 		const cacheMemcache = Array.isArray(env.CACHE_MEMCACHE) ? env.CACHE_MEMCACHE.join(',') : env.CACHE_MEMCACHE;
 
 		config.store = new KeyvMemcache(cacheMemcache);

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -143,9 +143,9 @@ Alternatively, you can provide the individual connection parameters:
 
 ### Memcache
 
-| Variable                | Description                        | Default Value |
-| ----------------------- | ---------------------------------- | ------------- |
-| `RATE_LIMITER_MEMCACHE` | Location of your memcache instance | ---           |
+| Variable                | Description                                                                                                                                                           | Default Value |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `RATE_LIMITER_MEMCACHE` | Location of your memcache instance. You can use [`array:` syntax](#environment-syntax-prefix), eg: `array:<instance-1>,<instance-2>` for multiple memcache instances. | ---           |
 
 ::: tip Additional Rate Limiter Variables
 
@@ -191,9 +191,9 @@ Alternatively, you can provide the individual connection parameters:
 
 ### Memcache
 
-| Variable         | Description                        | Default Value |
-| ---------------- | ---------------------------------- | ------------- |
-| `CACHE_MEMCACHE` | Location of your memcache instance | ---           |
+| Variable         | Description                                                                                                                                                           | Default Value |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `CACHE_MEMCACHE` | Location of your memcache instance. You can use [`array:` syntax](#environment-syntax-prefix), eg: `array:<instance-1>,<instance-2>` for multiple memcache instances. | ---           |
 
 ## Sessions
 
@@ -225,9 +225,9 @@ Alternatively, you can provide the individual connection parameters:
 
 ### Memcache
 
-| Variable                 | Description                        | Default Value |
-| ------------------------ | ---------------------------------- | ------------- |
-| `SESSION_MEMCACHE_HOSTS` | Location of your memcache instance | ---           |
+| Variable                 | Description                                                                                                                                                           | Default Value |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `SESSION_MEMCACHE_HOSTS` | Location of your memcache instance. You can use [`array:` syntax](#environment-syntax-prefix), eg: `array:<instance-1>,<instance-2>` for multiple memcache instances. | ---           |
 
 ### Database
 


### PR DESCRIPTION
Closes #7784

## Context

Currently in order to set `CACHE_MEMCACHE` and `RATE_LIMITER_MEMCACHE` to point to multiple memcache instances, the correct config will look like:

```yaml
CACHE_STORE: 'memcache'
CACHE_MEMCACHE: 'memcached-alpha,memcached-beta,memcached-gamma'
# ...
RATE_LIMITER_STORE: 'memcache'
RATE_LIMITER_MEMCACHE: 'array:memcached-alpha,memcached-beta,memcached-gamma'
```

Note that cache **does not** require `array:` prefix to work, whereas rate limiter require it. The reason being:

>  The cache provider (keyv) relies on memjs, while the rate limiter package relies on memcached. Memcached uses an array, while memjs uses a comma separated string

_Quote from here: <https://github.com/directus/directus/issues/7784#issuecomment-912206774>_

Hence the proposed change here: https://github.com/directus/directus/issues/7784#issuecomment-912779154 lead the changes made in this PR.

## Changes made

- Added `if` statement to check if `CACHE_MEMCACHE` is an array or not, and turn it into a comma separated string when applicable.
- Added comment for the above `if` statement. Will remove it if it's not necessary.
- Updated docs to mention the use of `array:` prefix for a cluster of Memcached servers. This is added to `RATE_LIMITER_MEMCACHE`, `CACHE_MEMCACHE`, and `SESSION_MEMCACHE_HOSTS`.

Additional note: There was also a concern for this in session management as stated in this comment: https://github.com/directus/directus/issues/7784#issuecomment-912743873. Since session for Memcached uses `connect-memcached` package, which in turn uses `memcached` package (same as rate limiter), the array syntax should work as well. Reference: <https://github.com/balor/connect-memcached#options>
