### PR TITLE
Remove npmrc files which prevent lockfile creation in workspaces

### DIFF
--- a/api/.npmrc
+++ b/api/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	},
 	"engines": {
 		"node": ">=16.0.0",
-		"npm": ">=7.0.0"
+		"npm": ">=8.5.0"
 	},
 	"devDependencies": {
 		"@types/dockerode": "3.3.0",
@@ -68,7 +68,7 @@
 		"*.{md,yaml}": "prettier --write"
 	},
 	"volta": {
-		"node": "16.13.2",
-		"npm": "8.1.4"
+		"node": "16.15.0",
+		"npm": "8.10.0"
 	}
 }

--- a/packages/cli/.npmrc
+++ b/packages/cli/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/create-directus-extension/.npmrc
+++ b/packages/create-directus-extension/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/create-directus-project/.npmrc
+++ b/packages/create-directus-project/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/drive-azure/.npmrc
+++ b/packages/drive-azure/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/drive-gcs/.npmrc
+++ b/packages/drive-gcs/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/drive-s3/.npmrc
+++ b/packages/drive-s3/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/drive/.npmrc
+++ b/packages/drive/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/extensions-sdk/.npmrc
+++ b/packages/extensions-sdk/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/format-title/.npmrc
+++ b/packages/format-title/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/gatsby-source-directus/.npmrc
+++ b/packages/gatsby-source-directus/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/schema/.npmrc
+++ b/packages/schema/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/sdk/.npmrc
+++ b/packages/sdk/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/shared/.npmrc
+++ b/packages/shared/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/specs/.npmrc
+++ b/packages/specs/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
Since `v8.5.0` npm will detect that it is running inside a workspace and issue commands at the root package.

This prevents a very annoying issue with the terminal not flushing properly, spilling `timing config:load:flatten Completed in 1ms` messages everywhere.