### PR TITLE
Ensure update of one_field in m2o

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2o.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2o.ts
@@ -18,6 +18,10 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 		preventCircularConstraint(updates, state);
 		setTypeToRelatedPrimaryKey(updates, state);
 	}
+
+	if (hasChanged('fields.corresponding')) {
+		setRelatedOneFieldForCorrespondingField(updates);
+	}
 }
 
 export function prepareRelation(updates: StateUpdates, state: State) {
@@ -97,5 +101,15 @@ export function setTypeToRelatedPrimaryKey(updates: StateUpdates, state: State) 
 		set(updates, 'field.type', primaryKeyField.type);
 	} else if (state.collections.related?.fields?.[0]?.type) {
 		set(updates, 'field.type', state.collections.related.fields[0].type);
+	}
+}
+
+export function setRelatedOneFieldForCorrespondingField(updates: StateUpdates) {
+	if (updates?.fields?.corresponding?.field) {
+		set(updates, 'relations.m2o.meta.one_field', updates.fields.corresponding.field);
+	}
+
+	if (!updates.fields?.corresponding) {
+		set(updates, 'relations.m2o.meta.one_field', null);
 	}
 }


### PR DESCRIPTION
fixes #9622

## Before

After creating an m2o field and checking add O2M field to corresponding collection, when we go to the created corresponding field, it's interface is showing as "Select a collection", hence the relation is somewhat broken:

https://user-images.githubusercontent.com/42867097/141248939-4914b4d9-bdd7-4a69-a7eb-a26055632c98.mp4

## After

https://user-images.githubusercontent.com/42867097/141249186-9ce2eb17-c08e-4386-8673-45be8c6a6fca.mp4

## Fix applied

Referred from m2m & m2a's `setRelatedOneFieldForCorrespondingField`:

https://github.com/directus/directus/blob/e4959d001b500bc038a434064118a06c1b5180f8/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts#L306-L314