### PR TITLE
add default preset for webhooks page

### DIFF
--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -16,7 +16,13 @@ fields:
     display_options:
       defaultForeground: 'var(--foreground-normal)'
       defaultBackground: 'var(--background-normal-alt)'
-      choices: null
+      choices:
+        - value: POST
+          foreground: 'var(--primary)'
+          background: 'var(--primary-25)'
+        - value: GET
+          foreground: 'var(--blue)'
+          background: 'var(--blue-25)'
       format: false
     options:
       choices:

--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -21,8 +21,8 @@ fields:
           foreground: 'var(--primary)'
           background: 'var(--primary-25)'
         - value: GET
-          foreground: 'var(--blue)'
-          background: 'var(--blue-25)'
+          foreground: 'var(--secondary)'
+          background: 'var(--seconary-25)'
       format: false
     options:
       choices:

--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -22,7 +22,7 @@ fields:
           background: 'var(--primary-25)'
         - value: GET
           foreground: 'var(--secondary)'
-          background: 'var(--seconary-25)'
+          background: 'var(--secondary-25)'
       format: false
     options:
       choices:

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -91,6 +91,27 @@ const systemDefaults: Record<string, Partial<Preset>> = {
 			},
 		},
 	},
+	directus_webhooks: {
+		collection: 'directus_webhooks',
+		layout: 'tabular',
+		layout_query: {
+			tabular: {
+				fields: ['status', 'method', 'name', 'url', 'collections', 'actions'],
+			},
+		},
+		layout_options: {
+			tabular: {
+				widths: {
+					status: 32,
+					method: 100,
+					name: 210,
+					url: 400,
+					collections: 240,
+					actions: 210,
+				},
+			},
+		},
+	},
 };
 
 const currentUpdate: Record<number, string> = {};

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -96,7 +96,7 @@ const systemDefaults: Record<string, Partial<Preset>> = {
 		layout: 'tabular',
 		layout_query: {
 			tabular: {
-				fields: ['status', 'method', 'name', 'url', 'collections', 'actions'],
+				fields: ['status', 'method', 'name', 'collections', 'actions'],
 			},
 		},
 		layout_options: {
@@ -105,7 +105,6 @@ const systemDefaults: Record<string, Partial<Preset>> = {
 					status: 32,
 					method: 100,
 					name: 210,
-					url: 400,
 					collections: 240,
 					actions: 210,
 				},


### PR DESCRIPTION
Not sure does this count as resolving #8913 as presets & roles don't have default presets, but at the same time those two are current non-configurable.

Used the same chips/display setting as actions for methods, but they may be not enough contrast, particularly for light theme. 

## After

### Light

![chrome_CrRphAo28v](https://user-images.githubusercontent.com/42867097/137877554-a8371cc2-fb0c-4ee5-bd0c-d14266df76f1.png)

### Dark

![chrome_lt4D8tqqz6](https://user-images.githubusercontent.com/42867097/137877706-a861606a-2fee-4d6f-aece-1a50fbd20d45.png)


