### PR TITLE
Adding sourceMap flag to extensions-sdk cli

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -26,7 +26,7 @@ import { getLanguageFromPath, isLanguage } from '../utils/languages';
 import { Language } from '../types';
 import loadConfig from '../utils/load-config';
 
-type BuildOptions = { type: string; input: string; output: string; language: string; force: boolean; watch: boolean };
+type BuildOptions = { type: string; input: string; output: string; language: string; force: boolean; watch: boolean; sourceMaps: boolean };
 
 export default async function build(options: BuildOptions): Promise<void> {
 	const packagePath = path.resolve('package.json');
@@ -79,8 +79,8 @@ export default async function build(options: BuildOptions): Promise<void> {
 
 	const spinner = ora('Building Directus extension...').start();
 
-	const rollupOptions = getRollupOptions(type, language, input, config.plugins);
-	const rollupOutputOptions = getRollupOutputOptions(type, output);
+	const rollupOptions = getRollupOptions(type, language, input, config.plugins, options);
+	const rollupOutputOptions = getRollupOutputOptions(type, output, options);
 
 	if (options.watch) {
 		const watcher = rollupWatch({
@@ -127,7 +127,8 @@ function getRollupOptions(
 	type: ExtensionType,
 	language: Language,
 	input: string,
-	plugins: Plugin[] = []
+	plugins: Plugin[] = [],
+	options: BuildOptions
 ): RollupOptions {
 	if (isAppExtension(type)) {
 		return {
@@ -147,7 +148,7 @@ function getRollupOptions(
 					},
 					preventAssignment: true,
 				}),
-				terser(),
+				options.sourceMaps ? null : terser(),
 			],
 		};
 	} else {
@@ -166,13 +167,13 @@ function getRollupOptions(
 					},
 					preventAssignment: true,
 				}),
-				terser(),
+				options.sourceMaps ? null : terser(),
 			],
 		};
 	}
 }
 
-function getRollupOutputOptions(type: ExtensionType, output: string): RollupOutputOptions {
+function getRollupOutputOptions(type: ExtensionType, output: string, options: BuildOptions): RollupOutputOptions {
 	if (isAppExtension(type)) {
 		return {
 			file: output,
@@ -183,6 +184,7 @@ function getRollupOutputOptions(type: ExtensionType, output: string): RollupOutp
 			file: output,
 			format: 'cjs',
 			exports: 'default',
+			sourcemap: options.sourceMaps
 		};
 	}
 }

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -26,7 +26,15 @@ import { getLanguageFromPath, isLanguage } from '../utils/languages';
 import { Language } from '../types';
 import loadConfig from '../utils/load-config';
 
-type BuildOptions = { type: string; input: string; output: string; language: string; force: boolean; watch: boolean; sourceMaps: boolean };
+type BuildOptions = {
+	type: string;
+	input: string;
+	output: string;
+	language: string;
+	force: boolean;
+	watch: boolean;
+	sourceMaps: boolean;
+};
 
 export default async function build(options: BuildOptions): Promise<void> {
 	const packagePath = path.resolve('package.json');
@@ -184,7 +192,7 @@ function getRollupOutputOptions(type: ExtensionType, output: string, options: Bu
 			file: output,
 			format: 'cjs',
 			exports: 'default',
-			sourcemap: options.sourceMaps
+			sourcemap: options.sourceMaps,
 		};
 	}
 }

--- a/packages/extensions-sdk/src/cli/run.ts
+++ b/packages/extensions-sdk/src/cli/run.ts
@@ -25,6 +25,7 @@ program
 	.option('-l, --language <language>', 'overwrite the language to use')
 	.option('-f, --force', 'ignore the package manifest')
 	.option('-w, --watch', 'watch and rebuild on changes')
+	.option('-m --sourceMaps', 'include source maps in output')
 	.action(build);
 
 program.parse(process.argv);


### PR DESCRIPTION
Adds a new option to the extension cli that will produce source maps.  Now you can use VS Code's interactive debugger to step through your extensions.

Example: `directus-extension build -m`

Note: When you request source maps with this flag I disable the `terser` rollup plugin.  It was mangling the js output (as expected) and preventing source maps from working properly.