### PR TITLE
Remove toLowerCase for dbSafe fields

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -248,7 +248,6 @@ export default defineComponent({
 				}
 
 				if (props.dbSafe === true) {
-					value = value.toLowerCase();
 					value = value.replace(/\s/g, '_');
 					// Replace é -> e etc
 					value = value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');


### PR DESCRIPTION
This fixes #9075 and adds support for PascalCase/camelCase fields in database