### PR TITLE
Flush caches after applying schema snapshot

### DIFF
--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -9,6 +9,7 @@ import { Collection, Snapshot, SnapshotDiff, SnapshotField } from '../types';
 import { getSchema } from './get-schema';
 import { getSnapshot } from './get-snapshot';
 import { getSnapshotDiff } from './get-snapshot-diff';
+import { getCache } from '../cache';
 
 type CollectionDelta = {
 	collection: string;
@@ -21,6 +22,7 @@ export async function applySnapshot(
 ): Promise<void> {
 	const database = options?.database ?? getDatabase();
 	const schema = options?.schema ?? (await getSchema({ database }));
+	const { systemCache } = getCache();
 
 	const current = options?.current ?? (await getSnapshot({ database, schema }));
 	const snapshotDiff = options?.diff ?? getSnapshotDiff(current, snapshot);
@@ -221,6 +223,8 @@ export async function applySnapshot(
 			}
 		}
 	});
+
+	await systemCache?.clear();
 }
 
 export function isNestedMetaUpdate(diff: Diff<SnapshotField | undefined>): boolean {


### PR DESCRIPTION
## Description

When applying a schema snapshot, the schema cached isn't flushed afterwards. This means that the app/API won't behave as expected if you apply the schema to a running instance.

Fixes #11436

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
