### PR TITLE
Fix schema apply for changes in field meta options & display_options

### DIFF
--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -8,7 +8,7 @@ import logger from '../../../logger';
 import { Snapshot } from '../../../types';
 import { getSnapshot } from '../../../utils/get-snapshot';
 import { getSnapshotDiff } from '../../../utils/get-snapshot-diff';
-import { applySnapshot, isUpdateFieldMetaNested } from '../../../utils/apply-snapshot';
+import { applySnapshot, isNestedMetaUpdate } from '../../../utils/apply-snapshot';
 import { flushCaches } from '../../../cache';
 
 export async function apply(snapshotPath: string, options?: { yes: boolean; dryRun: boolean }): Promise<void> {
@@ -82,7 +82,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 				message += '\n\n' + chalk.black.underline.bold('Fields:');
 
 				for (const { collection, field, diff } of snapshotDiff.fields) {
-					if (diff[0]?.kind === 'E' || isUpdateFieldMetaNested(diff[0])) {
+					if (diff[0]?.kind === 'E' || isNestedMetaUpdate(diff[0])) {
 						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
 
 						for (const change of diff) {

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -8,7 +8,7 @@ import logger from '../../../logger';
 import { Snapshot } from '../../../types';
 import { getSnapshot } from '../../../utils/get-snapshot';
 import { getSnapshotDiff } from '../../../utils/get-snapshot-diff';
-import { applySnapshot, isUpdateFieldMetaOptions } from '../../../utils/apply-snapshot';
+import { applySnapshot, isUpdateFieldMetaNested } from '../../../utils/apply-snapshot';
 import { flushCaches } from '../../../cache';
 
 export async function apply(snapshotPath: string, options?: { yes: boolean; dryRun: boolean }): Promise<void> {
@@ -82,7 +82,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 				message += '\n\n' + chalk.black.underline.bold('Fields:');
 
 				for (const { collection, field, diff } of snapshotDiff.fields) {
-					if (diff[0]?.kind === 'E' || isUpdateFieldMetaOptions(diff[0])) {
+					if (diff[0]?.kind === 'E' || isUpdateFieldMetaNested(diff[0])) {
 						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
 
 						for (const change of diff) {

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -8,7 +8,7 @@ import logger from '../../../logger';
 import { Snapshot } from '../../../types';
 import { getSnapshot } from '../../../utils/get-snapshot';
 import { getSnapshotDiff } from '../../../utils/get-snapshot-diff';
-import { applySnapshot } from '../../../utils/apply-snapshot';
+import { applySnapshot, isUpdateFieldMetaOptions } from '../../../utils/apply-snapshot';
 import { flushCaches } from '../../../cache';
 
 export async function apply(snapshotPath: string, options?: { yes: boolean; dryRun: boolean }): Promise<void> {
@@ -82,13 +82,17 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 				message += '\n\n' + chalk.black.underline.bold('Fields:');
 
 				for (const { collection, field, diff } of snapshotDiff.fields) {
-					if (diff[0]?.kind === 'E') {
+					if (diff[0]?.kind === 'E' || isUpdateFieldMetaOptions(diff[0])) {
 						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
 
 						for (const change of diff) {
+							const path = change.path!.slice(1).join('.');
 							if (change.kind === 'E') {
-								const path = change.path!.slice(1).join('.');
 								message += `\n    - Set ${path} to ${change.rhs}`;
+							} else if (change.kind === 'D') {
+								message += `\n    - Remove ${path}`;
+							} else if (change.kind === 'N') {
+								message += `\n    - Add ${path} and set it to ${change.rhs}`;
 							}
 						}
 					} else if (diff[0]?.kind === 'D') {

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -74,7 +74,7 @@ export async function applySnapshot(
 		const fieldsService = new FieldsService({ knex: trx, schema: await getSchema({ database: trx }) });
 
 		for (const { collection, field, diff } of snapshotDiff.fields) {
-			if (diff?.[0].kind === 'N' && !isUpdateFieldMetaNested(diff?.[0])) {
+			if (diff?.[0].kind === 'N' && !isNestedMetaUpdate(diff?.[0])) {
 				try {
 					await fieldsService.createField(collection, (diff[0] as DiffNew<Field>).rhs);
 				} catch (err) {
@@ -83,7 +83,7 @@ export async function applySnapshot(
 				}
 			}
 
-			if (diff?.[0].kind === 'E' || diff?.[0].kind === 'A' || isUpdateFieldMetaNested(diff?.[0])) {
+			if (diff?.[0].kind === 'E' || diff?.[0].kind === 'A' || isNestedMetaUpdate(diff?.[0])) {
 				const newValues = snapshot.fields.find((snapshotField) => {
 					return snapshotField.collection === collection && snapshotField.field === field;
 				});
@@ -100,7 +100,7 @@ export async function applySnapshot(
 				}
 			}
 
-			if (diff?.[0].kind === 'D' && !isUpdateFieldMetaNested(diff?.[0])) {
+			if (diff?.[0].kind === 'D' && !isNestedMetaUpdate(diff?.[0])) {
 				try {
 					await fieldsService.deleteField(collection, field);
 				} catch (err) {
@@ -161,9 +161,9 @@ export async function applySnapshot(
 	});
 }
 
-export function isUpdateFieldMetaNested(diff: Diff<SnapshotField | undefined>): boolean {
+export function isNestedMetaUpdate(diff: Diff<SnapshotField | undefined>): boolean {
 	if (!diff) return false;
 	if (diff.kind !== 'N' && diff.kind !== 'D') return false;
-	if (!diff.path || diff.path.length < 2) return false;
-	return diff.path.join('.').startsWith('meta.options') || diff.path.join('.').startsWith('meta.display_options');
+	if (!diff.path || diff.path.length < 2 || diff.path[0] !== 'meta') return false;
+	return true;
 }

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -74,7 +74,7 @@ export async function applySnapshot(
 		const fieldsService = new FieldsService({ knex: trx, schema: await getSchema({ database: trx }) });
 
 		for (const { collection, field, diff } of snapshotDiff.fields) {
-			if (diff?.[0].kind === 'N' && !isUpdateFieldMetaOptions(diff?.[0])) {
+			if (diff?.[0].kind === 'N' && !isUpdateFieldMetaNested(diff?.[0])) {
 				try {
 					await fieldsService.createField(collection, (diff[0] as DiffNew<Field>).rhs);
 				} catch (err) {
@@ -83,7 +83,7 @@ export async function applySnapshot(
 				}
 			}
 
-			if (diff?.[0].kind === 'E' || diff?.[0].kind === 'A' || isUpdateFieldMetaOptions(diff?.[0])) {
+			if (diff?.[0].kind === 'E' || diff?.[0].kind === 'A' || isUpdateFieldMetaNested(diff?.[0])) {
 				const newValues = snapshot.fields.find((snapshotField) => {
 					return snapshotField.collection === collection && snapshotField.field === field;
 				});
@@ -100,7 +100,7 @@ export async function applySnapshot(
 				}
 			}
 
-			if (diff?.[0].kind === 'D' && !isUpdateFieldMetaOptions(diff?.[0])) {
+			if (diff?.[0].kind === 'D' && !isUpdateFieldMetaNested(diff?.[0])) {
 				try {
 					await fieldsService.deleteField(collection, field);
 				} catch (err) {
@@ -161,9 +161,9 @@ export async function applySnapshot(
 	});
 }
 
-export function isUpdateFieldMetaOptions(diff: Diff<SnapshotField | undefined>): boolean {
+export function isUpdateFieldMetaNested(diff: Diff<SnapshotField | undefined>): boolean {
 	if (!diff) return false;
 	if (diff.kind !== 'N' && diff.kind !== 'D') return false;
 	if (!diff.path || diff.path.length < 2) return false;
-	return diff.path.join('.').startsWith('meta.options');
+	return diff.path.join('.').startsWith('meta.options') || diff.path.join('.').startsWith('meta.display_options');
 }


### PR DESCRIPTION
Fixes #10518, fixes #10755

## Investigation

Seemingly modifying a field options is being applied as CREATE or DELETE the field instead of UPDATE.

After investigating the schema snapshots, landed on a quick brief test with the code below:

```js
import { diff } from 'deep-diff';

const current = {
	collection: 'products',
	field: 'related_categories',
	type: 'alias',
	meta: {
		options: {
			template: '{{categories_id.name}}',
		},
	},
};

const after = {
	collection: 'products',
	field: 'related_categories',
	type: 'alias',
	meta: {
		options: {
			enableSelect: false, // <<<<<----- this is the only difference
			template: '{{categories_id.name}}',
		},
	},
};
const result_add_option = diff(current, after);
const result_remove_option = diff(after, current);

console.log(result_add_option);
console.log(result_remove_option);

```

which yields the following result:

```js
[
  DiffNew {
    kind: 'N',
    path: [ 'meta', 'options', 'enableSelect' ],
    rhs: false
  }
]
[
  DiffDeleted {
    kind: 'D',
    path: [ 'meta', 'options', 'enableSelect' ],
    lhs: false
  }
]
```

We can see that when adding/removing field options, they are technically correct to be "kind" `N` (adding new property) or `D` (removing non-existent property), but they ended up being interpreted as CREATE/DELETE the whole field. The correct behaviour should be to UPDATE it's meta options.

## Before

### Addition of an option

![WindowsTerminal_9yLDhFDc4b](https://user-images.githubusercontent.com/42867097/163038199-6be3a6c6-e48b-40a3-b118-f9689c4483af.png)

Since the diff actually is not creating a new field, so the field is empty, this is why when it attempts to create a field with the value `false`, the FieldService.createOne method errors out trying to create it. This is what #10518 reported.

### Removal of an option

![WindowsTerminal_Ig3XYdhY44](https://user-images.githubusercontent.com/42867097/163038080-1499409b-f269-46e2-a772-04353c30aed2.png)

Although this is successful, it is incorrect as it is flat out deleting the whole field, which was what #10755 reported.

## After

### Addition of an option

![WindowsTerminal_5loWZMamzc](https://user-images.githubusercontent.com/42867097/163038739-9a0d9983-f808-443b-ad4d-3a4959f8985c.png)

### Removal of an option

![WindowsTerminal_Spf4d9153n](https://user-images.githubusercontent.com/42867097/163038731-0c461620-895c-4f0a-bf10-9ca6e74c4b08.png)

