### PR TITLE
Expose server instance in action hook 'server.start'

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -106,7 +106,7 @@ export async function createServer(): Promise<http.Server> {
 	async function onShutdown() {
 		emitter.emitAction(
 			'server.stop',
-			{},
+			{ server },
 			{
 				database: getDatabase(),
 				schema: null,
@@ -141,9 +141,7 @@ export async function startServer(): Promise<void> {
 
 			emitter.emitAction(
 				'server.start',
-				{
-					server,
-				},
+				{ server },
 				{
 					database: getDatabase(),
 					schema: null,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -141,7 +141,9 @@ export async function startServer(): Promise<void> {
 
 			emitter.emitAction(
 				'server.start',
-				{},
+				{
+					server,
+				},
 				{
 					database: getDatabase(),
 					schema: null,

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -117,8 +117,8 @@ The context object has the following properties:
 
 | Name                          | Meta                                                |
 | ----------------------------- | --------------------------------------------------- |
-| `server.start`                | --                                                  |
-| `server.stop`                 | --                                                  |
+| `server.start`                | `server`                                            |
+| `server.stop`                 | `server`                                            |
 | `response`                    | `request`, `response`, `ip`, `duration`, `finished` |
 | `auth.login`                  | `payload`, `status`, `user`, `provider`             |
 | `files.upload`                | `payload`, `key`, `collection`                      |


### PR DESCRIPTION
Since hooks refactor, we cannot access anymore the http server instance. Expose it.
___
For reference:
https://github.com/directus/directus/discussions/9603