### PR TITLE
check system deny list in relations for GraphQL

### DIFF
--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -467,6 +467,8 @@ export class GraphQLService {
 
 			for (const relation of schema[action].relations) {
 				if (relation.related_collection) {
+					if (SYSTEM_DENY_LIST.includes(relation.related_collection)) continue;
+
 					CollectionTypes[relation.collection]?.addFields({
 						[relation.field]: {
 							type: CollectionTypes[relation.related_collection],
@@ -931,6 +933,8 @@ export class GraphQLService {
 
 			for (const relation of schema.read.relations) {
 				if (relation.related_collection) {
+					if (SYSTEM_DENY_LIST.includes(relation.related_collection)) continue;
+
 					ReadableCollectionFilterTypes[relation.collection]?.addFields({
 						[relation.field]: ReadableCollectionFilterTypes[relation.related_collection],
 					});


### PR DESCRIPTION
Fixes #10668

## Bug

Although the bug reported is based on custom interface, the same error can also be found when we are starting up a Gatsby project using `@directus/gatsby-source-directus`:

![WindowsTerminal_w068IIyapW](https://user-images.githubusercontent.com/42867097/147361859-33c824b8-e42e-4291-9f00-63370e76e590.png)

## Investigation

The new shares feature added a relation for `directus_shares` to `directus_collections`:

https://github.com/directus/directus/blob/5e698a77237f0ce80e4d69c7404ba21a34053bab/api/src/database/system-data/relations/relations.yaml#L100-L102

To provide additional context for the following investigation, note that there's also an existing relation for `directus_collections` to `directus_collections`:

https://github.com/directus/directus/blob/5e698a77237f0ce80e4d69c7404ba21a34053bab/api/src/database/system-data/relations/relations.yaml#L15-L17

For relations, the relevant code snippet would be:

https://github.com/directus/directus/blob/5e698a77237f0ce80e4d69c7404ba21a34053bab/api/src/services/graphql.ts#L469-L477

For the case of `directus_collections` to `directus_collections`,

- relation.collection = directus_collections
- relation.related_collection = directus_collections

it fails the `CollectionTypes[relation.collection]?.addFields()` optional chaining since CollectionTypes does not contain `directus_collections` as seen here, due to the SYSTEM_DENY_LIST:

(do ignore `articles` as it's a collection in my current Directus instance)

![Code_RkVtKoUmZj](https://user-images.githubusercontent.com/42867097/147361849-8b8b74a6-c1eb-49eb-b655-fe78234f0c24.png)

https://github.com/directus/directus/blob/5e698a77237f0ce80e4d69c7404ba21a34053bab/api/src/services/graphql.ts#L117-L123

since it fails, it'll never perform the addFields. However, for case of:

- relation.collection = directus_shares
- relation.related_collection = directus_collections

The addFields function will be performed. Since `CollectionTypes[relation.related_collection]` ends up being undefined, the error reported about "type undefined" will show up.

## Solution

Implemented early "if() continue;" statements by checking the `SYSTEM_DENY_LIST` for relations rather than relying on the optional chaining, similar to what's already been done for collections:

https://github.com/directus/directus/blob/5e698a77237f0ce80e4d69c7404ba21a34053bab/api/src/services/graphql.ts#L407

