### PR TITLE
Document `--yes` option for creating schema snapshots

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,6 +85,14 @@ with your team. To generate the snapshot, run
 npx directus schema snapshot ./snapshot.yaml
 ```
 
+To run non-interactively (e.g. when running in a CI/CD workflow), run
+
+```
+npx directus schema snapshot --yes true ./snapshot.yaml
+```
+
+Note, that this will force overwrite existing snapshot files.
+
 #### Applying a Snapshot
 
 To make a different instance up to date with the latest changes in your data model, you can apply the snapshot. By
@@ -98,7 +106,7 @@ To apply the generated snapshot, run
 npx directus schema apply ./path/to/snapshot.yaml
 ```
 
-To skip manual verification (e.g. when running in a CI workflow), run
+To run non-interactively (e.g. when running in a CI/CD workflow), run
 
 ```
 npx directus schema apply --yes true ./path/to/snapshot.yaml


### PR DESCRIPTION
Addition to #11356, this adds documentation for _creating_ schema snapshots using the `--yes` option. Also includes a consistent better wording for the previous change in #11356.