### PR TITLE
fix M2A field creation unable to be saved

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -92,7 +92,7 @@ export default defineComponent({
 		const relatedCollectionM2O = syncFieldDetailStoreProperty('relations.m2o.related_collection');
 		const o2mCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
 		const o2mField = syncFieldDetailStoreProperty('relations.o2m.field');
-		const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.one_allowed_fields', []);
+		const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.one_allowed_collections', []);
 
 		const availableCollections = computed(() => {
 			return orderBy(

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2a.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2a.ts
@@ -98,6 +98,7 @@ export function setDefaults(updates: StateUpdates, state: State, { getCurrent }:
 	set(updates, 'relations.o2m.field', `${currentCollection}_${currentCollectionPrimaryKeyField}`);
 	set(updates, 'relations.m2o.collection', junctionName);
 	set(updates, 'relations.m2o.field', 'item');
+	set(updates, 'relations.m2o.meta.one_allowed_collections', []);
 	set(updates, 'relations.m2o.meta.one_collection_field', 'collection');
 }
 


### PR DESCRIPTION
## Bug

Unable to save new M2A field, regardless of when we change the `Key` or `Related Collections`:

![H5zYUBBrqJ](https://user-images.githubusercontent.com/42867097/139852861-ca595628-a06f-489c-bcb6-915c77a54108.gif)

## First fix

Seems like there's a typo here, `one_allowed_fields` instead of `one_allowed_collections`:

https://github.com/directus/directus/blob/f73df5dffdca52aecae0705e08eb0a0550e0bdc4/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue#L95

At first it's odd that this still doesn't fix it, but I noticed changing the `Key` actually made it work (that's why earlier above I modified the key _after_ setting a related collection):

![yOi9TYMcrW](https://user-images.githubusercontent.com/42867097/139852890-3ed3748c-3117-41c8-8329-78d3c926ce80.gif)

## Second fix

Added the following line in the setDefaults of m2a:

```js
set(updates, 'relations.m2o.meta.one_allowed_collections', []);
```

Now everything seems to work as usual:

![Wg6aq3SLqd](https://user-images.githubusercontent.com/42867097/139852921-37be193c-1de3-4b91-88be-40f6f3dabf08.gif)

Honestly not 100% sure why this second fix worked, but more so a guess work based on how it's missing from here... Hope it doesn't end up being an unintended workaround.