### PR TITLE
Allows to customize the icon of bookmarks

### DIFF
--- a/api/src/database/migrations/20211003A-add-presets-icon-and-icon-color-fields.ts
+++ b/api/src/database/migrations/20211003A-add-presets-icon-and-icon-color-fields.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_presets', (table) => {
+		table.string('icon', 30).defaultTo('bookmark_border');
+		table.string('color', 10);
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_presets', (table) => {
+		table.dropColumn('icon');
+		table.dropColumn('color');
+	});
+}

--- a/api/src/database/system-data/fields/presets.yaml
+++ b/api/src/database/system-data/fields/presets.yaml
@@ -34,4 +34,15 @@ fields:
   - field: layout
     width: half
 
+  - field: icon
+    interface: select-icon
+    options:
+    width: half
+
+  - field: color
+    interface: select-color
+    options:
+      placeholder: $t:interfaces.select-color.placeholder
+    width: half
+
   - field: refresh_interval

--- a/app/src/composables/use-preset/use-preset.ts
+++ b/app/src/composables/use-preset/use-preset.ts
@@ -200,7 +200,7 @@ export function usePreset(
 
 	const bookmarkIcon = computed<string | null>({
 		get() {
-			return localPreset.value?.icon || 'bookmark_border';
+			return localPreset.value?.icon || null;
 		},
 		set(newIcon: string | null) {
 			localPreset.value = {

--- a/app/src/composables/use-preset/use-preset.ts
+++ b/app/src/composables/use-preset/use-preset.ts
@@ -15,6 +15,8 @@ type UsablePreset = {
 	savePreset: (preset?: Partial<Preset> | undefined) => Promise<any>;
 	saveCurrentAsBookmark: (overrides: Partial<Preset>) => Promise<any>;
 	bookmarkTitle: Ref<string | null>;
+	bookmarkIcon: Ref<string | null>;
+	bookmarkColor: Ref<string | null>;
 	resetPreset: () => Promise<void>;
 	bookmarkSaved: Ref<boolean>;
 	bookmarkIsMine: ComputedRef<boolean>;
@@ -196,6 +198,36 @@ export function usePreset(
 		},
 	});
 
+	const bookmarkIcon = computed<string | null>({
+		get() {
+			return localPreset.value?.icon || 'bookmark_border';
+		},
+		set(newIcon: string | null) {
+			localPreset.value = {
+				...localPreset.value,
+				icon: newIcon,
+			};
+
+			// This'll save immediately
+			savePreset();
+		},
+	});
+
+	const bookmarkColor = computed<string | null>({
+		get() {
+			return localPreset.value?.color || null;
+		},
+		set(newColor: string | null) {
+			localPreset.value = {
+				...localPreset.value,
+				color: newColor,
+			};
+
+			// This'll save immediately
+			savePreset();
+		},
+	});
+
 	return {
 		bookmarkExists,
 		layout,
@@ -207,6 +239,8 @@ export function usePreset(
 		savePreset,
 		saveCurrentAsBookmark,
 		bookmarkTitle,
+		bookmarkIcon,
+		bookmarkColor,
 		resetPreset,
 		bookmarkSaved,
 		bookmarkIsMine,

--- a/app/src/modules/collections/components/navigation-bookmark.vue
+++ b/app/src/modules/collections/components/navigation-bookmark.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-list-item :to="bookmark.to" query class="bookmark" @contextmenu.prevent.stop="activateContextMenu">
-		<v-list-item-icon>
-			<v-icon :name="bookmark.icon || 'bookmark_border'" :color="bookmark.color" />
+		<v-list-item-icon v-if="bookmark.icon">
+			<v-icon :name="bookmark.icon" :color="bookmark.color" />
 		</v-list-item-icon>
 		<v-list-item-content>
 			<v-text-overflow :text="bookmark.bookmark" />

--- a/app/src/modules/collections/components/navigation-bookmark.vue
+++ b/app/src/modules/collections/components/navigation-bookmark.vue
@@ -1,6 +1,8 @@
 <template>
 	<v-list-item :to="bookmark.to" query class="bookmark" @contextmenu.prevent.stop="activateContextMenu">
-		<v-list-item-icon><v-icon name="bookmark_outline" /></v-list-item-icon>
+		<v-list-item-icon>
+			<v-icon :name="bookmark.icon || 'bookmark_border'" :color="bookmark.color" />
+		</v-list-item-icon>
 		<v-list-item-content>
 			<v-text-overflow :text="bookmark.bookmark" />
 		</v-list-item-content>

--- a/app/src/modules/collections/routes/collection.vue
+++ b/app/src/modules/collections/routes/collection.vue
@@ -20,8 +20,8 @@
 			<template #title-outer:prepend>
 				<v-button class="header-icon" rounded icon secondary disabled>
 					<v-icon
-						:name="bookmarkExists ? bookmarkIcon : currentCollection.icon"
-						:color="bookmarkExists ? bookmarkColor : currentCollection.color"
+						:name="bookmarkIcon || currentCollection.icon"
+						:color="bookmarkIcon ? bookmarkColor : currentCollection.color"
 					/>
 				</v-button>
 			</template>

--- a/app/src/modules/collections/routes/collection.vue
+++ b/app/src/modules/collections/routes/collection.vue
@@ -19,7 +19,10 @@
 		>
 			<template #title-outer:prepend>
 				<v-button class="header-icon" rounded icon secondary disabled>
-					<v-icon :name="currentCollection.icon" :color="currentCollection.color" />
+					<v-icon
+						:name="bookmarkExists ? bookmarkIcon : currentCollection.icon"
+						:color="bookmarkExists ? bookmarkColor : currentCollection.color"
+					/>
 				</v-button>
 			</template>
 
@@ -328,6 +331,8 @@ export default defineComponent({
 			bookmarkExists,
 			saveCurrentAsBookmark,
 			bookmarkTitle,
+			bookmarkIcon,
+			bookmarkColor,
 			resetPreset,
 			bookmarkSaved,
 			bookmarkIsMine,
@@ -388,6 +393,8 @@ export default defineComponent({
 			creatingBookmark,
 			createBookmark,
 			bookmarkTitle,
+			bookmarkIcon,
+			bookmarkColor,
 			editingBookmark,
 			editBookmark,
 			breadcrumb,

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -157,6 +157,9 @@ type FormattedPreset = {
 
 	layout_options: Record<string, any> | null;
 	filters: readonly Filter[] | null;
+
+	icon: string | null;
+	color: string | null;
 };
 
 export default defineComponent({
@@ -267,6 +270,8 @@ export default defineComponent({
 				if (edits.value.layout_query) editsParsed.layout_query = edits.value.layout_query;
 				if (edits.value.layout_options) editsParsed.layout_options = edits.value.layout_options;
 				if (edits.value.filters) editsParsed.filters = edits.value.filters;
+				if ('icon' in edits.value) editsParsed.icon = edits.value.icon;
+				if ('color' in edits.value) editsParsed.color = edits.value.color;
 				editsParsed.search = edits.value.search;
 
 				if (edits.value.scope) {
@@ -335,6 +340,8 @@ export default defineComponent({
 					layout_query: null,
 					layout_options: null,
 					filters: null,
+					icon: 'bookmark_border',
+					color: null,
 				};
 				if (isNew.value === true) return defaultValues;
 				if (preset.value === null) return defaultValues;
@@ -358,6 +365,8 @@ export default defineComponent({
 					layout_query: preset.value.layout_query,
 					layout_options: preset.value.layout_options,
 					filters: preset.value.filters,
+					icon: preset.value.icon,
+					color: preset.value.color,
 				};
 
 				return value;
@@ -520,6 +529,24 @@ export default defineComponent({
 						options: {
 							placeholder: t('preset_name_placeholder'),
 						},
+					},
+				},
+				{
+					field: 'icon',
+					name: t('icon'),
+					type: 'string',
+					meta: {
+						interface: 'select-icon',
+						width: 'half',
+					},
+				},
+				{
+					field: 'color',
+					name: t('color'),
+					type: 'string',
+					meta: {
+						interface: 'select-color',
+						width: 'half',
 					},
 				},
 				{

--- a/packages/shared/src/types/presets.ts
+++ b/packages/shared/src/types/presets.ts
@@ -11,6 +11,8 @@ export type AppFilter = {
 export type Preset = {
 	id?: number;
 	bookmark: string | null;
+	icon: string | null;
+	color: string | null;
 	user: string | null;
 	role: string | null;
 	collection: string;


### PR DESCRIPTION
In the bookmarks configuration view there are two selectors to indicate the icon and its color, both fields are optional and the default value of the icon is the one currently shown in the application, it is a backward compatible change.

If we indicate icon and color:
- Appears in the navigation bar
- Appears in the collection view

If we do not indicate icon:
- Disappears in the navigation bar
- The original icon of the collection appears in the collection view.