### PR TITLE
Fix timestamp created with unexpected property in MariaDB

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -555,7 +555,7 @@ export class FieldsService {
 			if (!alter || alter.is_nullable === true) {
 				column.notNullable();
 			}
-		} else if (field.schema?.is_nullable === true) {
+		} else {
 			if (!alter || alter.is_nullable === false) {
 				column.nullable();
 			}


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/11446

Amazingly, when creating a `timestamp` column in MariaDB, without any further info, the column is created with a `NOT NULL` constraint, and even worse, a default value of `current_timestamp()` and even even worse, an *extra* option `on update current_timestamp()` which means that the column value will be updated to the current time whenever another row is updated.

Up until now, all `timestamp` columns created in MariaDB have those properties.

This is obviously very very wrong and unexpected as it is both the only database and the only `datetime` type to behave like that.

In order to prevent this behaviour, we need to explicitly create the column `nullable` when unspecified.