### PR TITLE
Improve keyboard navigation between elements

### DIFF
--- a/app/src/components/v-checkbox/v-checkbox.vue
+++ b/app/src/components/v-checkbox/v-checkbox.vue
@@ -233,6 +233,22 @@ body {
 		}
 	}
 
+	&:not(:disabled):focus-visible {
+		&.block {
+			border-color: var(--v-icon-color-hover);
+		}
+
+		&:not(.block) {
+			&.checked {
+				background-color: var(--background-subdued);
+			}
+
+			.checkbox {
+				color: var(--v-icon-color-hover);
+			}
+		}
+	}
+
 	.prepend,
 	.append {
 		display: contents;

--- a/app/src/components/v-radio/v-radio.vue
+++ b/app/src/components/v-radio/v-radio.vue
@@ -156,5 +156,13 @@ body {
 			}
 		}
 	}
+
+	&:not(:disabled):focus-visible {
+		border-color: var(--v-radio-color);
+
+		&.checked {
+			background-color: var(--background-subdued);
+		}
+	}
 }
 </style>

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="markdownInterface" class="interface-input-rich-text-md" :class="view[0]">
+	<div ref="markdownInterface" class="interface-input-rich-text-md" :class="[view[0], { focused }]">
 		<div class="toolbar">
 			<v-menu show-arrow placement="bottom-start">
 				<template #activator="{ toggle }">
@@ -195,6 +195,8 @@ export default defineComponent({
 
 		const imageDialogOpen = ref(false);
 
+		const focused = ref(false);
+
 		onMounted(async () => {
 			if (codemirrorEl.value) {
 				codemirror = CodeMirror(codemirrorEl.value, {
@@ -211,6 +213,14 @@ export default defineComponent({
 					const content = cm.getValue();
 
 					emit('input', content);
+				});
+
+				codemirror.on('focus', () => {
+					focused.value = true;
+				});
+
+				codemirror.on('blur', () => {
+					focused.value = false;
 				});
 			}
 		});
@@ -271,6 +281,7 @@ export default defineComponent({
 			codemirrorEl,
 			edit,
 			view,
+			focused,
 			markdownString,
 			table,
 			onImageUpload,
@@ -316,6 +327,10 @@ export default defineComponent({
 	overflow: hidden;
 	border: 2px solid var(--border-normal);
 	border-radius: var(--border-radius);
+
+	&.focused {
+		border-color: var(--primary);
+	}
 }
 
 textarea {

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-menu attached :disabled="disabled" :close-on-content-click="false">
-		<template #activator="{ activate }">
+		<template #activator="{ activate, deactivate }">
 			<v-input
 				v-model="hex"
 				:disabled="disabled"
@@ -9,6 +9,7 @@
 				class="color-input"
 				maxlength="7"
 				@focus="activate"
+				@keyup.escape="deactivate"
 			>
 				<template #prepend>
 					<v-input ref="htmlColorInput" v-model="hex" type="color" class="html-color-select" />

--- a/app/src/interfaces/select-icon/select-icon.vue
+++ b/app/src/interfaces/select-icon/select-icon.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-menu attached :disabled="disabled">
-		<template #activator="{ active, activate }">
+		<template #activator="{ active, activate, deactivate }">
 			<v-input
 				v-model="searchQuery"
 				:disabled="disabled"
@@ -8,6 +8,7 @@
 				:class="{ 'has-value': value }"
 				:nullable="false"
 				@focus="activate"
+				@blur="deactivate"
 			>
 				<template v-if="value" #prepend>
 					<v-icon clickable :name="value" :class="{ active: value }" @click="activate" />


### PR DESCRIPTION
Add keyboard navigation and highlight visual feedback when tabbing between elements
1. v-checkbox
2. v-radio
3. input-rich-text-md interface

Allow close the popup  selector with Esc key for:
1. select-color interface
2. select-icon