### PR TITLE
Fix data model edits tracking

### DIFF
--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -142,7 +142,10 @@ export default defineComponent({
 			collection
 		);
 
-		const hasEdits = computed<boolean>(() => Object.keys(edits.value).length > 0);
+		const hasEdits = computed<boolean>(() => {
+			if (!edits.value.meta) return false;
+			return Object.keys(edits.value.meta).length > 0;
+		});
 
 		useShortcut('meta+s', () => {
 			if (hasEdits.value) saveAndStay();


### PR DESCRIPTION
Fixes #8565. All edits in the form is stored in the `meta` variable.

https://github.com/directus/directus/blob/887c97b8c2acb0f01ee39698d1e36485711774dc/app/src/modules/settings/routes/data-model/fields/fields.vue#L68