### PR TITLE
use aggregate count for users in roles view

### DIFF
--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -130,7 +130,12 @@ export default defineComponent({
 
 			try {
 				const response = await api.get(`/roles`, {
-					params: { limit: -1, fields: 'id,name,description,icon,users.id', sort: 'name' },
+					params: {
+						limit: -1,
+						fields: 'id,name,description,icon,users.id',
+						deep: { users: { _aggregate: { count: 'id' } } },
+						sort: 'name',
+					},
 				});
 
 				roles.value = [
@@ -144,7 +149,7 @@ export default defineComponent({
 					...response.data.data.map((role: any) => {
 						return {
 							...role,
-							count: (role.users || []).length,
+							count: role.users[0]?.count.id || 0,
 						};
 					}),
 				];


### PR DESCRIPTION
Resolves #9824

## Before

User count in roles table are limited to 100, even when there's 1100 users for Regular role in this case:

![chrome_8IA61ER8ST](https://user-images.githubusercontent.com/42867097/141888243-e96cc8cf-dbac-4f0d-987a-80b979ab38d7.png)

This should be due to the `limit: -1` just being applicable to roles here, not the nested users:

https://github.com/directus/directus/blob/785c4306d63981360dad65b79e00a2ada844c636/app/src/modules/settings/routes/roles/collection.vue#L132-L134

## After

Opted to use aggregate count instead since the actual user IDs won't be needed in this view, and was just used as `.length` to count them.

![chrome_diI1YTDXBY](https://user-images.githubusercontent.com/42867097/141888258-dc379ad5-4f96-49af-a0cd-459c6c934f9a.png)

Not 100% sure the way I used it is super correct though. 😅