### PR TITLE
Ensure all fields are available for conditions/validation on Save

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -62,6 +62,24 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 
 	const { fields: fieldsWithPermissions } = usePermissions(collection, item, isNew);
 
+	// copied from v-form.vue, should move into useCollection/usePermissions?
+	const defaultValues = computed(() => {
+		return fieldsWithPermissions.value.reduce(function (acc, field) {
+			if (
+				field.schema?.default_value !== undefined &&
+				// Ignore autoincremented integer PK field
+				!(
+					field.schema.is_primary_key &&
+					field.schema.data_type === 'integer' &&
+					typeof field.schema.default_value === 'string'
+				)
+			) {
+				acc[field.field] = field.schema?.default_value;
+			}
+			return acc;
+		}, {} as Record<string, any>);
+	});
+
 	const itemEndpoint = computed(() => {
 		if (isSingle.value) {
 			return getEndpoint(collection.value);
@@ -111,7 +129,8 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 		saving.value = true;
 		validationErrors.value = [];
 
-		const errors = validateItem(merge({}, item.value, edits.value), fieldsWithPermissions.value, isNew.value);
+		const baseValues = isNew.value === true ? defaultValues.value : item.value;
+		const errors = validateItem(merge({}, baseValues, edits.value), fieldsWithPermissions.value, isNew.value);
 
 		if (errors.length > 0) {
 			validationErrors.value = errors;


### PR DESCRIPTION
Given the following fields in a collection with conditions:

- Field `Name`: optional
- Field `Age`: optional
- Field `Phone`: required with condition - optional when `id` is null

On creation load, all fields are rendered optional. However, required error is rendered against `Phone` field on Save.

![image](https://user-images.githubusercontent.com/76130324/143729435-23d3d836-3db8-4a23-a727-c7ee4bc2e361.png)

This is due to the fact that not all fields values are provided to the validation call during Save.

The above scenario is only for illustration. The fix covers update scenarios where conditions may also include rule on other un-edited fields.


