### PR TITLE
App: Show `field.id` on field context menu

### DIFF
--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -50,8 +50,10 @@
 			:disabled="!isAdmin"
 			:to="isAdmin ? `/settings/data-model/${field.collection}/${field.field}` : undefined"
 		>
-			<v-list-item-icon><v-icon name="tune" /></v-list-item-icon>
-			<v-list-item-content>{{ field.field }}</v-list-item-content>
+			<v-list-item-icon><v-icon name="settings" /></v-list-item-icon>
+			<v-list-item-content>
+				<code>{{ field.field }}</code>
+			</v-list-item-content>
 		</v-list-item>
 	</v-list>
 </template>
@@ -101,9 +103,3 @@ export default defineComponent({
 	},
 });
 </script>
-
-<style scoped>
-.model-field :deep(div) {
-	font-family: monospace;
-}
-</style>

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -44,13 +44,23 @@
 			<v-list-item-icon><v-icon name="delete_outline" /></v-list-item-icon>
 			<v-list-item-content>{{ t('clear_value') }}</v-list-item-content>
 		</v-list-item>
+		<v-divider />
+		<v-list-item
+			class="model-field"
+			:disabled="!isAdmin"
+			:to="isAdmin ? `/settings/data-model/${field.collection}/${field.field}` : undefined"
+		>
+			<v-list-item-icon><v-icon name="tune" /></v-list-item-icon>
+			<v-list-item-content>{{ field.field }}</v-list-item-content>
+		</v-list-item>
 	</v-list>
 </template>
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
+import { defineComponent, PropType, computed, ref } from 'vue';
 import { Field } from '@directus/shared/types';
+import { useUserStore } from '@/stores';
 
 export default defineComponent({
 	props: {
@@ -74,6 +84,7 @@ export default defineComponent({
 	emits: ['update:modelValue', 'unset', 'edit-raw', 'copy-raw', 'paste-raw'],
 	setup(props) {
 		const { t } = useI18n();
+		const userStore = useUserStore();
 
 		const defaultValue = computed(() => {
 			const savedValue = props.field?.schema?.default_value;
@@ -84,7 +95,15 @@ export default defineComponent({
 			return props.field?.schema?.is_nullable === false;
 		});
 
-		return { t, defaultValue, isRequired };
+		const isAdmin = ref(userStore.isAdmin);
+
+		return { t, defaultValue, isRequired, isAdmin };
 	},
 });
 </script>
+
+<style scoped>
+.model-field :deep(div) {
+	font-family: monospace;
+}
+</style>

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :key="field.field" class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
-		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow>
+		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow full-height>
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"

--- a/app/src/styles/_base.scss
+++ b/app/src/styles/_base.scss
@@ -150,3 +150,7 @@ input[type='search']::-webkit-search-results-button,
 input[type='search']::-webkit-search-results-decoration {
 	-webkit-appearance: none;
 }
+
+code {
+	font-family: monospace;
+}


### PR DESCRIPTION
This adds field id to field context menu.
Also, if user is admin and clicks on it leaves us to field detail page.
If is non-admin field show but disabled.

## Before

https://user-images.githubusercontent.com/14039341/153761612-5db67358-af86-4b83-be46-4d733565fbb9.mov

## After non-admin

https://user-images.githubusercontent.com/14039341/153761628-7a594792-24f1-403d-acf8-d54dddd1af34.mov

## After admin

https://user-images.githubusercontent.com/14039341/153761634-114492fa-ac95-483f-9183-e5d459d7ae9e.mov

Note:
This was discussed here:
https://discord.com/channels/725371605378924594/903639108646211694/942431698648453221
