### PR TITLE
Fix formatting of headers in request operation

### DIFF
--- a/api/src/operations/request/index.ts
+++ b/api/src/operations/request/index.ts
@@ -5,14 +5,19 @@ type Options = {
 	url: string;
 	method: Method;
 	body: Record<string, any> | string | null;
-	headers: Record<string, string>;
+	headers?: { header: string; value: string }[] | null;
 };
 
 export default defineOperationApi<Options>({
 	id: 'request',
 
 	handler: async ({ url, method, body, headers }) => {
-		const result = await axios({ url, method, data: body, headers });
+		const customHeaders = headers?.reduce((acc, { header, value }) => {
+			acc[header] = value;
+			return acc;
+		}, {} as Record<string, string>);
+
+		const result = await axios({ url, method, data: body, headers: customHeaders });
 
 		return { status: result.status, statusText: result.statusText, headers: result.headers, data: result.data };
 	},


### PR DESCRIPTION
## Description

Headers were passed to the operation in the `{ header: string, value: string }[]` format, but `axios` expects `{ [header: string]: string }`. 

Fixes #13737

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
