### PR TITLE
Align readMany and readByQuery in SDK

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -478,16 +478,24 @@ await articles.createMany([
 ]);
 ```
 
-### Read All
+### Read Single Item
 
 ```js
-await articles.readMany();
+await articles.readOne(15);
 ```
 
-### Read By Query
+Supports optional query:
 
 ```js
-await articles.readByQuery({
+await articles.readOne(15, {
+	fields: ['title'],
+});
+```
+
+### Read Multiple Items
+
+```js
+await articles.readMany({
 	search: 'Directus',
 	filter: {
 		date_published: {
@@ -497,16 +505,32 @@ await articles.readByQuery({
 });
 ```
 
-### Read By Primary Key(s)
+```js
+await articles.readMany({
+	limit: -1,
+});
+```
+
+### Update Single Item
 
 ```js
-await articles.readOne(15);
+await articles.updateOne(15, {
+	title: 'This articles now has a different title',
+});
 ```
 
 Supports optional query:
 
 ```js
-await articles.readOne(15, { fields: ['title'] });
+await articles.updateOne(
+	42,
+	{
+		title: 'This articles now has a similar title',
+	},
+	{
+		fields: ['title'],
+	}
+);
 ```
 
 ### Update Multiple Items


### PR DESCRIPTION
Aligned the docs with the current items API in the JS SDK as per  #11187 
- Removed reference to readByQuery
- Updated order of examples and aligned titles to match
- Added missing updateOne example