### PR TITLE
Docs: Add link to system templates

### DIFF
--- a/docs/extensions/email-templates.md
+++ b/docs/extensions/email-templates.md
@@ -12,7 +12,7 @@ Custom email templates are stored in the `templates` folder in your extensions f
 /extensions/templates/<template-name>.liquid
 ```
 
-To replace a system template with your own, simply name it `password-reset` or `user-invitation` for the password reset
+To replace a [system template](https://github.com/directus/directus/tree/main/api/src/services/mail/templates) with your own, simply name it `password-reset` or `user-invitation` for the password reset
 or user invite emails respectively.
 
 ::: tip Variables


### PR DESCRIPTION
Only adds a link to the system templates in the documentation of the email templates.
This makes it easier for developers to replace and modify the system templates without the need to search for the original ones by themselves.
