### PR TITLE
Improve Flows drawer editing experience

### DIFF
--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -94,17 +94,18 @@
 		<template #actions>
 			<v-button
 				v-if="currentTab[0] === 'flow_setup'"
-				v-tooltip.bottom="t('next')"
+				v-tooltip.bottom="isNew ? t('next') : t('save')"
 				:disabled="!values.name || values.name.length === 0"
+				:loading="saving"
 				icon
 				rounded
-				@click="currentTab = ['trigger_setup']"
+				@click="isNew ? (currentTab = ['trigger_setup']) : save()"
 			>
-				<v-icon name="arrow_forward" />
+				<v-icon :name="isNew ? 'arrow_forward' : 'check'" />
 			</v-button>
 			<v-button
 				v-if="currentTab[0] === 'trigger_setup'"
-				v-tooltip.bottom="t('finish_setup')"
+				v-tooltip.bottom="isNew ? t('finish_setup') : t('save')"
 				:disabled="!values.trigger"
 				:loading="saving"
 				icon


### PR DESCRIPTION
## Description

### Problem

When editing a flow, the drawer still requires us to navigate to the Trigger Setup tab even if we're only editing fields in Flow Setup for existing flows. The tooltip in Trigger Setup also shows `Finish Setup`.

https://user-images.githubusercontent.com/42867097/174071459-79260bb5-56c8-4af1-ac4f-26dd6b4291b2.mp4

### Solution

Now allows saving on either tabs and tooltip will show `Save` instead, for existing flows.

https://user-images.githubusercontent.com/42867097/174071423-359ffe50-d926-4f10-b455-5d1972722ed7.mp4

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
