### PR TITLE
break word for code tags in custom blocks

### DIFF
--- a/docs/.vuepress/theme/styles/custom-blocks.styl
+++ b/docs/.vuepress/theme/styles/custom-blocks.styl
@@ -10,6 +10,8 @@
     border-left-width 2px
     border-left-style solid
     margin 2rem 0
+    code
+      word-wrap break-word
   &.tip
     background-color var(--background-subdued)
     border-color var(--primary)


### PR DESCRIPTION
Prevents long code tags in custom blocks from overflowing the whole page:

![QkBp8vWref](https://user-images.githubusercontent.com/42867097/149709191-4e5adb86-98b5-498e-8915-3b3a1054bb14.gif)

