### PR TITLE
Hide delete action for last admin role

### DIFF
--- a/app/src/modules/insights/routes/panel-configuration.vue
+++ b/app/src/modules/insights/routes/panel-configuration.vue
@@ -81,7 +81,7 @@
 
 <script lang="ts">
 import ExtensionOptions from '../../settings/routes/data-model/field-detail/shared/extension-options.vue';
-import { computed, defineComponent, reactive, watch, PropType, ref } from 'vue';
+import { computed, defineComponent, reactive, watch, PropType } from 'vue';
 import { getPanels, getPanel } from '@/panels';
 import { FancySelectItem } from '@/components/v-fancy-select/types';
 import { Panel } from '@directus/shared/types';

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -72,6 +72,8 @@ type Role = {
 	id: number;
 	name: string;
 	description: string;
+	icon: string;
+	admin_access: boolean;
 	count: number;
 };
 
@@ -86,6 +88,11 @@ export default defineComponent({
 
 		const roles = ref<Role[]>([]);
 		const loading = ref(false);
+
+		const lastAdminRoleId = computed(() => {
+			const adminRoles = roles.value.filter((role) => role.admin_access === true);
+			return adminRoles.length === 1 ? adminRoles[0].id : null;
+		});
 
 		const tableHeaders: TableHeader[] = [
 			{
@@ -133,7 +140,7 @@ export default defineComponent({
 				const response = await api.get(`/roles`, {
 					params: {
 						limit: -1,
-						fields: ['id', 'name', 'description', 'icon', 'users'],
+						fields: ['id', 'name', 'description', 'icon', 'admin_access', 'users'],
 						deep: {
 							users: {
 								_aggregate: { count: 'id' },
@@ -169,7 +176,12 @@ export default defineComponent({
 		}
 
 		function navigateToRole({ item }: { item: Role }) {
-			router.push(`/settings/roles/${item.id}`);
+			router.push({
+				name: 'settings-roles-item',
+				params: lastAdminRoleId.value
+					? { primaryKey: item.id, lastAdminRoleId: lastAdminRoleId.value }
+					: { primaryKey: item.id },
+			});
 		}
 	},
 });

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -12,6 +12,7 @@
 			<v-dialog v-if="[1, 2].includes(+primaryKey) === false" v-model="confirmDelete" @esc="confirmDelete = false">
 				<template #activator="{ on }">
 					<v-button
+						v-if="primaryKey !== lastAdminRoleId"
 						v-tooltip.bottom="t('delete_label')"
 						rounded
 						icon
@@ -126,6 +127,10 @@ export default defineComponent({
 			required: true,
 		},
 		permissionKey: {
+			type: String,
+			default: null,
+		},
+		lastAdminRoleId: {
 			type: String,
 			default: null,
 		},


### PR DESCRIPTION
Fixes #11791

## Before

Currently the API does prevent the last admin from being deleted, but the UI still shows the delete button:

![oyx2ZZaTxp](https://user-images.githubusercontent.com/42867097/155142783-93df1b1c-458a-44ac-8d36-4ffe50cf7eb4.gif)

## After

Hides the delete button when it's the last admin role.

https://user-images.githubusercontent.com/42867097/155142816-7ea828e7-ebb5-4be9-9ff1-b944174d021e.mp4

 