### PR TITLE
docker - disable npm update warnings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,9 @@ RUN \
 USER node
 WORKDIR /directus
 
+# disable npm update warnings
+RUN echo "update-notifier=false" >> ~/.npmrc
+
 COPY --from=builder --chown=node:node /directus .
 
 RUN \


### PR DESCRIPTION
Since updates are useless in ephemeral containers, update warnings should be silent.