### PR TITLE
Fix metadata for directus_folders

### DIFF
--- a/api/src/controllers/folders.ts
+++ b/api/src/controllers/folders.ts
@@ -70,7 +70,7 @@ const readHandler = asyncHandler(async (req, res, next) => {
 		result = await service.readByQuery(req.sanitizedQuery);
 	}
 
-	const meta = await metaService.getMetaForQuery('directus_files', req.sanitizedQuery);
+	const meta = await metaService.getMetaForQuery('directus_folders', req.sanitizedQuery);
 
 	res.locals.payload = { data: result, meta };
 	return next();


### PR DESCRIPTION
Fixes #13525

## Problem

Metadata for `directus_folders` (`/folders` endpoint) is not returning the correct info. 

https://user-images.githubusercontent.com/42867097/170163177-be7eca82-db9a-4216-9e0c-a2f97f2dd071.mp4

## Solution

It was reading it from `directus_files` instead, hence the incorrect values, so changing it to `directus_folders` fixes it.

https://user-images.githubusercontent.com/42867097/170163156-0ae34885-cae8-4414-9a0b-6eb38492ff74.mp4


