### PR TITLE
Fix user info sidebar last access timestamp

### DIFF
--- a/app/src/modules/users/components/user-info-sidebar-detail.vue
+++ b/app/src/modules/users/components/user-info-sidebar-detail.vue
@@ -57,13 +57,16 @@ export default defineComponent({
 		const lastAccessDate = ref('');
 
 		watch(
-			() => props,
+			[() => props.user, () => props.isNew],
 			async () => {
 				if (!props.user) return;
-				lastAccessDate.value = await localizedFormat(
-					new Date(props.user.last_access),
-					String(t('date-fns_date_short'))
-				);
+
+				if (props.user.last_access) {
+					lastAccessDate.value = await localizedFormat(
+						new Date(props.user.last_access),
+						String(t('date-fns_date_short'))
+					);
+				}
 			},
 			{ immediate: true }
 		);


### PR DESCRIPTION
Fixes #12041

This was a mistake in #10903 as now the watcher doesn't trigger, hence the missing timestamp.

## Before

![chrome_JzHbgX26xM](https://user-images.githubusercontent.com/42867097/157380084-66137592-ca18-4149-be59-14c7ea0f72fe.png)

## After

![chrome_WGc3rF8nKq](https://user-images.githubusercontent.com/42867097/157380097-49711ed7-ea0a-497d-8a2b-72778e400875.png)

