### PR TITLE
API: Ignore `returning` not supported messages

### DIFF
--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -71,6 +71,7 @@ export default function getDatabase(): Knex {
 			warn: (msg) => {
 				// Ignore warnings about returning not being supported in some DBs
 				if (msg.startsWith('.returning()')) return;
+				if (msg.endsWith('does not currently support RETURNING clause')) return;
 
 				// Ignore warning about MySQL not supporting TRX for DDL
 				if (msg.startsWith('Transaction was implicitly committed, do not mix transactions and DDL with MySQL')) return;


### PR DESCRIPTION
## Description

As mentioned here https://github.com/directus/directus/pull/7259, we try to use `returning` clause every time. Although, some databases, like SQLite, do not support this operation. Thus, we're seeing a lot of messages like:
```
node-sqlite3 does not currently support RETURNING clause
```

Also, this message is declared in `knex` here: https://github.com/knex/knex/blob/master/lib/dialects/sqlite3/index.js#L195-L197

In order to get rid of messages like this, in this PR we ignore all the warnings coming from `knex` which ends with `does not currently support RETURNING clause`

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:
PS: I think it's a bugfix because this line seems to try to do the same: https://github.com/directus/directus/blob/master/api/src/database/index.ts#L73

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
