### PR TITLE
Set minimum value for string field length to 1

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -41,6 +41,7 @@
 					<v-input
 						v-model="maxLength"
 						type="number"
+						min="1"
 						:placeholder="type !== 'string' ? t('not_available_for_type') : '255'"
 						:disabled="isExisting || type !== 'string'"
 					/>


### PR DESCRIPTION
Currently, the minimum length on a string field did not exist on field-detail-advanced-schema This caused a SQL error when it was set below 1. Now there is a minimum.

Example of error:
<img width="599" alt="Screen Shot 2022-01-11 at 9 04 26 PM" src="https://user-images.githubusercontent.com/67079013/149162363-ed31420b-ae14-4c95-b920-f8cdc85332c6.png">

<img width="509" alt="Screen Shot 2022-01-11 at 9 14 05 PM" src="https://user-images.githubusercontent.com/67079013/149162359-7a81ac56-4279-4a00-a0a0-7e08eb4ad27e.png">