### PR TITLE
Add string-export support for related-values and translations display

### DIFF
--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -49,9 +49,9 @@ export default defineDisplay({
 	handler: async (value, options, { collection, field }) => {
 		if (!field || !collection) return value;
 
-		const relatedCollection = getRelatedCollection(collection, field.field);
+		const relatedCollections = getRelatedCollection(collection, field.field);
 
-		if (!relatedCollection) return value;
+		if (!relatedCollections) return value;
 
 		const fieldsStore = useFieldsStore();
 
@@ -61,7 +61,7 @@ export default defineDisplay({
 			return {
 				key: fieldKey,
 				field: fieldsStore.getField(
-					relatedCollection.junctionCollection ?? relatedCollection.relatedCollection,
+					relatedCollections.junctionCollection ?? relatedCollections.relatedCollection,
 					fieldKey
 				),
 			};
@@ -72,7 +72,7 @@ export default defineDisplay({
 		for (const { key, field } of fields) {
 			if (!field?.meta?.display) {
 				set(stringValues, key, get(value, key));
-				return;
+				continue;
 			}
 
 			const display = getDisplay(field.meta.display);

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -70,20 +70,24 @@ export default defineDisplay({
 		const stringValues: Record<string, string> = {};
 
 		for (const { key, field } of fields) {
+			const fieldValue = get(value, key);
+
+			if (!fieldValue) continue;
+
 			if (!field?.meta?.display) {
-				set(stringValues, key, get(value, key));
+				set(stringValues, key, fieldValue);
 				continue;
 			}
 
 			const display = getDisplay(field.meta.display);
 
 			const stringValue = display?.handler
-				? await display.handler(get(value, key), field?.meta?.display_options ?? {}, {
+				? await display.handler(fieldValue, field?.meta?.display_options ?? {}, {
 						interfaceOptions: field?.meta?.options ?? {},
 						field: field ?? undefined,
 						collection: collection,
 				  })
-				: get(value, key);
+				: fieldValue;
 
 			set(stringValues, key, stringValue);
 		}

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -72,7 +72,7 @@ export default defineDisplay({
 		for (const { key, field } of fields) {
 			const fieldValue = get(value, key);
 
-			if (!fieldValue) continue;
+			if (fieldValue === null || fieldValue === undefined) continue;
 
 			if (!field?.meta?.display) {
 				set(stringValues, key, fieldValue);

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -4,6 +4,9 @@ import { getFieldsFromTemplate } from '@directus/shared/utils';
 import getRelatedCollection from '@/utils/get-related-collection';
 import DisplayRelatedValues from './related-values.vue';
 import { useFieldsStore } from '@/stores';
+import { getDisplay } from '@/displays';
+import { get, set } from 'lodash';
+import { renderPlainStringTemplate } from '@/utils/render-string-template';
 
 type Options = {
 	template: string;
@@ -42,6 +45,50 @@ export default defineDisplay({
 				meta: displayTemplateMeta,
 			},
 		];
+	},
+	handler: async (value, options, { collection, field }) => {
+		if (!field || !collection) return value;
+
+		const relatedCollection = getRelatedCollection(collection, field.field);
+
+		if (!relatedCollection) return value;
+
+		const fieldsStore = useFieldsStore();
+
+		const fieldKeys = getFieldsFromTemplate(options.template);
+
+		const fields = fieldKeys.map((fieldKey) => {
+			return {
+				key: fieldKey,
+				field: fieldsStore.getField(
+					relatedCollection.junctionCollection ?? relatedCollection.relatedCollection,
+					fieldKey
+				),
+			};
+		});
+
+		const stringValues: Record<string, string> = {};
+
+		for (const { key, field } of fields) {
+			if (!field?.meta?.display) {
+				set(stringValues, key, get(value, key));
+				return;
+			}
+
+			const display = getDisplay(field.meta.display);
+
+			const stringValue = display?.handler
+				? await display.handler(get(value, key), field?.meta?.display_options ?? {}, {
+						interfaceOptions: field?.meta?.options ?? {},
+						field: field ?? undefined,
+						collection: collection,
+				  })
+				: get(value, key);
+
+			set(stringValues, key, stringValue);
+		}
+
+		return renderPlainStringTemplate(options.template, stringValues);
 	},
 	types: ['alias', 'string', 'uuid', 'integer', 'bigInteger', 'json'],
 	localTypes: ['m2m', 'm2o', 'o2m', 'translations', 'm2a', 'file', 'files'],

--- a/app/src/displays/translations/index.ts
+++ b/app/src/displays/translations/index.ts
@@ -1,8 +1,12 @@
-import { defineDisplay, getFieldsFromTemplate } from '@directus/shared/utils';
-import DisplayTranslations from './translations.vue';
-import { useFieldsStore } from '@/stores';
-import { useRelationsStore } from '@/stores';
+import { getDisplay } from '@/displays';
+import { useFieldsStore, useRelationsStore } from '@/stores';
 import adjustFieldsForDisplays from '@/utils/adjust-fields-for-displays';
+import { getRelatedCollection } from '@/utils/get-related-collection';
+import { renderPlainStringTemplate } from '@/utils/render-string-template';
+import { defineDisplay, getFieldsFromTemplate } from '@directus/shared/utils';
+import { get, set } from 'lodash';
+import DisplayTranslations from './translations.vue';
+import { i18n } from '@/lang';
 
 type Options = {
 	template: string;
@@ -15,6 +19,80 @@ export default defineDisplay({
 	description: '$t:displays.translations.description',
 	icon: 'translate',
 	component: DisplayTranslations,
+	handler: async (values, options, { collection, field }) => {
+		if (!field || !collection || !Array.isArray(values)) return values;
+
+		const relatedCollections = getRelatedCollection(collection, field.field);
+
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+
+		const relations = relationsStore.getRelationsForField(collection, field.field);
+
+		const junction = relations.find(
+			(relation) => relation.related_collection === collection && relation.meta?.one_field === field.field
+		);
+
+		if (!junction) return values;
+
+		const relation = relations.find(
+			(relation) => relation.collection === junction.collection && relation.field === junction.meta?.junction_field
+		);
+
+		const primaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relatedCollections.relatedCollection);
+
+		if (!relatedCollections || !primaryKeyField || !relation?.related_collection) return values;
+
+		const relatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relation.related_collection);
+
+		if (!relatedPrimaryKeyField) return values;
+
+		const value =
+			values.find((translatedItem: Record<string, any>) => {
+				const lang = translatedItem[relation!.field][relatedPrimaryKeyField.field];
+
+				// Default to first item if lang can't be found
+				if (!lang) return true;
+
+				if (options.userLanguage) {
+					return lang === i18n.global.locale.value;
+				}
+
+				return lang === options.defaultLanguage;
+			}) ?? values[0];
+
+		const fieldKeys = getFieldsFromTemplate(options.template);
+
+		const fields = fieldKeys.map((fieldKey) => {
+			return {
+				key: fieldKey,
+				field: fieldsStore.getField(relatedCollections.relatedCollection, fieldKey),
+			};
+		});
+
+		const stringValues: Record<string, string> = {};
+
+		for (const { key, field } of fields) {
+			if (!field?.meta?.display) {
+				set(stringValues, key, get(value, key));
+				continue;
+			}
+
+			const display = getDisplay(field.meta.display);
+
+			const stringValue = display?.handler
+				? await display.handler(get(value, key), field?.meta?.display_options ?? {}, {
+						interfaceOptions: field?.meta?.options ?? {},
+						field: field ?? undefined,
+						collection: collection,
+				  })
+				: get(value, key);
+
+			set(stringValues, key, stringValue);
+		}
+
+		return renderPlainStringTemplate(options.template, stringValues);
+	},
 	options: ({ relations }) => {
 		const fieldsStore = useFieldsStore();
 

--- a/app/src/displays/translations/index.ts
+++ b/app/src/displays/translations/index.ts
@@ -75,7 +75,7 @@ export default defineDisplay({
 		for (const { key, field } of fields) {
 			const fieldValue = get(value, key);
 
-			if (!fieldValue) continue;
+			if (fieldValue === null || fieldValue === undefined) continue;
 
 			if (!field?.meta?.display) {
 				set(stringValues, key, fieldValue);

--- a/app/src/displays/translations/index.ts
+++ b/app/src/displays/translations/index.ts
@@ -73,20 +73,24 @@ export default defineDisplay({
 		const stringValues: Record<string, string> = {};
 
 		for (const { key, field } of fields) {
+			const fieldValue = get(value, key);
+
+			if (!fieldValue) continue;
+
 			if (!field?.meta?.display) {
-				set(stringValues, key, get(value, key));
+				set(stringValues, key, fieldValue);
 				continue;
 			}
 
 			const display = getDisplay(field.meta.display);
 
 			const stringValue = display?.handler
-				? await display.handler(get(value, key), field?.meta?.display_options ?? {}, {
+				? await display.handler(fieldValue, field?.meta?.display_options ?? {}, {
 						interfaceOptions: field?.meta?.options ?? {},
 						field: field ?? undefined,
 						collection: collection,
 				  })
-				: get(value, key);
+				: fieldValue;
 
 			set(stringValues, key, stringValue);
 		}

--- a/app/src/utils/save-as-csv.ts
+++ b/app/src/utils/save-as-csv.ts
@@ -37,6 +37,7 @@ export async function saveAsCSV(collection: string, fields: string[], items: Ite
 					? await display.handler(value, fieldsUsed[key]?.meta?.display_options ?? {}, {
 							interfaceOptions: fieldsUsed[key]?.meta?.options ?? {},
 							field: fieldsUsed[key] ?? undefined,
+							collection: collection,
 					  })
 					: value;
 			} else {

--- a/packages/shared/src/types/displays.ts
+++ b/packages/shared/src/types/displays.ts
@@ -22,7 +22,7 @@ export interface DisplayConfig {
 	handler?: (
 		value: any,
 		options: Record<string, any>,
-		ctx: { interfaceOptions?: Record<string, any>; field?: Field }
+		ctx: { interfaceOptions?: Record<string, any>; field?: Field; collection?: string }
 	) => string | null | Promise<string | null>;
 	options:
 		| DeepPartial<Field>[]


### PR DESCRIPTION
Extends https://github.com/directus/directus/pull/13099 by adding support for the string-display export to the related-values and translations displays.