### PR TITLE
Form fields in a group unable to reset to default or undo changes

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -330,7 +330,14 @@ export default defineComponent({
 						return field.schema?.is_primary_key || !isDisabled(field);
 				  });
 
-			emit('update:modelValue', assign({}, props.modelValue, pick(updates, updatableKeys)));
+			if (!isNil(props.group)) {
+				const groupFields = getFieldsForGroup(props.group)
+					.filter((field) => !field.schema?.is_primary_key && !isDisabled(field))
+					.map((field) => field.field);
+				emit('update:modelValue', assign({}, omit(props.modelValue, groupFields), pick(updates, updatableKeys)));
+			} else {
+				emit('update:modelValue', pick(assign({}, props.modelValue, updates), updatableKeys));
+			}
 		}
 
 		function unsetValue(field: Field) {


### PR DESCRIPTION
# The problem
The `Reset to Default`, `Undo changes`, and Clear action on a form field nested in a group doesn't reset the value after PR #13158 

# The cause
I had indeed forgotten to test this particular aspect of the change for #13105 .
The strategy for "Undo" and "Reset to default" is to remove the key from the `modelValue` and let the interface re-initialize which is no longer possible with the change made.
All the "group" interfaces are trying to manipulate the same `modelValue` as the parent as it is not actually nesting the data.
This PR causing this issue was aimed to prevent a group form from removing field values from its parent which are not directly in the group being edited but implemented to broad preventing any field being unset.

# The solution
fixes #13197 
When applying an update for a form that represents a group `omit` the group fields from the `modelValue` before merging the changed values. And reverted back to the original update logic for non-group forms.
