### PR TITLE
Remove invalid CSS from presets item view

### DIFF
--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -91,25 +91,27 @@
 					<div v-md="t('page_help_settings_presets_item')" class="page-description" />
 				</sidebar-detail>
 
-				<sidebar-detail icon="search" :title="t('search')">
-					<v-input v-model="searchQuery" :placeholder="t('preset_search_placeholder')"></v-input>
-				</sidebar-detail>
+				<div class="layout-sidebar">
+					<sidebar-detail icon="search" :title="t('search')">
+						<v-input v-model="searchQuery" :placeholder="t('preset_search_placeholder')"></v-input>
+					</sidebar-detail>
 
-				<component
-					:is="`layout-sidebar-${values.layout}`"
-					v-if="values.layout && values.collection"
-					v-bind="layoutState"
-				/>
+					<component
+						:is="`layout-sidebar-${values.layout}`"
+						v-if="values.layout && values.collection"
+						v-bind="layoutState"
+					/>
 
-				<sidebar-detail icon="layers" :title="t('layout_options')">
-					<div class="layout-options">
-						<component
-							:is="`layout-options-${values.layout}`"
-							v-if="values.layout && values.collection"
-							v-bind="layoutState"
-						/>
-					</div>
-				</sidebar-detail>
+					<sidebar-detail icon="layers" :title="t('layout_options')">
+						<div class="layout-options">
+							<component
+								:is="`layout-options-${values.layout}`"
+								v-if="values.layout && values.collection"
+								v-bind="layoutState"
+							/>
+						</div>
+					</sidebar-detail>
+				</div>
 			</template>
 		</private-view>
 	</component>
@@ -528,6 +530,14 @@ export default defineComponent({
 	width: 100%;
 	margin-top: 48px;
 	overflow: auto;
+}
+
+.layout-sidebar {
+	--sidebar-detail-icon-color: var(--warning);
+	--sidebar-detail-color: var(--warning);
+	--sidebar-detail-color-active: var(--warning);
+	--form-vertical-gap: 24px;
+	display: contents;
 }
 
 :deep(.layout-options) {

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -537,6 +537,7 @@ export default defineComponent({
 	--sidebar-detail-color: var(--warning);
 	--sidebar-detail-color-active: var(--warning);
 	--form-vertical-gap: 24px;
+
 	display: contents;
 }
 

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -91,27 +91,25 @@
 					<div v-md="t('page_help_settings_presets_item')" class="page-description" />
 				</sidebar-detail>
 
-				<div class="layout-sidebar">
-					<sidebar-detail icon="search" :title="t('search')">
-						<v-input v-model="searchQuery" :placeholder="t('preset_search_placeholder')"></v-input>
-					</sidebar-detail>
+				<sidebar-detail icon="search" :title="t('search')">
+					<v-input v-model="searchQuery" :placeholder="t('preset_search_placeholder')"></v-input>
+				</sidebar-detail>
 
-					<component
-						:is="`layout-sidebar-${values.layout}`"
-						v-if="values.layout && values.collection"
-						v-bind="layoutState"
-					/>
+				<component
+					:is="`layout-sidebar-${values.layout}`"
+					v-if="values.layout && values.collection"
+					v-bind="layoutState"
+				/>
 
-					<sidebar-detail icon="layers" :title="t('layout_options')">
-						<div class="layout-options">
-							<component
-								:is="`layout-options-${values.layout}`"
-								v-if="values.layout && values.collection"
-								v-bind="layoutState"
-							/>
-						</div>
-					</sidebar-detail>
-				</div>
+				<sidebar-detail icon="layers" :title="t('layout_options')">
+					<div class="layout-options">
+						<component
+							:is="`layout-options-${values.layout}`"
+							v-if="values.layout && values.collection"
+							v-bind="layoutState"
+						/>
+					</div>
+				</sidebar-detail>
 			</template>
 		</private-view>
 	</component>
@@ -530,15 +528,6 @@ export default defineComponent({
 	width: 100%;
 	margin-top: 48px;
 	overflow: auto;
-}
-
-.layout-sidebar {
-	--sidebar-detail-icon-color: var(--primary);
-	--sidebar-detail-color: var(--primary);
-	--sidebar-detail-color-active: var(--primary);
-	--form-vertical-gap: 24px;
-
-	display: contents;
 }
 
 :deep(.layout-options) {


### PR DESCRIPTION
Fixes #8387. The div and class called `layout-sidebar` has been removed.
I suppose it was not removed when sidebars were updated.

## Before
<img width="274" alt="Screenshot 2021-09-28 at 10 00 34 PM" src="https://user-images.githubusercontent.com/26413686/135103018-00063383-15af-44b4-93a9-e9e13a79e91d.png">

## After
<img width="274" alt="Screenshot 2021-09-28 at 10 00 20 PM" src="https://user-images.githubusercontent.com/26413686/135102913-5d6fae6a-de07-42d3-9ec7-82b9b12cb226.png">
