### PR TITLE
fix LOGGER_LEVELS array being split as string

### DIFF
--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -4,6 +4,7 @@ import pinoHTTP, { stdSerializers } from 'pino-http';
 import { getConfigFromEnv } from './utils/get-config-from-env';
 import { URL } from 'url';
 import env from './env';
+import { toArray } from '@directus/shared/utils';
 
 const pinoOptions: LoggerOptions = {
 	level: env.LOG_LEVEL || 'info',
@@ -24,7 +25,7 @@ const loggerEnvConfig = getConfigFromEnv('LOGGER_', 'LOGGER_HTTP');
 if (loggerEnvConfig.levels) {
 	const customLogLevels: { [key: string]: string } = {};
 
-	for (const el of loggerEnvConfig.levels) {
+	for (const el of toArray(loggerEnvConfig.levels)) {
 		const key_val = el.split(':');
 		customLogLevels[key_val[0].trim()] = key_val[1].trim();
 	}

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -24,7 +24,7 @@ const loggerEnvConfig = getConfigFromEnv('LOGGER_', 'LOGGER_HTTP');
 if (loggerEnvConfig.levels) {
 	const customLogLevels: { [key: string]: string } = {};
 
-	for (const el of loggerEnvConfig.levels.split(',')) {
+	for (const el of loggerEnvConfig.levels) {
 		const key_val = el.split(':');
 		customLogLevels[key_val[0].trim()] = key_val[1].trim();
 	}

--- a/api/tests/env.test.ts
+++ b/api/tests/env.test.ts
@@ -1,0 +1,47 @@
+const testEnv = {
+	NUMBER: '1234',
+	NUMBER_CAST_AS_STRING: 'string:1234',
+	REGEX: 'regex:\\.example\\.com$',
+	CSV: 'one,two,three,four',
+	CSV_CAST_AS_STRING: 'string:one,two,three,four',
+	MULTIPLE: 'array:string:https://example.com,regex:\\.example2\\.com$',
+};
+
+describe('env processed values', () => {
+	const originalEnv = process.env;
+	let env: Record<string, any>;
+
+	beforeEach(() => {
+		jest.resetModules();
+		process.env = { ...testEnv };
+		env = jest.requireActual('../src/env').default;
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	test('Number value should be a number', () => {
+		expect(env.NUMBER).toStrictEqual(1234);
+	});
+
+	test('Number value casted as string should be a string', () => {
+		expect(env.NUMBER_CAST_AS_STRING).toStrictEqual('1234');
+	});
+
+	test('Value casted as regex', () => {
+		expect(env.REGEX).toBeInstanceOf(RegExp);
+	});
+
+	test('CSV value should be an array', () => {
+		expect(env.CSV).toStrictEqual(['one', 'two', 'three', 'four']);
+	});
+
+	test('CSV value casted as string should be a string', () => {
+		expect(env.CSV_CAST_AS_STRING).toStrictEqual('one,two,three,four');
+	});
+
+	test('Multiple type cast', () => {
+		expect(env.MULTIPLE).toStrictEqual(['https://example.com', /\.example2\.com$/]);
+	});
+});

--- a/api/tests/utils/get-config-from-env.test.ts
+++ b/api/tests/utils/get-config-from-env.test.ts
@@ -1,0 +1,20 @@
+import { getConfigFromEnv } from '../../src/utils/get-config-from-env';
+
+jest.mock('../../src/env', () => ({
+	OBJECT_BRAND__COLOR: 'purple',
+	OBJECT_BRAND__HEX: '#6644FF',
+	CAMELCASE_OBJECT__FIRST_KEY: 'firstValue',
+	CAMELCASE_OBJECT__SECOND_KEY: 'secondValue',
+}));
+
+describe('get config from env', () => {
+	test('Keys with double underscore should be an object', () => {
+		expect(getConfigFromEnv('OBJECT_')).toStrictEqual({ brand: { color: 'purple', hex: '#6644FF' } });
+	});
+
+	test('Keys with double underscore should be an object with camelCase keys', () => {
+		expect(getConfigFromEnv('CAMELCASE_')).toStrictEqual({
+			object: { firstKey: 'firstValue', secondKey: 'secondValue' },
+		});
+	});
+});


### PR DESCRIPTION
Fixes #12339

This is due to #12330 fixes csv to be treated as array correctly, but the codebase here still treats it as a string and attempts to `.split` an array which causes the error.