### PR TITLE
Fix compareValue check for _null and _empty type of operators

### DIFF
--- a/api/src/utils/apply-query/operators/is-empty.operator.ts
+++ b/api/src/utils/apply-query/operators/is-empty.operator.ts
@@ -3,7 +3,7 @@ import { registerOperator } from './operator-register';
 export default registerOperator({
 	operator: '_empty',
 	apply: ({ query, selectionRaw, compareValue }) => {
-		if (compareValue === true) {
+		if (compareValue) {
 			query.where(selectionRaw, '=', '');
 		} else {
 			query.where(selectionRaw, '!=', '');

--- a/api/src/utils/apply-query/operators/is-not-empty.operator.ts
+++ b/api/src/utils/apply-query/operators/is-not-empty.operator.ts
@@ -3,7 +3,7 @@ import { registerOperator } from './operator-register';
 export default registerOperator({
 	operator: '_nempty',
 	apply: ({ query, selectionRaw, compareValue }) => {
-		if (compareValue === true) {
+		if (compareValue) {
 			query.where(selectionRaw, '!=', '');
 		} else {
 			query.where(selectionRaw, '=', '');

--- a/api/src/utils/apply-query/operators/is-not-null.operator.ts
+++ b/api/src/utils/apply-query/operators/is-not-null.operator.ts
@@ -3,7 +3,7 @@ import { registerOperator } from './operator-register';
 export default registerOperator({
 	operator: '_nnull',
 	apply: ({ query, selectionRaw, compareValue }) => {
-		if (compareValue === true) {
+		if (compareValue) {
 			query.whereNotNull(selectionRaw);
 		} else {
 			query.whereNull(selectionRaw);

--- a/api/src/utils/apply-query/operators/is-null.operator.ts
+++ b/api/src/utils/apply-query/operators/is-null.operator.ts
@@ -3,7 +3,7 @@ import { registerOperator } from './operator-register';
 export default registerOperator({
 	operator: '_null',
 	apply: ({ query, selectionRaw, compareValue }) => {
-		if (compareValue === true) {
+		if (compareValue) {
 			query.whereNull(selectionRaw);
 		} else {
 			query.whereNotNull(selectionRaw);

--- a/packages/shared/src/types/filter.ts
+++ b/packages/shared/src/types/filter.ts
@@ -12,6 +12,7 @@ export type FilterOperator =
 	| 'contains'
 	| 'icontains'
 	| 'ncontains'
+	| 'nicontains'
 	| 'between'
 	| 'nbetween'
 	| 'empty'
@@ -51,7 +52,9 @@ export type FieldFilterOperator = {
 	_null?: boolean;
 	_nnull?: boolean;
 	_contains?: string;
+	_icontains?: string;
 	_ncontains?: string;
+	_nicontains?: string;
 	_starts_with?: string;
 	_nstarts_with?: string;
 	_ends_with?: string;


### PR DESCRIPTION
Fixes #13387.

The compareValue is of `number` type, thus it is `1` for `true` and `0` for `false`.

### Before

https://user-images.githubusercontent.com/26413686/169103390-962dadbf-0324-4ae0-b585-134e43e81d67.mov

### After

https://user-images.githubusercontent.com/26413686/169103423-1c19b390-1b03-4c31-adae-69b420f875e2.mov

