### PR TITLE
Add wait to await database

### DIFF
--- a/tests/setup/setup.ts
+++ b/tests/setup/setup.ts
@@ -209,7 +209,11 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 					global.knexInstances.map(({ vendor, knex }) => {
 						return {
 							title: config.names[vendor]!,
-							task: async () => await awaitDatabaseConnection(knex, config.knexConfig[vendor]!.waitTestSQL),
+
+							task: async () => {
+								await sleep(25000);
+								await awaitDatabaseConnection(knex, config.knexConfig[vendor]!.waitTestSQL);
+							},
 						};
 					}),
 					{ concurrent: true }
@@ -309,3 +313,11 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 
 	console.log('\n');
 };
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => {
+		setTimeout(() => {
+			resolve();
+		}, ms);
+	});
+}

--- a/tests/setup/setup.ts
+++ b/tests/setup/setup.ts
@@ -211,7 +211,7 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 							title: config.names[vendor]!,
 
 							task: async () => {
-								await sleep(3000);
+								await sleep(5000);
 								await awaitDatabaseConnection(knex, config.knexConfig[vendor]!.waitTestSQL);
 							},
 						};

--- a/tests/setup/setup.ts
+++ b/tests/setup/setup.ts
@@ -211,7 +211,7 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 							title: config.names[vendor]!,
 
 							task: async () => {
-								await sleep(5000);
+								await sleep(3000);
 								await awaitDatabaseConnection(knex, config.knexConfig[vendor]!.waitTestSQL);
 							},
 						};

--- a/tests/setup/setup.ts
+++ b/tests/setup/setup.ts
@@ -211,7 +211,7 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 							title: config.names[vendor]!,
 
 							task: async () => {
-								await sleep(25000);
+								await sleep(5000);
 								await awaitDatabaseConnection(knex, config.knexConfig[vendor]!.waitTestSQL);
 							},
 						};

--- a/tests/setup/utils/await-connection.ts
+++ b/tests/setup/utils/await-connection.ts
@@ -8,8 +8,9 @@ export async function awaitDatabaseConnection(
 ): Promise<void | null> {
 	try {
 		setTimeout(async () => {
-			await database.raw(checkSQL);
-		}, 500);
+			return null;
+		}, 1000);
+		await database.raw(checkSQL);
 	} catch {
 		if (currentAttempt === 10) {
 			throw new Error(`Couldn't connect to DB`);

--- a/tests/setup/utils/await-connection.ts
+++ b/tests/setup/utils/await-connection.ts
@@ -7,7 +7,9 @@ export async function awaitDatabaseConnection(
 	currentAttempt = 0
 ): Promise<void | null> {
 	try {
-		await database.raw(checkSQL);
+		setTimeout(async () => {
+			await database.raw(checkSQL);
+		}, 500);
 	} catch {
 		if (currentAttempt === 10) {
 			throw new Error(`Couldn't connect to DB`);

--- a/tests/setup/utils/await-connection.ts
+++ b/tests/setup/utils/await-connection.ts
@@ -7,9 +7,6 @@ export async function awaitDatabaseConnection(
 	currentAttempt = 0
 ): Promise<void | null> {
 	try {
-		setTimeout(async () => {
-			return null;
-		}, 1000);
 		await database.raw(checkSQL);
 	} catch {
 		if (currentAttempt === 10) {


### PR DESCRIPTION
Fixes e2e tests by adding a wait to allow the database dockers to start before pinging them.