### PR TITLE
Add empty state to revisions

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1209,6 +1209,7 @@ relationship: Relationship
 reset: Reset
 reset_password: Reset Password
 revisions: Revisions
+no_revisions: No Revisions Yet
 revert: Revert
 save: Save
 schema: Schema

--- a/app/src/views/private/components/revisions-drawer-detail/revisions-drawer-detail.vue
+++ b/app/src/views/private/components/revisions-drawer-detail/revisions-drawer-detail.vue
@@ -6,6 +6,10 @@
 	>
 		<v-progress-linear v-if="loading" indeterminate />
 
+		<div v-else-if="revisionsCount === 0" class="empty">
+			<div class="content">{{ t('no_revisions') }}</div>
+		</div>
+
 		<template v-else>
 			<template v-for="group in revisionsByDate" :key="group.date.toString()">
 				<RevisionsDateGroup :group="group" @click="openModal" />
@@ -264,6 +268,7 @@ export default defineComponent({
 .empty {
 	margin-top: 16px;
 	margin-bottom: 16px;
+	margin-left: 2px;
 	color: var(--foreground-subdued);
 	font-style: italic;
 }


### PR DESCRIPTION
## Before

When there are no revisions, the revisions sidebar can be opened but nothing is shown:

![chrome_3RyyWTqrx2](https://user-images.githubusercontent.com/42867097/147433543-8294e4fc-d316-4b1b-a580-02b889347fbd.png)

## Changes

- Added `No Revisions Yet` translation text based on existing one for comments

    https://github.com/directus/directus/blob/afa92c0bcb9b24c5e79928ecf1a60cfbce349570/app/src/lang/translations/en-US.yaml#L419-L420
    
- Added margin-left to empty class based on existing ones:

    https://github.com/directus/directus/blob/75abe59951837cfaed86bf559cf90ceb6980f8f8/app/src/views/private/components/comments-sidebar-detail/comments-sidebar-detail.vue#L212-L218
    
    https://github.com/directus/directus/blob/75abe59951837cfaed86bf559cf90ceb6980f8f8/app/src/views/private/components/shares-sidebar-detail/shares-sidebar-detail.vue#L282-L288

## After

![chrome_CSWVyDW3FI](https://user-images.githubusercontent.com/42867097/147433549-7972c845-7abe-445b-9321-44381f17be25.png)

