### PR TITLE
Allow creating big integer auto-incremented primary keys in MySQL and PostgreSQL

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -543,7 +543,12 @@ export class FieldsService {
 		if (field.type === 'alias' || field.type === 'unknown') return;
 
 		if (field.schema?.has_auto_increment) {
-			column = table.increments(field.field);
+			if (field.type === 'bigInteger') {
+				// Create an auto-incremented big integer (MySQL, PostgreSQL) or an auto-incremented integer (other DBs)
+				column = table.bigIncrements(field.field);
+			} else {
+				column = table.increments(field.field);
+			}
 		} else if (field.type === 'string') {
 			column = table.string(field.field, field.schema?.max_length ?? undefined);
 		} else if (['float', 'decimal'].includes(field.type)) {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -461,6 +461,7 @@ created_on: Created On
 creating_collection_info: Name the collection and setup its unique “key” field...
 creating_collection_system: Enable and rename any of these optional fields.
 auto_increment_integer: Auto-incremented integer
+auto_increment_big_integer: Auto-incremented big integer
 generated_uuid: Generated UUID
 manual_string: Manually entered string
 save_and_create_new: Save and Create New

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -53,6 +53,10 @@
 									value: 'auto_int',
 								},
 								{
+									text: t('auto_increment_big_integer'),
+									value: 'auto_big_int',
+								},
+								{
 									text: t('generated_uuid'),
 									value: 'uuid',
 								},
@@ -196,7 +200,7 @@ export default defineComponent({
 		const collectionName = ref(null);
 		const singleton = ref(false);
 		const primaryKeyFieldName = ref('id');
-		const primaryKeyFieldType = ref<'auto_int' | 'uuid' | 'manual'>('auto_int');
+		const primaryKeyFieldType = ref<'auto_int' | 'auto_big_int' | 'uuid' | 'manual'>('auto_int');
 
 		const sortField = ref<string>();
 
@@ -306,7 +310,7 @@ export default defineComponent({
 			} else {
 				return {
 					field: primaryKeyFieldName.value,
-					type: 'integer',
+					type: primaryKeyFieldType.value === 'auto_big_int' ? 'bigInteger' : 'integer',
 					meta: {
 						hidden: true,
 						interface: 'input',

--- a/docs/configuration/data-model.md
+++ b/docs/configuration/data-model.md
@@ -12,6 +12,7 @@
    default.
 3. Configure the name and type of the **Primary Key**.
    - Auto-Incremented Integer
+   - Auto-Incremented Big Integer (MySQL and PostgreSQL only)
    - Generated UUID
    - Manually Entered String
 4. Click on <span mi btn>arrow_forward</span>


### PR DESCRIPTION
Adds the ability to create tables with an auto-incremented big integer as the primary key.
This only works in MySQL and PostgreSQL as stated in the Knex documentation. (https://knexjs.org/#Schema-bigInteger)
I added this information to the docs as well.

Trying to create a big integer auto-incremented primary key in other DBs will fallback to a normal auto-incremented integer.
