### PR TITLE
fix translation input blur on revert to old value

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -54,7 +54,7 @@ import { useI18n } from 'vue-i18n';
 import api from '@/api';
 import { useCollection } from '@directus/shared/composables';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { cloneDeep, isEqual, assign } from 'lodash';
+import { cloneDeep, isEqual, assign, isNil } from 'lodash';
 import { notEmpty } from '@/utils/is-empty';
 import { useWindowSize } from '@/composables/use-window-size';
 import useRelation from '@/composables/use-m2m';
@@ -279,7 +279,7 @@ export default defineComponent({
 				(newVal, oldVal) => {
 					if (
 						newVal &&
-						newVal !== oldVal &&
+						isNil(newVal) !== isNil(oldVal) &&
 						newVal?.every((item) => typeof item === 'string' || typeof item === 'number')
 					) {
 						loadItems();


### PR DESCRIPTION
fixes #10060

## Before

When backspacing into the original value, `loadItems()` gets called again. This is true for both:

- backspacing in first language to original value
- backspacing in (new) second language to empty, which is the "original value"

![krBNC9l1PM](https://user-images.githubusercontent.com/42867097/143529360-6377ace3-27f5-4815-a23e-def75523ec8c.gif)

## After

![jqDgEfQMax](https://user-images.githubusercontent.com/42867097/143529252-d1ea8e94-58e0-4a70-9475-ea82b0b5f1fb.gif)


