### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db: ['mssql', 'mysql', 'postgres', 'maria', 'sqlite3']
+        db: ["mssql", "mysql", "postgres", "maria", "sqlite3"]
         # node-version: ['12-alpine', '14-alpine', '16-alpine']
-        node-version: ['16-alpine']
+        node-version: ["16-alpine"]
     env:
       CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
     steps:
@@ -32,7 +32,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
+          cache: npm
       - name: restore node_modules cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,19 +22,8 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version: "16"
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
@@ -36,7 +36,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16.x'
+          node-version: "16.x"
+          cache: npm
 
       # See https://github.com/npm/cli/issues/3637
       - run: npm i -g npm@7.20.2
@@ -49,7 +50,7 @@ jobs:
       - name: Cache build artifacts
         uses: actions/cache@v2
         with:
-          path: '**/dist'
+          path: "**/dist"
           key: build-artifacts-${{ github.sha }}
 
   publish-npm:
@@ -60,13 +61,14 @@ jobs:
       - name: Restore build artifacts
         uses: actions/cache@v2
         with:
-          path: '**/dist'
+          path: "**/dist"
           key: build-artifacts-${{ github.sha }}
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # See https://github.com/npm/cli/issues/3637
       - run: npm i -g npm@7.20.2
@@ -86,7 +88,7 @@ jobs:
       - name: Restore build artifacts
         uses: actions/cache@v2
         with:
-          path: '**/dist'
+          path: "**/dist"
           key: build-artifacts-${{ github.sha }}
 
       - name: Set up QEMU
@@ -137,14 +139,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: './docker/Dockerfile'
+          file: "./docker/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
-
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['16']
+        node: ["16"]
     name: Node ${{ matrix.node }}
     steps:
       - name: Cancel Previous Runs
@@ -26,18 +26,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
