### PR TITLE
Prevent group edited indicator in Shared View

### DIFF
--- a/app/src/routes/shared/components/share-item.vue
+++ b/app/src/routes/shared/components/share-item.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-form
-		v-model="item"
+		v-model="edits"
 		:collection="collection"
 		:initial-values="item"
 		:primary-key="primaryKey"
@@ -28,9 +28,9 @@ export default defineComponent({
 	setup(props) {
 		const { collection, primaryKey } = toRefs(props);
 
-		const { item, loading } = useItem(collection, primaryKey);
+		const { edits, item, loading } = useItem(collection, primaryKey);
 
-		return { item, loading };
+		return { edits, item, loading };
 	},
 });
 </script>


### PR DESCRIPTION
## Bug

Currently groups in the Shared View shows the dot beside their label, but it shouldn't be the case as it's a read-only view:

(Detail group will only show the dot when it's closed, hence it's not shown here)

![chrome_CzxRjgX0Ze](https://user-images.githubusercontent.com/42867097/151090423-1834eb5e-13ff-429e-99aa-e53e72815043.png)

## Investigation

This happens because shared view is passing the `item` into `v-model` as well:

https://github.com/directus/directus/blob/4e68cd2df429273512b2aa2a3b6ce8b568ff1ee9/app/src/routes/shared/components/share-item.vue#L2-L9

Whereas as shown in collection items, `edits` should be the one passed to `v-model`:

https://github.com/directus/directus/blob/4e68cd2df429273512b2aa2a3b6ce8b568ff1ee9/app/src/modules/content/routes/item.vue#L149-L160

## Solution

Initially removed the v-model flat out, but later on opted to use `edits` like the existing form in collection items in case editing shared item became possible in the future.

![chrome_qJ7Jn7DYEJ](https://user-images.githubusercontent.com/42867097/151090613-8bb5f295-3c72-4bce-b3b6-922984fd48cb.png)

