### PR TITLE
Change relation delete rule to `NO ACTION` for non-nullable fields

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2o.vue
@@ -51,29 +51,7 @@
 					v-model="onDeleteRelated"
 					:disabled="collection === relatedCollection"
 					:placeholder="t('choose_action') + '...'"
-					:items="[
-						{
-							text: t('referential_action_set_null', { field: currentField }),
-							value: 'SET NULL',
-						},
-						{
-							text: t('referential_action_set_default', { field: currentField }),
-							value: 'SET DEFAULT',
-						},
-						{
-							text: t('referential_action_cascade', {
-								collection: collection,
-								field: currentField,
-							}),
-							value: 'CASCADE',
-						},
-						{
-							text: t('referential_action_no_action', {
-								field: currentField,
-							}),
-							value: 'NO ACTION',
-						},
-					]"
+					:items="onDeleteOptions"
 				/>
 			</div>
 		</div>
@@ -152,6 +130,30 @@ export default defineComponent({
 			return t('add_field_related');
 		});
 
+		const onDeleteOptions = computed(() =>
+			[
+				{
+					text: t('referential_action_set_null', { field: currentField.value }),
+					value: 'SET NULL',
+				},
+				{
+					text: t('referential_action_set_default', { field: currentField.value }),
+					value: 'SET DEFAULT',
+				},
+				{
+					text: t('referential_action_cascade', {
+						collection: collection.value,
+						field: currentField.value,
+					}),
+					value: 'CASCADE',
+				},
+				{
+					text: t('referential_action_no_action', { field: currentField.value }),
+					value: 'NO ACTION',
+				},
+			].filter((o) => !(o.value === 'SET NULL' && field.value.schema?.is_nullable === false))
+		);
+
 		return {
 			t,
 			collection,
@@ -164,6 +166,7 @@ export default defineComponent({
 			correspondingFieldKey,
 			generationInfo,
 			onDeleteRelated,
+			onDeleteOptions,
 		};
 	},
 });

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/file.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/file.ts
@@ -2,7 +2,7 @@ import { StateUpdates, State, HelperFunctions } from '../types';
 import { set } from 'lodash';
 
 export function applyChanges(updates: StateUpdates, state: State, helperFn: HelperFunctions) {
-	const { hasChanged } = helperFn;
+	const { hasChanged, getCurrent } = helperFn;
 
 	if (hasChanged('localType')) {
 		setTypeToUUID(updates);
@@ -11,6 +11,12 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 
 	if (hasChanged('field.field')) {
 		updateRelationField(updates);
+	}
+
+	if (hasChanged('field.schema.is_nullable')) {
+		if (updates.field?.schema?.is_nullable === false && getCurrent('relations.m2o.schema.on_delete') === 'SET NULL') {
+			set(updates, 'relations.m2o.schema.on_delete', 'NO ACTION');
+		}
 	}
 }
 

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2o.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2o.ts
@@ -3,7 +3,7 @@ import { set } from 'lodash';
 import { useCollectionsStore, useFieldsStore } from '@/stores';
 
 export function applyChanges(updates: StateUpdates, state: State, helperFn: HelperFunctions) {
-	const { hasChanged } = helperFn;
+	const { hasChanged, getCurrent } = helperFn;
 
 	if (hasChanged('localType')) {
 		prepareRelation(updates, state);
@@ -21,6 +21,12 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 
 	if (hasChanged('fields.corresponding')) {
 		setRelatedOneFieldForCorrespondingField(updates);
+	}
+
+	if (hasChanged('field.schema.is_nullable')) {
+		if (updates.field?.schema?.is_nullable === false && getCurrent('relations.m2o.schema.on_delete') === 'SET NULL') {
+			set(updates, 'relations.m2o.schema.on_delete', 'NO ACTION');
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/9089

The problem was that the default onDelete rule when creating relational fields were `SET NULL`. When making the relational field not nullable, that constraint would be incompatible, leading to an error message (see #9089), and the field being created without the relation.