### PR TITLE
Allow adding items to the repeater interface if the (default) value is no array

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -1,10 +1,13 @@
 <template>
 	<div class="repeater">
-		<v-notice v-if="!value || value.length === 0">
+		<v-notice v-if="(Array.isArray(value) && value.length === 0) || value == null">
 			{{ placeholder }}
 		</v-notice>
+		<v-notice v-else-if="!Array.isArray(value)" type="warning">
+			<p>{{ t('interfaces.list.incompatible_data') }}</p>
+		</v-notice>
 
-		<v-list v-if="value && value.length > 0">
+		<v-list v-if="Array.isArray(value) && value.length > 0">
 			<draggable
 				:disabled="disabled"
 				:force-fallback="true"
@@ -260,9 +263,16 @@ export default defineComponent({
 				newDefaults[field.field!] = field.schema?.default_value;
 			});
 
-			if (props.value !== null) {
+			if (Array.isArray(props.value)) {
 				emitValue([...props.value, newDefaults]);
 			} else {
+				if (props.value != null) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						'The repeater interface expects an array as value, but the given value is no array. Overriding given value.'
+					);
+				}
+
 				emitValue([newDefaults]);
 			}
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1530,6 +1530,7 @@ interfaces:
     add_label: '"Create New" Label'
     field_name_placeholder: Enter field name...
     field_note_placeholder: Enter field note...
+    incompatible_data: The current data is not compatible with the repeater interface and will be overridden when adding items to the repeater
   slider:
     slider: Slider
     description: Select a number using a slider


### PR DESCRIPTION
Fixes #12584

Adding items to the repeater is now possible if the (default) value is no array. It also logs a warning to the console when clicking the "Create new" button to hint that the previous data is discarded.

In addition to the console warning, I also added a notice to indicate that the given data is not compatible with the repeater interface and will be overridden.
While I find it useful because it gives feedback to the user, I can also remove it again if you don't want it :)

![grafik](https://user-images.githubusercontent.com/16099891/161825477-1f4eebd8-0875-4940-a8d2-3a0abc445620.png)
