### PR TITLE
Add missing arguments in aggregated resolver

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -879,6 +879,13 @@ export class GraphQLService {
 					type: [AggregatedFunctions[collection.collection]],
 					args: {
 						groupBy: new GraphQLList(GraphQLString),
+						filter: ReadableCollectionFilterTypes[collection.collection],
+						search: {
+							type: GraphQLString,
+						},
+						sort: {
+							type: new GraphQLList(GraphQLString),
+						},
 					},
 					resolve: async ({ info, context }: { info: GraphQLResolveInfo; context: Record<string, any> }) => {
 						const result = await self.resolveQuery(info);


### PR DESCRIPTION
Aggregated queries support filtering/sorting/searching. This PR adds the missing arguments to GraphQL to expose this functionality