### PR TITLE
Auto approve pull requests from Crowdin

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -5,3 +5,6 @@ method = "squash"
 delete_branch_on_merge = true
 automerge_label = "Automerge"
 show_missing_automerge_label_message = false
+
+[approve]
+auto_approve_usernames = ["rijkvanzanten"]


### PR DESCRIPTION
## Description

It seems like the repository settings have been updated to require reviews on pull requests.
Therefore Kodiak is no longer able to auto-merge pull requests from Crowdin.
By auto-approving pull requests from `rijkvanzanten` this will start to work again.

**Note:** Since Kodiak is only used for Crowdin updates (pull requests with `Automerge` label) this does not affect any other pull requests.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
