### PR TITLE
hydrate permissionsStore only if user has role

### DIFF
--- a/app/src/hydrate.ts
+++ b/app/src/hydrate.ts
@@ -60,11 +60,11 @@ export async function hydrate(stores = useStores()): Promise<void> {
 		 * else.
 		 */
 		await userStore.hydrate();
-		await permissionsStore.hydrate();
-
-		const hydratedStores = ['userStore', 'permissionsStore'];
 
 		if (userStore.currentUser?.role) {
+			await permissionsStore.hydrate();
+			const hydratedStores = ['userStore', 'permissionsStore'];
+
 			await Promise.all(stores.filter(({ $id }) => !hydratedStores.includes($id)).map((store) => store.hydrate?.()));
 			await registerModules();
 


### PR DESCRIPTION
fixes #8885

## Reported bug

When a user without App Access logs in, it should show "No App Access", but now it shows a nondescript `Cannot read properties of undefined (reading 'id')` error instead.

## Investigation

The current hydration flow is to ensure usersStore runs first, followed by permissionsStore, then the rest:

https://github.com/directus/directus/blob/6db9e0cd7dc2fac93964a6ac45e47fadf4d09eff/app/src/hydrate.ts#L62-L63

The offending undefined "id" is due to role id here inside permissionsStore:

https://github.com/directus/directus/blob/6db9e0cd7dc2fac93964a6ac45e47fadf4d09eff/app/src/stores/permissions.ts#L16-L18

Since when a user has no app access, the `/users/me` endpoint only returns the user ID instead of an user object. This causes this line to fail as `userStore.currentUser` (which is only a string here) does not have `.role.id`.

permissionsStore hydration used to be inside the `userStore.currentUser?.role` if statement, but was brought out by #8533 recently. So my current running theory would be the `/users/me` endpoint has always returned just the ID string in the past, just that it was "safe" when it was within the if statement.

## Solution

Ensure permissionsStore is hydrated if currentUser has role, by moving it into the if statement.

## Questions

Is the `/user/me` returning just an ID string in this case, by design? If it's not, then this solution might not be apt as this solution is sort of just reverting to the previous logic in a way.