### PR TITLE
Remove geometryFormat from map interface options.

### DIFF
--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -131,10 +131,6 @@ export default defineComponent({
 			type: Boolean,
 			default: false,
 		},
-		geometryFormat: {
-			type: String as PropType<GeometryFormat>,
-			default: undefined,
-		},
 		geometryType: {
 			type: String as PropType<GeometryType>,
 			default: undefined,
@@ -156,7 +152,7 @@ export default defineComponent({
 		const geometryParsingError = ref<string | TranslateResult>();
 
 		const geometryType = props.geometryType || (props.fieldData?.type.split('.')[1] as GeometryType);
-		const geometryFormat = props.geometryFormat || getGeometryFormatForType(props.type)!;
+		const geometryFormat = getGeometryFormatForType(props.type)!;
 
 		const mapboxKey = getSetting('mapbox_key');
 		const basemaps = getBasemapSources();

--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -85,7 +85,6 @@ import { flatten, getBBox, getParser, getSerializer, getGeometryFormatForType } 
 import {
 	Field,
 	GeometryType,
-	GeometryFormat,
 	GeoJSONParser,
 	GeoJSONSerializer,
 	SimpleGeometry,

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="form-grid">
-		<div v-if="!nativeGeometryType && geometryFormat !== 'lnglat'" class="field half-left">
+		<div v-if="!nativeGeometryType && field.type !== 'csv'" class="field half-left">
 			<div class="type-label">{{ t('interfaces.map.geometry_type') }}</div>
 			<v-select
 				v-model="geometryType"
@@ -21,7 +21,6 @@ import { useI18n } from 'vue-i18n';
 import { ref, defineComponent, PropType, watch, onMounted, onUnmounted, computed, toRefs } from 'vue';
 import { GEOMETRY_TYPES } from '@directus/shared/constants';
 import { Field, GeometryType, GeometryFormat, GeometryOptions } from '@directus/shared/types';
-import { getGeometryFormatForType } from '@/utils/geometry';
 import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Map, CameraOptions } from 'maplibre-gl';
@@ -48,16 +47,15 @@ export default defineComponent({
 		const { t } = useI18n();
 
 		const nativeGeometryType = computed(() => props.field.type.split('.')[1] as GeometryType);
-		const geometryFormat = computed(() => getGeometryFormatForType(props.field.type));
 		const geometryType = ref<GeometryType>(nativeGeometryType.value ?? props.value?.geometryType ?? 'Point');
 		const defaultView = ref<CameraOptions | undefined>(props.value?.defaultView);
 
-		watch(geometryFormat, watchGeometryFormat);
+		watch(() => props.field.type, watchType);
 		watch(nativeGeometryType, watchNativeType);
 		watch([geometryType, defaultView], input, { immediate: true });
 
-		function watchGeometryFormat(format: GeometryFormat | undefined) {
-			if (format === 'lnglat') geometryType.value = 'Point';
+		function watchType(type: string | undefined) {
+			if (type === 'csv') geometryType.value = 'Point';
 		}
 
 		function watchNativeType(type: GeometryType) {
@@ -67,7 +65,6 @@ export default defineComponent({
 		function input() {
 			emit('input', {
 				defaultView,
-				geometryFormat: geometryFormat.value,
 				geometryType: geometryType.value,
 			});
 		}
@@ -108,7 +105,6 @@ export default defineComponent({
 		return {
 			t,
 			nativeGeometryType,
-			geometryFormat,
 			GEOMETRY_TYPES,
 			geometryType,
 			mapContainer,

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -20,7 +20,7 @@
 import { useI18n } from 'vue-i18n';
 import { ref, defineComponent, PropType, watch, onMounted, onUnmounted, computed, toRefs } from 'vue';
 import { GEOMETRY_TYPES } from '@directus/shared/constants';
-import { Field, GeometryType, GeometryFormat, GeometryOptions } from '@directus/shared/types';
+import { Field, GeometryType, GeometryOptions } from '@directus/shared/types';
 import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Map, CameraOptions } from 'maplibre-gl';

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -104,7 +104,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			}
 			const geometryField = field.field;
 			const geometryFormat = isGeometryFieldNative.value ? 'native' : field.meta?.options?.geometryFormat;
-			const geometryType = field.schema?.geometry_type ?? field.meta?.options?.geometryType;
+			const geometryType = field.type.split('.')[1] ?? field.meta?.options?.geometryType;
 			if (!geometryFormat) {
 				return;
 			}


### PR DESCRIPTION
Fixes a bug where the geometryFormat wasn't correctly updated when starting a field creation of type string, then switch to a geometric type.