### PR TITLE
App (Presets): Fix delete reactivity

### DIFF
--- a/app/src/modules/content/components/navigation-bookmark.vue
+++ b/app/src/modules/content/components/navigation-bookmark.vue
@@ -145,7 +145,7 @@ export default defineComponent({
 						navigateTo = `/content/${props.bookmark.collection}`;
 					}
 
-					await presetsStore.delete(props.bookmark.id);
+					await presetsStore.delete([props.bookmark.id!]);
 					deleteActive.value = false;
 
 					if (navigateTo) {

--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -91,7 +91,7 @@ import SettingsNavigation from '../../../components/navigation.vue';
 
 import api from '@/api';
 import { Header } from '@/components/v-table/types';
-import { useCollectionsStore } from '@/stores/';
+import { useCollectionsStore, usePresetsStore } from '@/stores/';
 import { getLayout } from '@/layouts';
 import { useRouter } from 'vue-router';
 import ValueNull from '@/views/private/components/value-null';
@@ -131,6 +131,7 @@ export default defineComponent({
 		const { loading, presets, getPresets } = usePresets();
 		const { headers } = useTable();
 		const { confirmDelete, deleting, deleteSelection } = useDelete();
+		const presetsStore = usePresetsStore();
 
 		getPresets();
 
@@ -277,7 +278,7 @@ export default defineComponent({
 
 				try {
 					const IDs = selection.value.map((item) => item.id);
-					await api.delete(`/presets`, { data: IDs });
+					await presetsStore.delete(IDs);
 					selection.value = [];
 					await getPresets();
 					confirmDelete.value = false;

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -313,7 +313,7 @@ export default defineComponent({
 				deleting.value = true;
 
 				try {
-					await api.delete(`/presets/${props.id}`);
+					await presetsStore.delete([Number(props.id)]);
 					router.replace(`/settings/presets`);
 				} catch (err: any) {
 					unexpectedError(err);

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -204,11 +204,11 @@ export const usePresetsStore = defineStore({
 
 			return response.data.data;
 		},
-		async delete(id: number) {
-			await api.delete(`/presets/${id}`);
+		async delete(ids: number[]) {
+			await api.delete('/presets', { data: ids });
 
 			this.collectionPresets = this.collectionPresets.filter((preset) => {
-				return preset.id !== id;
+				return !ids.includes(preset.id!);
 			});
 		},
 


### PR DESCRIPTION
## Description
On deleting a preset, the interface is not being updated.
We found the problem comes from not using the `presetsStore` `delete` method and also comparing `string` with `number` for filtering new items on `presetsStore`.

## Showcase
Before:

https://user-images.githubusercontent.com/14039341/148727762-8d3c4dad-21cb-471e-8512-bd735f722ac4.mov

After:

https://user-images.githubusercontent.com/14039341/148727776-ef5a5d1b-ca89-408b-885b-d3dded5dd02f.mov


