### PR TITLE
Prevent editing of fields within groups in Share

### DIFF
--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -24,6 +24,7 @@
 						:validation-errors="validationErrors"
 						:loading="loading"
 						:batch-mode="batchMode"
+						:disabled="disabled"
 						@update:model-value="$emit('apply', $event)"
 					/>
 				</div>

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -34,6 +34,7 @@
 			:validation-errors="validationErrors"
 			:loading="loading"
 			:batch-mode="batchMode"
+			:disabled="disabled"
 			@update:model-value="$emit('apply', $event)"
 		/>
 	</v-detail>

--- a/app/src/interfaces/group-raw/group-raw.vue
+++ b/app/src/interfaces/group-raw/group-raw.vue
@@ -8,6 +8,7 @@
 			:group="field.meta.field"
 			:validation-errors="validationErrors"
 			:loading="loading"
+			:disabled="disabled"
 			@update:model-value="$emit('apply', $event)"
 		/>
 	</div>


### PR DESCRIPTION
## Bug

In the share page, fields inside groups are still editable:

Seems like the `disabled` prop for the group interfaces aren't passed to their respective nested `<v-form>`.

https://user-images.githubusercontent.com/42867097/151088760-a7af19f0-1233-47c5-a547-68c1b4bf4ca3.mp4

## After Fix

![chrome_CzxRjgX0Ze](https://user-images.githubusercontent.com/42867097/151088861-98fae680-1477-4c3e-99af-4ff437df2cd7.png)

