### PR TITLE
Redirect to page not found for collections that do not exist

### DIFF
--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -62,12 +62,19 @@ export default defineModule({
 					async beforeEnter(to) {
 						const collectionsStore = useCollectionsStore();
 						const info = collectionsStore.getCollection(to.params.collection as string);
-						const fieldsStore = useFieldsStore();
+
+						if (!info) {
+							return {
+								name: 'settings-not-found',
+								params: { _: to.path.split('/').slice(1) },
+							};
+						}
 
 						if (!info?.meta) {
 							await api.patch(`/collections/${to.params.collection}`, { meta: {} });
 						}
 
+						const fieldsStore = useFieldsStore();
 						fieldsStore.hydrate();
 					},
 					props: (route) => ({


### PR DESCRIPTION
## Before

Here there is no collection named `empty`, but it'll show up as though it exists:

![chrome_EZOvXxGOCY](https://user-images.githubusercontent.com/42867097/155936492-3eed2522-1668-4d88-9123-1ce4da4993d0.png)

## After

When the collection is not found, redirect it to Page Not Found:

![chrome_hzSYpN8iXF](https://user-images.githubusercontent.com/42867097/155936500-d20b0498-ee5a-4035-90a7-ee73a35d89a6.png)

