### PR TITLE
Extend translations display

### DIFF
--- a/app/src/composables/use-translations-value.ts
+++ b/app/src/composables/use-translations-value.ts
@@ -1,0 +1,120 @@
+import { ref } from 'vue';
+import { useFieldsStore, useRelationsStore } from '@/stores';
+import useRelation from './use-m2m';
+import { Field } from '@directus/shared/types';
+import { notEmpty } from '@/utils/is-empty';
+import getRelatedCollection from '@/utils/get-related-collection';
+
+const LANG_KEY = '__lang';
+const FIELDS_COUNT_KEY = '__fieldsCount';
+const FILLED_FIELDS_KEY = '__filledFields';
+
+export default function useTranslationsValue(
+	value: object | any[],
+	field: string,
+	collection: string,
+	languageField: string | undefined,
+	defaultLanguage: string | undefined,
+	fallbackLanguage: string
+) {
+	const fieldsStore = useFieldsStore();
+	const relationsStore = useRelationsStore();
+	const langs: string[] = [];
+
+	function deepResolveValues(val: object | any[] | any, field: string, collection: string): any {
+		const fieldData = fieldsStore.getField(collection, field);
+
+		if (Array.isArray(val)) {
+			if (fieldData?.meta?.special?.includes('translations')) {
+				// resolve translations
+				const { relationPrimaryKeyField: langCode, relation } = useRelation(ref(collection), ref(field));
+
+				return val.map((el: any) => {
+					let item = JSON.parse(JSON.stringify(el));
+					const lang = item?.[relation.value.field]?.[languageField ?? langCode.value!.field] ?? defaultLanguage;
+					lang && !langs.includes(lang) && langs.push(lang);
+					// remove unneccessary lang relation
+					delete item[relation.value.field];
+					// deep resolve fields
+					item = deepResolveValues(item, field, collection);
+					const junctionFields = fieldsStore.getFieldsForCollection(relation.value.collection);
+					const writableFields = junctionFields.filter(
+						(field: Field) => field.type !== 'alias' && field.meta?.hidden === false && field.meta.readonly === false
+					);
+					item[LANG_KEY] = lang;
+					item[FIELDS_COUNT_KEY] = writableFields.length;
+					item[FILLED_FIELDS_KEY] = writableFields.filter((field) => {
+						return field.field in item && notEmpty(item[field.field]);
+					}).length;
+					return item;
+				});
+			}
+
+			if (fieldData?.meta?.special?.includes('m2a')) {
+				const relations = relationsStore.getRelationsForField(collection, field);
+				const m2aRelation = relations.find((relation) => relation.meta?.one_allowed_collections?.length);
+				const collectionKey = m2aRelation?.meta?.one_collection_field ?? 'collection';
+				return val.map((el) => ({
+					[`item:${el[collectionKey]}`]: deepResolveValues(el.item, 'item', el[collectionKey]),
+				}));
+			}
+			return val.map((el) => deepResolveValues(el, field, collection));
+		}
+		if (val && typeof val === 'object') {
+			return Object.keys(val).reduce((res, key) => {
+				const relatedCollection = fieldData ? getRelatedCollection(collection, field) : collection;
+				res[key] = deepResolveValues(val[key], key, relatedCollection);
+				return res;
+			}, {} as Record<string, any>);
+		}
+		return val;
+	}
+
+	function deepMapTranslations(val: any, lang: string): any {
+		if (Array.isArray(val) && val.every((el) => LANG_KEY in el)) {
+			return val.find((el) => el[LANG_KEY] === lang) ?? val[0];
+		}
+		if (Array.isArray(val)) {
+			return val.map((el) => deepMapTranslations(el, lang));
+		}
+		if (val && typeof val === 'object') {
+			return Object.keys(val).reduce((res, key) => {
+				res[key] = deepMapTranslations(val[key], lang);
+				return res;
+			}, {} as Record<string, any>);
+		}
+		return val;
+	}
+
+	function deepCalcProgress(item: any, totalFieldsCount = 0, totalFilledFields = 0) {
+		if (!item) return { totalFilledFields, totalFieldsCount };
+
+		if (LANG_KEY in item) {
+			totalFieldsCount += item[FIELDS_COUNT_KEY];
+			totalFilledFields += item[FILLED_FIELDS_KEY];
+		}
+
+		for (const key in item) {
+			if (typeof item[key] === 'object') {
+				const addedProgress = deepCalcProgress(item[key], totalFieldsCount, totalFilledFields);
+				totalFieldsCount += addedProgress.totalFieldsCount;
+				totalFilledFields += addedProgress.totalFilledFields;
+			}
+		}
+
+		return { totalFilledFields, totalFieldsCount };
+	}
+
+	const resolvedValues = deepResolveValues(value, field, collection);
+	const translations = (langs.length === 0 ? [fallbackLanguage] : langs).map((lang) => {
+		const item = deepMapTranslations(resolvedValues, lang);
+		const { totalFieldsCount, totalFilledFields } = deepCalcProgress(item);
+		const progress = totalFieldsCount > 0 ? Math.round((totalFilledFields / totalFieldsCount) * 100) : 0;
+		return {
+			lang,
+			progress,
+			item,
+		};
+	});
+	return ref(translations);
+}

--- a/app/src/utils/find-languages-collection/find-languages-collection.ts
+++ b/app/src/utils/find-languages-collection/find-languages-collection.ts
@@ -1,0 +1,37 @@
+import { Field } from '@directus/shared/types';
+import { useFieldsStore, useRelationsStore } from '@/stores';
+import getRelatedCollection from '../get-related-collection';
+
+export default function findLanguagesCollection(collection: string): string | null | undefined {
+	const fieldsStore = useFieldsStore();
+	const relationsStore = useRelationsStore();
+	const collectionFields = fieldsStore.getFieldsForCollection(collection);
+
+	for (const fieldData of collectionFields) {
+		const relations = relationsStore.getRelationsForField(collection, fieldData.field);
+
+		if (fieldData.meta?.special?.includes('translations')) {
+			return getLanguagesCollection(collection, fieldData);
+		} else if (fieldData.meta?.special?.includes('m2a')) {
+			const m2aRelation = relations.find((relation) => relation.meta?.one_allowed_collections?.length);
+			const allowedCollections = m2aRelation?.meta?.one_allowed_collections ?? [];
+			for (const allowedCollection of allowedCollections) {
+				const nestedLanguageCollection = findLanguagesCollection(allowedCollection);
+				if (nestedLanguageCollection) return nestedLanguageCollection;
+			}
+		} else if (relations.length) {
+			const relatedCollection = getRelatedCollection(collection, fieldData.field);
+			const nestedLanguageCollection = findLanguagesCollection(relatedCollection);
+			if (nestedLanguageCollection) return nestedLanguageCollection;
+		}
+	}
+
+	return null;
+}
+
+function getLanguagesCollection(collection: string, translationsField: Field) {
+	const relationsStore = useRelationsStore();
+	const translationsRelations = relationsStore.getRelationsForField(collection, translationsField.field);
+	const m2o = translationsRelations.find((relation) => relation.meta?.one_collection !== collection);
+	return m2o?.related_collection;
+}

--- a/app/src/utils/find-languages-collection/index.ts
+++ b/app/src/utils/find-languages-collection/index.ts
@@ -1,0 +1,4 @@
+import findLanguagesCollection from './find-languages-collection';
+
+export { findLanguagesCollection };
+export default findLanguagesCollection;

--- a/app/src/views/private/components/render-template-list/index.ts
+++ b/app/src/views/private/components/render-template-list/index.ts
@@ -1,0 +1,4 @@
+import RenderTemplateList from './render-template-list.vue';
+
+export { RenderTemplateList };
+export default RenderTemplateList;

--- a/app/src/views/private/components/render-template-list/render-template-list.vue
+++ b/app/src/views/private/components/render-template-list/render-template-list.vue
@@ -1,0 +1,56 @@
+<template>
+	<div class="render-template-list">
+		<template v-for="(item, index) in items" :key="index">
+			<render-template :template="template" :item="item" :fields="fields" :collection="collection" />
+			<span v-if="index < items.length - 1" class="separator">{{ separator }}</span>
+		</template>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { Field } from '@directus/shared/types';
+
+export default defineComponent({
+	props: {
+		collection: {
+			type: String,
+			default: null,
+		},
+		fields: {
+			type: Array as PropType<Field[]>,
+			default: null,
+		},
+		items: {
+			type: Array as PropType<Array<Record<string, any>>>,
+			default: null,
+		},
+		template: {
+			type: String,
+			required: true,
+		},
+		separator: {
+			type: String,
+			required: false,
+			default: ',',
+		},
+	},
+});
+</script>
+
+<style lang="scss" scoped>
+.render-template-list {
+	display: flex;
+	flex-wrap: wrap;
+
+	> * {
+		margin: 0;
+		padding: 0;
+	}
+}
+
+.separator {
+	padding-right: 4px;
+	padding-left: 4px;
+}
+</style>


### PR DESCRIPTION
This pull request makes the following changes to the translations display:
- Enable the use of nested values and translations
- Enable translations for also `m2o`, `o2m`, `m2m` and `m2a` relations

The way it works is that it recursively search for translations inside the desired template, and in the vue component it maps all the found languages into a readable form.

I also added a component called `render-template-list` which renders a list of items with the same template using a separator (mainly used for `m2m` and `m2a`).

Here is an example of the translations display used for the following types: `translations`, `m2o`, `m2m`, `o2m`:
<img width="936" alt="translations-display" src="https://user-images.githubusercontent.com/9766700/141646468-5d3143ec-e6d7-4986-b26f-e46dffeeec3e.png">

