### PR TITLE
Fixed issue when updating columns in Oracle

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -561,7 +561,7 @@ export class FieldsService {
 			}
 		} else if (field.schema?.is_nullable === true) {
 			if (!alter || alter?.is_nullable === false) {
-				column.nullable();	
+				column.nullable();
 			}
 		}
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -555,10 +555,14 @@ export class FieldsService {
 			}
 		}
 
-		if (field.schema?.is_nullable !== undefined && field.schema.is_nullable === false) {
-			column.notNullable();
-		} else {
-			column.nullable();
+		if (field.schema?.is_nullable === false) {
+			if (!alter || alter?.is_nullable === true) {
+				column.notNullable();
+			}
+		} else if (field.schema?.is_nullable === true) {
+			if (!alter || alter?.is_nullable === false) {
+				column.nullable();	
+			}
 		}
 
 		if (field.schema?.is_primary_key) {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -556,11 +556,11 @@ export class FieldsService {
 		}
 
 		if (field.schema?.is_nullable === false) {
-			if (!alter || alter?.is_nullable === true) {
+			if (!alter || alter.is_nullable === true) {
 				column.notNullable();
 			}
 		} else if (field.schema?.is_nullable === true) {
-			if (!alter || alter?.is_nullable === false) {
+			if (!alter || alter.is_nullable === false) {
 				column.nullable();
 			}
 		}


### PR DESCRIPTION
Fixes an issue with Oracle where you are unable to alter a column if you don't change it's nullability. Oracle will reject the update query if it tries to set the same nullability as is already set on the column. The solution is to skip setting the `nullable` constraint if it is unchanged (the same as the `is_unique` constraint below it).