### PR TITLE
Fix query limit -1 for o2m queries

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -341,7 +341,9 @@ function mergeWithParentItems(
 			});
 
 			parentItem[nestedNode.fieldKey].push(...itemChildren);
-			parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(0, nestedNode.query.limit ?? 100);
+			if (nestedNode.query.limit && nestedNode.query.limit >= 0) {
+				parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(0, nestedNode.query.limit ?? 100);
+			}
 			parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].sort((a: Item, b: Item) => {
 				// This is pre-filled in get-ast-from-query
 				const sortField = nestedNode.query.sort![0]!;


### PR DESCRIPTION
## Bug

Noticed that the roles & permissions page is no longer showing the user count anymore:

![chrome_Qnm7D2tVDN](https://user-images.githubusercontent.com/42867097/157066764-c0a38cbb-a9c7-424e-a254-a132985a8bed.png)

## Investigation

Was able to narrow it down to #11246, but verified the logged queries are the same except the LIMIT which is present after that PR.

Later on found out the issue being the `.slice` function with `nestedNode.query.limit` of `-1`: 

https://github.com/directus/directus/blob/c4fea0c9d7c17f417914d04fecd35c95e28a1292/api/src/database/run-ast.ts#L344

The original payload/array for each role was:

```js
[
  { role: '2ba2e54a-7fc0-4070-b597-ce23b2e60a0e', count: { id: '1' } }
]
[
  { role: 'bba858cd-895a-4df9-9b9f-3278651f0cf3', count: { id: '2' } }
]
[
  { role: '8a1c81f5-7819-4e2c-9a56-754847cd39ea', count: { id: '1' } }
]
```

However since the slice ended up doing `slice(0,-1)` which mean everything _except_ the last item, they all ended up returning empty array/result.

## Solution implemented

prevent slicing when limit is `-1`.

## After fix

Showing user count for each roles:

![chrome_9p4Rik42xL](https://user-images.githubusercontent.com/42867097/157066936-d9ff84df-9cb7-491b-9253-58a74bf1602a.png)

