### PR TITLE
Check for valid date when parsing end date for Calendar layout

### DIFF
--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -1,6 +1,6 @@
 import api from '@/api';
 import { useCollection } from '@directus/shared/composables';
-import { formatISO, parse, format } from 'date-fns';
+import { formatISO, parse, format, isValid } from 'date-fns';
 import { useItems } from '@directus/shared/composables';
 import { router } from '@/router';
 import { useAppStore } from '@/stores/app';
@@ -289,7 +289,7 @@ export default defineLayout<LayoutOptions>({
 			const allDay = endDateFieldInfo.value && endDateFieldInfo.value.type === 'date';
 
 			if (endDateField.value) {
-				if (allDay) {
+				if (allDay && isValid(item[endDateField.value])) {
 					const date = parse(item[endDateField.value], 'yyyy-MM-dd', new Date());
 					// FullCalendar uses exclusive end moments, so we'll have to increment the end date by 1 to get the
 					// expected result in the calendar


### PR DESCRIPTION
Fixes #12956

## Bug

When selecting end date which is a Date field, it will get parsed at line 293 so that it can be incremented to get the +1 day date value:

https://github.com/directus/directus/blob/ad4537a2212e4c0efbe929087339f2919f3bf994/app/src/layouts/calendar/index.ts#L287-L301

However when there are dates that are null, it crashes the `parse()` function, thus causing the app being unresponsive.

## Solution

Checks whether the value is a valid date before going through with the parsing.

## Before

https://user-images.githubusercontent.com/42867097/164722314-b1e81052-6d42-42b2-8bd6-19adf285398d.mp4

## After

https://user-images.githubusercontent.com/42867097/164722364-3f83b838-109a-4c24-814c-ff3956b40cc1.mp4


