### PR TITLE
fix tooltip directive modifiers

### DIFF
--- a/app/src/directives/tooltip/readme.md
+++ b/app/src/directives/tooltip/readme.md
@@ -14,8 +14,9 @@ The tooltip is displayed at the bottom of an element by default.
 | ---------- | ----------------------------------------------- |
 | `left`     | Display the tooltip to the left of the element  |
 | `right`    | Display the tooltip to the right of the element |
+| `top`      | Display the tooltip on top of the element       |
 | `bottom`   | Display the tooltip on bottom of the element    |
-| `start`    | Display the tooltip to the end of the element   |
-| `end`      | Display the tooltip to the start of the element |
+| `start`    | Places the tooltip at the start of the element  |
+| `end`      | Places the tooltip at the end of the element    |
 | `instant`  | Shows the tooltip instantly on hover            |
 | `inverted` | Inverts all colors                              |

--- a/app/src/directives/tooltip/tooltip.ts
+++ b/app/src/directives/tooltip/tooltip.ts
@@ -84,8 +84,6 @@ export function updateTooltip(element: HTMLElement, binding: DirectiveBinding, t
 	if ('right' in binding.modifiers) placement = 'right';
 	if ('bottom' in binding.modifiers) placement = 'bottom';
 	if ('left' in binding.modifiers) placement = 'left';
-	if ('start' in binding.modifiers) placement = 'start';
-	if ('end' in binding.modifiers) placement = 'end';
 
 	if (binding.modifiers.inverted) {
 		tooltip.classList.add('inverted');


### PR DESCRIPTION
Fixes #11260

## Reported Bug

Tooltip with `bottom.end` modifier is still showing up as top, particularly in latency indicator:

![chrome_TrbhnJsW4B](https://user-images.githubusercontent.com/42867097/150984091-417783ef-4681-4fc6-8025-5949f750b566.png)

## Investigation

#10977 added the following code:

https://github.com/directus/directus/blob/f2552222e424659df6d4cd3df836fe4a2952822d/app/src/directives/tooltip/tooltip.ts#L87-L88

However I believe the valid values for placement are only `top`, `bottom`, `left`, and `right`.

## Changes

- Removed placement assignment for `start` and `end`
- Updated the readme for v-tooltip directive

## Result

![chrome_ETUxeAN4ee](https://user-images.githubusercontent.com/42867097/150984855-b6f867ab-3486-4dc3-b326-98331e622495.png)

