### PR TITLE
Fixed readonly repeater fields from sorting

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -6,6 +6,7 @@
 
 		<v-list v-if="value && value.length > 0">
 			<draggable
+				:disabled="disabled"
 				:force-fallback="true"
 				:model-value="value"
 				item-key="id"
@@ -14,7 +15,7 @@
 			>
 				<template #item="{ element, index }">
 					<v-list-item :dense="value.length > 4" block @click="active = index">
-						<v-icon name="drag_handle" class="drag-handle" left @click.stop="() => {}" />
+						<v-icon v-if="!disabled" name="drag_handle" class="drag-handle" left @click.stop="() => {}" />
 						<render-template :fields="fields" :item="element" :template="templateWithDefaults" />
 						<div class="spacer" />
 						<v-icon v-if="!disabled" name="close" @click.stop="removeItem(element)" />


### PR DESCRIPTION
Fixes #8155. 

Disable the `<draggable>` and hide its `drag_handle`.

<img width="695" alt="Screenshot 2021-09-20 at 3 19 34 PM" src="https://user-images.githubusercontent.com/26413686/133969071-ff3bb6ff-622d-42ce-85b8-851b86efc4cf.png">

Edit: The `drag_handle` is hidden to be aligned with other interfaces (eg: o2m) with the same look.