### PR TITLE
Fix color-scheme for light theme

### DIFF
--- a/app/src/styles/themes/_light.scss
+++ b/app/src/styles/themes/_light.scss
@@ -1,5 +1,7 @@
 // Default / Light Mode
 @mixin light {
+	color-scheme: light;
+
 	--border-normal: #d3dae4;
 	--border-normal-alt: #a2b5cd;
 	--border-subdued: #f0f4f9;


### PR DESCRIPTION
#12865 added the meta tag `color-scheme` with content `dark light`:

https://github.com/directus/directus/blob/9ff39e1dcfcf9ad5779e43c98a70743ccc894c34/app/index.html#L18

But the `dark` preference still applies when a user with dark mode (system wide) uses the light theme.

Uses same approach as the dark theme:

https://github.com/directus/directus/blob/81483a80122d5ee03a895c9c5d2e7414fd231b4f/app/src/styles/themes/_dark.scss#L12

## Before

![chrome_eVsbyqNo5W](https://user-images.githubusercontent.com/42867097/164623385-117e1805-ff42-47ff-9549-474329c8e8f4.png)

## After

![chrome_kEfSge2MQM](https://user-images.githubusercontent.com/42867097/164623415-247ef9bb-89f4-4154-bd4b-98f2245e0daf.png)

