### PR TITLE
Fix auth token refresh to be on first load only

### DIFF
--- a/app/src/router.ts
+++ b/app/src/router.ts
@@ -62,12 +62,15 @@ export const router = createRouter({
 	routes: defaultRoutes,
 });
 
+let firstLoad = true;
+
 export const onBeforeEach: NavigationGuard = async (to, from) => {
 	const appStore = useAppStore();
 	const serverStore = useServerStore();
 
 	// First load
-	if (from.name === undefined) {
+	if (firstLoad) {
+		firstLoad = false;
 		// Try retrieving a fresh access token on first load
 		try {
 			await refresh({ navigate: false });


### PR DESCRIPTION
As discussed in #8201.

When routes are missing the `name` variable, the page navigation is seen as the first load, triggering a refresh of the auth token. Which may in turn trigger authentication issues.