### PR TITLE
Disable foreign keys on migrate

### DIFF
--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -4,7 +4,7 @@ import getDatabase from '../../../database';
 import logger from '../../../logger';
 
 export default async function start(): Promise<void> {
-	const database = getDatabase();
+	const database = getDatabase({ foreignKeys: false });
 
 	try {
 		await installSeeds(database);

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -13,7 +13,13 @@ import { promisify } from 'util';
 let database: Knex | null = null;
 let inspector: ReturnType<typeof SchemaInspector> | null = null;
 
-export default function getDatabase(): Knex {
+type DatabaseOptions = {
+	foreignKeys: boolean;
+};
+
+export default function getDatabase(databaseOptions?: DatabaseOptions): Knex {
+	const { foreignKeys = true } = databaseOptions || {};
+
 	if (database) {
 		return database;
 	}
@@ -78,7 +84,8 @@ export default function getDatabase(): Knex {
 			logger.trace('Enabling SQLite Foreign Keys support...');
 
 			const run = promisify(conn.run.bind(conn));
-			await run('PRAGMA foreign_keys = ON');
+
+			if (foreignKeys) await run('PRAGMA foreign_keys = ON');
 
 			callback(null, conn);
 		};


### PR DESCRIPTION
While migrating to latest, this error happened with SQLite database:
```
05:16:15 ✨ Initializing bootstrap...
05:16:15 ✨ Database already initialized, skipping install
05:16:15 ✨ Running migrations...
05:16:15 ✨ Applying Add Auth Provider...
[Error: DROP TABLE "directus_users" - SQLITE_CONSTRAINT: FOREIGN KEY constraint failed] {
  errno: 19,
  code: 'SQLITE_CONSTRAINT'
}
```

Since we are using foreign keys and SQLite needs to recreate tables when a column is added, it is expected to throw errors.
To prevent this behaviour, we can disable foreign keys while migrating, but keep them enabled on running the project.