### PR TITLE
add tooltip to sidebar components

### DIFF
--- a/app/src/views/private/components/sidebar-detail/sidebar-detail.vue
+++ b/app/src/views/private/components/sidebar-detail/sidebar-detail.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="sidebar-detail" :class="{ open: sidebarOpen }">
-		<button class="toggle" :class="{ open: active }" @click="toggle">
+		<button v-tooltip.left="title" class="toggle" :class="{ open: active }" @click="toggle">
 			<div class="icon">
 				<v-badge :dot="badge === true" bordered :value="badge" :disabled="!badge">
 					<v-icon :name="icon" outline />


### PR DESCRIPTION
## Context

Noticed sidebar component buttons doesn't have tooltip, whereas module buttons & activity log button has it.

## Result

https://user-images.githubusercontent.com/42867097/146178183-96d6deca-93e6-40ac-83b7-73f9a183e2c2.mp4

