### PR TITLE
Fix formatted json value display for 1 item arrays

### DIFF
--- a/app/src/displays/formatted-json-value/formatted-json-value.vue
+++ b/app/src/displays/formatted-json-value/formatted-json-value.vue
@@ -1,6 +1,6 @@
 <template>
 	<value-null v-if="!displayValue" />
-	<v-menu v-else-if="displayValue.length > 1" show-arrow>
+	<v-menu v-else-if="displayValue.length > 0" show-arrow>
 		<template #activator="{ toggle }">
 			<span class="toggle" @click.stop="toggle">
 				<span class="label">


### PR DESCRIPTION
Fixes 11650

Currently the condition used is `displayValue.length > 1`:

https://github.com/directus/directus/blob/40ec3229983f22ddf478d6bc191df4dd45ba4500/app/src/displays/formatted-json-value/formatted-json-value.vue#L3

Whereas it should be `displayValue.length > 0` for "1 items" to show properly.