### PR TITLE
Fix "Save as Copy" for relational fields

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -1,5 +1,6 @@
 import api from '@/api';
 import { useCollection } from '@directus/shared/composables';
+import { useFieldsStore, useRelationsStore } from '@/stores/';
 import { VALIDATION_TYPES } from '@/constants';
 import { i18n } from '@/lang';
 import { APIError } from '@/types';
@@ -178,6 +179,54 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 		// Make sure to delete the primary key
 		if (primaryKeyField.value && primaryKeyField.value.field in newItem) {
 			delete newItem[primaryKeyField.value.field];
+		}
+
+		// Make sure to delete nested relational primary keys
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+		const relations = relationsStore.getRelationsForCollection(collection.value);
+		for (const relation of relations) {
+			const relatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relation.collection);
+			const existsJunctionRelated = relationsStore.relations.find(
+				(r) => r.collection === relation.collection && r.meta?.many_field === relation.meta?.junction_field
+			);
+
+			if (relation.meta?.one_field && relation.meta.one_field in newItem) {
+				const fieldsToFetch = fields
+					.filter((field) => field.startsWith(relation.meta!.one_field!))
+					.map((field) => field.split('.').slice(1).join('.'));
+
+				const existingIds = newItem[relation.meta.one_field].filter((item: any) => typeof item !== 'object');
+
+				let existingItems: any[] = [];
+
+				if (existingIds.length > 0) {
+					const response = await api.get(getEndpoint(relation.collection), {
+						params: {
+							fields: [relatedPrimaryKeyField!.field, ...fieldsToFetch],
+							[`filter[${relatedPrimaryKeyField!.field}][_in]`]: existingIds.join(','),
+						},
+					});
+
+					existingItems = response.data.data;
+				}
+
+				newItem[relation.meta.one_field] = newItem[relation.meta.one_field].map((relatedItem: any) => {
+					if (typeof relatedItem !== 'object' && existingItems.length > 0) {
+						relatedItem = existingItems.find((existingItem: any) => existingItem.id === relatedItem);
+					}
+
+					delete relatedItem[relatedPrimaryKeyField!.field];
+
+					if (relation.meta?.junction_field && existsJunctionRelated?.related_collection) {
+						const junctionRelatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(
+							existsJunctionRelated.related_collection
+						);
+						delete relatedItem[relation.meta.junction_field][junctionRelatedPrimaryKeyField!.field];
+					}
+					return relatedItem;
+				});
+			}
 		}
 
 		const errors = validate(newItem);

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -472,7 +472,7 @@ export default defineComponent({
 		async function saveAsCopyAndNavigate() {
 			try {
 				const newPrimaryKey = await saveAsCopy();
-				if (newPrimaryKey) router.push(`/content/${props.collection}/${encodeURIComponent(newPrimaryKey)}`);
+				if (newPrimaryKey) router.replace(`/content/${props.collection}/${encodeURIComponent(newPrimaryKey)}`);
 			} catch {
 				// Save shows unexpected error dialog
 			}


### PR DESCRIPTION
Fixes #9991

## Before

Using "Save as copy" on relational fields will "re-assign" them to the new item, thus "removing" them from the original item. This is true even when Items Duplication Field has been setup (without the IDs).

https://user-images.githubusercontent.com/42867097/145423648-42ad442b-bc6a-44ac-9865-10125d4f421b.mp4

This is due to during saving, the relational fields still have their primary key attached to them.

## Investigation

Currently there's existing implementation to remove primary keys, but it doesn't check/delete nested ones:

https://github.com/directus/directus/blob/81262800cb271e033cc865dcd620f8061579579c/app/src/composables/use-item/use-item.ts#L178-L181

## Solution

- delete nested keys
  - at the same time, some nested items only has their ID when they are not actually edited. Hence during this process, we had to call the api again using the fields from item duplication fields, and replace the ID-only entries.
- Also changed `router.push` to `router.replace` since it felt more natural personally, but can be reverted if there's reasons for `router.push` that's not apparent for me at the moment.

## After

https://user-images.githubusercontent.com/42867097/145424113-8f3e58c8-7332-4f60-b5ed-d2afdd7f79ec.mp4


