### PR TITLE
Add configurable page-size to files/o2m/m2m/m2a interfaces

### DIFF
--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -148,6 +148,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		folder?: string;
+		limit?: number;
 	}>(),
 	{
 		value: () => [],
@@ -156,12 +157,13 @@ const props = withDefaults(
 		enableCreate: true,
 		enableSelect: true,
 		folder: undefined,
+		limit: 15,
 	}
 );
 
 const emit = defineEmits(['input']);
 const { t } = useI18n();
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, limit } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 
 const value = computed({
@@ -204,7 +206,6 @@ const fields = computed(() =>
 	)
 );
 
-const limit = ref(15);
 const page = ref(1);
 
 const query = computed<RelationQueryMultiple>(() => ({

--- a/app/src/interfaces/files/index.ts
+++ b/app/src/interfaces/files/index.ts
@@ -71,6 +71,7 @@ export default defineInterface({
 				type: 'integer',
 				meta: {
 					interface: 'input',
+					width: 'half',
 				},
 				schema: {
 					default_value: 15,

--- a/app/src/interfaces/files/index.ts
+++ b/app/src/interfaces/files/index.ts
@@ -65,6 +65,17 @@ export default defineInterface({
 					width: 'half',
 				},
 			},
+			{
+				field: 'limit',
+				name: '$t:per_page',
+				type: 'integer',
+				meta: {
+					interface: 'input',
+				},
+				schema: {
+					default_value: 15,
+				},
+			},
 		];
 	},
 	recommendedDisplays: ['related-values'],

--- a/app/src/interfaces/list-m2a/index.ts
+++ b/app/src/interfaces/list-m2a/index.ts
@@ -46,6 +46,7 @@ export default defineInterface({
 			type: 'integer',
 			meta: {
 				interface: 'input',
+				width: 'half',
 			},
 			schema: {
 				default_value: 15,

--- a/app/src/interfaces/list-m2a/index.ts
+++ b/app/src/interfaces/list-m2a/index.ts
@@ -40,6 +40,17 @@ export default defineInterface({
 				width: 'half',
 			},
 		},
+		{
+			field: 'limit',
+			name: '$t:per_page',
+			type: 'integer',
+			meta: {
+				interface: 'input',
+			},
+			schema: {
+				default_value: 15,
+			},
+		},
 	],
 	preview: PreviewSVG,
 });

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -157,18 +157,20 @@ const props = withDefaults(
 		disabled?: boolean;
 		enableCreate?: boolean;
 		enableSelect?: boolean;
+		limit?: number;
 	}>(),
 	{
 		value: () => [],
 		disabled: false,
 		enableCreate: true,
 		enableSelect: true,
+		limit: 15,
 	}
 );
 
 const emit = defineEmits(['input']);
 const { t } = useI18n();
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, limit } = toRefs(props);
 const { relationInfo } = useRelationM2A(collection, field);
 
 const value = computed({
@@ -206,7 +208,6 @@ const fields = computed(() => {
 	return fields;
 });
 
-const limit = ref(15);
 const page = ref(1);
 
 const query = computed<RelationQueryMultiple>(() => ({

--- a/app/src/interfaces/list-m2m/index.ts
+++ b/app/src/interfaces/list-m2m/index.ts
@@ -63,6 +63,17 @@ export default defineInterface({
 				},
 			},
 			{
+				field: 'limit',
+				name: '$t:per_page',
+				type: 'integer',
+				meta: {
+					interface: 'input',
+				},
+				schema: {
+					default_value: 15,
+				},
+			},
+			{
 				field: 'filter',
 				name: '$t:filter',
 				type: 'json',

--- a/app/src/interfaces/list-m2m/index.ts
+++ b/app/src/interfaces/list-m2m/index.ts
@@ -68,6 +68,7 @@ export default defineInterface({
 				type: 'integer',
 				meta: {
 					interface: 'input',
+					width: 'half',
 				},
 				schema: {
 					default_value: 15,

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -107,6 +107,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		filter?: Filter | null;
+		limit?: number;
 	}>(),
 	{
 		value: () => [],
@@ -115,12 +116,13 @@ const props = withDefaults(
 		enableCreate: true,
 		enableSelect: true,
 		filter: () => null,
+		limit: 15,
 	}
 );
 
 const emit = defineEmits(['input']);
 const { t } = useI18n();
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, limit } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 
 const value = computed({
@@ -164,7 +166,6 @@ const fields = computed(() => {
 	return addRelatedPrimaryKeyToFields(relationInfo.value?.junctionCollection.collection ?? '', displayFields);
 });
 
-const limit = ref(15);
 const page = ref(1);
 
 const query = computed<RelationQueryMultiple>(() => ({

--- a/app/src/interfaces/list-o2m/index.ts
+++ b/app/src/interfaces/list-o2m/index.ts
@@ -61,6 +61,7 @@ export default defineInterface({
 				type: 'integer',
 				meta: {
 					interface: 'input',
+					width: 'half',
 				},
 				schema: {
 					default_value: 15,

--- a/app/src/interfaces/list-o2m/index.ts
+++ b/app/src/interfaces/list-o2m/index.ts
@@ -56,6 +56,17 @@ export default defineInterface({
 				},
 			},
 			{
+				field: 'limit',
+				name: '$t:per_page',
+				type: 'integer',
+				meta: {
+					interface: 'input',
+				},
+				schema: {
+					default_value: 15,
+				},
+			},
+			{
 				field: 'filter',
 				name: '$t:filter',
 				type: 'json',

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -111,6 +111,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		filter?: Filter | null;
+		limit?: number;
 	}>(),
 	{
 		value: () => [],
@@ -119,12 +120,13 @@ const props = withDefaults(
 		enableCreate: true,
 		enableSelect: true,
 		filter: () => null,
+		limit: 15,
 	}
 );
 
 const emit = defineEmits(['input']);
 const { t } = useI18n();
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, limit } = toRefs(props);
 const { relationInfo } = useRelationO2M(collection, field);
 
 const value = computed({
@@ -150,7 +152,6 @@ const fields = computed(() => {
 	return addRelatedPrimaryKeyToFields(relationInfo.value?.relatedCollection.collection ?? '', displayFields);
 });
 
-const limit = ref(15);
 const page = ref(1);
 
 const query = computed<RelationQueryMultiple>(() => ({


### PR DESCRIPTION
## Description

Makes the per-page limit of the relational interfaces configurable. This is useful, seeing that drag and drop sorting is automatically disabled once the total amount of items exceeds the limit. By making the limit configurable, you can set the individual page size to a number that better suits your use case, and maintain the ability to do manual drag and drop.

Implements #12818

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included[^1]
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated

[^1]: No app component test setup exists yet