### PR TITLE
Make UUID/manual primary keys selectable with count in Time Series panels

### DIFF
--- a/app/src/panels/time-series/index.ts
+++ b/app/src/panels/time-series/index.ts
@@ -208,6 +208,7 @@ export default definePanel({
 						},
 						options: {
 							allowPrimaryKey: true,
+							typeAllowList: ['integer', 'bigInteger', 'uuid', 'string'],
 						},
 					},
 				],


### PR DESCRIPTION
## Description

Addresses https://github.com/directus/directus/discussions/13738#discussioncomment-2892750

### Problem

Although primary key was made selectable for Count/Count(Distinct) for Time Series panels in #13479, there's an existing `typeAllowList` that is still preventing us from actually being able to select UUID or manual string primary keys:

https://github.com/directus/directus/blob/9f10d1d97833ba5e1653666a51fe050860cb86b7/app/src/panels/time-series/index.ts#L200

![chrome_C9e63dIx7o](https://user-images.githubusercontent.com/42867097/172785891-f11e3e9c-304f-412e-a664-a14793d73414.gif)

### Solution

Override the `typeAllowList` in the same condition rule.

https://user-images.githubusercontent.com/42867097/172785911-9bdc5ac7-418e-47da-a875-c5d089305b7c.mp4

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
