### PR TITLE
Adds _none and _some operators

### DIFF
--- a/api/src/utils/apply-query/index.ts
+++ b/api/src/utils/apply-query/index.ts
@@ -319,7 +319,7 @@ export function applyFilter(
 		}
 	}
 
-	function callbackSubqueryRelation(relation: Relation, value: any) {
+	function subQueryBuilderSingle(relation: Relation, value: any) {
 		return function (subQueryKnex: Knex.QueryBuilder<any, any>) {
 			const field = relation!.field;
 			const collection = relation!.collection;
@@ -337,6 +337,22 @@ export function applyFilter(
 				schema,
 				true
 			);
+		};
+	}
+
+	function subQueryBuilderMultiple(relation: Relation, filter: Filter) {
+		return (subQueryKnex: Knex.QueryBuilder<any, unknown[]>) => {
+			const field = relation!.field;
+			const collection = relation!.collection;
+			const column = `${collection}.${field}`;
+
+			// specifically used for o2m, m2m subqueries
+			subQueryKnex
+				.select({ [field]: column })
+				.from(collection)
+				.whereNotNull(column);
+
+			applyQuery(knex, relation!.collection, subQueryKnex, { filter }, schema, true);
 		};
 	}
 
@@ -410,28 +426,15 @@ export function applyFilter(
 					pkField = knex.raw(`CAST(?? AS CHAR(255))`, [pkField]);
 				}
 
-				const subQueryBuilder = (filter: Filter) => (subQueryKnex: Knex.QueryBuilder<any, unknown[]>) => {
-					const field = relation!.field;
-					const collection = relation!.collection;
-					const column = `${collection}.${field}`;
-
-					subQueryKnex
-						.select({ [field]: column })
-						.from(collection)
-						.whereNotNull(column);
-
-					applyQuery(knex, relation!.collection, subQueryKnex, { filter }, schema, true);
-				};
-
 				if (filterOperator === '_none') {
-					dbQuery[logical].whereNotIn(pkField as string, subQueryBuilder(filterValue as Filter));
+					dbQuery[logical].whereNotIn(pkField as string, subQueryBuilderMultiple(relation, filterValue as Filter));
 				} else if (filterOperator === '_some') {
-					dbQuery[logical].whereIn(pkField as string, subQueryBuilder(filterValue as Filter));
+					dbQuery[logical].whereIn(pkField as string, subQueryBuilderMultiple(relation, filterValue as Filter));
 				} else if (isNegativeOperator(filterOperator)) {
 					inverseFilters(value);
-					dbQuery[logical].whereNotExists(callbackSubqueryRelation(relation, value));
+					dbQuery[logical].whereNotExists(subQueryBuilderSingle(relation, value));
 				} else {
-					dbQuery[logical].whereExists(callbackSubqueryRelation(relation, value));
+					dbQuery[logical].whereExists(subQueryBuilderSingle(relation, value));
 				}
 			}
 		}


### PR DESCRIPTION
# The problem
As the issue and Azreal pointed out the `_none` and `_some` operators were removed while still used in the m2m, m2a interfaces and needed for o2m filtering.

# The fix
fixes #13435 
Seems these were unintentionally left out in the operators refactor so I've opted to introduce them back in.