### PR TITLE
Remove `runMigrations` from `database install` (#9911)

### DIFF
--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -8,7 +8,6 @@ export default async function start(): Promise<void> {
 
 	try {
 		await installSeeds(database);
-		await runMigrations(database, 'latest');
 		database.destroy();
 		process.exit(0);
 	} catch (err: any) {

--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -1,4 +1,3 @@
-import runMigrations from '../../../database/migrations/run';
 import installSeeds from '../../../database/seeds/run';
 import getDatabase from '../../../database';
 import logger from '../../../logger';

--- a/docs/extensions/migrations.md
+++ b/docs/extensions/migrations.md
@@ -43,3 +43,17 @@ Seeing that these migrations are a bit of a free-for-all, you can really harm yo
 what you're doing and backup your database before adding these migrations.
 
 :::
+
+## Migrations and Directus schema
+
+Migrations can be used is for managing contents of Directus collections (e.g. initial hydration). In order
+to do it, you must ensure that schema is up to date before running migrations. One way of achieving it is opting out of default `directus bootstrap` process and running: 
+
+```
+npx directus database install
+# notice that schema is applied before running migrations
+npx directus schema apply ./path/to/snapshot.yaml
+npx directus database migrate:latest
+```
+
+You may want to add additional steps to reflect other responsibilities of `directus bootstrap`.

--- a/docs/extensions/migrations.md
+++ b/docs/extensions/migrations.md
@@ -46,7 +46,7 @@ what you're doing and backup your database before adding these migrations.
 
 ## Migrations and Directus schema
 
-Migrations can be used is for managing contents of Directus collections (e.g. initial hydration). In order
+Migrations can be used for managing contents of Directus collections (e.g. initial hydration). In order
 to do it, you must ensure that schema is up to date before running migrations. One way of achieving it is opting out of default `directus bootstrap` process and running: 
 
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -53,7 +53,11 @@ custom migration or an external service, for example).
 npx directus database install
 ```
 
-Installs the Directus system tables on an empty database. Used internally by `bootstrap`
+Installs the initial Directus system tables on an empty database. Used internally by `bootstrap`.
+
+It should be used only in specific cases, e.g. when you want to run something between `install` and `migrate`. You probably should call `directus database migrate:latest` afterwards manually.
+
+You may want to use `directus bootstrap` instead. 
 
 ### Upgrade the Database
 


### PR DESCRIPTION
**Notice:** `directus database install` will no longer run migrations automatically. Please use `directus bootstrap` if you're looking for that behavior.

---

Closes #9911.

Addresses #9986 and #9895.

I've added docs about potential use cases.
Be aware it probably should be marked as ⚠️ BREAKING CHANGE.