### PR TITLE
Skip tabbing on input number steppers

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -30,6 +30,7 @@
 					:class="{ disabled: !isStepUpAllowed }"
 					name="keyboard_arrow_up"
 					class="step-up"
+					tabindex="-1"
 					clickable
 					:disabled="!isStepUpAllowed"
 					@click="stepUp"
@@ -38,6 +39,7 @@
 					:class="{ disabled: !isStepDownAllowed }"
 					name="keyboard_arrow_down"
 					class="step-down"
+					tabindex="-1"
 					clickable
 					:disabled="!isStepDownAllowed"
 					@click="stepDown"


### PR DESCRIPTION
Currently when input component is number, it adds spin buttons for up/down stepping, but as they don't have any focus styles, and are not able to trigger via keyboard, it's bit of confusing to have them selectable while tabbing.

With this change, tabbing is skipping them, plus the fact that using keyboard allow entering value at all, does not make much sense else.

after:

https://user-images.githubusercontent.com/1009639/140794548-8f69753f-c132-4698-a36c-657f68858099.mov



