### PR TITLE
Prevent null being converted to empty object in deepMap utility function

### DIFF
--- a/packages/shared/src/utils/deep-map.ts
+++ b/packages/shared/src/utils/deep-map.ts
@@ -8,7 +8,7 @@ export function deepMap(
 		return object.map(function (val, key) {
 			return typeof val === 'object' ? deepMap(val, iterator, context) : iterator.call(context, val, key);
 		});
-	} else if (typeof object === 'object') {
+	} else if (object !== null && typeof object === 'object') {
 		const res: Record<string, any> = {};
 
 		for (const key in object) {

--- a/packages/shared/src/utils/deep-map.ts
+++ b/packages/shared/src/utils/deep-map.ts
@@ -1,20 +1,22 @@
+import { isObjectLike } from 'lodash';
+
 export function deepMap(
-	object: Record<string, any>,
+	object: any,
 	iterator: (value: any, key: string | number) => any,
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	context?: any
 ): any {
 	if (Array.isArray(object)) {
 		return object.map(function (val, key) {
-			return typeof val === 'object' ? deepMap(val, iterator, context) : iterator.call(context, val, key);
+			return isObjectLike(val) ? deepMap(val, iterator, context) : iterator.call(context, val, key);
 		});
-	} else if (object !== null && typeof object === 'object') {
+	} else if (isObjectLike(object)) {
 		const res: Record<string, any> = {};
 
 		for (const key in object) {
 			const val = object[key];
 
-			if (typeof val === 'object') {
+			if (isObjectLike(val)) {
 				res[key] = deepMap(val, iterator, context);
 			} else {
 				res[key] = iterator.call(context, val, key);


### PR DESCRIPTION
Closes #8096

## Reported Bug

When we leave Archive Value as null for a particular collection:

![chrome_8M4QxA2wT3](https://user-images.githubusercontent.com/42867097/133740050-ac60b50b-abda-4e66-a4f1-9bafbdfe8062.png)

We will face error when viewing that collection:

![ws1wHjdxQA](https://user-images.githubusercontent.com/42867097/133740114-5de2fd28-f638-4b2d-b353-79340a477c53.gif)

The underlying API call for it does have the filter `filter: {"status":{"_neq":null}}`. However I believe `_neq=null` is an acceptable filter for string so it should qualify as a bug, and it must be a recent change/regression as the issue owner mentioned that it used to work in the past.

## Investigation

If we check the `validateFilterPrimitive` function, it does return true if the value is null. Only if it's not, then it will return the error shown above:

https://github.com/directus/directus/blob/9967274ab276a4adfe4a76b775b614cf940dcb27/api/src/utils/validate-query.ts#L94-L102

Since the API call does request for `_neq: null`, what gives? As we can see here, the resulting query filter actually shows that it is an empty object, not `null`:

![Code_jAePeYEBKH](https://user-images.githubusercontent.com/42867097/133741697-3d9a8877-7cdd-499f-9f35-73b63a53e2e2.png)

Seems like in the SanitizeFilter, which happens before validateQuery, the deepmap function is responsible for turning `null` into an empty object:

  - Before processed by deepmap, it's `null`: 
      ![Code_J0RzRhYdxT](https://user-images.githubusercontent.com/42867097/133742424-04693dde-61b4-4415-8614-04787477e603.png)
        
  - After processed by deepmap, it's `{}`:
      ![Code_vlcjHVKcLl](https://user-images.githubusercontent.com/42867097/133742726-faef0dcb-690e-4555-aca1-bf9d029d0b8b.png)

Finally looks like `typeof null === 'object'` DOES equals to true, that's why it's turned into `{}`:

![nITT5mKkf4](https://user-images.githubusercontent.com/42867097/133742909-8e485484-8e53-4ae9-a61f-4e686e5619d4.gif) 

Note: this deepmap function was added in SanitizeFilter from the recent Geometry/Map feature, so once again that explains why the issue owner faced this error only after they update their Directus recently: https://github.com/directus/directus/pull/5684/files#diff-5b6b8ed21158e5378ab1be3561ca320371c142c323f7af9c4c7adbf27265115b

## Solution

Added `object !== null` to ensure it's not turned into an empty object.

## Uncertainty

Is the empty object by any chance an intended feature? Also not sure if this will break anything where they intentionally wants empty object instead of null.

I'm also unsure whether we need to add the `object !== null` check here:

https://github.com/directus/directus/blob/9967274ab276a4adfe4a76b775b614cf940dcb27/packages/shared/src/utils/deep-map.ts#L9

