### PR TITLE
fix color interface showing black color when empty

### DIFF
--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -168,7 +168,7 @@ const { t } = useI18n();
 
 interface Props {
 	disabled?: boolean;
-	value?: string;
+	value?: string | null;
 	placeholder?: string;
 	presets?: { name: string; color: string }[];
 	width: string;
@@ -177,7 +177,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
 	disabled: false,
-	value: undefined,
+	value: () => null,
 	placeholder: undefined,
 	opacity: false,
 	presets: () => [

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -223,6 +223,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits(['input']);
 
 const valueWithoutVariables = computed(() => {
+	if (!props.value) return null;
 	return props.value?.startsWith('var(--') ? cssVar(props.value.substring(4, props.value.length - 1)) : props.value;
 });
 


### PR DESCRIPTION
Fixes #12441

## Before

![chrome_HiLuRnfXiN](https://user-images.githubusercontent.com/42867097/160505547-19428557-8abf-472a-93fb-ee728c0e9918.png)

## Investigation

#12229 updated the select color interface to script setup, which turned the `value` prop from `null` to `undefined`.

As it is not `null`, this ternary operator in the watcher is true and it attempts to turn `undefined` into a color:

https://github.com/directus/directus/blob/31fda8fd988286394991da5fe087e75d54d0b9e2/app/src/interfaces/select-color/select-color.vue#L294-L300

## After

Used early return as null when prop is not set here. 

![chrome_vXKa2IrH6e](https://user-images.githubusercontent.com/42867097/160505557-48342568-6ed0-4e36-8327-6bf7db11c1d0.png)

---

Alternatively, we can also set the prop as null by default if that's a more preferred approach.
