### PR TITLE
Show errors for Save as Copy action

### DIFF
--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -144,25 +144,7 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 			edits.value = {};
 			return response.data.data;
 		} catch (err: any) {
-			if (err?.response?.data?.errors) {
-				validationErrors.value = err.response.data.errors
-					.filter((err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code))
-					.map((err: APIError) => {
-						return err.extensions;
-					});
-
-				const otherErrors = err.response.data.errors.filter(
-					(err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code) === false
-				);
-
-				if (otherErrors.length > 0) {
-					otherErrors.forEach(unexpectedError);
-				}
-			} else {
-				unexpectedError(err);
-			}
-
-			throw err;
+			saveErrorHandler(err);
 		} finally {
 			saving.value = false;
 		}
@@ -207,27 +189,31 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 
 			return primaryKeyField.value ? response.data.data[primaryKeyField.value.field] : null;
 		} catch (err: any) {
-			if (err?.response?.data?.errors) {
-				validationErrors.value = err.response.data.errors
-					.filter((err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code))
-					.map((err: APIError) => {
-						return err.extensions;
-					});
-
-				const otherErrors = err.response.data.errors.filter(
-					(err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code) === false
-				);
-
-				if (otherErrors.length > 0) {
-					otherErrors.forEach(unexpectedError);
-				}
-			} else {
-				unexpectedError(err);
-			}
-			throw err;
+			saveErrorHandler(err);
 		} finally {
 			saving.value = false;
 		}
+	}
+
+	function saveErrorHandler(err: any) {
+		if (err?.response?.data?.errors) {
+			validationErrors.value = err.response.data.errors
+				.filter((err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code))
+				.map((err: APIError) => {
+					return err.extensions;
+				});
+
+			const otherErrors = err.response.data.errors.filter(
+				(err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code) === false
+			);
+
+			if (otherErrors.length > 0) {
+				otherErrors.forEach(unexpectedError);
+			}
+		} else {
+			unexpectedError(err);
+		}
+		throw err;
 	}
 
 	async function archive() {

--- a/app/src/composables/use-item/use-item.ts
+++ b/app/src/composables/use-item/use-item.ts
@@ -209,14 +209,22 @@ export function useItem(collection: Ref<string>, primaryKey: Ref<string | number
 		} catch (err: any) {
 			if (err?.response?.data?.errors) {
 				validationErrors.value = err.response.data.errors
-					.filter((err: APIError) => err?.extensions?.code === 'FAILED_VALIDATION')
+					.filter((err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code))
 					.map((err: APIError) => {
 						return err.extensions;
 					});
+
+				const otherErrors = err.response.data.errors.filter(
+					(err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code) === false
+				);
+
+				if (otherErrors.length > 0) {
+					otherErrors.forEach(unexpectedError);
+				}
 			} else {
 				unexpectedError(err);
-				throw err;
 			}
+			throw err;
 		} finally {
 			saving.value = false;
 		}


### PR DESCRIPTION
Fixes #11722

## Before

No error is shown during Save as Copy when a user has no create permission or when a unique value is required:

![hAoMpA9NN3](https://user-images.githubusercontent.com/42867097/154897122-525e818d-821f-4097-8c2e-e8cf220b77ef.gif)

## After

Reuse the same logic as `save()`:

https://github.com/directus/directus/blob/6b02935116a4cb0566770f1c39ab49394464e89f/app/src/composables/use-item/use-item.ts#L147-L165

### No Create permission

![fjNgPe7xOF](https://user-images.githubusercontent.com/42867097/154897085-bb1f1bc2-176c-4306-82aa-2c3732b176e5.gif)

## Unique values

(necessary as this is applicable for admin users as well)

![MNLJ3nqUcv](https://user-images.githubusercontent.com/42867097/154897233-8f65a6f0-35fe-40dd-a494-1a4da492124a.gif)

