### PR TITLE
Clarify case rules for storage env vars

### DIFF
--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -443,6 +443,21 @@ STORAGE_LOCAL_ROOT="./uploads"
 
 :::
 
+::: warning Case sensitivity
+
+The location value(s) you specify should be capitalized when specifying the additional configuration values. For example, this will not work:
+```
+STORAGE_LOCATIONS="s3"
+STORAGE_s3_DRIVER="s3" # Will not work, lowercase "s3" ❌
+```
+but this will work:
+```
+STORAGE_LOCATIONS="s3"
+STORAGE_S3_DRIVER="s3" # Will work, "s3" is uppercased ✅
+```
+
+:::
+
 | Variable            | Description                                                                                                           | Default Value |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `STORAGE_LOCATIONS` | A CSV of storage locations (eg: `local,digitalocean,amazon`) to use. You can use any names you'd like for these keys. | `local`       |


### PR DESCRIPTION
This caused my team several hours of headaches before I started digging around the source code and came across [this line](https://github.com/directus/directus/blob/383b4a4926234f66487f7cdf45697044fcff0d14/api/src/storage.ts#L29). Hopefully this documentation change prevents anyone else from encountering this issue.

We had this issue because in our terraform config, we defined a variable for our location as "s3", and then created each of the env vars by doing 
```
STORAGE_{var.location}_DRIVER="s3"
```
which resolves to
```
STORAGE_s3_DRIVER="s3"
```