### PR TITLE
Small optimization in getNodeAtPath

### DIFF
--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -49,23 +49,7 @@ export function useFieldTree(
 			.filter(filter)
 			.flatMap((field) => makeNode(field, parent));
 
-		return fields.length ? fields : undefined;
-	}
-
-	function getRelatedCollections(field: Field): string[] {
-		const relation = getRelationForField(field);
-		if (!relation?.meta) return [];
-		const relationType = getRelationType({ relation, collection: field.collection, field: field.field });
-		switch (relationType) {
-			case 'o2m':
-				return [relation!.meta!.many_collection];
-			case 'm2o':
-				return [relation!.meta!.one_collection];
-			case 'm2a':
-				return relation!.meta!.one_allowed_collections!;
-			default:
-				return [];
-		}
+		return fields.length > 0 ? fields : undefined;
 	}
 
 	function makeNode(field: Field, parent?: FieldNode): FieldNode | FieldNode[] {
@@ -91,6 +75,22 @@ export function useFieldTree(
 		});
 	}
 
+	function getRelatedCollections(field: Field): string[] {
+		const relation = getRelationForField(field);
+		if (!relation?.meta) return [];
+		const relationType = getRelationType({ relation, collection: field.collection, field: field.field });
+		switch (relationType) {
+			case 'o2m':
+				return [relation!.meta!.many_collection];
+			case 'm2o':
+				return [relation!.meta!.one_collection];
+			case 'm2a':
+				return relation!.meta!.one_allowed_collections!;
+			default:
+				return [];
+		}
+	}
+
 	function getRelationForField(field: { collection: string; field: string }) {
 		const relations = [
 			...relationsStore.getRelationsForField(field.collection, field.field),
@@ -103,12 +103,11 @@ export function useFieldTree(
 		);
 	}
 
-	function getNodeAtPath(path: string, root?: FieldNode[]): FieldNode | undefined {
-		const [field, ...follow] = path.split('.');
+	function getNodeAtPath([field, ...path]: string[], root?: FieldNode[]): FieldNode | undefined {
 		for (const node of root || []) {
 			if (node.field === field) {
-				if (follow.length) {
-					return getNodeAtPath(follow.join('.'), node.children);
+				if (path.length) {
+					return getNodeAtPath(path, node.children);
 				} else {
 					return node;
 				}
@@ -119,7 +118,7 @@ export function useFieldTree(
 	function loadFieldRelations(path: string) {
 		if (!visitedPaths.value.has(path)) {
 			visitedPaths.value.add(path);
-			const node = getNodeAtPath(path, treeList.value);
+			const node = getNodeAtPath(path.split('.'), treeList.value);
 			for (const child of node?.children || []) {
 				child.children = getTree(child.relatedCollection, child);
 			}


### PR DESCRIPTION
Input path as `string[]` instead of having to split and join it at every level.
Move `getRelatedCollections` below `makeNode` to follow code discovery.