### PR TITLE
add "press enter to close" for time inputs

### DIFF
--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -36,12 +36,24 @@
 			placeholder="--"
 			@input="emitValue($event.target.value)"
 		/>
-		<v-menu :close-on-content-click="false" :show-arrow="true" placement="bottom-start" seamless full-height>
+		<v-menu
+			ref="dateTimeMenu"
+			:close-on-content-click="false"
+			:show-arrow="true"
+			placement="bottom-start"
+			seamless
+			full-height
+		>
 			<template #activator="{ toggle }">
 				<v-icon class="preview" name="event" small @click="toggle" />
 			</template>
 			<div class="date-input">
-				<v-date-picker :type="type" :model-value="value" @update:model-value="emitValue" />
+				<v-date-picker
+					:type="type"
+					:model-value="value"
+					@update:model-value="emitValue"
+					@close="dateTimeMenu?.deactivate"
+				/>
 			</div>
 		</v-menu>
 	</template>
@@ -100,6 +112,8 @@ export default defineComponent({
 		const inputEl = ref<HTMLElement>();
 		const { t } = useI18n();
 
+		const dateTimeMenu = ref();
+
 		const displayValue = computed(() => {
 			if (props.value === null) return null;
 			if (props.value === undefined) return null;
@@ -134,7 +148,7 @@ export default defineComponent({
 			if (props.focus) inputEl.value?.focus();
 		});
 
-		return { displayValue, width, t, emitValue, inputEl, inputPattern };
+		return { displayValue, width, t, emitValue, inputEl, inputPattern, dateTimeMenu };
 
 		function emitValue(val: unknown) {
 			if (val === '') {

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-menu :close-on-content-click="false" attached :disabled="disabled" full-height seamless>
+	<v-menu ref="dateTimeMenu" :close-on-content-click="false" attached :disabled="disabled" full-height seamless>
 		<template #activator="{ toggle, active }">
 			<v-input :active="active" clickable readonly :model-value="displayValue" :disabled="disabled" @click="toggle">
 				<template v-if="!disabled" #append>
@@ -15,6 +15,7 @@
 			:use-24="use24"
 			:model-value="value"
 			@update:model-value="$emit('input', $event)"
+			@close="dateTimeMenu?.deactivate"
 		/>
 	</v-menu>
 </template>
@@ -52,6 +53,8 @@ export default defineComponent({
 	emits: ['input'],
 	setup(props, { emit }) {
 		const { t } = useI18n();
+
+		const dateTimeMenu = ref();
 
 		const { displayValue } = useDisplayValue();
 
@@ -93,7 +96,7 @@ export default defineComponent({
 			emit('input', null);
 		}
 
-		return { displayValue, unsetValue };
+		return { displayValue, unsetValue, dateTimeMenu };
 	},
 });
 </script>


### PR DESCRIPTION
Closes #11700

Adds "press enter to close" event to the last input depending on whether it's minute, seconds, or AM/PM. 

The issue also mentioned about setting the value when focusing away & closing the calendar/time, but that is already implemented by #11670 👍

## Result

https://user-images.githubusercontent.com/42867097/154691405-bc64f8d6-3fb4-401f-9cf1-f13f926b64bc.mp4


