### PR TITLE
Apply cloneDeep to relations in FieldDetailStore

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -106,7 +106,7 @@ export const useFieldDetailStore = defineStore({
 				this.field = cloneDeep(fieldsStore.getField(collection, field)!);
 				this.localType = getLocalTypeForField(collection, field)!;
 
-				const relations = relationsStore.getRelationsForField(collection, field);
+				const relations = cloneDeep(relationsStore.getRelationsForField(collection, field));
 
 				// o2m relation is the same regardless of type
 				this.relations.o2m = relations.find(


### PR DESCRIPTION
fixes #9601

## Context

When we save modify a relational trigger of the `one` in m2o/o2m and hit save, nothing actually happens. We can verify this on the network tab, no patch request is done. Although opening the field again shows the "updated" value, it's just reflect what's in the relations store. Doing a refresh will make it show the original value again.

https://user-images.githubusercontent.com/42867097/141268336-97723df8-a683-451d-99c3-6f2804c93634.mp4

## Investigation

Within the FieldDetailStore, we can see field is cloneDeep-ed, but not for relations:

https://github.com/directus/directus/blob/194862cdee2963ea3b9f40b37007a86d4bfca5b3/app/src/modules/settings/routes/data-model/field-detail/store/index.ts#L106-L109

Since now `this.relations` in FieldDetailStore and the value in RelationsStore are in sync, upserting a relation will never happen since they are `isEqual()`:

https://github.com/directus/directus/blob/194862cdee2963ea3b9f40b37007a86d4bfca5b3/app/src/stores/relations.ts#L26-L36

## Solution

Make sure to use cloneDeep for relations in FieldDetailStore.

Result:

We can see it patched `NO ACTION` over the original `SET NULL`.

https://user-images.githubusercontent.com/42867097/141269088-508222bd-c03c-431f-820f-fb115065e4b1.mp4


---

Seems like actually cloneDeep was used in https://github.com/directus/directus/pull/9324/files#diff-5050f94209ae696d0ecf947342b5baa87f9386da27be6947ed29db10fb261325R106 to fix field configs, so it should be the same concept.