### PR TITLE
fix(graphql): remove __typename from selection nodes when present

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -1471,7 +1471,7 @@ export class GraphQLService {
 			query.aggregate[aggregateProperty] =
 				aggregationGroup.selectionSet?.selections
 					// filter out graphql pointers, like __typename
-					.filter((selectionNode) => !selectionNode.name.value.startsWith('__'))
+					.filter((selectionNode) => !(selectionNode as FieldNode)?.name.value.startsWith('__'))
 					.map((selectionNode) => {
 						selectionNode = selectionNode as FieldNode;
 						return selectionNode.name.value;

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -1469,10 +1469,13 @@ export class GraphQLService {
 			const aggregateProperty = aggregationGroup.name.value as keyof Aggregate;
 
 			query.aggregate[aggregateProperty] =
-				aggregationGroup.selectionSet?.selections.map((selectionNode) => {
-					selectionNode = selectionNode as FieldNode;
-					return selectionNode.name.value;
-				}) ?? [];
+				aggregationGroup.selectionSet?.selections
+					// filter out graphql pointers, like __typename
+					.filter((selectionNode) => !selectionNode.name.value.startsWith('__'))
+					.map((selectionNode) => {
+						selectionNode = selectionNode as FieldNode;
+						return selectionNode.name.value;
+					}) ?? [];
 		}
 
 		validateQuery(query);


### PR DESCRIPTION
As stated in #9278, `__typename` is only from root of aggregations.

This PR also removes applies the same filter to selection nodes in order to fix the following behavior:

```graphql
# This query works
 worktime_aggregated(
    filter: { billable: { _eq: true } } }
  ) {
    __typename
    sum {
      duration
    }
  }
}
```

```graphql
# This one does not (__typename is under sum, a selection node)
 worktime_aggregated(
    filter: { billable: { _eq: true } } }
  ) {
    __typename
    sum {
      duration
      __typename
    }
  }
}