### PR TITLE
Permissions: fix empty permissions

### DIFF
--- a/api/src/utils/merge-permissions.ts
+++ b/api/src/utils/merge-permissions.ts
@@ -1,4 +1,4 @@
-import { flatten, merge, omit } from 'lodash';
+import { flatten, merge, omit, isEmpty } from 'lodash';
 import { Permission, LogicalFilterOR } from '@directus/shared/types';
 
 export function mergePermissions(...permissions: Permission[][]): Permission[] {
@@ -26,12 +26,12 @@ function mergePerm(currentPerm: Permission, newPerm: Permission) {
 	let fields = currentPerm.fields;
 	let presets = currentPerm.presets;
 
-	if (newPerm.permissions) {
+	if (newPerm.permissions && !isEmpty(newPerm.permissions)) {
 		if (currentPerm.permissions && Object.keys(currentPerm.permissions)[0] === '_or') {
 			permissions = {
 				_or: [...(currentPerm.permissions as LogicalFilterOR)._or, newPerm.permissions],
 			};
-		} else if (currentPerm.permissions) {
+		} else if (currentPerm.permissions && !isEmpty(currentPerm.permissions)) {
 			permissions = {
 				_or: [currentPerm.permissions, newPerm.permissions],
 			};


### PR DESCRIPTION
Fix when permissions are empty or null

___
Edit:
After pull main branch into before this PR, my non-admin user was not able to login into the app. This happened because `null` was being inserted into `filter`.
Then in `applyQuery` https://github.com/directus/directus/blob/main/api/src/utils/apply-query.ts#L161 
an error was thrown because `Object.keys(null)` which is not correct.