### PR TITLE
prevent icons from being searchable

### DIFF
--- a/app/src/components/v-icon/v-icon.vue
+++ b/app/src/components/v-icon/v-icon.vue
@@ -9,7 +9,7 @@
 	>
 		<component :is="customIconName" v-if="customIconName" />
 		<socialIcon v-else-if="socialIconName" :name="socialIconName" />
-		<i v-else :class="{ filled }">{{ name }}</i>
+		<i v-else :class="{ filled }" :data-icon="name"></i>
 	</span>
 </template>
 
@@ -644,6 +644,10 @@ body {
 		text-transform: none;
 		word-wrap: normal;
 		font-feature-settings: 'liga';
+
+		&::after {
+			content: attr(data-icon);
+		}
 
 		&.filled {
 			/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */


### PR DESCRIPTION
Fixes #10789

Uses [the approach mentioned here](https://stackoverflow.com/a/61659184). One concern could be accessibility as the "searchable" text are not present now, and we can possibly resolve it with aria-label, but it also feels like it can be a situational thing (good to have for action button with icons only, probably not needed for navigations that already have labels etc).