### PR TITLE
Fix generated columns being required. 

### DIFF
--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -247,7 +247,7 @@ export class AuthorizationService {
 				specials.includes(name)
 			);
 
-			const notNullable = field.nullable === false && hasGenerateSpecial === false;
+			const notNullable = field.nullable === false && hasGenerateSpecial === false && field.generated === false;
 
 			if (notNullable) {
 				requiredColumns.push(field);

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -247,9 +247,9 @@ export class AuthorizationService {
 				specials.includes(name)
 			);
 
-			const notNullable = field.nullable === false && hasGenerateSpecial === false && field.generated === false;
+			const nullable = field.nullable || hasGenerateSpecial || field.generated;
 
-			if (notNullable) {
+			if (!nullable) {
 				requiredColumns.push(field);
 			}
 		}

--- a/api/src/types/schema.ts
+++ b/api/src/types/schema.ts
@@ -5,6 +5,7 @@ export type FieldOverview = {
 	field: string;
 	defaultValue: any;
 	nullable: boolean;
+	generated: boolean;
 	type: Type | 'unknown' | 'alias';
 	dbType: string | null;
 	precision: number | null;

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -154,6 +154,7 @@ async function getDatabaseSchema(
 					field: column.column_name,
 					defaultValue: getDefaultValue(column) ?? null,
 					nullable: column.is_nullable ?? true,
+					generated: column.is_generated ?? false,
 					type: getLocalType(column).type,
 					dbType: column.data_type,
 					precision: column.numeric_precision || null,

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -192,6 +192,7 @@ async function getDatabaseSchema(
 			field: field.field,
 			defaultValue: existing?.defaultValue ?? null,
 			nullable: existing?.nullable ?? true,
+			generated: existing?.generated ?? false,
 			type: type,
 			dbType: existing?.dbType || null,
 			precision: existing?.precision || null,

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -1,18 +1,18 @@
 <template>
 	<div class="form">
-		<div class="field half-left">
+		<div v-if="!isGenerated" class="field half-left">
 			<div class="label type-label">{{ t('readonly') }}</div>
 			<v-checkbox v-model="readonly" :label="t('disabled_editing_value')" block />
 		</div>
 
-		<div class="field half-right">
-			<div class="label type-label">{{ t('hidden') }}</div>
-			<v-checkbox v-model="hidden" :label="t('hidden_on_detail')" block />
+		<div v-if="!isGenerated" class="field half-right">
+			<div class="label type-label">{{ t('required') }}</div>
+			<v-checkbox v-model="required" :label="t('require_value_to_be_set')" block />
 		</div>
 
 		<div class="field half-left">
-			<div class="label type-label">{{ t('required') }}</div>
-			<v-checkbox v-model="required" :label="t('require_value_to_be_set')" block />
+			<div class="label type-label">{{ t('hidden') }}</div>
+			<v-checkbox v-model="hidden" :label="t('hidden_on_detail')" block />
 		</div>
 
 		<div v-if="type !== 'group'" class="field full">
@@ -84,8 +84,9 @@ export default defineComponent({
 		const { field } = storeToRefs(fieldDetailStore);
 
 		const type = computed(() => field.value.type);
+		const isGenerated = computed(() => field.value.schema?.is_generated);
 
-		return { t, readonly, hidden, required, note, translations, type };
+		return { t, readonly, hidden, required, note, translations, type, isGenerated };
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -85,7 +85,7 @@
 				</div>
 			</template>
 
-			<div v-if="!isAlias && !isPrimaryKey" class="field full">
+			<div v-if="!isAlias && !isPrimaryKey && !isGenerated" class="field full">
 				<div class="label type-label">{{ t('default_value') }}</div>
 
 				<v-input v-if="['string', 'uuid'].includes(type)" v-model="defaultValue" class="monospace" placeholder="NULL" />
@@ -134,12 +134,12 @@
 				<v-input v-else v-model="defaultValue" class="monospace" disabled placeholder="NULL" />
 			</div>
 
-			<div v-if="!isAlias" class="field half-left">
+			<div v-if="!isAlias && !isGenerated" class="field half-left">
 				<div class="label type-label">{{ t('nullable') }}</div>
 				<v-checkbox v-model="nullable" :label="t('allow_null_value')" block />
 			</div>
 
-			<div v-if="!isAlias" class="field half-right">
+			<div v-if="!isAlias && !isGenerated" class="field half-right">
 				<div class="label type-label">{{ t('unique') }}</div>
 				<v-checkbox v-model="unique" :label="t('value_unique')" block />
 			</div>
@@ -279,6 +279,10 @@ export default defineComponent({
 			return fieldDetailStore.field.schema?.is_primary_key === true;
 		});
 
+		const isGenerated = computed(() => {
+			return fieldDetailStore.field.schema?.is_generated;
+		});
+
 		return {
 			t,
 			typesWithLabels,
@@ -303,6 +307,7 @@ export default defineComponent({
 			unique,
 			isPrimaryKey,
 			isExisting,
+			isGenerated,
 		};
 
 		function useOnCreate() {

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -134,14 +134,14 @@
 				<v-input v-else v-model="defaultValue" class="monospace" disabled placeholder="NULL" />
 			</div>
 
-			<div v-if="!isAlias && !isGenerated" class="field half-left">
+			<div v-if="!isAlias" class="field half-left">
 				<div class="label type-label">{{ t('nullable') }}</div>
-				<v-checkbox v-model="nullable" :label="t('allow_null_value')" block />
+				<v-checkbox v-model="nullable" :disabled="!isGenerated" :label="t('allow_null_value')" block />
 			</div>
 
-			<div v-if="!isAlias && !isGenerated" class="field half-right">
+			<div v-if="!isAlias" class="field half-right">
 				<div class="label type-label">{{ t('unique') }}</div>
-				<v-checkbox v-model="unique" :label="t('value_unique')" block />
+				<v-checkbox v-model="unique" :disabled="!isGenerated" :label="t('value_unique')" block />
 			</div>
 		</div>
 	</div>

--- a/packages/schema/src/dialects/mssql.ts
+++ b/packages/schema/src/dialects/mssql.ts
@@ -17,10 +17,10 @@ export default class MSSQL extends KnexMSSQL implements SchemaInspector {
 				c.CHARACTER_MAXIMUM_LENGTH as max_length,
        			cc.is_computed as is_generated,
 				pk.PK_SET as column_key,
-				COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') as is_identity
+				COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') as is_identity,
+				COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsComputed') as is_generated
 			FROM
 				[${this.knex.client.database()}].INFORMATION_SCHEMA.COLUMNS as c
-			LEFT JOIN [sys].[computed_columns] AS [cc] ON [cc].[object_id] = [c].[object_id] AND [cc].[column_id] = [c].[column_id]
 			LEFT JOIN (
 				SELECT
 					PK_SET = CASE WHEN CONSTRAINT_NAME LIKE '%pk%' THEN 'PRIMARY' ELSE NULL END,

--- a/packages/schema/src/dialects/mssql.ts
+++ b/packages/schema/src/dialects/mssql.ts
@@ -15,10 +15,12 @@ export default class MSSQL extends KnexMSSQL implements SchemaInspector {
 				c.IS_NULLABLE as is_nullable,
 				c.DATA_TYPE as data_type,
 				c.CHARACTER_MAXIMUM_LENGTH as max_length,
+       			cc.is_computed as is_generated,
 				pk.PK_SET as column_key,
 				COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') as is_identity
 			FROM
 				[${this.knex.client.database()}].INFORMATION_SCHEMA.COLUMNS as c
+			LEFT JOIN [sys].[computed_columns] AS [cc] ON [cc].[object_id] = [c].[object_id] AND [cc].[column_id] = [c].[column_id]
 			LEFT JOIN (
 				SELECT
 					PK_SET = CASE WHEN CONSTRAINT_NAME LIKE '%pk%' THEN 'PRIMARY' ELSE NULL END,

--- a/packages/schema/src/dialects/mysql.ts
+++ b/packages/schema/src/dialects/mysql.ts
@@ -53,6 +53,7 @@ export default class MySQL extends KnexMySQL implements SchemaInspector {
 				...column,
 				default_value: column.extra === 'auto_increment' ? 'AUTO_INCREMENT' : parseDefaultValue(column.default_value),
 				is_nullable: column.is_nullable === 'YES',
+				is_generated: column.extra?.endsWith('GENERATED') ?? false,
 				data_type: dataType,
 			};
 		}

--- a/packages/schema/src/dialects/oracledb.ts
+++ b/packages/schema/src/dialects/oracledb.ts
@@ -36,6 +36,7 @@ export default class Oracle extends KnexOracle implements SchemaInspector {
 			column_name: string;
 			default_value: string;
 			is_nullable: string;
+			is_generated: string;
 			data_type: string;
 			numeric_precision: number | null;
 			numeric_scale: number | null;

--- a/packages/schema/src/dialects/oracledb.ts
+++ b/packages/schema/src/dialects/oracledb.ts
@@ -62,7 +62,8 @@ export default class Oracle extends KnexOracle implements SchemaInspector {
 				"c"."DATA_PRECISION" "numeric_precision",
 				"c"."DATA_SCALE" "numeric_scale",
 				"ct"."CONSTRAINT_TYPE" "column_key",
-				"c"."CHAR_LENGTH" "max_length"
+				"c"."CHAR_LENGTH" "max_length",
+				"c"."VIRTUAL_COLUMN" "is_generated",
 			FROM "USER_TAB_COLUMNS" "c"
 			LEFT JOIN "uc" "ct" ON "c"."TABLE_NAME" = "ct"."TABLE_NAME"
 				AND "c"."COLUMN_NAME" = "ct"."COLUMN_NAME"
@@ -88,6 +89,7 @@ export default class Oracle extends KnexOracle implements SchemaInspector {
 			overview[column.table_name].columns[column.column_name] = {
 				...column,
 				is_nullable: column.is_nullable === 'Y',
+				is_generated: column.is_generated === 'YES',
 				default_value: hasAutoIncrement ? 'AUTO_INCREMENT' : stripQuotes(column.default_value),
 			};
 		}

--- a/packages/schema/src/dialects/oracledb.ts
+++ b/packages/schema/src/dialects/oracledb.ts
@@ -64,7 +64,7 @@ export default class Oracle extends KnexOracle implements SchemaInspector {
 				"c"."DATA_SCALE" "numeric_scale",
 				"ct"."CONSTRAINT_TYPE" "column_key",
 				"c"."CHAR_LENGTH" "max_length",
-				"c"."VIRTUAL_COLUMN" "is_generated",
+				"c"."VIRTUAL_COLUMN" "is_generated"
 			FROM "USER_TAB_COLUMNS" "c"
 			LEFT JOIN "uc" "ct" ON "c"."TABLE_NAME" = "ct"."TABLE_NAME"
 				AND "c"."COLUMN_NAME" = "ct"."COLUMN_NAME"

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -13,6 +13,7 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
 			max_length: number | null;
 			is_identity: boolean;
 			is_nullable: boolean;
+			is_generated: boolean;
 		};
 
 		type RawGeometryColumn = {

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -31,6 +31,7 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
           , c.column_default as default_value
           , c.data_type
 			 		, c.character_maximum_length as max_length
+          , c.is_generated = 'ALWAYS' is_generated
           , CASE WHEN c.is_identity = 'YES' THEN true ELSE false END is_identity
           , CASE WHEN c.is_nullable = 'YES' THEN true ELSE false END is_nullable
         FROM

--- a/packages/schema/src/dialects/sqlite.ts
+++ b/packages/schema/src/dialects/sqlite.ts
@@ -10,6 +10,7 @@ type RawColumn = {
 	name: string;
 	type: string;
 	notnull: 0 | 1;
+	hidden: 0 | 1 | 2;
 	dflt_value: any;
 	pk: 0 | 1;
 };
@@ -24,7 +25,7 @@ export default class SQLite extends KnexSQLite implements SchemaInspector {
 		const overview: SchemaOverview = {};
 
 		for (const table of tables) {
-			const columns = await this.knex.raw<RawColumn[]>(`PRAGMA table_info(??)`, table);
+			const columns = await this.knex.raw<RawColumn[]>(`PRAGMA table_xinfo(??)`, table);
 
 			if (table in overview === false) {
 				overview[table] = {
@@ -42,6 +43,7 @@ export default class SQLite extends KnexSQLite implements SchemaInspector {
 							? 'AUTO_INCREMENT'
 							: stripQuotes(column.dflt_value),
 					is_nullable: column.notnull == 0,
+					is_generated: column.hidden !== 0,
 					data_type: extractType(column.type),
 					max_length: extractMaxLength(column.type),
 					numeric_precision: null,

--- a/packages/schema/src/types/overview.ts
+++ b/packages/schema/src/types/overview.ts
@@ -7,6 +7,7 @@ export type SchemaOverview = {
 				column_name: string;
 				default_value: any;
 				is_nullable: boolean;
+				is_generated: boolean;
 				data_type: string;
 				numeric_precision?: number | null;
 				numeric_scale?: number | null;


### PR DESCRIPTION
Changes:
* Add `generated` prop to `FieldOverview`
* Add `is_generated` prop to `SchemaOverview[<table>]['columns'][<column>]`
* Never add generated columns to the list of required fields in `AuthorizationService.validatePayload`

Also prevent schema changes on generated columns by disabling non-editable fields `unique` and `nullable` and hiding non applicable fields `default_value` and `required` (subject to modification).

Should fix https://github.com/directus/directus/issues/9189
Should fix https://github.com/directus/directus/issues/9196