### PR TITLE
Fix auto-casting of array like values in env

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -288,6 +288,7 @@ function processValues(env: Record<string, any>) {
 
 		if (String(value).includes(',')) {
 			env[key] = toArray(value);
+			continue;
 		}
 
 		// Try converting the value to a JS object. This allows JSON objects to be passed for nested


### PR DESCRIPTION
As per the docs, CSV like values in the .env should be treated as an array by default:

```
STORAGE_LOCATIONS="s3,local,example"
// ["s3", "local", "example"]
```

However, the JSON parsing:

https://github.com/directus/directus/blob/51ec656a064a1c0784098a5ef738b2e6cdd74ab7/api/src/env.ts#L295

revered the array cast back to the original string value.

Fixes https://github.com/directus/directus/issues/12259