### PR TITLE
Update docs links to installation

### DIFF
--- a/docs/.vuepress/theme/layouts/Homepage.vue
+++ b/docs/.vuepress/theme/layouts/Homepage.vue
@@ -101,7 +101,7 @@
 					<li><a href="/configuration/config-options/">Environment Variables</a></li>
 					<li><a href="/configuration/relationships/">Data Relationships</a></li>
 					<li><a href="/configuration/config-options/#authentication">Single Sign-On (SSO)</a></li>
-					<li><a href="/getting-started/installation/docker/">Installing with Docker</a></li>
+					<li><a href="/self-hosted/installation/docker/">Installing with Docker</a></li>
 				</ul>
 			</div>
 

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -2,7 +2,7 @@
 
 > This guide explains how to install the _Development_ version of Directus locally so that you can work on the
 > platform's source code. To install the _Production_ version locally, please follow to our
-> [standard installation guides](/getting-started/installation/).
+> [standard installation guides](/self-hosted/installation/).
 
 ::: tip Minimum Requirements
 
@@ -41,9 +41,8 @@ npm run build
 
 ## 5. Create a `.env` file
 
-Create an `.env` file under the `api` folder using vars from the online 
+Create an `.env` file under the `api` folder using vars from the online
 [config help](https://docs.directus.io/configuration/config-options/)
-
 
 ## 6. Initialize the database
 

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -277,7 +277,7 @@ often called `id`.
 A Project is a complete instance of the platform. Each project represents a **Database**, but also encapsulates a config
 file, asset storage, and any custom extensions. Projects are the highest level of organization in Directus.
 
-- [Creating a Project](/getting-started/installation/)
+- [Creating a Project](/self-hosted/installation/)
 - [Configuring a Project](/configuration/config-options/)
 - [Adjusting Project Settings](/configuration/project-settings/)
 - [Upgrading a Project](/configuration/upgrades-migrations/)

--- a/docs/getting-started/support.md
+++ b/docs/getting-started/support.md
@@ -11,7 +11,7 @@ If you're experiencing issues or think you have found a problem in Directus, be 
 [Reporting a Bug](/contributing/introduction/#bug-reporting):
 
 1. Ensure your server and database meet the
-   [minimum requirements](/getting-started/installation/cli/#_1-confirm-minimum-requirements).
+   [minimum requirements](/self-hosted/installation/cli/#_1-confirm-minimum-requirements).
 2. Ensure you’re on the [latest version](https://github.com/directus/directus/releases/latest) of Directus.
 3. Stop `CTRL+C` and restart the server `npx directus start`.
 4. Run the database migration script: `directus database migrate:latest`\

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,8 +29,8 @@ migrate it to the latest version (if it already exists and has missing migration
 
 This is very useful to use in environments where you're doing standalone automatic deployments, like a multi-container
 Kubernetes configuration, or a similar approach on
-[DigitalOcean App Platform](/getting-started/installation/digitalocean-app-platform/),
-[Google Cloud Platform](/getting-started/installation/gcp) or [AWS Elastic Beanstalk](/getting-started/installation/aws)
+[DigitalOcean App Platform](/self-hosted/installation/digitalocean-app-platform/),
+[Google Cloud Platform](/self-hosted/installation/gcp) or [AWS Elastic Beanstalk](/self-hosted/installation/aws)
 
 ::: tip First User
 

--- a/docs/self-hosted/installation.md
+++ b/docs/self-hosted/installation.md
@@ -6,9 +6,9 @@
 While our CLI is the recommended method for self-hosting, you can use whichever of these self-hosted options best suits
 your needs. These methods offer a high level of customization and are ideal for intermediate developers.
 
-- [Command Line Interface (CLI)](/getting-started/installation/cli/)
-- [Docker](/getting-started/installation/docker/)
-- [Manually](/getting-started/installation/manual/)
+- [Command Line Interface (CLI)](/self-hosted/installation/cli/)
+- [Docker](/self-hosted/installation/docker/)
+- [Manually](/self-hosted/installation/manual/)
 
 ::: tip Development Environment
 

--- a/docs/self-hosted/installation/aws.md
+++ b/docs/self-hosted/installation/aws.md
@@ -18,7 +18,7 @@ Will run Directus in an autoscaling environment with a load balancer. Makes sure
 replace individual instances in case of unexpected crashes.
 
 We recommend setting up a repo in GitHub (or another Git provider) and configuring it using
-[our manual installation flow](/getting-started/installation/manual). This allows you to later hook up the repo to your
+[our manual installation flow](/self-hosted/installation/manual). This allows you to later hook up the repo to your
 Elastic Beanstalk instance through CodeDeploy.
 
 See

--- a/docs/self-hosted/installation/digitalocean-app-platform.md
+++ b/docs/self-hosted/installation/digitalocean-app-platform.md
@@ -2,8 +2,7 @@
 
 ## 1. Setup a repo on GitHub
 
-See the doc on [installing Directus manually](/getting-started/installation/manual/) to learn how to configure this
-repo.
+See the doc on [installing Directus manually](/self-hosted/installation/manual/) to learn how to configure this repo.
 
 ## 2. Sign up for a DigitalOcean account
 
@@ -24,7 +23,7 @@ Make sure to select the database you created in step 2 during the configuration 
 While Directus itself doesn't have to be built from source in order to use it on App Platform, we do recommend adding
 `npx directus bootstrap` as the "build" step for DigitalOcean. This will automatically provision the database if it's
 empty, and migrate it to the latest version in case of upgrades. See
-[Command Line Interface](/getting-started/installation/cli/) for more information.
+[Command Line Interface](/self-hosted/installation/cli/) for more information.
 
 ## 6. Configure the environment variables
 

--- a/docs/self-hosted/installation/gcp.md
+++ b/docs/self-hosted/installation/gcp.md
@@ -52,7 +52,7 @@ Let's get into it.
 1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install). We will run a lot of `gcloud` commands to
    get your GCP environment setup.
 
-2. Go over the steps for [Manually installing Directus](/getting-started/installation/manual)
+2. Go over the steps for [Manually installing Directus](/self-hosted/installation/manual)
 
 3. Add a start script to your package.json like so:
 

--- a/docs/self-hosted/installation/manual.md
+++ b/docs/self-hosted/installation/manual.md
@@ -3,7 +3,7 @@
 ::: tip Automation
 
 We've created a little CLI tool you can run that does this process automatically. For more info, check the doc on
-[installing through the CLI](/getting-started/installation/cli/).
+[installing through the CLI](/self-hosted/installation/cli/).
 
 :::
 
@@ -16,8 +16,8 @@ npm init -y
 ```
 
 We recommend aliasing the `start` script to Directus' start for easier deployments to services like
-[AWS](/getting-started/installation/aws/), [Google Cloud Platform](/getting-started/installation/gcp) or
-[DigitalOcean App Platform](/getting-started/installation/digitalocean-app-platform/).
+[AWS](/self-hosted/installation/aws/), [Google Cloud Platform](/self-hosted/installation/gcp) or
+[DigitalOcean App Platform](/self-hosted/installation/digitalocean-app-platform/).
 
 ```json
 {

--- a/docs/self-hosted/installation/plesk.md
+++ b/docs/self-hosted/installation/plesk.md
@@ -128,7 +128,7 @@ Afterwards try `bootstrap` again.
 
 On Plesk you can't directly run an npx command. To use the Directus snapshot feature, you'd need to add a script to your
 `package.json`. For snapshot creation you can find an example in the
-[CLI docs: Date-based snapshots](/getting-started/installation/plesk#snapshot-the-data-model)
+[CLI docs: Date-based snapshots](/self-hosted/installation/plesk#snapshot-the-data-model)
 
 To apply a snapshot you need a custom wrapper using the non-interactive version:
 


### PR DESCRIPTION
Fixed all docs links that were referencing `getting-started > installation`
