### PR TITLE
Add cross-instance messenger pubsub setup

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -185,6 +185,7 @@
 		"@types/flat": "5.0.2",
 		"@types/fs-extra": "9.0.13",
 		"@types/inquirer": "8.1.3",
+		"@types/ioredis": "^4.28.10",
 		"@types/jest": "27.4.1",
 		"@types/js-yaml": "4.0.5",
 		"@types/json2csv": "5.0.3",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -50,7 +50,7 @@ import schema from './middleware/schema';
 import { track } from './utils/track';
 import { validateEnv } from './utils/validate-env';
 import { validateStorage } from './utils/validate-storage';
-import { register as registerWebhooks } from './webhooks';
+import { init as initWebhooks } from './webhooks';
 import { flushCaches } from './cache';
 import { registerAuthProviders } from './auth';
 import { Url } from './utils/url';
@@ -242,7 +242,7 @@ export default async function createApp(): Promise<express.Application> {
 	await emitter.emitInit('routes.after', { app });
 
 	// Register all webhooks
-	await registerWebhooks();
+	await initWebhooks();
 
 	track('serverStarted');
 

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -263,8 +263,8 @@ const typeMap: Record<string, string> = {
 
 let env: Record<string, any> = {
 	...defaults,
-	...process.env,
 	...getEnv(),
+	...process.env,
 };
 
 process.env = env;

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -263,8 +263,8 @@ const typeMap: Record<string, string> = {
 
 let env: Record<string, any> = {
 	...defaults,
-	...getEnv(),
 	...process.env,
+	...getEnv(),
 };
 
 process.env = env;

--- a/api/src/messenger.ts
+++ b/api/src/messenger.ts
@@ -3,7 +3,7 @@ import env from './env';
 import { getConfigFromEnv } from './utils/get-config-from-env';
 import { parseJSON } from './utils/parse-json';
 
-type MessengerSubscriptionCallback = (payload: Record<string, any>) => void;
+export type MessengerSubscriptionCallback = (payload: Record<string, any>) => void;
 
 export interface Messenger {
 	publish: (channel: string, payload: Record<string, any>) => void;

--- a/api/src/messenger.ts
+++ b/api/src/messenger.ts
@@ -1,0 +1,69 @@
+import IORedis from 'ioredis';
+import { getConfigFromEnv } from './utils/get-config-from-env';
+import { parseJSON } from './utils/parse-json';
+import env from './env';
+import { nanoid } from 'nanoid';
+
+type MessengerSubscriptionCallback = (payload: Record<string, any>) => void;
+
+export interface Messenger {
+	publish: (channel: string, payload: Record<string, any>) => void;
+	subscribe: (channel: string, callback: MessengerSubscriptionCallback) => void;
+	unsubscribe: (channel: string) => void;
+}
+
+export class MessengerRedis implements Messenger {
+	id: string;
+	namespace: string;
+	pub: IORedis.Redis;
+	sub: IORedis.Redis;
+
+	constructor() {
+		const config = getConfigFromEnv('MESSENGER_REDIS');
+		this.id = nanoid();
+		this.pub = new IORedis(env.MESSENGER_REDIS ?? config);
+		this.sub = new IORedis(env.MESSENGER_REDIS ?? config);
+		this.namespace = env.MESSENGER_NAMESPACE ?? 'directus';
+	}
+
+	publish(channel: string, payload: Record<string, any>) {
+		this.pub.publish(
+			`${this.namespace}:${channel}`,
+			JSON.stringify({
+				_hostID: this.id,
+				...payload,
+			})
+		);
+	}
+
+	subscribe(channel: string, callback: MessengerSubscriptionCallback) {
+		this.sub.subscribe(`${this.namespace}:${channel}`);
+
+		this.sub.on('message', (messageChannel, payloadString) => {
+			const payload = parseJSON(payloadString);
+
+			if (messageChannel === `${this.namespace}:${channel}` && payload._hostID !== this.id) {
+				callback(payload);
+			}
+		});
+	}
+
+	unsubscribe(channel: string) {
+		this.sub.unsubscribe(`${this.namespace}:${channel}`);
+	}
+}
+
+let messenger: Messenger;
+
+export function getMessenger() {
+	if (messenger) return messenger;
+
+	if (env.MESSENGER_STORE === 'redis') {
+		messenger = new MessengerRedis();
+	} else {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		messenger = { publish: () => {}, subscribe: () => {}, unsubscribe: () => {} };
+	}
+
+	return messenger;
+}

--- a/api/src/messenger.ts
+++ b/api/src/messenger.ts
@@ -1,7 +1,7 @@
 import IORedis from 'ioredis';
+import env from './env';
 import { getConfigFromEnv } from './utils/get-config-from-env';
 import { parseJSON } from './utils/parse-json';
-import env from './env';
 
 type MessengerSubscriptionCallback = (payload: Record<string, any>) => void;
 

--- a/api/src/services/webhooks.ts
+++ b/api/src/services/webhooks.ts
@@ -1,45 +1,56 @@
 import { AbstractServiceOptions, Item, PrimaryKey, Webhook, MutationOptions } from '../types';
 import { register } from '../webhooks';
 import { ItemsService } from './items';
+import { getMessenger, Messenger } from '../messenger';
 
 export class WebhooksService extends ItemsService<Webhook> {
+	messenger: Messenger;
+
 	constructor(options: AbstractServiceOptions) {
 		super('directus_webhooks', options);
+
+		this.messenger = getMessenger();
 	}
 
 	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const result = await super.createOne(data, opts);
 		await register();
+		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.createMany(data, opts);
 		await register();
+		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const result = await super.updateOne(key, data, opts);
 		await register();
+		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.updateMany(keys, data, opts);
 		await register();
+		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
 		const result = await super.deleteOne(key, opts);
 		await register();
+		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.deleteMany(keys, opts);
 		await register();
+		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 }

--- a/api/src/services/webhooks.ts
+++ b/api/src/services/webhooks.ts
@@ -1,5 +1,4 @@
 import { AbstractServiceOptions, Item, PrimaryKey, Webhook, MutationOptions } from '../types';
-import { register } from '../webhooks';
 import { ItemsService } from './items';
 import { getMessenger, Messenger } from '../messenger';
 
@@ -8,48 +7,41 @@ export class WebhooksService extends ItemsService<Webhook> {
 
 	constructor(options: AbstractServiceOptions) {
 		super('directus_webhooks', options);
-
 		this.messenger = getMessenger();
 	}
 
 	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const result = await super.createOne(data, opts);
-		await register();
 		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.createMany(data, opts);
-		await register();
 		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const result = await super.updateOne(key, data, opts);
-		await register();
 		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.updateMany(keys, data, opts);
-		await register();
 		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
 		const result = await super.deleteOne(key, opts);
-		await register();
 		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}
 
 	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.deleteMany(keys, opts);
-		await register();
 		this.messenger.publish('webhooks', { type: 'reload' });
 		return result;
 	}

--- a/api/src/webhooks.ts
+++ b/api/src/webhooks.ts
@@ -6,15 +6,31 @@ import { Webhook, WebhookHeader } from './types';
 import { WebhooksService } from './services';
 import { getSchema } from './utils/get-schema';
 import { ActionHandler } from '@directus/shared/types';
+import { getMessenger } from './messenger';
 
 let registered: { event: string; handler: ActionHandler }[] = [];
 
-export async function register(): Promise<void> {
-	unregister();
+export async function init(): Promise<void> {
+	await register();
+	const messenger = getMessenger();
 
+	messenger.subscribe('webhooks', (event) => {
+		if (event.type === 'reload') {
+			reload();
+		}
+	});
+}
+
+export async function reload(): Promise<void> {
+	unregister();
+	await register();
+}
+
+export async function register(): Promise<void> {
 	const webhookService = new WebhooksService({ knex: getDatabase(), schema: await getSchema() });
 
 	const webhooks = await webhookService.readByQuery({ filter: { status: { _eq: 'active' } } });
+
 	for (const webhook of webhooks) {
 		for (const action of webhook.actions) {
 			const event = `items.${action}`;

--- a/docs/configuration/config-options.md
+++ b/docs/configuration/config-options.md
@@ -779,6 +779,16 @@ AUTH_FACEBOOK_ICON="facebook"
 | `EXTENSIONS_PATH`        | Path to your local extensions folder.                   | `./extensions` |
 | `EXTENSIONS_AUTO_RELOAD` | Automatically reload extensions when they have changed. | `false`        |
 
+## Messenger
+
+| Variable              | Description                                       | Default Value |
+| --------------------- | ------------------------------------------------- | ------------- |
+| `MESSENGER_STORE`     | One of `memory`, `redis`<sup>[1]</sup>            | `memory`      |
+| `MESSENGER_NAMESPACE` | How to scope the channels in Redis                | `directus`    |
+| `MESSENGER_REDIS_*`   | The Redis configuration for the pubsub connection | --            |
+
+<sup>[1]</sup> `redis` should be used in load-balanced installations of Directus
+
 ## Email
 
 | Variable          | Description                                                              | Default Value          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,7 @@
 				"@types/flat": "5.0.2",
 				"@types/fs-extra": "9.0.13",
 				"@types/inquirer": "8.1.3",
+				"@types/ioredis": "^4.28.10",
 				"@types/jest": "27.4.1",
 				"@types/js-yaml": "4.0.5",
 				"@types/json2csv": "5.0.3",
@@ -13087,6 +13088,15 @@
 			"dependencies": {
 				"@types/through": "*",
 				"rxjs": "^7.2.0"
+			}
+		},
+		"node_modules/@types/ioredis": {
+			"version": "4.28.10",
+			"resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
+			"integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -64522,6 +64532,15 @@
 				"rxjs": "^7.2.0"
 			}
 		},
+		"@types/ioredis": {
+			"version": "4.28.10",
+			"resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
+			"integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -71792,6 +71811,7 @@
 				"@types/flat": "5.0.2",
 				"@types/fs-extra": "9.0.13",
 				"@types/inquirer": "8.1.3",
+				"@types/ioredis": "*",
 				"@types/jest": "27.4.1",
 				"@types/js-yaml": "4.0.5",
 				"@types/json2csv": "5.0.3",


### PR DESCRIPTION
## Description

Adds a Messenger system to Directus, which allows for cross-instance communication. This is currently used to fix #13650, but can in the future also be used for WebSockets, syncing CRON jobs, and other load balanced operations.

Every instance is both a publisher _and_ a subscriber, which allows any instance to trigger any change on other instances. 

When `MESSENGER_STORE` isn't configured to `redis`, it'll default to a no-op fallback (there's no need for a messenger setup like this if you're running Directus on a single instance)

Fixes https://github.com/directus/directus/issues/13650

_Request to instance w/ port 8055 triggers `RELOAD` on only 8056 and vice versa:_

https://user-images.githubusercontent.com/9141017/171296298-823f2bea-e961-49e0-b2f1-acef8b83780e.mp4


## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated

---

Left to-do:

- [x] Docs