### PR TITLE
In the E2E tests changed the event.cost value to be hardcoded to a float that works with all databases.

### DIFF
--- a/tests/e2e/setup/utils/factories.ts
+++ b/tests/e2e/setup/utils/factories.ts
@@ -138,7 +138,7 @@ export const createArtist = (): Artist => ({
 
 export const createEvent = (): Event => ({
 	id: uuid(),
-	cost: datatype.number(),
+	cost: 1504.04,
 	description: lorem.paragraphs(2),
 	created_at: randomDateTime(new Date(1030436120350), new Date(1633466120350)),
 	time: randomTime(),


### PR DESCRIPTION
Currently, the end-to-end tests only use an integer instead of a float for the float tests due to inconsistent rounding by Postgres 10. I have changed it to a hardcoded number that works with all databases.