### PR TITLE
Fix roles aggregate query for users count

### DIFF
--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -132,7 +132,7 @@ export default defineComponent({
 				const response = await api.get(`/roles`, {
 					params: {
 						limit: -1,
-						fields: 'id,name,description,icon,users.id',
+						fields: 'id,name,description,icon,users.role',
 						deep: { users: { _aggregate: { count: 'id' } } },
 						sort: 'name',
 					},


### PR DESCRIPTION
No idea why this error never happened in #9834, but this query is erroneous as we're selecting `directus_users.id` while aggregating on the same field. This results in the following error:

### Error when using Postgresql

![image](https://user-images.githubusercontent.com/42867097/143001559-ca2e6fe8-d376-41fa-b202-c05f937661db.png)

_Image courtesy of @joselcvarela as well as bringing up this error!_

### Error when using Mysql

![image](https://user-images.githubusercontent.com/42867097/143001600-82cd1ee8-48b1-4edb-9e98-3914e6fabaa6.png)

Thanks to @Oreilles for clearing this up 😄