### PR TITLE
Docs: replace 'files.create' by 'files.upload'

### DIFF
--- a/docs/guides/api-hooks.md
+++ b/docs/guides/api-hooks.md
@@ -22,7 +22,7 @@ System events are referenced with the format:
 ```
 <scope>.<action>(.<before>)
 // eg: items.create
-// eg: files.create
+// eg: files.upload
 // eg: collections.*
 // eg: users.update.before
 ```


### PR DESCRIPTION
because 'files.create' does not exist