### PR TITLE
Add link to Cleavr deployment guide

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,6 +27,7 @@ While Directus is always completely free, you will likely need to pay for these 
 - [Amazon AWS](/getting-started/installation/aws)
 - [DigitalOcean App Platform](/getting-started/installation/digitalocean-app-platform)
 - [Shared Hosting with Plesk](/getting-started/installation/plesk)
+- [Cleavr.io](https://docs.cleavr.io/guides/directus)
 
 ## One-Click Installs
 


### PR DESCRIPTION
Added a link to Cleavr's instructions for deploying Directus to a VPS. Or, if you prefer to have a guide on docs.directus.io, let me know and would be happy to do so.