### PR TITLE
Consolidate example domains in translations to example.com

### DIFF
--- a/app/src/lang/translations/bg-BG.yaml
+++ b/app/src/lang/translations/bg-BG.yaml
@@ -34,7 +34,7 @@ create_role: Създаване на роля
 create_user: Създаване на потребител
 create_webhook: Създаване на уеб-кука
 invite_users: Покана към потребители
-email_examples: "admin{'@'}example.com, potrebitel{'@'}organizacia.com..."
+email_examples: "admin{'@'}example.com, potrebitel{'@'}example.com..."
 invite: Покана
 email_already_invited: Вече е изпратена покана в пощата на "{email}"
 emails: E-пощи
@@ -846,7 +846,7 @@ field_options:
     auth_password_policy:
       none_text: Без - не се препоръчва
       weak_text: Слаба - минимум от 8 символа
-      strong_text: Силна - главни, малки, числа и специални символи 
+      strong_text: Силна - главни, малки, числа и специални символи
     storage_asset_presets:
       fit:
         contain_text: Напасване (запазване на съотношението)

--- a/app/src/lang/translations/cs-CZ.yaml
+++ b/app/src/lang/translations/cs-CZ.yaml
@@ -55,8 +55,8 @@ create_role: Vytvořit roli
 create_user: Vytvořit uživatele
 create_webhook: Vytvořit webhook
 invite_users: Pozvat uživatele
-email_examples: "admin{'@'}stranka.cz, user{'@'}stranka.cz..."
-url_example: "https://stranka.cz"
+email_examples: "admin{'@'}example.com, user{'@'}example.com..."
+url_example: "https://example.com"
 invite: Pozvat
 email_already_invited: E-mail "{email}" již byl pozván
 emails: E-mail

--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -58,7 +58,7 @@ create_role: Rolle erstellen
 create_user: Benutzer erstellen
 create_webhook: Webhook erstellen
 invite_users: Benutzer einladen
-email_examples: "admin{'@'}beispiel.de, benutzer{'@'}beispiel.de..."
+email_examples: "admin{'@'}example.com, benutzer{'@'}example.com..."
 url_example: "https://example.com"
 invite: Einladen
 email_already_invited: E-Mail "{email}" wurde bereits eingeladen

--- a/app/src/lang/translations/es-419.yaml
+++ b/app/src/lang/translations/es-419.yaml
@@ -29,7 +29,7 @@ create_role: Crear rol
 create_user: Crear Usuario
 create_webhook: Crear un gancho web
 invite_users: Invitar Usuarios
-email_examples: "admin{'@'}ejemplo.com, usuario{'@'}ejemplo.com..."
+email_examples: "admin{'@'}example.com, usuario{'@'}example.com..."
 invite: Invita
 email_already_invited: El correo electrónico "{email}" ya fue invitado con anterioridad
 emails: Correos electrónicos

--- a/app/src/lang/translations/es-CL.yaml
+++ b/app/src/lang/translations/es-CL.yaml
@@ -29,7 +29,7 @@ create_role: Crear Rol
 create_user: Crear usuario
 create_webhook: Crear un webhook(conección)
 invite_users: Invitar usuarios
-email_examples: "admin{'@'}ejemplo.com, usuario{'@'}ejemplo.com..."
+email_examples: "admin{'@'}example.com, usuario{'@'}example.com..."
 invite: Invitar
 email_already_invited: El correo electrónico "{email}" ya ha sido invitado
 emails: Correos electrónicos

--- a/app/src/lang/translations/es-ES.yaml
+++ b/app/src/lang/translations/es-ES.yaml
@@ -28,7 +28,7 @@ create_role: Crear Rol
 create_user: Crear Usuario
 create_webhook: Crear Webhook
 invite_users: Invitar Usuarios
-email_examples: "admin{'@'}ejemplo.com, usuario{'@'}ejemplo.com..."
+email_examples: "admin{'@'}example.com, usuario{'@'}example.com..."
 invite: Invitar
 email_already_invited: El correo electrónico "{email}" ya ha sido invitado
 emails: Correos Electrónicos

--- a/app/src/lang/translations/hi-IN.yaml
+++ b/app/src/lang/translations/hi-IN.yaml
@@ -20,7 +20,7 @@ create_role: भूमिका बनाएं
 create_user: यूजर बनाएं
 create_webhook: Webhook बनाएं
 invite_users: यूज़र आमंत्रित करें
-email_examples: "good"
+email_examples: "admin{'@'}example.com, user{'@'}example.com..."
 invite: आमंत्रित करें
 email_already_invited: ईमेल "{email}" पहले ही आमंत्रित किया जा चुका है
 emails: इमेल्स

--- a/app/src/lang/translations/lt-LT.yaml
+++ b/app/src/lang/translations/lt-LT.yaml
@@ -26,7 +26,7 @@ create_role: Kurti vaidmenį
 create_user: Sukurti vartotojo paskyrą
 create_webhook: Sukurti Webhook'ą
 invite_users: Pakviesti vartotojus
-email_examples: "administratorius{'@'}pavyzdys.lt, naudotojas{'@'}pavyzdys.lt..."
+email_examples: "administratorius{'@'}example.com, naudotojas{'@'}example.com..."
 invite: Pakviesti
 email_already_invited: El. pašto "{email}" adresatas jau buvo pakviestas
 emails: El. pašto adresai

--- a/app/src/lang/translations/mn-MN.yaml
+++ b/app/src/lang/translations/mn-MN.yaml
@@ -57,7 +57,7 @@ create_user: Хэрэглэгч үүсгэх
 create_webhook: Webhook үүсгэх
 invite_users: Хэрэглэгч урих
 email_examples: "admin{'@'}example.com, user{'@'}example.com..."
-url_example: "https://jishee.com"
+url_example: "https://example.com"
 invite: Урих
 email_already_invited: '"{email}" имэйл хаягийг өмнө нь урьсан байна'
 emails: Имэйл
@@ -92,7 +92,7 @@ os_totalmem: Үйлдлийн системийн санах ой
 archive: Архивлах
 archive_confirm: Та энэ мэдээллийг архивлахыг хүсч байна уу?
 archive_confirm_count: >-
-  Ямар нэг зүйл сонгогдоогүй | Та үүнийг архивлахдаа итгэлтэй байна уу? | Та энэ {count} 
+  Ямар нэг зүйл сонгогдоогүй | Та үүнийг архивлахдаа итгэлтэй байна уу? | Та энэ {count}
   зүйлсийг архивлахдаа итгэлтэй байна уу?
 reset_system_permissions_to: 'Системийн зөвшөөрлийг буцааж хэвэнд нь оруулах:'
 reset_system_permissions_copy: Энэ үйлдлийг хийснээр өмнө нь тохируулсан зөвшөөрлийн тохиргоо дарагдана. Хийх үү?

--- a/app/src/lang/translations/nl-NL.yaml
+++ b/app/src/lang/translations/nl-NL.yaml
@@ -29,7 +29,7 @@ create_role: Maak rol
 create_user: Gebruiker Aanmaken
 create_webhook: Webhook Aanmaken
 invite_users: Gebruikers Uitnodigen
-email_examples: "admin{'@'}voorbeeld.nl, gebruiker{'@'}voorbeeld.nl..."
+email_examples: "admin{'@'}example.com, gebruiker{'@'}example.com..."
 invite: Nodig uit
 email_already_invited: E-mailadres "{email}" is al uitgenodigd
 emails: E-mails

--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -34,7 +34,7 @@ create_role: Criar Função
 create_user: Criar usuário
 create_webhook: Criar Webgancho
 invite_users: Convidar Usuários
-email_examples: "admin{'@'}exemplo.com, usuario{'@'}exemplo.com..."
+email_examples: "admin{'@'}example.com, usuario{'@'}example.com..."
 invite: Convidar
 email_already_invited: Um convite já foi enviado para o email "{email}"
 emails: Emails
@@ -827,7 +827,7 @@ fields:
     collection_list: Navegação da Coleção
   directus_webhooks:
     name: Nome
-    method: Método 
+    method: Método
     status: Status
     data: Dados
     data_label: Enviar Dados do Evento

--- a/app/src/lang/translations/pt-PT.yaml
+++ b/app/src/lang/translations/pt-PT.yaml
@@ -29,7 +29,7 @@ create_role: Criar estatuto
 create_user: Criar utilizador
 create_webhook: Criar webhook
 invite_users: Convidar utlizadores
-email_examples: "admin{'@'}exemplo.com, usuário{'@'}exemplo.com..."
+email_examples: "admin{'@'}example.com, usuário{'@'}example.com..."
 invite: Convidar
 email_already_invited: Este e-mail já foi convidado
 emails: Emails

--- a/app/src/lang/translations/sr-CS.yaml
+++ b/app/src/lang/translations/sr-CS.yaml
@@ -20,7 +20,7 @@ create_role: Napravi ulogu
 create_user: Napravi korisnika
 create_webhook: Napravi Webhook
 invite_users: Pozovi korisnike
-email_examples: "admin{'@'}primjer.com, user{'@'}primjer.com..."
+email_examples: "admin{'@'}example.com, user{'@'}example.com..."
 invite: Pozovi
 email_already_invited: Na ovu "{email}" adresu je već poslat poziv
 emails: Email adrese


### PR DESCRIPTION
This is done to mainly avoid any potential issues with unsafe example domains.