### PR TITLE
Format filesize for display & file info sidebar

### DIFF
--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -6,7 +6,7 @@ export default defineDisplay({
 	name: '$t:displays.filesize.filesize',
 	description: '$t:displays.filesize.description',
 	icon: 'description',
-	component: ({ value }: { value: number }) => formatFilesize(value, false),
+	component: ({ value }: { value: number }) => formatFilesize(value),
 	options: [],
 	types: ['integer'],
 });

--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -1,12 +1,12 @@
 import { defineDisplay } from '@directus/shared/utils';
-import bytes from 'bytes';
+import formatFilesize from '@/utils/format-filesize';
 
 export default defineDisplay({
 	id: 'filesize',
 	name: '$t:displays.filesize.filesize',
 	description: '$t:displays.filesize.description',
 	icon: 'description',
-	component: ({ value }: { value: number }) => bytes(value, { decimalPlaces: 0 }),
+	component: ({ value }: { value: number }) => formatFilesize(value, false),
 	options: [],
 	types: ['integer'],
 });

--- a/app/src/modules/files/components/file-info-sidebar-detail.vue
+++ b/app/src/modules/files/components/file-info-sidebar-detail.vue
@@ -129,7 +129,7 @@
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed, ref, watch } from 'vue';
 import readableMimeType from '@/utils/readable-mime-type';
-import bytes from 'bytes';
+import formatFilesize from '@/utils/format-filesize';
 import localizedFormat from '@/utils/localized-format';
 import api, { addTokenToURL } from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
@@ -154,7 +154,7 @@ export default defineComponent({
 			if (!props.file) return null;
 			if (!props.file.filesize) return null;
 
-			return bytes(props.file.filesize, { decimalPlaces: 2, unitSeparator: ' ' }); // { locale: locale.value.split('-')[0] }
+			return formatFilesize(props.file.filesize, false); // { locale: locale.value.split('-')[0] }
 		});
 
 		const { creationDate, modificationDate } = useDates();

--- a/app/src/modules/files/components/file-info-sidebar-detail.vue
+++ b/app/src/modules/files/components/file-info-sidebar-detail.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 			if (!props.file) return null;
 			if (!props.file.filesize) return null;
 
-			return formatFilesize(props.file.filesize, false); // { locale: locale.value.split('-')[0] }
+			return formatFilesize(props.file.filesize); // { locale: locale.value.split('-')[0] }
 		});
 
 		const { creationDate, modificationDate } = useDates();


### PR DESCRIPTION
This is sort of brought up by #4945. Although it might not be what is actually suggested (interface), this feels like a good UX change regardless. Plus there's an existing `formatFilesize` utility function which helped to expedite this change.

## Before

### Cards subtitle

![chrome_SpAXKXLvhV](https://user-images.githubusercontent.com/42867097/137275623-e508261f-93a7-4609-aac2-60b8875d235c.png)

### File info sidebar

![chrome_eltxQWs5LN](https://user-images.githubusercontent.com/42867097/137275658-54500d14-49d6-460c-a35d-4bd0ed626248.png)

## After

### Cards subtitle

![chrome_Dj7qtnyCZ6](https://user-images.githubusercontent.com/42867097/137275690-b416ee01-d41a-4963-a216-d34d9f92cf4b.png)

### File info sidebar

![chrome_gHCBdmtA2i](https://user-images.githubusercontent.com/42867097/137275731-2b3775f1-d104-42e7-be65-c03d1966c984.png)

## Additional note

Didn't remove the `bytes` package as it's still being used over here:

https://github.com/directus/directus/blob/fcdb0aa62065bba974395da96f982da2a98241d5/app/src/modules/settings/composables/use-project-info.ts#L63