### PR TITLE
Revert "Update dependency knex-schema-inspector to v1.6.3 (#9015)"

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -116,7 +116,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"keyv": "^4.0.3",
 		"knex": "^0.95.11",
-		"knex-schema-inspector": "1.6.3",
+		"knex-schema-inspector": "1.6.2",
 		"liquidjs": "^9.25.0",
 		"lodash": "^4.17.21",
 		"macos-release": "^2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
 				"jsonwebtoken": "^8.5.1",
 				"keyv": "^4.0.3",
 				"knex": "^0.95.11",
-				"knex-schema-inspector": "1.6.3",
+				"knex-schema-inspector": "1.6.2",
 				"liquidjs": "^9.25.0",
 				"lodash": "^4.17.21",
 				"macos-release": "^2.4.1",
@@ -2949,9 +2949,9 @@
 			}
 		},
 		"node_modules/@babel/preset-modules": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
-			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+			"integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -3620,12 +3620,12 @@
 			"peer": true
 		},
 		"node_modules/@graphql-tools/import": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.5.tgz",
-			"integrity": "sha512-BG6HVm9Kf2X9RqaQ+qqmxgiQnTibW3yxL/W+xL4HBT7pmTVaNlIck6KaXmK4buMN4IGW0pujTK8b4/Uelol60A==",
+			"version": "6.5.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.6.tgz",
+			"integrity": "sha512-SxCpNhN3sIZM4wsMjQWXKkff/CBn7+WHoZ9OjZkdV5nxGbnzRKh5SZAAsvAFuj6Kst5Y9mlAaiwy+QufZZ1F1w==",
 			"peer": true,
 			"dependencies": {
-				"@graphql-tools/utils": "8.4.0",
+				"@graphql-tools/utils": "8.5.0",
 				"resolve-from": "5.0.0",
 				"tslib": "~2.3.0"
 			},
@@ -3634,9 +3634,9 @@
 			}
 		},
 		"node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.4.0.tgz",
-			"integrity": "sha512-rHp4aOdStGDj4xR4PbLm0cyasfTKQUcEKSAP6Ls/83/rmCGdZn9lMxJUSnyK2OfBzpS28kBmSTMaYQ+MeXUFlA==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.0.tgz",
+			"integrity": "sha512-jMwLm6YdN+Vbqntg5GHqDvGLpLa/xPSpRs/c40d0rBuel77wo7AaQ8jHeBSpp9y+7kp7HrGSWff1u7yJ7F8ppw==",
 			"peer": true,
 			"dependencies": {
 				"tslib": "~2.3.0"
@@ -5664,22 +5664,69 @@
 			"dev": true
 		},
 		"node_modules/@mapbox/node-pre-gyp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
-			"integrity": "sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.6.tgz",
+			"integrity": "sha512-qK1ECws8UxuPqOA8F5LFD90vyVU33W7N3hGfgsOVfrJaRVc8McC3JClTDHpeSbL9CBrOHly/4GsNPAvIgNZE+g==",
 			"dependencies": {
 				"detect-libc": "^1.0.3",
 				"https-proxy-agent": "^5.0.0",
 				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.1",
+				"node-fetch": "^2.6.5",
 				"nopt": "^5.0.0",
-				"npmlog": "^4.1.2",
+				"npmlog": "^5.0.1",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.4",
-				"tar": "^6.1.0"
+				"semver": "^7.3.5",
+				"tar": "^6.1.11"
 			},
 			"bin": {
 				"node-pre-gyp": "bin/node-pre-gyp"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
+			"integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1 || ^2.0.0",
+				"strip-ansi": "^3.0.1 || ^4.0.0",
+				"wide-align": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
@@ -5694,6 +5741,40 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"dependencies": {
+				"are-we-there-yet": "^2.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^3.0.0",
+				"set-blocking": "^2.0.0"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dependencies": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dependencies": {
+				"ansi-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@mapbox/parse-mapbox-token": {
@@ -6888,6 +6969,7 @@
 			"version": "0.36.2",
 			"resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
 			"integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
+			"deprecated": "Use the original unforked package instead: postcss-markdown",
 			"dev": true,
 			"dependencies": {
 				"remark": "^13.0.0",
@@ -7265,9 +7347,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
-			"integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
+			"version": "7.28.2",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
+			"integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
 			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -11706,8 +11788,7 @@
 		"node_modules/aproba": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true
+			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
 		},
 		"node_modules/arch": {
 			"version": "2.2.0",
@@ -11982,6 +12063,12 @@
 				"minimalistic-assert": "^1.0.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"node_modules/asn1.js/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
 		},
 		"node_modules/assert": {
 			"version": "1.5.0",
@@ -12814,9 +12901,9 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
 			"dev": true
 		},
 		"node_modules/body-parser": {
@@ -13005,12 +13092,6 @@
 				"randombytes": "^2.0.1"
 			}
 		},
-		"node_modules/browserify-rsa/node_modules/bn.js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-			"dev": true
-		},
 		"node_modules/browserify-sign": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
@@ -13027,12 +13108,6 @@
 				"readable-stream": "^3.6.0",
 				"safe-buffer": "^5.2.0"
 			}
-		},
-		"node_modules/browserify-sign/node_modules/bn.js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-			"dev": true
 		},
 		"node_modules/browserify-sign/node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -14407,6 +14482,14 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
 		"node_modules/color/node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -15632,6 +15715,12 @@
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.5.3"
 			}
+		},
+		"node_modules/create-ecdh/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
 		},
 		"node_modules/create-gatsby": {
 			"version": "1.14.0",
@@ -17807,6 +17896,12 @@
 				"randombytes": "^2.0.0"
 			}
 		},
+		"node_modules/diffie-hellman/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
+		},
 		"node_modules/dijkstrajs": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.2.tgz",
@@ -18151,9 +18246,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.876",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.876.tgz",
-			"integrity": "sha512-a6LR4738psrubCtGx5HxM/gNlrIsh4eFTNnokgOqvQo81GWd07lLcOjITkAXn2y4lIp18vgS+DGnehj+/oEAxQ=="
+			"version": "1.3.877",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.877.tgz",
+			"integrity": "sha512-fT5mW5Giw5iyVukeHb2XvB4joBKvzHtl8Vs3QzE7APATpFMt/T7RWyUcIKSZzYkKQgpMbu+vDBTCHfQZvh8klA=="
 		},
 		"node_modules/elegant-spinner": {
 			"version": "1.0.1",
@@ -18178,6 +18273,12 @@
 				"minimalistic-assert": "^1.0.1",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
+		},
+		"node_modules/elliptic/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -28341,9 +28442,9 @@
 			}
 		},
 		"node_modules/knex-schema-inspector": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.3.tgz",
-			"integrity": "sha512-Ujkle5mOy6KcqEuxRv7K82EKtrW86sGt8K/tC3BW1+jaWoWPbc2j4BwyF6ZCVbhgrdXVCQGoMMFSurRlrKn/Zw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.2.tgz",
+			"integrity": "sha512-eJi6lbLhiNE7CWJoXDloKn8iJIh/tBNh3xk6RvY1f7Gbc0Gzva69gW1XiODJapmDBt5UGWDwO26SX9z2wZhy3Q==",
 			"dependencies": {
 				"lodash.flatten": "^4.4.0",
 				"lodash.isnil": "^4.0.0"
@@ -32075,6 +32176,12 @@
 			"bin": {
 				"miller-rabin": "bin/miller-rabin"
 			}
+		},
+		"node_modules/miller-rabin/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
 		},
 		"node_modules/mime": {
 			"version": "2.5.2",
@@ -37639,6 +37746,12 @@
 				"randombytes": "^2.0.1",
 				"safe-buffer": "^5.1.2"
 			}
+		},
+		"node_modules/public-encrypt/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -49214,7 +49327,7 @@
 			"version": "9.0.0-rc.98",
 			"license": "GPL-3.0",
 			"dependencies": {
-				"knex-schema-inspector": "1.6.3",
+				"knex-schema-inspector": "1.6.2",
 				"lodash": "^4.17.21"
 			},
 			"devDependencies": {
@@ -51057,9 +51170,9 @@
 			}
 		},
 		"@babel/preset-modules": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
-			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+			"integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -51727,7 +51840,7 @@
 		"@directus/schema": {
 			"version": "file:packages/schema",
 			"requires": {
-				"knex-schema-inspector": "1.6.3",
+				"knex-schema-inspector": "1.6.2",
 				"lodash": "^4.17.21",
 				"npm-watch": "0.11.0",
 				"typescript": "4.4.4"
@@ -52213,20 +52326,20 @@
 			}
 		},
 		"@graphql-tools/import": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.5.tgz",
-			"integrity": "sha512-BG6HVm9Kf2X9RqaQ+qqmxgiQnTibW3yxL/W+xL4HBT7pmTVaNlIck6KaXmK4buMN4IGW0pujTK8b4/Uelol60A==",
+			"version": "6.5.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.6.tgz",
+			"integrity": "sha512-SxCpNhN3sIZM4wsMjQWXKkff/CBn7+WHoZ9OjZkdV5nxGbnzRKh5SZAAsvAFuj6Kst5Y9mlAaiwy+QufZZ1F1w==",
 			"peer": true,
 			"requires": {
-				"@graphql-tools/utils": "8.4.0",
+				"@graphql-tools/utils": "8.5.0",
 				"resolve-from": "5.0.0",
 				"tslib": "~2.3.0"
 			},
 			"dependencies": {
 				"@graphql-tools/utils": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.4.0.tgz",
-					"integrity": "sha512-rHp4aOdStGDj4xR4PbLm0cyasfTKQUcEKSAP6Ls/83/rmCGdZn9lMxJUSnyK2OfBzpS28kBmSTMaYQ+MeXUFlA==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.0.tgz",
+					"integrity": "sha512-jMwLm6YdN+Vbqntg5GHqDvGLpLa/xPSpRs/c40d0rBuel77wo7AaQ8jHeBSpp9y+7kp7HrGSWff1u7yJ7F8ppw==",
 					"peer": true,
 					"requires": {
 						"tslib": "~2.3.0"
@@ -53896,27 +54009,90 @@
 			}
 		},
 		"@mapbox/node-pre-gyp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
-			"integrity": "sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.6.tgz",
+			"integrity": "sha512-qK1ECws8UxuPqOA8F5LFD90vyVU33W7N3hGfgsOVfrJaRVc8McC3JClTDHpeSbL9CBrOHly/4GsNPAvIgNZE+g==",
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"https-proxy-agent": "^5.0.0",
 				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.1",
+				"node-fetch": "^2.6.5",
 				"nopt": "^5.0.0",
-				"npmlog": "^4.1.2",
+				"npmlog": "^5.0.1",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.4",
-				"tar": "^6.1.0"
+				"semver": "^7.3.5",
+				"tar": "^6.1.11"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"are-we-there-yet": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+					"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^3.6.0"
+					}
+				},
+				"gauge": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
+					"integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
+					"requires": {
+						"aproba": "^1.0.3 || ^2.0.0",
+						"color-support": "^1.1.2",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.1",
+						"object-assign": "^4.1.1",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1 || ^2.0.0",
+						"strip-ansi": "^3.0.1 || ^4.0.0",
+						"wide-align": "^1.1.2"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
 				"nopt": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
 					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
 					"requires": {
 						"abbrev": "1"
+					}
+				},
+				"npmlog": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+					"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+					"requires": {
+						"are-we-there-yet": "^2.0.0",
+						"console-control-strings": "^1.1.0",
+						"gauge": "^3.0.0",
+						"set-blocking": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -55238,9 +55414,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
-			"integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
+			"version": "7.28.2",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
+			"integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
 			"peer": true,
 			"requires": {
 				"@types/estree": "*",
@@ -59058,8 +59234,7 @@
 		"aproba": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true
+			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
 		},
 		"arch": {
 			"version": "2.2.0",
@@ -59263,6 +59438,14 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0",
 				"safer-buffer": "^2.1.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"assert": {
@@ -59949,9 +60132,9 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
 			"dev": true
 		},
 		"body-parser": {
@@ -60123,14 +60306,6 @@
 			"requires": {
 				"bn.js": "^5.0.0",
 				"randombytes": "^2.0.1"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-					"dev": true
-				}
 			}
 		},
 		"browserify-sign": {
@@ -60150,12 +60325,6 @@
 				"safe-buffer": "^5.2.0"
 			},
 			"dependencies": {
-				"bn.js": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-					"dev": true
-				},
 				"safe-buffer": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -61231,6 +61400,11 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+		},
 		"colord": {
 			"version": "2.9.1",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.1.tgz",
@@ -62272,6 +62446,14 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.5.3"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"create-gatsby": {
@@ -63888,6 +64070,14 @@
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"dijkstrajs": {
@@ -64001,7 +64191,7 @@
 				"keyv": "^4.0.3",
 				"keyv-memcache": "^1.2.5",
 				"knex": "^0.95.11",
-				"knex-schema-inspector": "1.6.3",
+				"knex-schema-inspector": "1.6.2",
 				"liquidjs": "^9.25.0",
 				"lodash": "^4.17.21",
 				"macos-release": "^2.4.1",
@@ -64381,9 +64571,9 @@
 			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.876",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.876.tgz",
-			"integrity": "sha512-a6LR4738psrubCtGx5HxM/gNlrIsh4eFTNnokgOqvQo81GWd07lLcOjITkAXn2y4lIp18vgS+DGnehj+/oEAxQ=="
+			"version": "1.3.877",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.877.tgz",
+			"integrity": "sha512-fT5mW5Giw5iyVukeHb2XvB4joBKvzHtl8Vs3QzE7APATpFMt/T7RWyUcIKSZzYkKQgpMbu+vDBTCHfQZvh8klA=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -64404,6 +64594,14 @@
 				"inherits": "^2.0.4",
 				"minimalistic-assert": "^1.0.1",
 				"minimalistic-crypto-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"emittery": {
@@ -72240,9 +72438,9 @@
 			}
 		},
 		"knex-schema-inspector": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.3.tgz",
-			"integrity": "sha512-Ujkle5mOy6KcqEuxRv7K82EKtrW86sGt8K/tC3BW1+jaWoWPbc2j4BwyF6ZCVbhgrdXVCQGoMMFSurRlrKn/Zw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.2.tgz",
+			"integrity": "sha512-eJi6lbLhiNE7CWJoXDloKn8iJIh/tBNh3xk6RvY1f7Gbc0Gzva69gW1XiODJapmDBt5UGWDwO26SX9z2wZhy3Q==",
 			"requires": {
 				"lodash.flatten": "^4.4.0",
 				"lodash.isnil": "^4.0.0"
@@ -75020,6 +75218,14 @@
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"mime": {
@@ -79519,6 +79725,14 @@
 				"parse-asn1": "^5.0.0",
 				"randombytes": "^2.0.1",
 				"safe-buffer": "^5.1.2"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"pump": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -42,7 +42,7 @@
 		"typescript": "4.4.4"
 	},
 	"dependencies": {
-		"knex-schema-inspector": "1.6.3",
+		"knex-schema-inspector": "1.6.2",
 		"lodash": "^4.17.21"
 	},
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd"


### PR DESCRIPTION
This reverts commit a234198110081cb017f5d5acfe065b9d86283954.

@Oreilles That knex-schema-inspector update makes MySQL 5 support in reading schema over 8-10x slower which unfortunately is a deal breaker.