### PR TITLE
fixes 404 links in docs

### DIFF
--- a/docs/configuration/data-model.md
+++ b/docs/configuration/data-model.md
@@ -303,7 +303,7 @@ Each field can have one or more _rules_. Each rule has the following configurati
 
 - **Name**: The name of the rule. This is only used internally for convenience purposes
 - **Rule**: The rule that controls whether or not these conditions are applied. Rule follows the
-  [Filter Rules](/configuration/filter-rules) spec
+  [Filter Rules](/reference/filter-rules) spec
 - **Readonly**: Whether or not the field is readonly when the condition is matched
 - **Hidden**: Whether or not the field is hidden when the condition is matched
 - **Required**: Whether or not the field is required when the condition is matched

--- a/docs/configuration/flows/operations.md
+++ b/docs/configuration/flows/operations.md
@@ -20,7 +20,7 @@ A Condition routes to the next success or failure Operation based on some condit
 Filter query. That means if the query condition is met, the Flow will move forward with the success Operation.
 Otherwise, the failure Operation will initiate.
 
-- **Condition Rules** — Create conditions with [Filter Rules](/configuration/filter-rules).
+- **Condition Rules** — Create conditions with [Filter Rules](/reference/filter-rules).
 
 ## Create Data
 
@@ -49,7 +49,7 @@ This Operation deletes Item(s) from a Collection by ID or query.
 - **Permissions** — Set the scope of permissions used for this Operation.
 - **Collection** — Use the dropdown menu to select the Collection you'd like to delete Items from.
 - **IDs** — Set Item IDs and press enter to confirm. Click the ID to remove.
-- **Query** — Select Items to delete with a query. To learn more, see [Filter Rules](/configuration/filter-rules).
+- **Query** — Select Items to delete with a query. To learn more, see [Filter Rules](/reference/filter-rules).
 
 :::tip
 
@@ -68,7 +68,7 @@ run a query to select the Items you wish to update.
 - **Permissions** — Set the scope of permissions used for this Operation.
 - **Collections** — Select the Collection from which you'd like to read Items.
 - **IDs** — Input the ID for Items you wish to read and press enter. Click the ID to remove.
-- **Query** — Select the Items with a query. To learn more, see [Filter Rules](/configuration/filter-rules).
+- **Query** — Select the Items with a query. To learn more, see [Filter Rules](/reference/filter-rules).
 
 ## Update Data
 
@@ -81,7 +81,7 @@ select the Items you wish to update.
 - **Collections** — Select the Collection from which you'd like to read Items.
 - **IDs** — Input the ID for Item(s) you wish to read and press enter. Click the ID to remove.
 - **Payload** — Update Items in a Collection. To learn more, see [API > Items](reference/items/).
-- **Query** — Select Items to update with a query. To learn more, see [Filter Rules](/configuration/filter-rules).
+- **Query** — Select Items to update with a query. To learn more, see [Filter Rules](/reference/filter-rules).
 
 ## Log to Console
 
@@ -115,7 +115,6 @@ provider may send it there automatically.
 ![Send Notification](https://cdn.directus.io/docs/v9/configuration/flows/operations/operations-20220603A/send-notification-20220603A.webp)
 
 This Operation sends a notification to an app user.
-
 
 - **Users** — Define a User by their primary key UUID. Use [Flow keys](/configuration/flows/flows/#the-flow-object) to
   set this dynamically.

--- a/docs/configuration/users-roles-permissions.md
+++ b/docs/configuration/users-roles-permissions.md
@@ -132,7 +132,7 @@ _action_.
 
 ### Read (Custom Access)
 
-5. **Item Permissions** control which items can be read, as defined by the [Filter Rules](/configuration/filter-rules)
+5. **Item Permissions** control which items can be read, as defined by the [Filter Rules](/reference/filter-rules)
    entered.
 6. **Field Permissions** control which fields can be read. Fields are individually toggled.
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -126,8 +126,8 @@ _Natively supported in GraphQL_
 <div class="left">
 
 Used to search items in a collection that matches the filter's conditions. The filter param follows
-[the Filter Rules spec](/configuration/filter-rules), which includes additional information on logical operators
-(AND/OR), nested relational filtering, and dynamic variables.
+[the Filter Rules spec](/reference/filter-rules), which includes additional information on logical operators (AND/OR),
+nested relational filtering, and dynamic variables.
 
 </div>
 </div>

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -39,10 +39,10 @@ Collection this permission rule applies to.
 What CRUD operation this permission rule applies to. One of `create`, `read`, `update`, `delete`.
 
 `permissions` **object**\
-What rules the item must pass before the role is allowed to alter it. Follows [the Filter Rules spec](/configuration/filter-rules).
+What rules the item must pass before the role is allowed to alter it. Follows [the Filter Rules spec](/reference/filter-rules).
 
 `validation` **object**\
-What rules the provided values must pass before the role is allowed to submit them for insertion/update. Follows [the Filter Rules spec](/configuration/filter-rules).
+What rules the provided values must pass before the role is allowed to submit them for insertion/update. Follows [the Filter Rules spec](/reference/filter-rules).
 
 `preset` **object**\
 Additional default values for the role.


### PR DESCRIPTION
## Description

Fixes 404 links in the docs. Several links still referred to the old `/configuration/filter-rules` path.

## Type of Change

- [X] Other, please describe:
404 links fix for the docs

## Requirements Checklist

- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code
