### PR TITLE
Fix sorting for alias fields

### DIFF
--- a/app/src/composables/use-form-fields/use-form-fields.ts
+++ b/app/src/composables/use-form-fields/use-form-fields.ts
@@ -56,7 +56,7 @@ export default function useFormFields(fields: Ref<Field[]>): { formFields: Compu
 			return systemFake === false;
 		});
 
-		formFields = orderBy(formFields, 'meta.sort');
+		formFields = orderBy(formFields, ['meta.sort', 'meta.id']);
 
 		formFields = translate(formFields);
 


### PR DESCRIPTION
fixes #8216 

## Reported Bug

Dividers are being pushed to the end of the form, despite it being in the middle of the data model in this case:
| Data Model Order | Form Order |
| --- | --- |
| ![chrome_rSFM04YvIG](https://user-images.githubusercontent.com/42867097/134622547-a26b89a3-8a1b-4f86-96b7-4b5b75764561.png) | ![chrome_GVeGOB0L2o](https://user-images.githubusercontent.com/42867097/134622560-b2dde1c9-b5be-4b62-98aa-72e4f6fb5dcc.png) |

If we look at their initial sort, it's `NULL` as intended.

![chrome_nXbYb0SVqL](https://user-images.githubusercontent.com/42867097/134623092-c3e78ed3-38a0-4479-af53-fd4b73a00dda.png)

## Investigation

Turns out it's not just dividers, but alias fields in general are pushed to the end. When we check the fields retrieved from the API, the ordering already puts them at the bottom of a particular collection:

![chrome_cVzVeyVU0M](https://user-images.githubusercontent.com/42867097/134622628-38399f05-24ba-4a64-a015-ba17657aa52d.png)

This is due to the fields array concatenation  putting alias fields at the end here:

https://github.com/directus/directus/blob/bcb0ddc44b6bee2288f30f01f2467b8c9ce949dc/api/src/services/fields.ts#L138-L140

One of the workaround was to manually move down and move back up the divider, but that only works because it sets the sort value:

![chrome_piqdYNxtn8](https://user-images.githubusercontent.com/42867097/134623258-1b67df7f-1a09-43cf-a81d-1a0f68fd5d68.png)

However new ones will still have NULL sort value, hence it'll be messed up again (added `divider_2` and `field_3`):

| Data Model Order | Form Order |
| --- | --- |
| ![chrome_9nE7pVhF3L](https://user-images.githubusercontent.com/42867097/134623405-a989911c-7b29-4e6e-9774-2f9eedd4f204.png) | ![chrome_vmkV77I9Om](https://user-images.githubusercontent.com/42867097/134623414-9f9d03f8-1b93-4b64-b4ba-4d4d184906e9.png) |

## Solution

Previously fields are ordered by the `sort` field only. Now we order them by `sort` first, then `id` for the ones that doesn't have sort defined as `id` dictates the "order" of creation. 

![chrome_KE3Zevdmf5](https://user-images.githubusercontent.com/42867097/134623449-51475f54-43f6-4e82-a340-1ca45fd058a4.png)

Not sure if there's any edge cases that can still break this, unless somehow the `id` aren't really in order. 


