### PR TITLE
Docs: Add FAQs section

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -147,6 +147,11 @@ module.exports = {
 						path: '/getting-started/glossary',
 						title: 'Glossary',
 					},
+					{
+						type: 'page',
+						path: '/getting-started/faqs',
+						title: 'FAQs',
+					},
 				],
 			},
 			{

--- a/docs/.vuepress/theme/styles/custom-blocks.styl
+++ b/docs/.vuepress/theme/styles/custom-blocks.styl
@@ -49,3 +49,5 @@
     summary
       outline none
       cursor pointer
+    *
+      max-width: 100%

--- a/docs/getting-started/faqs.md
+++ b/docs/getting-started/faqs.md
@@ -1,0 +1,36 @@
+# FAQs
+
+:::details How to see / edit Raw Value?
+
+To see / edit `Raw Value` you need to:
+
+1. Open an item page
+1. Click on the field name you want to see / edit the value
+1. Click on `Raw Value`
+
+**Demonstration**
+
+<video alt="See / edit Raw Value on Directus" muted controls>
+  <source src="https://cdn.directus.io/docs/v9/getting-started/faqs/raw-value-220124.mp4" type="video/mp4">
+</video>
+:::
+
+:::details How to debug Directus?
+
+There's two approaches to debug Directus:
+
+- By setting environment variable `DEBUG=*`
+  - This will log requests, queries on database and other useful logs.
+- Run with debbuger and attach to it. For this approach you need to:
+  1. Run the following command inside your directus instance folder
+  ```sh
+    node --inspect node_modules/.bin/directus start
+  ```
+  2. Attach debugger via VSCode or another debugger client, like Chrome
+
+**Demonstration**
+
+<video alt="Debug Directus" muted controls>
+  <source src="https://cdn.directus.io/docs/v9/getting-started/faqs/debugger-220124.mp4" type="video/mp4">
+</video>
+:::


### PR DESCRIPTION
Don't know if this should be the way to go, but at least we could provide this for now and remove on future.

## Purpose
The intent for this PR is to had a place where we show users how to do things. For example, instead of
`Please provide the Raw Value of the field`
we will be able to
`Please provide the [Raw Value](https://docs.directus.io/getting-started/faqs/#:~:text=There%27s%20two%20approaches%20to%20debug%20Directus) of the field`

(The last link it looks weird because HTML does not support opening details via URL. But if we select the text inside details and choose `Copy Link to Highlight`, it will open the details, at least on Chrome. We can also handle this by ourselves.)