### PR TITLE
Fix disabled state of code input

### DIFF
--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -237,7 +237,7 @@ export default defineComponent({
 				defaultOptions,
 				{
 					lineNumbers: props.lineNumber,
-					readOnly: false,
+					readOnly: props.disabled ? 'nocursor' : false,
 					mode: props.language,
 					placeholder: props.placeholder,
 				},


### PR DESCRIPTION
Fixes readonly code inputs being editable on page load. 

**Before fix** 
"Code Always Disabled" is always editable
https://user-images.githubusercontent.com/1536407/137131610-c3e467ed-5dfc-4267-b51c-9e2305479223.mp4

**After fix**
"Code Always Disabled" is never editable
https://user-images.githubusercontent.com/1536407/137131643-80331bd9-2f9f-4bf8-80ae-bdbfe63b2f46.mp4


