### PR TITLE
feat: update many array of data

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -339,7 +339,11 @@ export class CollectionsService {
 	/**
 	 * Update multiple collections by name
 	 */
-	async updateMany(collectionKeys: string[], data: Partial<Collection> | Partial<Collection>[], opts?: MutationOptions): Promise<string[]> {
+	async updateMany(
+		collectionKeys: string[],
+		data: Partial<Collection> | Partial<Collection>[],
+		opts?: MutationOptions
+	): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException();
 		}

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -339,11 +339,7 @@ export class CollectionsService {
 	/**
 	 * Update multiple collections by name
 	 */
-	async updateMany(
-		collectionKeys: string[],
-		data: Partial<Collection> | Partial<Collection>[],
-		opts?: MutationOptions
-	): Promise<string[]> {
+	async updateMany(collectionKeys: string[], data: Partial<Collection>, opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException();
 		}
@@ -356,14 +352,8 @@ export class CollectionsService {
 					knex: trx,
 				});
 
-				if (Array.isArray(data)) {
-					for (const [index, collectionKey] of collectionKeys.entries()) {
-						await service.updateOne(collectionKey, data[index], { autoPurgeCache: false });
-					}
-				} else {
-					for (const collectionKey of collectionKeys) {
-						await service.updateOne(collectionKey, data, { autoPurgeCache: false });
-					}
+				for (const collectionKey of collectionKeys) {
+					await service.updateOne(collectionKey, data, { autoPurgeCache: false });
 				}
 			});
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -339,7 +339,7 @@ export class CollectionsService {
 	/**
 	 * Update multiple collections by name
 	 */
-	async updateMany(collectionKeys: string[], data: Partial<Collection>, opts?: MutationOptions): Promise<string[]> {
+	async updateMany(collectionKeys: string[], data: Partial<Collection> | Partial<Collection>[], opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenException();
 		}
@@ -352,8 +352,14 @@ export class CollectionsService {
 					knex: trx,
 				});
 
-				for (const collectionKey of collectionKeys) {
-					await service.updateOne(collectionKey, data, { autoPurgeCache: false });
+				if (Array.isArray(data)) {
+					for (const [index, collectionKey] of collectionKeys.entries()) {
+						await service.updateOne(collectionKey, data[index], { autoPurgeCache: false });
+					}
+				} else {
+					for (const collectionKey of collectionKeys) {
+						await service.updateOne(collectionKey, data, { autoPurgeCache: false });
+					}
 				}
 			});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -382,7 +382,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		// Run all hooks that are attached to this event so the end user has the chance to augment the
 		// item that is about to be saved
 
-		const payloadAfterHooks = payload;
+		let payloadAfterHooks = payload;
 
 		if (opts?.emitEvents !== false) {
 			const eventName =
@@ -395,7 +395,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			};
 
 			if (isArrayPayload) {
-				await Promise.all(
+				payloadAfterHooks = await Promise.all(
 					payload.map((payload, index) =>
 						emitter.emitFilter(
 							eventName,
@@ -409,7 +409,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					)
 				);
 			} else {
-				await emitter.emitFilter(
+				payloadAfterHooks = await emitter.emitFilter(
 					eventName,
 					payload,
 					{

--- a/api/tests/services/items.test.ts
+++ b/api/tests/services/items.test.ts
@@ -28,6 +28,55 @@ describe('Integration Tests', () => {
 		tracker.reset();
 	});
 
+	describe('updateMany', () => {
+		it.each(Object.keys(schemas))(
+			`%s updates many items with single payload in collection as an admin, accountability: "null"`,
+			async (schema) => {
+				const table = schemas[schema].tables[0];
+				const ids = [1, 2];
+				const payload = { name: 'foo' };
+
+				const itemsService = new ItemsService(table, {
+					knex: db,
+					accountability: { role: 'admin', admin: true },
+					schema: schemas[schema].schema,
+				});
+
+				tracker.on.update(table).responseOnce(payload);
+
+				const response = await itemsService.updateMany(ids, payload, { emitEvents: false });
+
+				expect(tracker.history.update.length).toBe(1);
+				expect(tracker.history.update[0].bindings).toStrictEqual([payload.name, ...ids]);
+				expect(response).toBe(ids);
+			}
+		);
+
+		it.each(Object.keys(schemas))(
+			`%s updates many items with many payloads in collection as an admin, accountability: "null"`,
+			async (schema) => {
+				const table = schemas[schema].tables[0];
+				const ids = [1, 2];
+				const payloads = [{ name: 'foo' }, { name: 'bar' }];
+
+				const itemsService = new ItemsService(table, {
+					knex: db,
+					accountability: { role: 'admin', admin: true },
+					schema: schemas[schema].schema,
+				});
+
+				tracker.on.update(table).response(payloads);
+
+				const response = await itemsService.updateMany(ids, payloads, { emitEvents: false });
+
+				expect(tracker.history.update.length).toBe(2);
+				expect(tracker.history.update[0].bindings).toStrictEqual([payloads[0].name, ids[0]]);
+				expect(tracker.history.update[1].bindings).toStrictEqual([payloads[1].name, ids[1]]);
+				expect(response).toBe(ids);
+			}
+		);
+	});
+
 	describe('createOne', () => {
 		const item = { id: '6107c897-9182-40f7-b22e-4f044d1258d2', name: 'A.G.' };
 


### PR DESCRIPTION
Hi! I was a bit confused when it came to updating multiple items with multiple payloads in a single transaction because according to the docs, one should be able to use an "[an array of partial item objects](https://docs.directus.io/reference/items/#request-body-4)" but the `updateMany` method does not accept arrays.

This PR provides the possibility to use either a single object to update all items with the same properties, or an array of objects to modify each item individually. I hope that makes sense, let me know if I should add tests/docs myself and thanks for your amazing work 🙂