### PR TITLE
Add "Activity" to module bar

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -59,6 +59,12 @@ export const MODULE_BAR_DEFAULT = [
 	},
 	{
 		type: 'module',
+		id: 'activity',
+		enabled: true,
+		locked: false,
+	},
+	{
+		type: 'module',
 		id: 'docs',
 		enabled: true,
 	},


### PR DESCRIPTION
It seems a bit strange to me that the activity module is only accessible by opening the sidebar, clicking on "Notifications" and then on "Show all activity". So I've added it to the module bar. Feel free to close this PR if you don't like this.