### PR TITLE
add error handling for image component

### DIFF
--- a/app/src/displays/image/image.vue
+++ b/app/src/displays/image/image.vue
@@ -1,6 +1,13 @@
 <template>
-	<v-icon v-if="imgError" name="" />
-	<img v-else-if="src" :src="src" role="presentation" :alt="value && value.title" :class="{ circle }" />
+	<v-icon v-if="imageError" name="image" />
+	<img
+		v-else-if="src"
+		:src="src"
+		role="presentation"
+		:alt="value && value.title"
+		:class="{ circle }"
+		@error="imageError = true"
+	/>
 	<value-null v-else />
 </template>
 
@@ -29,7 +36,7 @@ export default defineComponent({
 		},
 	},
 	setup(props) {
-		const imgError = ref(false);
+		const imageError = ref(false);
 
 		const src = computed(() => {
 			if (props.value === null) return null;
@@ -37,7 +44,7 @@ export default defineComponent({
 			return addTokenToURL(url);
 		});
 
-		return { src, imgError };
+		return { src, imageError };
 	},
 });
 </script>


### PR DESCRIPTION
## Bug

_Part of investigation from #8069._

The image preview in tabular view is broken:

![chrome_r3OLaFX4mW](https://user-images.githubusercontent.com/42867097/133723448-8f13df58-dc3e-4a53-9406-464cdefce9de.png)

There's already an existing `imgError` variable to handle image load errors, but it was never hooked up to any error handler like `@error`.

## Solution

- Add error handler
- set the fallback icon as a generic image icon (previously no value)
- renamed `imgError` to `imageError` just for clearer naming

## After fix

![chrome_kLGjZDk68F](https://user-images.githubusercontent.com/42867097/133723606-1c0658f0-b402-426d-ba6b-760d98724fa1.png)

## Question

Do we need to handle error such as `ILLEGAL_ASSET_TRANSFORMATION` here? Arguably a better UX might be to handle it, then use a different icon + add a tooltip on hover showing "image too large to preview" or something, but on the other hand it might be unnecessary.

