### PR TITLE
fix number input step up/down when undefined

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -142,11 +142,11 @@ const classes = computed(() => [
 ]);
 
 const isStepUpAllowed = computed(() => {
-	return props.disabled === false && (props.max === null || parseInt(String(props.modelValue), 10) < props.max);
+	return props.disabled === false && (props.max === undefined || parseInt(String(props.modelValue), 10) < props.max);
 });
 
 const isStepDownAllowed = computed(() => {
-	return props.disabled === false && (props.min === null || parseInt(String(props.modelValue), 10) > props.min);
+	return props.disabled === false && (props.min === undefined || parseInt(String(props.modelValue), 10) > props.min);
 });
 
 function processValue(event: KeyboardEvent) {

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -100,11 +100,11 @@ export default defineComponent({
 		},
 		min: {
 			type: Number,
-			default: null,
+			default: undefined,
 		},
 		max: {
 			type: Number,
-			default: null,
+			default: undefined,
 		},
 		step: {
 			type: Number,


### PR DESCRIPTION
## Reasoning

Noticed the `limit` field step up/down isn't working. Seems like it's due to the script setup refactor changing `min` and `max` default value from `null` to `undefined`:

https://github.com/directus/directus/blob/9b685c815ef5ce9dd75e526b9e203c8bc089015d/app/src/components/v-input/v-input.vue#L107-L108

thus causing the null checks over here to fail:

https://github.com/directus/directus/blob/9b685c815ef5ce9dd75e526b9e203c8bc089015d/app/src/components/v-input/v-input.vue#L144-L150

## Before

![pioyq2xDWV](https://user-images.githubusercontent.com/42867097/158929751-6875c4da-0294-437f-8155-113270738118.gif)

## After

![X2gIsn0mvE](https://user-images.githubusercontent.com/42867097/158929761-f5127223-ddd7-4896-87ee-77edfa79fd3c.gif)

