### PR TITLE
Remove default hourly PR limit for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["config:base", ":disableDependencyDashboard", "schedule:weekly"],
+	"extends": ["config:base", ":disableDependencyDashboard", "schedule:weekly", ":prHourlyLimitNone"],
 	"timezone": "America/New_York",
 	"labels": ["Dependencies"],
 	"semanticCommits": "disabled",


### PR DESCRIPTION
I was wondering why there are no major NPM dependencies updates from Renovate and noticed that there is a hourly limit of two pull requests by default. Since we are now scheduling Renovate only once per week we need to remove this limit.

Tested in other repo ✅ 