### PR TITLE
Fix conditional markdown and code input glitches

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -39,8 +39,7 @@
 			/>
 
 			<form-field
-				v-else
-				v-show="!field.meta?.hidden"
+				v-else-if="!field.meta?.hidden"
 				:key="field.field"
 				:field="field"
 				:autofocus="index === firstEditableFieldIndex && autofocus"


### PR DESCRIPTION
Use `v-if` to toggle conditional fields instead of `v-show` (to make sure the mounted hook is run each time). 

This fixes the following bugs;

- Markdown inputs don't display the content until you click on the input
- Code inputs are styled incorrectly and line numbers cover the content

**Before**

https://user-images.githubusercontent.com/1536407/140702211-dde85612-7e58-4b4d-88a3-a208f33fa23b.mp4

**After**

https://user-images.githubusercontent.com/1536407/140702538-efc6b612-7427-48cf-aaf6-6c2d851fb32d.mp4