### PR TITLE
Fix app docs collection & item page

### DIFF
--- a/app/src/modules/docs/components/links.yaml
+++ b/app/src/modules/docs/components/links.yaml
@@ -2,12 +2,12 @@
   to: '/app/overview'
   icon: school
 
-- name: Content Collections
-  to: '/app/content-collections'
+- name: Collection Page
+  to: '/app/content/collections'
   icon: list_alt
 
-- name: Content Items
-  to: '/app/content-items'
+- name: Item Page
+  to: '/app/content/items'
   icon: edit_note
 
 - name: User Directory


### PR DESCRIPTION
Fixes #13313

#12046 updated the following:

```diff
- path: '/app/content-collections',
- title: 'Content Collections',
+ path: '/app/content/collections',
+ title: 'Collection Page',
```

```diff
- path: '/app/content-items',
- title: 'Content Items',
+ path: '/app/content/items',
+ title: 'Item Page',
```

So this PR updates the `links.yaml` used by the in app docs with the same changes.

## Before

![chrome_CLTdVGBaVD](https://user-images.githubusercontent.com/42867097/168562767-618be81a-0604-40cc-b7f8-5b3f9b4546fc.png)

## After

![chrome_LPuIZNEw7E](https://user-images.githubusercontent.com/42867097/168562747-481b9dbf-93ef-4037-bd36-8cf9c984e00c.png)

