### PR TITLE
Filter files by folder when an upload folder is specified in the file interface

### DIFF
--- a/app/src/components/v-upload/v-upload.vue
+++ b/app/src/components/v-upload/v-upload.vue
@@ -55,6 +55,7 @@
 				<drawer-collection
 					collection="directus_files"
 					:active="activeDialog === 'choose'"
+					:filter="filterByFolder"
 					@update:active="activeDialog = null"
 					@input="setSelection"
 				/>
@@ -133,6 +134,11 @@ export default defineComponent({
 		const { setSelection } = useSelection();
 		const activeDialog = ref<'choose' | 'url' | null>(null);
 
+		const filterByFolder = computed(() => {
+			if (!props.folder) return null;
+			return { folder: { id: { _eq: props.folder } } };
+		});
+
 		return {
 			t,
 			uploading,
@@ -145,6 +151,7 @@ export default defineComponent({
 			done,
 			numberOfFiles,
 			activeDialog,
+			filterByFolder,
 			url,
 			isValidURL,
 			urlLoading,


### PR DESCRIPTION
Related to #9280, #8998, #4999

Currently when we choose a specific folder for file/image interface, clicking "Choose from library" still shows the whole library:

![image](https://user-images.githubusercontent.com/42867097/139637310-f477327d-6f05-4072-b578-52f6c2235bb0.png)

## What this PR achieves

Based on the linked discussions, there can be much finer controls/filters in this drawer view. However this minor PR simply aims to achieve the basic version of "filtering by specified folder" in an attempt to alleviate some pain points in this area. Especially since most of the ground work of applying filter to a drawer-collection is already in place before this PR.

## Outcome

https://user-images.githubusercontent.com/42867097/139637238-1227fac2-eb6c-494d-a7bc-062c37ca6f17.mp4


