### PR TITLE
Fix translations interface divider's margin top

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -446,10 +446,6 @@ export default defineComponent({
 		margin-top: 32px;
 	}
 
-	.v-divider {
-		margin-top: var(--form-vertical-gap);
-	}
-
 	.primary {
 		--v-divider-color: var(--primary-50);
 	}
@@ -461,6 +457,13 @@ export default defineComponent({
 			--primary: var(--blue);
 			--v-chip-color: var(--blue);
 			--v-chip-background-color: var(--blue-alt);
+		}
+	}
+
+	.primary,
+	.secondary {
+		.v-divider {
+			margin-top: var(--form-vertical-gap);
 		}
 	}
 }


### PR DESCRIPTION
## Context

Prompted by https://github.com/directus/directus/issues/8811#issuecomment-1031150617, where the divider at the end of translations interface seemingly doesn't have margin top anymore:

![chrome_3ClVRjX6ow](https://user-images.githubusercontent.com/42867097/152747243-b2102f01-aa6e-4a24-8f04-4b648e4b50f1.png)

Apparently the margin top was being overridden by the following style which was added when #8467 was merged fairly recently:

https://github.com/directus/directus/blob/b8c4317cb1cd9a8ed0eeb1ad4db35f8771588624/app/src/components/v-form/v-form.vue#L355-L357

## Solution

Increased the specificity from `.translations .v-divider` to `.translations .primary .v-divider` (and .secondary respectively) so that it will not get overridden now:

![chrome_Zify0piDbZ](https://user-images.githubusercontent.com/42867097/152747266-782e0759-91b4-4d79-9c48-2e8c8e15fde7.png)

