### PR TITLE
Set no-cache header on extension sources

### DIFF
--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -47,6 +47,8 @@ router.get(
 		}
 
 		res.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
+		res.setHeader('Cache-Control', 'no-cache');
+		res.setHeader('Vary', 'Origin, Cache-Control');
 		res.end(extensionSource);
 	})
 );


### PR DESCRIPTION
This should hopefully fix caching issues some users were experiencing.