### PR TITLE
Tests for pluralize, toArray, validateExtensionManifest, and parseFilter

### DIFF
--- a/packages/shared/src/utils/parse-filter.test.ts
+++ b/packages/shared/src/utils/parse-filter.test.ts
@@ -31,6 +31,29 @@ describe('', () => {
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
 	});
 
+	it('returns the filter includes an _in it parses the filter with a deepMap', () => {
+		const mockFilter = {
+			_and: [
+				{
+					status: {
+						_in: 'published,draft',
+					},
+				},
+			],
+		} as Filter;
+		const mockResult = {
+			_and: [
+				{
+					status: {
+						_in: ['published', 'draft'],
+					},
+				},
+			],
+		} as Filter;
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
 	it('returns the date', () => {
 		const mockFilter = {
 			_and: [

--- a/packages/shared/src/utils/parse-filter.test.ts
+++ b/packages/shared/src/utils/parse-filter.test.ts
@@ -1,0 +1,171 @@
+import { parseFilter } from '.';
+import { Filter } from '../types/filter';
+
+describe('', () => {
+	it('returns the filter when passed accountability with only a role', () => {
+		const mockFilter = { _and: [{ field: 'field' }] } as Filter;
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockFilter);
+	});
+
+	it('returns the filter includes an _in it parses the filter with a deepMap', () => {
+		const mockFilter = {
+			_and: [
+				{
+					status: {
+						_in: 'published',
+					},
+				},
+			],
+		} as Filter;
+		const mockResult = {
+			_and: [
+				{
+					status: {
+						_in: ['published'],
+					},
+				},
+			],
+		} as Filter;
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('returns the date', () => {
+		const mockFilter = {
+			_and: [
+				{
+					date: {
+						_eq: '$NOW',
+					},
+				},
+			],
+		} as Filter;
+		const mockResult = {
+			_and: [
+				{
+					date: {
+						_eq: new Date(),
+					},
+				},
+			],
+		} as Filter;
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('returns the filter includes an _in it parses the filter with a deepMap', () => {
+		const mockFilter = {
+			_and: [
+				{
+					status: {
+						_in: ['published', 'draft'],
+					},
+				},
+			],
+		} as Filter;
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockFilter);
+	});
+
+	it('does proper type casting', () => {
+		const mockFilter = {
+			_and: [
+				{
+					status: {
+						_eq: 'true',
+					},
+					field: {
+						_eq: 'false',
+					},
+					field2: {
+						_eq: 'null',
+					},
+				},
+			],
+		} as Filter;
+
+		const mockResult = {
+			_and: [
+				{
+					status: {
+						_eq: true,
+					},
+					field: {
+						_eq: false,
+					},
+					field2: {
+						_eq: null,
+					},
+				},
+			],
+		};
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('replaces the user from accountability to $CURRENT_USER', () => {
+		const mockFilter = {
+			_and: [
+				{
+					owner: {
+						_eq: '$CURRENT_USER',
+					},
+				},
+			],
+		} as Filter;
+		const mockResult = {
+			_and: [
+				{
+					owner: {
+						_eq: 'user',
+					},
+				},
+			],
+		} as Filter;
+		const mockAccountability = { role: 'admin', user: 'user' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('replaces the role from accountability to $CURRENT_ROLE', () => {
+		const mockFilter = {
+			_and: [
+				{
+					owner: {
+						_eq: '$CURRENT_ROLE',
+					},
+				},
+			],
+		} as Filter;
+		const mockResult = {
+			_and: [
+				{
+					owner: {
+						_eq: 'admin',
+					},
+				},
+			],
+		} as Filter;
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('adjusts the date by 1 day', () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date(1632431505992));
+
+		const mockFilter = {
+			date: {
+				_eq: '$NOW(-1 day)',
+			},
+		} as Filter;
+		const mockResult = {
+			date: {
+				_eq: new Date('2021-09-22T21:11:45.992Z'),
+			},
+		} as Filter;
+		const mockAccountability = { role: 'admin', user: 'user' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+});

--- a/packages/shared/src/utils/pluralize.test.ts
+++ b/packages/shared/src/utils/pluralize.test.ts
@@ -1,0 +1,11 @@
+import { pluralize, depluralize } from '.';
+
+describe('pluralize', () => {
+	it('adds an s to the end of the string', () => {
+		expect(pluralize('test')).toBe('tests');
+	});
+
+	it('removes an s to the end of the string', () => {
+		expect(depluralize('tests')).toBe('test');
+	});
+});

--- a/packages/shared/src/utils/to-array.test.ts
+++ b/packages/shared/src/utils/to-array.test.ts
@@ -1,0 +1,11 @@
+import { toArray } from '.';
+
+describe('toArray', () => {
+	it('takes in a string and returns an array', () => {
+		expect(toArray('1,2,3,4,5')).toStrictEqual(['1', '2', '3', '4', '5']);
+	});
+
+	it('when passed an array returns the array', () => {
+		expect(toArray(['1', '2', '3', '4', '5'])).toStrictEqual(['1', '2', '3', '4', '5']);
+	});
+});

--- a/packages/shared/src/utils/validate-extension-manifest.test.ts
+++ b/packages/shared/src/utils/validate-extension-manifest.test.ts
@@ -1,0 +1,35 @@
+import { validateExtensionManifest } from '.';
+
+describe('', () => {
+	it('returns false when passed item with is no name or version', () => {
+		expect(validateExtensionManifest({})).toBe(false);
+	});
+
+	it('returns false when passed item with is no EXTENSION_PKG_KEY', () => {
+		const mockExtension = { name: 'test', version: '0.1' };
+		expect(validateExtensionManifest(mockExtension)).toBe(false);
+	});
+
+	it('returns false when passed item with is no type, path, source, host, or hidden', () => {
+		const mockExtension = { name: 'test', version: '0.1', 'directus:extension': {} };
+		expect(validateExtensionManifest(mockExtension)).toBe(false);
+	});
+
+	it('returns false when passed item has an invalid type', () => {
+		const mockExtension = {
+			name: 'test',
+			version: '0.1',
+			'directus:extension': { type: 'not_extension_type', path: './', source: 'test', host: 'localhost', hidden: true },
+		};
+		expect(validateExtensionManifest(mockExtension)).toBe(false);
+	});
+
+	it('returns true when passed an valid ExtensionManifestRaw', () => {
+		const mockExtension = {
+			name: 'test',
+			version: '0.1',
+			'directus:extension': { type: 'pack', path: './', source: 'test', host: 'localhost', hidden: true },
+		};
+		expect(validateExtensionManifest(mockExtension)).toBe(true);
+	});
+});


### PR DESCRIPTION
- Pluralize, passing 100% coverage
- toArray, passing 100% coverage
- validateExtensionManifest, passing 100% coverage
- parseFilter, passing 100% coverage