### PR TITLE
Don't show regex on permissions configuration

### DIFF
--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -332,7 +332,7 @@ function getCompareOptions(name: string) {
 		type = fieldInfo?.type || 'unknown';
 	}
 
-	return getFilterOperatorsForType(type, { includeValidation: true }).map((type) => ({
+	return getFilterOperatorsForType(type, { includeValidation: props.includeValidation }).map((type) => ({
 		text: t(`operators.${type}`),
 		value: `_${type}`,
 	}));

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -138,7 +138,7 @@ function addNode(key: string) {
 		} else {
 			type = field?.type || 'unknown';
 		}
-		let filterOperators = getFilterOperatorsForType(type);
+		let filterOperators = getFilterOperatorsForType(type, { includeValidation: props.includeValidation });
 		const operator = field?.meta?.options?.choices && filterOperators.includes('eq') ? 'eq' : filterOperators[0];
 		const node = set({}, key, { ['_' + operator]: null });
 		innerValue.value = innerValue.value.concat(node);

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/validation.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/validation.vue
@@ -45,6 +45,7 @@ export default defineComponent({
 					interface: 'system-filter',
 					options: {
 						collectionName: permissionSync.value.collection,
+						includeValidation: true,
 					},
 				},
 			},


### PR DESCRIPTION
It's only valid for validation. This makes sure it's only configurable for validation.