### PR TITLE
fix filter breaking instead of defaulting to `_eq`

### DIFF
--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -3,6 +3,7 @@ import { Accountability, Filter, User, Role } from '../types';
 import { toArray } from './to-array';
 import { adjustDate } from './adjust-date';
 import { isDynamicVariable } from './is-dynamic-variable';
+import { isObjectLike } from 'lodash';
 
 type ParseFilterContext = {
 	// The user can add any custom fields to user
@@ -16,6 +17,7 @@ export function parseFilter(
 	context: ParseFilterContext = {}
 ): Filter | null {
 	if (!filter) return null;
+	if (!isObjectLike(filter)) return filter;
 	return Object.entries(filter).reduce((result, [key, value]) => {
 		if (['_or', '_and'].includes(String(key))) {
 			result[key] = value.map((filter: Filter) => parseFilter(filter, accountability, context));


### PR DESCRIPTION
Fixes #10056

## Reported bug

`?filter[value]=5` used to work, but now it'll throw error 500 and it'll only work if we do `?filter[value][_eq]=5`.

## Investigation

At first it seemed like the "default to `_eq`" was removed, but it is actually still there:

https://github.com/directus/directus/blob/main/api/src/utils/apply-query.ts#L643-L645

Turns out it was an unintended side effect from the `applyFilter` refactoring in #9804, which aligns with the reports of it not working since `9.1.x`.

Based on the old logic, when the value is not "objectLike", it'll be returned directly as is:

https://github.com/directus/directus/blob/65291b95c49f6221327ae348f98279609aed4b08/packages/shared/src/utils/deep-map.ts#L14-L30

## Solution

Added an if statement to return value without any modifcation when it's not an object. This prevents it from being "processed" by the Object.entries like `Object.entries(5).reduce(()=> /* logic */, {})` which ended up returning `{}` instead.

## Test

![chrome_JRC7Sd3Pdf](https://user-images.githubusercontent.com/42867097/144253107-53395ac6-4b45-4396-9456-f27bff9960b8.png)

