### PR TITLE
fix directus_notifications default app access permissions fields not returning as array

### DIFF
--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -62,14 +62,14 @@
   permissions:
     recipient:
       _eq: $CURRENT_USER
-  fields: '*'
 
 - collection: directus_notifications
   action: update
   permissions:
     recipient:
       _eq: $CURRENT_USER
-  fields: 'status'
+  fields:
+    - status
 
 - collection: directus_users
   action: read


### PR DESCRIPTION
Fixes #11518

## Before

![chrome_u9uvDFgLQh](https://user-images.githubusercontent.com/42867097/153073197-7ca60419-7e29-44e0-8466-ce8c9b27623e.png)

## After

![chrome_U2PbG3WWm5](https://user-images.githubusercontent.com/42867097/153073213-77c0f999-b236-487e-9983-c51421a46ce5.png)

