### PR TITLE
Recommend npm init directus-project to create a project

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -36,7 +36,7 @@ Learn more at...
 Directus requires NodeJS 10+. Create a new project with our simple CLI tool:
 
 ```
-npx create-directus-project my-project
+npm init directus-project my-project
 ```
 
 Or using yarn:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -11,7 +11,7 @@ database ready to connect to.
 Run the following command in your terminal and follow the prompts.
 
 ```bash
-npx create-directus-project example-project
+npm init directus-project example-project
 ```
 
 ![Successful installation](../assets/getting-started/quickstart/terminal-install.png)

--- a/docs/guides/installation/cli.md
+++ b/docs/guides/installation/cli.md
@@ -38,7 +38,7 @@ Navigate to the directory where you wish to create a new Directus project. The n
 inside the current directory. Create a new Directus project by running the following npm command.
 
 ```bash
-npx create-directus-project my-project
+npm init directus-project my-project
 ```
 
 ::: warning

--- a/packages/create-directus-project/readme.md
+++ b/packages/create-directus-project/readme.md
@@ -7,7 +7,7 @@ A small installer util that will create a directory, add boilerplate folders, an
 This package is meant to be used through `npx` or `yarn`:
 
 ```
-npx create-directus-project my-project
+npm init directus-project my-project
 ```
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ certain features might be missing or broken. You can follow along with
 Create a new Directus project by running the following npm command:
 
 ```
-npx create-directus-project my-project
+npm init directus-project my-project
 ```
 
 Or, using yarn:


### PR DESCRIPTION
This slightly nicer syntax was introduced back in `npm@6.1.0`. `node@12.20.0`, which is the minimum version we require, ships with `npm@6.14.8`. `npm@6` versions below `6.1.0` were never actually shipped with any node version, so it should be very safe to use this syntax.