### PR TITLE
Prevent token refreshing when using auth.static() method

### DIFF
--- a/packages/sdk/src/base/auth.ts
+++ b/packages/sdk/src/base/auth.ts
@@ -118,6 +118,8 @@ export class Auth extends IAuth {
 	}
 
 	async static(token: AuthToken): Promise<boolean> {
+		if (!this.staticToken) this.staticToken = token;
+
 		await this._transport.get('/users/me', { params: { access_token: token }, headers: { Authorization: null } });
 
 		this.updateStorage<'StaticToken'>({ access_token: token, expires: null, refresh_token: null });


### PR DESCRIPTION
Fixes #13006

## Bug

When using `directus.auth.static("static_token")`, the SDK will attempt to refresh the token, but this was not the past behavior. 

However when _initializing_ the SDK with `new Directus('url', { auth: { staticToken: "static_token" } } )`, it does work as intended.

## Reasoning

Recently the SDK was updated to attempt token refresh before every requests:

https://github.com/directus/directus/blob/d7d47b4e141b43c79ed0354e7206bd81d34c8f7a/packages/sdk/src/base/directus.ts#L92-L93

But the `refreshIfExpired()` function itself does prevent refreshing when there's `this.staticToken`:

https://github.com/directus/directus/blob/d7d47b4e141b43c79ed0354e7206bd81d34c8f7a/packages/sdk/src/base/auth.ts#L70-L71

Although `this.staticToken` does get set when we initialize the instance:

https://github.com/directus/directus/blob/d7d47b4e141b43c79ed0354e7206bd81d34c8f7a/packages/sdk/src/base/auth.ts#L33-L36

But not when we use `directus.auth.static()` function directly, hence the cause of this bug.

## Before

![Code_EE23aQMvnv](https://user-images.githubusercontent.com/42867097/165296344-b7664a6e-470f-4e69-a3e2-7cc4d9d24b56.png)

## After

![Code_YEMJ0L4ap3](https://user-images.githubusercontent.com/42867097/165296358-40f9e8ac-d817-412c-98a6-98908d724b0c.png)

