### PR TITLE
API: Return more error messages for OpenID and OAuth2

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -5,11 +5,11 @@ import ms from 'ms';
 import { Client, errors, generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth';
 import env from '../../env';
+import { BaseException } from '@directus/shared/exceptions';
 import {
 	InvalidConfigException,
 	InvalidCredentialsException,
 	InvalidTokenException,
-	InvalidProviderException,
 	ServiceUnavailableException,
 } from '../../exceptions';
 import logger from '../../logger';
@@ -294,14 +294,8 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 				if (redirect) {
 					let reason = 'UNKNOWN_EXCEPTION';
 
-					if (error instanceof ServiceUnavailableException) {
-						reason = 'SERVICE_UNAVAILABLE';
-					} else if (error instanceof InvalidCredentialsException) {
-						reason = 'INVALID_USER';
-					} else if (error instanceof InvalidTokenException) {
-						reason = 'INVALID_TOKEN';
-					} else if (error instanceof InvalidProviderException) {
-						reason = 'INVALID_PROVIDER';
+					if (error instanceof BaseException) {
+						reason = error.code;
 					} else {
 						logger.warn(error, `[OAuth2] Unexpected error during OAuth2 login`);
 					}

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -5,11 +5,11 @@ import ms from 'ms';
 import { Client, errors, generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth';
 import env from '../../env';
+import { BaseException } from '@directus/shared/exceptions';
 import {
 	InvalidConfigException,
 	InvalidCredentialsException,
 	InvalidTokenException,
-	InvalidProviderException,
 	ServiceUnavailableException,
 } from '../../exceptions';
 import logger from '../../logger';
@@ -317,14 +317,8 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 				if (redirect) {
 					let reason = 'UNKNOWN_EXCEPTION';
 
-					if (error instanceof ServiceUnavailableException) {
-						reason = 'SERVICE_UNAVAILABLE';
-					} else if (error instanceof InvalidCredentialsException) {
-						reason = 'INVALID_USER';
-					} else if (error instanceof InvalidTokenException) {
-						reason = 'INVALID_TOKEN';
-					} else if (error instanceof InvalidProviderException) {
-						reason = 'INVALID_PROVIDER';
+					if (error instanceof BaseException) {
+						reason = error.code;
 					} else {
 						logger.warn(error, `[OpenID] Unexpected error during OpenID login`);
 					}


### PR DESCRIPTION
## Description
Right now, when OpenID or OAuth2 fails they only return specified errors. Although these specification is just a mirror of the exception `code` we use. 
By doing so, we can have more context other than `UNKNOWN_EXCEPTION` which is the fallback of the specification.

The initial motivation for this, relates to when a user tries to login, but their account already exists in database with another provider. This returns a `RecordNotUniqueException` but since it was not in the specification, final user just receives `UNKNOWN_EXCEPTION`, instead of `RECORD_NOT_UNIQUE` which is the `code` of that exception.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: *Improvement* 

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
