### PR TITLE
Fix fields order in Fields Permissions

### DIFF
--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -43,34 +43,13 @@ export function useFieldTree(
 	function getTree(collection?: string | null, parent?: FieldNode) {
 		const injectedFields = inject?.value?.fields.filter((field) => field.collection === collection);
 		const fields = fieldsStore
-			.getFieldsForCollection(collection!)
+			.getFieldsForCollectionSorted(collection!)
 			.concat(injectedFields || [])
-			.filter(
-				(field: Field) =>
-					field.meta?.special?.includes('group') ||
-					(!field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
-			);
-
-		const nonGroupFields = fields.filter((field: Field) => !field.meta?.group);
-
-		const sortGroupFields = (a: Field, b: Field) => {
-			if (!a.meta?.sort || !b.meta?.sort) return 0;
-			return a.meta.sort - b.meta.sort;
-		};
-
-		for (const [index, field] of nonGroupFields.entries()) {
-			const groupFields = fields.filter((groupField: Field) => groupField.meta?.group === field.field);
-			if (groupFields.length) {
-				nonGroupFields.splice(index + 1, 0, ...groupFields.sort(sortGroupFields));
-			}
-		}
-
-		const sortedFields = nonGroupFields
 			.filter((field) => !field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
 			.filter(filter)
 			.flatMap((field) => makeNode(field, parent));
 
-		return sortedFields.length ? sortedFields : undefined;
+		return fields.length ? fields : undefined;
 	}
 
 	function makeNode(field: Field, parent?: FieldNode): FieldNode | FieldNode[] {

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
@@ -58,29 +58,9 @@ export default defineComponent({
 		const internalPermission = useSync(props, 'permission', emit);
 
 		const fieldsInCollection = computed(() => {
-			const fields = fieldsStore
-				.getFieldsForCollection(props.permission.collection)
-				.filter(
-					(field: Field) =>
-						field.meta?.special?.includes('group') ||
-						(!field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
-				);
+			const fields = fieldsStore.getFieldsForCollectionSorted(props.permission.collection);
 
-			const nonGroupFields = fields.filter((field: Field) => !field.meta?.group);
-
-			const sortGroupFields = (a: Field, b: Field) => {
-				if (!a.meta?.sort || !b.meta?.sort) return 0;
-				return a.meta.sort - b.meta.sort;
-			};
-
-			for (const [index, field] of nonGroupFields.entries()) {
-				const groupFields = fields.filter((groupField: Field) => groupField.meta?.group === field.field);
-				if (groupFields.length) {
-					nonGroupFields.splice(index + 1, 0, ...groupFields.sort(sortGroupFields));
-				}
-			}
-
-			return nonGroupFields.map((field: Field) => {
+			return fields.map((field: Field) => {
 				return {
 					text: field.name,
 					value: field.field,

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -253,7 +253,8 @@ export const useFieldsStore = defineStore({
 			});
 		},
 		/**
-		 * Retrieve sorted fields including groups
+		 * Retrieve sorted fields including groups. This is necessary because
+		 * fields inside groups starts their sort number from 1 to N again.
 		 */
 		getFieldsForCollectionSorted(collection: string): Field[] {
 			const fields = this.fields

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -253,6 +253,34 @@ export const useFieldsStore = defineStore({
 			});
 		},
 		/**
+		 * Retrieve sorted fields including groups
+		 */
+		getFieldsForCollectionSorted(collection: string): Field[] {
+			const fields = this.fields
+				.filter((field) => field.collection === collection)
+				.filter(
+					(field: Field) =>
+						field.meta?.special?.includes('group') ||
+						(!field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
+				);
+
+			const nonGroupFields = fields.filter((field: Field) => !field.meta?.group);
+
+			const sortGroupFields = (a: Field, b: Field) => {
+				if (!a.meta?.sort || !b.meta?.sort) return 0;
+				return a.meta.sort - b.meta.sort;
+			};
+
+			for (const [index, field] of nonGroupFields.entries()) {
+				const groupFields = fields.filter((groupField: Field) => groupField.meta?.group === field.field);
+				if (groupFields.length) {
+					nonGroupFields.splice(index + 1, 0, ...groupFields.sort(sortGroupFields));
+				}
+			}
+
+			return nonGroupFields;
+		},
+		/**
 		 * Retrieve field info for a field or a related field
 		 */
 		getField(collection: string, fieldKey: string): Field | null {


### PR DESCRIPTION
Fixes #11062

## Reported Bug

Assuming a data model such as this:

![chrome_mfyPGcUnZW](https://user-images.githubusercontent.com/42867097/151003917-97698b96-5869-429b-ae64-de9ac10b671a.png)

The fields will end up having the wrong ordering in Fields Permissions:

![chrome_21OST3yUr1](https://user-images.githubusercontent.com/42867097/151003971-187b8d0a-fc81-4b98-88f7-7659bdc3ba7c.png)

Note that `Type` and `Color` in particular should actually be the last 2 fields after `Variants Group`.

## Investigation

Seems like it shares the same issue as #8932, where fields _inside_ groups starts their sort number from 1 to N again. So when we sort everything, "first field" and "first field in first group" both will have sort value 1.

## Changes

- uses the same logic of "sort fields but also make sure groups are sorted" applied in #10123
- since it ended up as repeating code, opted to move it into a reusable function in fieldsStore as `getFieldsForCollectionSorted`. Not sure if there's a better naming than `Sorted` so I've at least added a hopefully clear enough comment.

## Result

![chrome_ZFtDclyyZB](https://user-images.githubusercontent.com/42867097/151004178-0f4db170-013e-4f76-9255-a7ddc0c037fa.png)

