### PR TITLE
hide folder-collections in permissions settings

### DIFF
--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
@@ -97,7 +97,9 @@ export default defineComponent({
 		const collectionsStore = useCollectionsStore();
 
 		const regularCollections = computed(() =>
-			collectionsStore.collections.filter((collection) => collection.collection.startsWith('directus_') === false)
+			collectionsStore.collections.filter(
+				(collection) => collection.collection.startsWith('directus_') === false && collection.schema
+			)
 		);
 
 		const systemCollections = computed(() =>


### PR DESCRIPTION
fixes #8935

Based on the code here:

https://github.com/directus/directus/blob/ac3e11ebb97103d55aa2d13c4cc14104bba86fab/app/src/modules/settings/routes/data-model/collections/collections.vue#L152-L157

and by comparing folder-collections vs regular collections, I assume an empty `schema` is the differentiator here. Tested and works.