### PR TITLE
Fix nested M2O field breaking parent M2O preview

### DIFF
--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -101,6 +101,7 @@ import { Filter } from '@directus/shared/types';
 import { parseFilter } from '@/utils/parse-filter';
 import { render } from 'micromustache';
 import { deepMap } from '@directus/shared/utils';
+import { merge } from 'lodash';
 
 /**
  * @NOTE
@@ -479,10 +480,7 @@ export default defineComponent({
 					emit('input', newEdits);
 				}
 
-				currentItem.value = {
-					...currentItem.value,
-					...newEdits,
-				};
+				currentItem.value = merge({}, currentItem.value, newEdits);
 			}
 		}
 	},


### PR DESCRIPTION
Fixes #8030

## Before

Parent M2O field loses display preview when editing nested M2O field _that is NOT_ the preview field:

https://user-images.githubusercontent.com/42867097/153551189-cca94021-2b76-4153-bb2f-0ea5472a4c76.mp4

## Investigation

Originally the payload looks like this (it has `name` fetched so that the display template works):

```js
{
    mto_model_a: {
        name: "Model A Item 1"
    }
}
```

After editing, the payload will look like this instead:

```js
{
    mto_model_a: {
        id: 1,
        description: "Item 1 Description edited"
    }
}
```

This is why `name` field was lost, thus making the parent display unable to show it. This is because the current code is not a deep merge:

https://github.com/directus/directus/blob/051d4250087c499835bef93e93ab65164d89648c/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue#L482-L485

Solution is to use lodash's `merge` instead.

## After

https://user-images.githubusercontent.com/42867097/153551286-c441ea98-6963-4082-9ea0-c0d6f21cc64a.mp4


