### PR TITLE
Fix translations resetting for new records

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -298,8 +298,8 @@ export default defineComponent({
 					}
 
 					if (!newVal && oldVal) return; // when user clears whole translations value
-					if (newVal && newVal.some((item) => typeof item === 'object') && oldVal) return; // when there's any new edits since edits are objects
-					if (isEqual(newVal, oldVal)) return; // when user unfocus/blur inputs so they will be equal
+					if (newVal?.some((item) => typeof item === 'object')) return; // when there's any new edits since edits are objects
+					if (newVal?.some((item) => typeof item === 'object') && isEqual(newVal, oldVal)) return; // when user unfocus/blur inputs so they will be equal
 					if (isUndo.value) return; // when user undo to the original value
 
 					loadItems();


### PR DESCRIPTION
Follow up of #11697

For new items, the resulting old/new value are both the number array, hence they are "equal". This PR updates the isEqual logic to only apply to unsaved items instead.