### PR TITLE
fix orderBy to prioritize system fields first

### DIFF
--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -235,7 +235,7 @@ export const useFieldsStore = defineStore({
 		getFieldsForCollection(collection: string): Field[] {
 			return orderBy(
 				this.fields.filter((field) => field.collection === collection),
-				(collection) => (collection.meta?.sort ? Number(collection.meta?.sort) : null)
+				[(field) => field.meta?.system === true, (field) => (field.meta?.sort ? Number(field.meta?.sort) : null)]
 			);
 		},
 		getFieldsForCollectionAlphabetical(collection: string): Field[] {


### PR DESCRIPTION
fixes #8560

## Bug

After we reorder custom fields in system collections, the half fields are wrongly ordered & break the layout.

Example for `directus_users`:

https://user-images.githubusercontent.com/42867097/136321125-af5c64ac-0a12-4877-95b1-d02e65e2a875.mp4

## Investigation

The issue is with `half-right` being applied to the wrong fields here:

https://github.com/directus/directus/blob/e259fb496c77a4859fb1523e6e588d970b5ecc1f/app/src/composables/use-form-fields/use-form-fields.ts#L39-L45

This is because the system fields order are disrupted by the custom fields which jumbles up the original ordering.

When we reorder the custom fields, the `sort` value in the `directus_fields` table are set.

However they can be smaller/lower compared to existing system fields. But this is circumvented by ensuring they are larger than system fields by increasing their sort value here:

https://github.com/directus/directus/blob/e259fb496c77a4859fb1523e6e588d970b5ecc1f/app/src/composables/use-form-fields/use-form-fields.ts#L47-L49

With that said, this corrective sorting happened _after_ a preliminary sorting that happened over here:

https://github.com/directus/directus/blob/e259fb496c77a4859fb1523e6e588d970b5ecc1f/app/src/stores/fields.ts#L235-L240

Within the above sort, the custom fields still has the aforementioned smaller/lower sort value, which is why they will mess up the sort here before we can do the corrective sort.

## Solution

- Order by system fields first, then the existing logic of order by sort column
- (minor) corrected the variable name from `collection` to `field` 

## Uncertainty

Technically we can move the corrective sort directly into `getFieldsForCollection` to avoid multiple sorts, but there might be something I looked over/missed as I'm still not fully familiar with the whole flow.