### PR TITLE
fix: AUTH_PROVIDER ibmid should display as IBMid

### DIFF
--- a/packages/format-title/src/special-case.ts
+++ b/packages/format-title/src/special-case.ts
@@ -8,6 +8,7 @@ export default [
 	'DateTime',
 	'GitHub',
 	'HD',
+	'IBMid',
 	'ID',
 	'IDs',
 	'iMac',


### PR DESCRIPTION
[IBMid](https://cloud.ibm.com/docs/account?topic=account-account-getting-started#signup-ibmid) is an OpenID format used with IBM cloud.

```env
AUTH_PROVIDERS=ibmid
AUTH_IBMID_DRIVER=openid
...
```

Currently displays as "Login with **Ibmid**"
With this fix it will be "Login with **IBMid**"

```js
const formatTitle = require('@directus/format-title')
console.log(formatTitle('ibmid'))
// BEFORE change: Ibmid
// AFTER change: IBMid
```