### PR TITLE
Allow configuring overrides for the openid-client

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -18,6 +18,7 @@ import asyncHandler from '../../utils/async-handler';
 import { Url } from '../../utils/url';
 import logger from '../../logger';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
+import { getConfigFromEnv } from '../../utils/get-config-from-env';
 
 export class OAuth2AuthDriver extends LocalAuthDriver {
 	client: Client;
@@ -47,11 +48,18 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			issuer: additionalConfig.provider,
 		});
 
+		const clientOptionsOverrides = getConfigFromEnv(
+			`AUTH_${config.provider.toUpperCase()}_CLIENT_`,
+			[`AUTH_${config.provider.toUpperCase()}_CLIENT_ID`, `AUTH_${config.provider.toUpperCase()}_CLIENT_SECRET`],
+			'underscore'
+		);
+
 		this.client = new issuer.Client({
 			client_id: clientId,
 			client_secret: clientSecret,
 			redirect_uris: [this.redirectUrl],
 			response_types: ['code'],
+			...clientOptionsOverrides,
 		});
 	}
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -18,6 +18,7 @@ import asyncHandler from '../../utils/async-handler';
 import { Url } from '../../utils/url';
 import logger from '../../logger';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
+import { getConfigFromEnv } from '../../utils/get-config-from-env';
 
 export class OpenIDAuthDriver extends LocalAuthDriver {
 	client: Promise<Client>;
@@ -35,6 +36,12 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		}
 
 		const redirectUrl = new Url(env.PUBLIC_URL).addPath('auth', 'login', additionalConfig.provider, 'callback');
+
+		const clientOptionsOverrides = getConfigFromEnv(
+			`AUTH_${config.provider.toUpperCase()}_CLIENT_`,
+			[`AUTH_${config.provider.toUpperCase()}_CLIENT_ID`, `AUTH_${config.provider.toUpperCase()}_CLIENT_SECRET`],
+			'underscore'
+		);
 
 		this.redirectUrl = redirectUrl.toString();
 		this.usersService = new UsersService({ knex: this.knex, schema: this.schema });
@@ -57,6 +64,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 							client_secret: clientSecret,
 							redirect_uris: [this.redirectUrl],
 							response_types: ['code'],
+							...clientOptionsOverrides,
 						})
 					);
 				})


### PR DESCRIPTION
Resolves #11951

Passes any `AUTH_<PROVIDER>_CLIENT_*` environment variables on to the node-openid-client Client object. Allows for setting additional options for the auth providers that can be a little more fussy, like in #11951.

For example: `AUTH_TWITCH_CLIENT_TOKEN_ENDPOINT_AUTH_METHOD="client_secret_post"`