### PR TITLE
Fix slug not turning pasted value with spaces to separators

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -211,7 +211,7 @@ function emitValue(event: InputEvent) {
 	} else {
 		if (props.slug === true) {
 			// prevent pasting of non slugSafeCharacters from bypassing the keydown checks
-			value = value.replace(/[^a-zA-Z0-9-_~]/g, '');
+			value = value.replace(/[^a-zA-Z0-9\-_~\s]/g, '');
 
 			const endsWithSpace = value.endsWith(' ');
 			value = slugify(value, { separator: props.slugSeparator, preserveTrailingDash: true });


### PR DESCRIPTION
Following up to #12951 for slug fields, the safety measure was also "removing" spaces when pasting rather than letting the slugify function turn them into the separators. We also couldn't type a trailing dash/separator anymore.

`dbSafe` didn't have the same issue as there's a prior "replace all space with underscore" logic here:

https://github.com/directus/directus/blob/9a437f40669138be333157e3f38757635d55b0dc/app/src/components/v-input/v-input.vue#L222

## Before

https://user-images.githubusercontent.com/42867097/166670424-2ec7fd45-2552-4b6e-ac8b-09eeecaa0ab9.mp4

## After

https://user-images.githubusercontent.com/42867097/166670332-97e0fce7-c7d9-43b1-8172-8fa4e6788d57.mp4