### PR TITLE
Fix broken access token refresh on page load

### DIFF
--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -45,6 +45,7 @@ export async function login(credentials: LoginCredentials): Promise<void> {
 let refreshTimeout: any;
 let idle = false;
 let isRefreshing = false;
+let firstRefresh = true;
 
 // Prevent the auto-refresh when the app isn't in use
 idleTracker.on('idle', () => {
@@ -73,8 +74,11 @@ idleTracker.on('show', () => {
 });
 
 export async function refresh({ navigate }: LogoutOptions = { navigate: true }): Promise<string | undefined> {
+	if (firstRefresh) {
+		firstRefresh = false;
+	}
 	// Skip if not logged in
-	if (!api.defaults.headers?.['Authorization']) return;
+	else if (!api.defaults.headers?.['Authorization']) return;
 
 	// Prevent concurrent refreshes
 	if (isRefreshing) return;

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -74,9 +74,8 @@ idleTracker.on('show', () => {
 });
 
 export async function refresh({ navigate }: LogoutOptions = { navigate: true }): Promise<string | undefined> {
-	if (firstRefresh) {
-		firstRefresh = false;
-	}
+	// Allow refresh during initial page load
+	if (firstRefresh) firstRefresh = false;
 	// Skip if not logged in
 	else if (!api.defaults.headers?.['Authorization']) return;
 


### PR DESCRIPTION
Fixes #8808. Refresh() was not run on page load due to regression introduced in #8452.

@rijkvanzanten When new server requests are sent in after an auth refresh request is triggered and before the new access token is received, there is a very high chance that the access token used in those subsequent requests are invalid, therefore resulting in auth errors. The odds of this happening is definitely lower due to the reduced refresh in app. But I suppose it is still good to have, particularly when the token expiry is set to be short.

May I ask if it's okay to add the following code block back?

```js
	return new Promise((resolve) => {
		if (config.url && config.url === '/auth/refresh') {
			queue.pause();
			resolve(requestConfig);
			queue.start();
		} else {
			queue.add(() => resolve(requestConfig));
		}
	});
```

https://github.com/licitdev/directus/blob/6cb971bd48b2db497636f7eb3c2c7c5c671921fa/app/src/api.ts#L39-L47

