### PR TITLE
Allow passing 'version' to Knex

### DIFF
--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -53,6 +53,7 @@ export default function getDatabase(): Knex {
 
 	const knexConfig: Knex.Config = {
 		client: env.DB_CLIENT,
+		version: env.DB_VERSION,
 		searchPath: env.DB_SEARCH_PATH,
 		connection: env.DB_CONNECTION_STRING || connectionConfig,
 		log: {

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -25,6 +25,7 @@ export default function getDatabase(): Knex {
 		'DB_CONNECTION_STRING',
 		'DB_POOL',
 		'DB_EXCLUDE_TABLES',
+		'DB_VERSION',
 	]);
 
 	const poolConfig = getConfigFromEnv('DB_POOL');

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -209,6 +209,7 @@ needs to be publicly available on the internet.
 | `DB_POOL_*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --                            |
 | `DB_EXCLUDE_TABLES`    | CSV of tables you want Directus to ignore completely                                                                                               | `spatial_ref_sys,sysdiagrams` |
 | `DB_CHARSET`           | Charset/collation to use in the connection to MySQL/MariaDB                                                                                        | `UTF8_GENERAL_CI`             |
+| `DB_VERSION`           | Database version, in case you use the PostgreSQL adapter to connect a non-standard database. Not normally required.                                | --                            |
 
 ::: tip Additional Database Variables
 


### PR DESCRIPTION
Fixes #10941 by treating `DB_VERSION` as a special env var which needs to be added to the top level Knex configuration rather than merged into the connection object.