### PR TITLE
fix action event Flows for related tables

### DIFF
--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -182,7 +182,7 @@ class FlowManager {
 					const handler: ActionHandler = (meta, context) =>
 						this.executeFlow(flow, meta, {
 							accountability: context.accountability,
-							database: context.database,
+							database: getDatabase(),
 							getSchema: context.schema ? () => context.schema : getSchema,
 						});
 


### PR DESCRIPTION
## Description

Fixes #13747

The reported bug is specifically for `action` typed `event` trigger on _related_ tables (or junction table in the linked issue). This is because it is run asynchronously, thus reusing the transaction were causing the `Transaction query already complete` error. Ref: https://github.com/directus/directus/issues/11172#issuecomment-1020228594

Reusing the `database` in these 2 services within `executeFlow` were also the culprit:

https://github.com/directus/directus/blob/86a3914c280b46aa762d6ab7ce07127208301c92/api/src/flows.ts#L319-L322

https://github.com/directus/directus/blob/86a3914c280b46aa762d6ab7ce07127208301c92/api/src/flows.ts#L336-L339

### Before

- The subsequent `Create Data` operation did not run
- No logs are created

https://user-images.githubusercontent.com/42867097/174990850-e92f9ee8-ab24-4685-81e9-ac7ff3800082.mp4

### After

- The subsequent `Create Data` operation ran successfully and created item in `test` table
- Logs were created

https://user-images.githubusercontent.com/42867097/174990933-87113434-38d6-40a3-bf2e-c96fdd633bfd.mp4

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
