### PR TITLE
Fix "Show Hidden Collection" context menu in collections navigation

### DIFF
--- a/app/src/modules/collections/components/navigation.vue
+++ b/app/src/modules/collections/components/navigation.vue
@@ -112,11 +112,15 @@ export default defineComponent({
 }
 
 .collections-navigation-wrapper {
-	height: 100%;
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
 }
 
 .collections-navigation {
 	--v-list-min-height: calc(100% - 64px);
+
+	flex-grow: 1;
 
 	.v-detail {
 		:deep(.v-divider) {

--- a/app/src/modules/collections/components/navigation.vue
+++ b/app/src/modules/collections/components/navigation.vue
@@ -64,8 +64,9 @@ export default defineComponent({
 		const contextMenuTarget = ref<undefined | string>();
 
 		const rootItems = computed(() => {
+			const shownCollections = showHidden.value ? collectionsStore.allCollections : collectionsStore.visibleCollections;
 			return orderBy(
-				collectionsStore.visibleCollections.filter((collection) => {
+				shownCollections.filter((collection) => {
 					return isNil(collection?.meta?.group);
 				}),
 				['meta.sort', 'collection']

--- a/app/src/modules/collections/components/navigation.vue
+++ b/app/src/modules/collections/components/navigation.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="collections-navigation">
+	<div class="collections-navigation-wrapper">
 		<div v-if="showSearch" class="search-input">
 			<v-input v-model="search" type="search" :placeholder="t('search_collection')" />
 		</div>
@@ -108,6 +108,10 @@ export default defineComponent({
 		--v-button-background-color: var(--foreground-subdued);
 		--v-button-background-color-hover: var(--primary);
 	}
+}
+
+.collections-navigation-wrapper {
+	height: 100%;
 }
 
 .collections-navigation {

--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -23,10 +23,8 @@ export const useCollectionsStore = defineStore({
 				.filter(({ collection }) => collection.startsWith('directus_') === false)
 				.filter((collection) => collection.meta?.hidden !== true);
 		},
-		hiddenCollections(): Collection[] {
-			return this.collections
-				.filter(({ collection }) => collection.startsWith('directus_') === false)
-				.filter((collection) => collection.meta?.hidden !== false);
+		allCollections(): Collection[] {
+			return this.collections.filter(({ collection }) => collection.startsWith('directus_') === false);
 		},
 		crudSafeSystemCollections(): Collection[] {
 			return orderBy(


### PR DESCRIPTION
fixes #8871

## Reported bugs

1. Right-clicking to show hidden collections does not do anything

2. Need to right-click in a specific area before the context menu shows up

   This is because the height of the wrapping div is not fully filling up the space available:
   
   ![chrome_kiLsYoFcmB](https://user-images.githubusercontent.com/42867097/137669819-0dca684f-22f6-4f84-b8d7-0d6135bad02f.png)

## Solution

- Changed `hiddenCollections` in collections store into `allCollections` as I assume hiddenCollections was only used for the already-removed hidden collections nav. Then use the `showHidden` flag to determine the value of rootItems.

   Note: Do let me know if there's still a need to retain the `hiddenCollections` getter.

   ![xbkemLmpen](https://user-images.githubusercontent.com/42867097/137669899-e6e12d9c-ecc2-40f1-9a54-a83d3e2fa7b5.gif)

- Increase the hitbox for collections navigation

   - changed the class for the root div from `collections-navigation` to `collections-navigation-wrapper`, since the former is already being used by the inner `v-list`.
   
   - Add `height: 100%` to the wrapper class.
   
   ![w7aGPNMsWJ](https://user-images.githubusercontent.com/42867097/137669837-eeaa64e1-3c68-4dd7-b748-25989b330b7d.gif)
  