### PR TITLE
Improve dashboard saving experience

### DIFF
--- a/app/src/composables/use-edits-guard/use-edits-guard.ts
+++ b/app/src/composables/use-edits-guard/use-edits-guard.ts
@@ -1,7 +1,9 @@
 import { ref, Ref, onBeforeMount, onBeforeUnmount } from 'vue';
-import { onBeforeRouteUpdate, onBeforeRouteLeave, NavigationGuard } from 'vue-router';
+import { onBeforeRouteUpdate, onBeforeRouteLeave, NavigationGuard, useRoute } from 'vue-router';
 
 export function useEditsGuard(hasEdits: Ref<boolean>) {
+	const { path } = useRoute();
+
 	const confirmLeave = ref(false);
 	const leaveTo = ref<string | null>(null);
 
@@ -14,7 +16,7 @@ export function useEditsGuard(hasEdits: Ref<boolean>) {
 	};
 
 	const editsGuard: NavigationGuard = (to) => {
-		if (hasEdits.value) {
+		if (hasEdits.value && !to.path.startsWith(path)) {
 			confirmLeave.value = true;
 			leaveTo.value = to.fullPath;
 			return false;

--- a/app/src/modules/insights/routes/dashboard.vue
+++ b/app/src/modules/insights/routes/dashboard.vue
@@ -411,6 +411,7 @@ export default defineComponent({
 				await insightsStore.hydrate();
 
 				stagedPanels.value = [];
+				panelsToBeDeleted.value = [];
 				editMode.value = false;
 			} catch (err) {
 				unexpectedError(err);

--- a/app/src/modules/insights/routes/dashboard.vue
+++ b/app/src/modules/insights/routes/dashboard.vue
@@ -166,8 +166,8 @@ import { useI18n } from 'vue-i18n';
 import { pointOnLine } from '@/utils/point-on-line';
 import InsightsWorkspace from '../components/workspace.vue';
 import { md } from '@/utils/md';
-import { onBeforeRouteUpdate, onBeforeRouteLeave, NavigationGuard } from 'vue-router';
 import useShortcut from '@/composables/use-shortcut';
+import useEditsGuard from '@/composables/use-edits-guard';
 
 export default defineComponent({
 	name: 'InsightsDashboard',
@@ -294,26 +294,11 @@ export default defineComponent({
 			return withBorderRadii;
 		});
 
+		const hasEdits = computed(() => stagedPanels.value.length > 0 || panelsToBeDeleted.value.length > 0);
+
+		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
+
 		const confirmCancel = ref(false);
-		const confirmLeave = ref(false);
-		const leaveTo = ref<string | null>(null);
-
-		const editsGuard: NavigationGuard = (to) => {
-			const hasEdits = panelsToBeDeleted.value.length > 0 || stagedPanels.value.length > 0;
-
-			if (editMode.value && to.params.primaryKey !== props.primaryKey) {
-				if (hasEdits) {
-					confirmLeave.value = true;
-					leaveTo.value = to.fullPath;
-					return false;
-				} else {
-					editMode.value = false;
-				}
-			}
-		};
-
-		onBeforeRouteUpdate(editsGuard);
-		onBeforeRouteLeave(editsGuard);
 
 		return {
 			currentDashboard,
@@ -428,9 +413,7 @@ export default defineComponent({
 		}
 
 		function attemptCancelChanges(): void {
-			const hasEdits = stagedPanels.value.length > 0 || panelsToBeDeleted.value.length > 0;
-
-			if (hasEdits) {
+			if (hasEdits.value) {
 				confirmCancel.value = true;
 			} else {
 				cancelChanges();


### PR DESCRIPTION
The first commit clears the to be deleted panels array after saving to prevent the edits guard from showing up even though there are no edits.

The second commit alters the `useEditsGuard` to ignore route changes to subpaths and uses it in the dashboard component.