### PR TITLE
Custom filter support for relational interfaces

### DIFF
--- a/app/src/interfaces/list-m2m/index.ts
+++ b/app/src/interfaces/list-m2m/index.ts
@@ -52,6 +52,27 @@ export default defineInterface({
 					width: 'half',
 				},
 			},
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: relations.m2o?.related_collection ?? null,
+					},
+					conditions: [
+						{
+							rule: {
+								enableSelect: {
+									_eq: false,
+								},
+							},
+							hidden: true,
+						},
+					],
+				},
+			},
 		];
 	},
 	recommendedDisplays: ['related-values'],

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -70,6 +70,7 @@
 			v-model:active="selectModalActive"
 			:collection="relationCollection.collection"
 			:selection="selectedPrimaryKeys"
+			:filter="customFilter"
 			multiple
 			@input="stageSelection"
 		/>
@@ -78,11 +79,15 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, PropType, toRefs } from 'vue';
+import { defineComponent, computed, PropType, toRefs, inject, ref } from 'vue';
 import DrawerItem from '@/views/private/components/drawer-item';
 import DrawerCollection from '@/views/private/components/drawer-collection';
 import { get } from 'lodash';
 import Draggable from 'vuedraggable';
+import { Filter } from '@directus/shared/types';
+import { parseFilter } from '@/utils/parse-filter';
+import { render } from 'micromustache';
+import { deepMap } from '@directus/shared/utils';
 
 import useActions from './use-actions';
 import useRelation from '@/composables/use-m2m';
@@ -129,10 +134,28 @@ export default defineComponent({
 			type: Boolean,
 			default: true,
 		},
+		filter: {
+			type: Object as PropType<Filter>,
+			default: null,
+		},
 	},
 	emits: ['input'],
 	setup(props, { emit }) {
 		const { t } = useI18n();
+
+		const values = inject('values', ref<Record<string, any>>({}));
+
+		const customFilter = computed(() => {
+			return parseFilter(
+				deepMap(props.filter, (val: any) => {
+					if (val && typeof val === 'string') {
+						return render(val, values.value);
+					}
+
+					return val;
+				})
+			);
+		});
 
 		const { value, collection, field } = toRefs(props);
 
@@ -218,6 +241,7 @@ export default defineComponent({
 			templateWithDefaults,
 			createAllowed,
 			selectAllowed,
+			customFilter,
 		};
 
 		function emitter(newVal: any[] | null) {

--- a/app/src/interfaces/list-o2m-tree-view/index.ts
+++ b/app/src/interfaces/list-o2m-tree-view/index.ts
@@ -54,6 +54,27 @@ export default defineInterface({
 					width: 'half',
 				},
 			},
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
+					},
+					conditions: [
+						{
+							rule: {
+								enableSelect: {
+									_eq: false,
+								},
+							},
+							hidden: true,
+						},
+					],
+				},
+			},
 		];
 	},
 });

--- a/app/src/interfaces/list-o2m/index.ts
+++ b/app/src/interfaces/list-o2m/index.ts
@@ -55,6 +55,27 @@ export default defineInterface({
 					width: 'half',
 				},
 			},
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
+					},
+					conditions: [
+						{
+							rule: {
+								enableSelect: {
+									_eq: false,
+								},
+							},
+							hidden: true,
+						},
+					],
+				},
+			},
 		];
 	},
 	recommendedDisplays: ['related-values'],

--- a/app/src/interfaces/select-dropdown-m2o/index.ts
+++ b/app/src/interfaces/select-dropdown-m2o/index.ts
@@ -26,6 +26,17 @@ export default defineInterface({
 					},
 				},
 			},
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
+					},
+				},
+			},
 		];
 	},
 	recommendedDisplays: ['related-values'],


### PR DESCRIPTION
I think this feature has been mentioned somewhere that it would be eventually supported by Directus but we can't wait :P.

Basically, this allows a set of filters applied to list-m2m selection drawer (~~once the flow and implementation is finalised, it can be applied to other interfaces too~~). As you can see in the screenshot below, it supports parent record values' interpolation as well as built-in placeholders, i.e. `$NOW` or `$CURRENT_XXX`.

![image](https://user-images.githubusercontent.com/76130324/138983684-027706f9-a55d-4268-aee2-9b16ecc11632.png)

This isn't complete implementation without the notes below but I'd be happy if it meets the quality expection to merge and improve later. Or anyone can lend a hand/suggestion. My ideal implemenation would need:

1. ~~Replace the `input-code` interface with `interface-system-filter`. I attempted but somehow the rules don't get persisted. This would be a trivial task for the core team.~~
2. Add some notes for the custom filter option to explain the filter fields are from the related-collection and interpolating fields are from the owning record.