### PR TITLE
fix map interface extension options

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -27,7 +27,8 @@ import { getInterface } from '@/interfaces';
 import { getDisplay } from '@/displays';
 import { getPanel } from '@/panels';
 import { useI18n } from 'vue-i18n';
-import { Field } from '@directus/shared/types';
+import { useFieldDetailStore } from '../store';
+import { storeToRefs } from 'pinia';
 
 export default defineComponent({
 	props: {
@@ -51,18 +52,14 @@ export default defineComponent({
 			type: Object,
 			default: () => ({}),
 		},
-		collection: {
-			type: String,
-			default: '',
-		},
-		field: {
-			type: Object as PropType<Field>,
-			default: null,
-		},
 	},
 	emits: ['update:modelValue'],
 	setup(props, { emit }) {
 		const { t } = useI18n();
+
+		const fieldDetailStore = useFieldDetailStore();
+
+		const { collection, field } = storeToRefs(fieldDetailStore);
 
 		const extensionInfo = computed(() => {
 			switch (props.type) {
@@ -122,6 +119,8 @@ export default defineComponent({
 			optionsValues,
 			optionsFields,
 			t,
+			collection,
+			field,
 		};
 	},
 });


### PR DESCRIPTION
Fixes #11795

## Before


![uHN5BUkM09](https://user-images.githubusercontent.com/42867097/155157681-abb170ca-07de-4b77-b2e4-24eec7f1a6b6.gif)

## Investigation

Seems to be an unintended regression from #10828. Since `extension-options` never receives field & collection props, opted to remove them and [fallback to previous approach](https://github.com/directus/directus/blob/23f6baa4db019fa4d6093f48b9a251d486257e66/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue) which gets field & collection from the fieldDetailStore.

## After

![JdWpG5qyjs](https://user-images.githubusercontent.com/42867097/155157631-93880141-6e06-4024-b50f-d91f022aa1ac.gif)

