### PR TITLE
Fix video size within in-app docs

### DIFF
--- a/app/src/views/private/components/docs-wrapper/docs-wrapper.vue
+++ b/app/src/views/private/components/docs-wrapper/docs-wrapper.vue
@@ -215,7 +215,8 @@ export default defineComponent({
 	border-spacing: 0;
 }
 
-.md :deep(img) {
+.md :deep(img),
+.md :deep(video) {
 	max-width: 100%;
 	margin: 20px 0;
 	border-radius: 6px;


### PR DESCRIPTION
## Before

![chrome_o8fCTDM7x3](https://user-images.githubusercontent.com/42867097/155077491-0160c5d3-048b-43f1-9604-6cc1c352078e.png)

## After

![chrome_1ozmoQp8z8](https://user-images.githubusercontent.com/42867097/155077506-ec70e5ce-7263-494f-8f6a-f7a093a5a0e7.png)

