### PR TITLE
Set count on fresh init of defered tinymce

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -448,6 +448,7 @@ export default defineComponent({
 				editor.addShortcut('meta+k', 'Insert Link', () => {
 					editor.ui.registry.getAll().buttons.customlink.onAction();
 				});
+				setCount();
 			});
 		}
 


### PR DESCRIPTION

## Description

Follow-up to https://github.com/directus/directus/pull/13242 that should really fix #13235 this time. 

#13242 made sure the count was properly reset whenever TinyMCE indicated a SetContent, however, when the editor is initialized for the very first time, it's done so with the content already in place, meaning that the SetContent event won't fire. This change should account for those fresh initializations (which seemingly only happen on the very first load of the editor).

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
