### PR TITLE
Redirect to page not found for flows that do not exist

### DIFF
--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -1,6 +1,6 @@
 import api from '@/api';
 import { defineModule } from '@directus/shared/utils';
-import { useCollectionsStore, useFieldsStore } from '@/stores';
+import { useCollectionsStore, useFieldsStore, useFlowsStore } from '@/stores';
 import RouterPass from '@/utils/router-passthrough';
 import Collections from './routes/data-model/collections/collections.vue';
 import FieldDetail from './routes/data-model/field-detail/field-detail.vue';
@@ -193,6 +193,16 @@ export default defineModule({
 					path: ':primaryKey',
 					component: FlowsDetail,
 					props: true,
+					async beforeEnter(to) {
+						const { flows } = useFlowsStore();
+						const existingFlow = flows.find((flow) => flow.id === to.params.primaryKey);
+						if (!existingFlow) {
+							return {
+								name: 'settings-not-found',
+								params: { _: to.path.split('/').slice(1) },
+							};
+						}
+					},
 					children: [
 						{
 							name: 'settings-flows-operation',


### PR DESCRIPTION
## Description

Similar intention & fix to #11882, this PR redirects the user to the Page Not Found page upon routing to a non-existent flow ID. Flow page specifically bugs out without being able to interact with it further, hence it's a necessary fix after all.

### Before

https://user-images.githubusercontent.com/42867097/173843460-86c32a2e-114b-4d74-98c3-8249e5389e6c.mp4

### After

https://user-images.githubusercontent.com/42867097/173843505-27824996-9bb0-435d-bc10-e9af784ae86f.mp4

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
