### PR TITLE
Fix "Unrestricted file system access to" messages

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import yaml from '@rollup/plugin-yaml';
 import path from 'path';
@@ -32,6 +32,9 @@ export default defineConfig({
 				target: process.env.API_URL ? process.env.API_URL : 'http://localhost:8055/',
 				changeOrigin: true,
 			},
+		},
+		fs: {
+			allow: [searchForWorkspaceRoot(process.cwd()), '/admin/'],
 		},
 	},
 });


### PR DESCRIPTION
Prevent Vite from throwing the following messages in dev mode:
```
@directus/app: Unrestricted file system access to "/admin/src/displays/boolean/index.ts"
@directus/app: For security concerns, accessing files outside of serving allow list will be restricted by default in the future version of Vite. Refer to https://vitejs.dev/config/#server-fs-allow for more details.
@directus/app: Unrestricted file system access to "/admin/src/displays/collection/index.ts"
[...]
```