### PR TITLE
Sanitize query for item read/update/delete operations in Flows

### DIFF
--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -1,8 +1,9 @@
 import { Accountability, PrimaryKey } from '@directus/shared/types';
 import { defineOperationApi, toArray } from '@directus/shared/utils';
 import { ItemsService } from '../../services';
-import { optionToObject } from '../../utils/operation-options';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role';
+import { optionToObject } from '../../utils/operation-options';
+import { sanitizeQuery } from '../../utils/sanitize-query';
 
 type Options = {
 	collection: string;
@@ -36,11 +37,12 @@ export default defineOperationApi<Options>({
 		});
 
 		const queryObject = query ? optionToObject(query) : {};
+		const sanitizedQueryObject = sanitizeQuery(queryObject, customAccountability);
 
 		let result: PrimaryKey | PrimaryKey[] | null;
 
 		if (!key) {
-			result = await itemsService.deleteByQuery(queryObject);
+			result = await itemsService.deleteByQuery(sanitizedQueryObject);
 		} else {
 			const keys = toArray(key);
 

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -2,8 +2,9 @@ import { Accountability, PrimaryKey } from '@directus/shared/types';
 import { defineOperationApi, toArray } from '@directus/shared/utils';
 import { ItemsService } from '../../services';
 import { Item } from '../../types';
-import { optionToObject } from '../../utils/operation-options';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role';
+import { optionToObject } from '../../utils/operation-options';
+import { sanitizeQuery } from '../../utils/sanitize-query';
 
 type Options = {
 	collection: string;
@@ -37,18 +38,19 @@ export default defineOperationApi<Options>({
 		});
 
 		const queryObject = query ? optionToObject(query) : {};
+		const sanitizedQueryObject = sanitizeQuery(queryObject, customAccountability);
 
 		let result: Item | Item[] | null;
 
 		if (!key) {
-			result = await itemsService.readByQuery(queryObject);
+			result = await itemsService.readByQuery(sanitizedQueryObject);
 		} else {
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.readOne(keys[0], queryObject);
+				result = await itemsService.readOne(keys[0], sanitizedQueryObject);
 			} else {
-				result = await itemsService.readMany(keys, queryObject);
+				result = await itemsService.readMany(keys, sanitizedQueryObject);
 			}
 		}
 

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -2,8 +2,9 @@ import { Accountability, PrimaryKey } from '@directus/shared/types';
 import { defineOperationApi, toArray } from '@directus/shared/utils';
 import { ItemsService } from '../../services';
 import { Item } from '../../types';
-import { optionToObject } from '../../utils/operation-options';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role';
+import { optionToObject } from '../../utils/operation-options';
+import { sanitizeQuery } from '../../utils/sanitize-query';
 
 type Options = {
 	collection: string;
@@ -40,6 +41,7 @@ export default defineOperationApi<Options>({
 		const payloadObject: Partial<Item> | Partial<Item>[] | null = optionToObject(payload) ?? null;
 
 		const queryObject = query ? optionToObject(query) : {};
+		const sanitizedQueryObject = sanitizeQuery(queryObject, customAccountability);
 
 		if (!payloadObject) {
 			return null;
@@ -48,7 +50,7 @@ export default defineOperationApi<Options>({
 		let result: PrimaryKey | PrimaryKey[] | null;
 
 		if (!key) {
-			result = await itemsService.updateByQuery(queryObject, payloadObject);
+			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject);
 		} else {
 			const keys = toArray(key);
 


### PR DESCRIPTION
## Description

Fixes #13745

### Problem

Normally requests pass through `sanitizeQueryMiddleware`:

https://github.com/directus/directus/blob/e085228f70cbadc53c8ca878cc44980bf569d821/api/src/middleware/sanitize-query.ts#L10

which with the context of the reported issue in mind, includes `sanitizeFilter` that subsequently uses `parseFilter` to parse dynamic variables such as `$NOW(-24 hours)`:

https://github.com/directus/directus/blob/9b6e143c59a828685ff20cbc93048684eb4d60ff/api/src/utils/sanitize-query.ts#L116-L128

However, the item read/update/delete operations doesn't go through the same middleware, thus the queries are not sanitized nor parsed. This then causes error on PostgreSQL as it'll try to use the unparsed dynamic variable directly in the query:

``select "events"."id", "events"."timestamp" from "events" where "events"."timestamp" <= ? order by "events"."id" asc limit ? [ '$NOW(-24 hours)', 100 ]``

SQLite doesn't really throw an error, but we can also see that it's using NaN instead so the filter is incorrect:

``select `events`.`id`, `events`.`timestamp` from `events` where `events`.`timestamp` <= ? order by `events`.`id` asc limit ? [NaN, 100]``

### Solution

Use `sanitizeQuery` util function within item read/update/delete operations. 

- Formed query in SQlite: ``select `events`.`id`, `events`.`timestamp` from `events` where `events`.`timestamp` <= ? order by `events`.`id` asc limit ? [1655102827181, 100]``

- Formed query in PostgreSQL: ``select "events"."id", "events"."timestamp" from "events" where "events"."timestamp" <= $1 order by "events"."id" asc limit $2 [Tue Jun 14 2022 15:08:21 GMT+0800 (Singapore Standard Time), 100]``

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
