### PR TITLE
Fix items' translations not loaded in relational modal

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -289,12 +289,7 @@ export default defineComponent({
 			watch(
 				() => props.value,
 				(newVal, oldVal) => {
-					if (
-						newVal &&
-						!isEqual(newVal, oldVal) &&
-						newVal.every((item) => typeof item === 'string' || typeof item === 'number') &&
-						isUndo.value === false
-					) {
+					if (newVal && !oldVal && !isEqual(newVal, oldVal) && isUndo.value === false) {
 						loadItems();
 					}
 


### PR DESCRIPTION
closes #11259 
The problem was that the interface would be initialized with an array already containing the edits, thus not loading any existing values.
To fix this we now only load existing items when the value gets initialized.