### PR TITLE
Auto expand selections for checkbox tree in Show Selected mode

### DIFF
--- a/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
@@ -161,6 +161,10 @@ export default defineComponent({
 		});
 
 		const groupOpen = computed(() => {
+			if (props.showSelectionOnly === true) {
+				return visibleChildrenValues.value.length > 0;
+			}
+
 			return typeof props.search === 'string' && props.search.length > 0;
 		});
 


### PR DESCRIPTION
## Bug

Show Selected in Branch mode should auto-expand selections, at least down to the first full-checked node.

![OWoej0Icgv](https://user-images.githubusercontent.com/42867097/143853466-3e66a4cf-0d3c-4a6f-bc4f-18edb58e6fc7.gif)

## Fix

![0az8uhytQg](https://user-images.githubusercontent.com/42867097/143853414-b6ab14f2-229f-4320-abca-437b5bc3e3eb.gif)