### PR TITLE
prevent ambiguous role selection in middleware

### DIFF
--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -39,7 +39,7 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 		}
 
 		const user = await database
-			.select('role', 'directus_roles.admin_access', 'directus_roles.app_access')
+			.select('directus_users.role', 'directus_roles.admin_access', 'directus_roles.app_access')
 			.from('directus_users')
 			.leftJoin('directus_roles', 'directus_users.role', 'directus_roles.id')
 			.where({


### PR DESCRIPTION
fixes #8289

## Bug

The app stops working when there's an additional `role` column created in `directus_roles` table.

## Investigation

The authenticate middleware for API fails, hence the app will stop working from the get go. The error message shown in the logs:

```shell
error select "role", "directus_roles"."admin_access", "directus_roles"."app_access" from "directus_users" left join "directus_roles" on "directus_users"."role" = "directus_roles"."id" where "directus_users"."id" = $1 and "status" = $2 limit $3 - column reference "role" is ambiguous
```

This stems from:

https://github.com/directus/directus/blob/437e52a47ce91d90c974f8d9544268cb5f060406/api/src/middleware/authenticate.ts#L41-L44

Notice how line 42 just selects `role`, but there's 2 possibilities now which are `directus_users.role` and `directus_roles.role`, hence the "ambiguous" error. Ensuring we select `directus_users.role` (same like line 44) will prevent such error.



