### PR TITLE
Safe Metadata Upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage
 TODO
 schema.yaml
 schema.json
+.*.swp

--- a/api/example.env
+++ b/api/example.env
@@ -123,6 +123,10 @@ STORAGE_LOCAL_ROOT="./uploads"
 # STORAGE_GOOGLE_KEY_FILENAME="abcdef"
 # STORAGE_GOOGLE_BUCKET="my-files"
 
+
+## CSV of additional metadata keys
+# FILE_METADATA_ALLOWLIST=
+
 ####################################################################################################
 # Security
 

--- a/api/example.env
+++ b/api/example.env
@@ -125,7 +125,7 @@ STORAGE_LOCAL_ROOT="./uploads"
 
 
 ## CSV of additional metadata keys
-# FILE_METADATA_ALLOWLIST=
+# FILE_METADATA_ALLOW_LIST=
 
 ####################################################################################################
 # Security

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -85,7 +85,7 @@ const defaults: Record<string, any> = {
 
 	EXPORT_BATCH_SIZE: 5000,
 
-	FILE_METADATA_ALLOW_LIST: '',
+	FILE_METADATA_ALLOW_LIST: 'ifd0.Make,ifd0.Model,exif.FNumber,exif.ExposureTime,exif.FocalLength,exif.ISO',
 };
 
 // Allows us to force certain environment variable into a type, instead of relying

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -85,7 +85,7 @@ const defaults: Record<string, any> = {
 
 	EXPORT_BATCH_SIZE: 5000,
 
-	FILE_METADATA_ALLOWLIST: '',
+	FILE_METADATA_ALLOW_LIST: '',
 };
 
 // Allows us to force certain environment variable into a type, instead of relying
@@ -103,7 +103,7 @@ const typeMap: Record<string, string> = {
 	DB_EXCLUDE_TABLES: 'array',
 	IMPORT_IP_DENY_LIST: 'array',
 
-	FILE_METADATA_ALLOWLIST: 'array',
+	FILE_METADATA_ALLOW_LIST: 'array',
 };
 
 let env: Record<string, any> = {

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -84,6 +84,8 @@ const defaults: Record<string, any> = {
 	RELATIONAL_BATCH_SIZE: 25000,
 
 	EXPORT_BATCH_SIZE: 5000,
+
+	FILE_METADATA_ALLOWLIST: '',
 };
 
 // Allows us to force certain environment variable into a type, instead of relying
@@ -100,6 +102,8 @@ const typeMap: Record<string, string> = {
 
 	DB_EXCLUDE_TABLES: 'array',
 	IMPORT_IP_DENY_LIST: 'array',
+
+	FILE_METADATA_ALLOWLIST: 'array',
 };
 
 let env: Record<string, any> = {

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -146,10 +146,13 @@ export class FilesService extends ItemsService {
 
 		try {
 			const exifrMetadata = await exifr.parse(bufferContent, {
+				icc: false,
 				iptc: true,
 				ifd1: true,
 				interop: true,
-				icc: false,
+				translateValues: true,
+				reviveValues: true,
+				mergeOutput: false,
 			});
 
 			metadata.metadata = pick(exifrMetadata, allowList);

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -1,7 +1,7 @@
 import formatTitle from '@directus/format-title';
 import axios, { AxiosResponse } from 'axios';
 import exifr from 'exifr';
-import { clone } from 'lodash';
+import { clone, pick } from 'lodash';
 import { extension } from 'mime-types';
 import path from 'path';
 import sharp from 'sharp';
@@ -13,7 +13,7 @@ import env from '../env';
 import { ForbiddenException, ServiceUnavailableException } from '../exceptions';
 import logger from '../logger';
 import storage from '../storage';
-import { AbstractServiceOptions, File, PrimaryKey, MutationOptions } from '../types';
+import { AbstractServiceOptions, File, PrimaryKey, MutationOptions, Metadata } from '../types';
 import { toArray } from '@directus/shared/utils';
 import { ItemsService } from './items';
 import net from 'net';
@@ -81,46 +81,7 @@ export class FilesService extends ItemsService {
 
 		if (['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/tiff'].includes(payload.type)) {
 			const buffer = await storage.disk(data.storage).getBuffer(payload.filename_disk);
-			try {
-				const meta = await sharp(buffer.content, {}).metadata();
-
-				if (meta.orientation && meta.orientation >= 5) {
-					payload.height = meta.width;
-					payload.width = meta.height;
-				} else {
-					payload.width = meta.width;
-					payload.height = meta.height;
-				}
-			} catch (err: any) {
-				logger.warn(`Couldn't extract sharp metadata from file`);
-				logger.warn(err);
-			}
-
-			payload.metadata = {};
-
-			try {
-				payload.metadata = await exifr.parse(buffer.content, {
-					icc: false,
-					iptc: true,
-					ifd1: true,
-					interop: true,
-					translateValues: true,
-					reviveValues: true,
-					mergeOutput: false,
-				});
-				if (payload.metadata?.iptc?.Headline) {
-					payload.title = payload.metadata.iptc.Headline;
-				}
-				if (!payload.description && payload.metadata?.iptc?.Caption) {
-					payload.description = payload.metadata.iptc.Caption;
-				}
-				if (payload.metadata?.iptc?.Keywords) {
-					payload.tags = payload.metadata.iptc.Keywords;
-				}
-			} catch (err: any) {
-				logger.warn(`Couldn't extract EXIF metadata from file`);
-				logger.warn(err);
-			}
+			payload.metadata = await this.getMetadata(buffer.content);
 		}
 
 		// We do this in a service without accountability. Even if you don't have update permissions to the file,
@@ -153,6 +114,53 @@ export class FilesService extends ItemsService {
 		}
 
 		return primaryKey;
+	}
+
+	/**
+	 * Extract metadata from a buffer's content
+	 */
+	async getMetadata(bufferContent: any, allowList = env.FILE_METADATA_ALLOWLIST): Promise<Metadata> {
+		const metadata: Metadata = {};
+
+		try {
+			const sharpMetadata = await sharp(bufferContent, {}).metadata();
+
+			if (sharpMetadata.orientation && sharpMetadata.orientation >= 5) {
+				metadata.height = sharpMetadata.width;
+				metadata.width = sharpMetadata.height;
+			} else {
+				metadata.width = sharpMetadata.width;
+				metadata.height = sharpMetadata.height;
+			}
+		} catch (err: any) {
+			logger.warn(`Couldn't extract sharp metadata from file`);
+			logger.warn(err);
+		}
+
+		try {
+			const exifrMetadata = await exifr.parse(bufferContent, {
+				iptc: true,
+				ifd1: true,
+				interop: true,
+			});
+
+			metadata.metadata = pick(exifrMetadata, allowList);
+
+			if (!metadata.description && exifrMetadata.Caption) {
+				metadata.description = exifrMetadata.Caption;
+			}
+			if (exifrMetadata.Headline) {
+				metadata.title = exifrMetadata.Headline;
+			}
+			if (exifrMetadata.Keywords) {
+				metadata.tags = exifrMetadata.Keywords;
+			}
+		} catch (err: any) {
+			logger.warn(`Couldn't extract EXIF metadata from file`);
+			logger.warn(err);
+		}
+
+		return metadata;
 	}
 
 	/**

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -155,7 +155,11 @@ export class FilesService extends ItemsService {
 				mergeOutput: false,
 			});
 
-			metadata.metadata = pick(exifrMetadata, allowList);
+			if (allowList === '*' || allowList?.[0] === '*') {
+				metadata.metadata = exifrMetadata;
+			} else {
+				metadata.metadata = pick(exifrMetadata, allowList);
+			}
 
 			if (!metadata.description && exifrMetadata?.Caption) {
 				metadata.description = exifrMetadata.Caption;

--- a/api/src/types/files.ts
+++ b/api/src/types/files.ts
@@ -19,3 +19,12 @@ export type File = {
 	tags: string | null;
 	metadata: Record<string, any> | null;
 };
+
+export type Metadata = {
+	height?: number | undefined;
+	width?: number | undefined;
+	description?: string | undefined;
+	title?: string | undefined;
+	tags?: any | undefined;
+	metadata?: any | undefined;
+};

--- a/api/tests/services/files.test.ts
+++ b/api/tests/services/files.test.ts
@@ -1,0 +1,58 @@
+import exifr from 'exifr';
+import knex, { Knex } from 'knex';
+import { MockClient, Tracker, getTracker } from 'knex-mock-client';
+import { FilesService } from '../../src/services';
+
+jest.mock('exifr');
+jest.mock('../../src/database/index', () => {
+	return { getDatabaseClient: jest.fn().mockReturnValue('postgres') };
+});
+jest.requireMock('../../src/database/index');
+
+describe('Integration Tests', () => {
+	let db: jest.Mocked<Knex>;
+	let tracker: Tracker;
+
+	beforeAll(async () => {
+		db = knex({ client: MockClient }) as jest.Mocked<Knex>;
+		tracker = getTracker();
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	describe('Services / Files', () => {
+		describe('getMetadata', () => {
+			let service: FilesService;
+			let exifrParseSpy: jest.SpyInstance<any>;
+
+			const sampleMetadata = {
+				CustomTagA: 'value a',
+				CustomTagB: 'value b',
+				CustomTagC: 'value c',
+			};
+
+			beforeEach(() => {
+				exifrParseSpy = jest.spyOn(exifr, 'parse');
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+			});
+
+			it('accepts allowlist metadata tags', async () => {
+				exifrParseSpy.mockReturnValue(Promise.resolve({ ...sampleMetadata }));
+				const bufferContent = 'file buffer content';
+				const allowList = ['CustomTagB', 'CustomTagA'];
+
+				const metadata = await service.getMetadata(bufferContent, allowList);
+
+				expect(exifrParseSpy).toHaveBeenCalled();
+				expect(metadata.metadata.CustomTagA).toStrictEqual(sampleMetadata.CustomTagA);
+				expect(metadata.metadata.CustomTagB).toStrictEqual(sampleMetadata.CustomTagB);
+				expect(metadata.metadata.CustomTagC).toBeUndefined();
+			});
+		});
+	});
+});

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -569,9 +569,9 @@ STORAGE_AWS_BUCKET="my-files"
 When uploading an image, Directus persists the _description, title, and tags_ from available EXIF metadata. For security
 purposes, collection of additional metadata must be configured:
 
-| Variable                  | Description                                                                                                                     | Default Value |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `FILE_METADATA_ALLOWLIST` | A comma-separated list of metadata keys to collect during file upload. Unavailable fields are excluded from the saved metadata. | --            |
+| Variable                   | Description                                                                                                                     | Default Value |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `FILE_METADATA_ALLOW_LIST` | A comma-separated list of metadata keys to collect during file upload. Unavailable fields are excluded from the saved metadata. | --            |
 
 ## Assets
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -564,6 +564,15 @@ STORAGE_AWS_REGION="us-east-2"
 STORAGE_AWS_BUCKET="my-files"
 ```
 
+### Metadata
+
+When uploading an image, Directus persists the _description, title, and tags_ from available EXIF metadata. For security
+purposes, collection of additional metadata must be configured:
+
+| Variable                  | Description                                                                                                                     | Default Value |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `FILE_METADATA_ALLOWLIST` | A comma-separated list of metadata keys to collect during file upload. Unavailable fields are excluded from the saved metadata. | --            |
+
 ## Assets
 
 | Variable                               | Description                                                                                                                             | Default Value |

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -569,11 +569,11 @@ STORAGE_AWS_BUCKET="my-files"
 When uploading an image, Directus persists the _description, title, and tags_ from available EXIF metadata. For security
 purposes, collection of additional metadata must be configured:
 
-| Variable                   | Description                                                                                 | Default Value                                                                 |
-| -------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `FILE_METADATA_ALLOW_LIST` | A comma-separated list of metadata keys to collect during file upload. Use `*` for all[^1]. | ifd0.Make,ifd0.Model,exif.FNumber,exif.ExposureTime,exif.FocalLength,exif.ISO |
+| Variable                   | Description                                                                                           | Default Value                                                                 |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `FILE_METADATA_ALLOW_LIST` | A comma-separated list of metadata keys to collect during file upload. Use `*` for all<sup>[1]</sup>. | ifd0.Make,ifd0.Model,exif.FNumber,exif.ExposureTime,exif.FocalLength,exif.ISO |
 
-[^1]: Extracting all metadata might cause memory issues when the file has an unusually large set of metadata
+<sup>[1]</sup>: Extracting all metadata might cause memory issues when the file has an unusually large set of metadata
 
 ## Assets
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -569,9 +569,11 @@ STORAGE_AWS_BUCKET="my-files"
 When uploading an image, Directus persists the _description, title, and tags_ from available EXIF metadata. For security
 purposes, collection of additional metadata must be configured:
 
-| Variable                   | Description                                                                                                                     | Default Value |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `FILE_METADATA_ALLOW_LIST` | A comma-separated list of metadata keys to collect during file upload. Unavailable fields are excluded from the saved metadata. | --            |
+| Variable                   | Description                                                                                 | Default Value                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `FILE_METADATA_ALLOW_LIST` | A comma-separated list of metadata keys to collect during file upload. Use `*` for all[^1]. | ifd0.Make,ifd0.Model,exif.FNumber,exif.ExposureTime,exif.FocalLength,exif.ISO |
+
+[^1]: Extracting all metadata might cause memory issues when the file has an unusually large set of metadata
 
 ## Assets
 


### PR DESCRIPTION
Fixes #11292

Implementation of a metadata allowlist. This will prevent app crash from unexpectedly deep, large, or recursive metadata.