### PR TITLE
fix: display related translations 

### DIFF
--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -137,7 +137,7 @@ export default defineComponent({
 }
 
 .display-translations {
-	display: flex;
+	display: inline-block;
 
 	.icon {
 		color: var(--foreground-subdued);

--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -136,8 +136,12 @@ export default defineComponent({
 	width: 300px;
 }
 
-.display-translations {
+.vertical-aligner + .display-translations {
 	display: inline-block;
+}
+
+.display-translations {
+	display: flex;
 
 	.icon {
 		color: var(--foreground-subdued);

--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -136,12 +136,8 @@ export default defineComponent({
 	width: 300px;
 }
 
-.vertical-aligner + .display-translations {
-	display: inline-block;
-}
-
 .display-translations {
-	display: flex;
+	display: inline-flex;
 
 	.icon {
 		color: var(--foreground-subdued);


### PR DESCRIPTION
Resolves https://github.com/directus/directus/discussions/10867.

Currently, translations on a related field are not visible because `.display-translations` element is displayed as `flex` and its preceding sibling `.vertical-aligner` has a height of 100%. I just changed `flex` to `inline-block` to get the expected result.

### Before

<img width="1315" alt="Capture d’écran 2022-03-14 à 20 20 49" src="https://user-images.githubusercontent.com/13403295/158245409-eae41d72-b870-4b93-aff1-d03fc5d8c8a2.png">

### After

<img width="1315" alt="Capture d’écran 2022-03-14 à 20 21 20" src="https://user-images.githubusercontent.com/13403295/158245474-1aa6a29e-099e-4eb3-b07d-499e2c89bd8e.png">

