### PR TITLE
Cast checkbox value to boolean

### DIFF
--- a/app/src/components/v-checkbox/v-checkbox.vue
+++ b/app/src/components/v-checkbox/v-checkbox.vue
@@ -81,7 +81,7 @@ export default defineComponent({
 				return props.modelValue.includes(props.value);
 			}
 
-			return props.modelValue === true;
+			return !!props.modelValue === true;
 		});
 
 		const icon = computed<string>(() => {


### PR DESCRIPTION
fixes #8480 

## Reported bug

When the column is defined as TinyInt(1), the checkbox is showing unchecked/off state when the raw value is 1.

## Investigation & Solution

Seems like it's because `1 === true` is evaluated as false, thus the interface shows it as unchecked. 

Not sure if this is enough and/or introduces regressions 🤔