### PR TITLE
Use field key instead of ID for group value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ app/public/img/docs/*
 *.tsbuildinfo
 .e2e-containers.json
 coverage
+schema.yaml
+schema.json

--- a/api/src/database/migrations/20210927A-replace-fields-group.ts
+++ b/api/src/database/migrations/20210927A-replace-fields-group.ts
@@ -1,0 +1,63 @@
+import { Knex } from 'knex';
+import { uniq } from 'lodash';
+
+export async function up(knex: Knex): Promise<void> {
+	const groupsInUse = await knex.select('id', 'group').from('directus_fields').whereNotNull('group');
+
+	if (groupsInUse.length === 0) return;
+
+	const groupIDs: number[] = uniq(groupsInUse.map(({ group }) => group));
+
+	const groupFields = await knex.select('id', 'field').from('directus_fields').whereIn('id', groupIDs);
+
+	const groupMap = new Map();
+
+	for (const { id, field } of groupFields) {
+		groupMap.set(id, field);
+	}
+
+	await knex.schema.alterTable('directus_fields', (table) => {
+		table.dropColumn('group');
+	});
+
+	await knex.schema.alterTable('directus_fields', (table) => {
+		table.string('group', 64);
+	});
+
+	for (const { id, group } of groupsInUse) {
+		await knex('directus_fields')
+			.update({ group: groupMap.get(group) })
+			.where({ id });
+	}
+}
+
+export async function down(knex: Knex): Promise<void> {
+	const fieldsThatUseAGroup = await knex
+		.select('id', 'collection', 'group')
+		.from('directus_fields')
+		.whereNotNull('group');
+
+	if (fieldsThatUseAGroup.length === 0) return;
+
+	const groupMap = new Map();
+
+	for (const { collection, group } of fieldsThatUseAGroup) {
+		const { id } = await knex.select('id').from('directus_fields').where({ collection, field: group }).first();
+
+		groupMap.set(group, id);
+	}
+
+	await knex.schema.alterTable('directus_fields', (table) => {
+		table.dropColumn('group');
+	});
+
+	await knex.schema.alterTable('directus_fields', (table) => {
+		table.integer('group').references('id').inTable('directus_fields');
+	});
+
+	for (const { id, group } of fieldsThatUseAGroup) {
+		await knex('directus_fields')
+			.update({ group: groupMap.get(group) })
+			.where({ id });
+	}
+}

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -123,7 +123,7 @@ export default defineComponent({
 			default: false,
 		},
 		group: {
-			type: Number,
+			type: String,
 			default: null,
 		},
 		badge: {
@@ -280,7 +280,7 @@ export default defineComponent({
 
 			const { formFields } = useFormFields(fieldsInGroup);
 
-			const fieldsForGroup = computed(() => formFields.value.map((field) => getFieldsForGroup(field.meta!.id)));
+			const fieldsForGroup = computed(() => formFields.value.map((field) => getFieldsForGroup(field.meta!.field)));
 
 			return { formFields, isDisabled, getFieldsForGroup, fieldsForGroup };
 
@@ -294,14 +294,14 @@ export default defineComponent({
 				);
 			}
 
-			function getFieldsForGroup(group: null | number): Field[] {
+			function getFieldsForGroup(group: null | string): Field[] {
 				const fieldsInGroup: Field[] = fieldsParsed.value.filter(
 					(field) => field.meta?.group === group || (group === null && isNil(field.meta))
 				);
 
 				for (const field of fieldsInGroup) {
 					if (field.meta?.special?.includes('group')) {
-						fieldsInGroup.push(...getFieldsForGroup(field.meta!.id));
+						fieldsInGroup.push(...getFieldsForGroup(field.meta!.field));
 					}
 				}
 

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 			default: () => [],
 		},
 		group: {
-			type: Number,
+			type: String,
 			required: true,
 		},
 

--- a/app/src/interfaces/group-accordion/group-accordion.vue
+++ b/app/src/interfaces/group-accordion/group-accordion.vue
@@ -13,7 +13,7 @@
 			:primary-key="primaryKey"
 			:loading="loading"
 			:validation-errors="validationErrors"
-			:group="field.meta.id"
+			:group="field.meta.field"
 			:multiple="accordionMode === false"
 			@apply="$emit('apply', $event)"
 			@toggleAll="toggleAll"

--- a/app/src/interfaces/group-accordion/group-accordion.vue
+++ b/app/src/interfaces/group-accordion/group-accordion.vue
@@ -85,7 +85,7 @@ export default defineComponent({
 	emits: ['apply'],
 	setup(props) {
 		const rootFields = computed(() => {
-			return props.fields.filter((field) => field.meta?.group === props.field.meta?.id);
+			return props.fields.filter((field) => field.meta?.group === props.field.meta?.field);
 		});
 
 		const selection = ref<string[]>([]);

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -47,7 +47,7 @@ import { useI18n } from 'vue-i18n';
 import formatTitle from '@directus/format-title';
 
 export default defineComponent({
-	name: 'InterfaceGroupRaw',
+	name: 'InterfaceGroupDetail',
 	props: {
 		field: {
 			type: Object as PropType<Field>,

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -30,7 +30,7 @@
 			:fields="fields"
 			:model-value="values"
 			:primary-key="primaryKey"
-			:group="field.meta.id"
+			:group="field.meta.field"
 			:validation-errors="validationErrors"
 			:loading="loading"
 			:batch-mode="batchMode"

--- a/app/src/interfaces/group-raw/group-raw.vue
+++ b/app/src/interfaces/group-raw/group-raw.vue
@@ -5,7 +5,7 @@
 			:fields="fields"
 			:model-value="values"
 			:primary-key="primaryKey"
-			:group="field.meta.id"
+			:group="field.meta.field"
 			:validation-errors="validationErrors"
 			:loading="loading"
 			@update:model-value="$emit('apply', $event)"

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -192,7 +192,7 @@ export default defineComponent({
 
 		const localType = computed(() => getLocalTypeForField(props.field.collection, props.field.field));
 
-		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.meta?.id));
+		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.meta?.field));
 
 		return {
 			t,
@@ -315,7 +315,7 @@ export default defineComponent({
 				field: field.field,
 				meta: {
 					sort: index + 1,
-					group: props.field.meta!.id,
+					group: props.field.meta!.field,
 				},
 			}));
 

--- a/packages/shared/src/types/fields.ts
+++ b/packages/shared/src/types/fields.ts
@@ -22,7 +22,7 @@ export type FieldMeta = {
 	id: number;
 	collection: string;
 	field: string;
-	group: number | null;
+	group: string | null;
 	hidden: boolean;
 	interface: string | null;
 	display: string | null;


### PR DESCRIPTION
Fixes #8113

- Add migration to replace group ID with group name
- Replace group IDs with field names
- Tweak group interfaces
- Ignore schema export
