### PR TITLE
Error handling on List insights panel to prevent crash when missing options.

### DIFF
--- a/app/src/panels/list/list.vue
+++ b/app/src/panels/list/list.vue
@@ -16,15 +16,6 @@
 				</v-list-item>
 			</v-list>
 		</div>
-
-		<drawer-item
-			:active="!!currentlyEditing"
-			:collection="collection"
-			:primary-key="currentlyEditing ?? '+'"
-			:edits="editsAtStart"
-			@input="saveEdits"
-			@update:active="cancelEdit"
-		/>
 	</div>
 </template>
 
@@ -33,7 +24,6 @@ import { defineComponent, ref, watchEffect, computed, PropType } from 'vue';
 import api from '@/api';
 import { Filter } from '@directus/shared/types';
 import { useFieldsStore } from '@/stores';
-import DrawerItem from '@/views/private/components/drawer-item';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { getFieldsFromTemplate } from '@directus/shared/utils';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
@@ -41,7 +31,6 @@ import { getEndpoint } from '@/utils/get-endpoint';
 import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
-	components: { DrawerItem },
 	props: {
 		showHeader: {
 			type: Boolean,
@@ -113,6 +102,8 @@ export default defineComponent({
 
 		async function fetchData() {
 			if (!props) return;
+			if (!props.collection) return;
+			if (!props.sortField) return;
 
 			loading.value = true;
 


### PR DESCRIPTION
Currently, the List component crashes the entire insights dashboard when it is saved with a missing collection. This handles that by returning the `fetchData()` function before trying to make the request and by removing a seemingly unused drawer. If the drawer is in fact being used then a check on `hasData` is necessary.

Currently, I didn't modify the error handling to use the `v-notice.warn` that is used on the other insights panels that I am working on. I would love to though as I think it's more descriptive and more visible. The span also only displays "No data" and not why.

### Current error with the span:
<img width="252" alt="Screen Shot 2022-04-02 at 9 33 51 AM" src="https://user-images.githubusercontent.com/67079013/161385773-adb14e51-a309-4bae-821b-74f6ef20a11b.png">

### Using v-notice.warn
<img width="218" alt="Screen Shot 2022-04-02 at 9 41 19 AM" src="https://user-images.githubusercontent.com/67079013/161385985-9fa832cc-ce57-479a-aaee-c347de628124.png">


It also throws a SQL error when there is no sort field. I have "handled" this as well but am open to removing that. The cloud exclusive insights panels handle is slightly differently by using a v-notice which I think is a little nicer than the SQL pop-up and more descriptive than "t('no_data')". Also not sure what the SQL popup looks like for non-admin who can't see full errors.
