### PR TITLE
Fix sanitize aggregate on parse objects

### DIFF
--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -108,8 +108,8 @@ function sanitizeAggregate(rawAggregate: any): Aggregate {
 		}
 	}
 
-	for (const [operation, fields] of Object.entries(rawAggregate)) {
-		if (typeof fields === 'string') aggregate[operation as keyof Aggregate] = fields.split(',');
+	for (const [operation, fields] of Object.entries(aggregate)) {
+		if (typeof fields === 'string') aggregate[operation as keyof Aggregate] = (fields as string).split(',');
 		else if (Array.isArray(fields)) aggregate[operation as keyof Aggregate] = fields as string[];
 	}
 


### PR DESCRIPTION
I believe this was a typo.
Incredibly, it is working with raw strings x)

(Fixes https://discord.com/channels/725371605378924594/819637968259907628/892426480318029837)