### PR TITLE
Fix context menu directive's deactivate event

### DIFF
--- a/app/src/directives/context-menu/context-menu.ts
+++ b/app/src/directives/context-menu/context-menu.ts
@@ -4,14 +4,14 @@ function mounted(element: HTMLElement, binding: DirectiveBinding): void {
 	const contextMenu = binding.instance?.$refs[binding.value];
 
 	element.addEventListener('contextmenu', activateContextMenu(contextMenu));
-	element.addEventListener('focusout', deactivateContextMenu(contextMenu));
+	document.documentElement.addEventListener('pointerdown', deactivateContextMenu(contextMenu));
 }
 
 function unmounted(element: HTMLElement, binding: DirectiveBinding): void {
 	const contextMenu = binding.instance?.$refs[binding.value];
 
 	element.removeEventListener('contextmenu', activateContextMenu(contextMenu));
-	element.removeEventListener('focusout', deactivateContextMenu(contextMenu));
+	document.documentElement.removeEventListener('pointerdown', deactivateContextMenu(contextMenu));
 }
 
 const ContextMenu: Directive = {
@@ -26,12 +26,18 @@ function activateContextMenu(contextMenu: any) {
 		e.stopPropagation();
 		e.preventDefault();
 
-		if (contextMenu) contextMenu.activate(e);
+		if (!contextMenu) return;
+		contextMenu.activate(e);
 	};
 }
 
 function deactivateContextMenu(contextMenu: any) {
 	return (e: Event) => {
-		if (contextMenu) contextMenu.deactivate(e);
+		if (!contextMenu) return;
+
+		const composedPath = e.composedPath() as Element[];
+		if (composedPath.find((element) => element.id === contextMenu.id)) return;
+
+		contextMenu.deactivate(e);
 	};
 }

--- a/app/src/directives/context-menu/readme.md
+++ b/app/src/directives/context-menu/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 This allows the element to open a context menu with the specified ref. It adds `contextmenu` event (right click) to
-activate/open the context menu, and `focusout` event to deactivate/close it. .
+activate/open the context menu, and `pointerdown` event on document to deactivate/close when it's not the event target.
 
 ```html
 <element v-context-menu="'contextMenu'"></element>

--- a/app/src/modules/files/components/navigation-folder.vue
+++ b/app/src/modules/files/components/navigation-folder.vue
@@ -57,7 +57,7 @@
 						<v-text-overflow :text="t('move_to_folder')" />
 					</v-list-item-content>
 				</v-list-item>
-				<v-list-item clickable @click="deleteActive = true">
+				<v-list-item class="danger" clickable @click="deleteActive = true">
 					<v-list-item-icon>
 						<v-icon name="delete" outline />
 					</v-list-item-icon>
@@ -286,3 +286,11 @@ export default defineComponent({
 	},
 });
 </script>
+
+<style scoped>
+.v-list-item.danger {
+	--v-list-item-color: var(--danger);
+	--v-list-item-color-hover: var(--danger);
+	--v-list-item-icon-color: var(--danger);
+}
+</style>


### PR DESCRIPTION
Fixes #11633

## Context

Although the reported bug is in File Library's folders, it's an inherent bug with context menu directive as `focusout` ended up being finnicky 😬:

https://user-images.githubusercontent.com/42867097/154425474-40016474-81d7-487c-a32d-0272d905b905.mp4

## Solution

- Replaced the `focusout` event on the element itself to a `pointerdown` event on the document level, similar to the click-outside directive approach.

   However since the context menu is "teleported" and not within the path/child of the element, opted to use the `id` as a way to detect whether the click is on the context menu itself or outside of it via `composedPath()` elements.

   https://github.com/directus/directus/blob/aa0c7c76ff81120204a32ce0d922f78458f94618/app/src/components/v-menu/v-menu.vue#L142

- added danger styling to Delete Folder option in Folder context menu.

## After fix applied

https://user-images.githubusercontent.com/42867097/154425484-7fd83951-7b2c-48fb-a5f9-2b0cd3e80d0a.mp4


