### PR TITLE
Fix translation drawer delete button hover style

### DIFF
--- a/app/src/modules/settings/routes/translation-strings/translation-strings-drawer.vue
+++ b/app/src/modules/settings/routes/translation-strings/translation-strings-drawer.vue
@@ -208,7 +208,7 @@ async function deleteCurrentTranslationString() {
 	padding-bottom: var(--content-padding-bottom);
 }
 .v-button.delete-action {
-	--v-button-background-color-hover: var(--danger);
-	--v-button-color-hover: var(--foreground-inverted);
+	--v-button-background-color-hover: var(--danger) !important;
+	--v-button-color-hover: var(--foreground-inverted) !important;
 }
 </style>


### PR DESCRIPTION
## Changes

Similar change to what's already being done here:

https://github.com/directus/directus/blob/577e803bb5da75f314632152c5f02c9c47ec78db/app/src/modules/settings/routes/roles/item/item.vue#L228-L231

## Before

![chrome_MPbaISuW9A](https://user-images.githubusercontent.com/42867097/159890276-e2ae4040-62c4-4a56-be6e-b1845245b0da.png)

## After

![chrome_bmY5e4Cqc0](https://user-images.githubusercontent.com/42867097/159890284-ea156816-a841-4a17-94e4-619e03f9f177.png)
