### PR TITLE
pass MutationOptions to createOne

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -247,7 +247,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			const primaryKeys: PrimaryKey[] = [];
 
 			for (const payload of data) {
-				const primaryKey = await service.createOne(payload, { autoPurgeCache: false });
+				const primaryKey = await service.createOne(payload, { ...(opts || {}), autoPurgeCache: false });
 				primaryKeys.push(primaryKey);
 			}
 


### PR DESCRIPTION
fixes #8481

## Bug

The PATCH request detailed create syntax causes revision records to not have associated `parent` ID:

```js
// example of detailed create syntax
{
  "o2m_field": {
    "create": [1, 2, 3]
  }
}
```

Whereas the inline array syntax works properly:

```js
// example of inline array syntax
{
  "o2m_field": [1, 2, 3]
}
```

## Investigation

### Inline array syntax

The inline array syntax causes the use of `upsertMany` and passes callback for `onRevisionCreate` in the mutation options:

https://github.com/directus/directus/blob/995b8190997abfbf185f2b0e1fc16c380ec26cd1/api/src/services/payload.ts#L570-L572

`upsertMany` then calls `upsertOne` function here:

https://github.com/directus/directus/blob/995b8190997abfbf185f2b0e1fc16c380ec26cd1/api/src/services/items.ts#L583

Here it passes the `opts` (MutationOptions) properly.

### Detailed create syntax

The detailed create syntax causes the use of `createMany` and passes callback for `onRevisionCreate` in the mutation options:

https://github.com/directus/directus/blob/995b8190997abfbf185f2b0e1fc16c380ec26cd1/api/src/services/payload.ts#L613-L621

`createMany` then calls the `createOne` function here:

https://github.com/directus/directus/blob/995b8190997abfbf185f2b0e1fc16c380ec26cd1/api/src/services/items.ts#L250

However as we can see, the options `{ onRevisionCreate: (id) => revisions.push(id) }` was never passed from `createMany` to `createOne`, thus causing this mismatch issue even though they should've both create the same revisions records.

## Solution

Add the options to `createOne` by using the same syntax used in `upsertOne`.