### PR TITLE
Check for required fields on create

### DIFF
--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -246,10 +246,9 @@ export class AuthorizationService {
 				specials.includes(name)
 			);
 
-			const notNullable =
-				field.nullable === false || field.required === true || !hasGenerateSpecial || !field.generated;
+			const nullable = (field.nullable && field.required === false) || hasGenerateSpecial || field.generated;
 
-			if (notNullable) {
+			if (!nullable) {
 				requiredColumns.push(field);
 			}
 		}

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -246,9 +246,10 @@ export class AuthorizationService {
 				specials.includes(name)
 			);
 
-			const nullable = field.nullable || hasGenerateSpecial || field.generated;
+			const notNullable =
+				field.nullable === false || field.required === true || !hasGenerateSpecial || !field.generated;
 
-			if (!nullable) {
+			if (notNullable) {
 				requiredColumns.push(field);
 			}
 		}

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -412,9 +412,9 @@ export class GraphQLService {
 						let type: GraphQLScalarType | GraphQLNonNull<GraphQLNullableType> = getGraphQLType(field.type);
 
 						// GraphQL doesn't differentiate between not-null and has-to-be-submitted. We
-						// can't non-null in update, as that would require every not-nullable field to be
-						// submitted on updates
-						if (field.nullable === false && action !== 'update') {
+						// can't non-null in update, as that would require every not-nullable or required field
+						// to be submitted on updates
+						if ((field.nullable === false || field.required === true) && action !== 'update') {
 							type = GraphQLNonNull(type);
 						}
 

--- a/api/src/types/schema.ts
+++ b/api/src/types/schema.ts
@@ -12,6 +12,7 @@ export type FieldOverview = {
 	scale: number | null;
 	special: string[];
 	note: string | null;
+	required: boolean | null;
 	alias: boolean;
 };
 

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -107,6 +107,7 @@ async function getDatabaseSchema(
 					scale: column.numeric_scale || null,
 					special: [],
 					note: null,
+					required: null,
 					alias: false,
 				};
 			}),

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -115,13 +115,16 @@ async function getDatabaseSchema(
 
 	const fields = [
 		...(await database
-			.select<{ id: number; collection: string; field: string; special: string; note: string | null }[]>(
-				'id',
-				'collection',
-				'field',
-				'special',
-				'note'
-			)
+			.select<
+				{
+					id: number;
+					collection: string;
+					field: string;
+					special: string;
+					note: string | null;
+					required: boolean | null;
+				}[]
+			>('id', 'collection', 'field', 'special', 'note', 'required')
 			.from('directus_fields')),
 		...systemFieldRows,
 	].filter((field) => (field.special ? toArray(field.special) : []).includes('no-data') === false);
@@ -145,6 +148,7 @@ async function getDatabaseSchema(
 			scale: existing?.scale || null,
 			special: special,
 			note: field.note,
+			required: field.required,
 			alias: existing?.alias ?? true,
 		};
 	}


### PR DESCRIPTION
Fixes #10610

## Before

Here the "description" field is set as required, but we can still create new item via GraphQL or REST without it.

![chrome_vrXrOLwS7m](https://user-images.githubusercontent.com/42867097/148188228-eca59d6c-6662-431a-ba99-27907d804320.png)

There's no `!` appended to `String` for "description", thus interpreted as nullable:

```graphql
input create_bar_input {
  id: ID
  name: String
  description: String
}
```

And we can create it successfully without "description":

![chrome_rqk24SjeID](https://user-images.githubusercontent.com/42867097/148189003-a3695ce9-e9de-4c62-bf72-f44c5833be3a.png)

## After

- Added check for `required` value in fields and set them as non-nullable in GraphQL:

    ```graphql
    input create_bar_input {
      id: ID
      name: String
      description: String!
    }
    ```
    
    ![chrome_rMpaNciuBe](https://user-images.githubusercontent.com/42867097/148187854-ba1ce75b-e6e8-4148-8f8f-3dcfe2b50fc8.png)


- Added the same check to REST API:

    ![chrome_jjhohphHpY](https://user-images.githubusercontent.com/42867097/148187513-2302ef97-d162-49bb-84d9-4163ca0da402.png)

---

IIRC there was a discussion/issue about `required` being App only, though I can't recall whether that is _intended_ or not.

Update: on hindsight, this will break for conditional fields that manipulate "required" right? Not sure how can we mitigate that. This might have been the reason why "required" is App only now. @rijkvanzanten Could this change be the wrong direction?