### PR TITLE
Fix M2O interface in junction tables

### DIFF
--- a/app/src/composables/use-relation/use-relation-m2o.ts
+++ b/app/src/composables/use-relation/use-relation-m2o.ts
@@ -26,7 +26,7 @@ export function useRelationM2O(collection: Ref<string>, field: Ref<string>) {
 	const relationInfo = computed<RelationM2O | undefined>(() => {
 		const relations = relationsStore.getRelationsForField(collection.value, field.value);
 
-		if (relations.length !== 1) return undefined;
+		if (relations.length === 0) return undefined;
 
 		const relation = relations[0];
 


### PR DESCRIPTION
## Description

Fixes #13683

### Problem

When we have a M2M relationship, and we unhide the related columns in the junction table and configure them to use M2O interface towards either direction, it will show up as "The relationship hasn't been configured correctly":

https://user-images.githubusercontent.com/42867097/175482940-f913e0b3-2f63-4b37-bb4f-edce7d3eedbb.mp4

### Investigation

useRelationM2O has this piece of logic where it fetches the relations for a field, and will return `undefined` if `relations.length !== 1` since `relations[0]` is being used afterwards:

https://github.com/directus/directus/blob/4d7a5284eed974adb650dbc21750539d0434a631/app/src/composables/use-relation/use-relation-m2o.ts#L27-L31

However when getting the relations, and if it's an M2M relationship, it will also end up grabbing the other end of the relationship (`relations.push(secondaryRelation); `), thus return `2` relations instead of `1`:

https://github.com/directus/directus/blob/4d7a5284eed974adb650dbc21750539d0434a631/app/src/stores/relations.ts#L73-L85

This now fails the original `relations.length !== 1` condition and end up returning `undefined` instead, which shows "relationship is not configured correctly" when it actually is correct.

This PR changes the logic to `relations.length === 0` so that 2 relations will still pass this check. I assume this is unintended? I'm personally not sure if there's any significance in the original `!== 1` beyond preventing `relations[0]` from failing.

### Result

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
