### PR TITLE
Remove outline prop from v-icons

### DIFF
--- a/app/src/modules/insights/routes/overview.vue
+++ b/app/src/modules/insights/routes/overview.vue
@@ -53,7 +53,7 @@
 					<v-list>
 						<v-list-item class="warning" clickable @click="editDashboard = item">
 							<v-list-item-icon>
-								<v-icon name="edit" outline />
+								<v-icon name="edit" />
 							</v-list-item-icon>
 							<v-list-item-content>
 								{{ t('edit_dashboard') }}
@@ -62,7 +62,7 @@
 
 						<v-list-item class="danger" clickable @click="confirmDelete = item.id">
 							<v-list-item-icon>
-								<v-icon name="delete" outline />
+								<v-icon name="delete" />
 							</v-list-item-icon>
 							<v-list-item-content>
 								{{ t('delete_dashboard') }}

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -52,7 +52,6 @@ export default defineComponent({
 				icon: 'admin_panel_settings',
 				name: t('settings_permissions'),
 				to: `/settings/roles`,
-				outline: true,
 			},
 			{
 				icon: 'bookmark_border',
@@ -79,13 +78,11 @@ export default defineComponent({
 					icon: 'bug_report',
 					name: t('report_bug'),
 					href: `https://github.com/directus/directus/issues/new?${bugReportParams.toString()}`,
-					outline: true,
 				},
 				{
 					icon: 'new_releases',
 					name: t('request_feature'),
 					href: 'https://github.com/directus/directus/discussions/new',
-					outline: true,
 				},
 			];
 		});

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -7,7 +7,7 @@
 			<v-list>
 				<v-list-item clickable class="danger" @click="deleteActive = true">
 					<v-list-item-icon>
-						<v-icon name="delete" outline />
+						<v-icon name="delete" />
 					</v-list-item-icon>
 					<v-list-item-content>
 						{{ collection.schema ? t('delete_collection') : t('delete_folder') }}

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select-menu.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select-menu.vue
@@ -6,7 +6,7 @@
 
 		<v-list>
 			<v-list-item :to="`/settings/data-model/${field.collection}/${field.field}`">
-				<v-list-item-icon><v-icon name="edit" outline /></v-list-item-icon>
+				<v-list-item-icon><v-icon name="edit" /></v-list-item-icon>
 				<v-list-item-content>
 					{{ t('edit_field') }}
 				</v-list-item-content>
@@ -67,7 +67,7 @@
 				:disabled="field.schema?.is_primary_key === true || noDelete"
 				@click="$emit('delete')"
 			>
-				<v-list-item-icon><v-icon name="delete" outline /></v-list-item-icon>
+				<v-list-item-icon><v-icon name="delete" /></v-list-item-icon>
 				<v-list-item-content>
 					{{ t('delete_field') }}
 				</v-list-item-content>

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -22,7 +22,7 @@
 						:disabled="item === null"
 						@click="on"
 					>
-						<v-icon name="delete" outline />
+						<v-icon name="delete" />
 					</v-button>
 				</template>
 
@@ -79,7 +79,7 @@
 		</div>
 
 		<template #sidebar>
-			<sidebar-detail icon="info_outline" :title="t('information')" close>
+			<sidebar-detail icon="info" :title="t('information')" close>
 				<div v-md="t('page_help_settings_datamodel_fields')" class="page-description" />
 			</sidebar-detail>
 		</template>

--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -12,7 +12,7 @@
 			<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false">
 				<template #activator="{ on }">
 					<v-button v-tooltip.bottom="t('delete_label')" rounded icon class="action-delete" secondary @click="on">
-						<v-icon name="delete" outline />
+						<v-icon name="delete" />
 					</v-button>
 				</template>
 

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -35,7 +35,7 @@
 							:disabled="preset === null || id === '+'"
 							@click="on"
 						>
-							<v-icon name="delete" outline />
+							<v-icon name="delete" />
 						</v-button>
 					</template>
 

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -4,7 +4,7 @@
 
 		<template #title-outer:prepend>
 			<v-button class="header-icon" rounded disabled icon secondary>
-				<v-icon name="admin_panel_settings" outline />
+				<v-icon name="admin_panel_settings" />
 			</v-button>
 		</template>
 

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-header.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-header.vue
@@ -3,9 +3,9 @@
 		<span class="name">{{ t('collection') }}</span>
 		<v-icon v-tooltip="t('create')" name="add" />
 		<v-icon v-tooltip="t('read')" name="visibility" />
-		<v-icon v-tooltip="t('update')" name="edit" outline />
-		<v-icon v-tooltip="t('delete_label')" name="delete" outline />
-		<v-icon v-tooltip="t('share')" name="share" outline />
+		<v-icon v-tooltip="t('update')" name="edit" />
+		<v-icon v-tooltip="t('delete_label')" name="delete" />
+		<v-icon v-tooltip="t('share')" name="share" />
 	</div>
 </template>
 

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -21,7 +21,7 @@
 						:disabled="item === null"
 						@click="on"
 					>
-						<v-icon name="delete" outline />
+						<v-icon name="delete" />
 					</v-button>
 				</template>
 

--- a/app/src/modules/settings/routes/webhooks/collection.vue
+++ b/app/src/modules/settings/routes/webhooks/collection.vue
@@ -29,7 +29,7 @@
 				<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false">
 					<template #activator="{ on }">
 						<v-button rounded icon class="action-delete" secondary @click="on">
-							<v-icon name="delete" outline />
+							<v-icon name="delete" />
 						</v-button>
 					</template>
 
@@ -48,7 +48,7 @@
 				</v-dialog>
 
 				<v-button v-if="selection.length > 0" v-tooltip.bottom="t('edit')" rounded icon secondary :to="batchLink">
-					<v-icon name="edit" outline />
+					<v-icon name="edit" />
 				</v-button>
 
 				<v-button v-tooltip.bottom="t('create_webhook')" rounded icon :to="addNewLink">

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -14,7 +14,7 @@
 			<v-dialog v-model="confirmDelete" @esc="confirmDelete = false">
 				<template #activator="{ on }">
 					<v-button rounded icon class="action-delete" :disabled="item === null" @click="on">
-						<v-icon name="delete" outline />
+						<v-icon name="delete" />
 					</v-button>
 				</template>
 

--- a/app/src/modules/users/components/navigation-role.vue
+++ b/app/src/modules/users/components/navigation-role.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-list-item v-context-menu="'contextMenu'" :to="`/users/roles/${role.id}`">
-		<v-list-item-icon><v-icon :name="role.icon" outline /></v-list-item-icon>
+		<v-list-item-icon><v-icon :name="role.icon" /></v-list-item-icon>
 		<v-list-item-content>{{ role.name }}</v-list-item-content>
 
 		<v-menu v-if="isAdmin" ref="contextMenu" show-arrow placement="bottom-start">

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-list nav>
 		<v-list-item to="/users" exact :active="currentRole === null">
-			<v-list-item-icon><v-icon name="folder_shared" outline /></v-list-item-icon>
+			<v-list-item-icon><v-icon name="folder_shared" /></v-list-item-icon>
 			<v-list-item-content>{{ t('all_users') }}</v-list-item-content>
 		</v-list-item>
 

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -20,7 +20,7 @@
 
 			<template #title-outer:prepend>
 				<v-button class="header-icon" rounded disabled icon secondary>
-					<v-icon name="people_alt" outline />
+					<v-icon name="people_alt" />
 				</v-button>
 			</template>
 
@@ -42,7 +42,7 @@
 							secondary
 							@click="on"
 						>
-							<v-icon name="delete" outline />
+							<v-icon name="delete" />
 						</v-button>
 					</template>
 
@@ -69,7 +69,7 @@
 					:disabled="batchEditAllowed === false"
 					@click="batchEditActive = true"
 				>
-					<v-icon name="edit" outline />
+					<v-icon name="edit" />
 				</v-button>
 
 				<v-button

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -22,7 +22,7 @@
 						:disabled="item === null || deleteAllowed !== true"
 						@click="on"
 					>
-						<v-icon name="delete" outline />
+						<v-icon name="delete" />
 					</v-button>
 				</template>
 
@@ -56,7 +56,7 @@
 						:disabled="item === null || archiveAllowed !== true"
 						@click="on"
 					>
-						<v-icon :name="isArchived ? 'unarchive' : 'archive'" outline />
+						<v-icon :name="isArchived ? 'unarchive' : 'archive'" />
 					</v-button>
 				</template>
 
@@ -111,7 +111,7 @@
 						:alt="t('avatar')"
 						@error="avatarError = $event"
 					/>
-					<v-icon v-else name="account_circle" outline x-large />
+					<v-icon v-else name="account_circle" x-large />
 				</div>
 				<div class="user-box-content">
 					<template v-if="loading">
@@ -125,11 +125,11 @@
 							<span v-if="item.title" class="title">, {{ item.title }}</span>
 						</div>
 						<div v-if="item.email" class="email">
-							<v-icon name="alternate_email" small outline />
+							<v-icon name="alternate_email" small />
 							{{ item.email }}
 						</div>
 						<div v-if="item.location" class="location">
-							<v-icon name="place" small outline />
+							<v-icon name="place" small />
 							{{ item.location }}
 						</div>
 						<v-chip v-if="roleName" :class="item.status" small>{{ roleName }}</v-chip>

--- a/app/src/views/private/components/comments-sidebar-detail/comment-item-header.vue
+++ b/app/src/views/private/components/comments-sidebar-detail/comment-item-header.vue
@@ -30,11 +30,11 @@
 
 				<v-list>
 					<v-list-item clickable @click="$emit('edit')">
-						<v-list-item-icon><v-icon name="edit" outline /></v-list-item-icon>
+						<v-list-item-icon><v-icon name="edit" /></v-list-item-icon>
 						<v-list-item-content>{{ t('edit') }}</v-list-item-content>
 					</v-list-item>
 					<v-list-item clickable @click="confirmDelete = true">
-						<v-list-item-icon><v-icon name="delete" outline /></v-list-item-icon>
+						<v-list-item-icon><v-icon name="delete" /></v-list-item-icon>
 						<v-list-item-content>{{ t('delete_label') }}</v-list-item-content>
 					</v-list-item>
 				</v-list>

--- a/app/src/views/private/components/header-bar-actions/header-bar-actions.vue
+++ b/app/src/views/private/components/header-bar-actions/header-bar-actions.vue
@@ -14,7 +14,7 @@
 				outlined
 				@click="$emit('toggle:sidebar')"
 			>
-				<v-icon name="info" outline />
+				<v-icon name="info" />
 			</v-button>
 
 			<slot />

--- a/app/src/views/private/components/module-bar-avatar/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar/module-bar-avatar.vue
@@ -49,7 +49,7 @@
 						class="avatar-image"
 						@error="avatarError = $event"
 					/>
-					<v-icon v-else name="account_circle" outline />
+					<v-icon v-else name="account_circle" />
 				</v-avatar>
 			</router-link>
 		</v-hover>

--- a/app/src/views/private/components/module-bar.vue
+++ b/app/src/views/private/components/module-bar.vue
@@ -20,7 +20,7 @@
 						: null
 				"
 			>
-				<v-icon :name="modulePart.icon" outline />
+				<v-icon :name="modulePart.icon" />
 			</v-button>
 		</div>
 

--- a/app/src/views/private/components/sidebar-button/sidebar-button.vue
+++ b/app/src/views/private/components/sidebar-button/sidebar-button.vue
@@ -6,7 +6,7 @@
 		@click="$emit('click', $event)"
 	>
 		<div class="icon">
-			<v-icon :name="icon" outline />
+			<v-icon :name="icon" />
 		</div>
 		<div v-if="sidebarOpen" class="title">
 			<slot />

--- a/app/src/views/private/components/sidebar-detail/sidebar-detail.vue
+++ b/app/src/views/private/components/sidebar-detail/sidebar-detail.vue
@@ -3,14 +3,14 @@
 		<button v-tooltip.left="title" class="toggle" :class="{ open: active }" @click="toggle">
 			<div class="icon">
 				<v-badge :dot="badge === true" bordered :value="badge" :disabled="!badge">
-					<v-icon :name="icon" outline />
+					<v-icon :name="icon" />
 				</v-badge>
 			</div>
 			<div v-show="sidebarOpen" class="title">
 				{{ title }}
 			</div>
 			<div v-if="!close" class="icon">
-				<v-icon class="expand-icon" :name="active ? 'expand_less' : 'expand_more'" outline />
+				<v-icon class="expand-icon" :name="active ? 'expand_less' : 'expand_more'" />
 			</div>
 		</button>
 		<div v-if="close" v-show="sidebarOpen" class="close" @click="sidebarOpen = false">

--- a/app/src/views/private/components/user-popover/user-popover.vue
+++ b/app/src/views/private/components/user-popover/user-popover.vue
@@ -18,7 +18,7 @@
 		<div v-else-if="data" class="user-box" @click.stop="navigateToUser">
 			<v-avatar x-large class="avatar">
 				<img v-if="avatarSrc" :src="avatarSrc" :alt="data.first_name" />
-				<v-icon v-else name="person" outline />
+				<v-icon v-else name="person" />
 			</v-avatar>
 			<div class="data">
 				<div class="name type-title">{{ userName(data) }}</div>

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -137,9 +137,8 @@ is an excellent Digital Asset Management system.
 
 ### Material Icons
 
-Full list of icons [can be found here](https://fonts.google.com/icons). Directus currently supports both filled &
-outlined variants of Material icons. When you intend to use outlined variant of `account_circle`, you can use
-`account_circle_outline`.
+Full list of icons [can be found here](https://fonts.google.com/icons). Directus supports both filled & outlined
+variants of Material icons.
 
 ### Social Icons
 


### PR DESCRIPTION
## Motivation

Since this commit: https://github.com/directus/directus/commit/a8f68154a91aa9958aa0a05d8c95bf95f122e9f6, v-icons have defaulted to outline variant and uses `filled` prop instead:

https://github.com/directus/directus/blob/c1d705f94ad2061e6912d593a7183cb577cac6b2/app/src/components/v-icon/v-icon.vue#L552-L555

So any usage of `outline` as prop has become obsolete.

## Changes Made

- Removed `outline` props from all v-icons
- Removed `outline: true` property from nav items in settings navigation
- Updated Material Icon description in docs' glossary page as the current instruction of appending `_outline` is technically incorrect now