### PR TITLE
Fix `undefined` values in filters for GraphQL

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -436,6 +436,18 @@ export function applyFilter(
 				});
 			}
 
+			// The following fields however, require a value to be run. If no value is passed, we
+			// ignore them. This allows easier use in GraphQL, where you wouldn't be able to
+			// conditionally build out your filter structure (#4471)
+			if (compareValue === undefined) return;
+
+			if (Array.isArray(compareValue)) {
+				// Tip: when using a `[Type]` type in GraphQL, but don't provide the variable, it'll be
+				// reported as [undefined].
+				// We need to remove any undefined values, as they are useless
+				compareValue = compareValue.filter((val) => val !== undefined);
+			}
+
 			// Cast filter value (compareValue) based on function used
 			if (column.includes('(') && column.includes(')')) {
 				const functionName = column.split('(')[0] as FieldFunction;
@@ -468,18 +480,6 @@ export function applyFilter(
 						compareValue = Number(compareValue);
 					}
 				}
-			}
-
-			// The following fields however, require a value to be run. If no value is passed, we
-			// ignore them. This allows easier use in GraphQL, where you wouldn't be able to
-			// conditionally build out your filter structure (#4471)
-			if (compareValue === undefined) return;
-
-			if (Array.isArray(compareValue)) {
-				// Tip: when using a `[Type]` type in GraphQL, but don't provide the variable, it'll be
-				// reported as [undefined].
-				// We need to remove any undefined values, as they are useless
-				compareValue = compareValue.filter((val) => val !== undefined);
 			}
 
 			if (operator === '_eq') {


### PR DESCRIPTION
## Description

Fixes #13554

When not passing a variable used in filters in GraphQL, for example `_in` or `_nin`, the resulting array is `[undefined]`, but then it was _attempted_ to be casted as `Number(undefined)`, thus causing it to be `[NaN]` instead.

Previously this exact "did not pass variables in GraphQL" scenario was already reported in https://github.com/directus/directus/issues/4471, and it has been resolved by https://github.com/directus/directus/commit/98c9b9a9ffc373f407648c63f6945e1791f6d882 & https://github.com/directus/directus/pull/5506 which filters out `undefined` values. Note that this logic used to sit between the null/empty code blocks and the `_eq` code block when there were no casting involved.

However once casting of date/time/number was introduced, it is now being done _before_ the return/filtering of `undefined` values, thus making them into `NaN` and fail the previous safety measure.

This PR moves the `undefined` handling upwards before the casting of values to retain the original intention of the fix in https://github.com/directus/directus/commit/98c9b9a9ffc373f407648c63f6945e1791f6d882 & https://github.com/directus/directus/pull/5506.

### Before

![chrome_c23BLJsGTv](https://user-images.githubusercontent.com/42867097/175485259-d1e21179-14b5-4eb4-9243-e884e8ba61de.png)

### After

![chrome_HLuarw2FAZ](https://user-images.githubusercontent.com/42867097/175485268-02b4a99f-087d-447b-bbca-4b36f39f49f1.png)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
