### PR TITLE
Allow target="_blank" in markdown sanitization

### DIFF
--- a/app/src/utils/md.ts
+++ b/app/src/utils/md.ts
@@ -5,5 +5,11 @@ import dompurify from 'dompurify';
  * Render and sanitize a markdown string
  */
 export function md(str: string): string {
-	return dompurify.sanitize(marked(str));
+	dompurify.addHook('afterSanitizeAttributes', (node) => {
+		if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+			node.setAttribute('rel', 'noopener noreferrer');
+		}
+	});
+
+	return dompurify.sanitize(marked(str), { ADD_ATTR: ['target'] });
 }


### PR DESCRIPTION
Fixes #11477

- Prevent dompurify from removing `target` attributes via allow-list setting `{ ADD_ATTR: ['target'] }`.
- Add `rel` attribute if `target="_blank"` is used for security purposes.

Sample text used in notice:

![image](https://user-images.githubusercontent.com/42867097/155103340-8f9c0fcd-138a-4436-a237-a35d38022fd5.png)

## Before

![chrome_xQMcOmlazj](https://user-images.githubusercontent.com/42867097/155103178-a56959a9-a8e3-4740-a555-be5237f79052.png)

## After

![chrome_gKsUvxEDt5](https://user-images.githubusercontent.com/42867097/155103192-65315471-3414-4049-bae7-531031b330eb.png)

