### PR TITLE
fix permission for field functions

### DIFF
--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -15,6 +15,7 @@ import {
 } from '@directus/shared/types';
 import { ItemsService } from './items';
 import { PayloadService } from './payload';
+import { stripFunction } from '../utils/strip-function';
 
 export class AuthorizationService {
 	knex: Knex;
@@ -128,7 +129,7 @@ export class AuthorizationService {
 
 					if (allowedFields.includes('*')) continue;
 
-					const fieldKey = childNode.name;
+					const fieldKey = stripFunction(childNode.name);
 
 					if (allowedFields.includes(fieldKey) === false) {
 						throw new ForbiddenException();


### PR DESCRIPTION
Fixes #11713

## Before

When we grant read permission to a date field _only_:

![image](https://user-images.githubusercontent.com/42867097/154970067-f71b6401-d302-49cd-bb5e-90d5301718f1.png)

The API call fails, even though it worked if we grant _all_ read permission:

![chrome_etncc3eOLk](https://user-images.githubusercontent.com/42867097/154970245-5194b433-1756-4ecc-9ecb-8856fa1e5a6a.png)

## Investigation

https://github.com/directus/directus/blob/c02d5615654e2809109edc6723a4cf00c90b73e0/api/src/services/authorization.ts#L129-L135

- > even though it worked if we grant _all_ read permission

   Granting all permission works because of the first line, where the code will `continue` and stop doing checks.
   
- As for the reason it fails, now the allowed fields contain `start_dt`, but since the fieldKey is `year(start_dt)` instead, the check fails and throws forbidden exception.

## After

![chrome_3hbzSxOrEs](https://user-images.githubusercontent.com/42867097/154970626-3fc6cc95-5054-4a65-98eb-ae51e715df30.png)

