### PR TITLE
Clear selections after batch edit

### DIFF
--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -502,7 +502,6 @@ export default defineComponent({
 
 					await refresh();
 
-					selection.value = [];
 					confirmDelete.value = false;
 				} catch (err: any) {
 					error.value = err;
@@ -529,7 +528,6 @@ export default defineComponent({
 					});
 
 					confirmArchive.value = false;
-					selection.value = [];
 
 					await refresh();
 				} catch (err: any) {

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -450,6 +450,7 @@ export default defineComponent({
 		};
 
 		async function refresh() {
+			selection.value = [];
 			await layoutRef.value?.state?.refresh?.();
 		}
 

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -222,7 +222,7 @@
 				v-model:active="batchEditActive"
 				:primary-keys="selection"
 				:collection="collection"
-				@refresh="refresh"
+				@refresh="saveAndRefresh"
 			/>
 
 			<template #sidebar>
@@ -442,6 +442,7 @@ export default defineComponent({
 			bookmarkIsMine,
 			bookmarkSaving,
 			clearLocalSave,
+			saveAndRefresh,
 			refresh,
 			refreshInterval,
 			currentLayout,
@@ -450,8 +451,12 @@ export default defineComponent({
 		};
 
 		async function refresh() {
-			selection.value = [];
 			await layoutRef.value?.state?.refresh?.();
+		}
+
+		async function saveAndRefresh() {
+			selection.value = [];
+			await refresh();
 		}
 
 		function useBreadcrumb() {
@@ -500,6 +505,7 @@ export default defineComponent({
 						data: batchPrimaryKeys,
 					});
 
+					selection.value = [];
 					await refresh();
 
 					confirmDelete.value = false;
@@ -527,9 +533,10 @@ export default defineComponent({
 						},
 					});
 
-					confirmArchive.value = false;
-
+					selection.value = [];
 					await refresh();
+
+					confirmArchive.value = false;
 				} catch (err: any) {
 					error.value = err;
 				} finally {

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -222,7 +222,7 @@
 				v-model:active="batchEditActive"
 				:primary-keys="selection"
 				:collection="collection"
-				@refresh="saveAndRefresh"
+				@refresh="drawerBatchRefresh"
 			/>
 
 			<template #sidebar>
@@ -442,7 +442,7 @@ export default defineComponent({
 			bookmarkIsMine,
 			bookmarkSaving,
 			clearLocalSave,
-			saveAndRefresh,
+			drawerBatchRefresh,
 			refresh,
 			refreshInterval,
 			currentLayout,
@@ -454,7 +454,7 @@ export default defineComponent({
 			await layoutRef.value?.state?.refresh?.();
 		}
 
-		async function saveAndRefresh() {
+		async function drawerBatchRefresh() {
 			selection.value = [];
 			await refresh();
 		}


### PR DESCRIPTION
## Context

Ref #9791, saving after a batch edit doesn't clear the previous selections. This is more of an issue when there's a filter, which will cause future batch edits to still include the ones that are filtered out already. 

https://user-images.githubusercontent.com/42867097/141719752-a6ccb195-f771-494a-9555-e10f59e199eb.mp4

## Fix applied

- Add selection clear to `refresh()`
- removed selection clears in delete and archive as its done in `refresh()` now

---

Did thought of clearing selections by removing only ones that does not exist anymore in current items, but selections on page 2 for example will not be cleared in this case. Downside of current solution will indeed impact users that does batch edits consecutively on the same selections, but the number of users with this specific use case _should_ be not that many...
