### PR TITLE
Allow to extend user created by auth driver

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -159,6 +159,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 				identifier,
 				provider: this.config.provider,
 				accessToken: tokenSet.access_token,
+				userInfo,
 			},
 			{
 				database: getDatabase(),

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -158,7 +158,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			{
 				identifier,
 				provider: this.config.provider,
-				tokenSet,
+				accessToken: tokenSet.access_token,
 			},
 			{
 				database: getDatabase(),

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -18,6 +18,8 @@ import asyncHandler from '../../utils/async-handler';
 import { Url } from '../../utils/url';
 import logger from '../../logger';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
+import emitter from '../../emitter';
+import getDatabase from '../../database';
 
 export class OAuth2AuthDriver extends LocalAuthDriver {
 	client: Client;

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -180,6 +180,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				identifier,
 				provider: this.config.provider,
 				accessToken: tokenSet.access_token,
+				userInfo,
 			},
 			{
 				database: getDatabase(),

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -18,6 +18,8 @@ import asyncHandler from '../../utils/async-handler';
 import { Url } from '../../utils/url';
 import logger from '../../logger';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
+import emitter from '../../emitter';
+import getDatabase from '../../database';
 
 export class OpenIDAuthDriver extends LocalAuthDriver {
 	client: Promise<Client>;
@@ -159,7 +161,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsException();
 		}
 
-		await this.usersService.createOne({
+		const userPayload = {
 			provider: this.config.provider,
 			first_name: userInfo.given_name,
 			last_name: userInfo.family_name,
@@ -167,7 +169,26 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			external_identifier: identifier,
 			role: this.config.defaultRoleId,
 			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
-		});
+		};
+
+		// Run hook so the end user has the chance to augment the
+		// user that is about to be created
+		const updatedUserPayload = await emitter.emitFilter(
+			`auth.register`,
+			userPayload,
+			{
+				identifier,
+				provider: this.config.provider,
+				tokenSet,
+			},
+			{
+				database: getDatabase(),
+				schema: this.schema,
+				accountability: null,
+			}
+		);
+
+		await this.usersService.createOne(updatedUserPayload);
 
 		return (await this.fetchUserId(identifier)) as string;
 	}

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -179,7 +179,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			{
 				identifier,
 				provider: this.config.provider,
-				tokenSet,
+				accessToken: tokenSet.access_token,
 			},
 			{
 				database: getDatabase(),

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -152,6 +152,7 @@ export default ({ schedule }) => {
 | `request.error`               | The request errors   | --                                   |
 | `database.error`              | The database error   | `client`                             |
 | `auth.login`                  | The login payload    | `status`, `user`, `provider`         |
+| `auth.login`                  | The new user payload | `identifier`, `provider`, `tokenSet` |
 | `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type` |
 | `(<collection>.)items.read`   | The read item        | `collection`                         |
 | `(<collection>.)items.create` | The new item         | `collection`                         |

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -172,8 +172,8 @@ export default ({ schedule }) => {
 ::: tip Providers Authentication
 
 `auth.register` is triggered only for `openid` and `oauth2` providers. Moreover
-`AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` has to be enabled. `accessToken` is return by the corresponding providers
-and should not be mistaken with Directus accessToken.
+`AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` has to be enabled. `accessToken` is return by the corresponding provider and
+should not be mistaken with Directus accessToken.
 
 :::
 

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -152,7 +152,7 @@ export default ({ schedule }) => {
 | `request.error`               | The request errors   | --                                   |
 | `database.error`              | The database error   | `client`                             |
 | `auth.login`                  | The login payload    | `status`, `user`, `provider`         |
-| `auth.login`                  | The new user payload | `identifier`, `provider`, `tokenSet` |
+| `auth.register`               | The new user payload | `identifier`, `provider`, `tokenSet` |
 | `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type` |
 | `(<collection>.)items.read`   | The read item        | `collection`                         |
 | `(<collection>.)items.create` | The new item         | `collection`                         |

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -169,6 +169,14 @@ export default ({ schedule }) => {
 
 :::
 
+::: tip Providers Authentication
+
+`auth.register` is triggered only for `openid` and `oauth2` providers. Moreover
+`AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` has to be enabled. `accessToken` is return by the corresponding providers
+and should not be mistaken with Directus accessToken.
+
+:::
+
 ### Action Events
 
 | Name                          | Meta                                                |

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -146,21 +146,21 @@ export default ({ schedule }) => {
 
 ### Filter Events
 
-| Name                          | Payload              | Meta                                    |
-| ----------------------------- | -------------------- | --------------------------------------- |
-| `request.not_found`           | `false`              | `request`, `response`                   |
-| `request.error`               | The request errors   | --                                      |
-| `database.error`              | The database error   | `client`                                |
-| `auth.login`                  | The login payload    | `status`, `user`, `provider`            |
-| `auth.register`               | The new user payload | `identifier`, `provider`, `accessToken` |
-| `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type`    |
-| `(<collection>.)items.read`   | The read item        | `collection`                            |
-| `(<collection>.)items.create` | The new item         | `collection`                            |
-| `(<collection>.)items.update` | The updated item     | `keys`, `collection`                    |
-| `(<collection>.)items.delete` | The keys of the item | `collection`                            |
-| `<system-collection>.create`  | The new item         | `collection`                            |
-| `<system-collection>.update`  | The updated item     | `keys`, `collection`                    |
-| `<system-collection>.delete`  | The keys of the item | `collection`                            |
+| Name                          | Payload              | Meta                                                |
+| ----------------------------- | -------------------- | --------------------------------------------------- |
+| `request.not_found`           | `false`              | `request`, `response`                               |
+| `request.error`               | The request errors   | --                                                  |
+| `database.error`              | The database error   | `client`                                            |
+| `auth.login`                  | The login payload    | `status`, `user`, `provider`                        |
+| `auth.register`               | The new user payload | `identifier`, `provider`, `accessToken`, `userInfo` |
+| `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type`                |
+| `(<collection>.)items.read`   | The read item        | `collection`                                        |
+| `(<collection>.)items.create` | The new item         | `collection`                                        |
+| `(<collection>.)items.update` | The updated item     | `keys`, `collection`                                |
+| `(<collection>.)items.delete` | The keys of the item | `collection`                                        |
+| `<system-collection>.create`  | The new item         | `collection`                                        |
+| `<system-collection>.update`  | The updated item     | `keys`, `collection`                                |
+| `<system-collection>.delete`  | The keys of the item | `collection`                                        |
 
 ::: tip System Collections
 
@@ -173,7 +173,8 @@ export default ({ schedule }) => {
 
 `auth.register` is triggered only for `openid` and `oauth2` providers. Moreover
 `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` has to be enabled. `accessToken` is return by the corresponding provider and
-should not be mistaken with Directus accessToken.
+should not be mistaken with Directus accessToken. Caution: `userInfo` depends on the provider that is used. Therefore,
+object properties might be different according to the current provider.
 
 :::
 

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -146,21 +146,21 @@ export default ({ schedule }) => {
 
 ### Filter Events
 
-| Name                          | Payload              | Meta                                 |
-| ----------------------------- | -------------------- | ------------------------------------ |
-| `request.not_found`           | `false`              | `request`, `response`                |
-| `request.error`               | The request errors   | --                                   |
-| `database.error`              | The database error   | `client`                             |
-| `auth.login`                  | The login payload    | `status`, `user`, `provider`         |
-| `auth.register`               | The new user payload | `identifier`, `provider`, `tokenSet` |
-| `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type` |
-| `(<collection>.)items.read`   | The read item        | `collection`                         |
-| `(<collection>.)items.create` | The new item         | `collection`                         |
-| `(<collection>.)items.update` | The updated item     | `keys`, `collection`                 |
-| `(<collection>.)items.delete` | The keys of the item | `collection`                         |
-| `<system-collection>.create`  | The new item         | `collection`                         |
-| `<system-collection>.update`  | The updated item     | `keys`, `collection`                 |
-| `<system-collection>.delete`  | The keys of the item | `collection`                         |
+| Name                          | Payload              | Meta                                    |
+| ----------------------------- | -------------------- | --------------------------------------- |
+| `request.not_found`           | `false`              | `request`, `response`                   |
+| `request.error`               | The request errors   | --                                      |
+| `database.error`              | The database error   | `client`                                |
+| `auth.login`                  | The login payload    | `status`, `user`, `provider`            |
+| `auth.register`               | The new user payload | `identifier`, `provider`, `accessToken` |
+| `auth.jwt`                    | The auth token       | `status`, `user`, `provider`, `type`    |
+| `(<collection>.)items.read`   | The read item        | `collection`                            |
+| `(<collection>.)items.create` | The new item         | `collection`                            |
+| `(<collection>.)items.update` | The updated item     | `keys`, `collection`                    |
+| `(<collection>.)items.delete` | The keys of the item | `collection`                            |
+| `<system-collection>.create`  | The new item         | `collection`                            |
+| `<system-collection>.update`  | The updated item     | `keys`, `collection`                    |
+| `<system-collection>.delete`  | The keys of the item | `collection`                            |
 
 ::: tip System Collections
 


### PR DESCRIPTION
We are not able for now to extend the user payload used when registrering a new user.

Oauth2: we lack profile information like first_name and last_name at registration
Openid/Oauth2: 
- we are not able to add additionnal user information to the user that will be created
- we cannot performs any operations when a user login for the first time in Directus, this user might have give Directus applications some precious permissions. For instance allowed Directus to read deep user profile informations.

This will allow to decorate the new user and to get some addionnal profile informations based on the access_token we have just retrieved from the provider.
