### PR TITLE
fix template fields not clickable when editing

### DIFF
--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -287,7 +287,9 @@ export default defineComponent({
 
 						if (!field) return '';
 
-						return `<button contenteditable="false" data-field="${fieldKey}" disabled="${props.disabled}">${field.name}</button>`;
+						return `<button contenteditable="false" data-field="${fieldKey}" ${props.disabled ? 'disabled' : ''}>${
+							field.name
+						}</button>`;
 					})
 					.join('');
 				contentEl.value.innerHTML = newInnerHTML;


### PR DESCRIPTION
Fixes #8872 (particularly the first issue only)

## Before

We are unable to click/remove fields when editing display template:

![GPK971fsDQ](https://user-images.githubusercontent.com/42867097/141966935-06ffeae1-20ba-4284-98ea-1ffd15ca1d38.gif)

This is because the current logic will output 

- Not disabled: `<button disabled="false">`
- Disabled: `<button disabled="true">`

However `disabled` is [a boolean atttribute](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute) so it'll be true as long as its present, regardless of the "false" value.

## After

The current fix aims to add `disabled` attribute when applicable, and make sure it does not exist otherwise.

- Not disabled: `<button>`
- Disabled: `<button disabled>`

![2sD0FTbGQm](https://user-images.githubusercontent.com/42867097/141966778-8bd5e071-472c-4750-9189-959b45b13b89.gif)

