### PR TITLE
Make directus:extension.hidden optional

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -74,7 +74,6 @@ export default async function create(type: string, name: string, options: Create
 			path: 'dist/index.js',
 			source: `src/index.${languageToShort(options.language)}`,
 			host: `^${pkg.version}`,
-			hidden: false,
 		},
 		scripts: {
 			build: 'directus-extension build',

--- a/packages/shared/src/types/extensions.ts
+++ b/packages/shared/src/types/extensions.ts
@@ -56,7 +56,7 @@ export type ExtensionManifest = {
 		path: string;
 		source: string;
 		host: string;
-		hidden: boolean;
+		hidden?: boolean;
 	};
 };
 

--- a/packages/shared/src/utils/node/get-extensions.test.ts
+++ b/packages/shared/src/utils/node/get-extensions.test.ts
@@ -36,13 +36,13 @@ describe('getPackageExtensions', () => {
 			name: 'test',
 			version: '0.1',
 			dependencies: {},
-			'directus:extension': { type: 'pack', path: './', source: 'test', host: 'localhost', hidden: true },
+			'directus:extension': { type: 'pack', path: './', source: 'test', host: '^9.0.0' },
 		});
 
 		expect(await getPackageExtensions(childPackage.name, EXTENSION_PACKAGE_TYPES)).toStrictEqual([
 			{
 				children: [],
-				host: 'localhost',
+				host: '^9.0.0',
 				local: false,
 				name: 'directus-extension-test',
 				path: childPackage.name + '/directus-extension-test',
@@ -73,12 +73,12 @@ describe('getPackageExtensions', () => {
 			name: 'test',
 			version: '0.1',
 			dependencies: {},
-			'directus:extension': { type: 'interface', path: './', source: 'test', host: 'localhost', hidden: true },
+			'directus:extension': { type: 'interface', path: './', source: 'test', host: '^9.0.0' },
 		});
 
 		expect(await getPackageExtensions(typePackage.name, EXTENSION_PACKAGE_TYPES)).toStrictEqual([
 			{
-				host: 'localhost',
+				host: '^9.0.0',
 				entrypoint: './',
 				local: false,
 				name: 'directus-extension-type',

--- a/packages/shared/src/utils/validate-extension-manifest.test.ts
+++ b/packages/shared/src/utils/validate-extension-manifest.test.ts
@@ -24,7 +24,7 @@ describe('', () => {
 		expect(validateExtensionManifest(mockExtension)).toBe(false);
 	});
 
-	it('returns false when passed item has a type other than pack and has no path, source, host, or hidden', () => {
+	it('returns false when passed item has a type other than pack and has no path, source or host', () => {
 		const mockExtension = {
 			name: 'test',
 			version: '0.1',
@@ -33,7 +33,7 @@ describe('', () => {
 		expect(validateExtensionManifest(mockExtension)).toBe(false);
 	});
 
-	it('returns false when passed item has a type of pack and has no host or hidden', () => {
+	it('returns false when passed item has a type of pack and has no host', () => {
 		const mockExtension = {
 			name: 'test',
 			version: '0.1',
@@ -46,7 +46,7 @@ describe('', () => {
 		const mockExtension = {
 			name: 'test',
 			version: '0.1',
-			'directus:extension': { type: 'interface', path: './', source: 'test', host: '^9.0.0', hidden: true },
+			'directus:extension': { type: 'interface', path: './', source: 'test', host: '^9.0.0' },
 		};
 		expect(validateExtensionManifest(mockExtension)).toBe(true);
 	});
@@ -55,7 +55,7 @@ describe('', () => {
 		const mockExtension = {
 			name: 'test',
 			version: '0.1',
-			'directus:extension': { type: 'pack', host: '^9.0.0', hidden: true },
+			'directus:extension': { type: 'pack', host: '^9.0.0' },
 		};
 		expect(validateExtensionManifest(mockExtension)).toBe(true);
 	});

--- a/packages/shared/src/utils/validate-extension-manifest.ts
+++ b/packages/shared/src/utils/validate-extension-manifest.ts
@@ -27,13 +27,12 @@ export function validateExtensionManifest(
 		if (
 			extensionOptions.path === undefined ||
 			extensionOptions.source === undefined ||
-			extensionOptions.host === undefined ||
-			extensionOptions.hidden === undefined
+			extensionOptions.host === undefined
 		) {
 			return false;
 		}
 	} else {
-		if (extensionOptions.host === undefined || extensionOptions.hidden === undefined) {
+		if (extensionOptions.host === undefined) {
 			return false;
 		}
 	}


### PR DESCRIPTION
This field will be used in conjunction with pack extensions to be able to hide extensions that are only usable as part of a pack.
There is no need to make the field required, though.