### PR TITLE
Fix field conditions when null

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -144,7 +144,7 @@ export default defineComponent({
 		return { repeaterFields, conditions, onInput };
 
 		function onInput(event: Array<any>) {
-			conditions.value = event.map((evt) => {
+			conditions.value = (event ?? []).map((evt) => {
 				const conditionOptions = evt.options ?? {};
 				const defaultValues = unref(optionDefaults);
 				evt.options = { ...defaultValues, ...conditionOptions };


### PR DESCRIPTION
Fixes #13451

## Problem 

User is unable to delete the _last_ field condition in `9.11.0`, but it worked in prior versions.

https://user-images.githubusercontent.com/42867097/169737219-1adee8fc-62b9-462c-a76f-1a02728dcb4d.mp4

## Investigation

#13120 added onInput function, but as `event` can be null (removing last item from a repeater), the `.map` function errors out.

## Solution

Ensure the map function will receive an array even when `event` is null.