### PR TITLE
Fix translations display shown in m2m

### DIFF
--- a/app/src/displays/raw/index.ts
+++ b/app/src/displays/raw/index.ts
@@ -8,4 +8,5 @@ export default defineDisplay({
 	component: ({ value }) => String(value),
 	options: [],
 	types: TYPES,
+	groups: ['file', 'files', 'group', 'm2a', 'm2m', 'm2o', 'o2m', 'presentation', 'standard', 'translations'],
 });

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -18,7 +18,7 @@ export default defineDisplay({
 	component: DisplayRelatedValues,
 	options: options,
 	types: ['alias', 'string', 'uuid', 'integer', 'bigInteger', 'json'],
-	groups: ['m2m', 'm2o', 'o2m'],
+	groups: ['m2m', 'm2o', 'o2m', 'translations', 'm2a'],
 	fields: (options: Options | null, { field, collection }) => {
 		const relatedCollection = getRelatedCollection(collection, field);
 		const fieldsStore = useFieldsStore();

--- a/app/src/displays/translations/index.ts
+++ b/app/src/displays/translations/index.ts
@@ -17,8 +17,8 @@ export default defineDisplay({
 	icon: 'translate',
 	component: DisplayTranslations,
 	options: options,
-	types: ['alias', 'string', 'uuid', 'integer', 'bigInteger', 'json'],
-	groups: ['m2m'],
+	types: ['alias'],
+	groups: ['translations'],
 	fields: (options: Options | null, { field, collection }) => {
 		const fieldsStore = useFieldsStore();
 		const relationsStore = useRelationsStore();

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -71,7 +71,7 @@ function initLocalStore(collection: string, field: string, type: LocalType): voi
 		return displays.value
 			.filter((inter: DisplayConfig) => {
 				const matchesType = inter.types.includes(state.fieldData?.type || 'alias');
-				const matchesLocalType = (inter.groups || ['standard']).includes(type) || true;
+				const matchesLocalType = (inter.groups || ['standard']).includes(type) ?? true;
 
 				return matchesType && matchesLocalType;
 			})

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -71,7 +71,7 @@ function initLocalStore(collection: string, field: string, type: LocalType): voi
 		return displays.value
 			.filter((inter: DisplayConfig) => {
 				const matchesType = inter.types.includes(state.fieldData?.type || 'alias');
-				const matchesLocalType = (inter.groups || ['standard']).includes(type) ?? true;
+				const matchesLocalType = (inter.groups || ['standard']).includes(type);
 
 				return matchesType && matchesLocalType;
 			})


### PR DESCRIPTION
The translations display showed under fields it wasn't suppost to be shown.
related to #8811