### PR TITLE
fix time series date field allow list

### DIFF
--- a/app/src/panels/time-series/index.ts
+++ b/app/src/panels/time-series/index.ts
@@ -129,7 +129,7 @@ export default definePanel({
 				interface: 'system-field',
 				options: {
 					collectionField: 'collection',
-					typeAllowList: ['date', 'datetime', 'timestamp'],
+					typeAllowList: ['date', 'dateTime', 'timestamp'],
 				},
 				width: 'half',
 			},


### PR DESCRIPTION
## Context

Was trying to choose a DateTime field called `added_on`, but couldn't, as seen here:

![chrome_eMNegEfvYR](https://user-images.githubusercontent.com/42867097/138814913-a459fcc6-91f0-489f-ae2c-861b8bbfaeca.png)

Turns out the allow list used `datetime` instead of `dateTime` for field type. 

---

Oddly enough I recall others had mentioned they used datetime with this before, but now this proves that it shouldn't have been possible... though I also vaguely recall I could use datetime as well when I was reproducing issues in the past... 

Or perhaps this is a case of Mandela Effect 🤷‍♂️ Not sure what happened, so just noting this here in case there was any change that I'm not aware of.