### PR TITLE
Assets: Fix range requests

### DIFF
--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -140,7 +140,7 @@ router.get(
 
 		if (req.headers.range) {
 			// substring 6 = "bytes="
-			const rangeParts = /bytes=(.*)-(.*)/.exec(req.headers.range);
+			const rangeParts = /bytes=(.*?)-(.*)/.exec(req.headers.range);
 
 			range = {
 				start: rangeParts?.[1] ? Number(rangeParts[1]) : undefined,

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -148,7 +148,7 @@ router.get(
 			};
 
 			if (Number.isNaN(range.start) || Number.isNaN(range.end)) {
-				throw new RangeNotSatisfiableException(range);
+				throw new RangeNotSatisfiableException({ start: rangeParts?.[1], end: rangeParts?.[2] });
 			}
 		}
 

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -139,8 +139,7 @@ router.get(
 		let range: Range | undefined = undefined;
 
 		if (req.headers.range) {
-			// substring 6 = "bytes="
-			const rangeParts = /bytes=(.*?)-(.*)/.exec(req.headers.range);
+			const rangeParts = /bytes=([0-9]*)-([0-9]*)/.exec(req.headers.range);
 
 			range = {
 				start: rangeParts?.[1] ? Number(rangeParts[1]) : undefined,

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -136,22 +136,7 @@ router.get(
 			  )
 			: res.locals.transformation;
 
-		let range: Range | undefined = undefined;
-
-		if (req.headers.range) {
-			const rangeParts = /bytes=([0-9]*)-([0-9]*)/.exec(req.headers.range);
-
-			range = {
-				start: rangeParts?.[1] ? Number(rangeParts[1]) : undefined,
-				end: rangeParts?.[2] ? Number(rangeParts[2]) : undefined,
-			};
-
-			if (Number.isNaN(range.start) || Number.isNaN(range.end)) {
-				throw new RangeNotSatisfiableException({ start: rangeParts?.[1], end: rangeParts?.[2] });
-			}
-		}
-
-		const { stream, file, stat } = await service.getAsset(id, transformation, range);
+		const { stream, file, stat, range } = await service.getAsset(id, transformation, req.headers.range);
 
 		const access = req.accountability?.role ? 'private' : 'public';
 

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -147,7 +147,7 @@ router.get(
 			};
 
 			if (Number.isNaN(range.start) || Number.isNaN(range.end)) {
-				throw new RangeNotSatisfiableException(String(req.headers.range.split('bytes=').pop()));
+				throw new RangeNotSatisfiableException(range);
 			}
 		}
 

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -140,11 +140,11 @@ router.get(
 
 		if (req.headers.range) {
 			// substring 6 = "bytes="
-			const rangeParts = req.headers.range.substring(6).split('-');
+			const rangeParts = /bytes=(.*)-(.*)/.exec(req.headers.range);
 
 			range = {
-				start: rangeParts[0] ? Number(rangeParts[0]) : 0,
-				end: rangeParts[1] ? Number(rangeParts[1]) : undefined,
+				start: rangeParts?.[1] ? Number(rangeParts[1]) : undefined,
+				end: rangeParts?.[2] ? Number(rangeParts[2]) : undefined,
 			};
 
 			if (Number.isNaN(range.start) || Number.isNaN(range.end)) {
@@ -170,7 +170,7 @@ router.get(
 		if (range) {
 			res.setHeader('Content-Range', `bytes ${range.start}-${range.end || stat.size - 1}/${stat.size}`);
 			res.status(206);
-			res.setHeader('Content-Length', (range.end ? range.end + 1 : stat.size) - range.start);
+			res.setHeader('Content-Length', (range.end ? range.end + 1 : stat.size) - (range.start || 0));
 		} else {
 			res.setHeader('Content-Length', stat.size);
 		}

--- a/api/src/exceptions/range-not-satisfiable.ts
+++ b/api/src/exceptions/range-not-satisfiable.ts
@@ -1,8 +1,7 @@
-import { Range } from '@directus/drive';
 import { BaseException } from '@directus/shared/exceptions';
 
 export class RangeNotSatisfiableException extends BaseException {
-	constructor(range: Range) {
+	constructor(range: { start: any; end: any }) {
 		super(
 			`Range "${range.start}-${range.end}" is invalid or the file's size doesn't match the requested range.`,
 			416,

--- a/api/src/exceptions/range-not-satisfiable.ts
+++ b/api/src/exceptions/range-not-satisfiable.ts
@@ -3,7 +3,10 @@ import { Range } from '@directus/drive';
 
 export class RangeNotSatisfiableException extends BaseException {
 	constructor(range?: Range) {
-		const rangeString = range && (range?.start || range?.end) ? `"${range.start ?? ''}-${range.end ?? ''}" ` : '';
+		const rangeString =
+			range && (range?.start !== undefined || range?.end !== undefined)
+				? `"${range.start ?? ''}-${range.end ?? ''}" `
+				: '';
 
 		super(
 			`Range ${rangeString}is invalid or the file's size doesn't match the requested range.`,

--- a/api/src/exceptions/range-not-satisfiable.ts
+++ b/api/src/exceptions/range-not-satisfiable.ts
@@ -1,9 +1,12 @@
 import { BaseException } from '@directus/shared/exceptions';
+import { Range } from '@directus/drive';
 
 export class RangeNotSatisfiableException extends BaseException {
-	constructor(rangeValue: string) {
+	constructor(range?: Range) {
+		const rangeString = range && (range?.start || range?.end) ? `"${range.start ?? ''}-${range.end ?? ''}" ` : '';
+
 		super(
-			`Range "${rangeValue}" is invalid or the file's size doesn't match the requested range.`,
+			`Range ${rangeString}is invalid or the file's size doesn't match the requested range.`,
 			416,
 			'RANGE_NOT_SATISFIABLE'
 		);

--- a/api/src/exceptions/range-not-satisfiable.ts
+++ b/api/src/exceptions/range-not-satisfiable.ts
@@ -1,9 +1,9 @@
 import { BaseException } from '@directus/shared/exceptions';
 
 export class RangeNotSatisfiableException extends BaseException {
-	constructor(range: { start: any; end: any }) {
+	constructor(rangeValue: string) {
 		super(
-			`Range "${range.start}-${range.end}" is invalid or the file's size doesn't match the requested range.`,
+			`Range "${rangeValue}" is invalid or the file's size doesn't match the requested range.`,
 			416,
 			'RANGE_NOT_SATISFIABLE'
 		);

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -66,10 +66,47 @@ export class AssetsService {
 		if (!exists) throw new ForbiddenException();
 
 		if (range) {
-			if (range.end && range.end >= file.filesize) range.end = undefined;
-
-			if (range.start >= file.filesize || (range.end && range.start > range.end)) {
+			if (!range.start && !range.end) {
 				throw new RangeNotSatisfiableException(range);
+			}
+
+			if (range.end) {
+				if (range.end <= 0) {
+					throw new RangeNotSatisfiableException(range);
+				}
+
+				if (!range.start) {
+					// fetch chunk from tail
+					range.start = file.filesize - range.end;
+					range.end = file.filesize - 1;
+				}
+
+				if (range.end >= file.filesize) {
+					// fetch entire file
+					range.end = undefined;
+				}
+			}
+
+			if (range.start) {
+				if (range.start >= file.filesize) {
+					throw new RangeNotSatisfiableException(range);
+				}
+
+				if (!range.end) {
+					// fetch entire file
+					range.end = file.filesize - 1;
+				}
+
+				if (range.start < 0) {
+					// fetch file from head
+					range.start = 0;
+				}
+			}
+
+			if (range.start && range.end) {
+				if (range.start > range.end) {
+					throw new RangeNotSatisfiableException(range);
+				}
 			}
 		}
 

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -66,10 +66,10 @@ export class AssetsService {
 		if (!exists) throw new ForbiddenException();
 
 		if (range) {
-			const missingRangeLimits = range.start == null && range.end == null;
-			const endBeforeStart = range.start != null && range.end != null && range.end <= range.start;
-			const startOverflow = range.start != null && range.start >= file.filesize;
-			const endUnderflow = range.end != null && range.end <= 0;
+			const missingRangeLimits = range.start === undefined && range.end === undefined;
+			const endBeforeStart = range.start !== undefined && range.end !== undefined && range.end <= range.start;
+			const startOverflow = range.start !== undefined && range.start >= file.filesize;
+			const endUnderflow = range.end !== undefined && range.end <= 0;
 
 			if (missingRangeLimits || endBeforeStart || startOverflow || endUnderflow) {
 				throw new RangeNotSatisfiableException(range);
@@ -78,7 +78,7 @@ export class AssetsService {
 			const lastByte = file.filesize - 1;
 
 			if (range.end) {
-				if (range.start == null) {
+				if (range.start === undefined) {
 					// fetch chunk from tail
 					range.start = file.filesize - range.end;
 					range.end = lastByte;
@@ -91,7 +91,7 @@ export class AssetsService {
 			}
 
 			if (range.start) {
-				if (range.end == null) {
+				if (range.end === undefined) {
 					// fetch entire file
 					range.end = lastByte;
 				}

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -66,7 +66,9 @@ export class AssetsService {
 		if (!exists) throw new ForbiddenException();
 
 		if (range) {
-			if (range.start >= file.filesize || (range.end && range.end >= file.filesize)) {
+			if (range.end && range.end >= file.filesize) range.end = undefined;
+
+			if (range.start >= file.filesize || (range.end && range.start > range.end)) {
 				throw new RangeNotSatisfiableException(range);
 			}
 		}

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -36,7 +36,7 @@ export class AssetsService {
 		id: string,
 		transformation: TransformationParams | TransformationPreset,
 		range?: Range
-	): Promise<{ stream: NodeJS.ReadableStream; file: any; stat: StatResponse; range: Range | undefined }> {
+	): Promise<{ stream: NodeJS.ReadableStream; file: any; stat: StatResponse }> {
 		const publicSettings = await this.knex
 			.select('project_logo', 'public_background', 'public_foreground')
 			.from('directus_settings')
@@ -126,7 +126,6 @@ export class AssetsService {
 					stream: storage.disk(file.storage).getStream(assetFilename, range),
 					file,
 					stat: await storage.disk(file.storage).getStat(assetFilename),
-					range,
 				};
 			}
 
@@ -161,13 +160,12 @@ export class AssetsService {
 					stream: storage.disk(file.storage).getStream(assetFilename, range),
 					stat: await storage.disk(file.storage).getStat(assetFilename),
 					file,
-					range,
 				};
 			});
 		} else {
 			const readStream = storage.disk(file.storage).getStream(file.filename_disk, range);
 			const stat = await storage.disk(file.storage).getStat(file.filename_disk);
-			return { stream: readStream, file, stat, range };
+			return { stream: readStream, file, stat };
 		}
 	}
 }

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -66,10 +66,10 @@ export class AssetsService {
 		if (!exists) throw new ForbiddenException();
 
 		if (range) {
-			const missingRangeLimits = !range.start && !range.end;
-			const endBeforeStart = range.start && range.end && range.end <= range.start;
-			const startOverflow = range.start && range.start >= file.filesize;
-			const endUnderflow = range.end && range.end <= 0;
+			const missingRangeLimits = range.start == null && range.end == null;
+			const endBeforeStart = range.start != null && range.end != null && range.end <= range.start;
+			const startOverflow = range.start != null && range.start >= file.filesize;
+			const endUnderflow = range.end != null && range.end <= 0;
 
 			if (missingRangeLimits || endBeforeStart || startOverflow || endUnderflow) {
 				throw new RangeNotSatisfiableException(range);
@@ -78,7 +78,7 @@ export class AssetsService {
 			const lastByte = file.filesize - 1;
 
 			if (range.end) {
-				if (!range.start) {
+				if (range.start == null) {
 					// fetch chunk from tail
 					range.start = file.filesize - range.end;
 					range.end = lastByte;
@@ -91,7 +91,7 @@ export class AssetsService {
 			}
 
 			if (range.start) {
-				if (!range.end) {
+				if (range.end == null) {
 					// fetch entire file
 					range.end = lastByte;
 				}

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -72,7 +72,7 @@ export class AssetsService {
 			const endUnderflow = range.end != null && range.end <= 0;
 
 			if (missingRangeLimits || endBeforeStart || startOverflow || endUnderflow) {
-				throw new RangeNotSatisfiableException(`${range.start}-${range.end}`);
+				throw new RangeNotSatisfiableException(range);
 			}
 
 			const lastByte = file.filesize - 1;

--- a/packages/drive-azure/src/AzureBlobWebServices.ts
+++ b/packages/drive-azure/src/AzureBlobWebServices.ts
@@ -170,7 +170,7 @@ export class AzureBlobWebServicesStorage extends Storage {
 
 		const stream = this.$containerClient
 			.getBlobClient(location)
-			.download(range?.start, range?.end ? range.end - range.start : undefined);
+			.download(range?.start, range?.end ? range.end - (range.start || 0) : undefined);
 
 		try {
 			stream

--- a/packages/drive/src/types.ts
+++ b/packages/drive/src/types.ts
@@ -63,6 +63,6 @@ export interface DeleteResponse extends Response {
 }
 
 export interface Range {
-	start: number;
+	start: number | undefined;
 	end: number | undefined;
 }


### PR DESCRIPTION
## Description
The current implementation of `Range` header when requesting assets is too strict. For example, if we request a greater range than the file size, it will throw an `RangeNotSatisfiableException` with 416 status code.

Although, the RFC (https://httpwg.org/specs/rfc7233.html#byte.ranges) tells that:
- Both `first-pos`[^1] and `last-pos`[^2] can be specified: `Range: 100-200`;
- Only `first-pos` can be specified: `Range: 100-`;
- Only `last-pos` can be specified. In this case, requested bytes comes from tail of the file: `Range: -100`;
- If `last-pos` is defined, should be greater than `first-pos`: ~`Range: 100-50`~
- `first-pos` should be any number less than the max file size: `Range: -100-`

## To consider:
We are relying on `first-pos` and `last-pos` to be Numbers.
Although, they can be huge and JS could not handle them.
To proper implement the RFC, those should be handled properly using BigInt or Strings for example.
But for the sake of simplicity, since we can handle until ≈ 9007 Terabytes, let's keep it as is


[^1]: First position in `Range`
[^2]: Last position in `Range`

___
Fixes https://github.com/directus/cloud/issues/357
Fixes https://github.com/directus/cloud/issues/81