### PR TITLE
Autofocus first input in create item form

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 
 		const firstEditableFieldIndex = computed(() => {
 			for (let i = 0; i < formFields.value.length; i++) {
-				if (formFields.value[i].meta && !formFields.value[i].meta?.readonly) {
+				if (formFields.value[i].meta && !formFields.value[i].meta?.readonly && !formFields.value[i].meta?.hidden) {
 					return i;
 				}
 			}

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -18,6 +18,7 @@
 				:model-value="firstItem"
 				:initial-values="firstItemInitial"
 				:badge="languageOptions.find((lang) => lang.value === firstLang)?.text"
+				autofocus
 				@update:modelValue="updateValue($event, firstLang)"
 			/>
 			<v-divider />
@@ -81,6 +82,10 @@ export default defineComponent({
 		value: {
 			type: Array as PropType<(string | number | Record<string, any>)[] | null>,
 			default: null,
+		},
+		autofocus: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	emits: ['input'],

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -18,7 +18,7 @@
 				:model-value="firstItem"
 				:initial-values="firstItemInitial"
 				:badge="languageOptions.find((lang) => lang.value === firstLang)?.text"
-				autofocus
+				:autofocus="autofocus"
 				@update:modelValue="updateValue($event, firstLang)"
 			/>
 			<v-divider />

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -150,6 +150,7 @@
 			ref="form"
 			:key="collection"
 			v-model="edits"
+			:autofocus="isNew"
 			:disabled="isNew ? false : updateAllowed === false"
 			:loading="loading"
 			:initial-values="item"


### PR DESCRIPTION
Minor UX improvement, autofocus on first input when creating new item. Sort of a continuation  of #5346 (particularly the `firstEditableFieldIndex`), but it was added to drawers only.

## Result 

https://user-images.githubusercontent.com/42867097/140687622-363243c3-0185-4ce4-8ce5-2089494d3f4d.mp4



