### PR TITLE
Enable editing of Geometry types from the raw value modal

### DIFF
--- a/app/src/utils/get-js-type.ts
+++ b/app/src/utils/get-js-type.ts
@@ -10,6 +10,6 @@ export function getJSType(field: Field): string {
 	if (['string', 'text', 'uuid', 'hash'].includes(field.type)) return 'string';
 	if (['boolean'].includes(field.type)) return 'boolean';
 	if (['time', 'timestamp', 'date', 'dateTime'].includes(field.type)) return 'string';
-	if (['json', 'csv'].includes(field.type)) return 'object';
+	if (['json', 'csv', 'geometry'].includes(field.type)) return 'object';
 	return 'undefined';
 }


### PR DESCRIPTION
Geometry type data can now be edited as raw value (see #11590).

The value must be a valid GeoJSON _geometry_ object - see [article about GeoJSON on Wikipedia](https://en.wikipedia.org/wiki/GeoJSON#Geometries) for examples.

This is also a nice way to center the map at a location. Example with Point:

```json
{
    "coordinates": [10.7283109, 59.9168651],
    "type": "Point"
}
```