### PR TITLE
Reset existing image error after replacing it

### DIFF
--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -167,6 +167,7 @@ const { edits, stageEdits } = useEdits();
 
 async function fetchImage() {
 	loading.value = true;
+	imageError.value = null;
 
 	try {
 		const id = typeof props.value === 'string' ? props.value : props.value?.id;

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -278,6 +278,7 @@ img {
 	height: 100%;
 	color: var(--foreground-subdued);
 	background-color: var(--background-normal);
+	padding: 32px;
 
 	.v-icon {
 		margin-bottom: 6px;


### PR DESCRIPTION
Fixes #12431

Additionally added extra padding to `.image-error` class so that the error icon & message won't be edge-to-edge to the container.

## Before

After getting the error "Image source too large to preview", replacing it with a smaller image still shows the same error:

https://user-images.githubusercontent.com/42867097/162912386-6ddbbcb3-c657-4c88-9da6-72675a9c6229.mp4

## Investigation

The `imageError` ref was not reset on new image fetches or replace, thus the error always persists until page refresh. 

## After

https://user-images.githubusercontent.com/42867097/162912429-8ab283e6-3306-46b8-b834-76a36de781cb.mp4




