### PR TITLE
Only set field default value when available for singleton collections

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -693,7 +693,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					continue;
 				}
 
-				defaults[name] = field.defaultValue;
+				if (field.defaultValue) defaults[name] = field.defaultValue;
 			}
 
 			return defaults as Partial<Item>;


### PR DESCRIPTION
Fixes #12847

## Before

Currently a singleton collection returns null for every field as default value, but it is causing issue for relational interfaces:

https://user-images.githubusercontent.com/42867097/164031103-789766db-6bc0-494e-92fd-5faefca54224.mp4


## After

https://user-images.githubusercontent.com/42867097/164031084-9f32ad26-4f44-4ffc-b7cb-33fb87d192b0.mp4

