### PR TITLE
Show minutes by default in Calendar month layout

### DIFF
--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -136,6 +136,15 @@ export default defineLayout<LayoutOptions>({
 					center: 'title',
 					right: 'dayGridMonth,dayGridWeek,dayGridDay,listWeek',
 				},
+				views: {
+					dayGridMonth: {
+						eventTimeFormat: {
+							hour: 'numeric',
+							minute: '2-digit',
+							meridiem: 'narrow',
+						},
+					},
+				},
 				events: events.value,
 				initialDate: viewInfo.value?.startDateStr ?? formatISO(new Date()),
 				eventClick(info) {


### PR DESCRIPTION
Implements #12886

The default eventTimeFormat config for `dayGridMonth` is:

```js
{
  hour: 'numeric',
  minute: '2-digit',
  omitZeroMinute: true,
  meridiem: 'narrow',
}
```
_Link to above code: https://github.com/fullcalendar/fullcalendar/blob/f65d1fb3ee6e8b47ae8ff31a0b6292c35d183080/packages/daygrid/src/event-rendering.ts#L4-L9_

so the `omitZeroMinute` is hiding zero minutes. Removing this flag and always show minutes by default in this PR.

Configuration used is referenced from https://fullcalendar.io/docs/view-specific-options.

## Result

![chrome_bvbNPSRsCN](https://user-images.githubusercontent.com/42867097/164476702-0af9e6b1-c45a-47be-94d7-1b342c68166c.png)

