### PR TITLE
Add migration to rename `hook` triggers to `event`

### DIFF
--- a/api/src/database/migrations/20220614A-rename-hook-trigger-to-event.ts
+++ b/api/src/database/migrations/20220614A-rename-hook-trigger-to-event.ts
@@ -1,0 +1,9 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex('directus_flows').update({ trigger: 'event' }).where('trigger', '=', 'hook');
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex('directus_flows').update({ trigger: 'hook' }).where('trigger', '=', 'event');
+}


### PR DESCRIPTION
## Description

In the later stages of #12522, `hook` triggers were renamed to `event` but it was not renamed in the migration (line 49):

https://github.com/directus/directus/blob/583a555b0b291d830a2d6349fc51aa5f5e831225/api/src/database/migrations/20220429A-add-flows.ts#L45-L56 

hence webhooks are migrated as `hook` triggers. It then results in an empty trigger panel as the `.find()` here is unable to find `event` triggers:

https://github.com/directus/directus/blob/583a555b0b291d830a2d6349fc51aa5f5e831225/app/src/modules/settings/routes/flows/components/operation.vue#L210

![chrome_P1U3sWmowR](https://user-images.githubusercontent.com/42867097/173519519-9e37b642-0288-4e4b-bed8-ff9a626dbaff.png)

This PR adds a follow up migration to remedy this:

![chrome_Cu3EVxfriB](https://user-images.githubusercontent.com/42867097/173519591-1f7a24a2-1239-421e-a08a-fc0c2556df5d.png)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
