### PR TITLE
Fix text when deleting data-model folder

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -581,6 +581,7 @@ one_filtered_item: '1 filtered item'
 delete_collection_are_you_sure: >-
   Are you sure you want to delete this collection? This will delete the collection and all items in it. This action is
   permanent.
+delete_folder_are_you_sure: Are you sure you want to delete this folder? Nested folders and collections will be moved to the top most level.
 collections_shown: Collections Shown
 visible_collections: Visible Collections
 hidden_collections: Hidden Collections

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -33,13 +33,15 @@
 
 		<v-dialog v-model="deleteActive" @esc="deleteActive = null">
 			<v-card>
-				<v-card-title>{{ t('delete_collection_are_you_sure') }}</v-card-title>
+				<v-card-title>
+					{{ collection.schema ? t('delete_collection_are_you_sure') : t('delete_folder_are_you_sure') }}
+				</v-card-title>
 				<v-card-actions>
 					<v-button :disabled="deleting" secondary @click="deleteActive = null">
 						{{ t('cancel') }}
 					</v-button>
 					<v-button :loading="deleting" kind="danger" @click="deleteCollection">
-						{{ t('delete_collection') }}
+						{{ collection.schema ? t('delete_collection') : t('delete_folder') }}
 					</v-button>
 				</v-card-actions>
 			</v-card>


### PR DESCRIPTION
When deleting a folder in data-model, it would display the same text as when deleting a collection which can be very confusing.