### PR TITLE
Translate validation message in validation errors

### DIFF
--- a/app/src/components/v-form/validation-errors.vue
+++ b/app/src/components/v-form/validation-errors.vue
@@ -50,6 +50,7 @@ import { computed } from 'vue';
 import { ValidationError, Field } from '@directus/shared/types';
 import { formatFieldFunction } from '@/utils/format-field-function';
 import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
+import { translate } from '@/utils/translate-literal';
 
 interface Props {
 	validationErrors: ValidationError[];
@@ -80,7 +81,7 @@ const validationErrorsWithNames = computed<
 			...validationError,
 			fieldName,
 			groupName: group?.name ?? validationError.group,
-			customValidationMessage: field?.meta?.validation_message,
+			customValidationMessage: translate(field?.meta?.validation_message),
 		};
 	}) as (ValidationError & { fieldName: string; groupName: string; customValidationMessage: string | null })[];
 });


### PR DESCRIPTION
Addresses #12890

Field error messages are translated because they are from `formFields`, but #12553 had to opt out of using `formFields` and use the prop `fields` instead, which are not translated.

## Before

![chrome_stFQkVQ6kF](https://user-images.githubusercontent.com/42867097/164419185-2a24bedc-ca8d-484a-8fa3-199e3f6bf3c9.png)

## After

![chrome_ainHFRaT37](https://user-images.githubusercontent.com/42867097/164419218-a94187ae-6c16-4f36-b8cc-acb58577049b.png)

