### PR TITLE
Api (Assets): fix UUID verification

### DIFF
--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -44,10 +44,6 @@ export class AssetsService {
 
 		const systemPublicKeys = Object.values(publicSettings || {});
 
-		if (systemPublicKeys.includes(id) === false && this.accountability?.admin !== true) {
-			await this.authorizationService.checkAccess('read', 'directus_files', id);
-		}
-
 		/**
 		 * This is a little annoying. Postgres will error out if you're trying to search in `where`
 		 * with a wrong type. In case of directus_files where id is a uuid, we'll have to verify the
@@ -56,6 +52,10 @@ export class AssetsService {
 		const isValidUUID = validateUUID(id, 4);
 
 		if (isValidUUID === false) throw new ForbiddenException();
+
+		if (systemPublicKeys.includes(id) === false && this.accountability?.admin !== true) {
+			await this.authorizationService.checkAccess('read', 'directus_files', id);
+		}
 
 		const file = (await this.knex.select('*').from('directus_files').where({ id }).first()) as File;
 


### PR DESCRIPTION
Trying to get an asset with a key which is not an UUID results on `Internal Server Error`.
<img src="https://user-images.githubusercontent.com/14039341/148027327-6b3f5255-ea4f-4d23-9ffb-398f308fd662.png" width="400" />

It seems we just need to check if primary key is UUID before it reaches the permissions validation.
Now we got the proper error

<img src="https://user-images.githubusercontent.com/14039341/148027474-8aa009b6-e928-416f-ba66-1a70b38393c6.png" width="400" />