### PR TITLE
Clean up save-options

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -790,6 +790,7 @@ layout_setup: Layout Setup
 unsaved_changes: Unsaved Changes
 unsaved_changes_copy: Are you sure you want to leave this page?
 discard_changes: Discard Changes
+discard_all_changes: Discard All Changes
 discard_changes_copy: Are you sure you want to discard all the changes made?
 show_x_axis: Show X Axis
 show_y_axis: Show Y Axis

--- a/app/src/views/private/components/save-options/save-options.vue
+++ b/app/src/views/private/components/save-options/save-options.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-menu show-arrow>
 		<template #activator="{ toggle }">
-			<v-icon :class="{ disabled }" name="more_vert" clickable @click="toggle" />
+			<v-icon name="more_vert" clickable @click="toggle" />
 		</template>
 
 		<v-list>
@@ -21,7 +21,7 @@
 			</v-list-item>
 			<v-list-item v-if="!disabledOptions.includes('discard-and-stay')" clickable @click="$emit('discard-and-stay')">
 				<v-list-item-icon><v-icon name="undo" /></v-list-item-icon>
-				<v-list-item-content>{{ t('discard_changes') }}</v-list-item-content>
+				<v-list-item-content>{{ t('discard_all_changes') }}</v-list-item-content>
 			</v-list-item>
 		</v-list>
 	</v-menu>


### PR DESCRIPTION
Remove unused prop which throws warning and updated translation string to `Discard All Changes` as suggested in https://github.com/directus/directus/pull/9644#issuecomment-964245034