### PR TITLE
Close date picker on select

### DIFF
--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -94,11 +94,11 @@ export default defineComponent({
 				instance.calendarContainer.appendChild(setToNowButton);
 
 				if (!props.use24) {
-					instance.amPM?.addEventListener('keydown', enterToClose);
+					instance.amPM?.addEventListener('keyup', enterToClose);
 				} else if (props.includeSeconds) {
-					instance.secondElement?.addEventListener('keydown', enterToClose);
+					instance.secondElement?.addEventListener('keyup', enterToClose);
 				} else {
-					instance.minuteElement?.addEventListener('keydown', enterToClose);
+					instance.minuteElement?.addEventListener('keyup', enterToClose);
 				}
 			},
 		};
@@ -117,13 +117,22 @@ export default defineComponent({
 
 			switch (props.type) {
 				case 'dateTime':
-					return emit('update:modelValue', format(value, "yyyy-MM-dd'T'HH:mm:ss"));
+					emit('update:modelValue', format(value, "yyyy-MM-dd'T'HH:mm:ss"));
+					break;
 				case 'date':
-					return emit('update:modelValue', format(value, 'yyyy-MM-dd'));
+					emit('update:modelValue', format(value, 'yyyy-MM-dd'));
+					break;
 				case 'time':
-					return emit('update:modelValue', format(value, 'HH:mm:ss'));
+					emit('update:modelValue', format(value, 'HH:mm:ss'));
+					break;
 				case 'timestamp':
-					return emit('update:modelValue', formatISO(value));
+					emit('update:modelValue', formatISO(value));
+					break;
+			}
+
+			// close the calendar on input change if it's only a date picker without time input
+			if (props.type === 'date') {
+				emit('close');
 			}
 		}
 


### PR DESCRIPTION
Fixes #11841

This will not apply when there are time inputs, and purely a change for **date-only** inputs.

Side note: I've also updated the `keydown` listeners to `keyup` as I believe that'd make more sense.

## Before

![vGjG9nQ6pR](https://user-images.githubusercontent.com/42867097/155701590-56a5d724-90a5-4d5f-8f4d-d7652f779d28.gif)

## After

![x8x68LLYxn](https://user-images.githubusercontent.com/42867097/155701579-c33078bf-fb5b-4cc5-80ea-817803e8485e.gif)

