### PR TITLE
Fix logo url in shared view

### DIFF
--- a/app/src/views/shared/shared-view.vue
+++ b/app/src/views/shared/shared-view.vue
@@ -34,10 +34,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, computed } from 'vue';
 import { useServerStore } from '@/stores';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
+import { getRootPath } from '@/utils/get-root-path';
 
 export default defineComponent({
 	name: 'SharedView',
@@ -58,9 +59,15 @@ export default defineComponent({
 
 		const { t } = useI18n();
 
+		const logoURL = computed<string | null>(() => {
+			if (!serverStore.info?.project?.project_logo) return null;
+			return getRootPath() + `assets/${serverStore.info.project?.project_logo}`;
+		});
+
 		return {
 			serverInfo: info,
 			t,
+			logoURL,
 		};
 	},
 });


### PR DESCRIPTION
Fixes #10810

## Reported Bug

Custom logo is not showing up in shared view.

![chrome_dd9nWcxeq0](https://user-images.githubusercontent.com/42867097/147911268-f4902c93-6bbd-439d-b7b4-6147b28a74c6.png)

## Investigation

`shared-view.vue` has reference to `logoURL` for the image src, but it was never defined in the script:
https://github.com/directus/directus/blob/92c097d7ee2136439553debb86bc5893ddc233c1/app/src/views/shared/shared-view.vue#L12

## Solution

Copied `logoURL` computed property from `public-view.vue`:

https://github.com/directus/directus/blob/92c097d7ee2136439553debb86bc5893ddc233c1/app/src/views/public/public-view.vue#L79-L82

### Result

![chrome_7PluVI6img](https://user-images.githubusercontent.com/42867097/147911279-c1872fe9-b3ae-4a08-94da-98c55e328ebd.png)

