### PR TITLE
Added `DB_INCLUDE_TABLES` env variable

### DIFF
--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -26,6 +26,7 @@ export default function getDatabase(): Knex {
 		'DB_CONNECTION_STRING',
 		'DB_POOL',
 		'DB_EXCLUDE_TABLES',
+		'DB_INCLUDE_TABLES',
 		'DB_VERSION',
 	]);
 

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -20,6 +20,7 @@ const defaults: Record<string, any> = {
 	MAX_PAYLOAD_SIZE: '100kb',
 
 	DB_EXCLUDE_TABLES: 'spatial_ref_sys,sysdiagrams',
+	DB_INCLUDE_TABLES: '',
 
 	STORAGE_LOCATIONS: 'local',
 	STORAGE_LOCAL_DRIVER: 'local',
@@ -91,6 +92,7 @@ const typeMap: Record<string, string> = {
 	DB_PORT: 'number',
 
 	DB_EXCLUDE_TABLES: 'array',
+	DB_INCLUDE_TABLES: 'array',
 };
 
 let env: Record<string, any> = {

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -250,8 +250,25 @@ export class CollectionsService {
 			}
 		}
 
+		if (
+				env.DB_EXCLUDE_TABLES &&
+				env.DB_INCLUDE_TABLES && !(env.DB_INCLUDE_TABLES.length === 1 && env.DB_INCLUDE_TABLES[0] === '')
+		) {
+			return collections
+				.filter((collection) => env.DB_EXCLUDE_TABLES.includes(collection.collection) === false)
+				.filter((collection) =>
+					collection.collection.startsWith("directus_") ||
+					env.DB_INCLUDE_TABLES.includes(collection.collection) === true);
+		}
+
 		if (env.DB_EXCLUDE_TABLES) {
 			return collections.filter((collection) => env.DB_EXCLUDE_TABLES.includes(collection.collection) === false);
+		}
+
+		if (env.DB_INCLUDE_TABLES && !(env.DB_INCLUDE_TABLES.length === 1 && env.DB_INCLUDE_TABLES[0] === '')) {
+			return collections.filter((collection) =>
+				collection.collection.startsWith("directus_") ||
+				env.DB_INCLUDE_TABLES.includes(collection.collection) === true);
 		}
 
 		return collections;

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -69,7 +69,16 @@ async function getDatabaseSchema(
 	];
 
 	for (const [collection, info] of Object.entries(schemaOverview)) {
-		if (toArray(env.DB_EXCLUDE_TABLES).includes(collection)) {
+		if (env.DB_EXCLUDE_TABLES.includes(collection)) {
+			logger.trace(`Collection "${collection}" is configured to be excluded and will be ignored`);
+			continue;
+		}
+
+		if (
+			!collection.startsWith("directus_") &&
+			env.DB_INCLUDE_TABLES && !(env.DB_INCLUDE_TABLES.length === 1 && env.DB_INCLUDE_TABLES[0] === '') &&
+			!env.DB_INCLUDE_TABLES.includes(collection)
+		) {
 			logger.trace(`Collection "${collection}" is configured to be excluded and will be ignored`);
 			continue;
 		}

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -222,6 +222,7 @@ for example. The format for adding LEVELS values is:
 | `DB_CONNECTION_STRING` | When using `pg`, you can submit a connection string instead of individual properties. Using this will ignore any of the other connection settings. | --                            |
 | `DB_POOL_*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --                            |
 | `DB_EXCLUDE_TABLES`    | CSV of tables you want Directus to ignore completely                                                                                               | `spatial_ref_sys,sysdiagrams` |
+| `DB_INCLUDE_TABLES`    | CSV of tables you want Directus to **not** ignore (all other tables will be ignored completely)                                                    | --                            |
 | `DB_CHARSET`           | Charset/collation to use in the connection to MySQL/MariaDB                                                                                        | `UTF8_GENERAL_CI`             |
 | `DB_VERSION`           | Database version, in case you use the PostgreSQL adapter to connect a non-standard database. Not normally required.                                | --                            |
 


### PR DESCRIPTION
To address #11001.

I'll be the first to admit this code is a bit rough, so hopefully after taking a look it should only take a few minutes to tweak it to the best standard.

Also the table entry in the doc config table could probably be a bit more clear that when the setting is not specified it just includes all tables not specified in `DB_EXCLUDE_TABLES`, but I'm having trouble finding a clear and concise way to communicate that.