### PR TITLE
Prevent selecting foreign keys for junction sort

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
@@ -81,7 +81,11 @@ export default defineComponent({
 			return fieldsStore.getFieldsForCollectionAlphabetical(props.collection).map((field) => ({
 				text: field.field,
 				value: field.field,
-				disabled: !field.schema || field.schema?.is_primary_key || props.typeDenyList.includes(field.type),
+				disabled:
+					!field.schema ||
+					field.schema?.is_primary_key ||
+					field.schema?.foreign_key_table ||
+					props.typeDenyList.includes(field.type),
 			}));
 		});
 


### PR DESCRIPTION
Closes #12455

Ref https://github.com/directus/directus/issues/12455#issuecomment-1081905408

This is to make it consistent with the change in #11444 which prevents foreign keys from being selectable as sort field:

![chrome_2hrvPDmO1l](https://user-images.githubusercontent.com/42867097/160629051-94c491b1-1eae-4e1c-869d-906144f9a039.png)

## Before

![chrome_G5UJO1bcvV](https://user-images.githubusercontent.com/42867097/160629013-966e24fd-0bbe-4459-89d4-5781dcbe792c.png)

## After

Uses same logic `field.schema?.foreign_key_table` from here: https://github.com/directus/directus/pull/11444/files#diff-f8c5863d04ade7fe8e3437f8f48acf4754ba20e49614ccacd218a87ba3d9e124R91

![chrome_Xs1LBaui8q](https://user-images.githubusercontent.com/42867097/160629003-fe5be640-f667-4f8c-9e97-2a98fe2a1312.png)

