### PR TITLE
Fix auth refresh issue

### DIFF
--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -273,8 +273,8 @@ export class AuthenticationService {
 			.from('directus_sessions AS s')
 			.leftJoin('directus_users AS u', 's.user', 'u.id')
 			.leftJoin('directus_shares AS d', 's.share', 'd.id')
-			.leftJoin('directus_roles AS r', function () {
-				this.onIn('r.id', ['u.role', 'd.role']);
+			.leftJoin('directus_roles AS r', (join) => {
+				join.onIn('r.id', [this.knex.ref('u.role'), this.knex.ref('d.role')]);
 			})
 			.where('s.token', refreshToken)
 			.andWhere('s.expires', '>=', new Date())


### PR DESCRIPTION
Follow up from the change in #11077, which seems to actually break on other DBs, tested on SQLite and PostgreSQL. This is because `onIn` interpret the second argument as an array of values, not as an array of column reference. Thanks to @Oreilles for the explanation & solution 👍