### PR TITLE
Fix MySQL `tinyint(1)` not being treated as boolean

### DIFF
--- a/api/src/utils/get-local-type.ts
+++ b/api/src/utils/get-local-type.ts
@@ -1,8 +1,6 @@
 import { SchemaOverview } from '@directus/schema/dist/types/overview';
 import { Column } from 'knex-schema-inspector/dist/types/column';
 import { FieldMeta, Type } from '@directus/shared/types';
-import { getDatabaseClient } from '../database';
-import getDatabase from '../database';
 
 const localTypeMap: Record<string, Type | 'unknown'> = {
 	// Shared
@@ -109,9 +107,6 @@ export default function getLocalType(
 	column?: SchemaOverview[string]['columns'][string] | Column,
 	field?: { special?: FieldMeta['special'] }
 ): Type | 'unknown' {
-	const database = getDatabase();
-	const databaseClient = getDatabaseClient(database);
-
 	if (!column) return 'alias';
 
 	const dataType = column.data_type.toLowerCase();
@@ -137,11 +132,6 @@ export default function getLocalType(
 	/** Handle MS SQL varchar(MAX) (eg TEXT) types */
 	if (dataType === 'nvarchar(MAX)') {
 		return 'text';
-	}
-
-	/** Handle Boolean as TINYINT and edgecase MySQL where it still is just tinyint */
-	if (databaseClient === 'mysql' && dataType === 'tinyint(1)') {
-		return 'boolean';
 	}
 
 	return type ?? 'unknown';

--- a/packages/schema/src/dialects/mysql.ts
+++ b/packages/schema/src/dialects/mysql.ts
@@ -40,15 +40,9 @@ export default class MySQL extends KnexMySQL implements SchemaInspector {
 				};
 			}
 
-			let dataType = column.data_type.split('(')[0];
-
-			/**
-			 * Smooth out a difference between MySQL and MariaDB. MySQL reports the column type as `int
-			 * unsigned`, while MariaDB reports it as `int(11) unsigned`. This would cause the `unsigned` part
-			 * of the type to be dropped in the columnInfo retrieval for MariaDB powered databases.
-			 */
-			if (column.data_type.includes('unsigned') && dataType.includes('unsigned') === false) {
-				dataType += ' unsigned';
+			let dataType = column.data_type.replace(/\(.*?\)/, '');
+			if (column.data_type.startsWith('tinyint(1)')) {
+				dataType = 'boolean';
 			}
 
 			overview[column.table_name].columns[column.column_name] = {


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/10065.

Since MySQL doesn't have an actual boolean data type (even in the very latest version which is insane), Directus used to cast all `tinyint` as booleans. Which led to issues (#6665), because `tinyint`s are used to store up to 256 different integer values.

To kind of solve the underlying problem, rather than adding a proper boolean type, mysql added a *formatting* parameter to tinyints, resulting in the type `tinyint(1)` to which `bool` is an alias. So a check was added in `parseDefaultValue` so that only `tinyint(0)` would be casted to `boolean`.

But since both [`knex-schema-inspector`](https://github.com/knex/knex-schema-inspector/blob/edffc1c34739d0491d0296d30e0a1b6f79d24ab0/lib/dialects/mysql.ts#L37) and [`@directus/schema`](https://github.com/directus/directus/blob/d96e1ab0f84ae5f5a0c7b1ed6e96c99ee59d0e84/packages/schema/src/dialects/mysql.ts#L43 ) were stripping that presentation parameter out of the data type, we used to cast [all](https://github.com/directus/directus/blob/c95add08ef1386cab6e54546f03d541d889148ed/api/src/utils/get-local-type.ts#L138) MySQL `tinyint`s to `boolean`, which essentially lead to the same issue SQL Server users were having (#6665).

When fixing this, we forgot to the presentation parameter were stripped out, so `tinyint(1)` couldn't be casted to `boolean` anymore. To prevent this issue, the boolean casting should occur higher up, in the two schema inspectors. (https://github.com/knex/knex-schema-inspector/pull/85 should be merged too for this to work)