### PR TITLE
Fix update file endpoint

### DIFF
--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -18,8 +18,7 @@ const router = express.Router();
 router.use(useCollection('directus_files'));
 
 const multipartHandler = asyncHandler(async (req, res, next) => {
-	if (req.is('multipart/form-data') === false)
-		throw new UnsupportedMediaTypeException(`Unsupported Content-Type header`);
+	if (req.is('multipart/form-data') === false) return next();
 
 	let headers: BusboyHeaders;
 
@@ -114,6 +113,10 @@ router.post(
 	'/',
 	multipartHandler,
 	asyncHandler(async (req, res, next) => {
+		if (req.is('multipart/form-data') === false) {
+			throw new UnsupportedMediaTypeException(`Unsupported Content-Type header`);
+		}
+
 		const service = new FilesService({
 			accountability: req.accountability,
 			schema: req.schema,

--- a/packages/specs/src/paths/files/file.yaml
+++ b/packages/specs/src/paths/files/file.yaml
@@ -22,7 +22,7 @@ get:
 
 patch:
   summary: Update a File
-  description: Update an existing file.
+  description: Update an existing file, and/or replace it's file contents.
   tags:
     - Files
   operationId: updateFile
@@ -31,6 +31,39 @@ patch:
     - $ref: '../../openapi.yaml#/components/parameters/Meta'
   requestBody:
     content:
+      multipart/data:
+        schema:
+          type: object
+          required:
+            - file
+          properties:
+            title:
+              description: Title for the file. Is extracted from the filename on upload, but can be edited by the user.
+              example: User Avatar
+              type: string
+            filename_download:
+              description: Preferred filename when file is downloaded.
+              type: string
+            description:
+              description: Description for the file.
+              type: string
+              nullable: true
+            folder:
+              description: Virtual folder where this file resides in.
+              example: null
+              oneOf:
+                - type: string
+                - $ref: '../../openapi.yaml#/components/schemas/Folders'
+              nullable: true
+            tags:
+              description: Tags for the file. Is automatically populated based on EXIF data for images.
+              type: array
+              nullable: true
+              items:
+                type: string
+            file:
+              description: File contents.
+              format: binary
       application/json:
         schema:
           type: object
@@ -38,6 +71,9 @@ patch:
             title:
               description: Title for the file. Is extracted from the filename on upload, but can be edited by the user.
               example: User Avatar
+              type: string
+            filename_download:
+              description: Preferred filename when file is downloaded.
               type: string
             description:
               description: Description for the file.


### PR DESCRIPTION
Fixes #11335

## Context

In #11096, the exception were thrown in `multipartHandler`:

https://github.com/directus/directus/blob/efbda61b4d1c57119ddaa2df508de43823b230fa/api/src/controllers/files.ts#L20-L22

so that POST requests to upload files will enforce `multipart/data` content type header.

However PATCH requests are also using the same handler, thus ended up preventing any file metadata updates:

https://github.com/directus/directus/blob/efbda61b4d1c57119ddaa2df508de43823b230fa/api/src/controllers/files.ts#L272-L275

## Changes

- Revert check in multipartHandler to `if (req.is('multipart/form-data') === false) return next();` so that it'll passs through to file metadata updates from `application/json` requests.
- Moved the `multipart/data` check to POST request. 
- Added `multipart/data` request body type to Update File oas specs. Addresses https://github.com/directus/directus/issues/11335#issuecomment-1024923488