### PR TITLE
 Map layout and interface improvements

### DIFF
--- a/app/src/composables/use-layout.ts
+++ b/app/src/composables/use-layout.ts
@@ -59,6 +59,10 @@ function createLayoutWrapper<Options, Query>(layout: LayoutConfig): Component {
 				type: Function as PropType<() => Promise<void>>,
 				default: null,
 			},
+			clearFilters: {
+				type: Function as PropType<() => void>,
+				default: null,
+			},
 		},
 		emits: WRITABLE_PROPS.map((prop) => `update:${prop}` as const),
 		setup(props, { emit }) {

--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -116,7 +116,6 @@ export default defineComponent({
 		let map: Map;
 		let mapLoading = ref(true);
 		let currentGeometry: Geometry | null | undefined;
-		let hoveredFeatureId: string | null;
 
 		const geometryOptionsError = ref<string | null>();
 		const geometryParsingError = ref<string | TranslateResult>();

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1529,8 +1529,9 @@ layouts:
     invalid_geometry: Invalid geometry
     auto_location_filter: Always filter data to view bounds
     search_this_area: Search this area
-    clear_data_filter: Clear Data Filter
-    clear_location_filter: Clear Location Filter
+    clear_data_filters: Clear data filter
+    clear_location_filter: Clear location filter
+    no_results_here: No results in this area
 
 panels:
   metric:

--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -884,10 +884,11 @@ fields:
     png: PNG
     webP: WebP
     tiff: Tiff
+    basemaps: Fond de cartes
     basemaps_raster: Raster
     basemaps_tile: Raster TileJSON
     basemaps_style: Style de Mapbox
-    mapbox_key: Jeton d'accès Mapbox
+    mapbox_key: Clé d'accès Mapbox
     mapbox_placeholder: pk.eyJ1Ijo.....
     transforms_note: Le nom de la méthode Sharp et ses arguments. Voir https://sharp.pixelplumbing.com/api-constructor pour plus d'informations.
     additional_transforms: Transformations supplémentaires
@@ -1467,6 +1468,14 @@ layouts:
     map: Carte
     field: Géométrie
     search_this_area: Chercher dans cette zone
+    basemap: Fond de carte
+    layers: Couches
+    cluster: Regrouper les données
+    invalid_geometry: Invalid geometry
+    auto_location_filter: Toujours filter les données selon l'emprise
+    clear_data_filters: Effacer les filtres avancées
+    clear_location_filter: Effacer le filtre géographique
+    no_results_here: Aucun résultat dans cette zone
 panels:
   label:
     name: Étiquette

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -88,7 +88,9 @@ export default defineComponent({
 		});
 
 		const attributionControl = new AttributionControl({ compact: true });
-		const navigationControl = new NavigationControl();
+		const navigationControl = new NavigationControl({
+			showCompass: false,
+		});
 		const geolocateControl = new GeolocateControl();
 		const fitDataControl = new ButtonControl('mapboxgl-ctrl-fitdata', () => {
 			emit('fitdata');
@@ -115,6 +117,7 @@ export default defineComponent({
 				container: 'map-container',
 				style: style.value,
 				attributionControl: false,
+				dragRotate: false,
 				...props.camera,
 				...(mapboxKey ? { accessToken: mapboxKey } : {}),
 			});
@@ -245,6 +248,7 @@ export default defineComponent({
 			newSelection?.forEach((id) => {
 				map.setFeatureState({ id, source: '__directus' }, { selected: true });
 			});
+			boxSelectControl.showUnselect(newSelection?.length);
 		}
 
 		function onFeatureClick(event: MapLayerMouseEvent) {
@@ -470,6 +474,8 @@ export default defineComponent({
 }
 
 .mapboxgl-point-popup {
+	box-shadow: 10px 10px 10px solid red;
+
 	&.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
 		border-right-color: var(--background-normal);
 	}
@@ -493,12 +499,11 @@ export default defineComponent({
 		font-family: var(--family-sans-serif);
 		background-color: var(--background-normal);
 		border-radius: var(--border-radius);
+		box-shadow: var(--card-shadow);
 		pointer-events: none;
 	}
 }
-</style>
 
-<style lang="scss">
 #map-container.hover .mapboxgl-canvas-container {
 	cursor: pointer !important;
 }

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -51,6 +51,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		const customLayerDrawerOpen = ref(false);
 
+		const displayTemplate = syncOption(layoutOptions, 'displayTemplate', undefined);
 		const cameraOptions = syncOption(layoutOptions, 'cameraOptions', undefined);
 		const customLayers = syncOption(layoutOptions, 'customLayers', layers);
 		const autoLocationFilter = syncOption(layoutOptions, 'autoLocationFilter', false);
@@ -110,8 +111,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		});
 
 		const template = computed(() => {
-			if (info.value?.meta?.display_template) return info.value?.meta?.display_template;
-			return `{{ ${primaryKeyField.value?.field} }}`;
+			return displayTemplate.value || info.value?.meta?.display_template || `{{ ${primaryKeyField.value?.field} }}`;
 		});
 
 		const queryFields = computed(() => {
@@ -155,8 +155,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			shouldUpdateCamera.value = true;
 			locationFilterOutdated.value = false;
 			filters.value = filters.value.filter((filter) => filter.key !== 'location-filter');
+		}
+
+		function fitGeoJSONBounds() {
+			shouldUpdateCamera.value = true;
+			locationFilterOutdated.value = false;
 			if (geojson.value) {
-				geojsonBounds.value = geojson.value.bbox;
+				geojsonBounds.value = cloneDeep(geojson.value.bbox);
 			}
 		}
 
@@ -316,7 +321,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		});
 
 		return {
-			template,
 			geojson,
 			directusSource,
 			directusLayers,
@@ -332,6 +336,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			handleSelect,
 			geometryFormat,
 			geometryField,
+			displayTemplate,
 			isGeometryFieldNative,
 			cameraOptions,
 			autoLocationFilter,
@@ -359,6 +364,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			updateLocationFilter,
 			clearLocationFilter,
 			clearDataFilters,
+			fitGeoJSONBounds,
 		};
 
 		async function resetPresetAndRefresh() {

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -180,8 +180,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		}
 
 		function clearDataFilters() {
-			filter.value = null;
-			search.value = null;
+			props?.clearFilters();
 		}
 
 		const shouldUpdateCamera = ref(false);

--- a/app/src/layouts/map/map.vue
+++ b/app/src/layouts/map/map.vue
@@ -14,7 +14,7 @@
 			@featureclick="handleClick"
 			@featureselect="handleSelect"
 			@moveend="cameraOptionsWritable = $event"
-			@fitdata="clearLocationFilter"
+			@fitdata="fitGeoJSONBounds"
 		/>
 
 		<v-button
@@ -222,6 +222,10 @@ export default defineComponent({
 		},
 		locationFilterOutdated: {
 			type: Boolean,
+			required: true,
+		},
+		fitGeoJSONBounds: {
+			type: Function as PropType<() => void>,
 			required: true,
 		},
 		updateLocationFilter: {

--- a/app/src/layouts/map/map.vue
+++ b/app/src/layouts/map/map.vue
@@ -50,7 +50,7 @@
 				v-else-if="itemCount === 0 && (searchQuery || activeFilterCount > 0 || !locationFilterOutdated)"
 				icon="search"
 				center
-				:title="t('no_results_here')"
+				:title="t('layouts.map.no_results_here')"
 			>
 				<template #append>
 					<v-card-actions>
@@ -58,7 +58,7 @@
 							:disabled="!searchQuery && !filters.filter((f) => f.key !== 'location-filter').length"
 							@click="clearDataFilters"
 						>
-							{{ t('clear_data_filters') }}
+							{{ t('layouts.map.clear_data_filters') }}
 						</v-button>
 						<v-button :disabled="locationFilterOutdated" @click="clearLocationFilter">
 							{{ t('layouts.map.clear_location_filter') }}

--- a/app/src/layouts/map/options.vue
+++ b/app/src/layouts/map/options.vue
@@ -20,6 +20,11 @@
 	</template>
 
 	<div class="field">
+		<div class="type-label">{{ t('display_template') }}</div>
+		<v-field-template v-model="displayTemplateWritable" :collection="collection" />
+	</div>
+
+	<div class="field">
 		<v-checkbox
 			v-model="autoLocationFilterWritable"
 			:label="t('layouts.map.auto_location_filter')"
@@ -48,6 +53,10 @@ import { useSync } from '@directus/shared/composables';
 export default defineComponent({
 	inheritAttrs: false,
 	props: {
+		collection: {
+			type: String,
+			required: true,
+		},
 		geometryFields: {
 			type: Array as PropType<Item[]>,
 			required: true,
@@ -84,6 +93,10 @@ export default defineComponent({
 			type: Array as PropType<any[]>,
 			default: undefined,
 		},
+		displayTemplate: {
+			type: String as string | undefined,
+			default: undefined,
+		},
 	},
 	emits: [
 		'update:geometryField',
@@ -102,6 +115,7 @@ export default defineComponent({
 		const clusterDataWritable = useSync(props, 'clusterData', emit);
 		const customLayerDrawerOpenWritable = useSync(props, 'customLayerDrawerOpen', emit);
 		const customLayersWritable = useSync(props, 'customLayers', emit);
+		const displayTemplateWritable = useSync(props, 'displayTemplate', emit);
 
 		const basemaps = getBasemapSources();
 		const { basemap } = toRefs(appStore);
@@ -113,6 +127,7 @@ export default defineComponent({
 			clusterDataWritable,
 			customLayerDrawerOpenWritable,
 			customLayersWritable,
+			displayTemplateWritable,
 			basemaps,
 			basemap,
 		};

--- a/app/src/layouts/map/types.ts
+++ b/app/src/layouts/map/types.ts
@@ -16,4 +16,5 @@ export type LayoutOptions = {
 	autoLocationFilter?: boolean;
 	clusterData?: boolean;
 	animateOptions?: any;
+	displayTemplate?: string;
 };

--- a/app/src/modules/collections/routes/collection.vue
+++ b/app/src/modules/collections/routes/collection.vue
@@ -12,6 +12,7 @@
 		:search="search"
 		:collection="collection"
 		:reset-preset="resetPreset"
+		:clear-filters="clearFilters"
 	>
 		<collections-not-found v-if="!currentCollection || collection.startsWith('directus_')" />
 		<private-view

--- a/app/src/utils/geometry/controls.ts
+++ b/app/src/utils/geometry/controls.ts
@@ -113,10 +113,6 @@ export class BoxSelectControl {
 		const rect = container.getBoundingClientRect();
 		// @ts-ignore
 		return new Point(event.clientX - rect.left - container.clientLeft, event.clientY - rect.top - container.clientTop);
-		// return {
-		// 	x: event.clientX - rect.left - container.clientLeft,
-		// 	y: event.clientY - rect.top - container.clientTop
-		// };
 	}
 
 	onKeyDown(event: KeyboardEvent): void {
@@ -134,6 +130,10 @@ export class BoxSelectControl {
 		this.shiftPressed = yes;
 		this.selectButton.activate(yes);
 		this.map!.fire(`select.${yes ? 'enable' : 'disable'}`);
+	}
+
+	showUnselect(yes: boolean): void {
+		this.unselectButton.show(yes);
 	}
 
 	onKeyUp(event: KeyboardEvent): void {

--- a/packages/shared/src/types/layouts.ts
+++ b/packages/shared/src/types/layouts.ts
@@ -29,6 +29,7 @@ export interface LayoutProps<Options = any, Query = any> {
 	selectMode: boolean;
 	readonly: boolean;
 	resetPreset?: () => Promise<void>;
+	clearFilters?: () => void;
 }
 
 interface LayoutContext {


### PR DESCRIPTION
* Disable drag to rotate
* Add keyboard shortcut to delete items
* Hide unselect button when selection is empty
* Add display template setting
* Fixed fitData button behaviour

Cloned from #8610 because that one went messed up after the merge.
Regarding https://github.com/directus/directus/issues/7895 :


> The marker add/select/delete workflow is a bit confusing. I would recommend the following:
>  - Remove the "Delete Marker" button. The user can use the field's "Clear Value" option.

Since the value could contain multiple points and/or other geometries, we still need a way to delete single elements.
I added a keyboard shortcut to delete the active features with `backspace` or `delete`.

> Is it possible to give the marker a hover style?

It should be possible, but very hacky since `mapbox-gl-draw` doesn't use `map.setFeatureState`, and doesn't use native ids for the feature it handles. So in order to style features on hover, you need to use their own api to find feature at location (call it at every `mousemove` event), set a feature property with their own API too, remove the feature and add it again.

> Is it possible to slightly animate the selected marker so it's clear it's selected?

No, mapbox-gl doesn't supporting animation in styles. We could however style it more appropriately (different shadow, different color, different size, add a punch-hole in the middle of the marker...).

> Do we have _any_ control over the free map tile styling?

Nope, free osm tiles are png images, we can't restyle them - What we can do is change the default to a different provider (see [here](https://wiki.openstreetmap.org/wiki/Tile_servers), [here](https://switch2osm.org/providers/) and [here](https://leaflet-extras.github.io/leaflet-providers/preview/)).

>Let's figure out what free (no API key) license we can use to get not so blurry/pixelated base map tiles (if we can't find anything better, we might need to disable our Map support until they enter a key).

Fixed 👍

>I now see how to adjust rotation and pitch (right-click + drag)... but I'd rather disable these and remove the compass button

Done 👍

>I think the "Center Data" button (square brackets) could move to the right-click menu. It's also a bit finicky and doesn't work if you scroll away from data but don't hit "Search this area"
>Can we add a right-click context menu to the Maps? This might be good for hiding secondary buttons/features
>    Add Item Here
>    Fit Items in View
>    Change Map Tiles (if more than one available)

The "Center data" behaviour has been fixed. Apart from "Add item here", I believe all these actions deserve an always visible button, since their role is to change presentation. Right-clicking on the map generally involve direct interraction with the location that has been clicked. For example, in Google Maps, right-click options are "Route from here", "Measure distance", "Look around" etc. Buttons for changing background or searching items are always visible.

>For the Layout, can we only show the "X" button once you have some points selected?

Done 👍

>The "Locate Me" button takes a while to do anything. Can we swap this with a spinner while it's processing?

I haven't experienced this.. According to the docs, the geolocate control emits an event where the location has been found, but not when the request is initiated, so if we went this we'd have to hack it. Can you or anyone replicate ?

>On the Interface, let's remove the "Choose Tile Set" dropdown from the bottom-left. I'm getting a conflicting "MapLibre" watermark above it... and we can move this to the Right-Click anyway.
> I don't understand what the "OpenStreetMaps" dropdown in the bottom-left is for. I assume for toggling the map tiles? If so, this should be an interface option, not a UI option.

We made it an interface option initially, but it kind of makes sense that when a user is using the map layout to reach an item page, the map interface shown is the same background as the one that was previously used in the layout. Ultimately we could just remove it altogether, but I think being able to change the basemap while using the interface is a useful feature, for exemple switching between light/dark themes, or just using different informations to edit a geometry with better accuracy. I moved the "Maplibre" logo to the right so that it doesn't overlap with the dropdown.


>On the interface, let's add a hover to the marker that says: "Click to edit location" / "Click to set location"

Wouldn't it be a bit excessive to show a popup message every time an item is hovered ?

>For the Layout, the tooltip needs styling/dropshadow for contrast

Done 👍 I added the same `box-shadow` as the cards, is that fine now or do we need more than that ?
<img width="526" alt="Capture d’écran 2021-10-07 à 14 02 48" src="https://user-images.githubusercontent.com/33065839/136383430-815abc97-28fe-4571-9ac7-1404fac06a1e.png">

> For the Layout, we need a way to configure the data shown in the tooltip... right now it's just the ID

The template shown on the tooltip is the one used in the collection's own display template. Should we add an another option to overwrite it ?

> We need to adjust the color/styling of the Cluster circles (primary bg and white fg)

There currently are different colors for different cluster size. We could make them configurable - Actually, the whole style is customizable (item color, shape etc) according to the mapbox style specification. This used to be a layout option, but it has been removed since. Maybe we could add it back as global option (like the basemap settings) ?

<img width="645" alt="Capture d’écran 2021-10-07 à 14 35 03" src="https://user-images.githubusercontent.com/33065839/136385004-a033aa28-eab2-493d-ad9d-4c12372f35a8.png">