### PR TITLE
Replace knex.fn.now() to Date()

### DIFF
--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -275,12 +275,12 @@ export class AuthenticationService {
 			.leftJoin('directus_shares AS d', 's.share', 'd.id')
 			.joinRaw('LEFT JOIN directus_roles AS r ON r.id IN (u.role, d.role)')
 			.where('s.token', refreshToken)
-			.andWhere('s.expires', '>=', this.knex.fn.now())
+			.andWhere('s.expires', '>=', new Date())
 			.andWhere((subQuery) => {
-				subQuery.whereNull('d.date_end').orWhere('d.date_end', '>=', this.knex.fn.now());
+				subQuery.whereNull('d.date_end').orWhere('d.date_end', '>=', new Date());
 			})
 			.andWhere((subQuery) => {
-				subQuery.whereNull('d.date_start').orWhere('d.date_start', '<=', this.knex.fn.now());
+				subQuery.whereNull('d.date_start').orWhere('d.date_start', '<=', new Date());
 			})
 			.first();
 

--- a/api/src/services/shares.ts
+++ b/api/src/services/shares.ts
@@ -54,10 +54,10 @@ export class SharesService extends ItemsService {
 			.from('directus_shares')
 			.where('id', payload.share)
 			.andWhere((subQuery) => {
-				subQuery.whereNull('date_end').orWhere('date_end', '>=', this.knex.fn.now());
+				subQuery.whereNull('date_end').orWhere('date_end', '>=', new Date());
 			})
 			.andWhere((subQuery) => {
-				subQuery.whereNull('date_start').orWhere('date_start', '<=', this.knex.fn.now());
+				subQuery.whereNull('date_start').orWhere('date_start', '<=', new Date());
 			})
 			.andWhere((subQuery) => {
 				subQuery.whereNull('max_uses').orWhere('max_uses', '>=', this.knex.ref('times_used'));


### PR DESCRIPTION
`this.knex.fn.now()` gets translated to `CURRENT_TIMESTAMP` in SQLite which isn't a valid function for use in queries. https://www.sqlite.org/lang_datefunc.html

Issue surfaces when the app is refreshed, `/auth/refresh` fails as no record is found.
 https://github.com/directus/directus/blob/341c266e589e0bb3bb01249e14acc847e636eda8/api/src/services/authentication.ts#L287-L289