### PR TITLE
Only render project descriptor if it is set

### DIFF
--- a/app/src/views/private/components/project-info/project-info.vue
+++ b/app/src/views/private/components/project-info/project-info.vue
@@ -3,7 +3,7 @@
 		<latency-indicator />
 		<div class="name-container">
 			<v-text-overflow placement="right" class="name" :text="name" />
-			<v-text-overflow placement="right" class="descriptor" :text="descriptor" />
+			<v-text-overflow v-if="descriptor" placement="right" class="descriptor" :text="descriptor" />
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
This fixes a prop type check warning.