### PR TITLE
add text path to autocomplete api input

### DIFF
--- a/app/src/interfaces/input-autocomplete-api/index.ts
+++ b/app/src/interfaces/input-autocomplete-api/index.ts
@@ -36,6 +36,19 @@ export default defineInterface({
 					placeholder: 'result.predictions',
 					font: 'monospace',
 				},
+				width: 'full',
+			},
+		},
+		{
+			field: 'textPath',
+			name: '$t:interfaces.input-autocomplete-api.text_path',
+			type: 'string',
+			meta: {
+				interface: 'input',
+				options: {
+					placeholder: 'structured_main_text',
+					font: 'monospace',
+				},
 				width: 'half',
 			},
 		},
@@ -46,7 +59,7 @@ export default defineInterface({
 			meta: {
 				interface: 'input',
 				options: {
-					placeholder: 'structured_main_text',
+					placeholder: 'structured_main_value',
 					font: 'monospace',
 				},
 				width: 'half',

--- a/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
+++ b/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
@@ -20,8 +20,8 @@
 			</template>
 
 			<v-list v-if="results.length > 0">
-				<v-list-item v-for="result of results" :key="result" @click="() => emitValue(result)">
-					<v-list-item-content>{{ result }}</v-list-item-content>
+				<v-list-item v-for="result of results" :key="result.value" @click="() => emitValue(result.value)">
+					<v-list-item-content>{{ textPath ? result.text : result.value }}</v-list-item-content>
 				</v-list-item>
 			</v-list>
 		</v-menu>
@@ -46,6 +46,10 @@ export default defineComponent({
 			default: null,
 		},
 		resultsPath: {
+			type: String,
+			default: null,
+		},
+		textPath: {
 			type: String,
 			default: null,
 		},
@@ -86,7 +90,7 @@ export default defineComponent({
 	setup(props, { emit }) {
 		const { t } = useI18n();
 
-		const results = ref<string[]>([]);
+		const results = ref<Record<string, any>[]>([]);
 
 		const fetchResultsRaw = async (value: string | null) => {
 			if (!value) {
@@ -104,11 +108,17 @@ export default defineComponent({
 					// eslint-disable-next-line no-console
 					console.warn(`Expected results type of array, "${typeof resultsArray}" received`);
 					return;
-				} else {
-					results.value = resultsArray
-						.map((result: Record<string, unknown>) => (props.valuePath ? get(result, props.valuePath) : result))
-						.filter((val: unknown) => val);
 				}
+
+				results.value = resultsArray.map((result: Record<string, unknown>) => {
+					if (props.textPath && props.valuePath) {
+						return { text: get(result, props.textPath), value: get(result, props.valuePath) };
+					} else if (props.valuePath) {
+						return { value: get(result, props.valuePath) };
+					} else {
+						return { value: result };
+					}
+				});
 			} catch (err: any) {
 				// eslint-disable-next-line no-console
 				console.warn(err);

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1455,6 +1455,7 @@ interfaces:
     input-autocomplete-api: Autocomplete Input (API)
     description: A search typeahead for external API values.
     results_path: Results Path
+    text_path: Text Path
     value_path: Value Path
     trigger: Trigger
     rate: Rate


### PR DESCRIPTION
Partly prompted from #10128. This allows the similar concept of text & value for choices in dropdowns, where the user can configure a different display text from the actual selection value.

## Before

![53MUO6svpW](https://user-images.githubusercontent.com/42867097/144219386-03556165-5841-4c11-ae8c-e8afd7bb1d14.gif)

## After

![4RVsbCe5ED](https://user-images.githubusercontent.com/42867097/144219429-3b318b81-8770-4e4a-b8a6-6e8220b96a8b.gif)


