### PR TITLE
Prevent null field/collection translations from being merged

### DIFF
--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -54,18 +54,24 @@ export const useCollectionsStore = defineStore({
 				for (let i = 0; i < collection.meta.translations.length; i++) {
 					const { language, translation, singular, plural } = collection.meta.translations[i];
 
-					const literalInterpolatedTranslation = translation ? translation.replace(/([{}@$|])/g, "{'$1'}") : '';
+					const literalInterpolatedTranslation = translation ? translation.replace(/([{}@$|])/g, "{'$1'}") : null;
 
 					i18n.global.mergeLocaleMessage(language, {
-						collection_names: {
-							[collection.collection]: literalInterpolatedTranslation,
-						},
-						collection_names_singular: {
-							[collection.collection]: singular,
-						},
-						collection_names_plural: {
-							[collection.collection]: plural,
-						},
+						...(literalInterpolatedTranslation && {
+							collection_names: {
+								[collection.collection]: literalInterpolatedTranslation,
+							},
+						}),
+						...(singular && {
+							collection_names_singular: {
+								[collection.collection]: singular,
+							},
+						}),
+						...(plural && {
+							collection_names_plural: {
+								[collection.collection]: plural,
+							},
+						}),
 					});
 				}
 			}

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -76,14 +76,16 @@ export const useFieldsStore = defineStore({
 					const { language, translation } = field.meta.translations[i];
 
 					// Interpolate special characters in vue-i18n to prevent parsing error. Ref #11287
-					const literalInterpolatedTranslation = translation ? translation.replace(/([{}@$|])/g, "{'$1'}") : '';
+					const literalInterpolatedTranslation = translation ? translation.replace(/([{}@$|])/g, "{'$1'}") : null;
 
 					i18n.global.mergeLocaleMessage(language, {
-						fields: {
-							[field.collection]: {
-								[field.field]: literalInterpolatedTranslation,
+						...(literalInterpolatedTranslation && {
+							fields: {
+								[field.collection]: {
+									[field.field]: literalInterpolatedTranslation,
+								},
 							},
-						},
+						}),
 					});
 				}
 			}


### PR DESCRIPTION
## Before

When a collection translations is configured but doesn't have a value, the `Articles` collection shows up as empty title:


![chrome_lJRc7F0SIP](https://user-images.githubusercontent.com/42867097/158309605-9fb561f5-6a56-4636-929a-b8b81330d652.png)


## After

Prevent merging translations if they do not exist:

![chrome_Vyc86D8Btd](https://user-images.githubusercontent.com/42867097/158309610-d73c1093-a857-432d-8a2f-cee52b6c316b.png)

