### PR TITLE
Link to all (open & closed) issues in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
           required: true
         - label: I'm on [the latest version of Directus](https://github.com/directus/directus/releases).
           required: true
-        - label: There's [no other issue](https://github.com/directus/directus/issues) that already describes my problem.
+        - label: There's [no other issue](https://github.com/directus/directus/issues?q=is%3Aissue) that already describes my problem.
           required: true
   - type: textarea
     attributes:


### PR DESCRIPTION
So closed issues show up as well.

Do we want to add a link to the discussions, too?