### PR TITLE
Fix primitive values for JSON code input

### DIFF
--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -135,7 +135,7 @@ export default defineComponent({
 		);
 
 		watch(stringValue, () => {
-			// prevent redundant stringify caused by setValue (on change event) when same value
+			// prevent setting redundantly stringified json value when it's actually the same value
 			if (props.type === 'json' && codemirror?.getValue() === props.value) return;
 
 			if (codemirror?.getValue() !== stringValue.value) {

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -37,7 +37,7 @@ export default defineComponent({
 			default: false,
 		},
 		value: {
-			type: [String, Object, Array] as PropType<string | Record<string, any> | any[]>,
+			type: [String, Object, Array, Number, Boolean] as PropType<string | Record<string, any> | any[]>,
 			default: null,
 		},
 		altOptions: {
@@ -104,7 +104,9 @@ export default defineComponent({
 						}
 
 						try {
-							emit('input', JSON.parse(content));
+							const parsedJson = JSON.parse(content);
+							if (typeof parsedJson !== 'string') return emit('input', parsedJson);
+							return emit('input', content);
 						} catch {
 							// We won't stage invalid JSON
 						}
@@ -118,7 +120,7 @@ export default defineComponent({
 		const stringValue = computed<string>(() => {
 			if (props.value === null) return '';
 
-			if (typeof props.value === 'object') {
+			if (props.type === 'json' || typeof props.value === 'object') {
 				return JSON.stringify(props.value, null, 4);
 			}
 
@@ -133,6 +135,9 @@ export default defineComponent({
 		);
 
 		watch(stringValue, () => {
+			// prevent redundant stringify caused by setValue (on change event) when same value
+			if (props.type === 'json' && codemirror?.getValue() === props.value) return;
+
 			if (codemirror?.getValue() !== stringValue.value) {
 				codemirror?.setValue(stringValue.value || '');
 			}


### PR DESCRIPTION
Fixes #11098

## Before

Entering string will be rendered wrongly since it is not escaped, additionally it will fail when it's submitted. The same issue for other primitive values even though they are valid JSON value:

https://user-images.githubusercontent.com/42867097/162950996-ecfa1763-8098-43ad-867d-0f1d8f6abb9d.mp4

## After

https://user-images.githubusercontent.com/42867097/162951013-fcc4d9ef-e832-40fc-af7e-ba036e8ac846.mp4


