### PR TITLE
LDAP handle posix groups

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -172,7 +172,7 @@ export class LDAPAuthDriver extends AuthDriver {
 		});
 	}
 
-	private async fetchUserGroups(baseDn: string, filter: EqualityFilter, scope?: SearchScope): Promise<string[]> {
+	private async fetchUserGroups(baseDn: string, filter?: EqualityFilter, scope?: SearchScope): Promise<string[]> {
 		return new Promise((resolve, reject) => {
 			let userGroups: string[] = [];
 

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -13,7 +13,7 @@ import ldap, {
 } from 'ldapjs';
 import ms from 'ms';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
-import Joi, { number } from 'joi';
+import Joi from 'joi';
 import { AuthDriver } from '../auth';
 import { AuthDriverOptions, User } from '../../types';
 import {

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -13,7 +13,7 @@ import ldap, {
 } from 'ldapjs';
 import ms from 'ms';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
-import Joi, { number } from 'joi';
+import Joi from 'joi';
 import { AuthDriver } from '../auth';
 import { AuthDriverOptions, User } from '../../types';
 import {
@@ -151,11 +151,11 @@ export class LDAPAuthDriver extends AuthDriver {
 					res.on('searchEntry', ({ object }: SearchEntry) => {
 						const user = {
 							dn: object.dn,
-							uid: getAttributeValue(object.uid),
-							firstName: getAttributeValue(object[firstNameAttribute]),
-							lastName: getAttributeValue(object[lastNameAttribute]),
-							email: getAttributeValue(object[mailAttribute]),
-							userAccountControl: Number(getAttributeValue(object.userAccountControl) ?? 0),
+							uid: getEntryValue(object.uid),
+							firstName: getEntryValue(object[firstNameAttribute]),
+							lastName: getEntryValue(object[lastNameAttribute]),
+							email: getEntryValue(object[mailAttribute]),
+							userAccountControl: Number(getEntryValue(object.userAccountControl) ?? 0),
 						};
 						resolve(user);
 					});
@@ -346,7 +346,7 @@ const handleError = (e: Error) => {
 	});
 };
 
-const getAttributeValue = (value: string | string[] | undefined): string | undefined => {
+const getEntryValue = (value: string | string[] | undefined): string | undefined => {
 	return typeof value === 'object' ? value[0] : value;
 };
 


### PR DESCRIPTION
Combined `fetchUserInfo` and `fetchUserDn` into a single function and added more flexible filter parameters to LDAP  fetch functions.

Also added check to use posix `uid` when searching for groups by `memberUid` to improve support with posix users and groups #11754.

EDIT: I also accidentally included some of https://github.com/directus/directus/pull/11750 in this PR. Sorry @schlagmichdoch!