### PR TITLE
Adds x-directus-cache response header with HIT value

### DIFF
--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -14,7 +14,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 	if (!cache) return next();
 
 	if (req.headers['cache-control']?.includes('no-store') || req.headers['Cache-Control']?.includes('no-store')) {
-		if (env.CACHE_HEADER_KEY) res.setHeader(`${env.CACHE_HEADER_KEY}`, 'UNCACHEABLE');
+		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'UNCACHEABLE');
 		return next();
 	}
 
@@ -26,7 +26,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 		cachedData = await cache.get(key);
 	} catch (err: any) {
 		logger.warn(err, `[cache] Couldn't read key ${key}. ${err.message}`);
-		if (env.CACHE_HEADER_KEY) res.setHeader(`${env.CACHE_HEADER_KEY}`, 'MISS');
+		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'MISS');
 		return next();
 	}
 
@@ -37,7 +37,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 			cacheExpiryDate = (await cache.get(`${key}__expires_at`)) as number | null;
 		} catch (err: any) {
 			logger.warn(err, `[cache] Couldn't read key ${`${key}__expires_at`}. ${err.message}`);
-			if (env.CACHE_HEADER_KEY) res.setHeader(`${env.CACHE_HEADER_KEY}`, 'MISS');
+			if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'MISS');
 			return next();
 		}
 
@@ -45,11 +45,11 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 
 		res.setHeader('Cache-Control', getCacheControlHeader(req, cacheTTL));
 		res.setHeader('Vary', 'Origin, Cache-Control');
-		if (env.CACHE_HEADER_KEY) res.setHeader(`${env.CACHE_HEADER_KEY}`, 'HIT');
+		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'HIT');
 
 		return res.json(cachedData);
 	} else {
-		if (env.CACHE_HEADER_KEY) res.setHeader(`${env.CACHE_HEADER_KEY}`, 'MISS');
+		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'MISS');
 		return next();
 	}
 });

--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -42,6 +42,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 
 		res.setHeader('Cache-Control', getCacheControlHeader(req, cacheTTL));
 		res.setHeader('Vary', 'Origin, Cache-Control');
+		res.setHeader('x-directus-cache', 'HIT');
 
 		return res.json(cachedData);
 	} else {

--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -14,7 +14,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 	if (!cache) return next();
 
 	if (req.headers['cache-control']?.includes('no-store') || req.headers['Cache-Control']?.includes('no-store')) {
-		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'UNCACHEABLE');
+		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'MISS');
 		return next();
 	}
 

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -425,7 +425,7 @@ than you would cache database content. [Learn More](#assets)
 | `CACHE_PERMISSIONS`<sup>[3]</sup> | Whether or not the user permissions are cached. One of `false`, `true`                   | `true`           |
 | `CACHE_NAMESPACE`                 | How to scope the cache data.                                                             | `directus-cache` |
 | `CACHE_STORE`<sup>[4]</sup>       | Where to store the cache data. Either `memory`, `redis`, or `memcache`.                  | `memory`         |
-| `CACHE_STATUS_HEADER`             | If set will send a response header with cache `HIT`, `MISS` or `UNCACHEABLE`.            | --               |
+| `CACHE_STATUS_HEADER`             | If set, returns the cache status in the configured header. One of `HIT`, `MISS`.         | --               |
 
 <sup>[1]</sup> `CACHE_TTL` Based on your project's needs, you might be able to aggressively cache your data, only
 requiring new data to be fetched every hour or so. This allows you to squeeze the most performance out of your Directus

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -424,6 +424,7 @@ often possible to cache assets for far longer than you would cache database cont
 | `CACHE_PERMISSIONS`<sup>[3]</sup> | Whether or not the user permissions are cached. One of `false`, `true`                   | `true`           |
 | `CACHE_NAMESPACE`                 | How to scope the cache data.                                                             | `directus-cache` |
 | `CACHE_STORE`<sup>[4]</sup>       | Where to store the cache data. Either `memory`, `redis`, or `memcache`.                  | `memory`         |
+| `CACHE_HEADER_KEY`                | If set will send a response header with cache `HIT`, `MISS` or `UNCACHEABLE`.            | --               |
 
 <sup>[1]</sup> `CACHE_TTL` Based on your project's needs, you might be able to aggressively cache your data, only
 requiring new data to be fetched every hour or so. This allows you to squeeze the most performance out of your Directus

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -425,7 +425,7 @@ than you would cache database content. [Learn More](#assets)
 | `CACHE_PERMISSIONS`<sup>[3]</sup> | Whether or not the user permissions are cached. One of `false`, `true`                   | `true`           |
 | `CACHE_NAMESPACE`                 | How to scope the cache data.                                                             | `directus-cache` |
 | `CACHE_STORE`<sup>[4]</sup>       | Where to store the cache data. Either `memory`, `redis`, or `memcache`.                  | `memory`         |
-| `CACHE_HEADER_KEY`                | If set will send a response header with cache `HIT`, `MISS` or `UNCACHEABLE`.            | --               |
+| `CACHE_STATUS_HEADER`             | If set will send a response header with cache `HIT`, `MISS` or `UNCACHEABLE`.            | --               |
 
 <sup>[1]</sup> `CACHE_TTL` Based on your project's needs, you might be able to aggressively cache your data, only
 requiring new data to be fetched every hour or so. This allows you to squeeze the most performance out of your Directus


### PR DESCRIPTION
To be able to verify if data was retrieved from cache, besides response times.

This will add a response header named "x-directus-cache" with value "HIT" only if data was retreived from cache.

See https://github.com/directus/directus/discussions/12728