### PR TITLE
Allow selecting primary key when aggregating count in time series panel

### DIFF
--- a/app/src/panels/time-series/index.ts
+++ b/app/src/panels/time-series/index.ts
@@ -194,11 +194,23 @@ export default definePanel({
 			name: '$t:panels.time_series.value_field',
 			meta: {
 				interface: 'system-field',
+				width: 'half',
 				options: {
 					collectionField: 'collection',
 					typeAllowList: ['integer', 'bigInteger', 'float', 'decimal'],
 				},
-				width: 'half',
+				conditions: [
+					{
+						rule: {
+							function: {
+								_in: ['count', 'countDistinct'],
+							},
+						},
+						options: {
+							allowPrimaryKey: true,
+						},
+					},
+				],
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #13478

## Problem

When using count aggregation in time series panel, we are still not able to select the primary key as the value due `allowPrimaryKey` defaulting to false in system-field interface.

## Solution

Use condition to toggle on `allowPrimaryKey` only when it's count or countDistinct.

https://user-images.githubusercontent.com/42867097/169794888-631d611b-4f5d-48ed-8067-258fee3152a1.mp4


