### PR TITLE
Fix flow triggers being registered multiple times

### DIFF
--- a/api/src/services/flows.ts
+++ b/api/src/services/flows.ts
@@ -1,49 +1,64 @@
 import { FlowRaw } from '@directus/shared/types';
-import { getMessenger, Messenger } from '../messenger';
+import { getFlowManager } from '../flows';
 import { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '../types';
 import { ItemsService } from './items';
 
 export class FlowsService extends ItemsService<FlowRaw> {
-	messenger: Messenger;
-
 	constructor(options: AbstractServiceOptions) {
 		super('directus_flows', options);
-		this.messenger = getMessenger();
 	}
 
 	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		const flowManager = getFlowManager();
+
 		const result = await super.createOne(data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const flowManager = getFlowManager();
+
 		const result = await super.createMany(data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		const flowManager = getFlowManager();
+
 		const result = await super.updateOne(key, data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const flowManager = getFlowManager();
+
 		const result = await super.updateMany(keys, data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
+		const flowManager = getFlowManager();
+
 		const result = await super.deleteOne(key, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const flowManager = getFlowManager();
+
 		const result = await super.deleteMany(keys, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 }

--- a/api/src/services/operations.ts
+++ b/api/src/services/operations.ts
@@ -1,49 +1,64 @@
 import { OperationRaw } from '@directus/shared/types';
-import { getMessenger, Messenger } from '../messenger';
+import { getFlowManager } from '../flows';
 import { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '../types';
 import { ItemsService } from './items';
 
 export class OperationsService extends ItemsService<OperationRaw> {
-	messenger: Messenger;
-
 	constructor(options: AbstractServiceOptions) {
 		super('directus_operations', options);
-		this.messenger = getMessenger();
 	}
 
 	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		const flowManager = getFlowManager();
+
 		const result = await super.createOne(data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const flowManager = getFlowManager();
+
 		const result = await super.createMany(data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		const flowManager = getFlowManager();
+
 		const result = await super.updateOne(key, data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const flowManager = getFlowManager();
+
 		const result = await super.updateMany(keys, data, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
+		const flowManager = getFlowManager();
+
 		const result = await super.deleteOne(key, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 
 	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const flowManager = getFlowManager();
+
 		const result = await super.deleteMany(keys, opts);
-		this.messenger.publish('flows', { type: 'reload' });
+		await flowManager.reload();
+
 		return result;
 	}
 }

--- a/api/src/utils/job-queue.ts
+++ b/api/src/utils/job-queue.ts
@@ -1,0 +1,31 @@
+type Job = () => Promise<void> | void;
+
+export class JobQueue {
+	private running: boolean;
+	private jobs: Job[];
+
+	constructor() {
+		this.running = false;
+		this.jobs = [];
+	}
+
+	public enqueue(job: Job): void {
+		this.jobs.push(job);
+
+		if (!this.running) {
+			this.run();
+		}
+	}
+
+	private async run(): Promise<void> {
+		this.running = true;
+
+		while (this.jobs.length > 0) {
+			const job = this.jobs.shift()!;
+
+			await job();
+		}
+
+		this.running = false;
+	}
+}


### PR DESCRIPTION
## Description

When a flow gets updated, `updateOne()` is called which in turn calls `updateMany()`. Both of those functions will trigger a flow reload which means a reload might be triggered while another reload is already happening, resulting in a race condition. This race condition means event-based flows might be registered multiple times.

This fixes the issue by implementing a tiny `JobQueue` which ensures that flow reloads happen one after another.

Fixes #13739

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
