### PR TITLE
Fix ldap group mapping with posixgroup schema and ldap auth provider

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -186,7 +186,7 @@ export class LDAPAuthDriver extends AuthDriver {
 	}
 
 	private async fetchUserGroups(userDn: string, identifier: string): Promise<string[]> {
-		const { groupDn, groupAttribute, groupMemberIsDn, groupScope } = this.config;
+		const { groupDn, groupAttribute, groupScope } = this.config;
 		if (!groupDn) {
 			return Promise.resolve([]);
 		}
@@ -201,7 +201,7 @@ export class LDAPAuthDriver extends AuthDriver {
 					attributes: ['cn'],
 					filter: new EqualityFilter({
 						attribute: groupAttribute ?? 'member',
-						value: groupMemberIsDn ?? true ? userDn : identifier,
+						value: groupAttribute !== 'memberUid' ? userDn : identifier,
 					}),
 					scope: groupScope ?? 'one',
 				},

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -637,18 +637,19 @@ registrations.
 LDAP allows Active Directory users to authenticate and use Directus without having to be manually configured. User
 information and roles will be assigned from Active Directory.
 
-| Variable                          | Description                                                            | Default Value |
-| --------------------------------- | ---------------------------------------------------------------------- | ------------- |
-| `AUTH_<PROVIDER>_CLIENT_URL`      | LDAP connection URL.                                                   | --            |
-| `AUTH_<PROVIDER>_BIND_DN`         | Bind user <sup>[1]</sup> distinguished name.                           | --            |
-| `AUTH_<PROVIDER>_BIND_PASSWORD`   | Bind user password.                                                    | --            |
-| `AUTH_<PROVIDER>_USER_DN`         | Directory path containing users.                                       | --            |
-| `AUTH_<PROVIDER>_USER_ATTRIBUTE`  | Attribute to identify users by.                                        | `cn`          |
-| `AUTH_<PROVIDER>_USER_SCOPE`      | Scope of the user search, either `base`, `one`, `sub` <sup>[2]</sup>.  | `one`         |
-| `AUTH_<PROVIDER>_GROUP_DN`        | Directory path containing groups.                                      | --            |
-| `AUTH_<PROVIDER>_GROUP_ATTRIBUTE` | Attribute to identify user as a member of a group.                     | `member`      |
-| `AUTH_<PROVIDER>_GROUP_SCOPE`     | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>. | `one`         |
-| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user.                            | `mail`        |
+| Variable                             | Description                                                               | Default Value |
+| ------------------------------------ | ------------------------------------------------------------------------- | ------------- |
+| `AUTH_<PROVIDER>_CLIENT_URL`         | LDAP connection URL.                                                      | --            |
+| `AUTH_<PROVIDER>_BIND_DN`            | Bind user <sup>[1]</sup> distinguished name.                              | --            |
+| `AUTH_<PROVIDER>_BIND_PASSWORD`      | Bind user password.                                                       | --            |
+| `AUTH_<PROVIDER>_USER_DN`            | Directory path containing users.                                          | --            |
+| `AUTH_<PROVIDER>_USER_ATTRIBUTE`     | Attribute to identify users by.                                           | `cn`          |
+| `AUTH_<PROVIDER>_USER_SCOPE`         | Scope of the user search, either `base`, `one`, `sub` <sup>[2]</sup>.     | `one`         |
+| `AUTH_<PROVIDER>_GROUP_DN`           | Directory path containing groups.                                         | --            |
+| `AUTH_<PROVIDER>_GROUP_ATTRIBUTE`    | Attribute to identify user as a member of a group.                        | `member`      |
+| `AUTH_<PROVIDER>_GROUP_SCOPE`        | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>.    | `one`         |
+| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`     | Attribute containing the email of the user.                               | `mail`        |
+| `AUTH_<PROVIDER>_GROUP_MEMBER_IS_DN` | Attribute whether group attribute contains complete userdn <sup>[3]</sup> | `true`        |
 
 <sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
 
@@ -657,6 +658,8 @@ information and roles will be assigned from Active Directory.
 - `base`: Limits the scope to a single object defined by the associated DN.
 - `one`: Searches all objects within the associated DN.
 - `sub`: Searches all objects and sub-objects within the associated DN.
+
+<sup>[3]</sup> Set to false if group attribute contains uid instead of userdn (as for POSIX LDAP)
 
 ### Example: LDAP
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -637,19 +637,18 @@ registrations.
 LDAP allows Active Directory users to authenticate and use Directus without having to be manually configured. User
 information and roles will be assigned from Active Directory.
 
-| Variable                             | Description                                                               | Default Value |
-| ------------------------------------ | ------------------------------------------------------------------------- | ------------- |
-| `AUTH_<PROVIDER>_CLIENT_URL`         | LDAP connection URL.                                                      | --            |
-| `AUTH_<PROVIDER>_BIND_DN`            | Bind user <sup>[1]</sup> distinguished name.                              | --            |
-| `AUTH_<PROVIDER>_BIND_PASSWORD`      | Bind user password.                                                       | --            |
-| `AUTH_<PROVIDER>_USER_DN`            | Directory path containing users.                                          | --            |
-| `AUTH_<PROVIDER>_USER_ATTRIBUTE`     | Attribute to identify users by.                                           | `cn`          |
-| `AUTH_<PROVIDER>_USER_SCOPE`         | Scope of the user search, either `base`, `one`, `sub` <sup>[2]</sup>.     | `one`         |
-| `AUTH_<PROVIDER>_GROUP_DN`           | Directory path containing groups.                                         | --            |
-| `AUTH_<PROVIDER>_GROUP_ATTRIBUTE`    | Attribute to identify user as a member of a group.                        | `member`      |
-| `AUTH_<PROVIDER>_GROUP_SCOPE`        | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>.    | `one`         |
-| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`     | Attribute containing the email of the user.                               | `mail`        |
-| `AUTH_<PROVIDER>_GROUP_MEMBER_IS_DN` | Attribute whether group attribute contains complete userdn <sup>[3]</sup> | `true`        |
+| Variable                          | Description                                                            | Default Value |
+| --------------------------------- | ---------------------------------------------------------------------- | ------------- |
+| `AUTH_<PROVIDER>_CLIENT_URL`      | LDAP connection URL.                                                   | --            |
+| `AUTH_<PROVIDER>_BIND_DN`         | Bind user <sup>[1]</sup> distinguished name.                           | --            |
+| `AUTH_<PROVIDER>_BIND_PASSWORD`   | Bind user password.                                                    | --            |
+| `AUTH_<PROVIDER>_USER_DN`         | Directory path containing users.                                       | --            |
+| `AUTH_<PROVIDER>_USER_ATTRIBUTE`  | Attribute to identify users by.                                        | `cn`          |
+| `AUTH_<PROVIDER>_USER_SCOPE`      | Scope of the user search, either `base`, `one`, `sub` <sup>[2]</sup>.  | `one`         |
+| `AUTH_<PROVIDER>_GROUP_DN`        | Directory path containing groups.                                      | --            |
+| `AUTH_<PROVIDER>_GROUP_ATTRIBUTE` | Attribute to identify user as a member of a group.                     | `member`      |
+| `AUTH_<PROVIDER>_GROUP_SCOPE`     | Scope of the group search, either `base`, `one`, `sub` <sup>[2]</sup>. | `one`         |
+| `AUTH_<PROVIDER>_MAIL_ATTRIBUTE`  | Attribute containing the email of the user.                            | `mail`        |
 
 <sup>[1]</sup> The bind user must have permission to query users and groups to perform authentication.
 
@@ -658,8 +657,6 @@ information and roles will be assigned from Active Directory.
 - `base`: Limits the scope to a single object defined by the associated DN.
 - `one`: Searches all objects within the associated DN.
 - `sub`: Searches all objects and sub-objects within the associated DN.
-
-<sup>[3]</sup> Set to false if group attribute contains uid instead of userdn (as for POSIX LDAP)
 
 ### Example: LDAP
 


### PR DESCRIPTION
resolve issue #11754 

add config option `AUTH_LDAP_GROUP_MEMBER_IS_DN` in order to switch from userdn to useruid as comparison attribute for posix ldap structure