### PR TITLE
Tweak for logical operators snippet

### DIFF
--- a/docs/configuration/filter-rules.md
+++ b/docs/configuration/filter-rules.md
@@ -110,7 +110,7 @@ allowing for more complex filtering.
 		{
 			"_and": [
 				{
-					"owner": {
+					"user_created": {
 						"_eq": "$CURRENT_USER"
 					}
 				},
@@ -124,7 +124,7 @@ allowing for more complex filtering.
 		{
 			"_and": [
 				{
-					"owner": {
+					"user_created": {
 						"_neq": "$CURRENT_USER"
 					}
 				},


### PR DESCRIPTION
Might be less confusing to use the default collection field value of "user_created" instead of "owner". This snippet could then be used as a custom item permission out of the box.