### PR TITLE
Emit value before unmounting datepicker

### DIFF
--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -63,6 +63,9 @@ export default defineComponent({
 
 		onBeforeUnmount(() => {
 			if (flatpickr) {
+				const selectedDate = flatpickr.selectedDates.length > 0 ? flatpickr.selectedDates[0] : null;
+				emitValue(selectedDate);
+
 				flatpickr.destroy();
 				flatpickr = null;
 			}


### PR DESCRIPTION
When editing time values and clicking outside the datepicker, the `onChange` handler isn't triggered as it has been unmounted. 

## Before

https://user-images.githubusercontent.com/26413686/154272725-b3fcec5a-89d8-43ff-b1f2-736f541114eb.mov

## After

https://user-images.githubusercontent.com/26413686/154272752-01331b5e-8e39-4d67-b779-991a79f8af12.mov
