### PR TITLE
Fix translations junction field not using language table name

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
@@ -18,6 +18,7 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 
 	if (hasChanged('relations.m2o.related_collection')) {
 		preventCircularConstraint(updates, state, helperFn);
+		updateJunctionRelated(updates, state, helperFn);
 	}
 
 	if (hasChanged('relations.o2m.field')) {
@@ -106,6 +107,16 @@ export function preventCircularConstraint(updates: StateUpdates, _state: State, 
 export function setJunctionFields(updates: StateUpdates, _state: State, { getCurrent }: HelperFunctions) {
 	set(updates, 'relations.o2m.meta.junction_field', getCurrent('relations.m2o.field'));
 	set(updates, 'relations.m2o.meta.junction_field', getCurrent('relations.o2m.field'));
+}
+
+export function updateJunctionRelated(updates: StateUpdates, _state: State, { getCurrent }: HelperFunctions) {
+	const fieldsStore = useFieldsStore();
+
+	const relatedCollection = getCurrent('relations.m2o.related_collection');
+	const relatedCollectionPrimaryKeyField =
+		fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection)?.field ?? 'id';
+
+	set(updates, 'relations.m2o.field', `${relatedCollection}_${relatedCollectionPrimaryKeyField}`);
 }
 
 function collectionExists(collection: string) {


### PR DESCRIPTION
Fixes #12255

## Before

Whenever we change the language table name during creation of Translations field, the junction field always remains as `languages_id` instead:

https://user-images.githubusercontent.com/42867097/160622000-f707a08c-aeb0-45ab-9e39-d4d4e0eaeaa5.mp4

## Solution used

For m2m, whenever `relation.m2o.related_collection` has changed, it will call the `autoGenerateJunctionFields` function:

https://github.com/directus/directus/blob/d640fe9a01d5222c4fdd43882ea4b441f4cb86b3/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts#L22-L25

which then always updates the junction field name:

https://github.com/directus/directus/blob/d640fe9a01d5222c4fdd43882ea4b441f4cb86b3/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts#L139

Hence this solution uses a similar logic with `updateJunctionRelated` function to update said field.

## After

https://user-images.githubusercontent.com/42867097/160622033-2e203f8a-1e45-4566-8b2f-387bb1820230.mp4


