### PR TITLE
Use default filter operator for type in filter input.

### DIFF
--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -125,6 +125,7 @@ function validateList(value: any, key: string) {
 }
 
 function validateBoolean(value: any, key: string) {
+	if (value === null) return true;
 	if (typeof value !== 'boolean') {
 		throw new InvalidQueryException(`"${key}" has to be a boolean`);
 	}

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -133,8 +133,8 @@ function validateBoolean(value: any, key: string) {
 }
 
 function validateGeometry(value: any, key: string) {
+	if (value === null) return true;
 	try {
-		if (value === null) return true;
 		stringify(value);
 	} catch {
 		throw new InvalidQueryException(`"${key}" has to be a valid GeoJSON object`);

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -134,6 +134,7 @@ function validateBoolean(value: any, key: string) {
 
 function validateGeometry(value: any, key: string) {
 	try {
+		if (value === null) return true;
 		stringify(value);
 	} catch {
 		throw new InvalidQueryException(`"${key}" has to be a valid GeoJSON object`);

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -261,7 +261,11 @@ export default defineComponent({
 				case '_nintersects':
 				case '_intersects_bbox':
 				case '_nintersects_bbox':
-					update(null);
+					if (['_intersects', '_nintersects', '_intersects_bbox', '_nintersects_bbox'].includes(nodeInfo.comparator)) {
+						update(value);
+					} else {
+						update(null);
+					}
 					break;
 				default:
 					update(Array.isArray(value) ? value[0] : value);

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -257,6 +257,12 @@ export default defineComponent({
 				case '_nempty':
 					update(true);
 					break;
+				case '_intersects':
+				case '_nintersects':
+				case '_intersects_bbox':
+				case '_nintersects_bbox':
+					update(null);
+					break;
 				default:
 					update(Array.isArray(value) ? value[0] : value);
 					break;

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -143,24 +143,6 @@ export default defineComponent({
 			}
 		}
 
-		function defaultValueForOperator(operator: ClientFilterOperator) {
-			switch (operator) {
-				case 'in':
-				case 'nin':
-					return [];
-				case 'between':
-				case 'nbetween':
-					return [null, null];
-				case 'null':
-				case 'nnull':
-				case 'empty':
-				case 'nempty':
-					return true;
-				default:
-					return null;
-			}
-		}
-
 		function addNode(key: string) {
 			if (key === '$group') {
 				innerValue.value = [
@@ -174,8 +156,7 @@ export default defineComponent({
 
 				const field = fieldsStore.getField(collection.value, key)!;
 				const operator = getFilterOperatorsForType(field.type)[0];
-				const value = defaultValueForOperator(operator);
-				set(filterObj, key, { ['_' + operator]: value });
+				set(filterObj, key, { ['_' + operator]: null });
 
 				innerValue.value = [...innerValue.value, filterObj] as FieldFilter[];
 			}

--- a/packages/shared/src/utils/get-filter-operators-for-type.test.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.test.ts
@@ -4,14 +4,14 @@ import { TYPES } from '../constants/fields';
 describe('', () => {
 	it('returns the filter operators for alias', () => {
 		expect(getFilterOperatorsForType(TYPES[0])).toStrictEqual([
+			'contains',
+			'ncontains',
 			'eq',
 			'neq',
 			'lt',
 			'lte',
 			'gt',
 			'gte',
-			'contains',
-			'ncontains',
 			'between',
 			'nbetween',
 			'empty',

--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -68,14 +68,14 @@ export function getFilterOperatorsForType(type: Type): ClientFilterOperator[] {
 
 		default:
 			return [
+				'contains',
+				'ncontains',
 				'eq',
 				'neq',
 				'lt',
 				'lte',
 				'gt',
 				'gte',
-				'contains',
-				'ncontains',
 				'between',
 				'nbetween',
 				'empty',


### PR DESCRIPTION
Fix https://github.com/directus/directus/issues/8930

The default operator picked when a new filter node is added is the first one in the array returned by [`getFilterOperatorForType`](https://github.com/directus/directus./blob/9b66a77c39b42c7ab596eff1c93a8f4c442c992b/packages/shared/src/utils/get-filter-operators-for-type.ts)

This also contains a fix for an error on geometry operator update.
Also fix https://github.com/directus/directus/issues/9111
Should also fix https://github.com/directus/directus/issues/8807