### PR TITLE
Pass a custom emitter to API extensions

### DIFF
--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -22,13 +22,6 @@ export class Emitter {
 		this.initEmitter = new EventEmitter2(emitterOptions);
 	}
 
-	public eventsToEmit(event: string, meta: Record<string, any>) {
-		if (event.startsWith('items')) {
-			return [event, `${meta.collection}.${event}`];
-		}
-		return [event];
-	}
-
 	public async emitFilter<T>(event: string, payload: T, meta: Record<string, any>, context: HookContext): Promise<T> {
 		const events = this.eventsToEmit(event, meta);
 		const listeners = events.flatMap((event) => this.filterEmitter.listeners(event)) as FilterHandler[];
@@ -86,6 +79,19 @@ export class Emitter {
 
 	public offInit(event: string, handler: InitHandler): void {
 		this.initEmitter.off(event, handler);
+	}
+
+	public offAll(): void {
+		this.filterEmitter.removeAllListeners();
+		this.actionEmitter.removeAllListeners();
+		this.initEmitter.removeAllListeners();
+	}
+
+	private eventsToEmit(event: string, meta: Record<string, any>) {
+		if (event.startsWith('items')) {
+			return [event, `${meta.collection}.${event}`];
+		}
+		return [event];
 	}
 }
 

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -17,7 +17,7 @@ import {
 	EXTENSION_TYPES,
 } from '@directus/shared/constants';
 import getDatabase from './database';
-import emitter from './emitter';
+import emitter, { Emitter } from './emitter';
 import env from './env';
 import * as exceptions from './exceptions';
 import * as sharedExceptions from '@directus/shared/exceptions';
@@ -63,11 +63,13 @@ class ExtensionManager {
 	)[] = [];
 	private apiEndpoints: { path: string }[] = [];
 
+	private apiEmitter: Emitter;
 	private endpointRouter: Router;
 
 	private isScheduleHookEnabled = true;
 
 	constructor() {
+		this.apiEmitter = new Emitter();
 		this.endpointRouter = Router();
 	}
 
@@ -107,6 +109,8 @@ class ExtensionManager {
 
 		this.unregisterHooks();
 		this.unregisterEndpoints();
+
+		this.apiEmitter.offAll();
 
 		if (env.SERVE_APP) {
 			this.appExtensions = {};
@@ -283,7 +287,7 @@ class ExtensionManager {
 			exceptions: { ...exceptions, ...sharedExceptions },
 			env,
 			database: getDatabase(),
-			emitter,
+			emitter: this.apiEmitter,
 			logger,
 			getSchema,
 		});
@@ -306,7 +310,7 @@ class ExtensionManager {
 			exceptions: { ...exceptions, ...sharedExceptions },
 			env,
 			database: getDatabase(),
-			emitter,
+			emitter: this.apiEmitter,
 			logger,
 			getSchema,
 		});

--- a/packages/shared/src/types/extensions.ts
+++ b/packages/shared/src/types/extensions.ts
@@ -67,6 +67,7 @@ export type ApiExtensionContext = {
 	exceptions: any;
 	database: Knex;
 	env: Record<string, any>;
+	emitter: any;
 	logger: Logger;
 	getSchema: (options?: { accountability?: Accountability; database?: Knex }) => Promise<Record<string, any>>;
 };


### PR DESCRIPTION
This is slightly safer than re-using the internal emitter and it allows us to clean up the emitter when unregistering extensions.