### PR TITLE
Prevent inputs in deeply nested groups being duplicated

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -296,14 +296,15 @@ export default defineComponent({
 				);
 			}
 
-			function getFieldsForGroup(group: null | string): Field[] {
+			function getFieldsForGroup(group: null | string, passed: string[] = []): Field[] {
 				const fieldsInGroup: Field[] = fieldsParsed.value.filter(
 					(field) => field.meta?.group === group || (group === null && isNil(field.meta))
 				);
 
 				for (const field of fieldsInGroup) {
-					if (field.meta?.special?.includes('group')) {
-						fieldsInGroup.push(...getFieldsForGroup(field.meta!.field));
+					if (field.meta?.special?.includes('group') && !passed.includes(field.meta!.field)) {
+						passed.push(field.meta!.field);
+						fieldsInGroup.push(...getFieldsForGroup(field.meta!.field, passed));
 					}
 				}
 


### PR DESCRIPTION
# The problem
When groups are nested to 3 levels the `v-form` will start rendering duplicate inputs for that group. Typing in one of the duplicated fields will fill both simultaneously so they seem to be sharing the same state regardless of being rendered twice.

A data model like this:
![](https://i.imgur.com/3ztAq5E.png)

Will result in a form like this:
![](https://i.imgur.com/yc2oh3j.png)

# The cause
`getFieldsForGroup` in v-form also returns the groups it has flattened as fields and therefore walks the same recursive tree branches multiple times.

# The solution
fixes #13180
Added a `passed` parameter to the recursive `getFieldsForGroup` function so it doesnt try to get the fields for groups it has already seen in previous recursions.