### PR TITLE
Use "access_token" with "openid-client" to fix Facebook auth

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -96,7 +96,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 
 			const issuer = this.client.issuer;
 			if (issuer.metadata.userinfo_endpoint) {
-				userInfo = await this.client.userinfo(tokenSet);
+				userInfo = await this.client.userinfo(tokenSet.access_token!);
 			} else if (tokenSet.id_token) {
 				userInfo = tokenSet.claims();
 			} else {

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -98,7 +98,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 
 			const issuer = client.issuer;
 			if (issuer.metadata.userinfo_endpoint) {
-				userInfo = await client.userinfo(tokenSet);
+				userInfo = await client.userinfo(tokenSet.access_token!);
 			} else {
 				userInfo = tokenSet.claims();
 			}


### PR DESCRIPTION
This will enforce the use of "Bearer" when calling userinfo endpoints rather than "bearer" which Facebook doesn't support. This is a bug on Facebook side.

Tested with Okta, Github and Google.