### PR TITLE
add `Last-Modified` header to `/assets/*` responses

### DIFF
--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -146,6 +146,12 @@ router.get(
 		res.setHeader('Accept-Ranges', 'bytes');
 		res.setHeader('Cache-Control', `${access}, max-age=${ms(env.ASSETS_CACHE_TTL as string) / 1000}`);
 
+		const unixTime = Date.parse(file.modified_on);
+		if (!Number.isNaN(unixTime)) {
+			const lastModifiedDate = new Date(unixTime);
+			res.setHeader('Last-Modified', lastModifiedDate.toUTCString());
+		}
+
 		if (range) {
 			res.setHeader('Content-Range', `bytes ${range.start}-${range.end || stat.size - 1}/${stat.size}`);
 			res.status(206);

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -384,8 +384,9 @@ middleman servers (like CDNs) and even the browser.
 
 ::: tip Assets Cache
 
-The cache-control header for the `/assets` endpoint is separate from the regular data-cache. This is useful as it's
-often possible to cache assets for far longer than you would cache database content. [Learn More](#assets)
+`Cache-Control` and `Last-Modified` headers for the `/assets` endpoint are separate from the regular data-cache.
+`Last-Modified` comes from `modified_on` DB field. This is useful as it's often possible to cache assets for far longer
+than you would cache database content. [Learn More](#assets)
 
 :::
 


### PR DESCRIPTION
Related to a discussion:
https://github.com/directus/directus/discussions/6723

`Last-Modified` header basically enables caching in the browser. 
Without `Last-Modified`, `Cache-Control` is semi-useless in the browser. 

This enables asset caching for ~95% use cases