### PR TITLE
Add ability to configure IP extraction

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -115,6 +115,7 @@
 		"graphql": "^15.5.0",
 		"graphql-compose": "^9.0.1",
 		"inquirer": "^8.1.1",
+		"is-ip": "^3.1.0",
 		"joi": "^17.3.0",
 		"js-yaml": "^4.1.0",
 		"js2xmlparser": "^4.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -115,7 +115,6 @@
 		"graphql": "^15.5.0",
 		"graphql-compose": "^9.0.1",
 		"inquirer": "^8.1.1",
-		"is-ip": "^3.1.0",
 		"joi": "^17.3.0",
 		"js-yaml": "^4.1.0",
 		"js2xmlparser": "^4.0.1",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -86,7 +86,7 @@ export default async function createApp(): Promise<express.Application> {
 	const app = express();
 
 	app.disable('x-powered-by');
-	app.set('trust proxy', true);
+	app.set('trust proxy', env.IP_TRUST_PROXY);
 	app.set('query parser', (str: string) => qs.parse(str, { depth: 10 }));
 
 	await emitter.emitInit('app.before', { app });

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -12,6 +12,7 @@ import ldap, {
 	OperationsError,
 } from 'ldapjs';
 import ms from 'ms';
+import { getIPFromReq } from '../../utils/get-ip-from-req';
 import Joi from 'joi';
 import { AuthDriver } from '../auth';
 import { AuthDriverOptions, User } from '../../types';
@@ -361,7 +362,7 @@ export function createLDAPAuthRouter(provider: string): Router {
 		'/',
 		asyncHandler(async (req, res, next) => {
 			const accountability = {
-				ip: req.ip,
+				ip: getIPFromReq(req),
 				userAgent: req.get('user-agent'),
 				role: null,
 			};

--- a/api/src/auth/drivers/local.ts
+++ b/api/src/auth/drivers/local.ts
@@ -9,6 +9,7 @@ import asyncHandler from '../../utils/async-handler';
 import env from '../../env';
 import { respond } from '../../middleware/respond';
 import { COOKIE_OPTIONS } from '../../constants';
+import { getIPFromReq } from '../../utils/get-ip-from-req';
 
 export class LocalAuthDriver extends AuthDriver {
 	async getUserID(payload: Record<string, any>): Promise<string> {
@@ -54,7 +55,7 @@ export function createLocalAuthRouter(provider: string): Router {
 		'/',
 		asyncHandler(async (req, res, next) => {
 			const accountability = {
-				ip: req.ip,
+				ip: getIPFromReq(req),
 				userAgent: req.get('user-agent'),
 				role: null,
 			};

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -17,6 +17,7 @@ import { respond } from '../../middleware/respond';
 import asyncHandler from '../../utils/async-handler';
 import { Url } from '../../utils/url';
 import logger from '../../logger';
+import { getIPFromReq } from '../../utils/get-ip-from-req';
 
 export class OAuth2AuthDriver extends LocalAuthDriver {
 	client: Client;
@@ -260,7 +261,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 
 			const authenticationService = new AuthenticationService({
 				accountability: {
-					ip: req.ip,
+					ip: getIPFromReq(req),
 					userAgent: req.get('user-agent'),
 					role: null,
 				},

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -17,6 +17,7 @@ import { respond } from '../../middleware/respond';
 import asyncHandler from '../../utils/async-handler';
 import { Url } from '../../utils/url';
 import logger from '../../logger';
+import { getIPFromReq } from '../../utils/get-ip-from-req';
 
 export class OpenIDAuthDriver extends LocalAuthDriver {
 	client: Promise<Client>;
@@ -261,7 +262,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 
 			const authenticationService = new AuthenticationService({
 				accountability: {
-					ip: req.ip,
+					ip: getIPFromReq(req),
 					userAgent: req.get('user-agent'),
 					role: null,
 				},

--- a/api/src/controllers/activity.ts
+++ b/api/src/controllers/activity.ts
@@ -7,6 +7,7 @@ import { validateBatch } from '../middleware/validate-batch';
 import { ActivityService, MetaService } from '../services';
 import { Action } from '../types';
 import asyncHandler from '../utils/async-handler';
+import { getIPFromReq } from '../utils/get-ip-from-req';
 
 const router = express.Router();
 
@@ -89,7 +90,7 @@ router.post(
 			...req.body,
 			action: Action.COMMENT,
 			user: req.accountability?.user,
-			ip: req.ip,
+			ip: getIPFromReq(req),
 			user_agent: req.get('user-agent'),
 		});
 

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -14,6 +14,7 @@ import {
 	createLDAPAuthRouter,
 } from '../auth/drivers';
 import { DEFAULT_AUTH_PROVIDER } from '../constants';
+import { getIPFromReq } from '../utils/get-ip-from-req';
 
 const router = Router();
 
@@ -56,7 +57,7 @@ router.post(
 	'/refresh',
 	asyncHandler(async (req, res, next) => {
 		const accountability = {
-			ip: req.ip,
+			ip: getIPFromReq(req),
 			userAgent: req.get('user-agent'),
 			role: null,
 		};
@@ -104,7 +105,7 @@ router.post(
 	'/logout',
 	asyncHandler(async (req, res, next) => {
 		const accountability = {
-			ip: req.ip,
+			ip: getIPFromReq(req),
 			userAgent: req.get('user-agent'),
 			role: null,
 		};
@@ -144,7 +145,7 @@ router.post(
 		}
 
 		const accountability = {
-			ip: req.ip,
+			ip: getIPFromReq(req),
 			userAgent: req.get('user-agent'),
 			role: null,
 		};
@@ -178,7 +179,7 @@ router.post(
 		}
 
 		const accountability = {
-			ip: req.ip,
+			ip: getIPFromReq(req),
 			userAgent: req.get('user-agent'),
 			role: null,
 		};

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -72,6 +72,9 @@ const defaults: Record<string, any> = {
 	ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION: 6000,
 	ASSETS_TRANSFORM_MAX_OPERATIONS: 5,
 
+	IP_TRUST_PROXY: true,
+	IP_CUSTOM_HEADER: false,
+
 	SERVE_APP: true,
 };
 

--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -5,6 +5,7 @@ import env from '../env';
 import { InvalidCredentialsException } from '../exceptions';
 import { DirectusTokenPayload } from '../types';
 import asyncHandler from '../utils/async-handler';
+import { getIPFromReq } from '../utils/get-ip-from-req';
 import isDirectusJWT from '../utils/is-directus-jwt';
 
 /**
@@ -16,7 +17,7 @@ const authenticate: RequestHandler = asyncHandler(async (req, res, next) => {
 		role: null,
 		admin: false,
 		app: false,
-		ip: req.ip.startsWith('::ffff:') ? req.ip.substring(7) : req.ip,
+		ip: getIPFromReq(req),
 		userAgent: req.get('user-agent'),
 	};
 

--- a/api/src/middleware/rate-limiter.ts
+++ b/api/src/middleware/rate-limiter.ts
@@ -5,6 +5,7 @@ import env from '../env';
 import { HitRateLimitException } from '../exceptions';
 import { createRateLimiter } from '../rate-limiter';
 import asyncHandler from '../utils/async-handler';
+import { getIPFromReq } from '../utils/get-ip-from-req';
 import { validateEnv } from '../utils/validate-env';
 
 let checkRateLimit: RequestHandler = (req, res, next) => next();
@@ -17,7 +18,7 @@ if (env.RATE_LIMITER_ENABLED === true) {
 
 	checkRateLimit = asyncHandler(async (req, res, next) => {
 		try {
-			await rateLimiter.consume(req.ip, 1);
+			await rateLimiter.consume(getIPFromReq(req), 1);
 		} catch (rateLimiterRes: any) {
 			if (rateLimiterRes instanceof Error) throw rateLimiterRes;
 

--- a/api/src/utils/get-ip-from-req.ts
+++ b/api/src/utils/get-ip-from-req.ts
@@ -1,0 +1,20 @@
+import { Request } from 'express';
+import { isIP } from 'net';
+import env from '../env';
+import logger from '../logger';
+
+export function getIPFromReq(req: Request): string {
+	let ip = req.ip;
+
+	if (env.IP_CUSTOM_HEADER) {
+		const customIPHeaderValue = req.get(env.IP_CUSTOM_HEADER) as unknown;
+
+		if (typeof customIPHeaderValue === 'string' && isIP(customIPHeaderValue) !== 0) {
+			ip = customIPHeaderValue;
+		} else {
+			logger.warn(`Custom IP header didn't return valid IP address: ${JSON.stringify(customIPHeaderValue)}`);
+		}
+	}
+
+	return ip.startsWith('::ffff:') ? ip.substring(7) : ip;
+}

--- a/api/src/utils/get-ip-from-req.ts
+++ b/api/src/utils/get-ip-from-req.ts
@@ -16,5 +16,6 @@ export function getIPFromReq(req: Request): string {
 		}
 	}
 
+	// IP addresses starting with ::ffff: are IPv4 addresses in IPv6 format. We can strip the prefix to get back to IPv4
 	return ip.startsWith('::ffff:') ? ip.substring(7) : ip;
 }

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -196,19 +196,19 @@ needs to be publicly available on the internet.
 
 ## Database
 
-| Variable               | Description                                                                                                                                        | Default Value     |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `DB_CLIENT`            | **Required**. What database client to use. One of `pg` or `postgres`, `mysql`, `oracledb`, `mssql`, or `sqlite3`.                                  | --                |
-| `DB_HOST`              | Database host. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                |
-| `DB_PORT`              | Database port. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                |
-| `DB_DATABASE`          | Database name. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                |
-| `DB_USER`              | Database user. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                |
-| `DB_PASSWORD`          | Database user's password. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                           | --                |
-| `DB_FILENAME`          | Where to read/write the SQLite database. **Required** when using `sqlite3`.                                                                        | --                |
-| `DB_CONNECTION_STRING` | When using `pg`, you can submit a connection string instead of individual properties. Using this will ignore any of the other connection settings. | --                |
-| `DB_POOL_*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --                |
+| Variable               | Description                                                                                                                                        | Default Value                 |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `DB_CLIENT`            | **Required**. What database client to use. One of `pg` or `postgres`, `mysql`, `oracledb`, `mssql`, or `sqlite3`.                                  | --                            |
+| `DB_HOST`              | Database host. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                            |
+| `DB_PORT`              | Database port. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                            |
+| `DB_DATABASE`          | Database name. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                            |
+| `DB_USER`              | Database user. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                                      | --                            |
+| `DB_PASSWORD`          | Database user's password. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                           | --                            |
+| `DB_FILENAME`          | Where to read/write the SQLite database. **Required** when using `sqlite3`.                                                                        | --                            |
+| `DB_CONNECTION_STRING` | When using `pg`, you can submit a connection string instead of individual properties. Using this will ignore any of the other connection settings. | --                            |
+| `DB_POOL_*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --                            |
 | `DB_EXCLUDE_TABLES`    | CSV of tables you want Directus to ignore completely                                                                                               | `spatial_ref_sys,sysdiagrams` |
-| `DB_CHARSET`           | Charset/collation to use in the connection to MySQL/MariaDB                                                                                        | `UTF8_GENERAL_CI` |
+| `DB_CHARSET`           | Charset/collation to use in the connection to MySQL/MariaDB                                                                                        | `UTF8_GENERAL_CI`             |
 
 ::: tip Additional Database Variables
 
@@ -239,6 +239,8 @@ All the `DB_POOL_` prefixed options are passed to [`tarn.js`](https://github.com
 | `REFRESH_TOKEN_COOKIE_NAME`      | Name of refresh token cookie .                                                                                         | `directus_refresh_token` |
 | `PASSWORD_RESET_URL_ALLOW_LIST`  | List of URLs that can be used [as `reset_url` in /password/request](/reference/authentication/#request-password-reset) | --                       |
 | `USER_INVITE_URL_ALLOW_LIST`     | List of URLs that can be used [as `invite_url` in /users/invite](/reference/system/users/#invite-a-new-user)           | --                       |
+| `IP_TRUST_PROXY`                 | Settings for [express' trust proxy setting](https://expressjs.com/en/guide/behind-proxies.html)                        | true                     |
+| `IP_CUSTOM_HEADER`               | What custom request header to use for the IP address                                                                   | false                    |
 
 ::: tip Cookie Strictness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
 				"graphql": "^15.5.0",
 				"graphql-compose": "^9.0.1",
 				"inquirer": "^8.1.1",
-				"is-ip": "^3.1.0",
 				"joi": "^17.3.0",
 				"js-yaml": "^4.1.0",
 				"js2xmlparser": "^4.0.1",
@@ -25163,25 +25162,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-ip": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-			"dependencies": {
-				"ip-regex": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-ip/node_modules/ip-regex": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-lambda": {
@@ -58150,7 +58130,6 @@
 				"graphql-compose": "^9.0.1",
 				"inquirer": "^8.1.1",
 				"ioredis": "^4.27.6",
-				"is-ip": "*",
 				"jest": "27.3.1",
 				"joi": "^17.3.0",
 				"js-yaml": "^4.1.0",
@@ -63413,21 +63392,6 @@
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
-				}
-			}
-		},
-		"is-ip": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-			"requires": {
-				"ip-regex": "^4.0.0"
-			},
-			"dependencies": {
-				"ip-regex": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-					"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,20 +59,20 @@
 		},
 		"api": {
 			"name": "directus",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"@aws-sdk/client-ses": "^3.40.0",
-				"@directus/app": "9.4.0",
-				"@directus/drive": "9.4.0",
-				"@directus/drive-azure": "9.4.0",
-				"@directus/drive-gcs": "9.4.0",
-				"@directus/drive-s3": "9.4.0",
-				"@directus/extensions-sdk": "9.4.0",
-				"@directus/format-title": "9.4.0",
-				"@directus/schema": "9.4.0",
-				"@directus/shared": "9.4.0",
-				"@directus/specs": "9.4.0",
+				"@directus/app": "9.4.1",
+				"@directus/drive": "9.4.1",
+				"@directus/drive-azure": "9.4.1",
+				"@directus/drive-gcs": "9.4.1",
+				"@directus/drive-s3": "9.4.1",
+				"@directus/extensions-sdk": "9.4.1",
+				"@directus/format-title": "9.4.1",
+				"@directus/schema": "9.4.1",
+				"@directus/shared": "9.4.1",
+				"@directus/specs": "9.4.1",
 				"@godaddy/terminus": "^4.9.0",
 				"@rollup/plugin-alias": "^3.1.2",
 				"@rollup/plugin-virtual": "^2.0.3",
@@ -102,6 +102,7 @@
 				"graphql": "^15.5.0",
 				"graphql-compose": "^9.0.1",
 				"inquirer": "^8.1.1",
+				"is-ip": "^3.1.0",
 				"joi": "^17.3.0",
 				"js-yaml": "^4.1.0",
 				"js2xmlparser": "^4.0.1",
@@ -304,12 +305,12 @@
 		},
 		"app": {
 			"name": "@directus/app",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"devDependencies": {
-				"@directus/docs": "9.4.0",
-				"@directus/extensions-sdk": "9.4.0",
-				"@directus/format-title": "9.4.0",
-				"@directus/shared": "9.4.0",
+				"@directus/docs": "9.4.1",
+				"@directus/extensions-sdk": "9.4.1",
+				"@directus/format-title": "9.4.1",
+				"@directus/shared": "9.4.1",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.1",
@@ -445,7 +446,7 @@
 		},
 		"docs": {
 			"name": "@directus/docs",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "ISC",
 			"devDependencies": {
 				"directory-tree": "3.0.1",
@@ -25164,6 +25165,25 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-ip": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"dependencies": {
+				"ip-regex": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-ip/node_modules/ip-regex": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-lambda": {
 			"version": "1.0.1",
 			"dev": true,
@@ -45048,11 +45068,11 @@
 		},
 		"packages/cli": {
 			"name": "@directus/cli",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/format-title": "9.4.0",
-				"@directus/sdk": "9.4.0",
+				"@directus/format-title": "9.4.1",
+				"@directus/sdk": "9.4.1",
 				"@types/yargs": "^17.0.0",
 				"app-module-path": "^2.2.0",
 				"chalk": "^4.1.0",
@@ -45187,11 +45207,11 @@
 			}
 		},
 		"packages/create-directus-extension": {
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/extensions-sdk": "9.4.0",
-				"@directus/shared": "9.4.0",
+				"@directus/extensions-sdk": "9.4.1",
+				"@directus/shared": "9.4.1",
 				"inquirer": "^8.1.2"
 			},
 			"bin": {
@@ -45234,7 +45254,7 @@
 			"license": "0BSD"
 		},
 		"packages/create-directus-project": {
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"chalk": "^4.1.1",
@@ -45270,7 +45290,7 @@
 		},
 		"packages/drive": {
 			"name": "@directus/drive",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.0.0",
@@ -45289,11 +45309,11 @@
 		},
 		"packages/drive-azure": {
 			"name": "@directus/drive-azure",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.4.0",
+				"@directus/drive": "9.4.1",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -45324,10 +45344,10 @@
 		},
 		"packages/drive-gcs": {
 			"name": "@directus/drive-gcs",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.4.0",
+				"@directus/drive": "9.4.1",
 				"@google-cloud/storage": "^5.8.5",
 				"lodash": "4.17.21",
 				"normalize-path": "^3.0.0"
@@ -45347,10 +45367,10 @@
 		},
 		"packages/drive-s3": {
 			"name": "@directus/drive-s3",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.4.0",
+				"@directus/drive": "9.4.1",
 				"aws-sdk": "^2.928.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -45395,9 +45415,9 @@
 		},
 		"packages/extensions-sdk": {
 			"name": "@directus/extensions-sdk",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"dependencies": {
-				"@directus/shared": "9.4.0",
+				"@directus/shared": "9.4.1",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -45447,7 +45467,7 @@
 		},
 		"packages/format-title": {
 			"name": "@directus/format-title",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "21.0.1",
@@ -45467,10 +45487,10 @@
 		},
 		"packages/gatsby-source-directus": {
 			"name": "@directus/gatsby-source-directus",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/sdk": "9.4.0",
+				"@directus/sdk": "9.4.1",
 				"gatsby-source-filesystem": "4.2.0",
 				"gatsby-source-graphql": "4.2.0",
 				"ms": "2.1.3"
@@ -45482,7 +45502,7 @@
 		},
 		"packages/schema": {
 			"name": "@directus/schema",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"knex-schema-inspector": "^1.6.6",
@@ -45495,7 +45515,7 @@
 		},
 		"packages/sdk": {
 			"name": "@directus/sdk",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.24.0"
@@ -45524,7 +45544,7 @@
 		},
 		"packages/shared": {
 			"name": "@directus/shared",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"dependencies": {
 				"axios": "*",
 				"date-fns": "2.24.0",
@@ -45583,7 +45603,7 @@
 		},
 		"packages/specs": {
 			"name": "@directus/specs",
-			"version": "9.4.0",
+			"version": "9.4.1",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"openapi3-ts": "^2.0.1"
@@ -47872,10 +47892,10 @@
 		"@directus/app": {
 			"version": "file:app",
 			"requires": {
-				"@directus/docs": "9.4.0",
-				"@directus/extensions-sdk": "9.4.0",
-				"@directus/format-title": "9.4.0",
-				"@directus/shared": "9.4.0",
+				"@directus/docs": "9.4.1",
+				"@directus/extensions-sdk": "9.4.1",
+				"@directus/format-title": "9.4.1",
+				"@directus/shared": "9.4.1",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.1",
@@ -47978,8 +47998,8 @@
 		"@directus/cli": {
 			"version": "file:packages/cli",
 			"requires": {
-				"@directus/format-title": "9.4.0",
-				"@directus/sdk": "9.4.0",
+				"@directus/format-title": "9.4.1",
+				"@directus/sdk": "9.4.1",
 				"@types/figlet": "1.5.4",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
@@ -48131,7 +48151,7 @@
 			"version": "file:packages/drive-azure",
 			"requires": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.4.0",
+				"@directus/drive": "9.4.1",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
 				"@types/node": "16.11.9",
@@ -48159,7 +48179,7 @@
 		"@directus/drive-gcs": {
 			"version": "file:packages/drive-gcs",
 			"requires": {
-				"@directus/drive": "9.4.0",
+				"@directus/drive": "9.4.1",
 				"@google-cloud/storage": "^5.8.5",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
@@ -48178,7 +48198,7 @@
 		"@directus/drive-s3": {
 			"version": "file:packages/drive-s3",
 			"requires": {
-				"@directus/drive": "9.4.0",
+				"@directus/drive": "9.4.1",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
@@ -48208,7 +48228,7 @@
 		"@directus/extensions-sdk": {
 			"version": "file:packages/extensions-sdk",
 			"requires": {
-				"@directus/shared": "9.4.0",
+				"@directus/shared": "9.4.1",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -48260,7 +48280,7 @@
 		"@directus/gatsby-source-directus": {
 			"version": "file:packages/gatsby-source-directus",
 			"requires": {
-				"@directus/sdk": "9.4.0",
+				"@directus/sdk": "9.4.1",
 				"gatsby-source-filesystem": "4.2.0",
 				"gatsby-source-graphql": "4.2.0",
 				"ms": "2.1.3"
@@ -56700,8 +56720,8 @@
 		"create-directus-extension": {
 			"version": "file:packages/create-directus-extension",
 			"requires": {
-				"@directus/extensions-sdk": "9.4.0",
-				"@directus/shared": "9.4.0",
+				"@directus/extensions-sdk": "9.4.1",
+				"@directus/shared": "9.4.1",
 				"inquirer": "^8.1.2"
 			},
 			"dependencies": {
@@ -58049,16 +58069,16 @@
 			"version": "file:api",
 			"requires": {
 				"@aws-sdk/client-ses": "^3.40.0",
-				"@directus/app": "9.4.0",
-				"@directus/drive": "9.4.0",
-				"@directus/drive-azure": "9.4.0",
-				"@directus/drive-gcs": "9.4.0",
-				"@directus/drive-s3": "9.4.0",
-				"@directus/extensions-sdk": "9.4.0",
-				"@directus/format-title": "9.4.0",
-				"@directus/schema": "9.4.0",
-				"@directus/shared": "9.4.0",
-				"@directus/specs": "9.4.0",
+				"@directus/app": "9.4.1",
+				"@directus/drive": "9.4.1",
+				"@directus/drive-azure": "9.4.1",
+				"@directus/drive-gcs": "9.4.1",
+				"@directus/drive-s3": "9.4.1",
+				"@directus/extensions-sdk": "9.4.1",
+				"@directus/format-title": "9.4.1",
+				"@directus/schema": "9.4.1",
+				"@directus/shared": "9.4.1",
+				"@directus/specs": "9.4.1",
 				"@godaddy/terminus": "^4.9.0",
 				"@keyv/redis": "^2.1.2",
 				"@rollup/plugin-alias": "^3.1.2",
@@ -58130,6 +58150,7 @@
 				"graphql-compose": "^9.0.1",
 				"inquirer": "^8.1.1",
 				"ioredis": "^4.27.6",
+				"is-ip": "*",
 				"jest": "27.3.1",
 				"joi": "^17.3.0",
 				"js-yaml": "^4.1.0",
@@ -63392,6 +63413,21 @@
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
+				}
+			}
+		},
+		"is-ip": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"requires": {
+				"ip-regex": "^4.0.0"
+			},
+			"dependencies": {
+				"ip-regex": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+					"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
 				}
 			}
 		},


### PR DESCRIPTION
Allows you to fine-tune the configuration of where client IP addresses are pulled from. When using certain CDN services, like CloudFlare, the client IP is in a custom header. This allows you to configure where the IP address is extracted from, through two new environment variables:

`IP_TRUST_PROXY` — Settings for express' `trust proxy` setting, configures `X-Forwarded-For` header handling
`IP_CUSTOM_HEADER` — Use a custom request header for the client IP address

Implements https://github.com/directus/directus/discussions/10069 (cc @t7tran)