### PR TITLE
Fix limit/filter/search reactivity for export sidebar

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -284,6 +284,8 @@ const exportSettings = reactive({
 watch(
 	() => props.layoutQuery,
 	() => {
+		exportSettings.limit = props.layoutQuery?.limit ?? 25;
+
 		if (props.layoutQuery?.fields) {
 			exportSettings.fields = props.layoutQuery?.fields;
 		}
@@ -295,6 +297,15 @@ watch(
 				exportSettings.sort = props.layoutQuery.sort;
 			}
 		}
+	},
+	{ immediate: true }
+);
+
+watch(
+	[() => props.filter, () => props.search],
+	([filter, search]) => {
+		exportSettings.filter = filter;
+		exportSettings.search = search;
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
Fixes #13217

## Before

When `props.limit`, `props.filter` and `props.search` gets updated, `exportSettings` are not reactively updating based on their values:

https://user-images.githubusercontent.com/42867097/167773984-f2421f3d-6da2-4a58-b5c8-7efdc3f4ec53.mp4

## After

- Added watcher for `props.filter` and `props.search` to update filter and search

- Update `exportSettings.limit` in the existing watcher for `props.layoutQuery`

https://user-images.githubusercontent.com/42867097/167774010-d5a5ad9d-6199-4811-90ea-773cac904a88.mp4


