### PR TITLE
Adding logger to custom migrations

### DIFF
--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -8,6 +8,7 @@ import { Migration } from '../../types';
 import { orderBy } from 'lodash';
 
 export default async function run(database: Knex, direction: 'up' | 'down' | 'latest', log = true): Promise<void> {
+	const customMigrationOptions = { logger, log };
 	let migrationFiles = await fse.readdir(__dirname);
 
 	const customMigrationsPath = path.resolve(env.EXTENSIONS_PATH, 'migrations');
@@ -69,7 +70,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 			logger.info(`Applying ${nextVersion.name}...`);
 		}
 
-		await up(database);
+		await up(database, customMigrationOptions);
 		await database.insert({ version: nextVersion.version, name: nextVersion.name }).into('directus_migrations');
 	}
 
@@ -92,7 +93,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 			logger.info(`Undoing ${migration.name}...`);
 		}
 
-		await down(database);
+		await down(database, customMigrationOptions);
 		await database('directus_migrations').delete().where({ version: migration.version });
 	}
 
@@ -105,7 +106,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 					logger.info(`Applying ${migration.name}...`);
 				}
 
-				await up(database);
+				await up(database, customMigrationOptions);
 				await database.insert({ version: migration.version, name: migration.name }).into('directus_migrations');
 			}
 		}

--- a/docs/extensions/migrations.md
+++ b/docs/extensions/migrations.md
@@ -59,3 +59,7 @@ npx directus database migrate:latest
 ```
 
 You may want to add additional steps to reflect other responsibilities of `directus bootstrap`.
+
+## Logger
+
+The logger is an instance of `pino`. You can find the documentation [here](https://github.com/pinojs/pino/blob/master/docs/api.md#logger)

--- a/docs/extensions/migrations.md
+++ b/docs/extensions/migrations.md
@@ -19,12 +19,13 @@ for example:
 
 ## Structure
 
-Migrations have to export an `up` and a `down` function. These functions get a [Knex](http://knexjs.org) instance that
-can be used to do virtually whatever.
+Migrations have to export an `up` and a `down` function. These functions get a [Knex](http://knexjs.org) instance, that
+can be used to do virtually whatever, and optional logging parameters.
 
 ```js
 module.exports = {
-	async up(knex) {
+	async up(knex, { logger, log }) {
+		if (log) logger.warn('Creating test table');
 		await knex.schema.createTable('test', (table) => {
 			table.increments();
 			table.string('rijk');


### PR DESCRIPTION
This PR adds 2 new options to the custom migrations up/down methods.

`logger` - instance of `pino` logger for logging output to the console during migration execution
`log` - boolean for conditionally logging

Based on discussion here: https://github.com/directus/directus/discussions/11247

Documentation has also been updated to referenced the above parameters