### PR TITLE
Show edit drawer as preview for disabled many to one

### DIFF
--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -18,16 +18,16 @@
 				</div>
 			</template>
 
-			<template v-if="!disabled" #append>
+			<template #append>
 				<template v-if="displayItem">
+					<v-icon v-tooltip="t('edit')" name="open_in_new" class="edit" @click.stop="editModalActive = true" />
 					<v-icon
-						v-if="updateAllowed"
-						v-tooltip="t('edit')"
-						name="open_in_new"
-						class="edit"
-						@click.stop="editModalActive = true"
+						v-if="!disabled"
+						v-tooltip="t('deselect')"
+						name="close"
+						class="deselect"
+						@click.stop="$emit('input', null)"
 					/>
-					<v-icon v-tooltip="t('deselect')" name="close" class="deselect" @click.stop="$emit('input', null)" />
 				</template>
 				<template v-else>
 					<v-icon
@@ -43,13 +43,13 @@
 		</v-input>
 
 		<drawer-item
-			v-if="!disabled"
 			v-model:active="editModalActive"
 			:collection="relationInfo.relatedCollection.collection"
 			:primary-key="currentPrimaryKey"
 			:edits="edits"
 			:circular-field="relationInfo.relation.meta?.one_field ?? undefined"
-			@input="update"
+			:disabled="!updateAllowed || disabled"
+			@input="onDrawerItemInput"
 		/>
 
 		<drawer-collection
@@ -173,6 +173,11 @@ function onPreviewClick() {
 	if (props.disabled) return;
 
 	selectModalActive.value = true;
+}
+
+function onDrawerItemInput(event: any) {
+	if (props.disabled) return;
+	update(event);
 }
 
 const selection = computed<(number | string)[]>(() => {


### PR DESCRIPTION
### Description

Disabled many to one dropdown fields would hide the edit icon. It's expected to still be able to open the drawer for the related item, even when disabled, to preview the full related item.

### Problem

The interface would hide all buttons in the interface when disabled:

https://github.com/directus/directus/blob/51e90f6c4cbd1c3e9cd9e2b000eef694812280d5/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue#L21

### Solution

Rather than hiding all buttons, I've moved the disabled check down to just the deselect button, and added use of the `disabled` prop of the `drawer-item` component to render the related form disabled when the many to one field is disabled. This will still allow you to preview the related item, but won't allow you to edit anything (as the field is disabled).

### References

Fixes #13201