### PR TITLE
Don't use type=search for filter input

### DIFF
--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -10,7 +10,7 @@
 	<input
 		v-else-if="is === 'interface-input'"
 		ref="inputEl"
-		type="search"
+		type="text"
 		:pattern="inputPattern"
 		:value="value"
 		:style="{ width }"


### PR DESCRIPTION
Fixes #8759

The search type renders a browser native X in various browser specific styles, which causes conflicts in the GUI