### PR TITLE
fix repeater field names title format

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -163,7 +163,7 @@ export default defineComponent({
 			props.fields?.map((field) => {
 				return {
 					...field,
-					name: field.name ?? formatTitle(field.field!),
+					name: formatTitle(field.name ?? field.field!),
 				};
 			})
 		);


### PR DESCRIPTION
`field.name` wasn't wrapped by formatTitle here.