### PR TITLE
Added the 4 "_starts/ends_with" filter operators to type defs in SDK

### DIFF
--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -62,6 +62,10 @@ export type FilterOperators<T> = {
 	_nbetween?: [T, T];
 	_contains?: T;
 	_ncontains?: T;
+	_starts_with?: T;
+	_nstarts_with?: T;
+	_ends_with?: T;
+	_nends_with?: T;
 	_empty?: boolean;
 	_nempty?: boolean;
 	_nnull?: boolean;


### PR DESCRIPTION
The SDK supports the filter operators `_starts_with`, `_nstarts_with`, `_ends_with` and `_nends_with`, but their definitions were missing from the Typescript def so I've added them.