### PR TITLE
fix fields validation to include field presets

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -14,6 +14,7 @@ import { FailedValidationException } from '@directus/shared/exceptions';
 import { getEndpoint } from '@/utils/get-endpoint';
 import { applyConditions } from '@/utils/apply-conditions';
 import { translate } from '@/utils/translate-object-values';
+import { usePermissions } from '../use-permissions';
 
 type UsableItem = {
 	edits: Ref<Record<string, any>>;
@@ -36,7 +37,7 @@ type UsableItem = {
 };
 
 export function useItem(collection: Ref<string>, primaryKey: Ref<string | number | null>): UsableItem {
-	const { info: collectionInfo, primaryKeyField, fields } = useCollection(collection);
+	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 	const item = ref<Record<string, any> | null>(null);
 	const error = ref<any>(null);
 	const validationErrors = ref<any[]>([]);
@@ -58,6 +59,8 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 
 		return item.value?.[collectionInfo.value.meta.archive_field] === collectionInfo.value.meta.archive_value;
 	});
+
+	const { fields } = usePermissions(collection, item, isNew);
 
 	const itemEndpoint = computed(() => {
 		if (isSingle.value) {


### PR DESCRIPTION
Fixes #10854

- [x] Requires #10782 to be resolved first

## Bug

Field presets are not taken into account during validation. Even though the field is already filled by preset, the form returns `value is required`:
![9KCgxosx8o](https://user-images.githubusercontent.com/42867097/148345742-79da4aaf-8119-4c67-ae23-eff99a68000c.gif)

## Investigation

During the validation process, `fields.value` are checked with conditions and if default value isNil:

https://github.com/directus/directus/blob/8cdb6edfca1c217b02d8bc7965cd20116c30f075/app/src/composables/use-item/use-item.ts#L326-L337

However `fields.value` came from useCollection:

https://github.com/directus/directus/blob/8cdb6edfca1c217b02d8bc7965cd20116c30f075/app/src/composables/use-item/use-item.ts#L39

Which _does not_ have field presets merged as default values. Fields with presets are returned from usePermission instead:

https://github.com/directus/directus/blob/8cdb6edfca1c217b02d8bc7965cd20116c30f075/app/src/composables/use-permissions.ts#L73-L87

## Solution

![JKMWtt5YgC](https://user-images.githubusercontent.com/42867097/148345695-2d3b3720-01c0-493f-b72f-c338e0a82471.gif)

---

This PR requires #10782 to be fixed first, due to the presets wrongly parsed as filter syntax. That causes it to be interpreted as creating a new relational item instead:

![g9iume8LXE](https://user-images.githubusercontent.com/42867097/148345678-6ae491da-3202-4668-9e08-1063509a6c5a.gif)

