### PR TITLE
Fix: Make sort visible by default on relationships

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/files.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/files.ts
@@ -38,7 +38,7 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 			'relations.o2m.field',
 			'relations.m2o.field',
 			'relations.m2o.related_collection',
-			'relations.o2m.meta?.sort_field',
+			'relations.o2m.meta.sort_field',
 		].some(hasChanged)
 	) {
 		generateCollections(updates, state, helperFn);

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/files.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/files.ts
@@ -194,7 +194,7 @@ function generateFields(updates: StateUpdates, state: State, { getCurrent }: Hel
 			type: 'integer',
 			schema: {},
 			meta: {
-				hidden: true,
+				hidden: false,
 			},
 		});
 	} else {

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts
@@ -285,7 +285,7 @@ function generateFields(updates: StateUpdates, state: State, { getCurrent }: Hel
 			type: 'integer',
 			schema: {},
 			meta: {
-				hidden: true,
+				hidden: false,
 			},
 		});
 	} else {

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/o2m.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/o2m.ts
@@ -184,7 +184,7 @@ export function generateSortField(updates: StateUpdates, state: State, { getCurr
 			type: 'integer',
 			schema: {},
 			meta: {
-				hidden: true,
+				hidden: false,
 			},
 		});
 	}

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
@@ -258,7 +258,7 @@ function generateFields(updates: StateUpdates, state: State, { getCurrent }: Hel
 			type: 'integer',
 			schema: {},
 			meta: {
-				hidden: true,
+				hidden: false,
 			},
 		});
 	} else {

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
@@ -34,7 +34,7 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 			'relations.o2m.field',
 			'relations.m2o.field',
 			'relations.m2o.related_collection',
-			'relations.o2m.meta?.sort_field',
+			'relations.o2m.meta.sort_field',
 		].some(hasChanged)
 	) {
 		generateCollections(updates, state, helperFn);


### PR DESCRIPTION
## Issue about `sort` on relationships
On creating a new relationship, when we set `sort` field, it should be visible by default (`hidden: false`).
In the past versions, this was by default.
___

## Issue about `sort` on files, translations
There is a typo (I presume from copy, pasting) preventing the creation of sort field on files