### PR TITLE
fix public role sidebar not closable

### DIFF
--- a/app/src/modules/settings/routes/roles/item/components/role-info-sidebar-detail.vue
+++ b/app/src/modules/settings/routes/roles/item/components/role-info-sidebar-detail.vue
@@ -1,14 +1,15 @@
 <template>
 	<sidebar-detail icon="info_outline" :title="t('information')" close>
-		<dl v-if="!isNew && role">
-			<div>
-				<dt>{{ t('primary_key') }}</dt>
-				<dd>{{ role.id }}</dd>
-			</div>
-		</dl>
+		<template v-if="!isNew && role">
+			<dl>
+				<div>
+					<dt>{{ t('primary_key') }}</dt>
+					<dd>{{ role.id }}</dd>
+				</div>
+			</dl>
 
-		<v-divider />
-
+			<v-divider />
+		</template>
 		<div v-md="t('page_help_settings_roles_item')" class="page-description" />
 	</sidebar-detail>
 </template>

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -14,6 +14,10 @@
 		<div class="roles">
 			<permissions-overview :role="null" :permission="permissionKey" />
 		</div>
+
+		<template #sidebar>
+			<role-info-sidebar-detail :role="null" />
+		</template>
 	</private-view>
 </template>
 
@@ -23,10 +27,11 @@ import { defineComponent } from 'vue';
 
 import SettingsNavigation from '../../components/navigation.vue';
 import PermissionsOverview from './item/components/permissions-overview.vue';
+import RoleInfoSidebarDetail from './item/components/role-info-sidebar-detail.vue';
 
 export default defineComponent({
 	name: 'RolesItem',
-	components: { SettingsNavigation, PermissionsOverview },
+	components: { SettingsNavigation, PermissionsOverview, RoleInfoSidebarDetail },
 	props: {
 		permissionKey: {
 			type: String,


### PR DESCRIPTION
## Before

There's a pretty minor bug where when the sidebar is _already_ opened, and we view public role's permissions, we won't be able to close the sidebar since there's no button at all.

However when we view any other roles, we can still close the opened sidebar as usual.

https://user-images.githubusercontent.com/42867097/147232825-cfd90b29-be80-4b05-981f-b4f7526ec8af.mp4

## After

- Added roleInfoSidebarDetail to public role route
- used template to hide the v-divider as well

https://user-images.githubusercontent.com/42867097/147233000-30deb99c-ee57-4e9f-a255-7cfb3c5adbc8.mp4


