### PR TITLE
Always try to rebind on healthcheck error

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -90,7 +90,7 @@ export class LDAPAuthDriver extends AuthDriver {
 				});
 
 				res.on('error', () => {
-					// Attempt to rebind on seach error
+					// Attempt to rebind on search error
 					this.bindClient.bind(bindDn, bindPassword, (err: Error | null) => {
 						if (err) {
 							const error = handleError(err);

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -8,8 +8,7 @@ import ldap, {
 	LDAPResult,
 	InappropriateAuthenticationError,
 	InvalidCredentialsError,
-	InsufficientAccessRightsError,
-	OperationsError,
+	InsufficientAccessRightsError
 } from 'ldapjs';
 import ms from 'ms';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
@@ -90,13 +89,8 @@ export class LDAPAuthDriver extends AuthDriver {
 					resolve();
 				});
 
-				res.on('error', (err: Error) => {
-					if (!(err instanceof OperationsError)) {
-						reject(handleError(err));
-						return;
-					}
-
-					// Rebind on OperationsError
+				res.on('error', () => {
+					// Attempt to rebind on seach error
 					this.bindClient.bind(bindDn, bindPassword, (err: Error | null) => {
 						if (err) {
 							const error = handleError(err);
@@ -113,8 +107,8 @@ export class LDAPAuthDriver extends AuthDriver {
 				});
 
 				res.on('end', (result: LDAPResult | null) => {
+					// Handle edge case where authenticated bind user can't read their own DN
 					if (result?.status === 0) {
-						// Handle edge case where authenticated bind user could not fetch their own DN
 						reject(new UnexpectedResponseException('Failed to find bind user record'));
 					}
 				});

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -8,7 +8,7 @@ import ldap, {
 	LDAPResult,
 	InappropriateAuthenticationError,
 	InvalidCredentialsError,
-	InsufficientAccessRightsError
+	InsufficientAccessRightsError,
 } from 'ldapjs';
 import ms from 'ms';
 import { getIPFromReq } from '../../utils/get-ip-from-req';
@@ -107,7 +107,7 @@ export class LDAPAuthDriver extends AuthDriver {
 				});
 
 				res.on('end', (result: LDAPResult | null) => {
-					// Handle edge case where authenticated bind user can't read their own DN
+					// Handle edge case where authenticated bind user cannot read their own DN
 					if (result?.status === 0) {
 						reject(new UnexpectedResponseException('Failed to find bind user record'));
 					}


### PR DESCRIPTION
My thought is that if the search fails for a reason other than client being unbound then it'll probably fail in the same way when we try to bind the user, and the same error will be returned regardless.

Should resolve https://github.com/directus/directus/issues/12523 in which Jumpcloud does not return the expected `OperationsError` when performing a search with an unbound client.