### PR TITLE
Fixed firefox opacity of placeholders issue

### DIFF
--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -262,6 +262,10 @@ function stepDown() {
 	--v-input-border-color-focus: var(--primary);
 }
 
+::placeholder {
+	opacity: 1;
+}
+
 .v-input {
 	--arrow-color: var(--border-normal);
 	--v-icon-color: var(--foreground-subdued);

--- a/app/src/components/v-input/v-input.vue
+++ b/app/src/components/v-input/v-input.vue
@@ -262,10 +262,6 @@ function stepDown() {
 	--v-input-border-color-focus: var(--primary);
 }
 
-::placeholder {
-	opacity: 1;
-}
-
 .v-input {
 	--arrow-color: var(--border-normal);
 	--v-icon-color: var(--foreground-subdued);

--- a/app/src/styles/_base.scss
+++ b/app/src/styles/_base.scss
@@ -63,6 +63,10 @@ textarea,
 	}
 }
 
+::placeholder {
+	opacity: 1;
+}
+
 :invalid {
 	outline: 0;
 	box-shadow: none;


### PR DESCRIPTION
## Description

Firefox lowers the opacity of placeholders. This is a css override to that functionality. 
<img width="629" alt="Screen Shot 2022-06-23 at 4 21 34 PM" src="https://user-images.githubusercontent.com/67079013/175392661-3a0481f6-30cf-4d44-8ed4-f9b3c6bcbbd4.png">

<img width="592" alt="Screen Shot 2022-06-23 at 4 22 41 PM" src="https://user-images.githubusercontent.com/67079013/175392779-4fc32be1-b584-4318-9ae2-83e43889e34c.png">

Fixes #14025

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
