### PR TITLE
add --dry-run flag to `schema apply` CLI command

### DIFF
--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -92,6 +92,7 @@ export async function createCli(): Promise<Command> {
 		.command('apply')
 		.description('Apply a snapshot file to the current database')
 		.option('-y, --yes', `Assume "yes" as answer to all prompts and run non-interactively`)
+		.option('-d, --dry-run', 'Plan and log changes to be applied', false)
 		.argument('<path>', 'Path to snapshot file')
 		.action(apply);
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -127,6 +127,12 @@ To run non-interactively (e.g. when running in a CI/CD workflow), run
 npx directus schema apply --yes ./path/to/snapshot.yaml
 ```
 
+To diff the schema and database and print out the planned changes, run
+
+```
+npx directus schema apply --dry-run ./path/to/snapshot.yaml
+```
+
 ### Creating Users
 
 To create a new user with a specific role, run


### PR DESCRIPTION
Adds a `--dry-run` flag to the `directus schema apply` command:

```
directus schema apply --dry-run ./path/to/schema.yaml
```

This will print out the changes, but not attempt to apply them.

See discussion at https://github.com/directus/directus/discussions/11976