### PR TITLE
Fix inconsistent revisions after batch update

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -341,6 +341,11 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		const filterWithKey = { _and: [{ [primaryKeyField]: { _in: keys } }, query.filter ?? {}] };
 		const queryWithKey = assign({}, query, { filter: filterWithKey });
 
+		// Set query limit as the number of keys
+		if (!queryWithKey.limit) {
+			queryWithKey.limit = keys.length;
+		}
+
 		const results = await this.readByQuery(queryWithKey, opts);
 
 		return results;

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -401,6 +401,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				  )
 				: payload;
 
+		// Sort keys to ensure that the order is maintained
+		keys.sort();
+
 		if (this.accountability) {
 			await authorizationService.checkAccess('update', this.collection, keys);
 		}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -342,7 +342,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		const queryWithKey = assign({}, query, { filter: filterWithKey });
 
 		// Set query limit as the number of keys
-		if (keys.length > 0 && !queryWithKey.limit) {
+		if (Array.isArray(keys) && keys.length > 0 && !queryWithKey.limit) {
 			queryWithKey.limit = keys.length;
 		}
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -342,7 +342,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		const queryWithKey = assign({}, query, { filter: filterWithKey });
 
 		// Set query limit as the number of keys
-		if (!queryWithKey.limit) {
+		if (keys.length > 0 && !queryWithKey.limit) {
 			queryWithKey.limit = keys.length;
 		}
 

--- a/api/tests/services/items.test.ts
+++ b/api/tests/services/items.test.ts
@@ -685,7 +685,7 @@ describe('Integration Tests', () => {
 			const response = await itemsService.readMany([1, 2], { fields: ['id', 'name'] });
 
 			expect(tracker.history.select.length).toBe(1);
-			expect(tracker.history.select[0].bindings).toStrictEqual([1, 2, 100]);
+			expect(tracker.history.select[0].bindings).toStrictEqual([1, 2, 2]);
 			expect(tracker.history.select[0].sql).toBe(
 				`select ${sqlFieldFormatter(
 					schemas[schema].schema,


### PR DESCRIPTION
Closes #12460.

- Sorting of keys resolves the inconsistent revisions
- Setting of query limit resolves the `data = null` after the 100th record