### PR TITLE
Fix docs tables overflow

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -222,6 +222,7 @@ hr
   margin 3rem 0
 
 table
+  display block
   border-collapse collapse
   margin 1rem 0
   overflow-x: auto


### PR DESCRIPTION
## Before

Tables are overflowing to the right, causing the header bar's search input & the bottom right chat widget to be positioned oddly:


![AQBq9kC9YT](https://user-images.githubusercontent.com/42867097/141728329-331f8864-e68f-4db3-9fa8-7998c5f0fe86.gif)

## After

![hYvECoNp8L](https://user-images.githubusercontent.com/42867097/141728344-fa524d58-a87e-4599-8bbf-824b86971536.gif)


