### PR TITLE
re-enabling thumbsmith in the docs build process

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,8 +12,8 @@
 		"build": "node build.js",
 		"dev": "npm-watch build",
 		"dev:site": "vuepress dev",
-		"build:site": "vuepress build",
-		"update-thumbnail": "thumbsmith deploy .vuepress/.thumbsmith/docs.thumbnail.html"
+		"build:site": "vuepress build && npm run update-thumbnail",
+		"update-thumbnail": "thumbsmith deploy .vuepress/.thumbsmith/docs.thumbnail.html || exit 0"
 	},
 	"watch": {
 		"build": {


### PR DESCRIPTION
## Description

The API KEY seems to have been re-generated since adding it in the build. Since Thumbsmith has no tooling/logs to see why or when this happened i have opted to update the key and reintroduce the thumbsmith update but non-blocking this time so it won't block any builds if anything happens to the token in the future.

Refs #13714 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [X] Performed a self-review of the submitted code
