### PR TITLE
disable thumbsmith update blocking the docs build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
 		"build": "node build.js",
 		"dev": "npm-watch build",
 		"dev:site": "vuepress dev",
-		"build:site": "vuepress build && npm run update-thumbnail",
+		"build:site": "vuepress build",
 		"update-thumbnail": "thumbsmith deploy .vuepress/.thumbsmith/docs.thumbnail.html"
 	},
 	"watch": {


### PR DESCRIPTION
## Description
Hotfix disabling thumbsmith during docs build

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [X] Other, please describe:
Temporary fix until we get the thumbsmith api key sorted

