### PR TITLE
Fix timeseries for precision by week

### DIFF
--- a/app/src/panels/time-series/time-series.vue
+++ b/app/src/panels/time-series/time-series.vue
@@ -13,6 +13,7 @@ import { useFieldsStore } from '@/stores';
 import { Filter } from '@directus/shared/types';
 import { abbreviateNumber } from '@/utils/abbreviate-number';
 import { getEndpoint } from '@/utils/get-endpoint';
+import { addWeeks } from 'date-fns';
 
 export default defineComponent({
 	props: {
@@ -180,7 +181,14 @@ export default defineComponent({
 			function toISO(metric: Record<string, any>) {
 				const year = metric[`${props.dateField}_year`];
 				const month = padZero(metric[`${props.dateField}_month`] ?? 1);
-				const day = padZero(metric[`${props.dateField}_day`] ?? 1);
+				const day = metric[`${props.dateField}_week`]
+					? padZero(
+							addWeeks(
+								new Date(year, metric[`${props.dateField}_month`] - 1, 1),
+								metric[`${props.dateField}_week`]
+							).getDate()
+					  )
+					: padZero(metric[`${props.dateField}_day`] ?? 1);
 				const hour = padZero(metric[`${props.dateField}_hour`] ?? 0);
 				const minute = padZero(metric[`${props.dateField}_minute`] ?? 0);
 				const second = padZero(metric[`${props.dateField}_second`] ?? 0);
@@ -201,6 +209,9 @@ export default defineComponent({
 						break;
 					case 'month':
 						groups = ['year', 'month'];
+						break;
+					case 'week':
+						groups = ['year', 'month', 'week'];
 						break;
 					case 'day':
 						groups = ['year', 'month', 'day'];
@@ -290,7 +301,7 @@ export default defineComponent({
 					x: {
 						show: true,
 						formatter(date: number) {
-							return d(new Date(date), 'long');
+							return props.precision === 'week' ? date : d(new Date(date), 'long');
 						},
 					},
 					y: {
@@ -303,7 +314,7 @@ export default defineComponent({
 					},
 				},
 				xaxis: {
-					type: 'datetime',
+					type: props.precision === 'week' ? 'numeric' : 'datetime',
 					tooltip: {
 						enabled: false,
 					},

--- a/app/src/panels/time-series/time-series.vue
+++ b/app/src/panels/time-series/time-series.vue
@@ -301,7 +301,7 @@ export default defineComponent({
 					x: {
 						show: true,
 						formatter(date: number) {
-							return props.precision === 'week' ? date : d(new Date(date), 'long');
+							return d(new Date(date), 'long');
 						},
 					},
 					y: {
@@ -314,7 +314,7 @@ export default defineComponent({
 					},
 				},
 				xaxis: {
-					type: props.precision === 'week' ? 'numeric' : 'datetime',
+					type: 'datetime',
 					tooltip: {
 						enabled: false,
 					},

--- a/app/src/panels/time-series/time-series.vue
+++ b/app/src/panels/time-series/time-series.vue
@@ -181,13 +181,9 @@ export default defineComponent({
 			function toISO(metric: Record<string, any>) {
 				const year = metric[`${props.dateField}_year`];
 				const month = padZero(metric[`${props.dateField}_month`] ?? 1);
-				const day = metric[`${props.dateField}_week`]
-					? padZero(
-							addWeeks(
-								new Date(year, metric[`${props.dateField}_month`] - 1, 1),
-								metric[`${props.dateField}_week`]
-							).getDate()
-					  )
+				const week = metric[`${props.dateField}_week`];
+				const day = week
+					? padZero(getFirstDayOfNWeeksForYear(week, year))
 					: padZero(metric[`${props.dateField}_day`] ?? 1);
 				const hour = padZero(metric[`${props.dateField}_hour`] ?? 0);
 				const minute = padZero(metric[`${props.dateField}_minute`] ?? 0);
@@ -197,6 +193,10 @@ export default defineComponent({
 
 				function padZero(value: number) {
 					return String(value).padStart(2, '0');
+				}
+
+				function getFirstDayOfNWeeksForYear(numberOfWeeks: number, year: number) {
+					return addWeeks(new Date(year, 0, 1), numberOfWeeks).getDate();
 				}
 			}
 


### PR DESCRIPTION
fixes #9495

## Bug

Given the following dataset, aggregating them using sum per week should yield 3 data points - `200`, `100` and `10`. 

![image](https://user-images.githubusercontent.com/42867097/140459371-7b1e1169-1eb1-495d-8e35-e9ba5bcd1a58.png)

However currently it is showing the result as a per day aggregation (5 datapoints instead of 3):

![xyAFJMGewG](https://user-images.githubusercontent.com/42867097/140459588-ca937198-43c4-4e69-988e-d43c8ea127ca.gif)

## After fix

![7tL2eKBzua](https://user-images.githubusercontent.com/42867097/140459618-096d22a1-52c8-40ba-b476-9a7d60e1865b.gif)

