### PR TITLE
Prevent SDK from returning meta property when not available

### DIFF
--- a/packages/sdk/src/base/items.ts
+++ b/packages/sdk/src/base/items.ts
@@ -52,7 +52,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 		return {
 			data,
-			meta,
+			...(meta && { meta }),
 		};
 	}
 
@@ -64,7 +64,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 		return {
 			data,
-			meta,
+			...(meta && { meta }),
 		};
 	}
 


### PR DESCRIPTION
## Before

Currently the SDK always returns the `meta` property, even when it's not requested:

![Code_cKsKQl7JcJ](https://user-images.githubusercontent.com/42867097/165296994-a4fa9244-8044-4f26-927e-ddd6c59a74c0.png)

## After

Now it will only be returned when it's available to avoid any potential confusions, such when user observes the result of the same query being different compared to using the API directly:

![Code_O535ZQAsds](https://user-images.githubusercontent.com/42867097/165297002-5533a4b8-9dba-4ff6-aa70-84bfa91cb674.png)

