### PR TITLE
add default render template & scope to formatted JSON display

### DIFF
--- a/app/src/displays/formatted-json-value/formatted-json-value.vue
+++ b/app/src/displays/formatted-json-value/formatted-json-value.vue
@@ -46,14 +46,22 @@ export default defineComponent({
 
 			try {
 				if (Array.isArray(props.value)) {
-					return props.value.map((item: any) => render(props.format || '', item));
+					return props.value.map((item: any) => renderValue(item));
 				} else {
-					return [render(props.format || '', props.value)];
+					return [renderValue(props.value)];
 				}
 			} catch {
 				return null;
 			}
 		});
+
+		function renderValue(input: Record<string, any> | Record<string, any>[]) {
+			if (props.format) {
+				return render(props.format, input);
+			} else {
+				return render('{{ value }}', { value: input });
+			}
+		}
 
 		return { displayValue, t };
 	},


### PR DESCRIPTION
## Before

When there's no configured format, currently it'll default to `''` (empty string), thus causing the list to be blank:

![cix3nweWyb](https://user-images.githubusercontent.com/42867097/143851502-50cf6b34-05de-45e3-88a2-650969113997.gif)

## After

Note: Here the values themselves contained brackets. It's not something added by the current fix.

![E9czSroIaX](https://user-images.githubusercontent.com/42867097/143851718-a6a03fb0-4191-41da-a16a-b710cd8854fe.gif)


