### PR TITLE
Unify & translate initial role/user detail in `init` & `bootstrap` command

### DIFF
--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -8,6 +8,7 @@ import { getSchema } from '../../../utils/get-schema';
 import { RolesService, UsersService, SettingsService } from '../../../services';
 import getDatabase, { isInstalled, validateDatabaseConnection, hasDatabaseConnection } from '../../../database';
 import { SchemaOverview } from '../../../types';
+import { defaultAdminRole, defaultAdminUser } from '../../utils/defaults';
 
 export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boolean }): Promise<void> {
 	logger.info('Initializing bootstrap...');
@@ -65,7 +66,7 @@ async function waitForDatabase(database: Knex) {
 async function createDefaultAdmin(schema: SchemaOverview) {
 	logger.info('Setting up first admin role...');
 	const rolesService = new RolesService({ schema });
-	const role = await rolesService.createOne({ name: 'Admin', admin_access: true });
+	const role = await rolesService.createOne(defaultAdminRole);
 
 	logger.info('Adding first admin user...');
 	const usersService = new UsersService({ schema });
@@ -84,5 +85,5 @@ async function createDefaultAdmin(schema: SchemaOverview) {
 		logger.info(`No admin password provided. Defaulting to "${adminPassword}"`);
 	}
 
-	await usersService.createOne({ email: adminEmail, password: adminPassword, role });
+	await usersService.createOne({ email: adminEmail, password: adminPassword, role, ...defaultAdminUser });
 }

--- a/api/src/cli/commands/init/index.ts
+++ b/api/src/cli/commands/init/index.ts
@@ -11,6 +11,7 @@ import createEnv from '../../utils/create-env';
 import { drivers, getDriverForClient } from '../../utils/drivers';
 import { databaseQuestions } from './questions';
 import { generateHash } from '../../../utils/generate-hash';
+import { defaultAdminRole, defaultAdminUser } from '../../utils/defaults';
 
 export default async function init(): Promise<void> {
 	const rootPath = process.cwd();
@@ -94,20 +95,15 @@ export default async function init(): Promise<void> {
 
 	await db('directus_roles').insert({
 		id: roleID,
-		name: 'Administrator',
-		icon: 'verified',
-		admin_access: true,
-		description: 'Initial administrative role with unrestricted App/API access',
+		...defaultAdminRole,
 	});
 
 	await db('directus_users').insert({
 		id: userID,
-		status: 'active',
 		email: firstUser.email,
 		password: firstUser.password,
-		first_name: 'Admin',
-		last_name: 'User',
 		role: roleID,
+		...defaultAdminUser,
 	});
 
 	await db.destroy();

--- a/api/src/cli/utils/defaults.ts
+++ b/api/src/cli/utils/defaults.ts
@@ -1,0 +1,12 @@
+export const defaultAdminRole = {
+	name: 'Administrator',
+	icon: 'verified',
+	admin_access: true,
+	description: '$t:admin_description',
+};
+
+export const defaultAdminUser = {
+	status: 'active',
+	first_name: 'Admin',
+	last_name: 'User',
+};

--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -292,7 +292,10 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 	}
 
 	function setItemValueToResponse(response: AxiosResponse) {
-		if (collection.value === 'directus_collections' && response.data.data.collection?.startsWith('directus_')) {
+		if (
+			(collection.value.startsWith('directus_') && collection.value !== 'directus_collections') ||
+			(collection.value === 'directus_collections' && response.data.data.collection?.startsWith('directus_'))
+		) {
 			response.data.data = translate(response.data.data);
 		}
 		if (isBatch.value === false) {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -90,6 +90,7 @@ logoutReason:
   SESSION_EXPIRED: Session expired
 public_label: Public
 public_description: Controls what API data is available without authenticating.
+admin_description: Initial administrative role with unrestricted App/API access.
 not_allowed: Not Allowed
 directus_version: Directus Version
 node_version: Node Version

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -66,6 +66,7 @@ import { Header as TableHeader } from '@/components/v-table/types';
 import ValueNull from '@/views/private/components/value-null';
 import { useRouter } from 'vue-router';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { translate } from '@/utils/translate-object-values';
 
 type Role = {
 	id: number;
@@ -155,7 +156,7 @@ export default defineComponent({
 					},
 					...response.data.data.map((role: any) => {
 						return {
-							...role,
+							...translate(role),
 							count: role.users[0]?.count.id || 0,
 						};
 					}),


### PR DESCRIPTION
- Currently there's some difference in the initial role & user created via `init` vs `bootstrap`. Extracted them to utility objects for consistency, favoring the defaults from the `init` variant, particularly the description.
- translated the roles for Roles & Permissions page as a whole, and added `$t:admin_description` for initial admin role. Resolves #8926.

  ![image](https://user-images.githubusercontent.com/42867097/145967547-83493609-d541-4ccd-b084-056041a0fc5a.png)
