### PR TITLE
Improve folder picker selection highlight

### DIFF
--- a/app/src/modules/files/components/folder-picker-list-item.vue
+++ b/app/src/modules/files/components/folder-picker-list-item.vue
@@ -71,10 +71,3 @@ export default defineComponent({
 	},
 });
 </script>
-
-<style scoped>
-.folder-picker-list-item {
-	--v-list-item-background-color-hover: var(--background-normal-alt);
-	--v-list-item-background-color-active: var(--background-normal-alt);
-}
-</style>

--- a/app/src/modules/files/components/folder-picker.vue
+++ b/app/src/modules/files/components/folder-picker.vue
@@ -152,6 +152,9 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .folder-picker {
+	--v-list-item-background-color-hover: var(--background-normal-alt);
+	--v-list-item-background-color-active: var(--background-normal-alt);
+
 	padding: 12px;
 	background-color: var(--background-normal);
 	border-radius: var(--border-radius);


### PR DESCRIPTION
## Context

Assuming the following folder structure, when we move Folder A out, which means selecting File Library, it isn't being highlighted.

![chrome_sr7kTWS4rL](https://user-images.githubusercontent.com/42867097/138023502-aaf2064f-9246-44ff-8021-b1860cc2c916.png)

![t5bFtIcZaI](https://user-images.githubusercontent.com/42867097/138023473-7b226782-455a-4b4d-85f2-d63f197128d7.gif)

## Solution

Moved the CSS variables for v-list-item out to folder picker.

## After

![dnbMj66HQf](https://user-images.githubusercontent.com/42867097/138023495-4331954c-7feb-471d-9cc1-6f7d4392d731.gif)


