### PR TITLE
Fix relational interfaces to return null when the array is empty after deselecting item(s)

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -165,7 +165,7 @@ export default defineComponent({
 			required: true,
 		},
 		value: {
-			type: Array as PropType<any[]>,
+			type: Array as PropType<any[] | null>,
 			default: null,
 		},
 		disabled: {
@@ -529,10 +529,13 @@ export default defineComponent({
 			}
 
 			function deselect(item: any) {
-				emit(
-					'input',
-					(props.value || []).filter((current) => current !== item)
-				);
+				const newValue = (props.value || []).filter((current) => current !== item);
+
+				if (newValue.length === 0) {
+					emit('input', null);
+				} else {
+					emit('input', newValue);
+				}
 			}
 		}
 

--- a/app/src/interfaces/list-m2m/use-actions.ts
+++ b/app/src/interfaces/list-m2m/use-actions.ts
@@ -140,7 +140,12 @@ export default function useActions(
 
 			return isEqual(item, deletingItem) === false;
 		});
-		emit(newValue);
+
+		if (newValue.length === 0) {
+			emit(null);
+		} else {
+			emit(newValue);
+		}
 	}
 
 	return {

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -218,14 +218,18 @@ export default defineComponent({
 				return result;
 			}
 
-			function emitValue(value: Record<string, any>[]) {
-				stagedValues.value = value;
+			function emitValue(value: Record<string, any>[] | null) {
+				if (!value || value.length === 0) {
+					emit('input', null);
+				} else {
+					stagedValues.value = value;
 
-				if (relation.value.meta?.sort_field) {
-					return emit('input', addSort(value));
+					if (relation.value.meta?.sort_field) {
+						return emit('input', addSort(value));
+					}
+
+					emit('input', value);
 				}
-
-				emit('input', value);
 
 				function addSort(value: Record<string, any>[]): Record<string, any>[] {
 					return (value || []).map((item, index) => {
@@ -315,7 +319,7 @@ export default defineComponent({
 
 				const newVal = [...response.data.data, ...stagedValues.value];
 
-				if (newVal.length === 0) emitValue([]);
+				if (newVal.length === 0) emitValue(null);
 				else emitValue(newVal);
 
 				loading.value = false;

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -220,6 +220,7 @@ export default defineComponent({
 
 			function emitValue(value: Record<string, any>[] | null) {
 				if (!value || value.length === 0) {
+					stagedValues.value = [];
 					emit('input', null);
 				} else {
 					stagedValues.value = value;

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -259,16 +259,19 @@ export default defineComponent({
 			}
 
 			const id = item[relatedPrimKey];
-			emit(
-				'input',
-				props.value.filter((item) => {
-					if (typeof item === 'number' || typeof item === 'string') return item !== id;
-					if (typeof item === 'object' && relatedPrimKey in item) {
-						return item[relatedPrimKey] !== id;
-					}
-					return true;
-				})
-			);
+			const newValue = props.value.filter((item) => {
+				if (typeof item === 'number' || typeof item === 'string') return item !== id;
+				if (typeof item === 'object' && relatedPrimKey in item) {
+					return item[relatedPrimKey] !== id;
+				}
+				return true;
+			});
+
+			if (newValue.length === 0) {
+				emit('input', null);
+			} else {
+				emit('input', newValue);
+			}
 		}
 
 		function useSort() {


### PR DESCRIPTION
Fixes #11757

## Before

Deselecting/removing items in relational interfaces is returning empty array rather than `null`, which passes "required" field check:

https://user-images.githubusercontent.com/42867097/154921471-6629b4ec-5164-4e58-8f97-155775269007.mp4

Setting value to `null` when the array is empty is already implemented in edits, but not when deselecting/removing item:

https://github.com/directus/directus/blob/c02d5615654e2809109edc6723a4cf00c90b73e0/app/src/interfaces/list-o2m/list-o2m.vue#L445-L446

## After

All `null` relational fields now correctly fails with "Value can't be null" error on submit

https://user-images.githubusercontent.com/42867097/154922036-018aa4be-8252-479e-8fff-b5eb1fc67c4f.mp4


