### PR TITLE
Debounce app idle tracker autorefresh token

### DIFF
--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -2,6 +2,7 @@ import api from '@/api';
 import { dehydrate, hydrate } from '@/hydrate';
 import { router } from '@/router';
 import { useAppStore } from '@/stores';
+import { debounce } from 'lodash';
 import { RouteLocationRaw } from 'vue-router';
 import { idleTracker } from './idle';
 
@@ -52,19 +53,25 @@ idleTracker.on('hide', () => {
 });
 
 // Restart the autorefresh process when the app is used (again)
-idleTracker.on('active', () => {
-	if (idle === true) {
-		refresh();
-		idle = false;
-	}
-});
+idleTracker.on(
+	'active',
+	debounce(() => {
+		if (idle === true) {
+			refresh();
+			idle = false;
+		}
+	}, 500)
+);
 
-idleTracker.on('show', () => {
-	if (idle === true) {
-		refresh();
-		idle = false;
-	}
-});
+idleTracker.on(
+	'show',
+	debounce(() => {
+		if (idle === true) {
+			refresh();
+			idle = false;
+		}
+	}, 500)
+);
 
 export async function refresh({ navigate }: LogoutOptions = { navigate: true }): Promise<string | undefined> {
 	const appStore = useAppStore();

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -60,7 +60,7 @@ idleTracker.on(
 			refresh();
 			idle = false;
 		}
-	}, 500)
+	}, 1000)
 );
 
 idleTracker.on(
@@ -70,7 +70,7 @@ idleTracker.on(
 			refresh();
 			idle = false;
 		}
-	}, 500)
+	}, 1000)
 );
 
 export async function refresh({ navigate }: LogoutOptions = { navigate: true }): Promise<string | undefined> {


### PR DESCRIPTION
fixes #8302

## Reported bug

Sometimes users will get abruptly logged out when they are switching tabs. This scenario is seemingly more prominent when they switched tabs **during** something in progress.

Here's a reproduction of what was described:

  https://user-images.githubusercontent.com/42867097/134881279-5f256c07-902e-4417-acf4-e93cdf0c8c27.mp4

## Investigation

I found out just doing quick successions of switching tabs (CTRL-Tab) can also induce this effect easier, and we can see a manual refresh afterwards makes it work again as usual:    

  https://user-images.githubusercontent.com/42867097/134881031-3211dfc6-1a62-45ae-a567-53e846dee218.mp4

As the network tab showed, the refresh endpoint is returning error.

These idle trackers were responsible for triggering the token refresh on tab switches:

https://github.com/directus/directus/blob/437e52a47ce91d90c974f8d9544268cb5f060406/app/src/auth.ts#L54-L67

Here is where the 401 error is returned by API (The record ended up being empty, but the refreshToken still exists/passed during this API call):
  https://github.com/directus/directus/blob/437e52a47ce91d90c974f8d9544268cb5f060406/api/src/services/authentication.ts#L250-L252

which in turn causes the App refresh to fail, and trigger logout in the catch block:

https://github.com/directus/directus/blob/437e52a47ce91d90c974f8d9544268cb5f060406/app/src/auth.ts#L69-L98

This is because the failed refresh call was triggered too soon, before the previous refresh call can respond to set the **new** refresh token cookie. Since the follow up refresh call was still technically using the old refresh token, hence the above `record` returns null.

This concern was also mentioned at the end when the idle tracker was added back in #7177.

## Solution

Added a debounce to the idle + refresh event so that it won't be triggered too often too fast. 

## After fix

https://user-images.githubusercontent.com/42867097/134889785-74fadb08-3040-489c-b296-3ea2f1111f58.mp4


