### PR TITLE
fix file local type for displaysForType

### DIFF
--- a/api/src/utils/get-local-type.ts
+++ b/api/src/utils/get-local-type.ts
@@ -118,7 +118,7 @@ export default function getLocalType(
 		if (special.includes('json')) return 'json';
 		if (special.includes('hash')) return 'hash';
 		if (special.includes('csv')) return 'csv';
-		if (special.includes('uuid')) return 'uuid';
+		if (special.includes('uuid') || special.includes('file')) return 'uuid';
 		if (type?.startsWith('geometry')) {
 			return (special[0] as Type) || 'geometry';
 		}


### PR DESCRIPTION
Fixes #10134

Refer to https://github.com/directus/directus/issues/10134#issuecomment-997807398 for more detail.

## Before

https://user-images.githubusercontent.com/42867097/147927768-fce5e357-e22f-4253-b69e-3cac121ffd0b.mp4

## After

https://user-images.githubusercontent.com/42867097/147927795-51935baa-a9f5-43e8-9930-391ba9d1d015.mp4

---

## Note

This may not be the correct approach... though I'm also unsure what would be the potential regressions here unless `'file'` can somehow _not_ be UUID in certain scenarios?

In addition, reportedly this was working in rc.94, however it seems like it's only partially working, as we can see we won't be able to change the interface/display after saving:

https://user-images.githubusercontent.com/42867097/147927692-c6d1f247-2a3f-4b69-869e-0001a99daa40.mp4

However in rc.94 case, we can also see the resulting field is also returning as String, so I can only assume it's something to do with changes in get-local-type, hence the doubt of whether this fix is correct or more of a stop gap. 

This also depends on whether returning UUID even though they're not actually UUID (for SQLite and MySQL) is acceptable. That said, we do return CSV and hash even though that's not the actual underlying type..