### PR TITLE
fix sort field not updating in export sidebar

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -348,6 +348,11 @@ watch(exportSettings, () => {
 	getItemCount();
 });
 
+watch(primaryKeyField, (newVal) => {
+	if (!newVal) return;
+	exportSettings.sort = newVal.field;
+});
+
 const sortDirection = computed({
 	get() {
 		return exportSettings.sort.startsWith('-') ? 'DESC' : 'ASC';

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -349,8 +349,7 @@ watch(exportSettings, () => {
 });
 
 watch(primaryKeyField, (newVal) => {
-	if (!newVal) return;
-	exportSettings.sort = newVal.field;
+	exportSettings.sort = newVal?.field ?? '';
 });
 
 const sortDirection = computed({
@@ -463,7 +462,7 @@ function exportDataLocal() {
 		export: format.value,
 	};
 
-	if (exportSettings.sort) params.sort = exportSettings.sort;
+	if (exportSettings.sort && exportSettings.sort !== '') params.sort = exportSettings.sort;
 	if (exportSettings.fields) params.fields = exportSettings.fields;
 	if (exportSettings.limit) params.limit = exportSettings.limit;
 	if (exportSettings.search) params.search = exportSettings.search;
@@ -485,7 +484,7 @@ async function exportDataFiles() {
 		await api.post(`/utils/export/${collection.value}`, {
 			query: {
 				...exportSettings,
-				sort: [exportSettings.sort],
+				...(exportSettings.sort && exportSettings.sort !== '' && { sort: [exportSettings.sort] }),
 			},
 			format: format.value,
 			file: {


### PR DESCRIPTION
Fixes #13125

As `exportSettings.sort` is set initially based on `primaryKeyField.value?.field` here:

https://github.com/directus/directus/blob/1ec4fe165b674c413efc0ee708f2425191e0f6d1/app/src/views/private/components/export-sidebar-detail.vue#L278

it was not updated when switching collections (when primaryKeyField changes).

## Before

https://user-images.githubusercontent.com/42867097/166900447-285756ec-1528-4155-9326-6141be68d966.mp4

## After

https://user-images.githubusercontent.com/42867097/166900424-162bdcf9-c6fa-4a61-bd15-932f14f1b233.mp4

