### PR TITLE
Fix activity fields using invalid display

### DIFF
--- a/api/src/database/system-data/fields/activity.yaml
+++ b/api/src/database/system-data/fields/activity.yaml
@@ -46,19 +46,19 @@ fields:
     width: half
 
   - field: comment
-    display: formatted-text
+    display: formatted-value
     display_options:
-      subdued: true
+      color: 'var(--foreground-subdued)'
     width: half
 
   - field: user_agent
-    display: formatted-text
+    display: formatted-value
     display_options:
       font: monospace
     width: half
 
   - field: ip
-    display: formatted-text
+    display: formatted-value
     display_options:
       font: monospace
     width: half


### PR DESCRIPTION
Fixes #12347

- It was using an invalid display, hence it seemed to be invisible
- replaced the previous `subdued` display option since it is not a valid option as of now

## Before

![chrome_QVppRiboGJ](https://user-images.githubusercontent.com/42867097/159887630-deb84811-b64b-4b84-9f5c-8511d4532ad2.png)

## After

![chrome_fdxlixxUtM](https://user-images.githubusercontent.com/42867097/159887651-7eb562a4-ed62-44e7-a620-7aceb169545b.png)

