### PR TITLE
Fix PR title for major updates from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
 	"extends": ["config:base", ":disableDependencyDashboard", "schedule:weekly"],
 	"timezone": "America/New_York",
 	"labels": ["Dependencies"],
-	"commitMessage": "{{commitMessageAction}} {{commitMessageTopic}} {{commitMessageExtra}} {{commitMessageSuffix}}",
+	"semanticCommits": "disabled",
+	"separateMajorMinor": false,
 	"force": {
 		"constraints": {
 			"node": ">=16.0.0",


### PR DESCRIPTION
The PR title currently is "Update NPM dependencies (major) (major)".
* Since we're already grouping major / non-major updates we can disable `separateMajorMinor` which should then also lead to the correct title "Update NPM dependencies (major)"
* Editing of `commitMessage` directly is now deprecated and not recommended. Disabling `semanticCommits` will give us the same output.