### PR TITLE
Clear collection cache & schema cache on update

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -344,7 +344,7 @@ export class CollectionsService {
 	/**
 	 * Update multiple collections by name
 	 */
-	async updateMany(collectionKeys: string[], data: Partial<Collection>): Promise<string[]> {
+	async updateMany(collectionKeys: string[], data: Partial<Collection>, opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException();
 		}
@@ -361,7 +361,7 @@ export class CollectionsService {
 			}
 		});
 
-		if (this.cache && env.CACHE_AUTO_PURGE) {
+		if (this.cache && env.CACHE_AUTO_PURGE && opts?.autoPurgeCache !== false) {
 			await this.cache.clear();
 		}
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -330,6 +330,14 @@ export class CollectionsService {
 			await collectionItemsService.createOne({ ...payload.meta, collection: collectionKey }, opts);
 		}
 
+		if (this.cache && env.CACHE_AUTO_PURGE && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
+		if (this.schemaCache) {
+			await this.schemaCache.clear();
+		}
+
 		return collectionKey;
 	}
 
@@ -352,6 +360,14 @@ export class CollectionsService {
 				await service.updateOne(collectionKey, data, { autoPurgeCache: false });
 			}
 		});
+
+		if (this.cache && env.CACHE_AUTO_PURGE) {
+			await this.cache.clear();
+		}
+
+		if (this.schemaCache) {
+			await this.schemaCache.clear();
+		}
 
 		return collectionKeys;
 	}


### PR DESCRIPTION
fixes #7990

## Bug

Collections' cache and schema cache are cleared for Create and Delete operations, but not for Update operations.

## Solution

Add the same cache clearing logic to Update operations.

## Pending change

~Check comments below~ Resolved