### PR TITLE
Add custom panel extensions template & docs

### DIFF
--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -113,6 +113,7 @@ To learn more about developing extensions of a specific type, you can refer to o
 - [Displays](/extensions/displays/)
 - [Layouts](/extensions/layouts/)
 - [Modules](/extensions/modules/)
+- [Panels](/extensions/panels/)
 
 #### API Extensions
 

--- a/docs/extensions/panels.md
+++ b/docs/extensions/panels.md
@@ -1,8 +1,132 @@
-# Panels <small></small>
+# Custom Panels <small></small>
 
-> Panels are modular units of data visualization that exist within the Insights module. Each panel exists within a
-> Dashboard and can be positioned and resized as needed.
+> Panels are modular units of data visualization that exist within the [Insights module](/app/insights). Each panel
+> exists within a Dashboard and can be positioned and resized as needed.
+> [Learn more about Panels](/getting-started/glossary/#panels).
 
-## 1. Setup the Boilerplate
+## Extension Entrypoint
 
-... TK, requires same flow as Interfaces, etc.
+The entrypoint of your panel is the `index` file inside the `src/` folder of your extension package. It exports a
+configuration object with options to configure the behavior of your panel. When loading your panel, this object is
+imported by the Directus host.
+
+Example of an entrypoint:
+
+```js
+import PanelComponent from './panel.vue';
+
+export default {
+	id: 'custom',
+	name: 'Custom',
+	icon: 'box',
+	description: 'This is my custom panel!',
+	component: PanelComponent,
+	options: [
+		{
+			field: 'text',
+			name: 'Text',
+			type: 'string',
+			meta: {
+				interface: 'input',
+				width: 'full',
+			},
+		},
+	],
+	minWidth: 12,
+	minHeight: 8,
+};
+```
+
+#### Available Options
+
+- `id` — The unique key for this panel. It is good practice to scope proprietary panels with an author prefix.
+- `name` — The human-readable name for this panel.
+- `icon` — An icon name from the [material icon set](/getting-started/glossary/#material-icons), or the extended list of
+  Directus custom icons.
+- `description` — A short description (<80 characters) of this panel shown in the App.
+- `component` — A reference to your panel component.
+- `options` — The options of your panel. Can be either an options object or a dedicated Vue component.
+- `minWidth` - The minimum width in grid units of your panel on a dashboard.
+- `minHeight` - The minimum height in grid units of your panel on a dashboard.
+
+## Panel Component
+
+The panel component is the part of your extension that will be rendered by the Directus App whenever your panel should
+be used for data visualization in a dashboard within the Insights module. This panel component has to be Vue component.
+The most straightforward way to write a Vue component is to use the Vue Single File Component syntax.
+
+Example of a panel component using the Vue SFC syntax:
+
+```vue
+<template>
+	<div class="text" :class="{ 'has-header': showHeader }">
+		{{ text }}
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		showHeader: {
+			type: Boolean,
+			default: false,
+		},
+		text: {
+			type: String,
+			default: '',
+		},
+	},
+};
+</script>
+
+<style scoped>
+.text {
+	padding: 12px;
+}
+
+.text.has-header {
+	padding: 0 12px;
+}
+</style>
+```
+
+#### Available Props
+
+- `showHeader` **boolean** — Whether the header is shown. Useful for alternative styling based on the extra/reduced
+  space.
+- `dashboard` **uuid** - The UUID string of the dashboard containing the panel.
+- `height` **number** - The current configured height of the panel.
+- `width` **number** - The current configured width of the panel.
+- `now` **Date** - The Date object as of the moment of viewing the dashboard containing the panel.
+
+::: warning Vue Version
+
+The Directus App uses Vue 3. There might be 3rd party libraries that aren't yet compatible with Vue 3.
+
+:::
+
+## Accessing Internal Systems
+
+To access internal systems like the API or the stores, you can use the `useApi()` and `useStores()` composables exported
+by the `@directus/extensions-sdk` package. They can be used inside a `setup()` function like this:
+
+```js
+import { useApi, useStores } from '@directus/extensions-sdk';
+
+export default {
+	setup() {
+		const api = useApi();
+
+		const { useCollectionsStore } = useStores();
+		const collectionsStore = useCollectionsStore();
+
+		// ...
+	},
+};
+```
+
+::: tip Vue Options API
+
+If you prefer to use the Vue Options API, you can inject the `api` and `stores` properties directly.
+
+:::

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -241,9 +241,12 @@ two main ways to achieve multitenancy:
 
 ## Panels
 
-Panels are modular units of data visualization that exist within the Insights module. Each panel exists within a
-[Dashboard](#dashboards) and can be positioned and resized as needed.
-[Panels are a Modular Extension Type](/extensions/panels/).
+Panels are modular units of data visualization that exist within the [Insights module](/app/insights). Each panel exists
+within a [Dashboard](#dashboards) and can be positioned and resized as needed.
+
+### Relevant Guides
+
+- [Creating a Custom Panel](/extensions/panels/)
 
 ## Permissions
 

--- a/packages/extensions-sdk/src/index.ts
+++ b/packages/extensions-sdk/src/index.ts
@@ -3,6 +3,7 @@ export {
 	defineDisplay,
 	defineLayout,
 	defineModule,
+	definePanel,
 	defineHook,
 	defineEndpoint,
 	getFieldsFromTemplate,

--- a/packages/extensions-sdk/templates/panel/javascript/src/index.js
+++ b/packages/extensions-sdk/templates/panel/javascript/src/index.js
@@ -1,0 +1,22 @@
+import PanelComponent from './panel.vue';
+
+export default {
+	id: 'custom',
+	name: 'Custom',
+	icon: 'box',
+	description: 'This is my custom panel!',
+	component: PanelComponent,
+	options: [
+		{
+			field: 'text',
+			name: 'Text',
+			type: 'string',
+			meta: {
+				interface: 'input',
+				width: 'full',
+			},
+		},
+	],
+	minWidth: 12,
+	minHeight: 8,
+};

--- a/packages/extensions-sdk/templates/panel/javascript/src/panel.vue
+++ b/packages/extensions-sdk/templates/panel/javascript/src/panel.vue
@@ -1,0 +1,30 @@
+<template>
+	<div class="text" :class="{ 'has-header': showHeader }">
+		{{ text }}
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		showHeader: {
+			type: Boolean,
+			default: false,
+		},
+		text: {
+			type: String,
+			default: '',
+		},
+	},
+};
+</script>
+
+<style scoped>
+.text {
+	padding: 12px;
+}
+
+.text.has-header {
+	padding: 0 12px;
+}
+</style>

--- a/packages/extensions-sdk/templates/panel/typescript/src/index.ts
+++ b/packages/extensions-sdk/templates/panel/typescript/src/index.ts
@@ -1,0 +1,23 @@
+import { definePanel } from '@directus/extensions-sdk';
+import PanelComponent from './panel.vue';
+
+export default definePanel({
+	id: 'custom',
+	name: 'Custom',
+	icon: 'box',
+	description: 'This is my custom panel!',
+	component: PanelComponent,
+	options: [
+		{
+			field: 'text',
+			name: 'Text',
+			type: 'string',
+			meta: {
+				interface: 'input',
+				width: 'full',
+			},
+		},
+	],
+	minWidth: 12,
+	minHeight: 8,
+});

--- a/packages/extensions-sdk/templates/panel/typescript/src/panel.vue
+++ b/packages/extensions-sdk/templates/panel/typescript/src/panel.vue
@@ -1,0 +1,32 @@
+<template>
+	<div class="text" :class="{ 'has-header': showHeader }">
+		{{ text }}
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+	props: {
+		showHeader: {
+			type: Boolean,
+			default: false,
+		},
+		text: {
+			type: String,
+			default: '',
+		},
+	},
+});
+</script>
+
+<style scoped>
+.text {
+	padding: 12px;
+}
+
+.text.has-header {
+	padding: 0 12px;
+}
+</style>

--- a/packages/extensions-sdk/templates/panel/typescript/src/shims.d.ts
+++ b/packages/extensions-sdk/templates/panel/typescript/src/shims.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+	import { DefineComponent } from 'vue';
+	const component: DefineComponent<{}, {}, any>;
+	export default component;
+}


### PR DESCRIPTION
## How the minimal example of custom panel will look like

Technically it's a stripped down version of the Label panel now, but I believe a more elaborate example/cookbook would be more suited under Guides later on.

### On dashboard

![chrome_TkSEdUoMMw](https://user-images.githubusercontent.com/42867097/145195781-d62bded5-5fdc-44b7-9fe2-37cfc974855e.png)

### Configuration options

![O4mGcxfJNl](https://user-images.githubusercontent.com/42867097/145195812-6cc46917-be0e-4e56-9079-089a5ae6d7d3.gif)

## Slight notice

Since the docs refers to panel templates & `definePanel` which is not in the released version of `@directus/extensions-sdk` yet, perhaps this PR can only be merged right before the next release to avoid any potential confusions.