### PR TITLE
Fix aliased DB table names in filter query

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -357,7 +357,7 @@ export function applyFilter(
 
 					if (!columnName) continue;
 
-					if (relation && relation.related_collection) {
+					if (relation?.related_collection) {
 						applyFilterToQuery(columnName, filterOperator, filterValue, logical, relation.related_collection); // m2o
 					} else if (filterPath[0].includes(':')) {
 						applyFilterToQuery(columnName, filterOperator, filterValue, logical, filterPath[0].split(':')[1]); // a2o

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -357,7 +357,13 @@ export function applyFilter(
 
 					if (!columnName) continue;
 
-					applyFilterToQuery(columnName, filterOperator, filterValue, logical);
+					if (relation && relation.related_collection) {
+						applyFilterToQuery(columnName, filterOperator, filterValue, logical, relation.related_collection); // m2o
+					} else if (filterPath[0].includes(':')) {
+						applyFilterToQuery(columnName, filterOperator, filterValue, logical, filterPath[0].split(':')[1]); // a2o
+					} else {
+						applyFilterToQuery(columnName, filterOperator, filterValue, logical);
+					}
 				} else {
 					applyFilterToQuery(`${collection}.${filterPath[0]}`, filterOperator, filterValue, logical);
 				}
@@ -394,7 +400,13 @@ export function applyFilter(
 				}
 			}
 		}
-		function applyFilterToQuery(key: string, operator: string, compareValue: any, logical: 'and' | 'or' = 'and') {
+		function applyFilterToQuery(
+			key: string,
+			operator: string,
+			compareValue: any,
+			logical: 'and' | 'or' = 'and',
+			aliasedCollection?: string
+		) {
 			const [table, column] = key.split('.');
 
 			// Is processed through Knex.Raw, so should be safe to string-inject into these where queries
@@ -436,9 +448,10 @@ export function applyFilter(
 
 			// Cast filter value (compareValue) based on type of field being filtered against
 			const [collection, field] = key.split('.');
+			const mappedCollection = aliasedCollection || collection;
 
-			if (collection in schema.collections && field in schema.collections[collection].fields) {
-				const type = schema.collections[collection].fields[field].type;
+			if (mappedCollection in schema.collections && field in schema.collections[mappedCollection].fields) {
+				const type = schema.collections[mappedCollection].fields[field].type;
 
 				if (['date', 'dateTime', 'time', 'timestamp'].includes(type)) {
 					if (Array.isArray(compareValue)) {

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -405,7 +405,7 @@ export function applyFilter(
 			operator: string,
 			compareValue: any,
 			logical: 'and' | 'or' = 'and',
-			aliasedCollection?: string
+			originalCollectionName?: string
 		) {
 			const [table, column] = key.split('.');
 
@@ -448,7 +448,7 @@ export function applyFilter(
 
 			// Cast filter value (compareValue) based on type of field being filtered against
 			const [collection, field] = key.split('.');
-			const mappedCollection = aliasedCollection || collection;
+			const mappedCollection = originalCollectionName || collection;
 
 			if (mappedCollection in schema.collections && field in schema.collections[mappedCollection].fields) {
 				const type = schema.collections[mappedCollection].fields[field].type;


### PR DESCRIPTION
Filters involving relational fields may result in aliased table names in subqueries.
Parsing of variables are not processed as the alias  (below).
This PR is crucial as it fixes the filtering of relational fields with date types in SQLite. 

https://github.com/directus/directus/blob/0a1229bcde7df88f66de5901c7bab5c6fc48d121/api/src/utils/apply-query.ts#L440-L458