### PR TITLE
Don't show all migrations logged on init

### DIFF
--- a/api/src/cli/commands/init/index.ts
+++ b/api/src/cli/commands/init/index.ts
@@ -45,7 +45,7 @@ export default async function init(): Promise<void> {
 
 		try {
 			await runSeed(db);
-			await runMigrations(db, 'latest');
+			await runMigrations(db, 'latest', false);
 		} catch (err: any) {
 			process.stdout.write('\nSomething went wrong while seeding the database:\n');
 			process.stdout.write(`\n${chalk.red(`[${err.code || 'Error'}]`)} ${err.message}\n`);

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -7,7 +7,7 @@ import logger from '../../logger';
 import { Migration } from '../../types';
 import { orderBy } from 'lodash';
 
-export default async function run(database: Knex, direction: 'up' | 'down' | 'latest'): Promise<void> {
+export default async function run(database: Knex, direction: 'up' | 'down' | 'latest', log = true): Promise<void> {
 	let migrationFiles = await fse.readdir(__dirname);
 
 	const customMigrationsPath = path.resolve(env.EXTENSIONS_PATH, 'migrations');
@@ -67,7 +67,9 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 
 		const { up } = require(nextVersion.file);
 
-		logger.info(`Applying ${nextVersion.name}...`);
+		if (log) {
+			logger.info(`Applying ${nextVersion.name}...`);
+		}
 
 		await up(database);
 		await database.insert({ version: nextVersion.version, name: nextVersion.name }).into('directus_migrations');
@@ -88,7 +90,9 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 
 		const { down } = require(migration.file);
 
-		logger.info(`Undoing ${migration.name}...`);
+		if (log) {
+			logger.info(`Undoing ${migration.name}...`);
+		}
 
 		await down(database);
 		await database('directus_migrations').delete().where({ version: migration.version });
@@ -99,7 +103,9 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 			if (migration.completed === false) {
 				const { up } = require(migration.file);
 
-				logger.info(`Applying ${migration.name}...`);
+				if (log) {
+					logger.info(`Applying ${migration.name}...`);
+				}
 
 				await up(database);
 				await database.insert({ version: migration.version, name: migration.name }).into('directus_migrations');


### PR DESCRIPTION
No need to show "Applying migration XXX" 25 times on first installation