### PR TITLE
Creating corresponding relational field for file fields throws errors

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/file.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/file.ts
@@ -1,5 +1,6 @@
 import { StateUpdates, State, HelperFunctions } from '../types';
 import { set } from 'lodash';
+import { setRelatedOneFieldForCorrespondingField } from './m2o';
 
 export function applyChanges(updates: StateUpdates, state: State, helperFn: HelperFunctions) {
 	const { hasChanged, getCurrent } = helperFn;
@@ -11,6 +12,10 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 
 	if (hasChanged('field.field')) {
 		updateRelationField(updates);
+	}
+
+	if (hasChanged('fields.corresponding')) {
+		setRelatedOneFieldForCorrespondingField(updates);
 	}
 
 	if (hasChanged('field.schema.is_nullable')) {


### PR DESCRIPTION
# The problem
Creating corresponding relational field for file fields throws an error when uploading images.
![](https://user-images.githubusercontent.com/43739995/160067752-1a86cd0d-2ac7-4353-bf89-0865237d8517.png)

# The cause
The relations `one_field` is not filled when creating the relation so it does not get recognised as a relational field when running the next select query.

# The solution
fixes #11719
Applied the same `setRelatedOneFieldForCorrespondingField` function used by m2o