### PR TITLE
fix M2M and M2A drawer item validation

### DIFF
--- a/app/src/views/private/components/drawer-item/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item/drawer-item.vue
@@ -135,7 +135,7 @@ export default defineComponent({
 
 		const { info: collectionInfo } = useCollection(collection);
 
-		const isNew = computed(() => props.primaryKey === '+');
+		const isNew = computed(() => props.primaryKey === '+' && props.relatedPrimaryKey === '+');
 
 		const title = computed(() => {
 			const collection = junctionRelatedCollectionInfo?.value || collectionInfo.value!;


### PR DESCRIPTION
Fixes #12599

## Before

https://user-images.githubusercontent.com/42867097/162398281-805e201e-ebf3-44ed-b214-9079c5f865af.mp4

## Investigation

M2M and M2A additionally passed `relatedPrimaryKey` prop:

https://github.com/directus/directus/blob/069e5eae1610cfbd6028f905dd94a860287e5a2d/app/src/interfaces/list-m2m/list-m2m.vue#L59-L60

https://github.com/directus/directus/blob/069e5eae1610cfbd6028f905dd94a860287e5a2d/app/src/interfaces/list-m2a/list-m2a.vue#L129-L130

So the `isNew` computed property should also take `relatedPrimaryKey === '+'` into account.

## After

https://user-images.githubusercontent.com/42867097/162398291-94ee8c10-c02f-4385-bf7b-c3327a863591.mp4


