### PR TITLE
Dashboards: Add missing system `color` field

### DIFF
--- a/api/src/database/system-data/fields/dashboards.yaml
+++ b/api/src/database/system-data/fields/dashboards.yaml
@@ -14,3 +14,4 @@ fields:
   - field: user_created
     special: user-created
   - field: note
+  - field: color


### PR DESCRIPTION
## Description
When trying to apply a schema this change appears every time:
```
Fields:
  - Delete directus_dashboards.color
```

Be debugging a little I found that column `color` was added to `directus_dashboards` table, but is not specified on system fields (yaml files):
https://github.com/directus/directus/blob/fix/missing-dashboard-field/api/src/database/migrations/20220429B-add-color-to-insights-icon.ts#L10

This cause the schema to be applied wrongly.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
