### PR TITLE
Don't validate query for uuid. 

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -1,7 +1,6 @@
 import { Knex } from 'knex';
 import { clone, get, isPlainObject, set } from 'lodash';
 import { customAlphabet } from 'nanoid';
-import validate from 'uuid-validate';
 import { InvalidQueryException } from '../exceptions';
 import { Aggregate, Filter, Query, Relation, RelationMeta, SchemaOverview } from '@directus/shared/types';
 import { getColumn } from './get-column';
@@ -600,7 +599,7 @@ export async function applySearch(
 			} else if (['bigInteger', 'integer', 'decimal', 'float'].includes(field.type)) {
 				const number = Number(searchQuery);
 				if (!isNaN(number)) this.orWhere({ [`${collection}.${name}`]: number });
-			} else if (field.type === 'uuid' && validate(searchQuery)) {
+			} else if (field.type === 'uuid') {
 				this.orWhere({ [`${collection}.${name}`]: searchQuery });
 			}
 		});


### PR DESCRIPTION
Should be able to use custom uuid formats and even legacy values and still be able to filter on them.

Note, it will still need to be the exact value in order to match any results.

Fixes: #11940 