### PR TITLE
use type json for select-color presets options field

### DIFF
--- a/app/src/interfaces/select-color/index.ts
+++ b/app/src/interfaces/select-color/index.ts
@@ -27,7 +27,7 @@ export default defineInterface({
 		{
 			field: 'presets',
 			name: '$t:interfaces.select-color.preset_colors',
-			type: 'string',
+			type: 'json',
 			meta: {
 				width: 'full',
 				interface: 'list',


### PR DESCRIPTION
Fixes #12189

It needs to be `json` to have the type `object` here:

https://github.com/directus/directus/blob/d82eb5243c1bae11f070162b8e22228248a6a176/app/src/utils/get-js-type.ts#L13

So that it will get JSON.stringify-ed properly in raw value:

https://github.com/directus/directus/blob/d82eb5243c1bae11f070162b8e22228248a6a176/app/src/components/v-form/form-field.vue#L198-L200

## Before

![UmpkxcaEPa](https://user-images.githubusercontent.com/42867097/158600826-ce0c48fd-3e77-4d88-a0cd-db4b4c7eee16.gif)

## After

![dd56gAlrsA](https://user-images.githubusercontent.com/42867097/158600839-f16e7e36-ce01-432f-8f54-da9ea729ed1b.gif)

