### PR TITLE
Add empty state for Translation Strings page

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -71,6 +71,8 @@ create_user: Create User
 delete_panel: Delete Panel
 create_webhook: Create Webhook
 create_translation_string: Create Translation String
+no_translation_string: No Translation Strings
+no_translation_string_copy: There are no translation strings yet.
 translation_string_key_placeholder: Translation string key...
 translation_string_translations_placeholder: Add a new translation
 edit_translation_string: Edit Translation String

--- a/app/src/modules/settings/routes/translation-strings/collection.vue
+++ b/app/src/modules/settings/routes/translation-strings/collection.vue
@@ -25,7 +25,15 @@
 		</template>
 
 		<div class="translation-strings">
+			<v-info v-if="!loading && tableItems.length === 0" icon="translate" :title="t('no_translation_string')" center>
+				{{ t('no_translation_string_copy') }}
+
+				<template #append>
+					<v-button @click="openTranslationStringDialog">{{ t('create_translation_string') }}</v-button>
+				</template>
+			</v-info>
 			<v-table
+				v-else
 				:headers="tableHeaders"
 				fixed-header
 				item-key="key"


### PR DESCRIPTION
This is sort of missed/omitted when Translation Strings was first added, but this will make it more inline with the empty state notice available throughout other places in the App.

## Before

![chrome_a8OfXLiIk6](https://user-images.githubusercontent.com/42867097/169960861-7eeab7b0-b8ec-46a4-8827-fa60756f21dd.png)

## After

![chrome_Snz9uV6aSW](https://user-images.githubusercontent.com/42867097/169960875-500e464c-92cf-4ac7-8bfe-5109c82acbcb.png)

