### PR TITLE
fix collection & folder delete dialog message

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -34,11 +34,7 @@
 						<v-icon name="delete" />
 					</v-list-item-icon>
 					<v-list-item-content>
-						{{
-							collection.schema
-								? t('delete_collection', { collection: collection.collection })
-								: t('delete_folder', { folder: folder.folder })
-						}}
+						{{ collection.schema ? t('delete_collection') : t('delete_folder') }}
 					</v-list-item-content>
 				</v-list-item>
 			</v-list>
@@ -47,7 +43,11 @@
 		<v-dialog v-model="deleteActive" @esc="deleteActive = null">
 			<v-card>
 				<v-card-title>
-					{{ collection.schema ? t('delete_collection_are_you_sure') : t('delete_folder_are_you_sure') }}
+					{{
+						collection.schema
+							? t('delete_collection_are_you_sure', { collection: collection.collection })
+							: t('delete_folder_are_you_sure', { folder: collection.collection })
+					}}
 				</v-card-title>
 				<v-card-actions>
 					<v-button :disabled="deleting" secondary @click="deleteActive = null">


### PR DESCRIPTION
## Description

Note: This PR doesn't have a corresponding issue, but is meant as a follow up fix for #13610.

### Problem

#13610 was updating `delete_collection_are_you_sure` and `delete_folder_are_you_sure`, but was adding the named formatting collection/folder to `delete_collection` and `delete_folder` instead, which results in an empty quotes when trying to show `{collection}`:

![chrome_u8DtYyQPRy](https://user-images.githubusercontent.com/42867097/171600997-a95820af-33af-42d5-ba0d-6b17028bbfb3.png)


### Solution

The collection name `model_b` is now shown between the quotes:

![chrome_pIs3FKtJTO](https://user-images.githubusercontent.com/42867097/171600615-20e4e721-8835-419f-83a2-64dff99f4ae2.png)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally (tested via App locally)
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
