### PR TITLE
Fix autocomplete field options not selectable

### DIFF
--- a/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
+++ b/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
@@ -4,7 +4,7 @@
 	</v-notice>
 	<div v-else>
 		<v-menu attached :disabled="disabled">
-			<template #activator="{ activate, deactivate }">
+			<template #activator="{ activate }">
 				<v-input
 					:placeholder="placeholder"
 					:disabled="disabled"
@@ -12,7 +12,6 @@
 					:model-value="value"
 					@update:model-value="onInput"
 					@focus="activate"
-					@blur="deactivate"
 				>
 					<template v-if="iconLeft" #prepend><v-icon :name="iconLeft" /></template>
 					<template v-if="iconRight" #append><v-icon :name="iconRight" /></template>


### PR DESCRIPTION
## Description

Fixes #13860

### Before

The `@blur="deactivate"` event on the input is firing "earlier", thus the options menu is closing first before our click on the option actually registers:

https://user-images.githubusercontent.com/42867097/175069990-c8ac7907-e2ae-4ef4-bd5c-64ada8c3fbad.mp4

### After

Removed the `@blur` event, as v-menu by itself already has `v-click-outside` to close itself when "blur", similar to how v-select doesn't have usage of `@blur`. 

https://user-images.githubusercontent.com/42867097/175070200-199955f8-34be-440f-bd64-a251ece90e1e.mp4

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
