### PR TITLE
Serve robots.txt from root

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -49,6 +49,7 @@ import extractToken from './middleware/extract-token';
 import rateLimiter from './middleware/rate-limiter';
 import sanitizeQuery from './middleware/sanitize-query';
 import schema from './middleware/schema';
+import { ROBOTSTXT } from './constants';
 
 import { track } from './utils/track';
 import { validateEnv } from './utils/validate-env';
@@ -168,6 +169,12 @@ export default async function createApp(): Promise<express.Application> {
 		} else {
 			next();
 		}
+	});
+
+	app.get('/robots.txt', (_, res) => {
+		res.set('Content-Type', 'text/plain');
+		res.status(200);
+		res.send(ROBOTSTXT);
 	});
 
 	if (env.SERVE_APP) {

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -57,3 +57,8 @@ export const COOKIE_OPTIONS = {
 	secure: env.REFRESH_TOKEN_COOKIE_SECURE ?? false,
 	sameSite: (env.REFRESH_TOKEN_COOKIE_SAME_SITE as 'lax' | 'strict' | 'none') || 'strict',
 };
+
+export const ROBOTSTXT = `
+User-agent: *
+Disallow: /
+`.trim();

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
## Description

`robots.txt` was served from the apps public folder, meaning it would only trigger on /admin/robots.txt. This PR moves it to be served directly from the API, meaning it's available on /robots.txt. 

Fixes #13734

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
