### PR TITLE
Allow unused vars starting with underscore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,15 +48,15 @@ module.exports = {
 				// It's recommended to turn off this rule on TypeScript projects
 				'no-undef': 'off',
 				// Allow ts-directive comments (used to suppress TypeScript compiler errors)
-				'@typescript-eslint/ban-ts-comment': 0,
+				'@typescript-eslint/ban-ts-comment': 'off',
 				// Allow usage of the any type (consider to enable this rule later on)
-				'@typescript-eslint/no-explicit-any': 0,
+				'@typescript-eslint/no-explicit-any': 'off',
 				// Allow usage of require statements (consider to enable this rule later on)
-				'@typescript-eslint/no-var-requires': 0,
+				'@typescript-eslint/no-var-requires': 'off',
 				// Allow non-null assertions for now (consider to enable this rule later on)
-				'@typescript-eslint/no-non-null-assertion': 0,
-				// Allow unused variables when they begin with an underscore
-				'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+				'@typescript-eslint/no-non-null-assertion': 'off',
+				// Allow unused arguments and variables when they begin with an underscore
+				'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
 			},
 		},
 	],


### PR DESCRIPTION
Also using 'off' instead of 0 for other rules to make it clearer

~Fixes~ Hides warning:
```
/Users/<...>/Development/directus/tests/api/ping.test.ts
  18:15  warning  '_vendor' is assigned a value but never used  @typescript-eslint/no-unused-vars
```