### PR TITLE
Fix WYSIWYG being disabled due to loading

### DIFF
--- a/app/src/composables/use-relation/use-relation-multiple.ts
+++ b/app/src/composables/use-relation/use-relation-multiple.ts
@@ -278,6 +278,12 @@ export function useRelationMultiple(
 	async function updateFetchedItems() {
 		if (!relation.value) return;
 
+		if (!itemId.value || itemId.value === '+') {
+			existingItemCount.value = 0;
+			fetchedItems.value = [];
+			return;
+		}
+
 		let targetCollection: string;
 		let targetPKField: string;
 		let reverseJunctionField: string;
@@ -317,22 +323,18 @@ export function useRelationMultiple(
 
 			await updateItemCount(targetCollection, targetPKField, reverseJunctionField);
 
-			if (!itemId.value || itemId.value === '+') {
-				fetchedItems.value = [];
-			} else {
-				const response = await api.get(getEndpoint(targetCollection), {
-					params: {
-						fields: Array.from(fields),
-						filter: {
-							[reverseJunctionField]: itemId.value,
-						},
-						page: previewQuery.value.page,
-						limit: previewQuery.value.limit,
+			const response = await api.get(getEndpoint(targetCollection), {
+				params: {
+					fields: Array.from(fields),
+					filter: {
+						[reverseJunctionField]: itemId.value,
 					},
-				});
+					page: previewQuery.value.page,
+					limit: previewQuery.value.limit,
+				},
+			});
 
-				fetchedItems.value = response.data.data;
-			}
+			fetchedItems.value = response.data.data;
 		} catch (err: any) {
 			unexpectedError(err);
 		} finally {
@@ -341,10 +343,6 @@ export function useRelationMultiple(
 	}
 
 	async function updateItemCount(targetCollection: string, targetPKField: string, reverseJunctionField: string) {
-		if (!itemId.value || itemId.value === '+') {
-			existingItemCount.value = 0;
-			return;
-		}
 		const response = await api.get(getEndpoint(targetCollection), {
 			params: {
 				aggregate: {


### PR DESCRIPTION
Fixes #13143

## Before

When viewing a non-singleton collection item with a WYSIWYG translations field, the field becomes disabled initially, even when we verified via devtools that it is not disabled:

https://user-images.githubusercontent.com/42867097/167067845-e2fa7893-8f36-40d1-9569-ef14293cb793.mp4

We can also see that when we add a toggle just to "reset" the disabled to false, it does in fact work properly.

## Cause

It seems to be caused by the loading flag, since a field will be disabled if loading is true:

https://github.com/directus/directus/blob/7573a84521e34fe8579106d629a6de2020e73583/app/src/components/v-form/v-form.vue#L289-L291

In the new `useRelationMultiple` composable, loading is _briefly_ set to true before checking primaryKey as `+` then set loading to false in the `finally` statement:

https://github.com/directus/directus/blob/7573a84521e34fe8579106d629a6de2020e73583/app/src/composables/use-relation/use-relation-multiple.ts#L316-L322

thus it seems like because of the brief delay when the WYSIWYG editor is "mounted", TinyMCE was mounting as disabled even though the disabled state becomes false right after.

In the past, the old translations interface logic will return early before the loading flag, which should explain why this did not happen prior to the relational rework:

https://github.com/directus/directus/blob/1b9f7bf3bc45152f647689dc0b56308ea6e43fa4/app/src/interfaces/translations/translations.vue#L353-L356

## After

https://user-images.githubusercontent.com/42867097/167068833-141da499-0dd3-49ba-b31b-7f9b0c7bc447.mp4


