### PR TITLE
Fix alias fields not showing up in permissions

### DIFF
--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -45,7 +45,11 @@ export function useFieldTree(
 		const fields = fieldsStore
 			.getFieldsForCollectionSorted(collection!)
 			.concat(injectedFields || [])
-			.filter((field) => !field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
+			.filter(
+				(field) =>
+					field.meta?.special?.includes('group') ||
+					(!field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
+			)
 			.filter(filter)
 			.flatMap((field) => makeNode(field, parent));
 

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -267,13 +267,7 @@ export const useFieldsStore = defineStore({
 		 * fields inside groups starts their sort number from 1 to N again.
 		 */
 		getFieldsForCollectionSorted(collection: string): Field[] {
-			const fields = this.fields
-				.filter((field) => field.collection === collection)
-				.filter(
-					(field: Field) =>
-						field.meta?.special?.includes('group') ||
-						(!field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
-				);
+			const fields = this.fields.filter((field) => field.collection === collection);
 
 			const nonGroupFields = fields.filter((field: Field) => !field.meta?.group);
 


### PR DESCRIPTION
Fixes #11683

## Bug

With the following data model as example:

![image](https://user-images.githubusercontent.com/42867097/154473426-9a2a1c6a-0b02-4261-bda0-cc71460f81b4.png)

Alias fields like Notice aren't showing up in Field permissions, hence the admin is unable to grant read permission to the restricted users/roles:

![chrome_6VYljD0EQ2](https://user-images.githubusercontent.com/42867097/154473354-f14f5259-93a8-42a9-aa1f-9a2bb476566a.png)

## Investigation

#11265 extracted `getFieldsForCollectionSorted` as a function, but the second `.filter()` here shouldn't be present as that should only be applicable in `use-field-tree` to hide groups/aliases from the Filter input.

https://github.com/directus/directus/blob/aa0c7c76ff81120204a32ce0d922f78458f94618/app/src/stores/fields.ts#L270-L276

## After fix applied

![chrome_ota9bTPr8W](https://user-images.githubusercontent.com/42867097/154473495-3052b501-a73f-42cb-9284-fb9879000e8f.png)

