### PR TITLE
Fix condition to translate directus collections

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -292,7 +292,7 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 	}
 
 	function setItemValueToResponse(response: AxiosResponse) {
-		if (response.data.data.collection?.startsWith('directus_')) {
+		if (typeof response.data.data.collection === 'string' && response.data.data.collection.startsWith('directus_')) {
 			response.data.data = translate(response.data.data);
 		}
 		if (isBatch.value === false) {

--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -292,7 +292,7 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 	}
 
 	function setItemValueToResponse(response: AxiosResponse) {
-		if (typeof response.data.data.collection === 'string' && response.data.data.collection.startsWith('directus_')) {
+		if (collection.value === 'directus_collections' && response.data.data.collection?.startsWith('directus_')) {
 			response.data.data = translate(response.data.data);
 		}
 		if (isBatch.value === false) {


### PR DESCRIPTION
Only do the `startsWith` check if the `collection` field is a string - otherwise this fails on items having a field called "collection" (for example a relation to a collection called `Collections`, see issue #9227).

Fixes #9227