### PR TITLE
Export API dist folder at the root of the package path

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -47,6 +47,11 @@
 		}
 	],
 	"main": "index.js",
+	"exports": {
+		".": "./index.js",
+		"./*": "./dist/*.js",
+		"./package.json": "./package.json"
+	},
 	"bin": {
 		"directus": "cli.js"
 	},

--- a/docs/configuration/installation/iis.md
+++ b/docs/configuration/installation/iis.md
@@ -14,7 +14,7 @@ available. Since iisnode simply pipes requests to files, running the directus CL
 this, use an entrypoint script like the `index.js` below.
 
 ```js
-var { startServer } = require('directus/dist/server');
+var { startServer } = require('directus/server');
 
 startServer();
 ```

--- a/docs/configuration/installation/plesk.md
+++ b/docs/configuration/installation/plesk.md
@@ -66,7 +66,7 @@ a script entry for it.
 Instead of a start command, Plesk wants a startup file. So create a `index.js` with the following content:
 
 ```js
-var { startServer } = require('directus/dist/server');
+var { startServer } = require('directus/server');
 
 startServer();
 ```


### PR DESCRIPTION
⚠️  **Notice**: We've added an "exports" flag to package.json, which means that the `dist` part has been dropped from imports of the package. Please update your custom code if you relied on this (undocumented) functionality

---

I'd prefer exporting nothing by default and exposing anything that might be useful through `index.js`.