### PR TITLE
Align displayed time for 24 hours format

### DIFF
--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -67,7 +67,8 @@ export default defineComponent({
 					displayValue.value = null;
 					return;
 				}
-				const timeFormat = props.includeSeconds ? 'date-fns_time' : 'date-fns_time_no_seconds';
+				let timeFormat = props.includeSeconds ? 'date-fns_time' : 'date-fns_time_no_seconds';
+				if (props.use24) timeFormat = props.includeSeconds ? 'date-fns_time_24hour' : 'date-fns_time_no_seconds_24hour';
 				let format = `${t('date-fns_date')} ${t(timeFormat)}`;
 				if (props.type === 'date') format = String(t('date-fns_date'));
 				if (props.type === 'time') format = String(t(timeFormat));

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -363,6 +363,8 @@ delete_share: Delete Share
 date-fns_date: PPP
 date-fns_time: 'h:mm:ss a'
 date-fns_time_no_seconds: 'h:mm a'
+date-fns_time_24hour: 'HH:mm:ss'
+date-fns_time_no_seconds_24hour: 'HH:mm'
 date-fns_date_short: 'MMM d, u'
 date-fns_time_short: 'h:mma'
 date-fns_date_short_no_year: MMM d


### PR DESCRIPTION
Fixes #11701

## Before

![qz2Zg2o7eE](https://user-images.githubusercontent.com/42867097/154678680-82f6a124-0c78-48c5-8c5f-362be213a0e6.gif)

## After

![AdL3ArZw8P](https://user-images.githubusercontent.com/42867097/154678670-a87c915c-ef81-434a-bc8b-053961220273.gif)

---

@rijkvanzanten hope the `_24hour` suffix for the translation keys are okay, but definitely open to change it if there's a better naming convention in mind 👍
