### PR TITLE
Prevent stale filter value when switching between maps

### DIFF
--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -81,6 +81,15 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				if (!geometryField.value && fields.length > 0) {
 					geometryField.value = fields[0].field;
 				}
+
+				// clear the location filter when it is no longer using a valid geometryField
+				if (
+					geometryField.value &&
+					locationFilter.value &&
+					!Object.keys(locationFilter.value).includes(geometryField.value)
+				) {
+					locationFilter.value = undefined;
+				}
 			},
 			{ immediate: true }
 		);


### PR DESCRIPTION
Fixes directus/organization#20

## Description

Context:

- Submarine Cables map uses geometry field `route`
- US Counties map uses geometry field `area`

When switching between them, the location filter which uses the geometry field is still using the previous map's filter for a split second, hence causing the error since `area` does not exist in Submarine Cables table and vice versa.

## Before

https://user-images.githubusercontent.com/42867097/163667962-133988e1-9819-4015-812f-ddcb6d8efe30.mp4

## After

https://user-images.githubusercontent.com/42867097/163668034-dcdd80b8-4646-4b9b-a508-77aa9d47eb23.mp4


