### PR TITLE
Fix slug input

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -243,7 +243,7 @@ export default defineComponent({
 			} else {
 				if (props.slug === true) {
 					const endsWithSpace = value.endsWith(' ');
-					value = slugify(value, { separator: props.slugSeparator });
+					value = slugify(value, { separator: props.slugSeparator, preserveTrailingDash: true });
 					if (endsWithSpace) value += props.slugSeparator;
 				}
 

--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -179,7 +179,17 @@ export default defineComponent({
 		function processValue(event: KeyboardEvent) {
 			if (!event.key) return;
 			const key = event.key.toLowerCase();
-			const systemKeys = ['meta', 'shift', 'alt', 'backspace', 'tab'];
+			const systemKeys = [
+				'meta',
+				'shift',
+				'alt',
+				'backspace',
+				'tab',
+				'arrowup',
+				'arrowdown',
+				'arrowleft',
+				'arrowright',
+			];
 			const value = (event.target as HTMLInputElement).value;
 
 			if (props.slug === true) {


### PR DESCRIPTION
fixes #8883

## Reported bugs

1. Cannot move text cursor

2. Backspace causes trailing dash to be removed as well

   This is because the Slugify package ran on keypress (backspace in this case), and automatically trimmed the trailing dash when it was `qwe-`.
   
   ![o2Mx5oyLT7](https://user-images.githubusercontent.com/42867097/137661351-3bc9db57-44f9-4747-aad3-a0b0b0450573.gif)
   
## Solution

- Added arrow keys to allowed list of systemKeys

   ![ZkSPblPSIk](https://user-images.githubusercontent.com/42867097/137661320-7512cec9-086d-47f3-bb91-807e37151908.gif)
 
- Added `preserveTrailingDash: true` option (which was added [fairly recently](https://github.com/sindresorhus/slugify/pull/57), thus the reason why is was not implemented when slug input feature was added)

   ![p4ujpr1KT1](https://user-images.githubusercontent.com/42867097/137661386-4b2148e1-e1ba-46ee-bb90-995ee9a1dc3b.gif)
  