### PR TITLE
remove obsolete selectionFilters in O2M tree view

### DIFF
--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -134,7 +134,6 @@ export default defineComponent({
 			emitValue,
 			stageSelection,
 			selectDrawer,
-			selectionFilters,
 			addNewActive,
 			addNew,
 		};


### PR DESCRIPTION
fixes #8736

This was missed when `selectionFilters` got removed over here: https://github.com/directus/directus/pull/8570/files#diff-9fbb64e6f2881d20e39054cc5d484d33e515284a46c9fb93c1fab19aad0a338f