### PR TITLE
App: add 'schema' to body in M2M and M2A

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -423,6 +423,9 @@ function initLocalStore(collection: string, field: string, type: LocalType): voi
 							hidden: true,
 							icon: 'import_export',
 						},
+						schema: {
+							name: junctionCollection,
+						},
 						fields: [
 							{
 								field: 'id',
@@ -855,6 +858,9 @@ function initLocalStore(collection: string, field: string, type: LocalType): voi
 						meta: {
 							hidden: true,
 							icon: 'import_export',
+						},
+						schema: {
+							name: junctionCollection,
 						},
 						fields: [
 							{


### PR DESCRIPTION
Fixes #8854, Fixes #8866

Investigation:
Found the source of the issue was introduced on https://github.com/directus/directus/pull/8623, more specifically on this line
https://github.com/directus/directus/pull/8623/files#diff-5304ccdeed068ae9dbe314d517f470f219218da43f28c98ac1e12c4576d98807R83

In order to fix, we need to pass the `schema` property  so it can pass the condition.