### PR TITLE
Fix collection options menu clicks

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -6,7 +6,7 @@
 			clickable
 			:class="{ hidden: collection.meta?.hidden }"
 			:to="collection.schema ? `/settings/data-model/${collection.collection}` : undefined"
-			@click="!collection.schema ? $emit('editCollection', collection) : null"
+			@click.self="!collection.schema ? $emit('editCollection', collection) : null"
 		>
 			<v-list-item-icon>
 				<v-icon v-if="!disableDrag" class="drag-handle" name="drag_handle" />
@@ -185,6 +185,7 @@ export default defineComponent({
 	align-items: center;
 	height: 100%;
 	font-family: var(--family-monospace);
+	pointer-events: none;
 }
 
 .collection-icon {

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -1,8 +1,8 @@
 <template>
 	<div v-if="collection.collection.startsWith('directus_') === false">
 		<v-menu placement="left-start" show-arrow>
-			<template #activator="{ toggle, deactivate }">
-				<v-icon name="more_vert" clickable class="ctx-toggle" @click.stop.prevent="toggle" @focusout="deactivate" />
+			<template #activator="{ toggle }">
+				<v-icon name="more_vert" clickable class="ctx-toggle" @click.prevent="toggle" />
 			</template>
 			<v-list>
 				<v-list-item clickable class="danger" @click="deleteActive = true">


### PR DESCRIPTION
Resolves #11082

## Context

One way to reliably reproduce it is by _holding_ the click, and see that the menu closes without it registering click on the options. But it still works if we click as usual rather than hold:

![1AvvQiZpDF](https://user-images.githubusercontent.com/42867097/149704662-4504ad3b-9d36-4319-aa35-69d118c33630.gif)

Hence probably why it wasn't reported earlier. 

## Changes

- Removed `@focusout` as it turn out to be unreliable in practice. That said, we'd also have to remove the `.stop` modifier for `@click` so that it will properly close the current menu when we are opening another collection's options menu.

- Doing the above change will also make the click event for Folders to occur, so we need to add `.self` modifier to the parent, and add `pointer-events: none` to the collection name for the click to go through:

    Issue if we don't add `.self`:
    
    ![c0IQGubGQk](https://user-images.githubusercontent.com/42867097/149704865-b0b3e13c-c9f5-4eeb-812b-d27ddb3348f3.gif)

## Result

https://user-images.githubusercontent.com/42867097/149704734-ee9ce3ff-a050-4703-a75b-1907c2e1c9a8.mp4

 