### PR TITLE
add citext as a supported local type

### DIFF
--- a/api/src/utils/get-local-type.ts
+++ b/api/src/utils/get-local-type.ts
@@ -94,6 +94,7 @@ const localTypeMap: Record<string, Type | 'unknown'> = {
 	'time without time zone': 'time',
 	float4: 'float',
 	float8: 'float',
+	citext: 'text',
 
 	// Oracle
 	number: 'integer',


### PR DESCRIPTION
Closes #12658

Uses `text` based on the [citext module docs](https://www.postgresql.org/docs/current/citext.html):

> The `citext` module provides a case-insensitive character string type, `citext`. Essentially, it internally calls `lower` when comparing values. Otherwise, it behaves almost exactly like `text`.

## Before

https://user-images.githubusercontent.com/42867097/162681469-5663c933-2226-4472-84ef-eb846ed1f8a2.mp4

## After

https://user-images.githubusercontent.com/42867097/162681497-811722b0-c174-4769-8f6a-20a369e88106.mp4


