### PR TITLE
Fix broken wysiwyg editor when width and height are set in image

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -292,7 +292,7 @@ export default defineComponent({
 					params.set('access_token', token);
 				}
 
-				const paramsString = params.toString().length > 0 ? `?${params.toString()}` : '';
+				const paramsString = params.toString().length > 0 ? `?${params.toString().replace(/&/g, '&amp;')}` : '';
 
 				return `${pre}${matched.origin}${matched.pathname}${paramsString}${post}`;
 			});


### PR DESCRIPTION
Fixes https://github.com/directus/directus/pull/10054#issuecomment-991035152

I am sorry for adding this issue in the first place but tinymce has a very weird way of handling `&` characters :D