### PR TITLE
[SDK] Add further request options to `items` functions

### DIFF
--- a/packages/sdk/src/base/items.ts
+++ b/packages/sdk/src/base/items.ts
@@ -15,8 +15,8 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 	async readOne(id: ID, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>> {
 		const response = await this.transport.get<T>(`${this.endpoint}/${encodeURI(id as string)}`, {
-			...options?.requestOptions,
 			params: query,
+			...options?.requestOptions,
 		});
 
 		return response.data as T;
@@ -28,7 +28,6 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		const primaryKeyField = collectionFields.data?.find((field: any) => field.schema.is_primary_key === true);
 
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
-			...options?.requestOptions,
 			params: {
 				filter: {
 					[primaryKeyField!.field]: { _in: ids },
@@ -37,6 +36,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				sort: query?.sort || primaryKeyField!.field,
 				...query,
 			},
+			...options?.requestOptions,
 		});
 
 		return {
@@ -47,8 +47,8 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 	async readByQuery(query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>> {
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
-			...options?.requestOptions,
 			params: query,
+			...options?.requestOptions,
 		});
 
 		return {
@@ -60,24 +60,24 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 	async createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.post<T>(`${this.endpoint}`, item, {
-				...options?.requestOptions,
 				params: query,
+				...options?.requestOptions,
 			})
 		).data;
 	}
 
 	async createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>> {
 		return await this.transport.post<PartialItem<T>[]>(`${this.endpoint}`, items, {
-			...options?.requestOptions,
 			params: query,
+			...options?.requestOptions,
 		});
 	}
 
 	async updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.patch<PartialItem<T>>(`${this.endpoint}/${encodeURI(id as string)}`, item, {
-				...options?.requestOptions,
 				params: query,
+				...options?.requestOptions,
 			})
 		).data;
 	}
@@ -95,8 +95,8 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				data,
 			},
 			{
-				...options?.requestOptions,
 				params: query,
+				...options?.requestOptions,
 			}
 		);
 	}
@@ -114,8 +114,8 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				data,
 			},
 			{
-				...options?.requestOptions,
 				params: query,
+				...options?.requestOptions,
 			}
 		);
 	}

--- a/packages/sdk/src/base/items.ts
+++ b/packages/sdk/src/base/items.ts
@@ -1,4 +1,4 @@
-import { ITransport } from '../transport';
+import { ITransport, TransportOptions } from '../transport';
 import { IItems, Item, QueryOne, QueryMany, OneItem, ManyItems, PartialItem } from '../items';
 import { ID, FieldType } from '../types';
 
@@ -13,20 +13,22 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		this.endpoint = collection.startsWith('directus_') ? `/${collection.substring(9)}` : `/items/${collection}`;
 	}
 
-	async readOne(id: ID, query?: QueryOne<T>): Promise<OneItem<T>> {
+	async readOne(id: ID, query?: QueryOne<T>, options?: TransportOptions): Promise<OneItem<T>> {
 		const response = await this.transport.get<T>(`${this.endpoint}/${encodeURI(id as string)}`, {
+			...options,
 			params: query,
 		});
 
 		return response.data as T;
 	}
 
-	async readMany(ids: ID[], query?: QueryMany<T>): Promise<ManyItems<T>> {
+	async readMany(ids: ID[], query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
 		const collectionFields = await this.transport.get<FieldType[]>(`/fields/${this.collection}`);
 
 		const primaryKeyField = collectionFields.data?.find((field: any) => field.schema.is_primary_key === true);
 
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
+			...options,
 			params: {
 				filter: {
 					[primaryKeyField!.field]: { _in: ids },
@@ -43,8 +45,9 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		};
 	}
 
-	async readByQuery(query?: QueryMany<T>): Promise<ManyItems<T>> {
+	async readByQuery(query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
+			...options,
 			params: query,
 		});
 
@@ -54,29 +57,32 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		};
 	}
 
-	async createOne(item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>> {
+	async createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: TransportOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.post<T>(`${this.endpoint}`, item, {
+				...options,
 				params: query,
 			})
 		).data;
 	}
 
-	async createMany(items: PartialItem<T>[], query?: QueryMany<T>): Promise<ManyItems<T>> {
+	async createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
 		return await this.transport.post<PartialItem<T>[]>(`${this.endpoint}`, items, {
+			...options,
 			params: query,
 		});
 	}
 
-	async updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>> {
+	async updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: TransportOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.patch<PartialItem<T>>(`${this.endpoint}/${encodeURI(id as string)}`, item, {
+				...options,
 				params: query,
 			})
 		).data;
 	}
 
-	async updateMany(ids: ID[], data: PartialItem<T>, query?: QueryMany<T>): Promise<ManyItems<T>> {
+	async updateMany(ids: ID[], data: PartialItem<T>, query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
 		return await this.transport.patch<PartialItem<T>[]>(
 			`${this.endpoint}`,
 			{
@@ -84,12 +90,13 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				data,
 			},
 			{
+				...options,
 				params: query,
 			}
 		);
 	}
 
-	async updateByQuery(updateQuery: QueryMany<T>, data: PartialItem<T>, query?: QueryMany<T>): Promise<ManyItems<T>> {
+	async updateByQuery(updateQuery: QueryMany<T>, data: PartialItem<T>, query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
 		return await this.transport.patch<PartialItem<T>[]>(
 			`${this.endpoint}`,
 			{
@@ -97,16 +104,17 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				data,
 			},
 			{
+				...options,
 				params: query,
 			}
 		);
 	}
 
-	async deleteOne(id: ID): Promise<void> {
-		await this.transport.delete(`${this.endpoint}/${encodeURI(id as string)}`);
+	async deleteOne(id: ID, options?: TransportOptions): Promise<void> {
+		await this.transport.delete(`${this.endpoint}/${encodeURI(id as string)}`, undefined, options);
 	}
 
-	async deleteMany(ids: ID[]): Promise<void> {
-		await this.transport.delete(`${this.endpoint}`, ids);
+	async deleteMany(ids: ID[], options?: TransportOptions): Promise<void> {
+		await this.transport.delete(`${this.endpoint}`, ids, options);
 	}
 }

--- a/packages/sdk/src/base/items.ts
+++ b/packages/sdk/src/base/items.ts
@@ -1,4 +1,4 @@
-import { ITransport, TransportOptions } from '../transport';
+import { ITransport, TransportRequestOptions } from '../transport';
 import { IItems, Item, QueryOne, QueryMany, OneItem, ManyItems, PartialItem } from '../items';
 import { ID, FieldType } from '../types';
 
@@ -13,7 +13,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		this.endpoint = collection.startsWith('directus_') ? `/${collection.substring(9)}` : `/items/${collection}`;
 	}
 
-	async readOne(id: ID, query?: QueryOne<T>, options?: TransportOptions): Promise<OneItem<T>> {
+	async readOne(id: ID, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>> {
 		const response = await this.transport.get<T>(`${this.endpoint}/${encodeURI(id as string)}`, {
 			...options,
 			params: query,
@@ -22,7 +22,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		return response.data as T;
 	}
 
-	async readMany(ids: ID[], query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
+	async readMany(ids: ID[], query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>> {
 		const collectionFields = await this.transport.get<FieldType[]>(`/fields/${this.collection}`);
 
 		const primaryKeyField = collectionFields.data?.find((field: any) => field.schema.is_primary_key === true);
@@ -45,7 +45,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		};
 	}
 
-	async readByQuery(query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
+	async readByQuery(query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>> {
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
 			...options,
 			params: query,
@@ -57,7 +57,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		};
 	}
 
-	async createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: TransportOptions): Promise<OneItem<T>> {
+	async createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.post<T>(`${this.endpoint}`, item, {
 				...options,
@@ -66,14 +66,23 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		).data;
 	}
 
-	async createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
+	async createMany(
+		items: PartialItem<T>[],
+		query?: QueryMany<T>,
+		options?: TransportRequestOptions
+	): Promise<ManyItems<T>> {
 		return await this.transport.post<PartialItem<T>[]>(`${this.endpoint}`, items, {
 			...options,
 			params: query,
 		});
 	}
 
-	async updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: TransportOptions): Promise<OneItem<T>> {
+	async updateOne(
+		id: ID,
+		item: PartialItem<T>,
+		query?: QueryOne<T>,
+		options?: TransportRequestOptions
+	): Promise<OneItem<T>> {
 		return (
 			await this.transport.patch<PartialItem<T>>(`${this.endpoint}/${encodeURI(id as string)}`, item, {
 				...options,
@@ -82,7 +91,12 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		).data;
 	}
 
-	async updateMany(ids: ID[], data: PartialItem<T>, query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
+	async updateMany(
+		ids: ID[],
+		data: PartialItem<T>,
+		query?: QueryMany<T>,
+		options?: TransportRequestOptions
+	): Promise<ManyItems<T>> {
 		return await this.transport.patch<PartialItem<T>[]>(
 			`${this.endpoint}`,
 			{
@@ -96,7 +110,12 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		);
 	}
 
-	async updateByQuery(updateQuery: QueryMany<T>, data: PartialItem<T>, query?: QueryMany<T>, options?: TransportOptions): Promise<ManyItems<T>> {
+	async updateByQuery(
+		updateQuery: QueryMany<T>,
+		data: PartialItem<T>,
+		query?: QueryMany<T>,
+		options?: TransportRequestOptions
+	): Promise<ManyItems<T>> {
 		return await this.transport.patch<PartialItem<T>[]>(
 			`${this.endpoint}`,
 			{
@@ -110,11 +129,11 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		);
 	}
 
-	async deleteOne(id: ID, options?: TransportOptions): Promise<void> {
+	async deleteOne(id: ID, options?: TransportRequestOptions): Promise<void> {
 		await this.transport.delete(`${this.endpoint}/${encodeURI(id as string)}`, undefined, options);
 	}
 
-	async deleteMany(ids: ID[], options?: TransportOptions): Promise<void> {
+	async deleteMany(ids: ID[], options?: TransportRequestOptions): Promise<void> {
 		await this.transport.delete(`${this.endpoint}`, ids, options);
 	}
 }

--- a/packages/sdk/src/base/items.ts
+++ b/packages/sdk/src/base/items.ts
@@ -1,5 +1,5 @@
-import { ITransport, TransportRequestOptions } from '../transport';
-import { IItems, Item, QueryOne, QueryMany, OneItem, ManyItems, PartialItem } from '../items';
+import { ITransport } from '../transport';
+import { IItems, Item, QueryOne, QueryMany, OneItem, ManyItems, PartialItem, ItemsOptions } from '../items';
 import { ID, FieldType } from '../types';
 
 export class ItemsHandler<T extends Item> implements IItems<T> {
@@ -13,22 +13,22 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		this.endpoint = collection.startsWith('directus_') ? `/${collection.substring(9)}` : `/items/${collection}`;
 	}
 
-	async readOne(id: ID, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>> {
+	async readOne(id: ID, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>> {
 		const response = await this.transport.get<T>(`${this.endpoint}/${encodeURI(id as string)}`, {
-			...options,
+			...options?.requestOptions,
 			params: query,
 		});
 
 		return response.data as T;
 	}
 
-	async readMany(ids: ID[], query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>> {
+	async readMany(ids: ID[], query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>> {
 		const collectionFields = await this.transport.get<FieldType[]>(`/fields/${this.collection}`);
 
 		const primaryKeyField = collectionFields.data?.find((field: any) => field.schema.is_primary_key === true);
 
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
-			...options,
+			...options?.requestOptions,
 			params: {
 				filter: {
 					[primaryKeyField!.field]: { _in: ids },
@@ -45,9 +45,9 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		};
 	}
 
-	async readByQuery(query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>> {
+	async readByQuery(query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>> {
 		const { data, meta } = await this.transport.get<T[]>(`${this.endpoint}`, {
-			...options,
+			...options?.requestOptions,
 			params: query,
 		});
 
@@ -57,35 +57,26 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		};
 	}
 
-	async createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>> {
+	async createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.post<T>(`${this.endpoint}`, item, {
-				...options,
+				...options?.requestOptions,
 				params: query,
 			})
 		).data;
 	}
 
-	async createMany(
-		items: PartialItem<T>[],
-		query?: QueryMany<T>,
-		options?: TransportRequestOptions
-	): Promise<ManyItems<T>> {
+	async createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>> {
 		return await this.transport.post<PartialItem<T>[]>(`${this.endpoint}`, items, {
-			...options,
+			...options?.requestOptions,
 			params: query,
 		});
 	}
 
-	async updateOne(
-		id: ID,
-		item: PartialItem<T>,
-		query?: QueryOne<T>,
-		options?: TransportRequestOptions
-	): Promise<OneItem<T>> {
+	async updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>> {
 		return (
 			await this.transport.patch<PartialItem<T>>(`${this.endpoint}/${encodeURI(id as string)}`, item, {
-				...options,
+				...options?.requestOptions,
 				params: query,
 			})
 		).data;
@@ -95,7 +86,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		ids: ID[],
 		data: PartialItem<T>,
 		query?: QueryMany<T>,
-		options?: TransportRequestOptions
+		options?: ItemsOptions
 	): Promise<ManyItems<T>> {
 		return await this.transport.patch<PartialItem<T>[]>(
 			`${this.endpoint}`,
@@ -104,7 +95,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				data,
 			},
 			{
-				...options,
+				...options?.requestOptions,
 				params: query,
 			}
 		);
@@ -114,7 +105,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 		updateQuery: QueryMany<T>,
 		data: PartialItem<T>,
 		query?: QueryMany<T>,
-		options?: TransportRequestOptions
+		options?: ItemsOptions
 	): Promise<ManyItems<T>> {
 		return await this.transport.patch<PartialItem<T>[]>(
 			`${this.endpoint}`,
@@ -123,17 +114,17 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 				data,
 			},
 			{
-				...options,
+				...options?.requestOptions,
 				params: query,
 			}
 		);
 	}
 
-	async deleteOne(id: ID, options?: TransportRequestOptions): Promise<void> {
-		await this.transport.delete(`${this.endpoint}/${encodeURI(id as string)}`, undefined, options);
+	async deleteOne(id: ID, options?: ItemsOptions): Promise<void> {
+		await this.transport.delete(`${this.endpoint}/${encodeURI(id as string)}`, undefined, options?.requestOptions);
 	}
 
-	async deleteMany(ids: ID[], options?: TransportRequestOptions): Promise<void> {
-		await this.transport.delete(`${this.endpoint}`, ids, options);
+	async deleteMany(ids: ID[], options?: ItemsOptions): Promise<void> {
+		await this.transport.delete(`${this.endpoint}`, ids, options?.requestOptions);
 	}
 }

--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -1,3 +1,4 @@
+import { TransportRequestOptions } from './transport';
 import { ID } from './types';
 
 export type Field = string;
@@ -90,16 +91,21 @@ export type Filter<T> = LogicalFilter<T> | FieldFilter<T extends Array<unknown> 
  * CRUD at its finest
  */
 export interface IItems<T extends Item> {
-	createOne(item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>>;
-	createMany(items: PartialItem<T>[], query?: QueryMany<T>): Promise<ManyItems<T>>;
+	createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>>;
+	createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>>;
 
-	readOne(id: ID, query?: QueryOne<T>): Promise<OneItem<T>>;
-	readMany(ids: ID[], query?: QueryMany<T>): Promise<ManyItems<T>>;
-	readByQuery(query?: QueryMany<T>): Promise<ManyItems<T>>;
+	readOne(id: ID, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>>;
+	readMany(ids: ID[], query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>>;
+	readByQuery(query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>>;
 
-	updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>>;
-	updateMany(ids: ID[], item: PartialItem<T>, query?: QueryMany<T>): Promise<ManyItems<T>>;
+	updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>>;
+	updateMany(
+		ids: ID[],
+		item: PartialItem<T>,
+		query?: QueryMany<T>,
+		options?: TransportRequestOptions
+	): Promise<ManyItems<T>>;
 
-	deleteOne(id: ID): Promise<void>;
-	deleteMany(ids: ID[]): Promise<void>;
+	deleteOne(id: ID, options?: TransportRequestOptions): Promise<void>;
+	deleteMany(ids: ID[], options?: TransportRequestOptions): Promise<void>;
 }

--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -87,25 +87,24 @@ export type FieldFilter<T> = {
 
 export type Filter<T> = LogicalFilter<T> | FieldFilter<T extends Array<unknown> ? T[number] : T>;
 
+export type ItemsOptions = {
+	requestOptions: TransportRequestOptions;
+};
+
 /**
  * CRUD at its finest
  */
 export interface IItems<T extends Item> {
-	createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>>;
-	createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>>;
+	createOne(item: PartialItem<T>, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>>;
+	createMany(items: PartialItem<T>[], query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>>;
 
-	readOne(id: ID, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>>;
-	readMany(ids: ID[], query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>>;
-	readByQuery(query?: QueryMany<T>, options?: TransportRequestOptions): Promise<ManyItems<T>>;
+	readOne(id: ID, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>>;
+	readMany(ids: ID[], query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>>;
+	readByQuery(query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>>;
 
-	updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: TransportRequestOptions): Promise<OneItem<T>>;
-	updateMany(
-		ids: ID[],
-		item: PartialItem<T>,
-		query?: QueryMany<T>,
-		options?: TransportRequestOptions
-	): Promise<ManyItems<T>>;
+	updateOne(id: ID, item: PartialItem<T>, query?: QueryOne<T>, options?: ItemsOptions): Promise<OneItem<T>>;
+	updateMany(ids: ID[], item: PartialItem<T>, query?: QueryMany<T>, options?: ItemsOptions): Promise<ManyItems<T>>;
 
-	deleteOne(id: ID, options?: TransportRequestOptions): Promise<void>;
-	deleteMany(ids: ID[], options?: TransportRequestOptions): Promise<void>;
+	deleteOne(id: ID, options?: ItemsOptions): Promise<void>;
+	deleteMany(ids: ID[], options?: ItemsOptions): Promise<void>;
 }

--- a/packages/sdk/tests/items.test.ts
+++ b/packages/sdk/tests/items.test.ts
@@ -295,4 +295,34 @@ describe('items', function () {
 
 		expect(scope.pendingMocks().length).toBe(0);
 	});
+	test('should passthrough additional headers', async (url, nock) => {
+		const postData = {
+			title: 'New post',
+			body: 'This is a new post',
+			published: false,
+		};
+		const id = 3;
+		const expectedData = {
+			id,
+			...postData,
+		};
+		const headerName = 'X-Custom-Header';
+		const headerValue = 'Custom header value';
+		const customOptions = {
+			headers: {
+				[headerName]: headerValue,
+			},
+		};
+		nock()
+			.post('/items/posts')
+			// check if custom header is present
+			.matchHeader(headerName, headerValue)
+			.reply(200, {
+				data: expectedData,
+			});
+
+		const sdk = new Directus<Blog>(url);
+		const item = await sdk.items('posts').createOne(postData, undefined, customOptions);
+		expect(item).toMatchObject(expectedData);
+	});
 });

--- a/packages/sdk/tests/items.test.ts
+++ b/packages/sdk/tests/items.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { Blog } from './blog.d';
-import { Directus } from '../src';
+import { Directus, ItemsOptions } from '../src';
 import { test } from './utils';
 
 describe('items', function () {
@@ -308,9 +308,11 @@ describe('items', function () {
 		};
 		const headerName = 'X-Custom-Header';
 		const headerValue = 'Custom header value';
-		const customOptions = {
-			headers: {
-				[headerName]: headerValue,
+		const customOptions: ItemsOptions = {
+			requestOptions: {
+				headers: {
+					[headerName]: headerValue,
+				},
 			},
 		};
 		nock()


### PR DESCRIPTION
Resolves #12390

This change adds the possibility to pass further options to the [`items` functions](https://docs.directus.io/reference/sdk/#items).

It adds an optional `options` parameter to all functions which gets merged with possible other passed in options (eg. `query`). These options are directly passed into the underlying function of the `Transport` object.

Like this it is possible to pass custom `headers` to the request like in the following example.

When uploading a file in a Node environment with the `form-data` package you need to provide the headers created by the constructor to the request. With the change this is possible like this:

```js
const FormData = require('form-data');
const form = new FormData();
form.append('file', fs.createReadStream(someImagePath));
// using `items`
const response = await directus.items('directus_files').createMany(form, undefined, {
    headers: {
        ...form.getHeaders()
    }
});
// using the `files` alias
const response = await directus.files.createMany(form, undefined, {
    headers: {
        ...form.getHeaders()
    }
});
```