### PR TITLE
Show file-image actions button upon focus; Use hover style for focuse…

### DIFF
--- a/app/src/components/v-button/v-button.vue
+++ b/app/src/components/v-button/v-button.vue
@@ -300,6 +300,7 @@ export default defineComponent({
 	transition-property: background-color border;
 }
 
+.button:focus,
 .button:hover {
 	color: var(--v-button-color-hover);
 	background-color: var(--v-button-background-color-hover);
@@ -339,6 +340,7 @@ export default defineComponent({
 	background-color: transparent;
 }
 
+.outlined:not(.active):focus,
 .outlined:not(.active):hover {
 	color: var(--v-button-background-color-hover);
 	background-color: transparent;

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -369,6 +369,7 @@ img {
 	transition: max-height var(--fast) var(--transition);
 }
 
+.image-preview:focus-within,
 .image-preview:hover {
 	.shadow {
 		height: 100%;


### PR DESCRIPTION
When tabulating over files-image interface, it's bit confusing because the focused buttons are hidden, and displayed only on hover.

After:

https://user-images.githubusercontent.com/1009639/136404677-62b38713-6e3b-4cd7-ad01-3b24a23aaf4c.mp4

