### PR TITLE
Bearer token no longer case sensitive for API authenticatiom

### DIFF
--- a/api/src/middleware/extract-token.ts
+++ b/api/src/middleware/extract-token.ts
@@ -19,7 +19,7 @@ const extractToken: RequestHandler = (req, res, next) => {
 	if (req.headers && req.headers.authorization) {
 		const parts = req.headers.authorization.split(' ');
 
-		if (parts.length === 2 && parts[0] === 'Bearer') {
+		if (parts.length === 2 && parts[0].toLowerCase() === 'bearer') {
 			token = parts[1];
 		}
 	}

--- a/api/tests/unit/middleware/extract-token.test.ts
+++ b/api/tests/unit/middleware/extract-token.test.ts
@@ -1,0 +1,69 @@
+import { NextFunction, Request, Response } from 'express';
+import extractToken from '../../../src/middleware/extract-token';
+import '../../../src/types/express.d.ts';
+
+describe('Middleware / Extract Token', () => {
+	let mockRequest: Partial<Request & { token?: string }>;
+	let mockResponse: Partial<Response>;
+	const nextFunction: NextFunction = jest.fn();
+
+	beforeEach(() => {
+		mockRequest = {};
+		mockResponse = {};
+		jest.clearAllMocks();
+	});
+
+	test('Token from query', () => {
+		mockRequest = {
+			query: {
+				access_token: 'test',
+			},
+		};
+
+		extractToken(mockRequest as Request, mockResponse as Response, nextFunction);
+		expect(mockRequest.token).toBe('test');
+		expect(nextFunction).toBeCalledTimes(1);
+	});
+
+	test('Token from Authorization header (capitalized)', () => {
+		mockRequest = {
+			headers: {
+				authorization: 'Bearer test',
+			},
+		};
+
+		extractToken(mockRequest as Request, mockResponse as Response, nextFunction);
+		expect(mockRequest.token).toBe('test');
+		expect(nextFunction).toBeCalledTimes(1);
+	});
+
+	test('Token from Authorization header (lowercase)', () => {
+		mockRequest = {
+			headers: {
+				authorization: 'bearer test',
+			},
+		};
+
+		extractToken(mockRequest as Request, mockResponse as Response, nextFunction);
+		expect(mockRequest.token).toBe('test');
+		expect(nextFunction).toBeCalledTimes(1);
+	});
+
+	test('Ignore the token if authorization header is too many parts', () => {
+		mockRequest = {
+			headers: {
+				authorization: 'bearer test what another one',
+			},
+		};
+
+		extractToken(mockRequest as Request, mockResponse as Response, nextFunction);
+		expect(mockRequest.token).toBeNull();
+		expect(nextFunction).toBeCalledTimes(1);
+	});
+
+	test('Null if no token passed', () => {
+		extractToken(mockRequest as Request, mockResponse as Response, nextFunction);
+		expect(mockRequest.token).toBeNull();
+		expect(nextFunction).toBeCalledTimes(1);
+	});
+});


### PR DESCRIPTION
fixes #11300

Please give feedback if this is a bad change for whatever reason.

I can write some tests later if you want.