### PR TITLE
Hide Save as Copy when creating new item

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -134,7 +134,7 @@
 				<template #append-outer>
 					<save-options
 						v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true && isSavable === true"
-						:disabled-options="createAllowed ? [] : ['save-and-add-new', 'save-as-copy']"
+						:disabled-options="disabledOptions"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"
@@ -366,6 +366,12 @@ export default defineComponent({
 			return props.primaryKey;
 		});
 
+		const disabledOptions = computed(() => {
+			if (!createAllowed.value) return ['save-and-add-new', 'save-as-copy'];
+			if (isNew.value) return ['save-as-copy'];
+			return [];
+		});
+
 		return {
 			t,
 			router,
@@ -384,6 +390,7 @@ export default defineComponent({
 			confirmArchive,
 			deleting,
 			archiving,
+			disabledOptions,
 			saveAndStay,
 			saveAndAddNew,
 			saveAsCopyAndNavigate,


### PR DESCRIPTION
Fixes #13407

### Problem

Clicking "Save as Copy" when creating a new item causes error as "Save as Copy" works by fetching the existing item by ID first to "duplicate" the item.

### Solution

Technically "Save as Copy" should only appear when something _can_ be copied, i.e. an existing item rather than being possible in item that does not exist yet. Hence this PR hides the button during **new** item creation:

![chrome_rt22A0UZN7](https://user-images.githubusercontent.com/42867097/169269551-142f5f9c-bffa-41a1-bdc7-d51cd1db162d.png)

