### PR TITLE
Don't track primary keys of relations/fields

### DIFF
--- a/api/src/cli/commands/schema/snapshot.ts
+++ b/api/src/cli/commands/schema/snapshot.ts
@@ -5,6 +5,7 @@ import { constants as fsConstants, promises as fs } from 'fs';
 import path from 'path';
 import inquirer from 'inquirer';
 import { dump as toYaml } from 'js-yaml';
+import { flushCaches } from '../../../cache';
 
 export async function snapshot(
 	snapshotPath: string,
@@ -34,6 +35,8 @@ export async function snapshot(
 			process.exit(0);
 		}
 	}
+
+	await flushCaches();
 
 	const database = getDatabase();
 

--- a/api/src/types/snapshot.ts
+++ b/api/src/types/snapshot.ts
@@ -1,15 +1,18 @@
 import { Collection } from './collection';
-import { Relation } from './relation';
-import { Field } from '@directus/shared/types';
+import { Relation, RelationMeta } from './relation';
+import { Field, FieldMeta } from '@directus/shared/types';
 import { Diff } from 'deep-diff';
 
 export type Snapshot = {
 	version: number;
 	directus: string;
 	collections: Collection[];
-	fields: Field[];
-	relations: Relation[];
+	fields: SnapshotField[];
+	relations: SnapshotRelation[];
 };
+
+export type SnapshotField = Field & { meta: Omit<FieldMeta, 'id'> };
+export type SnapshotRelation = Relation & { meta: Omit<RelationMeta, 'id'> };
 
 export type SnapshotDiff = {
 	collections: {
@@ -19,12 +22,12 @@ export type SnapshotDiff = {
 	fields: {
 		collection: string;
 		field: string;
-		diff: Diff<Field | undefined>[];
+		diff: Diff<SnapshotField | undefined>[];
 	}[];
 	relations: {
 		collection: string;
 		field: string;
 		related_collection: string | null;
-		diff: Diff<Relation | undefined>[];
+		diff: Diff<SnapshotRelation | undefined>[];
 	}[];
 };

--- a/api/src/utils/get-snapshot.ts
+++ b/api/src/utils/get-snapshot.ts
@@ -2,8 +2,9 @@ import getDatabase from '../database';
 import { getSchema } from './get-schema';
 import { CollectionsService, FieldsService, RelationsService } from '../services';
 import { version } from '../../package.json';
-import { SchemaOverview, Snapshot } from '../types';
+import { SchemaOverview, Snapshot, SnapshotField, SnapshotRelation } from '../types';
 import { Knex } from 'knex';
+import { omit } from 'lodash';
 
 export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOverview }): Promise<Snapshot> {
 	const database = options?.database ?? getDatabase();
@@ -23,12 +24,16 @@ export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOv
 		version: 1,
 		directus: version,
 		collections: collections.filter((item: any) => excludeSystem(item)),
-		fields: fields.filter((item: any) => excludeSystem(item)),
-		relations: relations.filter((item: any) => excludeSystem(item)),
+		fields: fields.filter((item: any) => excludeSystem(item)).map(omitID) as SnapshotField[],
+		relations: relations.filter((item: any) => excludeSystem(item)).map(omitID) as SnapshotRelation[],
 	};
 }
 
 function excludeSystem(item: { meta?: { system?: boolean } }) {
 	if (item?.meta?.system === true) return false;
 	return true;
+}
+
+function omitID(item: Record<string, any>) {
+	return omit(item, 'meta.id');
 }


### PR DESCRIPTION
Fixes #8161

\+ Flush caches before starting snapshot/apply operations, to ensure cached schema info doesn't affect the operations