### PR TITLE
Add geo operators to FilterOperators type

### DIFF
--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -63,7 +63,11 @@ export type FilterOperators =
 	| '_null'
 	| '_nnull'
 	| '_empty'
-	| '_nempty';
+	| '_nempty'
+	| '_intersects'
+	| '_nintersects'
+	| '_intersects_bbox'
+	| '_nintersects_bbox';
 
 export type FilterOperator<T, K extends keyof T> = {
 	[O in FilterOperators]?: Filter<T> | T[K];


### PR DESCRIPTION
This small PR updates the `FilterOperators` type in Directus SDK to include geo filters (the list taken from the [docs](https://docs.directus.io/reference/filter-rules/#filter-operators))