### PR TITLE
Remove underscore prefix for deep aggregate operations

### DIFF
--- a/packages/sdk/src/items.ts
+++ b/packages/sdk/src/items.ts
@@ -49,11 +49,7 @@ export type QueryMany<T> = QueryOne<T> & {
 };
 
 export type DeepQueryMany<T> = {
-	[K in keyof Omit<QueryMany<T>, 'aggregate'> as `_${string & K}`]: QueryMany<T>[K];
-} & {
-	_aggregate?: {
-		[A in keyof Aggregate as `_${string & A}`]: Aggregate[A];
-	};
+	[K in keyof QueryMany<T> as `_${string & K}`]: QueryMany<T>[K];
 };
 
 export type Aggregate = {


### PR DESCRIPTION
Ref https://github.com/directus/directus/discussions/12925#discussioncomment-2608736, where the type for deep aggregate operations like `sum`, `min`, `max` etc shouldn't need to be prefixed.

## Before

![Code_Pnio1292wZ](https://user-images.githubusercontent.com/42867097/164710531-f2e81ddd-dda9-4f33-ae89-6e6adf0f4546.png)

## After

![Code_Ju1LHgQmXm](https://user-images.githubusercontent.com/42867097/164710563-e9410700-a4f2-434b-a5a8-2e3071ab17a3.png)

