### PR TITLE
Allow specify custom preview threshold for select-multiple-dropdown

### DIFF
--- a/app/src/interfaces/select-multiple-dropdown/index.ts
+++ b/app/src/interfaces/select-multiple-dropdown/index.ts
@@ -103,6 +103,18 @@ export default defineInterface({
 				interface: 'select-icon',
 			},
 		},
+		{
+			field: 'previewThreshold',
+			name: '$t:interfaces.select-dropdown.preview_threshold',
+			type: 'integer',
+			meta: {
+				width: 'half',
+				interface: 'input',
+			},
+			schema: {
+				default_value: 3,
+			},
+		},
 	],
 	recommendedDisplays: ['labels'],
 });

--- a/app/src/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue
+++ b/app/src/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue
@@ -12,6 +12,7 @@
 		:placeholder="placeholder"
 		:allow-other="allowOther"
 		:close-on-content-click="false"
+		:multiple-preview-threshold="previewThreshold"
 		@update:model-value="$emit('input', $event)"
 	>
 		<template v-if="icon" #prepend>
@@ -58,6 +59,10 @@ export default defineComponent({
 		allowOther: {
 			type: Boolean,
 			default: false,
+		},
+		previewThreshold: {
+			type: Number,
+			default: 3,
 		},
 	},
 	emits: ['input'],

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1289,6 +1289,7 @@ interfaces:
     allow_none_label: Allow No Selection
     choices_name_placeholder: Enter a name...
     choices_value_placeholder: Enter a value...
+    preview_threshold: Preview Threshold
   select-multiple-dropdown:
     select-multiple-dropdown: Dropdown (Multiple)
     description: Select multiple values from a dropdown


### PR DESCRIPTION
Just another minor contribution on `select-multiple-dropdown`'s options. It simply passes `multiple-preview-threshold` option value down to the `v-select` component.

![2021-10-29_08-42](https://user-images.githubusercontent.com/76130324/139341119-7fd64157-9035-4950-bb00-353f64f84dd2.png)

![2021-10-29_08-43](https://user-images.githubusercontent.com/76130324/139341146-1510ad13-cd33-43fb-a9f0-201d0b2b5e46.png)

![2021-10-29_08-43_1](https://user-images.githubusercontent.com/76130324/139341152-df5ea2e3-1d31-4775-8986-768bb4e250f6.png)

