### PR TITLE
fix tree view interface display template

### DIFF
--- a/app/src/interfaces/list-o2m-tree-view/index.ts
+++ b/app/src/interfaces/list-o2m-tree-view/index.ts
@@ -16,7 +16,7 @@ export default defineInterface({
 
 		return [
 			{
-				field: 'template',
+				field: 'displayTemplate',
 				name: '$t:display_template',
 				meta: {
 					interface: 'system-display-template',


### PR DESCRIPTION
fixes #9511

The interface prop for the template is `displayTemplate`:

https://github.com/directus/directus/blob/057af2313c90a112b7e850650f4f1a3335bbf765/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue#L69-L72

but the interface configuration field is saving it as `template`:

https://github.com/directus/directus/blob/057af2313c90a112b7e850650f4f1a3335bbf765/app/src/interfaces/list-o2m-tree-view/index.ts#L18-L28

---

Even though this fixes it, now every existing tree views might end up saving this to the DB (example taken from what I have now):

```js
{"template":"{{label}}{{id}}","displayTemplate":"{{label}}"}
```

so the old "template" property will be dangling here. Not sure should we note this in the release.