### PR TITLE
Fix indeterminate properties in advanded field creation

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -75,9 +75,9 @@ export default defineComponent({
 
 		const fieldDetailStore = useFieldDetailStore();
 
-		const readonly = syncFieldDetailStoreProperty('field.meta.readonly');
-		const hidden = syncFieldDetailStoreProperty('field.meta.hidden');
-		const required = syncFieldDetailStoreProperty('field.meta.required');
+		const readonly = syncFieldDetailStoreProperty('field.meta.readonly', false);
+		const hidden = syncFieldDetailStoreProperty('field.meta.hidden', false);
+		const required = syncFieldDetailStoreProperty('field.meta.required', false);
 		const note = syncFieldDetailStoreProperty('field.meta.note');
 		const translations = syncFieldDetailStoreProperty('field.meta.translations');
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -252,8 +252,8 @@ export default defineComponent({
 		const special = syncFieldDetailStoreProperty('field.meta.special');
 		const maxLength = syncFieldDetailStoreProperty('field.schema.max_length');
 		const numericPrecision = syncFieldDetailStoreProperty('field.schema.numeric_precision');
-		const nullable = syncFieldDetailStoreProperty('field.schema.is_nullable');
-		const unique = syncFieldDetailStoreProperty('field.schema.is_unique');
+		const nullable = syncFieldDetailStoreProperty('field.schema.is_nullable', true);
+		const unique = syncFieldDetailStoreProperty('field.schema.is_unique', false);
 		const numericScale = syncFieldDetailStoreProperty('field.schema.numeric_scale');
 
 		const { t } = useI18n();

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
@@ -51,40 +51,23 @@ export function setTypeForInterface(updates: StateUpdates, state: State) {
  * the local type is standard
  */
 export function setSpecialForLocalType(updates: StateUpdates) {
-	if (updates?.localType === 'o2m') {
-		set(updates, 'field.meta.special', ['o2m']);
-	}
-
-	if (updates?.localType === 'm2m') {
-		set(updates, 'field.meta.special', ['m2m']);
-	}
-
-	if (updates?.localType === 'm2a') {
-		set(updates, 'field.meta.special', ['m2a']);
-	}
-
-	if (updates?.localType === 'm2o') {
-		set(updates, 'field.meta.special', ['m2o']);
-	}
-
-	if (updates?.localType === 'translations') {
-		set(updates, 'field.meta.special', ['translations']);
-	}
-
-	if (updates?.localType === 'file') {
-		set(updates, 'field.meta.special', ['file']);
-	}
-
-	if (updates?.localType === 'files') {
-		set(updates, 'field.meta.special', ['files']);
-	}
-
-	if (updates?.localType === 'presentation') {
-		set(updates, 'field.meta.special', ['alias', 'no-data']);
-	}
-
-	if (updates?.localType === 'group') {
-		set(updates, 'field.meta.special', ['alias', 'no-data', 'group']);
+	const localType = updates?.localType;
+	switch (localType) {
+		case 'o2m':
+		case 'm2m':
+		case 'm2a':
+		case 'm2o':
+		case 'translations':
+		case 'file':
+		case 'files':
+			set(updates, 'field.meta.special', [localType]);
+			break;
+		case 'presentation':
+			set(updates, 'field.meta.special', ['alias', 'no-data']);
+			break;
+		case 'group':
+			set(updates, 'field.meta.special', ['alias', 'no-data', 'group']);
+			break;
 	}
 }
 

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/index.ts
@@ -1,0 +1,11 @@
+export * as global from './global';
+export * as file from './file';
+export * as files from './files';
+export * as group from './group';
+export * as m2a from './m2a';
+export * as m2m from './m2m';
+export * as m2o from './m2o';
+export * as o2m from './o2m';
+export * as presentation from './presentation';
+export * as standard from './standard';
+export * as translations from './translations';

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts
@@ -11,27 +11,16 @@ export function applyChanges(updates: StateUpdates, _state: State, helperFn: Hel
 
 export function setSpecialForType(updates: StateUpdates) {
 	const type = updates.field?.type;
-
-	if (!type) return;
-
 	switch (type) {
 		case 'uuid':
-			set(updates, 'field.meta.special', ['uuid']);
-			break;
 		case 'hash':
-			set(updates, 'field.meta.special', ['hash']);
-			break;
 		case 'json':
-			set(updates, 'field.meta.special', ['json']);
-			break;
 		case 'csv':
-			set(updates, 'field.meta.special', ['csv']);
-			break;
 		case 'boolean':
-			set(updates, 'field.meta.special', ['boolean']);
-			break;
 		case 'geometry':
-			set(updates, 'field.meta.special', ['geometry']);
+			set(updates, 'field.meta.special', [type]);
+			break;
+		case undefined:
 			break;
 		default:
 			set(updates, 'field.meta.special', null);

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -17,17 +17,7 @@ import { get, set } from 'lodash';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { useCollectionsStore, useFieldsStore, useRelationsStore } from '@/stores';
 
-import * as global from './alterations/global';
-import * as file from './alterations/file';
-import * as files from './alterations/files';
-import * as group from './alterations/group';
-import * as m2a from './alterations/m2a';
-import * as m2m from './alterations/m2m';
-import * as m2o from './alterations/m2o';
-import * as o2m from './alterations/o2m';
-import * as presentation from './alterations/presentation';
-import * as standard from './alterations/standard';
-import * as translations from './alterations/translations';
+import * as alterations from './alterations';
 import { getLocalTypeForField } from '../../get-local-type';
 import api from '@/api';
 
@@ -136,47 +126,19 @@ export const useFieldDetailStore = defineStore({
 			const helperFn = { hasChanged, getCurrent };
 
 			if (hasChanged('field.meta.interface')) {
-				global.setLocalTypeForInterface(updates);
-				global.setTypeForInterface(updates, this);
+				alterations.global.setLocalTypeForInterface(updates);
+				alterations.global.setTypeForInterface(updates, this);
 			}
 
 			if (hasChanged('localType')) {
-				global.resetSchema(updates, this);
-				global.resetRelations(updates);
-				global.setSpecialForLocalType(updates);
+				alterations.global.resetSchema(updates, this);
+				alterations.global.resetRelations(updates);
+				alterations.global.setSpecialForLocalType(updates);
 			}
 
-			switch (getCurrent('localType')) {
-				case 'file':
-					file.applyChanges(updates, this, helperFn);
-					break;
-				case 'files':
-					files.applyChanges(updates, this, helperFn);
-					break;
-				case 'group':
-					group.applyChanges(updates, this, helperFn);
-					break;
-				case 'm2a':
-					m2a.applyChanges(updates, this, helperFn);
-					break;
-				case 'm2m':
-					m2m.applyChanges(updates, this, helperFn);
-					break;
-				case 'm2o':
-					m2o.applyChanges(updates, this, helperFn);
-					break;
-				case 'o2m':
-					o2m.applyChanges(updates, this, helperFn);
-					break;
-				case 'presentation':
-					presentation.applyChanges(updates, this, helperFn);
-					break;
-				case 'standard':
-					standard.applyChanges(updates, this, helperFn);
-					break;
-				case 'translations':
-					translations.applyChanges(updates, this, helperFn);
-					break;
+			if (updates.localType) {
+				const alteration = alterations[updates.localType];
+				alteration.applyChanges(updates, this, helperFn);
 			}
 
 			this.$patch(updates);


### PR DESCRIPTION
In advanced field creation, all checkbox inputs `schema.is_nullable`, `schema.is_unique`, `meta.readonly`, `meta.hidden`, `meta.required` were undefined and therefore in the indeterminate state.
I took example from `field-configuration-simple.vue`, where this is solved in the presentation:
https://github.com/directus/directus/blob/a920041c5b12eab72b5daeb71eaea11129cec8f8/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue#L101
This also comes with slight refactors in the store alterations.