### PR TITLE
Add CLI to exports

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -50,6 +50,7 @@
 	"exports": {
 		".": "./index.js",
 		"./*": "./dist/*.js",
+		"./cli": "./dist/cli/*.js",
 		"./package.json": "./package.json"
 	},
 	"bin": {


### PR DESCRIPTION
The CLI was missing, as it's not included under the root of the package