### PR TITLE
Fix sort on relationships

### DIFF
--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -277,9 +277,12 @@ export default defineComponent({
 			function onUpload(files: Record<string, any>[]) {
 				showUpload.value = false;
 				if (files.length === 0) return;
-				const { junctionField } = relationInfo.value;
-				const filesAsJunctionRows = files.map((file) => {
+				const { junctionField, sortField } = relationInfo.value;
+				const filesAsJunctionRows = files.map((file, i) => {
+					const nextSort = sortField ? { [sortField]: items.value.length + i } : null;
+
 					return {
+						...nextSort,
 						[junctionField]: file.id,
 					};
 				});

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -513,11 +513,15 @@ export default defineComponent({
 			function stageSelection(selection: (number | string)[]) {
 				const { field } = anyRelation.value;
 				const oneCollectionField = anyRelation.value.meta!.one_collection_field!;
+				const sortField = o2mRelation.value.meta?.sort_field;
 
 				const currentValue = props.value || [];
 
-				const selectionAsJunctionRows = selection.map((key) => {
+				const selectionAsJunctionRows = selection.map((key, i) => {
+					const nextSort = sortField ? { [sortField]: currentValue.length + i } : null;
+
 					return {
+						...nextSort,
 						[oneCollectionField]: selectingFrom.value,
 						[field]: key,
 					};

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -518,7 +518,7 @@ export default defineComponent({
 				const currentValue = props.value || [];
 
 				const selectionAsJunctionRows = selection.map((key, i) => {
-					const nextSort = sortField ? { [sortField]: currentValue.length + i } : null;
+					const nextSort = sortField ? { [sortField]: i } : null;
 
 					return {
 						...nextSort,

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -46,7 +46,7 @@
 		</v-list>
 
 		<div v-if="!disabled" class="actions">
-			<v-button v-if="enableCreate && createAllowed" @click="editModalActive = true">{{ t('create_new') }}</v-button>
+			<v-button v-if="enableCreate && createAllowed" @click="createNew()">{{ t('create_new') }}</v-button>
 			<v-button v-if="enableSelect && selectAllowed" @click="selectModalActive = true">
 				{{ t('add_existing') }}
 			</v-button>
@@ -181,8 +181,16 @@ export default defineComponent({
 			getPrimaryKeys
 		);
 
-		const { currentlyEditing, editItem, editsAtStart, stageEdits, cancelEdit, relatedPrimaryKey, editModalActive } =
-			useEdit(value, relationInfo, emitter);
+		const {
+			currentlyEditing,
+			editItem,
+			createNew,
+			editsAtStart,
+			stageEdits,
+			cancelEdit,
+			relatedPrimaryKey,
+			editModalActive,
+		} = useEdit(value, relationInfo, emitter);
 
 		const { stageSelection, selectModalActive, selectedPrimaryKeys } = useSelection(
 			items,
@@ -203,6 +211,7 @@ export default defineComponent({
 			loading,
 			currentlyEditing,
 			editItem,
+			createNew,
 			junctionCollection,
 			relationCollection,
 			editsAtStart,

--- a/app/src/interfaces/list-m2m/use-edit.ts
+++ b/app/src/interfaces/list-m2m/use-edit.ts
@@ -4,6 +4,7 @@ import { RelationInfo } from '@/composables/use-m2m';
 
 type UsableEdit = {
 	currentlyEditing: Ref<string | number | null>;
+	createNew: (item: any) => void;
 	editItem: (item: any) => void;
 	editsAtStart: Ref<Record<string, any>>;
 	stageEdits: (edits: any) => void;
@@ -33,8 +34,17 @@ export default function useEdit(
 		relatedPrimaryKey.value = get(item, [junctionField, relationPkField], null);
 	}
 
+	function createNew() {
+		const { sortField } = relation.value;
+
+		editModalActive.value = true;
+		editsAtStart.value = { ...(sortField ? { [sortField]: (value.value || []).length } : null) };
+		currentlyEditing.value = null;
+		relatedPrimaryKey.value = null;
+	}
+
 	function stageEdits(edits: any) {
-		const { relationPkField, junctionField, junctionPkField } = relation.value;
+		const { relationPkField, junctionField, junctionPkField, sortField } = relation.value;
 
 		const newValue = (value.value || []).map((item) => {
 			if (currentlyEditing.value !== null) {
@@ -78,5 +88,14 @@ export default function useEdit(
 		relatedPrimaryKey.value = null;
 	}
 
-	return { currentlyEditing, editItem, editsAtStart, stageEdits, cancelEdit, relatedPrimaryKey, editModalActive };
+	return {
+		currentlyEditing,
+		editItem,
+		createNew,
+		editsAtStart,
+		stageEdits,
+		cancelEdit,
+		relatedPrimaryKey,
+		editModalActive,
+	};
 }

--- a/app/src/interfaces/list-m2m/use-selection.ts
+++ b/app/src/interfaces/list-m2m/use-selection.ts
@@ -31,13 +31,15 @@ export default function useSelection(
 	});
 
 	function stageSelection(newSelection: (number | string)[]) {
-		const { junctionField, junctionPkField } = relation.value;
+		const { junctionField, junctionPkField, sortField } = relation.value;
 
-		const selection = newSelection.map((item) => {
+		const selection = newSelection.map((item, i) => {
 			const initial = initialItems.value.find((existent) => existent[junctionField][junctionPkField] === item);
 			const draft = items.value.find((draft) => draft[junctionField][junctionPkField] === item);
+			const nextSort = sortField ? { [sortField]: items.value.length + i } : null;
 
 			return {
+				...nextSort,
 				...initial,
 				...draft,
 				[junctionField]: {

--- a/app/src/interfaces/list-m2m/use-selection.ts
+++ b/app/src/interfaces/list-m2m/use-selection.ts
@@ -36,7 +36,7 @@ export default function useSelection(
 		const selection = newSelection.map((item, i) => {
 			const initial = initialItems.value.find((existent) => existent[junctionField][junctionPkField] === item);
 			const draft = items.value.find((draft) => draft[junctionField][junctionPkField] === item);
-			const nextSort = sortField ? { [sortField]: items.value.length + i } : null;
+			const nextSort = sortField ? { [sortField]: i } : null;
 
 			return {
 				...nextSort,

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -308,7 +308,7 @@ export default defineComponent({
 				});
 
 				const newSelectionItems = response.data.data.map((item: Record<string, any>[], i: number) => {
-					const newSort = sortField ? { [sortField]: stagedValues.value.length + i } : null;
+					const newSort = sortField ? { [sortField]: i } : null;
 
 					return { ...newSort, ...item };
 				});


### PR DESCRIPTION
~~Fixes 6111~~

While testing this issue I found all interfaces lacked the `sort` field set on create when relationship has sort configured.
This tries to solve this issue.
Also, during the process some "data lose" on editing relationships is solved.