### PR TITLE
Reinstate v-click-outside event in v-menu

### DIFF
--- a/app/src/components/v-menu/v-menu.vue
+++ b/app/src/components/v-menu/v-menu.vue
@@ -28,6 +28,7 @@
 						handler: deactivate,
 						middleware: onClickOutsideMiddleware,
 						disabled: isActive === false || closeOnClick === false,
+						events: ['click'],
 					}"
 					class="v-menu-popper"
 					:class="{ active: isActive, attached }"


### PR DESCRIPTION
fixes #8250

## Context

The menu for datetime inputs are closing whenever we try to choose a value for day/month/year/hour/minute, except 'Set Now' button.

![ZaEwvBQUIS](https://user-images.githubusercontent.com/42867097/134453845-3d61370e-2f77-4e22-8679-78636f2e1ad1.gif)

## After fix

![GkDePTXTzv](https://user-images.githubusercontent.com/42867097/134453856-eec89187-29be-4d3f-a74a-bd6612ebc8ab.gif)

---

## Deliberation

Back in #7962, the concern was initially the menus in Data Model page are not closing when another one is opened. The initial solution of using focus event was wrong, so @rijkvanzanten suggested two approaches:

> 1. Use a different event (like pointerdown instead of click) for the click-outside directive, or;
> 2. Restructure the field-select boxes so only the name is clickable, instead of the whole box:

_link to above quote: https://github.com/directus/directus/pull/7962#issuecomment-917070444_

Later on I proceeded with the second approach which does not involve modifying v-click-outside. 

Before it was merged, our further discussion off GitHub prompted to change the events for v-click-directive from `click` to `pointerdown` just to be safe, hence it was changed here: https://github.com/directus/directus/pull/7962/commits/b7b0756f2a330e260137fbb133080dfd28a84793#diff-eb4ea217834f7cc833cbdf55c167abb1530fee44b35984fc31a22ebaaae05ab8R31.  However after that it got removed as seen here: https://github.com/directus/directus/pull/7962/commits/7f0268d095e90a28caeebb6532b64d09ecae3475#diff-eb4ea217834f7cc833cbdf55c167abb1530fee44b35984fc31a22ebaaae05ab8L31

Perhaps that was unintentional? From what I gathered/tested, seems like adding it back resolves the menu issues (tests shown below), but do let me know if I missed some other edge cases in the tests.

### EDIT: Important note

The reported bug and bugged tests shown in this PR will still be present if we do `events: ['pointerdown']` instead of `events: ['click']`.

## Additional tests in other areas of concern 

### Color picker
| Before | After |
| --- | --- |
| ![vbmdCMmsPe](https://user-images.githubusercontent.com/42867097/134454264-dd24010a-66f6-48e2-9d58-4b3da4a5606a.gif) |  ![W9SYU8orxl](https://user-images.githubusercontent.com/42867097/134454385-7b97477d-36fc-42b8-ac5b-04e189297c67.gif) |
| Selecting RGB/HSL breaks it | Works |

### Fields in Data Model page

It is working without any issue **regardless** of whether this click event is present for v-click-outside:

![UcNmVE6cap](https://user-images.githubusercontent.com/42867097/134454234-5d01e1b5-a61a-4663-a948-ddd07d34a17d.gif)

