### PR TITLE
fix M2A list not updating

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -201,7 +201,7 @@ export default defineComponent({
 			useEdits();
 		const { onSort } = useManualSort();
 
-		watch(props, fetchValues, { immediate: true, deep: true });
+		watch(() => props.value, fetchValues, { immediate: true, deep: true });
 
 		return {
 			t,


### PR DESCRIPTION
Fixes #10474

## Bug

- Adding items (either creating new item or existing ones) in M2A list doesn't seem to do anything, but the raw value shows that they are indeed created/added successfully in the form.

- When opening an existing M2A list, the value are loaded (checked via raw value) but they are not showing up in the list.

## Investigation

Recently PR #10368 (despite title being M2M) also added a fix to M2A to avoid it from constantly refreshing, by checking if the new & old value is the same:

https://github.com/directus/directus/blob/530db94c53fefcca785a81033665b8ba2861acfc/app/src/interfaces/list-m2a/list-m2a.vue#L384

When we do check the `newVal` and `oldVal`, oddly enough they are both showing the SAME values when we are adding new things:
 
https://user-images.githubusercontent.com/42867097/146791200-b7c98c32-4a9e-4537-878a-73f38456b4b8.mp4

It should be `null` initially for old value, then the new value would have actual values.

This weird occurence is also the same when we are loading an existing M2A list:

https://user-images.githubusercontent.com/42867097/146791799-af0327b4-05fe-497e-b5cd-fd39e2454dac.mp4

Seems like the watcher may be the root cause here:

https://github.com/directus/directus/blob/530db94c53fefcca785a81033665b8ba2861acfc/app/src/interfaces/list-m2a/list-m2a.vue#L204

As [this SO answer](https://stackoverflow.com/a/59127059) pointed out, we should either do 

```js
watch(() => props.value, /* ... */)

// or

const { value } = toRefs(props)

watch(value, /* ... */)
```

for it to work properly, and not `watch(props, /* ... */)` directly.

## After fix

We can see the value is properly reactive, while being `null` initially to ensure isEqual is not true to load starting data.

### new M2A

https://user-images.githubusercontent.com/42867097/146792725-0619c342-02c1-424f-9019-c852df20c01c.mp4

### Existing M2A list

https://user-images.githubusercontent.com/42867097/146792629-0eb9be1c-25c5-4038-ae6c-f5617a61677d.mp4

---

Opted to watch `props.value` only here since I believe we don't need watch other values, at least from my understanding. Do correct me if that is not the case here.
