### PR TITLE
Add shadows to v-menu angles

### DIFF
--- a/app/src/components/v-menu/v-menu.vue
+++ b/app/src/components/v-menu/v-menu.vue
@@ -350,7 +350,7 @@ body {
 
 	&::after {
 		bottom: 2px;
-		// box-shadow: 2.5px 2.5px 4px 0px rgba(var(--card-shadow-color), 0.2);
+		box-shadow: 2px 2px 4px -2px rgba(var(--card-shadow-color), 0.2);
 	}
 }
 
@@ -359,7 +359,7 @@ body {
 
 	&::after {
 		top: 2px;
-		// box-shadow: -2.5px -2.5px 4px 0px rgba(var(--card-shadow-color), 0.2);
+		box-shadow: -2px -2px 4px -2px rgba(var(--card-shadow-color), 0.2);
 	}
 }
 
@@ -368,7 +368,7 @@ body {
 
 	&::after {
 		left: 2px;
-		// box-shadow: -2.5px 2.5px 4px 0px rgba(var(--card-shadow-color), 0.2);
+		box-shadow: -2px 2px 4px -2px rgba(var(--card-shadow-color), 0.2);
 	}
 }
 
@@ -377,7 +377,7 @@ body {
 
 	&::after {
 		right: 2px;
-		// box-shadow: 2.5px -2.5px 4px 0px rgba(var(--card-shadow-color), 0.2);
+		box-shadow: 2px -2px 4px -2px rgba(var(--card-shadow-color), 0.2);
 	}
 }
 


### PR DESCRIPTION
There was commented shadows that didn't play very nice.

This change tries to fix it.

Before:
![Screenshot 2021-11-01 at 13 40 26](https://user-images.githubusercontent.com/1009639/139668635-8b0ca1f2-8943-4c27-9844-ef83c545ad75.png)
![Screenshot 2021-11-01 at 13 56 05](https://user-images.githubusercontent.com/1009639/139668658-5e2fe27b-f16c-4655-932f-ab94bfab7dd2.png)

After
![Screenshot 2021-11-01 at 13 54 57](https://user-images.githubusercontent.com/1009639/139668672-b22a28af-25ef-4679-b048-628ab48ccd3c.png)
![Screenshot 2021-11-01 at 13 56 48](https://user-images.githubusercontent.com/1009639/139668680-63982981-9353-4076-9adb-a23722aa1250.png)


