### PR TITLE
Use expression instead of alias in groupBy query

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -5,7 +5,6 @@ import validate from 'uuid-validate';
 import { InvalidQueryException } from '../exceptions';
 import { Relation, SchemaOverview } from '../types';
 import { Aggregate, Filter, LogicalFilterAND, Query } from '@directus/shared/types';
-import { applyFunctionToColumnName } from './apply-function-to-column-name';
 import { getColumn } from './get-column';
 import { getRelationType } from './get-relation-type';
 import { getHelpers } from '../database/helpers';
@@ -59,7 +58,7 @@ export default function applyQuery(
 	}
 
 	if (query.group) {
-		dbQuery.groupBy(`${collection}.${query.group.map(applyFunctionToColumnName)}`);
+		dbQuery.groupBy(query.group.map((column) => getColumn(knex, collection, column, false)));
 	}
 
 	if (query.aggregate) {


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/10300
Before:
```sql
SELECT
       EXTRACT(YEAR FROM "brands"."date_updated")  AS "date_updated_year",
       EXTRACT(MONTH FROM "brands"."date_updated") AS "date_updated_month",
       COUNT("brands"."counter")                   AS "count->counter"
FROM "brands"
GROUP BY
       "date_updated_year",
       "date_updated_month",
```
After:

```sql
SELECT
       EXTRACT(YEAR FROM "brands"."date_updated")  AS "date_updated_year",
       EXTRACT(MONTH FROM "brands"."date_updated") AS "date_updated_month",
       COUNT("brands"."counter")                   AS "count->counter"
FROM "brands"
GROUP BY
       EXTRACT(YEAR FROM "brands"."date_updated"),
       EXTRACT(MONTH FROM "brands"."date_updated")
```

This will avoid any ambiguities in column names and will work for both columns and column expressions.