### PR TITLE
Default to upgrade-insecure-requests turned off

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -100,6 +100,11 @@ export default async function createApp(): Promise<express.Application> {
 					directives: {
 						// Unsafe-eval is required for vue3 / vue-i18n / app extensions
 						scriptSrc: ["'self'", "'unsafe-eval'"],
+
+						// Even though this is recommended to have enabled, it breaks most local
+						// installations. Making this opt-in rather than opt-out is a little more
+						// friendly. Ref #10806
+						upgradeInsecureRequests: null,
 					},
 				},
 				getConfigFromEnv('CONTENT_SECURITY_POLICY_')


### PR DESCRIPTION
Makes the `upgrade-insecure-requests` directive opt-in rather than opt-out, which should prevent a heap of confusion occurring when you're running Directus on HTTP, as the error you'd see is very vague and the solution non-obvious.

Fixes #10806
