### PR TITLE
Update get-filter-operators-for-type.ts

### DIFF
--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -60,8 +60,6 @@ export function getFilterOperatorsForType(
 			return [
 				'eq',
 				'neq',
-				'null',
-				'nnull',
 				'lt',
 				'lte',
 				'gt',


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #14000.
Remove the duplicated `null` and `nnull` for Datetime types. This results in duplicated tests run for the affected fields.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
