### PR TITLE
use parsePreset in App side

### DIFF
--- a/app/src/stores/permissions.ts
+++ b/app/src/stores/permissions.ts
@@ -1,6 +1,7 @@
 import api from '@/api';
 import { Permission } from '@directus/shared/types';
 import { parseFilter } from '@/utils/parse-filter';
+import { parsePreset } from '@/utils/parse-preset';
 import { defineStore } from 'pinia';
 import { useUserStore } from '../stores/user';
 
@@ -24,6 +25,10 @@ export const usePermissionsStore = defineStore({
 
 				if (rawPermission.validation) {
 					rawPermission.validation = parseFilter(rawPermission.validation);
+				}
+
+				if (rawPermission.presets) {
+					rawPermission.presets = parsePreset(rawPermission.presets);
 				}
 
 				return rawPermission;

--- a/app/src/utils/parse-preset.ts
+++ b/app/src/utils/parse-preset.ts
@@ -1,0 +1,21 @@
+import { useUserStore } from '@/stores';
+import { Accountability, Role, User } from '@directus/shared/types';
+import { parsePreset as parsePresetShared } from '@directus/shared/utils';
+
+export function parsePreset(preset: Record<string, any> | null): Record<string, any> {
+	const { currentUser } = useUserStore();
+
+	if (!currentUser) return preset ?? {};
+
+	const accountability: Accountability = {
+		role: currentUser.role.id,
+		user: currentUser.id,
+	};
+
+	return (
+		parsePresetShared(preset, accountability, {
+			$CURRENT_ROLE: currentUser.role as Role,
+			$CURRENT_USER: currentUser as User,
+		}) ?? {}
+	);
+}


### PR DESCRIPTION
## Description

Fixes #13806

### Problem

Ref https://github.com/directus/directus/issues/13806#issuecomment-1152142420

Before #10576, presets were being parsed as filters in the App side, hence turning `{ "f": "test" }` into `{ "_eq": "test" }` instead. The PR #10576's solution were to totally remove parsing of presets App side, under the assumption it's not required. 

However although the API side does still parse presets accordingly, there may be use cases where it is required App side such as forming URL based on id, as described in https://github.com/directus/directus/discussions/9682#discussioncomment-2911547.

### Solution

#11423 added the `parsePreset` function, so opted to use it app side similar to how the app has a `parseFilter` utility that is using the `parseFilter` from the shared package:

https://github.com/directus/directus/blob/06a238cbf0e6d1cb7ef2b5ad0474c33282bf2753/app/src/utils/parse-filter.ts#L6-L17

### Result

https://user-images.githubusercontent.com/42867097/173034430-4d97c5d6-4010-4cf3-9e12-5b7a28e98bd9.mp4

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
