### PR TITLE
Fix signin info text in dark mode

### DIFF
--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -152,7 +152,6 @@ const logoURL = computed<string | null>(() => {
 	display: flex;
 	width: 100%;
 	height: 100%;
-	color: #263238;
 
 	:slotted(.v-icon) {
 		--v-icon-color: var(--foreground-subdued);


### PR DESCRIPTION
## Before

<table>
<tr><th>Light Mode</th><th>Dark Mode</th></tr>
<tr>
<td>

![localhost_8080_admin_login (2)](https://user-images.githubusercontent.com/10547444/164836651-cc1691e5-d0b0-4116-9ee3-3ccc7af662c9.png)

</td>
<td>

![localhost_8080_admin_login (3)](https://user-images.githubusercontent.com/10547444/164836663-52292758-39b5-4d99-9de0-61f50c37ecf7.png)

</td>
</tr>
</table>

## After

<table>
<tr><th>Light Mode</th><th>Dark Mode</th></tr>
<tr>
<td>

![localhost_8080_admin_login (1)](https://user-images.githubusercontent.com/10547444/164836633-d189b4a7-af70-4e91-b25a-a8c5605e512f.png)

</td>
<td>

![localhost_8080_admin_login](https://user-images.githubusercontent.com/10547444/164836620-64b03bba-8e37-49ee-a0c3-ac2b34a54b1b.png)

</td>
</tr>
</table>