### PR TITLE
Fix notifications position when sidebar is open

### DIFF
--- a/app/src/views/private/components/notifications-group/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group/notifications-group.vue
@@ -1,5 +1,5 @@
 <template>
-	<transition-group class="notifications-group" name="slide-fade" tag="div">
+	<transition-group class="notifications-group" :class="{ 'sidebar-open': !dense }" name="slide-fade" tag="div">
 		<slot />
 		<notification-item
 			v-for="(notification, index) in queue"
@@ -47,6 +47,13 @@ export default defineComponent({
 	> *,
 	> :deep(*) {
 		direction: ltr;
+	}
+
+	&.sidebar-open {
+		top: auto;
+		right: 12px;
+		bottom: 76px;
+		left: auto;
 	}
 
 	@media (min-width: 960px) {

--- a/app/src/views/private/components/notifications-group/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group/notifications-group.vue
@@ -1,12 +1,12 @@
 <template>
-	<transition-group class="notifications-group" :class="{ 'sidebar-open': !dense }" name="slide-fade" tag="div">
+	<transition-group class="notifications-group" :class="{ 'sidebar-open': sidebarOpen }" name="slide-fade" tag="div">
 		<slot />
 		<notification-item
 			v-for="(notification, index) in queue"
 			:key="notification.id"
 			v-bind="notification"
 			:tail="index === queue.length - 1"
-			:dense="dense"
+			:dense="sidebarOpen === false"
 			:show-close="notification.persist === true && notification.closeable !== false"
 		/>
 	</transition-group>
@@ -20,7 +20,7 @@ import NotificationItem from '../notification-item';
 export default defineComponent({
 	components: { NotificationItem },
 	props: {
-		dense: {
+		sidebarOpen: {
 			type: Boolean,
 			default: false,
 		},

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -58,7 +58,7 @@
 		<v-overlay class="sidebar-overlay" :active="sidebarOpen" @click="sidebarOpen = false" />
 
 		<notifications-drawer />
-		<notifications-group v-if="notificationsPreviewActive === false" :dense="sidebarOpen === false" />
+		<notifications-group v-if="notificationsPreviewActive === false" :sidebar-open="sidebarOpen" />
 		<notification-dialogs />
 	</div>
 </template>


### PR DESCRIPTION
## Change

Added class to make sure it stays at bottom right when sidebar is open even in lower widths. Since `dense` is technically used <notification-item> and not <notifications-group>, opted to rename the notifications-group prop to `sidebarOpen` instead for clarity and pass `sidebarOpen === false` to determine `dense`.

## Before

![G6D4nYGbYn](https://user-images.githubusercontent.com/42867097/151103015-833e9f49-c5bb-49c2-95fe-831a5be7dc8c.gif)

## After

![PamGaOGvHd](https://user-images.githubusercontent.com/42867097/151103027-1c7ee0c8-a766-468f-b951-ab0af0e279a9.gif)

