### PR TITLE
Add Archive sidebar component

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -237,17 +237,20 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 			if (value === 'true') value = true;
 			if (value === 'false') value = false;
 
+			await api.patch(itemEndpoint.value, {
+				[field]: value,
+			});
+
 			item.value = {
 				...item.value,
 				[field]: value,
 			};
 
-			await api.patch(itemEndpoint.value, {
-				[field]: value,
-			});
-
 			notify({
-				title: i18n.global.t('item_delete_success', isBatch.value ? 2 : 1),
+				title:
+					value === archiveValue
+						? i18n.global.t('item_delete_success', isBatch.value ? 2 : 1)
+						: i18n.global.t('item_update_success', isBatch.value ? 2 : 1),
 				type: 'success',
 			});
 		} catch (err: any) {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -53,9 +53,9 @@ edit_collection: Edit Collection
 exclusive: Exclusive
 children: Children
 db_only_click_to_configure: 'Database Only: Click to Configure'
-show_items: Show Items
+show_active_items: Show Active Items
 show_archived_items: Show Archived Items
-show_items_and_archived_items: Show Items + Archived Items
+show_all_items: Show All Items
 edited: Value Edited
 required: Required
 required_for_app_access: Required for App Access

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -53,7 +53,9 @@ edit_collection: Edit Collection
 exclusive: Exclusive
 children: Children
 db_only_click_to_configure: 'Database Only: Click to Configure'
+show_items: Show Items
 show_archived_items: Show Archived Items
+show_items_and_archived_items: Show Items + Archived Items
 edited: Value Edited
 required: Required
 required_for_app_access: Required for App Access

--- a/app/src/modules/content/components/navigation-item.vue
+++ b/app/src/modules/content/components/navigation-item.vue
@@ -44,14 +44,6 @@
 
 	<v-menu v-if="hasContextMenu" ref="contextMenu" show-arrow placement="bottom-start">
 		<v-list>
-			<v-list-item v-if="hasArchive" clickable :to="`/content/${collection.collection}?archive`" exact query>
-				<v-list-item-icon>
-					<v-icon name="archive" outline />
-				</v-list-item-icon>
-				<v-list-item-content>
-					<v-text-overflow :text="t('show_archived_items')" />
-				</v-list-item-content>
-			</v-list-item>
 			<v-list-item v-if="isAdmin" clickable :to="`/settings/data-model/${collection.collection}`">
 				<v-list-item-icon>
 					<v-icon name="list_alt" />
@@ -102,10 +94,6 @@ export default defineComponent({
 
 		const childBookmarks = computed(() => getChildBookmarks(props.collection));
 
-		const hasArchive = computed(
-			() => props.collection.meta?.archive_field && props.collection.meta?.archive_app_filter
-		);
-
 		const isGroup = computed(() => childCollections.value.length > 0 || childBookmarks.value.length > 0);
 
 		const to = computed(() => (props.collection.schema ? `/content/${props.collection.collection}` : ''));
@@ -137,7 +125,7 @@ export default defineComponent({
 			}
 		});
 
-		const hasContextMenu = computed(() => hasArchive.value || isAdmin);
+		const hasContextMenu = computed(() => isAdmin);
 
 		return {
 			childCollections,
@@ -147,7 +135,6 @@ export default defineComponent({
 			matchesSearch,
 			isAdmin,
 			t,
-			hasArchive,
 			hasContextMenu,
 		};
 

--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -1,7 +1,7 @@
 import { defineModule } from '@directus/shared/utils';
 import { addQueryToPath } from '@/utils/add-query-to-path';
 import RouterPass from '@/utils/router-passthrough';
-import { NavigationGuard } from 'vue-router';
+import { LocationQuery, NavigationGuard } from 'vue-router';
 import CollectionOrItem from './routes/collection-or-item.vue';
 import Item from './routes/item.vue';
 import ItemNotFound from './routes/not-found.vue';
@@ -54,6 +54,16 @@ const checkForSystem: NavigationGuard = (to, from) => {
 		to.params.collection === from.params.collection
 	) {
 		return addQueryToPath(to.fullPath, { bookmark: from.query.bookmark });
+	}
+};
+
+const getArchiveValue = (query: LocationQuery) => {
+	if ('archived_only' in query) {
+		return 'archived_only';
+	} else if ('archived' in query) {
+		return 'archived';
+	} else {
+		return null;
 	}
 };
 
@@ -119,11 +129,14 @@ export default defineModule({
 					name: 'content-collection',
 					path: '',
 					component: CollectionOrItem,
-					props: (route) => ({
-						collection: route.params.collection,
-						bookmark: route.query.bookmark,
-						archive: 'archive' in route.query,
-					}),
+					props: (route) => {
+						const archive = getArchiveValue(route.query);
+						return {
+							collection: route.params.collection,
+							bookmark: route.query.bookmark,
+							archive,
+						};
+					},
 					beforeEnter: checkForSystem,
 				},
 				{

--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -58,8 +58,8 @@ const checkForSystem: NavigationGuard = (to, from) => {
 };
 
 const getArchiveValue = (query: LocationQuery) => {
-	if ('archived_only' in query) {
-		return 'archived_only';
+	if ('all' in query) {
+		return 'all';
 	} else if ('archived' in query) {
 		return 'archived';
 	} else {

--- a/app/src/modules/content/routes/collection-or-item.vue
+++ b/app/src/modules/content/routes/collection-or-item.vue
@@ -29,8 +29,8 @@ export default defineComponent({
 			default: null,
 		},
 		archive: {
-			type: Boolean,
-			default: false,
+			type: String,
+			default: null,
 		},
 	},
 	setup(props) {

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -122,7 +122,12 @@
 				</v-dialog>
 
 				<v-dialog
-					v-if="selection.length > 0 && currentCollection.meta && currentCollection.meta.archive_field"
+					v-if="
+						selection.length > 0 &&
+						currentCollection.meta &&
+						currentCollection.meta.archive_field &&
+						archive !== 'archived_only'
+					"
 					v-model="confirmArchive"
 					@esc="confirmArchive = false"
 				>
@@ -236,6 +241,7 @@
 					<component :is="`layout-options-${layout || 'tabular'}`" v-bind="layoutState" />
 				</layout-sidebar-detail>
 				<component :is="`layout-sidebar-${layout || 'tabular'}`" v-bind="layoutState" />
+				<archive-sidebar-detail v-if="hasArchive" :collection="collection" :archive="archive" />
 				<refresh-sidebar-detail v-model="refreshInterval" @refresh="refresh" />
 				<export-sidebar-detail
 					:collection="collection"
@@ -269,6 +275,7 @@ import { useCollection } from '@directus/shared/composables';
 import { useLayout } from '@/composables/use-layout';
 import usePreset from '@/composables/use-preset';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail';
+import ArchiveSidebarDetail from '@/views/private/components/archive-sidebar-detail';
 import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail';
 import SearchInput from '@/views/private/components/search-input';
 import BookmarkAdd from '@/views/private/components/bookmark-add';
@@ -279,6 +286,7 @@ import DrawerBatch from '@/views/private/components/drawer-batch';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { getLayouts } from '@/layouts';
 import { mergeFilters } from '@directus/shared/utils';
+import { Filter } from '@directus/shared/types';
 
 type Item = {
 	[field: string]: any;
@@ -294,6 +302,7 @@ export default defineComponent({
 		BookmarkAdd,
 		BookmarkEdit,
 		DrawerBatch,
+		ArchiveSidebarDetail,
 		RefreshSidebarDetail,
 	},
 	props: {
@@ -306,8 +315,8 @@ export default defineComponent({
 			default: null,
 		},
 		archive: {
-			type: Boolean,
-			default: false,
+			type: String,
+			default: null,
 		},
 	},
 	setup(props) {
@@ -353,7 +362,7 @@ export default defineComponent({
 			deleting,
 			batchDelete,
 			confirmArchive,
-			archive: archiveItems,
+			archiveItems,
 			archiving,
 			error: deleteError,
 			batchEditActive,
@@ -375,7 +384,25 @@ export default defineComponent({
 
 		const { batchEditAllowed, batchArchiveAllowed, batchDeleteAllowed, createAllowed } = usePermissions();
 
-		const archiveFilter = computed(() => {
+		const hasArchive = computed(
+			() =>
+				currentCollection.value &&
+				currentCollection.value.meta?.archive_field &&
+				currentCollection.value.meta?.archive_app_filter
+		);
+
+		// watch(
+		// 	() => selectedArchiveFilter.value,
+		// 	() => {
+		// 		if (selectedArchiveFilter.value === null) {
+		// 			router.replace(`/content/${props.collection}`);
+		// 		} else {
+		// 			router.push(`/content/${props.collection}?${selectedArchiveFilter.value}`);
+		// 		}
+		// 	}
+		// );
+
+		const archiveFilter = computed<Filter | null>(() => {
 			if (!currentCollection.value?.meta) return null;
 			if (!currentCollection.value?.meta?.archive_app_filter) return null;
 
@@ -387,11 +414,26 @@ export default defineComponent({
 			if (archiveValue === 'true') archiveValue = true;
 			if (archiveValue === 'false') archiveValue = false;
 
-			if (props.archive) {
+			if (props.archive === 'archived_only') {
 				return {
 					[field]: {
 						_eq: archiveValue,
 					},
+				};
+			} else if (props.archive === 'archived') {
+				return {
+					_or: [
+						{
+							[field]: {
+								_eq: archiveValue,
+							},
+						},
+						{
+							[field]: {
+								_neq: archiveValue,
+							},
+						},
+					],
 				};
 			} else {
 				return {
@@ -446,6 +488,7 @@ export default defineComponent({
 			refresh,
 			refreshInterval,
 			currentLayout,
+			hasArchive,
 			archiveFilter,
 			mergeFilters,
 		};

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -391,17 +391,6 @@ export default defineComponent({
 				currentCollection.value.meta?.archive_app_filter
 		);
 
-		// watch(
-		// 	() => selectedArchiveFilter.value,
-		// 	() => {
-		// 		if (selectedArchiveFilter.value === null) {
-		// 			router.replace(`/content/${props.collection}`);
-		// 		} else {
-		// 			router.push(`/content/${props.collection}?${selectedArchiveFilter.value}`);
-		// 		}
-		// 	}
-		// );
-
 		const archiveFilter = computed<Filter | null>(() => {
 			if (!currentCollection.value?.meta) return null;
 			if (!currentCollection.value?.meta?.archive_app_filter) return null;

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -126,7 +126,7 @@
 						selection.length > 0 &&
 						currentCollection.meta &&
 						currentCollection.meta.archive_field &&
-						archive !== 'archived_only'
+						archive !== 'archived'
 					"
 					v-model="confirmArchive"
 					@esc="confirmArchive = false"
@@ -403,13 +403,7 @@ export default defineComponent({
 			if (archiveValue === 'true') archiveValue = true;
 			if (archiveValue === 'false') archiveValue = false;
 
-			if (props.archive === 'archived_only') {
-				return {
-					[field]: {
-						_eq: archiveValue,
-					},
-				};
-			} else if (props.archive === 'archived') {
+			if (props.archive === 'all') {
 				return {
 					_or: [
 						{
@@ -423,6 +417,12 @@ export default defineComponent({
 							},
 						},
 					],
+				};
+			} else if (props.archive === 'archived') {
+				return {
+					[field]: {
+						_eq: archiveValue,
+					},
 				};
 			} else {
 				return {

--- a/app/src/views/private/components/archive-sidebar-detail/archive-sidebar-detail.vue
+++ b/app/src/views/private/components/archive-sidebar-detail/archive-sidebar-detail.vue
@@ -1,0 +1,74 @@
+<template>
+	<sidebar-detail icon="archive" :title="t('archive')" :badge="active">
+		<div class="fields">
+			<div class="field full">
+				<p class="type-label">{{ t('filter') }}</p>
+				<v-select v-model="selectedItem" :items="items" />
+			</div>
+		</div>
+	</sidebar-detail>
+</template>
+
+<script lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { computed, defineComponent, watch, ref } from 'vue';
+
+export default defineComponent({
+	props: {
+		collection: {
+			type: String,
+			default: null,
+		},
+		archive: {
+			type: String,
+			default: null,
+		},
+	},
+	setup(props) {
+		const { t } = useI18n();
+
+		const router = useRouter();
+
+		const selectedItem = ref<string | null>(props.archive);
+
+		const items = [
+			{
+				text: t('show_items'),
+				value: null,
+			},
+			{ text: t('show_archived_items'), value: 'archived_only' },
+			{ text: t('show_items_and_archived_items'), value: 'archived' },
+		];
+
+		const active = computed(() => selectedItem.value !== null);
+
+		watch(
+			() => selectedItem.value,
+			() => {
+				if (selectedItem.value === null) {
+					router.push(`/content/${props.collection}`);
+				} else {
+					router.push(`/content/${props.collection}?${selectedItem.value}`);
+				}
+			}
+		);
+
+		return { t, active, selectedItem, items };
+	},
+});
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/mixins/form-grid';
+
+.fields {
+	--form-vertical-gap: 24px;
+
+	@include form-grid;
+
+	.type-label {
+		font-size: 1rem;
+	}
+}
+</style>

--- a/app/src/views/private/components/archive-sidebar-detail/archive-sidebar-detail.vue
+++ b/app/src/views/private/components/archive-sidebar-detail/archive-sidebar-detail.vue
@@ -2,8 +2,14 @@
 	<sidebar-detail icon="archive" :title="t('archive')" :badge="active">
 		<div class="fields">
 			<div class="field full">
-				<p class="type-label">{{ t('filter') }}</p>
-				<v-select v-model="selectedItem" :items="items" />
+				<v-radio
+					v-for="item in items"
+					:key="item.value"
+					:value="item.value"
+					:label="item.text"
+					:model-value="selectedItem"
+					@update:model-value="selectedItem = $event"
+				/>
 			</div>
 		</div>
 	</sidebar-detail>
@@ -34,11 +40,11 @@ export default defineComponent({
 
 		const items = [
 			{
-				text: t('show_items'),
+				text: t('show_active_items'),
 				value: null,
 			},
-			{ text: t('show_archived_items'), value: 'archived_only' },
-			{ text: t('show_items_and_archived_items'), value: 'archived' },
+			{ text: t('show_archived_items'), value: 'archived' },
+			{ text: t('show_all_items'), value: 'all' },
 		];
 
 		const active = computed(() => selectedItem.value !== null);
@@ -69,6 +75,10 @@ export default defineComponent({
 
 	.type-label {
 		font-size: 1rem;
+	}
+
+	.v-radio + .v-radio {
+		margin-top: 8px;
 	}
 }
 </style>

--- a/app/src/views/private/components/archive-sidebar-detail/index.ts
+++ b/app/src/views/private/components/archive-sidebar-detail/index.ts
@@ -1,0 +1,4 @@
+import ArchiveSidebarDetail from './archive-sidebar-detail.vue';
+
+export { ArchiveSidebarDetail };
+export default ArchiveSidebarDetail;

--- a/docs/app/content-collections.md
+++ b/docs/app/content-collections.md
@@ -128,6 +128,15 @@ options are available:
 6. Enter a value in the field filter's input(s)
 7. Remove unwanted filters by hovering over the field and clicking "X"
 
+## Viewing Archived Items
+
+**[Learn more about Archive](/configuration/data-model/#archive).**
+
+1. Navigate to the [Content Module](/app/overview/#_1-module-bar)
+2. Navigate to the collection of the items you want to view
+3. Click "Archive" in the page sidebar
+4. Choose the desired view: `Show Items` (default), `Show Archived Items`, or `Show Items + Archived Items`
+
 ## Bookmarking Item Presets
 
 1. Navigate to the [Content Module](/app/overview/#_1-module-bar)

--- a/docs/app/content-items.md
+++ b/docs/app/content-items.md
@@ -57,7 +57,7 @@ icon) button located in the header.
 1. Navigate to the [Content Module](/app/overview#1.-module-bar)
 2. Navigate to the collection of the item you want to archive
 3. Select the item(s) within the desired layout (eg: the checkbox on the table row)
-4. Click the "Archive Item" (trash icon) button located in the header
+4. Click the "Archive Item" (archive icon) button located in the header
 5. Confirm the action within the dialog by clicking "Archive"
 
 ::: warning Requires Configuration


### PR DESCRIPTION
Resolves #9523.

Changes made:

- Removed "Show Archived Items" from collection context menu
- Added "Archive" sidebar component
  - Doesn't show for collection without app filter configured.
  - Uses router query like how it was, just with different values.
- Fixed minor UX issue where the archive dialog changed before the change is made, and the notification is still showing "deleted" when we are unarchiving instead of archiving:

    https://user-images.githubusercontent.com/42867097/146167288-44294171-9149-4035-b4f1-6016a8d2be1f.mp4
- Minor update to docs to reflect this change.


## Result

https://user-images.githubusercontent.com/42867097/146167559-7ae70820-23d2-4927-b229-a181f7154a8a.mp4

## Uncertainties

- Not super sure is the title `Filter` for selecting show items and/or archived items is ok, or if there's a better existing/new translated text for it.
- Maybe the route query can be `include_archived` instead of `archived`? sticked with the latter for now as the existing one was `archive`.