### PR TITLE
Fix user info sidebar watcher causing error

### DIFF
--- a/app/src/modules/users/components/user-info-sidebar-detail.vue
+++ b/app/src/modules/users/components/user-info-sidebar-detail.vue
@@ -57,7 +57,7 @@ export default defineComponent({
 		const lastAccessDate = ref('');
 
 		watch(
-			props,
+			() => props,
 			async () => {
 				if (!props.user) return;
 				lastAccessDate.value = await localizedFormat(


### PR DESCRIPTION
Whenever a user with role that has app access views the user page, the user sidebar will cause error described in #8015. This PR only fixes the watcher syntax for props in user sidebar and does not resolve the issue in #8015.

## Before

![hLtfAGGri7](https://user-images.githubusercontent.com/42867097/148518058-6a40a0a7-909c-4570-94de-6439be0c6c3f.gif)

## After

![yjM0Rg0E0l](https://user-images.githubusercontent.com/42867097/148518095-1c7ab50f-07ab-43e0-9571-ab6c6bd9efa8.gif)

