### PR TITLE
Fix field names in groups for validation errors

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -3,7 +3,7 @@
 		<validation-errors
 			v-if="!nested && validationErrors.length > 0"
 			:validation-errors="validationErrors"
-			:fields="formFields"
+			:fields="fields ? fields : []"
 			@scroll-to-field="scrollToField"
 		/>
 		<template v-for="(field, index) in formFields">


### PR DESCRIPTION
Fixes #12526

## Before

`variant` and `remark` field is not showing their translated field names "Test Variants" and "Test Remark":

![chrome_yFZGN65Rqj](https://user-images.githubusercontent.com/42867097/161477946-a378e844-bacc-4158-bb90-e7c24ed712a6.png)

## Breakdown

Currently `formFields` is passed to `<validation-errors>` component, but `formFields` actually only contains "current level" fields:

https://github.com/directus/directus/blob/703fb8426f59619a4f21e80f670ed4347d01666c/app/src/components/v-form/v-form.vue#L276-L282

and since the current logic within the validation-errors component defaults to `validationError.field` if the field is not found:

https://github.com/directus/directus/blob/703fb8426f59619a4f21e80f670ed4347d01666c/app/src/components/v-form/validation-errors.vue#L73

this is why fields within groups does not show their actual field labels.

## After

![chrome_HWHuhmqxDp](https://user-images.githubusercontent.com/42867097/161477995-53a49706-ec0c-4b1d-9d5b-ab2a9710bc99.png)

