### PR TITLE
Add shares to app access minimum permissions

### DIFF
--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -71,6 +71,12 @@
   fields:
     - status
 
+- collection: directus_shares
+  action: read
+  permissions:
+    user_created:
+      _eq: $CURRENT_USER
+
 - collection: directus_users
   action: read
   permissions:

--- a/app/src/modules/settings/routes/roles/app-permissions.ts
+++ b/app/src/modules/settings/routes/roles/app-permissions.ts
@@ -297,6 +297,15 @@ export const appMinimalPermissions: Partial<Permission>[] = [
 		action: 'read',
 	},
 	{
+		collection: 'directus_shares',
+		action: 'read',
+		permissions: {
+			user_created: {
+				_eq: '$CURRENT_USER',
+			},
+		},
+	},
+	{
 		collection: 'directus_users',
 		action: 'read',
 		permissions: {


### PR DESCRIPTION
Closes #11559. Shares is a core feature within the app, users should at least have permissions to see the shares that they have created.