### PR TITLE
fix revision detail refresh for "Save and Stay"

### DIFF
--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -441,7 +441,7 @@ export default defineComponent({
 			try {
 				const savedItem: Record<string, any> = await save();
 
-				revisionsDrawerDetail.value?.$data?.refresh?.();
+				revisionsDrawerDetail.value?.refresh?.();
 
 				if (props.primaryKey === '+') {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -387,7 +387,7 @@ export default defineComponent({
 		async function saveAndStay() {
 			try {
 				await save();
-				revisionsDrawerDetail.value?.$data?.refresh?.();
+				revisionsDrawerDetail.value?.refresh?.();
 			} catch {
 				// `save` will show unexpected error dialog
 			}

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -388,7 +388,7 @@ export default defineComponent({
 				const savedItem: Record<string, any> = await save();
 				await setLang(savedItem);
 
-				revisionsDrawerDetail.value?.$data?.refresh?.();
+				revisionsDrawerDetail.value?.refresh?.();
 
 				if (props.primaryKey === '+') {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
Fixes #7930

## Reported Bug

Currently the revisions detail for collections is not refreshing after "Save and Stay":

![NtsE2wFquA](https://user-images.githubusercontent.com/42867097/133025247-9ee066a1-a7d9-4eb5-a06c-186603434ecf.gif)

upon further inspection, seems like this is also true for Users and Files:

![6jOOvu6ek4](https://user-images.githubusercontent.com/42867097/133025322-7991f0ce-6db5-4eb3-849d-344aea38d943.gif)

![Yxq27J9Cr8](https://user-images.githubusercontent.com/42867097/133025434-25a89416-04ea-47ae-a889-0119af764693.gif)

## Investigation & Solution

Looks like there's actually already existing logic to refresh the revision detail in each of their Save and Stay function as seen here:

https://github.com/directus/directus/blob/53c0f51d542e7d835b7551935ec0f9ca2a0b41f7/app/src/modules/collections/routes/item.vue#L444

https://github.com/directus/directus/blob/53c0f51d542e7d835b7551935ec0f9ca2a0b41f7/app/src/modules/users/routes/item.vue#L391

https://github.com/directus/directus/blob/53c0f51d542e7d835b7551935ec0f9ca2a0b41f7/app/src/modules/files/routes/item.vue#L390

and they're supposed to trigger the refresh function that triggers the reloading of revisions:

https://github.com/directus/directus/blob/53c0f51d542e7d835b7551935ec0f9ca2a0b41f7/app/src/views/private/components/revisions-drawer-detail/revisions-drawer-detail.vue#L227-L229

but currently it's not really working. We need to remove `$data?.` for them to work properly.

## After Fix

### Collections

![gt0AsKyK28](https://user-images.githubusercontent.com/42867097/133025354-2e49d5e1-a828-435d-88ff-365330c1a934.gif)

### Users

![vbjVzvAIhc](https://user-images.githubusercontent.com/42867097/133025810-4c076615-0f9d-479d-9ce8-ecb280deab90.gif)

### Files

![iBRyiZCb4J](https://user-images.githubusercontent.com/42867097/133025821-ba27948f-1984-4d51-a46d-59f5f0bd6266.gif)
