### PR TITLE
Add dot indicator to groups with modified fields

### DIFF
--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-item :value="field.field" scope="group-accordion" class="accordion-section">
 		<template #default="{ active, toggle }">
-			<div class="label type-title" :class="{ active }" @click="handleModifier($event, toggle)">
+			<div class="label type-title" :class="{ active, edited }" @click="handleModifier($event, toggle)">
 				<v-icon class="icon" :class="{ active }" name="expand_more" />
 				{{ field.name }}
 				<v-icon
@@ -113,6 +113,13 @@ export default defineComponent({
 				});
 		});
 
+		const edited = computed(() => {
+			if (!props.values) return false;
+
+			const editedFields = Object.keys(props.values);
+			return fieldsInSection.value.some((field) => editedFields.includes(field.field)) ? true : false;
+		});
+
 		const validationMessage = computed(() => {
 			const validationError = props.validationErrors.find((error) => error.field === props.field.field);
 			if (validationError === undefined) return;
@@ -124,7 +131,7 @@ export default defineComponent({
 			}
 		});
 
-		return { fieldsInSection, handleModifier, validationMessage };
+		return { fieldsInSection, edited, handleModifier, validationMessage };
 
 		function handleModifier(event: MouseEvent, toggle: () => void) {
 			if (props.multiple === false) {
@@ -152,6 +159,7 @@ export default defineComponent({
 }
 
 .label {
+	position: relative;
 	display: flex;
 	align-items: center;
 	margin: 8px 0;
@@ -163,6 +171,19 @@ export default defineComponent({
 .label:hover,
 .label.active {
 	color: var(--foreground-normal);
+}
+
+.label.edited::before {
+	position: absolute;
+	top: 14px;
+	left: -7px;
+	display: block;
+	width: 4px;
+	height: 4px;
+	background-color: var(--foreground-subdued);
+	border-radius: 4px;
+	content: '';
+	pointer-events: none;
 }
 
 .icon {

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -5,7 +5,7 @@
 				:style="{
 					'--v-divider-label-color': headerColor,
 				}"
-				:class="{ active }"
+				:class="{ active, edited }"
 				:inline-title="false"
 				large
 				@click="toggle"
@@ -108,6 +108,13 @@ export default defineComponent({
 	setup(props) {
 		const { t } = useI18n();
 
+		const edited = computed(() => {
+			if (!props.values) return false;
+
+			const editedFields = Object.keys(props.values);
+			return props.fields.some((field) => editedFields.includes(field.field)) ? true : false;
+		});
+
 		const validationMessages = computed(() => {
 			if (!props.validationErrors) return;
 
@@ -134,7 +141,7 @@ export default defineComponent({
 			return errors.join('\n');
 		});
 
-		return { validationMessages };
+		return { edited, validationMessages };
 	},
 });
 </script>
@@ -156,6 +163,23 @@ export default defineComponent({
 
 .v-divider.active .expand-icon {
 	transform: rotate(0) !important;
+}
+
+.v-divider .title {
+	position: relative;
+}
+
+.v-divider.edited:not(.active) .title::before {
+	position: absolute;
+	top: 14px;
+	left: -7px;
+	display: block;
+	width: 4px;
+	height: 4px;
+	background-color: var(--foreground-subdued);
+	border-radius: 4px;
+	content: '';
+	pointer-events: none;
 }
 
 .header-icon {


### PR DESCRIPTION
## Before

- Accordion Group: since the labels of the fields are hidden, the indicator are not shown regardless of when it's opened or collapsed.
- Detail Group: the fields still have the dot indicator as usual, but it will not be visible/known when it is collapsed.

![tjyude2kZO](https://user-images.githubusercontent.com/42867097/143982983-4cd4047a-683e-45bf-9f9a-8f486087df2d.gif)

## After

- Accordion Group: Now shows the indicator when any child fields are modified.
- Detail Group: Now shows the indicator when any child fields are modified and it is collapsed.

![FAMWJjqzW3](https://user-images.githubusercontent.com/42867097/143983398-1543bf50-8b83-47fd-83cb-f5b349b1f913.gif)


