### PR TITLE
add missing directus_shares note

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -902,6 +902,7 @@ directus_collection:
   directus_roles: Permission groups for system users
   directus_sessions: User session information
   directus_settings: Project configuration options
+  directus_shares: Tracks externally shared items
   directus_users: System users for the platform
   directus_webhooks: Configuration for event-based HTTP requests
 fields:


### PR DESCRIPTION
for some reason, similar to the Copy/Paste context menu translations, the Crowdin update removed `directus_shares` translations again over here: https://github.com/directus/directus/pull/11711/files#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6aL905

cc @rijkvanzanten as I'm not sure why this is happening 🤔