### PR TITLE
Fix click on relational filters with children

### DIFF
--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -57,7 +57,7 @@ export function useFieldTree(
 				key,
 				field: fieldName,
 				children: children.length > 0 ? children : undefined,
-				selectable: true,
+				selectable: !children || children.length === 0,
 			};
 		});
 	}


### PR DESCRIPTION
## Fix

Allow relational filters fields that have children to toggle when clicked.

## Before

https://user-images.githubusercontent.com/26413686/138260969-f8f33c22-1017-4fb4-82f0-0bf4a3ac30f2.mov

## After

https://user-images.githubusercontent.com/26413686/138260906-96ee7988-459d-4cad-afa9-b3a78fae2be5.mov


