### PR TITLE
Cast input data for filters

### DIFF
--- a/api/src/database/helpers/fn/dialects/sqlite.ts
+++ b/api/src/database/helpers/fn/dialects/sqlite.ts
@@ -3,35 +3,35 @@ import { Knex } from 'knex';
 
 export class FnHelperSQLite extends FnHelper {
 	year(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%Y', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%Y', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	month(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%m', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%m', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	week(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%W', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%W', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	day(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%d', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%d', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	weekday(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%w', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%w', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	hour(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%H', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%H', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	minute(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%M', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%M', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	second(table: string, column: string): Knex.Raw {
-		return this.knex.raw("strftime('%S', ??.?? / 1000, 'unixepoch')", [table, column]);
+		return this.knex.raw("CAST(strftime('%S', ??.?? / 1000, 'unixepoch') AS INTEGER)", [table, column]);
 	}
 
 	count(table: string, column: string): Knex.Raw<any> {


### PR DESCRIPTION
Fixes #12510

## Before

Example query formed: ``select `suppliers`.`name`, `suppliers`.`id` from `suppliers` where ((select count(*) from `products` where `supplier` = `suppliers`.`id`) >= '2') order by `suppliers`.`id` asc limit 25``

Due to the filter value being string, it doesn't work as expected:

https://user-images.githubusercontent.com/42867097/161214815-3cbd65f8-952f-4630-b4c5-e4271e64bf72.mp4


## Changes made

- Added casting based on function, and uses `getOutputTypeForFunction` here to determine the type:

   https://github.com/directus/directus/blob/8f850bb7db454fde85afc50ea9296c14c80677ab/packages/shared/src/utils/get-output-type-for-function.ts#L3-L17


- Added `CAST(...) AS INTEGER` to SQLite function helpers. 

   This is to make it aligned with `getOutputTypeForFunction` above which states they are integers, not string. One alternative to this change would be to make said output type differ between db vendors? But I was thinking this is the more streamlined approach. Hopefully it is.

- Added casting to number depending on field type

  Seems like this casting based on field as outlined in the issue, was actually implemented in #7774 to also fix date filter values for SQLite specifically, with the following code:
  
  https://github.com/directus/directus/blob/8f850bb7db454fde85afc50ea9296c14c80677ab/api/src/utils/apply-query.ts#L413-L425

   hence this PR added number types in the mix.

## After

Example query formed: ``select `suppliers`.`name`, `suppliers`.`id` from `suppliers` where ((select count(*) from `products` where `supplier` = `suppliers`.`id`) >= 2) order by `suppliers`.`id` asc limit 25``

https://user-images.githubusercontent.com/42867097/161214879-6d1efdcc-b049-4888-ad83-ae48cb533fb8.mp4


