### PR TITLE
Fix parsing of time and dates when filtering in SQLite

### DIFF
--- a/api/src/database/helpers/date/dialects/sqlite.ts
+++ b/api/src/database/helpers/date/dialects/sqlite.ts
@@ -2,8 +2,13 @@ import { DateHelper } from '../types';
 
 export class DateHelperSQLite extends DateHelper {
 	parse(date: string): string {
-		const newDate = new Date(date);
-		return (newDate.getTime() - newDate.getTimezoneOffset() * 60 * 1000).toString();
+		// Return the time as string
+		if (date.length <= 8 && date.includes(':')) {
+			return date;
+		}
+
+		// Return dates in epoch milliseconds
+		return String(new Date(date).getTime());
 	}
 
 	fieldFlagForField(fieldType: string): string {


### PR DESCRIPTION
1. Time is stored as "HH:MM:SS" in SQLite and the current parsing results in an `NaN`.
2. Timezone offset causes the filtering value to be parsed with an incorrect offset.

### Before

https://user-images.githubusercontent.com/26413686/169289226-7b9c493a-5fea-4e8c-a639-dbae9335db5c.mov

### After

https://user-images.githubusercontent.com/26413686/169289253-0f9ce1ec-ab26-451e-86c7-27d9afc53728.mov


