### PR TITLE
batch edit toggle not rendered side-by-side

### DIFF
--- a/app/src/components/v-chip/v-chip.vue
+++ b/app/src/components/v-chip/v-chip.vue
@@ -162,6 +162,7 @@ body {
 	.chip-content {
 		display: inline-flex;
 		align-items: center;
+		white-space: nowrap;
 
 		.close-outline {
 			position: relative;

--- a/app/src/components/v-form/form-field-label.vue
+++ b/app/src/components/v-form/form-field-label.vue
@@ -1,12 +1,12 @@
 <template>
 	<div class="field-label type-label" :class="{ disabled, edited: edited && !batchMode && !hasError && !loading }">
-		<v-checkbox
-			v-if="batchMode"
-			:model-value="batchActive"
-			:value="field.field"
-			@update:model-value="$emit('toggle-batch', field)"
-		/>
 		<span class="field-name" @click="toggle">
+			<v-checkbox
+				v-if="batchMode"
+				:model-value="batchActive"
+				:value="field.field"
+				@update:model-value="$emit('toggle-batch', field)"
+			/>
 			<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>
 			<v-text-overflow :text="field.name" />
 			<v-icon v-if="field.meta?.required === true" class="required" :class="{ 'has-badge': badge }" sup name="star" />


### PR DESCRIPTION
## Description

Follow up on translation labels not being rendered side-by-side.

### Before
![image](https://user-images.githubusercontent.com/9389634/174258057-472092d9-006c-4631-99f4-8215e49b2e37.png)

### After
![image](https://user-images.githubusercontent.com/9389634/174258071-87ac548b-91c0-470d-a97e-877478b35d74.png)

Refs #13842 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

