### PR TITLE
Adjust "Report Bug" link to the new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,12 +29,14 @@ body:
     validations:
       required: true
   - type: input
+    id: directus-version
     attributes:
       label: What version of Directus are you using?
       description: 'For example: v9.1.4'
     validations:
       required: true
   - type: input
+    id: node-version
     attributes:
       label: What version of Node.js are you using?
       description: 'For example: 12.0.0'
@@ -53,6 +55,7 @@ body:
     validations:
       required: true
   - type: input
+    id: operating-system
     attributes:
       label: What operating system are you using?
       description: 'For example: macOS, Windows'

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -29,10 +29,13 @@
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
 import { version } from '../../../../package.json';
+import { useProjectInfo } from '../composables/use-project-info';
 
 export default defineComponent({
 	setup() {
 		const { t } = useI18n();
+
+		const { parsedInfo } = useProjectInfo();
 
 		const navItems = [
 			{
@@ -63,20 +66,30 @@ export default defineComponent({
 			},
 		];
 
-		const externalItems = [
-			{
-				icon: 'bug_report',
-				name: t('report_bug'),
-				href: `https://github.com/directus/directus/issues/new?labels=Bug+%28Potential%29&template=bug_report.yml`,
-				outline: true,
-			},
-			{
-				icon: 'new_releases',
-				name: t('request_feature'),
-				href: 'https://github.com/directus/directus/discussions/new',
-				outline: true,
-			},
-		];
+		const externalItems = computed(() => {
+			const bugReportParams = new URLSearchParams({
+				labels: 'Bug (Potential)',
+				template: 'bug_report.yml',
+				'directus-version': parsedInfo.value?.directus.version ?? '',
+				'node-version': parsedInfo.value?.node.version ?? '',
+				'operating-system': `${parsedInfo.value?.os.type ?? ''} ${parsedInfo.value?.os.version ?? ''}`,
+			});
+
+			return [
+				{
+					icon: 'bug_report',
+					name: t('report_bug'),
+					href: `https://github.com/directus/directus/issues/new?${bugReportParams.toString()}`,
+					outline: true,
+				},
+				{
+					icon: 'new_releases',
+					name: t('request_feature'),
+					href: 'https://github.com/directus/directus/discussions/new',
+					outline: true,
+				},
+			];
+		});
 
 		return { version, navItems, externalItems };
 	},

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -29,13 +29,10 @@
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
 import { version } from '../../../../package.json';
-import { useProjectInfo } from '../composables/use-project-info';
 
 export default defineComponent({
 	setup() {
 		const { t } = useI18n();
-
-		const { parsedInfo } = useProjectInfo();
 
 		const navItems = [
 			{
@@ -66,33 +63,20 @@ export default defineComponent({
 			},
 		];
 
-		const externalItems = computed(() => {
-			const debugInfo = `<!-- Please put a detailed explanation of the problem here. -->
-
----
-
-### Project details
-Directus Version: ${parsedInfo.value?.directus.version}
-Environment: ${import.meta.env.MODE}
-OS: ${parsedInfo.value?.os.type} ${parsedInfo.value?.os.version}
-Node: ${parsedInfo.value?.node.version}
-			`;
-
-			return [
-				{
-					icon: 'bug_report',
-					name: t('report_bug'),
-					href: `https://github.com/directus/directus/issues/new?body=${encodeURIComponent(debugInfo)}`,
-					outline: true,
-				},
-				{
-					icon: 'new_releases',
-					name: t('request_feature'),
-					href: 'https://github.com/directus/directus/discussions/new',
-					outline: true,
-				},
-			];
-		});
+		const externalItems = [
+			{
+				icon: 'bug_report',
+				name: t('report_bug'),
+				href: `https://github.com/directus/directus/issues/new?labels=Bug+%28Potential%29&template=bug_report.yml`,
+				outline: true,
+			},
+			{
+				icon: 'new_releases',
+				name: t('request_feature'),
+				href: 'https://github.com/directus/directus/discussions/new',
+				outline: true,
+			},
+		];
 
 		return { version, navItems, externalItems };
 	},


### PR DESCRIPTION
~Removing computed link for now... Unfortunately, it's not (yet?) possible to auto-fill the fields in the template
via query...~

The "Report bug" button now links to the new issue template and auto-fills some fields.
We might want to auto-fill more fields later on (e.g. database type).