### PR TITLE
M2A interface collection name layout fix

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -684,8 +684,9 @@ export default defineComponent({
 
 .v-list-item {
 	.collection {
-		margin-right: 1ch;
 		color: var(--primary);
+		white-space: nowrap;
+		margin-right: 1ch;
 	}
 }
 


### PR DESCRIPTION
If collection names have a whitespaces in m2a interface, this looks like this:

![image](https://user-images.githubusercontent.com/26179694/158368765-be1ba4e4-f281-4ace-b1a3-bcf6bfbe01d1.png)

And after this patch:

![image](https://user-images.githubusercontent.com/26179694/158368905-ea122002-5458-4573-93de-ec1fd7e9bdc0.png)
