### PR TITLE
Added scope support to LDAP group and user search

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -108,11 +108,7 @@ export class LDAPAuthDriver extends AuthDriver {
 			// Search for the user in LDAP by attribute
 			this.bindClient.search(
 				userDn,
-				{
-					attributes: ['cn'],
-					filter: `(${userAttribute ?? 'cn'}=${identifier})`,
-					scope: userScope ?? 'one',
-				},
+				{ filter: `(${userAttribute ?? 'cn'}=${identifier})`, scope: userScope ?? 'one' },
 				(err: Error | null, res: SearchCallbackResponse) => {
 					if (err) {
 						reject(handleError(err));
@@ -120,8 +116,7 @@ export class LDAPAuthDriver extends AuthDriver {
 					}
 
 					res.on('searchEntry', ({ object }: SearchEntry) => {
-						const userCn = typeof object.cn === 'object' ? object.cn[0] : object.cn;
-						resolve(`cn=${userCn},${userDn}`.toLowerCase());
+						resolve(object.dn.toLowerCase());
 					});
 
 					res.on('error', (err: Error) => {

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -102,7 +102,7 @@ export class LDAPAuthDriver extends AuthDriver {
 	}
 
 	private async fetchUserDn(identifier: string): Promise<string | undefined> {
-		const { userDn, userAttribute } = this.config;
+		const { userDn, userAttribute, userScope } = this.config;
 
 		return new Promise((resolve, reject) => {
 			// Search for the user in LDAP by attribute
@@ -111,7 +111,7 @@ export class LDAPAuthDriver extends AuthDriver {
 				{
 					attributes: ['cn'],
 					filter: `(${userAttribute ?? 'cn'}=${identifier})`,
-					scope: 'one',
+					scope: userScope ?? 'one',
 				},
 				(err: Error | null, res: SearchCallbackResponse) => {
 					if (err) {
@@ -177,7 +177,7 @@ export class LDAPAuthDriver extends AuthDriver {
 	}
 
 	private async fetchUserGroups(userDn: string): Promise<string[]> {
-		const { groupDn, groupAttribute } = this.config;
+		const { groupDn, groupAttribute, groupScope } = this.config;
 
 		if (!groupDn) {
 			return Promise.resolve([]);
@@ -192,7 +192,7 @@ export class LDAPAuthDriver extends AuthDriver {
 				{
 					attributes: ['cn'],
 					filter: `(${groupAttribute ?? 'member'}=${userDn})`,
-					scope: 'one',
+					scope: groupScope ?? 'one',
 				},
 				(err: Error | null, res: SearchCallbackResponse) => {
 					if (err) {

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -611,7 +611,7 @@ information and roles will be assigned from Active Directory.
 
 <sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
 
-<sup>[2]</sup> The scope define the following behaviours:
+<sup>[2]</sup> The scope defines the following behaviors:
 
 - `base`: Limits the scope to a single object defined by the associated DN.
 - `one`: Searches all objects within the associated DN.

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -596,18 +596,25 @@ registrations.
 LDAP allows Active Directory users to authenticate and use Directus without having to be manually configured. User
 information and roles will be assigned from Active Directory.
 
-| Variable                          | Description                                        | Default Value |
-| --------------------------------- | -------------------------------------------------- | ------------- |
-| `AUTH_<PROVIDER>_CLIENT_URL`      | LDAP connection URL.                               | --            |
-| `AUTH_<PROVIDER>_BIND_DN`         | Bind user <sup>[1]</sup> distinguished name.       | --            |
-| `AUTH_<PROVIDER>_BIND_PASSWORD`   | Bind user password.                                | --            |
-| `AUTH_<PROVIDER>_USER_DN`         | Directory path containing users.                   | --            |
-| `AUTH_<PROVIDER>_USER_ATTRIBUTE`  | Attribute to identify users by.                    | `cn`          |
-| `AUTH_<PROVIDER>_GROUP_DN`        | Directory path containing groups.                  | --            |
-| `AUTH_<PROVIDER>_GROUP_ATTRIBUTE` | Attribute to identify user as a member of a group. | `member`      |
-| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user.        | `mail`        |
+| Variable                          | Description                                                            | Default Value |
+| --------------------------------- | ---------------------------------------------------------------------- | ------------- |
+| `AUTH_<PROVIDER>_CLIENT_URL`      | LDAP connection URL.                                                   | --            |
+| `AUTH_<PROVIDER>_BIND_DN`         | Bind user <sup>[1]</sup> distinguished name.                           | --            |
+| `AUTH_<PROVIDER>_BIND_PASSWORD`   | Bind user password.                                                    | --            |
+| `AUTH_<PROVIDER>_USER_DN`         | Directory path containing users.                                       | --            |
+| `AUTH_<PROVIDER>_USER_ATTRIBUTE`  | Attribute to identify users by.                                        | `cn`          |
+| `AUTH_<PROVIDER>_USER_SCOPE`      | Scope of the user search, either `base`, `one`, `sub` <sup>[2]</sup>.  | `one`         |
+| `AUTH_<PROVIDER>_GROUP_DN`        | Directory path containing groups.                                      | --            |
+| `AUTH_<PROVIDER>_GROUP_ATTRIBUTE` | Attribute to identify user as a member of a group.                     | `member`      |
+| `AUTH_<PROVIDER>_GROUP_SCOPE`     | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>. | `one`         |
+| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user.                            | `mail`        |
 
-<sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
+<sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication. <sup>[2]</sup>
+The scope define the following behaviours:
+
+- `base`: Limits the scope to a single object defined by the associated DN.
+- `one`: Searches all objects within the associated DN.
+- `sub`: Searches all objects and sub-objects within the associated DN.
 
 ### Example: LDAP
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -609,8 +609,9 @@ information and roles will be assigned from Active Directory.
 | `AUTH_<PROVIDER>_GROUP_SCOPE`     | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>. | `one`         |
 | `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user.                            | `mail`        |
 
-<sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication. <sup>[2]</sup>
-The scope define the following behaviours:
+<sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
+
+<sup>[2]</sup> The scope define the following behaviours:
 
 - `base`: Limits the scope to a single object defined by the associated DN.
 - `one`: Searches all objects within the associated DN.


### PR DESCRIPTION
Allows the provider to recursively search for users in LDAP, or limit access to a single user or group.