### PR TITLE
Use JSON.parse wrapper function to prevent pollution attacks

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -1,25 +1,26 @@
 import { Router } from 'express';
-import { Issuer, Client, generators, errors } from 'openid-client';
+import flatten from 'flat';
 import jwt from 'jsonwebtoken';
 import ms from 'ms';
-import flatten from 'flat';
-import { LocalAuthDriver } from './local';
+import { Client, errors, generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth';
 import env from '../../env';
-import { AuthenticationService, UsersService } from '../../services';
-import { AuthDriverOptions, User, AuthData } from '../../types';
 import {
-	InvalidCredentialsException,
-	ServiceUnavailableException,
 	InvalidConfigException,
+	InvalidCredentialsException,
 	InvalidTokenException,
+	ServiceUnavailableException,
 } from '../../exceptions';
-import { respond } from '../../middleware/respond';
-import asyncHandler from '../../utils/async-handler';
-import { Url } from '../../utils/url';
 import logger from '../../logger';
-import { getIPFromReq } from '../../utils/get-ip-from-req';
+import { respond } from '../../middleware/respond';
+import { AuthenticationService, UsersService } from '../../services';
+import { AuthData, AuthDriverOptions, User } from '../../types';
+import asyncHandler from '../../utils/async-handler';
 import { getConfigFromEnv } from '../../utils/get-config-from-env';
+import { getIPFromReq } from '../../utils/get-ip-from-req';
+import { parseJSON } from '../../utils/parse-json';
+import { Url } from '../../utils/url';
+import { LocalAuthDriver } from './local';
 
 export class OAuth2AuthDriver extends LocalAuthDriver {
 	client: Client;
@@ -172,7 +173,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 
 		if (typeof authData === 'string') {
 			try {
-				authData = JSON.parse(authData);
+				authData = parseJSON(authData);
 			} catch {
 				logger.warn(`[OAuth2] Session data isn't valid JSON: ${authData}`);
 			}

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -1,25 +1,26 @@
 import { Router } from 'express';
-import { Issuer, Client, generators, errors } from 'openid-client';
+import flatten from 'flat';
 import jwt from 'jsonwebtoken';
 import ms from 'ms';
-import flatten from 'flat';
-import { LocalAuthDriver } from './local';
+import { Client, errors, generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth';
 import env from '../../env';
-import { AuthenticationService, UsersService } from '../../services';
-import { AuthDriverOptions, User, AuthData } from '../../types';
 import {
-	InvalidCredentialsException,
-	ServiceUnavailableException,
 	InvalidConfigException,
+	InvalidCredentialsException,
 	InvalidTokenException,
+	ServiceUnavailableException,
 } from '../../exceptions';
-import { respond } from '../../middleware/respond';
-import asyncHandler from '../../utils/async-handler';
-import { Url } from '../../utils/url';
 import logger from '../../logger';
-import { getIPFromReq } from '../../utils/get-ip-from-req';
+import { respond } from '../../middleware/respond';
+import { AuthenticationService, UsersService } from '../../services';
+import { AuthData, AuthDriverOptions, User } from '../../types';
+import asyncHandler from '../../utils/async-handler';
 import { getConfigFromEnv } from '../../utils/get-config-from-env';
+import { getIPFromReq } from '../../utils/get-ip-from-req';
+import { parseJSON } from '../../utils/parse-json';
+import { Url } from '../../utils/url';
+import { LocalAuthDriver } from './local';
 
 export class OpenIDAuthDriver extends LocalAuthDriver {
 	client: Promise<Client>;
@@ -192,7 +193,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 
 		if (typeof authData === 'string') {
 			try {
-				authData = JSON.parse(authData);
+				authData = parseJSON(authData);
 			} catch {
 				logger.warn(`[OpenID] Session data isn't valid JSON: ${authData}`);
 			}

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -3,13 +3,14 @@ import { promises as fs } from 'fs';
 import inquirer from 'inquirer';
 import { load as loadYaml } from 'js-yaml';
 import path from 'path';
-import getDatabase, { validateDatabaseConnection, isInstalled } from '../../../database';
+import { flushCaches } from '../../../cache';
+import getDatabase, { isInstalled, validateDatabaseConnection } from '../../../database';
 import logger from '../../../logger';
 import { Snapshot } from '../../../types';
+import { applySnapshot, isNestedMetaUpdate } from '../../../utils/apply-snapshot';
 import { getSnapshot } from '../../../utils/get-snapshot';
 import { getSnapshotDiff } from '../../../utils/get-snapshot-diff';
-import { applySnapshot, isNestedMetaUpdate } from '../../../utils/apply-snapshot';
-import { flushCaches } from '../../../cache';
+import { parseJSON } from '../../../utils/parse-json';
 
 export async function apply(snapshotPath: string, options?: { yes: boolean; dryRun: boolean }): Promise<void> {
 	const filename = path.resolve(process.cwd(), snapshotPath);
@@ -34,7 +35,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 		if (filename.endsWith('.yaml') || filename.endsWith('.yml')) {
 			snapshot = (await loadYaml(fileContents)) as Snapshot;
 		} else {
-			snapshot = JSON.parse(fileContents) as Snapshot;
+			snapshot = parseJSON(fileContents) as Snapshot;
 		}
 
 		const currentSnapshot = await getSnapshot({ database });

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -1,6 +1,7 @@
 import { Range } from '@directus/drive';
 import { Router } from 'express';
-import { pick } from 'lodash';
+import helmet from 'helmet';
+import { merge, pick } from 'lodash';
 import ms from 'ms';
 import { ASSET_TRANSFORM_QUERY_KEYS, SYSTEM_ASSET_ALLOW_LIST } from '../constants';
 import getDatabase from '../database';
@@ -8,11 +9,10 @@ import env from '../env';
 import { InvalidQueryException, RangeNotSatisfiableException } from '../exceptions';
 import useCollection from '../middleware/use-collection';
 import { AssetsService, PayloadService } from '../services';
-import { TransformationParams, TransformationMethods, TransformationPreset } from '../types/assets';
+import { TransformationMethods, TransformationParams, TransformationPreset } from '../types/assets';
 import asyncHandler from '../utils/async-handler';
-import helmet from 'helmet';
-import { merge } from 'lodash';
 import { getConfigFromEnv } from '../utils/get-config-from-env';
+import { parseJSON } from '../utils/parse-json';
 
 const router = Router();
 
@@ -48,7 +48,7 @@ router.get(
 
 			// Try parse the JSON array
 			try {
-				transforms = JSON.parse(transformation['transforms'] as string);
+				transforms = parseJSON(transformation['transforms'] as string);
 			} catch {
 				throw new InvalidQueryException(`"transforms" Parameter needs to be a JSON array of allowed transformations.`);
 			}

--- a/api/src/database/migrations/20210225A-add-relations-sort-field.ts
+++ b/api/src/database/migrations/20210225A-add-relations-sort-field.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { parseJSON } from '../../utils/parse-json';
 
 export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_relations', (table) => {
@@ -11,7 +12,7 @@ export async function up(knex: Knex): Promise<void> {
 		.whereIn('interface', ['one-to-many', 'm2a-builder', 'many-to-many']);
 
 	for (const field of fieldsWithSort) {
-		const options = typeof field.options === 'string' ? JSON.parse(field.options) : field.options ?? {};
+		const options = typeof field.options === 'string' ? parseJSON(field.options) : field.options ?? {};
 
 		if ('sortField' in options) {
 			await knex('directus_relations')

--- a/api/src/database/migrations/20210506A-rename-interfaces.ts
+++ b/api/src/database/migrations/20210506A-rename-interfaces.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { parseJSON } from '../../utils/parse-json';
 
 // [before, after, after-option additions]
 const changes: [string, string, Record<string, any>?][] = [
@@ -57,7 +58,7 @@ export async function up(knex: Knex): Promise<void> {
 
 			for (const { id, options: existingOptionsRaw } of fields) {
 				const existingOptions =
-					typeof existingOptionsRaw === 'string' ? JSON.parse(existingOptionsRaw) : existingOptionsRaw;
+					typeof existingOptionsRaw === 'string' ? parseJSON(existingOptionsRaw) : existingOptionsRaw;
 
 				const newOptions = {
 					...(existingOptions || {}),

--- a/api/src/database/migrations/20210802A-replace-groups.ts
+++ b/api/src/database/migrations/20210802A-replace-groups.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 import logger from '../../logger';
+import { parseJSON } from '../../utils/parse-json';
 
 export async function up(knex: Knex): Promise<void> {
 	const dividerGroups = await knex.select('*').from('directus_fields').where('interface', '=', 'group-divider');
@@ -10,7 +11,7 @@ export async function up(knex: Knex): Promise<void> {
 		if (dividerGroup.options) {
 			try {
 				const options =
-					typeof dividerGroup.options === 'string' ? JSON.parse(dividerGroup.options) : dividerGroup.options;
+					typeof dividerGroup.options === 'string' ? parseJSON(dividerGroup.options) : dividerGroup.options;
 
 				if (options.icon) newOptions.headerIcon = options.icon;
 				if (options.color) newOptions.headerColor = options.color;

--- a/api/src/database/migrations/20210805A-update-groups.ts
+++ b/api/src/database/migrations/20210805A-update-groups.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { parseJSON } from '../../utils/parse-json';
 
 export async function up(knex: Knex): Promise<void> {
 	const groups = await knex.select('*').from('directus_fields').where({ interface: 'group-standard' });
@@ -7,7 +8,7 @@ export async function up(knex: Knex): Promise<void> {
 	const detail = [];
 
 	for (const group of groups) {
-		const options = typeof group.options === 'string' ? JSON.parse(group.options) : group.options || {};
+		const options = typeof group.options === 'string' ? parseJSON(group.options) : group.options || {};
 
 		if (options.showHeader === true) {
 			detail.push(group);

--- a/api/src/database/migrations/20210805B-change-image-metadata-structure.ts
+++ b/api/src/database/migrations/20210805B-change-image-metadata-structure.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { parseJSON } from '../../utils/parse-json';
 
 // Change image metadata structure to match the output from 'exifr'
 export async function up(knex: Knex): Promise<void> {
@@ -11,7 +12,7 @@ export async function up(knex: Knex): Promise<void> {
 		let prevMetadata;
 
 		try {
-			prevMetadata = JSON.parse(metadata);
+			prevMetadata = parseJSON(metadata);
 		} catch {
 			continue;
 		}
@@ -58,7 +59,7 @@ export async function down(knex: Knex): Promise<void> {
 		.whereNot('metadata', '{}');
 
 	for (const { id, metadata } of files) {
-		const prevMetadata = JSON.parse(metadata);
+		const prevMetadata = parseJSON(metadata);
 
 		// Update only required if metadata has keys other than 'icc' and 'iptc'
 		if (Object.keys(prevMetadata).filter((key) => key !== 'icc' && key !== 'iptc').length > 0) {

--- a/api/src/database/migrations/20211007A-update-presets.ts
+++ b/api/src/database/migrations/20211007A-update-presets.ts
@@ -1,6 +1,7 @@
 import { Filter, LogicalFilterAND } from '@directus/shared/types';
 import { Knex } from 'knex';
 import { nanoid } from 'nanoid';
+import { parseJSON } from '../../utils/parse-json';
 
 type OldFilter = {
 	key: string;
@@ -25,7 +26,7 @@ export async function up(knex: Knex): Promise<void> {
 	for (const preset of presets) {
 		if (preset.filters) {
 			const oldFilters: OldFilter[] =
-				(typeof preset.filters === 'string' ? JSON.parse(preset.filters) : preset.filters) ?? [];
+				(typeof preset.filters === 'string' ? parseJSON(preset.filters) : preset.filters) ?? [];
 
 			if (oldFilters.length === 0) continue;
 
@@ -52,7 +53,7 @@ export async function up(knex: Knex): Promise<void> {
 
 		if (preset.layout_query) {
 			const layoutQuery: Record<string, any> =
-				typeof preset.layout_query === 'string' ? JSON.parse(preset.layout_query) : preset.layout_query;
+				typeof preset.layout_query === 'string' ? parseJSON(preset.layout_query) : preset.layout_query;
 
 			for (const [layout, query] of Object.entries(layoutQuery)) {
 				if (query.sort) {
@@ -89,7 +90,7 @@ export async function down(knex: Knex): Promise<void> {
 	for (const preset of presets) {
 		if (preset.filter) {
 			const newFilter: LogicalFilterAND =
-				(typeof preset.filter === 'string' ? JSON.parse(preset.filter) : preset.filter) ?? {};
+				(typeof preset.filter === 'string' ? parseJSON(preset.filter) : preset.filter) ?? {};
 
 			if (Object.keys(newFilter).length === 0) continue;
 
@@ -119,7 +120,7 @@ export async function down(knex: Knex): Promise<void> {
 
 		if (preset.layout_query) {
 			const layoutQuery: Record<string, any> =
-				typeof preset.layout_query === 'string' ? JSON.parse(preset.layout_query) : preset.layout_query;
+				typeof preset.layout_query === 'string' ? parseJSON(preset.layout_query) : preset.layout_query;
 
 			for (const [layout, query] of Object.entries(layoutQuery)) {
 				if (query.sort && Array.isArray(query.sort)) {

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -9,6 +9,7 @@ import { clone, toNumber, toString } from 'lodash';
 import path from 'path';
 import { requireYAML } from './utils/require-yaml';
 import { toArray } from '@directus/shared/utils';
+import { parseJSON } from './utils/parse-json';
 
 const acceptedEnvTypes = ['string', 'number', 'regex', 'array', 'json'];
 
@@ -316,7 +317,7 @@ function processValues(env: Record<string, any>) {
 
 function tryJSON(value: any) {
 	try {
-		return JSON.parse(value);
+		return parseJSON(value);
 	} catch {
 		return value;
 	}

--- a/api/src/middleware/graphql.ts
+++ b/api/src/middleware/graphql.ts
@@ -3,6 +3,7 @@ import { DocumentNode, getOperationAST, parse, Source } from 'graphql';
 import { InvalidPayloadException, InvalidQueryException, MethodNotAllowedException } from '../exceptions';
 import { GraphQLParams } from '../types';
 import asyncHandler from '../utils/async-handler';
+import { parseJSON } from '../utils/parse-json';
 
 export const parseGraphQL: RequestHandler = asyncHandler(async (req, res, next) => {
 	if (req.method !== 'GET' && req.method !== 'POST') {
@@ -19,7 +20,7 @@ export const parseGraphQL: RequestHandler = asyncHandler(async (req, res, next) 
 
 		if (req.query.variables) {
 			try {
-				variables = JSON.parse(req.query.variables as string);
+				variables = parseJSON(req.query.variables as string);
 			} catch {
 				throw new InvalidQueryException(`Variables are invalid JSON.`);
 			}

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -1,18 +1,19 @@
-import { format } from 'date-fns';
-import Joi from 'joi';
-import { Knex } from 'knex';
-import { clone, cloneDeep, isObject, isPlainObject, omit, pick, isNil } from 'lodash';
-import { v4 as uuidv4 } from 'uuid';
-import getDatabase from '../database';
-import { ForbiddenException, InvalidPayloadException } from '../exceptions';
-import { AbstractServiceOptions, Item, PrimaryKey, Alterations } from '../types';
 import { Accountability, Query, SchemaOverview } from '@directus/shared/types';
 import { toArray } from '@directus/shared/utils';
-import { ItemsService } from './items';
+import { format } from 'date-fns';
 import { unflatten } from 'flat';
-import { getHelpers, Helpers } from '../database/helpers';
+import Joi from 'joi';
+import { Knex } from 'knex';
+import { clone, cloneDeep, isNil, isObject, isPlainObject, omit, pick } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 import { parse as wktToGeoJSON } from 'wellknown';
+import getDatabase from '../database';
+import { getHelpers, Helpers } from '../database/helpers';
+import { ForbiddenException, InvalidPayloadException } from '../exceptions';
+import { AbstractServiceOptions, Alterations, Item, PrimaryKey } from '../types';
 import { generateHash } from '../utils/generate-hash';
+import { parseJSON } from '../utils/parse-json';
+import { ItemsService } from './items';
 
 type Action = 'create' | 'read' | 'update';
 
@@ -81,7 +82,7 @@ export class PayloadService {
 			if (action === 'read') {
 				if (typeof value === 'string') {
 					try {
-						return JSON.parse(value);
+						return parseJSON(value);
 					} catch {
 						return value;
 					}
@@ -241,7 +242,7 @@ export class PayloadService {
 		const process =
 			action == 'read'
 				? (value: any) => (typeof value === 'string' ? wktToGeoJSON(value) : value)
-				: (value: any) => this.helpers.st.fromGeoJSON(typeof value == 'string' ? JSON.parse(value) : value);
+				: (value: any) => this.helpers.st.fromGeoJSON(typeof value == 'string' ? parseJSON(value) : value);
 
 		const fieldsInCollection = Object.entries(this.schema.collections[this.collection].fields);
 		const geometryColumns = fieldsInCollection.filter(([_, field]) => field.type.startsWith('geometry'));

--- a/api/src/utils/get-default-value.ts
+++ b/api/src/utils/get-default-value.ts
@@ -1,8 +1,9 @@
 import { SchemaOverview } from '@directus/schema/dist/types/overview';
 import { Column } from 'knex-schema-inspector/dist/types/column';
-import getLocalType from './get-local-type';
-import logger from '../logger';
 import env from '../env';
+import logger from '../logger';
+import getLocalType from './get-local-type';
+import { parseJSON } from './parse-json';
 
 export default function getDefaultValue(
 	column: SchemaOverview[string]['columns'][string] | Column
@@ -59,7 +60,7 @@ function castToObject(value: any): any | any[] {
 
 	if (typeof value === 'string') {
 		try {
-			return JSON.parse(value);
+			return parseJSON(value);
 		} catch (err: any) {
 			if (env.NODE_ENV === 'development') {
 				logger.error(err);

--- a/api/src/utils/get-permissions.ts
+++ b/api/src/utils/get-permissions.ts
@@ -1,15 +1,16 @@
-import { Permission, Accountability, SchemaOverview } from '@directus/shared/types';
+import { Accountability, Permission, SchemaOverview } from '@directus/shared/types';
 import { deepMap, parseFilter, parsePreset } from '@directus/shared/utils';
 import { cloneDeep } from 'lodash';
+import hash from 'object-hash';
+import { getCache, setSystemCache } from '../cache';
 import getDatabase from '../database';
 import { appAccessMinimalPermissions } from '../database/system-data/app-access-permissions';
+import env from '../env';
+import { RolesService } from '../services/roles';
+import { UsersService } from '../services/users';
 import { mergePermissions } from '../utils/merge-permissions';
 import { mergePermissionsForShare } from './merge-permissions-for-share';
-import { UsersService } from '../services/users';
-import { RolesService } from '../services/roles';
-import { getCache, setSystemCache } from '../cache';
-import hash from 'object-hash';
-import env from '../env';
+import { parseJSON } from './parse-json';
 
 export async function getPermissions(accountability: Accountability, schema: SchemaOverview) {
 	const database = getDatabase();
@@ -117,19 +118,19 @@ function parsePermissions(permissions: any[]) {
 		const permission = cloneDeep(permissionRaw);
 
 		if (permission.permissions && typeof permission.permissions === 'string') {
-			permission.permissions = JSON.parse(permission.permissions);
+			permission.permissions = parseJSON(permission.permissions);
 		} else if (permission.permissions === null) {
 			permission.permissions = {};
 		}
 
 		if (permission.validation && typeof permission.validation === 'string') {
-			permission.validation = JSON.parse(permission.validation);
+			permission.validation = parseJSON(permission.validation);
 		} else if (permission.validation === null) {
 			permission.validation = {};
 		}
 
 		if (permission.presets && typeof permission.presets === 'string') {
-			permission.presets = JSON.parse(permission.presets);
+			permission.presets = parseJSON(permission.presets);
 		} else if (permission.presets === null) {
 			permission.presets = {};
 		}

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -13,6 +13,7 @@ import logger from '../logger';
 import { RelationsService } from '../services';
 import getDefaultValue from './get-default-value';
 import getLocalType from './get-local-type';
+import { parseJSON } from './parse-json';
 
 export async function getSchema(options?: {
 	accountability?: Accountability;
@@ -142,7 +143,7 @@ async function getDatabaseSchema(
 		const type = (existing && getLocalType(column, { special })) || 'alias';
 		let validation = field.validation ?? null;
 
-		if (validation && typeof validation === 'string') validation = JSON.parse(validation);
+		if (validation && typeof validation === 'string') validation = parseJSON(validation);
 
 		result.collections[field.collection].fields[field.field] = {
 			field: field.field,

--- a/api/src/utils/parse-json.ts
+++ b/api/src/utils/parse-json.ts
@@ -1,0 +1,16 @@
+/**
+ * Run JSON.parse, but ignore `__proto__` properties. This prevents prototype pollution attacks
+ */
+export function parseJSON(input: string): any {
+	if (String(input).includes('__proto__')) {
+		return JSON.parse(input, noproto);
+	}
+
+	return JSON.parse(input);
+}
+
+export function noproto<T>(key: string, value: T): T | void {
+	if (key !== '__proto__') {
+		return value;
+	}
+}

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -1,9 +1,9 @@
+import { Accountability, Aggregate, Filter, Query } from '@directus/shared/types';
+import { parseFilter } from '@directus/shared/utils';
 import { flatten, get, isPlainObject, merge, set } from 'lodash';
 import logger from '../logger';
 import { Meta } from '../types';
-import { Query, Aggregate, Filter } from '@directus/shared/types';
-import { Accountability } from '@directus/shared/types';
-import { parseFilter } from '@directus/shared/utils';
+import { parseJSON } from './parse-json';
 
 export function sanitizeQuery(rawQuery: Record<string, any>, accountability?: Accountability | null): Query {
 	const query: Query = {};
@@ -99,7 +99,7 @@ function sanitizeAggregate(rawAggregate: any): Aggregate {
 
 	if (typeof rawAggregate === 'string') {
 		try {
-			aggregate = JSON.parse(rawAggregate);
+			aggregate = parseJSON(rawAggregate);
 		} catch {
 			logger.warn('Invalid value passed for filter query parameter.');
 		}
@@ -118,7 +118,7 @@ function sanitizeFilter(rawFilter: any, accountability: Accountability | null) {
 
 	if (typeof rawFilter === 'string') {
 		try {
-			filters = JSON.parse(rawFilter);
+			filters = parseJSON(rawFilter);
 		} catch {
 			logger.warn('Invalid value passed for filter query parameter.');
 		}
@@ -161,7 +161,7 @@ function sanitizeDeep(deep: Record<string, any>, accountability?: Accountability
 
 	if (typeof deep === 'string') {
 		try {
-			deep = JSON.parse(deep);
+			deep = parseJSON(deep);
 		} catch {
 			logger.warn('Invalid value passed for deep query parameter.');
 		}
@@ -200,7 +200,7 @@ function sanitizeAlias(rawAlias: any) {
 
 	if (typeof rawAlias === 'string') {
 		try {
-			alias = JSON.parse(rawAlias);
+			alias = parseJSON(rawAlias);
 		} catch (err) {
 			logger.warn('Invalid value passed for alias query parameter.');
 		}

--- a/api/tests/utils/parse-json.test.ts
+++ b/api/tests/utils/parse-json.test.ts
@@ -1,0 +1,23 @@
+import { noproto, parseJSON } from '../../src/utils/parse-json';
+
+describe('noproto', () => {
+	it('Returns the value if the key is not __proto__', () => {
+		let result = noproto('anything', 'value');
+		expect(result).toBe('value');
+
+		result = noproto('__proto__', 'malicious');
+		expect(result).toBe(undefined);
+	});
+});
+
+describe('parseJSON', () => {
+	it('Parses JSON strings', () => {
+		const result = parseJSON(`{"name": "Directus"}`);
+		expect(result).toEqual({ name: 'Directus' });
+	});
+
+	it('Ignores __proto__ properties', () => {
+		const result = parseJSON(`{"name": "Directus", "__proto__": "malicious" }`);
+		expect(result).toEqual({ name: 'Directus' });
+	});
+});


### PR DESCRIPTION
There's currently no indication of any problem or malicious use regarding `__proto__` injection within the platform. This PR is a defensive programming measure to prevent that attack vector from even having the chance of becoming an issue down the line.

---

TL;DR: `JSON.parse()` will create a regular new JavaScript object using whatever you pass it. This also means that passing `{ "__proto__": { "x": "y" }}` will result in a JS object of `{ __proto__: { x: 'y' }}`. Harmless by itself, but dangerous once you start using that object elsewhere, like `{ a: 'b', ...malicious }` as JavaScript allows you to overwrite the parent object class' prototype through the special `__proto__` property. 