### PR TITLE
Added "json" to acceptedEnvTypes

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import { requireYAML } from './utils/require-yaml';
 import { toArray } from '@directus/shared/utils';
 
-const acceptedEnvTypes = ['string', 'number', 'regex', 'array'];
+const acceptedEnvTypes = ['string', 'number', 'regex', 'array', 'json'];
 
 const defaults: Record<string, any> = {
 	CONFIG_PATH: path.resolve(process.cwd(), '.env'),


### PR DESCRIPTION
Right now it's no longer possible to explicitly define an env var as a json which causes it to be cast to an array.