### PR TITLE
Fix snapshot output

### DIFF
--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -131,7 +131,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 				}
 			}
 
-			message += 'The following changes will be applied:\n\n' + chalk.black(message);
+			message = 'The following changes will be applied:\n\n' + chalk.black(message);
 			if (dryRun) {
 				logger.info(message);
 				process.exit(0);


### PR DESCRIPTION
## Before

Noticed the `The following changes will be applied` message is getting appended to the parent directly:

![WindowsTerminal_MYIZtFRnn6](https://user-images.githubusercontent.com/42867097/161712608-0f6d3ca3-6606-4ebd-9f68-1d9f59e187c9.png)

On second glance it's due to the message itself is being repeated twice. #12006 moved `'The following changes will be applied:\n\n' + chalk.black(message);` up from the prompt below, but this meant we should use `=` instead of `+=` since `chalk.black(message)` already is the whole message.

## After

![WindowsTerminal_F8lS6i5nv8](https://user-images.githubusercontent.com/42867097/161712918-47e3ccd4-6db3-4801-96e9-6494d11f7aea.png)

