### PR TITLE
Fix field validation not being cast as json

### DIFF
--- a/api/src/database/system-data/fields/fields.yaml
+++ b/api/src/database/system-data/fields/fields.yaml
@@ -84,3 +84,12 @@ fields:
     field: conditions
     hidden: true
     special: cast-json
+
+  - collection: directus_fields
+    field: validation
+    hidden: true
+    special: cast-json
+
+  - collection: directus_fields
+    field: validation_message
+    hidden: true

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -152,7 +152,7 @@ async function getDatabaseSchema(
 			special: special,
 			note: field.note,
 			alias: existing?.alias ?? true,
-			validation: (field.validation as Filter) ?? null,
+			validation: (validation as Filter) ?? null,
 		};
 	}
 


### PR DESCRIPTION
Follow up to #12363, with the fix being similar to #12349.

## Before

After saving the validation, it is returned as string thus breaking the validation rule builder:

![chrome_S6JdeZstcH](https://user-images.githubusercontent.com/42867097/160831594-842aaa3c-07cb-46b7-8da9-5b40f388ef26.png)

## After

![chrome_VWMcC7lmh3](https://user-images.githubusercontent.com/42867097/160831684-f784c514-9e51-4a8b-85b8-96bb51eb16cf.png)

