### PR TITLE
NPM install saves to package.json

### DIFF
--- a/docs/getting-started/installation/manual.md
+++ b/docs/getting-started/installation/manual.md
@@ -32,7 +32,7 @@ We recommend aliasing the `start` script to Directus' start for easier deploymen
 ## 2. Install Directus
 
 ```bash
-npm install directus
+npm install --save directus
 ```
 
 ## 3. Setup a Configuration File


### PR DESCRIPTION
Given the steps start with `npm init -y` I *think* you'll want to persist the directus installation to the package.json but wasn't sure.