### PR TITLE
Remove workaround in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '16.15'
           cache: npm
-
-      # See https://github.com/npm/cli/issues/3637
-      - name: Downgrade NPM
-        run: npm i -g npm@7.20.2
 
       - name: Setup NPM cache
         uses: c-hive/gha-npm-cache@v1
@@ -83,13 +79,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '16.15'
           registry-url: https://registry.npmjs.org
           cache: npm
-
-      # See https://github.com/npm/cli/issues/3637
-      - name: Downgrade NPM
-        run: npm i -g npm@7.20.2
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This forces the release workflow to use `node@16.15` which includes `npm@8.5`.

Ref https://github.com/directus/directus/pull/13444#issuecomment-1133043147