### PR TITLE
Enable global-agent package which allows user to use GLOBAL_AGNET_HTTP_PROXY

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -106,6 +106,7 @@
 		"express": "^4.17.1",
 		"express-session": "^1.17.2",
 		"fs-extra": "^10.0.0",
+		"global-agent": "^3.0.0",
 		"grant": "^5.4.14",
 		"graphql": "^15.5.0",
 		"graphql-compose": "^9.0.1",

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -12,6 +12,7 @@ import logger from './logger';
 import emitter, { emitAsyncSafe } from './emitter';
 import checkForUpdate from 'update-check';
 import pkg from '../package.json';
+import 'global-agent/bootstrap';
 
 export async function createServer(): Promise<http.Server> {
 	const server = http.createServer(await createApp());


### PR DESCRIPTION
Enable global-agent package which allows user to setup GLOBAL_AGENT_PROXY variables, that solves the problems that app needs to connect to outside the network