### PR TITLE
Add the generic stroke to notice preview icon

### DIFF
--- a/app/src/interfaces/presentation-notice/preview.svg
+++ b/app/src/interfaces/presentation-notice/preview.svg
@@ -1,5 +1,6 @@
 <svg width="156" height="96" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<rect x="18" y="25" width="120" height="46" rx="6" fill="var(--background-page)" class="glow" />
+	<rect x="19" y="26" width="118" height="44" rx="5" stroke="var(--primary)" stroke-width="2" />
 	<rect x="46" y="35" width="50" height="6" rx="2" fill="var(--primary)" fill-opacity=".25" />
 	<rect x="46" y="45" width="74" height="6" rx="2" fill="var(--primary)" fill-opacity=".25" />
 	<rect x="46" y="55" width="30" height="6" rx="2" fill="var(--primary)" fill-opacity=".25" />


### PR DESCRIPTION
I _noticed_ that the Notice interface icon is missing the stroke that every other preview icons have.

It's at the bottom right corner in these before/after images.

## Before

![chrome_2MQtju9NFJ](https://user-images.githubusercontent.com/42867097/140017270-ca1d8ec8-3ab4-453a-ac9c-2579b982fd2a.png)

## After

![chrome_vXF6elE3C7](https://user-images.githubusercontent.com/42867097/140017303-c1cb5d59-cf33-413f-9a93-312c9d4088cc.png)

