### PR TITLE
Add CSP directives for MapLibre to work

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -105,6 +105,12 @@ export default async function createApp(): Promise<express.Application> {
 						// installations. Making this opt-in rather than opt-out is a little more
 						// friendly. Ref #10806
 						upgradeInsecureRequests: null,
+
+						// These are required for MapLibre
+						workerSrc: ["'self'", 'blob:'],
+						childSrc: ["'self'", 'blob:'],
+						imgSrc: ["'self'", 'data:', 'blob:'],
+						connectSrc: ["'self'", 'https://*'],
 					},
 				},
 				getConfigFromEnv('CONTENT_SECURITY_POLICY_')


### PR DESCRIPTION
Fixes #10834

Directives added are based on https://maplibre.org/maplibre-gl-js-docs/api/#csp-directives. Adding `workerSrc` and `connectSrc` seemed to have worked from what I tested, but ultimately opted to add the other directives as described in the aforementioned link.