### PR TITLE
Added fallback to "id_token" info if profile URL not defined

### DIFF
--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -95,7 +95,13 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				{ code: payload.code, state: payload.state },
 				{ code_verifier: payload.codeVerifier, state: generators.codeChallenge(payload.codeVerifier) }
 			);
-			userInfo = await client.userinfo(tokenSet);
+
+			const issuer = client.issuer;
+			if (issuer.metadata.userinfo_endpoint) {
+				userInfo = await client.userinfo(tokenSet);
+			} else {
+				userInfo = tokenSet.claims();
+			}
 		} catch (e) {
 			throw handleError(e);
 		}


### PR DESCRIPTION
Some OpenID providers don't have userinfo endpoints, and exclusively provide information through the "id_token". In this instance, we should fall back to the token data for user info.