### PR TITLE
Fix multiple issues in Data Model view

### DIFF
--- a/api/src/database/system-data/fields/collections.yaml
+++ b/api/src/database/system-data/fields/collections.yaml
@@ -21,7 +21,7 @@ fields:
   - field: note
     interface: input
     options:
-      placeholder: A description of this collection...
+      placeholder: $t:field_options.directus_collections.note_placeholder
     width: half
 
   - field: icon

--- a/api/src/database/system-data/fields/collections.yaml
+++ b/api/src/database/system-data/fields/collections.yaml
@@ -52,7 +52,7 @@ fields:
     special: boolean
     interface: boolean
     options:
-      label: Treat as single object
+      label: $t:singleton_label
     width: half
 
   - field: translations

--- a/api/src/database/system-data/fields/collections.yaml
+++ b/api/src/database/system-data/fields/collections.yaml
@@ -32,7 +32,7 @@ fields:
   - field: color
     interface: select-color
     options:
-      placeholder: $t:field_options.directus_collections.note_placeholder
+      placeholder: $t:interfaces.select-color.placeholder
     width: half
 
   - field: display_template

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -281,7 +281,7 @@ export default defineComponent({
 
 						if (!field) return '';
 
-						return `<button contenteditable="false" data-field="${fieldKey}">${field.name}</button>`;
+						return `<button contenteditable="false" data-field="${fieldKey}" disabled="${props.disabled}">${field.name}</button>`;
 					})
 					.join('');
 				contentEl.value.innerHTML = newInnerHTML;
@@ -323,7 +323,7 @@ export default defineComponent({
 	user-select: none;
 }
 
-:deep(button:hover) {
+:deep(button:not(:disabled):hover) {
 	color: var(--white);
 	background-color: var(--danger);
 }

--- a/app/src/lang/translations/ar-SA.yaml
+++ b/app/src/lang/translations/ar-SA.yaml
@@ -672,6 +672,7 @@ fields:
     collection: المجموعة
     icon: أيقونة
     note: ملحوظة
+    color: لون
     display_template: عرض القالب
     hidden: مخفي
     translations: ترجمات تسمية المجموعات

--- a/app/src/lang/translations/bg-BG.yaml
+++ b/app/src/lang/translations/bg-BG.yaml
@@ -769,6 +769,7 @@ fields:
     collection: Колекция
     icon: Икона
     note: Бележка
+    color: Цвят
     display_template: Шаблон при показване
     hidden: Скриване
     singleton: Сек
@@ -894,7 +895,7 @@ field_options:
     auth_password_policy:
       none_text: Без - не се препоръчва
       weak_text: Слаба - минимум от 8 символа
-      strong_text: Силна - главни, малки, числа и специални символи 
+      strong_text: Силна - главни, малки, числа и специални символи
     storage_asset_presets:
       fit:
         contain_text: Напасване (запазване на съотношението)

--- a/app/src/lang/translations/ca-ES.yaml
+++ b/app/src/lang/translations/ca-ES.yaml
@@ -598,7 +598,7 @@ wysiwyg_options:
   superscript: Superíndex
   codeblock: Codi
   blockquote: Bloc de cita
-  bullist: Llista amb vinyetes 
+  bullist: Llista amb vinyetes
   numlist: Llista ordenada
   hr: Regle horitzontal
   link: Afegeix / Edita l'enllaç
@@ -720,6 +720,7 @@ fields:
     collection: Coŀlecció
     icon: Icona
     note: Nota
+    color: Color
     display_template: Mostra la plantilla
     hidden: Amagat
     singleton: Singleton

--- a/app/src/lang/translations/cs-CZ.yaml
+++ b/app/src/lang/translations/cs-CZ.yaml
@@ -314,6 +314,7 @@ fields:
     collection: Kategorie
     icon: Ikona
     note: Poznámka
+    color: Barva
     hidden: Skryté
   directus_files:
     title: Název

--- a/app/src/lang/translations/da-DK.yaml
+++ b/app/src/lang/translations/da-DK.yaml
@@ -289,6 +289,7 @@ fields:
     collection: Samling
     icon: Ikon
     note: Kommentar
+    color: Farve
     hidden: Skjult
   directus_files:
     title: Titel

--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -834,6 +834,7 @@ fields:
     collection: Sammlung
     icon: Symbol
     note: Notiz
+    color: Farbe
     display_template: Anzeigevorlage
     hidden: Ausgeblendet
     singleton: Einzelnes Element

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -847,6 +847,7 @@ fields:
     collection: Collection
     icon: Icon
     note: Note
+    color: Color
     display_template: Display Template
     hidden: Hidden
     singleton: Singleton

--- a/app/src/lang/translations/es-419.yaml
+++ b/app/src/lang/translations/es-419.yaml
@@ -703,6 +703,7 @@ fields:
     collection: Colección
     icon: Ícono
     note: Nota
+    color: Color
     display_template: Plantilla de Presentación
     hidden: Oculto
     singleton: Singleton

--- a/app/src/lang/translations/es-CL.yaml
+++ b/app/src/lang/translations/es-CL.yaml
@@ -703,6 +703,7 @@ fields:
     collection: Colección
     icon: Icono
     note: Nota
+    color: Color
     display_template: Plantilla de Presentación
     hidden: Oculto
     singleton: Singleton

--- a/app/src/lang/translations/es-ES.yaml
+++ b/app/src/lang/translations/es-ES.yaml
@@ -702,6 +702,7 @@ fields:
     collection: Colección
     icon: Ícono
     note: Nota
+    color: Color
     display_template: Plantilla de Presentación
     hidden: Oculto
     singleton: Singleton

--- a/app/src/lang/translations/et-EE.yaml
+++ b/app/src/lang/translations/et-EE.yaml
@@ -640,7 +640,7 @@ page_help_docs_global: >-
 page_help_files_collection: >-
   **Failikogu* - Näitab kõiki faile ja pilte selles projektis. Muuta saab vaateid, filtreid jm ning lisada järjehoidjaid
 page_help_files_item: >-
-  **Faili detailid* - Vorm, milles saab muuta faili metaandmeid, ligipääse jm 
+  **Faili detailid* - Vorm, milles saab muuta faili metaandmeid, ligipääse jm
 page_help_settings_project: "**Projekti seaded** - Sinu projekti üldised seaded"
 page_help_settings_datamodel_collections: >-
   **Andmekogud** - Näitab kõiki andmekogusid (sh süsteemseid)
@@ -686,6 +686,7 @@ fields:
     collection: Kogud
     icon: Ikoon
     note: Märkus
+    color: Värv
     display_template: Vaate mall
     hidden: Peidetud
     singleton: Üksik

--- a/app/src/lang/translations/fi-FI.yaml
+++ b/app/src/lang/translations/fi-FI.yaml
@@ -683,6 +683,7 @@ fields:
     collection: Kokoelma
     icon: Kuvake
     note: Muistiinpano
+    color: Väri
     display_template: Esitysmalli
     hidden: Piilotettu
     singleton: Singleton

--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -764,6 +764,7 @@ fields:
     collection: Collection
     icon: Icône
     note: Remarque
+    color: Couleur
     display_template: Modèle d'affichage
     hidden: Caché
     singleton: Singleton

--- a/app/src/lang/translations/hu-HU.yaml
+++ b/app/src/lang/translations/hu-HU.yaml
@@ -740,6 +740,7 @@ fields:
     collection: Gyűjtemény
     icon: Ikon
     note: Jegyzet
+    color: Szín
     display_template: Megjelenítési sablon
     hidden: Rejtett
     singleton: Egyedüli

--- a/app/src/lang/translations/id-ID.yaml
+++ b/app/src/lang/translations/id-ID.yaml
@@ -489,6 +489,7 @@ fields:
     collection: Koleksi
     icon: Ikon
     note: Catatan
+    color: Warna
     display_template: Tampilan Template
     hidden: Tersembunyi
     sort_field: Sortir Baris

--- a/app/src/lang/translations/it-IT.yaml
+++ b/app/src/lang/translations/it-IT.yaml
@@ -834,6 +834,7 @@ fields:
     collection: Raccolta
     icon: Icona
     note: Nota
+    color: Colore
     display_template: Display Template
     hidden: Nascosto
     singleton: Singleton

--- a/app/src/lang/translations/ja-JP.yaml
+++ b/app/src/lang/translations/ja-JP.yaml
@@ -312,6 +312,7 @@ fields:
   directus_collections:
     icon: アイコン
     note: 備考
+    color: 色
     hidden: 非表示
     singleton: シングルトン
     sort_field: フィールドの並べ替え

--- a/app/src/lang/translations/lt-LT.yaml
+++ b/app/src/lang/translations/lt-LT.yaml
@@ -639,6 +639,7 @@ fields:
     collection: Rinkinys
     icon: Ikona
     note: Pastaba
+    color: Spalva
     display_template: Rodymo šablonas
     hidden: Paslėptas
     singleton: Singleton objektas

--- a/app/src/lang/translations/ms-MY.yaml
+++ b/app/src/lang/translations/ms-MY.yaml
@@ -97,6 +97,7 @@ fields:
   directus_collections:
     collection: Koleksi
     note: Nota
+    color: Warna
   directus_files:
     title: Tajuk
     description: Penerangan

--- a/app/src/lang/translations/nl-NL.yaml
+++ b/app/src/lang/translations/nl-NL.yaml
@@ -703,6 +703,7 @@ fields:
     collection: Collectie
     icon: Icoon
     note: Notitie
+    color: Kleur
     display_template: Weergavesjabloon
     hidden: Verborgen
     singleton: Singleton

--- a/app/src/lang/translations/pl-PL.yaml
+++ b/app/src/lang/translations/pl-PL.yaml
@@ -708,6 +708,7 @@ fields:
     collection: Kolekcja
     icon: Ikona
     note: Notatka
+    color: Kolor
     display_template: Wyświetl szablon
     hidden: Ukryte
     singleton: Singleton

--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -721,6 +721,7 @@ fields:
     collection: Coleção
     icon: Ícone
     note: Nota
+    color: Cor
     display_template: Modelo de exibição
     hidden: Oculto
     singleton: Singleton
@@ -826,7 +827,7 @@ fields:
     collection_list: Navegação da Coleção
   directus_webhooks:
     name: Nome
-    method: Método 
+    method: Método
     status: Status
     data: Dados
     data_label: Enviar Dados do Evento

--- a/app/src/lang/translations/pt-PT.yaml
+++ b/app/src/lang/translations/pt-PT.yaml
@@ -558,6 +558,7 @@ fields:
   directus_collections:
     collection: Coleção
     note: Nota
+    color: Cor
     display_template: Templates de Exibição
     sort_field: Campo de ordenação
   directus_files:

--- a/app/src/lang/translations/ru-RU.yaml
+++ b/app/src/lang/translations/ru-RU.yaml
@@ -768,6 +768,7 @@ fields:
     collection: Коллекция
     icon: Иконка
     note: Заметка
+    color: Цвет
     display_template: Шаблон отображения
     hidden: Скрыто
     singleton: Синглтон

--- a/app/src/lang/translations/sl-SI.yaml
+++ b/app/src/lang/translations/sl-SI.yaml
@@ -722,6 +722,7 @@ fields:
     collection: Zbirka
     icon: Ikona
     note: Opomba
+    color: Barva
     display_template: Prikaži predlogo
     hidden: Skrito
     singleton: En zapis

--- a/app/src/lang/translations/sr-CS.yaml
+++ b/app/src/lang/translations/sr-CS.yaml
@@ -685,6 +685,7 @@ fields:
     collection: Kolekcija
     icon: Ikonica
     note: Napomena
+    color: Boja
     display_template: Šablon za Prikaz
     hidden: Sakriveno
     singleton: Singleton

--- a/app/src/lang/translations/sv-SE.yaml
+++ b/app/src/lang/translations/sv-SE.yaml
@@ -664,6 +664,7 @@ fields:
     collection: Kollektion
     icon: Ikon
     note: Anteckning
+    color: Färg
     display_template: Visningsmall
     hidden: Dold
     singleton: Singleton

--- a/app/src/lang/translations/th-TH.yaml
+++ b/app/src/lang/translations/th-TH.yaml
@@ -744,6 +744,7 @@ fields:
     collection: คอลเลกชัน
     icon: ไอคอน
     note: หมายเหตุ
+    color: สี
     display_template: แม่แบบการแสดงผล
     hidden: ซ่อน
     singleton: Singleton

--- a/app/src/lang/translations/tr-TR.yaml
+++ b/app/src/lang/translations/tr-TR.yaml
@@ -550,6 +550,7 @@ fields:
     collection: Koleksiyon
     icon: İkon
     note: Not
+    color: Renk
     display_template: Görüntüleme Şablonu
     hidden: Gizli
     sort_field: Sıralama Alanı

--- a/app/src/lang/translations/uk-UA.yaml
+++ b/app/src/lang/translations/uk-UA.yaml
@@ -235,6 +235,7 @@ fields:
     collection: Колекція
     icon: Іконка
     note: Примітка
+    color: Колір
     hidden: Приховано
   directus_files:
     title: Заголовок

--- a/app/src/lang/translations/vi-VN.yaml
+++ b/app/src/lang/translations/vi-VN.yaml
@@ -490,6 +490,7 @@ fields:
     collection: Danh mục
     icon: Biểu tượng
     note: Ghi chú
+    color: Màu sắc
     display_template: Mẫu hiển thị
     hidden: Ẩn
     sort_field: Sắp xếp theo trường

--- a/app/src/lang/translations/zh-CN.yaml
+++ b/app/src/lang/translations/zh-CN.yaml
@@ -766,6 +766,7 @@ fields:
     collection: 收藏
     icon: 图标
     note: 注释
+    color: 颜色
     display_template: 显示模板
     hidden: 隐藏
     singleton: 单一

--- a/app/src/lang/translations/zh-TW.yaml
+++ b/app/src/lang/translations/zh-TW.yaml
@@ -456,6 +456,7 @@ fields:
     collection: 集合
     icon: 圖示
     note: 備註
+    color: 顏色
     display_template: 顯示模板
     hidden: 隱藏
     sort_field: 排序欄位


### PR DESCRIPTION
fixes #8314

## Reported Bugs & Solutions

There are a few issues in the data model edit view (admin/settings/data-model/<collection>) under "Collection Setup":

- [x] 1. Only for system collections: Labels in the display template field can be removed by clicking on them while it's not possible to add them anymore since the field is actually read-only.
  - Solution: Prevent labels from being clickable when disabled and prevent :hover CSS triggering for disabled labels.
- [ ] 2. Only for system collections: Value of "Note" field is not translated
- [x] 3. Wrong placeholder in "Color" field (same as in "Note" field)
  - Solution: Fix placeholder, but also added translations for the field name.
- [x] 4. Value "Treat as single object" is not translated (when switching to another language)
  - Solution: Use translation key `$t:singleton_label`.

Additional fixes:

- change collections note placeholder to `$t:field_options.directus_collections.note_placeholder`.

## Pending

Issue no.2 above might be fixed by #8104