### PR TITLE
Map layout and interface improvements

### DIFF
--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -79,7 +79,7 @@ import { useAppStore } from '@/stores';
 import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
 
 const MARKER_ICON_URL =
-	'https://cdn.jsdelivr.net/gh/google/material-design-icons/png/maps/place/materialicons/24dp/2x/baseline_place_black_24dp.png';
+	'https://cdn.jsdelivr.net/gh/google/material-design-icons/png/maps/place/materialicons/48dp/2x/baseline_place_black_48dp.png';
 
 export default defineComponent({
 	props: {

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -1,16 +1,11 @@
 <template>
 	<div class="form-grid">
-		<div class="field half-left">
-			<div class="type-label">{{ t('interfaces.map.geometry_format') }}</div>
-			<v-input v-model="geometryFormat" :disabled="true" :value="t(`interfaces.map.${compatibleFormat}`)" />
-		</div>
-		<div class="field half-right">
+		<div v-if="!nativeGeometryType && geometryFormat !== 'lnglat'" class="field half-left">
 			<div class="type-label">{{ t('interfaces.map.geometry_type') }}</div>
 			<v-select
 				v-model="geometryType"
 				:placeholder="t('any')"
 				:show-deselect="true"
-				:disabled="!!nativeGeometryType || geometryFormat == 'lnglat'"
 				:items="GEOMETRY_TYPES.map((value) => ({ value, text: value }))"
 			/>
 		</div>
@@ -54,18 +49,16 @@ export default defineComponent({
 
 		const isGeometry = props.fieldData.type == 'geometry';
 		const nativeGeometryType = isGeometry ? (props.fieldData!.schema!.geometry_type as GeometryType) : undefined;
-		const compatibleFormat = isGeometry ? ('native' as const) : getGeometryFormatForType(props.fieldData.type);
-
-		const geometryFormat = ref<GeometryFormat>(compatibleFormat!);
+		const geometryFormat = isGeometry ? ('native' as const) : getGeometryFormatForType(props.fieldData.type);
 		const geometryType = ref<GeometryType>(
 			geometryFormat.value == 'lnglat' ? 'Point' : nativeGeometryType ?? props.value?.geometryType
 		);
 		const defaultView = ref<CameraOptions | undefined>(props.value?.defaultView);
 
 		watch(
-			[geometryFormat, geometryType, defaultView],
+			[geometryType, defaultView],
 			() => {
-				const type = geometryFormat.value == 'lnglat' ? 'Point' : geometryType;
+				const type = geometryFormat == 'lnglat' ? 'Point' : geometryType;
 				emit('input', { defaultView, geometryFormat, geometryType: type });
 			},
 			{ immediate: true }
@@ -108,7 +101,6 @@ export default defineComponent({
 			t,
 			isGeometry,
 			nativeGeometryType,
-			compatibleFormat,
 			geometryFormat,
 			GEOMETRY_TYPES,
 			geometryType,

--- a/app/src/interfaces/map/style.ts
+++ b/app/src/interfaces/map/style.ts
@@ -4,8 +4,8 @@ export default [
 		type: 'fill',
 		filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static']],
 		paint: {
-			'fill-color': '#3bb2d0',
-			'fill-outline-color': '#3bb2d0',
+			'fill-color': '#00c897',
+			'fill-outline-color': '#00c897',
 			'fill-opacity': 0.1,
 		},
 	},
@@ -37,7 +37,7 @@ export default [
 			'line-join': 'round',
 		},
 		paint: {
-			'line-color': '#3bb2d0',
+			'line-color': '#00c897',
 			'line-width': 2,
 		},
 	},
@@ -64,7 +64,7 @@ export default [
 			'line-join': 'round',
 		},
 		paint: {
-			'line-color': '#3bb2d0',
+			'line-color': '#00c897',
 			'line-width': 2,
 		},
 	},
@@ -101,23 +101,6 @@ export default [
 		},
 	},
 	{
-		id: 'directus-points-shadow',
-		filter: [
-			'all',
-			['==', 'active', 'false'],
-			['==', '$type', 'Point'],
-			['==', 'meta', 'feature'],
-			['!=', 'meta', 'midpoint'],
-		],
-		type: 'circle',
-		paint: {
-			'circle-pitch-alignment': 'map',
-			'circle-blur': 1,
-			'circle-opacity': 0.5,
-			'circle-radius': 6,
-		},
-	},
-	{
 		id: 'directus-point-inactive',
 		filter: [
 			'all',
@@ -131,11 +114,11 @@ export default [
 			'icon-image': 'place',
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
-			'icon-size': 1,
+			'icon-size': 0.5,
 			'icon-offset': [0, 3],
 		},
 		paint: {
-			'icon-color': '#3bb2d0',
+			'icon-color': '#00c897',
 		},
 	},
 	{
@@ -152,7 +135,7 @@ export default [
 			'icon-image': 'place',
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
-			'icon-size': 1,
+			'icon-size': 0.5,
 			'icon-offset': [0, 3],
 		},
 		paint: {
@@ -173,7 +156,7 @@ export default [
 			'icon-image': 'place',
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
-			'icon-size': 1,
+			'icon-size': 0.5,
 			'icon-offset': [0, 3],
 		},
 		paint: {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1319,9 +1319,9 @@ interfaces:
     map: Map
     description: Select a location on a map
     zoom: Zoom
-    geometry_type: Geometry type
-    geometry_format: Geometry format
-    default_view: Default view
+    geometry_type: Geometry Type
+    geometry_format: Geometry Format
+    default_view: Default View
     invalid_options: Invalid options
     invalid_format: Invalid format ({format})
     unexpected_geometry: Expected {expected}, got {got}.
@@ -1555,13 +1555,13 @@ layouts:
     layers: Layers
     edit_custom_layers: Edit Layers
     cluster_options: Clustering options
-    cluster: Activate clustering
+    cluster: Cluster Nearby Data
     cluster_radius: Cluster radius
     cluster_minpoints: Cluster minimum size
     cluster_maxzoom: Maximum zoom for clustering
     field: Geometry
     invalid_geometry: Invalid geometry
-    auto_location_filter: Always filter data to view bounds
+    auto_location_filter: Auto-Filter within View
     search_this_area: Search this area
     clear_data_filter: Clear data filter
     clear_location_filter: Clear location filter

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -84,7 +84,7 @@ export default defineComponent({
 			closeOnClick: false,
 			className: 'mapboxgl-point-popup',
 			maxWidth: 'unset',
-			offset: 20,
+			offset: 10,
 		});
 
 		const attributionControl = new AttributionControl({ compact: true });
@@ -415,7 +415,7 @@ export default defineComponent({
 	font-size: inherit !important;
 	font-family: inherit !important;
 	line-height: inherit !important;
-	background-color: var(--background-subdued);
+	background-color: var(--background-page);
 
 	&,
 	&.suggestions {
@@ -474,8 +474,6 @@ export default defineComponent({
 }
 
 .mapboxgl-point-popup {
-	box-shadow: 10px 10px 10px solid red;
-
 	&.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
 		border-right-color: var(--background-normal);
 	}

--- a/app/src/layouts/map/style.ts
+++ b/app/src/layouts/map/style.ts
@@ -1,6 +1,6 @@
 import { AnyLayer, Expression } from 'maplibre-gl';
 
-const baseColor = '#09f';
+const baseColor = '#00c897';
 const selectColor = '#FFA500';
 const fill: Expression = ['case', ['boolean', ['feature-state', 'selected'], false], selectColor, baseColor];
 const outline: Expression = [
@@ -62,8 +62,9 @@ export const layers: AnyLayer[] = [
 		source: '__directus',
 		filter: ['has', 'point_count'],
 		paint: {
-			'circle-color': ['step', ['get', 'point_count'], '#51bbd6', 100, '#f1f075', 750, '#f28cb1'],
 			'circle-radius': ['step', ['get', 'point_count'], 20, 100, 30, 750, 40],
+			'circle-color': ['step', ['get', 'point_count'], '#7fe3ca', 100, '#fde2a7', 750, '#f0a7b3'],
+			'circle-opacity': 0.7,
 		},
 	},
 	{
@@ -75,6 +76,11 @@ export const layers: AnyLayer[] = [
 			'text-field': '{point_count_abbreviated}',
 			'text-font': ['Open Sans Semibold'],
 			'text-size': ['step', ['get', 'point_count'], 15, 100, 17, 750, 19],
+		},
+		paint: {
+			// 'text-color': ['step', ['get', 'point_count'], '#0ba582', 100, '#c8a34c', 750, '#b64c5f'],
+			// 'text-color': ['step', ['get', 'point_count'], '#17826d', 100, '#948049', 750, '#b64c5f'],
+			'text-opacity': 0.85,
 		},
 	},
 ];


### PR DESCRIPTION
- Improved marker resolution
- Make the default maker green
- Reduce popup padding in layout
- Capitalize geometry related translations
- Hide geometry_format and geometry_type when disabled
- Set geocoder search bar background color to `--background-page`
- Rename Activate clustering to Cluster Nearby Data
- Default Cluster Nearby Data to `true`
- Update cluster colors to match Directus colors

See https://github.com/directus/directus/issues/7895#issuecomment-945711692