### PR TITLE
Fix column resizing for collections overview

### DIFF
--- a/app/src/modules/collections/routes/overview.vue
+++ b/app/src/modules/collections/routes/overview.vue
@@ -46,7 +46,8 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, ref } from 'vue';
+import { HeaderRaw } from '@/components/v-table/types';
 import CollectionsNavigation from '../components/navigation.vue';
 import CollectionsNavigationSearch from '../components/navigation-search.vue';
 import useNavigation, { NavItem } from '../composables/use-navigation';
@@ -67,7 +68,7 @@ export default defineComponent({
 
 		const userStore = useUserStore();
 
-		const tableHeaders = [
+		const tableHeaders = ref<HeaderRaw[]>([
 			{
 				text: '',
 				value: 'icon',
@@ -84,7 +85,7 @@ export default defineComponent({
 				value: 'note',
 				width: 360,
 			},
-		];
+		]);
 
 		const { navItems } = useNavigation();
 


### PR DESCRIPTION
fixes #8778

Implementation mirrored from data-model table, turning tableHeaders into a `ref` of type `HeaderRaw[]`:

https://github.com/directus/directus/blob/e56ccb991a201a6961b96fe3b4db15f7bdefdcea/app/src/modules/settings/routes/data-model/collections/collections.vue#L121-L138