### PR TITLE
Add nested permissions

### DIFF
--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-header.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-header.vue
@@ -23,9 +23,9 @@ const { t } = useI18n();
 	top: calc(var(--header-bar-height) - 1px); // minus 1px to avoid gaps
 	z-index: 4;
 	display: flex;
-	padding: 12px;
+	padding: 10px;
+	padding-left: 0;
 	background-color: var(--background-input);
-	border-bottom: var(--border-width) solid var(--border-normal);
 
 	.name {
 		flex-grow: 1;


### PR DESCRIPTION
## Explanation

I had to much free time, so I just wanted to know if I could do it :)

I hope this is how you would like to have it as well.

With this change the collections within the `role permissions` page follow the same layout as in the `data-model` page.
This introduces a nested tree structure, which makes everything much easier to use and understand.
The worst case scenario of the old list was that in some cases you might have multiple collections that have the same display name because they are located in different folders. These used to have been very tricky to tell apart.

On mobile it falls back to a list structure, because the screen space is just to small.

For more information see: #10689

## Screenshots

<table>
<tr><th>Large Screens</th><th>Small Screens</th></tr>
<tr>
<td>

![image](https://user-images.githubusercontent.com/10547444/163493954-c8f73f8e-b27a-4c5d-b24e-ff43c5689197.png)

</td>
<td width="33%">

![localhost_8080_admin_settings_roles_22a9c76c-0831-4760-a12f-c87740eba47c(Pixel 5) (1)](https://user-images.githubusercontent.com/10547444/163494122-d7059738-3381-4b96-ab47-ba843684195c.png)


</td>
</tr>
</table>