### PR TITLE
refresh edited insights panel on change

### DIFF
--- a/api/src/utils/get-default-index-name.ts
+++ b/api/src/utils/get-default-index-name.ts
@@ -1,5 +1,4 @@
-import { simpleHash } from './get-simple-hash';
-
+import { getSimpleHash } from '@directus/shared/utils';
 /**
  * Generate an index name for a given collection + fields combination.
  *
@@ -20,7 +19,7 @@ export function getDefaultIndexName(
 
 	if (indexName.length <= 60) return indexName;
 
-	const suffix = `__${simpleHash(indexName)}_${type}`;
+	const suffix = `__${getSimpleHash(indexName)}_${type}`;
 	const prefix = indexName.substring(0, 60 - suffix.length);
 
 	return `${prefix}${suffix}`;

--- a/app/src/modules/insights/components/workspace.vue
+++ b/app/src/modules/insights/components/workspace.vue
@@ -33,6 +33,7 @@ import { omit } from 'lodash';
 import { Panel } from '@/types';
 import InsightsPanel from '../components/panel.vue';
 import { useElementSize } from '@/composables/use-element-size';
+import { getSimpleHash } from '@directus/shared/utils';
 
 export default defineComponent({
 	name: 'InsightsWorkspace',
@@ -127,14 +128,7 @@ export default defineComponent({
 
 		function getSimpleHashForPanel(panel: Panel & { _coordinates: [number, number][] }) {
 			const trackedProperties = omit(panel, ['position_x', 'position_y', '_coordinates']);
-			const str = JSON.stringify(trackedProperties);
-
-			let hash = 0;
-			for (let i = 0; i < str.length; hash &= hash) {
-				hash = 31 * hash + str.charCodeAt(i++);
-			}
-
-			return Math.abs(hash).toString(16);
+			return getSimpleHash(JSON.stringify(trackedProperties));
 		}
 	},
 });

--- a/app/src/modules/insights/components/workspace.vue
+++ b/app/src/modules/insights/components/workspace.vue
@@ -14,7 +14,7 @@
 		>
 			<insights-panel
 				v-for="panel in panels"
-				:key="panel.id"
+				:key="getSimpleHashForPanel(panel)"
 				:panel="panel"
 				:edit-mode="editMode"
 				:now="now"
@@ -29,6 +29,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType, computed, inject, ref } from 'vue';
+import { omit } from 'lodash';
 import { Panel } from '@/types';
 import InsightsPanel from '../components/panel.vue';
 import { useElementSize } from '@/composables/use-element-size';
@@ -117,11 +118,23 @@ export default defineComponent({
 			};
 		});
 
-		return { workspaceSize, workspaceBoxSize, mainElement, zoomScale };
+		return { workspaceSize, workspaceBoxSize, mainElement, zoomScale, getSimpleHashForPanel };
 
 		function getVar(cssVar: string) {
 			if (!mainElement.value) return;
 			return getComputedStyle(mainElement.value).getPropertyValue(cssVar).trim();
+		}
+
+		function getSimpleHashForPanel(panel: Panel & { _coordinates: [number, number][] }) {
+			const trackedProperties = omit(panel, ['position_x', 'position_y', '_coordinates']);
+			const str = JSON.stringify(trackedProperties);
+
+			let hash = 0;
+			for (let i = 0; i < str.length; hash &= hash) {
+				hash = 31 * hash + str.charCodeAt(i++);
+			}
+
+			return Math.abs(hash).toString(16);
 		}
 	},
 });

--- a/app/src/modules/insights/components/workspace.vue
+++ b/app/src/modules/insights/components/workspace.vue
@@ -14,7 +14,7 @@
 		>
 			<insights-panel
 				v-for="panel in panels"
-				:key="getSimpleHashForPanel(panel)"
+				:key="panel.id"
 				:panel="panel"
 				:edit-mode="editMode"
 				:now="now"
@@ -33,7 +33,6 @@ import { omit } from 'lodash';
 import { Panel } from '@/types';
 import InsightsPanel from '../components/panel.vue';
 import { useElementSize } from '@/composables/use-element-size';
-import { getSimpleHash } from '@directus/shared/utils';
 
 export default defineComponent({
 	name: 'InsightsWorkspace',
@@ -119,16 +118,11 @@ export default defineComponent({
 			};
 		});
 
-		return { workspaceSize, workspaceBoxSize, mainElement, zoomScale, getSimpleHashForPanel };
+		return { workspaceSize, workspaceBoxSize, mainElement, zoomScale };
 
 		function getVar(cssVar: string) {
 			if (!mainElement.value) return;
 			return getComputedStyle(mainElement.value).getPropertyValue(cssVar).trim();
-		}
-
-		function getSimpleHashForPanel(panel: Panel & { _coordinates: [number, number][] }) {
-			const trackedProperties = omit(panel, ['position_x', 'position_y', '_coordinates']);
-			return getSimpleHash(JSON.stringify(trackedProperties));
 		}
 	},
 });

--- a/app/src/modules/insights/components/workspace.vue
+++ b/app/src/modules/insights/components/workspace.vue
@@ -29,7 +29,6 @@
 
 <script lang="ts">
 import { defineComponent, PropType, computed, inject, ref } from 'vue';
-import { omit } from 'lodash';
 import { Panel } from '@/types';
 import InsightsPanel from '../components/panel.vue';
 import { useElementSize } from '@/composables/use-element-size';

--- a/app/src/panels/time-series/time-series.vue
+++ b/app/src/panels/time-series/time-series.vue
@@ -8,7 +8,7 @@ import api from '@/api';
 import ApexCharts from 'apexcharts';
 import { adjustDate } from '@/utils/adjust-date';
 import { useI18n } from 'vue-i18n';
-import { isEqual, isNil } from 'lodash';
+import { isNil } from 'lodash';
 import { useFieldsStore } from '@/stores';
 import { Filter } from '@directus/shared/types';
 import { abbreviateNumber } from '@/utils/abbreviate-number';
@@ -111,13 +111,11 @@ export default defineComponent({
 		});
 
 		watch(
-			[() => props, () => props.showHeader, () => props.height],
-			(newVal, oldVal) => {
-				if (isEqual(newVal, oldVal) === false) {
-					fetchData();
-					chart.value?.destroy();
-					setupChart();
-				}
+			() => props,
+			() => {
+				fetchData();
+				chart.value?.destroy();
+				setupChart();
 			},
 			{ deep: true }
 		);

--- a/packages/shared/src/utils/get-simple-hash.test.ts
+++ b/packages/shared/src/utils/get-simple-hash.test.ts
@@ -1,0 +1,11 @@
+import { getSimpleHash } from './get-simple-hash';
+
+describe('getSimpleHash', () => {
+	it('returns "364492" for string "test"', () => {
+		expect(getSimpleHash('test')).toBe('364492');
+	});
+
+	it('returns "28cb67ba" for stringified object "{ key: \'value\' }"', () => {
+		expect(getSimpleHash(JSON.stringify({ key: 'value' }))).toBe('28cb67ba');
+	});
+});

--- a/packages/shared/src/utils/get-simple-hash.ts
+++ b/packages/shared/src/utils/get-simple-hash.ts
@@ -2,7 +2,7 @@
  * Generate a simple short hash for a given string
  * This is not cryptographically secure in any way, and has a high chance of collision
  */
-export function simpleHash(str: string) {
+export function getSimpleHash(str: string) {
 	let hash = 0;
 
 	for (let i = 0; i < str.length; hash &= hash) {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './get-collection-type';
 export * from './get-fields-from-template';
 export * from './get-filter-operators-for-type';
 export * from './get-relation-type';
+export * from './get-simple-hash';
 export * from './is-dynamic-variable';
 export * from './is-extension';
 export * from './merge-filters';


### PR DESCRIPTION
Fixes #10177

## Before

After a panel gets staged/created, it will not change even when we modify any settings, and we'll have to refresh to see the changes:

https://user-images.githubusercontent.com/42867097/144173424-f2ba9b7e-1c24-4fc7-84e7-c531e51eac2b.mp4

## After

Uses Vue key to re-render the panel whenever any property gets changed, except position x/y and coordinates to prevent re-render when the user is only moving them around.

https://user-images.githubusercontent.com/42867097/144173436-5bd47b64-9813-4296-b5bc-f959365e47f7.mp4


