### PR TITLE
Add fields to directus_user app recommended permission

### DIFF
--- a/app/src/modules/settings/routes/roles/app-permissions.ts
+++ b/app/src/modules/settings/routes/roles/app-permissions.ts
@@ -100,6 +100,7 @@ export const appRecommendedPermissions: Partial<Permission>[] = [
 		collection: 'directus_users',
 		action: 'read',
 		permissions: {},
+		fields: ['*'],
 	},
 	{
 		collection: 'directus_users',


### PR DESCRIPTION
Closes #12233.

Fields are not set for `directus_users`, leading to an issue when app access is removed.
There's no issue when app access isn't removed as there's permissions merging with the minimal permissions for app access.