### PR TITLE
Input translated string improvements

### DIFF
--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -10,6 +10,9 @@
 					:disabled="disabled"
 					:active="active"
 					@update:model-value="localValue = $event"
+					@focus="isFocused = !isFocused"
+					@blur="blur"
+					@keydown.enter="checkKeyValidity"
 				>
 					<template v-if="hasValidKey" #input>
 						<button :disabled="disabled" @click.stop="setValue(null)">{{ value && getKeyWithoutPrefix(value) }}</button>
@@ -20,6 +23,7 @@
 							class="translate-icon"
 							:class="{ active }"
 							clickable
+							:tabindex="-1"
 							:disabled="disabled"
 							@click="toggle"
 						/>
@@ -108,6 +112,7 @@ const { t } = useI18n();
 
 const menuEl = ref();
 const hasValidKey = ref<boolean>(false);
+const isFocused = ref<boolean>(false);
 const searchValue = ref<string | null>(null);
 
 const { translationStrings } = useTranslationStrings();
@@ -150,18 +155,19 @@ function selectKey(key: string) {
 	searchValue.value = null;
 }
 
-function setValue(newValue: any) {
-	hasValidKey.value = false;
-
-	if (
-		newValue &&
-		newValue.startsWith(translationPrefix) &&
-		translations.value.find((t) => t.key?.includes(getKeyWithoutPrefix(newValue)))
-	) {
-		hasValidKey.value = true;
-	}
-
+function setValue(newValue: string | null) {
+	if (newValue?.startsWith(translationPrefix)) newValue = newValue.replace(/\s/g, '_');
 	localValue.value = newValue;
+	if (!isFocused.value) checkKeyValidity();
+}
+
+function blur() {
+	isFocused.value = false;
+	checkKeyValidity();
+}
+
+function checkKeyValidity() {
+	hasValidKey.value = localValue.value?.startsWith(translationPrefix) ?? false;
 }
 
 function openNewTranslationStringDialog() {

--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -10,7 +10,7 @@
 					:disabled="disabled"
 					:active="active"
 					@update:model-value="localValue = $event"
-					@focus="isFocused = !isFocused"
+					@focus="isFocused = true"
 					@blur="blur"
 					@keydown.enter="checkKeyValidity"
 				>


### PR DESCRIPTION
Addresses https://github.com/directus/directus/discussions/12861#discussioncomment-2595578

## Before 

- Currently it only checks for existing custom translation strings to turn it into a purple button, but this meant actual translation keys like `$t:published` are being ignored

- Typing a key manually is slightly bugged, as the "turning into a button" fires too quickly without us being able to fully type it

  https://user-images.githubusercontent.com/42867097/164173147-d8fd5afd-f8bf-40f4-9e0f-7af7bbe60fe0.mp4

## After

- Works for any key starting with `$t:`

- Now allows manual typing with `$t:` properly, also changes any spaces into underscores (as they will be used as object keys). Also triggers on blur & enter key.

https://user-images.githubusercontent.com/42867097/164173504-82d04ca0-8e4d-4c03-875a-8bb8ebdc9843.mp4


