### PR TITLE
Prevent vue-i18n special characters causing error

### DIFF
--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -74,11 +74,12 @@ export const useFieldsStore = defineStore({
 			if (field.meta && notEmpty(field.meta.translations) && field.meta.translations.length > 0) {
 				for (let i = 0; i < field.meta.translations.length; i++) {
 					const { language, translation } = field.meta.translations[i];
+					const literalInterpolatedTranslation = translation.replace(/([{}@$|])/g, "{'$1'}");
 
 					i18n.global.mergeLocaleMessage(language, {
 						fields: {
 							[field.collection]: {
-								[field.field]: translation,
+								[field.field]: literalInterpolatedTranslation,
 							},
 						},
 					});

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -74,6 +74,8 @@ export const useFieldsStore = defineStore({
 			if (field.meta && notEmpty(field.meta.translations) && field.meta.translations.length > 0) {
 				for (let i = 0; i < field.meta.translations.length; i++) {
 					const { language, translation } = field.meta.translations[i];
+
+					// Interpolate special characters in vue-i18n to prevent parsing error. Ref #11287
 					const literalInterpolatedTranslation = translation.replace(/([{}@$|])/g, "{'$1'}");
 
 					i18n.global.mergeLocaleMessage(language, {


### PR DESCRIPTION
Fixes #11056

## Context

Ref https://github.com/directus/directus/issues/11056#issuecomment-1014320059. There are [several special characters in vue-i18n](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#special-characters) that will cause error when users add them in field/collection translations.

For example, if a user types `title@here` as the field  translation, the `@` will be interpreted as [linked message](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#linked-messages). But since the format is malformed (it should be `@:key` where `key` is an existing translation key), it errors out.

The offending line is here inside `parseField` function:

https://github.com/directus/directus/blob/3a905b1ba447863e66b40a57f7b8cd0c508910f7/app/src/stores/fields.ts#L90

This will only throw console errors during dev, but it ends up throwing an error in production environment and prevent any logged in user in that particular locale from doing anything.

![WGujPJ7WSZ](https://user-images.githubusercontent.com/42867097/151110295-1da32aef-25c2-4f51-8007-d6f6931c02ab.gif)

## Solution

Apply the [recommended literal interpolations](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#literal-interpolation) on all the special characters when they are parsed. 

## Result

![Wt4BNiSOKE](https://user-images.githubusercontent.com/42867097/151110303-3b3bd7b4-313f-42c2-ad36-424a27ba2831.gif)

