### PR TITLE
Hide nav resize handle when it is not open

### DIFF
--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -275,6 +275,12 @@ function openSidebar(event: PointerEvent) {
 			transform: translateX(0);
 		}
 
+		&:not(.is-open) {
+			.module-nav-resize-handle {
+				display: none;
+			}
+		}
+
 		.module-nav {
 			position: relative;
 			display: inline-block;
@@ -320,6 +326,12 @@ function openSidebar(event: PointerEvent) {
 		@media (min-width: 960px) {
 			position: relative;
 			transform: none;
+
+			&:not(.is-open) {
+				.module-nav-resize-handle {
+					display: block;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Before

Currently when the navigation is not open (in lower screen width), the handle is still present which can prevent resizing of browser window itself:

![ANRq8KLU9H](https://user-images.githubusercontent.com/42867097/157409844-ec855f2c-437c-4be1-95d3-040a9a6429fc.gif)

## After

Ensured it is hidden when the nav is closed, but present when nav is open. It will always be present for min-width 960px.

![cBph90xrfZ](https://user-images.githubusercontent.com/42867097/157410067-c121b574-574d-42d4-b2d5-8aa88602af90.gif)

