### PR TITLE
Hide certain save options for users without create permission

### DIFF
--- a/app/src/composables/use-permissions.ts
+++ b/app/src/composables/use-permissions.ts
@@ -6,6 +6,7 @@ import { isAllowed } from '../utils/is-allowed';
 import { useCollection } from '@directus/shared/composables';
 
 type UsablePermissions = {
+	createAllowed: ComputedRef<boolean>;
 	deleteAllowed: ComputedRef<boolean>;
 	saveAllowed: ComputedRef<boolean>;
 	archiveAllowed: ComputedRef<boolean>;
@@ -20,6 +21,8 @@ export function usePermissions(collection: Ref<string>, item: Ref<any>, isNew: R
 	const permissionsStore = usePermissionsStore();
 
 	const { info: collectionInfo, fields: rawFields } = useCollection(collection);
+
+	const createAllowed = computed(() => isAllowed(collection.value, 'create', item.value));
 
 	const deleteAllowed = computed(() => isAllowed(collection.value, 'delete', item.value));
 
@@ -93,5 +96,14 @@ export function usePermissions(collection: Ref<string>, item: Ref<any>, isNew: R
 		);
 	});
 
-	return { deleteAllowed, saveAllowed, archiveAllowed, updateAllowed, shareAllowed, fields, revisionsAllowed };
+	return {
+		createAllowed,
+		deleteAllowed,
+		saveAllowed,
+		archiveAllowed,
+		updateAllowed,
+		shareAllowed,
+		fields,
+		revisionsAllowed,
+	};
 }

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -133,6 +133,7 @@
 				<template #append-outer>
 					<save-options
 						v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true && isSavable === true"
+						:disabled-options="createAllowed ? [] : ['save-and-add-new', 'save-as-copy']"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
@@ -345,8 +346,16 @@ export default defineComponent({
 		useShortcut('meta+s', saveAndStay, form);
 		useShortcut('meta+shift+s', saveAndAddNew, form);
 
-		const { deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, shareAllowed, fields, revisionsAllowed } =
-			usePermissions(collection, item, isNew);
+		const {
+			createAllowed,
+			deleteAllowed,
+			archiveAllowed,
+			saveAllowed,
+			updateAllowed,
+			shareAllowed,
+			fields,
+			revisionsAllowed,
+		} = usePermissions(collection, item, isNew);
 
 		const internalPrimaryKey = computed(() => {
 			if (isNew.value) return '+';
@@ -388,6 +397,7 @@ export default defineComponent({
 			confirmLeave,
 			leaveTo,
 			discardAndLeave,
+			createAllowed,
 			deleteAllowed,
 			saveAllowed,
 			archiveAllowed,

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -100,7 +100,7 @@
 				<template #append-outer>
 					<save-options
 						v-if="isSavable"
-						:disabled-options="['save-and-add-new']"
+						:disabled-options="createAllowed ? ['save-and-add-new'] : ['save-and-add-new', 'save-as-copy']"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
 						@discard-and-stay="discardAndStay"
@@ -291,7 +291,7 @@ export default defineComponent({
 
 		useShortcut('meta+s', saveAndStay, form);
 
-		const { deleteAllowed, saveAllowed, updateAllowed, fields, revisionsAllowed } = usePermissions(
+		const { createAllowed, deleteAllowed, saveAllowed, updateAllowed, fields, revisionsAllowed } = usePermissions(
 			ref('directus_files'),
 			item,
 			isNew
@@ -335,6 +335,7 @@ export default defineComponent({
 			to,
 			replaceFileDialogActive,
 			refresh,
+			createAllowed,
 			deleteAllowed,
 			saveAllowed,
 			updateAllowed,

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -86,6 +86,7 @@
 				<template #append-outer>
 					<save-options
 						v-if="isSavable"
+						:disabled-options="createAllowed ? [] : ['save-and-add-new', 'save-as-copy']"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
@@ -282,11 +283,8 @@ export default defineComponent({
 
 		const { loading: previewLoading, avatarSrc, roleName } = useUserPreview();
 
-		const { deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, revisionsAllowed, fields } = usePermissions(
-			ref('directus_users'),
-			item,
-			isNew
-		);
+		const { createAllowed, deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, revisionsAllowed, fields } =
+			usePermissions(ref('directus_users'), item, isNew);
 
 		// These fields will be shown in the sidebar instead
 		const fieldsDenyList = [
@@ -349,6 +347,7 @@ export default defineComponent({
 			leaveTo,
 			discardAndLeave,
 			formFields,
+			createAllowed,
 			deleteAllowed,
 			saveAllowed,
 			archiveAllowed,


### PR DESCRIPTION
Fixes #11723

Applied changes to Content items, Files & Users.

## Before

![chrome_tv3jjgAJGf](https://user-images.githubusercontent.com/42867097/154897922-af8cdee8-f72e-4094-8971-f413665bd495.png)

## After

![chrome_jA2SIOrhMQ](https://user-images.githubusercontent.com/42867097/154897977-f58790ae-53d3-48e4-b7f9-c0b09e2e7ec1.png)

