### PR TITLE
Make registered extensions accessible from extensions

### DIFF
--- a/app/src/composables/use-system.ts
+++ b/app/src/composables/use-system.ts
@@ -1,9 +1,23 @@
 import { provide } from 'vue';
 import api from '@/api';
 import * as stores from '@/stores';
-import { API_INJECT, STORES_INJECT } from '@directus/shared/constants';
+import { API_INJECT, EXTENSIONS_INJECT, STORES_INJECT } from '@directus/shared/constants';
+import { getInterfaces } from '@/interfaces';
+import { getDisplays } from '@/displays';
+import { getLayouts } from '@/layouts';
+import { getModules } from '@/modules';
+import { getPanels } from '@/panels';
 
 export default function useSystem(): void {
 	provide(STORES_INJECT, stores);
+
 	provide(API_INJECT, api);
+
+	provide(EXTENSIONS_INJECT, {
+		interfaces: getInterfaces().interfaces,
+		displays: getDisplays().displays,
+		layouts: getLayouts().layouts,
+		modules: getModules().modules,
+		panels: getPanels().panels,
+	});
 }

--- a/packages/extensions-sdk/src/index.ts
+++ b/packages/extensions-sdk/src/index.ts
@@ -9,4 +9,12 @@ export {
 	getFieldsFromTemplate,
 	getRelationType,
 } from '@directus/shared/utils';
-export { useStores, useApi, useSync, useCollection, useItems, useFilterFields } from '@directus/shared/composables';
+export {
+	useStores,
+	useApi,
+	useExtensions,
+	useSync,
+	useCollection,
+	useItems,
+	useFilterFields,
+} from '@directus/shared/composables';

--- a/packages/shared/src/composables/use-system.ts
+++ b/packages/shared/src/composables/use-system.ts
@@ -1,6 +1,7 @@
 import { inject } from 'vue';
 import { AxiosInstance } from 'axios';
-import { API_INJECT, STORES_INJECT } from '../constants';
+import { API_INJECT, EXTENSIONS_INJECT, STORES_INJECT } from '../constants';
+import { AppExtensionConfigs } from '../types';
 
 export function useStores(): Record<string, any> {
 	const stores = inject<Record<string, any>>(STORES_INJECT);
@@ -16,4 +17,12 @@ export function useApi(): AxiosInstance {
 	if (!api) throw new Error('[useApi]: The api could not be found.');
 
 	return api;
+}
+
+export function useExtensions(): AppExtensionConfigs {
+	const extensions = inject<AppExtensionConfigs>(EXTENSIONS_INJECT);
+
+	if (!extensions) throw new Error('[useExtensions]: The extensions could not be found.');
+
+	return extensions;
 }

--- a/packages/shared/src/constants/injection.ts
+++ b/packages/shared/src/constants/injection.ts
@@ -1,2 +1,3 @@
 export const STORES_INJECT = 'stores';
 export const API_INJECT = 'api';
+export const EXTENSIONS_INJECT = 'extensions';

--- a/packages/shared/src/types/extensions.ts
+++ b/packages/shared/src/types/extensions.ts
@@ -10,8 +10,19 @@ import {
 	EXTENSION_TYPES,
 } from '../constants';
 import { Accountability } from './accountability';
-import { Collection, Field, Relation, DeepPartial } from '.';
+import {
+	Collection,
+	Field,
+	Relation,
+	DeepPartial,
+	InterfaceConfig,
+	DisplayConfig,
+	LayoutConfig,
+	ModuleConfig,
+	PanelConfig,
+} from '.';
 import { LOCAL_TYPES } from '../constants';
+import { Ref } from 'vue';
 
 export type AppExtensionType = typeof APP_EXTENSION_TYPES[number];
 export type ApiExtensionType = typeof API_EXTENSION_TYPES[number];
@@ -60,6 +71,14 @@ export type ExtensionManifest = {
 		host: string;
 		hidden?: boolean;
 	};
+};
+
+export type AppExtensionConfigs = {
+	interfaces: Ref<InterfaceConfig[]>;
+	displays: Ref<DisplayConfig[]>;
+	layouts: Ref<LayoutConfig[]>;
+	modules: Ref<ModuleConfig[]>;
+	panels: Ref<PanelConfig[]>;
 };
 
 export type ApiExtensionContext = {


### PR DESCRIPTION
This adds an extensions system provide and a `useExtensions` composable and exposes it to extensions through the Extensions SDK.