### PR TITLE
CSV import converts numeric strings to numbers

### DIFF
--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -128,7 +128,11 @@ export class ImportService {
 							} else {
 								try {
 									const parsedJson = parseJSON(value);
-									set(result, key, parsedJson);
+									if (typeof parsedJson === 'number') {
+										set(result, key, value);
+									} else {
+										set(result, key, parsedJson);
+									}
 								} catch {
 									set(result, key, value);
 								}


### PR DESCRIPTION
## Description

The CSV importer uses `JSON.parse` to check for relational objects in the import. This function however also parses numerical strings to numbers (losing precision in the process).
![image](https://user-images.githubusercontent.com/9389634/175271647-4fa1074d-5e17-4e72-b09d-b721bdf188da.png)
This fix simply checks if the result is of type "number" and if so uses the original string instead as there is no need to parse the input to numbers at this stage.

I've chosen not to do this globally in the `parseJSON` helper function as there might be situations where the numerical parsing is useful or expected.

Fixes #14051, fixes #12028

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code
