### PR TITLE
Fix labels display for non-null empty value

### DIFF
--- a/app/src/displays/labels/labels.vue
+++ b/app/src/displays/labels/labels.vue
@@ -31,6 +31,7 @@
 import { defineComponent, computed, PropType } from 'vue';
 import formatTitle from '@directus/format-title';
 import { translate } from '@/utils/translate-object-values';
+import { isEmpty } from 'lodash';
 
 type Choice = {
 	value: string;
@@ -75,7 +76,7 @@ export default defineComponent({
 		const items = computed(() => {
 			let items: string[];
 
-			if (props.value === null) items = [];
+			if (isEmpty(props.value)) items = [];
 			else if (props.type === 'string') items = [props.value as string];
 			else items = props.value as string[];
 


### PR DESCRIPTION
## Context

For webhooks, we can deselect any actions (Create, Update, Delete), resulting in the actions column being an empty string `""`.

Then for labels display, the `if(props.value === null) items = []` won't be true, and it'll error when trying to map the empty string.
 
https://github.com/directus/directus/blob/ac3e11ebb97103d55aa2d13c4cc14104bba86fab/app/src/displays/labels/labels.vue#L78-L82