### PR TITLE
Use latest vue version when scaffolding extension packages

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -105,7 +105,7 @@ async function getPackageDeps(type: ExtensionType, language: Language) {
 						typescript: `^${await getPackageVersion('typescript')}`,
 				  }
 				: {}),
-			vue: `^${await getPackageVersion('vue', 'next')}`,
+			vue: `^${await getPackageVersion('vue')}`,
 		};
 	} else {
 		return {


### PR DESCRIPTION
## Description

Now that `vue@3` is pushed to the latest tag, we can pull in the current version using `latest` instead of `next`.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
