### PR TITLE
Fix errors thrown in CRON hook not caught

### DIFF
--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -172,7 +172,13 @@ function registerHooks(hooks: Extension[]) {
 				if (!cron || validate(cron) === false) {
 					logger.warn(`Couldn't register cron hook. Provided cron is invalid: ${cron}`);
 				} else {
-					schedule(cron, handler);
+					schedule(cron, async () => {
+						try {
+							await handler();
+						} catch (error: any) {
+							logger.error(error);
+						}
+					});
 				}
 			} else {
 				emitter.on(event, handler);


### PR DESCRIPTION
Fixes #8022 by wrapping the handler function with a try catch.

## Basic hook test
``` js
module.exports = function registerHook() {
	console.log("Registered hook");
    return {
        // run every five seconds
        "cron(*/5 * * * * *)": async () => {
            console.log('runs...')
            throw new Error("error");
        },
    };
};
```

## Console output
<img width="889" alt="Screenshot 2021-09-21 at 5 03 46 PM" src="https://user-images.githubusercontent.com/26413686/134143937-14f86452-1e9d-4e8d-859e-d028f0301c8b.png">