### PR TITLE
Default CORS to disabled

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -39,8 +39,8 @@ const defaults: Record<string, any> = {
 
 	ROOT_REDIRECT: './admin',
 
-	CORS_ENABLED: true,
-	CORS_ORIGIN: true,
+	CORS_ENABLED: false,
+	CORS_ORIGIN: false,
 	CORS_METHODS: 'GET,POST,PATCH,DELETE',
 	CORS_ALLOWED_HEADERS: 'Content-Type,Authorization',
 	CORS_EXPOSED_HEADERS: 'Content-Range',

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -319,8 +319,8 @@ multiplied. This may cause out of memory errors, especially when running in cont
 
 | Variable               | Description                                                                                                                                            | Default Value                |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| `CORS_ENABLED`         | Whether or not to enable the CORS headers.                                                                                                             | `true`                       |
-| `CORS_ORIGIN`          | Value for the `Access-Control-Allow-Origin` header. Use `true` to match the Origin header, or provide a domain or a CSV of domains for specific access | `true`                       |
+| `CORS_ENABLED`         | Whether or not to enable the CORS headers.                                                                                                             | `false`                      |
+| `CORS_ORIGIN`          | Value for the `Access-Control-Allow-Origin` header. Use `true` to match the Origin header, or provide a domain or a CSV of domains for specific access | `false`                      |
 | `CORS_METHODS`         | Value for the `Access-Control-Allow-Methods` header.                                                                                                   | `GET,POST,PATCH,DELETE`      |
 | `CORS_ALLOWED_HEADERS` | Value for the `Access-Control-Allow-Headers` header.                                                                                                   | `Content-Type,Authorization` |
 | `CORS_EXPOSED_HEADERS` | Value for the `Access-Control-Expose-Headers` header.                                                                                                  | `Content-Range`              |


### PR DESCRIPTION
The defaults used to be very permissive to make getting started as easy as possible, but leaving the CORS settings this open can be a bit of a security footgun. The safer default is to have it disabled completely, and allow an explicit opt-in (ideally with exact domains, rather than the match-origin `true`).

---

To go back to the way things were before this PR, set `CORS_ENABLED=true` and `CORS_ORIGIN=true`. That being said, it's highly recommend to use a domain allowlist, like `CORS_ORIGIN=https://directus.io`.