### PR TITLE
Fix scoping of v-list-group to the same as v-list

### DIFF
--- a/app/src/components/v-list/v-list-group.vue
+++ b/app/src/components/v-list/v-list-group.vue
@@ -72,7 +72,7 @@ export default defineComponent({
 		},
 		scope: {
 			type: String,
-			default: undefined,
+			default: 'v-list',
 		},
 		value: {
 			type: [String, Number],


### PR DESCRIPTION
Because of this the advanced filter wouldn't open.