### PR TITLE
SDK: Start auth refresh job when constructor is initialised

### DIFF
--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -84,10 +84,11 @@ export class Auth extends IAuth {
 	}
 
 	async refresh(): Promise<AuthResult | false> {
+		const refresh_token = this._storage.auth_refresh_token;
 		this.resetStorage();
 
 		const response = await this._transport.post<AuthResult>('/auth/refresh', {
-			refresh_token: this.mode === 'json' ? this._storage.auth_refresh_token : undefined,
+			refresh_token: this.mode === 'json' ? refresh_token : undefined,
 		});
 
 		this.updateStorage<'DynamicToken'>(response.data!);

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -34,7 +34,15 @@ export class Auth extends IAuth {
 			this.updateStorage<'StaticToken'>({ access_token: this.staticToken, expires: null, refresh_token: null });
 		}
 
-		this.timer = false;
+		if (this.autoRefresh) {
+		  try {
+		    this.autoRefreshJob();
+		  } catch {
+		    // Ignore error
+		  }
+		} else {
+		  this.timer = false;
+		}
 	}
 
 	get storage(): IStorage {

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -16,12 +16,13 @@ export class Auth extends IAuth {
 
 	private _storage: IStorage;
 	private _transport: ITransport;
-	private timer: ReturnType<typeof setTimeout> | false;
+	private timer: ReturnType<typeof setTimeout> | null;
 	private passwords?: PasswordsHandler;
 
 	constructor(options: AuthOptions) {
 		super();
 
+		this.timer = null;
 		this._transport = options.transport;
 		this._storage = options.storage;
 
@@ -32,16 +33,8 @@ export class Auth extends IAuth {
 		if (options?.staticToken) {
 			this.staticToken = options?.staticToken;
 			this.updateStorage<'StaticToken'>({ access_token: this.staticToken, expires: null, refresh_token: null });
-		}
-
-		if (this.autoRefresh) {
-		  try {
-		    this.autoRefreshJob();
-		  } catch {
-		    // Ignore error
-		  }
-		} else {
-		  this.timer = false;
+		} else if (this.autoRefresh) {
+			this.autoRefreshJob();
 		}
 	}
 
@@ -61,6 +54,12 @@ export class Auth extends IAuth {
 		return (this.passwords = this.passwords || new PasswordsHandler(this._transport));
 	}
 
+	private resetStorage() {
+		this._storage.auth_token = null;
+		this._storage.auth_refresh_token = null;
+		this._storage.auth_expires = null;
+	}
+
 	private updateStorage<T extends AuthTokenType>(result: AuthStorage<T>) {
 		this._storage.auth_token = result.access_token;
 		this._storage.auth_refresh_token = result.refresh_token ?? null;
@@ -70,6 +69,8 @@ export class Auth extends IAuth {
 	private autoRefreshJob() {
 		if (!this.autoRefresh) return;
 		if (!this._storage.auth_expires) return;
+
+		if (this.timer) clearTimeout(this.timer);
 
 		const msWaitUntilRefresh = this._storage.auth_expires - this.msRefreshBeforeExpires;
 
@@ -83,11 +84,15 @@ export class Auth extends IAuth {
 	}
 
 	async refresh(): Promise<AuthResult | false> {
+		this.resetStorage();
+
 		const response = await this._transport.post<AuthResult>('/auth/refresh', {
 			refresh_token: this.mode === 'json' ? this._storage.auth_refresh_token : undefined,
 		});
 
 		this.updateStorage<'DynamicToken'>(response.data!);
+
+		if (this.autoRefresh) this.autoRefreshJob();
 
 		return {
 			access_token: response.data!.access_token,
@@ -97,6 +102,8 @@ export class Auth extends IAuth {
 	}
 
 	async login(credentials: AuthCredentials): Promise<AuthResult> {
+		this.resetStorage();
+
 		const response = await this._transport.post<AuthResult>(
 			'/auth/login',
 			{ mode: this.mode, ...credentials },


### PR DESCRIPTION
Ref https://github.com/directus/directus/discussions/9720#discussioncomment-1634470

If autorefresh is enabled, then this will cause the SDK to refresh tokens whenever it's loaded. This fixes bug #9639 (discussion #9720)