### PR TITLE
Save last accessed collection in Content Module

### DIFF
--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -10,6 +10,7 @@ import { useCollectionsStore } from '@/stores';
 import { Collection } from '@directus/shared/types';
 import { orderBy, isNil } from 'lodash';
 import { useNavigation } from './composables/use-navigation';
+import useLocalStorage from '@/composables/use-local-storage';
 import { ref } from 'vue';
 
 const checkForSystem: NavigationGuard = (to, from) => {
@@ -88,6 +89,11 @@ export default defineModule({
 					}),
 					['meta.sort', 'collection']
 				);
+
+				const { data } = useLocalStorage('last-accessed-collection');
+				if (data.value && rootCollections.find((rootCollection) => rootCollection.collection === data.value)) {
+					return `/content/${data.value}`;
+				}
 
 				let firstCollection = findFirst(rootCollections);
 

--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -91,7 +91,10 @@ export default defineModule({
 				);
 
 				const { data } = useLocalStorage('last-accessed-collection');
-				if (data.value && rootCollections.find((rootCollection) => rootCollection.collection === data.value)) {
+				if (
+					data.value &&
+					collectionsStore.visibleCollections.find((visibleCollection) => visibleCollection.collection === data.value)
+				) {
 					return `/content/${data.value}`;
 				}
 

--- a/app/src/modules/content/routes/collection-or-item.vue
+++ b/app/src/modules/content/routes/collection-or-item.vue
@@ -9,10 +9,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, watch } from 'vue';
 import CollectionRoute from './collection.vue';
 import ItemRoute from './item.vue';
 import { useCollectionsStore } from '@/stores/';
+import { useRoute } from 'vue-router';
+import useLocalStorage from '@/composables/use-local-storage';
 
 export default defineComponent({
 	components: {
@@ -34,12 +36,26 @@ export default defineComponent({
 		},
 	},
 	setup(props) {
+		const route = useRoute();
+
+		const { data } = useLocalStorage('last-accessed-collection');
+
 		const collectionsStore = useCollectionsStore();
 
 		const isSingleton = computed(() => {
 			const collectionInfo = collectionsStore.getCollection(props.collection);
 			return !!collectionInfo?.meta?.singleton === true;
 		});
+
+		watch(
+			() => route.params,
+			(newParams) => {
+				if (newParams.collection && data.value !== newParams.collection) {
+					data.value = newParams.collection;
+				}
+			},
+			{ immediate: true }
+		);
 
 		return { isSingleton };
 	},


### PR DESCRIPTION
Resolves #9032

## Before

Clicking the Content Module will always bring us to the first collection:

https://user-images.githubusercontent.com/42867097/159624992-c79c4631-fb3a-40a6-aa64-fea9455af672.mp4

## After

- Changes to index.ts — ensures redirection to "last accessed collection" when
  - there is existing value in localStorage
  - the collection is one of visibleCollections
- Changes to collection-or-item.vue — ensure children route changes (when switching collections) updates the "last accessed collection" value

https://user-images.githubusercontent.com/42867097/159625909-b9feeb70-5d2b-4e75-925a-256b0098a9e5.mp4



