### PR TITLE
Improve app loading background

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,7 @@
 		<meta name="MobileOptimized" content="width" />
 		<meta name="msapplication-TileColor" content="#263238" />
 		<meta name="theme-color" content="#263238" />
+		<meta name="color-scheme" content="dark light">
 		<meta name="mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -23,7 +24,7 @@
 		<title>Loading&hellip;</title>
 		<style id="custom-css"></style>
 	</head>
-	<body class="light">
+	<body class="auto">
 		<noscript>
 			<strong>We're sorry but Directus doesn't work without JavaScript enabled. Please enable it to continue.</strong>
 		</noscript>

--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -70,8 +70,8 @@ export default defineComponent({
 						.querySelector('head meta[name="theme-color"]')
 						?.setAttribute('content', newUser.theme === 'light' ? '#ffffff' : '#263238');
 				} else {
-					// Default to light mode
-					document.body.classList.add('light');
+					// Default to auto mode
+					document.body.classList.add('auto');
 				}
 			},
 			{ immediate: true }
@@ -115,7 +115,7 @@ export default defineComponent({
 	justify-content: center;
 	width: 100%;
 	height: 100%;
-	background: rgb(255 255 255 / 0.5);
+	/*background: rgb(255 255 255 / 0.5);*/
 	backdrop-filter: blur(10px);
 }
 

--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -115,7 +115,6 @@ export default defineComponent({
 	justify-content: center;
 	width: 100%;
 	height: 100%;
-	/*background: rgb(255 255 255 / 0.5);*/
 	backdrop-filter: blur(10px);
 }
 

--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -180,7 +180,6 @@ const logoURL = computed<string | null>(() => {
 		/* Page Content Spacing */
 		font-size: 15px;
 		line-height: 24px;
-		background-color: #fff;
 		box-shadow: 0 0 40px 0 rgb(38 50 56 / 0.1);
 		transition: max-width var(--medium) var(--transition);
 


### PR DESCRIPTION
When the webapp is loading, in the current version of directus, it starts with a white background no matter if you're system is in dark mode or not. Then the loading screen after that (with the indicator) has a weird background color in dark mode instead of using the default background that the rest of the app is using.

This PR fixes both problems:
- I changed the default theme to "auto" so that at first the system theme will be used and then it will change to what ever is selected by the user. I think this is the best approach in handling dark and light mode in an equal way.
- I added a color-scheme meta tag, so that browsers know that the page supports dark mode. This way even the first paint will not be white if the system is in dark mode, so there will be no black white flickering anymore :)
- I removed the custom background from the indicator loading screen to make it more consistent with the rest of the app
- I removed the white background from the login screen, to make it compatible with auto mode (I think the login screen should not have light mode by default anyways. It makes most sense that it follows the color-scheme of the browser. If your browser is in dark mode, you would expect it to be dark. The app already does this anyways.

## Before

https://user-images.githubusercontent.com/10547444/164081608-6c40c742-3111-4f37-96e7-b4b5fb55fbec.mp4

## After

https://user-images.githubusercontent.com/10547444/164081631-fca2aee9-671f-4610-8bcc-9fc1d5261031.mp4