### PR TITLE
Fix render-template not working for M2M relationship

### DIFF
--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -18,7 +18,11 @@
 		<v-list class="links">
 			<v-list-item v-for="item in value" :key="item[primaryKeyFieldPath]">
 				<v-list-item-content>
-					<render-template :template="internalTemplate" :item="item" :collection="relatedCollection" />
+					<render-template
+						:template="internalTemplate"
+						:item="item"
+						:collection="junctionCollection ?? relatedCollection"
+					/>
 				</v-list-item-content>
 				<v-list-item-icon>
 					<router-link :to="getLinkForItem(item)"><v-icon name="launch" small /></router-link>
@@ -69,6 +73,10 @@ export default defineComponent({
 			return relatedCollectionData.value.relatedCollection;
 		});
 
+		const junctionCollection = computed(() => {
+			return relatedCollectionData.value.junctionCollection;
+		});
+
 		const localType = computed(() => {
 			return getLocalTypeForField(props.collection, props.field);
 		});
@@ -105,7 +113,15 @@ export default defineComponent({
 			return null;
 		});
 
-		return { relatedCollection, primaryKeyFieldPath, getLinkForItem, internalTemplate, unit, localType };
+		return {
+			relatedCollection,
+			junctionCollection,
+			primaryKeyFieldPath,
+			getLinkForItem,
+			internalTemplate,
+			unit,
+			localType,
+		};
 
 		function getLinkForItem(item: any) {
 			if (!relatedCollectionData.value || !primaryKeyFieldPath.value) return null;

--- a/app/src/utils/get-related-collection/get-related-collection.ts
+++ b/app/src/utils/get-related-collection/get-related-collection.ts
@@ -4,6 +4,7 @@ import { getLocalTypeForField } from '../../modules/settings/routes/data-model/g
 
 export interface RelatedCollectionData {
 	relatedCollection: string;
+	junctionCollection?: string;
 	path?: string[];
 }
 
@@ -18,6 +19,7 @@ export default function getRelatedCollection(collection: string, field: string):
 		if (localType == 'm2m' && relations.length > 1) {
 			return {
 				relatedCollection: relations[1].related_collection!,
+				junctionCollection: relations[0].collection,
 				path: [relations[1].field],
 			};
 		}


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/9864
The bug was caused by a [recent change](https://github.com/directus/directus/commit/ce9efb42fa6aa913606ed980122b4b78ba42a497#diff-43ccacb6a0a2bcb45fa0c815d77b6c86ccf4261fd86dc7861995e500df8a08e3) in `getRelatedCollection`

The related collection which is passed to `render-template` here:
https://github.com/directus/directus/blob/ce9efb42fa6aa913606ed980122b4b78ba42a497/app/src/displays/related-values/related-values.vue#L21

used to be the M2M's junction table (e.g. `foo_bar`), but in the new version, it was changed to the actually related table (e.g.`bar`). But then the template couldn't be rendered because its fields are relative to the junction table, not to the related table.

This fix is the least invasive I could think of, but you might have a better solution here @rijkvanzanten !