### PR TITLE
Fix issue with OAuth setting incorrect initial session data

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -145,8 +145,8 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		return (await this.fetchUserId(identifier)) as string;
 	}
 
-	async login(user: User, sessionData: SessionData): Promise<SessionData> {
-		return this.refresh(user, sessionData);
+	async login(user: User): Promise<SessionData> {
+		return this.refresh(user, null);
 	}
 
 	async refresh(user: User, sessionData: SessionData): Promise<SessionData> {

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -158,8 +158,8 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		return (await this.fetchUserId(identifier)) as string;
 	}
 
-	async login(user: User, sessionData: SessionData): Promise<SessionData> {
-		return this.refresh(user, sessionData);
+	async login(user: User): Promise<SessionData> {
+		return this.refresh(user, null);
 	}
 
 	async refresh(user: User, sessionData: SessionData): Promise<SessionData> {


### PR DESCRIPTION
The `login` function incorrectly used the login payload as `sessionData` causing the payload to be stored in the session for providers without a `refresh_token`. At this point there should be no session data, so we send null to `refresh` instead.