### PR TITLE
SDK: split `readMany` into itself and `readByQuery`

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -21,7 +21,7 @@ const directus = new Directus('http://directus.example.com');
 
 async function start() {
 	// We don't need to authenticate if data is public
-	const publicData = await directus.items('public').readMany({ meta: 'total_count' });
+	const publicData = await directus.items('public').readByQuery({ meta: 'total_count' });
 
 	console.log({
 		items: publicData.data,
@@ -55,7 +55,7 @@ async function start() {
 	}
 
 	// After authentication, we can fetch the private data in case the user has access to it
-	const privateData = await directus.items('privateData').readMany({ meta: 'total_count' });
+	const privateData = await directus.items('privateData').readByQuery({ meta: 'total_count' });
 
 	console.log({
 		items: privateData.data,

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -478,6 +478,30 @@ await articles.createMany([
 ]);
 ```
 
+### Read By Query
+
+```js
+await articles.readByQuery({
+	search: 'Directus',
+	filter: {
+		date_published: {
+			_gte: '$NOW',
+		},
+	},
+});
+```
+
+### Read All
+
+```js
+await articles.readByQuery({
+	// By default API limits results to 100.
+	// With -1, it will return all results, but it may lead to performance degradation
+	// for large result sets.
+	limit: -1,
+});
+```
+
 ### Read Single Item
 
 ```js
@@ -495,19 +519,14 @@ await articles.readOne(15, {
 ### Read Multiple Items
 
 ```js
-await articles.readMany({
-	search: 'Directus',
-	filter: {
-		date_published: {
-			_gte: '$NOW',
-		},
-	},
-});
+await articles.readMany([15, 16, 17]);
 ```
 
+Supports optional query:
+
 ```js
-await articles.readMany({
-	limit: -1,
+await articles.readMany([15, 16, 17], {
+	fields: ['title'],
 });
 ```
 

--- a/packages/cli/src/cli/commands/items/read/many.ts
+++ b/packages/cli/src/cli/commands/items/read/many.ts
@@ -35,7 +35,7 @@ export default command(
 		},
 	},
 	async function ({ output, query, sdk }, params) {
-		const item = await sdk.items(params.collection).readMany(query.many);
+		const item = await sdk.items(params.collection).readByQuery(query.many);
 		if (item.data && !Array.isArray(item.data)) {
 			item.data = [item.data];
 		}

--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
 	testURL: process.env.TEST_URL || 'http://localhost',
 	collectCoverageFrom: ['src/**/*.ts'],
 	testPathIgnorePatterns: ['dist'],
+	testMatch: ['<rootDir>/tests/**/*.test.ts'],
 };

--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -94,7 +94,8 @@ export interface IItems<T extends Item> {
 	createMany(items: PartialItem<T>[], query?: QueryMany<T>): Promise<ManyItems<T>>;
 
 	readOne(id: ID, query?: QueryOne<T>): Promise<OneItem<T>>;
-	readMany(query?: QueryMany<T>): Promise<ManyItems<T>>;
+	readMany(ids: ID[], query?: QueryMany<T>): Promise<ManyItems<T>>;
+	readByQuery(query?: QueryMany<T>): Promise<ManyItems<T>>;
 
 	updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>>;
 	updateMany(ids: ID[], item: PartialItem<T>, query?: QueryMany<T>): Promise<ManyItems<T>>;

--- a/packages/sdk/tests/items.test.ts
+++ b/packages/sdk/tests/items.test.ts
@@ -47,19 +47,35 @@ describe('items', function () {
 		expect(item?.name).toBe('Double Slash');
 	});
 
-	test(`can get multiple items by id`, async (url, nock) => {
+	test(`can get multiple items by primary key`, async (url, nock) => {
 		nock()
-			.get('/items/posts')
+			.get('/fields/posts')
 			.reply(200, {
 				data: [
 					{
-						id: 1,
+						collection: 'posts',
+						field: 'primary_key',
+						schema: { is_primary_key: true },
+					},
+				],
+			});
+
+		nock()
+			.get('/items/posts')
+			.query({
+				filter: '{"primary_key":{"_in":[1,2]}}',
+				sort: 'primary_key',
+			})
+			.reply(200, {
+				data: [
+					{
+						primary_key: 1,
 						title: 'My first post',
 						body: '<h1>Hey there!</h1>',
 						published: false,
 					},
 					{
-						id: 2,
+						primary_key: 2,
 						title: 'My second post',
 						body: '<h1>Hey there!</h1>',
 						published: true,
@@ -68,17 +84,17 @@ describe('items', function () {
 			});
 
 		const sdk = new Directus<Blog>(url);
-		const items = await sdk.items('posts').readMany();
+		const items = await sdk.items('posts').readMany([1, 2]);
 
 		expect(items.data?.[0]).toMatchObject({
-			id: 1,
+			primary_key: 1,
 			title: 'My first post',
 			body: '<h1>Hey there!</h1>',
 			published: false,
 		});
 
 		expect(items.data?.[1]).toMatchObject({
-			id: 2,
+			primary_key: 2,
 			title: 'My second post',
 			body: '<h1>Hey there!</h1>',
 			published: true,
@@ -105,7 +121,7 @@ describe('items', function () {
 			});
 
 		const sdk = new Directus<Blog>(url);
-		const items = await sdk.items('posts').readMany({
+		const items = await sdk.items('posts').readByQuery({
 			fields: ['id', 'title'],
 		});
 


### PR DESCRIPTION
Fixes #11187

We want to follow the same structure we have on `ItemsService`. For that we need to have:
- `readMany`: which reads multiple rows by its primary keys
- `readByQuery`: which read multiple rows by specifying a query, like `filter` or `search`

## Breaking Changes
The ones who are using `readMany` need to replace by `readByQuery` and that's it. The parameters should be the same.
