### PR TITLE
Add Content-Security-Policy header by default

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -114,6 +114,7 @@
 		"fs-extra": "^10.0.0",
 		"graphql": "^15.5.0",
 		"graphql-compose": "^9.0.1",
+		"helmet": "^4.6.0",
 		"inquirer": "^8.1.1",
 		"joi": "^17.3.0",
 		"js-yaml": "^4.1.0",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -3,6 +3,7 @@ import express, { Request, Response, RequestHandler } from 'express';
 import fse from 'fs-extra';
 import path from 'path';
 import qs from 'qs';
+import helmet from 'helmet';
 
 import activityRouter from './controllers/activity';
 import assetsRouter from './controllers/assets';
@@ -53,6 +54,7 @@ import { register as registerWebhooks } from './webhooks';
 import { flushCaches } from './cache';
 import { registerAuthProviders } from './auth';
 import { Url } from './utils/url';
+import { getConfigFromEnv } from './utils/get-config-from-env';
 
 export default async function createApp(): Promise<express.Application> {
 	validateEnv(['KEY', 'SECRET']);
@@ -88,6 +90,8 @@ export default async function createApp(): Promise<express.Application> {
 	app.disable('x-powered-by');
 	app.set('trust proxy', env.IP_TRUST_PROXY);
 	app.set('query parser', (str: string) => qs.parse(str, { depth: 10 }));
+
+	app.use(helmet.contentSecurityPolicy(getConfigFromEnv('CONTENT_SECURITY_POLICY_')));
 
 	await emitter.emitInit('app.before', { app });
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -227,20 +227,21 @@ All the `DB_POOL_` prefixed options are passed to [`tarn.js`](https://github.com
 
 ## Security
 
-| Variable                         | Description                                                                                                            | Default Value            |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `KEY`                            | Unique identifier for the project.                                                                                     | --                       |
-| `SECRET`                         | Secret string for the project.                                                                                         | --                       |
-| `ACCESS_TOKEN_TTL`               | The duration that the access token is valid.                                                                           | `15m`                    |
-| `REFRESH_TOKEN_TTL`              | The duration that the refresh token is valid, and also how long users stay logged-in to the App.                       | `7d`                     |
-| `REFRESH_TOKEN_COOKIE_DOMAIN`    | Which domain to use for the refresh cookie. Useful for development mode.                                               | --                       |
-| `REFRESH_TOKEN_COOKIE_SECURE`    | Whether or not to use a secure cookie for the refresh token in cookie mode.                                            | `false`                  |
-| `REFRESH_TOKEN_COOKIE_SAME_SITE` | Value for `sameSite` in the refresh token cookie when in cookie mode.                                                  | `lax`                    |
-| `REFRESH_TOKEN_COOKIE_NAME`      | Name of refresh token cookie .                                                                                         | `directus_refresh_token` |
-| `PASSWORD_RESET_URL_ALLOW_LIST`  | List of URLs that can be used [as `reset_url` in /password/request](/reference/authentication/#request-password-reset) | --                       |
-| `USER_INVITE_URL_ALLOW_LIST`     | List of URLs that can be used [as `invite_url` in /users/invite](/reference/system/users/#invite-a-new-user)           | --                       |
-| `IP_TRUST_PROXY`                 | Settings for [express' trust proxy setting](https://expressjs.com/en/guide/behind-proxies.html)                        | true                     |
-| `IP_CUSTOM_HEADER`               | What custom request header to use for the IP address                                                                   | false                    |
+| Variable                         | Description                                                                                                                           | Default Value            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `KEY`                            | Unique identifier for the project.                                                                                                    | --                       |
+| `SECRET`                         | Secret string for the project.                                                                                                        | --                       |
+| `ACCESS_TOKEN_TTL`               | The duration that the access token is valid.                                                                                          | `15m`                    |
+| `REFRESH_TOKEN_TTL`              | The duration that the refresh token is valid, and also how long users stay logged-in to the App.                                      | `7d`                     |
+| `REFRESH_TOKEN_COOKIE_DOMAIN`    | Which domain to use for the refresh cookie. Useful for development mode.                                                              | --                       |
+| `REFRESH_TOKEN_COOKIE_SECURE`    | Whether or not to use a secure cookie for the refresh token in cookie mode.                                                           | `false`                  |
+| `REFRESH_TOKEN_COOKIE_SAME_SITE` | Value for `sameSite` in the refresh token cookie when in cookie mode.                                                                 | `lax`                    |
+| `REFRESH_TOKEN_COOKIE_NAME`      | Name of refresh token cookie .                                                                                                        | `directus_refresh_token` |
+| `PASSWORD_RESET_URL_ALLOW_LIST`  | List of URLs that can be used [as `reset_url` in /password/request](/reference/authentication/#request-password-reset)                | --                       |
+| `USER_INVITE_URL_ALLOW_LIST`     | List of URLs that can be used [as `invite_url` in /users/invite](/reference/system/users/#invite-a-new-user)                          | --                       |
+| `IP_TRUST_PROXY`                 | Settings for [express' trust proxy setting](https://expressjs.com/en/guide/behind-proxies.html)                                       | true                     |
+| `IP_CUSTOM_HEADER`               | What custom request header to use for the IP address                                                                                  | false                    |
+| `CONTENT_SECURITY_POLICY`        | Custom options for the Content-Security-Policy header. See [helmet's documentation](https://helmetjs.github.io) for more information. | --                       |
 
 ::: tip Cookie Strictness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
 				"fs-extra": "^10.0.0",
 				"graphql": "^15.5.0",
 				"graphql-compose": "^9.0.1",
+				"helmet": "^4.6.0",
 				"inquirer": "^8.1.1",
 				"joi": "^17.3.0",
 				"js-yaml": "^4.1.0",
@@ -23938,6 +23939,14 @@
 			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
+			}
+		},
+		"node_modules/helmet": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+			"integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/hex-color-regex": {
@@ -58128,6 +58137,7 @@
 				"fs-extra": "^10.0.0",
 				"graphql": "^15.5.0",
 				"graphql-compose": "^9.0.1",
+				"helmet": "*",
 				"inquirer": "^8.1.1",
 				"ioredis": "^4.27.6",
 				"jest": "27.3.1",
@@ -62591,6 +62601,11 @@
 		"he": {
 			"version": "1.2.0",
 			"dev": true
+		},
+		"helmet": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+			"integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
 		},
 		"hex-color-regex": {
 			"version": "1.1.0"


### PR DESCRIPTION
Improves security by preventing scripts to run in inlined assets. This shouldn't affect any usual operation or API usage. Just in case, the exact directives used can be modified through a new `CONTENT_SECURITY_POLICY` environment variable, that maps to Helmet's `contentSecurityPolicy` method's options.