### PR TITLE
Remove the paste value check on slug inputs

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -210,9 +210,6 @@ function emitValue(event: InputEvent) {
 		}
 	} else {
 		if (props.slug === true) {
-			// prevent pasting of non slugSafeCharacters from bypassing the keydown checks
-			value = value.replace(/[^a-zA-Z0-9\-_~\s]/g, '');
-
 			const endsWithSpace = value.endsWith(' ');
 			value = slugify(value, { separator: props.slugSeparator, preserveTrailingDash: true });
 			if (endsWithSpace) value += props.slugSeparator;


### PR DESCRIPTION
Fixes #13530

Pasting unicode/cyrillic characters in slug inputs will result in them being removed:

https://user-images.githubusercontent.com/42867097/170202885-a66265aa-06c6-4986-91a2-34e696e3d9f0.mp4

it is due to #12951 preventing pasting invalid values for slug and dbsafe inputs (although the original issue for #12951 was primary about dbsafe).

Although this check is technically conforming to the slug safe character list:

https://github.com/directus/directus/blob/1052803a5e64a8baf4dc2362872b60f37d73fe13/app/src/components/v-input/v-input.vue#L159

some users were actually indirectly relying on the [transliteration](https://github.com/sindresorhus/transliterate) done by the `@sindresorhus/slugify` package when they paste into slug inputs.

## Solution

Opted to remove the check altogether, since the original stricter check would be more critical for dbsafe inputs, but less so for slug inputs (at least as far as I can tell).

https://user-images.githubusercontent.com/42867097/170202723-e1380466-efa0-4d61-8f31-cf1fdd7705b0.mp4


