### PR TITLE
Skip publish-npm job in the release workflow for forked repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ github.repository_owner == 'directus' }}
     steps:
       - uses: actions/checkout@v2
       - name: Restore build artifacts


### PR DESCRIPTION
This simple job condition allows the release workflow to be used as is in all forks. Thanks.