### PR TITLE
Fix nested transactions on SQLite

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -122,7 +122,7 @@ export class CollectionsService {
 					return field;
 				});
 
-				await this.knex.transaction(async (schemaTrx) => {
+				await trx.transaction(async (schemaTrx) => {
 					await schemaTrx.schema.createTable(payload.collection, (table) => {
 						for (const field of payload.fields!) {
 							if (field.type && ALIAS_TYPES.includes(field.type) === false) {
@@ -447,7 +447,7 @@ export class CollectionsService {
 						.where({ id: relation.meta!.id });
 				}
 
-				await this.knex.transaction(async (schemaTrx) => {
+				await trx.transaction(async (schemaTrx) => {
 					await schemaTrx.schema.dropTable(collectionKey);
 				});
 			}

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -262,7 +262,7 @@ export class FieldsService {
 				if (table) {
 					this.addColumnToTable(table, hookAdjustedField as Field);
 				} else {
-					await this.knex.transaction(async (schemaTrx) => {
+					await trx.transaction(async (schemaTrx) => {
 						await schemaTrx.schema.alterTable(collection, (table) => {
 							this.addColumnToTable(table, hookAdjustedField as Field);
 						});
@@ -486,7 +486,7 @@ export class FieldsService {
 				field in this.schema.collections[collection].fields &&
 				this.schema.collections[collection].fields[field].alias === false
 			) {
-				await this.knex.transaction(async (schemaTrx) => {
+				await trx.transaction(async (schemaTrx) => {
 					await schemaTrx.schema.table(collection, (table) => {
 						table.dropColumn(field);
 					});

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -91,7 +91,7 @@ const config: Config = {
 				password: 'Test@123',
 				host: 'localhost',
 				port: 6104,
-				requestTimeout: 30000,
+				requestTimeout: 60000,
 			},
 			...knexConfig,
 		},


### PR DESCRIPTION
Fixes `Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?` error for nested transactions on SQLite.

This error prevents the creation of new collections & fields.