### PR TITLE
Fix: no options in repeater causes empty page

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -131,7 +131,9 @@ export default defineComponent({
 		const drawerOpen = computed(() => active.value !== null);
 		const { value } = toRefs(props);
 
-		const templateWithDefaults = computed(() => props.template || `{{${props.fields[0].field}}}`);
+		const templateWithDefaults = computed(() =>
+			props.template || props.fields?.[0]?.field ? `{{${props.fields[0].field}}}` : ''
+		);
 
 		const showAddNew = computed(() => {
 			if (props.disabled) return false;


### PR DESCRIPTION
before: page does render if repeater has no options
![image](https://user-images.githubusercontent.com/14039341/138645329-4d173c7b-5cd9-4106-a15b-fbae25c65859.png)


after: page renders and repeater show no options
![image](https://user-images.githubusercontent.com/14039341/138645342-7dd0e5fa-1a88-4067-bb2a-3d51f7267366.png)
