### PR TITLE
Default filter operator to `eq` for field with choices

### DIFF
--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -130,15 +130,16 @@ function addNode(key: string) {
 		innerValue.value = innerValue.value.concat({ _and: [] });
 	} else {
 		let type: Type;
+		const field = fieldsStore.getField(collection.value, key);
 
 		if (key.includes('(') && key.includes(')')) {
 			const functionName = key.split('(')[0];
 			type = getOutputTypeForFunction(functionName);
 		} else {
-			const field = fieldsStore.getField(collection.value, key)!;
 			type = field?.type || 'unknown';
 		}
-		const operator = getFilterOperatorsForType(type)[0];
+		let filterOperators = getFilterOperatorsForType(type);
+		const operator = field?.meta?.options?.choices && filterOperators.includes('eq') ? 'eq' : filterOperators[0];
 		const node = set({}, key, { ['_' + operator]: null });
 		innerValue.value = innerValue.value.concat(node);
 	}

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -55,7 +55,7 @@
 
 <script lang="ts" setup>
 import { useFieldsStore } from '@/stores';
-import { Filter, Type } from '@directus/shared/types';
+import { Filter, Type, FieldFunction } from '@directus/shared/types';
 import { getFilterOperatorsForType, getOutputTypeForFunction } from '@directus/shared/utils';
 import { cloneDeep, get, isEmpty, set } from 'lodash';
 import { computed, inject, ref } from 'vue';
@@ -133,7 +133,7 @@ function addNode(key: string) {
 		const field = fieldsStore.getField(collection.value, key);
 
 		if (key.includes('(') && key.includes(')')) {
-			const functionName = key.split('(')[0];
+			const functionName = key.split('(')[0] as FieldFunction;
 			type = getOutputTypeForFunction(functionName);
 		} else {
 			type = field?.type || 'unknown';


### PR DESCRIPTION
## Before

Ref #12542, field with choices are still defaulting to `contains` but that operator does not show the dropdown for available choices:

![chrome_vPiIyEAajd](https://user-images.githubusercontent.com/42867097/161926827-bd896752-4e01-4c0e-b626-6df45ff67707.gif)

## After

Uses the same logic used here to determine whether there are choices:

https://github.com/directus/directus/blob/c2cd010eec120f308e3ce43b181200cdf55bda6b/app/src/interfaces/_system/system-filter/input-group.vue#L148

![chrome_J1ulPWC47L](https://user-images.githubusercontent.com/42867097/161926806-49f2b429-6d3e-4a43-881f-d5424c18bc66.gif)
