### PR TITLE
Fix dashboard panels distinct functions

### DIFF
--- a/app/src/panels/metric/index.ts
+++ b/app/src/panels/metric/index.ts
@@ -81,7 +81,7 @@ export default definePanel({
 
 							{
 								text: 'Count (Distinct)',
-								value: 'count_distinct',
+								value: 'countDistinct',
 								disabled: !supportsAggregate.value,
 							},
 							{
@@ -91,7 +91,7 @@ export default definePanel({
 							},
 							{
 								text: 'Average (Distinct)',
-								value: 'avg_distinct',
+								value: 'avgDistinct',
 								disabled: !supportsAggregate.value,
 							},
 							{
@@ -101,7 +101,7 @@ export default definePanel({
 							},
 							{
 								text: 'Sum (Distinct)',
-								value: 'sum_distinct',
+								value: 'sumDistinct',
 								disabled: !supportsAggregate.value,
 							},
 							{

--- a/app/src/panels/metric/metric.vue
+++ b/app/src/panels/metric/metric.vue
@@ -43,7 +43,7 @@ export default defineComponent({
 		},
 		function: {
 			type: String as PropType<
-				'avg' | 'avg_distinct' | 'sum' | 'sum_distinct' | 'count' | 'count_distinct' | 'min' | 'max' | 'first' | 'last'
+				'avg' | 'avgDistinct' | 'sum' | 'sumDistinct' | 'count' | 'countDistinct' | 'min' | 'max' | 'first' | 'last'
 			>,
 			required: true,
 		},

--- a/app/src/panels/time-series/index.ts
+++ b/app/src/panels/time-series/index.ts
@@ -47,7 +47,7 @@ export default definePanel({
 						},
 						{
 							text: 'Count (Distinct)',
-							value: 'count_distinct',
+							value: 'countDistinct',
 						},
 						{
 							text: 'Average',
@@ -55,7 +55,7 @@ export default definePanel({
 						},
 						{
 							text: 'Average (Distinct)',
-							value: 'avg_distinct',
+							value: 'avgDistinct',
 						},
 						{
 							text: 'Sum',
@@ -63,7 +63,7 @@ export default definePanel({
 						},
 						{
 							text: 'Sum (Distinct)',
-							value: 'sum_distinct',
+							value: 'sumDistinct',
 						},
 						{
 							text: 'Minimum',

--- a/app/src/panels/time-series/time-series.vue
+++ b/app/src/panels/time-series/time-series.vue
@@ -52,7 +52,7 @@ export default defineComponent({
 		},
 		function: {
 			type: String as PropType<
-				'avg' | 'avg_distinct' | 'sum' | 'sum_distinct' | 'count' | 'count_distinct' | 'min' | 'max'
+				'avg' | 'avgDistinct' | 'sum' | 'sumDistinct' | 'count' | 'countDistinct' | 'min' | 'max'
 			>,
 			required: true,
 		},


### PR DESCRIPTION
Fixes #11574

## Context

When we select `Count (Distinct)` aggregate function for applicable panels, the value is sent as `count_distinct` (snake_case):

https://github.com/directus/directus/blob/051d4250087c499835bef93e93ab65164d89648c/app/src/panels/metric/index.ts#L83-L84

However the API expects `countDistinct` (camelCase):

https://github.com/directus/directus/blob/051d4250087c499835bef93e93ab65164d89648c/api/src/utils/apply-query.ts#L662-L664

## Before

It should show aggregate functiosn on two numbers, 20 and 30. 3rd number is not distinct, hence it should be omitted. But since the functions are the wrong case, they were never applied and the API returns empty result (blank UI).

![chrome_GB3TGleGRN](https://user-images.githubusercontent.com/42867097/153536683-90bd920d-1d17-4276-a384-1cf65a565ed4.png)

## After

![chrome_S4aOXlIN8Y](https://user-images.githubusercontent.com/42867097/153536752-dfac4bbd-17e0-40d2-8599-c57fef255305.png)

