### PR TITLE
Rename sourceMaps flag to sourcemap to align with other tools and add no-minify flag to the extensions-sdk CLI

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -33,7 +33,7 @@ type BuildOptions = {
 	language: string;
 	force: boolean;
 	watch: boolean;
-	sourceMaps: boolean;
+	sourcemap: boolean;
 };
 
 export default async function build(options: BuildOptions): Promise<void> {
@@ -148,7 +148,7 @@ function getRollupOptions(
 				styles(),
 				...plugins,
 				nodeResolve({ browser: true }),
-				commonjs({ esmExternals: true, sourceMap: false }),
+				commonjs({ esmExternals: true, sourceMap: options.sourcemap }),
 				json(),
 				replace({
 					values: {
@@ -156,7 +156,7 @@ function getRollupOptions(
 					},
 					preventAssignment: true,
 				}),
-				options.sourceMaps ? null : terser(),
+				terser(),
 			],
 		};
 	} else {
@@ -167,7 +167,7 @@ function getRollupOptions(
 				language === 'typescript' ? typescript({ check: false }) : null,
 				...plugins,
 				nodeResolve(),
-				commonjs({ sourceMap: false }),
+				commonjs({ sourceMap: options.sourcemap }),
 				json(),
 				replace({
 					values: {
@@ -175,7 +175,7 @@ function getRollupOptions(
 					},
 					preventAssignment: true,
 				}),
-				options.sourceMaps ? null : terser(),
+				terser(),
 			],
 		};
 	}
@@ -187,6 +187,7 @@ function getRollupOutputOptions(type: ExtensionType, output: string, options: Bu
 			file: output,
 			format: 'es',
 			inlineDynamicImports: true,
+			sourcemap: options.sourcemap,
 		};
 	} else {
 		return {
@@ -194,7 +195,7 @@ function getRollupOutputOptions(type: ExtensionType, output: string, options: Bu
 			format: 'cjs',
 			exports: 'default',
 			inlineDynamicImports: true,
-			sourcemap: options.sourceMaps,
+			sourcemap: options.sourcemap,
 		};
 	}
 }

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -33,6 +33,7 @@ type BuildOptions = {
 	language: string;
 	force: boolean;
 	watch: boolean;
+	minify: boolean;
 	sourcemap: boolean;
 };
 
@@ -156,7 +157,7 @@ function getRollupOptions(
 					},
 					preventAssignment: true,
 				}),
-				terser(),
+				options.minify ? terser() : null,
 			],
 		};
 	} else {
@@ -175,7 +176,7 @@ function getRollupOptions(
 					},
 					preventAssignment: true,
 				}),
-				terser(),
+				options.minify ? terser() : null,
 			],
 		};
 	}

--- a/packages/extensions-sdk/src/cli/run.ts
+++ b/packages/extensions-sdk/src/cli/run.ts
@@ -25,7 +25,7 @@ program
 	.option('-l, --language <language>', 'overwrite the language to use')
 	.option('-f, --force', 'ignore the package manifest')
 	.option('-w, --watch', 'watch and rebuild on changes')
-	.option('-m --sourceMaps', 'include source maps in output')
+	.option('--sourcemap', 'include source maps in output')
 	.action(build);
 
 program.parse(process.argv);

--- a/packages/extensions-sdk/src/cli/run.ts
+++ b/packages/extensions-sdk/src/cli/run.ts
@@ -25,6 +25,7 @@ program
 	.option('-l, --language <language>', 'overwrite the language to use')
 	.option('-f, --force', 'ignore the package manifest')
 	.option('-w, --watch', 'watch and rebuild on changes')
+	.option('--no-minify', 'disable minification')
 	.option('--sourcemap', 'include source maps in output')
 	.action(build);
 


### PR DESCRIPTION
Technically this is a _BREAKING CHANGE_, but I doubt the flag is often used and I think it's worth it to align with tools like rollup and vite.