### PR TITLE
Remove extensions-sdk and axios from the list of shared deps

### DIFF
--- a/packages/shared/src/constants/extensions.ts
+++ b/packages/shared/src/constants/extensions.ts
@@ -1,5 +1,5 @@
 export const APP_SHARED_DEPS = ['@directus/extensions-sdk', 'vue', 'vue-router', 'vue-i18n', 'pinia'];
-export const API_SHARED_DEPS = ['@directus/extensions-sdk', 'axios'];
+export const API_SHARED_DEPS = ['directus'];
 
 export const APP_EXTENSION_TYPES = ['interface', 'display', 'layout', 'module', 'panel'] as const;
 export const API_EXTENSION_TYPES = ['hook', 'endpoint'] as const;


### PR DESCRIPTION
This ensures that extensions work with an out-of-root extensions folder.
Instead of leaving the list of API shared deps empty, this adds `directus` as the only shared dep because it is never a good idea to bundle the Directus API into an extension.