### PR TITLE
Define middlewares before using in `app.use`, clean up middlewares definitions (#8713)

### DIFF
--- a/api/src/middleware/payload-size-limiter.ts
+++ b/api/src/middleware/payload-size-limiter.ts
@@ -1,0 +1,19 @@
+import express, { RequestHandler } from 'express';
+import env from '../env';
+import { InvalidPayloadException } from '../exceptions';
+
+const payloadSizeLimiter: RequestHandler = (req, res, next) => {
+	(
+		express.json({
+			limit: env.MAX_PAYLOAD_SIZE,
+		}) as RequestHandler
+	)(req, res, (err: any) => {
+		if (err) {
+			return next(new InvalidPayloadException(err.message));
+		}
+
+		return next();
+	});
+};
+
+export default payloadSizeLimiter;

--- a/api/src/middleware/powered-by.ts
+++ b/api/src/middleware/powered-by.ts
@@ -1,0 +1,8 @@
+import { RequestHandler } from 'express';
+
+const poweredBy: RequestHandler = (req, res, next) => {
+	res.setHeader('X-Powered-By', 'Directus');
+	next();
+};
+
+export default poweredBy;

--- a/api/src/middleware/root-redirect.ts
+++ b/api/src/middleware/root-redirect.ts
@@ -1,0 +1,12 @@
+import { RequestHandler } from 'express';
+import env from '../env';
+
+const rootRedirect: RequestHandler = (req, res, next) => {
+	if (env.ROOT_REDIRECT) {
+		res.redirect(env.ROOT_REDIRECT);
+	} else {
+		next();
+	}
+};
+
+export default rootRedirect;

--- a/api/src/middlewares.ts
+++ b/api/src/middlewares.ts
@@ -1,0 +1,43 @@
+import { RequestHandler } from 'express';
+import { expressLogger } from './logger';
+import cookieParser from 'cookie-parser';
+import extractToken from './middleware/extract-token';
+import payloadSizeLimiter from './middleware/payload-size-limiter';
+import poweredBy from './middleware/powered-by';
+import env from './env';
+import cors from './middleware/cors';
+import rootRedirect from './middleware/root-redirect';
+import rateLimiter from './middleware/rate-limiter';
+import { session } from './middleware/session';
+import authenticate from './middleware/authenticate';
+import { checkIP } from './middleware/check-ip';
+import sanitizeQuery from './middleware/sanitize-query';
+
+export function middlewaresFactory(): { name: string; handler: RequestHandler }[] {
+	const middlewares: { name: string; handler: RequestHandler }[] = [];
+
+	middlewares.push({ name: 'expressLogger', handler: expressLogger });
+	middlewares.push({ name: 'payloadSizeLimiter', handler: payloadSizeLimiter });
+	middlewares.push({ name: 'cookieParser', handler: cookieParser() });
+	middlewares.push({ name: 'extractToken', handler: extractToken });
+	middlewares.push({ name: 'poweredBy', handler: poweredBy });
+
+	if (env.CORS_ENABLED === true) {
+		middlewares.push({ name: 'cors', handler: cors });
+	}
+
+	middlewares.push({ name: 'rootRedirect', handler: rootRedirect });
+
+	if (env.RATE_LIMITER_ENABLED === true) {
+		// use the rate limiter - all routes for now
+		middlewares.push({ name: 'rateLimiter', handler: rateLimiter });
+	}
+
+	// We only rely on cookie-sessions in the oAuth flow where it's required
+	middlewares.push({ name: 'session', handler: session });
+	middlewares.push({ name: 'authenticate', handler: authenticate });
+	middlewares.push({ name: 'checkIP', handler: checkIP });
+	middlewares.push({ name: 'sanitizeQuery', handler: sanitizeQuery });
+
+	return middlewares;
+}


### PR DESCRIPTION
This PR proposal shows solution to #8713 discussion.

There is this code in `app.ts` between middlewares injecting:
```ts
if (env.SERVE_APP) {
	const adminPath = require.resolve('@directus/app/dist/index.html');
	const adminUrl = new Url(env.PUBLIC_URL).addPath('admin');

	// Set the App's base path according to the APIs public URL
	let html = fse.readFileSync(adminPath, 'utf-8');
	html = html.replace(
		/<meta charset="utf-8" \/>/,
		`<meta charset="utf-8" />\n\t\t<base href="${adminUrl.toString({ rootRelative: true })}/">`
	);

	app.get('/admin', (req, res) => res.send(html));
	app.use('/admin', express.static(path.join(adminPath, '..')));
	app.use('/admin/*', (req, res) => {
		res.send(html);
	});
}
});
```
Is it crucial, that this `app.use` runs here, or can it be run before / after creating all middlewares between `middlewares.init.before` and `middlewares.init.after`?

I will update docs when solution is approved.