### PR TITLE
SDK: Fix type arrays on filter

### DIFF
--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -74,7 +74,7 @@ export type LogicalFilterOr<T> = { _or: Filter<T>[] };
 export type LogicalFilter<T> = LogicalFilterAnd<T> | LogicalFilterOr<T>;
 
 export type FieldFilterOperator<T, K extends keyof T> = {
-	[O in FilterOperators]?: T[K];
+	[O in FilterOperators]?: T[K] | Array<T[K]>;
 };
 
 export type FieldFilter<T> = {

--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -49,36 +49,35 @@ export type DeepQueryMany<T> = {
 
 export type Sort<T> = (`${Extract<keyof T, string>}` | `-${Extract<keyof T, string>}`)[];
 
-export type FilterOperators =
-	| '_eq'
-	| '_neq'
-	| '_contains'
-	| '_ncontains'
-	| '_in'
-	| '_nin'
-	| '_gt'
-	| '_gte'
-	| '_lt'
-	| '_lte'
-	| '_null'
-	| '_nnull'
-	| '_empty'
-	| '_nempty'
-	| '_intersects'
-	| '_nintersects'
-	| '_intersects_bbox'
-	| '_nintersects_bbox';
+export type FilterOperators<T> = {
+	_eq?: T;
+	_neq?: T;
+	_gt?: T;
+	_gte?: T;
+	_lt?: T;
+	_lte?: T;
+	_in?: T[];
+	_nin?: T[];
+	_between?: [T, T];
+	_nbetween?: [T, T];
+	_contains?: T;
+	_ncontains?: T;
+	_empty?: boolean;
+	_nempty?: boolean;
+	_nnull?: boolean;
+	_null?: boolean;
+	_intersects?: T;
+	_nintersects?: T;
+	_intersects_bbox?: T;
+	_nintersects_bbox?: T;
+};
 
 export type LogicalFilterAnd<T> = { _and: Filter<T>[] };
 export type LogicalFilterOr<T> = { _or: Filter<T>[] };
 export type LogicalFilter<T> = LogicalFilterAnd<T> | LogicalFilterOr<T>;
 
-export type FieldFilterOperator<T, K extends keyof T> = {
-	[O in FilterOperators]?: T[K] | Array<T[K]>;
-};
-
 export type FieldFilter<T> = {
-	[K in keyof T]?: FieldFilterOperator<T, K> | FieldFilter<T[K]>;
+	[K in keyof T]?: FilterOperators<T[K]> | FieldFilter<T[K]>;
 };
 
 export type Filter<T> = LogicalFilter<T> | FieldFilter<T extends Array<unknown> ? T[number] : T>;


### PR DESCRIPTION
Previously, only the same type as definition was accepted.
<img width="778" alt="Screenshot 2021-11-29 at 14 25 39" src="https://user-images.githubusercontent.com/14039341/143885394-6a43e334-563e-4c28-81b8-e25d0ba78a26.png">


Now accept both the type defined and and array of that type
