### PR TITLE
Mark shared as side effects free

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,6 +33,7 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"sideEffects": false,
 	"scripts": {
 		"build": "run-p \"build:* -- {@}\" --",
 		"build:esm": "tsc --project ./tsconfig.json --module ES2015 --outDir ./dist/esm",


### PR DESCRIPTION
Since #11099 the extensions-sdk isn't externalized anymore when bundling API extensions.
This causes rollup to pull in a lot of unnecessary dependencies that aren't automatically tree-shaken.

Fixes #11275