### PR TITLE
Docs: re-edited user-directory + users-roles-permissions

### DIFF
--- a/docs/app/content/data-sharing.md
+++ b/docs/app/content/data-sharing.md
@@ -35,10 +35,9 @@ permissions. We welcome any [pull-requests](/contributing/introduction/) to addr
 
 ::: warning Users, Roles and Permissions!
 
-You will need to understand how
-[Users, Roles, and Permissions](/configuration/users-roles-permissions/#configuring-permissions) work in Directus to
-configure Shares properly. That said, if you're unfamiliar with those concepts, it is quite reasonable to learn them in
-tandem with Data Sharing.
+You will need to understand how [Users, Roles, and Permissions](/configuration/users-roles-permissions) work in Directus
+to configure Shares properly. That said, if you're unfamiliar with those concepts, it is quite reasonable to learn them
+in tandem with Data Sharing.
 
 :::
 
@@ -109,8 +108,8 @@ Share permissions.
 Any given Share will inherit the same read permissions as the Role it was associated with in the Share Options Menu.
 
 This system allows for absolutely granular configuration options on Shares... _but it also means you'll need to
-understand [Users, Roles, and Permissions](/configuration/users-roles-permissions/#configuring-permissions) thoroughly
-to use Shares properly_. Here are some highlights of what you can do:
+understand [Users, Roles, and Permissions](/configuration/users-roles-permissions/) thoroughly to use Shares properly_.
+Here are some highlights of what you can do:
 
 - Set the Collections a Role can view or share.
 - Filter for specific Items a Role can view or share.

--- a/docs/app/insights.md
+++ b/docs/app/insights.md
@@ -33,8 +33,8 @@ Each Directus Dashboard provides a drag-and-drop canvas where you can create and
 build out customized analytics. The Dashboard area automatically expands as you add more and more Panels. In theory, a
 Dashboard area can expand infinitely large... but in practice, users will probably only want to build Dashboards as
 large as the screen they will be viewing on. You are able to create as many Dashboards as you need. Additionally, the
-Dashboard view, edit, and create permissions are
-[fully configurable](/configuration/users-roles-permissions/#configuring-permissions) by User Role.
+Dashboard view, edit, and create permissions are [fully configurable](/configuration/users-roles-permissions/) by User
+Role.
 
 ![Dashboard Grid Area](https://cdn.directus.io/docs/v9/app-guide/insights/insights-20220216A/dashboards-overview-20220216A.webp)
 

--- a/docs/app/user-directory.md
+++ b/docs/app/user-directory.md
@@ -1,31 +1,36 @@
 # User Directory
 
 > The User Directory is the management system for all Users within a Project. [Users](/getting-started/glossary#users)
-> are the individual accounts for logging in to the App. Each user belongs to a [Role](/getting-started/glossary#roles)
+> are the individual accounts for logging in to the App. Each User belongs to a [Role](/getting-started/glossary#roles)
 > which defines its [Permissions](/getting-started/glossary#permissions).
 
 ![User Directory Page](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-directory-20220222A.webp)
 
 [[toc]]
 
+<!-- @TODO getting-started > learn-directus
+
+:::tip Before You Begin
+
+To use this Module effectively, you will need to understand
+[Users, Roles and Permissions](/configuration/users-roles-permissions.md).
+
+:::
+-->
+
 ## How it Works
 
-This Module is a management system that enables one to view, invite, create, edit, and delete Users. In order to
-understand and use this Module effectively, you will need to understand
-[Users, Roles, and Permissions](/configuration/users-roles-permissions.md).
+This Module is a management system that enables one to view, invite, create, edit, and delete Users and User
+information. Users can be created directly in the app, or invited to join via email.
 
-## Access Permissions
+When a User is created, they must also be assigned a Role. This Role defines the User's data access permissions within
+Directus. In other words, it determines what a User can see and do inside the app.
 
-The permissions configured for your Role will determine what you can see and do inside the User Directory. Roles with
-_Admin Access_ enabled are created with full Permissions. Roles with _App Access_ enabled are created with some limited
-Permissions configured by default. Roles that have neither _Admin_ nor _App Access_ enabled (such as the built-in
-_Public_ Role) are created with no access permissions _(to anything)_ by default. Default permissions can be fully
-configured in **Settings > Roles & Permissions**.
+The User Directory is composed of two pages: The User Directory Page and the User Details Page. It has all the same
+features and functionality as the [Content Module](/app/collections) such as manual and automatic sorting, batch
+edit/delete/archive, import/export from files, etc.
 
 ## User Directory Page
-
-Lists all Users in a Project, with a navigation that allows quick access to Users by Role. This page has the same
-functionality as other [Content Pages](/app/content-collections/).
 
 <video title="User Directory Options" autoplay muted loop controls>
 	<source src="https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-directory-options-20220222A.mp4" />
@@ -34,41 +39,83 @@ functionality as other [Content Pages](/app/content-collections/).
 	</p>
 </video>
 
-- **Select All** – Selects all Users currently in queue.
-- **Card Size** – Toggles size of User Displays.
-- **Sort Field** – Selects Field used to Users by.
-- **Sort Direction** – Toggles ascending & descending sort order.
-- **Search** – Enables classic type-based searching.
-- **Filter** – Enables advanced query-based search.
-- <span mi btn sec>person_add</span> – [Invite people](/configuration/users-roles-permissions/#inviting-a-user) to
+The User Directory Page lists all Users in a Project, with a navigation that allows quick access to Users by Role. This
+page has the same functionality as the [Collection Page](/app/content/collections/).
+
+- **Select All** — Selects all Users currently in queue.
+- **Card Size** — Toggles size of User Displays.
+- **Sort Field** — Selects Field used to Users by.
+- **Sort Direction** — Toggles ascending & descending sort order.
+- **Search** — Enables classic type-based searching.
+- **Filter** — Enables advanced query-based search.
+- <span mi btn sec>person_add</span> — [Invite people](/configuration/users-roles-permissions/#inviting-a-user) to
   become Users via email.
-- <span mi btn>add</span> – [Create User](/configuration/users-roles-permissions/#creating-a-user) manually.
+- <span mi btn>add</span> — [Create User](/configuration/users-roles-permissions/#creating-a-user) manually.
 
 _The following are only visible once Users are selected._
 
-- <span mi btn warn>edit</span> – Opens a User Details page to apply a single edit across multiple Users.
-- **<span mi btn dngr>delete</span>** – Deletes one or more Users.
+- <span mi btn warn>edit</span> — Opens a User Details page to apply a single edit across multiple Users.
+- **<span mi btn dngr>delete</span>** — Deletes one or more Users.
 
 ### Layout Options
 
-The **Sidebar > Layout Options** _(denoted by <span mi icon>layers</span> when Sidebar is minimized)_ allows you to
-adjust how Users are displayed on the User Directory.
-
 ![User Directory Layout Options](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-directory-layout-options-20220222A.webp)
 
-#### Layout
+The **Sidebar > Layout Options** _(denoted by <span mi icon>layers</span> when Sidebar is minimized)_ allows you to
+adjust how Users are displayed on the User Directory. To learn more, see [Layouts](/app/layouts/).
 
-- **Layout** – Toggles User Display from a dropdown menu.
-- **Image Source** – Selects the image Field for the User Display.
-- **Title** – Sets a title for the User via Display Templates.
-- **Subtitle** – Sets a subtitle for the User via Display Templates.
+## User Details Page
 
-#### Layout Setup
+![The User Page](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-profile-20220222A.webp)
 
-- **Image Fit** – Displays the image as cropped or contained.
-- **Fallback Icon** – Sets a default icon for Users that have no image set.
+A User's profile page can be accessed from the User Directory or by clicking the User Menu at the bottom of the
+[Module Bar](/app/overview/#_1-module-bar). The profile page has the same features and functionality as the
+[Item Page](/app/content-items/). Administrators can add and customize Fields under
+[Settings > Data Model > Directus Users](/configuration/data-model), but the following are available by default.
 
-## Viewing a User
+- **First Name** — The given name.
+- **Last Name** — The family/surname.
+- **Email** — A unique email address.
+- **Password** — A hashed system password.
+- **Avatar** — An image to represent the User.
+- **Location** — The city, country, office, or branch name.
+- **Title** — The professional staff title.
+- **Description** — A freeform text description.
+- **Tags** — Keywords for search-ability.
+
+### User Preferences
+
+![User Preferences](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-preferences-20220222A.webp)
+
+- **Language** — The preferred App language/locale.
+- **Theme** — Light or Dark mode (or based on system preferences).
+- **Multi-Factor Authentication** — Configuration for MFA.
+- **Email Notifications** — Receive emails for notifications.
+
+### Admin Options
+
+![Admin Options](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/admin-options-20220222A.webp)
+
+- **Status** — Sets User status as Draft, Invited, Active, Suspended, Archived.
+- **Role** — Defines the User's Role.
+- **Token** — Accepts any string as a User access token.\
+  _Note: At least 19-20 characters recommended for an access token, but we give you the flexibility to set this according
+  to you own internal security policies._
+- **Provider** — _read-only:_ SSO provider associated with User. See our built-in [SSO options](/configuration/sso).
+- **External Identifier** — Displays external identifier generated by SSO provider.
+
+### Read-only Info
+
+![User Profile Sidebar Information](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-profile-sidebar-information-20220309A.webp)
+
+Information in the Sidebar _(denoted by <span mi icon dark>info</span> when Sidebar is minimized)_ also includes the
+following read-only details:
+
+- **User Key** — The Primary Key of the User.
+- **Last Page** — The last App page accessed by the User.
+- **Last Access** — The timestamp of the User's last App or API action.
+
+## View a User
 
 <video autoplay muted loop controls>
 	<source src="https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/viewing-a-user-20220222A.mp4" />
@@ -80,61 +127,78 @@ adjust how Users are displayed on the User Directory.
 Users are referenced throughout the app, often for accountability purposes. Hovering over a User in this context will
 provide a popover with basic information. Clicking that popover will navigate you to a view of that User's profile page.
 
-## User Profile Page
+## Create a User
 
-![The User Page](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-profile-20220222A.webp)
+To create a User, follow these steps:
 
-A User's profile page can be accessed from the User Directory or by clicking the User Menu at the bottom of the
-[Module Bar](/app/overview/#_1-module-bar). The profile page has the same features and functionality as the
-[Item Page](/app/content-items/). Administrators can customize the Fields on this page, but the following are available
-by default.
+1. Navigate to the **User Library**.
+2. Click <span mi btn>add</span> in the page header.
+3. Enter an **Email Address**.
+4. Optional: Fill in the other User details as desired.
+5. Click <span mi btn>check</span> to save the User.
 
-### User Details
+## Invite a User
 
-![User Details](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-details-20220222A.webp)
+To invite User(s) via email, follow these steps:
 
-- **First Name** – The given name.
-- **Last Name** – The family/surname.
-- **Email** – A unique email address.
-- **Password** – A hashed system password.
-- **Avatar** – An image to represent the User.
-- **Location** – The city, country, office, or branch name.
-- **Title** – The professional staff title.
-- **Description** – A freeform text description.
-- **Tags** – Keywords for search-ability.
+1. Navigate to the **User Library**.
+2. Click <span mi btn sec>person_add</span> in the page header.
+3. Enter one or more email addresses, separated by a comma and a space.\
+   _Tip: You can also add emails on a new line._
+4. Select the **Role** you want to assign to the User(s).
+5. Click **Invite**.
 
-### User Preferences
+After that, the invited User(s) will receive an email with a link to the App where they set a password and enable their
+account.
 
-![User Preferences](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-preferences-20220222A.webp)
+## Edit User Details
 
-- **Language** – The preferred App language/locale.
-- **Theme** – Light or Dark mode (or based on system preferences).
-- **Multi-Factor Authentication** – Configuration for MFA.
-- **Email Notifications** – Receive emails for notifications.
+To edit User details, follow these steps:
 
-### Admin Options
+1. Navigate to the **User Library**.
+2. Click on the User you wish to manage and the User Details Page will open.
+3. Reset User details as desired.
 
-![Admin Options](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/admin-options-20220222A.webp)
+The User Detail is only editable by the current User and admins, and the following fields are only available to admins:
 
-- **Status** – Sets User status as Draft, Invited, Active, Suspended, Archived.
-- **Role** – Defines the User's Role.
-- **Token** – Accepts any string as User access token. At least 19-20 characters recommended, but we give you the tools
-  and flexibility to set this according to you own internal security policies.
-- **Provider** – _read-only:_ SSO provider associated with User. See our built-in [SSO options](/configuration/sso).
-- **External Identifier** – Displays external identifier generated by SSO provider.
+- **Status** — Determines if an account is able to access the platform or not. Only the `active` state is able to
+  authenticate, all others are simply descriptive inactive states.
+  - **Draft** — An incomplete User; no App/API access.
+  - **Invited** — Has a pending invite to the project; no App/API access until accepted.
+  - **Active** — The only status that has proper access to the App and API.
+  - **Suspended** — A User that has been temporarily disabled; no App/API access.
+  - **Archived** — A soft-deleted User; no App/API access.
+- **Role** — The User's role determines their permissions and access.
+- **Token** — A User's token is an alternate way to [authenticate into the API](/reference/authentication/) using a
+  static string. When NULL, the token is disabled. When enabled, ensure that a secure string is used.
 
-### Read-only Info
+## Archive a User
 
-![User Profile Sidebar Information](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-profile-sidebar-information-20220309A.webp)
+To archive a User, follow these steps:
 
-Information in the Sidebar _(denoted by <span mi icon dark>info</span> when Sidebar is minimized)_ also includes the
-following read-only details:
+1. Navigate to the **User Library**.
+2. Click the User you with to archive to go to their User Detail page.
+3. Click on <span mi btn warn>archive</span> in the header.
+4. Confirm this decision by clicking **Archive** in the dialog.
 
-- **User Key** – The Primary Key of the Usser.
-- **Last Page** – The last App page accessed by the user.
-- **Last Access** – The timestamp of the User's last App or API action.
+::: warning Disables Access
 
-## More Help
+Archiving is equivalent to a _soft-delete_. These Users are unable to access the App or API.
 
-Looking for technical support for your non-enterprise project? Chat with thousands of engineers within our growing
-[Community on Discord](https://discord.com/invite/directus)
+:::
+
+## Delete a User
+
+To delete a User, follow these steps:
+
+1. Navigate to the **User Library**.
+2. Select one or more Users you wish to delete.
+3. Click on <span mi btn dngr>delete</span> in the header.
+4. Confirm this decision by clicking **Delete** in the dialog.
+
+::: danger Irreversible Change
+
+This action is permanent and can not be undone. Please proceed with caution. If you wish to soft-delete Users, see
+[Archive a User](#archive-a-user).
+
+:::

--- a/docs/configuration/users-roles-permissions.md
+++ b/docs/configuration/users-roles-permissions.md
@@ -6,72 +6,37 @@
 
 [[toc]]
 
-## Creating a User
+<!--
 
-1. Navigate to the **User Library**
-2. Click <span mi btn>add</span> in the header
-3. Enter an **Email Address**
-4. Optional: Complete the **other user form fields**
-5. Click <span mi btn>check</span> to save the user.
+:::tip Before You Begin
 
-## Inviting a User
-
-1. Navigate to the **User Library**
-2. Click <span mi btn sec>person_add</span> in the header
-3. Enter **one or more email addresses**, separated by new lines, in the modal
-4. Select the **Role** you want to assign to the user(s)
-5. Click **Invite**
-
-At this point the invited user(s) will receive an email with a link to the App where they set a password and enable
-their account.
-
-## Configuring a User
-
-1. Navigate to the **User Library**
-2. **Click on the user** you wish to manage
-3. **Complete the form** of [User Fields](/app/user-directory/#editing-a-user)
-
-The User Detail is only editable by the current user and admins, and the following fields are only available to admins:
-
-- **Status** — Determines if an account is able to access the platform or not. Only the `active` state is able to
-  authenticate, all others are simply descriptive inactive states.
-  - **Draft** — An incomplete user; no App/API access
-  - **Invited** — Has a pending invite to the project; no App/API access until accepted
-  - **Active** — The only status that has proper access to the App and API
-  - **Suspended** — A user that has been temporarily disabled; no App/API access
-  - **Archived** — A soft-deleted user; no App/API access
-- **Role** — The user's role determines their permissions and access
-- **Token** — A user's token is an alternate way to [authenticate into the API](/reference/authentication/) using a
-  static string. When NULL, the token is disabled. When enabled, ensure that a secure string is used.
-
-## Archiving a User
-
-1. Navigate to the **User Library**
-2. Click the user you with to archive to go to their User Detail page
-3. Click on <span mi btn warn>archive</span> in the header
-4. Confirm this decision by clicking **Archive** in the dialog
-
-::: warning Disables Access
-
-Archiving uses _soft-delete_, therefore archived users are unable to access the App or API.
 
 :::
 
-## Deleting a User
+## Overview
+Users are managed in the User Directory, while Roles and Permissions are managed in
+However, Roles and Permissions are inherently intwined with Users- as every User must be assigned a Role, which in turn defines access permissions. Directus comes with two Roles out of the box, Admin and Public.
+The Admin role provides full Permissions for all data in the app, and this cannot be limited.
+The Public role comes with all permissions turned off by default and can be fully reconfigured as needed.
+The Public role determines the access permissions for any incoming request from an un-authenticated User.
+Roles with _App Access_ enabled are created with some limited Permissions configured by default, so they can access the app and their own profile information.
+Roles that have neither _Admin_ nor _App Access_ enabled (such as the built-in _Public_ Role) are created with Public access permissions.
 
-1. Navigate to the **User Library**
-2. Select one or more users you wish to delete
-3. Click on <span mi btn dngr>delete</span> in the header
-4. Confirm this decision by clicking **Delete** in the dialog
+### Configure Public Permissions
 
-::: danger Irreversible Change
+The Public permissions control what project data is accessible without authentication. This is managed via the Public
+"role", which is included in the system by default and can not be deleted.
 
-Unlike the soft-delete of archiving, this process is a hard-delete. Therefore, this action is permanent and can not be
-undone. Please proceed with caution.
+::: warning Private by Default
+
+All of the data within the platform is private by default. Permissions for the public role can be granted on a
+case-by-case basis by administrators.
 
 :::
 
-## Creating a Role
+-->
+
+## Create a Role
 
 1. Navigate to **Settings <span mi icon dark>chevron_right</span> Roles & Permissions**
 2. Click <span mi btn>add</span> in the header
@@ -80,9 +45,9 @@ undone. Please proceed with caution.
 5. Enabling **Admin Access** gives full permission to project data and Settings
 6. Click on **Save** to save the role
 
-## Configuring a Role
+## Configure a Role
 
-- **Permissions** — Defines the role's access permissions
+- **Permissions** — Configure [access permissions](#configure-permissions) for the role
 - **Role Name** — This is the name of the role
 - **Role Icon** — The icon used throughout the App when referencing this role
 - **Description** — A helpful note that explains the role's purpose
@@ -92,7 +57,7 @@ undone. Please proceed with caution.
 - **Require 2FA** — Forces all users within this role to use two-factor authentication
 - **Users in Role** — A list of all users within this role
 
-## Deleting a Role
+## Delete a Role
 
 1. Navigate to **Settings <span mi icon dark>chevron_right</span> Roles & Permissions
    <span mi icon dark>chevron_right</span> [Role Name]**
@@ -102,8 +67,7 @@ undone. Please proceed with caution.
 ::: warning Users in a Deleted Role
 
 If you delete a role that still has users in it, those users will be given a `NULL` role, which denies their App access
-and limits them to the [Public Role](/configuration/users-roles-permissions/#configuring-public-permissions)
-permissions. They can then be reassigned to a new role by an admin.
+and limits them to Public permissions. They can then be reassigned to a new role by an admin.
 
 :::
 
@@ -120,7 +84,7 @@ Public access permissions.
 
 :::
 
-## Configuring Permissions
+## Configure Permissions
 
 Directus possesses an extremely granular, yet easy to configure, permissions system. When creating a new role,
 permissions are disabled for all project collections by default — allowing you to give explicit access to only what is
@@ -135,8 +99,8 @@ Every change made to the permissions of a role is saved automatically and instan
 
 ::: warning Admin Roles
 
-If a role is set to **Admin Access** then it is granted complete access to the platform, and therefore the permission
-configuration field is disabled.
+If a role is set to **Admin Access** then it is granted complete access to the platform, and Permission configuration is
+disabled.
 
 :::
 
@@ -147,8 +111,8 @@ configuration field is disabled.
 4. Choose the desired permission level: <span mi icon>check</span> **All Access**, <span mi icon>block</span> **No
    Access**, or <span mi icon>rule</span> **Use Custom**
 
-**If you selected "<span mi icon>check</span> All Access" or "<span mi icon>block</span> No Access" then setup is
-complete.** If you chose to customize permissions then continue with the appropriate guide below based on the relevant
+If you selected **"<span mi icon>check</span> All Access"** or **"<span mi icon>block</span> No Access"** then setup is
+complete. If you chose to customize permissions then continue with the appropriate guide below based on the relevant
 _action_.
 
 ### Create (Custom Access)
@@ -186,24 +150,16 @@ App's soft-delete and manual sorting features.
 
 ---
 
-### Configuring Public Permissions
-
-The Public permissions control what project data is accessible without authentication. This is managed via the Public
-"role", which is included in the system by default and can not be deleted.
-
-::: warning Private by Default
-
-All of the data within the platform is private by default. Permissions for the public role can be granted on a
-case-by-case basis by administrators.
-
-:::
-
-### Configuring System Permissions
+### Configure System Permissions
 
 In addition to permissions for _your_ custom collections, you can also customize the permissions for _system_
-collections. It is important to note that when App Access is enabled for a role, Directus will automatically add
-permission for the necessary system collections. To edit system permissions, simply click "System Collections" at the
-bottom of the permissions configuration.
+collections. To edit system permissions, follow these steps:
+
+1. Go to **Roles and Permissions** and select the desired Role.\
+   _You will be taken to the permissions configuration page._
+2. Click **System Collections** at the bottom of the page.
+3. Find the desired System Collection.
+4. Set permissions as desired.
 
 There are two pre-configured options you can use for resetting the role's system permissions and ensure proper App
 access. To access these, click "System Collections" to expand, and then click one of the buttons at the bottom of the
@@ -212,7 +168,14 @@ listing.
 - **App Access Minimum** — The minimum permissions required to properly access the App
 - **Recommended Defaults** — More permissive but balanced for a better App user experience
 
-## Configuring Workflows
+:::tip Remember
+
+When App Access is enabled, Directus will automatically add _(and hardcode)_ permissions for the necessary system
+collections for that Role.
+
+:::
+
+## Configure Workflows
 
 Workflows are a way to add structured stages to the flow of content authoring. They are primarily defined through the
 permissions for a Collection, but can be further enhanced via email notifications, custom interfaces, and automation.

--- a/docs/configuration/users-roles-permissions.md
+++ b/docs/configuration/users-roles-permissions.md
@@ -12,16 +12,25 @@
 
 
 :::
+-->
 
 ## Overview
-Users are managed in the User Directory, while Roles and Permissions are managed in
-However, Roles and Permissions are inherently intwined with Users- as every User must be assigned a Role, which in turn defines access permissions. Directus comes with two Roles out of the box, Admin and Public.
-The Admin role provides full Permissions for all data in the app, and this cannot be limited.
-The Public role comes with all permissions turned off by default and can be fully reconfigured as needed.
-The Public role determines the access permissions for any incoming request from an un-authenticated User.
+
+While this page focuses on configuration of Roles and Permissions, it is important to remember that Roles and
+Permissions are inherently intwined with Users. This is because every User must be assigned a Role to define their
+access permissions.
+
+Directus comes with two Roles out of the box, Admin and Public. The Admin role provides full Permissions for all data in
+the app, and this cannot be limited. This Admin Role provides full, app-wide control to the Project owners,
+administrators, and creators. The Public role comes with all permissions turned off by default and these can be fully
+reconfigured as needed. This Public role determines the access permissions given for any unauthenticated request to app
+data including un-authenticated users, visitors to your website or any other web request to your Directus Project's API.
+
+In addition, Admins can create as many Roles as they wish and configure permissions granularly.
+
+<!--
 Roles with _App Access_ enabled are created with some limited Permissions configured by default, so they can access the app and their own profile information.
 Roles that have neither _Admin_ nor _App Access_ enabled (such as the built-in _Public_ Role) are created with Public access permissions.
-
 ### Configure Public Permissions
 
 The Public permissions control what project data is accessible without authentication. This is managed via the Public

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -313,9 +313,9 @@ There is also a "Public" role that determines access for unauthenticated access.
 ### Relevant Guides
 
 - [Creating a Role](/configuration/users-roles-permissions/#creating-a-role)
-- [Configuring a Role](/configuration/users-roles-permissions/#configuring-a-role)
-- [Configuring Role Permissions](/configuration/users-roles-permissions/#configuring-permissions)
-- [Configuring System Permissions](/configuration/users-roles-permissions/#configuring-system-permissions)
+- [Configuring a Role](/configuration/users-roles-permissions/#configure-a-role)
+- [Configuring Role Permissions](/configuration/users-roles-permissions/#configure-permissions)
+- [Configuring System Permissions](/configuration/users-roles-permissions/#configure-system-permissions)
 - [Deleting a Role](/configuration/users-roles-permissions/#deleting-a-role)
 
 ## Storage Adapters

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -8,8 +8,8 @@ pageClass: page-reference
 <div class="left">
 
 > All data within the platform is private by default. The
-> [public role](/configuration/users-roles-permissions/#configuring-public-permissions) can be configured to expose data
-> without authentication, or you can pass an access token to the API to access private data.
+> [public role](/configuration/users-roles-permissions/#configure-permissions) can be configured to expose data without
+> authentication, or you can pass an access token to the API to access private data.
 
 </div>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -158,8 +158,8 @@ npx directus roles create --role <role-name>
 ```
 
 These roles are created with the
-[minimum permissions required](/configuration/users-roles-permissions/#configuring-system-permissions) to properly
-access the App by default.
+[minimum permissions required](/configuration/users-roles-permissions/#configure-system-permissions) to properly access
+the App by default.
 
 To create a new role with admin access, set the `--admin` flag to `true`, such as
 


### PR DESCRIPTION
Attempting to address [this issue]( https://github.com/directus/organization/issues/88), I fell into an editing wormhole.

- [x] Added an Overview to succinctly explain the interaction between users-roles-permissions
- [x] Refactored User CRUD instructions from `config > usr-role-perm` into `user-directory` (media not added yet)
- [x] Re-edited User Directory for clarity and to apply a few of style updates.
- [x] Updated Titles (and links across the docs) for the new title format.
- [x] Improved copy to address [this issue]( https://github.com/directus/organization/issues/88)

Lots of work to go for Users, Roles and Permissions but this is a start.