### PR TITLE
Refine option labels for Folders in Data Model

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -569,6 +569,8 @@ update_collection_success: Updated Collection
 delete_collection_success: Deleted Collection
 make_collection_visible: Make Collection Visible
 make_collection_hidden: Make Collection Hidden
+make_folder_visible: Make Folder Visible
+make_folder_hidden: Make Folder Hidden
 start_end_of_count_items: '{start}-{end} of {count} items'
 start_end_of_count_filtered_items: '{start}-{end} of {count} filtered items'
 one_item: '1 item'

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -10,18 +10,22 @@
 						<v-icon name="delete" outline />
 					</v-list-item-icon>
 					<v-list-item-content>
-						{{ t('delete_collection') }}
+						{{ collection.schema ? t('delete_collection') : t('delete_folder') }}
 					</v-list-item-content>
 				</v-list-item>
 
 				<v-list-item clickable @click="update({ meta: { hidden: !collection.meta?.hidden } })">
 					<template v-if="collection.meta?.hidden === false">
 						<v-list-item-icon><v-icon name="visibility_off" /></v-list-item-icon>
-						<v-list-item-content>{{ t('make_collection_hidden') }}</v-list-item-content>
+						<v-list-item-content>
+							{{ collection.schema ? t('make_collection_hidden') : t('make_folder_hidden') }}
+						</v-list-item-content>
 					</template>
 					<template v-else>
 						<v-list-item-icon><v-icon name="visibility" /></v-list-item-icon>
-						<v-list-item-content>{{ t('make_collection_visible') }}</v-list-item-content>
+						<v-list-item-content>
+							{{ collection.schema ? t('make_collection_visible') : t('make_folder_visible') }}
+						</v-list-item-content>
 					</template>
 				</v-list-item>
 			</v-list>


### PR DESCRIPTION
## Motivation

To improve the UX for Folders in Data Model, especially for users that may not be aware of folder being a schema-less collection under the hood.

## Changes

- Change mentions of `collection` in options for Folders to `folder`
- Add necessary translation keys
  - Note: `delete_folder` isn't added in this PR as it already exists
    https://github.com/directus/directus/blob/f2552222e424659df6d4cd3df836fe4a2952822d/app/src/lang/translations/en-US.yaml#L83

## Result

https://user-images.githubusercontent.com/42867097/150909917-2ce99e08-69c7-4478-b022-1148928b6e11.mp4


