### PR TITLE
Docs: Slightly better scrollbars in dark mode

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -159,6 +159,10 @@ pre
       background var(--background-page) url(/search.svg) 0.4rem 0.3rem no-repeat !important
 
 @media (prefers-color-scheme: dark)
+  html
+    color-scheme dark
+  iframe
+    color-scheme auto
   .search-box
     input
       background var(--background-page) url(/search-dark.svg) 0.4rem 0.3rem no-repeat !important


### PR DESCRIPTION
Right now, on chrome, in darkmode, scrollbars look like this:

![Screen Shot 2022-03-23 at 11 01 09 PM](https://user-images.githubusercontent.com/14101189/159834791-cc049672-93db-4d86-8f67-683fa021b252.png)

With `color-scheme: dark;`, it enables some native dark mode behaviours, such as the dark scrollbar color, which looks like this:

![Screen Shot 2022-03-23 at 11 01 27 PM](https://user-images.githubusercontent.com/14101189/159834833-dfd8b64e-32ac-428f-af9a-e7ee2964281f.png)

The rule on the iframe is for the hubspot chat widget that looks weird in the dark color scheme