### PR TITLE
Prevent file interface from preloading "Choose from Library" drawer

### DIFF
--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -104,6 +104,7 @@
 		</v-dialog>
 
 		<drawer-collection
+			v-if="activeDialog === 'choose'"
 			collection="directus_files"
 			:active="activeDialog === 'choose'"
 			@update:active="activeDialog = null"


### PR DESCRIPTION
## Before

Currently the file interface loads the <drawer-collection> component even before we choose it, so it'll make unnecessary API calls too early on load. This is more prominent on the Project Settings page since there are 3 file interfaces, namely `Project Logo`, `Public Foreground` and `Public Background`:

https://user-images.githubusercontent.com/42867097/139625029-ca409bfe-9646-4387-bf4c-3d1e617871b1.mp4

## After

Only load the drawer (and API call) when the user explicitly chose the "Choose from library" option:

https://user-images.githubusercontent.com/42867097/139624964-50395868-ce85-4616-81ea-ba34c5d2b31a.mp4

