### PR TITLE
Add title attribute to v-checkbox

### DIFF
--- a/app/src/components/v-checkbox/v-checkbox.vue
+++ b/app/src/components/v-checkbox/v-checkbox.vue
@@ -4,6 +4,7 @@
 		class="v-checkbox"
 		type="button"
 		role="checkbox"
+		:title="customValue === false ? label : internalValue"
 		:aria-pressed="isChecked ? 'true' : 'false'"
 		:disabled="disabled"
 		:class="{ checked: isChecked, indeterminate, block }"


### PR DESCRIPTION
Allows for label hinting when checkbox label gets cut off (in dropdown menus, for example).

![image](https://user-images.githubusercontent.com/1226786/140537490-7fadd430-c306-47cc-9095-f52143195f7c.png)