### PR TITLE
Removed trailing comma from barchart name translations

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1832,7 +1832,7 @@ panels:
     name: List
     description: Filter and list fields from a collection
   barchart:
-    name: Bar Chart,
+    name: Bar Chart
     description: Bar or column charts for comparing groups of values
     select_field: You must select a field.
     select_collection: You must select a collection.

--- a/app/src/lang/translations/pl-PL.yaml
+++ b/app/src/lang/translations/pl-PL.yaml
@@ -1805,7 +1805,7 @@ panels:
     name: Lista
     description: Filtruj i wyświetl pola z kolekcji
   barchart:
-    name: Wykres słupkowy,
+    name: Wykres słupkowy
     description: Pasek lub wykresy kolumnowe do porównywania grup wartości
     select_field: Musisz wybrać pole.
     select_collection: Musisz wybrać kolekcję.


### PR DESCRIPTION
Removed trailing comma from panels.barchart.name.