### PR TITLE
Load spatialite for SQLite users

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -164,7 +164,7 @@
 		"mysql": "^2.18.1",
 		"nodemailer-mailgun-transport": "^2.1.3",
 		"pg": "^8.6.0",
-		"sqlite3": "^5.0.2",
+		"sqlite3": "github:mapbox/node-sqlite3#918052b538b0effe6c4a44c74a16b2749c08a0d2",
 		"tedious": "^13.0.0"
 	},
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd",

--- a/api/src/cli/utils/create-env/index.ts
+++ b/api/src/cli/utils/create-env/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { promisify } from 'util';
 import { v4 as uuidv4 } from 'uuid';
 import { Credentials } from '../create-db-connection';
-import { drivers } from '../drivers';
+import { drivers, Client } from '../drivers';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -23,11 +23,7 @@ const defaults = {
 	},
 };
 
-export default async function createEnv(
-	client: keyof typeof drivers,
-	credentials: Credentials,
-	directory: string
-): Promise<void> {
+export default async function createEnv(client: Client, credentials: Credentials, directory: string): Promise<void> {
 	const config: Record<string, any> = {
 		...defaults,
 		database: {

--- a/api/src/cli/utils/drivers.ts
+++ b/api/src/cli/utils/drivers.ts
@@ -1,15 +1,9 @@
-export const drivers = {
-	pg: 'PostgreSQL / Redshift',
-	mysql: 'MySQL / MariaDB / Aurora',
-	sqlite3: 'SQLite',
-	mssql: 'Microsoft SQL Server',
-	oracledb: 'Oracle Database (Alpha)',
-};
+export const drivers = [
+	{ value: 'pg', name: 'PostgreSQL / Redshift' },
+	{ value: 'mysql', name: 'MySQL / MariaDB / Aurora' },
+	{ value: 'sqlite3', name: 'SQLite' },
+	{ value: 'mssql', name: 'Microsoft SQL Server' },
+	{ value: 'oracledb', name: 'Oracle Database (Alpha)' },
+] as const;
 
-export function getDriverForClient(client: string): keyof typeof drivers | null {
-	for (const [key, value] of Object.entries(drivers)) {
-		if (value === client) return key as keyof typeof drivers;
-	}
-
-	return null;
-}
+export type Client = typeof drivers[number]['value'];

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -81,6 +81,9 @@ export default function getDatabase(): Knex {
 			const run = promisify(conn.run.bind(conn));
 			await run('PRAGMA foreign_keys = ON');
 
+			const loadExtension = promisify(conn.loadExtension.bind(conn));
+			const loaded = await loadExtension('mod_spatialite').catch(() => undefined);
+
 			callback(null, conn);
 		};
 	}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN rm *.tgz
 FROM node:${NODE_VERSION}
 
 ARG VERSION
-ARG REPOSITORY=directus/directus
 
 LABEL directus.version="${VERSION}"
 
@@ -36,6 +35,8 @@ RUN \
   # Upgrade system and install 'ssmtp' to be able to send mails
   apk upgrade --no-cache && apk add --no-cache \
   ssmtp \
+  libspatialite \
+  && ln -s /usr/lib/mod_spatialite.so.7 /usr/lib/mod_spatialite.so \
   # Create directory for Directus with corresponding ownership
   # (can be omitted on newer Docker versions since WORKDIR below will do the same)
   && mkdir /directus && chown node:node /directus

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,7 +5,6 @@ tag=latest
 cmd=
 user=directus
 registry=docker.io
-repository=directus/directus
 
 .PHONY: build-images
 
@@ -14,7 +13,6 @@ build-images:
 	npm run pack
 	docker build \
 		--build-arg VERSION=$(version) \
-		--build-arg REPOSITORY=$(repository) \
 		-t directus:temp \
 		-f ./Dockerfile \
 		..

--- a/package.json
+++ b/package.json
@@ -20,13 +20,15 @@
 		"test:e2e": "jest tests -c tests/jest.config.js",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"posttest:e2e:watch": "ts-node --project ./tests/tsconfig.json --transpile-only ./tests/setup/teardown.ts",
-		"cli": "cross-env NODE_ENV=development SERVE_APP=false DOTENV_CONFIG_PATH=api/.env ts-node -r dotenv/config --script-mode --transpile-only api/src/cli/run.ts"
+		"cli": "cross-env NODE_ENV=development SERVE_APP=false DOTENV_CONFIG_PATH=api/.env ts-node -r dotenv/config --script-mode --transpile-only api/src/cli/run.ts",
+		"postinstall": "npm i -w api mapbox/node-sqlite3#918052b538b0effe6c4a44c74a16b2749c08a0d2 --build-from-source"
 	},
 	"engines": {
 		"node": ">=16.0.0",
 		"npm": ">=7.0.0"
 	},
 	"devDependencies": {
+		"@mapbox/node-pre-gyp": "^1.0.7",
 		"@types/dockerode": "3.3.0",
 		"@types/faker": "5.5.9",
 		"@types/jest": "27.0.2",


### PR DESCRIPTION
* Added a `postinstall` script to the main `package.json` to install SQLite from source after running `npm i`
* Change `init` script to install SQLite from source too
* Install `libspatialite` too in the Docker image
* Remove arg `REPOSITORY` from the `Dockerfile` (unused ?)
* Try loading Spatialite with `load_extension('mod_spatialite')` after the connection is made

Installation of Spatialite:
* macOS:
  * `brew install libspatialite`
* linux
  * `sudo apt install libsqlite3-mod-spatialite`
* windows:
  * (64-bit) Download http://www.gaia-gis.it/gaia-sins/windows-bin-amd64/mod_spatialite-5.0.1-win-amd64.7z
  * (32-bit) Download http://www.gaia-gis.it/gaia-sins/windows-bin-x86/mod_spatialite-5.0.1-win-x86.7z
  * Unzip
  * Add `mod_spatialite.dll` to your PATH ([how to](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/))

Once installed, you also need to run this command in `/api`:
```
npm i mapbox/node-sqlite3#918052b538b0effe6c4a44c74a16b2749c08a0d2 --build-from-source
```
The reason is that node-sqlite3 uses the built-in SQLite binary by default. But there's a catch - Spatialite versions must be compiled against the same SQLite version they'll be used with, and Spatialite only distribute the binaries for the latest version - Which most likely won't be the one you have on your system.

This draft PR can be used to discuss how to document this and automate the process for use in different setup (local, docker...)