### PR TITLE
Prevent creation of relationships on primary keys

### DIFF
--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -143,6 +143,15 @@ export class RelationsService {
 			);
 		}
 
+		const columnInfo = await this.schemaInspector.columnInfo(relation.collection, relation.field);
+
+		// A primary key should not be a foreign key
+		if (columnInfo.is_primary_key) {
+			throw new InvalidPayloadException(
+				`Field "${relation.field}" in collection "${relation.collection}" is a primary key`
+			);
+		}
+
 		if (relation.related_collection && relation.related_collection in this.schema.collections === false) {
 			throw new InvalidPayloadException(`Collection "${relation.related_collection}" doesn't exist`);
 		}

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -143,10 +143,8 @@ export class RelationsService {
 			);
 		}
 
-		const columnInfo = await this.schemaInspector.columnInfo(relation.collection, relation.field);
-
 		// A primary key should not be a foreign key
-		if (columnInfo.is_primary_key) {
+		if (this.schema.collections[relation.collection].primary === relation.field) {
 			throw new InvalidPayloadException(
 				`Field "${relation.field}" in collection "${relation.collection}" is a primary key`
 			);


### PR DESCRIPTION
Closes #11357.

Was thinking if the same change should be added to relation's `updateOne()`. Currently not added as I think it may lead to issues surfacing from users with existing relations on primary keys.