### PR TITLE
SDK: Fix bundles

### DIFF
--- a/packages/sdk/index.mjs
+++ b/packages/sdk/index.mjs
@@ -1,1 +1,0 @@
-export * from './dist/index.js'

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,23 +6,19 @@
 		"type": "git",
 		"url": "https://github.com/directus/directus.git"
 	},
-	"main": "./dist/index.js",
+	"main": "dist/sdk.cjs.js",
 	"exports": {
 		".": {
-			"import": {
-				"node": "./index.mjs",
-				"default": "./dist/sdk.esm.js"
-			},
-			"require": "./dist/index.js"
+			"import": "./dist/sdk.bundler.mjs",
+			"require": "./dist/sdk.cjs.js"
 		},
 		"./package.json": "./package.json"
 	},
-	"module": "./dist/sdk.esm.js",
-	"unpkg": "./dist/sdk.esm.min.js",
-	"types": "./dist/index.d.ts",
+	"module": "dist/sdk.bundler.mjs",
+	"unpkg": "dist/sdk.global.min.js",
+	"types": "dist/types/index.d.ts",
 	"files": [
-		"dist",
-		"index.mjs"
+		"dist"
 	],
 	"scripts": {
 		"prebuild": "npm run cleanup",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -5,6 +5,7 @@
 		"module": "es2015",
 		"moduleResolution": "node",
 		"declaration": true,
+		"declarationDir": "dist/types",
 		"declarationMap": true,
 		"strict": true,
 		"noFallthroughCasesInSwitch": true,

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2015",
 		"lib": ["ES2015", "DOM"],
-		"module": "CommonJS",
+		"module": "es2015",
 		"moduleResolution": "node",
 		"declaration": true,
 		"declarationMap": true,


### PR DESCRIPTION
Fixes #https://github.com/directus/directus/issues/8079

Although this seemed to be fixed, for Nuxt builds it was complaining about
 `XMLHttpRequest is not defined`
 
 I believe the cause of this Rollup for SDK was only building for browsers, ignoring Node: https://github.com/directus/directus/blob/53b8b6b382b0c3f1490d4f5ab5e259743f666c5c/packages/sdk/rollup.config.js#L21-L23
 
 Inside Axios the `getAdapater` was always returning the `xhrAdapter`.
 
 In order to fix this, I have inherited configuration from `format-title` with the slight difference that exports `.mjs` for ES modules instead of regular `.js`.
 Now Is uses `xhrAdapter` for browsers and `httpAdapter` for Node.
 
 Tested and working on Nuxt, React, Node CJS, Node MJS and TS-Node.