### PR TITLE
Remove quotes for CSS variable in selection style

### DIFF
--- a/app/src/styles/_base.scss
+++ b/app/src/styles/_base.scss
@@ -108,7 +108,7 @@ strong {
 }
 
 ::selection {
-	background: var('--background-normal-alt');
+	background: var(--background-normal-alt);
 }
 
 dl > div {


### PR DESCRIPTION
Oversight in #10437 with unnecessary quotes for CSS variable.