### PR TITLE
Fix SQLite date functions not working in aggregate queries

### DIFF
--- a/api/src/database/helpers/date/dialects/sqlite.ts
+++ b/api/src/database/helpers/date/dialects/sqlite.ts
@@ -3,35 +3,35 @@ import { Knex } from 'knex';
 
 export class DateHelperSQLite extends DateHelper {
 	year(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%Y', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%Y', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	month(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%m', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%m', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	week(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%W', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%W', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	day(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%d', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%d', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	weekday(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%w', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%w', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	hour(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%H', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%H', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	minute(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%M', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%M', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	second(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%S', ??.??)", [table, column]);
+		return this.knex.raw("strftime('%S', ??.?? / 1000, 'unixepoch')", [table, column]);
 	}
 
 	parse(date: string): string {


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/10253
`node-sqlite` stores dates as milliseconds since the epoch, so we need to process them before using `strftime`.