### PR TITLE
Fix layouts stuck at page 1 with filters

### DIFF
--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -111,7 +111,9 @@ export default defineComponent({
 			if (val === '') {
 				emit('input', null);
 			} else {
-				emit('input', val);
+				if (typeof val !== 'string' || new RegExp(inputPattern.value).test(val)) {
+					emit('input', val);
+				}
 			}
 		}
 	},

--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -59,7 +59,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		const { size, icon, imageSource, title, subtitle, imageFit } = useLayoutOptions();
 		const { sort, limit, page, fields } = useLayoutQuery();
-		watch([collection, search, limit, sort], () => (page.value = 1));
 
 		const { items, loading, error, totalPages, itemCount, totalCount, getItems } = useItems(collection, {
 			sort,
@@ -143,10 +142,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		function toPage(newPage: number) {
 			page.value = newPage;
-			mainElement.value?.scrollTo({
-				top: 0,
-				behavior: 'smooth',
-			});
 		}
 
 		function useLayoutOptions() {
@@ -179,6 +174,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			const limit = syncRefProperty(layoutQuery, 'limit', 25);
 			const defaultSort = computed(() => (primaryKeyField.value ? [primaryKeyField.value?.field] : []));
 			const sort = syncRefProperty(layoutQuery, 'sort', defaultSort.value);
+
+			watch(
+				() => page.value,
+				() => {
+					mainElement.value?.scrollTo({ top: 0, behavior: 'smooth' });
+				}
+			);
 
 			const fields = computed<string[]>(() => {
 				if (!primaryKeyField.value || !props.collection) return [];

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -177,9 +177,9 @@ export default defineComponent({
 		}
 
 		function fitBounds() {
-			const bbox = props.data.bbox as LngLatBoundsLike;
+			const bbox = props.data.bbox?.map((x) => x % 90);
 			if (map && bbox) {
-				map.fitBounds(bbox, {
+				map.fitBounds(bbox as LngLatBoundsLike, {
 					padding: 100,
 					speed: 1.3,
 					maxZoom: 14,

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -28,8 +28,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	component: MapLayout,
 	slots: {
 		options: MapOptions,
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		sidebar: () => {},
+		sidebar: () => undefined,
 		actions: MapActions,
 	},
 	setup(props, { emit }) {
@@ -229,7 +228,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		function onQueryChange() {
 			shouldUpdateCamera.value = true;
 			geojsonLoading.value = false;
-			page.value = 1;
 		}
 
 		function updateGeojson() {

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -45,7 +45,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		const { info, primaryKeyField, fields: fieldsInCollection, sortField } = useCollection(collection);
 
 		const { sort, limit, page, fields, fieldsWithRelational } = useItemOptions();
-		watch([collection, search, limit, sort], () => (page.value = 1));
 
 		const { items, loading, error, totalPages, itemCount, totalCount, changeManualSort, getItems } = useItems(
 			collection,
@@ -134,10 +133,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		function toPage(newPage: number) {
 			page.value = newPage;
-			mainElement.value?.scrollTo({
-				top: 0,
-				behavior: 'smooth',
-			});
 		}
 
 		function selectAll() {
@@ -164,6 +159,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				if (!props.collection) return [];
 				return adjustFieldsForDisplays(fields.value, props.collection);
 			});
+
+			watch(
+				() => page.value,
+				() => {
+					mainElement.value?.scrollTo({ top: 0, behavior: 'smooth' });
+				}
+			);
 
 			return { sort, limit, page, fields, fieldsWithRelational };
 		}

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -77,11 +77,16 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 			if (!newCollection || !query) return;
 
-			if (newFilter !== oldFilter || newLimit !== oldLimit || newSort !== oldSort || newSearch !== oldSearch) {
+			if (
+				!isEqual(newFilter, oldFilter) ||
+				!isEqual(newSort, oldSort) ||
+				newLimit !== oldLimit ||
+				newSearch !== oldSearch
+			) {
 				page.value = 1;
 			}
 
-			if (isEqual(newCollection, oldCollection) === false) {
+			if (newCollection !== oldCollection) {
 				reset();
 			}
 


### PR DESCRIPTION
https://github.com/directus/directus/blob/0ff35036f63bacdeda4f2f85c1b549018b88ecda/packages/shared/src/composables/use-items.ts#L80-L85

All three layouts were already resetting the page to 1 when the query or the collection changed.