### PR TITLE
Fix itemId being null

### DIFF
--- a/app/src/composables/use-relation/use-relation-multiple.ts
+++ b/app/src/composables/use-relation/use-relation-multiple.ts
@@ -4,7 +4,6 @@ import { unexpectedError } from '@/utils/unexpected-error';
 import { clamp, cloneDeep, isEqual, merge, isPlainObject } from 'lodash';
 import { computed, ref, Ref, watch } from 'vue';
 import { RelationM2A, RelationM2M, RelationO2M } from '@/composables/use-relation';
-import { Method } from 'axios';
 
 export type RelationQueryMultiple = {
 	page: number;
@@ -318,7 +317,7 @@ export function useRelationMultiple(
 
 			await updateItemCount(targetCollection, targetPKField, reverseJunctionField);
 
-			if (itemId.value === '+') {
+			if (!itemId.value || itemId.value === '+') {
 				fetchedItems.value = [];
 			} else {
 				const response = await api.get(getEndpoint(targetCollection), {
@@ -342,7 +341,7 @@ export function useRelationMultiple(
 	}
 
 	async function updateItemCount(targetCollection: string, targetPKField: string, reverseJunctionField: string) {
-		if (itemId.value === '+') {
+		if (!itemId.value || itemId.value === '+') {
 			existingItemCount.value = 0;
 			return;
 		}

--- a/app/src/composables/use-relation/use-relation-single.ts
+++ b/app/src/composables/use-relation/use-relation-single.ts
@@ -55,7 +55,7 @@ export function useRelationSingle(
 		const id = typeof val === 'object' ? val[relation.value.relatedPrimaryKeyField.field] : val;
 
 		if (!id) {
-			displayItem.value = val;
+			displayItem.value = val as Record<string, any>;
 			return;
 		}
 


### PR DESCRIPTION
closes #12786

I was not able to reproduce the bug but checking the id for null should avoid calling the api with an id of `null`.