### PR TITLE
Prevent password managers from triggering on input-hash fields

### DIFF
--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -3,6 +3,7 @@
 		:placeholder="internalPlaceholder"
 		:disabled="disabled"
 		:type="masked ? 'password' : 'text'"
+		:autocomplete="masked ? 'new-password' : 'off'"
 		:model-value="localValue"
 		:class="{ hashed: isHashed && !localValue }"
 		@update:model-value="emitValue"

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -13,6 +13,7 @@
 		:min="min"
 		:max="max"
 		:step="step"
+		:autocomplete="masked ? 'new-password' : 'off'"
 		@update:model-value="$emit('input', $event)"
 	>
 		<template v-if="iconLeft" #prepend><v-icon :name="iconLeft" /></template>


### PR DESCRIPTION
This was already attempted in 65daa69 and subsequently reverted in #8344.