### PR TITLE
fix field advanced display config not working

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
@@ -40,7 +40,6 @@ export default defineComponent({
 
 		const interfaceID = computed(() => field.value.meta?.interface);
 		const display = syncFieldDetailStoreProperty('field.meta.display');
-		const options = syncFieldDetailStoreProperty('field.meta.display_options');
 
 		const selectedInterface = computed(() => getInterface(interfaceID.value));
 		const selectedDisplay = computed(() => getDisplay(display.value));
@@ -91,6 +90,20 @@ export default defineComponent({
 			}
 
 			return null;
+		});
+
+		const options = computed({
+			get() {
+				return fieldDetailStore.field.meta?.display_options ?? {};
+			},
+			set(newOptions: Record<string, any>) {
+				fieldDetailStore.$patch((state) => {
+					state.field.meta = {
+						...(state.field.meta ?? {}),
+						display_options: newOptions,
+					};
+				});
+			},
 		});
 
 		return { t, selectItems, selectedDisplay, display, options, customOptionsFields };


### PR DESCRIPTION
Fixes #11442

## Reported Bug

Although the user reported 2 separate occasions of unable to uncheck options, narrowing them down would be both occuring in Display config:

![kXndC1JCEA](https://user-images.githubusercontent.com/42867097/152735917-53045fcf-a76d-4697-baf4-2614fd4f7c98.gif)

## Investigation

After changes in #10828, `options` passed to `<extension-options>` in `<field-display-advanced-display>` component aren't updated upon change: 

https://github.com/directus/directus/blob/b8c4317cb1cd9a8ed0eeb1ad4db35f8771588624/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue#L43

which made the `props.modelValue` subsequently doesn't get updated, hence the form seemingly "freeze" after the first changes made by user:

https://github.com/directus/directus/blob/b8c4317cb1cd9a8ed0eeb1ad4db35f8771588624/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue#L112 

## After Fix

![r9o0RPCJqe](https://user-images.githubusercontent.com/42867097/152737045-340739db-950e-485b-b4d8-8a0b9ed0fa52.gif)

