### PR TITLE
`last_page` type was `date` instead of `str`

### DIFF
--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -78,7 +78,7 @@ Static access token for the user.
 `last_access` **date**\
 Last time the user accessed the API.
 
-`last_page` **date**\
+`last_page` **str**\
 Last page in the app the user used.
 
 `provider` **string**\

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -78,7 +78,7 @@ Static access token for the user.
 `last_access` **date**\
 Last time the user accessed the API.
 
-`last_page` **str**\
+`last_page` **string**\
 Last page in the app the user used.
 
 `provider` **string**\


### PR DESCRIPTION
From the example, we can see `last_page` is expected to be a string, not a date: https://docs.directus.io/reference/system/users/