### PR TITLE
Fix v-form overwriting type of input-hash interface

### DIFF
--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -18,6 +18,7 @@ import { useI18n } from 'vue-i18n';
 import { defineComponent, computed, ref, watch } from 'vue';
 
 export default defineComponent({
+	inheritAttrs: false,
 	props: {
 		value: {
 			type: String,


### PR DESCRIPTION
This was causing the password field on the user details page to show the password in clear text when inputting a new one.

@rijkvanzanten I think we should set `inheritAttrs: false` on each component defined by an extension to not clutter the dom and to prevent such errors.