### PR TITLE
Fix creation of primary key field when it is uuid

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -484,7 +484,9 @@ export class FieldsService {
 			column.nullable();
 		}
 
-		if (field.schema?.is_unique === true) {
+		if (field.schema?.is_primary_key) {
+			column.primary().notNullable();
+		} else if (field.schema?.is_unique === true) {
 			if (!alter || alter.is_unique === false) {
 				column.unique();
 			}
@@ -492,10 +494,6 @@ export class FieldsService {
 			if (alter && alter.is_unique === true) {
 				table.dropUnique([field.field]);
 			}
-		}
-
-		if (field.schema?.is_primary_key) {
-			column.primary().notNullable();
 		}
 
 		if (alter) {


### PR DESCRIPTION
### Background

Before upgrading to RC96 version from RC95 version, I created a snapshot, I started a new project and restored the snapshot, I tested the application and the interface was failing only for the collections that had an id of type uuid, when I visualized the data model from directus I saw that the ids were not marked as primary key, I checked the database and I saw that the fields had two indices, one unique and another primary, then I remembered some issue related to fields with two indices, I updated the yml file and all the primary key fields I set the is_unique value to false and I restored the snapshot in a new project, at that moment it was working.


### Fix

I have reviewed the field creation service and I have seen that the fields that are primary and unique create both indexes, I do not know why in the case of the incremental ones it does not create the unique index, but in the rest of the case it does.

The fastest temporary solution that I have found is that the indexes are exclusive, if it is primary it cannot be unique explicitly.