### PR TITLE
Don't require default connection params when using non default type

### DIFF
--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -54,7 +54,11 @@ export default function getDatabase(): Knex {
 				requiredEnvVars.push('DB_CONNECTION_STRING');
 			}
 			break;
-
+		case 'mssql':
+			if (!env.DB_TYPE || env.DB_TYPE === 'default') {
+				requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');
+			}
+			break;
 		default:
 			requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');
 	}


### PR DESCRIPTION
`tedious` allow for multiple authentication methods:

> Type of the authentication method, valid types are default, ntlm, azure-active-directory-default, azure-active-directory-password, azure-active-directory-access-token, azure-active-directory-msi-vm, azure-active-directory-msi-app-service, or azure-active-directory-service-principal-secret

our database env vars validation checks for the required params for `default`, making the other auth methods inaccessible in the process. This PR alleviates that by effectively disabling the env var validation when ms sql is used with a non default authentication type. 