### PR TITLE
Fix stacked drawers layering

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -142,7 +142,6 @@
 
 		<div id="app"></div>
 
-		<div id="drawer-outlet"></div>
 		<div id="dialog-outlet"></div>
 		<div id="menu-outlet"></div>
 

--- a/app/src/components/v-dialog/v-dialog.vue
+++ b/app/src/components/v-dialog/v-dialog.vue
@@ -2,21 +2,17 @@
 	<div class="v-dialog">
 		<slot name="activator" v-bind="{ on: () => (internalActive = true) }" />
 
-		<teleport v-if="placement === 'right'" to="#drawer-outlet">
+		<teleport to="#dialog-outlet">
 			<transition-dialog @after-leave="leave">
-				<div v-if="internalActive" class="container" :class="[className, placement]">
+				<component
+					:is="placement === 'right' ? 'div' : 'span'"
+					v-if="internalActive"
+					class="container"
+					:class="[className, placement]"
+				>
 					<v-overlay active absolute @click="emitToggle" />
 					<slot />
-				</div>
-			</transition-dialog>
-		</teleport>
-
-		<teleport v-else to="#dialog-outlet">
-			<transition-dialog @after-leave="leave">
-				<div v-if="internalActive" class="container" :class="[className, placement]">
-					<v-overlay active absolute @click="emitToggle" />
-					<slot />
-				</div>
+				</component>
 			</transition-dialog>
 		</teleport>
 	</div>

--- a/app/src/styles/_stacked-drawers.scss
+++ b/app/src/styles/_stacked-drawers.scss
@@ -1,4 +1,4 @@
-#drawer-outlet {
+#dialog-outlet {
 	.container.right .v-drawer {
 		transition: var(--slow) var(--transition);
 		transition-property: transform, border-radius;


### PR DESCRIPTION
Closes #10892.

https://user-images.githubusercontent.com/26413686/154048780-6f3d9e3c-7b4b-418c-8c07-e0215c6d916d.mov

Implements the use of a different tag for dialogs and drawers as suggested in https://github.com/directus/directus/issues/10892#issuecomment-1011163395.

Note: `<span>` is used for dialogs as it breaks layering in `v-menu` if used for drawers.

