### PR TITLE
Group updates from Renovate and schedule them weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,24 @@
 {
+	"extends": ["config:base", ":disableDependencyDashboard", "schedule:weekly"],
+	"timezone": "America/New_York",
 	"labels": ["Dependencies"],
-	"extends": ["config:base", ":disableDependencyDashboard"],
+	"commitMessage": "{{commitMessageAction}} {{commitMessageTopic}} {{commitMessageExtra}} {{commitMessageSuffix}}",
 	"force": {
 		"constraints": {
 			"node": ">=16.0.0",
 			"npm": ">=7.0.0"
 		}
 	},
-	"commitMessage": "{{commitMessageAction}} {{commitMessageTopic}} {{commitMessageExtra}} {{commitMessageSuffix}}"
+	"packageRules": [
+		{
+			"matchDatasources": ["npm"],
+			"matchUpdateTypes": ["major"],
+			"groupName": "NPM dependencies (major)"
+		},
+		{
+			"matchDatasources": ["npm"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "NPM dependencies (non-major)"
+		}
+	]
 }


### PR DESCRIPTION
An attempt to make it easier to handle updates from Renovate:
* Group NPM updates together in single PR's - one group for major and one for non-major updates
* Schedule Renovate to run only once per week

Note: We need figure out whether a) the configuration is valid b) it actually eases the workflow 😃 