### PR TITLE
Update Oracle to support `is_generated`

### DIFF
--- a/packages/schema/src/dialects/oracledb.ts
+++ b/packages/schema/src/dialects/oracledb.ts
@@ -65,7 +65,7 @@ export default class Oracle extends KnexOracle implements SchemaInspector {
 				"ct"."CONSTRAINT_TYPE" "column_key",
 				"c"."CHAR_LENGTH" "max_length",
 				"c"."VIRTUAL_COLUMN" "is_generated"
-			FROM "USER_TAB_COLUMNS" "c"
+			FROM "USER_TAB_COLS" "c"
 			LEFT JOIN "uc" "ct" ON "c"."TABLE_NAME" = "ct"."TABLE_NAME"
 				AND "c"."COLUMN_NAME" = "ct"."COLUMN_NAME"
 		`);


### PR DESCRIPTION
"VIRTUAL_COLUMN" isn't a column in `USER_TAB_COLUMNS`. We should use `USER_TAB_COLS`.

https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/ALL_TAB_COLUMNS.html