### PR TITLE
Make auto-merge of Crowdin updates work even when other workflows are performed

### DIFF
--- a/.github/workflows/auto-merge-crowdin.yml
+++ b/.github/workflows/auto-merge-crowdin.yml
@@ -15,6 +15,19 @@ jobs:
     if: github.event.pull_request.user.login == 'rijkvanzanten' && github.event.pull_request.title == 'New Crowdin updates' && github.head_ref == 'translations'
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for checks
+        uses: lewagon/wait-on-check-action@v1.1.1
+        # Ensure this step doesn't run too long
+        timeout-minutes: 8
+        # Still try to auto-merge if this step has failed
+        continue-on-error: true
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          running-workflow-name: Auto-Merge
+          wait-interval: 15
+          allowed-conclusions: success,skipped,cancelled,failure
+
       - name: Auto-Merge
         uses: pascalgn/automerge-action@v0.14.3
         env:


### PR DESCRIPTION
### Context

The workflow to auto-merge updates from Crowdin is not working at the moment 😞 

Currently, the workflow expects that no other workflows (linting, ...) are performed on pull requests from Crowdin.
However, due to the nature of the [skip-duplicate-actions](https://github.com/fkirc/skip-duplicate-actions#how-does-path-skipping-work) used in the pre-check of the CI jobs, other workflows might still be performed.
This is especially the case since the end-to-end test aren't working at the moment which means the pre-check cannot find successful runs.

### Solution

There are two ways I can think of to solve this problem:
* **Chosen solution**: Wait for other workflows to complete before merging the pull request from Crowdin.
  * Safer: Unchecked commits will not just be ignored.
  * "Future-proof": Will still work if other workflows (concerning those pull requests) are added in the future.
* Add another pre-check to ensure that no other workflows are performed on pull request from Crowdin.
  * Disadvantage: Pre-check takes longer and is more complicated.
  * Advantage: We could use the [path-filter](https://github.com/dorny/paths-filter) action for this and use it to do other interesting stuff. (Might be relevant in the future)
  * Unnecessary: Because the end-to-end test are expected to work again in the near future, the CI jobs shouldn't be performed on Crowdin pull request anymore.

### Summary

Make @rijkvanzanten (and @paescuj) happy!