### PR TITLE
Fix repeater's extension options not updating when configured

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -14,10 +14,10 @@
 	<component
 		:is="`${type}-options-${extensionInfo.id}`"
 		v-else
-		v-model="optionsValues"
 		:value="optionsValues"
 		:collection="collection"
 		:field="field"
+		@input="optionsValues = $event"
 	/>
 </template>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -12,7 +12,7 @@
 	/>
 
 	<component
-		:is="`${type}-options-${extensionInfo.id}`"
+		:is="`${type}-options-${extensionInfo!.id}`"
 		v-else
 		:value="optionsValues"
 		:collection="collection"

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -60,7 +60,7 @@ export default defineComponent({
 			default: null,
 		},
 	},
-	emits: ['update:model-value'],
+	emits: ['update:modelValue'],
 	setup(props, { emit }) {
 		const { t } = useI18n();
 
@@ -112,7 +112,7 @@ export default defineComponent({
 				return props.modelValue;
 			},
 			set(values: Record<string, any>) {
-				emit('update:model-value', values);
+				emit('update:modelValue', values);
 			},
 		});
 


### PR DESCRIPTION
Fixes #11447

## Investigation

The bug occurs due to extension options being `null` (as seen in the bug report errors). Seems like in  #10828, `@input` was replaced with `v-model` here: https://github.com/directus/directus/pull/10828/files#diff-922856f7e4b8d662bef225e06b6c4f096632405eb04f56692933576ab202f3f7L20

However the list extension options emits `input` rather than `update:modelValue` as seen here:

https://github.com/directus/directus/blob/232c21ed1aefd035d37664ef88ab33157db2ae45/app/src/interfaces/list/options.vue#L42

Hence options are not being updated when configured.

## Changes made

- Replaced `v-model="optionsValues"` with `@input="optionsValues = $event"` to fix the reported issue..

- Fixed lint warning for `extensionInfo` possibly undefined in ``:is="`${type}-options-${extensionInfo!.id}`"``. `usesCustomComponent` will only be true when extensionInfo has value.

- Changed emitted `update:model-value` to camelCase `update:modelValue` just for consistency as the latter is used throughout the app.