### PR TITLE
Major input delays on text fields in complex documents

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -8,17 +8,20 @@
 		/>
 		<template v-for="(fieldName, index) in fieldNames">
 			<component
-				:is="`interface-${field.meta?.interface || 'group-standard'}`"
-				v-if="fields?.[index]?.meta?.special?.includes('group')"
-				v-show="!fields?.[index]?.meta?.hidden"
+				:is="`interface-${formFields[index].meta?.interface || 'group-standard'}`"
+				v-if="formFields[index]?.meta?.special?.includes('group')"
+				v-show="!formFields[index]?.meta?.hidden"
 				:ref="
 					(el: Element) => {
 						formFieldEls[fieldName] = el;
 					}
 				"
 				:key="fieldName"
-				:class="[fields?.[index]?.meta?.width || 'full', index === firstVisibleFieldIndex ? 'first-visible-field' : '']"
-				:field="fields?.[index]"
+				:class="[
+					formFields[index]?.meta?.width || 'full',
+					index === firstVisibleFieldIndex ? 'first-visible-field' : '',
+				]"
+				:field="formFields[index]"
 				:fields="fieldsForGroup[index]"
 				:values="modelValue || {}"
 				:initial-values="initialValues || {}"
@@ -29,12 +32,12 @@
 				:loading="loading"
 				:validation-errors="validationErrors"
 				:badge="badge"
-				v-bind="fields?.[index]?.meta?.options || {}"
+				v-bind="formFields[index]?.meta?.options || {}"
 				@apply="apply"
 			/>
 
 			<form-field
-				v-else-if="!fields?.[index]?.meta?.hidden"
+				v-else-if="!formFields[index]?.meta?.hidden"
 				:ref="
 					(el: Element) => {
 						formFieldEls[fieldName] = el;
@@ -42,11 +45,11 @@
 				"
 				:key="fieldName + '_'"
 				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
-				:field="fields?.[index]"
+				:field="formFields[index]"
 				:autofocus="index === firstEditableFieldIndex && autofocus"
 				:model-value="(values || {})[fieldName]"
 				:initial-value="(initialValues || {})[fieldName]"
-				:disabled="isDisabled(fields?.[index])"
+				:disabled="isDisabled(formFields[index])"
 				:batch-mode="batchMode"
 				:batch-active="batchActiveFields.includes(fieldName)"
 				:primary-key="primaryKey"
@@ -54,15 +57,15 @@
 				:validation-error="
 					validationErrors.find(
 						(err) =>
-							err.collection === fields?.[index]?.collection &&
+							err.collection === formFields[index]?.collection &&
 							(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
 					)
 				"
 				:badge="badge"
 				@update:model-value="setValue(fieldName, $event)"
 				@set-field-value="setValue($event.field, $event.value)"
-				@unset="unsetValue(fields?.[index]!)"
-				@toggle-batch="toggleBatchField(fields?.[index]!)"
+				@unset="unsetValue(formFields[index])"
+				@toggle-batch="toggleBatchField(formFields[index])"
 			/>
 		</template>
 	</div>

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -6,19 +6,19 @@
 			:fields="fields ? fields : []"
 			@scroll-to-field="scrollToField"
 		/>
-		<template v-for="(field, index) in formFields">
+		<template v-for="(fieldName, index) in fieldNames">
 			<component
 				:is="`interface-${field.meta?.interface || 'group-standard'}`"
-				v-if="field.meta?.special?.includes('group')"
-				v-show="!field.meta?.hidden"
+				v-if="fields?.[index]?.meta?.special?.includes('group')"
+				v-show="!fields?.[index]?.meta?.hidden"
 				:ref="
 					(el: Element) => {
-						formFieldEls[field.field] = el;
+						formFieldEls[fieldName] = el;
 					}
 				"
-				:key="field.field"
-				:class="[field.meta?.width || 'full', index === firstVisibleFieldIndex ? 'first-visible-field' : '']"
-				:field="field"
+				:key="fieldName"
+				:class="[fields?.[index]?.meta?.width || 'full', index === firstVisibleFieldIndex ? 'first-visible-field' : '']"
+				:field="fields?.[index]"
 				:fields="fieldsForGroup[index]"
 				:values="modelValue || {}"
 				:initial-values="initialValues || {}"
@@ -29,40 +29,40 @@
 				:loading="loading"
 				:validation-errors="validationErrors"
 				:badge="badge"
-				v-bind="field.meta?.options || {}"
+				v-bind="fields?.[index]?.meta?.options || {}"
 				@apply="apply"
 			/>
 
 			<form-field
-				v-else-if="!field.meta?.hidden"
+				v-else-if="!fields?.[index]?.meta?.hidden"
 				:ref="
 					(el: Element) => {
-						formFieldEls[field.field] = el;
+						formFieldEls[fieldName] = el;
 					}
 				"
-				:key="field.field"
+				:key="fieldName + '_'"
 				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
-				:field="field"
+				:field="fields?.[index]"
 				:autofocus="index === firstEditableFieldIndex && autofocus"
-				:model-value="(values || {})[field.field]"
-				:initial-value="(initialValues || {})[field.field]"
-				:disabled="isDisabled(field)"
+				:model-value="(values || {})[fieldName]"
+				:initial-value="(initialValues || {})[fieldName]"
+				:disabled="isDisabled(fields?.[index])"
 				:batch-mode="batchMode"
-				:batch-active="batchActiveFields.includes(field.field)"
+				:batch-active="batchActiveFields.includes(fieldName)"
 				:primary-key="primaryKey"
 				:loading="loading"
 				:validation-error="
 					validationErrors.find(
 						(err) =>
-							err.collection === field.collection &&
-							(err.field === field.field || err.field.endsWith(`(${field.field})`))
+							err.collection === fields?.[index]?.collection &&
+							(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
 					)
 				"
 				:badge="badge"
-				@update:model-value="setValue(field.field, $event)"
+				@update:model-value="setValue(fieldName, $event)"
 				@set-field-value="setValue($event.field, $event.value)"
-				@unset="unsetValue(field)"
-				@toggle-batch="toggleBatchField(field)"
+				@unset="unsetValue(fields?.[index]!)"
+				@toggle-batch="toggleBatchField(fields?.[index]!)"
 			/>
 		</template>
 	</div>
@@ -160,6 +160,8 @@ export default defineComponent({
 
 			throw new Error('[v-form]: You need to pass either the collection or fields prop.');
 		});
+		// might still need to be updated?
+		const fieldNames = Object.freeze(fields.value.map((f) => f.field));
 
 		const values = computed(() => {
 			return Object.assign({}, props.initialValues, props.modelValue);
@@ -237,6 +239,7 @@ export default defineComponent({
 			isDisabled,
 			scrollToField,
 			formFieldEls,
+			fieldNames,
 		};
 
 		function useForm() {

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -280,9 +280,11 @@ export default defineComponent({
 					return field;
 				};
 
-				const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
+				// why are we merging values in here? ah the conditions trigger a re-render of all fields for each value change
+				// const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
+				// console.log(valuesWithDefaults);
 
-				return fields.value.map((field) => applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field)));
+				return fields.value; //.map((field) => applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field)));
 			});
 
 			const fieldsInGroup = computed(() =>

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -6,17 +6,17 @@
 			:fields="fields ? fields : []"
 			@scroll-to-field="scrollToField"
 		/>
-		<template v-for="(fieldName, index) in fieldNames">
+		<template v-for="(field, index) in fields">
 			<component
 				:is="`interface-${fieldsMeta[index]?.interface || 'group-standard'}`"
 				v-if="fieldsMeta[index]?.special?.includes('group')"
 				v-show="!fieldsMeta[index]?.hidden"
 				:ref="
 					(el: Element) => {
-						formFieldEls[fieldName] = el;
+						formFieldEls[field.field] = el;
 					}
 				"
-				:key="fieldName + '_group'"
+				:key="field.field + '_group'"
 				:class="[fieldsMeta[index]?.width || 'full', index === firstVisibleFieldIndex ? 'first-visible-field' : '']"
 				:field="formFields[index]"
 				:fields="fieldsForGroup[index]"
@@ -37,29 +37,29 @@
 				v-else-if="!fieldsMeta[index]?.hidden"
 				:ref="
 					(el: Element) => {
-						formFieldEls[fieldName] = el;
+						formFieldEls[field.field] = el;
 					}
 				"
-				:key="fieldName + '_field'"
+				:key="field.field + '_field'"
 				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
 				:field="formFields[index]"
 				:autofocus="index === firstEditableFieldIndex && autofocus"
-				:model-value="(values || {})[fieldName]"
-				:initial-value="(initialValues || {})[fieldName]"
+				:model-value="(values || {})[field.field]"
+				:initial-value="(initialValues || {})[field.field]"
 				:disabled="isDisabled(formFields[index])"
 				:batch-mode="batchMode"
-				:batch-active="batchActiveFields.includes(fieldName)"
+				:batch-active="batchActiveFields.includes(field.field)"
 				:primary-key="primaryKey"
 				:loading="loading"
 				:validation-error="
 					validationErrors.find(
 						(err) =>
 							err.collection === formFields[index]?.collection &&
-							(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
+							(err.field === field.field || err.field.endsWith(`(${field.field})`))
 					)
 				"
 				:badge="badge"
-				@update:model-value="setValue(fieldName, $event)"
+				@update:model-value="setValue(field.field, $event)"
 				@set-field-value="setValue($event.field, $event.value)"
 				@unset="unsetValue(formFields[index])"
 				@toggle-batch="toggleBatchField(formFields[index])"
@@ -160,8 +160,6 @@ export default defineComponent({
 
 			throw new Error('[v-form]: You need to pass either the collection or fields prop.');
 		});
-		// might still need to be updated?
-		const fieldNames = Object.freeze(fields.value.map((f) => f.field));
 
 		const values = computed(() => {
 			return Object.assign({}, props.initialValues, props.modelValue);
@@ -239,7 +237,6 @@ export default defineComponent({
 			isDisabled,
 			scrollToField,
 			formFieldEls,
-			fieldNames,
 			fieldsMeta,
 		};
 


### PR DESCRIPTION
## Description

Applying the field conditions was causing an update loop. Whenever any value changed all field definitions were re-evaluated and updated resulting in each and every input in the `v-form` re-rendering for any value change.

My solutions attempts to split the reactive meta fields updated by conditions and the field definitions to prevent unnecessary re-renders.

Fixes #13237, fixes #13460

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

