### PR TITLE
Feat/custom ldap mail attribute

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -134,13 +134,11 @@ export class LDAPAuthDriver extends AuthDriver {
 					}
 
 					res.on('searchEntry', ({ object }: SearchEntry) => {
+						const email = object[mailAttribute ?? 'mail'];
 						const user = {
 							firstName: typeof object.givenName === 'object' ? object.givenName[0] : object.givenName,
 							lastName: typeof object.sn === 'object' ? object.sn[0] : object.sn,
-							email:
-								typeof object[mailAttribute ?? 'mail'] === 'object'
-									? object[mailAttribute ?? 'mail'][0]
-									: String(object[mailAttribute ?? 'mail']),
+							email: typeof email === 'object' ? email[0] : email,
 							userAccountControl:
 								typeof object.userAccountControl === 'object'
 									? Number(object.userAccountControl[0])

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -120,12 +120,13 @@ export class LDAPAuthDriver extends AuthDriver {
 
 	private async fetchUserInfo(userDn: string): Promise<UserInfo | undefined> {
 		const client = await this.bindClient;
+		const { mailAttribute } = this.config;
 
 		return new Promise((resolve, reject) => {
 			// Fetch user info in LDAP by domain component
 			client.search(
 				userDn,
-				{ attributes: ['givenName', 'sn', 'mail', 'userAccountControl'] },
+				{ attributes: ['givenName', 'sn', mailAttribute ?? 'mail', 'userAccountControl'] },
 				(err: Error | null, res: SearchCallbackResponse) => {
 					if (err) {
 						reject(handleError(err));
@@ -136,7 +137,10 @@ export class LDAPAuthDriver extends AuthDriver {
 						const user = {
 							firstName: typeof object.givenName === 'object' ? object.givenName[0] : object.givenName,
 							lastName: typeof object.sn === 'object' ? object.sn[0] : object.sn,
-							email: typeof object.mail === 'object' ? object.mail[0] : object.mail,
+							email:
+								typeof object[mailAttribute ?? 'mail'] === 'object'
+									? object[mailAttribute ?? 'mail'][0]
+									: String(object[mailAttribute ?? 'mail']),
 							userAccountControl:
 								typeof object.userAccountControl === 'object'
 									? Number(object.userAccountControl[0])

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -605,6 +605,7 @@ information and roles will be assigned from Active Directory.
 | `AUTH_<PROVIDER>_USER_ATTRIBUTE`  | Attribute to identify users by.                    | `cn`          |
 | `AUTH_<PROVIDER>_GROUP_DN`        | Directory path containing groups.                  | --            |
 | `AUTH_<PROVIDER>_GROUP_ATTRIBUTE` | Attribute to identify user as a member of a group. | `member`      |
+| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user         | `mail`        |
 
 <sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,24 +54,24 @@
 			},
 			"engines": {
 				"node": ">=16.0.0",
-				"npm": ">=8.1.0"
+				"npm": ">=7.0.0"
 			}
 		},
 		"api": {
 			"name": "directus",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/app": "9.0.0-rc.99",
-				"@directus/drive": "9.0.0-rc.99",
-				"@directus/drive-azure": "9.0.0-rc.99",
-				"@directus/drive-gcs": "9.0.0-rc.99",
-				"@directus/drive-s3": "9.0.0-rc.99",
-				"@directus/extensions-sdk": "9.0.0-rc.99",
-				"@directus/format-title": "9.0.0-rc.99",
-				"@directus/schema": "9.0.0-rc.99",
-				"@directus/shared": "9.0.0-rc.99",
-				"@directus/specs": "9.0.0-rc.99",
+				"@directus/app": "9.0.0-rc.100",
+				"@directus/drive": "9.0.0-rc.100",
+				"@directus/drive-azure": "9.0.0-rc.100",
+				"@directus/drive-gcs": "9.0.0-rc.100",
+				"@directus/drive-s3": "9.0.0-rc.100",
+				"@directus/extensions-sdk": "9.0.0-rc.100",
+				"@directus/format-title": "9.0.0-rc.100",
+				"@directus/schema": "9.0.0-rc.100",
+				"@directus/shared": "9.0.0-rc.100",
+				"@directus/specs": "9.0.0-rc.100",
 				"@godaddy/terminus": "^4.9.0",
 				"@rollup/plugin-alias": "^3.1.2",
 				"@rollup/plugin-virtual": "^2.0.3",
@@ -289,12 +289,12 @@
 		},
 		"app": {
 			"name": "@directus/app",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"devDependencies": {
-				"@directus/docs": "9.0.0-rc.99",
-				"@directus/extensions-sdk": "9.0.0-rc.99",
-				"@directus/format-title": "9.0.0-rc.99",
-				"@directus/shared": "9.0.0-rc.99",
+				"@directus/docs": "9.0.0-rc.100",
+				"@directus/extensions-sdk": "9.0.0-rc.100",
+				"@directus/format-title": "9.0.0-rc.100",
+				"@directus/shared": "9.0.0-rc.100",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.0",
@@ -417,7 +417,7 @@
 		},
 		"docs": {
 			"name": "@directus/docs",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "ISC",
 			"devDependencies": {
 				"directory-tree": "3.0.0",
@@ -41965,11 +41965,11 @@
 		},
 		"packages/cli": {
 			"name": "@directus/cli",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/format-title": "9.0.0-rc.99",
-				"@directus/sdk": "9.0.0-rc.99",
+				"@directus/format-title": "9.0.0-rc.100",
+				"@directus/sdk": "9.0.0-rc.100",
 				"@types/yargs": "^17.0.0",
 				"app-module-path": "^2.2.0",
 				"chalk": "^4.1.0",
@@ -42151,11 +42151,11 @@
 			}
 		},
 		"packages/create-directus-extension": {
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/extensions-sdk": "9.0.0-rc.99",
-				"@directus/shared": "9.0.0-rc.99",
+				"@directus/extensions-sdk": "9.0.0-rc.100",
+				"@directus/shared": "9.0.0-rc.100",
 				"inquirer": "^8.1.2"
 			},
 			"bin": {
@@ -42198,7 +42198,7 @@
 			"license": "0BSD"
 		},
 		"packages/create-directus-project": {
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"chalk": "^4.1.1",
@@ -42234,7 +42234,7 @@
 		},
 		"packages/drive": {
 			"name": "@directus/drive",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.0.0",
@@ -42253,11 +42253,11 @@
 		},
 		"packages/drive-azure": {
 			"name": "@directus/drive-azure",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.0.0-rc.99",
+				"@directus/drive": "9.0.0-rc.100",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -42288,10 +42288,10 @@
 		},
 		"packages/drive-gcs": {
 			"name": "@directus/drive-gcs",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.0.0-rc.99",
+				"@directus/drive": "9.0.0-rc.100",
 				"@google-cloud/storage": "^5.8.5",
 				"lodash": "4.17.21",
 				"normalize-path": "^3.0.0"
@@ -42311,10 +42311,10 @@
 		},
 		"packages/drive-s3": {
 			"name": "@directus/drive-s3",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.0.0-rc.99",
+				"@directus/drive": "9.0.0-rc.100",
 				"aws-sdk": "^2.928.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -42359,9 +42359,9 @@
 		},
 		"packages/extensions-sdk": {
 			"name": "@directus/extensions-sdk",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"dependencies": {
-				"@directus/shared": "9.0.0-rc.99",
+				"@directus/shared": "9.0.0-rc.100",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -42411,7 +42411,7 @@
 		},
 		"packages/format-title": {
 			"name": "@directus/format-title",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "21.0.1",
@@ -42430,10 +42430,10 @@
 		},
 		"packages/gatsby-source-directus": {
 			"name": "@directus/gatsby-source-directus",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/sdk": "9.0.0-rc.99",
+				"@directus/sdk": "9.0.0-rc.100",
 				"chalk": "4.1.2",
 				"gatsby-source-filesystem": "4.0.0",
 				"gatsby-source-graphql": "4.0.0",
@@ -44581,7 +44581,7 @@
 		},
 		"packages/schema": {
 			"name": "@directus/schema",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"knex-schema-inspector": "1.6.4",
@@ -44594,7 +44594,7 @@
 		},
 		"packages/sdk": {
 			"name": "@directus/sdk",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.24.0"
@@ -44623,7 +44623,7 @@
 		},
 		"packages/shared": {
 			"name": "@directus/shared",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"dependencies": {
 				"axios": "*",
 				"date-fns": "2.24.0",
@@ -44682,7 +44682,7 @@
 		},
 		"packages/specs": {
 			"name": "@directus/specs",
-			"version": "9.0.0-rc.99",
+			"version": "9.0.0-rc.100",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"openapi3-ts": "^2.0.1"
@@ -46162,10 +46162,10 @@
 		"@directus/app": {
 			"version": "file:app",
 			"requires": {
-				"@directus/docs": "9.0.0-rc.99",
-				"@directus/extensions-sdk": "9.0.0-rc.99",
-				"@directus/format-title": "9.0.0-rc.99",
-				"@directus/shared": "9.0.0-rc.99",
+				"@directus/docs": "9.0.0-rc.100",
+				"@directus/extensions-sdk": "9.0.0-rc.100",
+				"@directus/format-title": "9.0.0-rc.100",
+				"@directus/shared": "9.0.0-rc.100",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.0",
@@ -46262,8 +46262,8 @@
 		"@directus/cli": {
 			"version": "file:packages/cli",
 			"requires": {
-				"@directus/format-title": "9.0.0-rc.99",
-				"@directus/sdk": "9.0.0-rc.99",
+				"@directus/format-title": "9.0.0-rc.100",
+				"@directus/sdk": "9.0.0-rc.100",
 				"@types/figlet": "1.5.4",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.2",
@@ -46434,7 +46434,7 @@
 			"version": "file:packages/drive-azure",
 			"requires": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.0.0-rc.99",
+				"@directus/drive": "9.0.0-rc.100",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.2",
 				"@types/node": "16.11.6",
@@ -46462,7 +46462,7 @@
 		"@directus/drive-gcs": {
 			"version": "file:packages/drive-gcs",
 			"requires": {
-				"@directus/drive": "9.0.0-rc.99",
+				"@directus/drive": "9.0.0-rc.100",
 				"@google-cloud/storage": "^5.8.5",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
@@ -46481,7 +46481,7 @@
 		"@directus/drive-s3": {
 			"version": "file:packages/drive-s3",
 			"requires": {
-				"@directus/drive": "9.0.0-rc.99",
+				"@directus/drive": "9.0.0-rc.100",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.2",
@@ -46511,7 +46511,7 @@
 		"@directus/extensions-sdk": {
 			"version": "file:packages/extensions-sdk",
 			"requires": {
-				"@directus/shared": "9.0.0-rc.99",
+				"@directus/shared": "9.0.0-rc.100",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -46562,7 +46562,7 @@
 		"@directus/gatsby-source-directus": {
 			"version": "file:packages/gatsby-source-directus",
 			"requires": {
-				"@directus/sdk": "9.0.0-rc.99",
+				"@directus/sdk": "9.0.0-rc.100",
 				"chalk": "4.1.2",
 				"gatsby-source-filesystem": "4.0.0",
 				"gatsby-source-graphql": "4.0.0",
@@ -56389,8 +56389,8 @@
 		"create-directus-extension": {
 			"version": "file:packages/create-directus-extension",
 			"requires": {
-				"@directus/extensions-sdk": "9.0.0-rc.99",
-				"@directus/shared": "9.0.0-rc.99",
+				"@directus/extensions-sdk": "9.0.0-rc.100",
+				"@directus/shared": "9.0.0-rc.100",
 				"inquirer": "^8.1.2"
 			},
 			"dependencies": {
@@ -57728,16 +57728,16 @@
 		"directus": {
 			"version": "file:api",
 			"requires": {
-				"@directus/app": "9.0.0-rc.99",
-				"@directus/drive": "9.0.0-rc.99",
-				"@directus/drive-azure": "9.0.0-rc.99",
-				"@directus/drive-gcs": "9.0.0-rc.99",
-				"@directus/drive-s3": "9.0.0-rc.99",
-				"@directus/extensions-sdk": "9.0.0-rc.99",
-				"@directus/format-title": "9.0.0-rc.99",
-				"@directus/schema": "9.0.0-rc.99",
-				"@directus/shared": "9.0.0-rc.99",
-				"@directus/specs": "9.0.0-rc.99",
+				"@directus/app": "9.0.0-rc.100",
+				"@directus/drive": "9.0.0-rc.100",
+				"@directus/drive-azure": "9.0.0-rc.100",
+				"@directus/drive-gcs": "9.0.0-rc.100",
+				"@directus/drive-s3": "9.0.0-rc.100",
+				"@directus/extensions-sdk": "9.0.0-rc.100",
+				"@directus/format-title": "9.0.0-rc.100",
+				"@directus/schema": "9.0.0-rc.100",
+				"@directus/shared": "9.0.0-rc.100",
+				"@directus/specs": "9.0.0-rc.100",
 				"@godaddy/terminus": "^4.9.0",
 				"@keyv/redis": "^2.1.2",
 				"@rollup/plugin-alias": "^3.1.2",


### PR DESCRIPTION
Hi,

I created this based on the discussion [over here](https://github.com/directus/directus/discussions/9294).
Does not really do much, just add the config option `AUTH_<PROVIDER>_MAIL_ATTRIBUTE` which allows users to import mail addresses from a field other than `mail`.
What do you think? :slightly_smiling_face: 

Regards,
Dorian