### PR TITLE
No 'latest' Docker tag on pre-releases anymore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,6 @@ jobs:
           images: |
             ${{ env.DOCKERHUB_IMAGE }}
             ${{ env.GHCR_IMAGE }}
-          # Remove this once v9 is released
-          flavor: |
-            latest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
With the stable release of Directus v9 (🥳) we need to adjust the release workflow to don't tag pre-releases on Docker with `latest` anymore.

This was required before since we wanted to have the `latest` tag on 'rc' releases (e.g. `v9.0.0-rc.101`).
However, it's important to change this behavior now to ensure that users relying on the `latest` tag only receive stable updates.

Props to @rijkvanzanten for being so attentive 😃

Edit: This has been tested in a private repo and it works as expected! 