### PR TITLE
Update selection styling to use CSS variable

### DIFF
--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -23,6 +23,9 @@ export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospac
 	url(${merriweatherRegular}) format('woff');
 }
 
+::selection {
+	background: ${cssVar('--background-normal-alt')};
+}
 body {
 	color: ${cssVar('--foreground-normal')};
 	background-color: ${cssVar('--background-input')};

--- a/app/src/styles/_base.scss
+++ b/app/src/styles/_base.scss
@@ -108,7 +108,7 @@ strong {
 }
 
 ::selection {
-	background: #e1f0fa;
+	background: var('--background-normal-alt');
 }
 
 dl > div {


### PR DESCRIPTION
## Context

Noticed the base `::selection` is using a hardcoded `#e1f0fa`, hence it may look odd in dark theme. Seems like WYSIWYG interface (TinyMCE) also didn't have this set.

Choice of `background-normal-alt` referred from input-code interface as it was set for CodeMirror here:

https://github.com/directus/directus/blob/60c0a05a94d2fbbf1e2578c2410083ef7f18a0b7/app/src/styles/lib/_codemirror.scss#L534-L543

## Results

### Usual inputs

|Before|After|
|---|---|
|![chrome_OXoHeMOv0I](https://user-images.githubusercontent.com/42867097/145572754-ab16a3f8-9711-4b70-8557-cee0b49f88e5.png)|![chrome_kx0P5yBZl7](https://user-images.githubusercontent.com/42867097/145572867-0d68a278-2c6c-4712-bc75-ad6326611d2d.png)|
|![chrome_GJI8r951E6](https://user-images.githubusercontent.com/42867097/145572919-572a4708-9a78-4de0-a2aa-f283893df933.png)|![chrome_FFwFHbDbMV](https://user-images.githubusercontent.com/42867097/145572940-ed63c213-7cca-4bbd-88cc-1d682e4fd68c.png)|

### WYSIWYG

|Before|After|
|---|---|
|![chrome_z8teqez8Uz](https://user-images.githubusercontent.com/42867097/145573136-fb710fb1-2ffb-4f9d-9071-381ab288187e.png)|![chrome_R5JfnPToji](https://user-images.githubusercontent.com/42867097/145573151-6cb11a26-817e-49ac-b78c-ea8d4cff60c0.png)|
|![chrome_EOGgJvPrEy](https://user-images.githubusercontent.com/42867097/145573198-ab8550f6-621d-49af-8dbd-4a475d067cb7.png)|![chrome_QawJRcKvkO](https://user-images.githubusercontent.com/42867097/145573229-4f6e2f22-3c63-448c-8143-9d0984e529d2.png)|