### PR TITLE
Remove relation from store when translations field is deleted

### DIFF
--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -222,7 +222,12 @@ export const useFieldsStore = defineStore({
 			});
 
 			relationsStore.relations = relationsStore.relations.filter((relation) => {
-				if (relation.collection === collectionKey && relation.field === fieldKey) return false;
+				if (
+					(relation.collection === collectionKey && relation.field === fieldKey) ||
+					(relation.related_collection === collectionKey && relation.meta?.one_field === fieldKey)
+				) {
+					return false;
+				}
 				return true;
 			});
 


### PR DESCRIPTION
Closes #9069

## Before

Ref https://github.com/directus/directus/issues/9069#issuecomment-962489602, the reproduction steps are:

> 1. Create a new Collection called `something`
> 2. Add a translation field, leaving everything as default
> 3. Head to the `something_translations` table and add a string field called `one`
> 4. Head back to `something` and delete `translations`
> 5. Add a translation field again, leaving everything as default
> 6. Head to the `something_translations_1` table and add a string field called `two`
> 7. Head over to the Content module, create a new entry in `something`
> 8. Notice that the string field is `one`, which is supposed to be deleted

https://user-images.githubusercontent.com/42867097/153567691-4c70f11a-0ee9-41c6-9752-edc62c8b4b64.mp4

## Findings & Implementation

When a field is deleted, it does "remove the relation" and update the relationsStore by filtering it out here:

https://github.com/directus/directus/blob/051d4250087c499835bef93e93ab65164d89648c/app/src/stores/fields.ts#L224-L227

However this doesn't work for translations as the `collectionKey` is `something_translations`, not `something` so it never got filtered out.

This is further proven by the translations display's relation logic:

https://github.com/directus/directus/blob/051d4250087c499835bef93e93ab65164d89648c/app/src/displays/translations/index.ts#L84-L86

So the current solution opted to copy the logic in `getRelationsForField` which covers both cases:

https://github.com/directus/directus/blob/051d4250087c499835bef93e93ab65164d89648c/app/src/stores/relations.ts#L65-L66

## After

https://user-images.githubusercontent.com/42867097/153567444-ffd92e99-bddd-4780-84aa-a7a7272ba5f0.mp4