### PR TITLE
allow delete keypresses in v-input

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -182,23 +182,13 @@ export default defineComponent({
 		function processValue(event: KeyboardEvent) {
 			if (!event.key) return;
 			const key = event.key.toLowerCase();
-			const systemKeys = [
-				'meta',
-				'shift',
-				'alt',
-				'backspace',
-				'tab',
-				'arrowup',
-				'arrowdown',
-				'arrowleft',
-				'arrowright',
-			];
+			const systemKeys = ['meta', 'shift', 'alt', 'backspace', 'delete', 'tab'];
 			const value = (event.target as HTMLInputElement).value;
 
 			if (props.slug === true) {
 				const slugSafeCharacters = 'abcdefghijklmnopqrstuvwxyz01234567890-_~ '.split('');
 
-				const isAllowed = slugSafeCharacters.includes(key) || systemKeys.includes(key);
+				const isAllowed = slugSafeCharacters.includes(key) || systemKeys.includes(key) || key.startsWith('arrow');
 
 				if (isAllowed === false) {
 					event.preventDefault();


### PR DESCRIPTION
Since there's backspace, allowing delete should feel more natural.

Also noticed that props.dbSafe actually uses `key.startsWith('arrow')` to check for arrow keys, so I removed them from the systemKeys array and added the same logic for props.slug.

https://github.com/directus/directus/blob/11a71a7df08f236397f160592bf96cdfb58613c6/app/src/components/v-input/v-input.vue#L215