### PR TITLE
fix styling problem with nested render-template

### DIFF
--- a/app/src/views/private/components/render-template/render-template.vue
+++ b/app/src/views/private/components/render-template/render-template.vue
@@ -140,6 +140,10 @@ export default defineComponent({
 	> * {
 		vertical-align: middle;
 	}
+
+	.render-template {
+		display: inline;
+	}
 }
 
 .subdued {


### PR DESCRIPTION
Fixes a style bug when using nested render-template (for example rendering a "translations" column within a m2o), which causes everything after said placeholder (including) on a new line (making it invisible)

Fixes https://github.com/directus/directus/issues/9525