### PR TITLE
Fix panel not assigned on insights

### DIFF
--- a/app/src/modules/insights/routes/dashboard.vue
+++ b/app/src/modules/insights/routes/dashboard.vue
@@ -88,7 +88,7 @@
 		<router-view
 			name="detail"
 			:dashboard-key="primaryKey"
-			:panel="panels.find((panel) => panel.id === panelKey)"
+			:panel="panelKey ? panels.find((panel) => panel.id === panelKey) : null"
 			@save="stageConfiguration"
 			@cancel="$router.push(`/insights/${primaryKey}`)"
 		/>


### PR DESCRIPTION
Fixes #8252 

I presume the problem is the template couldn't detect when panelKey was changed.
Still I can't explain why this does not happen in dev, but my guess is the fact dev is running in Runtime mode while Production is running via Compiled mode