### PR TITLE
Fix MySQL wkt conversion and fix SRID for Postgres geometry columns

### DIFF
--- a/api/src/database/helpers/geometry.ts
+++ b/api/src/database/helpers/geometry.ts
@@ -87,6 +87,7 @@ class KnexSpatial_SQLite extends KnexSpatial {
 		return this.knex.raw('asgeojson(??.??) as ??', [table, column, column]);
 	}
 }
+
 class KnexSpatial_PG extends KnexSpatial {
 	async supported() {
 		const res = await this.knex.select('oid').from('pg_proc').where({ proname: 'postgis_version' });
@@ -94,7 +95,7 @@ class KnexSpatial_PG extends KnexSpatial {
 	}
 	createColumn(table: Knex.CreateTableBuilder, field: RawField | Field) {
 		const type = field.type.split('.')[1] ?? 'geometry';
-		return table.specificType(field.field, `geometry(${type})`);
+		return table.specificType(field.field, `geometry(${type}, 4326)`);
 	}
 	_intersects_bbox(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		const geometry = this.fromGeoJSON(geojson);
@@ -108,6 +109,9 @@ class KnexSpatial_MySQL extends KnexSpatial {
 			`concat('geometrycollection(', group_concat(? separator ', '), ')'`,
 			this.asText(table, column)
 		);
+	}
+	fromText(text: string): Knex.Raw {
+		return this.knex.raw('st_geomfromtext(?)', text);
 	}
 }
 


### PR DESCRIPTION
Don't set SRID in mysql st_geomfromtext because it then invert longitude and latitude.
Add explicit SRID when creating Postgis geometry columns.
Fixes https://github.com/directus/directus/issues/9614