### PR TITLE
fix: missing action and item id in webhook data (#9518)

### DIFF
--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -47,6 +47,7 @@ class Emitter {
 
 	public emitAction(event: string, meta: Record<string, any>, context: HookContext): void {
 		const events = this.eventsToEmit(event, meta);
+		meta['action'] = event; // use in webhook ActionHandler
 		for (const event of events) {
 			this.actionEmitter.emitAsync(event, meta, context).catch((err) => {
 				logger.warn(`An error was thrown while executing action "${event}"`);

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -208,6 +208,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				{
 					payload,
 					key: primaryKey,
+					keys: [primaryKey],
 					collection: this.collection,
 				},
 				{
@@ -664,6 +665,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			emitter.emitAction(
 				`${this.eventScope}.delete`,
 				{
+					keys: keys,
 					payload: keys,
 					collection: this.collection,
 				},

--- a/api/src/webhooks.ts
+++ b/api/src/webhooks.ts
@@ -44,12 +44,15 @@ function createHandler(webhook: Webhook): ActionHandler {
 	return async (data) => {
 		if (webhook.collections.includes('*') === false && webhook.collections.includes(data.collection) === false) return;
 
+		data['item'] = data['keys'];
+
 		const webhookPayload = pick(data, [
 			'event',
 			'accountability.user',
 			'accountability.role',
 			'collection',
 			'item',
+			'keys', //support both item and keys
 			'action',
 			'payload',
 		]);


### PR DESCRIPTION
fixed #9518 
- set `action` in `meta` when emit event
- set `keys` when create/update items