### PR TITLE
Fix PG10 support

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -126,7 +126,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"keyv": "^4.0.3",
 		"knex": "^0.95.14",
-		"knex-schema-inspector": "1.7.2",
+		"knex-schema-inspector": "1.7.3",
 		"ldapjs": "^2.3.1",
 		"liquidjs": "^9.25.0",
 		"lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,20 +59,20 @@
 		},
 		"api": {
 			"name": "directus",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"@aws-sdk/client-ses": "^3.40.0",
-				"@directus/app": "9.4.3",
-				"@directus/drive": "9.4.3",
-				"@directus/drive-azure": "9.4.3",
-				"@directus/drive-gcs": "9.4.3",
-				"@directus/drive-s3": "9.4.3",
-				"@directus/extensions-sdk": "9.4.3",
-				"@directus/format-title": "9.4.3",
-				"@directus/schema": "9.4.3",
-				"@directus/shared": "9.4.3",
-				"@directus/specs": "9.4.3",
+				"@directus/app": "9.5.0",
+				"@directus/drive": "9.5.0",
+				"@directus/drive-azure": "9.5.0",
+				"@directus/drive-gcs": "9.5.0",
+				"@directus/drive-s3": "9.5.0",
+				"@directus/extensions-sdk": "9.5.0",
+				"@directus/format-title": "9.5.0",
+				"@directus/schema": "9.5.0",
+				"@directus/shared": "9.5.0",
+				"@directus/specs": "9.5.0",
 				"@godaddy/terminus": "^4.9.0",
 				"@rollup/plugin-alias": "^3.1.2",
 				"@rollup/plugin-virtual": "^2.0.3",
@@ -111,7 +111,7 @@
 				"jsonwebtoken": "^8.5.1",
 				"keyv": "^4.0.3",
 				"knex": "^0.95.14",
-				"knex-schema-inspector": "1.7.2",
+				"knex-schema-inspector": "1.7.3",
 				"ldapjs": "^2.3.1",
 				"liquidjs": "^9.25.0",
 				"lodash": "^4.17.21",
@@ -296,12 +296,12 @@
 		},
 		"app": {
 			"name": "@directus/app",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"devDependencies": {
-				"@directus/docs": "9.4.3",
-				"@directus/extensions-sdk": "9.4.3",
-				"@directus/format-title": "9.4.3",
-				"@directus/shared": "9.4.3",
+				"@directus/docs": "9.5.0",
+				"@directus/extensions-sdk": "9.5.0",
+				"@directus/format-title": "9.5.0",
+				"@directus/shared": "9.5.0",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.1",
@@ -571,7 +571,7 @@
 		},
 		"docs": {
 			"name": "@directus/docs",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "ISC",
 			"devDependencies": {
 				"directory-tree": "3.0.1",
@@ -26654,9 +26654,9 @@
 			}
 		},
 		"node_modules/knex-schema-inspector": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.7.2.tgz",
-			"integrity": "sha512-kJjQKWG4iSE25+TnIa+0Y7gbuk6hdjChuzvsIW+thrCncCFngStOO3bnYeqINfn8c1bFtWuafL4feHqMvT/zkA==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.7.3.tgz",
+			"integrity": "sha512-jbH46UaAx0eLf7jmLsaHQ+2x76CxvAEBtGP0NZ262qW+VcCxh89CJ/fNnwyrrMWqVPNNxmtlEtshc6k9z7Aalw==",
 			"dependencies": {
 				"lodash.flatten": "^4.4.0",
 				"lodash.isnil": "^4.0.0"
@@ -44068,11 +44068,11 @@
 		},
 		"packages/cli": {
 			"name": "@directus/cli",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/format-title": "9.4.3",
-				"@directus/sdk": "9.4.3",
+				"@directus/format-title": "9.5.0",
+				"@directus/sdk": "9.5.0",
 				"@types/yargs": "^17.0.0",
 				"app-module-path": "^2.2.0",
 				"chalk": "^4.1.0",
@@ -44182,11 +44182,11 @@
 			}
 		},
 		"packages/create-directus-extension": {
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"@directus/extensions-sdk": "9.4.3",
-				"@directus/shared": "9.4.3",
+				"@directus/extensions-sdk": "9.5.0",
+				"@directus/shared": "9.5.0",
 				"inquirer": "^8.1.2"
 			},
 			"bin": {
@@ -44229,7 +44229,7 @@
 			"license": "0BSD"
 		},
 		"packages/create-directus-project": {
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"chalk": "^4.1.1",
@@ -44265,7 +44265,7 @@
 		},
 		"packages/drive": {
 			"name": "@directus/drive",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.0.0",
@@ -44284,11 +44284,11 @@
 		},
 		"packages/drive-azure": {
 			"name": "@directus/drive-azure",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.4.3",
+				"@directus/drive": "9.5.0",
 				"normalize-path": "^3.0.0"
 			},
 			"devDependencies": {
@@ -44319,10 +44319,10 @@
 		},
 		"packages/drive-gcs": {
 			"name": "@directus/drive-gcs",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.4.3",
+				"@directus/drive": "9.5.0",
 				"@google-cloud/storage": "^5.8.5",
 				"lodash": "4.17.21",
 				"normalize-path": "^3.0.0"
@@ -44342,10 +44342,10 @@
 		},
 		"packages/drive-s3": {
 			"name": "@directus/drive-s3",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/drive": "9.4.3",
+				"@directus/drive": "9.5.0",
 				"aws-sdk": "^2.928.0",
 				"normalize-path": "^3.0.0"
 			},
@@ -44390,9 +44390,9 @@
 		},
 		"packages/extensions-sdk": {
 			"name": "@directus/extensions-sdk",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"dependencies": {
-				"@directus/shared": "9.4.3",
+				"@directus/shared": "9.5.0",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -44442,7 +44442,7 @@
 		},
 		"packages/format-title": {
 			"name": "@directus/format-title",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "21.0.1",
@@ -44462,10 +44462,10 @@
 		},
 		"packages/gatsby-source-directus": {
 			"name": "@directus/gatsby-source-directus",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
-				"@directus/sdk": "9.4.3",
+				"@directus/sdk": "9.5.0",
 				"gatsby-source-filesystem": "4.2.0",
 				"gatsby-source-graphql": "4.2.0",
 				"ms": "2.1.3"
@@ -44477,10 +44477,10 @@
 		},
 		"packages/schema": {
 			"name": "@directus/schema",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "GPL-3.0",
 			"dependencies": {
-				"knex-schema-inspector": "1.7.2",
+				"knex-schema-inspector": "1.7.3",
 				"lodash": "^4.17.21"
 			},
 			"devDependencies": {
@@ -44490,7 +44490,7 @@
 		},
 		"packages/sdk": {
 			"name": "@directus/sdk",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.24.0"
@@ -44519,7 +44519,7 @@
 		},
 		"packages/shared": {
 			"name": "@directus/shared",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"dependencies": {
 				"date-fns": "2.24.0",
 				"fs-extra": "10.0.0",
@@ -44583,7 +44583,7 @@
 		},
 		"packages/specs": {
 			"name": "@directus/specs",
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"openapi3-ts": "^2.0.1"
@@ -46927,10 +46927,10 @@
 		"@directus/app": {
 			"version": "file:app",
 			"requires": {
-				"@directus/docs": "9.4.3",
-				"@directus/extensions-sdk": "9.4.3",
-				"@directus/format-title": "9.4.3",
-				"@directus/shared": "9.4.3",
+				"@directus/docs": "9.5.0",
+				"@directus/extensions-sdk": "9.5.0",
+				"@directus/format-title": "9.5.0",
+				"@directus/shared": "9.5.0",
 				"@fortawesome/fontawesome-svg-core": "1.2.36",
 				"@fortawesome/free-brands-svg-icons": "5.15.4",
 				"@fullcalendar/core": "5.10.1",
@@ -47115,8 +47115,8 @@
 		"@directus/cli": {
 			"version": "file:packages/cli",
 			"requires": {
-				"@directus/format-title": "9.4.3",
-				"@directus/sdk": "9.4.3",
+				"@directus/format-title": "9.5.0",
+				"@directus/sdk": "9.5.0",
 				"@types/figlet": "1.5.4",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
@@ -47254,7 +47254,7 @@
 			"version": "file:packages/drive-azure",
 			"requires": {
 				"@azure/storage-blob": "^12.6.0",
-				"@directus/drive": "9.4.3",
+				"@directus/drive": "9.5.0",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
 				"@types/node": "16.11.9",
@@ -47282,7 +47282,7 @@
 		"@directus/drive-gcs": {
 			"version": "file:packages/drive-gcs",
 			"requires": {
-				"@directus/drive": "9.4.3",
+				"@directus/drive": "9.5.0",
 				"@google-cloud/storage": "^5.8.5",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
@@ -47301,7 +47301,7 @@
 		"@directus/drive-s3": {
 			"version": "file:packages/drive-s3",
 			"requires": {
-				"@directus/drive": "9.4.3",
+				"@directus/drive": "9.5.0",
 				"@lukeed/uuid": "2.0.0",
 				"@types/fs-extra": "9.0.13",
 				"@types/jest": "27.0.3",
@@ -47331,7 +47331,7 @@
 		"@directus/extensions-sdk": {
 			"version": "file:packages/extensions-sdk",
 			"requires": {
-				"@directus/shared": "9.4.3",
+				"@directus/shared": "9.5.0",
 				"@rollup/plugin-commonjs": "^21.0.0",
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.0",
@@ -47383,7 +47383,7 @@
 		"@directus/gatsby-source-directus": {
 			"version": "file:packages/gatsby-source-directus",
 			"requires": {
-				"@directus/sdk": "9.4.3",
+				"@directus/sdk": "9.5.0",
 				"gatsby-source-filesystem": "4.2.0",
 				"gatsby-source-graphql": "4.2.0",
 				"ms": "2.1.3"
@@ -47397,7 +47397,7 @@
 		"@directus/schema": {
 			"version": "file:packages/schema",
 			"requires": {
-				"knex-schema-inspector": "1.7.2",
+				"knex-schema-inspector": "1.7.3",
 				"lodash": "^4.17.21",
 				"npm-watch": "0.11.0",
 				"typescript": "4.5.2"
@@ -55619,8 +55619,8 @@
 		"create-directus-extension": {
 			"version": "file:packages/create-directus-extension",
 			"requires": {
-				"@directus/extensions-sdk": "9.4.3",
-				"@directus/shared": "9.4.3",
+				"@directus/extensions-sdk": "9.5.0",
+				"@directus/shared": "9.5.0",
 				"inquirer": "^8.1.2"
 			},
 			"dependencies": {
@@ -56977,16 +56977,16 @@
 			"version": "file:api",
 			"requires": {
 				"@aws-sdk/client-ses": "^3.40.0",
-				"@directus/app": "9.4.3",
-				"@directus/drive": "9.4.3",
-				"@directus/drive-azure": "9.4.3",
-				"@directus/drive-gcs": "9.4.3",
-				"@directus/drive-s3": "9.4.3",
-				"@directus/extensions-sdk": "9.4.3",
-				"@directus/format-title": "9.4.3",
-				"@directus/schema": "9.4.3",
-				"@directus/shared": "9.4.3",
-				"@directus/specs": "9.4.3",
+				"@directus/app": "9.5.0",
+				"@directus/drive": "9.5.0",
+				"@directus/drive-azure": "9.5.0",
+				"@directus/drive-gcs": "9.5.0",
+				"@directus/drive-s3": "9.5.0",
+				"@directus/extensions-sdk": "9.5.0",
+				"@directus/format-title": "9.5.0",
+				"@directus/schema": "9.5.0",
+				"@directus/shared": "9.5.0",
+				"@directus/specs": "9.5.0",
 				"@godaddy/terminus": "^4.9.0",
 				"@keyv/redis": "^2.1.2",
 				"@rollup/plugin-alias": "^3.1.2",
@@ -57070,7 +57070,7 @@
 				"keyv-memcache": "^1.2.5",
 				"knex": "^0.95.14",
 				"knex-mock-client": "1.6.1",
-				"knex-schema-inspector": "1.7.2",
+				"knex-schema-inspector": "1.7.3",
 				"ldapjs": "^2.3.1",
 				"liquidjs": "^9.25.0",
 				"lodash": "^4.17.21",
@@ -63532,9 +63532,9 @@
 			}
 		},
 		"knex-schema-inspector": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.7.2.tgz",
-			"integrity": "sha512-kJjQKWG4iSE25+TnIa+0Y7gbuk6hdjChuzvsIW+thrCncCFngStOO3bnYeqINfn8c1bFtWuafL4feHqMvT/zkA==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.7.3.tgz",
+			"integrity": "sha512-jbH46UaAx0eLf7jmLsaHQ+2x76CxvAEBtGP0NZ262qW+VcCxh89CJ/fNnwyrrMWqVPNNxmtlEtshc6k9z7Aalw==",
 			"requires": {
 				"lodash.flatten": "^4.4.0",
 				"lodash.isnil": "^4.0.0"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -47,7 +47,7 @@
 		"typescript": "4.5.2"
 	},
 	"dependencies": {
-		"knex-schema-inspector": "1.7.2",
+		"knex-schema-inspector": "1.7.3",
 		"lodash": "^4.17.21"
 	},
 	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd"


### PR DESCRIPTION
`knex-schema-inspector` was making a call to a column that doesn't exist in Postgres versions < 12. That was resolved in 1.7.3 