### PR TITLE
Fix reuse same M2M junction fields

### DIFF
--- a/app/src/composables/use-m2m.ts
+++ b/app/src/composables/use-m2m.ts
@@ -42,9 +42,7 @@ export default function useRelation(collection: Ref<string>, field: Ref<string>)
 	const relation = computed(() => {
 		return relations.value.find(
 			(relation) =>
-				relation.collection === junction.value.collection &&
-				relation.field !== junction.value.field &&
-				relation.field === junction.value.meta?.junction_field
+				relation.collection === junction.value.collection && relation.field === junction.value.meta?.junction_field
 		) as Relation;
 	});
 


### PR DESCRIPTION
## Scenario
1. Create collection A
2. Create collection B
3. Add M2M to B referencing A - this will auto generate an `b_a` junction table
4. Add M2M to A referencing B reusing same `b_a` junction table

This error will throw:
<img src="https://user-images.githubusercontent.com/14039341/141678552-ac2205ef-5441-42c6-a1d0-78a955ae6c19.png" width="300" />

## Investigation
The issue here is on step 4 it will modify the fields created on step 3. One of the modification sets the `one_field` to `null`.

## Solution
Get the existing relation and reuse the same `one_field`.

