### PR TITLE
fix(docs): update link in persistence section

### DIFF
--- a/docs/guides/installation/docker.md
+++ b/docs/guides/installation/docker.md
@@ -38,7 +38,7 @@ Containers are ephemeral, and this means that whenever you stop a container, all
 be removed [unless you persist them](https://docs.docker.com/storage/) when creating your container.
 
 Directus image by default
-[will use the following locations](https://github.com/directus/directus/blob/main/.github/actions/build-images/rootfs/directus/images/main/Dockerfile#L93-L96)
+[will use the following locations](https://github.com/directus/directus/blob/main/docker/Dockerfile#L56-L60)
 for data persistence (note that these can be changed through environment variables)
 
 - `/directus/uploads` for uploads


### PR DESCRIPTION
Hi 👋 ,

The link in docs was returning 404. Now it shows the mentioned volumes. I bumped into that while reading the docs, submitting this change to prevent other people bump it as I did.

Not sure if this is a future-proof way though. If in the future these volumes change, docs need to reflect that change. For now, this is what I can think of to fix it in the easiest way possible. 

I hope you'll consider this change.

Best,
G.