### PR TITLE
Add OpenStreetMaps Attribution

### DIFF
--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -250,7 +250,7 @@ export default defineComponent({
 			map = new Map({
 				container: container.value!,
 				style: style.value,
-				attributionControl: false,
+				customAttribution: '© OpenStreetMap contributors',
 				dragRotate: false,
 				logoPosition: 'bottom-right',
 				...props.defaultView,

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -85,7 +85,7 @@ export default defineComponent({
 			map = new Map({
 				container: mapContainer.value!,
 				style: style.value,
-				attributionControl: false,
+				customAttribution: '© OpenStreetMap contributors',
 				...(defaultView.value || {}),
 				...(mapboxKey ? { accessToken: mapboxKey } : {}),
 			});

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -125,7 +125,7 @@ export default defineComponent({
 			map = new Map({
 				container: 'map-container',
 				style: style.value,
-				attributionControl: false,
+				customAttribution: '© OpenStreetMap contributors',
 				dragRotate: false,
 				...props.camera,
 				...(mapboxKey ? { accessToken: mapboxKey } : {}),

--- a/app/src/styles/lib/_mapbox.scss
+++ b/app/src/styles/lib/_mapbox.scss
@@ -1,4 +1,3 @@
-
 .mapboxgl-map {
 	font: inherit;
 }
@@ -71,7 +70,8 @@
 }
 
 .mapboxgl-search-location-dot {
-	&, &::before {
+	&,
+	&::before {
 		background-color: var(--purple);
 	}
 }
@@ -79,7 +79,7 @@
 .mapboxgl-ctrl-attrib.mapboxgl-compact {
 	min-width: 24px;
 	min-height: 24px;
-	color: var(--foreground-subdued);
+	color: var(--foreground-normal);
 	background: var(--background-input) !important;
 	box-shadow: var(--card-shadow);
 
@@ -106,6 +106,16 @@
 		font-size: 12px;
 		line-height: 20px;
 	}
+}
+
+.mapboxgl-ctrl-attrib:not(.mapboxgl-compact) {
+	font-size: 0.8em;
+	color: var(--foreground-normal);
+	background: var(--background-input);
+	border-radius: 6px 0 0 0;
+	border: 1px solid var(--border-normal);
+	border-right: none;
+	border-bottom: none;
 }
 
 .mapboxgl-ctrl-geocoder {
@@ -170,7 +180,6 @@
 	border: 1px solid rgb(56 135 190);
 	pointer-events: none;
 }
-
 
 .maplibregl-ctrl-top-right {
 	max-width: 80%;


### PR DESCRIPTION
Closes #10671 

Adds a `© OpenStreetMap contributors` to the map interface.

In light mode:

![Screenshot_20211226_011647](https://user-images.githubusercontent.com/48161361/147395990-7ad61da4-4526-48fe-8d1a-a57b26044333.png)

In dark mode:

![Screenshot_20211226_011658](https://user-images.githubusercontent.com/48161361/147395991-a77b193b-6936-4ae8-9cdf-a9455d3ac5d9.png)

In the compact view:

![Screenshot_20211226_011758](https://user-images.githubusercontent.com/48161361/147395995-1b8535da-1ca7-45c1-af5c-9fa965eb4222.png)

