### PR TITLE
Fix saving error with custom permissions in O2M fields

### DIFF
--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -210,6 +210,11 @@ function editItem(item: DisplayItem) {
 	const pkField = relationInfo.value.relatedPrimaryKeyField.field;
 
 	newItem = false;
+	for (const entry in item) {
+		if (entry !== pkField) {
+			delete item[entry];
+		}
+	}
 	editsAtStart.value = item;
 
 	if (item?.$type === 'created' && !isItemSelected(item)) {

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -210,12 +210,7 @@ function editItem(item: DisplayItem) {
 	const pkField = relationInfo.value.relatedPrimaryKeyField.field;
 
 	newItem = false;
-	for (const entry in item) {
-		if (entry !== pkField) {
-			delete item[entry];
-		}
-	}
-	editsAtStart.value = item;
+	editsAtStart.value = { [pkField]: item[pkField] };
 
 	if (item?.$type === 'created' && !isItemSelected(item)) {
 		currentlyEditing.value = '+';


### PR DESCRIPTION
## Description

This is a simple bug fix for #13765 and #13997. When editing an item with relation fields and also have RBAC controls, users may get "You don't have permission to access this" error. The reason is when user click the relation items in the main item view, the list-o2m.editItem() will set the editsAtStart to the displayItem which contains the related fields. In fact, we just need to pass the key value of this item as the editsAtStart as when the drawer pops up, the value will be fetched from backend. So the fix is also simple, just remove all unrelated fields from the displayItem except the key field.

Fixes #13765

## Type of Change
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
