### PR TITLE
Show collection notes

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -900,6 +900,7 @@ directus_collection:
   directus_roles: Permission groups for system users
   directus_sessions: User session information
   directus_settings: Project configuration options
+  directus_shares: Tracks externally shared items
   directus_users: System users for the platform
   directus_webhooks: Configuration for event-based HTTP requests
 fields:

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -236,11 +236,6 @@ export default defineComponent({
 	--v-list-item-color: var(--foreground-subdued);
 }
 
-.collection-name {
-	flex-grow: 1;
-	font-family: var(--family-monospace);
-}
-
 .collection-icon {
 	margin-right: 8px;
 }

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -35,13 +35,7 @@
 				</template>
 			</v-info>
 
-			<v-list
-				v-else
-				class="draggable-list"
-				:style="{
-					'--collection-name-min-width': `${collectionNameWidth}px`,
-				}"
-			>
+			<v-list v-else class="draggable-list">
 				<draggable
 					:force-fallback="true"
 					:model-value="rootCollections"
@@ -58,7 +52,6 @@
 							:collections="collections"
 							@editCollection="editCollection = $event"
 							@setNestedSort="onSort"
-							@set-collection-name-width="setCollectionNameWidth"
 						/>
 					</template>
 				</draggable>
@@ -87,19 +80,13 @@
 				</v-list-item>
 			</v-list>
 
-			<v-detail
-				:label="t('system_collections')"
-				:style="{
-					'--collection-name-min-width': `${systemCollectionNameWidth}px`,
-				}"
-			>
+			<v-detail :label="t('system_collections')">
 				<collection-item
 					v-for="collection of systemCollections"
 					:key="collection.collection"
 					:collection="collection"
 					:collections="systemCollections"
 					disable-drag
-					@set-collection-name-width="setSystemCollectionNameWidth"
 				/>
 			</v-detail>
 		</div>
@@ -139,9 +126,6 @@ export default defineComponent({
 	components: { SettingsNavigation, CollectionItem, CollectionOptions, Draggable, CollectionDialog },
 	setup() {
 		const { t } = useI18n();
-
-		const collectionNameWidth = ref(0);
-		const systemCollectionNameWidth = ref(0);
 
 		const collectionDialogActive = ref(false);
 		const editCollection = ref<Collection | null>();
@@ -197,10 +181,6 @@ export default defineComponent({
 			onSort,
 			rootCollections,
 			editCollection,
-			collectionNameWidth,
-			setCollectionNameWidth,
-			systemCollectionNameWidth,
-			setSystemCollectionNameWidth,
 		};
 
 		async function onSort(updates: Collection[], removeGroup = false) {
@@ -226,18 +206,6 @@ export default defineComponent({
 				);
 			} catch (err: any) {
 				unexpectedError(err);
-			}
-		}
-
-		function setCollectionNameWidth(width: number) {
-			if (width > collectionNameWidth.value) {
-				collectionNameWidth.value = width;
-			}
-		}
-
-		function setSystemCollectionNameWidth(width: number) {
-			if (width > systemCollectionNameWidth.value) {
-				systemCollectionNameWidth.value = width;
 			}
 		}
 	},

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -35,7 +35,13 @@
 				</template>
 			</v-info>
 
-			<v-list v-else class="draggable-list">
+			<v-list
+				v-else
+				class="draggable-list"
+				:style="{
+					'--collection-name-min-width': `${collectionNameWidth}px`,
+				}"
+			>
 				<draggable
 					:force-fallback="true"
 					:model-value="rootCollections"
@@ -52,6 +58,7 @@
 							:collections="collections"
 							@editCollection="editCollection = $event"
 							@setNestedSort="onSort"
+							@set-collection-name-width="setCollectionNameWidth"
 						/>
 					</template>
 				</draggable>
@@ -80,13 +87,19 @@
 				</v-list-item>
 			</v-list>
 
-			<v-detail :label="t('system_collections')">
+			<v-detail
+				:label="t('system_collections')"
+				:style="{
+					'--collection-name-min-width': `${systemCollectionNameWidth}px`,
+				}"
+			>
 				<collection-item
 					v-for="collection of systemCollections"
 					:key="collection.collection"
 					:collection="collection"
 					:collections="systemCollections"
 					disable-drag
+					@set-collection-name-width="setSystemCollectionNameWidth"
 				/>
 			</v-detail>
 		</div>
@@ -126,6 +139,9 @@ export default defineComponent({
 	components: { SettingsNavigation, CollectionItem, CollectionOptions, Draggable, CollectionDialog },
 	setup() {
 		const { t } = useI18n();
+
+		const collectionNameWidth = ref(0);
+		const systemCollectionNameWidth = ref(0);
 
 		const collectionDialogActive = ref(false);
 		const editCollection = ref<Collection | null>();
@@ -181,6 +197,10 @@ export default defineComponent({
 			onSort,
 			rootCollections,
 			editCollection,
+			collectionNameWidth,
+			setCollectionNameWidth,
+			systemCollectionNameWidth,
+			setSystemCollectionNameWidth,
 		};
 
 		async function onSort(updates: Collection[], removeGroup = false) {
@@ -206,6 +226,18 @@ export default defineComponent({
 				);
 			} catch (err: any) {
 				unexpectedError(err);
+			}
+		}
+
+		function setCollectionNameWidth(width: number) {
+			if (width > collectionNameWidth.value) {
+				collectionNameWidth.value = width;
+			}
+		}
+
+		function setSystemCollectionNameWidth(width: number) {
+			if (width > systemCollectionNameWidth.value) {
+				systemCollectionNameWidth.value = width;
 			}
 		}
 	},

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -46,7 +46,6 @@
 		>
 			<template #item="{ element }">
 				<collection-item
-					class="nested"
 					:collection="element"
 					:collections="collections"
 					@editCollection="$emit('editCollection', $event)"
@@ -84,7 +83,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: ['setNestedSort', 'editCollection', 'setCollectionNameWidth'],
+	emits: ['setNestedSort', 'editCollection'],
 	setup(props, { emit }) {
 		const collectionsStore = useCollectionsStore();
 		const { t } = useI18n();

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -185,13 +185,21 @@ export default defineComponent({
 	flex-grow: 1;
 	align-items: center;
 	height: 100%;
+	overflow: hidden;
 	font-family: var(--family-monospace);
 	pointer-events: none;
 }
 
+.collection-name {
+	flex-shrink: 0;
+}
+
 .collection-note {
 	margin-left: 8px;
+	overflow: hidden;
 	color: var(--foreground-subdued);
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .collection-icon {

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -11,13 +11,14 @@
 			<v-list-item-icon>
 				<v-icon v-if="!disableDrag" class="drag-handle" name="drag_handle" />
 			</v-list-item-icon>
-			<div class="collection-name">
+			<div class="collection-item-detail">
 				<v-icon
 					:color="collection.meta?.hidden ? 'var(--foreground-subdued)' : collection.color"
 					class="collection-icon"
 					:name="collection.meta?.hidden ? 'visibility_off' : collection.icon"
 				/>
-				<span>{{ collection.name }}</span>
+				<span class="collection-name">{{ collection.name }}</span>
+				<span v-if="collection.meta?.note" class="collection-note">- {{ collection.meta.note }}</span>
 			</div>
 			<template v-if="collection.type === 'alias' || nestedCollections.length">
 				<v-progress-circular v-if="collapseLoading" small indeterminate />
@@ -179,13 +180,18 @@ export default defineComponent({
 	margin-bottom: 8px;
 }
 
-.collection-name {
+.collection-item-detail {
 	display: flex;
 	flex-grow: 1;
 	align-items: center;
 	height: 100%;
 	font-family: var(--family-monospace);
 	pointer-events: none;
+}
+
+.collection-note {
+	margin-left: 8px;
+	color: var(--foreground-subdued);
 }
 
 .collection-icon {
@@ -196,8 +202,7 @@ export default defineComponent({
 	cursor: grab;
 }
 
-.hidden {
-	--v-list-item-color: var(--foreground-subdued);
-	--v-icon-color: var(--foreground-subdued);
+.hidden .collection-name {
+	color: var(--foreground-subdued);
 }
 </style>

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -17,7 +17,7 @@
 					class="collection-icon"
 					:name="collection.meta?.hidden ? 'visibility_off' : collection.icon"
 				/>
-				<span class="collection-name">{{ collection.name }}</span>
+				<span ref="collectionName" class="collection-name">{{ collection.name }}</span>
 				<span v-if="collection.meta?.note" class="collection-note">— {{ collection.meta.note }}</span>
 			</div>
 			<template v-if="collection.type === 'alias' || nestedCollections.length">
@@ -46,6 +46,7 @@
 		>
 			<template #item="{ element }">
 				<collection-item
+					class="nested"
 					:collection="element"
 					:collections="collections"
 					@editCollection="$emit('editCollection', $event)"
@@ -57,7 +58,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, ref } from 'vue';
+import { defineComponent, PropType, computed, ref, onMounted } from 'vue';
 import CollectionOptions from './collection-options.vue';
 import { Collection } from '@/types';
 import Draggable from 'vuedraggable';
@@ -83,10 +84,18 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: ['setNestedSort', 'editCollection'],
+	emits: ['setNestedSort', 'editCollection', 'setCollectionNameWidth'],
 	setup(props, { emit }) {
 		const collectionsStore = useCollectionsStore();
 		const { t } = useI18n();
+
+		const collectionName = ref<HTMLElement>();
+
+		onMounted(() => {
+			if (collectionName.value) {
+				emit('setCollectionNameWidth', collectionName.value.clientWidth);
+			}
+		});
 
 		const nestedCollections = computed(() =>
 			props.collections.filter((collection) => collection.meta?.group === props.collection.collection)
@@ -128,6 +137,7 @@ export default defineComponent({
 			toggleCollapse,
 			collapseTooltip,
 			collapseLoading,
+			collectionName,
 		};
 
 		async function toggleCollapse() {
@@ -192,6 +202,15 @@ export default defineComponent({
 
 .collection-name {
 	flex-shrink: 0;
+	min-width: var(--collection-name-min-width);
+}
+
+.hidden .collection-name {
+	color: var(--foreground-subdued);
+}
+
+.collection-item.nested .collection-name {
+	min-width: auto;
 }
 
 .collection-note {
@@ -208,9 +227,5 @@ export default defineComponent({
 
 .drag-handle {
 	cursor: grab;
-}
-
-.hidden .collection-name {
-	color: var(--foreground-subdued);
 }
 </style>

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -18,7 +18,7 @@
 					:name="collection.meta?.hidden ? 'visibility_off' : collection.icon"
 				/>
 				<span ref="collectionName" class="collection-name">{{ collection.name }}</span>
-				<span v-if="collection.meta?.note" class="collection-note">— {{ collection.meta.note }}</span>
+				<span v-if="collection.meta?.note" class="collection-note">{{ collection.meta.note }}</span>
 			</div>
 			<template v-if="collection.type === 'alias' || nestedCollections.length">
 				<v-progress-circular v-if="collapseLoading" small indeterminate />
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, ref, onMounted } from 'vue';
+import { defineComponent, PropType, computed, ref } from 'vue';
 import CollectionOptions from './collection-options.vue';
 import { Collection } from '@/types';
 import Draggable from 'vuedraggable';
@@ -88,14 +88,6 @@ export default defineComponent({
 	setup(props, { emit }) {
 		const collectionsStore = useCollectionsStore();
 		const { t } = useI18n();
-
-		const collectionName = ref<HTMLElement>();
-
-		onMounted(() => {
-			if (collectionName.value) {
-				emit('setCollectionNameWidth', collectionName.value.clientWidth);
-			}
-		});
 
 		const nestedCollections = computed(() =>
 			props.collections.filter((collection) => collection.meta?.group === props.collection.collection)
@@ -137,7 +129,6 @@ export default defineComponent({
 			toggleCollapse,
 			collapseTooltip,
 			collapseLoading,
-			collectionName,
 		};
 
 		async function toggleCollapse() {
@@ -202,23 +193,24 @@ export default defineComponent({
 
 .collection-name {
 	flex-shrink: 0;
-	min-width: var(--collection-name-min-width);
 }
 
 .hidden .collection-name {
 	color: var(--foreground-subdued);
 }
 
-.collection-item.nested .collection-name {
-	min-width: auto;
-}
-
 .collection-note {
-	margin-left: 8px;
+	margin-left: 16px;
 	overflow: hidden;
 	color: var(--foreground-subdued);
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	opacity: 0;
+	transition: opacity var(--fast) var(--transition);
+}
+
+.v-list-item:hover .collection-note {
+	opacity: 1;
 }
 
 .collection-icon {

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -18,7 +18,7 @@
 					:name="collection.meta?.hidden ? 'visibility_off' : collection.icon"
 				/>
 				<span class="collection-name">{{ collection.name }}</span>
-				<span v-if="collection.meta?.note" class="collection-note">- {{ collection.meta.note }}</span>
+				<span v-if="collection.meta?.note" class="collection-note">— {{ collection.meta.note }}</span>
 			</div>
 			<template v-if="collection.type === 'alias' || nestedCollections.length">
 				<v-progress-circular v-if="collapseLoading" small indeterminate />


### PR DESCRIPTION
Closes #8925

Implements the following points as described in referenced issue:

- [x] Should be right behind the collection name. All notes should left align with each other.
- [x] The nested item descriptions should align to themselves, but not the parent.

Pending tasks:

- [x] Confirm the note for `directus_shares`

## Before

![chrome_tnjGzXyHBt](https://user-images.githubusercontent.com/42867097/154674487-ce224ba8-7427-4fc4-8097-72604d60f40d.png)

## After

![Qj4lHj9djV](https://user-images.githubusercontent.com/42867097/154674616-bc768bc3-a49b-418a-baac-2a4123aeb5cc.png)
