### PR TITLE
Show collection key instead of name in Data Model

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -17,7 +17,7 @@
 					class="collection-icon"
 					:name="collection.meta?.hidden ? 'visibility_off' : collection.icon"
 				/>
-				<span ref="collectionName" class="collection-name">{{ collection.name }}</span>
+				<span ref="collectionName" class="collection-name">{{ collection.collection }}</span>
 				<span v-if="collection.meta?.note" class="collection-note">{{ collection.meta.note }}</span>
 			</div>
 			<template v-if="collection.type === 'alias' || nestedCollections.length">

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="permissions-overview-row">
 		<span class="name">
-			{{ collection.name }}
+			<span v-tooltip.left="collection.collection">{{ collection.name }}</span>
 			<span class="actions">
 				<span class="all" @click="setFullAccessAll">{{ t('all') }}</span>
 				<span class="divider">/</span>


### PR DESCRIPTION
Currently in the Data Model page, it is showing formatted/translated collection name instead of the collection key.

This PR changes it to show key, as it addresses the following:

- aligns with Fields configuration in a given Collection, since they do show field key instead of field name

- prevents potential confusion for users requesting the collection items via the API, eg. user created `Articles`, but they requested `/items/articles` instead of `/items/Articles`

- differentiates collections with the same name but different capitalization

## Before

![chrome_njGOZrXLGD](https://user-images.githubusercontent.com/42867097/166573050-164b73a1-dc31-4f0d-a1cf-e3ec203f481b.png)

## After

![chrome_EjehSwmOgN](https://user-images.githubusercontent.com/42867097/166572997-d9789be2-6475-404f-82fe-9f62c2ff5088.png)

As a related change, added a tooltip in Permissions & Roles to show the collection key as well:

![chrome_AhNbPwd2Mv](https://user-images.githubusercontent.com/42867097/166572972-6b30260b-e6fa-4226-8278-2cb71e44ac52.png)
