### PR TITLE
add a hint to a working docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
-# This composer file is meant to spin up a copy of all supported database vendors + Redis and S3 (Minio).
+# This compose file is meant to spin up a copy of all supported database vendors + Redis and S3 (Minio).
+# For production use see the docker compose file example in the docs:
+#     https://docs.directus.io/getting-started/installation/docker/#docker-compose
 #
 # ONLY FOR DEBUGGING. THIS IS NOT INTENDED FOR PRODUCTION USE.
 #


### PR DESCRIPTION
That'll save some user the time to dig for the proper docker compose file template.