### PR TITLE
Add GitHub Action to Auto-Merge Translations from Crowdin

### DIFF
--- a/.github/workflows/auto-merge-crowdin.yml
+++ b/.github/workflows/auto-merge-crowdin.yml
@@ -1,0 +1,26 @@
+name: Auto-Merge Translations from Crowdin
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'app/src/lang/translations/*.yaml'
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    if: github.event.pull_request.user.login == 'rijkvanzanten' && github.event.pull_request.title == 'New Crowdin updates' && github.head_ref == 'translations'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-Merge
+        uses: pascalgn/automerge-action@v0.14.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_LABELS: ''
+          UPDATE_LABELS: ''
+          MERGE_METHOD: squash
+          MERGE_COMMIT_MESSAGE: '{pullRequest.title} (#{pullRequest.number})'
+          # Wait for a maximum of 6 minutes for the checks to be completed
+          MERGE_RETRIES: '36'
+          MERGE_RETRY_SLEEP: '10000'

--- a/.github/workflows/auto-merge-crowdin.yml
+++ b/.github/workflows/auto-merge-crowdin.yml
@@ -21,6 +21,3 @@ jobs:
           UPDATE_LABELS: ''
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: '{pullRequest.title} (#{pullRequest.number})'
-          # Wait for a maximum of 6 minutes for the checks to be completed
-          MERGE_RETRIES: '36'
-          MERGE_RETRY_SLEEP: '10000'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,14 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
   pull_request:
     branches: [ main ]
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
   schedule:
     - cron: '42 23 * * 5'
 

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,8 +1,13 @@
 name: E2E
+
 on:
   push:
     branches:
       - main
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
   pull_request:
     branches:
       - main
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
   pull_request:
     branches:
       - main
+    # Don't run on translation updates
+    paths-ignore:
+     - 'app/src/lang/translations/*.yaml'
 
 jobs:
   test:


### PR DESCRIPTION
This action triggers only if a PR includes changes in `*.yaml` files under `app/src/lang/translations`.
Additionally, it's getting skipped if the following conditions aren't met on the PR:
* Submitted by: _rijkvanzanten_
* Title: _New Crowdin updates_
* Source branch: _translations_

This should always be the case for the PRs opened via Crowdin (for example #8873).

The action is configured to use the same commit message as when merged manually ("New Crowdin updates (#...)").

~The PRs are only getting auto-merged once all required checks have been completed.~

~Unfortunately, there is (currently) no way to trigger the action **after** required checks have been completed so we have to retry until this is the case (see `MERGE_RETRIES` & `MERGE_RETRY_SLEEP`). I've limited it to 6 minutes since I don't want to consume too much of the GitHub action run time - hopefully the checks will be completed within this time frame.~

Other actions have been updated so they won't be triggered by changes in translation files.