### PR TITLE
Left Join-ing on roles to allow users without roles to login

### DIFF
--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -14,9 +14,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 	let customMigrationFiles =
 		((await fse.pathExists(customMigrationsPath)) && (await fse.readdir(customMigrationsPath))) || [];
 
-	migrationFiles = migrationFiles.filter(
-		(file: string) => file.startsWith('run') === false && file.endsWith('.d.ts') === false
-	);
+	migrationFiles = migrationFiles.filter((file: string) => file.startsWith('run') === false && file.endsWith('.js'));
 	customMigrationFiles = customMigrationFiles.filter((file: string) => file.endsWith('.js'));
 
 	const completedMigrations = await database.select<Migration[]>('*').from('directus_migrations').orderBy('version');
@@ -24,9 +22,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 	const migrations = [
 		...migrationFiles.map((path) => parseFilePath(path)),
 		...customMigrationFiles.map((path) => parseFilePath(path, true)),
-	]
-		.sort((a, b) => (a.version > b.version ? 1 : -1))
-		.filter((m) => m.file.endsWith('.js'));
+	].sort((a, b) => (a.version > b.version ? 1 : -1));
 
 	const migrationKeys = new Set(migrations.map((m) => m.version));
 	if (migrations.length > migrationKeys.size) {

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -24,7 +24,9 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 	const migrations = [
 		...migrationFiles.map((path) => parseFilePath(path)),
 		...customMigrationFiles.map((path) => parseFilePath(path, true)),
-	].sort((a, b) => (a.version > b.version ? 1 : -1));
+	]
+		.sort((a, b) => (a.version > b.version ? 1 : -1))
+		.filter((m) => m.file.endsWith('.js'));
 
 	const migrationKeys = new Set(migrations.map((m) => m.version));
 	if (migrations.length > migrationKeys.size) {

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -74,7 +74,7 @@ export class AuthenticationService {
 				'u.auth_data'
 			)
 			.from('directus_users as u')
-			.innerJoin('directus_roles as r', 'u.role', 'r.id')
+			.leftJoin('directus_roles as r', 'u.role', 'r.id')
 			.where('u.id', await provider.getUserID(cloneDeep(payload)))
 			.andWhere('u.provider', providerName)
 			.first();

--- a/tests/e2e/api/auth/login.test.ts
+++ b/tests/e2e/api/auth/login.test.ts
@@ -59,6 +59,29 @@ describe('auth', () => {
 					},
 				});
 			});
+			it.each(getDBsToTest())(
+				`%p returns an access_token, expires and a refresh_token for noRoleUser`,
+				async (vendor) => {
+					const url = `http://localhost:${config.ports[vendor]!}`;
+
+					const response = await request(url)
+						.post(`/auth/login`)
+						.send({
+							email: 'test@noroleuser.com',
+							password: 'TestNoRoleUserPassword',
+						})
+						.expect('Content-Type', /application\/json/)
+						.expect(200);
+
+					expect(response.body).toMatchObject({
+						data: {
+							access_token: expect.any(String),
+							expires: expect.any(Number),
+							refresh_token: expect.any(String),
+						},
+					});
+				}
+			);
 		});
 		describe('when incorrect credentials are provided', () => {
 			it.each(getDBsToTest())(`%p returns code: UNAUTHORIZED for incorrect password`, async (vendor) => {

--- a/tests/e2e/setup/seeds/04_directus_users.js
+++ b/tests/e2e/setup/seeds/04_directus_users.js
@@ -18,5 +18,12 @@ exports.seed = async function (knex) {
 			role: '214faee7-d6a6-4a4c-b1cd-f9e9bd0b6fb7',
 			token: 'UserToken',
 		},
+		{
+			id: 'cb8cd13b-037f-40ca-862a-ea1e1f4bfca3',
+			email: 'test@noroleuser.com',
+			password: await generateHash.hash('TestNoRoleUserPassword'),
+			status: 'active',
+			token: 'NoRoleUserToken',
+		},
 	]);
 };


### PR DESCRIPTION
Looks like a change in https://github.com/directus/directus/pull/10663 added an `inner join` on `directus_roles` on the user login lookup query with the unintended side effect that users without roles can no longer login. See: https://github.com/directus/directus/pull/10663/files#diff-03b58901729f938551b47a9357d79ae1d0c62868265a05e8f9980d30b22c0e95R77

This changes that line to a `left join` so the role fields will return as `null`

Adds a test for this condition to prevent future regressions.

*Bonus; adds a `filter` to the migration objects list witch solves an edge case where `.map` files were getting included as migration candidates (after enabling sourceMap) making it look like there are duplicate migration keys and throwing the duplicate key check exception.
