### PR TITLE
Fix batch editing for fields in groups

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -319,11 +319,13 @@ export default defineComponent({
 		}
 
 		function apply(updates: { [field: string]: any }) {
-			const updatableKeys = Object.keys(updates).filter((key) => {
-				const field = props.fields?.find((field) => field.field === key);
-				if (!field) return false;
-				return field.schema?.is_primary_key || !isDisabled(field);
-			});
+			const updatableKeys = props.batchMode
+				? Object.keys(updates)
+				: Object.keys(updates).filter((key) => {
+						const field = props.fields?.find((field) => field.field === key);
+						if (!field) return false;
+						return field.schema?.is_primary_key || !isDisabled(field);
+				  });
 
 			emit('update:modelValue', pick(assign({}, props.modelValue, updates), updatableKeys));
 		}


### PR DESCRIPTION
Fixes #12258

## Before

We are not able to batch edit fields that are within groups:

https://user-images.githubusercontent.com/42867097/161764539-321777ac-d642-465e-9526-06f5e6f7c26d.mp4

## Investigation

#12216 Changed the `apply()` function (which are emitted by groups) from this:

https://github.com/directus/directus/blob/5a77ac2f301357cb154cb05305745712c9389bea/app/src/components/v-form/v-form.vue#L315-L317

to this to prevent updates to disabled fields:

https://github.com/directus/directus/blob/0930c2df97b480ad0d12dc8f1672360aa9d04e1f/app/src/components/v-form/v-form.vue#L321-L329

However since there is a `props.fields` check in the filter, and batch editing specifically does not actually pass fields prop:

https://github.com/directus/directus/blob/0930c2df97b480ad0d12dc8f1672360aa9d04e1f/app/src/views/private/components/drawer-batch/drawer-batch.vue#L15-L21

so this check will always fail, thus prevent editing when we are in batch edit mode.

## Solution

Essentially reverts back to the original interaction _only when_ it is in batch mode.

## After

https://user-images.githubusercontent.com/42867097/161764674-96d15995-606d-4cbd-8110-ba9eb34525cc.mp4


