### PR TITLE
Stalling Sqlite when using cascading foreign contraints

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -605,7 +605,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			const authorizationService = new AuthorizationService({
 				accountability: this.accountability,
 				schema: this.schema,
-				knex: this.knex
+				knex: this.knex,
 			});
 
 			await authorizationService.checkAccess('delete', this.collection, keys);

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -605,6 +605,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			const authorizationService = new AuthorizationService({
 				accountability: this.accountability,
 				schema: this.schema,
+				knex: this.knex
 			});
 
 			await authorizationService.checkAccess('delete', this.collection, keys);


### PR DESCRIPTION
Fixes #10462

otherwise the transaction pool of knex runs full. reusing the knex transaction/connection fixes it. 