### PR TITLE
Fix #9390 - graphql aliases not working

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -459,8 +459,8 @@ export class GraphQLService {
 					CollectionTypes[relation.collection]?.addFields({
 						[relation.field]: {
 							type: CollectionTypes[relation.related_collection],
-							resolve: (obj: Record<string, any>, _, __, info) => {
-								return obj[info?.path?.key ?? relation.field];
+							resolve: (obj: Record<string, any>) => {
+								return obj[relation.field];
 							},
 						},
 					});
@@ -469,8 +469,8 @@ export class GraphQLService {
 						CollectionTypes[relation.related_collection]?.addFields({
 							[relation.meta.one_field]: {
 								type: [CollectionTypes[relation.collection]],
-								resolve: (obj: Record<string, any>, _, __, info) => {
-									return obj[info?.path?.key ?? relation.meta!.one_field];
+								resolve: (obj: Record<string, any>) => {
+									return obj[relation.meta!.one_field!];
 								},
 							},
 						});
@@ -482,7 +482,7 @@ export class GraphQLService {
 							type: new GraphQLUnionType({
 								name: `${relation.collection}_${relation.field}_union`,
 								types: relation.meta.one_allowed_collections.map((collection) => CollectionTypes[collection].getType()),
-								resolveType(value, context, info) {
+								resolveType(_, context, info) {
 									let path: (string | number)[] = [];
 									let currentPath = info.path;
 
@@ -503,8 +503,8 @@ export class GraphQLService {
 									return CollectionTypes[collection].getType();
 								},
 							}),
-							resolve: (obj: Record<string, any>, _, __, info) => {
-								return obj[info?.path?.key ?? relation.field];
+							resolve: (obj: Record<string, any>) => {
+								return obj[relation.field];
 							},
 						},
 					});
@@ -1340,20 +1340,6 @@ export class GraphQLService {
 	): Query {
 		const query: Query = sanitizeQuery(rawQuery, this.accountability);
 
-		const parseAliases = (selections: readonly SelectionNode[]) => {
-			const aliases: Record<string, string> = {};
-
-			for (const selection of selections) {
-				if (selection.kind !== 'Field') continue;
-
-				if (selection.alias?.value) {
-					aliases[selection.alias.value] = selection.name.value;
-				}
-			}
-
-			return aliases;
-		};
-
 		const parseFields = (selections: readonly SelectionNode[], parent?: string): string[] => {
 			const fields: string[] = [];
 
@@ -1445,7 +1431,7 @@ export class GraphQLService {
 			}
 		};
 
-		query.alias = parseAliases(selections);
+		query.alias = {};
 		query.fields = parseFields(selections);
 		query.filter = replaceFuncs(query.filter);
 


### PR DESCRIPTION
fixes #9390

To explain the fix a little bit. 
Originally there was an implementation where GraphQL aliases were passed on to the ItemsService, but only for first level fields (not nested / fragment fields).

The `parseAliases` function was incomplete.

My initial fix in #9012 solved only the nested fields but because the `parseAliases` function was still used, broke the regular (first level) fields.

Next I tried to improve `parseAliases` but due to complexity and no apparent reason to actually have it - I decided to scrub this and go without passing the aliases on to the query.

Instead, I modified the code to always use the real field name.

I tested all affected code paths and everything seems to work, but feel free to test for yourself.

@rijkvanzanten @iksent 

PS: I would consider this a critical / important fix for the recent 9.0.0 release