### PR TITLE
Vertically center content of v-button

### DIFF
--- a/app/src/components/v-button/v-button.vue
+++ b/app/src/components/v-button/v-button.vue
@@ -271,6 +271,7 @@ export default defineComponent({
 
 .v-button {
 	display: inline-flex;
+	align-items: center;
 }
 
 .v-button.full-width {


### PR DESCRIPTION
Has been removed in 19f87222dc39858f55ecc8428dd78d90ed606691. Was this intentional?

### Before
![Screenshot 2021-09-24 at 18-31-15 Creating Item in Test](https://user-images.githubusercontent.com/5363448/134709845-e581bc2c-4418-414b-ad01-f7ccf24f970b.png)

### After
![Screenshot 2021-09-24 at 18-31-37 Creating Item in Test](https://user-images.githubusercontent.com/5363448/134709853-0bf0ce86-af66-4ed9-8149-b5af6d3f1ca4.png)

