### PR TITLE
CLI docs Tip: Create date based snapshots

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -93,6 +93,17 @@ npx directus schema snapshot --yes ./snapshot.yaml
 
 Note, that this will force overwrite existing snapshot files.
 
+::: tip Date-based snapshots
+
+To keep multiple snapshot organized by date, create a folder `snapshots` in your project root directory add the following custom script to your `package.json`:
+```
+"create-snapshot": "npx directus schema snapshot ./snapshots/\"$(date \"+%F\")\"-snapshot-\"$(date \"+%s\")\".yaml"
+```
+
+When you run the command via `npm run create-snapshot` it will create a new snapshot with the following naming schema: `[YYYY-MM-DD]-snapshot-[timestamp].json`. This command can be run e.g by your deployent pipeline before each deploy on your server to keep a schema backup.
+
+:::
+
 #### Applying a Snapshot
 
 To make a different instance up to date with the latest changes in your data model, you can apply the snapshot. By


### PR DESCRIPTION
A small custom script to create multiple snapshots organized by date. Can be used e.g on a server where git is not available for snapshot versionizing.