### PR TITLE
Hide revision's revert button for created entries

### DIFF
--- a/app/src/views/private/components/revisions-drawer-detail/revisions-drawer.vue
+++ b/app/src/views/private/components/revisions-drawer-detail/revisions-drawer.vue
@@ -29,7 +29,7 @@
 			</div>
 
 			<template #actions>
-				<v-button v-tooltip.bottom="t('revert')" class="revert" icon rounded @click="revert">
+				<v-button v-if="hasPastRevision" v-tooltip.bottom="t('revert')" class="revert" icon rounded @click="revert">
 					<v-icon name="restore" />
 				</v-button>
 				<v-button v-tooltip.bottom="t('done')" icon rounded @click="internalActive = false">
@@ -110,9 +110,13 @@ export default defineComponent({
 				  ];
 		});
 
+		const hasPastRevision = computed(() => {
+			return currentRevision.value?.activity.action !== 'create' ? true : false;
+		});
+
 		watchEffect(() => (currentTab.value = [tabs.value[0].value]));
 
-		return { t, internalActive, internalCurrent, title, currentRevision, currentTab, tabs, revert };
+		return { t, internalActive, internalCurrent, title, currentRevision, currentTab, tabs, hasPastRevision, revert };
 
 		function revert() {
 			if (!currentRevision.value) return;


### PR DESCRIPTION
Fixes #8503.

<img width="761" alt="Screenshot 2021-10-02 at 10 24 13 PM" src="https://user-images.githubusercontent.com/26413686/135721381-8d192c97-5f76-4d6b-a350-7f78b809fd06.png">

