### PR TITLE
App: fix stacked drawers on mobile

### DIFF
--- a/app/src/components/v-overlay/v-overlay.vue
+++ b/app/src/components/v-overlay/v-overlay.vue
@@ -69,10 +69,16 @@ body {
 		width: 100%;
 		height: 100%;
 		background-color: var(--v-overlay-color);
+		opacity: 0;
+		transition: opacity var(--slow) var(--transition);
 	}
 
 	&.active {
 		pointer-events: auto;
+
+		.overlay {
+			opacity: 1;
+		}
 	}
 
 	.content {


### PR DESCRIPTION
Issue
It seems the `active` UI behaviour on `v-overlay` was removed here: https://github.com/directus/directus/pull/6440/files#diff-0087a85062bab4100ae1100c149d7ffe742e338f78bf565e2bbbb16d9876442aL69-L84

Description
Before:

https://user-images.githubusercontent.com/14039341/147471543-769e170d-96f2-4926-8d75-323fdcc7b10f.mov

After:

https://user-images.githubusercontent.com/14039341/147471558-f1cf06d9-b138-4c7b-92ee-2d75791fba35.mov


