### PR TITLE
Fix API response for non existent fields & collections

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -276,6 +276,9 @@ export class CollectionsService {
 	 */
 	async readOne(collectionKey: string): Promise<Collection> {
 		const result = await this.readMany([collectionKey]);
+
+		if (result.length === 0) throw new ForbiddenException();
+
 		return result[0];
 	}
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -216,6 +216,8 @@ export class FieldsService {
 			// Do nothing
 		}
 
+		if (!column && !fieldInfo) throw new ForbiddenException();
+
 		const type = getLocalType(column, fieldInfo);
 
 		const data = {


### PR DESCRIPTION
Fixes #9366

## Bug

When fetching non existent fields or collections, the API still returns status `200`, albeit incomplete data since they don't really exist.

However fetching non existent relations correctly returns error `403`.

## Solution

Uses same or similar logic in relations where it throws forbidden exception if there are no actual result:

https://github.com/directus/directus/blob/81483a80122d5ee03a895c9c5d2e7414fd231b4f/api/src/services/relations.ts#L113-L115

## Before / After

### Fields

|Before|After|
|---|---|
|![chrome_crJjlSk81L](https://user-images.githubusercontent.com/42867097/164676451-a5a13089-c097-4840-b45f-e1f50c7ee59c.png)|![chrome_TaI1ngdT01](https://user-images.githubusercontent.com/42867097/164676494-0bd89144-145f-4579-a667-7cc9fb380763.png)|

### Collections

|Before|After|
|---|---|
|![chrome_MWeUgJOWVs](https://user-images.githubusercontent.com/42867097/164676557-56f52e8e-d429-4c55-8360-48d1c1adbc79.png)|![chrome_frNWTK9t8A](https://user-images.githubusercontent.com/42867097/164676567-1967974e-25b5-4be4-8294-96f2bb3b7833.png)|

