### PR TITLE
Move union query application to applyQuery, fix where clause

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -69,24 +69,7 @@ export default async function runAST(
 		);
 
 		// The actual knex query builder instance. This is a promise that resolves with the raw items from the db
-		let dbQuery = getDBQuery(schema, knex, collection, fieldNodes, query);
-
-		if (query.union) {
-			const [field, keys] = query.union;
-
-			if (keys.length) {
-				const queries = keys.map((key) => {
-					return knex.select('*').from(
-						dbQuery
-							.clone()
-							.andWhere({ [field]: key })
-							.as('foo')
-					);
-				});
-
-				dbQuery = knex.unionAll(queries);
-			}
-		}
+		const dbQuery = getDBQuery(schema, knex, collection, fieldNodes, query);
 
 		const rawItems: Item | Item[] = await dbQuery;
 

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -213,9 +213,7 @@ function getDBQuery(
 
 	queryCopy.limit = typeof queryCopy.limit === 'number' ? queryCopy.limit : 100;
 
-	applyQuery(knex, table, dbQuery, queryCopy, schema);
-
-	return dbQuery;
+	return applyQuery(knex, table, dbQuery, queryCopy, schema);
 }
 
 function applyParentFilters(

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -23,7 +23,7 @@ export default function applyQuery(
 	query: Query,
 	schema: SchemaOverview,
 	subQuery = false
-): void {
+): Knex.QueryBuilder {
 	if (query.sort) {
 		dbQuery.orderBy(
 			query.sort.map((sortField) => {
@@ -91,6 +91,8 @@ export default function applyQuery(
 	if (query.aggregate) {
 		applyAggregate(dbQuery, query.aggregate, collection);
 	}
+
+	return dbQuery;
 }
 
 /**

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -55,6 +55,18 @@ export default function applyQuery(
 		dbQuery.offset(query.limit * (query.page - 1));
 	}
 
+	if (query.search) {
+		applySearch(schema, dbQuery, query.search, collection);
+	}
+
+	if (query.group) {
+		dbQuery.groupBy(query.group.map(applyFunctionToColumnName));
+	}
+
+	if (query.aggregate) {
+		applyAggregate(dbQuery, query.aggregate, collection);
+	}
+
 	if (query.union && query.union[1].length > 0) {
 		const [field, keys] = query.union as [string, (string | number)[]];
 
@@ -78,18 +90,6 @@ export default function applyQuery(
 		dbQuery = knex.unionAll(queries);
 	} else if (query.filter) {
 		applyFilter(knex, schema, dbQuery, query.filter, collection, subQuery);
-	}
-
-	if (query.search) {
-		applySearch(schema, dbQuery, query.search, collection);
-	}
-
-	if (query.group) {
-		dbQuery.groupBy(query.group.map(applyFunctionToColumnName));
-	}
-
-	if (query.aggregate) {
-		applyAggregate(dbQuery, query.aggregate, collection);
 	}
 
 	return dbQuery;


### PR DESCRIPTION
Fixes #9228

---

@Oreilles Fix turned out to be fairly straightforward. Instead of relying on `.andWhere({ [field]: key })`, I simply passed the additional filter into the existing `query.filter` object to have the previously existing `applyFilters` function handle the alias mapping and joins as it should. Seems to work as expected with the repro in #9228 👍🏻 