### PR TITLE
Fix anonymous binding ldap

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -51,7 +51,13 @@ export class LDAPAuthDriver extends AuthDriver {
 
 		const { bindDn, bindPassword, userDn, provider, clientUrl } = config;
 
-		if (!bindDn || !bindPassword || !userDn || !provider || (!clientUrl && !config.client?.socketPath)) {
+		if (
+			bindDn === undefined ||
+			bindPassword === undefined ||
+			!userDn ||
+			!provider ||
+			(!clientUrl && !config.client?.socketPath)
+		) {
 			throw new InvalidConfigException('Invalid provider config', { provider });
 		}
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -650,7 +650,8 @@ information and roles will be assigned from Active Directory.
 | `AUTH_<PROVIDER>_GROUP_SCOPE`     | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>. | `one`         |
 | `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user.                            | `mail`        |
 
-<sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
+<sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication. To bind
+anonymously use `AUTH_LDAP_BIND_DN=""` and `AUTH_LDAP_BIND_PASSWORD=""`
 
 <sup>[2]</sup> The scope defines the following behaviors:
 


### PR DESCRIPTION
Fixes #11547 

Fix wrongly thrown error message to apply rfc possibility binding anonymously to ldap instance by leaving dn and psw empty

