### PR TITLE
Translations: Make password reset notice clearer

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -604,7 +604,7 @@ unexpected_error_copy: An unexpected error has occurred. Please try again later.
 copy_details: Copy Details
 no_app_access: No App Access
 no_app_access_copy: This user isn't allowed to use the admin app.
-password_reset_sent: We've sent you a secure link to reset your password
+password_reset_sent: If you have an account, we've sent you a secure link to reset your password
 password_reset_successful: Password successfully reset
 back: Back
 filter: Filter


### PR DESCRIPTION
## Description
Some users are misleaded when they are trying to reset password, because if they put an e-mail that is not registered, it will say that an e-mail was sent. But in fact it wasn't.
This PR tells the user if they have an account, they will receive an e-mail.

## Type of Change

- [x] Other, please describe: Make password reset message clearer

## Requirements Checklist

- [ ] ~~New / updated tests are included~~ => Not Applicable
- [ ] ~~All tests are passing locally~~ => Not Applicable
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] ~~Documentation was added/updated~~ => Not Applicable
