### PR TITLE
Feat: Improve shortcuts

### DIFF
--- a/app/src/components/v-fancy-select/v-fancy-select.vue
+++ b/app/src/components/v-fancy-select/v-fancy-select.vue
@@ -3,7 +3,7 @@
 		<transition-group tag="div" name="option">
 			<template v-for="(item, index) in visibleItems" :key="index">
 				<v-divider v-if="item.divider === true" />
-				<div
+				<button
 					v-else
 					class="v-fancy-select-option"
 					:class="{ active: item.value === modelValue, disabled }"
@@ -23,7 +23,7 @@
 
 					<v-icon v-if="modelValue === item.value && disabled === false" name="cancel" @click.stop="toggle(item)" />
 					<v-icon v-else-if="item.iconRight" class="icon-right" :name="item.iconRight" />
-				</div>
+				</button>
 			</template>
 		</transition-group>
 	</div>
@@ -82,6 +82,7 @@ export default defineComponent({
 	width: 100%;
 	margin-bottom: 8px;
 	padding: 12px;
+	text-align: left;
 	background-color: var(--background-normal);
 	border: 2px solid var(--background-normal);
 	border-radius: 6px;
@@ -91,7 +92,8 @@ export default defineComponent({
 	transition-duration: var(--fast);
 	transition-property: background-color, border-color;
 
-	&:not(.disabled):hover {
+	&:not(.disabled):hover,
+	&:not(.disabled):focus {
 		border-color: var(--background-normal-alt);
 	}
 

--- a/app/src/components/v-icon/v-icon.vue
+++ b/app/src/components/v-icon/v-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<span
+	<button
 		class="v-icon"
 		:class="[sizeClass, { 'has-click': !disabled && clickable, left, right }]"
 		:role="clickable ? 'button' : null"
@@ -10,7 +10,7 @@
 		<component :is="customIconName" v-if="customIconName" />
 		<socialIcon v-else-if="socialIconName" :name="socialIconName" />
 		<i v-else :class="{ filled }">{{ name }}</i>
-	</span>
+	</button>
 </template>
 
 <script lang="ts">
@@ -666,7 +666,8 @@ body {
 		cursor: pointer;
 		transition: color var(--fast) var(--transition);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--v-icon-color-hover);
 		}
 	}

--- a/app/src/composables/use-folders.ts
+++ b/app/src/composables/use-folders.ts
@@ -1,4 +1,5 @@
 import api from '@/api';
+import { usePermissionsStore } from '@/stores';
 import { ref, Ref } from 'vue';
 
 type FolderRaw = {
@@ -31,6 +32,8 @@ let openFolders: Ref<string[] | null> | null = null;
 let error: Ref<any> | null = null;
 
 export default function useFolders(): UsableFolders {
+	const permissionsStore = usePermissionsStore();
+
 	if (loading === null) loading = ref(false);
 	if (folders === null) folders = ref<Folder[] | null>(null);
 	if (nestedFolders === null) nestedFolders = ref<Folder[] | null>(null);
@@ -44,6 +47,7 @@ export default function useFolders(): UsableFolders {
 	return { loading, folders, nestedFolders, error, fetchFolders, openFolders };
 
 	async function fetchFolders() {
+		if (!permissionsStore.hasPermission('directus_folders', 'read')) return;
 		if (loading === null) return;
 		if (folders === null) return;
 		if (nestedFolders === null) return;

--- a/app/src/composables/use-permissions.ts
+++ b/app/src/composables/use-permissions.ts
@@ -8,6 +8,7 @@ import { useCollection } from '@directus/shared/composables';
 type UsablePermissions = {
 	deleteAllowed: ComputedRef<boolean>;
 	saveAllowed: ComputedRef<boolean>;
+	createAllowed: ComputedRef<boolean>;
 	archiveAllowed: ComputedRef<boolean>;
 	updateAllowed: ComputedRef<boolean>;
 	fields: ComputedRef<Field[]>;
@@ -19,6 +20,8 @@ export function usePermissions(collection: Ref<string>, item: Ref<any>, isNew: R
 	const permissionsStore = usePermissionsStore();
 
 	const { info: collectionInfo, fields: rawFields } = useCollection(collection);
+
+	const createAllowed = computed(() => isAllowed(collection.value, 'create', item.value));
 
 	const deleteAllowed = computed(() => isAllowed(collection.value, 'delete', item.value));
 
@@ -90,5 +93,5 @@ export function usePermissions(collection: Ref<string>, item: Ref<any>, isNew: R
 		);
 	});
 
-	return { deleteAllowed, saveAllowed, archiveAllowed, updateAllowed, fields, revisionsAllowed };
+	return { deleteAllowed, saveAllowed, archiveAllowed, updateAllowed, fields, revisionsAllowed, createAllowed };
 }

--- a/app/src/modules/collections/routes/collection-or-item.vue
+++ b/app/src/modules/collections/routes/collection-or-item.vue
@@ -10,9 +10,11 @@
 
 <script lang="ts">
 import { defineComponent, computed } from 'vue';
+import { useRouter } from 'vue-router';
 import CollectionRoute from './collection.vue';
 import ItemRoute from './item.vue';
 import { useCollectionsStore } from '@/stores/';
+import useShortcut from '@/composables/use-shortcut';
 
 export default defineComponent({
 	components: {
@@ -35,13 +37,20 @@ export default defineComponent({
 	},
 	setup(props) {
 		const collectionsStore = useCollectionsStore();
+		const router = useRouter();
 
 		const isSingleton = computed(() => {
 			const collectionInfo = collectionsStore.getCollection(props.collection);
 			return !!collectionInfo?.meta?.singleton === true;
 		});
 
+		useShortcut('alt+n', createNew);
+
 		return { isSingleton };
+
+		function createNew() {
+			router.push(`/collections/${props.collection}/+`);
+		}
 	},
 });
 </script>

--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -338,7 +338,7 @@ export default defineComponent({
 		});
 
 		useShortcut('meta+s', saveAndStay, form);
-		useShortcut('meta+shift+s', saveAndAddNew, form);
+		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
 
 		const editsGuard: NavigationGuard = (to) => {
 			if (hasEdits.value) {

--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -132,10 +132,12 @@
 
 				<template #append-outer>
 					<save-options
-						v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true && isSavable === true"
+						v-if="collectionInfo?.meta?.singleton !== true"
+						:is-updatable="isSavable"
+						:is-creatable="createAllowed === true"
 						@save-and-stay="saveAndStay"
-						@create-new="createNew"
 						@save-as-copy="saveAsCopyAndNavigate"
+						@create-new="createNew"
 					/>
 				</template>
 			</v-button>
@@ -351,11 +353,8 @@ export default defineComponent({
 		onBeforeRouteUpdate(editsGuard);
 		onBeforeRouteLeave(editsGuard);
 
-		const { deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, fields, revisionsAllowed } = usePermissions(
-			collection,
-			item,
-			isNew
-		);
+		const { deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, fields, revisionsAllowed, createAllowed } =
+			usePermissions(collection, item, isNew);
 
 		const internalPrimaryKey = computed(() => {
 			if (isNew.value) return '+';
@@ -398,6 +397,7 @@ export default defineComponent({
 			discardAndLeave,
 			deleteAllowed,
 			saveAllowed,
+			createAllowed,
 			archiveAllowed,
 			isArchived,
 			updateAllowed,
@@ -451,7 +451,7 @@ export default defineComponent({
 			}
 		}
 
-		async function createNew() {
+		function createNew() {
 			router.push(`/collections/${props.collection}/+`);
 		}
 

--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -341,7 +341,14 @@ export default defineComponent({
 
 		useShortcut('meta+s', saveAndStay, form);
 		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
-		useShortcut('alt+n', createNew, form);
+		useShortcut(
+			'alt+n',
+			async () => {
+				await saveAndStay();
+				createNew();
+			},
+			form
+		);
 
 		const editsGuard: NavigationGuard = (to) => {
 			if (hasEdits.value) {

--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -134,7 +134,7 @@
 					<save-options
 						v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true && isSavable === true"
 						@save-and-stay="saveAndStay"
-						@save-and-add-new="saveAndAddNew"
+						@create-new="createNew"
 						@save-as-copy="saveAsCopyAndNavigate"
 					/>
 				</template>
@@ -339,6 +339,7 @@ export default defineComponent({
 
 		useShortcut('meta+s', saveAndStay, form);
 		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
+		useShortcut('alt+n', createNew, form);
 
 		const editsGuard: NavigationGuard = (to) => {
 			if (hasEdits.value) {
@@ -383,7 +384,7 @@ export default defineComponent({
 			deleting,
 			archiving,
 			saveAndStay,
-			saveAndAddNew,
+			createNew,
 			saveAsCopyAndNavigate,
 			templateData,
 			templateDataLoading,
@@ -450,20 +451,8 @@ export default defineComponent({
 			}
 		}
 
-		async function saveAndAddNew() {
-			if (isSavable.value === false) return;
-
-			try {
-				await save();
-
-				if (isNew.value === true) {
-					refresh();
-				} else {
-					router.push(`/collections/${props.collection}/+`);
-				}
-			} catch {
-				// Save shows unexpected error dialog
-			}
+		async function createNew() {
+			router.push(`/collections/${props.collection}/+`);
 		}
 
 		async function saveAsCopyAndNavigate() {

--- a/app/src/modules/files/components/navigation-folder.vue
+++ b/app/src/modules/files/components/navigation-folder.vue
@@ -43,7 +43,7 @@
 
 		<v-menu ref="contextMenu" show-arrow placement="bottom-start">
 			<v-list>
-				<v-list-item clickable @click="renameActive = true">
+				<v-list-item clickable :disabled="!updateAllowed" @click="renameActive = true">
 					<v-list-item-icon>
 						<v-icon name="edit" outline />
 					</v-list-item-icon>
@@ -51,7 +51,7 @@
 						<v-text-overflow :text="t('rename_folder')" />
 					</v-list-item-content>
 				</v-list-item>
-				<v-list-item clickable @click="moveActive = true">
+				<v-list-item clickable :disabled="!updateAllowed" @click="moveActive = true">
 					<v-list-item-icon>
 						<v-icon name="folder_move" />
 					</v-list-item-icon>
@@ -59,7 +59,7 @@
 						<v-text-overflow :text="t('move_to_folder')" />
 					</v-list-item-content>
 				</v-list-item>
-				<v-list-item clickable @click="deleteActive = true">
+				<v-list-item clickable :disabled="!deleteAllowed" @click="deleteActive = true">
 					<v-list-item-icon>
 						<v-icon name="delete" outline />
 					</v-list-item-icon>
@@ -123,6 +123,7 @@ import api from '@/api';
 import FolderPicker from './folder-picker.vue';
 import { useRouter } from 'vue-router';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { usePermissions } from '@/composables/use-permissions';
 
 export default defineComponent({
 	name: 'NavigationFolder',
@@ -148,6 +149,11 @@ export default defineComponent({
 
 		const contextMenu = ref();
 
+		const { deleteAllowed, saveAllowed, updateAllowed } = usePermissions(
+			ref('directus_folders'),
+			ref(null),
+			ref(false)
+		);
 		const { renameActive, renameValue, renameSave, renameSaving } = useRenameFolder();
 		const { moveActive, moveValue, moveSave, moveSaving } = useMoveFolder();
 		const { deleteActive, deleteSave, deleteSaving } = useDeleteFolder();
@@ -170,6 +176,9 @@ export default defineComponent({
 			contextMenu,
 			activateContextMenu,
 			deactivateContextMenu,
+			updateAllowed,
+			saveAllowed,
+			deleteAllowed,
 		};
 
 		function useRenameFolder() {

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -46,7 +46,7 @@
 						v-tooltip.bottom="t('move_to_folder')"
 						rounded
 						icon
-						:disabled="item === null"
+						:disabled="item === null || saveAllowed === false"
 						class="folder"
 						@click="on"
 					>

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -82,6 +82,7 @@
 				rounded
 				icon
 				class="edit"
+				:disabled="saveAllowed === false"
 				@click="editActive = true"
 			>
 				<v-icon name="tune" />

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -119,6 +119,7 @@
 				:width="item.width"
 				:height="item.height"
 				:title="item.title"
+				:readonly="saveAllowed !== true"
 				@click="replaceFileDialogActive = true"
 			/>
 

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -295,7 +295,14 @@ export default defineComponent({
 
 		useShortcut('meta+s', saveAndStay, form);
 		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
-		useShortcut('alt+n', createNew, form);
+		useShortcut(
+			'alt+n',
+			async () => {
+				await saveAndStay();
+				createNew();
+			},
+			form
+		);
 
 		const editsGuard: NavigationGuard = (to) => {
 			if (hasEdits.value) {

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -100,9 +100,11 @@
 
 				<template #append-outer>
 					<save-options
-						v-if="hasEdits === true || saveAllowed === true"
+						:is-savable="hasEdits === true && saveAllowed === true"
+						:is-creatable="createAllowed === true"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
+						@create-new="createNew"
 					/>
 				</template>
 			</v-button>
@@ -292,6 +294,8 @@ export default defineComponent({
 		const { moveToDialogActive, moveToFolder, moving, selectedFolder } = useMovetoFolder();
 
 		useShortcut('meta+s', saveAndStay, form);
+		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
+		useShortcut('alt+n', createNew, form);
 
 		const editsGuard: NavigationGuard = (to) => {
 			if (hasEdits.value) {
@@ -303,7 +307,7 @@ export default defineComponent({
 		onBeforeRouteUpdate(editsGuard);
 		onBeforeRouteLeave(editsGuard);
 
-		const { deleteAllowed, saveAllowed, updateAllowed, fields, revisionsAllowed } = usePermissions(
+		const { deleteAllowed, saveAllowed, updateAllowed, fields, revisionsAllowed, createAllowed } = usePermissions(
 			ref('directus_files'),
 			item,
 			isNew
@@ -330,6 +334,7 @@ export default defineComponent({
 			deleting,
 			saveAndStay,
 			saveAsCopyAndNavigate,
+			createNew,
 			isBatch,
 			editActive,
 			revisionsDrawerDetail,
@@ -348,6 +353,7 @@ export default defineComponent({
 			refresh,
 			deleteAllowed,
 			saveAllowed,
+			createAllowed,
 			updateAllowed,
 			fields,
 			fieldsFiltered,
@@ -398,6 +404,10 @@ export default defineComponent({
 		async function saveAsCopyAndNavigate() {
 			const newPrimaryKey = await saveAsCopy();
 			if (newPrimaryKey) router.push(`/files/${newPrimaryKey}`);
+		}
+
+		function createNew() {
+			router.push(`/files/+`);
 		}
 
 		async function deleteAndQuit() {

--- a/app/src/modules/insights/components/workspace.vue
+++ b/app/src/modules/insights/components/workspace.vue
@@ -21,7 +21,7 @@
 				@update="$emit('update', { edits: $event, id: panel.id })"
 				@move="$emit('move', panel.id)"
 				@delete="$emit('delete', panel.id)"
-				@duplicate="$emit('duplicate', panel)"
+				@duplicate="$emit('duplicate', panel.id)"
 			/>
 		</div>
 	</div>

--- a/app/src/modules/insights/routes/panel-configuration.vue
+++ b/app/src/modules/insights/routes/panel-configuration.vue
@@ -94,6 +94,7 @@ import { FancySelectItem } from '@/components/v-fancy-select/types';
 import { Panel } from '@/types';
 import { useI18n } from 'vue-i18n';
 import { useDialogRoute } from '@/composables/use-dialog-route';
+import useShortcut from '@/composables/use-shortcut';
 
 export default defineComponent({
 	name: 'PanelConfiguration',
@@ -103,7 +104,7 @@ export default defineComponent({
 			default: null,
 		},
 	},
-	emits: ['cancel', 'save'],
+	emits: ['cancel', 'save', 'duplicate', 'delete'],
 	setup(props, { emit }) {
 		const { t } = useI18n();
 
@@ -152,6 +153,10 @@ export default defineComponent({
 			}
 		});
 
+		useShortcut('meta+s', emitSave);
+		useShortcut('meta+shift+s', emitDuplicate);
+		useShortcut('meta+backspace', emitDelete);
+
 		return {
 			selectItems,
 			selectedPanel,
@@ -164,6 +169,14 @@ export default defineComponent({
 
 		function emitSave() {
 			emit('save', edits);
+		}
+
+		function emitDuplicate() {
+			emit('duplicate', props.panel.id);
+		}
+
+		function emitDelete() {
+			emit('delete', props.panel.id);
 		}
 	},
 });

--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -74,6 +74,7 @@ export default defineModule({
 						collection: route.params.collection,
 						field: route.params.field,
 						type: route.query.type,
+						duplicate: route.query.duplicate,
 					}),
 					children: [
 						{

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -62,7 +62,6 @@ import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store/';
 import { storeToRefs } from 'pinia';
 import ExtensionOptions from '../shared/extension-options.vue';
 import RelationshipConfiguration from './relationship-configuration.vue';
-import useShortcut from '@/composables/use-shortcut';
 
 export default defineComponent({
 	components: { ExtensionOptions, RelationshipConfiguration },
@@ -102,8 +101,6 @@ export default defineComponent({
 		const defaultValue = syncFieldDetailStoreProperty('field.schema.default_value');
 		const required = syncFieldDetailStoreProperty('field.meta.required', false);
 		const note = syncFieldDetailStoreProperty('field.meta.note');
-
-		useShortcut('meta+s', () => emit('save'), form);
 
 		return {
 			form,

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="field-configuration" :style="{ 'grid-row': row }">
+	<form ref="form" class="field-configuration" :style="{ 'grid-row': row }">
 		<div class="setup">
 			<div class="schema">
 				<div class="field half-left">
@@ -51,17 +51,18 @@
 				{{ t('continue_in_advanced_field_creation_mode') }}
 			</button>
 		</div>
-	</div>
+	</form>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, ref } from 'vue';
 import { getInterfaces } from '@/interfaces';
 import { useI18n } from 'vue-i18n';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store/';
 import { storeToRefs } from 'pinia';
 import ExtensionOptions from '../shared/extension-options.vue';
 import RelationshipConfiguration from './relationship-configuration.vue';
+import useShortcut from '@/composables/use-shortcut';
 
 export default defineComponent({
 	components: { ExtensionOptions, RelationshipConfiguration },
@@ -76,9 +77,10 @@ export default defineComponent({
 		},
 	},
 	emits: ['save', 'toggleAdvanced'],
-	setup(props) {
+	setup(props, { emit }) {
 		const fieldDetail = useFieldDetailStore();
 
+		const form = ref<HTMLFormElement>();
 		const { readyToSave, saving, localType, collection } = storeToRefs(fieldDetail);
 		const { t } = useI18n();
 
@@ -101,7 +103,10 @@ export default defineComponent({
 		const required = syncFieldDetailStoreProperty('field.meta.required', false);
 		const note = syncFieldDetailStoreProperty('field.meta.note');
 
+		useShortcut('meta+s', () => emit('save'), form);
+
 		return {
+			form,
 			key,
 			t,
 			type,

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -68,10 +68,18 @@ export default defineComponent({
 		);
 
 		useShortcut('meta+s', () => {
-			if (readyToSave.value !== false) save();
+			if (readyToSave.value !== false) saveAndStay();
 		});
 
-		useShortcut('alt+n', createNew);
+		useShortcut('meta+shift+s', async () => {
+			if (readyToSave.value !== false) await saveAndStay();
+			duplicate();
+		});
+
+		useShortcut('alt+n', async () => {
+			if (readyToSave.value !== false) await saveAndStay();
+			createNew();
+		});
 
 		const collectionsStore = useCollectionsStore();
 		const fieldsStore = useFieldsStore();
@@ -102,6 +110,14 @@ export default defineComponent({
 		});
 
 		return { simple, cancel, collectionInfo, t, title, save, isOpen, currentTab, showAdvanced };
+
+		async function saveAndStay() {
+			await save();
+		}
+
+		async function duplicate() {
+			router.push(`/settings/data-model/${props.collection}?duplicate=${props.field}`);
+		}
 
 		function createNew() {
 			router.push(`/settings/data-model/${props.collection}/+`);

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -33,6 +33,7 @@ import { useI18n } from 'vue-i18n';
 import formatTitle from '@directus/format-title';
 import { useDialogRoute } from '@/composables/use-dialog-route';
 import { storeToRefs } from 'pinia';
+import useShortcut from '@/composables/use-shortcut';
 
 export default defineComponent({
 	name: 'FieldDetail',
@@ -58,13 +59,19 @@ export default defineComponent({
 
 		const fieldDetail = useFieldDetailStore();
 
-		const { editing } = storeToRefs(fieldDetail);
+		const { editing, readyToSave } = storeToRefs(fieldDetail);
 
 		watch(
 			() => props.field,
 			() => fieldDetail.startEditing(props.collection, props.field, props.type),
 			{ immediate: true }
 		);
+
+		useShortcut('meta+s', () => {
+			if (readyToSave.value !== false) save();
+		});
+
+		useShortcut('alt+n', createNew);
 
 		const collectionsStore = useCollectionsStore();
 		const fieldsStore = useFieldsStore();
@@ -95,6 +102,10 @@ export default defineComponent({
 		});
 
 		return { simple, cancel, collectionInfo, t, title, save, isOpen, currentTab, showAdvanced };
+
+		function createNew() {
+			router.push(`/settings/data-model/${props.collection}/+`);
+		}
 
 		async function cancel() {
 			await router.push(`/settings/data-model/${props.collection}`);

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -139,7 +139,7 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed } from 'vue';
+import { defineComponent, PropType, ref, computed, watch } from 'vue';
 import { useCollectionsStore, useFieldsStore } from '@/stores/';
 import { getInterfaces } from '@/interfaces';
 import { useRouter } from 'vue-router';
@@ -168,6 +168,10 @@ export default defineComponent({
 			type: Array as PropType<Field[]>,
 			default: () => [],
 		},
+		duplicate: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	emits: ['setNestedSort'],
 	setup(props, { emit }) {
@@ -193,6 +197,13 @@ export default defineComponent({
 		const localType = computed(() => getLocalTypeForField(props.field.collection, props.field.field));
 
 		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.field));
+
+		watch(
+			() => props.duplicate,
+			() => {
+				duplicateActive.value = props.duplicate;
+			}
+		);
 
 		return {
 			t,

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -18,7 +18,12 @@
 			@update:model-value="setSort"
 		>
 			<template #item="{ element }">
-				<field-select :field="element" :fields="usableFields" @setNestedSort="setNestedSort" />
+				<field-select
+					:field="element"
+					:fields="usableFields"
+					:duplicate="duplicate === element.field"
+					@setNestedSort="setNestedSort"
+				/>
 			</template>
 		</draggable>
 
@@ -68,6 +73,10 @@ export default defineComponent({
 		collection: {
 			type: String,
 			required: true,
+		},
+		duplicate: {
+			type: String,
+			default: null,
 		},
 	},
 	setup(props) {

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -61,7 +61,7 @@
 					{{ t('fields_and_layout') }}
 					<span class="instant-save">{{ t('saves_automatically') }}</span>
 				</h2>
-				<fields-management :collection="collection" />
+				<fields-management :collection="collection" :duplicate="duplicate" />
 			</div>
 
 			<router-view name="field" :collection="collection" :field="field" :type="type" />
@@ -125,6 +125,10 @@ export default defineComponent({
 			default: null,
 		},
 		type: {
+			type: String,
+			default: null,
+		},
+		duplicate: {
 			type: String,
 			default: null,
 		},

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -153,7 +153,10 @@ export default defineComponent({
 			if (hasEdits.value) saveAndStay();
 		});
 
-		useShortcut('alt+n', createNewField);
+		useShortcut('alt+n', async () => {
+			if (hasEdits.value) await saveAndStay();
+			createNewField();
+		});
 
 		const confirmDelete = ref(false);
 

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -153,6 +153,8 @@ export default defineComponent({
 			if (hasEdits.value) saveAndStay();
 		});
 
+		useShortcut('alt+n', createNewField);
+
 		const confirmDelete = ref(false);
 
 		const isSavable = computed(() => {
@@ -218,6 +220,10 @@ export default defineComponent({
 			await collectionsStore.hydrate();
 			await fieldsStore.hydrate();
 			router.push(`/settings/data-model`);
+		}
+
+		function createNewField() {
+			router.push(`/settings/data-model/${collection.value}/+`);
 		}
 
 		function discardAndLeave() {

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -204,6 +204,11 @@ export default defineComponent({
 			if (hasEdits.value) save();
 		});
 
+		useShortcut('alt+n', async () => {
+			if (hasEdits.value) await save();
+			createNew();
+		});
+
 		const isSavable = computed(() => {
 			if (hasEdits.value === true) return true;
 			return hasEdits.value;
@@ -250,6 +255,10 @@ export default defineComponent({
 			leaveTo,
 			discardAndLeave,
 		};
+
+		function createNew() {
+			router.push('/settings/presets/+');
+		}
 
 		function useSave() {
 			const saving = ref(false);

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -139,7 +139,7 @@ export default defineComponent({
 		const userInviteModalActive = ref(false);
 		const { primaryKey } = toRefs(props);
 
-		const { edits, item, saving, loading, error, save, remove, deleting, isBatch } = useItem(
+		const { edits, item, saving, loading, error, save, remove, deleting, isBatch, saveAsCopy } = useItem(
 			ref('directus_roles'),
 			primaryKey
 		);
@@ -168,6 +168,15 @@ export default defineComponent({
 
 		useShortcut('meta+s', () => {
 			if (hasEdits.value) saveAndStay();
+		});
+
+		useShortcut('meta+shift+s', () => {
+			saveAsCopyAndNavigate();
+		});
+
+		useShortcut('alt+n', async () => {
+			if (hasEdits.value) await saveAndStay();
+			createNew();
 		});
 
 		const isSavable = computed(() => {
@@ -222,6 +231,15 @@ export default defineComponent({
 		async function saveAndStay() {
 			await save();
 			await userStore.hydrate();
+		}
+
+		async function saveAsCopyAndNavigate() {
+			const newPrimaryKey = await saveAsCopy();
+			if (newPrimaryKey) router.push(`/settings/roles/${newPrimaryKey}`);
+		}
+
+		function createNew() {
+			router.push(`/settings/roles/+`);
 		}
 
 		async function saveAndQuit() {

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -139,7 +139,7 @@ export default defineComponent({
 		});
 
 		useShortcut('meta+shift+s', () => {
-			if (hasEdits.value) saveAndAddNew();
+			if (hasEdits.value) saveAsCopyAndNavigate();
 		});
 
 		const isSavable = computed(() => {

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -140,7 +140,12 @@ export default defineComponent({
 		});
 
 		useShortcut('meta+shift+s', () => {
-			if (hasEdits.value) saveAsCopyAndNavigate();
+			saveAsCopyAndNavigate();
+		});
+
+		useShortcut('alt+n', async () => {
+			if (hasEdits.value) await saveAndStay();
+			createNew();
 		});
 
 		const isSavable = computed(() => {

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -39,7 +39,7 @@
 					<save-options
 						:disabled="hasEdits === false"
 						@save-and-stay="saveAndStay"
-						@save-and-add-new="saveAndAddNew"
+						@create-new="createNew"
 						@save-as-copy="saveAsCopyAndNavigate"
 					/>
 				</template>
@@ -176,7 +176,7 @@ export default defineComponent({
 			confirmDelete,
 			deleting,
 			saveAndStay,
-			saveAndAddNew,
+			createNew,
 			saveAsCopyAndNavigate,
 			isBatch,
 			title,
@@ -196,8 +196,7 @@ export default defineComponent({
 			await save();
 		}
 
-		async function saveAndAddNew() {
-			await save();
+		async function createNew() {
 			router.push(`/settings/webhooks/+`);
 		}
 

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -37,7 +37,8 @@
 
 				<template #append-outer>
 					<save-options
-						:disabled="hasEdits === false"
+						:is-savable="hasEdits === false"
+						:is-creatable="true"
 						@save-and-stay="saveAndStay"
 						@create-new="createNew"
 						@save-as-copy="saveAsCopyAndNavigate"

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -323,7 +323,7 @@ export default defineComponent({
 		});
 
 		useShortcut('meta+s', saveAndStay, form);
-		useShortcut('meta+shift+s', saveAndAddNew, form);
+		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
 
 		return {
 			t,

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -85,7 +85,8 @@
 
 				<template #append-outer>
 					<save-options
-						v-if="hasEdits === true"
+						:is-savable="hasEdits === true || saveAllowed === true"
+						:is-creatable="createAllowed === true"
 						@save-and-stay="saveAndStay"
 						@create-new="createNew"
 						@save-as-copy="saveAsCopyAndNavigate"
@@ -286,11 +287,8 @@ export default defineComponent({
 		onBeforeRouteUpdate(editsGuard);
 		onBeforeRouteLeave(editsGuard);
 
-		const { deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, revisionsAllowed, fields } = usePermissions(
-			ref('directus_users'),
-			item,
-			isNew
-		);
+		const { deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, revisionsAllowed, fields, createAllowed } =
+			usePermissions(ref('directus_users'), item, isNew);
 
 		// These fields will be shown in the sidebar instead
 		const fieldsDenyList = [
@@ -354,6 +352,7 @@ export default defineComponent({
 			formFields,
 			deleteAllowed,
 			saveAllowed,
+			createAllowed,
 			archiveAllowed,
 			isArchived,
 			updateAllowed,

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -87,7 +87,7 @@
 					<save-options
 						v-if="hasEdits === true"
 						@save-and-stay="saveAndStay"
-						@save-and-add-new="saveAndAddNew"
+						@create-new="createNew"
 						@save-as-copy="saveAsCopyAndNavigate"
 					/>
 				</template>
@@ -341,7 +341,7 @@ export default defineComponent({
 			confirmDelete,
 			deleting,
 			saveAndStay,
-			saveAndAddNew,
+			createNew,
 			saveAsCopyAndNavigate,
 			isBatch,
 			revisionsDrawerDetail,
@@ -407,15 +407,8 @@ export default defineComponent({
 			}
 		}
 
-		async function saveAndAddNew() {
-			try {
-				const savedItem: Record<string, any> = await save();
-				await setLang(savedItem);
-				await refreshCurrentUser();
-				router.push(`/users/+`);
-			} catch {
-				// `save` will show unexpected error dialog
-			}
+		async function createNew() {
+			router.push(`/users/+`);
 		}
 
 		async function saveAsCopyAndNavigate() {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -320,8 +320,30 @@ export default defineComponent({
 			return t('archive');
 		});
 
-		useShortcut('meta+s', saveAndStay, form);
-		useShortcut('meta+shift+s', saveAsCopyAndNavigate, form);
+		useShortcut(
+			'meta+s',
+			() => {
+				if (hasEdits.value) saveAndStay();
+			},
+			form
+		);
+
+		useShortcut(
+			'meta+shift+s',
+			() => {
+				saveAsCopyAndNavigate();
+			},
+			form
+		);
+
+		useShortcut(
+			'alt+n',
+			() => {
+				if (hasEdits.value) saveAndStay();
+				createNew();
+			},
+			form
+		);
 
 		return {
 			t,

--- a/app/src/views/private/components/file-preview/file-preview.vue
+++ b/app/src/views/private/components/file-preview/file-preview.vue
@@ -3,11 +3,11 @@
 		<div
 			v-if="type === 'image'"
 			class="image"
-			:class="{ svg: isSVG, 'max-size': inModal === false }"
-			@click="$emit('click')"
+			:class="{ svg: isSVG, 'max-size': inModal === false, pointer: !readonly }"
+			@click="readonly ? null : $emit('click')"
 		>
 			<img :src="src" :width="width" :height="height" :alt="title" @error="imgError = true" />
-			<v-icon v-if="inModal === false" name="upload" />
+			<v-icon v-if="!readonly && inModal === false" name="upload" />
 		</div>
 
 		<video v-else-if="type === 'video'" controls :src="src" />
@@ -21,6 +21,10 @@ import { defineComponent, computed, ref } from 'vue';
 
 export default defineComponent({
 	props: {
+		readonly: {
+			type: Boolean,
+			default: false,
+		},
 		mime: {
 			type: String,
 			required: true,
@@ -96,7 +100,6 @@ audio {
 .image {
 	width: 100%;
 	height: 100%;
-	cursor: pointer;
 
 	&.max-size {
 		max-height: 75vh;
@@ -137,5 +140,9 @@ audio {
 		// Max height - padding * 2
 		max-height: calc(75vh - 128px);
 	}
+}
+
+.pointer {
+	cursor: pointer;
 }
 </style>

--- a/app/src/views/private/components/image-editor/image-editor.vue
+++ b/app/src/views/private/components/image-editor/image-editor.vue
@@ -123,6 +123,7 @@ import throttle from 'lodash/throttle';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { addTokenToURL } from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
+import useShortcut from '@/composables/use-shortcut';
 
 type Image = {
 	type: string;
@@ -190,6 +191,21 @@ export default defineComponent({
 		const imageURL = computed(() => {
 			return addTokenToURL(`${getRootPath()}assets/${props.id}?${nanoid()}`);
 		});
+
+		useShortcut('meta+s', save);
+		useShortcut('escape', (event, stop) => {
+			if (cropping.value) {
+				cropping.value = false;
+				stop();
+			}
+		});
+		useShortcut('meta+m', () => {
+			dragMode.value = dragMode.value === 'crop' ? 'move' : 'crop';
+		});
+		useShortcut('meta+arrowleft', rotate);
+		useShortcut('meta+arrowright', rotate);
+		useShortcut('meta+arrowup', () => flip('vertical'));
+		useShortcut('meta+arrowdown', () => flip('horizontal'));
 
 		return {
 			t,

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -10,14 +10,14 @@
 				<v-list-item-content>{{ t('save_and_stay') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-and-add-new')">
-				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
-				<v-list-item-content>{{ t('save_and_create_new') }}</v-list-item-content>
-				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
-			</v-list-item>
 			<v-list-item :disabled="disabled" clickable @click="$emit('save-as-copy')">
 				<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
+				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
+			</v-list-item>
+			<v-list-item :disabled="disabled" clickable @click="$emit('save-and-add-new')">
+				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
+				<v-list-item-content>{{ t('save_and_create_new') }}</v-list-item-content>
 			</v-list-item>
 		</v-list>
 	</v-menu>

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -18,6 +18,7 @@
 			<v-list-item :disabled="disabled || !isCreatable" clickable @click="$emit('create-new')">
 				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
 				<v-list-item-content>{{ t('create_new') }}</v-list-item-content>
+				<v-list-item-hint>{{ translateShortcut(['alt', 'n']) }}</v-list-item-hint>
 			</v-list-item>
 		</v-list>
 	</v-menu>

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -5,17 +5,17 @@
 		</template>
 
 		<v-list>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-and-stay')">
+			<v-list-item :disabled="disabled || !isSavable" clickable @click="$emit('save-and-stay')">
 				<v-list-item-icon><v-icon name="check" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_stay') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-as-copy')">
+			<v-list-item :disabled="disabled || !isCreatable" clickable @click="$emit('save-as-copy')">
 				<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('create-new')">
+			<v-list-item :disabled="disabled || !isCreatable" clickable @click="$emit('create-new')">
 				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
 				<v-list-item-content>{{ t('create_new') }}</v-list-item-content>
 			</v-list-item>
@@ -30,6 +30,14 @@ import translateShortcut from '@/utils/translate-shortcut';
 
 export default defineComponent({
 	props: {
+		isSavable: {
+			type: Boolean,
+			default: false,
+		},
+		isCreatable: {
+			type: Boolean,
+			default: true,
+		},
 		disabled: {
 			type: Boolean,
 			default: false,

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -15,9 +15,9 @@
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-and-add-new')">
+			<v-list-item :disabled="disabled" clickable @click="$emit('create-new')">
 				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
-				<v-list-item-content>{{ t('save_and_create_new') }}</v-list-item-content>
+				<v-list-item-content>{{ t('create_new') }}</v-list-item-content>
 			</v-list-item>
 		</v-list>
 	</v-menu>
@@ -35,7 +35,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: ['save-and-stay', 'save-and-add-new', 'save-as-copy'],
+	emits: ['save-and-stay', 'create-new', 'save-as-copy'],
 	setup() {
 		const { t } = useI18n();
 


### PR DESCRIPTION
~I believe this feels more natural because text editors like VSCode as "Save as..." option which let us to save current document (with changes) as another document.~

Resume:
1. `CMD + Shift + S`: saves item as a new one (Save as copy)
2. `Option + N`: creates a new  item (It's not possible to use `CMD + N` on chromium browsers [source](https://stackoverflow.com/a/7296303))
3. `Save and Create new` replaced by `Create New`. If user want to save and create new, should do `CMD+S`, then `Option + N`. 
4. `save_and_create_new` translations removed
5. Some folder and files buttons disabled according to user permissions.