### PR TITLE
Fixed broken auth SQL on Oracle

### DIFF
--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -273,7 +273,7 @@ export class AuthenticationService {
 			.from('directus_sessions AS s')
 			.leftJoin('directus_users AS u', 's.user', 'u.id')
 			.leftJoin('directus_shares AS d', 's.share', 'd.id')
-			.leftJoin('directus_roles AS r', () => {
+			.leftJoin('directus_roles AS r', function() {
 				this.onIn('r.id', ['u.role', 'd.role']);
 			})
 			.where('s.token', refreshToken)

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -273,7 +273,9 @@ export class AuthenticationService {
 			.from('directus_sessions AS s')
 			.leftJoin('directus_users AS u', 's.user', 'u.id')
 			.leftJoin('directus_shares AS d', 's.share', 'd.id')
-			.joinRaw('LEFT JOIN directus_roles AS r ON r.id IN (u.role, d.role)')
+			.leftJoin('directus_roles AS r', () => {
+				this.onIn('r.id', ['u.role', 'd.role']);
+			})
 			.where('s.token', refreshToken)
 			.andWhere('s.expires', '>=', new Date())
 			.andWhere((subQuery) => {

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -273,7 +273,7 @@ export class AuthenticationService {
 			.from('directus_sessions AS s')
 			.leftJoin('directus_users AS u', 's.user', 'u.id')
 			.leftJoin('directus_shares AS d', 's.share', 'd.id')
-			.leftJoin('directus_roles AS r', function() {
+			.leftJoin('directus_roles AS r', function () {
 				this.onIn('r.id', ['u.role', 'd.role']);
 			})
 			.where('s.token', refreshToken)


### PR DESCRIPTION
Stop breaking Oracle!! 😡 

Seriously though, we should add Oracle to the integration tests (I unfortunately don't have time to set it up, but I did set up knex-schema-inspector which can be used as a reference) and avoid using `raw` functions. Oracle frustratingly requires consistent quotes so this kinda thing doesn't work:

```
/* Knex join */
left join "directus_shares" "d" on "s"."share"="d"."id"
/* Raw join */
LEFT JOIN directus_roles AS r ON r.id IN (u.role, d.role)
```