### PR TITLE
Add default values when tracking edits in list interface

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -290,6 +290,7 @@ export default defineComponent({
 				emitValue(props.value.slice(0, -1));
 			}
 
+			edits.value = {};
 			active.value = null;
 		}
 	},

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -213,7 +213,8 @@ export default defineComponent({
 		}
 
 		function trackEdits(updatedValues: any) {
-			Object.assign(edits.value, updatedValues);
+			const combinedValues = Object.assign({}, defaults.value, updatedValues);
+			Object.assign(edits.value, combinedValues);
 		}
 
 		function checkDiscard() {


### PR DESCRIPTION
fixes #9538

## Context

When we first click `block` in Markdown custom blocks, it works. But when we try to revert back to `inline`, nothing seems to happen.

![WLKjlBftMB](https://user-images.githubusercontent.com/42867097/141239689-41799e55-c340-4f5a-aa72-fe4cf6b596ee.gif)

## Investigation

The update:model-value for the list form was modified in #8169 here:

https://github.com/directus/directus/blob/194862cdee2963ea3b9f40b37007a86d4bfca5b3/app/src/interfaces/list/list.vue#L215-L217

However due to the nature of "if input is the same as the default value", in this case the default is `inline`, the <FormField> doesn't end up emitting `box: inline` here because the `unset` kicks in:

https://github.com/directus/directus/blob/194862cdee2963ea3b9f40b37007a86d4bfca5b3/app/src/components/v-form/form-field.vue#L163-L173

Hence the `updatedValues` in `trackEdits()` above never has the property `box`, so it stays as `block`.

## Fix

Added defaults in case the `updatedValues` doesn't have specific properties, implying it should "revert" to the default value when we assign it to edits.value.

![SqyDQba6l1](https://user-images.githubusercontent.com/42867097/141240296-10511985-a022-4062-85fb-af5e879b78f8.gif)

Also added a line to clear edits value when the drawer is closed.

