### PR TITLE
add `meta` to list responses for OAS

### DIFF
--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -298,6 +298,17 @@ components:
       type: apiKey
       in: header
       name: 'Authorization'
+  x-metadata:
+    type: object
+    properties:
+      total_count:
+        description: Returns the total item count of the collection you're querying.
+        type: integer
+      filter_count:
+        description:
+          Returns the item count of the collection you're querying, taking the current filter/search parameters into
+          account.
+        type: integer
 security:
   - Auth: []
   - KeyAuth: []

--- a/packages/specs/src/paths/activity/activities.yaml
+++ b/packages/specs/src/paths/activity/activities.yaml
@@ -22,6 +22,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Activity'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
       description: Successful request
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'

--- a/packages/specs/src/paths/files/files.yaml
+++ b/packages/specs/src/paths/files/files.yaml
@@ -24,6 +24,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Files'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
 

--- a/packages/specs/src/paths/folders/folders.yaml
+++ b/packages/specs/src/paths/folders/folders.yaml
@@ -22,6 +22,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Folders'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
     '404':

--- a/packages/specs/src/paths/items/items.yaml
+++ b/packages/specs/src/paths/items/items.yaml
@@ -27,6 +27,8 @@ get:
                 type: array
                 items:
                   type: object
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
 

--- a/packages/specs/src/paths/permissions/permissions.yaml
+++ b/packages/specs/src/paths/permissions/permissions.yaml
@@ -24,6 +24,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Permissions'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
     '404':

--- a/packages/specs/src/paths/presets/presets.yaml
+++ b/packages/specs/src/paths/presets/presets.yaml
@@ -28,6 +28,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Presets'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
 

--- a/packages/specs/src/paths/revisions/revisions.yaml
+++ b/packages/specs/src/paths/revisions/revisions.yaml
@@ -24,6 +24,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Revisions'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
     '404':

--- a/packages/specs/src/paths/roles/roles.yaml
+++ b/packages/specs/src/paths/roles/roles.yaml
@@ -24,6 +24,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Roles'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
     '404':

--- a/packages/specs/src/paths/users/users.yaml
+++ b/packages/specs/src/paths/users/users.yaml
@@ -23,6 +23,8 @@ get:
                 type: array
                 items:
                   $ref: '../../openapi.yaml#/components/schemas/Users'
+              meta:
+                $ref: '../../openapi.yaml#/components/x-metadata'
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
     '404':


### PR DESCRIPTION
Closes #13380

## Problem

The `meta` property is not present on list responses:

![chrome_WdNpAD4CyD](https://user-images.githubusercontent.com/42867097/170196117-b7a235d8-ef44-4947-8dbb-5d561da25c39.png)

and OpenAPI client generators as reported in the linked issue.

## Solution

Used `x-metadata` as [extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) in `components`. Added for `items` in general and other system collections where applicable.

![chrome_tJq17VuKHZ](https://user-images.githubusercontent.com/42867097/170196108-815315d0-3cc4-4c63-b757-14834f1d55db.png)

---

Note: Not sure do we want to add it in `components.schemas` instead, depending on spec conformation. However if we were to add `Meta` within `components.schemas`, currently it will not work since `schemas` will be "reset" or reconstructed based on available collections:

https://github.com/directus/directus/blob/1052803a5e64a8baf4dc2362872b60f37d73fe13/api/src/services/specifications.ts#L328-L336 

So further changes to the specification service will be required.