### PR TITLE
fix translations not refreshing on save

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -57,7 +57,7 @@ import { useI18n } from 'vue-i18n';
 import api from '@/api';
 import { useCollection } from '@directus/shared/composables';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { cloneDeep, isEqual, assign, isNil } from 'lodash';
+import { cloneDeep, isEqual, assign } from 'lodash';
 import { notEmpty } from '@/utils/is-empty';
 import { useWindowSize } from '@/composables/use-window-size';
 import useRelation from '@/composables/use-m2m';

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -278,6 +278,7 @@ export default defineComponent({
 			const items = ref<Record<string, any>[]>([]);
 			const loading = ref(false);
 			const error = ref(null);
+			const isUndo = ref(false);
 
 			const firstItem = computed(() => getEditedValue(firstLang));
 			const secondItem = computed(() => getEditedValue(secondLang));
@@ -290,8 +291,9 @@ export default defineComponent({
 				(newVal, oldVal) => {
 					if (
 						newVal &&
-						isNil(newVal) !== isNil(oldVal) &&
-						newVal?.every((item) => typeof item === 'string' || typeof item === 'number')
+						!isEqual(newVal, oldVal) &&
+						newVal.every((item) => typeof item === 'string' || typeof item === 'number') &&
+						isUndo.value === false
 					) {
 						loadItems();
 					}
@@ -383,9 +385,11 @@ export default defineComponent({
 
 				if (!pkField || !langField) return;
 
+				isUndo.value = false;
+
 				let copyValue = cloneDeep(value.value ?? []);
 
-				if (pkField in values === false) {
+				if (pkField in values === false && langField in values === false) {
 					const newIndex = copyValue.findIndex((item) => typeof item === 'object' && item[langField] === lang);
 
 					if (newIndex !== -1) {
@@ -413,6 +417,7 @@ export default defineComponent({
 						} else {
 							if (values[pkField] === item[pkField]) {
 								if (isEqual(initialValues, { ...initialValues, ...values })) {
+									isUndo.value = true;
 									return values[pkField];
 								} else {
 									return values;


### PR DESCRIPTION
Fixes #10389

## Before

We can see after saving, o2m lists gets refreshed, but translations doesn't refresh. Translations also seemingly got reverted, but it's just the edits getting cleared so it ends up showing old data.

https://user-images.githubusercontent.com/42867097/145367459-dacd33ae-7387-48d4-8ebc-aa7fb499af1b.mp4

## Investigation & solution

Seems like this is caused by #10060, where the "update" of saving also gets ignored, hence translations doesn't refreshes.

Opted to use an `isUndo` flag at line 420 to prevent backspace from reloading when it's going back to the original data. The change in line 392 is also to prevent backspace from "has value" to "empty" from reloading for other languages without existing values.

## After

https://user-images.githubusercontent.com/42867097/145367745-94074fe0-4ffb-48a0-bafc-ab5f0d222a6d.mp4


