### PR TITLE
Prevent unsaved changes dialog from appearing after item is deleted

### DIFF
--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -481,6 +481,7 @@ export default defineComponent({
 		async function deleteAndQuit() {
 			try {
 				await remove();
+				edits.value = {};
 				router.push(`/collections/${props.collection}`);
 			} catch {
 				// `remove` will show the unexpected error dialog


### PR DESCRIPTION
fixes #8146 

## Reported Bug

When there's unsaved edits and the item is deleted, the unsaved changes dialog still shows up despite the item already cease to exist:

![RZ6Ykm1fkc](https://user-images.githubusercontent.com/42867097/133971411-fd46edf6-322e-4e8d-869c-9d5aa9c071b4.gif)

## Solution

Clear the edits state after item is deleted. Basically referred the `edits.value = {}` usage from `discardAndLeave()`:

https://github.com/directus/directus/blob/36362153fa417fce54469257f67f2514f4af1009/app/src/modules/collections/routes/item.vue#L504-L509

## After fix

![6luWlSSC8X](https://user-images.githubusercontent.com/42867097/133971503-47d3bb93-fdeb-4f9b-8734-525cc5b4e65b.gif)


