### PR TITLE
Add placeholder to Language Indicator Field for first Translations setup

### DIFF
--- a/app/src/displays/translations/index.ts
+++ b/app/src/displays/translations/index.ts
@@ -16,7 +16,7 @@ export default defineDisplay({
 	description: '$t:displays.translations.description',
 	icon: 'translate',
 	component: DisplayTranslations,
-	options: ({ collection, field, relations }: ExtensionsOptionsContext) => {
+	options: ({ relations }: ExtensionsOptionsContext) => {
 		const fieldsStore = useFieldsStore();
 
 		const junctionCollection = relations.o2m?.collection;

--- a/app/src/interfaces/translations/index.ts
+++ b/app/src/interfaces/translations/index.ts
@@ -25,19 +25,20 @@ export default defineInterface({
 				value: field.field,
 			}));
 		}
-
-		return [
-			{
-				field: 'languageField',
-				type: 'string',
-				name: '$t:interfaces.translations.language_field',
-				meta: {
-					interface: 'select-dropdown',
-					options: {
-						choices,
+		return choices.length > 0
+			? [
+					{
+						field: 'languageField',
+						type: 'string',
+						name: '$t:interfaces.translations.language_field',
+						meta: {
+							interface: 'select-dropdown',
+							options: {
+								choices,
+							},
+						},
 					},
-				},
-			},
-		];
+			  ]
+			: [];
 	},
 });

--- a/app/src/interfaces/translations/index.ts
+++ b/app/src/interfaces/translations/index.ts
@@ -25,20 +25,19 @@ export default defineInterface({
 				value: field.field,
 			}));
 		}
-		return choices.length > 0
-			? [
-					{
-						field: 'languageField',
-						type: 'string',
-						name: '$t:interfaces.translations.language_field',
-						meta: {
-							interface: 'select-dropdown',
-							options: {
-								choices,
-							},
-						},
+		return [
+			{
+				field: 'languageField',
+				type: 'string',
+				name: '$t:interfaces.translations.language_field',
+				meta: {
+					interface: 'select-dropdown',
+					options: {
+						placeholder: '$t:primary_key',
+						choices,
 					},
-			  ]
-			: [];
+				},
+			},
+		];
 	},
 });


### PR DESCRIPTION
## Before

Currently when we first setup translations, where "languages" collection does not exist, the Language Indicator Field is present. However we won't really be able to choose anything, so hiding it should lessen the possibility of confusions.

![yEorcmyaKC](https://user-images.githubusercontent.com/42867097/139818934-88aa3f3d-5060-4a3b-a40a-adf7c1973055.gif)

## After

Now it's hidden.

![chrome_hlbUTebWZc](https://user-images.githubusercontent.com/42867097/139818602-5c22dd48-78de-440f-9e76-7ac8ee35a843.png)

## Alternatives

Alternatively we can also maybe show a notice, or perhaps the list of languages that will be added? 🤔 Perhaps that'll be clearer to new users coming into Directus.

