### PR TITLE
End-to-end tests setup refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
   e2e_tests:
     name: End-to-End Tests
     needs: pre_check
-    uses: directus/directus/.github/workflows/e2e-tests.yml@main
+    uses: directus/directus/.github/workflows/e2e-tests.yml@0f833b20dc32c0b96c6933ecfc98eea0e9b5c851
     with:
       should_skip: ${{ needs.pre_check.outputs.should_skip == 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
   e2e_tests:
     name: End-to-End Tests
     needs: pre_check
-    uses: directus/directus/.github/workflows/e2e-tests.yml@b9b0ab014974bc51d093eba6fe0db5c2bc9f9726
+    uses: directus/directus/.github/workflows/e2e-tests.yml@f831ad4a1fdfa463954a17aafc1e8198cc93c4a6
     with:
       should_skip: ${{ needs.pre_check.outputs.should_skip == 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
   e2e_tests:
     name: End-to-End Tests
     needs: pre_check
-    uses: directus/directus/.github/workflows/e2e-tests.yml@f831ad4a1fdfa463954a17aafc1e8198cc93c4a6
+    uses: directus/directus/.github/workflows/e2e-tests.yml@ed82632786375f6312a21d3a28b17e654942000a
     with:
       should_skip: ${{ needs.pre_check.outputs.should_skip == 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
   e2e_tests:
     name: End-to-End Tests
     needs: pre_check
-    uses: directus/directus/.github/workflows/e2e-tests.yml@c26eb24df58789a990f9fa634309f4c54aacdc6f
+    uses: directus/directus/.github/workflows/e2e-tests.yml@b9b0ab014974bc51d093eba6fe0db5c2bc9f9726
     with:
       should_skip: ${{ needs.pre_check.outputs.should_skip == 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
   e2e_tests:
     name: End-to-End Tests
     needs: pre_check
-    uses: directus/directus/.github/workflows/e2e-tests.yml@0f833b20dc32c0b96c6933ecfc98eea0e9b5c851
+    uses: directus/directus/.github/workflows/e2e-tests.yml@c26eb24df58789a990f9fa634309f4c54aacdc6f
     with:
       should_skip: ${{ needs.pre_check.outputs.should_skip == 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        db:
-          - mssql
-          - mysql
-          - postgres
-          - maria
-          - postgres10
-          # - sqlite3
-        node-version:
-          - '16'
+      # matrix:
+      #   db:
+      #     - mssql
+      #     - mysql
+      #     - postgres
+      #     - maria
+      #     - postgres10
+      #     # - sqlite3
+      #   node-version:
+      #     - '16'
     env:
       CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
     steps:
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16
           cache: npm
 
       - name: Install dependencies
@@ -59,8 +59,6 @@ jobs:
           SECRET: TEST_SECRET
 
       - name: Run tests
-        env:
-          TEST_DB: ${{ matrix.db }}
         run: npm run test:e2e
 
   result:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Sleep for 60 seconds
-        run: sleep 60s
+      - name: Sleep for 120 seconds
+        run: sleep 120s
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,51 +24,41 @@ jobs:
           - postgres10
           # - sqlite3
         node-version:
-          # - 12-alpine
-          # - 14-alpine
-          - 16-alpine
+          - '16'
     env:
       CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
     steps:
-      - name: Login to GitHub container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull cached test image
-        run: |
-          docker pull $CACHED_IMAGE || true
-          docker tag $CACHED_IMAGE directus-test-image || true
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build packages
         run: npm run build
+
+      - name: Start databases
+        run: docker compose up -d
+
+      - name: Sleep for 20 seconds
+        run: sleep 20s
+        shell: bash
+
+      - name: Run tests
+        run: npm run test:e2e
+        env:
+          SECRET: TEST_SECRET
 
       - name: Run tests
         env:
-          TEST_NODE_VERSION: ${{ matrix.node-version }}
           TEST_DB: ${{ matrix.db }}
         run: npm run test:e2e
-
-      - name: Push updated test image
-        # Only push the new cache image on the main branch once per node version
-        if: github.ref == 'refs/heads/main' && github.repository == 'directus/directus' && matrix.db == 'postgres'
-        run: |
-          docker tag directus-test-image $CACHED_IMAGE
-          docker push $CACHED_IMAGE || true
 
   result:
     name: Result

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,19 +23,22 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Start databases containers
-        run: docker compose up -d --wait --quiet-pull
+        run: docker compose up -d --quiet-pull
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
+          # cache: npm
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build packages
         run: npm run build
+
+      - name: Wait for databases to be ready
+        run: docker compose up -d --quiet-pull --wait
 
       - name: Run tests
         run: npm run test:e2e

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,13 +16,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db:
-          - mssql
-          - mysql
-          - postgres
-          - maria
-          - postgres10
-          # - sqlite3
         node-version:
           - '16'
     env:
@@ -48,8 +41,6 @@ jobs:
 
       - name: Run tests
         run: npm run test:e2e
-        env:
-          TEST_DB: ${{ matrix.db }}
 
   result:
     name: Result

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,8 +18,6 @@ jobs:
       matrix:
         node-version:
           - '16'
-    env:
-      CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Start databases containers
-        run: docker compose up -d --wait
+        run: docker compose up -d --wait --quiet-pull
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -49,12 +49,7 @@ jobs:
       - name: Run tests
         run: npm run test:e2e
         env:
-          SECRET: TEST_SECRET
-
-      - name: Run tests
-        env:
           TEST_DB: ${{ matrix.db }}
-        run: npm run test:e2e
 
   result:
     name: Result

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Sleep for 30 seconds
-        run: sleep 30s
+      - name: Sleep for 60 seconds
+        run: sleep 60s
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,32 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # matrix:
-      #   db:
-      #     - mssql
-      #     - mysql
-      #     - postgres
-      #     - maria
-      #     - postgres10
-      #     # - sqlite3
-      #   node-version:
-      #     - '16'
+      matrix:
+        db:
+          - mssql
+          - mysql
+          - postgres
+          - maria
+          - postgres10
+          # - sqlite3
+        node-version:
+          - '16'
     env:
       CACHED_IMAGE: ghcr.io/directus/directus-e2e-test-cache:${{ matrix.node-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Pull database images
-        run: docker compose pull
-
       - name: Start databases containers
-        run: docker compose up -d
+        run: docker compose up -d --wait
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -49,16 +46,14 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Sleep for 120 seconds
-        run: sleep 120s
-        shell: bash
-
       - name: Run tests
         run: npm run test:e2e
         env:
           SECRET: TEST_SECRET
 
       - name: Run tests
+        env:
+          TEST_DB: ${{ matrix.db }}
         run: npm run test:e2e
 
   result:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Pull database images
+        run: docker compose pull
+
+      - name: Start databases containers
+        run: docker compose up -d
+
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
@@ -43,11 +49,8 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Start databases
-        run: docker compose up -d
-
-      - name: Sleep for 20 seconds
-        run: sleep 20s
+      - name: Sleep for 30 seconds
+        run: sleep 30s
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i stylelint eslint npm-run-all
 
       - name: Run linters
         run: npm run lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       MYSQL_DATABASE: directus
     ports:
       - 5101:3306
+    cap_add:
+      - SYS_NICE
 
   maria:
     image: mariadb:10.7

--- a/tests/e2e/api/auth/login.test.ts
+++ b/tests/e2e/api/auth/login.test.ts
@@ -3,6 +3,8 @@ import config from '../../config';
 import request from 'supertest';
 import vendors from '../../get-dbs-to-test';
 
+// Debug test
+
 describe('auth', () => {
 	describe('login', () => {
 		const databases = new Map<string, Knex>();

--- a/tests/e2e/api/auth/login.test.ts
+++ b/tests/e2e/api/auth/login.test.ts
@@ -1,15 +1,13 @@
 import knex, { Knex } from 'knex';
 import config from '../../config';
 import request from 'supertest';
-import { getDBsToTest } from '../../get-dbs-to-test';
+import vendors from '../../get-dbs-to-test';
 
 describe('auth', () => {
 	describe('login', () => {
 		const databases = new Map<string, Knex>();
 
 		beforeAll(async () => {
-			const vendors = getDBsToTest();
-
 			for (const vendor of vendors) {
 				databases.set(vendor, knex(config.knexConfig[vendor]!));
 			}
@@ -22,8 +20,8 @@ describe('auth', () => {
 		});
 
 		describe('when correct credentials are provided', () => {
-			it.each(getDBsToTest())(`%p returns an access_token, expires and a refresh_token for admin`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p returns an access_token, expires and a refresh_token for admin`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await request(url)
 					.post(`/auth/login`)
@@ -39,8 +37,8 @@ describe('auth', () => {
 					},
 				});
 			});
-			it.each(getDBsToTest())(`%p returns an access_token, expires and a refresh_token for user`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p returns an access_token, expires and a refresh_token for user`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await request(url)
 					.post(`/auth/login`)
@@ -61,8 +59,8 @@ describe('auth', () => {
 			});
 		});
 		describe('when incorrect credentials are provided', () => {
-			it.each(getDBsToTest())(`%p returns code: UNAUTHORIZED for incorrect password`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p returns code: UNAUTHORIZED for incorrect password`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await request(url)
 					.post(`/auth/login`)
@@ -72,7 +70,7 @@ describe('auth', () => {
 					})
 					.expect('Content-Type', /application\/json/)
 					.expect(401);
-				expect(response.body).toStrictEqual({
+				expect(response.body).toMatchObject({
 					errors: [
 						{
 							message: 'Invalid user credentials.',
@@ -83,8 +81,8 @@ describe('auth', () => {
 					],
 				});
 			});
-			it.each(getDBsToTest())(`%p returns code: UNAUTHORIZED for unregistered email`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p returns code: UNAUTHORIZED for unregistered email`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await request(url)
 					.post(`/auth/login`)
@@ -95,7 +93,7 @@ describe('auth', () => {
 					.expect('Content-Type', /application\/json/)
 					.expect(401);
 
-				expect(response.body).toStrictEqual({
+				expect(response.body).toMatchObject({
 					errors: [
 						{
 							message: 'Invalid user credentials.',
@@ -106,8 +104,8 @@ describe('auth', () => {
 					],
 				});
 			});
-			it.each(getDBsToTest())(`%p returns code: INVALID_CREDENTIALS for invalid email`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p returns code: INVALID_CREDENTIALS for invalid email`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await request(url)
 					.post(`/auth/login`)
@@ -118,7 +116,7 @@ describe('auth', () => {
 					.expect('Content-Type', /application\/json/)
 					.expect(400);
 
-				expect(response.body).toStrictEqual({
+				expect(response.body).toMatchObject({
 					errors: [
 						{
 							message: '"email" must be a valid email',
@@ -129,31 +127,28 @@ describe('auth', () => {
 					],
 				});
 			});
-			it.each(getDBsToTest())(
-				`%p returns message: "password is required" when no password is provided`,
-				async (vendor) => {
-					const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p returns message: "password is required" when no password is provided`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
-					const response = await request(url)
-						.post(`/auth/login`)
-						.send({
-							email: 'test@admin.com',
-						})
-						.expect('Content-Type', /application\/json/)
-						.expect(400);
+				const response = await request(url)
+					.post(`/auth/login`)
+					.send({
+						email: 'test@admin.com',
+					})
+					.expect('Content-Type', /application\/json/)
+					.expect(400);
 
-					expect(response.body).toStrictEqual({
-						errors: [
-							{
-								message: '"password" is required',
-								extensions: {
-									code: 'INVALID_PAYLOAD',
-								},
+				expect(response.body).toMatchObject({
+					errors: [
+						{
+							message: '"password" is required',
+							extensions: {
+								code: 'INVALID_PAYLOAD',
 							},
-						],
-					});
-				}
-			);
+						},
+					],
+				});
+			});
 		});
 	});
 });

--- a/tests/e2e/api/items/filters.test.ts
+++ b/tests/e2e/api/items/filters.test.ts
@@ -1,5 +1,5 @@
 import config from '../../config';
-import { getDBsToTest } from '../../get-dbs-to-test';
+import vendors from '../../get-dbs-to-test';
 import request from 'supertest';
 import knex, { Knex } from 'knex';
 import { createArtist, createGuest, seedTable, createMany } from '../../setup/utils/factories';
@@ -9,8 +9,6 @@ describe('/items', () => {
 	const databases = new Map<string, Knex>();
 
 	beforeAll(async () => {
-		const vendors = getDBsToTest();
-
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 		}
@@ -24,8 +22,8 @@ describe('/items', () => {
 
 	describe('/:collection GET', () => {
 		describe('Mathmatical Operators', () => {
-			it.each(getDBsToTest())('%p returns users with name _eq', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns users with name _eq', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const name = internet.email();
 				const guests: any[] = createMany(createGuest, 10);
 				for (const guest of guests) {
@@ -45,8 +43,8 @@ describe('/items', () => {
 					name: name,
 				});
 			});
-			it.each(getDBsToTest())('%p returns users with name _neq', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns users with name _neq', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const guests: any[] = createMany(createGuest, 10);
 				await seedTable(databases.get(vendor)!, 1, 'guests', guests);
 
@@ -61,8 +59,8 @@ describe('/items', () => {
 		});
 
 		describe('Logical Operators', () => {
-			it.each(getDBsToTest())('%p returns users with name equality _AND favorite_artist equality', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns users with name equality _AND favorite_artist equality', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const name = internet.email();
 				const guests: any[] = createMany(createGuest, 10, { name });
 				await seedTable(databases.get(vendor)!, 1, 'guests', guests);
@@ -85,8 +83,8 @@ describe('/items', () => {
 
 				expect(response.body.data.length).toBe(guests.length);
 			});
-			it.each(getDBsToTest())('%p returns users with name equality _OR favorite_artist equality', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns users with name equality _OR favorite_artist equality', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const name = internet.email();
 
 				const artist = createArtist();

--- a/tests/e2e/api/items/many-to-many.test.ts
+++ b/tests/e2e/api/items/many-to-many.test.ts
@@ -1,15 +1,13 @@
 import axios from 'axios';
 import request from 'supertest';
 import config from '../../config';
-import { getDBsToTest } from '../../get-dbs-to-test';
+import vendors from '../../get-dbs-to-test';
 import knex, { Knex } from 'knex';
 import { createArtist, createEvent, createMany, seedTable, Item } from '../../setup/utils/factories';
 describe('/items', () => {
 	const databases = new Map<string, Knex>();
 
 	beforeAll(async () => {
-		const vendors = getDBsToTest();
-
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 		}
@@ -22,8 +20,8 @@ describe('/items', () => {
 	});
 
 	describe('/:collection/:id GET', () => {
-		it.each(getDBsToTest())(`%p retrieves an artist and an event off the artists_events table`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p retrieves an artist and an event off the artists_events table`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			const event = createEvent();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist);
@@ -58,8 +56,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection/:id PATCH', () => {
-		it.each(getDBsToTest())(`%p updates one artists_events to a different artist`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p updates one artists_events to a different artist`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const insertedArtist = await seedTable(databases.get(vendor)!, 1, 'artists', createArtist(), {
 				select: ['id'],
 			});
@@ -90,8 +88,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection/:id DELETE', () => {
-		it.each(getDBsToTest())(`%p deletes an artists_events without deleting the artist or event`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p deletes an artists_events without deleting the artist or event`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			const event = createEvent();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist, {
@@ -135,8 +133,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection GET', () => {
-		it.each(getDBsToTest())(`%p retrieves artists and events for each entry in artists_events`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p retrieves artists and events for each entry in artists_events`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			const event = createEvent();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist, {
@@ -166,8 +164,8 @@ describe('/items', () => {
 
 	describe('/:collection POST', () => {
 		describe('createOne', () => {
-			it.each(getDBsToTest())(`%p creates an artist_events entry`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p creates an artist_events entry`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const artist = createArtist();
 				const event = createEvent();
 				await seedTable(databases.get(vendor)!, 1, 'artists', artist, {
@@ -196,8 +194,8 @@ describe('/items', () => {
 			});
 		});
 		describe('createMany', () => {
-			it.each(getDBsToTest())(`%p creates 5 artist_events entries`, async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)(`%p creates 5 artist_events entries`, async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const artist = createArtist();
 				const event = createEvent();
 				await seedTable(databases.get(vendor)!, 1, 'artists', artist, {
@@ -223,8 +221,8 @@ describe('/items', () => {
 	});
 
 	describe('/:collection PATCH', () => {
-		it.each(getDBsToTest())(`%p updates many artists_events to a different artist`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p updates many artists_events to a different artist`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			const event = createEvent();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist, {
@@ -273,8 +271,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection DELETE', () => {
-		it.each(getDBsToTest())(`%p deletes many artists_events without deleting the artists or events`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p deletes many artists_events without deleting the artists or events`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			const event = createEvent();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist, {

--- a/tests/e2e/api/items/no-relations.test.ts
+++ b/tests/e2e/api/items/no-relations.test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import request from 'supertest';
 import config from '../../config';
-import { getDBsToTest } from '../../get-dbs-to-test';
+import vendors from '../../get-dbs-to-test';
 import knex, { Knex } from 'knex';
 import { createArtist, createEvent, createGuest, createMany, seedTable } from '../../setup/utils/factories';
 import { v4 as uuid } from 'uuid';
@@ -10,8 +10,6 @@ describe('/items', () => {
 	const databases = new Map<string, Knex>();
 
 	beforeAll(async () => {
-		const vendors = getDBsToTest();
-
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 		}
@@ -24,8 +22,8 @@ describe('/items', () => {
 	});
 
 	describe('/:collection/:id GET', () => {
-		it.each(getDBsToTest())('%p retrieves one artist', async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)('%p retrieves one artist', async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist);
 
@@ -37,8 +35,8 @@ describe('/items', () => {
 
 			expect(response.body.data).toMatchObject({ name: expect.any(String) });
 		});
-		it.each(getDBsToTest())(`%p retrieves a guest's favorite artist`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p retrieves a guest's favorite artist`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const guest = createGuest();
 			const artist = createArtist();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist, {
@@ -58,8 +56,8 @@ describe('/items', () => {
 
 			expect(response.body.data).toMatchObject({ name: expect.any(String) });
 		});
-		it.each(getDBsToTest())(`%p retrieves an artist and an event off the artists_events table`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p retrieves an artist and an event off the artists_events table`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const insertedArtist = await seedTable(databases.get(vendor)!, 1, 'artists', createArtist(), {
 				select: ['id'],
 			});
@@ -88,8 +86,8 @@ describe('/items', () => {
 			});
 		});
 		describe('Error handling', () => {
-			it.each(getDBsToTest())('%p returns an error when an invalid id is used', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns an error when an invalid id is used', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await axios
 					.get(`${url}/items/artists/invalid_id`, {
@@ -114,8 +112,8 @@ describe('/items', () => {
 					expect(response.message).toBe('Request failed with status code 403');
 				}
 			});
-			it.each(getDBsToTest())('%p returns an error when an invalid table is used', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns an error when an invalid table is used', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await axios
 					.get(`${url}/items/invalid_table/1`, {
@@ -136,8 +134,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection/:id PATCH', () => {
-		it.each(getDBsToTest())(`%p updates one artist's name with no relations`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p updates one artist's name with no relations`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist);
 
@@ -153,8 +151,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection/:id DELETE', () => {
-		it.each(getDBsToTest())(`%p deletes an artist with no relations`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p deletes an artist with no relations`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artist = createArtist();
 			await seedTable(databases.get(vendor)!, 1, 'artists', artist);
 
@@ -170,8 +168,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection GET', () => {
-		it.each(getDBsToTest())('%p retrieves all items from artist table with no relations', async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)('%p retrieves all items from artist table with no relations', async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			await seedTable(databases.get(vendor)!, 50, 'artists', createArtist);
 			const response = await request(url)
 				.get('/items/artists')
@@ -182,8 +180,8 @@ describe('/items', () => {
 			expect(response.body.data.length).toBeGreaterThanOrEqual(50);
 		});
 		describe('Error handling', () => {
-			it.each(getDBsToTest())('%p returns an error when an invalid table is used', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns an error when an invalid table is used', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 				const response = await axios
 					.get(`${url}/items/invalid_table/`, {
@@ -206,8 +204,8 @@ describe('/items', () => {
 
 	describe('/:collection POST', () => {
 		describe('createOne', () => {
-			it.each(getDBsToTest())('%p creates one artist', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p creates one artist', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const body = createArtist();
 				const response: any = await axios.post(`${url}/items/artists`, body, {
 					headers: {
@@ -219,8 +217,8 @@ describe('/items', () => {
 			});
 		});
 		describe('createMany', () => {
-			it.each(getDBsToTest())('%p creates 5 artists', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p creates 5 artists', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const body = createMany(createArtist, 5)!;
 				const response: any = await axios.post(`${url}/items/artists`, body, {
 					headers: {
@@ -232,8 +230,8 @@ describe('/items', () => {
 			});
 		});
 		describe('Error handling', () => {
-			it.each(getDBsToTest())('%p returns an error when an invalid table is used', async (vendor) => {
-				const url = `http://localhost:${config.ports[vendor]!}`;
+			it.each(vendors)('%p returns an error when an invalid table is used', async (vendor) => {
+				const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 				const body = createArtist();
 				const response = await axios
 					.post(`${url}/items/invalid_table`, body, {
@@ -255,8 +253,8 @@ describe('/items', () => {
 	});
 
 	describe('/:collection PATCH', () => {
-		it.each(getDBsToTest())(`%p updates many artists to a different name`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p updates many artists to a different name`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 			let items;
 			const keys: any[] = [];
@@ -303,8 +301,8 @@ describe('/items', () => {
 		});
 	});
 	describe('/:collection DELETE', () => {
-		it.each(getDBsToTest())(`%p deletes many artists with no relations`, async (vendor) => {
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)(`%p deletes many artists with no relations`, async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 			const artists = createMany(createArtist, 10, { id: uuid });
 			await seedTable(databases.get(vendor)!, 1, 'artists', artists);
 			const body: any[] = [];

--- a/tests/e2e/api/ping.test.ts
+++ b/tests/e2e/api/ping.test.ts
@@ -1,14 +1,12 @@
 import request from 'supertest';
 import config from '../config';
-import { getDBsToTest } from '../get-dbs-to-test';
+import vendors from '../get-dbs-to-test';
 import knex, { Knex } from 'knex';
 
 describe('/server', () => {
 	const databases = new Map<string, Knex>();
 
 	beforeAll(() => {
-		const vendors = getDBsToTest();
-
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 		}
@@ -21,10 +19,8 @@ describe('/server', () => {
 	});
 
 	describe('/ping', () => {
-		it.each(getDBsToTest())('%p', async (vendor) => {
-			// const knex = databases.get(vendor);
-
-			const url = `http://localhost:${config.ports[vendor]!}`;
+		it.each(vendors)('%p', async (vendor) => {
+			const url = `http://localhost:${config.envs[vendor]!.PORT!}`;
 
 			const response = await request(url)
 				.get('/server/ping')

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -1,227 +1,101 @@
-import Dockerode from 'dockerode';
 import { Knex } from 'knex';
 import { allVendors } from './get-dbs-to-test';
-import { customAlphabet } from 'nanoid';
-
-const generateID = customAlphabet('abcdefghijklmnopqrstuvwxyz', 5);
 
 type Vendor = typeof allVendors[number];
 
 export type Config = {
-	containerConfig: Record<
-		Vendor,
-		(Dockerode.ContainerSpec & Dockerode.ContainerCreateOptions & { name: string }) | false
-	>;
 	knexConfig: Record<Vendor, Knex.Config & { waitTestSQL: string }>;
-	ports: Record<Vendor, number>;
 	names: Record<Vendor, string>;
-	envs: Record<Vendor, string[]>;
+	envs: Record<Vendor, Record<string, string | number>>;
 };
-
-export const processID = generateID();
-
-export const CONTAINER_PERSISTENCE_FILE = '.e2e-containers.json';
 
 const migrationsDir = './tests/e2e/setup/migrations';
 const seedsDir = './tests/e2e/setup/seeds';
 
-const config: Config = {
-	containerConfig: {
-		postgres: {
-			name: `directus-test-database-postgres-${process.pid}`,
-			Image: 'postgres:12-alpine',
-			Hostname: `directus-test-database-postgres-${process.pid}`,
-			Env: ['POSTGRES_PASSWORD=secret', 'POSTGRES_DB=directus'],
-			HostConfig: {
-				PortBindings: {
-					'5432/tcp': [{ HostPort: '6000' }],
-				},
-			},
-		},
-		postgres10: {
-			name: `directus-test-database-postgres10-${process.pid}`,
-			Image: 'postgis/postgis:10-3.1-alpine',
-			Hostname: `directus-test-database-postgres10-${process.pid}`,
-			Env: ['POSTGRES_PASSWORD=secret', 'POSTGRES_DB=directus'],
-			HostConfig: {
-				PortBindings: {
-					'5432/tcp': [{ HostPort: '6006' }],
-				},
-			},
-		},
-		mysql: {
-			name: `directus-test-database-mysql-${process.pid}`,
-			Image: 'mysql:8',
-			Cmd: ['--default-authentication-plugin=mysql_native_password'],
-			Hostname: `directus-test-database-mysql-${process.pid}`,
-			Env: ['MYSQL_ROOT_PASSWORD=secret', 'MYSQL_DATABASE=directus'],
-			HostConfig: {
-				PortBindings: {
-					'3306/tcp': [{ HostPort: '6001' }],
-				},
-			},
-		},
-		maria: {
-			name: `directus-test-database-maria-${process.pid}`,
-			Image: 'mariadb:10.5',
-			Hostname: `directus-test-database-maria-${process.pid}`,
-			Env: ['MYSQL_ROOT_PASSWORD=secret', 'MYSQL_DATABASE=directus'],
-			HostConfig: {
-				PortBindings: {
-					'3306/tcp': [{ HostPort: '6002' }],
-				},
-			},
-		},
-		mssql: {
-			name: `directus-test-database-mssql-${process.pid}`,
-			Image: 'mcr.microsoft.com/mssql/server:2019-latest',
-			Hostname: `directus-test-database-mssql-${process.pid}`,
-			Env: ['ACCEPT_EULA=Y', 'SA_PASSWORD=Test@123'],
-			HostConfig: {
-				PortBindings: {
-					'1433/tcp': [{ HostPort: '6003' }],
-				},
-			},
-		},
-		oracle: {
-			name: `directus-test-database-oracle-${process.pid}`,
-			Image: 'quillbuilduser/oracle-18-xe-micro-sq',
-			Hostname: `directus-test-database-oracle-${process.pid}`,
-			Env: [
-				'OPATCH_JRE_MEMORY_OPTIONS=-Xms128m -Xmx256m -XX:PermSize=16m -XX:MaxPermSize=32m -Xss1m',
-				'ORACLE_ALLOW_REMOTE=true',
-			],
-			HostConfig: {
-				PortBindings: {
-					'1521/tcp': [{ HostPort: '6004' }],
-				},
-			},
-		},
-		sqlite3: false,
+const knexConfig = {
+	waitTestSQL: 'SELECT 1',
+	migrations: {
+		directory: migrationsDir,
 	},
+	seeds: {
+		directory: seedsDir,
+	},
+};
+
+const config: Config = {
 	knexConfig: {
 		postgres: {
 			client: 'pg',
 			connection: {
-				host: 'localhost',
-				port: 6000,
+				database: 'directus',
 				user: 'postgres',
 				password: 'secret',
-				database: 'directus',
+				host: 'localhost',
+				port: 5100,
 			},
-			waitTestSQL: 'SELECT 1',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
+			...knexConfig,
 		},
 		postgres10: {
 			client: 'pg',
 			connection: {
-				host: 'localhost',
-				port: 6006,
+				database: 'directus',
 				user: 'postgres',
 				password: 'secret',
-				database: 'directus',
+				host: 'localhost',
+				port: 5111,
 			},
-			waitTestSQL: 'SELECT 1',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
+			...knexConfig,
 		},
 		mysql: {
 			client: 'mysql',
 			connection: {
-				host: 'localhost',
-				port: 6001,
+				database: 'directus',
 				user: 'root',
 				password: 'secret',
-				database: 'directus',
+				host: 'localhost',
+				port: 5101,
 			},
-			waitTestSQL: 'SELECT 1',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
+			...knexConfig,
 		},
 		maria: {
 			client: 'mysql',
 			connection: {
-				host: 'localhost',
-				port: 6002,
+				database: 'directus',
 				user: 'root',
 				password: 'secret',
-				database: 'directus',
+				host: 'localhost',
+				port: 5102,
 			},
-			waitTestSQL: 'SELECT 1',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
+			...knexConfig,
 		},
 		mssql: {
 			client: 'mssql',
 			connection: {
-				host: 'localhost',
-				port: 6003,
+				database: 'model',
 				user: 'sa',
 				password: 'Test@123',
-				database: 'model',
+				host: 'localhost',
+				port: 5103,
 			},
-			waitTestSQL: 'SELECT 1',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
+			...knexConfig,
 		},
 		oracle: {
 			client: 'oracledb',
 			connection: {
 				user: 'secretsysuser',
 				password: 'secretpassword',
-				connectString: 'localhost:6004/XE',
+				connectString: 'localhost:5104/XE',
 			},
+			...knexConfig,
 			waitTestSQL: 'SELECT 1 FROM DUAL',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
 		},
 		sqlite3: {
 			client: 'sqlite3',
 			connection: {
 				filename: './data.db',
 			},
-			waitTestSQL: 'SELECT 1',
-			migrations: {
-				directory: migrationsDir,
-			},
-			seeds: {
-				directory: seedsDir,
-			},
+			...knexConfig,
 		},
-	},
-	ports: {
-		postgres: 6100,
-		postgres10: 6106,
-		mysql: 6101,
-		maria: 6102,
-		mssql: 6103,
-		oracle: 6104,
-		sqlite3: 6105,
 	},
 	names: {
 		postgres: 'Postgres',
@@ -233,53 +107,63 @@ const config: Config = {
 		sqlite3: 'SQLite 3',
 	},
 	envs: {
-		postgres: [
-			'DB_CLIENT=pg',
-			`DB_HOST=directus-test-database-postgres-${process.pid}`,
-			'DB_USER=postgres',
-			'DB_PASSWORD=secret',
-			'DB_PORT=5432',
-			'DB_DATABASE=directus',
-		],
-		postgres10: [
-			'DB_CLIENT=pg',
-			`DB_HOST=directus-test-database-postgres10-${process.pid}`,
-			'DB_USER=postgres',
-			'DB_PASSWORD=secret',
-			'DB_PORT=5432',
-			'DB_DATABASE=directus',
-		],
-		mysql: [
-			'DB_CLIENT=mysql',
-			`DB_HOST=directus-test-database-mysql-${process.pid}`,
-			'DB_PORT=3306',
-			'DB_USER=root',
-			'DB_PASSWORD=secret',
-			'DB_DATABASE=directus',
-		],
-		maria: [
-			'DB_CLIENT=mysql',
-			`DB_HOST=directus-test-database-maria-${process.pid}`,
-			'DB_PORT=3306',
-			'DB_USER=root',
-			'DB_PASSWORD=secret',
-			'DB_DATABASE=directus',
-		],
-		mssql: [
-			'DB_CLIENT=mssql',
-			`DB_HOST=directus-test-database-mssql-${process.pid}`,
-			'DB_PORT=1433',
-			'DB_USER=sa',
-			'DB_PASSWORD=Test@123',
-			'DB_DATABASE=model',
-		],
-		oracle: [
-			'DB_CLIENT=oracledb',
-			'DB_USER=secretsysuser',
-			'DB_PASSWORD=secretpassword',
-			`DB_CONNECT_STRING=directus-test-database-oracle-${process.pid}:1521/XE`,
-		],
-		sqlite3: ['DB_CLIENT=sqlite3', 'DB_FILENAME=./data.db'],
+		postgres: {
+			DB_CLIENT: 'pg',
+			DB_HOST: `localhost`,
+			DB_USER: 'postgres',
+			DB_PASSWORD: 'secret',
+			DB_PORT: '5100',
+			DB_DATABASE: 'directus',
+			PORT: 49152,
+		},
+		postgres10: {
+			DB_CLIENT: 'pg',
+			DB_HOST: `localhost`,
+			DB_USER: 'postgres',
+			DB_PASSWORD: 'secret',
+			DB_PORT: '5111',
+			DB_DATABASE: 'directus',
+			PORT: 49153,
+		},
+		mysql: {
+			DB_CLIENT: 'mysql',
+			DB_HOST: `localhost`,
+			DB_PORT: '5101',
+			DB_USER: 'root',
+			DB_PASSWORD: 'secret',
+			DB_DATABASE: 'directus',
+			PORT: 49154,
+		},
+		maria: {
+			DB_CLIENT: 'mysql',
+			DB_HOST: `localhost`,
+			DB_PORT: '5102',
+			DB_USER: 'root',
+			DB_PASSWORD: 'secret',
+			DB_DATABASE: 'directus',
+			PORT: 49155,
+		},
+		mssql: {
+			DB_CLIENT: 'mssql',
+			DB_HOST: `localhost`,
+			DB_PORT: '5103',
+			DB_USER: 'sa',
+			DB_PASSWORD: 'Test@123',
+			DB_DATABASE: 'model',
+			PORT: 49156,
+		},
+		oracle: {
+			DB_CLIENT: 'oracledb',
+			DB_USER: 'secretsysuser',
+			DB_PASSWORD: 'secretpassword',
+			DB_CONNECT_STRING: `localhost:5104/XE`,
+			PORT: 49157,
+		},
+		sqlite3: {
+			DB_CLIENT: 'sqlite3',
+			DB_FILENAME: './data.db',
+			PORT: 49158,
+		},
 	},
 };
 

--- a/tests/e2e/get-dbs-to-test.ts
+++ b/tests/e2e/get-dbs-to-test.ts
@@ -1,24 +1,12 @@
 /** @TODO once Oracle is officially supported, enable it here */
 export const allVendors = ['mssql', 'mysql', 'postgres', /* 'oracle', */ 'maria' /*, 'sqlite3'*/, 'postgres10'];
 
-export function getDBsToTest(): string[] {
-	const testVendors = process.env.TEST_DB || '*';
+const vendors = process.env.TEST_DB?.split(',').map((v) => v.trim()) ?? allVendors;
 
-	let vendors = [];
-
-	if (testVendors === '*') {
-		vendors = allVendors;
-	} else if (testVendors.includes(',')) {
-		vendors = testVendors.split(',').map((v) => v.trim());
-	} else {
-		vendors = [testVendors];
+for (const vendor of vendors) {
+	if (allVendors.includes(vendor) === false) {
+		throw new Error(`No e2e testing capabilities for vendor "${vendor}".`);
 	}
-
-	for (const vendor of vendors) {
-		if (allVendors.includes(vendor) === false) {
-			throw new Error(`No e2e testing capabilities for vendor "${vendor}".`);
-		}
-	}
-
-	return vendors;
 }
+
+export default vendors;

--- a/tests/e2e/get-urls-to-test.ts
+++ b/tests/e2e/get-urls-to-test.ts
@@ -1,8 +1,0 @@
-import { getDBsToTest } from './get-dbs-to-test';
-import config from './config';
-
-export function getURLsToTest(): string[] {
-	const dbVendors = getDBsToTest();
-	const urls = dbVendors.map((vendor) => `http://localhost:${config.ports[vendor]!}`);
-	return urls;
-}

--- a/tests/e2e/setup/global.ts
+++ b/tests/e2e/setup/global.ts
@@ -1,16 +1,7 @@
-import Dockerode from 'dockerode';
-import { Knex } from 'knex';
+import { ChildProcess } from 'child_process';
 
-type Global = {
-	databaseContainers: { vendor: string; container: Dockerode.Container }[];
-	directusContainers: { vendor: string; container: Dockerode.Container }[];
-	knexInstances: { vendor: string; knex: Knex }[];
-};
-
-const global: Global = {
-	databaseContainers: [],
-	directusContainers: [],
-	knexInstances: [],
+const global = {
+	directus: {} as { [vendor: string]: ChildProcess },
 };
 
 export default global;

--- a/tests/e2e/setup/setup.ts
+++ b/tests/e2e/setup/setup.ts
@@ -6,7 +6,7 @@ import vendors from '../get-dbs-to-test';
 import config from '../config';
 import global from './global';
 import { spawn, spawnSync } from 'child_process';
-import { awaitDirectusConnection } from './utils/await-connection';
+import { awaitDatabaseConnection, awaitDirectusConnection } from './utils/await-connection';
 
 let started = false;
 
@@ -28,6 +28,7 @@ export default async (): Promise<void> => {
 							title: config.names[vendor]!,
 							task: async () => {
 								const database = knex(config.knexConfig[vendor]!);
+								await awaitDatabaseConnection(database, config.knexConfig[vendor]!.waitTestSQL);
 								const env = {
 									...config.envs[vendor]!,
 									ADMIN_EMAIL: 'admin@example.com',

--- a/tests/e2e/setup/setup.ts
+++ b/tests/e2e/setup/setup.ts
@@ -44,7 +44,7 @@ export default async (): Promise<void> => {
 								await database.migrate.latest();
 								await database.seed.run();
 								await database.destroy();
-								const server = spawn('sh', ['-lc', 'npx directus start'], { env });
+								const server = spawn('sh', ['-lc', 'npx directus start'], { env, stdio: 'ignore' });
 								await awaitDirectusConnection(config.envs[vendor]!.PORT as number);
 								global.directus[vendor] = server;
 							},

--- a/tests/e2e/setup/setup.ts
+++ b/tests/e2e/setup/setup.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 
 import knex from 'knex';
-import { sleep } from './utils/sleep';
 import Listr from 'listr';
 import vendors from '../get-dbs-to-test';
 import config from '../config';
@@ -69,6 +68,5 @@ export default async (): Promise<void> => {
 		},
 	]).run();
 
-	await sleep(10000);
 	console.log('\n');
 };

--- a/tests/e2e/setup/setup.ts
+++ b/tests/e2e/setup/setup.ts
@@ -6,7 +6,7 @@ import vendors from '../get-dbs-to-test';
 import config from '../config';
 import global from './global';
 import { spawn, spawnSync } from 'child_process';
-import { awaitDatabaseConnection, awaitDirectusConnection } from './utils/await-connection';
+import { awaitDirectusConnection } from './utils/await-connection';
 
 let started = false;
 
@@ -28,7 +28,6 @@ export default async (): Promise<void> => {
 							title: config.names[vendor]!,
 							task: async () => {
 								const database = knex(config.knexConfig[vendor]!);
-								await awaitDatabaseConnection(database, config.knexConfig[vendor]!.waitTestSQL);
 								const env = {
 									...config.envs[vendor]!,
 									ADMIN_EMAIL: 'admin@example.com',

--- a/tests/e2e/setup/setup.ts
+++ b/tests/e2e/setup/setup.ts
@@ -1,21 +1,16 @@
 /* eslint-disable no-console */
 
-import Dockerode, { ContainerSpec } from 'dockerode';
 import knex from 'knex';
-import { awaitDatabaseConnection, awaitDirectusConnection } from './utils/await-connection';
-import Listr, { ListrTask } from 'listr';
-import { getDBsToTest } from '../get-dbs-to-test';
-import config, { CONTAINER_PERSISTENCE_FILE } from '../config';
-import globby from 'globby';
-import path from 'path';
-import { GlobalConfigTsJest } from 'ts-jest/dist/types';
-import { writeFileSync } from 'fs';
+import { sleep } from './utils/sleep';
+import Listr from 'listr';
+import vendors from '../get-dbs-to-test';
+import config from '../config';
 import global from './global';
+import { spawn, spawnSync } from 'child_process';
 
-const docker = new Dockerode();
 let started = false;
 
-export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
+export default async (): Promise<void> => {
 	if (started) return;
 	started = true;
 
@@ -23,252 +18,29 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 
 	console.log(`👮‍♀️ Starting tests!\n`);
 
-	const vendors = getDBsToTest();
-
-	const NODE_VERSION = process.env.TEST_NODE_VERSION || '16-alpine';
-
 	await new Listr([
 		{
-			title: 'Create Directus Docker Image',
-			task: async (_, task) => {
-				const result = await globby(['**/*', '!node_modules', '!**/node_modules', '!**/src', '!tests', '!**/tests'], {
-					cwd: path.resolve(__dirname, '..', '..', '..'),
-				});
-
-				const stream = await docker.buildImage(
-					{
-						context: path.resolve(__dirname, '..', '..', '..'),
-						src: ['Dockerfile', ...result],
-					},
-					{
-						t: 'directus-test-image',
-						buildargs: { NODE_VERSION },
-						cachefrom: ['directus-test-image'], // Docker now requires this to be an actual array, but Dockerode's types haven't been updated yet
-					} as unknown as Dockerode.ImageBuildOptions
-				);
-
-				await new Promise((resolve, reject) => {
-					docker.modem.followProgress(
-						stream,
-						(err, res) => {
-							if (err) {
-								reject(err);
-							} else {
-								resolve(res);
-							}
-						},
-						(event: any) => {
-							if (event.stream?.startsWith('Step')) {
-								task.output = event.stream;
-							}
-						}
-					);
-				});
-			},
-		},
-		{
-			title: 'Pulling Required Images',
-			task: () => {
-				return new Listr(
-					vendors
-						.map((vendor) => {
-							return {
-								title: config.names[vendor]!,
-								task: async (_, task) => {
-									const image =
-										config.containerConfig[vendor]! &&
-										(config.containerConfig[vendor]! as Dockerode.ContainerSpec).Image;
-
-									if (!image) return;
-
-									const stream = await docker.pull(image);
-
-									await new Promise((resolve, reject) => {
-										docker.modem.followProgress(
-											stream,
-											(err, res) => {
-												if (err) {
-													reject(err);
-												} else {
-													resolve(res);
-												}
-											},
-											(event: any) => {
-												if (event.stream?.startsWith('Step')) {
-													task.output = event.stream;
-												}
-											}
-										);
-									});
-								},
-							} as ListrTask;
-						})
-						.filter((t) => t),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Create Docker containers',
-			task: () => {
-				return new Listr(
-					vendors.map((vendor) => {
-						return {
-							title: config.names[vendor]!,
-							task: () => {
-								return new Listr([
-									{
-										title: 'Database',
-										task: async () => {
-											if (!config.containerConfig[vendor] || config.containerConfig[vendor] === false) return;
-											const container = await docker.createContainer(config.containerConfig[vendor]! as ContainerSpec);
-											global.databaseContainers.push({
-												vendor,
-												container,
-											});
-										},
-									},
-									{
-										title: 'Directus',
-										task: async () => {
-											const container = await docker.createContainer({
-												name: `directus-test-directus-${vendor}-${process.pid}`,
-												Image: 'directus-test-image',
-												Env: [
-													...config.envs[vendor]!,
-													'ADMIN_EMAIL=admin@example.com',
-													'ADMIN_PASSWORD=password',
-													'KEY=directus-test',
-													'SECRET=directus-test',
-													'TELEMETRY=false',
-													'CACHE_SCHEMA=false',
-													'CACHE_ENABLED=false',
-													'RATE_LIMITER_ENABLED=false',
-												],
-												HostConfig: {
-													Links:
-														vendor === 'sqlite3'
-															? undefined
-															: [
-																	`directus-test-database-${vendor}-${process.pid}:directus-test-database-${vendor}-${process.pid}`,
-															  ],
-													PortBindings: {
-														'8055/tcp': [{ HostPort: String(config.ports[vendor]!) }],
-													},
-												},
-											} as ContainerSpec);
-
-											global.directusContainers.push({
-												vendor,
-												container,
-											});
-										},
-									},
-								]);
-							},
-						};
-					}),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Start Database Docker containers',
-			task: () => {
-				return new Listr(
-					global.databaseContainers.map(({ vendor, container }) => {
-						return {
-							title: config.names[vendor]!,
-							task: async () => await container.start(),
-						};
-					}),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Create Knex instances',
-			task: () => {
-				return new Listr(
-					vendors.map((vendor) => {
-						return {
-							title: config.names[vendor]!,
-							task: () => {
-								global.knexInstances.push({ vendor, knex: knex(config.knexConfig[vendor]!) });
-							},
-						};
-					}),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Wait for databases to be ready',
-			task: async () => {
-				return new Listr(
-					global.knexInstances.map(({ vendor, knex }) => {
-						return {
-							title: config.names[vendor]!,
-
-							task: async () => {
-								// Give the database image some time to startup before checking the connection
-								await sleep(15000);
-								await awaitDatabaseConnection(knex, config.knexConfig[vendor]!.waitTestSQL);
-							},
-						};
-					}),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Close Knex instances',
-			task: () => {
-				return new Listr(
-					global.knexInstances.map(({ vendor, knex }) => {
-						return {
-							title: config.names[vendor]!,
-							task: async () => await knex.destroy(),
-						};
-					}),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Start Directus Docker containers',
-			task: () => {
-				return new Listr(
-					global.directusContainers.map(({ vendor, container }) => {
-						return {
-							title: config.names[vendor]!,
-							task: async () => await container.start(),
-						};
-					}),
-					{ concurrent: true }
-				);
-			},
-		},
-		{
-			title: 'Wait for Directus to be ready',
+			title: 'Bootstrap databases and start servers',
 			task: async () => {
 				return new Listr(
 					vendors.map((vendor) => {
 						return {
 							title: config.names[vendor]!,
 							task: async () => {
-								try {
-									await awaitDirectusConnection(config.ports[vendor]!);
-								} catch {
-									const container = global.directusContainers.find(
-										({ vendor: containerVendor }) => containerVendor === vendor
-									);
-
-									const logBuffer = await container?.container?.logs({ follow: false, stderr: true, tail: 50 });
-									const logString = logBuffer ? '\n\n' + logBuffer.toString() + '\n\n' : `Directus couldn't start.`;
-
-									throw new Error(logString);
-								}
+								const env = {
+									...config.envs[vendor]!,
+									ADMIN_EMAIL: 'admin@example.com',
+									ADMIN_PASSWORD: 'password',
+									KEY: 'directus-test',
+									SECRET: 'directus-test',
+									TELEMETRY: 'false',
+									CACHE_SCHEMA: 'false',
+									CACHE_ENABLED: 'false',
+									RATE_LIMITER_ENABLED: 'false',
+								};
+								spawnSync('sh', ['-lc', 'npx directus bootstrap'], { env });
+								const server = spawn('sh', ['-lc', 'npx directus start'], { env });
+								global.directus[vendor] = server;
 							},
 						};
 					}),
@@ -280,7 +52,7 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 			title: 'Migrate and seed databases',
 			task: async () => {
 				return new Listr(
-					global.knexInstances.map(({ vendor }) => {
+					vendors.map((vendor) => {
 						return {
 							title: config.names[vendor]!,
 							task: async () => {
@@ -295,30 +67,8 @@ export default async (jestConfig: GlobalConfigTsJest): Promise<void> => {
 				);
 			},
 		},
-		{
-			skip: () => !jestConfig.watch,
-			title: 'Persist container info',
-			task: () => {
-				const persistContainer = ({ container, vendor }: { container: Dockerode.Container; vendor: string }) => ({
-					id: container.id,
-					vendor,
-				});
-				const containers = {
-					db: global.databaseContainers.map(persistContainer),
-					directus: global.directusContainers.map(persistContainer),
-				};
-				writeFileSync(CONTAINER_PERSISTENCE_FILE, JSON.stringify(containers));
-			},
-		},
 	]).run();
 
+	await sleep(10000);
 	console.log('\n');
 };
-
-function sleep(ms: number) {
-	return new Promise<void>((resolve) => {
-		setTimeout(() => {
-			resolve();
-		}, ms);
-	});
-}

--- a/tests/e2e/setup/teardown.ts
+++ b/tests/e2e/setup/teardown.ts
@@ -1,105 +1,30 @@
 /* eslint-disable no-console */
 
 import Listr from 'listr';
-import Dockerode from 'dockerode';
-import { getDBsToTest } from '../get-dbs-to-test';
-import config, { CONTAINER_PERSISTENCE_FILE } from '../config';
+import vendors from '../get-dbs-to-test';
+import config from '../config';
 import { GlobalConfigTsJest } from 'ts-jest/dist/types';
-import { readFileSync, rmSync } from 'fs';
 import global from './global';
-
-const docker = new Dockerode();
 
 if (require.main === module) {
 	teardown(undefined, true);
 }
 
-export default async function teardown(jestConfig?: GlobalConfigTsJest, isAfterWatch = false): Promise<void> {
+export default async function teardown(jestConfig?: GlobalConfigTsJest, _isAfterWatch = false): Promise<void> {
 	if (jestConfig?.watch || jestConfig?.watchAll) return;
-
-	const vendors = getDBsToTest();
-
-	console.log('\n');
 
 	await new Listr([
 		{
-			skip: () => !isAfterWatch,
-			title: 'Restore container info',
-			task: async () => {
-				const containers = JSON.parse(readFileSync(CONTAINER_PERSISTENCE_FILE).toString());
-				if (!(containers.db && containers.directus)) {
-					throw new Error('Could not load saved containers');
-				}
-				const restorePersistedContainer = ({ vendor, id }: { vendor: string; id: string }) => ({
-					vendor,
-					container: docker.getContainer(id),
-				});
-				global.databaseContainers = containers.db.map(restorePersistedContainer);
-				global.directusContainers = containers.directus.map(restorePersistedContainer);
-				rmSync(CONTAINER_PERSISTENCE_FILE);
-			},
-		},
-		{
-			title: 'Stop Docker containers',
+			title: 'Stop Directus servers',
 			task: () => {
 				return new Listr(
 					vendors.map((vendor) => {
 						return {
 							title: config.names[vendor]!,
-							task: () => {
-								return new Listr(
-									[
-										{
-											title: 'Database',
-											task: async () =>
-												await global.databaseContainers
-													.find((containerInfo) => containerInfo.vendor === vendor)
-													?.container.stop(),
-										},
-										{
-											title: 'Directus',
-											task: async () =>
-												await global.directusContainers
-													.find((containerInfo) => containerInfo.vendor === vendor)
-													?.container.stop(),
-										},
-									],
-									{ concurrent: true, exitOnError: false }
-								);
-							},
-						};
-					}),
-					{ concurrent: true, exitOnError: false }
-				);
-			},
-		},
-		{
-			title: 'Remove Docker containers',
-			task: () => {
-				return new Listr(
-					vendors.map((vendor) => {
-						return {
-							title: config.names[vendor]!,
-							task: () => {
-								return new Listr(
-									[
-										{
-											title: 'Database',
-											task: async () =>
-												await global.databaseContainers
-													.find((containerInfo) => containerInfo.vendor === vendor)
-													?.container.remove(),
-										},
-										{
-											title: 'Directus',
-											task: async () =>
-												await global.directusContainers
-													.find((containerInfo) => containerInfo.vendor === vendor)
-													?.container.remove(),
-										},
-									],
-									{ concurrent: true, exitOnError: false }
-								);
+							task: async () => {
+								const directus = global.directus[vendor];
+								directus!.stdin!.end();
+								directus!.kill();
 							},
 						};
 					}),

--- a/tests/e2e/setup/teardown.ts
+++ b/tests/e2e/setup/teardown.ts
@@ -23,7 +23,6 @@ export default async function teardown(jestConfig?: GlobalConfigTsJest, _isAfter
 							title: config.names[vendor]!,
 							task: async () => {
 								const directus = global.directus[vendor];
-								directus!.stdin!.end();
 								directus!.kill();
 							},
 						};

--- a/tests/e2e/setup/utils/await-connection.ts
+++ b/tests/e2e/setup/utils/await-connection.ts
@@ -16,7 +16,7 @@ export async function awaitDatabaseConnection(database: Knex, checkSQL: string):
 }
 
 export async function awaitDirectusConnection(port: number): Promise<void | null> {
-	for (let attempt = 0; attempt <= 10; attempt++) {
+	for (let attempt = 0; attempt <= 15; attempt++) {
 		try {
 			await axios.get(`http://localhost:${port}/server/ping`);
 			return null; // success

--- a/tests/e2e/setup/utils/factories.test.ts
+++ b/tests/e2e/setup/utils/factories.test.ts
@@ -9,7 +9,7 @@ import {
 } from './factories';
 import knex, { Knex } from 'knex';
 import config from '../../config';
-import { getDBsToTest } from '../../get-dbs-to-test';
+import vendors from '../../get-dbs-to-test';
 
 describe('Item factories', () => {
 	describe('createArtist', () => {
@@ -75,35 +75,31 @@ describe('Item factories', () => {
 describe('seeding databases', () => {
 	const databases = new Map<string, Knex>();
 	beforeAll(async () => {
-		const vendors = getDBsToTest();
-
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 		}
 	});
 	afterAll(async () => {
-		const vendors = getDBsToTest();
-
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 			await databases.get(vendor)!.destroy();
 		}
 	});
 	describe('seedTable', () => {
-		it.each(getDBsToTest())('%p returns void when there is no options', async (vendor) => {
-			const database = databases.get(vendor);
+		it.each(vendors)('%p returns void when there is no options', async (vendor) => {
+			const database = databases.get(vendor)!;
 			expect(await seedTable(database!, 5, 'artists', createArtist)).toBe(undefined);
 		});
-		it.each(getDBsToTest())('%p to insert the correct number of artists', async (vendor) => {
-			const database = databases.get(vendor);
+		it.each(vendors)('%p to insert the correct number of artists', async (vendor) => {
+			const database = databases.get(vendor)!;
 
 			expect(await seedTable(database!, 1606, 'artists', createArtist)).toBe(undefined);
 
 			const count = await database!('artists').count('*', { as: 'artists' });
 			if (typeof count[0]?.artists === 'string') expect(parseInt(count[0]?.artists)).toBeGreaterThanOrEqual(1606);
 		});
-		it.each(getDBsToTest())('%p has a response based on passed in options select and where', async (vendor) => {
-			const database = databases.get(vendor);
+		it.each(vendors)('%p has a response based on passed in options select and where', async (vendor) => {
+			const database = databases.get(vendor)!;
 			const artist = createArtist();
 			const options = { select: ['name', 'id'], where: ['name', artist.name] };
 			const insert: any = await seedTable(database!, 1, 'artists', artist, options);
@@ -112,8 +108,8 @@ describe('seeding databases', () => {
 				name: artist.name,
 			});
 		});
-		it.each(getDBsToTest())('%p has a response based on passed in options raw', async (vendor) => {
-			const database = databases.get(vendor);
+		it.each(vendors)('%p has a response based on passed in options raw', async (vendor) => {
+			const database = databases.get(vendor)!;
 			const artist = createArtist();
 			const options = { raw: `SELECT name from artists WHERE name='${artist.name}';` };
 			const response: any = await seedTable(database!, 1, 'artists', artist, options);
@@ -136,8 +132,8 @@ describe('seeding databases', () => {
 	});
 	describe('inserting factories', () => {
 		describe('createArtist', () => {
-			it.each(getDBsToTest())('%p returns an artist object of column names and values', async (vendor) => {
-				const database = databases.get(vendor);
+			it.each(vendors)('%p returns an artist object of column names and values', async (vendor) => {
+				const database = databases.get(vendor)!;
 				const artist = createArtist();
 				if (vendor === 'postgres' && typeof artist.members === 'string') {
 					const options = { select: ['*'], where: ['name', artist.name] };
@@ -163,7 +159,7 @@ describe('seeding databases', () => {
 		});
 
 		describe('createEvent', () => {
-			it.each(getDBsToTest())('%p returns an event object of column names and values', async (vendor) => {
+			it.each(vendors)('%p returns an event object of column names and values', async (vendor) => {
 				const database = databases.get(vendor)!;
 				const event = createEvent();
 				const options = { select: ['*'], where: ['id', event.id] };
@@ -194,7 +190,7 @@ describe('seeding databases', () => {
 		});
 
 		describe('createGuest', () => {
-			it.each(getDBsToTest())('%p returns an guest object of column names and values', async (vendor) => {
+			it.each(vendors)('%p returns an guest object of column names and values', async (vendor) => {
 				const database = databases.get(vendor)!;
 				const guest = createGuest();
 				const options = { select: ['*'], where: ['name', guest.name] };
@@ -222,7 +218,7 @@ describe('seeding databases', () => {
 		});
 
 		describe('createTour', () => {
-			it.each(getDBsToTest())('%p returns an tour object of column names and values', async (vendor) => {
+			it.each(vendors)('%p returns an tour object of column names and values', async (vendor) => {
 				const database = databases.get(vendor)!;
 				const tour = createTour();
 				const options = { select: ['*'], where: ['revenue', tour.revenue] };
@@ -241,7 +237,7 @@ describe('seeding databases', () => {
 		});
 
 		describe('createOrganizer', () => {
-			it.each(getDBsToTest())('%p returns an organizer object of column names and values', async (vendor) => {
+			it.each(vendors)('%p returns an organizer object of column names and values', async (vendor) => {
 				const database = databases.get(vendor)!;
 				const organizer = createOrganizer();
 				const options = { select: ['*'], where: ['id', organizer.id] };
@@ -254,7 +250,7 @@ describe('seeding databases', () => {
 		});
 
 		describe('createMany', () => {
-			it.each(getDBsToTest())('%p returns array of guests', async (vendor) => {
+			it.each(vendors)('%p returns array of guests', async (vendor) => {
 				const database = databases.get(vendor)!;
 				const artist = createArtist();
 				await seedTable(database, 1, 'artists', artist, { select: ['id'] });
@@ -270,7 +266,7 @@ describe('seeding databases', () => {
 				expect(response[0]).toMatchObject({ name: expect.any(String), favorite_artist: expect.any(String) });
 				expect(response.length).toBe(5);
 			});
-			it.each(getDBsToTest())('%p returns array of guests', async (vendor) => {
+			it.each(vendors)('%p returns array of guests', async (vendor) => {
 				const database = databases.get(vendor)!;
 				const artist = createArtist();
 				await seedTable(database, 1, 'artists', artist, { select: ['id'] });

--- a/tests/e2e/setup/utils/sleep.ts
+++ b/tests/e2e/setup/utils/sleep.ts
@@ -1,0 +1,7 @@
+export function sleep(ms: number) {
+	return new Promise<void>((resolve) => {
+		setTimeout(() => {
+			resolve();
+		}, ms);
+	});
+}


### PR DESCRIPTION
This will remove all dependencies on Dockerode in the e2e tests.
They used to require building the Directus image and spinning a Directus container for each test database.
With those changes, the local Directus code is used instead, making it much faster.

TODO:
- [ ] Documentation 
- [ ] Github Actions configuration

In order to run the tests, you now have to run those commands from the repository root:
* `npm run build`
* `docker compose down` (clean up in case you ran the tests before)
* `docker compose up -d`
* Wait for all containers to launch
* `npm run test:e2e`