### PR TITLE
Prevent hyphens in auto generated operation keys

### DIFF
--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -153,7 +153,9 @@ const selectedOperation = computed(() => getOperation(operationType.value));
 const generatedName = computed(() => (selectedOperation.value ? selectedOperation.value?.name : t('operation_name')));
 
 const generatedKey = computed(() =>
-	selectedOperation.value ? selectedOperation.value?.id + '_' + generateSuffix() : t('operation_key')
+	selectedOperation.value
+		? slugify(selectedOperation.value?.id + '_' + generateSuffix(), { separator: '_' })
+		: t('operation_key')
 );
 
 const { operations } = getOperations();


### PR DESCRIPTION
## Description

Currently the auto generated key combines the operation id such as `item-create` with a suffix, but since the operation key input doesn't allow hyphens and it will also be `db-safe`/only-underscore when we manually input the name:

https://github.com/directus/directus/blob/817a6c18911eaac34eb68603028822e65d6c6626/app/src/modules/settings/routes/flows/components/operation-detail.vue#L32

This solution uses the same slugify approach in generating keys from manually typed names:

https://github.com/directus/directus/blob/817a6c18911eaac34eb68603028822e65d6c6626/app/src/modules/settings/routes/flows/components/operation-detail.vue#L134-L149

### Before

![chrome_yzL3Ik3BCN](https://user-images.githubusercontent.com/42867097/175041206-2c3916c2-fdf2-43c8-aaba-c440823dcfa4.png)

### After

![chrome_d5tfnwo0fR](https://user-images.githubusercontent.com/42867097/175041219-03a8c1b2-7db6-481f-9405-3b936320356e.png)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Tweak for consistency

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
