### PR TITLE
fix roles aggregation query to fit all db vendors

### DIFF
--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -132,8 +132,8 @@ export default defineComponent({
 				const response = await api.get(`/roles`, {
 					params: {
 						limit: -1,
-						fields: 'id,name,description,icon,users.role',
-						deep: { users: { _aggregate: { count: 'id' } } },
+						fields: 'id,name,description,icon,users',
+						deep: { users: { _aggregate: { count: 'id' }, _groupBy: ['role'], _sort: 'role', _limit: -1 } },
 						sort: 'name',
 					},
 				});

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -132,8 +132,15 @@ export default defineComponent({
 				const response = await api.get(`/roles`, {
 					params: {
 						limit: -1,
-						fields: 'id,name,description,icon,users',
-						deep: { users: { _aggregate: { count: 'id' }, _groupBy: ['role'], _sort: 'role', _limit: -1 } },
+						fields: ['id', 'name', 'description', 'icon', 'users'],
+						deep: {
+							users: {
+								_aggregate: { count: 'id' },
+								_groupBy: ['role'],
+								_sort: 'role',
+								_limit: -1,
+							},
+						},
 						sort: 'name',
 					},
 				});


### PR DESCRIPTION
fixes #10047

It seems like there are some inconsistency with the query formed via aggregation, since it'll work in some vendors but not others, hence the unfortunately repeated fix here.

Adding a groupBy should work:

```js
params: {
    limit: -1,
    fields: 'id,name,description,icon,users',
    deep: {
        users: {
            _aggregate: {
                count: 'id'
            },
            _groupBy: ['role']
        }
    },
    sort: 'name',
},
```

Example of it working via direct SQL query:
![chrome_YjzzO6HnBP](https://user-images.githubusercontent.com/42867097/143452184-ed3a70d2-31c5-4776-84c4-df6f9dca0379.png)

However `directus_users`.`id` is still used in ORDER BY with above filter, thus triggering this error:

![chrome_ItoTkTbgZu](https://user-images.githubusercontent.com/42867097/143451623-e630e38a-01df-4b90-8212-a03845a38c1e.png)

This is why the current solution (tested on MySQL and Postgres) adds `_sort: 'role'` to make sure it's `ORDER BY 'role'` instead of ID. `_limit: -1` is also added to prevent LIMIT from being added to the final query.