### PR TITLE
Add required field indicators to accordion group

### DIFF
--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -4,6 +4,7 @@
 			<div class="label type-title" :class="{ active, edited }" @click="handleModifier($event, toggle)">
 				<v-icon class="icon" :class="{ active }" name="expand_more" />
 				{{ field.name }}
+				<v-icon v-if="field.meta?.required === true" class="required" sup name="star" />
 				<v-icon
 					v-if="!active && validationMessage"
 					v-tooltip="validationMessage"
@@ -150,13 +151,13 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .accordion-section {
 	border-top: var(--border-width) solid var(--border-normal);
-}
 
-.accordion-section:last-child {
-	border-bottom: var(--border-width) solid var(--border-normal);
+	&:last-child {
+		border-bottom: var(--border-width) solid var(--border-normal);
+	}
 }
 
 .label {
@@ -167,34 +168,41 @@ export default defineComponent({
 	color: var(--foreground-subdued);
 	cursor: pointer;
 	transition: color var(--fast) var(--transition);
-}
 
-.label:hover,
-.label.active {
-	color: var(--foreground-normal);
-}
+	&:hover,
+	&.active {
+		color: var(--foreground-normal);
+	}
 
-.label.edited::before {
-	position: absolute;
-	top: 14px;
-	left: -7px;
-	display: block;
-	width: 4px;
-	height: 4px;
-	background-color: var(--foreground-subdued);
-	border-radius: 4px;
-	content: '';
-	pointer-events: none;
+	.required {
+		--v-icon-color: var(--primary);
+
+		margin-top: -12px;
+		margin-left: 2px;
+	}
+
+	&.edited::before {
+		position: absolute;
+		top: 14px;
+		left: -7px;
+		display: block;
+		width: 4px;
+		height: 4px;
+		background-color: var(--foreground-subdued);
+		border-radius: 4px;
+		content: '';
+		pointer-events: none;
+	}
 }
 
 .icon {
 	margin-right: 12px;
 	transform: rotate(-90deg);
 	transition: transform var(--fast) var(--transition);
-}
 
-.icon.active {
-	transform: rotate(0);
+	&.active {
+		transform: rotate(0);
+	}
 }
 
 .warning {


### PR DESCRIPTION
## Context

Accordion group fields turns the field labels into the title of each section, but it doesn't show the asterisk/star for required fields.

## Before

In this case, `Accordion Field 2` is a required field:

![chrome_NEvM6YchBk](https://user-images.githubusercontent.com/42867097/154024820-a839583e-d1d8-42d9-83c3-7809b661297a.png)

## After

![chrome_iFy0qBDREQ](https://user-images.githubusercontent.com/42867097/154024801-354fd7df-9045-44c2-8848-9201881105f3.png)
