### PR TITLE
removing remaining links to example.env

### DIFF
--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -41,13 +41,9 @@ npm run build
 
 ## 5. Create a `.env` file
 
-Create a `.env` file under the `api` folder. You can use the `example.env` file provided under `api` as a starting
-point.
+Create an `.env` file under the `api` folder using vars from the online 
+[config help](https://docs.directus.io/configuration/config-options/)
 
-```bash
-# To use the example file
-cp api/example.env api/.env
-```
 
 ## 6. Initialize the database
 

--- a/docs/self-hosted/installation/manual.md
+++ b/docs/self-hosted/installation/manual.md
@@ -40,7 +40,4 @@ npm install directus
 Finally, you'll need to setup your `.env` file, or configure the environment variables through other means, such as
 Docker, etc.
 
-You can use a copy of [the `example.env` file](https://github.com/directus/directus/blob/main/api/example.env) as a
-starting point.
-
 See [Environment Variables](/configuration/config-options/#general) for all available variables.

--- a/docs/self-hosted/installation/plesk.md
+++ b/docs/self-hosted/installation/plesk.md
@@ -22,9 +22,8 @@ On the server, create a project folder with 4 files in it.
 ### 1. Add .env file
 
 This file is used to configure Directus. Normally, the `init` script would create it for us. So now we have to do it
-manually. You can just copy it from another Directus installation or use the
-[example file](https://github.com/directus/directus/blob/main/api/example.env) of Directus and then modify it (see
-[Environment Variables](/configuration/config-options/#general)). You likely have to adjust the database information.
+manually. You can just copy it from another Directus installation or add the relevant variables using this help page:
+[Environment Variables](/configuration/config-options/)).
 
 If you have not already a user in the database make sure to add a first user by adding the following two lines so that
 you can later login to Directus.


### PR DESCRIPTION
There are a few remaining links to example.env in the docs that I missed which were caught in https://github.com/directus/directus/discussions/13653. For now, I've removed them.

This raises an interesting question: should such places have a reference to the new stub instead? If so, then `{database}` and `{security}` would mess up the stub being used as an example if blindly copied, so I can think of three solutions:

1. Changing the two placeholders that are used by the installation script to have a comment at the start of the line (so the user copying the stub won't see errors if they don't remove them) with a quick comment above it explaining what it's for?

I presume a quick change to the installation script to replace the whole line, rather than just the placeholder?

So, I'm thinking of something like this: updating stub.env
```
# The below line is a placeholder for the Directus installation script and can be removed if using this file as an example.
# {database}

...
# The below line is a placeholder for the Directus installation script and can be removed if using this file as an example.
# {security}
```
So, the installation script can then replace the `# {database}` line with the necessary generated lines.

2. Don't add a `#` to the start of placeholders, but leave the placeholder with the comment line above.  Maybe the docs that link to this stub could point out removing the two placeholders.
3. Alternatively, just state that the CLI installation is the recommended way of installing Directus and make no mention of using the stub as an example.env?