### PR TITLE
Fix field conditions optionDefaults computed property

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -98,9 +98,9 @@ export default defineComponent({
 
 		const optionDefaults = computed(() => {
 			const selectedInterface = getInterface(interfaceID.value);
-			if (!selectedInterface) return [];
+			if (!selectedInterface || !selectedInterface.options) return [];
 
-			let optionsObjectOrArray = [];
+			let optionsObjectOrArray;
 
 			if (typeof selectedInterface.options === 'function') {
 				optionsObjectOrArray = selectedInterface.options({
@@ -108,7 +108,7 @@ export default defineComponent({
 						type: 'unknown',
 					},
 					editing: '+',
-					collection: collection,
+					collection: collection.value,
 					relations: {
 						o2m: undefined,
 						m2o: undefined,

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -130,7 +130,7 @@ export default defineComponent({
 					saving: false,
 				});
 			} else {
-				optionsObjectOrArray = selectedInterface.value.options;
+				optionsObjectOrArray = selectedInterface.options;
 			}
 			const optionsArray = Array.isArray(optionsObjectOrArray)
 				? optionsObjectOrArray


### PR DESCRIPTION
This PR simply fixes a bug that throws an error when trying to add a display condition to a field (as below). 

<img width="669" alt="Capture d’écran 2022-05-26 à 08 53 29" src="https://user-images.githubusercontent.com/13403295/170434299-6e000e12-c729-493e-90e5-4f811f9902b9.png">