### PR TITLE
Fix 5752 by setting 'item' as 'editsAtStart.value' when there is no pk

### DIFF
--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -377,15 +377,12 @@ export default defineComponent({
 				const pkField = relatedPrimaryKeyField.value?.field;
 				if (!pkField) return;
 				const hasPrimaryKey = pkField in item;
-
+				
 				const edits = (props.value || []).find(
-					(edit: any) =>
-						typeof edit === 'object' &&
-						relatedPrimaryKeyField.value?.field &&
-						edit[relatedPrimaryKeyField.value?.field] === item[relatedPrimaryKeyField.value?.field]
+					(edit: any) => typeof edit === 'object' && pkField && edit[pkField] === item[pkField]
 				);
-
-				editsAtStart.value = edits || { [pkField]: item[pkField] || {} };
+				
+				editsAtStart.value = hasPrimaryKey ? edits || { [pkField]: item[pkField] || {} } : item;
 				currentlyEditing.value = hasPrimaryKey ? item[pkField] : '+';
 			}
 

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -377,15 +377,15 @@ export default defineComponent({
 				const pkField = relatedPrimaryKeyField.value?.field;
 				if (!pkField) return;
 				const hasPrimaryKey = pkField in item;
-
+				
 				const edits = (props.value || []).find(
 					(edit: any) =>
 						typeof edit === 'object' &&
 						relatedPrimaryKeyField.value?.field &&
 						edit[relatedPrimaryKeyField.value?.field] === item[relatedPrimaryKeyField.value?.field]
 				);
-
-				editsAtStart.value = edits || { [pkField]: item[pkField] || {} };
+				
+				editsAtStart.value = hasPrimaryKey ? edits || { [pkField]: item[pkField] || {} } : item;
 				currentlyEditing.value = hasPrimaryKey ? item[pkField] : '+';
 			}
 

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -377,11 +377,11 @@ export default defineComponent({
 				const pkField = relatedPrimaryKeyField.value?.field;
 				if (!pkField) return;
 				const hasPrimaryKey = pkField in item;
-				
+
 				const edits = (props.value || []).find(
 					(edit: any) => typeof edit === 'object' && pkField && edit[pkField] === item[pkField]
 				);
-				
+
 				editsAtStart.value = hasPrimaryKey ? edits || { [pkField]: item[pkField] || {} } : item;
 				currentlyEditing.value = hasPrimaryKey ? item[pkField] : '+';
 			}


### PR DESCRIPTION
Fix #5752 (partially) by setting 'item' as 'editsAtStart.value' when there is no primary key.