### PR TITLE
Add divider for modules section in project settings

### DIFF
--- a/api/src/database/system-data/fields/settings.yaml
+++ b/api/src/database/system-data/fields/settings.yaml
@@ -333,6 +333,16 @@ fields:
                     _neq: 'raster'
                 hidden: true
 
+  - field: modules_divider
+    interface: presentation-divider
+    options:
+      icon: view_module
+      title: $t:modules
+    special:
+      - alias
+      - no-data
+    width: full
+
   - field: module_bar
     interface: system-modules
     special: json

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -23,6 +23,7 @@
 published: Published
 draft: Draft
 archived: Archived
+modules: Modules
 module_bar: Module Bar
 tile_size: Tile Size
 edit_field: Edit Field


### PR DESCRIPTION
A divider is added. Currently, the module bar is in the project settings, in the Maps section

May I ask what is the procedure to add new words for translation?
I have just added a word into `en-US.yaml`.

## Before

<img width="616" alt="Screenshot 2021-09-22 at 11 52 33 PM" src="https://user-images.githubusercontent.com/26413686/134378651-a32adc86-da31-4bae-9229-f4468e3b1eed.png">

## After

<img width="616" alt="Screenshot 2021-09-22 at 11 52 49 PM" src="https://user-images.githubusercontent.com/26413686/134378704-34b4a415-93e1-4176-9876-b395156220a9.png">