### PR TITLE
Check create & update permissions for M2O field

### DIFF
--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -29,11 +29,23 @@
 
 					<template v-if="!disabled" #append>
 						<template v-if="currentItem">
-							<v-icon v-tooltip="t('edit')" name="open_in_new" class="edit" @click.stop="editModalActive = true" />
+							<v-icon
+								v-if="updateAllowed"
+								v-tooltip="t('edit')"
+								name="open_in_new"
+								class="edit"
+								@click.stop="editModalActive = true"
+							/>
 							<v-icon v-tooltip="t('deselect')" name="close" class="deselect" @click.stop="$emit('input', null)" />
 						</template>
 						<template v-else>
-							<v-icon v-tooltip="t('create_item')" class="add" name="add" @click.stop="editModalActive = true" />
+							<v-icon
+								v-if="createAllowed"
+								v-tooltip="t('create_item')"
+								class="add"
+								name="add"
+								@click.stop="editModalActive = true"
+							/>
 							<v-icon class="expand" :class="{ active }" name="expand_more" />
 						</template>
 					</template>
@@ -89,7 +101,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed, ref, toRefs, watch, PropType, inject } from 'vue';
-import { useCollectionsStore, useRelationsStore } from '@/stores/';
+import { useCollectionsStore, useRelationsStore, usePermissionsStore, useUserStore } from '@/stores/';
 import { useCollection } from '@directus/shared/composables';
 import { getFieldsFromTemplate } from '@directus/shared/utils';
 import api from '@/api';
@@ -165,6 +177,7 @@ export default defineComponent({
 
 		const relationsStore = useRelationsStore();
 		const collectionsStore = useCollectionsStore();
+		const { hasPermission } = usePermissionsStore();
 
 		const { relation, relatedCollection, relatedPrimaryKeyField } = useRelation();
 		const { usesMenu, menuActive } = useMenu();
@@ -176,6 +189,8 @@ export default defineComponent({
 		const { setCurrent, currentItem, loading: loadingCurrent, currentPrimaryKey } = useCurrent();
 
 		const { edits, stageEdits } = useEdits();
+
+		const { createAllowed, updateAllowed } = usePermissions();
 
 		const editModalActive = ref(false);
 
@@ -203,6 +218,8 @@ export default defineComponent({
 			editModalActive,
 			relatedPrimaryKeyField,
 			customFilter,
+			createAllowed,
+			updateAllowed,
 		};
 
 		function useCurrent() {
@@ -487,6 +504,20 @@ export default defineComponent({
 
 				currentItem.value = merge({}, currentItem.value, newEdits);
 			}
+		}
+
+		function usePermissions() {
+			const createAllowed = computed(() => {
+				if (!relatedCollection.value) return false;
+				return hasPermission(relatedCollection.value.collection, 'create');
+			});
+
+			const updateAllowed = computed(() => {
+				if (!relatedCollection.value) return false;
+				return hasPermission(relatedCollection.value.collection, 'update');
+			});
+
+			return { createAllowed, updateAllowed };
 		}
 	},
 });

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -101,7 +101,7 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed, ref, toRefs, watch, PropType, inject } from 'vue';
-import { useCollectionsStore, useRelationsStore, usePermissionsStore, useUserStore } from '@/stores/';
+import { useCollectionsStore, useRelationsStore, usePermissionsStore } from '@/stores/';
 import { useCollection } from '@directus/shared/composables';
 import { getFieldsFromTemplate } from '@directus/shared/utils';
 import api from '@/api';


### PR DESCRIPTION
Fixes #12602

Additionally added update permissions check to hide the edit button.

## Before

We can still create M2O item with the `+` icon being visible, but the API correctly denies it:

https://user-images.githubusercontent.com/42867097/162121246-61f0d49b-13d5-4f7a-bf32-e67257b6e440.mp4

## After

### With no create and no update permission

https://user-images.githubusercontent.com/42867097/162121384-b232bbc4-55bc-4898-8e26-59936df66b39.mp4

### With no create but with has update permission

https://user-images.githubusercontent.com/42867097/162121485-8f95537f-22a2-485e-9b84-6e3462dc34fd.mp4


