### PR TITLE
Refresh datetime display value every minute for relative format

### DIFF
--- a/app/src/displays/datetime/datetime.vue
+++ b/app/src/displays/datetime/datetime.vue
@@ -2,104 +2,93 @@
 	<span class="datetime">{{ displayValue }}</span>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, watch, PropType, computed, onMounted, onUnmounted } from 'vue';
+import { ref, watch, computed, onMounted, onUnmounted } from 'vue';
 import localizedFormat from '@/utils/localized-format';
 import localizedFormatDistance from '@/utils/localized-format-distance';
 import { parseISO, parse } from 'date-fns';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: String,
-			required: true,
-		},
-		type: {
-			type: String as PropType<'dateTime' | 'time' | 'date' | 'timestamp'>,
-			required: true,
-			validator: (val: string) => ['dateTime', 'date', 'time', 'timestamp'].includes(val),
-		},
-		format: {
-			type: String,
-			default: 'long',
-		},
-		relative: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+interface Props {
+	value: string;
+	type: 'dateTime' | 'date' | 'time' | 'timestamp';
+	format?: string;
+	relative?: boolean;
+}
 
-		const localValue = computed(() => {
-			if (!props.value) return null;
+const props = withDefaults(defineProps<Props>(), {
+	format: 'long',
+	relative: true,
+});
 
-			if (props.type === 'timestamp') {
-				return parseISO(props.value);
-			} else if (props.type === 'dateTime') {
-				return parse(props.value, "yyyy-MM-dd'T'HH:mm:ss", new Date());
-			} else if (props.type === 'date') {
-				return parse(props.value, 'yyyy-MM-dd', new Date());
-			} else if (props.type === 'time') {
-				return parse(props.value, 'HH:mm:ss', new Date());
+const { t } = useI18n();
+
+const displayValue = ref<string | null>(null);
+
+const localValue = computed(() => {
+	if (!props.value) return null;
+
+	if (props.type === 'timestamp') {
+		return parseISO(props.value);
+	} else if (props.type === 'dateTime') {
+		return parse(props.value, "yyyy-MM-dd'T'HH:mm:ss", new Date());
+	} else if (props.type === 'date') {
+		return parse(props.value, 'yyyy-MM-dd', new Date());
+	} else if (props.type === 'time') {
+		return parse(props.value, 'HH:mm:ss', new Date());
+	}
+
+	return null;
+});
+
+const relativeFormat = (value: Date) =>
+	localizedFormatDistance(value, new Date(), {
+		addSuffix: true,
+	});
+
+watch(
+	localValue,
+	async (newValue) => {
+		if (newValue === null) {
+			displayValue.value = null;
+			return;
+		}
+
+		if (props.relative) {
+			displayValue.value = await relativeFormat(newValue);
+		} else {
+			let format;
+			if (props.format === 'long') {
+				format = `${t('date-fns_date')} ${t('date-fns_time')}`;
+				if (props.type === 'date') format = String(t('date-fns_date'));
+				if (props.type === 'time') format = String(t('date-fns_time'));
+			} else if (props.format === 'short') {
+				format = `${t('date-fns_date_short')} ${t('date-fns_time_short')}`;
+				if (props.type === 'date') format = String(t('date-fns_date_short'));
+				if (props.type === 'time') format = String(t('date-fns_time_short'));
+			} else {
+				format = props.format;
 			}
 
-			return null;
-		});
-
-		const displayValue = ref<string | null>(null);
-		const refreshInterval = ref<number | null>(null);
-
-		onMounted(async () => {
-			if (!props.relative) return;
-
-			refreshInterval.value = window.setInterval(async () => {
-				if (!localValue.value) return;
-				displayValue.value = await localizedFormatDistance(localValue.value, new Date(), {
-					addSuffix: true,
-				});
-			}, 60000);
-		});
-
-		onUnmounted(() => {
-			if (refreshInterval.value) clearInterval(refreshInterval.value);
-		});
-
-		watch(
-			localValue,
-			async (newValue) => {
-				if (newValue === null) {
-					displayValue.value = null;
-					return;
-				}
-
-				if (props.relative) {
-					displayValue.value = await localizedFormatDistance(newValue, new Date(), {
-						addSuffix: true,
-					});
-				} else {
-					let format;
-					if (props.format === 'long') {
-						format = `${t('date-fns_date')} ${t('date-fns_time')}`;
-						if (props.type === 'date') format = String(t('date-fns_date'));
-						if (props.type === 'time') format = String(t('date-fns_time'));
-					} else if (props.format === 'short') {
-						format = `${t('date-fns_date_short')} ${t('date-fns_time_short')}`;
-						if (props.type === 'date') format = String(t('date-fns_date_short'));
-						if (props.type === 'time') format = String(t('date-fns_time_short'));
-					} else {
-						format = props.format;
-					}
-
-					displayValue.value = await localizedFormat(newValue, format);
-				}
-			},
-			{ immediate: true }
-		);
-
-		return { displayValue };
+			displayValue.value = await localizedFormat(newValue, format);
+		}
 	},
+	{ immediate: true }
+);
+
+const refreshInterval = ref<number | null>(null);
+
+onMounted(async () => {
+	if (!props.relative) return;
+
+	refreshInterval.value = window.setInterval(async () => {
+		if (!localValue.value) return;
+		displayValue.value = await relativeFormat(localValue.value);
+	}, 60000);
+});
+
+onUnmounted(() => {
+	if (refreshInterval.value) clearInterval(refreshInterval.value);
 });
 </script>
 

--- a/app/src/displays/datetime/datetime.vue
+++ b/app/src/displays/datetime/datetime.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, watch, PropType, computed } from 'vue';
+import { defineComponent, ref, watch, PropType, computed, onMounted, onUnmounted } from 'vue';
 import localizedFormat from '@/utils/localized-format';
 import localizedFormatDistance from '@/utils/localized-format-distance';
 import { parseISO, parse } from 'date-fns';
@@ -49,6 +49,22 @@ export default defineComponent({
 		});
 
 		const displayValue = ref<string | null>(null);
+		const refreshInterval = ref<number | null>(null);
+
+		onMounted(async () => {
+			if (!props.relative) return;
+
+			refreshInterval.value = window.setInterval(async () => {
+				if (!localValue.value) return;
+				displayValue.value = await localizedFormatDistance(localValue.value, new Date(), {
+					addSuffix: true,
+				});
+			}, 60000);
+		});
+
+		onUnmounted(() => {
+			if (refreshInterval.value) clearInterval(refreshInterval.value);
+		});
 
 		watch(
 			localValue,

--- a/app/src/displays/datetime/datetime.vue
+++ b/app/src/displays/datetime/datetime.vue
@@ -76,19 +76,19 @@ watch(
 	{ immediate: true }
 );
 
-const refreshInterval = ref<number | null>(null);
+let refreshInterval: number | null = null;
 
 onMounted(async () => {
 	if (!props.relative) return;
 
-	refreshInterval.value = window.setInterval(async () => {
+	refreshInterval = window.setInterval(async () => {
 		if (!localValue.value) return;
 		displayValue.value = await relativeFormat(localValue.value);
 	}, 60000);
 });
 
 onUnmounted(() => {
-	if (refreshInterval.value) clearInterval(refreshInterval.value);
+	if (refreshInterval) clearInterval(refreshInterval);
 });
 </script>
 


### PR DESCRIPTION
Fixes #12859

Set to 1 minute interval when relative prop is true, as lower interval wouldn't be useful to change `1 minute ago` to `2 minutes ago` for example.

## After change

https://user-images.githubusercontent.com/42867097/164191218-2f930127-f316-4d15-a027-980b2f4addd5.mp4


