### PR TITLE
Fix auto generated field keys not being reset

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -29,7 +29,6 @@
 					<field-configuration
 						v-if="chosenInterface && !!group.interfaces.some((inter) => inter.id === chosenInterface)"
 						:row="configRow"
-						:chosen-interface="chosenInterface"
 						@save="$emit('save')"
 						@toggleAdvanced="$emit('toggleAdvanced')"
 					/>


### PR DESCRIPTION
Closes #13093

As `chosenInterface` was a prop of <field-configuration> and it was within a v-for of groups, the state isn't "shared", hence the `oldVal` here is always undefined initially when changing _between_ groups:

https://github.com/directus/directus/blob/2c93f256f6bc0be8d6b7e0e1a1075bcdf6380bc6/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue#L141-L143

Fixed by getting it from the store instead of passing prop:

```js
const chosenInterface = syncFieldDetailStoreProperty('field.meta.interface');
```

## After

https://user-images.githubusercontent.com/42867097/166572443-1aa5392d-ec6c-4991-8106-e66ce996d271.mp4


