### PR TITLE
Fix M2A editing of new but unsaved items

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -557,26 +557,31 @@ export default defineComponent({
 			function stageEdits(edits: Record<string, any>) {
 				const currentValue = props.value || [];
 
-				// Whether or not the currently-being-edited item exists in the staged values
-				const hasBeenStaged =
-					currentValue.includes(editsAtStart.value) || currentValue.includes(currentlyEditing.value);
+				const newValue = currentValue.map((item) => {
+					if (
+						typeof item === 'object' &&
+						item[anyRelation.value.meta!.one_collection_field!] ===
+							edits[anyRelation.value.meta!.one_collection_field!] &&
+						item[anyRelation.value.field] ===
+							edits[anyRelation.value.field][primaryKeys.value[edits[anyRelation.value.meta!.one_collection_field!]]]
+					) {
+						return edits;
+					} else if (['number', 'string'].includes(typeof item)) {
+						if (item === edits[o2mRelationPrimaryKeyField.value]) return edits;
+					}
+
+					return item;
+				});
 
 				// Whether or not the currently-being-edited item has been saved to the database
 				const isNew = currentlyEditing.value === '+' && relatedPrimaryKey.value === '+';
 
-				if (isNew && hasBeenStaged === false) {
-					emit('input', [...currentValue, edits]);
-				} else {
-					emit(
-						'input',
-						currentValue.map((val) => {
-							if (val === editsAtStart.value || val == currentlyEditing.value) {
-								return edits;
-							}
-							return val;
-						})
-					);
+				if (isNew) {
+					newValue.push(edits);
 				}
+
+				if (newValue.length === 0) emit('input', null);
+				else emit('input', newValue);
 			}
 
 			function cancelEdit() {
@@ -620,9 +625,16 @@ export default defineComponent({
 
 				if (isPlainObject(relatedKey)) {
 					relatedKey = item[anyRelation.value.field][primaryKeys.value[relatedCollectiom]];
+					editsAtStart.value = item;
+				} else {
+					editsAtStart.value = {
+						[anyRelation.value.meta!.one_collection_field!]: relatedCollectiom,
+						[anyRelation.value.field]: {
+							[o2mRelationPrimaryKeyField.value]: relatedKey,
+						},
+					};
 				}
 
-				editsAtStart.value = item;
 				relatedPrimaryKey.value = relatedKey || '+';
 				currentlyEditing.value = junctionPrimaryKey || '+';
 			}

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -630,7 +630,7 @@ export default defineComponent({
 					editsAtStart.value = {
 						[anyRelation.value.meta!.one_collection_field!]: relatedCollectiom,
 						[anyRelation.value.field]: {
-							[o2mRelationPrimaryKeyField.value]: relatedKey,
+							[primaryKeys.value[relatedCollectiom]]: relatedKey,
 						},
 					};
 				}


### PR DESCRIPTION
Fixes #12603

## Before

https://user-images.githubusercontent.com/42867097/162400174-1fa18f94-048d-4600-b5dc-241feee12c7b.mp4

## Investigation

`<drawer-item>` receives `editsAtStart` as the edit value:

https://github.com/directus/directus/blob/069e5eae1610cfbd6028f905dd94a860287e5a2d/app/src/interfaces/list-m2a/list-m2a.vue#L132

However when editing a new but unsaved item, only the id itself gets passed as `editsAtStart`:

https://github.com/directus/directus/blob/069e5eae1610cfbd6028f905dd94a860287e5a2d/app/src/interfaces/list-m2a/list-m2a.vue#L625

Hence the form's model value is just the id itself, rather than an object with fields, thus breaking the editing:

![chrome_hkrnDmpQQ7](https://user-images.githubusercontent.com/42867097/162403613-68768acf-105c-4a72-baa0-f3378b066492.png)

## After

https://user-images.githubusercontent.com/42867097/162402455-66e01ebc-43b5-457f-ba95-3aef0f6418d7.mp4


