### PR TITLE
Improved invalid JWT handling

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -214,7 +214,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 			let tokenData;
 
 			try {
-				tokenData = jwt.verify(req.cookies[`openid.${providerName}`], env.SECRET as string, { issuer: 'directus' }) as {
+				tokenData = jwt.verify(req.cookies[`oauth2.${providerName}`], env.SECRET as string, { issuer: 'directus' }) as {
 					verifier: string;
 					redirect?: string;
 				};

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -211,16 +211,18 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 	router.get(
 		'/callback',
 		asyncHandler(async (req, res, next) => {
-			const token = req.cookies[`oauth2.${providerName}`];
+			let tokenData;
 
-			if (!token) {
+			try {
+				tokenData = jwt.verify(req.cookies[`openid.${providerName}`], env.SECRET as string, { issuer: 'directus' }) as {
+					verifier: string;
+					redirect?: string;
+				};
+			} catch (e) {
 				throw new InvalidCredentialsException();
 			}
 
-			const { verifier, redirect } = jwt.verify(token, env.SECRET as string, { issuer: 'directus' }) as {
-				verifier: string;
-				redirect: string;
-			};
+			const { verifier, redirect } = tokenData;
 
 			const authenticationService = new AuthenticationService({
 				accountability: {
@@ -236,10 +238,8 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 			try {
 				res.clearCookie(`oauth2.${providerName}`);
 
-				const { code } = req.query;
-
-				if (!code) {
-					logger.warn(`Couldn't extract oAuth2 code from query: ${JSON.stringify(req.query)}`);
+				if (!req.query.code) {
+					logger.warn(`Couldn't extract OAuth2 code from query: ${JSON.stringify(req.query)}`);
 				}
 
 				authResponse = await authenticationService.login(providerName, {

--- a/api/src/types/auth.ts
+++ b/api/src/types/auth.ts
@@ -24,7 +24,7 @@ export type AuthData = Record<string, any> | null;
 export interface Session {
 	token: string;
 	expires: Date;
-	data: string | null;
+	data: string | Record<string, unknown> | null;
 }
 
 export type SessionData = Record<string, any> | null;


### PR DESCRIPTION
This update ensures that Invalid and Expired JWT tokens are also handled by the OAuth flow. Also applied JWT and `code` validation to the OpenID flow, as well as sneaking in a fix for an incomplete type.