### PR TITLE
add `Emit Events` option to item update/delete operations in Flows

### DIFF
--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -9,13 +9,14 @@ type Options = {
 	collection: string;
 	key?: PrimaryKey | PrimaryKey[] | null;
 	query?: Record<string, any> | string | null;
+	emitEvents: boolean;
 	permissions: string; // $public, $trigger, $full, or UUID of a role
 };
 
 export default defineOperationApi<Options>({
 	id: 'item-delete',
 
-	handler: async ({ collection, key, query, permissions }, { accountability, database, getSchema }) => {
+	handler: async ({ collection, key, query, emitEvents, permissions }, { accountability, database, getSchema }) => {
 		const schema = await getSchema({ database });
 
 		let customAccountability: Accountability | null;
@@ -47,9 +48,9 @@ export default defineOperationApi<Options>({
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.deleteOne(keys[0]);
+				result = await itemsService.deleteOne(keys[0], { emitEvents });
 			} else {
-				result = await itemsService.deleteMany(keys);
+				result = await itemsService.deleteMany(keys, { emitEvents });
 			}
 		}
 

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -11,13 +11,17 @@ type Options = {
 	key?: PrimaryKey | PrimaryKey[] | null;
 	payload?: Record<string, any> | string | null;
 	query?: Record<string, any> | string | null;
+	emitEvents: boolean;
 	permissions: string; // $public, $trigger, $full, or UUID of a role
 };
 
 export default defineOperationApi<Options>({
 	id: 'item-update',
 
-	handler: async ({ collection, key, payload, query, permissions }, { accountability, database, getSchema }) => {
+	handler: async (
+		{ collection, key, payload, query, emitEvents, permissions },
+		{ accountability, database, getSchema }
+	) => {
 		const schema = await getSchema({ database });
 
 		let customAccountability: Accountability | null;
@@ -50,14 +54,14 @@ export default defineOperationApi<Options>({
 		let result: PrimaryKey | PrimaryKey[] | null;
 
 		if (!key) {
-			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject);
+			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents });
 		} else {
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.updateOne(keys[0], payloadObject);
+				result = await itemsService.updateOne(keys[0], payloadObject, { emitEvents });
 			} else {
-				result = await itemsService.updateMany(keys, payloadObject);
+				result = await itemsService.updateMany(keys, payloadObject, { emitEvents });
 			}
 		}
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2024,6 +2024,7 @@ operations:
   item-delete:
     name: Delete Data
     description: Delete items in the database
+    emit_events: Emit Events
     key: IDs
     query: Query
   item-read:
@@ -2034,6 +2035,7 @@ operations:
   item-update:
     name: Update Data
     description: Update items in the database
+    emit_events: Emit Events
     key: IDs
     payload: Payload
     query: Query

--- a/app/src/operations/item-create/index.ts
+++ b/app/src/operations/item-create/index.ts
@@ -63,7 +63,7 @@ export default defineOperationApp({
 				interface: 'boolean',
 			},
 			schema: {
-				default_value: true,
+				default_value: false,
 			},
 		},
 		{

--- a/app/src/operations/item-delete/index.ts
+++ b/app/src/operations/item-delete/index.ts
@@ -25,6 +25,15 @@ export default defineOperationApp({
 	},
 	options: [
 		{
+			field: 'collection',
+			name: '$t:collection',
+			type: 'string',
+			meta: {
+				width: 'half',
+				interface: 'system-collection',
+			},
+		},
+		{
 			field: 'permissions',
 			name: '$t:permissions',
 			type: 'string',
@@ -32,7 +41,7 @@ export default defineOperationApp({
 				default_value: '$trigger',
 			},
 			meta: {
-				width: 'full',
+				width: 'half',
 				interface: 'select-dropdown',
 				options: {
 					choices: [
@@ -54,12 +63,15 @@ export default defineOperationApp({
 			},
 		},
 		{
-			field: 'collection',
-			name: '$t:collection',
-			type: 'string',
+			field: 'emitEvents',
+			name: '$t:operations.item-delete.emit_events',
+			type: 'boolean',
 			meta: {
 				width: 'half',
-				interface: 'system-collection',
+				interface: 'boolean',
+			},
+			schema: {
+				default_value: false,
 			},
 		},
 		{

--- a/app/src/operations/item-update/index.ts
+++ b/app/src/operations/item-update/index.ts
@@ -24,6 +24,15 @@ export default defineOperationApp({
 	},
 	options: [
 		{
+			field: 'collection',
+			name: '$t:collection',
+			type: 'string',
+			meta: {
+				width: 'half',
+				interface: 'system-collection',
+			},
+		},
+		{
 			field: 'permissions',
 			name: '$t:permissions',
 			type: 'string',
@@ -31,7 +40,7 @@ export default defineOperationApp({
 				default_value: '$trigger',
 			},
 			meta: {
-				width: 'full',
+				width: 'half',
 				interface: 'select-dropdown',
 				options: {
 					choices: [
@@ -53,12 +62,15 @@ export default defineOperationApp({
 			},
 		},
 		{
-			field: 'collection',
-			name: '$t:collection',
-			type: 'string',
+			field: 'emitEvents',
+			name: '$t:operations.item-update.emit_events',
+			type: 'boolean',
 			meta: {
 				width: 'half',
-				interface: 'system-collection',
+				interface: 'boolean',
+			},
+			schema: {
+				default_value: false,
 			},
 		},
 		{

--- a/docs/configuration/flows/operations.md
+++ b/docs/configuration/flows/operations.md
@@ -46,8 +46,9 @@ Items.
 
 Deletes some Item(s) from a Collection by ID or query.
 
-- **Permissions** — Set the scope of permissions used for this Operation.
 - **Collection** — Use the dropdown to set the Collection to delete Items from.
+- **Permissions** — Set the scope of permissions used for this Operation.
+- **Emit Events** — Toggle whether the event is emitted.
 - **IDs** — Set Item IDs and press enter to confirm. Click the ID to remove.
 - **Query** — Select Items to delete with a query. To learn more, see [Filter Rules](/configuration/filter-rules).
 
@@ -76,9 +77,10 @@ select the Items you wish to update.
 
 Updates Item(s) in a Collection. You may select Items by their ID or run a query to select the Items you wish to update.
 
+- **Collections** — Select the Collection to update Items from.
 - **Permissions** — Defines Role that this Operation will inherit permissions from.
-- **Collections** — Select the Collection to read Items from.
-- **IDs** — Input ID for Item(s) you wish to read and press enter. Click the ID to remove.
+- **Emit Events** — Toggle whether the event is emitted.
+- **IDs** — Input ID for Item(s) you wish to update and press enter. Click the ID to remove.
 - **Payload** — Updates Item(s) in a Collection. To learn more, see [API > Items](/reference/items/).
 - **Query** — Select Items to update with a query. To learn more, see [Filter Rules](/configuration/filter-rules).
 


### PR DESCRIPTION
## Description

This PR adds the `Emit Events` toggle to item update and delete operations (currently exists on item create operation) to configure whether or not it should fire it's own events.

It is also disabled by default, as a recursive flow can leading a huge amount of revisions when enabled.

### Before

![chrome_6MwBii7DXo](https://user-images.githubusercontent.com/42867097/173943066-22d7cdbb-08ea-4a3c-88f2-d793b0f8d732.png)

### After

![chrome_0o6v7hq1Qu](https://user-images.githubusercontent.com/42867097/173943059-feff80ee-8e77-497b-b222-db1a5e2368f5.png)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated
