### PR TITLE
Fix repeater interface template

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -132,7 +132,7 @@ export default defineComponent({
 		const { value } = toRefs(props);
 
 		const templateWithDefaults = computed(() =>
-			props.template || props.fields?.[0]?.field ? `{{${props.fields[0].field}}}` : ''
+			props.fields?.[0]?.field ? props.template || `{{${props.fields[0].field}}}` : ''
 		);
 
 		const showAddNew = computed(() => {


### PR DESCRIPTION
fixes #9587

## Context

Previously the logic was "return either `props.template` or first field":

https://github.com/directus/directus/blob/7eb2cb1137b5fff29dc192656dd480baade0d38d/app/src/interfaces/list/list.vue#L134

However the current logic is `props.template` became a condition check in #9113:

https://github.com/directus/directus/blob/057af2313c90a112b7e850650f4f1a3335bbf765/app/src/interfaces/list/list.vue#L134-L136

So we'll need to move `props.template` back into the if statement body.