### PR TITLE
Flatten arrays after parsing filters

### DIFF
--- a/packages/shared/src/utils/flatten-arrays.ts
+++ b/packages/shared/src/utils/flatten-arrays.ts
@@ -1,0 +1,12 @@
+import { isObjectLike, flattenDeep } from 'lodash';
+
+export function flattenArrays(obj: any) {
+	for (const key in obj) {
+		if (Array.isArray(obj[key])) {
+			obj[key] = flattenDeep(obj[key]);
+		} else if (isObjectLike(obj[key])) {
+			obj[key] = flattenArrays(obj[key]);
+		}
+	}
+	return obj;
+}

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -4,6 +4,7 @@ import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { deepMap } from './deep-map';
 import { isDynamicVariable } from './is-dynamic-variable';
+import { flattenArrays } from './flatten-arrays';
 
 type ParseFilterContext = {
 	// The user can add any custom fields to user
@@ -18,7 +19,7 @@ export function parseFilter(
 ): any {
 	if (!filter) return filter;
 
-	return deepMap(filter, applyFilter);
+	return flattenArrays(deepMap(filter, applyFilter));
 
 	function applyFilter(val: any, key: string | number) {
 		if (val === 'true') return true;


### PR DESCRIPTION
Permission filtering using user dynamic variables containing arrays throws an error `operator does not exist: integer = record`, with the resulting query containing nested array.