### PR TITLE
Minor tweak to fallback interface selectors

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -236,12 +236,13 @@ export default defineComponent({
 }
 
 .preview .fallback {
-	--v-icon-color: var(--primary-50);
+	--v-icon-color: var(--primary-75);
 
 	display: block;
 	padding: 8px 16px;
+	border: 2px solid var(--primary);
 	border-radius: var(--border-radius);
-	box-shadow: 0 0 8px var(--primary-50);
+	box-shadow: 0 0 8px var(--primary-75);
 }
 
 .interface:hover .preview {


### PR DESCRIPTION
## Motivation

The fallback interface selectors (the ones without custom SVGs) such as:

- tags
- toggle
- map
- color
- icon
- checkboxes

seems a little dim compared to others. This is an attempt to make them more in line as a whole.

## Before

![chrome_gmq5ROb17g](https://user-images.githubusercontent.com/42867097/139448013-f9905ae9-af77-4a24-a1e7-c8b069e1754b.png)

## After

![chrome_d5cD4mZlL0](https://user-images.githubusercontent.com/42867097/139448165-e8f78261-a215-4813-9af5-c94b91c3e887.png)

