### PR TITLE
collections broken link fix

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -97,7 +97,7 @@ to make it your own!
 
 ::: tip More Info on Collections
 
-For a more in-depth guide to setting up Collections, see [Collections](/app/content-collections).
+For a more in-depth guide to setting up Collections, see [Collections](/app/content/collections).
 
 :::
 


### PR DESCRIPTION
On this [page](https://docs.directus.io/getting-started/quickstart/#_3-create-a-collection) in the `More Info on Collections` section there is incorrect link.