### PR TITLE
Resolve dynamic variables for field validation

### DIFF
--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -8,7 +8,7 @@ import {
 	Query,
 	SchemaOverview,
 } from '@directus/shared/types';
-import { validatePayload } from '@directus/shared/utils';
+import { validatePayload, parseFilter } from '@directus/shared/utils';
 import { Knex } from 'knex';
 import { cloneDeep, flatten, isArray, isNil, merge, reduce, uniq, uniqWith } from 'lodash';
 import getDatabase from '../database';
@@ -472,7 +472,7 @@ export class AuthorizationService {
 		const payloadWithPresets = merge({}, preset, payload);
 
 		const fieldValidationRules = Object.values(this.schema.collections[collection].fields)
-			.map((field) => field.validation)
+			.map((field) => parseFilter(field.validation, this.accountability))
 			.filter((v) => v) as Filter[];
 
 		const hasValidationRules =


### PR DESCRIPTION
# The problem
If a date field validation is set to less than or equals to $NOW, it throws an error.
![](https://user-images.githubusercontent.com/9326922/167538239-eb8c9d8e-376d-4107-8158-46e642b22479.jpg)

# The cause
The `Joi` filter validator is correctly throwing errors for filters like `[{"_and":[{"date_created":{"_lte":"$NOW"}}]}]` because `$NOW` is indeed not a valid date format. This works for field validation in roles because the dynamic variables are being resolved when the `accountability` object is created for the request.

# The solution
fixes #13198 
Added the `parse-filter` utility, used in role based field validation, for field validations to resolve the dynamic variables before the payload is validated.