### PR TITLE
Fix system collection forms with custom fields

### DIFF
--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -241,7 +241,8 @@ export const useFieldsStore = defineStore({
 		getFieldsForCollection(collection: string): Field[] {
 			return orderBy(
 				this.fields.filter((field) => field.collection === collection),
-				[(field) => field.meta?.system === true, (field) => (field.meta?.sort ? Number(field.meta?.sort) : null)]
+				[(field) => field.meta?.system === true, (field) => (field.meta?.sort ? Number(field.meta?.sort) : null)],
+				['desc', 'asc']
 			);
 		},
 		getFieldsForCollectionAlphabetical(collection: string): Field[] {


### PR DESCRIPTION
fixes #10059

## Before

https://user-images.githubusercontent.com/42867097/143558178-a4ffe513-5d27-4a02-a5cc-c03d817e8ffb.mp4

## Solution used

Follows the same "descending" order for system fields in #8876. Seems like for booleans in lodash's `orderBy`, the ascending order is actually false to true, not the other way around:

![chrome_c8akIae5fL](https://user-images.githubusercontent.com/42867097/143558082-15eeb709-65e2-4831-a722-e2da78089e63.png)

hence the need to use descending order here.

## After

https://user-images.githubusercontent.com/42867097/143558196-26aaa59f-d628-4d6b-9ca1-ee401df4d567.mp4


