### PR TITLE
Document `--yes` option for applying schema snapshots

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,6 +98,12 @@ To apply the generated snapshot, run
 npx directus schema apply ./path/to/snapshot.yaml
 ```
 
+To skip manual verification (e.g. when running in a CI workflow), run
+
+```
+npx directus schema apply --yes true ./path/to/snapshot.yaml
+```
+
 ### Creating Users
 
 To create a new user with a specific role, run


### PR DESCRIPTION
There's [an undocumented `--yes` option](https://github.com/directus/directus/blob/c01f507696031068cca29bc63ce994215190b768/api/src/cli/commands/schema/apply.ts#L14), which is a rather valuable information and should be documented. For example, when you run the migration step in a CI/CD workflow, you don't want the manual prompt.