### PR TITLE
Fix marginTop not implemented in presentation divider

### DIFF
--- a/app/src/interfaces/presentation-divider/index.ts
+++ b/app/src/interfaces/presentation-divider/index.ts
@@ -54,7 +54,7 @@ export default defineInterface({
 				},
 			},
 			schema: {
-				default_value: false,
+				default_value: true,
 			},
 		},
 		{

--- a/app/src/interfaces/presentation-divider/presentation-divider.vue
+++ b/app/src/interfaces/presentation-divider/presentation-divider.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-divider
-		:class="{ margin: icon || title }"
+		:class="{ 'add-margin-top': marginTop }"
 		:style="{
 			'--v-divider-label-color': color,
 			'--v-divider-color': 'var(--border-subdued)',
@@ -34,13 +34,21 @@ export default defineComponent({
 			type: Boolean,
 			default: false,
 		},
+		marginTop: {
+			type: Boolean,
+			default: true,
+		},
 	},
 });
 </script>
 
 <style lang="scss" scoped>
-.margin {
-	margin-top: 40px;
+.v-divider {
+	margin-top: 10px;
 	margin-bottom: -10px;
+}
+
+.add-margin-top {
+	margin-top: 40px;
 }
 </style>


### PR DESCRIPTION
Fixes #8374.

Added the use of `marginTop` prop, defaulting it to `true`.

## Before
<img width="521" alt="Screenshot 2021-09-28 at 7 05 53 PM" src="https://user-images.githubusercontent.com/26413686/135075753-d73eb851-897d-4774-9810-2ecc04180ad4.png">

## After
<img width="521" alt="Screenshot 2021-09-28 at 7 05 37 PM" src="https://user-images.githubusercontent.com/26413686/135075786-1ec57924-8a1a-4df5-b580-e4526617e099.png">

## Note
There will still be a gap due to the padding in `v-form`.
<img width="521" alt="Screenshot 2021-09-28 at 7 09 54 PM" src="https://user-images.githubusercontent.com/26413686/135076152-490c444f-09d9-4f61-95e7-fed60e032f28.png">

