### PR TITLE
Set CRDB options to avoid inconsistencies between vendors

### DIFF
--- a/api/src/cli/utils/create-db-connection.ts
+++ b/api/src/cli/utils/create-db-connection.ts
@@ -1,5 +1,6 @@
 import { knex, Knex } from 'knex';
 import path from 'path';
+import { promisify } from 'util';
 
 export type Credentials = {
 	filename?: string;
@@ -55,10 +56,22 @@ export default function createDBConnection(
 			extension: 'js',
 			directory: path.resolve(__dirname, '../../database/seeds/'),
 		},
+		pool: {},
 	};
 
 	if (client === 'sqlite3') {
 		knexConfig.useNullAsDefault = true;
+	}
+
+	if (client === 'cockroachdb') {
+		knexConfig.pool!.afterCreate = async (conn: any, callback: any) => {
+			const run = promisify(conn.query.bind(conn));
+
+			await run('SET serial_normalization = "sql_sequence"');
+			await run('SET default_int_size = 4');
+
+			callback(null, conn);
+		};
 	}
 
 	const db = knex(knexConfig);

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -96,6 +96,18 @@ export default function getDatabase(): Knex {
 		};
 	}
 
+	if (env.DB_CLIENT === 'cockroachdb') {
+		poolConfig.afterCreate = async (conn: any, callback: any) => {
+			logger.trace('Setting CRDB serial_normalization and default_int_size');
+			const run = promisify(conn.query.bind(conn));
+
+			await run('SET serial_normalization = "sql_sequence"');
+			await run('SET default_int_size = 4');
+
+			callback(null, conn);
+		};
+	}
+
 	if (env.DB_CLIENT === 'mssql') {
 		// This brings MS SQL in line with the other DB vendors. We shouldn't do any automatic
 		// timezone conversion on the database level, especially not when other database vendors don't

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -62,6 +62,7 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
           AND pg_attribute.attnum = ANY (pg_index.indkey)
           AND indisprimary
           AND indnatts = 1
+			 AND relam != 0
       `,
 				[this.explodedSchema.join(',')]
 			),

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -62,7 +62,7 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
           AND pg_attribute.attnum = ANY (pg_index.indkey)
           AND indisprimary
           AND indnatts = 1
-			 AND relam != 0
+			 AND relkind != 'S'
       `,
 				[this.explodedSchema.join(',')]
 			),

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -114,6 +114,14 @@ const config: Config = {
 				host: 'localhost',
 				port: 6106,
 			},
+			pool: {
+				afterCreate: async (conn: any, callback: any) => {
+					const run = promisify(conn.query.bind(conn));
+					await run('SET serial_normalization = "sql_sequence"');
+					await run('SET default_int_size = 4');
+					callback(null, conn);
+				},
+			},
 			...knexConfig,
 		},
 		sqlite3: {


### PR DESCRIPTION
CockroachDB by default doesn't handle knex's way of passing `increments()` and `integers()` the same as the other database vendors. These two options ensure consistent/expected usage between Cockroach and the other vendors.

See https://github.com/knex/knex/issues/4953 for more information