### PR TITLE
Fix wrong source of meta info for notifications API

### DIFF
--- a/api/src/controllers/notifications.ts
+++ b/api/src/controllers/notifications.ts
@@ -70,7 +70,7 @@ const readHandler = asyncHandler(async (req, res, next) => {
 		result = await service.readByQuery(req.sanitizedQuery);
 	}
 
-	const meta = await metaService.getMetaForQuery('directus_presets', req.sanitizedQuery);
+	const meta = await metaService.getMetaForQuery('directus_notifications', req.sanitizedQuery);
 
 	res.locals.payload = { data: result, meta };
 	return next();


### PR DESCRIPTION
## Description

When listing notifications, the getMetaForQuery was being called for `directus_presets` instead of `directus_notifications` in the notification controller. Probably left by copy pasting code
 
Fixes #13659

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

