### PR TITLE
Able to search for a value in a json type field

### DIFF
--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -39,7 +39,7 @@ export function getFilterOperatorsForType(
 		case 'uuid':
 			return ['eq', 'neq', 'null', 'nnull', 'in', 'nin'];
 		case 'json':
-			return ['null', 'nnull'];
+			return ['contains', 'ncontains', 'null', 'nnull'];
 
 		// Boolean
 		case 'boolean':


### PR DESCRIPTION
Since it is basically a json string at DB level it is possible to search and filter on JSON type fields.

This is a lot more handy rather than just being able to search for null or not null.