### PR TITLE
Try to fix "Assign author to PR" action

### DIFF
--- a/.github/workflows/assign-author-to-pr.yml
+++ b/.github/workflows/assign-author-to-pr.yml
@@ -1,11 +1,12 @@
 name: Assign author to PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
   assign-author:
+    name: Assign author to PR
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/assign-author@v1


### PR DESCRIPTION
Currently, it doesn't work and the log shows the following message: `Warning: Resource not accessible by integration`

Follow up of #8733