### PR TITLE
Fix incorrect env ASSETS_TRANSFORM_MAX_CONCURRENT

### DIFF
--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -18,7 +18,7 @@ sharp.concurrency(1);
 
 // Note: don't put this in the service. The service can be initialized in multiple places, but they
 // should all share the same semaphore instance.
-const semaphore = new Semaphore(env.ASSETS_MAX_CONCURRENT_TRANSFORMATIONS);
+const semaphore = new Semaphore(env.ASSETS_TRANSFORM_MAX_CONCURRENT);
 
 export class AssetsService {
 	knex: Knex;


### PR DESCRIPTION
I picked `ASSETS_TRANSFORM_MAX_CONCURRENT` instead of `ASSETS_MAX_CONCURRENT_TRANSFORMATIONS` in order to follow the nomenclature of the other env var names



https://github.com/directus/directus/blob/6405db831bb6f71e35c5303f0c615395ff0d0d7a/docs/reference/environment-variables.md#L296-L298
