### PR TITLE
Fix docs module routes from triggering auth refresh

### DIFF
--- a/app/src/modules/docs/index.ts
+++ b/app/src/modules/docs/index.ts
@@ -28,6 +28,7 @@ function getRoutes(routes: DocsRoutes): RouteRecordRaw[] {
 	for (const route of routes) {
 		if (!('children' in route)) {
 			updatedRoutes.push({
+				name: `docs-${route.path.replace('/', '-')}`,
 				path: route.path,
 				component: StaticDocs,
 				meta: {


### PR DESCRIPTION
Fixes #8200. Dynamically generated routes were missing the `name` variable.

Changed the '/' to '-' to make it consistent with route names from other modules.