### PR TITLE
docs updates on file library, content sidebar etc

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -154,13 +154,21 @@ module.exports = {
 					},
 					{
 						type: 'page',
-						path: '/app/content-collections',
-						title: 'Content Collections',
-					},
-					{
-						type: 'page',
-						path: '/app/content-items',
-						title: 'Content Items',
+						path: '/app/content',
+						title: 'Content',
+						collapsable: false,
+						children: [
+							{
+								type: 'page',
+								path: '/app/content-collections',
+								title: 'Content Collections',
+							},
+							{
+								type: 'page',
+								path: '/app/content-items',
+								title: 'Content Items',
+							},
+						],
 					},
 					{
 						type: 'page',

--- a/docs/app/file-library.md
+++ b/docs/app/file-library.md
@@ -34,16 +34,18 @@ The file sidebar also includes the following details:
 - **Size** — The file-size the asset takes up within the storage adapter
 - **Created** — The timestamp of when the file was uploaded to the project
 - **Owner** — The Directus user that uploaded the file to the project
+- **Modified** - The timestamp of when the file was last modified
+- **Edited By** — The Directus user that modified the file
 - **Folder** — The current parent folder that contains the file
 - **Metadata** — Metadata JSON dump of the file's EXIF, IPTC, and ICC information
 
 #### Action Buttons
 
-- **Save** — Saves any edits made to the page
-- **Edit** — Saves any edits made to the page
-- **Download** — Saves any edits made to the page
-- **Move Folder** — Saves any edits made to the page
-- **Delete** — Permanently removes this file and its metadata. This action is permanent and can not be undone.
+- **Save** — Saves any edits made to the file
+- **Edit** — Refer [Editing an Image](#editing-an-image)
+- **Download** — Downloads the file to your current device
+- **Move to Folder** — Move the file to another folder
+- **Delete** — Permanently removes the file and its metadata. This action is permanent and can not be undone.
 
 ## Editing an Image
 
@@ -69,3 +71,32 @@ keep in mind that files can also be added directly through different interfaces.
    - Dragging a file from your desktop to the modal
    - Click the modal area to manually select a file from your device
    - Clicking the "..." icon and choosing "Import from URL"
+
+## Creating a Folder
+
+1. From the **File Library**, click on the **"Create Folder"** (folder with plus icon) button located in the header
+2. Fill in the folder name
+3. Click "Save"
+
+## Renaming a Folder
+
+1. From the **File Library**, right-click on the folder you wish to rename and select "Rename Folder"
+2. Update the folder name
+3. Click "Save"
+
+## Moving a Folder
+
+1. From the **File Library**, right-click on the folder you wish to move and select "Move to Folder"
+2. Select a folder that will be the new parent folder
+3. Click "Save"
+
+## Deleting a Folder
+
+1. From the **File Library**, right-click on the folder you wish to delete and select "Delete Folder"
+2. Click "Delete"
+
+::: tip
+
+When you delete a folder, any nested files and folders will be moved one level up.
+
+:::

--- a/docs/configuration/data-model.md
+++ b/docs/configuration/data-model.md
@@ -44,8 +44,8 @@ are available:
 
 - **Fields & Layout** — This manages the fields of this collection, and their form layout. For more information on this
   configuration, refer to the sections below on Field Management.
-  - [Creating a Field](#creating-a-field)
-  - [Updating a Field](#updating-a-field)
+  - [Creating a Field](#creating-a-field-standard)
+  - [Configuring a Field](#configuring-a-field)
   - [Deleting a Field](#deleting-a-field)
   - [Duplicating a Field](#duplicating-a-field)
   - [Changing Field Order & Layout](#adjusting-the-collection-form)

--- a/docs/configuration/project-settings.md
+++ b/docs/configuration/project-settings.md
@@ -9,7 +9,7 @@
   login/public pages
 - **Project URL** — The URL when clicking the logo at the top of the [Module Bar](/app/overview/#_1-module-bar)
 
-## Branding
+## Branding & Style
 
 - **Project Color** — The color used behind the logo at the top of the [Module Bar](/app/overview/#_1-module-bar), on
   the login/public pages, and for the browser's FavIcon

--- a/docs/configuration/users-roles-permissions.md
+++ b/docs/configuration/users-roles-permissions.md
@@ -175,7 +175,7 @@ App's soft-delete and manual sorting features.
 ### Delete (Custom Access)
 
 5. **Item Permissions** control which items can be deleted, as defined by the
-   [Filter Rules](/configuration/filter-rules/)) entered.
+   [Filter Rules](/configuration/filter-rules/) entered.
 
 ---
 

--- a/docs/contributing/codebase-overview.md
+++ b/docs/contributing/codebase-overview.md
@@ -31,10 +31,6 @@ Database manipulation abstraction, system migrations, and system data. Also wher
 
 Classes for the different errors the API is expected to throw. Used to set the HTTP status and error codes.
 
-#### `/api/src/mail`
-
-Mail abstraction. Allows Directus to send emails. (Note: this is planned to be moved into a MailService. See below)
-
 #### `/api/src/middleware`
 
 Various (express) routing middleware. Includes things like cache-checker, authenticator, etc.
@@ -50,13 +46,13 @@ TypeScript types that are shared between the different parts of the API.
 
 #### `/api/src/utils`
 
-Utility functions
+Various utility functions.
 
 ## `/app`
 
 Contains the Directus Admin App, written in Vue.js 3 w/ the Composition API.
 
-## `/app/public`
+#### `/app/public`
 
 Assets that are included with the app, but not bundled.
 
@@ -75,7 +71,7 @@ from now, fetching a single item, etc.
 
 #### `/app/src/directives`
 
-Custom Vue directives (e.g. `v-tooltip`)
+Custom Vue directives (e.g. `v-tooltip`).
 
 #### `/app/src/interfaces`
 
@@ -84,7 +80,7 @@ The core-included interfaces.
 #### `/app/src/lang`
 
 Translations abstraction, and language files. The language yaml files are maintained through
-[Crowdin](https://locales.directus.io)
+[Crowdin](https://locales.directus.io).
 
 #### `/app/src/layouts`
 

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -178,8 +178,8 @@ module.exports = function registerHook({ schedule }) {
 ### 1. Create a Hook File
 
 Custom hooks are dynamically loaded from within your extensions folder. By default, this directory is located at
-`/extensions`, but it can be configured within your project's env file to be located anywhere. The hook-id is the name
-of your hook.
+`/extensions/hooks`, but it can be configured within your project's env file to be located anywhere. The hook-id is the
+name of your hook.
 
 #### Default Standalone Hook Location
 

--- a/docs/extensions/migrations.md
+++ b/docs/extensions/migrations.md
@@ -46,10 +46,11 @@ what you're doing and backup your database before adding these migrations.
 
 ## Migrations and Directus schema
 
-Migrations can be used for managing contents of Directus collections (e.g. initial hydration). In order
-to do it, you must ensure that schema is up to date before running migrations. One way of achieving it is opting out of default `directus bootstrap` process and running: 
+Migrations can be used for managing contents of Directus collections (e.g. initial hydration). In order to do it, you
+must ensure that schema is up to date before running migrations. One way of achieving it is opting out of default
+`directus bootstrap` process and running:
 
-```
+```bash
 npx directus database install
 # notice that schema is applied before running migrations
 npx directus schema apply ./path/to/snapshot.yaml

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -27,8 +27,8 @@ See [Adjusting Project Settings](/configuration/project-settings/)
 You can also override any core CSS directly within the App through Project Settings. This makes it easy to edit the CSS
 variables listed in the themes above.
 
-1. Navigate to **Settings > Project Settings**
-2. Scroll to the **CSS Overrides** field
+1. Navigate to **Settings Module > Project Settings**
+2. Scroll to the **Custom CSS** field
 3. Enter any **valid CSS**
 4. Click the **Save** action button in the header
 

--- a/docs/getting-started/installation/docker.md
+++ b/docs/getting-started/installation/docker.md
@@ -131,14 +131,14 @@ networks:
 If you are not using the `latest` tag for the Directus image you need to adjust your `docker-compose.yml` file to
 increment the tag version number, e.g.:
 
-```
+```diff
 -   image: directus/directus:9.0.0-rc.101
 +   image: directus/directus:9.0.0
 ```
 
 You can then issue the following two commands (from your docker-compose root):
 
-```
+```bash
 docker-compose pull
 docker-compose up -d
 ```

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -97,7 +97,7 @@ extension types in the platform's App and API.
 - **[Migrations](/extensions/migrations/)** — Custom migrations for tracking project schema and content updates
 - **[Modules](/extensions/modules/)** — The highest and broadest level of organization within the App
 - **[Panels](/extensions/panels/)** — A way to view dashboard data within the Insights Module
-- **[Themes](/extensions/themes/)** — Whitelabeling through App Themes and CSS Overrides
+- **[Themes](/extensions/themes/)** — Whitelabeling through App Themes and Custom CSS
 
 ## The Directus Ecosystem
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,7 +19,7 @@ npm init directus-project example-project
 Once the installation is complete, you can start Directus by navigating to your project folder (in this case
 `example-project`) and running:
 
-```
+```bash
 npx directus start
 ```
 


### PR DESCRIPTION
- update File Library module docs
- nest content-collections and content-items pages under Content in App Guide sidebar since the `/app/content` page apparently already exists. Should make more sense in terms of Content module as a whole.
- fix CSS Overrides as it's been renamed to Custom CSS
- add languages to some code blocks
- Miscellaneous clean ups