### PR TITLE
Await when token is refreshing & reinstate `msRefreshBeforeExpires` flag

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -173,7 +173,7 @@ const directus = new Directus(url, init);
 
     - `autoRefresh` [optional] _Boolean_ - Tells SDK if it should handle refresh tokens automatically. Defaults to
       `true`.
-	- `msRefreshBeforeExpires` [optional] _Number_ - When `autoRefresh` is enabled, this tells how many milliseconds
+    - `msRefreshBeforeExpires` [optional] _Number_ - When `autoRefresh` is enabled, this tells how many milliseconds
       before the refresh token expires and needs to be refreshed. Defaults to `30000`.
     - `staticToken` [optional] _String_ - Defines the static token to use. It is not compatible with the options above
       since it does not refresh. Defaults to `''` (no static token).

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -173,6 +173,8 @@ const directus = new Directus(url, init);
 
     - `autoRefresh` [optional] _Boolean_ - Tells SDK if it should handle refresh tokens automatically. Defaults to
       `true`.
+	- `msRefreshBeforeExpires` [optional] _Number_ - When `autoRefresh` is enabled, this tells how many milliseconds
+      before the refresh token expires and needs to be refreshed. Defaults to `30000`.
     - `staticToken` [optional] _String_ - Defines the static token to use. It is not compatible with the options above
       since it does not refresh. Defaults to `''` (no static token).
 

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -23,6 +23,7 @@ export type AuthMode = 'json' | 'cookie';
 export type AuthOptions = {
 	mode?: AuthMode;
 	autoRefresh?: boolean;
+	msRefreshBeforeExpires?: number
 	staticToken?: string;
 	transport: ITransport;
 	storage: IStorage;

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -23,7 +23,7 @@ export type AuthMode = 'json' | 'cookie';
 export type AuthOptions = {
 	mode?: AuthMode;
 	autoRefresh?: boolean;
-	msRefreshBeforeExpires?: number
+	msRefreshBeforeExpires?: number;
 	staticToken?: string;
 	transport: ITransport;
 	storage: IStorage;

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -11,6 +11,7 @@ export type AuthStorage<T extends AuthTokenType = 'DynamicToken'> = {
 
 export class Auth extends IAuth {
 	autoRefresh = true;
+	msRefreshBeforeExpires = 30000;
 	staticToken = '';
 
 	private _storage: IStorage;
@@ -27,6 +28,7 @@ export class Auth extends IAuth {
 
 		this.autoRefresh = options?.autoRefresh ?? this.autoRefresh;
 		this.mode = options?.mode ?? this.mode;
+		this.msRefreshBeforeExpires = options?.msRefreshBeforeExpires ?? this.msRefreshBeforeExpires;
 
 		if (options?.staticToken) {
 			this.staticToken = options?.staticToken;
@@ -74,7 +76,7 @@ export class Auth extends IAuth {
 			return;
 		}
 
-		if (this._storage.auth_expires_at < new Date().getTime()) {
+		if (this._storage.auth_expires_at < new Date().getTime() + this.msRefreshBeforeExpires) {
 			this._refreshPromise = this.refresh();
 		}
 		await this._refreshPromise; // wait for refresh

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -18,7 +18,7 @@ export class Auth extends IAuth {
 	private _transport: ITransport;
 	private passwords?: PasswordsHandler;
 
-	private _refreshPromise?: Promise<false | AuthResult>;
+	private _refreshPromise?: Promise<AuthResult | false>;
 
 	constructor(options: AuthOptions) {
 		super();

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -17,7 +17,7 @@ export class Auth extends IAuth {
 	private _storage: IStorage;
 	private _transport: ITransport;
 	private passwords?: PasswordsHandler;
-	
+
 	private _refreshPromise?: Promise<false | AuthResult>;
 
 	constructor(options: AuthOptions) {

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -92,8 +92,6 @@ export class Auth extends IAuth {
 
 		this.updateStorage<'DynamicToken'>(response.data!);
 
-		if (this.autoRefresh) this.refreshIfExpired();
-
 		return {
 			access_token: response.data!.access_token,
 			refresh_token: response.data?.refresh_token,
@@ -111,8 +109,6 @@ export class Auth extends IAuth {
 		);
 
 		this.updateStorage(response.data!);
-
-		if (this.autoRefresh) this.refreshIfExpired();
 
 		return {
 			access_token: response.data!.access_token,

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -70,7 +70,7 @@ export class Auth extends IAuth {
 		if (!this.autoRefresh) return;
 		if (!this._storage.auth_expires_at) {
 			// wait because resetStorage() call in refresh()
-		        await this._refreshPromise;
+			await this._refreshPromise;
 			return;
 		}
 

--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -94,7 +94,7 @@ export class Auth extends IAuth {
 
 		return {
 			access_token: response.data!.access_token,
-			refresh_token: response.data?.refresh_token,
+			...(response.data?.refresh_token && { refresh_token: response.data.refresh_token }),
 			expires: response.data!.expires,
 		};
 	}
@@ -112,7 +112,7 @@ export class Auth extends IAuth {
 
 		return {
 			access_token: response.data!.access_token,
-			refresh_token: response.data?.refresh_token,
+			...(response.data?.refresh_token && { refresh_token: response.data.refresh_token }),
 			expires: response.data!.expires,
 		};
 	}

--- a/packages/sdk/tests/base/auth.node.test.ts
+++ b/packages/sdk/tests/base/auth.node.test.ts
@@ -42,6 +42,7 @@ describe('auth (node)', function () {
 					data: {
 						access_token: 'auth_token',
 						refresh_token: 'json_refresh_token',
+						expires: 60000,
 					},
 				},
 				{


### PR DESCRIPTION
Fix #12648

Refer discussion #12636. 

## Changes

- A reference to the refresh promise is used to wait in `refreshIfExpired()`.
- Re-added `msRefreshBeforeExpires` option.
- Removed nested refresh calls in `refresh()` and `login()`.
- Do not return `refresh_token` property when it does not exist to prevent potential confusion. Mentioned in https://github.com/directus/directus/issues/12427#issuecomment-1086604045.
