### PR TITLE
Prevent filename overflow in import file field for Import/Export sidebar

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -28,7 +28,7 @@
 									hidden
 									@change="onChange"
 								/>
-								<label for="import-file" class="import-file-label"></label>
+								<label v-tooltip="file && file.name" for="import-file" class="import-file-label"></label>
 								<span class="import-file-text" :class="{ 'no-file': !file }">
 									{{ file ? file.name : t('import_data_input_placeholder') }}
 								</span>
@@ -629,6 +629,10 @@ const createAllowed = computed<boolean>(() => hasPermission(collection.value, 'c
 
 .import-file-text {
 	flex-grow: 1;
+	overflow: hidden;
+	line-height: normal;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 
 	&.no-file {
 		color: var(--foreground-subdued);


### PR DESCRIPTION
## Description

### Before

Long file names will overflow out of the field:

![chrome_sNXgpJFBLz](https://user-images.githubusercontent.com/42867097/175320975-95e85245-87d0-4d9c-83b3-a2867d8df16a.png)

### After

- Now it doesn't overflow
- hovering on the field shows the full file name (as the `<label>` is covering on top of the text and required for click event to work, so couldn't use `<v-text-overflow>` here)

![chrome_PiaXvz3c7p](https://user-images.githubusercontent.com/42867097/175320994-b2b46e79-68bf-43a1-8d08-dbf57c0ca57a.gif)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Minor improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
