### PR TITLE
show items without archive value in all items view

### DIFF
--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -403,20 +403,7 @@ export default defineComponent({
 			if (archiveValue === 'false') archiveValue = false;
 
 			if (props.archive === 'all') {
-				return {
-					_or: [
-						{
-							[field]: {
-								_eq: archiveValue,
-							},
-						},
-						{
-							[field]: {
-								_neq: archiveValue,
-							},
-						},
-					],
-				};
+				return null;
 			} else if (props.archive === 'archived') {
 				return {
 					[field]: {


### PR DESCRIPTION
The existing logic will actually not show items without archive value (`null`). Removing any filter instead will ensure they are shown. Thanks to @joselcvarela for pointing this out 👍