### PR TITLE
patch translations interface for new translations

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -389,11 +389,12 @@ export default defineComponent({
 
 				let copyValue = cloneDeep(value.value ?? []);
 
-				if (pkField in values === false && langField in values === false) {
+				if (pkField in values === false) {
 					const newIndex = copyValue.findIndex((item) => typeof item === 'object' && item[langField] === lang);
 
 					if (newIndex !== -1) {
 						if (Object.keys(values).length === 1 && langField in values) {
+							isUndo.value = true;
 							copyValue.splice(newIndex, 1);
 						} else {
 							copyValue[newIndex] = values;


### PR DESCRIPTION
The addition of `&& langField in values === false` in #10410 to mitigate refreshing when backspacing on new translations to empty (empty was the "initial state" for any new translations) ended up being error prone. Opted to use the same `isUndo` flag when a new translation gets removed on backspace (hence the splice).