### PR TITLE
Disable sqlite3 in E2E tests on CI

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db: ["mssql", "mysql", "postgres", "maria", "sqlite3"]
+        db: ['mssql', 'mysql', 'postgres', 'maria'] #sqlite
         # node-version: ['12-alpine', '14-alpine', '16-alpine']
-        node-version: ["16-alpine"]
+        node-version: ['16-alpine']
     env:
       CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
     steps:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: '16'
           cache: npm
       - name: restore node_modules cache
         uses: actions/cache@v2


### PR DESCRIPTION
Disabling sqlite3 on end to end tests until the data.db location in the docker is sorted.