### PR TITLE
Prevent boolean as string for filter value when switching from null/empty operators

### DIFF
--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -273,7 +273,12 @@ function updateComparator(index: number, operator: keyof FieldFilterOperator) {
 			}
 			break;
 		default:
-			update(Array.isArray(value) ? value[0] : value);
+			// avoid setting value as string 'true'/'false' when switching from null/empty operators
+			if (['_null', '_nnull', '_empty', '_nempty'].includes(nodeInfo.comparator)) {
+				update(null);
+			} else {
+				update(Array.isArray(value) ? value[0] : value);
+			}
 			break;
 	}
 


### PR DESCRIPTION
Closes #11919

## Before

When we switch from null/empty operators to string type operators, the filter value is being set as boolean in string format such as 'true' or 'false':

![chrome_8Xp0njbLh0](https://user-images.githubusercontent.com/42867097/161909771-8ba59575-b638-417b-b5f3-e4e6070522f0.gif)


## After

Clears the value when switching from null/empty operators:

![chrome_33Ambw5tG7](https://user-images.githubusercontent.com/42867097/161909763-8fd5c3a5-84ab-425e-a84f-3e474baa51ea.gif)
