### PR TITLE
Fixed missing documentation due to directory-tree update

### DIFF
--- a/docs/build.js
+++ b/docs/build.js
@@ -9,6 +9,7 @@ const tree = dirTree('.', {
 	extensions: /\.md$/,
 	exclude: /(node_modules|.vuepress|.vscode|dist)/,
 	normalizePath: true,
+	attributes: ['type', 'extension'],
 });
 
 const index = `export default ${generateIndex(tree.children)};`;


### PR DESCRIPTION
Fixes #8106, issue arose due to an update to the `directory-tree` library which no longer includes the attributes required.