### PR TITLE
fix default values from permission's field presets

### DIFF
--- a/app/src/stores/permissions.ts
+++ b/app/src/stores/permissions.ts
@@ -26,10 +26,6 @@ export const usePermissionsStore = defineStore({
 					rawPermission.validation = parseFilter(rawPermission.validation);
 				}
 
-				if (rawPermission.presets) {
-					rawPermission.presets = parseFilter(rawPermission.presets);
-				}
-
 				return rawPermission;
 			});
 		},


### PR DESCRIPTION
Fixes #10535

## Bug

After adding field presets to a particular role to set a default value on create, the default value ended up showing `[object Object]` instead of `testing` in this case:

![chrome_vszPkMWMC4](https://user-images.githubusercontent.com/42867097/146503729-ebfc617e-4796-49c7-9e9e-6dc256e38865.png)

![chrome_hr3gfjR5fq](https://user-images.githubusercontent.com/42867097/146503849-0f65c492-81c7-4064-a39e-e91a0e53f3c6.png)

## Investigation

Seems like it's because the parseFilter here:

https://github.com/directus/directus/blob/4ba3ef4070b543dacdb25b7d3b3949b8ef77dcce/app/src/stores/permissions.ts#L29-L31

And when it gets set as the default value here:

https://github.com/directus/directus/blob/4ba3ef4070b543dacdb25b7d3b3949b8ef77dcce/app/src/composables/use-permissions.ts#L75

It resulted in `{ _eq: "test" }` (hence the [object Object]) instead of `"test"`:

![chrome_GkEZ0ojKmr](https://user-images.githubusercontent.com/42867097/146504366-42519b08-b59f-47d0-8f71-69e377edbe37.png)

## Solution

Opted to remove the parsing on Presets since I believe they don't need to be parsed? unless there's some misunderstanding on my part. It's also odd how this wasn't brought up before, but it might be some form of unintended regression from the more recent parseFilter change.

## After fix applied

![chrome_X3FxNGYmkU](https://user-images.githubusercontent.com/42867097/146503887-6bb48744-936f-4a8a-b117-0cd5544ee669.png)

