### PR TITLE
Fix Metrics type panel creation

### DIFF
--- a/app/src/panels/metric/index.ts
+++ b/app/src/panels/metric/index.ts
@@ -18,9 +18,9 @@ export default definePanel({
 				: null;
 		});
 
-		const supportsAggregate = computed(() => {
-			return fieldType.value ? ['integer', 'bigInteger', 'float', 'decimal'].includes(fieldType.value) : false;
-		});
+		const supportsAggregate = computed(() =>
+			fieldType.value ? ['integer', 'bigInteger', 'float', 'decimal'].includes(fieldType.value) : false
+		);
 
 		return [
 			{

--- a/app/src/panels/metric/index.ts
+++ b/app/src/panels/metric/index.ts
@@ -1,7 +1,6 @@
 import { computed } from 'vue';
 import { useFieldsStore } from '@/stores';
 import { definePanel } from '@directus/shared/utils';
-import { Panel } from '@directus/shared/types';
 import PanelMetric from './metric.vue';
 
 export default definePanel({
@@ -10,18 +9,18 @@ export default definePanel({
 	description: '$t:panels.metric.description',
 	icon: 'functions',
 	component: PanelMetric,
-	options: (edits) => {
+	options: ({ options }) => {
 		const fieldsStore = useFieldsStore();
 
 		const fieldType = computed(() => {
-			const fieldStore = useFieldsStore();
-			const field = fieldStore.getField(edits.options?.collection, edits.options?.field);
-			return field?.type ?? null;
+			return options?.collection && options?.field
+				? fieldsStore.getField(options.collection, options.field)?.type
+				: null;
 		});
 
-		const supportsAggregate = computed(
-			() => fieldType.value && ['integer', 'bigInteger', 'float', 'decimal'].includes(fieldType.value)
-		);
+		const supportsAggregate = computed(() => {
+			return fieldType.value ? ['integer', 'bigInteger', 'float', 'decimal'].includes(fieldType.value) : false;
+		});
 
 		return [
 			{


### PR DESCRIPTION
Fixes #11435

## Investigation

Currently Metrics panel find the `fieldType` based on the selected collection & field in order to decide whether that field supports aggregate or not.

https://github.com/directus/directus/blob/f01928bea6cf8681640d0212114f80edfbf84c79/app/src/panels/metric/index.ts#L16-L24

However right when we first _click_ on Metrics, both collection & field are null as they are not selected yet, which causes the `fieldStore.getField(<collection>, <field>)` to fail as it requires both collection & field to be defined.

https://github.com/directus/directus/blob/f01928bea6cf8681640d0212114f80edfbf84c79/app/src/panels/metric/index.ts#L18

## Changes Made

- Made sure collection & field is not null when passing them to `fieldsStore.getField()`
- Slightly unimportant but made sure `supportsAggregate` to be `boolean` instead of `boolean | null`.

## Result

![XnfJhmzqE6](https://user-images.githubusercontent.com/42867097/152665941-37bfb160-f07f-4c36-99d1-344ca0a47714.gif)

