### PR TITLE
[POC] Serve app at `/` and api at `/api`

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -131,20 +131,20 @@ export default async function createApp(): Promise<express.Application> {
 
 	if (env.SERVE_APP) {
 		const adminPath = require.resolve('@directus/app');
-		const adminUrl = new Url(env.PUBLIC_URL).addPath('admin');
+		const adminUrl = new Url(env.PUBLIC_URL).toString({ rootRelative: true });
 
 		// Set the App's base path according to the APIs public URL
 		const html = await fse.readFile(adminPath, 'utf8');
-		const htmlWithBase = html.replace(/<base \/>/, `<base href="${adminUrl.toString({ rootRelative: true })}/" />`);
+		const htmlWithBase = html.replace(/<base \/>/, `<base href="${adminUrl}/" />`);
 
 		const noCacheIndexHtmlHandler = (req: Request, res: Response) => {
 			res.setHeader('Cache-Control', 'no-cache');
 			res.send(htmlWithBase);
 		};
 
-		app.get('/admin', noCacheIndexHtmlHandler);
-		app.use('/admin', express.static(path.join(adminPath, '..')));
-		app.use('/admin/*', noCacheIndexHtmlHandler);
+		app.get('/', noCacheIndexHtmlHandler);
+		app.use('/', express.static(path.join(adminPath, '..')));
+		app.use('/(?!api)/*', noCacheIndexHtmlHandler);
 	}
 
 	// use the rate limiter - all routes for now
@@ -168,31 +168,31 @@ export default async function createApp(): Promise<express.Application> {
 
 	await emitter.emitInit('routes.before', { app });
 
-	app.use('/auth', authRouter);
+	app.use('/api/auth', authRouter);
 
-	app.use('/graphql', graphqlRouter);
+	app.use('/api/graphql', graphqlRouter);
 
-	app.use('/activity', activityRouter);
-	app.use('/assets', assetsRouter);
-	app.use('/collections', collectionsRouter);
-	app.use('/dashboards', dashboardsRouter);
-	app.use('/extensions', extensionsRouter);
-	app.use('/fields', fieldsRouter);
-	app.use('/files', filesRouter);
-	app.use('/folders', foldersRouter);
-	app.use('/items', itemsRouter);
-	app.use('/notifications', notificationsRouter);
-	app.use('/panels', panelsRouter);
-	app.use('/permissions', permissionsRouter);
-	app.use('/presets', presetsRouter);
-	app.use('/relations', relationsRouter);
-	app.use('/revisions', revisionsRouter);
-	app.use('/roles', rolesRouter);
-	app.use('/server', serverRouter);
-	app.use('/settings', settingsRouter);
-	app.use('/users', usersRouter);
-	app.use('/utils', utilsRouter);
-	app.use('/webhooks', webhooksRouter);
+	app.use('/api/activity', activityRouter);
+	app.use('/api/assets', assetsRouter);
+	app.use('/api/collections', collectionsRouter);
+	app.use('/api/dashboards', dashboardsRouter);
+	app.use('/api/extensions', extensionsRouter);
+	app.use('/api/fields', fieldsRouter);
+	app.use('/api/files', filesRouter);
+	app.use('/api/folders', foldersRouter);
+	app.use('/api/items', itemsRouter);
+	app.use('/api/notifications', notificationsRouter);
+	app.use('/api/panels', panelsRouter);
+	app.use('/api/permissions', permissionsRouter);
+	app.use('/api/presets', presetsRouter);
+	app.use('/api/relations', relationsRouter);
+	app.use('/api/revisions', revisionsRouter);
+	app.use('/api/roles', rolesRouter);
+	app.use('/api/server', serverRouter);
+	app.use('/api/settings', settingsRouter);
+	app.use('/api/users', usersRouter);
+	app.use('/api/utils', utilsRouter);
+	app.use('/api/webhooks', webhooksRouter);
 
 	// Register custom endpoints
 	await emitter.emitInit('routes.custom.before', { app });

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -33,7 +33,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw new InvalidConfigException('Invalid provider config', { provider: additionalConfig.provider });
 		}
 
-		const redirectUrl = new Url(env.PUBLIC_URL).addPath('auth', 'login', additionalConfig.provider, 'callback');
+		const redirectUrl = new Url(env.PUBLIC_URL).addPath('api', 'auth', 'login', additionalConfig.provider, 'callback');
 
 		this.redirectUrl = redirectUrl.toString();
 		this.usersService = new UsersService({ knex: this.knex, schema: this.schema });

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -33,7 +33,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			throw new InvalidConfigException('Invalid provider config', { provider: additionalConfig.provider });
 		}
 
-		const redirectUrl = new Url(env.PUBLIC_URL).addPath('auth', 'login', additionalConfig.provider, 'callback');
+		const redirectUrl = new Url(env.PUBLIC_URL).addPath('api', 'auth', 'login', additionalConfig.provider, 'callback');
 
 		this.redirectUrl = redirectUrl.toString();
 		this.usersService = new UsersService({ knex: this.knex, schema: this.schema });

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -36,7 +36,7 @@ const defaults: Record<string, any> = {
 	REFRESH_TOKEN_COOKIE_SAME_SITE: 'lax',
 	REFRESH_TOKEN_COOKIE_NAME: 'directus_refresh_token',
 
-	ROOT_REDIRECT: './admin',
+	ROOT_REDIRECT: false,
 
 	CORS_ENABLED: true,
 	CORS_ORIGIN: true,

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -185,7 +185,7 @@ class ExtensionManager {
 			const depName = appDir.find((file) => dep.replace(/\//g, '_') === file.substring(0, file.indexOf('.')));
 
 			if (depName) {
-				const depUrl = new Url(env.PUBLIC_URL).addPath('admin', depName);
+				const depUrl = new Url(env.PUBLIC_URL).addPath(depName);
 
 				depsMapping[dep] = depUrl.toString({ rootRelative: true });
 			} else {

--- a/api/src/services/activity.ts
+++ b/api/src/services/activity.ts
@@ -82,7 +82,7 @@ ${userName(sender)} has mentioned you in a comment:
 
 ${comment}
 
-<a href="${env.PUBLIC_URL}/admin/content/${data.collection}/${data.item}">Click here to view.</a>
+<a href="${env.PUBLIC_URL}/content/${data.collection}/${data.item}">Click here to view.</a>
 `;
 
 					await this.notificationsService.createOne({

--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -106,9 +106,9 @@ export class MailService {
 			const projectLogoUrl = new Url(env.PUBLIC_URL);
 
 			if (logoID) {
-				projectLogoUrl.addPath('assets', logoID);
+				projectLogoUrl.addPath('api', 'assets', logoID);
 			} else {
-				projectLogoUrl.addPath('admin', 'img', 'directus-white.png');
+				projectLogoUrl.addPath('img', 'directus-white.png');
 			}
 
 			return projectLogoUrl.toString();

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -259,7 +259,7 @@ export class UsersService extends ItemsService {
 			const payload = { email, scope: 'invite' };
 			const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '7d', issuer: 'directus' });
 			const subjectLine = subject ?? "You've been invited";
-			const inviteURL = url ? new Url(url) : new Url(env.PUBLIC_URL).addPath('admin', 'accept-invite');
+			const inviteURL = url ? new Url(url) : new Url(env.PUBLIC_URL).addPath('accept-invite');
 			inviteURL.setQuery('token', token);
 
 			// Create user first to verify uniqueness
@@ -325,7 +325,7 @@ export class UsersService extends ItemsService {
 
 		const payload = { email, scope: 'password-reset', hash: getSimpleHash('' + user.password) };
 		const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '1d', issuer: 'directus' });
-		const acceptURL = url ? `${url}?token=${token}` : `${env.PUBLIC_URL}/admin/reset-password?token=${token}`;
+		const acceptURL = url ? `${url}?token=${token}` : `${env.PUBLIC_URL}/reset-password?token=${token}`;
 		const subjectLine = subject ? subject : 'Password Reset Request';
 
 		await mailService.send({

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -1,12 +1,11 @@
 import { logout, LogoutReason, refresh } from '@/auth';
 import { useRequestsStore } from '@/stores/';
-import { getRootPath } from '@/utils/get-root-path';
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { addQueryToPath } from './utils/add-query-to-path';
 import PQueue from 'p-queue';
 
 const api = axios.create({
-	baseURL: getRootPath(),
+	baseURL: '/api/',
 	withCredentials: true,
 	headers: {
 		'Cache-Control': 'no-store',

--- a/app/src/router.ts
+++ b/app/src/router.ts
@@ -58,7 +58,7 @@ export const defaultRoutes: RouteRecordRaw[] = [
 ];
 
 export const router = createRouter({
-	history: createWebHistory(getRootPath() + 'admin/'),
+	history: createWebHistory(getRootPath()),
 	routes: defaultRoutes,
 });
 

--- a/app/src/utils/get-root-path.ts
+++ b/app/src/utils/get-root-path.ts
@@ -1,15 +1,7 @@
 export function getRootPath(): string {
-	const path = window.location.pathname;
-	const parts = path.split('/');
-	const adminIndex = parts.indexOf('admin');
-	const rootPath = parts.slice(0, adminIndex).join('/') + '/';
-	return rootPath;
+	return '/';
 }
 
 export function getPublicURL(): string {
-	const path = window.location.href;
-	const parts = path.split('/');
-	const adminIndex = parts.indexOf('admin');
-	const rootPath = parts.slice(0, adminIndex).join('/') + '/';
-	return rootPath;
+	return window.location.origin + '/';
 }

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -121,17 +121,17 @@ export default defineConfig({
 	resolve: {
 		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
 	},
-	base: process.env.NODE_ENV === 'production' ? '' : '/admin/',
+	base: '',
 	server: {
 		port: 8080,
 		proxy: {
-			'^/(?!admin)': {
+			'^/(?=api)': {
 				target: process.env.API_URL ? process.env.API_URL : 'http://localhost:8055/',
 				changeOrigin: true,
 			},
 		},
 		fs: {
-			allow: [searchForWorkspaceRoot(process.cwd()), '/admin/'],
+			allow: [searchForWorkspaceRoot(process.cwd())],
 		},
 	},
 });

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -188,8 +188,8 @@ prefixing the value with `{type}:`. The following types are available:
 | `LOG_LEVEL`                | What level of detail to log. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`.        | `info`        |
 | `LOG_STYLE`                | Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.                                | `pretty`      |
 | `MAX_PAYLOAD_SIZE`         | Controls the maximum request body size. Accepts number of bytes, or human readable string.                 | `100kb`       |
-| `ROOT_REDIRECT`            | Where to redirect to when navigating to `/`. Accepts a relative path, absolute URL, or `false` to disable. | `./admin`     |
-| `SERVE_APP`                | Whether or not to serve the Admin App under `/admin`.                                                      | `true`        |
+| `ROOT_REDIRECT`            | Where to redirect to when navigating to `/`. Accepts a relative path, absolute URL, or `false` to disable. | `false`       |
+| `SERVE_APP`                | Whether or not to serve the Admin App.                                                                     | `true`        |
 
 <sup>[1]</sup> The PUBLIC_URL value is used for things like OAuth redirects, forgot-password emails, and logos that
 needs to be publicly available on the internet.

--- a/docs/reference/system/notifications.md
+++ b/docs/reference/system/notifications.md
@@ -64,7 +64,7 @@ Primary key of the item this notification references.
 	"recipient": "3EE34828-B43C-4FB2-A721-5151579B08EA",
 	"sender": "497a495e-5529-4e46-8feb-2f35e9b85601",
 	"subject": "You were mentioned in articles",
-	"message": "\nHello admin@example.com,\n\rijk@directus.io has mentioned you in a comment:\n\n> Hello <em>admin@example.com</em>!\n\n<a href=\"http://localhost:8080/admin/content/articles/1\">Click here to view.</a>\n",
+	"message": "\nHello admin@example.com,\n\rijk@directus.io has mentioned you in a comment:\n\n> Hello <em>admin@example.com</em>!\n\n<a href=\"http://localhost:8080/content/articles/1\">Click here to view.</a>\n",
 	"collection": "articles",
 	"item": "1"
 }


### PR DESCRIPTION
The new share feature will add a new route to the app, and having it at `/admin/shared` seems a bit silly.
So instead, we'll move the whole app from `/admin` to `/`, and the api from `/` to `/api`.
This also makes Directus more in line with other platforms as having an `/api` endpoint is a very common practice (Data platforms such as CartoDB, Apache Superset and Metabase does this to name a few).