### PR TITLE
Change some API calls to use getEndpoint utility

### DIFF
--- a/app/src/interfaces/list-m2m/use-preview.ts
+++ b/app/src/interfaces/list-m2m/use-preview.ts
@@ -6,6 +6,7 @@ import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to
 import { cloneDeep, get, merge } from 'lodash';
 import { Ref, ref, watch } from 'vue';
 import { RelationInfo } from './use-relation';
+import { getEndpoint } from '@/utils/get-endpoint';
 
 type UsablePreview = {
 	tableHeaders: Ref<Header[]>;
@@ -194,11 +195,9 @@ export default function usePreview(
 	) {
 		if (fields === null || fields.length === 0 || primaryKeys === null || primaryKeys.length === 0) return [];
 
-		const endpoint = collection.startsWith('directus_') ? `/${collection.substring(9)}` : `/items/${collection}`;
-
 		const fieldsToFetch = addRelatedPrimaryKeyToFields(collection, fields);
 
-		const response = await api.get(endpoint, {
+		const response = await api.get(getEndpoint(collection), {
 			params: {
 				fields: fieldsToFetch,
 				[`filter[${filteredField}][_in]`]: primaryKeys.join(','),

--- a/app/src/panels/list/list.vue
+++ b/app/src/panels/list/list.vue
@@ -38,6 +38,7 @@ import DrawerItem from '@/views/private/components/drawer-item';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { getFieldsFromTemplate } from '@directus/shared/utils';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { getEndpoint } from '@/utils/get-endpoint';
 import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
@@ -128,7 +129,7 @@ export default defineComponent({
 			try {
 				const sort = props.sortField;
 
-				const res = await api.get(`/items/${props.collection}`, {
+				const res = await api.get(getEndpoint(props.collection), {
 					params: {
 						fields: [
 							primaryKeyField.value.field,

--- a/app/src/panels/metric/metric.vue
+++ b/app/src/panels/metric/metric.vue
@@ -17,6 +17,7 @@ import { Filter } from '@directus/shared/types';
 import { useI18n } from 'vue-i18n';
 import { abbreviateNumber } from '@/utils/abbreviate-number';
 import { isNil } from 'lodash';
+import { getEndpoint } from '@/utils/get-endpoint';
 
 export default defineComponent({
 	props: {
@@ -156,7 +157,7 @@ export default defineComponent({
 							[props.function]: [props.field || '*'],
 					  };
 
-				const res = await api.get(`/items/${props.collection}`, {
+				const res = await api.get(getEndpoint(props.collection), {
 					params: {
 						aggregate,
 						filter: props.filter,

--- a/app/src/panels/time-series/time-series.vue
+++ b/app/src/panels/time-series/time-series.vue
@@ -12,6 +12,7 @@ import { isEqual, isNil } from 'lodash';
 import { useFieldsStore } from '@/stores';
 import { Filter } from '@directus/shared/types';
 import { abbreviateNumber } from '@/utils/abbreviate-number';
+import { getEndpoint } from '@/utils/get-endpoint';
 
 export default defineComponent({
 	props: {
@@ -134,7 +135,7 @@ export default defineComponent({
 			loading.value = true;
 
 			try {
-				const results = await api.get(`/items/${props.collection}`, {
+				const results = await api.get(getEndpoint(props.collection), {
 					params: {
 						groupBy: getGroups(),
 						aggregate: {


### PR DESCRIPTION
## Context

Some panels in the new Insights module (beta) were not properly handling the endpoints for Directus system tables. Seems like the util function `getEndpoint` already exists so just had to actually use it in these parts.

## Question

Does removing the following `endpoint` computed value and putting `getEndpoint()` inside `itemEndpoint` breaks anything? Just want to avoid any oversight on my part.

https://github.com/directus/directus/blob/695baf75d20af86695a8d0da99282b2e15f906f3/app/src/composables/use-item/use-item.ts#L59-L71