### PR TITLE
Add nested translations support

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -13,6 +13,7 @@
 				</template>
 			</language-select>
 			<v-form
+				:primary-key="translationsPrimaryKeyField?.field ? firstItemInitial?.[translationsPrimaryKeyField.field] : null"
 				:disabled="disabled"
 				:loading="valuesLoading"
 				:fields="fields"
@@ -36,6 +37,9 @@
 				</template>
 			</language-select>
 			<v-form
+				:primary-key="
+					translationsPrimaryKeyField?.field ? secondItemInitial?.[translationsPrimaryKeyField.field] : null
+				"
 				:disabled="disabled"
 				:loading="valuesLoading"
 				:initial-values="secondItemInitial"


### PR DESCRIPTION
Closes #11440

## Context

Currently nested translation interfaces does not fetch/load items. This is due to the parent `<v-form>` of the parent `<translations>` has the `primaryKey` prop (due to route param), but not the nested `<v-form>`s.

Ref https://github.com/directus/directus/issues/11440#issuecomment-1034061631 stating this was possible on V8, so this PR adds support to it. 

_Slightly concerned on the 80/20 rule or the current stance on this use case, but also can't see the "harm" of adding this since it should be a progressive enhancement and shouldn't affect other existing use cases to date._

## Before

![chrome_AhoyRNrFPg](https://user-images.githubusercontent.com/42867097/154288282-1ee88ada-44cd-40b5-b4ae-b79b3dffcda9.png)

## After 

![chrome_htrvuHOMtc](https://user-images.githubusercontent.com/42867097/154288296-5bc6fa5f-da9a-4835-b408-618ee701f11b.png)

