### PR TITLE
Fix missing/removed translations 

### DIFF
--- a/app/src/lang/translations/af-ZA.yaml
+++ b/app/src/lang/translations/af-ZA.yaml
@@ -46,6 +46,7 @@ create_field: Skep Veld
 auto_generate: Auto-Genereer
 add_note: Voeg 'n nuttige nota vir gebruikers...
 default_value: Standaard Waarde
+clear_value: Vee waarde uit
 title: Titel
 checksum: Kontrolesom
 owner: Eienaar

--- a/app/src/lang/translations/ar-SA.yaml
+++ b/app/src/lang/translations/ar-SA.yaml
@@ -274,7 +274,10 @@ dismiss: تجاهل
 raw_value: قيمة خام
 edit_raw_value: تعديل القيمة الخام
 enter_raw_value: أدخل قيمة سطر...
+clear_value: إزالة القيمة
 clear_changes: مسح التغييرات
+reset_to_default: إعادة تعيين إلى الافتراضي
+undo_changes: التراجع عن التغييرات
 notifications: إشعارات
 show_all_activity: أظهر كل النشاط
 page_not_found: الصفحة غير موجودة

--- a/app/src/lang/translations/bg-BG.yaml
+++ b/app/src/lang/translations/bg-BG.yaml
@@ -1032,7 +1032,7 @@ field_options:
     auth_password_policy:
       none_text: Няма - не се препоръчва
       weak_text: Слаба - минимум от 8 символа
-      strong_text: Силна - главни, малки, числа и специални символи 
+      strong_text: Силна - главни, малки, числа и специални символи
     storage_asset_presets:
       fit_label: Напасване
       upscaling: Уголемяване

--- a/app/src/lang/translations/br-FR.yaml
+++ b/app/src/lang/translations/br-FR.yaml
@@ -202,6 +202,9 @@ dismiss: Lezel hebiou
 raw_value: Talvoud krai
 edit_raw_value: Kemm an talvoud krai
 enter_raw_value: Bizskrivit un talvoud krai...
+clear_value: Dilemel an talvoud
+reset_to_default: Restaoler an arventennoù dre ziouer
+undo_changes: Dizober ar c'hemmoù
 notifications: Kemennadennoù
 show_all_activity: Diskwel an oberezh a-bezh
 page_not_found: N'eo ket bet kavet ar bajenn

--- a/app/src/lang/translations/ca-ES.yaml
+++ b/app/src/lang/translations/ca-ES.yaml
@@ -213,6 +213,9 @@ dismiss: Descarta
 raw_value: Valor en brut
 edit_raw_value: Edita valor en brut
 enter_raw_value: Introdueix valor en brut...
+clear_value: Esborra el valor
+reset_to_default: Restableix valors predeterminats
+undo_changes: Desfer els canvis
 notifications: Notificacions
 show_all_activity: Mostra tota l'activitat
 page_not_found: Pàgina no trobada

--- a/app/src/lang/translations/cs-CZ.yaml
+++ b/app/src/lang/translations/cs-CZ.yaml
@@ -182,6 +182,9 @@ length: Délka
 readonly: Pouze pro čtení
 unique: Unikátní
 primary_key: Primární klíč
+clear_value: Vymazat hodnotu
+reset_to_default: Obnovit výchozí nastavení
+undo_changes: Vrátit změny
 notifications: Notifikace
 page_not_found: Stránka nenalezena
 page_not_found_body: Hledaná stránka nebyla nalezena.

--- a/app/src/lang/translations/da-DK.yaml
+++ b/app/src/lang/translations/da-DK.yaml
@@ -249,7 +249,10 @@ dismiss: Afvis
 raw_value: Rå værdi
 edit_raw_value: Rediger Rå Værdi
 enter_raw_value: Indtast rå værdi...
+clear_value: Nulstil værdi
 clear_changes: Ryd Ændringer
+reset_to_default: Nulstil til standard
+undo_changes: Fortryd ændringer
 notifications: Notifikationer
 show_all_activity: Vis al aktivitet
 page_not_found: Siden blev ikke fundet

--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -285,7 +285,10 @@ dismiss: Verwerfen
 raw_value: Rohwert
 edit_raw_value: Rohwert bearbeiten
 enter_raw_value: Rohwert eingeben...
+clear_value: Wert löschen
 clear_changes: Änderungen löschen
+reset_to_default: Auf Standard zurücksetzen
+undo_changes: Änderungen verwerfen
 notifications: Benachrichtigungen
 show_all_activity: Alle Aktivitäten anzeigen
 page_not_found: Seite nicht gefunden

--- a/app/src/lang/translations/el-GR.yaml
+++ b/app/src/lang/translations/el-GR.yaml
@@ -85,6 +85,7 @@ next: Επόμενο
 note: Σημείωση
 length: Μήκος
 unique: Μοναδικό
+clear_value: Εκκαθάριση αξίας
 title: Τίτλος
 leave_comment: Άφηστε ένα σχόλιο...
 submit: Υποβολή

--- a/app/src/lang/translations/en-CA.yaml
+++ b/app/src/lang/translations/en-CA.yaml
@@ -285,7 +285,10 @@ dismiss: Dismiss
 raw_value: Raw value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
+clear_value: Clear value
 clear_changes: Clear Changes
+reset_to_default: Reset to default
+undo_changes: Undo changes
 notifications: Notifications
 show_all_activity: Show All Activity
 page_not_found: Page Not Found
@@ -1228,6 +1231,7 @@ translation: Translation
 translation_placeholder: Enter a translation...
 value: Value
 view_project: View Project
+weeks: { }
 report_error: Report Error
 start: Start
 interfaces:

--- a/app/src/lang/translations/en-CA.yaml
+++ b/app/src/lang/translations/en-CA.yaml
@@ -283,12 +283,19 @@ foreign_key: Foreign Key
 finish_setup: Finish Setup
 dismiss: Dismiss
 raw_value: Raw value
+copy_raw_value: Copy Raw Value
+copy_raw_value_success: Copied
+copy_raw_value_fail: Copy Failed
+paste_raw_value: Paste Raw Value
+paste_raw_value_success: Pasted
+paste_raw_value_fail: Paste Failed
+view_raw_value: View Raw Value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
 clear_value: Clear value
 clear_changes: Clear Changes
-reset_to_default: Reset to default
-undo_changes: Undo changes
+reset_to_default: Reset to Default
+undo_changes: Undo Changes
 notifications: Notifications
 show_all_activity: Show All Activity
 page_not_found: Page Not Found

--- a/app/src/lang/translations/en-GB.yaml
+++ b/app/src/lang/translations/en-GB.yaml
@@ -284,7 +284,10 @@ dismiss: Dismiss
 raw_value: Raw value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
+clear_value: Clear value
 clear_changes: Clear Changes
+reset_to_default: Reset to default
+undo_changes: Undo changes
 notifications: Notifications
 show_all_activity: Show All Activity
 page_not_found: Page Not Found

--- a/app/src/lang/translations/en-GB.yaml
+++ b/app/src/lang/translations/en-GB.yaml
@@ -282,12 +282,19 @@ foreign_key: Foreign Key
 finish_setup: Finish Setup
 dismiss: Dismiss
 raw_value: Raw value
+copy_raw_value: Copy Raw Value
+copy_raw_value_success: Copied
+copy_raw_value_fail: Copy Failed
+paste_raw_value: Paste Raw Value
+paste_raw_value_success: Pasted
+paste_raw_value_fail: Paste Failed
+view_raw_value: View Raw Value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
-clear_value: Clear value
+clear_value: Clear Value
 clear_changes: Clear Changes
-reset_to_default: Reset to default
-undo_changes: Undo changes
+reset_to_default: Reset to Default
+undo_changes: Undo Changes
 notifications: Notifications
 show_all_activity: Show All Activity
 page_not_found: Page Not Found

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -289,12 +289,19 @@ foreign_key: Foreign Key
 finish_setup: Finish Setup
 dismiss: Dismiss
 raw_value: Raw value
+copy_raw_value: Copy Raw Value
+copy_raw_value_success: Copied
+copy_raw_value_fail: Copy Failed
+paste_raw_value: Paste Raw Value
+paste_raw_value_success: Pasted
+paste_raw_value_fail: Paste Failed
+view_raw_value: View Raw Value
 edit_raw_value: Edit Raw Value
 enter_raw_value: Enter raw value...
-clear_value: Clear value
+clear_value: Clear Value
 clear_changes: Clear Changes
-reset_to_default: Reset to default
-undo_changes: Undo changes
+reset_to_default: Reset to Default
+undo_changes: Undo Changes
 notifications: Notifications
 show_all_activity: Show All Activity
 page_not_found: Page Not Found

--- a/app/src/lang/translations/es-419.yaml
+++ b/app/src/lang/translations/es-419.yaml
@@ -285,7 +285,10 @@ dismiss: Ignorar
 raw_value: Valor sin interpretar
 edit_raw_value: Editar Valor Plano
 enter_raw_value: Ingresar valor plano...
+clear_value: Limpiar valor
 clear_changes: Borrar_Cambios
+reset_to_default: Restablecer ajustes por defecto
+undo_changes: Deshacer cambios
 notifications: Notificaciones
 show_all_activity: Mostrar Toda La Actividad
 page_not_found: Página no encontrada

--- a/app/src/lang/translations/es-CL.yaml
+++ b/app/src/lang/translations/es-CL.yaml
@@ -282,7 +282,10 @@ dismiss: Cerrar
 raw_value: Valor Plano
 edit_raw_value: Editar Valor Plano
 enter_raw_value: Ingresar valor plano...
+clear_value: Limpiar valor
 clear_changes: Borrar Cambios
+reset_to_default: Restablecen a los predeterminados
+undo_changes: Deshacer cambios
 notifications: Notificaciones
 show_all_activity: Presentar toda la actividad
 page_not_found: Página no encontrada

--- a/app/src/lang/translations/es-ES.yaml
+++ b/app/src/lang/translations/es-ES.yaml
@@ -282,7 +282,10 @@ dismiss: Cerrar
 raw_value: Valor Plano
 edit_raw_value: Editar Valor Plano
 enter_raw_value: Ingresar valor plano...
+clear_value: Limpiar valor
 clear_changes: Borrar Cambios
+reset_to_default: Restablecer ajustes
+undo_changes: Deshacer cambios
 notifications: Notificaciones
 show_all_activity: Presentar toda la actividad
 page_not_found: Página No Encontrada

--- a/app/src/lang/translations/et-EE.yaml
+++ b/app/src/lang/translations/et-EE.yaml
@@ -221,6 +221,9 @@ dismiss: Loobu
 raw_value: Algne väärtus
 edit_raw_value: Muuda algväärtust
 enter_raw_value: Sisesta väärtus...
+clear_value: Tühjenda väärtus
+reset_to_default: Taasta vaikeväärtused
+undo_changes: Tühista muudatused
 notifications: Teavitused
 show_all_activity: Näita kogu aktiivsust
 page_not_found: Lehekülge ei leitud

--- a/app/src/lang/translations/fa-IR.yaml
+++ b/app/src/lang/translations/fa-IR.yaml
@@ -217,6 +217,9 @@ dismiss: نادیده گرفتن
 raw_value: مقدار خام
 edit_raw_value: ویرایش مقدار
 enter_raw_value: یک مقدار وارد کنید...
+clear_value: مقدار روشن است
+reset_to_default: بازگردانی به حالت پیش فرض
+undo_changes: برگرداندن تغییرات به حالت قبل
 notifications: اعلانات
 show_all_activity: نمایش فعالیت های اخیر
 page_not_found: برگه یافت نشد

--- a/app/src/lang/translations/fi-FI.yaml
+++ b/app/src/lang/translations/fi-FI.yaml
@@ -280,7 +280,10 @@ dismiss: Hylkää
 raw_value: Raaka-arvo
 edit_raw_value: Muokkaa raaka-arvoa
 enter_raw_value: Syötä raakaarvo...
+clear_value: Tyhjennä
 clear_changes: Tyhjennä muutokset
+reset_to_default: Palauta oletukseksi
+undo_changes: Peru muutokset
 notifications: Ilmoitukset
 show_all_activity: Näytä kaikki toiminta
 page_not_found: Sivua ei löydy

--- a/app/src/lang/translations/fr-CA.yaml
+++ b/app/src/lang/translations/fr-CA.yaml
@@ -1231,6 +1231,7 @@ translation: Traduction
 translation_placeholder: Entrez une nouvelle traduction...
 value: Valeur
 view_project: Voir le projet
+weeks: { }
 report_error: Signaler l'erreur
 start: Début
 interfaces:

--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -1505,7 +1505,7 @@ interfaces:
     name: Regroupement
     description: Rendre les champs comme une section pliable
     show_header: En-tête de groupe
-    header_icon: Icônes de l'en-tête 
+    header_icon: Icônes de l'en-tête
     header_color: Couleur d'en-tête
     start_open: Ouvert par défaut
     start_closed: Fermé par défaut

--- a/app/src/lang/translations/hu-HU.yaml
+++ b/app/src/lang/translations/hu-HU.yaml
@@ -242,7 +242,10 @@ dismiss: Elutasít
 raw_value: Nyers érték
 edit_raw_value: Nyers érték szerkesztése
 enter_raw_value: Nyers érték megadása...
+clear_value: Érték törlése
 clear_changes: Változások törlése
+reset_to_default: Visszaállítás alaphelyzetbe
+undo_changes: Változások visszavonása
 notifications: Értesítések
 show_all_activity: Összes tevékenység mutatása
 page_not_found: Az oldal nem található

--- a/app/src/lang/translations/id-ID.yaml
+++ b/app/src/lang/translations/id-ID.yaml
@@ -278,6 +278,9 @@ dismiss: Abaikan
 raw_value: Nilai mentah
 edit_raw_value: Sunting Nilai Mentah
 enter_raw_value: Masukkan nilai mentah...
+clear_value: Bersihkan nilai
+reset_to_default: Kembalikan ke default
+undo_changes: Batalkan Perubahan
 notifications: Notifikasi
 show_all_activity: Tampilkan Semua Aktivitas
 page_not_found: Halaman Tidak Ditemukan

--- a/app/src/lang/translations/ja-JP.yaml
+++ b/app/src/lang/translations/ja-JP.yaml
@@ -101,6 +101,9 @@ updated_on: 更新日時
 updated_by: 最後に更新したユーザー
 primary_key: プライマリーキー
 raw_value: 値を加工しない
+clear_value: 値の削除
+reset_to_default: 初期化
+undo_changes: 変更を元に戻す
 notifications: 通知
 page_not_found: ページが見つかりませんでした
 page_not_found_body: お探しのページは存在しません。

--- a/app/src/lang/translations/ka-GE.yaml
+++ b/app/src/lang/translations/ka-GE.yaml
@@ -3,6 +3,7 @@ avatar: პროფილის ფოტო
 create_role: შექმენით როლი
 create_field: შექმენით ველი
 auto_generate: ავტო-გენერირება
+clear_value: მნიშვნელობის გასუფთავება
 title: სათაური
 owner: მფლობელი
 comments: კომენტარები

--- a/app/src/lang/translations/lt-LT.yaml
+++ b/app/src/lang/translations/lt-LT.yaml
@@ -202,6 +202,9 @@ dismiss: Atmesti
 raw_value: Neapdorota reikšmė
 edit_raw_value: Redaguoti neapdorotą reikšmę
 enter_raw_value: Įvesti neapdorotą reikšmę...
+clear_value: Išvalyti reikšmę
+reset_to_default: Atstatyti numatytuosius
+undo_changes: Anuliuoti pakeitimus
 notifications: Pranešimai
 show_all_activity: Rodyti visą veiklos istoriją
 page_not_found: Puslapis nerastas

--- a/app/src/lang/translations/ms-MY.yaml
+++ b/app/src/lang/translations/ms-MY.yaml
@@ -60,6 +60,7 @@ length: Panjang
 readonly: Baca Sahaja
 unique: Unik
 primary_key: Kunci Utama
+clear_value: Kosongkan nilai
 page_not_found: Halaman Tidak Dijumpai
 page_not_found_body: Halaman yang anda cari tidak wujud
 title: Tajuk

--- a/app/src/lang/translations/nl-NL.yaml
+++ b/app/src/lang/translations/nl-NL.yaml
@@ -207,6 +207,9 @@ dismiss: Negeren
 raw_value: Ruwe waarde
 edit_raw_value: Bewerk Ruwe Waarde
 enter_raw_value: Ruwe waarde invoeren...
+clear_value: Verwijder waarde
+reset_to_default: Terug naar standaardwaarde
+undo_changes: Ongedaan maken
 notifications: Notificaties
 show_all_activity: Alle activiteiten tonen
 page_not_found: Pagina niet gevonden

--- a/app/src/lang/translations/no-NO.yaml
+++ b/app/src/lang/translations/no-NO.yaml
@@ -258,6 +258,9 @@ dismiss: Lukk
 raw_value: Rå verdi
 edit_raw_value: Rediger råverdi
 enter_raw_value: Legg inn råverdi...
+clear_value: Tøm innhold
+reset_to_default: Tilbakestill til standard
+undo_changes: Angre endringer
 notifications: Varsler
 show_all_activity: Vis all aktivitet
 page_not_found: Side ikke funnet

--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -276,7 +276,10 @@ dismiss: Dispensar
 raw_value: Valor bruto
 edit_raw_value: Editar valor bruto
 enter_raw_value: Insira valor bruto...
+clear_value: Limpar valor
 clear_changes: Limpar alterações
+reset_to_default: Redefinir para o padrão
+undo_changes: Desfazer alterações
 notifications: Notificações
 show_all_activity: Mostrar todas as atividades
 page_not_found: Página não encontrada

--- a/app/src/lang/translations/pt-PT.yaml
+++ b/app/src/lang/translations/pt-PT.yaml
@@ -206,6 +206,9 @@ dismiss: Dispensar
 raw_value: Valor bruto
 edit_raw_value: Editar Valor Bruto
 enter_raw_value: Insira valor bruto...
+clear_value: Limpar valor
+reset_to_default: Restaurar predefinições
+undo_changes: Anular alterações
 notifications: Notificações
 show_all_activity: Mostrar todas as atividades
 page_not_found: Página Não Encontrada

--- a/app/src/lang/translations/ro-RO.yaml
+++ b/app/src/lang/translations/ro-RO.yaml
@@ -113,6 +113,7 @@ create_field: Creează Câmp
 auto_generate: Generare automată
 add_note: Adaugă o notă ajutătoare pentru utilizatori...
 default_value: Valoare implicită
+clear_value: Șterge valoarea
 title: Titlu
 checksum: Sumă de control
 owner: Proprietar

--- a/app/src/lang/translations/ru-RU.yaml
+++ b/app/src/lang/translations/ru-RU.yaml
@@ -280,7 +280,10 @@ dismiss: Скрыть
 raw_value: Сырое значение
 edit_raw_value: Редактировать Сырое Значение
 enter_raw_value: Введите сырое значение...
+clear_value: Очистить значение
 clear_changes: Сбросить изменения
+reset_to_default: Вернуться к настройкам по умолчанию
+undo_changes: Отменить изменения
 notifications: Уведомления
 show_all_activity: Показать Всю Активность
 page_not_found: Страница не найдена

--- a/app/src/lang/translations/sl-SI.yaml
+++ b/app/src/lang/translations/sl-SI.yaml
@@ -214,6 +214,9 @@ dismiss: Opusti
 raw_value: Vnešena vrednost
 edit_raw_value: Uredi vrednost
 enter_raw_value: Vnesite vrednost ...
+clear_value: Počisti vrednost
+reset_to_default: Ponastavi na privzeto
+undo_changes: Razveljavi spremembe
 notifications: Obvestila
 show_all_activity: Pokaži vse dejavnosti
 page_not_found: Strani ni mogoče najti

--- a/app/src/lang/translations/sr-CS.yaml
+++ b/app/src/lang/translations/sr-CS.yaml
@@ -197,6 +197,9 @@ dismiss: Ignoriši
 raw_value: Vrijednost
 edit_raw_value: Izmijeni Vrijednost
 enter_raw_value: Unesi vrijednost...
+clear_value: Obriši vrijednost
+reset_to_default: Vrati na podrazumijevano
+undo_changes: Poništi izmjene
 notifications: Obavještenja
 show_all_activity: Prikaži svu aktivnost
 page_not_found: Stranica nijе pronađеna

--- a/app/src/lang/translations/sr-SP.yaml
+++ b/app/src/lang/translations/sr-SP.yaml
@@ -36,6 +36,7 @@ text: Текст
 auto_generate: Аутоматски генериши
 add_note: Додај помоћну напомену за кориснике...
 default_value: Подразумевана вредност
+clear_value: Обриши вредност
 title: Наслов
 leave_comment: Оставите коментар...
 months:

--- a/app/src/lang/translations/sv-SE.yaml
+++ b/app/src/lang/translations/sv-SE.yaml
@@ -278,7 +278,10 @@ dismiss: Avfärda
 raw_value: Obearbetat värde
 edit_raw_value: Redigera obearbetat värde
 enter_raw_value: Ange obearbetat värde...
+clear_value: Rensa fält
 clear_changes: Rensa ändringar
+reset_to_default: Återställ till förval
+undo_changes: Ångra ändringar
 notifications: Aviseringar
 show_all_activity: Visa all aktivitet
 page_not_found: Sidan hittades inte

--- a/app/src/lang/translations/th-TH.yaml
+++ b/app/src/lang/translations/th-TH.yaml
@@ -247,6 +247,9 @@ dismiss: ปิด
 raw_value: ข้อมูลดิบ
 edit_raw_value: แก้ไขข้อมูลดิบ
 enter_raw_value: กรุณาใส่ข้อมูลดิบ
+clear_value: ล้างค่า
+reset_to_default: คืนค่าเริ่มต้น
+undo_changes: ยกเลิกการเปลี่ยนแปลง
 notifications: การแจ้งเตือน
 show_all_activity: แสดงทุกกิจกรรม
 page_not_found: ไม่พบหน้านี้

--- a/app/src/lang/translations/uk-UA.yaml
+++ b/app/src/lang/translations/uk-UA.yaml
@@ -276,7 +276,10 @@ dismiss: Відмінити
 raw_value: Необроблене значення
 edit_raw_value: Змінити необроблене значення
 enter_raw_value: Введіть необроблене значення...
+clear_value: Очистити значення
 clear_changes: Очистити зміни
+reset_to_default: Відновити налаштування за умовчанням
+undo_changes: Відмінити зміни
 notifications: Сповіщення
 show_all_activity: Показати всю активність
 page_not_found: Сторінку не знайдено

--- a/app/src/lang/translations/vi-VN.yaml
+++ b/app/src/lang/translations/vi-VN.yaml
@@ -242,7 +242,10 @@ dismiss: Bỏ qua
 raw_value: Dữ liệu thực tế
 edit_raw_value: Thay đổi dữ liệu thực tế
 enter_raw_value: Nhập vào giá trị thực tế...
+clear_value: Xoá giá trị
 clear_changes: Xoá thay đổi
+reset_to_default: Khôi phục về mặc định
+undo_changes: Phục hồi các thay đổi
 notifications: Thông báo
 show_all_activity: Hiển Thị Tất Cả Hoạt Động
 page_not_found: Không tìm thấy trang này

--- a/app/src/lang/translations/zh-CN.yaml
+++ b/app/src/lang/translations/zh-CN.yaml
@@ -247,7 +247,10 @@ dismiss: 关闭
 raw_value: 原始值
 edit_raw_value: 编辑原始值
 enter_raw_value: 输入原始值...
+clear_value: 清除
 clear_changes: 清除更改
+reset_to_default: 重置为默认值
+undo_changes: 撤销更改
 notifications: 通知
 show_all_activity: 显示所有活动
 page_not_found: 找不到页面

--- a/app/src/lang/translations/zh-TW.yaml
+++ b/app/src/lang/translations/zh-TW.yaml
@@ -197,7 +197,10 @@ dismiss: 忽略
 raw_value: 原始值
 edit_raw_value: 編輯原始值
 enter_raw_value: 輸入原始值...
+clear_value: 清除內容
 clear_changes: 清除更改
+reset_to_default: 重設為預設值
+undo_changes: 還原變更
 notifications: 通知
 show_all_activity: 顯示所有活動
 page_not_found: 無法找到網頁


### PR DESCRIPTION
Ref https://github.com/directus/directus/pull/10995#discussion_r783635913

#10995 seems to have removed many keys mistakenly, including ones added in #10992. This PR reverts _mostly_ the changes there such as adding back `clear_value`, `reset_to_default` and `undo_changes`, but retains the changes to `es-419`.