### PR TITLE
Remove BASIC acronym

### DIFF
--- a/packages/format-title/src/acronyms.ts
+++ b/packages/format-title/src/acronyms.ts
@@ -3,7 +3,6 @@ export default [
 	'3D',
 	'4WD',
 	'API',
-	'BASIC',
 	'BIOS',
 	'CCTV',
 	'CC',


### PR DESCRIPTION
## Description

Fixes #13628

This is due to the acronyms in format-title package here: https://github.com/directus/directus/blob/d78ebb2e8942174a5b018e8b97c4fccb47ab4d85/packages/format-title/src/acronyms.ts#L6

The current recommendation would be to use collection translations to ensure it will be the preferred casing format, but the question now would be will the acronym [BASIC](https://en.wikipedia.org/wiki/BASIC) (still) fit the 80/20 rule vs the word Basic, as in we can/should recommend users intentionally wanting it to be in all-caps to use translations instead.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Tweak / Change

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
