### PR TITLE
Allow dynamic user variables to be used with filter rules (cont.)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -34,6 +34,7 @@ import { InvalidPayloadException } from './exceptions';
 import { getExtensionManager } from './extensions';
 import logger, { expressLogger } from './logger';
 import authenticate from './middleware/authenticate';
+import getPermissions from './middleware/get-permissions';
 import cache from './middleware/cache';
 import { checkIP } from './middleware/check-ip';
 import cors from './middleware/cors';
@@ -153,13 +154,15 @@ export default async function createApp(): Promise<express.Application> {
 
 	app.use(sanitizeQuery);
 
-	await emitAsyncSafe('middlewares.init.after', { app });
-
-	await emitAsyncSafe('routes.init.before', { app });
-
 	app.use(cache);
 
 	app.use(schema);
+
+	app.use(getPermissions);
+
+	await emitAsyncSafe('middlewares.init.after', { app });
+
+	await emitAsyncSafe('routes.init.before', { app });
 
 	app.use('/auth', authRouter);
 

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -6,26 +6,26 @@ import { getConfigFromEnv } from './utils/get-config-from-env';
 import { validateEnv } from './utils/validate-env';
 
 let cache: Keyv | null = null;
-let schemaCache: Keyv | null = null;
+let systemCache: Keyv | null = null;
 
-export function getCache(): { cache: Keyv | null; schemaCache: Keyv | null } {
+export function getCache(): { cache: Keyv | null; systemCache: Keyv | null } {
 	if (env.CACHE_ENABLED === true && cache === null) {
 		validateEnv(['CACHE_NAMESPACE', 'CACHE_TTL', 'CACHE_STORE']);
 		cache = getKeyvInstance(ms(env.CACHE_TTL as string));
 		cache.on('error', (err) => logger.warn(err, `[cache] ${err}`));
 	}
 
-	if (env.CACHE_SCHEMA !== false && schemaCache === null) {
-		schemaCache = getKeyvInstance(typeof env.CACHE_SCHEMA === 'string' ? ms(env.CACHE_SCHEMA) : undefined, '_schema');
-		schemaCache.on('error', (err) => logger.warn(err, `[cache] ${err}`));
+	if (env.CACHE_SCHEMA !== false && systemCache === null) {
+		systemCache = getKeyvInstance(typeof env.CACHE_SCHEMA === 'string' ? ms(env.CACHE_SCHEMA) : undefined, '_schema');
+		systemCache.on('error', (err) => logger.warn(err, `[cache] ${err}`));
 	}
 
-	return { cache, schemaCache };
+	return { cache, systemCache };
 }
 
 export async function flushCaches(): Promise<void> {
-	const { schemaCache, cache } = getCache();
-	await schemaCache?.clear();
+	const { systemCache, cache } = getCache();
+	await systemCache?.clear();
 	await cache?.clear();
 }
 

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -8,15 +8,15 @@ import { validateEnv } from './utils/validate-env';
 let cache: Keyv | null = null;
 let systemCache: Keyv | null = null;
 
-export function getCache(): { cache: Keyv | null; systemCache: Keyv | null } {
+export function getCache(): { cache: Keyv | null; systemCache: Keyv } {
 	if (env.CACHE_ENABLED === true && cache === null) {
 		validateEnv(['CACHE_NAMESPACE', 'CACHE_TTL', 'CACHE_STORE']);
 		cache = getKeyvInstance(ms(env.CACHE_TTL as string));
 		cache.on('error', (err) => logger.warn(err, `[cache] ${err}`));
 	}
 
-	if (env.CACHE_SCHEMA !== false && systemCache === null) {
-		systemCache = getKeyvInstance(typeof env.CACHE_SCHEMA === 'string' ? ms(env.CACHE_SCHEMA) : undefined, '_schema');
+	if (systemCache === null) {
+		systemCache = getKeyvInstance(undefined, '_system');
 		systemCache.on('error', (err) => logger.warn(err, `[cache] ${err}`));
 	}
 

--- a/api/src/database/system-data/fields/activity.yaml
+++ b/api/src/database/system-data/fields/activity.yaml
@@ -10,8 +10,6 @@ fields:
   - field: action
     display: labels
     display_options:
-      defaultForeground: 'var(--foreground-normal)'
-      defaultBackground: 'var(--background-normal-alt)'
       choices:
         - text: $t:field_options.directus_activity.create
           value: create

--- a/api/src/database/system-data/fields/files.yaml
+++ b/api/src/database/system-data/fields/files.yaml
@@ -27,7 +27,6 @@ fields:
     width: full
     display: labels
     display_options:
-      defaultBackground: '#ECEFF1'
       choices: null
       format: false
 

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -56,7 +56,6 @@ fields:
       iconRight: local_offer
     display: labels
     display_options:
-      defaultBackground: '#ECEFF1'
       choices: null
       format: false
 

--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -14,8 +14,6 @@ fields:
     interface: select-dropdown
     display: labels
     display_options:
-      defaultForeground: 'var(--foreground-normal)'
-      defaultBackground: 'var(--background-normal-alt)'
       choices:
         - value: POST
           foreground: 'var(--primary)'
@@ -40,8 +38,6 @@ fields:
     interface: select-dropdown
     display: labels
     display_options:
-      defaultForeground: 'var(--foreground-normal)'
-      defaultBackground: 'var(--background-normal-alt)'
       showAsDot: true
       choices:
         - text: $t:active
@@ -113,8 +109,6 @@ fields:
     width: full
     display: labels
     display_options:
-      defaultForeground: 'var(--foreground-normal)'
-      defaultBackground: 'var(--background-normal-alt)'
       choices:
         - text: $t:create
           value: create
@@ -139,7 +133,5 @@ fields:
     width: full
     display: labels
     display_options:
-      defaultForeground: 'var(--foreground-normal)'
-      defaultBackground: 'var(--background-normal-alt)'
       choices: null
       format: false

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -53,6 +53,7 @@ const defaults: Record<string, any> = {
 	CACHE_AUTO_PURGE: false,
 	CACHE_CONTROL_S_MAXAGE: '0',
 	CACHE_SCHEMA: true,
+	CACHE_PERMISSIONS: true,
 
 	AUTH_PROVIDERS: '',
 

--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -5,6 +5,9 @@ import env from '../env';
 import { InvalidCredentialsException } from '../exceptions';
 import asyncHandler from '../utils/async-handler';
 import isDirectusJWT from '../utils/is-directus-jwt';
+import { Permission } from '@directus/shared/types';
+import { appAccessMinimalPermissions } from '../database/system-data/app-access-permissions';
+import { mergePermissions } from '../utils/merge-permissions';
 
 /**
  * Verify the passed JWT and assign the user ID and role to `req`
@@ -77,6 +80,52 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 		req.accountability.admin = user.admin_access === true || user.admin_access == 1;
 		req.accountability.app = user.app_access === true || user.app_access == 1;
 	}
+
+	let permissions: Permission[] = [];
+
+	if (req.accountability.admin !== true) {
+		const permissionsForRole = await database
+			.select('*')
+			.from('directus_permissions')
+			.where({ role: req.accountability.role });
+
+		permissions = permissionsForRole.map((permissionRaw) => {
+			if (permissionRaw.permissions && typeof permissionRaw.permissions === 'string') {
+				permissionRaw.permissions = JSON.parse(permissionRaw.permissions);
+			} else if (permissionRaw.permissions === null) {
+				permissionRaw.permissions = {};
+			}
+
+			if (permissionRaw.validation && typeof permissionRaw.validation === 'string') {
+				permissionRaw.validation = JSON.parse(permissionRaw.validation);
+			} else if (permissionRaw.validation === null) {
+				permissionRaw.validation = {};
+			}
+
+			if (permissionRaw.presets && typeof permissionRaw.presets === 'string') {
+				permissionRaw.presets = JSON.parse(permissionRaw.presets);
+			} else if (permissionRaw.presets === null) {
+				permissionRaw.presets = {};
+			}
+
+			if (permissionRaw.fields && typeof permissionRaw.fields === 'string') {
+				permissionRaw.fields = permissionRaw.fields.split(',');
+			} else if (permissionRaw.fields === null) {
+				permissionRaw.fields = [];
+			}
+
+			return permissionRaw;
+		});
+
+		if (req.accountability.app === true) {
+			permissions = mergePermissions(
+				permissions,
+				appAccessMinimalPermissions.map((perm) => ({ ...perm, role: req.accountability!.role }))
+			);
+		}
+	}
+
+	req.accountability.permissions = permissions;
 
 	return next();
 });

--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -22,63 +22,63 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 		userAgent: req.get('user-agent'),
 	};
 
-	if (!req.token) return next();
-
 	const database = getDatabase();
 
-	if (isDirectusJWT(req.token)) {
-		let payload: { id: string };
+	if (req.token) {
+		if (isDirectusJWT(req.token)) {
+			let payload: { id: string };
 
-		try {
-			payload = jwt.verify(req.token, env.SECRET as string, { issuer: 'directus' }) as { id: string };
-		} catch (err: any) {
-			if (err instanceof TokenExpiredError) {
-				throw new InvalidCredentialsException('Token expired.');
-			} else if (err instanceof JsonWebTokenError) {
-				throw new InvalidCredentialsException('Token invalid.');
-			} else {
-				throw err;
+			try {
+				payload = jwt.verify(req.token, env.SECRET as string, { issuer: 'directus' }) as { id: string };
+			} catch (err: any) {
+				if (err instanceof TokenExpiredError) {
+					throw new InvalidCredentialsException('Token expired.');
+				} else if (err instanceof JsonWebTokenError) {
+					throw new InvalidCredentialsException('Token invalid.');
+				} else {
+					throw err;
+				}
 			}
+
+			const user = await database
+				.select('directus_users.role', 'directus_roles.admin_access', 'directus_roles.app_access')
+				.from('directus_users')
+				.leftJoin('directus_roles', 'directus_users.role', 'directus_roles.id')
+				.where({
+					'directus_users.id': payload.id,
+					status: 'active',
+				})
+				.first();
+
+			if (!user) {
+				throw new InvalidCredentialsException();
+			}
+
+			req.accountability.user = payload.id;
+			req.accountability.role = user.role;
+			req.accountability.admin = user.admin_access === true || user.admin_access == 1;
+			req.accountability.app = user.app_access === true || user.app_access == 1;
+		} else {
+			// Try finding the user with the provided token
+			const user = await database
+				.select('directus_users.id', 'directus_users.role', 'directus_roles.admin_access', 'directus_roles.app_access')
+				.from('directus_users')
+				.leftJoin('directus_roles', 'directus_users.role', 'directus_roles.id')
+				.where({
+					'directus_users.token': req.token,
+					status: 'active',
+				})
+				.first();
+
+			if (!user) {
+				throw new InvalidCredentialsException();
+			}
+
+			req.accountability.user = user.id;
+			req.accountability.role = user.role;
+			req.accountability.admin = user.admin_access === true || user.admin_access == 1;
+			req.accountability.app = user.app_access === true || user.app_access == 1;
 		}
-
-		const user = await database
-			.select('directus_users.role', 'directus_roles.admin_access', 'directus_roles.app_access')
-			.from('directus_users')
-			.leftJoin('directus_roles', 'directus_users.role', 'directus_roles.id')
-			.where({
-				'directus_users.id': payload.id,
-				status: 'active',
-			})
-			.first();
-
-		if (!user) {
-			throw new InvalidCredentialsException();
-		}
-
-		req.accountability.user = payload.id;
-		req.accountability.role = user.role;
-		req.accountability.admin = user.admin_access === true || user.admin_access == 1;
-		req.accountability.app = user.app_access === true || user.app_access == 1;
-	} else {
-		// Try finding the user with the provided token
-		const user = await database
-			.select('directus_users.id', 'directus_users.role', 'directus_roles.admin_access', 'directus_roles.app_access')
-			.from('directus_users')
-			.leftJoin('directus_roles', 'directus_users.role', 'directus_roles.id')
-			.where({
-				'directus_users.token': req.token,
-				status: 'active',
-			})
-			.first();
-
-		if (!user) {
-			throw new InvalidCredentialsException();
-		}
-
-		req.accountability.user = user.id;
-		req.accountability.role = user.role;
-		req.accountability.admin = user.admin_access === true || user.admin_access == 1;
-		req.accountability.app = user.app_access === true || user.app_access == 1;
 	}
 
 	let permissions: Permission[] = [];

--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -5,9 +5,6 @@ import env from '../env';
 import { InvalidCredentialsException } from '../exceptions';
 import asyncHandler from '../utils/async-handler';
 import isDirectusJWT from '../utils/is-directus-jwt';
-import { Permission } from '@directus/shared/types';
-import { appAccessMinimalPermissions } from '../database/system-data/app-access-permissions';
-import { mergePermissions } from '../utils/merge-permissions';
 
 /**
  * Verify the passed JWT and assign the user ID and role to `req`
@@ -80,52 +77,6 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 			req.accountability.app = user.app_access === true || user.app_access == 1;
 		}
 	}
-
-	let permissions: Permission[] = [];
-
-	if (req.accountability.admin !== true) {
-		const permissionsForRole = await database
-			.select('*')
-			.from('directus_permissions')
-			.where({ role: req.accountability.role });
-
-		permissions = permissionsForRole.map((permissionRaw) => {
-			if (permissionRaw.permissions && typeof permissionRaw.permissions === 'string') {
-				permissionRaw.permissions = JSON.parse(permissionRaw.permissions);
-			} else if (permissionRaw.permissions === null) {
-				permissionRaw.permissions = {};
-			}
-
-			if (permissionRaw.validation && typeof permissionRaw.validation === 'string') {
-				permissionRaw.validation = JSON.parse(permissionRaw.validation);
-			} else if (permissionRaw.validation === null) {
-				permissionRaw.validation = {};
-			}
-
-			if (permissionRaw.presets && typeof permissionRaw.presets === 'string') {
-				permissionRaw.presets = JSON.parse(permissionRaw.presets);
-			} else if (permissionRaw.presets === null) {
-				permissionRaw.presets = {};
-			}
-
-			if (permissionRaw.fields && typeof permissionRaw.fields === 'string') {
-				permissionRaw.fields = permissionRaw.fields.split(',');
-			} else if (permissionRaw.fields === null) {
-				permissionRaw.fields = [];
-			}
-
-			return permissionRaw;
-		});
-
-		if (req.accountability.app === true) {
-			permissions = mergePermissions(
-				permissions,
-				appAccessMinimalPermissions.map((perm) => ({ ...perm, role: req.accountability!.role }))
-			);
-		}
-	}
-
-	req.accountability.permissions = permissions;
 
 	return next();
 });

--- a/api/src/middleware/get-permissions.ts
+++ b/api/src/middleware/get-permissions.ts
@@ -1,0 +1,120 @@
+import { Permission } from '@directus/shared/types';
+import { deepMap, parseFilter } from '@directus/shared/utils';
+import { RequestHandler } from 'express';
+import { cloneDeep } from 'lodash';
+import getDatabase from '../database';
+import { appAccessMinimalPermissions } from '../database/system-data/app-access-permissions';
+import asyncHandler from '../utils/async-handler';
+import { mergePermissions } from '../utils/merge-permissions';
+import { UsersService } from '../services/users';
+import { RolesService } from '../services/roles';
+
+const getPermissions: RequestHandler = asyncHandler(async (req, res, next) => {
+	const database = getDatabase();
+
+	let permissions: Permission[] = [];
+
+	if (!req.accountability) {
+		throw new Error('"getPermissions" needs to be used after the "authenticate" middleware');
+	}
+
+	if (!req.schema) {
+		throw new Error('"getPermissions" needs to be used after the "schema" middleware');
+	}
+
+	if (req.accountability.admin !== true) {
+		const permissionsForRole = await database
+			.select('*')
+			.from('directus_permissions')
+			.where({ role: req.accountability.role });
+
+		const requiredPermissionData = {
+			$CURRENT_USER: [] as string[],
+			$CURRENT_ROLE: [] as string[],
+		};
+
+		permissions = permissionsForRole.map((permissionRaw) => {
+			const permission = cloneDeep(permissionRaw);
+
+			if (permission.permissions && typeof permission.permissions === 'string') {
+				permission.permissions = JSON.parse(permission.permissions);
+			} else if (permission.permissions === null) {
+				permission.permissions = {};
+			}
+
+			if (permission.validation && typeof permission.validation === 'string') {
+				permission.validation = JSON.parse(permission.validation);
+			} else if (permission.validation === null) {
+				permission.validation = {};
+			}
+
+			if (permission.presets && typeof permission.presets === 'string') {
+				permission.presets = JSON.parse(permission.presets);
+			} else if (permission.presets === null) {
+				permission.presets = {};
+			}
+
+			if (permission.fields && typeof permission.fields === 'string') {
+				permission.fields = permission.fields.split(',');
+			} else if (permission.fields === null) {
+				permission.fields = [];
+			}
+
+			const extractPermissionData = (val: any) => {
+				if (typeof val === 'string' && val.startsWith('$CURRENT_USER.')) {
+					requiredPermissionData.$CURRENT_USER.push(val.replace('$CURRENT_USER.', ''));
+				}
+
+				if (typeof val === 'string' && val.startsWith('$CURRENT_ROLE.')) {
+					requiredPermissionData.$CURRENT_ROLE.push(val.replace('$CURRENT_ROLE.', ''));
+				}
+
+				return val;
+			};
+
+			deepMap(permission.permissions, extractPermissionData);
+			deepMap(permission.validation, extractPermissionData);
+			deepMap(permission.presets, extractPermissionData);
+
+			return permission;
+		});
+
+		if (req.accountability.app === true) {
+			permissions = mergePermissions(
+				permissions,
+				appAccessMinimalPermissions.map((perm) => ({ ...perm, role: req.accountability!.role }))
+			);
+		}
+
+		const usersService = new UsersService({ schema: req.schema });
+		const rolesService = new RolesService({ schema: req.schema });
+
+		const filterContext: Record<string, any> = {};
+
+		if (req.accountability.user && requiredPermissionData.$CURRENT_USER.length > 0) {
+			filterContext.$CURRENT_USER = await usersService.readOne(req.accountability.user, {
+				fields: requiredPermissionData.$CURRENT_USER,
+			});
+		}
+
+		if (req.accountability.role && requiredPermissionData.$CURRENT_ROLE.length > 0) {
+			filterContext.$CURRENT_ROLE = await rolesService.readOne(req.accountability.role, {
+				fields: requiredPermissionData.$CURRENT_ROLE,
+			});
+		}
+
+		permissions = permissions.map((permission) => {
+			permission.permissions = parseFilter(permission.permissions, req.accountability!, filterContext);
+			permission.validation = parseFilter(permission.validation, req.accountability!, filterContext);
+			permission.presets = parseFilter(permission.presets, req.accountability!, filterContext);
+
+			return permission;
+		});
+	}
+
+	req.accountability.permissions = permissions;
+
+	return next();
+});
+
+export default getPermissions;

--- a/api/src/middleware/get-permissions.ts
+++ b/api/src/middleware/get-permissions.ts
@@ -26,7 +26,8 @@ const getPermissions: RequestHandler = asyncHandler(async (req, res, next) => {
 		throw new Error('"getPermissions" needs to be used after the "schema" middleware');
 	}
 
-	const cacheKey = `permissions-${hash(req.accountability)}`;
+	const { user, role, app, admin } = req.accountability;
+	const cacheKey = `permissions-${hash({ user, role, app, admin })}`;
 
 	if (env.CACHE_PERMISSIONS !== false) {
 		const cachedPermissions = await systemCache.get(cacheKey);

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -37,15 +37,16 @@ export class AuthorizationService {
 	async processAST(ast: AST, action: PermissionsAction = 'read'): Promise<AST> {
 		const collectionsRequested = getCollectionsFromAST(ast);
 
-		const permissionsForCollections = uniqWith(
-			this.schema.permissions.filter((permission) => {
-				return (
-					permission.action === action &&
-					collectionsRequested.map(({ collection }) => collection).includes(permission.collection)
-				);
-			}),
-			(curr, prev) => curr.collection === prev.collection && curr.action === prev.action && curr.role === prev.role
-		);
+		const permissionsForCollections =
+			uniqWith(
+				this.accountability?.permissions?.filter((permission) => {
+					return (
+						permission.action === action &&
+						collectionsRequested.map(({ collection }) => collection).includes(permission.collection)
+					);
+				}),
+				(curr, prev) => curr.collection === prev.collection && curr.action === prev.action && curr.role === prev.role
+			) ?? [];
 
 		// If the permissions don't match the collections, you don't have permission to read all of them
 		const uniqueCollectionsRequestedCount = uniq(collectionsRequested.map(({ collection }) => collection)).length;
@@ -211,7 +212,7 @@ export class AuthorizationService {
 				presets: {},
 			};
 		} else {
-			permission = this.schema.permissions.find((permission) => {
+			permission = this.accountability?.permissions?.find((permission) => {
 				return permission.collection === collection && permission.action === action;
 			});
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -199,8 +199,8 @@ export class CollectionsService {
 		meta.push(...systemCollectionRows);
 
 		if (this.accountability && this.accountability.admin !== true) {
-			const collectionsYouHavePermissionToRead: string[] = this.schema.permissions
-				.filter((permission) => {
+			const collectionsYouHavePermissionToRead: string[] = this.accountability
+				.permissions!.filter((permission) => {
 					return permission.action === 'read';
 				})
 				.map(({ collection }) => collection);
@@ -258,7 +258,7 @@ export class CollectionsService {
 	 */
 	async readMany(collectionKeys: string[]): Promise<Collection[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			const permissions = this.schema.permissions.filter((permission) => {
+			const permissions = this.accountability.permissions!.filter((permission) => {
 				return permission.action === 'read' && collectionKeys.includes(permission.collection);
 			});
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -26,7 +26,7 @@ export class CollectionsService {
 	schemaInspector: ReturnType<typeof SchemaInspector>;
 	schema: SchemaOverview;
 	cache: Keyv<any> | null;
-	systemCache: Keyv<any> | null;
+	systemCache: Keyv<any>;
 
 	constructor(options: AbstractServiceOptions) {
 		this.knex = options.knex || getDatabase();
@@ -141,9 +141,7 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return payload.collection;
 	}
@@ -173,9 +171,7 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return collections;
 	}
@@ -313,9 +309,7 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return collectionKey;
 	}
@@ -344,9 +338,7 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return collectionKeys;
 	}
@@ -445,9 +437,7 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return collectionKey;
 	}
@@ -476,9 +466,7 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return collectionKeys;
 	}

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -26,7 +26,7 @@ export class CollectionsService {
 	schemaInspector: ReturnType<typeof SchemaInspector>;
 	schema: SchemaOverview;
 	cache: Keyv<any> | null;
-	schemaCache: Keyv<any> | null;
+	systemCache: Keyv<any> | null;
 
 	constructor(options: AbstractServiceOptions) {
 		this.knex = options.knex || getDatabase();
@@ -34,9 +34,9 @@ export class CollectionsService {
 		this.schemaInspector = options.knex ? SchemaInspector(options.knex) : getSchemaInspector();
 		this.schema = options.schema;
 
-		const { cache, schemaCache } = getCache();
+		const { cache, systemCache } = getCache();
 		this.cache = cache;
-		this.schemaCache = schemaCache;
+		this.systemCache = systemCache;
 	}
 
 	/**
@@ -141,8 +141,8 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return payload.collection;
@@ -173,8 +173,8 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return collections;
@@ -313,8 +313,8 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return collectionKey;
@@ -344,8 +344,8 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return collectionKeys;
@@ -445,8 +445,8 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return collectionKey;
@@ -476,8 +476,8 @@ export class CollectionsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return collectionKeys;

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -30,7 +30,7 @@ export class FieldsService {
 	schemaInspector: ReturnType<typeof SchemaInspector>;
 	schema: SchemaOverview;
 	cache: Keyv<any> | null;
-	schemaCache: Keyv<any> | null;
+	systemCache: Keyv<any> | null;
 
 	constructor(options: AbstractServiceOptions) {
 		this.knex = options.knex || getDatabase();
@@ -40,9 +40,9 @@ export class FieldsService {
 		this.payloadService = new PayloadService('directus_fields', options);
 		this.schema = options.schema;
 
-		const { cache, schemaCache } = getCache();
+		const { cache, systemCache } = getCache();
 		this.cache = cache;
-		this.schemaCache = schemaCache;
+		this.systemCache = systemCache;
 	}
 
 	private get hasReadAccess() {
@@ -266,8 +266,8 @@ export class FieldsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 	}
 
@@ -317,8 +317,8 @@ export class FieldsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		return field.field;
@@ -431,8 +431,8 @@ export class FieldsService {
 			await this.cache.clear();
 		}
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 
 		emitAsyncSafe(`fields.delete`, {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -46,7 +46,7 @@ export class FieldsService {
 	}
 
 	private get hasReadAccess() {
-		return !!this.schema.permissions.find((permission) => {
+		return !!this.accountability?.permissions?.find((permission) => {
 			return permission.collection === 'directus_fields' && permission.action === 'read';
 		});
 	}
@@ -144,7 +144,7 @@ export class FieldsService {
 
 		// Filter the result so we only return the fields you have read access to
 		if (this.accountability && this.accountability.admin !== true) {
-			const permissions = this.schema.permissions.filter((permission) => {
+			const permissions = this.accountability.permissions!.filter((permission) => {
 				return permission.action === 'read';
 			});
 
@@ -175,7 +175,7 @@ export class FieldsService {
 				throw new ForbiddenException();
 			}
 
-			const permissions = this.schema.permissions.find((permission) => {
+			const permissions = this.accountability.permissions!.find((permission) => {
 				return permission.action === 'read' && permission.collection === collection;
 			});
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -30,7 +30,7 @@ export class FieldsService {
 	schemaInspector: ReturnType<typeof SchemaInspector>;
 	schema: SchemaOverview;
 	cache: Keyv<any> | null;
-	systemCache: Keyv<any> | null;
+	systemCache: Keyv<any>;
 
 	constructor(options: AbstractServiceOptions) {
 		this.knex = options.knex || getDatabase();
@@ -266,9 +266,7 @@ export class FieldsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 	}
 
 	async updateField(collection: string, field: RawField): Promise<string> {
@@ -317,9 +315,7 @@ export class FieldsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		return field.field;
 	}
@@ -431,9 +427,7 @@ export class FieldsService {
 			await this.cache.clear();
 		}
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 
 		emitAsyncSafe(`fields.delete`, {
 			event: `fields.delete`,

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -41,6 +41,7 @@ export class FieldsService {
 		this.schema = options.schema;
 
 		const { cache, systemCache } = getCache();
+
 		this.cache = cache;
 		this.systemCache = systemCache;
 	}

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -142,7 +142,7 @@ export class FilesService extends ItemsService {
 	 * Import a single file from an external URL
 	 */
 	async importOne(importURL: string, body: Partial<File>): Promise<PrimaryKey> {
-		const fileCreatePermissions = this.schema.permissions.find(
+		const fileCreatePermissions = this.accountability?.permissions?.find(
 			(permission) => permission.collection === 'directus_files' && permission.action === 'create'
 		);
 

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -2013,7 +2013,7 @@ export class GraphQLService {
 					const { cache, systemCache } = getCache();
 
 					await cache?.clear();
-					await systemCache?.clear();
+					await systemCache.clear();
 
 					return;
 				},

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -186,10 +186,14 @@ export class GraphQLService {
 		const schemaComposer = new SchemaComposer<GraphQLParams['contextValue']>();
 
 		const schema = {
-			read: this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, ['read']),
-			create: this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, ['create']),
-			update: this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, ['update']),
-			delete: this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, ['delete']),
+			read:
+				this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, this.accountability, ['read']),
+			create:
+				this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, this.accountability, ['create']),
+			update:
+				this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, this.accountability, ['update']),
+			delete:
+				this.accountability?.admin === true ? this.schema : reduceSchema(this.schema, this.accountability, ['delete']),
 		};
 
 		const { ReadCollectionTypes } = getReadableTypes();

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -2010,10 +2010,10 @@ export class GraphQLService {
 						throw new ForbiddenException();
 					}
 
-					const { cache, schemaCache } = getCache();
+					const { cache, systemCache } = getCache();
 
 					await cache?.clear();
-					await schemaCache?.clear();
+					await systemCache?.clear();
 
 					return;
 				},

--- a/api/src/services/import.ts
+++ b/api/src/services/import.ts
@@ -24,11 +24,11 @@ export class ImportService {
 	async import(collection: string, mimetype: string, stream: NodeJS.ReadableStream): Promise<void> {
 		if (collection.startsWith('directus_')) throw new ForbiddenException();
 
-		const createPermissions = this.schema.permissions.find(
+		const createPermissions = this.accountability?.permissions?.find(
 			(permission) => permission.collection === collection && permission.action === 'create'
 		);
 
-		const updatePermissions = this.schema.permissions.find(
+		const updatePermissions = this.accountability?.permissions?.find(
 			(permission) => permission.collection === collection && permission.action === 'update'
 		);
 

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -46,7 +46,7 @@ export class MetaService {
 
 			if (!permissionsRecord) throw new ForbiddenException();
 
-			const permissions = parseFilter(permissionsRecord.permissions, this.accountability);
+			const permissions = permissionsRecord.permissions ?? {};
 
 			applyFilter(this.knex, this.schema, dbQuery, permissions, collection);
 		}
@@ -68,7 +68,7 @@ export class MetaService {
 
 			if (!permissionsRecord) throw new ForbiddenException();
 
-			const permissions = parseFilter(permissionsRecord.permissions, this.accountability);
+			const permissions = permissionsRecord.permissions ?? {};
 
 			if (Object.keys(filter).length > 0) {
 				filter = { _and: [permissions, filter] };

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -4,7 +4,6 @@ import { ForbiddenException } from '../exceptions';
 import { AbstractServiceOptions, SchemaOverview } from '../types';
 import { Accountability, Query } from '@directus/shared/types';
 import { applyFilter, applySearch } from '../utils/apply-query';
-import { parseFilter } from '@directus/shared/utils';
 
 export class MetaService {
 	knex: Knex;

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -40,7 +40,7 @@ export class MetaService {
 		const dbQuery = this.knex(collection).count('*', { as: 'count' }).first();
 
 		if (this.accountability?.admin !== true) {
-			const permissionsRecord = this.schema.permissions.find((permission) => {
+			const permissionsRecord = this.accountability?.permissions?.find((permission) => {
 				return permission.action === 'read' && permission.collection === collection;
 			});
 
@@ -62,7 +62,7 @@ export class MetaService {
 		let filter = query.filter || {};
 
 		if (this.accountability?.admin !== true) {
-			const permissionsRecord = this.schema.permissions.find((permission) => {
+			const permissionsRecord = this.accountability?.permissions?.find((permission) => {
 				return permission.action === 'read' && permission.collection === collection;
 			});
 

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -10,17 +10,18 @@ export class PermissionsService extends ItemsService {
 	}
 
 	getAllowedFields(action: PermissionsAction, collection?: string): Record<string, string[]> {
-		const results = this.schema.permissions.filter((permission) => {
-			let matchesCollection = true;
+		const results =
+			this.accountability?.permissions?.filter((permission) => {
+				let matchesCollection = true;
 
-			if (collection) {
-				matchesCollection = permission.collection === collection;
-			}
+				if (collection) {
+					matchesCollection = permission.collection === collection;
+				}
 
-			const matchesAction = permission.action === action;
+				const matchesAction = permission.action === action;
 
-			return collection ? matchesCollection && matchesAction : matchesAction;
-		});
+				return collection ? matchesCollection && matchesAction : matchesAction;
+			}) ?? [];
 
 		const fieldsPerCollection: Record<string, string[]> = {};
 

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -1,12 +1,20 @@
 import { appAccessMinimalPermissions } from '../database/system-data/app-access-permissions';
-import { ItemsService, QueryOptions } from '../services/items';
+import { ItemsService, QueryOptions, MutationOptions } from '../services/items';
 import { AbstractServiceOptions, Item, PrimaryKey } from '../types';
 import { Query, PermissionsAction } from '@directus/shared/types';
 import { filterItems } from '../utils/filter-items';
+import Keyv from 'keyv';
+import { getCache } from '../cache';
 
 export class PermissionsService extends ItemsService {
+	systemCache: Keyv<any>;
+
 	constructor(options: AbstractServiceOptions) {
 		super('directus_permissions', options);
+
+		const { systemCache } = getCache();
+
+		this.systemCache = systemCache;
 	}
 
 	getAllowedFields(action: PermissionsAction, collection?: string): Record<string, string[]> {
@@ -68,5 +76,65 @@ export class PermissionsService extends ItemsService {
 		}
 
 		return result;
+	}
+
+	async createOne(data: Partial<Item>, opts?: MutationOptions) {
+		const res = await super.createOne(data, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async createMany(data: Partial<Item>[], opts?: MutationOptions) {
+		const res = await super.createMany(data, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async updateByQuery(query: Query, data: Partial<Item>, opts?: MutationOptions) {
+		const res = await super.updateByQuery(query, data, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions) {
+		const res = await super.updateOne(key, data, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions) {
+		const res = await super.updateMany(keys, data, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async upsertOne(payload: Partial<Item>, opts?: MutationOptions) {
+		const res = await super.upsertOne(payload, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async upsertMany(payloads: Partial<Item>[], opts?: MutationOptions) {
+		const res = await super.upsertMany(payloads, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async deleteByQuery(query: Query, opts?: MutationOptions) {
+		const res = await super.deleteByQuery(query, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async deleteOne(key: PrimaryKey, opts?: MutationOptions) {
+		const res = await super.deleteOne(key, opts);
+		await this.systemCache.clear();
+		return res;
+	}
+
+	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions) {
+		const res = await super.deleteMany(keys, opts);
+		await this.systemCache.clear();
+		return res;
 	}
 }

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -21,7 +21,7 @@ export class RelationsService {
 	accountability: Accountability | null;
 	schema: SchemaOverview;
 	relationsItemService: ItemsService<RelationMeta>;
-	schemaCache: Keyv<any> | null;
+	systemCache: Keyv<any> | null;
 
 	constructor(options: AbstractServiceOptions) {
 		this.knex = options.knex || getDatabase();
@@ -37,7 +37,7 @@ export class RelationsService {
 			// happens in `filterForbidden` down below
 		});
 
-		this.schemaCache = getCache().schemaCache;
+		this.systemCache = getCache().systemCache;
 	}
 
 	async readAll(collection?: string, opts?: QueryOptions): Promise<Relation[]> {
@@ -195,8 +195,8 @@ export class RelationsService {
 			await relationsItemService.createOne(metaRow);
 		});
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 	}
 
@@ -275,8 +275,8 @@ export class RelationsService {
 			}
 		});
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 	}
 
@@ -316,8 +316,8 @@ export class RelationsService {
 			}
 		});
 
-		if (this.schemaCache) {
-			await this.schemaCache.clear();
+		if (this.systemCache) {
+			await this.systemCache.clear();
 		}
 	}
 

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -76,7 +76,7 @@ export class RelationsService {
 				throw new ForbiddenException();
 			}
 
-			const permissions = this.schema.permissions.find((permission) => {
+			const permissions = this.accountability.permissions?.find((permission) => {
 				return permission.action === 'read' && permission.collection === collection;
 			});
 
@@ -325,7 +325,7 @@ export class RelationsService {
 	 * Whether or not the current user has read access to relations
 	 */
 	private get hasReadAccess() {
-		return !!this.schema.permissions.find((permission) => {
+		return !!this.accountability?.permissions?.find((permission) => {
 			return permission.collection === 'directus_relations' && permission.action === 'read';
 		});
 	}
@@ -380,11 +380,12 @@ export class RelationsService {
 	private async filterForbidden(relations: Relation[]): Promise<Relation[]> {
 		if (this.accountability === null || this.accountability?.admin === true) return relations;
 
-		const allowedCollections = this.schema.permissions
-			.filter((permission) => {
-				return permission.action === 'read';
-			})
-			.map(({ collection }) => collection);
+		const allowedCollections =
+			this.accountability.permissions
+				?.filter((permission) => {
+					return permission.action === 'read';
+				})
+				.map(({ collection }) => collection) ?? [];
 
 		const allowedFields = this.permissionsService.getAllowedFields('read');
 

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -21,7 +21,7 @@ export class RelationsService {
 	accountability: Accountability | null;
 	schema: SchemaOverview;
 	relationsItemService: ItemsService<RelationMeta>;
-	systemCache: Keyv<any> | null;
+	systemCache: Keyv<any>;
 
 	constructor(options: AbstractServiceOptions) {
 		this.knex = options.knex || getDatabase();
@@ -195,9 +195,7 @@ export class RelationsService {
 			await relationsItemService.createOne(metaRow);
 		});
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 	}
 
 	/**
@@ -275,9 +273,7 @@ export class RelationsService {
 			}
 		});
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 	}
 
 	/**
@@ -316,9 +312,7 @@ export class RelationsService {
 			}
 		});
 
-		if (this.systemCache) {
-			await this.systemCache.clear();
-		}
+		await this.systemCache.clear();
 	}
 
 	/**

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -92,7 +92,7 @@ class OASSpecsService implements SpecificationSubService {
 		const collections = await this.collectionsService.readByQuery();
 		const fields = await this.fieldsService.readAll();
 		const relations = (await this.relationsService.readAll()) as Relation[];
-		const permissions = this.schema.permissions;
+		const permissions = this.accountability?.permissions ?? [];
 
 		const tags = await this.generateTags(collections);
 		const paths = await this.generatePaths(permissions, tags);

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -28,7 +28,7 @@ export class UtilsService {
 		}
 
 		if (this.accountability?.admin !== true) {
-			const permissions = this.schema.permissions.find((permission) => {
+			const permissions = this.accountability?.permissions?.find((permission) => {
 				return permission.collection === collection && permission.action === 'update';
 			});
 

--- a/api/src/types/schema.ts
+++ b/api/src/types/schema.ts
@@ -1,4 +1,4 @@
-import { Type, Permission } from '@directus/shared/types';
+import { Type } from '@directus/shared/types';
 import { Relation } from './relation';
 
 export type FieldOverview = {
@@ -32,5 +32,4 @@ export type CollectionsOverview = {
 export type SchemaOverview = {
 	collections: CollectionsOverview;
 	relations: Relation[];
-	permissions: Permission[];
 };

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -32,9 +32,9 @@ export default async function getASTFromQuery(
 
 	const permissions =
 		accountability && accountability.admin !== true
-			? schema.permissions.filter((permission) => {
+			? accountability?.permissions?.filter((permission) => {
 					return permission.action === action;
-			  })
+			  }) ?? []
 			: null;
 
 	const ast: AST = {

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -21,15 +21,15 @@ export async function getSchema(options?: {
 }): Promise<SchemaOverview> {
 	const database = options?.database || getDatabase();
 	const schemaInspector = SchemaInspector(database);
-	const { schemaCache } = getCache();
+	const { systemCache } = getCache();
 
 	let result: SchemaOverview;
 
-	if (env.CACHE_SCHEMA !== false && schemaCache) {
+	if (env.CACHE_SCHEMA !== false && systemCache) {
 		let cachedSchema;
 
 		try {
-			cachedSchema = (await schemaCache.get('schema')) as SchemaOverview;
+			cachedSchema = (await systemCache.get('schema')) as SchemaOverview;
 		} catch (err: any) {
 			logger.warn(err, `[schema-cache] Couldn't retrieve cache. ${err}`);
 		}
@@ -40,7 +40,7 @@ export async function getSchema(options?: {
 			result = await getDatabaseSchema(database, schemaInspector);
 
 			try {
-				await schemaCache.set(
+				await systemCache.set(
 					'schema',
 					result,
 					typeof env.CACHE_SCHEMA === 'string' ? ms(env.CACHE_SCHEMA) : undefined

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -13,7 +13,6 @@ import getLocalType from './get-local-type';
 import getDatabase from '../database';
 import { getCache } from '../cache';
 import env from '../env';
-import ms from 'ms';
 
 export async function getSchema(options?: {
 	accountability?: Accountability;
@@ -25,7 +24,7 @@ export async function getSchema(options?: {
 
 	let result: SchemaOverview;
 
-	if (env.CACHE_SCHEMA !== false && systemCache) {
+	if (env.CACHE_SCHEMA !== false) {
 		let cachedSchema;
 
 		try {
@@ -40,11 +39,7 @@ export async function getSchema(options?: {
 			result = await getDatabaseSchema(database, schemaInspector);
 
 			try {
-				await systemCache.set(
-					'schema',
-					result,
-					typeof env.CACHE_SCHEMA === 'string' ? ms(env.CACHE_SCHEMA) : undefined
-				);
+				await systemCache.set('schema', result);
 			} catch (err: any) {
 				logger.warn(err, `[schema-cache] Couldn't save cache. ${err}`);
 			}

--- a/api/src/utils/reduce-schema.ts
+++ b/api/src/utils/reduce-schema.ts
@@ -1,6 +1,6 @@
 import { uniq } from 'lodash';
 import { SchemaOverview } from '../types';
-import { PermissionsAction } from '@directus/shared/types';
+import { Accountability, PermissionsAction } from '@directus/shared/types';
 
 /**
  * Reduces the schema based on the included permissions. The resulting object is the schema structure, but with only
@@ -11,31 +11,32 @@ import { PermissionsAction } from '@directus/shared/types';
  */
 export function reduceSchema(
 	schema: SchemaOverview,
+	accountability: Accountability | null,
 	actions: PermissionsAction[] = ['create', 'read', 'update', 'delete']
 ): SchemaOverview {
 	const reduced: SchemaOverview = {
 		collections: {},
 		relations: [],
-		permissions: schema.permissions,
 	};
 
-	const allowedFieldsInCollection = schema.permissions
-		.filter((permission) => actions.includes(permission.action))
-		.reduce((acc, permission) => {
-			if (!acc[permission.collection]) {
-				acc[permission.collection] = [];
-			}
+	const allowedFieldsInCollection =
+		accountability?.permissions
+			?.filter((permission) => actions.includes(permission.action))
+			.reduce((acc, permission) => {
+				if (!acc[permission.collection]) {
+					acc[permission.collection] = [];
+				}
 
-			if (permission.fields) {
-				acc[permission.collection] = uniq([...acc[permission.collection], ...permission.fields]);
-			}
+				if (permission.fields) {
+					acc[permission.collection] = uniq([...acc[permission.collection], ...permission.fields]);
+				}
 
-			return acc;
-		}, {} as { [collection: string]: string[] });
+				return acc;
+			}, {} as { [collection: string]: string[] }) ?? {};
 
 	for (const [collectionName, collection] of Object.entries(schema.collections)) {
 		if (
-			schema.permissions.some(
+			accountability?.permissions?.some(
 				(permission) => permission.collection === collectionName && actions.includes(permission.action)
 			)
 		) {

--- a/app/src/displays/labels/labels.vue
+++ b/app/src/displays/labels/labels.vue
@@ -16,13 +16,7 @@
 			</v-chip>
 		</template>
 		<template v-else>
-			<display-color
-				v-for="item in items"
-				:key="item.value"
-				v-tooltip="item.text"
-				:value="item.background"
-				:default-color="defaultBackground"
-			/>
+			<display-color v-for="item in items" :key="item.value" v-tooltip="item.text" :value="item.background" />
 		</template>
 	</div>
 </template>

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -103,36 +103,19 @@ export default defineComponent({
 			return (props.value?.toString().length || 2) + 1 + 'ch';
 		});
 
-		const inputPattern = computed(() => {
-			switch (props.type) {
-				case 'integer':
-				case 'bigInteger':
-					return '[+-]?[0-9]+';
-				case 'decimal':
-				case 'float':
-					return '[+-]?[0-9]+\\.?[0-9]*';
-				case 'uuid':
-					return '\\$CURRENT_USER|\\$CURRENT_ROLE|[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}';
-				default:
-					return '';
-			}
-		});
-
 		onMounted(() => {
 			if (props.focus) inputEl.value?.focus();
 		});
 
 		const emitValueDebounced = debounce((val: unknown) => emitValue(val), 250);
 
-		return { displayValue, width, t, emitValueDebounced, inputEl, inputPattern };
+		return { displayValue, width, t, emitValueDebounced, inputEl };
 
 		function emitValue(val: unknown) {
 			if (val === '') {
 				emit('input', null);
 			} else {
-				if (typeof val !== 'string' || new RegExp(inputPattern.value).test(val)) {
-					emit('input', val);
-				}
+				emit('input', val);
 			}
 		}
 	},

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -22,8 +22,8 @@
 		inline
 		:items="choices"
 		:model-value="value"
-		allow-other
 		:placeholder="t('select')"
+		allow-other
 		@update:model-value="emitValue($event)"
 	/>
 	<v-menu v-else :close-on-content-click="false" :show-arrow="true" placement="bottom-start">
@@ -80,8 +80,6 @@ export default defineComponent({
 		const inputEl = ref<HTMLElement>();
 		const { t } = useI18n();
 
-		const localValue = ref(props.value);
-
 		const displayValue = computed(() => {
 			if (props.value === null) return null;
 			if (props.value === undefined) return null;
@@ -94,7 +92,7 @@ export default defineComponent({
 		});
 
 		const width = computed(() => {
-			return (localValue.value?.toString().length || 2) + 1 + 'ch';
+			return (props.value?.toString().length || 2) + 1 + 'ch';
 		});
 
 		const inputPattern = computed(() => {
@@ -106,7 +104,7 @@ export default defineComponent({
 				case 'float':
 					return '[+-]?[0-9]+\\.?[0-9]*';
 				case 'uuid':
-					return '\\$CURRENT_USER|\\$CURRENT_ROLE|[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}';
+					return '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}';
 				default:
 					return '';
 			}
@@ -120,9 +118,18 @@ export default defineComponent({
 
 		function emitValue(val: unknown) {
 			if (val === '') {
-				emit('input', null);
-			} else {
-				emit('input', val);
+				return emit('input', null);
+			}
+
+			if (
+				typeof val === 'string' &&
+				['$NOW', '$CURRENT_USER', '$CURRENT_ROLE'].some((prefix) => val.startsWith(prefix))
+			) {
+				return emit('input', val);
+			}
+
+			if (typeof val !== 'string' || new RegExp(inputPattern.value).test(val)) {
+				return emit('input', val);
 			}
 		}
 	},

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -19,7 +19,7 @@
 	>
 		<input-component
 			:is="interfaceType"
-			:choices="fieldInfo.meta?.options?.choices"
+			:choices="choices"
 			:type="fieldInfo.type"
 			:value="value"
 			@input="value = $event"
@@ -37,7 +37,7 @@
 				:type="fieldInfo.type"
 				:value="val"
 				:focus="false"
-				:choices="fieldInfo.meta?.options?.choices"
+				:choices="choices"
 				@input="setValueAt(index, $event)"
 			/>
 		</div>
@@ -46,7 +46,7 @@
 	<template v-else-if="['_between', '_nbetween'].includes(getComparator(field))" class="between">
 		<input-component
 			:is="interfaceType"
-			:choices="fieldInfo.meta?.options?.choices"
+			:choices="choices"
 			:type="fieldInfo.type"
 			:value="value[0]"
 			@input="setValueAt(0, $event)"
@@ -54,7 +54,7 @@
 		<div class="and">{{ t('interfaces.filter.and') }}</div>
 		<input-component
 			:is="interfaceType"
-			:choices="fieldInfo.meta?.options?.choices"
+			:choices="choices"
 			:type="fieldInfo.type"
 			:value="value[1]"
 			@input="setValueAt(1, $event)"
@@ -70,6 +70,7 @@ import { clone, get } from 'lodash';
 import InputComponent from './input-component.vue';
 import { FieldFilter } from '@directus/shared/types';
 import { fieldToFilter, getComparator, getField } from './utils';
+import { translate } from '@/utils/translate-object-values';
 
 export default defineComponent({
 	components: { InputComponent },
@@ -145,13 +146,15 @@ export default defineComponent({
 			},
 		});
 
+		const choices = computed(() => translate(fieldInfo.value?.meta?.options?.choices ?? {}));
+
+		return { t, choices, fieldInfo, interfaceType, value, setValueAt, getComparator };
+
 		function setValueAt(index: number, newVal: any) {
 			let newArray = Array.isArray(value.value) ? clone(value.value) : new Array(index + 1);
 			newArray[index] = newVal;
 			value.value = newArray;
 		}
-
-		return { t, fieldInfo, interfaceType, value, setValueAt, getComparator };
 	},
 });
 </script>

--- a/app/src/utils/translate-literal.ts
+++ b/app/src/utils/translate-literal.ts
@@ -1,9 +1,9 @@
 import { i18n } from '@/lang';
 
-export function translate(literal: string): string {
+export function translate(literal: any): string {
 	let translated = literal;
 
-	if (literal.startsWith('$t:')) translated = i18n.global.t(literal.replace('$t:', ''));
+	if (typeof literal === 'string' && literal.startsWith('$t:')) translated = i18n.global.t(literal.replace('$t:', ''));
 
 	return translated;
 }

--- a/app/src/views/private/components/search-input/search-input.vue
+++ b/app/src/views/private/components/search-input/search-input.vue
@@ -10,13 +10,7 @@
 			@click="active = true"
 		>
 			<v-icon v-tooltip.bottom="active ? null : t('search')" name="search" class="icon-search" :clickable="!active" />
-			<input
-				ref="input"
-				:value="modelValue"
-				:placeholder="t('search_items')"
-				@input="emitValueDebounced"
-				@paste="emitValueDebounced"
-			/>
+			<input ref="input" :value="modelValue" :placeholder="t('search_items')" @input="emitValue" @paste="emitValue" />
 			<v-icon
 				v-if="modelValue"
 				clickable
@@ -109,14 +103,12 @@ export default defineComponent({
 			}
 		});
 
-		const emitValueDebounced = debounce(() => emitValue(), 250);
-
 		return {
 			t,
 			active,
 			disable,
 			input,
-			emitValueDebounced,
+			emitValue,
 			activeFilterCount,
 			filterActive,
 			onClickOutside,

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -371,15 +371,15 @@ often possible to cache assets for far longer than you would cache database cont
 
 :::
 
-| Variable                         | Description                                                                                  | Default Value    |
-| -------------------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
-| `CACHE_ENABLED`                  | Whether or not caching is enabled.                                                           | `false`          |
-| `CACHE_TTL`<sup>[1]</sup>        | How long the cache is persisted.                                                             | `30m`            |
-| `CACHE_CONTROL_S_MAXAGE`         | Whether to not to add the `s-maxage` expiration flag. Set to a number for a custom value     | `0`              |
-| `CACHE_AUTO_PURGE`<sup>[2]</sup> | Automatically purge the cache on `create`, `update`, and `delete` actions.                   | `false`          |
-| `CACHE_SCHEMA`<sup>[3]</sup>     | Whether or not the database schema is cached. One of `false`, `true`, or a string time value | `true`           |
-| `CACHE_NAMESPACE`                | How to scope the cache data.                                                                 | `directus-cache` |
-| `CACHE_STORE`<sup>[4]</sup>      | Where to store the cache data. Either `memory`, `redis`, or `memcache`.                      | `memory`         |
+| Variable                         | Description                                                                              | Default Value    |
+| -------------------------------- | ---------------------------------------------------------------------------------------- | ---------------- |
+| `CACHE_ENABLED`                  | Whether or not caching is enabled.                                                       | `false`          |
+| `CACHE_TTL`<sup>[1]</sup>        | How long the cache is persisted.                                                         | `30m`            |
+| `CACHE_CONTROL_S_MAXAGE`         | Whether to not to add the `s-maxage` expiration flag. Set to a number for a custom value | `0`              |
+| `CACHE_AUTO_PURGE`<sup>[2]</sup> | Automatically purge the cache on `create`, `update`, and `delete` actions.               | `false`          |
+| `CACHE_SCHEMA`<sup>[3]</sup>     | Whether or not the database schema is cached. One of `false`, `true`                     | `true`           |
+| `CACHE_NAMESPACE`                | How to scope the cache data.                                                             | `directus-cache` |
+| `CACHE_STORE`<sup>[4]</sup>      | Where to store the cache data. Either `memory`, `redis`, or `memcache`.                  | `memory`         |
 
 <sup>[1]</sup> `CACHE_TTL` Based on your project's needs, you might be able to aggressively cache your data, only
 requiring new data to be fetched every hour or so. This allows you to squeeze the most performance out of your Directus

--- a/docs/configuration/filter-rules.md
+++ b/docs/configuration/filter-rules.md
@@ -148,3 +148,11 @@ In addition to static values, you can also filter against _dynamic_ values using
 - `$NOW` — The current timestamp
 - `$NOW(<adjustment>)` - The current timestamp plus/minus a given distance, for example `$NOW(-1 year)`,
   `$NOW(+2 hours)`
+
+::: tip Nested User / Role variables
+
+`$CURRENT_USER` and `$CURRENT_ROLE` allow you to specify any (nested) field under the current user/role as well as the
+root ID. For example: `$CURRENT_ROLE.name` or `$CURRENT_USER.avatar.filesize`. This includes custom fields that were
+added to the directus_users/directus_roles tables.
+
+:::

--- a/docs/configuration/filter-rules.md
+++ b/docs/configuration/filter-rules.md
@@ -149,10 +149,13 @@ In addition to static values, you can also filter against _dynamic_ values using
 - `$NOW(<adjustment>)` - The current timestamp plus/minus a given distance, for example `$NOW(-1 year)`,
   `$NOW(+2 hours)`
 
-::: tip Nested User / Role variables
+::: tip Nested User / Role variables in Permissions
 
-`$CURRENT_USER` and `$CURRENT_ROLE` allow you to specify any (nested) field under the current user/role as well as the
-root ID. For example: `$CURRENT_ROLE.name` or `$CURRENT_USER.avatar.filesize`. This includes custom fields that were
-added to the directus_users/directus_roles tables.
+When configuring permissions, `$CURRENT_USER` and `$CURRENT_ROLE` allow you to specify any (nested) field under the
+current user/role as well as the root ID. For example: `$CURRENT_ROLE.name` or `$CURRENT_USER.avatar.filesize`. This
+includes custom fields that were added to the directus_users/directus_roles tables.
+
+Note: This feature is only available for permissions, validation, and presets. Regular filters and conditional fields
+currently only support the root ID.
 
 :::

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -61,7 +61,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 	let currentRequest: CancelTokenSource | null = null;
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
-	const fetchItems = throttle(getItems, 350);
+	const fetchItems = throttle(getItems, 500);
 
 	if (fetchOnInit) {
 		fetchItems();

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -3,7 +3,7 @@ import axios, { CancelTokenSource } from 'axios';
 import { useCollection } from './use-collection';
 import { Item } from '../types';
 import { moveInArray } from '../utils';
-import { isEqual, throttle, debounce } from 'lodash';
+import { isEqual, throttle } from 'lodash';
 import { computed, ComputedRef, ref, Ref, watch, WritableComputedRef, unref } from 'vue';
 import { Query } from '../types/query';
 
@@ -69,7 +69,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 	watch(
 		[collection, limit, sort, search, filter, fields, page],
-		debounce(async (after, before) => {
+		async (after, before) => {
 			if (isEqual(after, before)) return;
 
 			const [newCollection, newLimit, newSort, newSearch, newFilter, _newFields, _newPage] = after;
@@ -91,7 +91,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 			}
 
 			fetchItems();
-		}, 300),
+		},
 		{ deep: true, immediate: true }
 	);
 

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -3,7 +3,7 @@ import axios, { CancelTokenSource } from 'axios';
 import { useCollection } from './use-collection';
 import { Item } from '../types';
 import { moveInArray } from '../utils';
-import { isEqual, throttle } from 'lodash';
+import { isEqual, throttle, debounce } from 'lodash';
 import { computed, ComputedRef, ref, Ref, watch, WritableComputedRef, unref } from 'vue';
 import { Query } from '../types/query';
 
@@ -69,7 +69,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 	watch(
 		[collection, limit, sort, search, filter, fields, page],
-		async (after, before) => {
+		debounce(async (after, before) => {
 			if (isEqual(after, before)) return;
 
 			const [newCollection, newLimit, newSort, newSearch, newFilter, _newFields, _newPage] = after;
@@ -91,7 +91,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 			}
 
 			fetchItems();
-		},
+		}, 300),
 		{ deep: true, immediate: true }
 	);
 

--- a/packages/shared/src/types/accountability.ts
+++ b/packages/shared/src/types/accountability.ts
@@ -1,8 +1,11 @@
+import { Permission } from '.';
+
 export type Accountability = {
 	role: string | null;
 	user?: string | null;
 	admin?: boolean;
 	app?: boolean;
+	permissions?: Permission[];
 
 	ip?: string;
 	userAgent?: string;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './get-collection-type';
 export * from './get-fields-from-template';
 export * from './get-filter-operators-for-type';
 export * from './get-relation-type';
+export * from './is-dynamic-variable';
 export * from './is-extension';
 export * from './merge-filters';
 export * from './move-in-array';

--- a/packages/shared/src/utils/is-dynamic-variable.test.ts
+++ b/packages/shared/src/utils/is-dynamic-variable.test.ts
@@ -1,0 +1,20 @@
+import { isDynamicVariable } from './is-dynamic-variable';
+
+const tests: [string, boolean][] = [
+	['$NOW', true],
+	['$NOW(- 1 year)', true],
+	['test', false],
+	['$CUSTOM', false],
+	['$CURRENT_USER', true],
+	['$CURRENT_ROLE', true],
+	['$CURRENT_USER.role.name', true],
+	['$CURRENT_ROLE.users.id', true],
+];
+
+describe('is extension type', () => {
+	for (const [value, result] of tests) {
+		it(value, () => {
+			expect(isDynamicVariable(value)).toBe(result);
+		});
+	}
+});

--- a/packages/shared/src/utils/is-dynamic-variable.ts
+++ b/packages/shared/src/utils/is-dynamic-variable.ts
@@ -1,0 +1,5 @@
+const dynamicVariablePrefixes = ['$NOW', '$CURRENT_USER', '$CURRENT_ROLE'];
+
+export function isDynamicVariable(value: any) {
+	return typeof value === 'string' && dynamicVariablePrefixes.some((prefix) => value.startsWith(prefix));
+}

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -1,10 +1,21 @@
 import { REGEX_BETWEEN_PARENS } from '../constants';
-import { Accountability, Filter } from '../types';
+import { Accountability, Filter, User, Role } from '../types';
 import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { deepMap } from './deep-map';
+import { get } from 'lodash';
 
-export function parseFilter(filter: Filter | null, accountability: Accountability | null): any {
+type ParseFilterContext = {
+	// The user can add any custom fields to user
+	$CURRENT_USER?: User & { [field: string]: any };
+	$CURRENT_ROLE?: Role & { [field: string]: any };
+};
+
+export function parseFilter(
+	filter: Filter | null,
+	accountability: Accountability | null,
+	context: ParseFilterContext = {}
+): any {
 	if (!filter) return filter;
 
 	return deepMap(filter, applyFilter);
@@ -29,8 +40,15 @@ export function parseFilter(filter: Filter | null, accountability: Accountabilit
 			return new Date();
 		}
 
-		if (val === '$CURRENT_USER') return accountability?.user || null;
-		if (val === '$CURRENT_ROLE') return accountability?.role || null;
+		if (typeof val === 'string' && val.startsWith('$CURRENT_USER')) {
+			if (val === '$CURRENT_USER') return accountability?.user ?? null;
+			return get(context, val, null);
+		}
+
+		if (typeof val === 'string' && val.startsWith('$CURRENT_ROLE')) {
+			if (val === '$CURRENT_ROLE') return accountability?.role ?? null;
+			return get(context, val, null);
+		}
 
 		return val;
 	}

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -3,7 +3,6 @@ import { Accountability, Filter, User, Role } from '../types';
 import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { deepMap } from './deep-map';
-import { get } from 'lodash';
 
 type ParseFilterContext = {
 	// The user can add any custom fields to user
@@ -51,5 +50,28 @@ export function parseFilter(
 		}
 
 		return val;
+	}
+}
+
+function get(obj: Record<string, any> | any[], path: string, defaultValue: any) {
+	const pathParts = path.split('.');
+	let val = obj;
+
+	while (pathParts.length) {
+		const key = pathParts.shift();
+
+		if (key) {
+			val = processLevel(val, key);
+		}
+	}
+
+	return val || defaultValue;
+
+	function processLevel(value: Record<string, any> | any[], key: string) {
+		if (Array.isArray(value)) {
+			return value.map((subVal) => subVal[key]);
+		} else if (value && typeof value === 'object') {
+			return value[key];
+		}
 	}
 }

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -3,6 +3,7 @@ import { Accountability, Filter, User, Role } from '../types';
 import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { deepMap } from './deep-map';
+import { isDynamicVariable } from '@directus/shared/utils';
 
 type ParseFilterContext = {
 	// The user can add any custom fields to user
@@ -29,24 +30,26 @@ export function parseFilter(
 			else return deepMap(toArray(val), applyFilter);
 		}
 
-		if (val && typeof val === 'string' && val.startsWith('$NOW')) {
-			if (val.includes('(') && val.includes(')')) {
-				const adjustment = val.match(REGEX_BETWEEN_PARENS)?.[1];
-				if (!adjustment) return new Date();
-				return adjustDate(new Date(), adjustment);
+		if (isDynamicVariable(val)) {
+			if (val.startsWith('$NOW')) {
+				if (val.includes('(') && val.includes(')')) {
+					const adjustment = val.match(REGEX_BETWEEN_PARENS)?.[1];
+					if (!adjustment) return new Date();
+					return adjustDate(new Date(), adjustment);
+				}
+
+				return new Date();
 			}
 
-			return new Date();
-		}
+			if (val.startsWith('$CURRENT_USER')) {
+				if (val === '$CURRENT_USER') return accountability?.user ?? null;
+				return get(context, val, null);
+			}
 
-		if (typeof val === 'string' && val.startsWith('$CURRENT_USER')) {
-			if (val === '$CURRENT_USER') return accountability?.user ?? null;
-			return get(context, val, null);
-		}
-
-		if (typeof val === 'string' && val.startsWith('$CURRENT_ROLE')) {
-			if (val === '$CURRENT_ROLE') return accountability?.role ?? null;
-			return get(context, val, null);
+			if (val.startsWith('$CURRENT_ROLE')) {
+				if (val === '$CURRENT_ROLE') return accountability?.role ?? null;
+				return get(context, val, null);
+			}
 		}
 
 		return val;

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -3,7 +3,7 @@ import { Accountability, Filter, User, Role } from '../types';
 import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { deepMap } from './deep-map';
-import { isDynamicVariable } from '@directus/shared/utils';
+import { isDynamicVariable } from './is-dynamic-variable';
 
 type ParseFilterContext = {
 	// The user can add any custom fields to user


### PR DESCRIPTION
**Note**: Permissions are now stored under `Accountability` instead of `SchemaOverview`. If you were relying on the permissions existing under `SchemaOverview`, please make sure to update your code to rely on `Accountability` instead.

---

Continuation of #7890 that aims to implement nested dynamic variables for $CURRENT_USER and $CURRENT_ROLE as per https://github.com/directus/directus/discussions/2993.

This PR adds nested dynamic variables, and caching on top of what @licitdev started. This also slightly restructures the internal flow for authenticating and user accountability creation.