### PR TITLE
Set integer type on tileSize

### DIFF
--- a/api/src/database/system-data/fields/settings.yaml
+++ b/api/src/database/system-data/fields/settings.yaml
@@ -320,6 +320,7 @@ fields:
               placeholder: http://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png
         - field: tileSize
           name: $t:tile_size
+          type: integer
           schema:
             is_nullable: true
           meta:


### PR DESCRIPTION
Fixes an issue when setting tile size for custom map.

![image](https://user-images.githubusercontent.com/1009639/135835874-b16c560f-dac4-4d63-a6eb-41ea965a91c5.png)
