### PR TITLE
fix notifications button hover color on dark theme

### DIFF
--- a/app/src/views/private/components/module-bar-avatar/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar/module-bar-avatar.vue
@@ -148,6 +148,7 @@ export default defineComponent({
 
 	.notifications {
 		--v-button-color: var(--module-icon);
+		--v-button-color-hover: var(--white);
 		--v-button-background-color: var(--module-background);
 		--v-button-background-color-hover: var(--module-background);
 	}


### PR DESCRIPTION
## Before

Currently `v-button` defaults to `--foreground-inverted` on hover, which looks dim in dark theme:

![etYNr1dHsR](https://user-images.githubusercontent.com/42867097/143457109-f2e178f1-8e93-442e-8a9e-ca95f1af3137.gif)

## After

Uses the same override as v-avatar:

https://github.com/directus/directus/blob/53b8b6b382b0c3f1490d4f5ab5e259743f666c5c/app/src/views/private/components/module-bar-avatar/module-bar-avatar.vue#L104

![qiEaAjGP6B](https://user-images.githubusercontent.com/42867097/143456932-59e2e072-318b-4fe2-bb2c-065a2cc31ebb.gif)
