### PR TITLE
Allow for discarding of changes without leaving

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -136,6 +136,7 @@
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
+						@discard-and-stay="discardAndStay"
 					/>
 				</template>
 			</v-button>
@@ -385,6 +386,7 @@ export default defineComponent({
 			saveAndStay,
 			saveAndAddNew,
 			saveAsCopyAndNavigate,
+			discardAndStay,
 			templateData,
 			templateDataLoading,
 			archiveTooltip,
@@ -504,6 +506,11 @@ export default defineComponent({
 			edits.value = {};
 			confirmLeave.value = false;
 			router.push(leaveTo.value);
+		}
+
+		function discardAndStay() {
+			edits.value = {};
+			confirmLeave.value = false;
 		}
 
 		function revert(values: Record<string, any>) {

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -102,6 +102,7 @@
 						v-if="hasEdits === true || saveAllowed === true"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
+						@discard-and-stay="discardAndStay"
 					/>
 				</template>
 			</v-button>
@@ -328,6 +329,7 @@ export default defineComponent({
 			deleting,
 			saveAndStay,
 			saveAsCopyAndNavigate,
+			discardAndStay,
 			isBatch,
 			editActive,
 			revisionsDrawerDetail,
@@ -411,7 +413,13 @@ export default defineComponent({
 		function discardAndLeave() {
 			if (!leaveTo.value) return;
 			edits.value = {};
+			confirmLeave.value = false;
 			router.push(leaveTo.value);
+		}
+
+		function discardAndStay() {
+			edits.value = {};
+			confirmLeave.value = false;
 		}
 
 		function downloadFile() {

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -99,7 +99,7 @@
 
 				<template #append-outer>
 					<save-options
-						v-if="hasEdits === true || saveAllowed === true"
+						v-if="hasEdits === true && saveAllowed === true"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
 						@discard-and-stay="discardAndStay"

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -100,6 +100,7 @@
 				<template #append-outer>
 					<save-options
 						v-if="hasEdits === true && saveAllowed === true"
+						:disabled-options="['save-and-add-new']"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
 						@discard-and-stay="discardAndStay"

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -41,6 +41,7 @@
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
+						@discard-and-stay="discardAndStay"
 					/>
 				</template>
 			</v-button>
@@ -178,6 +179,7 @@ export default defineComponent({
 			saveAndStay,
 			saveAndAddNew,
 			saveAsCopyAndNavigate,
+			discardAndStay,
 			isBatch,
 			title,
 			validationErrors,
@@ -216,6 +218,11 @@ export default defineComponent({
 			edits.value = {};
 			confirmLeave.value = false;
 			router.push(leaveTo.value);
+		}
+
+		function discardAndStay() {
+			edits.value = {};
+			confirmLeave.value = false;
 		}
 	},
 });

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -37,7 +37,7 @@
 
 				<template #append-outer>
 					<save-options
-						:disabled="hasEdits === false"
+						v-if="hasEdits === true"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -89,6 +89,7 @@
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
+						@discard-and-stay="discardAndStay"
 					/>
 				</template>
 			</v-button>
@@ -343,6 +344,7 @@ export default defineComponent({
 			saveAndStay,
 			saveAndAddNew,
 			saveAsCopyAndNavigate,
+			discardAndStay,
 			isBatch,
 			revisionsDrawerDetail,
 			previewLoading,
@@ -492,7 +494,13 @@ export default defineComponent({
 		function discardAndLeave() {
 			if (!leaveTo.value) return;
 			edits.value = {};
+			confirmLeave.value = false;
 			router.push(leaveTo.value);
+		}
+
+		function discardAndStay() {
+			edits.value = {};
+			confirmLeave.value = false;
 		}
 
 		async function toggleArchive() {

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -5,21 +5,41 @@
 		</template>
 
 		<v-list>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-and-stay')">
+			<v-list-item
+				v-if="!disabledOptions.includes('save-and-stay')"
+				:disabled="disabled"
+				clickable
+				@click="$emit('save-and-stay')"
+			>
 				<v-list-item-icon><v-icon name="check" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_stay') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-and-add-new')">
+			<v-list-item
+				v-if="!disabledOptions.includes('save-and-add-new')"
+				:disabled="disabled"
+				clickable
+				@click="$emit('save-and-add-new')"
+			>
 				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_create_new') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('save-as-copy')">
+			<v-list-item
+				v-if="!disabledOptions.includes('save-as-copy')"
+				:disabled="disabled"
+				clickable
+				@click="$emit('save-as-copy')"
+			>
 				<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
 			</v-list-item>
-			<v-list-item :disabled="disabled" clickable @click="$emit('discard-and-stay')">
+			<v-list-item
+				v-if="!disabledOptions.includes('discard-and-stay')"
+				:disabled="disabled"
+				clickable
+				@click="$emit('discard-and-stay')"
+			>
 				<v-list-item-icon><v-icon name="undo" /></v-list-item-icon>
 				<v-list-item-content>{{ t('discard_changes') }}</v-list-item-content>
 			</v-list-item>
@@ -37,6 +57,10 @@ export default defineComponent({
 		disabled: {
 			type: Boolean,
 			default: false,
+		},
+		disabledOptions: {
+			type: Array,
+			default: () => [],
 		},
 	},
 	emits: ['save-and-stay', 'save-and-add-new', 'save-as-copy', 'discard-and-stay'],

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -19,6 +19,10 @@
 				<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
 			</v-list-item>
+			<v-list-item :disabled="disabled" clickable @click="$emit('discard-and-stay')">
+				<v-list-item-icon><v-icon name="undo" /></v-list-item-icon>
+				<v-list-item-content>{{ t('discard_changes') }}</v-list-item-content>
+			</v-list-item>
 		</v-list>
 	</v-menu>
 </template>
@@ -35,7 +39,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: ['save-and-stay', 'save-and-add-new', 'save-as-copy'],
+	emits: ['save-and-stay', 'save-and-add-new', 'save-as-copy', 'discard-and-stay'],
 	setup() {
 		const { t } = useI18n();
 

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -1,45 +1,25 @@
 <template>
-	<v-menu show-arrow :disabled="disabled">
+	<v-menu show-arrow>
 		<template #activator="{ toggle }">
 			<v-icon :class="{ disabled }" name="more_vert" clickable @click="toggle" />
 		</template>
 
 		<v-list>
-			<v-list-item
-				v-if="!disabledOptions.includes('save-and-stay')"
-				:disabled="disabled"
-				clickable
-				@click="$emit('save-and-stay')"
-			>
+			<v-list-item v-if="!disabledOptions.includes('save-and-stay')" clickable @click="$emit('save-and-stay')">
 				<v-list-item-icon><v-icon name="check" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_stay') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item
-				v-if="!disabledOptions.includes('save-and-add-new')"
-				:disabled="disabled"
-				clickable
-				@click="$emit('save-and-add-new')"
-			>
+			<v-list-item v-if="!disabledOptions.includes('save-and-add-new')" clickable @click="$emit('save-and-add-new')">
 				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_create_new') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item
-				v-if="!disabledOptions.includes('save-as-copy')"
-				:disabled="disabled"
-				clickable
-				@click="$emit('save-as-copy')"
-			>
+			<v-list-item v-if="!disabledOptions.includes('save-as-copy')" clickable @click="$emit('save-as-copy')">
 				<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
 			</v-list-item>
-			<v-list-item
-				v-if="!disabledOptions.includes('discard-and-stay')"
-				:disabled="disabled"
-				clickable
-				@click="$emit('discard-and-stay')"
-			>
+			<v-list-item v-if="!disabledOptions.includes('discard-and-stay')" clickable @click="$emit('discard-and-stay')">
 				<v-list-item-icon><v-icon name="undo" /></v-list-item-icon>
 				<v-list-item-content>{{ t('discard_changes') }}</v-list-item-content>
 			</v-list-item>
@@ -54,10 +34,6 @@ import translateShortcut from '@/utils/translate-shortcut';
 
 export default defineComponent({
 	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
 		disabledOptions: {
 			type: Array,
 			default: () => [],


### PR DESCRIPTION
Closes #9642.

<img width="217" alt="discard-changes" src="https://user-images.githubusercontent.com/26413686/140909777-52052059-b71b-44e2-b2e1-ac9afb90f2fc.png">

It is implemented alongside `save-options` so that there is no need to prompt for confirmation, same as save as copy etc.