### PR TITLE
Fix schema apply for CURRENT_TIMESTAMP default value

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -568,6 +568,7 @@ export class FieldsService {
 			) {
 				column.defaultTo(this.knex.fn.now());
 			} else if (
+				typeof field.schema.default_value === 'string' &&
 				field.schema.default_value.includes('CURRENT_TIMESTAMP(') &&
 				field.schema.default_value.includes(')')
 			) {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -20,6 +20,7 @@ import { isEqual, isNil } from 'lodash';
 import { RelationsService } from './relations';
 import { getHelpers, Helpers } from '../database/helpers';
 import Keyv from 'keyv';
+import { REGEX_BETWEEN_PARENS } from '@directus/shared/constants';
 
 export class FieldsService {
 	knex: Knex;
@@ -561,8 +562,17 @@ export class FieldsService {
 		}
 
 		if (field.schema?.default_value !== undefined) {
-			if (typeof field.schema.default_value === 'string' && field.schema.default_value.toLowerCase() === 'now()') {
+			if (
+				typeof field.schema.default_value === 'string' &&
+				(field.schema.default_value.toLowerCase() === 'now()' || field.schema.default_value === 'CURRENT_TIMESTAMP')
+			) {
 				column.defaultTo(this.knex.fn.now());
+			} else if (
+				field.schema.default_value.includes('CURRENT_TIMESTAMP(') &&
+				field.schema.default_value.includes(')')
+			) {
+				const precision = field.schema.default_value.match(REGEX_BETWEEN_PARENS)![1];
+				column.defaultTo(this.knex.fn.now(Number(precision)));
 			} else if (
 				typeof field.schema.default_value === 'string' &&
 				['"null"', 'null'].includes(field.schema.default_value.toLowerCase())


### PR DESCRIPTION
Fixes #12042

## Before

When the default value of a datetime/timestamp field is set as `CURRENT_TIMESTAMP` or `CURRENT_TIMESTAMP(N)` (`N` being the precision), it will attempt to as a string here and fails:

https://github.com/directus/directus/blob/34e7d2174af854f856cf244de23c377572cec234/api/src/services/fields.ts#L571-L573

![WindowsTerminal_6tBYNsLWMb](https://user-images.githubusercontent.com/42867097/163123824-b06c29e8-4fe5-49da-b24d-048448c2b41e.png)

## Solution used

Since knex's helper function `now()` is also using `CURRENT_TIMESTAMP` under the hood:

https://github.com/knex/knex/blob/f2a75277a779fd74688378fd904ed5631cf0c5d0/lib/knex-builder/FunctionHelper.js#L10-L15

Opted to check for the default value to match it as the string. Also uses similar logic in query functions to extract the precision if the default contains precision like `CURRENT_TIMESTAMP(4)`.

## After

![WindowsTerminal_mCpXznn1A1](https://user-images.githubusercontent.com/42867097/163123833-3168f42d-61e6-4f06-b98d-49f533a2d519.png)

