### PR TITLE
Add ability to create conditions with context of the current item

### DIFF
--- a/app/src/utils/apply-conditions.ts
+++ b/app/src/utils/apply-conditions.ts
@@ -9,7 +9,7 @@ export function applyConditions(item: Record<string, any>, field: Field) {
 
 		const matchingCondition = conditions.find((condition) => {
 			if (!condition.rule || Object.keys(condition.rule).length !== 1) return;
-			const rule = parseFilter(condition.rule);
+			const rule = parseFilter(condition.rule, { $ITEM: item });
 			const errors = validatePayload(rule, item, { requireAll: true });
 			return errors.length === 0;
 		});

--- a/app/src/utils/parse-filter.ts
+++ b/app/src/utils/parse-filter.ts
@@ -1,9 +1,8 @@
 import { useUserStore } from '@/stores';
-import { Accountability } from '@directus/shared/types';
+import { Accountability, Filter, ParseFilterContext } from '@directus/shared/types';
 import { parseFilter as parseFilterShared } from '@directus/shared/utils';
-import { Filter } from '@directus/shared/types';
 
-export function parseFilter(filter: Filter | null): Filter {
+export function parseFilter(filter: Record<string, any>, context: ParseFilterContext = {}): Filter {
 	const userStore = useUserStore();
 
 	if (!userStore.currentUser) return filter ?? {};
@@ -13,5 +12,5 @@ export function parseFilter(filter: Filter | null): Filter {
 		user: userStore.currentUser.id,
 	};
 
-	return parseFilterShared(filter, accountability) ?? {};
+	return parseFilterShared(filter, accountability, context) ?? {};
 }

--- a/packages/shared/src/types/filter.ts
+++ b/packages/shared/src/types/filter.ts
@@ -1,4 +1,4 @@
-import { Role, User } from "./users";
+import { Role, User } from './users';
 
 export type FilterOperator =
 	| 'eq'

--- a/packages/shared/src/types/filter.ts
+++ b/packages/shared/src/types/filter.ts
@@ -1,3 +1,5 @@
+import {Role, User} from "./users";
+
 export type FilterOperator =
 	| 'eq'
 	| 'neq'
@@ -58,4 +60,12 @@ export type FieldFilterOperator = {
 export type FieldValidationOperator = {
 	_submitted?: boolean;
 	_regex?: string;
+};
+
+export type ParseFilterContext = {
+	// The user can add any custom fields to user
+	$CURRENT_USER?: User & Record<string, any>;
+	$CURRENT_ROLE?: Role & Record<string, any>;
+	// The current item, only during validations
+	$ITEM?: Record<string, any>;
 };

--- a/packages/shared/src/types/filter.ts
+++ b/packages/shared/src/types/filter.ts
@@ -1,4 +1,4 @@
-import {Role, User} from "./users";
+import { Role, User } from "./users";
 
 export type FilterOperator =
 	| 'eq'
@@ -66,6 +66,6 @@ export type ParseFilterContext = {
 	// The user can add any custom fields to user
 	$CURRENT_USER?: User & Record<string, any>;
 	$CURRENT_ROLE?: Role & Record<string, any>;
-	// The current item, only during validations
+	// The current item
 	$ITEM?: Record<string, any>;
 };

--- a/packages/shared/src/utils/is-dynamic-variable.ts
+++ b/packages/shared/src/utils/is-dynamic-variable.ts
@@ -1,4 +1,4 @@
-const dynamicVariablePrefixes = ['$NOW', '$CURRENT_USER', '$CURRENT_ROLE'];
+const dynamicVariablePrefixes = ['$NOW', '$CURRENT_USER', '$CURRENT_ROLE', '$ITEM'];
 
 export function isDynamicVariable(value: any) {
 	return typeof value === 'string' && dynamicVariablePrefixes.some((prefix) => value.startsWith(prefix));

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -1,14 +1,8 @@
 import { REGEX_BETWEEN_PARENS } from '../constants';
-import { Accountability, Filter, User, Role } from '../types';
+import { Accountability, Filter, ParseFilterContext } from '../types';
 import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { isDynamicVariable } from './is-dynamic-variable';
-
-type ParseFilterContext = {
-	// The user can add any custom fields to user
-	$CURRENT_USER?: User & Record<string, any>;
-	$CURRENT_ROLE?: Role & Record<string, any>;
-};
 
 export function parseFilter(
 	filter: Filter | null,
@@ -49,15 +43,10 @@ function parseDynamicVariable(value: any, accountability: Accountability | null,
 		return new Date();
 	}
 
-	if (value.startsWith('$CURRENT_USER')) {
-		if (value === '$CURRENT_USER') return accountability?.user ?? null;
-		return get(context, value, null);
-	}
+	if (value === '$CURRENT_USER') return accountability?.user ?? null;
+	if (value === '$CURRENT_ROLE') return accountability?.role ?? null;
 
-	if (value.startsWith('$CURRENT_ROLE')) {
-		if (value === '$CURRENT_ROLE') return accountability?.role ?? null;
-		return get(context, value, null);
-	}
+	return get(context, value, null);
 }
 
 function get(object: Record<string, any> | any[], path: string, defaultValue: any): any {


### PR DESCRIPTION
The idea for this is to allow you to use `$ITEM` in the conditions logic, for example when validating two fields with each other.

So you could create your own notice field for example and write the following condition, assuming you also have a `fromDate` and `toDate` fields for example:

```
{
  "fromDate": {
      "_gt": "$ITEM.toDate"
  }
}
```