### PR TITLE
Prevent translations validation error matching parent

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -52,7 +52,11 @@
 				:primary-key="primaryKey"
 				:loading="loading"
 				:validation-error="
-					validationErrors.find((err) => err.field === field.field || err.field.endsWith(`(${field.field})`))
+					validationErrors.find(
+						(err) =>
+							err.collection === field.collection &&
+							(err.field === field.field || err.field.endsWith(`(${field.field})`))
+					)
 				"
 				:badge="badge"
 				@update:model-value="setValue(field.field, $event)"

--- a/packages/shared/src/types/fields.ts
+++ b/packages/shared/src/types/fields.ts
@@ -60,6 +60,7 @@ export type RawField = DeepPartial<Field> & { field: string; type: Type };
 
 export type ValidationError = {
 	code: string;
+	collection: string;
 	field: string;
 	type: FilterOperator;
 	hidden?: boolean;


### PR DESCRIPTION
## Description

Fixes #10532

### Solution

Adds `err.collection === field.collection` in the validation-error prop logic to ensure nested translations fields (essentially a different collection) doesn't match the parent collection with same field key.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
