### PR TITLE
Emitting action/filter events for api extensions

### DIFF
--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -2,7 +2,7 @@ import { EventEmitter2 } from 'eventemitter2';
 import logger from './logger';
 import { ActionHandler, FilterHandler, HookContext, InitHandler } from './types';
 
-class Emitter {
+export class Emitter {
 	private filterEmitter;
 	private actionEmitter;
 	private initEmitter;

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -283,6 +283,7 @@ class ExtensionManager {
 			exceptions: { ...exceptions, ...sharedExceptions },
 			env,
 			database: getDatabase(),
+			emitter,
 			logger,
 			getSchema,
 		});
@@ -305,6 +306,7 @@ class ExtensionManager {
 			exceptions: { ...exceptions, ...sharedExceptions },
 			env,
 			database: getDatabase(),
+			emitter,
 			logger,
 			getSchema,
 		});

--- a/api/src/types/extensions.ts
+++ b/api/src/types/extensions.ts
@@ -5,6 +5,7 @@ import { Logger } from 'pino';
 import env from '../env';
 import * as exceptions from '../exceptions';
 import * as services from '../services';
+import { Emitter } from '../emitter';
 import { getSchema } from '../utils/get-schema';
 import { SchemaOverview } from './schema';
 
@@ -13,6 +14,7 @@ export type ExtensionContext = {
 	exceptions: typeof exceptions;
 	database: Knex;
 	env: typeof env;
+	emitter: Emitter;
 	logger: Logger;
 	getSchema: typeof getSchema;
 };

--- a/docs/extensions/endpoints.md
+++ b/docs/extensions/endpoints.md
@@ -54,6 +54,15 @@ The register function receives the two parameters `router` and `context`. `route
 - `getSchema` — Async function that reads the full available schema for use in services
 - `env` — Parsed environment variables.
 - `logger` — [Pino](https://github.com/pinojs/pino) instance.
+- `emitter` — [Event emitter](https://github.com/directus/directus/blob/main/api/src/emitter.ts) instance that can be
+  used to trigger custom events for other extensions.
+
+::: warning Event loop
+
+When implementing custom events using the emitter make sure you never directly or indirectly emit the same event your
+hook is currently handling as that would result in an infinite loop!
+
+:::
 
 ## Example: Recipes
 

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -224,6 +224,15 @@ The second parameter is a context object with the following properties:
 - `getSchema` — Async function that reads the full available schema for use in services
 - `env` — Parsed environment variables
 - `logger` — [Pino](https://github.com/pinojs/pino) instance.
+- `emitter` — [Event emitter](https://github.com/directus/directus/blob/main/api/src/emitter.ts) instance that can be
+  used to trigger custom events for other extensions.
+
+::: warning Event loop
+
+When implementing custom events using the emitter make sure you never directly or indirectly emit the same event your
+hook is currently handling as that would result in an infinite loop!
+
+:::
 
 ## Example: Sync with External
 


### PR DESCRIPTION
As discussed here #10400 added the event emitter to the hook context so extensions can trigger events for consumption by other extensions.