### PR TITLE
Fix LDAP race condition

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -295,12 +295,12 @@ export class LDAPAuthDriver extends AuthDriver {
 			});
 
 			client.bind(user.external_identifier!, password, (err: Error | null) => {
-				client.destroy();
 				if (err) {
 					reject(handleError(err));
-					return;
+				} else {
+					resolve();
 				}
-				resolve();
+				client.destroy();
 			});
 		});
 	}


### PR DESCRIPTION
Sometimes calling `client.destroy()` early will cause the `client.on('error')` callback to trigger and reject before the `verify` function has resolved as it should. Moving the destroy function to after `verify` solves this.

This is a very rare occurrence in my experience.