### PR TITLE
Docs: Fix how to refresh token example on SSO example

### DIFF
--- a/docs/self-hosted/sso.md
+++ b/docs/self-hosted/sso.md
@@ -101,7 +101,7 @@ REFRESH_TOKEN_COOKIE_SAME_SITE="None"
      ```js
      await fetch('https://directus.myserver.com/auth/refresh', {
      	method: 'POST',
-     	withCredentials: true, // this is required in order to send the refresh token cookie
+     	credentials: 'include', // this is required in order to send the refresh token cookie
      });
      ```
 


### PR DESCRIPTION
## Description
The example on SSO is not right:
https://docs.directus.io/self-hosted/sso/#:~:text=via%20REST%20API%20/%20fetch

`withCredentials: true` is `axios` syntax, although the example is using `fetch`
## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: *Documentation* 

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated
