### PR TITLE
Authenticate input-autocomplete-api requests to Directus API

### DIFF
--- a/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
+++ b/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
@@ -34,6 +34,8 @@ import { defineComponent, ref, PropType } from 'vue';
 import axios from 'axios';
 import { throttle, get, debounce } from 'lodash';
 import { render } from 'micromustache';
+import { addTokenToURL } from '@/api.ts';
+import { getRootPath } from '@/utils/get-root-path';
 
 export default defineComponent({
 	props: {
@@ -94,7 +96,10 @@ export default defineComponent({
 				return;
 			}
 
-			const url = render(props.url, { value });
+			let url = render(props.url, { value });
+			
+			if (url.startsWith(getRootPath())
+				url = addTokenToURL(url);
 
 			try {
 				const result = await axios.get(url);


### PR DESCRIPTION
This allows querying the Directus API itself.

We could also add many variables to the "scope" passed to the URL, such as `access_token`, environment variables or stores in addition to `{{value}}`.

Notes:
- [ ] The check to detect the Directus url could probably be improved.
- [ ] I found no documentation to update about input-autocomplete-api