### PR TITLE
Fix reloading hooks with schedule events

### DIFF
--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -335,7 +335,7 @@ class ExtensionManager {
 					emitter.offInit(hook.event, hook.handler);
 					break;
 				case 'schedule':
-					hook.task.destroy();
+					hook.task.stop();
 					break;
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,20 +59,20 @@
 		},
 		"api": {
 			"name": "directus",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"@aws-sdk/client-ses": "^3.40.0",
-				"@directus/app": "9.4.1",
-				"@directus/drive": "9.4.1",
-				"@directus/drive-azure": "9.4.1",
-				"@directus/drive-gcs": "9.4.1",
-				"@directus/drive-s3": "9.4.1",
-				"@directus/extensions-sdk": "9.4.1",
-				"@directus/format-title": "9.4.1",
-				"@directus/schema": "9.4.1",
-				"@directus/shared": "9.4.1",
-				"@directus/specs": "9.4.1",
+				"@directus/app": "9.4.2",
+				"@directus/drive": "9.4.2",
+				"@directus/drive-azure": "9.4.2",
+				"@directus/drive-gcs": "9.4.2",
+				"@directus/drive-s3": "9.4.2",
+				"@directus/extensions-sdk": "9.4.2",
+				"@directus/format-title": "9.4.2",
+				"@directus/schema": "9.4.2",
+				"@directus/shared": "9.4.2",
+				"@directus/specs": "9.4.2",
 				"@godaddy/terminus": "^4.9.0",
 				"@rollup/plugin-alias": "^3.1.2",
 				"@rollup/plugin-virtual": "^2.0.3",
@@ -305,12 +305,12 @@
 		},
 		"app": {
 			"name": "@directus/app",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"devDependencies": {
-				"@directus/docs": "9.4.1",
-				"@directus/extensions-sdk": "9.4.1",
-				"@directus/format-title": "9.4.1",
-				"@directus/shared": "9.4.1",
+				"@directus/docs": "9.4.2",
+				"@directus/extensions-sdk": "9.4.2",
+				"@directus/format-title": "9.4.2",
+				"@directus/shared": "9.4.2",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.1",
@@ -446,7 +446,7 @@
 		},
 		"docs": {
 			"name": "@directus/docs",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "ISC",
 			"devDependencies": {
 				"directory-tree": "3.0.1",
@@ -44955,11 +44955,11 @@
 		},
 		"packages/cli": {
 			"name": "@directus/cli",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/format-title": "9.4.1",
-				"@directus/sdk": "9.4.1",
+				"@directus/format-title": "9.4.2",
+				"@directus/sdk": "9.4.2",
 				"@types/yargs": "^17.0.0",
 				"app-module-path": "^2.2.0",
 				"chalk": "^4.1.0",
@@ -45094,11 +45094,11 @@
 			}
 		},
 		"packages/create-directus-extension": {
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/extensions-sdk": "9.4.1",
-				"@directus/shared": "9.4.1",
+				"@directus/extensions-sdk": "9.4.2",
+				"@directus/shared": "9.4.2",
 				"inquirer": "^8.1.2"
 			},
 			"bin": {
@@ -45141,7 +45141,7 @@
 			"license": "0BSD"
 		},
 		"packages/create-directus-project": {
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"chalk": "^4.1.1",
@@ -45177,7 +45177,7 @@
 		},
 		"packages/drive": {
 			"name": "@directus/drive",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.0.0",
@@ -45196,11 +45196,11 @@
 		},
 		"packages/drive-azure": {
 			"name": "@directus/drive-azure",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.4.1",
+				"@directus/drive": "9.4.2",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -45231,10 +45231,10 @@
 		},
 		"packages/drive-gcs": {
 			"name": "@directus/drive-gcs",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.4.1",
+				"@directus/drive": "9.4.2",
 				"@google-cloud/storage": "^5.8.5",
 				"lodash": "4.17.21",
 				"normalize-path": "^3.0.0"
@@ -45254,10 +45254,10 @@
 		},
 		"packages/drive-s3": {
 			"name": "@directus/drive-s3",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.4.1",
+				"@directus/drive": "9.4.2",
 				"aws-sdk": "^2.928.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -45302,9 +45302,9 @@
 		},
 		"packages/extensions-sdk": {
 			"name": "@directus/extensions-sdk",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"dependencies": {
-				"@directus/shared": "9.4.1",
+				"@directus/shared": "9.4.2",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -45354,7 +45354,7 @@
 		},
 		"packages/format-title": {
 			"name": "@directus/format-title",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "21.0.1",
@@ -45374,10 +45374,10 @@
 		},
 		"packages/gatsby-source-directus": {
 			"name": "@directus/gatsby-source-directus",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/sdk": "9.4.1",
+				"@directus/sdk": "9.4.2",
 				"gatsby-source-filesystem": "4.2.0",
 				"gatsby-source-graphql": "4.2.0",
 				"ms": "2.1.3"
@@ -45389,7 +45389,7 @@
 		},
 		"packages/schema": {
 			"name": "@directus/schema",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"knex-schema-inspector": "^1.6.6",
@@ -45402,7 +45402,7 @@
 		},
 		"packages/sdk": {
 			"name": "@directus/sdk",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.24.0"
@@ -45431,7 +45431,7 @@
 		},
 		"packages/shared": {
 			"name": "@directus/shared",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"dependencies": {
 				"axios": "*",
 				"date-fns": "2.24.0",
@@ -45490,7 +45490,7 @@
 		},
 		"packages/specs": {
 			"name": "@directus/specs",
-			"version": "9.4.1",
+			"version": "9.4.2",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"openapi3-ts": "^2.0.1"
@@ -47779,10 +47779,10 @@
 		"@directus/app": {
 			"version": "file:app",
 			"requires": {
-				"@directus/docs": "9.4.1",
-				"@directus/extensions-sdk": "9.4.1",
-				"@directus/format-title": "9.4.1",
-				"@directus/shared": "9.4.1",
+				"@directus/docs": "9.4.2",
+				"@directus/extensions-sdk": "9.4.2",
+				"@directus/format-title": "9.4.2",
+				"@directus/shared": "9.4.2",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.1",
@@ -47885,8 +47885,8 @@
 		"@directus/cli": {
 			"version": "file:packages/cli",
 			"requires": {
-				"@directus/format-title": "9.4.1",
-				"@directus/sdk": "9.4.1",
+				"@directus/format-title": "9.4.2",
+				"@directus/sdk": "9.4.2",
 				"@types/figlet": "1.5.4",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
@@ -48038,7 +48038,7 @@
 			"version": "file:packages/drive-azure",
 			"requires": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.4.1",
+				"@directus/drive": "9.4.2",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
 				"@types/node": "16.11.9",
@@ -48066,7 +48066,7 @@
 		"@directus/drive-gcs": {
 			"version": "file:packages/drive-gcs",
 			"requires": {
-				"@directus/drive": "9.4.1",
+				"@directus/drive": "9.4.2",
 				"@google-cloud/storage": "^5.8.5",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
@@ -48085,7 +48085,7 @@
 		"@directus/drive-s3": {
 			"version": "file:packages/drive-s3",
 			"requires": {
-				"@directus/drive": "9.4.1",
+				"@directus/drive": "9.4.2",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
@@ -48115,7 +48115,7 @@
 		"@directus/extensions-sdk": {
 			"version": "file:packages/extensions-sdk",
 			"requires": {
-				"@directus/shared": "9.4.1",
+				"@directus/shared": "9.4.2",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -48167,7 +48167,7 @@
 		"@directus/gatsby-source-directus": {
 			"version": "file:packages/gatsby-source-directus",
 			"requires": {
-				"@directus/sdk": "9.4.1",
+				"@directus/sdk": "9.4.2",
 				"gatsby-source-filesystem": "4.2.0",
 				"gatsby-source-graphql": "4.2.0",
 				"ms": "2.1.3"
@@ -56503,8 +56503,8 @@
 		"create-directus-extension": {
 			"version": "file:packages/create-directus-extension",
 			"requires": {
-				"@directus/extensions-sdk": "9.4.1",
-				"@directus/shared": "9.4.1",
+				"@directus/extensions-sdk": "9.4.2",
+				"@directus/shared": "9.4.2",
 				"inquirer": "^8.1.2"
 			},
 			"dependencies": {
@@ -57850,16 +57850,16 @@
 			"version": "file:api",
 			"requires": {
 				"@aws-sdk/client-ses": "^3.40.0",
-				"@directus/app": "9.4.1",
-				"@directus/drive": "9.4.1",
-				"@directus/drive-azure": "9.4.1",
-				"@directus/drive-gcs": "9.4.1",
-				"@directus/drive-s3": "9.4.1",
-				"@directus/extensions-sdk": "9.4.1",
-				"@directus/format-title": "9.4.1",
-				"@directus/schema": "9.4.1",
-				"@directus/shared": "9.4.1",
-				"@directus/specs": "9.4.1",
+				"@directus/app": "9.4.2",
+				"@directus/drive": "9.4.2",
+				"@directus/drive-azure": "9.4.2",
+				"@directus/drive-gcs": "9.4.2",
+				"@directus/drive-s3": "9.4.2",
+				"@directus/extensions-sdk": "9.4.2",
+				"@directus/format-title": "9.4.2",
+				"@directus/schema": "9.4.2",
+				"@directus/shared": "9.4.2",
+				"@directus/specs": "9.4.2",
 				"@godaddy/terminus": "^4.9.0",
 				"@keyv/redis": "^2.1.2",
 				"@rollup/plugin-alias": "^3.1.2",


### PR DESCRIPTION
Looks like `ScheduledTask.destroy()` was never part of `node-cron@3.0.0`.