### PR TITLE
Support modifying authentication flow using `auth.accountability` hook (#8727)

### DIFF
--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -151,6 +151,7 @@ export default ({ schedule }) => {
 | `request.not_found`           | `false`              | `request`, `response`                |
 | `request.error`               | The request errors   | --                                   |
 | `database.error`              | The database error   | `client`                             |
+| `auth.accountability`         | `null`               | `req`, `token`, `isDirectusJWT`      |
 | `auth.login`                  | The login payload    | `status`, `user`, `provider`         |
 | `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type` |
 | `(<collection>.)items.read`   | The read item        | `collection`                         |
@@ -167,6 +168,24 @@ export default ({ schedule }) => {
 `folders`, `permissions`, `presets`, `relations`, `revisions`, `roles`, `settings`, `users` or `webhooks`.
 
 :::
+
+#### Custom accountability factory (custom authentication mechanism)
+
+To opt-out from Directus authentication flow, use `auth.accountability` filter hook and return an object
+that matches expected `accountability` interface:
+
+```ts
+{
+	user: string | null; // user id
+	role: string | null; // role id
+	admin: boolean; // admin access
+	app: boolean; // Directus panel access
+	ip: string; // example: req.ip.startsWith('::ffff:') ? req.ip.substring(7) : req.ip
+	userAgent: string; // example: req.get('user-agent')
+}
+```
+
+Return `null` or `undefined` to use Directus authentication flow.
 
 ### Action Events
 


### PR DESCRIPTION
I've created a new PR in response to discussion #8727. PR #8750 was closed due to changes in `hooks` API.

Regarding the naming problem, I agree with @rijkvanzanten [comment](https://github.com/directus/directus/pull/8750#discussion_r762107342), scoping the name of this event under `auth`. My suggestion is `auth.accountability`. I have added documentation explaining this event.

---

While working, I had two doubts regarding the new hooks implementation.

1. `HookContext` duplicates `ExtensionContext`

Both types hold `database` and `schema` fields. Moreover - `HookContext` has synchronous `schema`, while it may be not required in all use cases, meanwhile `ExtensionContext` provides a correct asynchronous way to get schema in hooks. I think that `HookContext` is not properly designed.

2. There is no way to tell whether anything was changed after `emitFilter`.

I can work around this by passing `null` as hook payload, but it does not look like a proper flow.