### PR TITLE
Fixed adding existing element for m2m relation

### DIFF
--- a/app/src/displays/file/file.vue
+++ b/app/src/displays/file/file.vue
@@ -2,7 +2,7 @@
 	<img
 		v-if="imageThumbnail && !imgError"
 		:src="imageThumbnail"
-		:class="{ 'is-svg': value && value.type.includes('svg') }"
+		:class="{ 'is-svg': value && value.type?.includes('svg') }"
 		:alt="value.title"
 		@error="imgError = true"
 	/>
@@ -46,8 +46,8 @@ export default defineComponent({
 
 		const imageThumbnail = computed(() => {
 			if (!props.value) return null;
-			if (props.value.type.includes('svg')) return addTokenToURL(getRootPath() + `assets/${props.value.id}`);
-			if (props.value.type.includes('image') === false) return null;
+			if (props.value.type?.includes('svg')) return addTokenToURL(getRootPath() + `assets/${props.value.id}`);
+			if (props.value.type?.includes('image') === false) return null;
 			return addTokenToURL(getRootPath() + `assets/${props.value.id}?key=system-small-cover`);
 		});
 

--- a/app/src/interfaces/list-m2m/use-actions.ts
+++ b/app/src/interfaces/list-m2m/use-actions.ts
@@ -44,14 +44,17 @@ export default function useActions(
 
 	// Returns all items that do not have an existing junction and related item.
 	function getNewItems() {
-		const { junctionPkField } = relation.value;
+		const { junctionField, junctionPkField } = relation.value;
 
 		if (value.value === null || junctionPkField === null) return [];
 
-		return value.value.filter((item: any) => typeof item === 'object' && !item?.[junctionPkField]) as Record<
-			string,
-			any
-		>[];
+		return value.value.filter(
+			(item: any) =>
+				typeof item === 'object' &&
+				!item?.[junctionPkField] &&
+				junctionField in item &&
+				typeof item[junctionField] === 'object'
+		) as Record<string, any>[];
 	}
 
 	// Returns a list of items which related or junction item does exist but had changes.

--- a/app/src/interfaces/list-m2m/use-selection.ts
+++ b/app/src/interfaces/list-m2m/use-selection.ts
@@ -36,13 +36,20 @@ export default function useSelection(
 		const selection = newSelection.map((item) => {
 			const initial = initialItems.value.find((existent) => existent[junctionField][relationPkField] === item);
 			const draft = items.value.find((draft) => draft[junctionField][relationPkField] === item);
+			// If for the first time an element is selected that does not yet have a connecting element,
+			// but the associated element exists.
+			if (!initial && !draft) {
+				return {
+					[junctionField]: item,
+				};
+			}
 
 			return {
 				...initial,
 				...draft,
 				[junctionField]: {
-					...initial?.[relationPkField],
-					...draft?.[relationPkField],
+					...initial?.[junctionField],
+					...draft?.[junctionField],
 					[relationPkField]: item,
 				},
 			};


### PR DESCRIPTION
Fix #10916.
Edits in the `file.vue` are only needed to prevent future unhandled exceptions if an unfilled object arrives there