### PR TITLE
Fix incorrect order of migrations when reverting

### DIFF
--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -74,7 +74,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 	}
 
 	async function down() {
-		const lastAppliedMigration = orderBy(completedMigrations, ['timestamp'], ['desc'])[0];
+		const lastAppliedMigration = orderBy(completedMigrations, ['timestamp', 'version'], ['desc', 'desc'])[0];
 
 		if (!lastAppliedMigration) {
 			throw Error('Nothing to downgrade');


### PR DESCRIPTION
Closes #12080. This occurs when migrations are run for DBs without accurate timestamps (in milliseconds), resulting in multiple migrations having the same timestamp.