### PR TITLE
Move danger styling to field-select-menu component

### DIFF
--- a/app/src/modules/settings/routes/data-model/fields/components/field-select-menu.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select-menu.vue
@@ -107,3 +107,11 @@ export default defineComponent({
 	},
 });
 </script>
+
+<style scoped>
+.v-list-item.danger {
+	--v-list-item-color: var(--danger);
+	--v-list-item-color-hover: var(--danger);
+	--v-list-item-icon-color: var(--danger);
+}
+</style>

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -500,12 +500,6 @@ export default defineComponent({
 	}
 }
 
-.v-list-item.danger {
-	--v-list-item-color: var(--danger);
-	--v-list-item-color-hover: var(--danger);
-	--v-list-item-icon-color: var(--danger);
-}
-
 .icons {
 	.v-icon + .v-icon:not(:last-child) {
 		margin-left: 8px;


### PR DESCRIPTION
## Context

The CSS style was not moved to `field-select-menu` when the context menu was moved to this component.

## Result

![chrome_fo3vqcKyV6](https://user-images.githubusercontent.com/42867097/149271557-763ac9fa-6298-49fd-aa13-e8016c3efd2e.png)

