### PR TITLE
Add support to extend `server` properties

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -12,9 +12,12 @@ import logger from './logger';
 import emitter from './emitter';
 import checkForUpdate from 'update-check';
 import pkg from '../package.json';
+import { getConfigFromEnv } from './utils/get-config-from-env';
 
 export async function createServer(): Promise<http.Server> {
 	const server = http.createServer(await createApp());
+
+	Object.assign(server, getConfigFromEnv('SERVER_'));
 
 	server.on('request', function (req: http.IncomingMessage & Request, res: http.ServerResponse) {
 		const startTime = process.hrtime();

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -208,6 +208,22 @@ for example. The format for adding LEVELS values is:
 
 :::
 
+## Server
+
+| Variable                    | Description                                        | Default Value                                                                                                |
+| --------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `SERVER_KEEP_ALIVE_TIMEOUT` | Timeout in milliseconds for socket to be destroyed | [server.keepAliveTimeout](https://github.com/nodejs/node/blob/master/doc/api/http.md#serverkeepalivetimeout) |
+| `SERVER_HEADERS_TIMEOUT`    | Timeout in milliseconds to parse HTTP headers      | [server.headersTimeout](https://github.com/nodejs/node/blob/master/doc/api/http.md#serverheaderstimeout)     |
+
+::: tip Additional Server Variables
+
+All `SERVER_*` environment variables are merged with `server` instance properties created from
+[http.Server](https://github.com/nodejs/node/blob/master/doc/api/http.md#class-httpserver). This allows to configure
+server behind a proxy, a load balancer, etc. Be careful to not override methods of this instance otherwise you may incur
+into unexpected behaviors.
+
+:::
+
 ## Database
 
 | Variable               | Description                                                                                                                                        | Default Value                 |


### PR DESCRIPTION
Fixes #11866

This allows to configure Directus to be used behind a load balancer, a proxy, etc.
We can customize keep alive timeout, parse headers timeout, request timeout, etc. All those options can be found here https://github.com/nodejs/node/blob/master/doc/api/http.md#class-httpserver

The main goal of this PR is to fix 502 Bad Gateway for instance behind load balancers