### PR TITLE
[bootstrap] runMigrations after createDefaultAdmin

### DIFF
--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -21,9 +21,6 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 
 		await installDatabase(database);
 
-		logger.info('Running migrations...');
-		await runMigrations(database, 'latest');
-
 		const schema = await getSchema();
 
 		if (skipAdminInit == null) {
@@ -31,6 +28,9 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 		} else {
 			logger.info('Skipping creation of default Admin user and role...');
 		}
+		
+		logger.info('Running migrations...');
+		await runMigrations(database, 'latest');
 
 		if (env.PROJECT_NAME && typeof env.PROJECT_NAME === 'string' && env.PROJECT_NAME.length > 0) {
 			const settingsService = new SettingsService({ schema });


### PR DESCRIPTION
On install, If admin user is supplied, and we'd like to apply a migration to set the `token` column for instance, nothing happens since  all migrations are executed right before creating the admin-user.

Here's the output:
```
...
directus-one-1  | 17:06:36 ✨ Applying Remove Collections Listing...
directus-one-1  | 17:06:36 ✨ Applying Tenant Migration... _(vainly, since admin-user is not yet created)_
directus-one-1  | 17:06:36 ✨ Setting up first admin role...
directus-one-1  | 17:06:36 ✨ Adding first admin user...
directus-one-1  | 17:06:36 ✨ Done
...
```

Migration:
```
module.exports = {
	async up(knex) {
		await knex("directus_users").update({
			token: "VjocVHdFiz5vG",
			first_name: "Tenant",
			last_name: "One"
		}).where('email', 'tenant1@directus.de')
	},
	async down(knex) {
	},
};
```

Is there another approach to achieve this or is it safe to shift `runMigrations`?