### PR TITLE
Add cast-timestamp field flag to system tables

### DIFF
--- a/api/src/database/system-data/fields/activity.yaml
+++ b/api/src/database/system-data/fields/activity.yaml
@@ -37,6 +37,9 @@ fields:
 
   - field: timestamp
     display: datetime
+    special:
+      - date-created
+      - cast-timestamp
     options:
       relative: true
     width: half

--- a/api/src/database/system-data/fields/dashboards.yaml
+++ b/api/src/database/system-data/fields/dashboards.yaml
@@ -8,7 +8,9 @@ fields:
   - field: panels
     special: o2m
   - field: date_created
-    special: date-created
+    special:
+      - date-created
+      - cast-timestamp
   - field: user_created
     special: user-created
   - field: note

--- a/api/src/database/system-data/fields/notifications.yaml
+++ b/api/src/database/system-data/fields/notifications.yaml
@@ -3,7 +3,9 @@ table: directus_notifications
 fields:
   - field: id
   - field: timestamp
-    special: date-created
+    special:
+      - date-created
+      - cast-timestamp
   - field: status
   - field: recipient
   - field: sender

--- a/api/src/database/system-data/fields/panels.yaml
+++ b/api/src/database/system-data/fields/panels.yaml
@@ -17,7 +17,9 @@ fields:
   - field: options
     special: cast-json
   - field: date_created
-    special: date-created
+    special:
+      - date-created
+      - cast-timestamp
   - field: user_created
     special: user-created
   - field: dashboard

--- a/api/src/database/system-data/fields/shares.yaml
+++ b/api/src/database/system-data/fields/shares.yaml
@@ -51,7 +51,9 @@ fields:
     readonly: true
 
   - field: date_created
-    special: date-created
+    special:
+      - date-created
+      - cast-timestamp
     width: half
     readonly: true
     conditions:


### PR DESCRIPTION
Closes #13427.

Timestamps stored in `directus_activity` are not processed as a `dateTime` field in SQLite.
Hence, `cast-timestamp` is added to ensure that the field is seen as a `timestamp` field type.

It is also using the default value of `CURRENT_TIMESTAMP`, which results in an offset based on the server timezone. Hence, `date-created` is used to ensure that the timestamp value is correct.

The update is also replicated for other system tables.