### PR TITLE
show System Collections in empty Data Model page

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -27,7 +27,7 @@
 		</template>
 
 		<div class="padding-box">
-			<v-info v-if="collections.length === 0" type="warning" icon="box" :title="t('no_collections')" center>
+			<v-info v-if="collections.length === 0" type="warning" icon="box" :title="t('no_collections')">
 				{{ t('no_collections_copy_admin') }}
 
 				<template #append>
@@ -79,7 +79,7 @@
 				</v-list-item>
 			</v-list>
 
-			<v-detail v-if="collections.length > 0" :label="t('system_collections')">
+			<v-detail :label="t('system_collections')">
 				<collection-item
 					v-for="collection of systemCollections"
 					:key="collection.collection"
@@ -215,6 +215,10 @@ export default defineComponent({
 .padding-box {
 	padding: var(--content-padding);
 	padding-top: 0;
+}
+
+.v-info {
+	padding: var(--content-padding) 0;
 }
 
 .root-drag-container {


### PR DESCRIPTION
fixes #8914

Regarding the added padding to `.v-info`, here's a comparison:

| No padding | Added padding |
|---|---|
|  ![chrome_frTpBN2rmT](https://user-images.githubusercontent.com/42867097/137865514-b8797fc9-c682-4859-a23e-74d9ff8a2cad.png) | ![chrome_TEFkpcPIWD](https://user-images.githubusercontent.com/42867097/137865742-e4fc46d1-55d4-42da-91d1-81526c5bb6aa.png) |

Let me know if the added padding feels unnecessary. 