### PR TITLE
Only trigger edits guard if there are edits

### DIFF
--- a/app/src/composables/use-edits-guard/use-edits-guard.ts
+++ b/app/src/composables/use-edits-guard/use-edits-guard.ts
@@ -1,12 +1,12 @@
 import { ref, Ref, onBeforeMount, onBeforeUnmount } from 'vue';
 import { onBeforeRouteUpdate, onBeforeRouteLeave, NavigationGuard } from 'vue-router';
 
-export function useEditsGuard(isSavable: Ref<boolean>) {
+export function useEditsGuard(hasEdits: Ref<boolean>) {
 	const confirmLeave = ref(false);
 	const leaveTo = ref<string | null>(null);
 
 	const beforeUnload = (event: BeforeUnloadEvent) => {
-		if (isSavable.value) {
+		if (hasEdits.value) {
 			event.preventDefault();
 			event.returnValue = '';
 			return '';
@@ -14,7 +14,7 @@ export function useEditsGuard(isSavable: Ref<boolean>) {
 	};
 
 	const editsGuard: NavigationGuard = (to) => {
-		if (isSavable.value) {
+		if (hasEdits.value) {
 			confirmLeave.value = true;
 			leaveTo.value = to.fullPath;
 			return false;

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -125,7 +125,7 @@
 				rounded
 				icon
 				:loading="saving"
-				:disabled="isSavable === false || saveAllowed === false"
+				:disabled="!isSavable"
 				@click="saveAndQuit"
 			>
 				<v-icon name="check" />
@@ -302,7 +302,7 @@ export default defineComponent({
 			return hasEdits.value;
 		});
 
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 		const confirmDelete = ref(false);
 		const confirmArchive = ref(false);
 

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -88,7 +88,7 @@
 			</v-button>
 
 			<v-button
-				v-tooltip.bottom="isSavable ? t('save') : t('not_allowed')"
+				v-tooltip.bottom="saveAllowed ? t('save') : t('not_allowed')"
 				rounded
 				icon
 				:loading="saving"
@@ -99,7 +99,7 @@
 
 				<template #append-outer>
 					<save-options
-						v-if="hasEdits === true && saveAllowed === true"
+						v-if="isSavable"
 						:disabled-options="['save-and-add-new']"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
@@ -251,7 +251,7 @@ export default defineComponent({
 
 		const isSavable = computed(() => saveAllowed.value && hasEdits.value);
 
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		const confirmDelete = ref(false);
 		const editActive = ref(false);

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -155,12 +155,7 @@ export default defineComponent({
 
 		const confirmDelete = ref(false);
 
-		const isSavable = computed(() => {
-			if (hasEdits.value === true) return true;
-			return hasEdits.value;
-		});
-
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		return {
 			t,
@@ -181,7 +176,6 @@ export default defineComponent({
 			deleteAndQuit,
 			saveAndQuit,
 			hasEdits,
-			isSavable,
 			confirmLeave,
 			leaveTo,
 			discardAndLeave,

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -205,12 +205,7 @@ export default defineComponent({
 			if (hasEdits.value) save();
 		});
 
-		const isSavable = computed(() => {
-			if (hasEdits.value === true) return true;
-			return hasEdits.value;
-		});
-
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		return {
 			t,
@@ -233,7 +228,6 @@ export default defineComponent({
 			confirmDelete,
 			updateFilters,
 			search,
-			isSavable,
 			confirmLeave,
 			leaveTo,
 			discardAndLeave,

--- a/app/src/modules/settings/routes/project/project.vue
+++ b/app/src/modules/settings/routes/project/project.vue
@@ -8,7 +8,7 @@
 		</template>
 
 		<template #actions>
-			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="noEdits" :loading="saving" @click="save">
+			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!hasEdits" :loading="saving" @click="save">
 				<v-icon name="check" />
 			</v-button>
 		</template>
@@ -68,29 +68,23 @@ export default defineComponent({
 
 		const edits = ref<{ [key: string]: any } | null>(null);
 
-		const noEdits = computed<boolean>(() => edits.value === null || Object.keys(edits.value).length === 0);
+		const hasEdits = computed(() => edits.value !== null && Object.keys(edits.value).length > 0);
 
 		const saving = ref(false);
 
 		useShortcut('meta+s', () => {
-			if (!noEdits.value) save();
+			if (hasEdits.value) save();
 		});
 
-		const isSavable = computed(() => {
-			if (noEdits.value === true) return false;
-			return noEdits.value;
-		});
-
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		return {
 			t,
 			fields,
 			initialValues,
 			edits,
-			noEdits,
+			hasEdits,
 			saving,
-			isSavable,
 			confirmLeave,
 			leaveTo,
 			save,

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -168,12 +168,7 @@ export default defineComponent({
 			if (hasEdits.value) saveAndStay();
 		});
 
-		const isSavable = computed(() => {
-			if (hasEdits.value === true) return true;
-			return hasEdits.value;
-		});
-
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		return {
 			t,
@@ -191,7 +186,6 @@ export default defineComponent({
 			adminEnabled,
 			userInviteModalActive,
 			appAccess,
-			isSavable,
 			confirmLeave,
 			leaveTo,
 			discardAndLeave,

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -143,12 +143,7 @@ export default defineComponent({
 			if (hasEdits.value) saveAndAddNew();
 		});
 
-		const isSavable = computed(() => {
-			if (hasEdits.value === true) return true;
-			return hasEdits.value;
-		});
-
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		return {
 			t,
@@ -170,7 +165,6 @@ export default defineComponent({
 			isBatch,
 			title,
 			validationErrors,
-			isSavable,
 			confirmLeave,
 			leaveTo,
 			discardAndLeave,

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -74,7 +74,7 @@
 			</v-dialog>
 
 			<v-button
-				v-tooltip.bottom="isSavable ? t('save') : t('not_allowed')"
+				v-tooltip.bottom="saveAllowed ? t('save') : t('not_allowed')"
 				rounded
 				icon
 				:loading="saving"
@@ -85,7 +85,7 @@
 
 				<template #append-outer>
 					<save-options
-						v-if="hasEdits === true"
+						v-if="isSavable"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
@@ -262,7 +262,7 @@ export default defineComponent({
 
 		const isSavable = computed(() => saveAllowed.value && hasEdits.value);
 
-		const { confirmLeave, leaveTo } = useEditsGuard(isSavable);
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 		const confirmDelete = ref(false);
 		const confirmArchive = ref(false);


### PR DESCRIPTION
We should only show a warning if the user actually made changes to the item.

Fixes #11088