### PR TITLE
Fix user update going through status check even when the payload does not have `status` in it

### DIFF
--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -197,7 +197,7 @@ export class UsersService extends ItemsService {
 			}
 		}
 
-		if (data.status !== 'active') {
+		if (data.status !== undefined && data.status !== 'active') {
 			await this.checkRemainingActiveAdmin(keys);
 		}
 


### PR DESCRIPTION
Particularly this is triggering when the page tracking update happens:

![chrome_7bhmWyBlS0](https://user-images.githubusercontent.com/42867097/168975831-e2bcc7b2-0121-46f2-b001-fb53f24f8bbb.png)

So the solution is to ensure `status` exists in the payload first before doing the "last admin must be active" check added in #13309.