### PR TITLE
fix sorting of select-multiple-dropdown values

### DIFF
--- a/app/src/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue
+++ b/app/src/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue
@@ -12,7 +12,7 @@
 		:placeholder="placeholder"
 		:allow-other="allowOther"
 		:close-on-content-click="false"
-		@update:model-value="$emit('input', $event)"
+		@update:model-value="updateValue($event)"
 	>
 		<template v-if="icon" #prepend>
 			<v-icon :name="icon" />
@@ -23,6 +23,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, PropType } from 'vue';
+import { sortBy } from 'lodash';
 
 type Option = {
 	text: string;
@@ -61,9 +62,19 @@ export default defineComponent({
 		},
 	},
 	emits: ['input'],
-	setup() {
+	setup(props, { emit }) {
 		const { t } = useI18n();
-		return { t };
+
+		return { t, updateValue };
+
+		function updateValue(value: PropType<string[]>) {
+			const sortedValue = sortBy(value, (val) => {
+				const sortIndex = props.choices.findIndex((choice) => val === choice.value);
+				return sortIndex !== -1 ? sortIndex : value.length;
+			});
+
+			emit('input', sortedValue);
+		}
 	},
 });
 </script>


### PR DESCRIPTION
Fixes #10639 

## Before

When we do the following:

1. untick & tick `Bold` again
2. tick `Background Color`
3. tick `Foreground Color`

The expectation is these 3 will be at the start of the toolbar. However currently they end up at the last positions instead based on our tick order:

https://user-images.githubusercontent.com/42867097/151127227-697f33e3-a285-4115-b028-88724e23290d.mp4

## After

https://user-images.githubusercontent.com/42867097/151126849-6d81e058-6531-4614-a857-d7da5ae246db.mp4