### PR TITLE
Add filter option to m2o, o2m and m2m interfaces

### DIFF
--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -70,6 +70,7 @@
 			v-model:active="selectModalActive"
 			:collection="relationCollection.collection"
 			:selection="selectedPrimaryKeys"
+			:filter="filter"
 			multiple
 			@input="stageSelection"
 		/>
@@ -108,6 +109,10 @@ export default defineComponent({
 		collection: {
 			type: String,
 			required: true,
+		},
+		filter: {
+			type: Object,
+			default: () => null,
 		},
 		field: {
 			type: String,

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -40,6 +40,7 @@
 			v-model:active="selectDrawer"
 			:collection="collection"
 			:selection="[]"
+			:filter="filter"
 			multiple
 			@input="stageSelection"
 		/>
@@ -81,6 +82,10 @@ export default defineComponent({
 		field: {
 			type: String,
 			required: true,
+		},
+		filter: {
+			type: Object,
+			default: () => null,
 		},
 		primaryKey: {
 			type: [String, Number],

--- a/app/src/interfaces/list-o2m-tree-view/options.vue
+++ b/app/src/interfaces/list-o2m-tree-view/options.vue
@@ -8,6 +8,11 @@
 			<v-field-template v-model="template" :collection="collection" :depth="1"></v-field-template>
 		</div>
 
+		<div class="field full">
+			<p class="type-label">{{ t('filter') }}</p>
+			<system-filter :value="filter" :collection-name="relatedCollection" @input="filter = $event"></system-filter>
+		</div>
+
 		<div class="field half-left">
 			<p class="type-label">{{ t('creating_items') }}</p>
 			<v-checkbox v-model="enableCreate" block :label="t('enable_create_button')" />
@@ -24,7 +29,12 @@
 import { useI18n } from 'vue-i18n';
 import { Field, Relation } from '@directus/shared/types';
 import { defineComponent, PropType, computed } from 'vue';
+import SystemFilter from '../_system/system-filter/system-filter.vue';
+
 export default defineComponent({
+	components: {
+		SystemFilter,
+	},
 	props: {
 		collection: {
 			type: String,
@@ -59,6 +69,18 @@ export default defineComponent({
 			},
 		});
 
+		const filter = computed({
+			get() {
+				return props.value?.filter || null;
+			},
+			set(newFilters: any) {
+				emit('input', {
+					...(props.value || {}),
+					filter: newFilters,
+				});
+			},
+		});
+
 		const enableCreate = computed({
 			get() {
 				return props.value?.enableCreate ?? true;
@@ -83,7 +105,16 @@ export default defineComponent({
 			},
 		});
 
-		return { t, template, enableCreate, enableSelect };
+		const relatedCollection = computed(() => {
+			if (!props.fieldData || !props.relations || props.relations.length === 0) return null;
+			const { field } = props.fieldData;
+			const relatedRelation = props.relations.find(
+				(relation) => relation.related_collection === props.collection && relation.meta?.one_field === field
+			);
+			return relatedRelation?.collection || null;
+		});
+
+		return { t, template, filter, relatedCollection, enableCreate, enableSelect };
 	},
 });
 </script>

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -71,6 +71,7 @@
 			v-model:active="selectModalActive"
 			:collection="relatedCollection.collection"
 			:selection="selectedPrimaryKeys"
+			:filter="filter"
 			multiple
 			@input="$emit('input', $event.length > 0 ? $event : null)"
 		/>
@@ -115,6 +116,10 @@ export default defineComponent({
 		template: {
 			type: String,
 			default: null,
+		},
+		filter: {
+			type: Object,
+			default: () => null,
 		},
 		disabled: {
 			type: Boolean,

--- a/app/src/interfaces/list-o2m/options.vue
+++ b/app/src/interfaces/list-o2m/options.vue
@@ -16,6 +16,11 @@
 			/>
 		</div>
 
+		<div class="field full">
+			<p class="type-label">{{ t('filter') }}</p>
+			<system-filter :value="filter" :collection-name="relatedCollection" @input="filter = $event"></system-filter>
+		</div>
+
 		<div class="field half-left">
 			<p class="type-label">{{ t('creating_items') }}</p>
 			<v-checkbox v-model="enableCreate" block :label="t('enable_create_button')" />
@@ -34,8 +39,12 @@ import { Field, Relation } from '@directus/shared/types';
 import { Collection } from '@/types';
 import { defineComponent, PropType, computed } from 'vue';
 import { useCollectionsStore } from '@/stores/';
+import SystemFilter from '../_system/system-filter/system-filter.vue';
 
 export default defineComponent({
+	components: {
+		SystemFilter,
+	},
 	props: {
 		collection: {
 			type: String,
@@ -80,6 +89,18 @@ export default defineComponent({
 			},
 		});
 
+		const filter = computed({
+			get() {
+				return props.value?.filter || null;
+			},
+			set(newFilters: any) {
+				emit('input', {
+					...(props.value || {}),
+					filter: newFilters,
+				});
+			},
+		});
+
 		const enableCreate = computed({
 			get() {
 				return props.value?.enableCreate ?? true;
@@ -118,7 +139,7 @@ export default defineComponent({
 			return collectionsStore.getCollection(relatedCollection.value);
 		});
 
-		return { t, template, enableCreate, enableSelect, relatedCollection, relatedCollectionInfo };
+		return { t, template, filter, enableCreate, enableSelect, relatedCollection, relatedCollectionInfo };
 	},
 });
 </script>

--- a/app/src/interfaces/select-dropdown-m2o/options.vue
+++ b/app/src/interfaces/select-dropdown-m2o/options.vue
@@ -7,6 +7,10 @@
 			<p class="type-label">{{ t('interfaces.select-dropdown-m2o.display_template') }}</p>
 			<v-field-template v-model="template" :collection="relatedCollection" :depth="2"></v-field-template>
 		</div>
+		<div class="field full">
+			<p class="type-label">{{ t('filter') }}</p>
+			<system-filter :value="filter" :collection-name="relatedCollection" @input="filter = $event"></system-filter>
+		</div>
 	</div>
 </template>
 
@@ -14,8 +18,12 @@
 import { useI18n } from 'vue-i18n';
 import { Field, Relation } from '@directus/shared/types';
 import { defineComponent, PropType, computed } from 'vue';
+import SystemFilter from '../_system/system-filter/system-filter.vue';
 
 export default defineComponent({
+	components: {
+		SystemFilter,
+	},
 	props: {
 		collection: {
 			type: String,
@@ -50,6 +58,18 @@ export default defineComponent({
 			},
 		});
 
+		const filter = computed({
+			get() {
+				return props.value?.filter || null;
+			},
+			set(newFilters: any) {
+				emit('input', {
+					...(props.value || {}),
+					filter: newFilters,
+				});
+			},
+		});
+
 		const relatedCollection = computed(() => {
 			if (!props.fieldData || !props.relations || props.relations.length === 0) return null;
 			const { field } = props.fieldData;
@@ -59,7 +79,7 @@ export default defineComponent({
 			return relation?.related_collection || null;
 		});
 
-		return { t, template, relatedCollection };
+		return { t, template, filter, relatedCollection };
 	},
 });
 </script>

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -80,6 +80,7 @@
 			v-model:active="selectModalActive"
 			:collection="relatedCollection.collection"
 			:selection="selection"
+			:filter="filter"
 			@input="stageSelection"
 		/>
 	</div>
@@ -123,6 +124,10 @@ export default defineComponent({
 		template: {
 			type: String,
 			default: null,
+		},
+		filter: {
+			type: Object,
+			default: () => null,
 		},
 		selectMode: {
 			type: String as PropType<'auto' | 'dropdown' | 'modal'>,


### PR DESCRIPTION
Thanks to the system filter interface it's quite ease to add filtering option for the relational interfaces, so to filter unwanted for selection items.

<img width="643" alt="Screenshot 2021-10-24 at 12 44 13" src="https://user-images.githubusercontent.com/1009639/138588707-01035fe5-1b67-4e93-aa0d-69faf7795563.png">


