### PR TITLE
Add a tip explaining HTTP Only cookies issue

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -238,7 +238,10 @@ await directus.auth.refresh();
 
 ::: tip Developing Locally
 
-If you're developing locally, you might not be able to refresh your auth token automatically in all browsers. This is because the default auth configuration requires secure cookies to be set, and not all browsers allow this for localhost. You can use a browser which does support this such as Firefox, or [disable secure cookies](https://docs.directus.io/configuration/config-options/#security).
+If you're developing locally, you might not be able to refresh your auth token automatically in all browsers. This is
+because the default auth configuration requires secure cookies to be set, and not all browsers allow this for localhost.
+You can use a browser which does support this such as Firefox, or
+[disable secure cookies](/configuration/config-options/#security).
 
 :::
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -236,6 +236,12 @@ By default, Directus will handle token refreshes. Although, you can handle this 
 await directus.auth.refresh();
 ```
 
+::: tip Developing Locally
+
+If you're developing locally, you might not be able to refresh your auth token automatically in all browsers. This is because the default auth configuration requires secure cookies to be set, and not all browsers allow this for localhost. You can use a browser which does support this such as Firefox, or [disable secure cookies](https://docs.directus.io/configuration/config-options/#security).
+
+:::
+
 ### Logout
 
 ```js


### PR DESCRIPTION
Watching the Discord, I see this issue coming up fairly frequently, when someone is developing a front end app locally, and their app suddenly stops working with the message

> Error: "refresh_token" is required in either the JSON payload or Cookie

This tip explains the cause of the issue, and two different workarounds.