### PR TITLE
Improve the system language selector

### DIFF
--- a/app/src/components/v-select/types.ts
+++ b/app/src/components/v-select/types.ts
@@ -6,4 +6,5 @@ export type Option = {
 	children?: Option[];
 	divider?: boolean;
 	selectable?: boolean;
+	mostUsed?: boolean;
 };

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -48,6 +48,27 @@
 				<v-divider />
 			</template>
 
+			<template v-for="(item, index) in mostUsedItems" :key="index">
+				<select-list-item-group
+					v-if="item.children"
+					:item="item"
+					:model-value="modelValue"
+					:multiple="multiple"
+					:allow-other="allowOther"
+					@update:model-value="$emit('update:modelValue', $event)"
+				/>
+				<select-list-item
+					v-else
+					:model-value="modelValue"
+					:item="item"
+					:multiple="multiple"
+					:allow-other="allowOther"
+					@update:model-value="$emit('update:modelValue', $event)"
+				/>
+			</template>
+
+			<v-divider v-if="mostUsedItems.length" />
+
 			<template v-for="(item, index) in internalItems" :key="index">
 				<select-list-item-group
 					v-if="item.children"
@@ -156,6 +177,10 @@ export default defineComponent({
 			type: String,
 			default: 'selectable',
 		},
+		itemMostUsed: {
+			type: String,
+			default: 'mostUsed',
+		},
 		itemChildren: {
 			type: String,
 			default: 'children',
@@ -213,7 +238,7 @@ export default defineComponent({
 	setup(props, { emit }) {
 		const { t } = useI18n();
 
-		const { internalItems } = useItems();
+		const { internalItems, mostUsedItems } = useItems();
 		const { displayValue } = useDisplayValue();
 		const { modelValue } = toRefs(props);
 		const { otherValue, usesOtherValue } = useCustomSelection(modelValue as Ref<string>, internalItems, (value) =>
@@ -225,7 +250,17 @@ export default defineComponent({
 			(value) => emit('update:modelValue', value)
 		);
 
-		return { t, internalItems, displayValue, otherValue, usesOtherValue, otherValues, addOtherValue, setOtherValue };
+		return {
+			t,
+			mostUsedItems,
+			internalItems,
+			displayValue,
+			otherValue,
+			usesOtherValue,
+			otherValues,
+			addOtherValue,
+			setOtherValue,
+		};
 
 		function useItems() {
 			const internalItems = computed(() => {
@@ -248,6 +283,7 @@ export default defineComponent({
 						disabled: get(item, props.itemDisabled),
 						selectable: get(item, props.itemSelectable),
 						children,
+						mostUsed: get(item, props.itemMostUsed),
 					};
 				};
 
@@ -256,7 +292,9 @@ export default defineComponent({
 				return items;
 			});
 
-			return { internalItems };
+			const mostUsedItems = internalItems.value.filter((item) => item.mostUsed);
+
+			return { internalItems, mostUsedItems };
 		}
 
 		function useDisplayValue() {

--- a/app/src/interfaces/_system/system-language/system-language.vue
+++ b/app/src/interfaces/_system/system-language/system-language.vue
@@ -4,6 +4,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useUserStore } from '@/stores/';
 import availableLanguages from '@/lang/available-languages.yaml';
 
 export default defineComponent({
@@ -19,9 +20,12 @@ export default defineComponent({
 	},
 	emits: ['input'],
 	setup() {
+		const userStore = useUserStore();
+
 		const languages = Object.entries(availableLanguages).map(([key, value]) => ({
 			text: value,
 			value: key,
+			mostUsed: key === userStore?.currentUser?.language,
 		}));
 
 		return { languages };


### PR DESCRIPTION
This change is intended to improve the usability of the system translations for users who do not use the default language of directus, for example:

When you are defining the data model and you want to indicate a name to each field for the user's language you have to go through the whole list of languages every time, hopefully your language is at the top of the list, but that's not my case 😥

The proposal has two parts:
- Allow v-select component items to be "flagged" as frequent or most used options to appear first.
- "Flag" the user's language as most used.

As futuribles, it could be allowed to disable system languages that are not used or flag languages that are allowed in that instance.