### PR TITLE
Fix SQL Server text casting

### DIFF
--- a/api/src/utils/get-local-type.ts
+++ b/api/src/utils/get-local-type.ts
@@ -135,7 +135,7 @@ export default function getLocalType(
 	}
 
 	/** Handle MS SQL varchar(MAX) (eg TEXT) types */
-	if (dataType === 'nvarchar(MAX)') {
+	if (column.data_type === 'nvarchar' && column.max_length === -1) {
 		return 'text';
 	}
 


### PR DESCRIPTION
Revert change in https://github.com/directus/directus/commit/ad54b9618402c23957c367223a0a1f542e840161#diff-76fec47728f612b32d7995d0c50ec111e5ff6da5f837040e95dcdcd77c7d10ed :

```diff
- if (column && column.data_type === 'nvarchar' && column.max_length === -1) {
+ if (dataType === 'nvarchar(MAX)') {
	return 'text';
	return 'text';
 }
```
 This change cannot work since only `nvarchar` will be present in `column.data_type`. Reverted to previous implementation.