### PR TITLE
Add autofocus prop to input translated string

### DIFF
--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -5,6 +5,7 @@
 				<v-input
 					class="translation-input"
 					:model-value="localValue"
+					:autofocus="autofocus"
 					:placeholder="placeholder"
 					:disabled="disabled"
 					:active="active"
@@ -89,11 +90,17 @@ const translationPrefix = '$t:';
 
 interface Props {
 	value?: string | null;
+	autofocus?: boolean;
 	disabled?: boolean;
 	placeholder?: string | null;
 }
 
-const props = withDefaults(defineProps<Props>(), { value: () => null, disabled: false, placeholder: () => null });
+const props = withDefaults(defineProps<Props>(), {
+	value: () => null,
+	autofocus: false,
+	disabled: false,
+	placeholder: () => null,
+});
 
 const emit = defineEmits(['input']);
 


### PR DESCRIPTION
## Before

The translated string input is not focused when the drawer is open:

![chrome_acsLGC3kzl](https://user-images.githubusercontent.com/42867097/161909198-f6f31118-65ba-4ac3-9a2c-a8bcdd381184.gif)

## After

![chrome_PxhQQxNnXq](https://user-images.githubusercontent.com/42867097/161909214-bb5096ed-a16a-4894-b0e6-0a031fcff4d2.gif)

