### PR TITLE
Convert to object default json value

### DIFF
--- a/api/src/utils/get-default-value.ts
+++ b/api/src/utils/get-default-value.ts
@@ -50,7 +50,9 @@ function castToBoolean(value: any): boolean {
 	return Boolean(value);
 }
 
-function castToObject(value: any): Record<string, any> | any[] {
+function castToObject(value: any): any | any[] {
+	if (!value) return value;
+
 	if (typeof value === 'object') return value;
 
 	if (typeof value === 'string') {
@@ -60,6 +62,8 @@ function castToObject(value: any): Record<string, any> | any[] {
 			if (env.NODE_ENV === 'development') {
 				logger.error(err);
 			}
+
+			return value;
 		}
 	}
 

--- a/api/src/utils/get-default-value.ts
+++ b/api/src/utils/get-default-value.ts
@@ -1,10 +1,12 @@
 import { SchemaOverview } from '@directus/schema/dist/types/overview';
 import { Column } from 'knex-schema-inspector/dist/types/column';
 import getLocalType from './get-local-type';
+import logger from '../logger';
+import env from '../env';
 
 export default function getDefaultValue(
 	column: SchemaOverview[string]['columns'][string] | Column
-): string | boolean | null {
+): string | boolean | number | Record<string, any> | any[] | null {
 	const { type } = getLocalType(column);
 
 	let defaultValue = column.default_value ?? null;
@@ -29,6 +31,8 @@ export default function getDefaultValue(
 			return Number.isNaN(Number(defaultValue)) === false ? Number(defaultValue) : defaultValue;
 		case 'boolean':
 			return castToBoolean(defaultValue);
+		case 'json':
+			return castToObject(defaultValue);
 		default:
 			return defaultValue;
 	}
@@ -44,4 +48,20 @@ function castToBoolean(value: any): boolean {
 	if (value === 'true' || value === true) return true;
 
 	return Boolean(value);
+}
+
+function castToObject(value: any): Record<string, any> | any[] {
+	if (typeof value === 'object') return value;
+
+	if (typeof value === 'string') {
+		try {
+			return JSON.parse(value);
+		} catch (err: any) {
+			if (env.NODE_ENV === 'development') {
+				logger.error(err);
+			}
+		}
+	}
+
+	return {};
 }


### PR DESCRIPTION
With this PR #8012 I couldn't run app locally.
Basically, I found that PR is adding a new json column to an existent table with a default value.
Turns out that default value comes as string instead of an json object (at least in SQLite).

![image](https://user-images.githubusercontent.com/14039341/133380913-a0ecc8da-c6bd-4869-807b-25ab28aa97be.png)

This ensures the returned value is a json object.

PS: I can't replicate anymore since I have populated that field. It seems this is an edge case, but I think it could be helpful on future.