### PR TITLE
Use ActivityService/RevisionsService to save accountability records

### DIFF
--- a/api/src/database/system-data/collections/collections.yaml
+++ b/api/src/database/system-data/collections/collections.yaml
@@ -13,6 +13,7 @@ defaults:
 data:
   - collection: directus_activity
     note: $t:directus_collection.directus_activity
+    accountability: null
   - collection: directus_collections
     icon: list_alt
     note: $t:directus_collection.directus_collections
@@ -40,6 +41,7 @@ data:
     note: $t:directus_collection.directus_relations
   - collection: directus_revisions
     note: $t:directus_collection.directus_revisions
+    accountability: null
   - collection: directus_roles
     icon: supervised_user_circle
     note: $t:directus_collection.directus_roles

--- a/api/src/services/activity.ts
+++ b/api/src/services/activity.ts
@@ -1,5 +1,5 @@
 import { AbstractServiceOptions } from '../types';
-import { ItemsService } from './items';
+import { ItemsService } from './internal';
 
 /**
  * @TODO only return activity of the collections you have access to

--- a/api/src/services/activity.ts
+++ b/api/src/services/activity.ts
@@ -1,5 +1,5 @@
 import { AbstractServiceOptions } from '../types';
-import { ItemsService } from './internal';
+import { ItemsService } from './index';
 
 /**
  * @TODO only return activity of the collections you have access to

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,3 +1,5 @@
+// Note: "items" must kept at the top to prevent circular dependencies issues between ItemsService <-> ActivityService / RevisionsService
+export * from './items';
 export * from './activity';
 export * from './assets';
 export * from './authentication';
@@ -8,7 +10,6 @@ export * from './files';
 export * from './folders';
 export * from './graphql';
 export * from './import';
-export * from './items';
 export * from './mail';
 export * from './meta';
 export * from './panels';

--- a/api/src/services/internal.ts
+++ b/api/src/services/internal.ts
@@ -1,0 +1,6 @@
+// This file is used to prevent circular dependencies issues between ItemsService <-> ActivityService / RevisionsService
+// Context: https://github.com/directus/directus/issues/5453
+// Pattern: https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de
+export * from './items';
+export * from './activity';
+export * from './revisions';

--- a/api/src/services/internal.ts
+++ b/api/src/services/internal.ts
@@ -1,6 +1,0 @@
-// This file is used to prevent circular dependencies issues between ItemsService <-> ActivityService / RevisionsService
-// Context: https://github.com/directus/directus/issues/5453
-// Pattern: https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de
-export * from './items';
-export * from './activity';
-export * from './revisions';

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -24,6 +24,7 @@ import getASTFromQuery from '../utils/get-ast-from-query';
 import { toArray } from '@directus/shared/utils';
 import { AuthorizationService } from './authorization';
 import { PayloadService } from './payload';
+import { ActivityService, RevisionsService } from './internal';
 
 export type QueryOptions = {
 	stripNonRequested?: boolean;
@@ -34,7 +35,7 @@ export type MutationOptions = {
 	/**
 	 * Callback function that's fired whenever a revision is made in the mutation
 	 */
-	onRevisionCreate?: (id: number) => void;
+	onRevisionCreate?: (pk: PrimaryKey) => void;
 
 	/**
 	 * Flag to disable the auto purging of the cache. Is ignored when CACHE_AUTO_PURGE isn't enabled.
@@ -172,38 +173,44 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 			// If this is an authenticated action, and accountability tracking is enabled, save activity row
 			if (this.accountability && this.schema.collections[this.collection].accountability !== null) {
-				const activityRecord = {
+				const activityService = new ActivityService({
+					knex: trx,
+					schema: this.schema,
+				});
+
+				const activity = await activityService.createOne({
 					action: Action.CREATE,
 					user: this.accountability!.user,
 					collection: this.collection,
 					ip: this.accountability!.ip,
 					user_agent: this.accountability!.userAgent,
 					item: primaryKey,
-				};
-
-				const activityID = (await trx.insert(activityRecord).into('directus_activity').returning('id'))[0] as number;
+				});
 
 				// If revisions are tracked, create revisions record
 				if (this.schema.collections[this.collection].accountability === 'all') {
-					const revisionRecord = {
-						activity: activityID,
+					const revisionsService = new RevisionsService({
+						knex: trx,
+						schema: this.schema,
+					});
+
+					const revision = await revisionsService.createOne({
+						activity: activity,
 						collection: this.collection,
 						item: primaryKey,
 						data: await payloadService.prepareDelta(payload),
 						delta: await payloadService.prepareDelta(payload),
-					};
-
-					const revisionID = (await trx.insert(revisionRecord).into('directus_revisions').returning('id'))[0] as number;
+					});
 
 					// Make sure to set the parent field of the child-revision rows
 					const childrenRevisions = [...revisionsM2O, ...revisionsA2O, ...revisionsO2M];
 
 					if (childrenRevisions.length > 0) {
-						await trx('directus_revisions').update({ parent: revisionID }).whereIn('id', childrenRevisions);
+						await revisionsService.updateMany(childrenRevisions, { parent: revision });
 					}
 
 					if (opts?.onRevisionCreate) {
-						opts.onRevisionCreate(revisionID);
+						opts.onRevisionCreate(revision);
 					}
 				}
 			}
@@ -457,21 +464,21 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 			// If this is an authenticated action, and accountability tracking is enabled, save activity row
 			if (this.accountability && this.schema.collections[this.collection].accountability !== null) {
-				const activityRecords = keys.map((key) => ({
-					action: Action.UPDATE,
-					user: this.accountability!.user,
-					collection: this.collection,
-					ip: this.accountability!.ip,
-					user_agent: this.accountability!.userAgent,
-					item: key,
-				}));
+				const activityService = new ActivityService({
+					knex: trx,
+					schema: this.schema,
+				});
 
-				const activityPrimaryKeys: PrimaryKey[] = [];
-
-				for (const activityRecord of activityRecords) {
-					const primaryKey = (await trx.insert(activityRecord).into('directus_activity').returning('id'))[0] as number;
-					activityPrimaryKeys.push(primaryKey);
-				}
+				const activity = await activityService.createMany(
+					keys.map((key) => ({
+						action: Action.UPDATE,
+						user: this.accountability!.user,
+						collection: this.collection,
+						ip: this.accountability!.ip,
+						user_agent: this.accountability!.userAgent,
+						item: key,
+					}))
+				);
 
 				if (this.schema.collections[this.collection].accountability === 'all') {
 					const itemsService = new ItemsService(this.collection, {
@@ -481,43 +488,39 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 					const snapshots = await itemsService.readMany(keys);
 
-					const revisionRecords: {
-						activity: PrimaryKey;
-						collection: string;
-						item: PrimaryKey;
-						data: string;
-						delta: string;
-					}[] = [];
+					const revisionsService = new RevisionsService({
+						knex: trx,
+						schema: this.schema,
+					});
 
-					for (let i = 0; i < activityPrimaryKeys.length; i++) {
-						revisionRecords.push({
-							activity: activityPrimaryKeys[i],
-							collection: this.collection,
-							item: keys[i],
-							data: snapshots && Array.isArray(snapshots) ? JSON.stringify(snapshots[i]) : JSON.stringify(snapshots),
-							delta: await payloadService.prepareDelta(payloadWithTypeCasting),
-						});
-					}
+					const revision = await revisionsService.createMany(
+						await Promise.all(
+							activity.map(async (activity, index) => ({
+								activity: activity,
+								collection: this.collection,
+								item: keys[index],
+								data:
+									snapshots && Array.isArray(snapshots) ? JSON.stringify(snapshots[index]) : JSON.stringify(snapshots),
+								delta: await payloadService.prepareDelta(payloadWithTypeCasting),
+							}))
+						)
+					);
 
-					for (let i = 0; i < revisionRecords.length; i++) {
-						const revisionID = (
-							await trx.insert(revisionRecords[i]).into('directus_revisions').returning('id')
-						)[0] as number;
-
+					revision.forEach(async (revision, index) => {
 						if (opts?.onRevisionCreate) {
-							opts.onRevisionCreate(revisionID);
+							opts.onRevisionCreate(revision);
 						}
 
-						if (i === 0) {
+						if (index === 0) {
 							// In case of a nested relational creation/update in a updateMany, the nested m2o/a2o
 							// creation is only done once. We treat the first updated item as the "main" update,
 							// with all other revisions on the current level as regular "flat" updates, and
 							// nested revisions as children of this first "root" item.
 							if (childrenRevisions.length > 0) {
-								await trx('directus_revisions').update({ parent: revisionID }).whereIn('id', childrenRevisions);
+								await revisionsService.updateMany(childrenRevisions, { parent: revision });
 							}
 						}
-					}
+					});
 				}
 			}
 		});
@@ -642,18 +645,21 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			await trx(this.collection).whereIn(primaryKeyField, keys).delete();
 
 			if (this.accountability && this.schema.collections[this.collection].accountability !== null) {
-				const activityRecords = keys.map((key) => ({
-					action: Action.DELETE,
-					user: this.accountability!.user,
-					collection: this.collection,
-					ip: this.accountability!.ip,
-					user_agent: this.accountability!.userAgent,
-					item: key,
-				}));
+				const activityService = new ActivityService({
+					knex: trx,
+					schema: this.schema,
+				});
 
-				if (activityRecords.length > 0) {
-					await trx.insert(activityRecords).into('directus_activity');
-				}
+				await activityService.createMany(
+					keys.map((key) => ({
+						action: Action.DELETE,
+						user: this.accountability!.user,
+						collection: this.collection,
+						ip: this.accountability!.ip,
+						user_agent: this.accountability!.userAgent,
+						item: key,
+					}))
+				);
 			}
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -24,7 +24,7 @@ import getASTFromQuery from '../utils/get-ast-from-query';
 import { toArray } from '@directus/shared/utils';
 import { AuthorizationService } from './authorization';
 import { PayloadService } from './payload';
-import { ActivityService, RevisionsService } from './internal';
+import { ActivityService, RevisionsService } from './index';
 
 export type QueryOptions = {
 	stripNonRequested?: boolean;

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -399,12 +399,12 @@ export class PayloadService {
 
 				if (Object.keys(fieldsToUpdate).length > 0) {
 					await itemsService.updateOne(relatedPrimaryKey, relatedRecord, {
-						onRevisionCreate: (id) => revisions.push(id),
+						onRevisionCreate: (pk) => revisions.push(pk),
 					});
 				}
 			} else {
 				relatedPrimaryKey = await itemsService.createOne(relatedRecord, {
-					onRevisionCreate: (id) => revisions.push(id),
+					onRevisionCreate: (pk) => revisions.push(pk),
 				});
 			}
 
@@ -467,12 +467,12 @@ export class PayloadService {
 
 				if (Object.keys(fieldsToUpdate).length > 0) {
 					await itemsService.updateOne(relatedPrimaryKey, relatedRecord, {
-						onRevisionCreate: (id) => revisions.push(id),
+						onRevisionCreate: (pk) => revisions.push(pk),
 					});
 				}
 			} else {
 				relatedPrimaryKey = await itemsService.createOne(relatedRecord, {
-					onRevisionCreate: (id) => revisions.push(id),
+					onRevisionCreate: (pk) => revisions.push(pk),
 				});
 			}
 
@@ -568,7 +568,7 @@ export class PayloadService {
 
 				savedPrimaryKeys.push(
 					...(await itemsService.upsertMany(recordsToUpsert, {
-						onRevisionCreate: (id) => revisions.push(id),
+						onRevisionCreate: (pk) => revisions.push(pk),
 					}))
 				);
 
@@ -598,7 +598,7 @@ export class PayloadService {
 						query,
 						{ [relation.field]: null },
 						{
-							onRevisionCreate: (id) => revisions.push(id),
+							onRevisionCreate: (pk) => revisions.push(pk),
 						}
 					);
 				}
@@ -616,7 +616,7 @@ export class PayloadService {
 							[relation.field]: parent || payload[currentPrimaryKeyField],
 						})),
 						{
-							onRevisionCreate: (id) => revisions.push(id),
+							onRevisionCreate: (pk) => revisions.push(pk),
 						}
 					);
 				}
@@ -632,7 +632,7 @@ export class PayloadService {
 								[relation.field]: parent || payload[currentPrimaryKeyField],
 							},
 							{
-								onRevisionCreate: (id) => revisions.push(id),
+								onRevisionCreate: (pk) => revisions.push(pk),
 							}
 						);
 					}
@@ -663,7 +663,7 @@ export class PayloadService {
 							query,
 							{ [relation.field]: null },
 							{
-								onRevisionCreate: (id) => revisions.push(id),
+								onRevisionCreate: (pk) => revisions.push(pk),
 							}
 						);
 					}

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, InvalidPayloadException } from '../exceptions';
 import { AbstractServiceOptions, PrimaryKey } from '../types';
-import { ItemsService } from './items';
+import { ItemsService } from './internal';
 
 export class RevisionsService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, InvalidPayloadException } from '../exceptions';
 import { AbstractServiceOptions, PrimaryKey } from '../types';
-import { ItemsService } from './internal';
+import { ItemsService } from './index';
 
 export class RevisionsService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {


### PR DESCRIPTION
Fixes #5453

I've used a pattern from https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de to solve the issue with circular dependencies.

## Testing
To check whether the hooks are now fired, you can use the following simple hook file:
```js
module.exports = function registerHook({ logger }) {
	return {
		'revisions.*': async function ({ event }) {
			logger.info(`Hook triggered 🎉: ${event}`);
		},
		'activity.*': async function ({ event }) {
			logger.info(`Hook triggered 🎉: ${event}`);
		},
	};
};
```

Console output without this PR (😉):
```
```

With PR:
```
directus: 11:34:07 ✨ Hook triggered 🎉: activity.create
directus: 11:34:07 ✨ Hook triggered 🎉: revisions.create
```

@rijkvanzanten Don't worry, this work is not related to the #Hacktoberfest 😉 As I promised, I'll try to solve another issue with the "Hacktoberfest" label 😄


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#5453: Hooks for activity and revisions aren't firing](https://issuehunt.io/repos/7122594/issues/5453)
---
</details>
<!-- /Issuehunt content-->