### PR TITLE
Disable fields that are groups to be selected in field list

### DIFF
--- a/app/src/components/v-field-list/v-field-list-item.vue
+++ b/app/src/components/v-field-list/v-field-list-item.vue
@@ -58,17 +58,12 @@ export default {
 
 <script lang="ts" setup>
 import formatTitle from '@directus/format-title';
-import { Type } from '@directus/shared/types';
 import { getFunctionsForType } from '@directus/shared/utils';
+import { FieldNode } from '@/composables/use-field-tree';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-type FieldInfo = {
-	field: string;
-	name: string;
-	key: string;
-	path: string;
-	type: Type;
+type FieldInfo = FieldNode & {
 	disabled?: boolean;
 	children?: FieldInfo[];
 };
@@ -86,7 +81,7 @@ defineEmits(['add']);
 const { t } = useI18n();
 
 const supportedFunctions = computed(() => {
-	if (!props.includeFunctions) return [];
+	if (!props.includeFunctions || props.field.group) return [];
 	return getFunctionsForType(props.field.type);
 });
 </script>

--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -72,7 +72,7 @@ const treeList = computed(() => {
 	function setDisabled(
 		field: typeof treeListOriginal.value[number]
 	): typeof treeListOriginal.value[number] & { disabled: boolean } {
-		let disabled = false;
+		let disabled = field.group || false;
 
 		if (props.disabledFields?.includes(field.key)) disabled = true;
 


### PR DESCRIPTION
By default disable fields that are groups to be selected in field list, since they anyways can't be filtered on.