### PR TITLE
Fix missing and wrong translations

### DIFF
--- a/api/src/database/system-data/fields/settings.yaml
+++ b/api/src/database/system-data/fields/settings.yaml
@@ -36,7 +36,7 @@ fields:
 
   - field: project_color
     interface: select-color
-    note: $t:field_options.directus_settings.project_logo_note
+    note: $t:field_options.directus_settings.project_color_note
     translations:
       language: en-US
       translations: Brand Color
@@ -44,7 +44,7 @@ fields:
 
   - field: project_logo
     interface: file
-    note: White 40x40 SVG/PNG
+    note: $t:field_options.directus_settings.project_logo_note
     translations:
       language: en-US
       translations: Brand Logo
@@ -170,7 +170,7 @@ fields:
               onlyOnCreate: false
             width: full
         - field: fit
-          name: Fit
+          name: $t:field_options.directus_settings.storage_asset_presets.fit_label
           type: string
           schema:
             is_nullable: false
@@ -217,7 +217,7 @@ fields:
               step: 1
             width: half
         - field: withoutEnlargement
-          name: Upscaling
+          name: $t:field_options.directus_settings.storage_asset_presets.upscaling
           type: boolean
           schema:
             default_value: false
@@ -227,7 +227,7 @@ fields:
             options:
               label: $t:no_upscale
         - field: format
-          name: Format
+          name: $t:format
           type: string
           schema:
             is_nullable: false
@@ -307,7 +307,7 @@ fields:
           meta:
             interface: text-input
             options:
-              placeholder: Enter the basemap name...
+              placeholder: $t:field_options.directus_settings.basemaps_name_placeholder
         - field: type
           name: $t:type
           meta:

--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -40,19 +40,19 @@ fields:
     display_options:
       showAsDot: true
       choices:
-        - text: $t:active
+        - text: $t:field_options.directus_webhooks.status_options_active
           value: active
           foreground: 'var(--primary-10)'
           background: 'var(--primary)'
-        - text: $t:inactive
+        - text: $t:field_options.directus_webhooks.status_options_inactive
           value: inactive
           foreground: 'var(--foreground-normal)'
           background: 'var(--background-normal-alt)'
     options:
       choices:
-        - text: $t:active
+        - text: $t:field_options.directus_webhooks.status_options_active
           value: active
-        - text: $t:inactive
+        - text: $t:field_options.directus_webhooks.status_options_inactive
           value: inactive
     width: half
 

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -122,8 +122,8 @@
 			<div class="spacer"></div>
 
 			<v-item-group v-model="view" class="view" mandatory rounded>
-				<v-button x-small value="editor">Editor</v-button>
-				<v-button x-small value="preview">Preview</v-button>
+				<v-button x-small value="editor">{{ t('interfaces.input-rich-text-md.editor') }}</v-button>
+				<v-button x-small value="preview">{{ t('interfaces.input-rich-text-md.preview') }}</v-button>
 			</v-item-group>
 		</div>
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -890,6 +890,8 @@ fields:
     unarchive_value: Unarchive Value
     sort_field: Sort Field
     accountability: Activity & Revision Tracking
+    archive_field: Archive Field
+    item_duplication_fields: Item Duplication Fields
   directus_files:
     $thumbnail: Thumbnail
     title: Title
@@ -1010,7 +1012,8 @@ fields:
 field_options:
   directus_settings:
     project_name_placeholder: My project...
-    project_logo_note: Login & Logo Background
+    project_color_note: Login & Logo Background
+    project_logo_note: White 40x40 SVG/PNG
     public_note_placeholder: A short, public message that supports markdown formatting...
     security_divider_title: Security
     auth_password_policy:
@@ -1018,6 +1021,8 @@ field_options:
       weak_text: Weak – Minimum 8 Characters
       strong_text: Strong – Upper / Lowercase / Numbers / Special
     storage_asset_presets:
+      fit_label: Fit
+      upscaling: Upscaling
       fit:
         contain_text: Contain (preserve aspect ratio)
         cover_text: Cover (forces exact size)
@@ -1028,6 +1033,7 @@ field_options:
     mapbox_key: Mapbox Access Token
     mapbox_placeholder: pk.eyJ1Ijo.....
     basemaps: Basemaps
+    basemaps_name_placeholder: Enter the basemap name...
     basemaps_raster: Raster
     basemaps_tile: Raster TileJSON
     basemaps_style: Mapbox Style
@@ -1053,7 +1059,6 @@ field_options:
     singular_unit: Singular Unit
     plural_unit: Plural Unit
     archive_divider: Archive
-    archive_field: Archive Field
     archive_field_placeholder: Choose a field...
     archive_app_filter: Enable App Archive Filter
     archive_value: Value set when archiving...
@@ -1062,7 +1067,6 @@ field_options:
     sort_field: Choose a field...
     accountability_divider: Accountability
     duplication_divider: Duplication
-    item_duplication_fields: Item Duplication Fields
   directus_files:
     title: A unique title...
     description: An optional description...
@@ -1333,6 +1337,8 @@ interfaces:
     box: Block / Inline
     imageToken: Image Token
     imageToken_label: What (static) token to append to image sources
+    preview: Preview
+    editor: Editor
   map:
     map: Map
     description: Select a location on a map
@@ -1581,6 +1587,7 @@ layouts:
     invalid_geometry: Invalid geometry
     find_location: Find location...
     default_template: Using Collection Default...
+    no_compatible_fields: No compatible fields
 
 panels:
   metric:

--- a/app/src/layouts/map/options.vue
+++ b/app/src/layouts/map/options.vue
@@ -6,7 +6,7 @@
 
 	<template v-if="geometryFields.length == 0">
 		<div class="field">
-			<v-input type="text" disabled :prefix="'No compatible fields'"></v-input>
+			<v-input type="text" disabled :prefix="t('layouts.map.no_compatible_fields')"></v-input>
 		</div>
 	</template>
 	<template v-else>


### PR DESCRIPTION
This PR tries to fix the missing and wrong translations

1. For directus_webhooks there is own translations in the language files, but the global active/inactive are used, so fix to owns
2. item_duplication_fields and archive_field from the directus_settings were in wrong section
3. project_color_note and project_logo_note where wrong