### PR TITLE
Fix presets layout query/options edits on load

### DIFF
--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -146,6 +146,7 @@ import { unexpectedError } from '@/utils/unexpected-error';
 import { useLayout } from '@/composables/use-layout';
 import useShortcut from '@/composables/use-shortcut';
 import unsavedChanges from '@/composables/unsaved-changes';
+import { isEqual } from 'lodash';
 
 type FormattedPreset = {
 	id: number;
@@ -378,6 +379,14 @@ export default defineComponent({
 					return values.value.layout_query[values.value.layout];
 				},
 				set(newQuery) {
+					if (
+						values.value.layout_query &&
+						values.value.layout &&
+						isEqual(newQuery, values.value.layout_query[values.value.layout])
+					) {
+						return;
+					}
+
 					edits.value = {
 						...edits.value,
 						layout_query: {
@@ -396,6 +405,14 @@ export default defineComponent({
 					return values.value.layout_options[values.value.layout];
 				},
 				set(newOptions) {
+					if (
+						values.value.layout_options &&
+						values.value.layout &&
+						isEqual(newOptions, values.value.layout_options[values.value.layout])
+					) {
+						return;
+					}
+
 					edits.value = {
 						...edits.value,
 						layout_options: {


### PR DESCRIPTION
## Before

When we enter a preset without changing anything, going back still shows the unsaved change dialog. It's due to layout query (and likely options) triggering edits:

https://user-images.githubusercontent.com/42867097/140690234-83600713-f6d7-4ade-88cb-838cc5b68061.mp4

## After

https://user-images.githubusercontent.com/42867097/140690258-472447ee-1a23-4e47-a502-6571ecdc727e.mp4


