### PR TITLE
Fix filter error when switching between collections with map layout

### DIFF
--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -79,7 +79,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			if (!geometryFormat) {
 				return;
 			}
-			return { geometryField, geometryFormat, geometryType };
+			return { geometryField, geometryFormat, geometryType } as GeometryOptions;
 		});
 
 		const isGeometryFieldNative = computed(() => geometryOptions.value?.geometryFormat === 'native');

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -43,17 +43,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		const defaultSort = computed(() => (primaryKeyField.value ? [primaryKeyField.value?.field] : []));
 		const sort = syncRefProperty(layoutQuery, 'sort', defaultSort);
 
-		const locationFilter = ref<Filter>();
-
-		const filterWithLocation = computed<Filter | null>(() => {
-			if (!locationFilter.value) return filter.value;
-			if (!filter.value) return locationFilter.value;
-
-			return {
-				_and: [filter.value, locationFilter.value],
-			};
-		});
-
 		const displayTemplate = syncRefProperty(layoutOptions, 'displayTemplate', undefined);
 		const cameraOptions = syncRefProperty(layoutOptions, 'cameraOptions', undefined);
 		const clusterData = syncRefProperty(layoutOptions, 'clusterData', false);
@@ -74,15 +63,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			(fields) => {
 				if (!geometryField.value && fields.length > 0) {
 					geometryField.value = fields[0].field;
-				}
-
-				// clear the location filter when it is no longer using a valid geometryField
-				if (
-					geometryField.value &&
-					locationFilter.value &&
-					!Object.keys(locationFilter.value).includes(geometryField.value)
-				) {
-					locationFilter.value = undefined;
 				}
 			},
 			{ immediate: true }
@@ -114,9 +94,9 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				.filter((e) => !!e) as string[];
 		});
 
-		function getLocationFilter(): Filter | undefined {
+		const locationFilter = computed<Filter | null>(() => {
 			if (!isGeometryFieldNative.value || !cameraOptions.value || !geometryField.value) {
-				return;
+				return null;
 			}
 
 			const bbox = cameraOptions.value.bbox;
@@ -137,14 +117,22 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					},
 				},
 			} as Filter;
-		}
+		});
+
+		const filterWithLocation = computed<Filter | null>(() => {
+			if (!locationFilter.value) return filter.value;
+			if (!filter.value) return locationFilter.value;
+
+			return {
+				_and: [filter.value, locationFilter.value],
+			};
+		});
 
 		const shouldUpdateCamera = ref(false);
 
 		function fitDataBounds() {
 			shouldUpdateCamera.value = true;
 			if (isGeometryFieldNative.value) {
-				locationFilter.value = undefined;
 				return;
 			}
 			if (geojson.value?.features.length) {
@@ -154,7 +142,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		watch(cameraOptions, () => {
 			shouldUpdateCamera.value = false;
-			locationFilter.value = getLocationFilter();
 		});
 
 		const { items, loading, error, totalPages, itemCount, totalCount, getItems } = useItems(collection, {


### PR DESCRIPTION
## Description

Unfortunately I wasn't able to reproduce this locally, not even with performance and/or network throttling, but it's definitely happens on Directus Cloud so there's some odd timing issue.

That said, the current solution opted to change `locationFilter` from a ref to a computed property to ensure it "stays in sync" and doesn't end up using a wrong filter. Works without a hitch locally, but still not 100% sure will it be the same for cloud.

Fixes #13700 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
