### PR TITLE
Enable context menu for read-only fields & adds copy/paste options

### DIFF
--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-list>
 		<v-list-item
-			v-if="defaultValue === null || !isRequired"
+			v-if="!restricted && (defaultValue === null || !isRequired)"
 			:disabled="modelValue === null"
 			clickable
 			@click="$emit('update:modelValue', null)"
@@ -10,7 +10,7 @@
 			<v-list-item-content>{{ t('clear_value') }}</v-list-item-content>
 		</v-list-item>
 		<v-list-item
-			v-if="defaultValue !== null"
+			v-if="!restricted && defaultValue !== null"
 			:disabled="modelValue === defaultValue"
 			clickable
 			@click="$emit('update:modelValue', defaultValue)"
@@ -21,7 +21,7 @@
 			<v-list-item-content>{{ t('reset_to_default') }}</v-list-item-content>
 		</v-list-item>
 		<v-list-item
-			v-if="initialValue"
+			v-if="!restricted && initialValue"
 			:disabled="initialValue === undefined || modelValue === initialValue"
 			clickable
 			@click="$emit('unset', field)"
@@ -56,6 +56,10 @@ export default defineComponent({
 		initialValue: {
 			type: [String, Number, Object, Array, Boolean],
 			default: null,
+		},
+		restricted: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	emits: ['update:modelValue', 'unset', 'edit-raw'],

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -1,5 +1,9 @@
 <template>
 	<v-list>
+		<v-list-item :disabled="modelValue === null" clickable @click="$emit('copy-raw')">
+			<v-list-item-icon><v-icon name="copy_outline" /></v-list-item-icon>
+			<v-list-item-content>{{ t('copy_value') }}</v-list-item-content>
+		</v-list-item>
 		<v-list-item
 			v-if="!restricted && (defaultValue === null || !isRequired)"
 			:disabled="modelValue === null"
@@ -62,7 +66,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: ['update:modelValue', 'unset', 'edit-raw'],
+	emits: ['update:modelValue', 'unset', 'edit-raw', 'copy-raw'],
 	setup(props) {
 		const { t } = useI18n();
 

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -1,18 +1,18 @@
 <template>
 	<v-list>
+		<v-list-item clickable @click="$emit('edit-raw')">
+			<v-list-item-icon><v-icon name="code" /></v-list-item-icon>
+			<v-list-item-content>{{ restricted ? t('view_raw_value') : t('edit_raw_value') }}</v-list-item-content>
+		</v-list-item>
 		<v-list-item :disabled="modelValue === null" clickable @click="$emit('copy-raw')">
 			<v-list-item-icon><v-icon name="copy_outline" /></v-list-item-icon>
-			<v-list-item-content>{{ t('copy_value') }}</v-list-item-content>
+			<v-list-item-content>{{ t('copy_raw_value') }}</v-list-item-content>
 		</v-list-item>
-		<v-list-item
-			v-if="!restricted && (defaultValue === null || !isRequired)"
-			:disabled="modelValue === null"
-			clickable
-			@click="$emit('update:modelValue', null)"
-		>
-			<v-list-item-icon><v-icon name="delete_outline" /></v-list-item-icon>
-			<v-list-item-content>{{ t('clear_value') }}</v-list-item-content>
+		<v-list-item v-if="!restricted" clickable @click="$emit('paste-raw')">
+			<v-list-item-icon><v-icon name="paste_outline" /></v-list-item-icon>
+			<v-list-item-content>{{ t('paste_raw_value') }}</v-list-item-content>
 		</v-list-item>
+		<v-divider v-if="!restricted" />
 		<v-list-item
 			v-if="!restricted && defaultValue !== null"
 			:disabled="modelValue === defaultValue"
@@ -35,9 +35,14 @@
 			</v-list-item-icon>
 			<v-list-item-content>{{ t('undo_changes') }}</v-list-item-content>
 		</v-list-item>
-		<v-list-item clickable @click="$emit('edit-raw')">
-			<v-list-item-icon><v-icon name="code" /></v-list-item-icon>
-			<v-list-item-content>{{ t('raw_value') }}</v-list-item-content>
+		<v-list-item
+			v-if="!restricted && (defaultValue === null || !isRequired)"
+			:disabled="modelValue === null"
+			clickable
+			@click="$emit('update:modelValue', null)"
+		>
+			<v-list-item-icon><v-icon name="delete_outline" /></v-list-item-icon>
+			<v-list-item-content>{{ t('clear_value') }}</v-list-item-content>
 		</v-list-item>
 	</v-list>
 </template>
@@ -66,7 +71,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: ['update:modelValue', 'unset', 'edit-raw', 'copy-raw'],
+	emits: ['update:modelValue', 'unset', 'edit-raw', 'copy-raw', 'paste-raw'],
 	setup(props) {
 		const { t } = useI18n();
 

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -24,6 +24,7 @@
 				@update:model-value="emitValue($event)"
 				@unset="$emit('unset', $event)"
 				@edit-raw="showRaw = true"
+				@copy-raw="copyRaw"
 			/>
 		</v-menu>
 		<div v-else-if="['full', 'fill'].includes(field.meta && field.meta.width) === false" class="label-spacer" />
@@ -146,7 +147,7 @@ export default defineComponent({
 			return props.modelValue !== undefined && isEqual(props.modelValue, props.initialValue) === false;
 		});
 
-		const { showRaw, rawValue } = useRaw();
+		const { showRaw, rawValue, copyRaw } = useRaw();
 
 		const validationMessage = computed(() => {
 			if (!props.validationError) return null;
@@ -158,7 +159,7 @@ export default defineComponent({
 			}
 		});
 
-		return { t, isDisabled, internalValue, emitValue, showRaw, rawValue, validationMessage, isEdited };
+		return { t, isDisabled, internalValue, emitValue, showRaw, rawValue, copyRaw, validationMessage, isEdited };
 
 		function emitValue(value: any) {
 			if (
@@ -212,7 +213,11 @@ export default defineComponent({
 				},
 			});
 
-			return { showRaw, rawValue };
+			async function copyRaw() {
+				await navigator?.clipboard?.writeText(rawValue.value);
+			}
+
+			return { showRaw, rawValue, copyRaw };
 		}
 	},
 });

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -43,7 +43,7 @@
 
 		<v-dialog v-model="showRaw" @esc="showRaw = false">
 			<v-card>
-				<v-card-title>{{ t('edit_raw_value') }}</v-card-title>
+				<v-card-title>{{ isDisabled ? t('view_raw_value') : t('edit_raw_value') }}</v-card-title>
 				<v-card-text>
 					<v-textarea v-model="rawValue" :disabled="isDisabled" class="raw-value" :placeholder="t('enter_raw_value')" />
 				</v-card-text>

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -1,12 +1,11 @@
 <template>
 	<div :key="field.field" class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
-		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow :disabled="isDisabled">
+		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow>
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"
 					:toggle="toggle"
 					:active="active"
-					:disabled="isDisabled"
 					:batch-mode="batchMode"
 					:batch-active="batchActive"
 					:edited="isEdited"
@@ -21,6 +20,7 @@
 				:field="field"
 				:model-value="internalValue"
 				:initial-value="initialValue"
+				:restricted="isDisabled"
 				@update:model-value="emitValue($event)"
 				@unset="$emit('unset', $event)"
 				@edit-raw="showRaw = true"
@@ -44,7 +44,7 @@
 			<v-card>
 				<v-card-title>{{ t('edit_raw_value') }}</v-card-title>
 				<v-card-text>
-					<v-textarea v-model="rawValue" class="raw-value" :placeholder="t('enter_raw_value')" />
+					<v-textarea v-model="rawValue" :disabled="isDisabled" class="raw-value" :placeholder="t('enter_raw_value')" />
 				</v-card-text>
 				<v-card-actions>
 					<v-button @click="showRaw = false">{{ t('done') }}</v-button>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -289,14 +289,19 @@ foreign_key: Foreign Key
 finish_setup: Finish Setup
 dismiss: Dismiss
 raw_value: Raw value
+copy_raw_value: Copy Raw Value
+copy_raw_value_success: Copied
+copy_raw_value_fail: Copy Failed
+paste_raw_value: Paste Raw Value
+paste_raw_value_success: Pasted
+paste_raw_value_fail: Paste Failed
 view_raw_value: View Raw Value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
-copy_value: Copy value
-clear_value: Clear value
+clear_value: Clear Value
 clear_changes: Clear Changes
-reset_to_default: Reset to default
-undo_changes: Undo changes
+reset_to_default: Reset to Default
+undo_changes: Undo Changes
 notifications: Notifications
 show_all_activity: Show All Activity
 page_not_found: Page Not Found

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -289,6 +289,7 @@ foreign_key: Foreign Key
 finish_setup: Finish Setup
 dismiss: Dismiss
 raw_value: Raw value
+view_raw_value: View Raw Value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
 copy_value: Copy value

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -291,6 +291,7 @@ dismiss: Dismiss
 raw_value: Raw value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
+copy_value: Copy value
 clear_value: Clear value
 clear_changes: Clear Changes
 reset_to_default: Reset to default

--- a/app/src/utils/notify.ts
+++ b/app/src/utils/notify.ts
@@ -1,9 +1,9 @@
 import { useNotificationsStore } from '@/stores/';
-import { NotificationRaw } from '@/types';
+import { SnackbarRaw } from '@/types';
 
 let store: any;
 
-export function notify(notification: NotificationRaw): void {
+export function notify(notification: SnackbarRaw): void {
 	if (!store) store = useNotificationsStore();
 	store.add(notification);
 }


### PR DESCRIPTION
## Changes

- Allows viewing of raw values for read-only fields (previously not possible)
- Raw value dialog box to view/edit based on fields
- Adds copy/paste options to the context menu

## Result

https://user-images.githubusercontent.com/42867097/149150743-fea06a4f-582a-41db-a9e2-5b4d56afc892.mp4

