### PR TITLE
Clean up format-title build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36673,6 +36673,28 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/rollup-plugin-dts": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.0.1.tgz",
+			"integrity": "sha512-DNv5F8pro/r0Hkx3JWKRtJZocDnqXfgypoajeiaNq134rYaFcEIl/oas5PogD1qexMadVijsHyVko1Chig0OOQ==",
+			"dev": true,
+			"dependencies": {
+				"magic-string": "^0.25.7"
+			},
+			"engines": {
+				"node": ">=v12.22.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Swatinem"
+			},
+			"optionalDependencies": {
+				"@babel/code-frame": "^7.14.5"
+			},
+			"peerDependencies": {
+				"rollup": "^2.56.3",
+				"typescript": "^4.4.2"
+			}
+		},
 		"node_modules/rollup-plugin-sourcemaps": {
 			"version": "0.6.3",
 			"dev": true,
@@ -45528,6 +45550,7 @@
 				"@rollup/plugin-node-resolve": "13.0.6",
 				"rimraf": "3.0.2",
 				"rollup": "2.60.1",
+				"rollup-plugin-dts": "4.0.1",
 				"rollup-plugin-sourcemaps": "0.6.3",
 				"rollup-plugin-terser": "7.0.2",
 				"rollup-plugin-typescript2": "0.31.0",
@@ -48342,6 +48365,7 @@
 				"@rollup/plugin-node-resolve": "13.0.6",
 				"rimraf": "3.0.2",
 				"rollup": "2.60.1",
+				"rollup-plugin-dts": "4.0.1",
 				"rollup-plugin-sourcemaps": "0.6.3",
 				"rollup-plugin-terser": "7.0.2",
 				"rollup-plugin-typescript2": "0.31.0",
@@ -71223,6 +71247,16 @@
 					"version": "0.1.2",
 					"dev": true
 				}
+			}
+		},
+		"rollup-plugin-dts": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.0.1.tgz",
+			"integrity": "sha512-DNv5F8pro/r0Hkx3JWKRtJZocDnqXfgypoajeiaNq134rYaFcEIl/oas5PogD1qexMadVijsHyVko1Chig0OOQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.14.5",
+				"magic-string": "^0.25.7"
 			}
 		},
 		"rollup-plugin-sourcemaps": {

--- a/packages/format-title/index.mjs
+++ b/packages/format-title/index.mjs
@@ -1,0 +1,1 @@
+export * from './dist/format-title.cjs.js'

--- a/packages/format-title/package.json
+++ b/packages/format-title/package.json
@@ -16,27 +16,34 @@
 	"main": "dist/format-title.cjs.js",
 	"exports": {
 		".": {
-			"import": "./dist/format-title.bundler.js",
+			"import": {
+				"node": "./index.mjs",
+				"default": "./dist/format-title.bundler.js"
+			},
 			"require": "./dist/format-title.cjs.js"
 		},
 		"./package.json": "./package.json"
 	},
 	"module": "dist/format-title.bundler.js",
-	"unpkg": "dist/format-title.global.min.js",
-	"types": "dist/types/index.d.ts",
+	"unpkg": "dist/format-title.esm.min.js",
+	"types": "dist/index.d.ts",
 	"files": [
-		"dist"
+		"dist",
+		"index.mjs"
 	],
 	"author": "rijkvanzanten <rijkvanzanten@me.com>",
-	"repository": "directus/format-title",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/directus/directus.git"
+	},
 	"license": "MIT",
 	"engines": {
 		"node": ">=6.0.0"
 	},
 	"scripts": {
 		"prebuild": "rimraf dist",
-		"build": "rollup -c rollup.config.js",
-		"start": "rollup -c rollup.config.js -w"
+		"build": "rollup -c",
+		"dev": "rollup -c -w"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "21.0.1",
@@ -44,6 +51,7 @@
 		"@rollup/plugin-node-resolve": "13.0.6",
 		"rimraf": "3.0.2",
 		"rollup": "2.60.1",
+		"rollup-plugin-dts": "4.0.1",
 		"rollup-plugin-sourcemaps": "0.6.3",
 		"rollup-plugin-terser": "7.0.2",
 		"rollup-plugin-typescript2": "0.31.0",

--- a/packages/format-title/rollup.config.js
+++ b/packages/format-title/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import { terser } from 'rollup-plugin-terser';
+import dts from 'rollup-plugin-dts';
 
 import pkg from './package.json';
 
@@ -11,63 +12,57 @@ const globalName = 'formatTitle';
 
 const configs = {
 	global: {
-		file: pkg.unpkg,
+		file: pkg.unpkg.replace('esm', 'global'),
 		format: 'iife',
 		target: 'es5',
-		mode: 'production',
 		browser: true,
 	},
 	browser: {
-		file: pkg.module.replace('bundler', 'esm'),
+		file: pkg.unpkg,
 		format: 'es',
-		target: 'es2018',
-		mode: 'production',
 		browser: true,
+		external: false,
 	},
 	bundler: {
 		file: pkg.module,
 		format: 'es',
-		target: 'es2018',
-		mode: 'development',
+		dev: true,
 	},
 	cjs: {
 		file: pkg.main,
 		format: 'cjs',
-		target: 'es2018',
-		mode: 'development',
+		dev: true,
 	},
 };
 
 function createConfig({
 	file,
 	format,
-	target,
-	mode,
+	target = null,
+	dev = false,
 	browser = false,
 	external = Object.fromEntries(Object.keys(pkg.dependencies || {}).map((x) => [x, x])),
 }) {
-	const isProduction = mode === 'production';
-
 	const config = {
 		input: 'src/index.ts',
 		output: {
-			file: isProduction && !file.endsWith('.min.js') ? file.replace('.js', '.min.js') : file,
+			file,
 			format,
 			exports: 'auto',
 			sourcemap: true,
 		},
-		external: Object.keys(external),
+		external: external ? Object.keys(external) : undefined,
 		watch: {
 			include: 'src/**/*',
 		},
 		plugins: [
 			json(),
 			typescript({
-				useTsconfigDeclarationDir: true,
 				tsconfigOverride: {
 					compilerOptions: {
-						target,
-						lib: [target],
+						...(target ? { target, lib: [target] } : {}),
+						declaration: false,
+						declarationMap: false,
 					},
 				},
 			}),
@@ -79,13 +74,13 @@ function createConfig({
 
 	if (format === 'iife') {
 		config.output.name = globalName;
-		config.output.globals = external;
+		config.output.globals = external ?? {};
 	}
 
-	if (isProduction) {
+	if (!dev) {
 		config.plugins.push(
 			terser({
-				ecma: target.replace('es', ''),
+				ecma: target?.replace('es', '') ?? '2019',
 			})
 		);
 	}
@@ -94,7 +89,13 @@ function createConfig({
 }
 
 function createConfigs(configs) {
-	return Object.keys(configs).map((key) => createConfig(configs[key]));
+	const typesConfig = {
+		input: 'src/index.ts',
+		output: [{ file: pkg.types, format: 'es' }],
+		plugins: [dts()],
+	};
+
+	return [...Object.keys(configs).map((key) => createConfig(configs[key])), typesConfig];
 }
 
 export default createConfigs(configs);

--- a/packages/format-title/src/index.ts
+++ b/packages/format-title/src/index.ts
@@ -7,8 +7,8 @@ function handleSpecialWords(str: string, index: number, words: string[]): string
 	const lowercaseStr = str.toLowerCase();
 	const uppercaseStr = str.toUpperCase();
 
-	for (let i = 0; i < specialCase.length; i += 1) {
-		if (specialCase[i].toLowerCase() === lowercaseStr) return specialCase[i];
+	for (const special of specialCase) {
+		if (special.toLowerCase() === lowercaseStr) return special;
 	}
 
 	if (acronyms.includes(uppercaseStr)) return uppercaseStr;

--- a/packages/format-title/tsconfig.json
+++ b/packages/format-title/tsconfig.json
@@ -1,19 +1,31 @@
 {
 	"compilerOptions": {
-		"target": "es5",
-		"lib": ["es5"],
-		"module": "es2015",
+		"target": "ES2019",
+		"lib": ["ES2019"],
+		"module": "ES2015",
 		"moduleResolution": "node",
-		"sourceMap": true,
 		"declaration": true,
-		"declarationDir": "dist/types",
-		"noEmit": true,
-		"noEmitOnError": true,
+		"declarationMap": true,
 		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"esModuleInterop": true,
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedParameters": true,
+		"alwaysStrict": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"strictBindCallApply": true,
+		"strictPropertyInitialization": true,
+		"resolveJsonModule": false,
 		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
 		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": true
+		"isolatedModules": true,
+		"rootDir": "./src"
 	},
-	"include": ["src/**/*.ts"],
-	"exclude": ["node_modules"]
+	"include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
In addition to the cleanups, this also increases the target version to ES2019 for all builds except the global one, it changes unpkg's default entrypoint to the esm one to align with the sdk and it bundles the types to a single file resulting in a tiny two-line declaration file.

The build process and the way the exports in `package.json` work is inspired by [vue-next](https://github.com/vuejs/vue-next).

The secondary goal of this PR is to find a build config that can also be applied to the SDK. (ref #10053, cc @joselcvarela)