### PR TITLE
Fix geometry fields raw value edits

### DIFF
--- a/app/src/utils/get-js-type.ts
+++ b/app/src/utils/get-js-type.ts
@@ -10,6 +10,7 @@ export function getJSType(field: Field): string {
 	if (['string', 'text', 'uuid', 'hash'].includes(field.type)) return 'string';
 	if (['boolean'].includes(field.type)) return 'boolean';
 	if (['time', 'timestamp', 'date', 'dateTime'].includes(field.type)) return 'string';
-	if (['json', 'csv', 'geometry'].includes(field.type)) return 'object';
+	if (['json', 'csv'].includes(field.type)) return 'object';
+	if (field.type.startsWith('geometry')) return 'object';
 	return 'undefined';
 }


### PR DESCRIPTION
Addresses https://github.com/directus/directus/pull/11945#issuecomment-1079967672

#11945 added `geometry` field type, but the other specific geometry fields has a "fuller" type definition since #9397:

https://github.com/directus/directus/blob/31fda8fd988286394991da5fe087e75d54d0b9e2/packages/shared/src/constants/fields.ts#L19-L25

![chrome_dvi5PAf7TH](https://user-images.githubusercontent.com/42867097/160527951-016af928-e02c-4836-94fe-daec86d2aeb0.png)

thus doing `geometry` includes on them does not work and they are not parsed when shown as raw value.

## Solution

Uses the same `field.type.startsWith('geometry')` logic used in the API:

https://github.com/directus/directus/blob/31fda8fd988286394991da5fe087e75d54d0b9e2/api/src/database/run-ast.ts#L224-L226

## Before

https://user-images.githubusercontent.com/42867097/160527871-462eadf6-644c-468f-a532-35cf3535a4ef.mp4

## After

https://user-images.githubusercontent.com/42867097/160527855-72d49fa1-92cc-49fe-9c16-6e6514607582.mp4