### PR TITLE
Always inline dynamic imports when bundling extensions

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -186,12 +186,14 @@ function getRollupOutputOptions(type: ExtensionType, output: string, options: Bu
 		return {
 			file: output,
 			format: 'es',
+			inlineDynamicImports: true,
 		};
 	} else {
 		return {
 			file: output,
 			format: 'cjs',
 			exports: 'default',
+			inlineDynamicImports: true,
 			sourcemap: options.sourceMaps,
 		};
 	}


### PR DESCRIPTION
This ensures that the Extensions SDK always generates a single `index.js`.