### PR TITLE
Use `pull_request_target` instead of `pull_request` for auto-project-assign

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/add-to-project@v0.0.3
         with:
           project-url: https://github.com/orgs/directus/projects/6
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT || github.token }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/add-to-project@v0.0.3
         with:
           project-url: https://github.com/orgs/directus/projects/6
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT || github.token }}


### PR DESCRIPTION
## Description

Github Actions are currently failing on contributor PRs. The PR doesn't use the token to add the PR to the projects (beta). This uses a fallback to github.token.

NOTE: I don't know how to test this besides throwing it into the wild. 

Fixes #

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
