### PR TITLE
Show deletion error in File Library view

### DIFF
--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -371,10 +371,11 @@ export default defineComponent({
 					await refresh();
 
 					selection.value = [];
-					confirmDelete.value = false;
 				} catch (err: any) {
+					unexpectedError(err);
 					error.value = err;
 				} finally {
+					confirmDelete.value = false;
 					deleting.value = false;
 				}
 			}

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -404,6 +404,7 @@ export default defineComponent({
 				router.push(to.value);
 			} catch {
 				// `remove` will show the unexpected error dialog
+				confirmDelete.value = false;
 			}
 		}
 


### PR DESCRIPTION
fixes #8821

## Reported bug

When deleting an image currently in use by Project Settings in the File Library view, no error is shown.

https://user-images.githubusercontent.com/42867097/137496106-07c13e5c-149f-40e5-b40a-b03dcf082f2a.mp4

Whereas when we view the file & delete it from there, there is an error pop up (albeit not truly as a user friendly message).

https://user-images.githubusercontent.com/42867097/137496420-c139debc-9ae6-4508-a938-5a734892cd0b.mp4

However notice that the deletion dialog still stays open.

## Investigation

When deleting a single item, `unexpectedError` utility function is used to show the error:

https://github.com/directus/directus/blob/8396eee95f0908949b80ec7b4ed578c3c475f8d7/app/src/composables/use-item/use-item.ts#L261-L279

Whereas it's not currently used in batch deletion, which is used in File Library.

## Solution

- Added `unexpectedError` for File Library view, also closes the previous deletion dialog once that happens

   https://user-images.githubusercontent.com/42867097/137496872-dec5f064-e26a-4ad1-870f-3b43c9c5abd8.mp4

- Closes the deletion dialog in single item view as well

   https://user-images.githubusercontent.com/42867097/137497042-adec1de1-2987-4467-b427-2885fd22d619.mp4



