### PR TITLE
Fix ability to change M2O field type and prevent incompatible interfaces in advanced mode

### DIFF
--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -38,7 +38,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, PropType, computed } from 'vue';
-import { Field, InterfaceConfig } from '@directus/shared/types';
+import { Field } from '@directus/shared/types';
 import { getInterface } from '@/interfaces';
 import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
 

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -39,7 +39,7 @@
 import { useI18n } from 'vue-i18n';
 import { defineComponent, PropType, computed } from 'vue';
 import { Field, InterfaceConfig } from '@directus/shared/types';
-import { getInterfaces } from '@/interfaces';
+import { getInterface } from '@/interfaces';
 import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
 
 export default defineComponent({
@@ -81,11 +81,7 @@ export default defineComponent({
 	setup(props) {
 		const { t } = useI18n();
 
-		const { interfaces } = getInterfaces();
-
-		const interfaceExists = computed(() => {
-			return !!interfaces.value.find((inter: InterfaceConfig) => inter.id === props.field?.meta?.interface || 'input');
-		});
+		const interfaceExists = computed(() => !!getInterface(props.field?.meta?.interface || 'input'));
 
 		return { t, interfaceExists, getDefaultInterfaceForType };
 	},

--- a/app/src/composables/use-form-fields/use-form-fields.ts
+++ b/app/src/composables/use-form-fields/use-form-fields.ts
@@ -1,28 +1,23 @@
 import { FormField } from '@/components/v-form/types';
-import { getInterfaces } from '@/interfaces';
-import { Field, InterfaceConfig } from '@directus/shared/types';
+import { getInterface } from '@/interfaces';
+import { Field } from '@directus/shared/types';
 import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
 import { clone, orderBy } from 'lodash';
 import { computed, ComputedRef, Ref } from 'vue';
 import { translate } from '@/utils/translate-object-values';
 
 export default function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<Field[]> } {
-	const { interfaces } = getInterfaces();
-
 	const formFields = computed(() => {
 		let formFields = clone(fields.value);
 
 		formFields = formFields.map((field, index) => {
 			if (!field.meta) return field;
 
-			let interfaceUsed = interfaces.value.find((int: InterfaceConfig) => int.id === field.meta?.interface);
-			const interfaceExists = interfaceUsed !== undefined;
-
-			if (interfaceExists === false) {
+			let interfaceUsed = getInterface(field.meta.interface);
+			if (interfaceUsed === undefined) {
 				field.meta.interface = getDefaultInterfaceForType(field.type);
+				interfaceUsed = getInterface(field.meta.interface);
 			}
-
-			interfaceUsed = interfaces.value.find((int: InterfaceConfig) => int.id === field.meta?.interface);
 
 			if (interfaceUsed?.hideLabel === true) {
 				(field as FormField).hideLabel = true;

--- a/app/src/displays/index.ts
+++ b/app/src/displays/index.ts
@@ -7,3 +7,7 @@ const displays: Ref<DisplayConfig[]> = shallowRef([]);
 export function getDisplays(): { displays: Ref<DisplayConfig[]>; displaysRaw: Ref<DisplayConfig[]> } {
 	return { displays, displaysRaw };
 }
+
+export function getDisplay(name?: string | null): DisplayConfig | undefined {
+	return !name ? undefined : displays.value.find(({ id }) => id === name);
+}

--- a/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
+++ b/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
@@ -29,8 +29,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed, inject, ref } from 'vue';
-import { getInterfaces } from '@/interfaces';
-import { InterfaceConfig } from '@directus/shared/types';
+import { getInterface } from '@/interfaces';
 
 export default defineComponent({
 	props: {
@@ -55,8 +54,6 @@ export default defineComponent({
 	setup(props, { emit }) {
 		const { t } = useI18n();
 
-		const { interfaces } = getInterfaces();
-
 		const options = computed({
 			get() {
 				return props.value;
@@ -70,12 +67,12 @@ export default defineComponent({
 
 		const selectedInterface = computed(() => {
 			if (props.interface) {
-				return interfaces.value.find((inter: InterfaceConfig) => inter.id === props.interface);
+				return getInterface(props.interface);
 			}
 
 			if (!values.value[props.interfaceField]) return;
 
-			return interfaces.value.find((inter: InterfaceConfig) => inter.id === values.value[props.interfaceField]);
+			return getInterface(values.value[props.interfaceField]);
 		});
 
 		const usesCustomComponent = computed(() => {

--- a/app/src/interfaces/index.ts
+++ b/app/src/interfaces/index.ts
@@ -7,3 +7,7 @@ const interfaces: Ref<InterfaceConfig[]> = shallowRef([]);
 export function getInterfaces(): { interfaces: Ref<InterfaceConfig[]>; interfacesRaw: Ref<InterfaceConfig[]> } {
 	return { interfaces, interfacesRaw };
 }
+
+export function getInterface(name?: string | null): InterfaceConfig | undefined {
+	return !name ? undefined : interfaces.value.find(({ id }) => id === name);
+}

--- a/app/src/layouts/index.ts
+++ b/app/src/layouts/index.ts
@@ -7,3 +7,7 @@ const layouts: Ref<LayoutConfig[]> = shallowRef([]);
 export function getLayouts(): { layouts: Ref<LayoutConfig[]>; layoutsRaw: Ref<LayoutConfig[]> } {
 	return { layouts, layoutsRaw };
 }
+
+export function getLayout(name?: string | null): LayoutConfig | undefined {
+	return !name ? undefined : layouts.value.find(({ id }) => id === name);
+}

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
@@ -15,11 +15,10 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
-import { getDisplays } from '@/displays';
-import { getInterfaces } from '@/interfaces';
+import { getDisplay } from '@/displays';
+import { getInterface } from '@/interfaces';
 import { FancySelectItem } from '@/components/v-fancy-select/types';
 import { clone } from 'lodash';
-import { InterfaceConfig, DisplayConfig } from '@directus/shared/types';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import ExtensionOptions from '../shared/extension-options.vue';
@@ -36,12 +35,7 @@ export default defineComponent({
 		const interfaceID = computed(() => field.value.meta?.interface);
 		const display = syncFieldDetailStoreProperty('field.meta.display');
 
-		const { displays } = getDisplays();
-		const { interfaces } = getInterfaces();
-
-		const selectedInterface = computed(() => {
-			return interfaces.value.find((inter: InterfaceConfig) => inter.id === interfaceID.value);
-		});
+		const selectedInterface = computed(() => getInterface(interfaceID.value));
 
 		const selectItems = computed(() => {
 			let recommended = clone(selectedInterface.value?.recommendedDisplays) || [];
@@ -83,9 +77,7 @@ export default defineComponent({
 			return recommendedItems;
 		});
 
-		const selectedDisplay = computed(() => {
-			return displays.value.find((displayConfig: DisplayConfig) => displayConfig.id === display.value);
-		});
+		const selectedDisplay = computed(() => getDisplay(display.value));
 
 		return { t, selectItems, selectedDisplay, display };
 	},

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
@@ -20,7 +20,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
-import { getInterfaces } from '@/interfaces';
+import { getInterface } from '@/interfaces';
 import { FancySelectItem } from '@/components/v-fancy-select/types';
 import { InterfaceConfig } from '@directus/shared/types';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store/';
@@ -39,8 +39,6 @@ export default defineComponent({
 
 		const { field, interfacesForType } = storeToRefs(fieldDetailStore);
 		const type = computed(() => field.value.type);
-
-		const { interfaces } = getInterfaces();
 
 		const selectItems = computed(() => {
 			const recommendedInterfacesPerType: { [type: string]: string[] } = {
@@ -96,9 +94,7 @@ export default defineComponent({
 			return recommendedItems;
 		});
 
-		const selectedInterface = computed(() => {
-			return interfaces.value.find((inter: InterfaceConfig) => inter.id === interfaceID.value);
-		});
+		const selectedInterface = computed(() => getInterface(interfaceID.value));
 
 		return { t, selectItems, selectedInterface, interfaceID, options };
 	},

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
@@ -22,7 +22,6 @@ import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
 import { getInterface } from '@/interfaces';
 import { FancySelectItem } from '@/components/v-fancy-select/types';
-import { InterfaceConfig } from '@directus/shared/types';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store/';
 import { storeToRefs } from 'pinia';
 import ExtensionOptions from '../shared/extension-options.vue';

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -260,9 +260,7 @@ export default defineComponent({
 
 		const typesWithLabels = computed(() => translate(fieldTypes));
 
-		const typeDisabled = computed(() => {
-			return ['file', 'files', 'o2m', 'm2m', 'm2a', 'm2o', 'translations'].includes(localType.value);
-		});
+		const typeDisabled = computed(() => localType.value !== 'standard');
 
 		const typePlaceholder = computed(() => {
 			if (localType.value === 'm2o') {

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -16,7 +16,7 @@
 						{{ t('type') }}
 					</div>
 
-					<v-select v-model="type" :items="typeOptions" :disabled="typeOptions.length === 1" />
+					<v-select v-model="type" :items="typeOptions" :disabled="typeDisabled" />
 				</div>
 
 				<div class="field half-left">
@@ -56,7 +56,7 @@
 
 <script lang="ts">
 import { defineComponent, computed } from 'vue';
-import { getInterfaces } from '@/interfaces';
+import { getInterface } from '@/interfaces';
 import { useI18n } from 'vue-i18n';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store/';
 import { storeToRefs } from 'pinia';
@@ -82,9 +82,7 @@ export default defineComponent({
 		const { readyToSave, saving, localType, collection } = storeToRefs(fieldDetail);
 		const { t } = useI18n();
 
-		const { interfaces } = getInterfaces();
-
-		const chosenInterface = computed(() => interfaces.value.find((inter) => inter.id === props.chosenInterface));
+		const chosenInterface = computed(() => getInterface(props.chosenInterface));
 
 		const typeOptions = computed(() => {
 			if (!chosenInterface.value) return [];
@@ -94,6 +92,8 @@ export default defineComponent({
 				value: type,
 			}));
 		});
+
+		const typeDisabled = computed(() => typeOptions.value.length === 1 || localType.value !== 'standard');
 
 		const key = syncFieldDetailStoreProperty('field.field');
 		const type = syncFieldDetailStoreProperty('field.type');
@@ -105,6 +105,7 @@ export default defineComponent({
 			key,
 			t,
 			type,
+			typeDisabled,
 			typeOptions,
 			defaultValue,
 			required,

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -23,8 +23,8 @@
 
 <script lang="ts">
 import { defineComponent, PropType, computed } from 'vue';
-import { getInterfaces } from '@/interfaces';
-import { getDisplays } from '@/displays';
+import { getInterface } from '@/interfaces';
+import { getDisplay } from '@/displays';
 import { useFieldDetailStore } from '../store/';
 import { get } from 'lodash';
 import { storeToRefs } from 'pinia';
@@ -53,19 +53,15 @@ export default defineComponent({
 
 		const { collection, field, relations, fields, collections } = storeToRefs(fieldDetail);
 
-		const { interfaces } = getInterfaces();
-		const { displays } = getDisplays();
-
 		const extensionInfo = computed(() => {
-			if (props.type === 'interface') {
-				return interfaces.value.find((inter) => inter.id === props.extension);
+			switch (props.type) {
+				case 'interface':
+					return getInterface(props.extension);
+				case 'display':
+					return getDisplay(props.extension);
+				default:
+					return null;
 			}
-
-			if (props.type === 'display') {
-				return displays.value.find((display) => display.id === props.extension);
-			}
-
-			return null;
 		});
 
 		const usesCustomComponent = computed(() => {

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
@@ -1,6 +1,6 @@
 import { set } from 'lodash';
 import { State, StateUpdates } from '../types';
-import { getInterfaces } from '@/interfaces';
+import { getInterface } from '@/interfaces';
 
 /**
  * In case a relational field removed the schema object, we'll have to make sure it's re-added
@@ -20,7 +20,7 @@ export function resetSchema(updates: StateUpdates, state: State) {
 export function setLocalTypeForInterface(updates: StateUpdates) {
 	if (!updates.field?.meta?.interface) return;
 
-	const chosenInterface = getInterfaces().interfaces.value.find((inter) => inter.id === updates.field!.meta!.interface);
+	const chosenInterface = getInterface(updates.field.meta.interface);
 
 	if (!chosenInterface) return;
 
@@ -36,7 +36,7 @@ export function setLocalTypeForInterface(updates: StateUpdates) {
 export function setTypeForInterface(updates: StateUpdates, state: State) {
 	if (!updates.field?.meta?.interface) return;
 
-	const chosenInterface = getInterfaces().interfaces.value.find((inter) => inter.id === updates.field!.meta!.interface);
+	const chosenInterface = getInterface(updates.field.meta.interface);
 
 	if (!chosenInterface) return updates;
 

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts
@@ -1,4 +1,5 @@
 import { HelperFunctions, State, StateUpdates } from '../types';
+import { getInterface } from '@/interfaces';
 import { set } from 'lodash';
 
 export function applyChanges(updates: StateUpdates, _state: State, helperFn: HelperFunctions) {
@@ -6,10 +7,11 @@ export function applyChanges(updates: StateUpdates, _state: State, helperFn: Hel
 
 	if (hasChanged('field.type')) {
 		setSpecialForType(updates);
+		updateInterface(updates, helperFn);
 	}
 }
 
-export function setSpecialForType(updates: StateUpdates) {
+function setSpecialForType(updates: StateUpdates) {
 	const type = updates.field?.type;
 	switch (type) {
 		case 'uuid':
@@ -24,5 +26,13 @@ export function setSpecialForType(updates: StateUpdates) {
 			break;
 		default:
 			set(updates, 'field.meta.special', null);
+	}
+}
+
+function updateInterface(updates: StateUpdates, fn: HelperFunctions) {
+	const interfayce = getInterface(fn.getCurrent('field.meta.interface'));
+	const type = updates.field?.type;
+	if (type && !interfayce?.types.includes(type)) {
+		set(updates, 'field.meta.interface', undefined);
 	}
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts
@@ -30,9 +30,9 @@ function setSpecialForType(updates: StateUpdates) {
 }
 
 function updateInterface(updates: StateUpdates, fn: HelperFunctions) {
-	const interfayce = getInterface(fn.getCurrent('field.meta.interface'));
+	const interface_ = getInterface(fn.getCurrent('field.meta.interface'));
 	const type = updates.field?.type;
-	if (type && !interfayce?.types.includes(type)) {
+	if (type && !interface_?.types.includes(type)) {
 		set(updates, 'field.meta.interface', undefined);
 	}
 }

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -147,7 +147,7 @@ import { cloneDeep } from 'lodash';
 import { getLocalTypeForField } from '../../get-local-type';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { Field, InterfaceConfig } from '@directus/shared/types';
+import { Field } from '@directus/shared/types';
 import FieldSelectMenu from './field-select-menu.vue';
 import hideDragImage from '@/utils/hide-drag-image';
 import Draggable from 'vuedraggable';

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -141,7 +141,7 @@
 import { useI18n } from 'vue-i18n';
 import { defineComponent, PropType, ref, computed } from 'vue';
 import { useCollectionsStore, useFieldsStore } from '@/stores/';
-import { getInterfaces } from '@/interfaces';
+import { getInterface } from '@/interfaces';
 import { useRouter } from 'vue-router';
 import { cloneDeep } from 'lodash';
 import { getLocalTypeForField } from '../../get-local-type';
@@ -178,16 +178,13 @@ export default defineComponent({
 
 		const collectionsStore = useCollectionsStore();
 		const fieldsStore = useFieldsStore();
-		const { interfaces } = getInterfaces();
 
 		const editActive = ref(false);
 
 		const { deleteActive, deleting, deleteField } = useDeleteField();
 		const { duplicateActive, duplicateName, collections, duplicateTo, saveDuplicate, duplicating } = useDuplicate();
 
-		const interfaceName = computed(() => {
-			return interfaces.value.find((inter: InterfaceConfig) => inter.id === props.field.meta?.interface)?.name;
-		});
+		const interfaceName = computed(() => getInterface(props.field.meta?.interface)?.name);
 
 		const hidden = computed(() => props.field.meta?.hidden === true);
 

--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -92,7 +92,7 @@ import SettingsNavigation from '../../../components/navigation.vue';
 import api from '@/api';
 import { Header } from '@/components/v-table/types';
 import { useCollectionsStore } from '@/stores/';
-import { getLayouts } from '@/layouts';
+import { getLayout } from '@/layouts';
 import { useRouter } from 'vue-router';
 import ValueNull from '@/views/private/components/value-null';
 import PresetsInfoSidebarDetail from './components/presets-info-sidebar-detail.vue';
@@ -123,7 +123,6 @@ export default defineComponent({
 
 		const router = useRouter();
 
-		const { layouts } = getLayouts();
 		const collectionsStore = useCollectionsStore();
 
 		const selection = ref<Preset[]>([]);
@@ -175,7 +174,7 @@ export default defineComponent({
 					}
 
 					const collection = collectionsStore.getCollection(preset.collection)?.name;
-					const layout = layouts.value.find((l) => l.id === preset.layout)?.name;
+					const layout = getLayout(preset.layout)?.name;
 
 					return {
 						id: preset.id,

--- a/app/src/utils/adjust-fields-for-displays/adjust-fields-for-displays.ts
+++ b/app/src/utils/adjust-fields-for-displays/adjust-fields-for-displays.ts
@@ -1,19 +1,18 @@
-import { getDisplays } from '@/displays';
+import { getDisplay } from '@/displays';
 import { useFieldsStore } from '@/stores/';
-import { DisplayConfig, Field } from '@directus/shared/types';
+import { Field } from '@directus/shared/types';
 
 export default function adjustFieldsForDisplays(fields: readonly string[], parentCollection: string): string[] {
 	const fieldsStore = useFieldsStore();
-	const { displays } = getDisplays();
 
 	const adjustedFields: string[] = fields
 		.map((fieldKey) => {
-			const field: Field = fieldsStore.getField(parentCollection, fieldKey);
+			const field: Field | null = fieldsStore.getField(parentCollection, fieldKey);
 
 			if (!field) return fieldKey;
 			if (field.meta?.display === null) return fieldKey;
 
-			const display = displays.value.find((d: DisplayConfig) => d.id === field.meta?.display);
+			const display = getDisplay(field.meta?.display);
 
 			if (!display) return fieldKey;
 			if (!display?.fields) return fieldKey;

--- a/app/src/views/private/components/layout-sidebar-detail/layout-sidebar-detail.vue
+++ b/app/src/views/private/components/layout-sidebar-detail/layout-sidebar-detail.vue
@@ -18,7 +18,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed } from 'vue';
-import { getLayouts } from '@/layouts';
+import { getLayouts, getLayout } from '@/layouts';
 import { useSync } from '@directus/shared/composables';
 
 export default defineComponent({
@@ -34,15 +34,7 @@ export default defineComponent({
 
 		const { layouts } = getLayouts();
 
-		const currentLayout = computed(() => {
-			const layout = layouts.value.find((layout) => layout.id === props.modelValue);
-
-			if (layout === undefined) {
-				return layouts.value.find((layout) => layout.id === 'tabular');
-			}
-
-			return layout;
-		});
+		const currentLayout = computed(() => getLayout(props.modelValue) ?? getLayout('tabular'));
 
 		const layout = useSync(props, 'modelValue', emit);
 

--- a/app/src/views/private/components/render-display/render-display.vue
+++ b/app/src/views/private/components/render-display/render-display.vue
@@ -16,9 +16,8 @@
 
 <script lang="ts">
 import { defineComponent, computed } from 'vue';
-import { getDisplays } from '@/displays';
+import { getDisplay } from '@/displays';
 import ValueNull from '@/views/private/components/value-null';
-import { DisplayConfig } from '@directus/shared/types';
 
 export default defineComponent({
 	components: { ValueNull },
@@ -57,10 +56,7 @@ export default defineComponent({
 		},
 	},
 	setup(props) {
-		const { displays } = getDisplays();
-		const displayInfo = computed(
-			() => displays.value.find((display: DisplayConfig) => display.id === props.display) || null
-		);
+		const displayInfo = computed(() => getDisplay(props.display));
 		return { displayInfo };
 	},
 });

--- a/app/src/views/private/components/render-template/render-template.vue
+++ b/app/src/views/private/components/render-template/render-template.vue
@@ -24,7 +24,7 @@
 import { defineComponent, PropType, computed, ref } from 'vue';
 import { useFieldsStore } from '@/stores';
 import { get } from 'lodash';
-import { DisplayConfig, Field } from '@directus/shared/types';
+import { Field } from '@directus/shared/types';
 import { getDisplay } from '@/displays';
 import ValueNull from '@/views/private/components/value-null';
 import { getDefaultDisplayForType } from '@/utils/get-default-display-for-type';

--- a/app/src/views/private/components/render-template/render-template.vue
+++ b/app/src/views/private/components/render-template/render-template.vue
@@ -25,7 +25,7 @@ import { defineComponent, PropType, computed, ref } from 'vue';
 import { useFieldsStore } from '@/stores';
 import { get } from 'lodash';
 import { DisplayConfig, Field } from '@directus/shared/types';
-import { getDisplays } from '@/displays';
+import { getDisplay } from '@/displays';
 import ValueNull from '@/views/private/components/value-null';
 import { getDefaultDisplayForType } from '@/utils/get-default-display-for-type';
 import { translate } from '@/utils/translate-literal';
@@ -52,7 +52,6 @@ export default defineComponent({
 	},
 	setup(props) {
 		const fieldsStore = useFieldsStore();
-		const { displays } = getDisplays();
 
 		const templateEl = ref<HTMLElement>();
 
@@ -96,7 +95,7 @@ export default defineComponent({
 					// No need to render the empty display overhead in this case
 					if (display === 'raw') return value;
 
-					const displayInfo = displays.value.find((display: DisplayConfig) => display.id === field.meta?.display);
+					const displayInfo = getDisplay(field.meta?.display);
 
 					// If used display doesn't exist in the current project, return raw value
 					if (!displayInfo) return value;


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/10122
Important parts are:
https://github.com/directus/directus/blob/b8db750cb00153275a90fb0aec7d4877ef8660ad/app/src/modules/settings/routes/data-model/field-detail/store/alterations/standard.ts#L32-L38
https://github.com/directus/directus/blob/b8db750cb00153275a90fb0aec7d4877ef8660ad/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue#L19
https://github.com/directus/directus/blob/b8db750cb00153275a90fb0aec7d4877ef8660ad/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue#L96
Rest of file changes are just updates from all the `interfaces.value.find((interface) => interface.id === something` to `getInterface(something)` ( and similar for `getLayout` and `getDisplays` )