### PR TITLE
Fix deep groupBy

### DIFF
--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -196,7 +196,8 @@ function sanitizeDeep(deep: Record<string, any>, accountability?: Accountability
 				const parsedSubQuery = sanitizeQuery({ [key.substring(1)]: value }, accountability);
 				// ...however we want to keep them for the nested structure of deep, otherwise there's no
 				// way of knowing when to keep nesting and when to stop
-				parsedLevel[key] = Object.values(parsedSubQuery)[0];
+				const [parsedKey, parsedValue] = Object.entries(parsedSubQuery)[0];
+				parsedLevel[`_${parsedKey}`] = parsedValue;
 			} else {
 				parse(value, [...path, key]);
 			}

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -133,7 +133,7 @@ export default defineComponent({
 					params: {
 						limit: -1,
 						fields: 'id,name,description,icon,users.id',
-						deep: { users: { _aggregate: { count: 'id' } } },
+						deep: { users: { _aggregate: { count: 'id' }, _groupBy: ['id'] } },
 						sort: 'name',
 					},
 				});

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -133,7 +133,7 @@ export default defineComponent({
 					params: {
 						limit: -1,
 						fields: 'id,name,description,icon,users.id',
-						deep: { users: { _aggregate: { count: 'id' }, _groupBy: ['id'] } },
+						deep: { users: { _aggregate: { count: 'id' } } },
 						sort: 'name',
 					},
 				});


### PR DESCRIPTION
When `rawQuery.groupBy` gets sanitized, it is turned into `query.group` for the rest of the operations:

https://github.com/directus/directus/blob/28f53473f456e46e3c3bb48d5ed7968a4f84eba7/api/src/utils/sanitize-query.ts#L23-L25

However when deep groupBy queries are parsed here:

https://github.com/directus/directus/blob/28f53473f456e46e3c3bb48d5ed7968a4f84eba7/api/src/utils/sanitize-query.ts#L194-L201

`parsedLevel[key]` ended up with `parsedLevel._groupBy` which is the original key at line 194, rather then the `.group` in `parsedSubQuery`.