### PR TITLE
Don't crash on misconfigured scope trigger

### DIFF
--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -1,4 +1,5 @@
 import { DeepPartial, Field, FlowRaw, TriggerType, Width } from '@directus/shared/types';
+import { toArray } from '@directus/shared/utils';
 import { useI18n } from 'vue-i18n';
 import { getPublicURL } from '../../../../utils/get-root-path';
 
@@ -33,15 +34,13 @@ export function getTriggers() {
 
 				labels.push({
 					label: t('scope'),
-					text: scope.join(', '),
+					text: scope ? toArray(scope).join(', ') : '--',
 				});
 
-				if (collections?.length) {
-					labels.push({
-						label: t('collections'),
-						text: collections.join(', '),
-					});
-				}
+				labels.push({
+					label: t('collections'),
+					text: collections ? toArray(collections).join(', ') : '--',
+				});
 
 				return labels;
 			},
@@ -326,12 +325,10 @@ export function getTriggers() {
 					},
 				];
 
-				if (collections?.length) {
-					labels.push({
-						label: t('collections'),
-						text: collections.join(', '),
-					});
-				}
+				labels.push({
+					label: t('collections'),
+					text: collections ? toArray(collections).join(', ') : '--',
+				});
 
 				return labels;
 			},


### PR DESCRIPTION
## Description

The app expected scope/collections to be an array of values. This handles null / undefined / strings as well.

Fixes #13697

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
