### PR TITLE
Turn GCS credentials from camelCase to snake_case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50283,6 +50283,7 @@
 			"dependencies": {
 				"@directus/drive": "9.0.0-rc.95",
 				"@google-cloud/storage": "^5.8.5",
+				"lodash": "4.17.21",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -52875,6 +52876,7 @@
 				"@types/normalize-path": "3.0.0",
 				"dotenv": "10.0.0",
 				"jest": "27.2.4",
+				"lodash": "4.17.21",
 				"normalize-path": "^3.0.0",
 				"npm-run-all": "4.1.5",
 				"ts-jest": "27.0.5",

--- a/packages/drive-gcs/package.json
+++ b/packages/drive-gcs/package.json
@@ -35,6 +35,7 @@
 	"dependencies": {
 		"@directus/drive": "9.0.0-rc.95",
 		"@google-cloud/storage": "^5.8.5",
+		"lodash": "4.17.21",
 		"normalize-path": "^3.0.0"
 	},
 	"devDependencies": {

--- a/packages/drive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/drive-gcs/src/GoogleCloudStorage.ts
@@ -55,6 +55,7 @@ export class GoogleCloudStorage extends Storage {
 
 	public constructor(config: GoogleCloudStorageConfig) {
 		super();
+		// This is necessary as only credentials are in snake_case, not camelCase. Ref #8601
 		if (config.credentials) {
 			config.credentials = mapKeys(config.credentials, (_value, key) => snakeCase(key));
 		}

--- a/packages/drive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/drive-gcs/src/GoogleCloudStorage.ts
@@ -30,6 +30,8 @@ import path from 'path';
 
 import normalize from 'normalize-path';
 
+import { mapKeys, snakeCase } from 'lodash';
+
 function handleError(err: Error & { code?: number | string }, path: string): Error {
 	switch (err.code) {
 		case 401:
@@ -53,6 +55,9 @@ export class GoogleCloudStorage extends Storage {
 
 	public constructor(config: GoogleCloudStorageConfig) {
 		super();
+		if (config.credentials) {
+			config.credentials = mapKeys(config.credentials, (_value, key) => snakeCase(key));
+		}
 		this.$config = config;
 		const GCSStorage = require('@google-cloud/storage').Storage;
 		this.$driver = new GCSStorage(config);


### PR DESCRIPTION
fixes #8569

## Reasoning

All the properties of `StorageOptions` in `@google-cloud/storage` are in camelCase _except_ `credentials.client_email` and `credentials.private_key`. Hence we had to add this logic to cater to this edge case.