### PR TITLE
Fix field preview background color

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -252,7 +252,7 @@ export default defineComponent({
 }
 
 .interface.active .preview {
-	background-color: var(--primary-10);
+	background-color: var(--primary-alt);
 	border-color: var(--primary);
 }
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -252,7 +252,7 @@ export default defineComponent({
 }
 
 .interface.active .preview {
-	background-color: var(--primary-alt);
+	background-color: var(--primary-10);
 	border-color: var(--primary);
 }
 

--- a/app/src/styles/themes/_dark.scss
+++ b/app/src/styles/themes/_dark.scss
@@ -48,7 +48,7 @@
 	--yellow-alt: var(--yellow-10);
 	--orange-alt: var(--orange-10);
 	--red-alt: var(--red-10);
-	--primary-alt: var(--pink-10);
+	--primary-alt: var(--primary-10);
 	--secondary-alt: var(--secondary-10);
 	--success-alt: var(--green-10);
 	--warning-alt: var(--yellow-10);


### PR DESCRIPTION
Currently the new `--primary-alt` for dark theme is deriving from `--pink-10`, hence a slight difference in color tone. This proposes to use `--primary-10` for similar color.

|Theme|Current `(--primary-alt)`|Proposed `(--primary-10`|
|---|---|---|
|Light|![chrome_4MRzhIF4e4](https://user-images.githubusercontent.com/42867097/159271640-f10ce0a9-c85b-4bc2-a460-54a1912ee48e.png)|![chrome_XWnfSzyiW2](https://user-images.githubusercontent.com/42867097/159271902-78663388-e7c7-4e2d-ac88-23490238878f.png)|
|Dark|![chrome_Frl7Y2p2E0](https://user-images.githubusercontent.com/42867097/159271982-2f0d6e68-186a-46a0-a693-3d9dc5d4d0eb.png)|![chrome_bXDp2IHhoW](https://user-images.githubusercontent.com/42867097/159272013-e67189d9-c630-49c1-922c-0892521ed6b5.png)|