### PR TITLE
add missing query parameters in SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52779,6 +52779,7 @@
 			"version": "9.8.0",
 			"license": "MIT",
 			"dependencies": {
+				"@directus/shared": "9.8.0",
 				"axios": "^0.24.0"
 			},
 			"devDependencies": {
@@ -56023,6 +56024,7 @@
 		"@directus/sdk": {
 			"version": "file:packages/sdk",
 			"requires": {
+				"@directus/shared": "9.8.0",
 				"@rollup/plugin-commonjs": "21.0.1",
 				"@rollup/plugin-json": "4.1.0",
 				"@rollup/plugin-node-resolve": "13.1.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,6 +47,7 @@
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"license": "MIT",
 	"dependencies": {
+		"@directus/shared": "9.8.0",
 		"axios": "^0.24.0"
 	},
 	"devDependencies": {

--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -1,5 +1,6 @@
 import { TransportRequestOptions } from './transport';
 import { ID } from './types';
+import { Aggregate as SharedAggregate } from '@directus/shared/types';
 
 export type Field = string;
 
@@ -42,10 +43,21 @@ export type QueryMany<T> = QueryOne<T> & {
 	offset?: number;
 	page?: number;
 	meta?: keyof ItemMetadata | '*';
+	groupBy?: string | string[];
+	aggregate?: Aggregate;
+	alias?: Record<string, string>;
 };
 
 export type DeepQueryMany<T> = {
-	[K in keyof QueryMany<T> as `_${string & K}`]: QueryMany<T>[K];
+	[K in keyof Omit<QueryMany<T>, 'aggregate'> as `_${string & K}`]: QueryMany<T>[K];
+} & {
+	_aggregate?: {
+		[A in keyof Aggregate as `_${string & A}`]: Aggregate[A];
+	};
+};
+
+export type Aggregate = {
+	[K in keyof SharedAggregate]: string;
 };
 
 export type Sort<T> = (`${Extract<keyof T, string>}` | `-${Extract<keyof T, string>}`)[];


### PR DESCRIPTION
Fixes directus/directus#11870

- Added `alias`, `aggregate` and `groupBy`:

   ![Code_zEuaV3Edqm](https://user-images.githubusercontent.com/42867097/162415090-03e27671-6334-49e6-a541-1ab598d5459a.png)
   
- Reused Aggregate type from `@directus/shared/types` for `aggregate` query:

   ![Code_5cTepU0dao](https://user-images.githubusercontent.com/42867097/162415269-83884542-27ce-4daf-8e17-a54ab274c13f.png)

