### PR TITLE
use SearchEntry.object.dn in fetchUserDn

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -120,8 +120,7 @@ export class LDAPAuthDriver extends AuthDriver {
 					}
 
 					res.on('searchEntry', ({ object }: SearchEntry) => {
-						const userCn = typeof object.cn === 'object' ? object.cn[0] : object.cn;
-						resolve(`cn=${userCn},${userDn}`.toLowerCase());
+						resolve(object.dn.toLowerCase());
 					});
 
 					res.on('error', (err: Error) => {


### PR DESCRIPTION
this avoids issues when userAttribute != cn or when using scope sub and is just generally cleaner.

cc @aidenfoxx 