### PR TITLE
Ignore WYSIWYG change on first load

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -6,6 +6,7 @@
 			:init="editorOptions"
 			:disabled="disabled"
 			model-events="change keydown blur focus paste ExecCommand SetContent"
+			@dirty="setDirty"
 			@focusin="setFocus(true)"
 			@focusout="setFocus(false)"
 		/>
@@ -237,6 +238,7 @@ export default defineComponent({
 
 		const editorRef = ref<any | null>(null);
 		const editorElement = ref<ComponentPublicInstance | null>(null);
+		const isEditorDirty = ref(false);
 		const { imageToken } = toRefs(props);
 
 		const { imageDrawerOpen, imageSelection, closeImageDrawer, onImageSelect, saveImage, imageButton } = useImage(
@@ -293,6 +295,7 @@ export default defineComponent({
 				return replaceTokens(props.value, getToken());
 			},
 			set(newValue: string) {
+				if (!isEditorDirty.value) return;
 				if (newValue !== props.value && (props.value === null && newValue === '') === false) {
 					const removeToken = replaceTokens(newValue, props.imageToken ?? null);
 					emit('input', removeToken);
@@ -350,6 +353,7 @@ export default defineComponent({
 			editorOptions,
 			internalValue,
 			setFocus,
+			setDirty,
 			onImageSelect,
 			saveImage,
 			imageDrawerOpen,
@@ -384,6 +388,10 @@ export default defineComponent({
 			editor.ui.registry.addToggleButton('customMedia', mediaButton);
 			editor.ui.registry.addToggleButton('customLink', linkButton);
 			editor.ui.registry.addButton('customCode', sourceCodeButton);
+		}
+
+		function setDirty() {
+			isEditorDirty.value = true;
 		}
 
 		function setFocus(val: boolean) {


### PR DESCRIPTION
fixes #6957

## Bug

The WYSIWYG interface is triggering a change when it is technically loading/setting the original value here:

https://github.com/directus/directus/blob/11d259b5851795e916b02339bb1dbd7c713e6d5a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue#L8

Unfortunately, I couldn't reproduce the exact same issue. However, I've also noticed another similar thing that can trigger this behaviour is by setting a default value to the WYSIWYG input. Since when the component is still loading, it's seen as not having a value, hence the default value kicks in, thus replacing the original value with the default value.

https://user-images.githubusercontent.com/42867097/136339155-9110ee61-3c43-4738-8af3-1f7d20c0b323.mp4

And this became the basis of this solution, though I also believe this should solve the report bug. Ultimately, we might need someone that actually face this bug to try this out to be 100% sure (or find a way to reliably reproduce this).

## Investigation

TinyMCE has an event called `Dirty` which is fired (only once) when the content is actually changed/modified, hence the term "dirty".

![image](https://user-images.githubusercontent.com/42867097/136339559-b9eeb6e4-7285-4fa4-80b5-ffdd1bf42c62.png)

Link to docs for above image: https://www.tiny.cloud/docs/advanced/events/#editorcoreevents

Additional info:

> Returns true/false if the editor is dirty or not. It will get dirty if the user has made modifications to the contents. The dirty state is automatically set to `true` when the user modifies editor content after initialization or the last `editor.save()` call. This includes changes made using undo or redo.
> _Reference: https://www.tiny.cloud/docs/api/tinymce/tinymce.editor/#isdirty_

We can then use this to fulfill this proposal by @rijkvanzanten (particularly the latter half): 

>  We'll have to figure out some sort of way to ignore that change on first load, and only start accepting it after people have interacted with the editor
> _Link to above comment: https://github.com/directus/directus/issues/6957#issuecomment-936351590_

## Solution

Only allow the computed value to be set when `isEditorDirty` is true.

https://user-images.githubusercontent.com/42867097/136339401-c72ec78e-3440-4d4d-97d4-f6c5bb729a60.mp4


