### PR TITLE
use v-if instead of v-show in v-detail component

### DIFF
--- a/app/src/components/v-detail/v-detail.vue
+++ b/app/src/components/v-detail/v-detail.vue
@@ -7,7 +7,7 @@
 			</v-divider>
 		</slot>
 		<transition-expand>
-			<div v-show="internalActive">
+			<div v-if="internalActive">
 				<slot />
 			</div>
 		</transition-expand>


### PR DESCRIPTION
## Description

Fixes #13620

Initially v-detail has been using `v-if` in the past, however it was changed to `v-show` in #12001.

I believe the change to `v-show` was meant to allow the "click and scroll to field" interaction in validation errors notice to work (so that they are in the DOM to be the scroll target). However as details groups currently will expand if they have any error, it will still work without needing to use `v-show`, so opted to change it back to `v-if` instead.

https://user-images.githubusercontent.com/42867097/171101266-fe36c2c3-e634-435b-a35e-ee4f51aa5cca.mp4

On a related note, based on the quote below in #13460, it may be one of the reason why this change unintentionally surfaced performance issues:

> Also worth mentioning - changing the 4 field groups from Detail Groups to Raw Groups nested in an Accordion seems to have reduced the impact. Using this as a work around for now, but having the groups with the checkbox trees open is still almost unusable because of input delays.

But as the quote says, this doesn't really resolve it, but more so make it less impactful like how it used to be since now they are not added to the DOM when closed. This is also why the above "raw group in accordion" workaround worked, since Accordion sections is using `v-if` as well:

https://github.com/directus/directus/blob/d78ebb2e8942174a5b018e8b97c4fccb47ab4d85/app/src/interfaces/group-accordion/accordion-section.vue#L18

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
