### PR TITLE
Prevent literal interpolation on null translations & apply to collection translations

### DIFF
--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -54,9 +54,11 @@ export const useCollectionsStore = defineStore({
 				for (let i = 0; i < collection.meta.translations.length; i++) {
 					const { language, translation, singular, plural } = collection.meta.translations[i];
 
+					const literalInterpolatedTranslation = translation ? translation.replace(/([{}@$|])/g, "{'$1'}") : '';
+
 					i18n.global.mergeLocaleMessage(language, {
 						collection_names: {
-							[collection.collection]: translation,
+							[collection.collection]: literalInterpolatedTranslation,
 						},
 						collection_names_singular: {
 							[collection.collection]: singular,

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -76,7 +76,7 @@ export const useFieldsStore = defineStore({
 					const { language, translation } = field.meta.translations[i];
 
 					// Interpolate special characters in vue-i18n to prevent parsing error. Ref #11287
-					const literalInterpolatedTranslation = translation.replace(/([{}@$|])/g, "{'$1'}");
+					const literalInterpolatedTranslation = translation ? translation.replace(/([{}@$|])/g, "{'$1'}") : '';
 
 					i18n.global.mergeLocaleMessage(language, {
 						fields: {


### PR DESCRIPTION
Sort of a follow up of #11287

## Changes made

- translation could be null if the user had only selected a language for translating a field/collection, so the regex replace will error. Added ternary operator to handle it. Fixes #11458 

- Noticed the fix wasn't applied to collection translations, so I've added the same logic over there as well.