### PR TITLE
Fix performance drop in stacked drawer when many layers

### DIFF
--- a/app/src/styles/_stacked-drawers.scss
+++ b/app/src/styles/_stacked-drawers.scss
@@ -4,6 +4,10 @@
 		transition-property: transform, border-radius;
 	}
 
+	.container.right:not(:nth-last-child(-n + 5)) {
+		display: none;
+	}
+
 	.container.right:not(:last-of-type) .v-drawer {
 		overflow: hidden;
 	}


### PR DESCRIPTION
In the stacked layer, because the opacity, only 5-6 layers are clearly visibible, therefore no need to actually displays the rest of them. In example, if opened more than 5-6 (rear cases, but anyway), this cause performance drop and lot of memory consumption.

With this change, simply all but not latest 5 of them are set to be not displayed.