### PR TITLE
Fix alias

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -168,7 +168,7 @@ async function parseCurrentLevel(
 		if (!child.relation) continue;
 
 		if (child.type === 'm2o') {
-			columnsToSelectInternal.push(child.fieldKey);
+			columnsToSelectInternal.push(child.relation.field);
 		}
 
 		if (child.type === 'a2o') {
@@ -193,7 +193,9 @@ async function parseCurrentLevel(
 
 	const fieldNodes = columnsToSelect.map(
 		(column: string) =>
-			children.find((childNode) => childNode.type === 'field' && childNode.fieldKey === column) ?? {
+			children.find(
+				(childNode) => childNode.type === 'field' && (childNode.fieldKey === column || childNode.name === column)
+			) ?? {
 				type: 'field',
 				name: column,
 				fieldKey: column,
@@ -322,7 +324,7 @@ function mergeWithParentItems(
 			const itemChild = nestedItems.find((nestedItem) => {
 				return (
 					nestedItem[schema.collections[nestedNode.relation.related_collection!].primary] ==
-					parentItem[nestedNode.fieldKey]
+					parentItem[nestedNode.relation.field]
 				);
 			});
 

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -1414,6 +1414,7 @@ export class GraphQLService {
 				selection = selection as FieldNode | InlineFragmentNode;
 
 				let current: string;
+				let currentAlias: string | null = null;
 
 				// Union type (Many-to-Any)
 				if (selection.kind === 'InlineFragment') {
@@ -1427,6 +1428,10 @@ export class GraphQLService {
 					if (selection.name.value.startsWith('__')) continue;
 
 					current = selection.name.value;
+
+					if (selection.alias && query.alias && selection.alias.value in query.alias) {
+						currentAlias = selection.alias.value;
+					}
 
 					if (parent) {
 						current = `${parent}.${current}`;
@@ -1446,7 +1451,7 @@ export class GraphQLService {
 							children.push(`${subSelection.name!.value}(${rootField})`);
 						}
 					} else {
-						children = parseFields(selection.selectionSet.selections, current);
+						children = parseFields(selection.selectionSet.selections, currentAlias ?? current);
 					}
 
 					fields.push(...children);

--- a/api/src/services/graphql.ts
+++ b/api/src/services/graphql.ts
@@ -1429,12 +1429,26 @@ export class GraphQLService {
 
 					current = selection.name.value;
 
-					if (selection.alias && query.alias && selection.alias.value in query.alias) {
+					if (selection.alias) {
 						currentAlias = selection.alias.value;
 					}
 
 					if (parent) {
 						current = `${parent}.${current}`;
+
+						if (currentAlias) {
+							currentAlias = `${parent}.${currentAlias}`;
+
+							// add nested aliases into deep query
+							if (selection.selectionSet) {
+								if (!query.deep) query.deep = {};
+								set(
+									query.deep,
+									parent,
+									merge(get(query.deep, parent), { _alias: { [selection.alias!.value]: selection.name.value } })
+								);
+							}
+						}
 					}
 				}
 

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -3,7 +3,7 @@
  */
 
 import { Knex } from 'knex';
-import { cloneDeep, mapKeys, omitBy, uniq } from 'lodash';
+import { cloneDeep, mapKeys, omitBy, uniq, isEmpty } from 'lodash';
 import { AST, FieldNode, NestedCollectionNode } from '../types';
 import { Query, PermissionsAction, Accountability, SchemaOverview } from '@directus/shared/types';
 import { getRelationType } from '../utils/get-relation-type';
@@ -114,10 +114,17 @@ export default async function getASTFromQuery(
 		for (const fieldKey of fields) {
 			let name = fieldKey;
 
-			const isAlias = (query.alias && name in query.alias) ?? false;
+			if (query.alias) {
+				// check for field alias (is is one of the key)
+				if (name in query.alias) {
+					name = query.alias[fieldKey];
+				}
 
-			if (isAlias) {
-				name = query.alias![fieldKey];
+				// check for junction alias (it is one of the value instead of the key)
+				if (Object.values(query.alias).includes(name)) {
+					const aliasKey = Object.keys(query.alias).find((key) => query.alias?.[key] === name);
+					if (aliasKey && fieldKey !== aliasKey) name = aliasKey;
+				}
 			}
 
 			const isRelational =
@@ -221,6 +228,11 @@ export default async function getASTFromQuery(
 			} else if (relatedCollection) {
 				if (permissions && permissions.some((permission) => permission.collection === relatedCollection) === false) {
 					continue;
+				}
+
+				const deepAlias = getDeepQuery(deep?.[fieldKey] || {})?.alias;
+				if (!isEmpty(deepAlias)) {
+					query.alias = deepAlias;
 				}
 
 				child = {

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -230,10 +230,9 @@ export default async function getASTFromQuery(
 					continue;
 				}
 
+				// update query alias for children parseFields
 				const deepAlias = getDeepQuery(deep?.[fieldKey] || {})?.alias;
-				if (!isEmpty(deepAlias)) {
-					query.alias = deepAlias;
-				}
+				if (!isEmpty(deepAlias)) query.alias = deepAlias;
 
 				child = {
 					type: relationType,


### PR DESCRIPTION
Closes #12776, closes #9390

For #9390, the error actually turned out to be the same as #12776 which is related to M2O aliases in general, not just GraphQL specific.

However there were other inconsistencies between them for aliases on different type of fields, hence this PR aims to fix them as well.

## Simple test setup locally

(this could still be incomplete, but not sure how to test all of them otherwise)

### Before

![WindowsTerminal_Op1TdydDJL](https://user-images.githubusercontent.com/42867097/163952041-3d793a9f-3fcb-4f00-9729-43239099046b.png)

### After

![WindowsTerminal_0jXcl8QsXK](https://user-images.githubusercontent.com/42867097/163952118-20b32bf7-b97e-4cd0-8413-b63058d9e7f5.png)

