### PR TITLE
Add link display

### DIFF
--- a/app/src/displays/link/index.ts
+++ b/app/src/displays/link/index.ts
@@ -1,0 +1,12 @@
+import { defineDisplay } from '@directus/shared/utils';
+import DisplayLink from './link.vue';
+
+export default defineDisplay({
+	id: 'link',
+	name: '$t:displays.link.link',
+	description: '$t:displays.link.description',
+	icon: 'open_in_new',
+	component: DisplayLink,
+	options: [],
+	types: ['string'],
+});

--- a/app/src/displays/link/link.vue
+++ b/app/src/displays/link/link.vue
@@ -2,15 +2,17 @@
 	<div class="link">
 		<value-null v-if="value === null" />
 		<template v-else>
-			<a :href="value" target="_blank" @click.stop>
-				<v-icon name="open_in_new"></v-icon>
+			<a class="link-icon" :href="value" target="_blank" @click.stop>
+				<v-icon v-tooltip="t('displays.link.tooltip')" name="open_in_new"></v-icon>
 			</a>
-			<span>{{ parsedValue }}</span>
+
+			<span class="value">{{ parsedValue }}</span>
 		</template>
 	</div>
 </template>
 
 <script lang="ts">
+import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
 
 export default defineComponent({
@@ -21,6 +23,8 @@ export default defineComponent({
 		},
 	},
 	setup(props) {
+		const { t } = useI18n();
+
 		const parsedValue = computed(() => {
 			if (typeof props.value === 'string') {
 				return props.value.split('://')[1];
@@ -28,7 +32,7 @@ export default defineComponent({
 			return props.value;
 		});
 
-		return { parsedValue };
+		return { t, parsedValue };
 	},
 });
 </script>
@@ -38,12 +42,18 @@ export default defineComponent({
 	display: inline-flex;
 	align-items: center;
 
+	.value {
+		display: inline-block;
+		line-height: var(--v-icon-size);
+	}
+
 	.v-icon {
 		margin-right: 4px;
-		color: #999;
+		color: var(--foreground-subdued);
+		transition: color var(--fast) var(--transition);
 
 		&:hover {
-			color: #666;
+			color: var(--foreground-normal-alt);
 		}
 	}
 }

--- a/app/src/displays/link/link.vue
+++ b/app/src/displays/link/link.vue
@@ -1,0 +1,50 @@
+<template>
+	<div class="link">
+		<value-null v-if="value === null" />
+		<template v-else>
+			<a :href="value" target="_blank" @click.stop>
+				<v-icon name="open_in_new"></v-icon>
+			</a>
+			<span>{{ parsedValue }}</span>
+		</template>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from 'vue';
+
+export default defineComponent({
+	props: {
+		value: {
+			type: String,
+			default: null,
+		},
+	},
+	setup(props) {
+		const parsedValue = computed(() => {
+			if (typeof props.value === 'string') {
+				return props.value.split('://')[1];
+			}
+			return props.value;
+		});
+
+		return { parsedValue };
+	},
+});
+</script>
+
+<style lang="scss" scoped>
+.link {
+	display: inline-flex;
+	align-items: center;
+
+	.v-icon {
+		margin-right: 4px;
+		color: #999;
+
+		&:hover {
+			color: #666;
+		}
+	}
+}
+</style>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1474,6 +1474,7 @@ displays:
   link:
     link: Link
     description: Allows to navigate to the link
+    tooltip: Open link
   mime-type:
     mime-type: MIME Type
     description: Show the MIME-Type of a file

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1471,6 +1471,9 @@ displays:
     show_as_dot: Show As Dot
     choices_value_placeholder: Enter a value...
     choices_text_placeholder: Enter a text...
+  link:
+    link: Link
+    description: Allows to navigate to the link
   mime-type:
     mime-type: MIME Type
     description: Show the MIME-Type of a file

--- a/app/src/lang/translations/es-ES.yaml
+++ b/app/src/lang/translations/es-ES.yaml
@@ -1169,6 +1169,9 @@ displays:
     show_as_dot: Presentar como Punto
     choices_value_placeholder: Ingrese un valor...
     choices_text_placeholder: Ingresar un texto...
+  link:
+    link: Enlace
+    description: Permite navegar hacia el enlace
   mime-type:
     mime-type: Tipo MIME
     description: Presentar el Tipo MIME del archivo

--- a/app/src/lang/translations/es-ES.yaml
+++ b/app/src/lang/translations/es-ES.yaml
@@ -1172,6 +1172,7 @@ displays:
   link:
     link: Enlace
     description: Permite navegar hacia el enlace
+    tooltip: Abrir enlace
   mime-type:
     mime-type: Tipo MIME
     description: Presentar el Tipo MIME del archivo


### PR DESCRIPTION
In some projects I use directus as a CRM and create some bookmarks for a quick visualization of the most important data, some of these data are often external links.

In this proposal I intend to improve the access to the links, currently you have to enter the detail view copy the link from the input and paste it in a new tab, with the new change an icon appears before the field with a link to the url.

As an improvement, you can check if it is an email or a phone number to customize the action when clicking the link.