### PR TITLE
Make skipping of workflows work again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,28 +45,35 @@ jobs:
                 - 'api/**/*'
                 - 'tests/**/*'
                 - 'docker-compose.yml'
-                - '.github/workflows/e2e-tests.yml'
+                - '.github/workflows/{ci,e2e-tests}.yml'
+
+  # Workflows are called in every case and need to handle the value of should_skip themselves.
+  # This is needed to pass required checks on pull requests.
 
   lint:
     name: Lint
     needs: pre_check
     uses: directus/directus/.github/workflows/lint.yml@main
-    if: needs.pre_check.should_skip != 'true'
+    with:
+      should_skip: ${{ needs.pre_check.outputs.should_skip }}
 
   codeql_analysis:
     name: CodeQL Analysis
     needs: pre_check
     uses: directus/directus/.github/workflows/codeql-analysis.yml@main
-    if: needs.pre_check.should_skip != 'true'
+    with:
+      should_skip: ${{ needs.pre_check.outputs.should_skip }}
 
   unit_tests:
     name: Unit Tests
     needs: pre_check
-    if: needs.pre_check.should_skip != 'true'
     uses: directus/directus/.github/workflows/unit-tests.yml@main
+    with:
+      should_skip: ${{ needs.pre_check.outputs.should_skip }}
 
   e2e_tests:
     name: End-to-End Tests
     needs: pre_check
     uses: directus/directus/.github/workflows/e2e-tests.yml@main
-    if: needs.pre_check.should_skip != 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip
+    with:
+      should_skip: ${{ needs.pre_check.outputs.should_skip == 'true' || fromJSON(needs.pre_check.outputs.paths_result).e2e_tests.should_skip }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,10 @@ name: CodeQL Analysis
 
 on:
   workflow_call:
+    inputs:
+      should_skip:
+        required: false
+        type: string
   schedule:
     - cron: '42 23 * * 5'
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,6 +3,10 @@ name: End-to-End Tests
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      should_skip:
+        required: false
+        type: string
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on:
   workflow_call:
+    inputs:
+      should_skip:
+        required: false
+        type: string
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,10 @@ name: Unit Tests
 
 on:
   workflow_call:
+    inputs:
+      should_skip:
+        required: false
+        type: string
 
 jobs:
   test:


### PR DESCRIPTION
Revert parts of the recent End-to-end tests refactoring (#10968).

@Oreilles Thank you very much for the refactoring! This is great! However please take care with such changes as you did in the workflow files. It took me very long to come up with this solution. I know it might look a bit ugly, but those "should_skip input definitions" are there for a reason. You could have easily checked that with a "git blame" (which would have led you to #9240). You're very welcome to ping me if there are any uncertainties. In any case, please verify your changes (you can see that workflows are no longer skipped on translation updates - for example on #11074). Thanks!

Note: Checks won't work on this pull request. Please merge anyway.