### PR TITLE
Use router.replace() to prevent invalid history navigations

### DIFF
--- a/app/src/modules/content/components/navigation-bookmark.vue
+++ b/app/src/modules/content/components/navigation-bookmark.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 					deleteActive.value = false;
 
 					if (navigateTo) {
-						router.push(navigateTo);
+						router.replace(navigateTo);
 					}
 				} catch (err: any) {
 					unexpectedError(err);

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -481,7 +481,7 @@ export default defineComponent({
 			try {
 				await remove();
 				edits.value = {};
-				router.push(`/content/${props.collection}`);
+				router.replace(`/content/${props.collection}`);
 			} catch {
 				// `remove` will show the unexpected error dialog
 			}

--- a/app/src/modules/files/components/navigation-folder.vue
+++ b/app/src/modules/files/components/navigation-folder.vue
@@ -276,9 +276,9 @@ export default defineComponent({
 					await api.delete(`/folders/${props.folder.id}`);
 
 					if (newParent) {
-						router.push(`/files/folders/${newParent}`);
+						router.replace(`/files/folders/${newParent}`);
 					} else {
-						router.push('/files');
+						router.replace('/files');
 					}
 
 					deleteActive.value = false;

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -404,7 +404,7 @@ export default defineComponent({
 		async function deleteAndQuit() {
 			try {
 				await remove();
-				router.push(to.value);
+				router.replace(to.value);
 			} catch {
 				// `remove` will show the unexpected error dialog
 				confirmDelete.value = false;

--- a/app/src/modules/insights/routes/dashboard.vue
+++ b/app/src/modules/insights/routes/dashboard.vue
@@ -90,7 +90,7 @@
 			:dashboard-key="primaryKey"
 			:panel="panelKey ? panels.find((panel) => panel.id === panelKey) : null"
 			@save="stageConfiguration"
-			@cancel="$router.push(`/insights/${primaryKey}`)"
+			@cancel="$router.replace(`/insights/${primaryKey}`)"
 		/>
 
 		<v-dialog :model-value="!!movePanelID" @update:model-value="movePanelID = null" @esc="movePanelID = null">
@@ -361,7 +361,7 @@ export default defineComponent({
 
 		function stageConfiguration(edits: Partial<Panel>) {
 			stagePanelEdits({ edits });
-			router.push(`/insights/${props.primaryKey}`);
+			router.replace(`/insights/${props.primaryKey}`);
 		}
 
 		async function saveChanges() {

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -204,7 +204,7 @@ export default defineComponent({
 			await remove();
 			await collectionsStore.hydrate();
 			await fieldsStore.hydrate();
-			router.push(`/settings/data-model`);
+			router.replace(`/settings/data-model`);
 		}
 
 		async function saveAndStay() {

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -264,7 +264,7 @@ export default defineComponent({
 					type: 'success',
 				});
 
-				router.push(`/settings/data-model/${collectionName.value}`);
+				router.replace(`/settings/data-model/${collectionName.value}`);
 			} catch (err: any) {
 				unexpectedError(err);
 			} finally {

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -314,7 +314,7 @@ export default defineComponent({
 
 				try {
 					await api.delete(`/presets/${props.id}`);
-					router.push(`/settings/presets`);
+					router.replace(`/settings/presets`);
 				} catch (err: any) {
 					unexpectedError(err);
 				} finally {

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -232,7 +232,7 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
-			router.push(`/settings/roles`);
+			router.replace(`/settings/roles`);
 		}
 
 		function discardAndLeave() {

--- a/app/src/modules/settings/routes/roles/permissions-detail/permissions-detail.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/permissions-detail.vue
@@ -179,9 +179,10 @@ export default defineComponent({
 		async function close() {
 			if (permission.value && isPermissionEmpty(permission.value)) {
 				await api.delete(`/permissions/${permission.value.id}`);
+				router.replace(`/settings/roles/${props.roleKey || 'public'}`);
+			} else {
+				router.push(`/settings/roles/${props.roleKey || 'public'}`);
 			}
-
-			router.push(`/settings/roles/${props.roleKey || 'public'}`);
 		}
 
 		async function load() {

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -210,7 +210,7 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
-			router.push(`/settings/webhooks`);
+			router.replace(`/settings/webhooks`);
 		}
 
 		function discardAndLeave() {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -432,7 +432,7 @@ export default defineComponent({
 		async function deleteAndQuit() {
 			try {
 				await remove();
-				router.push(`/users`);
+				router.replace(`/users`);
 			} catch {
 				// `remove` will show the unexpected error dialog
 			}


### PR DESCRIPTION
Prevents invalid back navigation when things are deleted or simply to prevent the access.
An example is the insights panel addition after exiting the edit mode.

https://user-images.githubusercontent.com/26413686/142765507-61cfb209-e397-4257-95f8-4d71b5a94a8c.mov

