### PR TITLE
Don't force commandTimeout in redis based caches

### DIFF
--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -54,9 +54,7 @@ function getConfig(
 	if (store === 'redis') {
 		const KeyvRedis = require('@keyv/redis');
 
-		config.store = new KeyvRedis(env.CACHE_REDIS || getConfigFromEnv('CACHE_REDIS_'), {
-			commandTimeout: 500,
-		});
+		config.store = new KeyvRedis(env.CACHE_REDIS || getConfigFromEnv('CACHE_REDIS_'));
 	}
 
 	if (store === 'memcache') {


### PR DESCRIPTION
You can already configure this through `CACHE_REDIS_COMMAND_TIMEOUT`. No need for us to hardcode that to an arbitrary value like 500ms (ref https://github.com/directus/directus/discussions/10660)

