### PR TITLE
Auto approve pull requests from Crowdin via label

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -5,3 +5,6 @@ method = "squash"
 delete_branch_on_merge = true
 automerge_label = "Automerge"
 show_missing_automerge_label_message = false
+
+[approve]
+auto_approve_labels = ["Automerge"]


### PR DESCRIPTION
## Description

Auto approve pull requests from Crowdin (labeled with https://github.com/directus/directus/labels/Automerge) by using the new `approve.auto_approve_labels` option from Kodiak (https://github.com/chdsbd/kodiak/pull/817).
Ref #13633.

**Note:** Although the new option has already been released in v0.52.0, it seems like it hasn't been rolled-out to Kodiak's server yet. Nevertheless, this pull request can already be merged and it will come into effect as soon as Kodiak's server has been updated.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Optimization

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
