### PR TITLE
App/Export: Get all items instead of maximum of 100

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail/export-sidebar-detail.vue
@@ -101,6 +101,8 @@ export default defineComponent({
 				if (props.search) {
 					params.search = props.search;
 				}
+			} else {
+				params.limit = -1;
 			}
 
 			const exportUrl = api.getUri({


### PR DESCRIPTION
By default API applies limit to 100.
But we can fetch all by setting this field to -1