### PR TITLE
Hide Kodiak status when no automerge label

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -4,3 +4,4 @@ version = 1
 method = "squash"
 delete_branch_on_merge = true
 automerge_label = "Automerge"
+show_missing_automerge_label_message = false


### PR DESCRIPTION
With the [latest release](https://github.com/chdsbd/kodiak/releases/tag/v0.48.0) of Kodiak, we now have the possibility to hide Kodiak's status message on PR's which don't have the automerge label.

Note: It seems like the Kodiak GitHub app hasn't been updated to the latest release yet. While this PR can already be merged, this will only take effect once the app is updated.