### PR TITLE
Checkbox Tree Field Expand/Collapse in Show Selected

### DIFF
--- a/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
@@ -1,11 +1,5 @@
 <template>
-	<v-list-group
-		v-if="visibleChildrenValues.length > 0"
-		v-show="groupShown"
-		:value="value"
-		:open="groupOpen"
-		arrow-placement="before"
-	>
+	<v-list-group v-if="visibleChildrenValues.length > 0" v-show="groupShown" :value="value" arrow-placement="before">
 		<template #activator>
 			<v-checkbox
 				v-model="treeValue"
@@ -141,14 +135,6 @@ export default defineComponent({
 			return !props.hidden;
 		});
 
-		const groupOpen = computed(() => {
-			if (props.showSelectionOnly === true) {
-				return visibleChildrenValues.value.length > 0;
-			}
-
-			return false;
-		});
-
 		const childrenValues = computed(() => props.children?.map((child) => child[props.itemValue]) || []);
 
 		const treeValue = computed({
@@ -242,7 +228,6 @@ export default defineComponent({
 			groupIndeterminateState,
 			visibleChildrenValues,
 			groupShown,
-			groupOpen,
 		};
 
 		function emitAll(rawValue: (string | number)[], { added, removed }: Delta) {


### PR DESCRIPTION
## Description

The open state of groups was being overridden to always be `true` when the "show selected" option is active. 

I've made a change to `v-list-group` allowing manual override of the open state when prop `open=true` this way the group will react to both state changes in the `open` prop passed to it and its internal state when a group is manually opened or closed.

Note: as `v-list-group` is used in a bunch of other places i had to do an update to `navigation-folder` as well to make sure the folder sidebar behaves the same as before.
Fixes #13710 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code
