### PR TITLE
App Docs Module Improvements

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -108,7 +108,7 @@
 		"ts-jest": "27.1.3",
 		"typescript": "4.7.3",
 		"vite": "2.9.9",
-		"vite-plugin-md": "0.13.1",
+		"vite-plugin-vue-markdown": "0.1.1",
 		"vue": "3.2.36",
 		"vue-i18n": "9.1.10",
 		"vue-router": "4.0.15",

--- a/app/src/views/private/components/docs-wrapper/docs-wrapper.vue
+++ b/app/src/views/private/components/docs-wrapper/docs-wrapper.vue
@@ -458,6 +458,77 @@ export default defineComponent({
 	color: var(--foreground-subdued);
 }
 
+.md :deep(span[mi]) {
+	font-family: 'Material Icons Outline';
+	font-weight: normal;
+	font-style: normal;
+	font-size: 18px;
+	line-height: 1;
+	letter-spacing: normal;
+	text-transform: none;
+	display: inline-block;
+	white-space: nowrap;
+	word-wrap: normal;
+	direction: ltr;
+	font-feature-settings: 'liga';
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.md :deep(span[mi][btn]) {
+	color: var(--foreground-inverted);
+	background-color: var(--primary);
+	border-radius: 50%;
+	width: 28px;
+	height: 28px;
+	vertical-align: middle;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 4px;
+}
+.md :deep(span[mi][btn][dngr]) {
+	background-color: var(--danger-10);
+	color: var(--danger);
+}
+.md :deep(span[mi][btn][sec]) {
+	background-color: var(--primary-10);
+	color: var(--primary);
+}
+.md :deep(span[mi][btn][warn]) {
+	background-color: var(--warning-10);
+	color: var(--warning);
+}
+.md :deep(span[mi][btn][outline]) {
+	background-color: transparent;
+	border: 2px solid var(--primary);
+	color: var(--primary);
+}
+.md :deep(span[mi][btn][action]) {
+	background-color: var(--success-10);
+	color: var(--success);
+}
+.md :deep(span[mi][btn][muted]) {
+	background-color: var(--background-normal);
+	color: var(--foreground-normal);
+}
+.md :deep(span[mi][icon]) {
+	vertical-align: middle;
+	margin-bottom: 4px;
+	color: var(--foreground-subdued);
+}
+.md :deep(span[mi][icon][prmry]) {
+	color: var(--primary);
+}
+.md :deep(span[mi][icon][dark]) {
+	color: var(--foreground-normal-alt);
+}
+.md :deep(span[mi][icon][dngr]) {
+	color: var(--danger);
+}
+.md :deep(span[mi][icon][warn]) {
+	color: var(--warning);
+}
+
 .md.page-reference :deep(.definitions) {
 	font-size: 0.9rem;
 	line-height: 1.5rem;

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import md from 'vite-plugin-md';
+import md from 'vite-plugin-vue-markdown';
 import yaml from '@rollup/plugin-yaml';
 import path from 'path';
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,25 +365,12 @@
 				"ts-jest": "27.1.3",
 				"typescript": "4.7.3",
 				"vite": "2.9.9",
-				"vite-plugin-md": "0.13.1",
+				"vite-plugin-vue-markdown": "0.1.1",
 				"vue": "3.2.36",
 				"vue-i18n": "9.1.10",
 				"vue-router": "4.0.15",
 				"vuedraggable": "4.1.0",
 				"wellknown": "0.5.0"
-			}
-		},
-		"app/node_modules/@rollup/pluginutils": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-			"dev": true,
-			"dependencies": {
-				"estree-walker": "^2.0.1",
-				"picomatch": "^2.2.2"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
 			}
 		},
 		"app/node_modules/@types/jest": {
@@ -477,26 +464,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"app/node_modules/vite-plugin-md": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/vite-plugin-md/-/vite-plugin-md-0.13.1.tgz",
-			"integrity": "sha512-ZLXRuhQCFVCvxTE79CtSOj71TknT7Hube5SN3aU65k7FpsIQ8ftQhMn3PbdVjHUlQRR462IuPsTYbyXHyrOmOQ==",
-			"dev": true,
-			"dependencies": {
-				"@antfu/utils": "^0.5.1",
-				"@rollup/pluginutils": "^4.2.1",
-				"@types/markdown-it": "^12.2.3",
-				"@vue/runtime-core": "^3.2.33",
-				"gray-matter": "^4.0.3",
-				"markdown-it": "^13.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"vite": "^2.0.0"
 			}
 		},
 		"docs": {
@@ -14614,14 +14581,6 @@
 			"version": "6.1.4",
 			"license": "MIT"
 		},
-		"node_modules/@vue/reactivity": {
-			"version": "3.2.37",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vue/shared": "3.2.37"
-			}
-		},
 		"node_modules/@vue/reactivity-transform": {
 			"version": "3.2.36",
 			"license": "MIT",
@@ -14632,25 +14591,6 @@
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.25.7"
 			}
-		},
-		"node_modules/@vue/reactivity/node_modules/@vue/shared": {
-			"version": "3.2.37",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@vue/runtime-core": {
-			"version": "3.2.37",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vue/reactivity": "3.2.37",
-				"@vue/shared": "3.2.37"
-			}
-		},
-		"node_modules/@vue/runtime-core/node_modules/@vue/shared": {
-			"version": "3.2.37",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@vue/runtime-dom": {
 			"version": "3.2.36",
@@ -45760,6 +45700,38 @@
 				}
 			}
 		},
+		"node_modules/vite-plugin-vue-markdown": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/vite-plugin-vue-markdown/-/vite-plugin-vue-markdown-0.1.1.tgz",
+			"integrity": "sha512-A68hNB46N6+do20LJz5HjEOegdAeSNRSivE2VhGwoNxV/v9ShqS/pXv2ENoifFWClqqD+j4pf3pjCaYFGR+74w==",
+			"dev": true,
+			"dependencies": {
+				"@antfu/utils": "^0.5.2",
+				"@rollup/pluginutils": "^4.2.1",
+				"@types/markdown-it": "^12.2.3",
+				"gray-matter": "^4.0.3",
+				"markdown-it": "^13.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vite": "^2.0.0"
+			}
+		},
+		"node_modules/vite-plugin-vue-markdown/node_modules/@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
 		"node_modules/vm-browserify": {
 			"version": "1.1.2",
 			"license": "MIT"
@@ -52050,7 +52022,7 @@
 				"ts-jest": "27.1.3",
 				"typescript": "4.7.3",
 				"vite": "2.9.9",
-				"vite-plugin-md": "0.13.1",
+				"vite-plugin-vue-markdown": "0.1.1",
 				"vue": "3.2.36",
 				"vue-i18n": "9.1.10",
 				"vue-router": "4.0.15",
@@ -52058,16 +52030,6 @@
 				"wellknown": "0.5.0"
 			},
 			"dependencies": {
-				"@rollup/pluginutils": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-					"dev": true,
-					"requires": {
-						"estree-walker": "^2.0.1",
-						"picomatch": "^2.2.2"
-					}
-				},
 				"@types/jest": {
 					"version": "27.4.0",
 					"dev": true,
@@ -52112,20 +52074,6 @@
 				"prettier": {
 					"version": "2.4.1",
 					"dev": true
-				},
-				"vite-plugin-md": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/vite-plugin-md/-/vite-plugin-md-0.13.1.tgz",
-					"integrity": "sha512-ZLXRuhQCFVCvxTE79CtSOj71TknT7Hube5SN3aU65k7FpsIQ8ftQhMn3PbdVjHUlQRR462IuPsTYbyXHyrOmOQ==",
-					"dev": true,
-					"requires": {
-						"@antfu/utils": "^0.5.1",
-						"@rollup/pluginutils": "^4.2.1",
-						"@types/markdown-it": "^12.2.3",
-						"@vue/runtime-core": "^3.2.33",
-						"gray-matter": "^4.0.3",
-						"markdown-it": "^13.0.0"
-					}
 				}
 			}
 		},
@@ -60719,19 +60667,6 @@
 		"@vue/devtools-api": {
 			"version": "6.1.4"
 		},
-		"@vue/reactivity": {
-			"version": "3.2.37",
-			"dev": true,
-			"requires": {
-				"@vue/shared": "3.2.37"
-			},
-			"dependencies": {
-				"@vue/shared": {
-					"version": "3.2.37",
-					"dev": true
-				}
-			}
-		},
 		"@vue/reactivity-transform": {
 			"version": "3.2.36",
 			"requires": {
@@ -60740,20 +60675,6 @@
 				"@vue/shared": "3.2.36",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.25.7"
-			}
-		},
-		"@vue/runtime-core": {
-			"version": "3.2.37",
-			"dev": true,
-			"requires": {
-				"@vue/reactivity": "3.2.37",
-				"@vue/shared": "3.2.37"
-			},
-			"dependencies": {
-				"@vue/shared": {
-					"version": "3.2.37",
-					"dev": true
-				}
 			}
 		},
 		"@vue/runtime-dom": {
@@ -81735,6 +81656,31 @@
 				"postcss": "^8.4.13",
 				"resolve": "^1.22.0",
 				"rollup": "^2.59.0"
+			}
+		},
+		"vite-plugin-vue-markdown": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/vite-plugin-vue-markdown/-/vite-plugin-vue-markdown-0.1.1.tgz",
+			"integrity": "sha512-A68hNB46N6+do20LJz5HjEOegdAeSNRSivE2VhGwoNxV/v9ShqS/pXv2ENoifFWClqqD+j4pf3pjCaYFGR+74w==",
+			"dev": true,
+			"requires": {
+				"@antfu/utils": "^0.5.2",
+				"@rollup/pluginutils": "^4.2.1",
+				"@types/markdown-it": "^12.2.3",
+				"gray-matter": "^4.0.3",
+				"markdown-it": "^13.0.1"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
+					}
+				}
 			}
 		},
 		"vm-browserify": {


### PR DESCRIPTION
## Description

This is a follow up of #13953. 

### Switch vite-plugin-md to vite-plugin-vue-markdown

The docs module used to use vite-plugin-md `0.11.4`, but the later versions of `vite-plugin-md` had introduced newer changes and features that were not needed for the current implementation as mentioned in #13953.

They have since created a lite version of `vite-plugin-md` prior to `0.13.0` called `vite-plugin-vue-markdown`:

> From v0.13, we introduced a pipeline and builder engine ([#54](https://github.com/antfu/vite-plugin-md/pull/54), [#77](https://github.com/antfu/vite-plugin-md/pull/77)) to provide full customizability. If you still prefer the simple Markdown-to-Vue transformation prior to v0.13, it has been moved to [`vite-plugin-vue-markdown`](https://github.com/antfu/vite-plugin-vue-markdown).

_reference to above quote in their readme: https://github.com/antfu/vite-plugin-md_
 
hence this PR switches to that package going forward.

### Icon support

Also noticed that the relatively newer icon support added to docs were not reflected in the app Docs module. Copied & tweaked the Stylus from here:

https://github.com/directus/directus/blob/4d7a5284eed974adb650dbc21750539d0434a631/docs/.vuepress/theme/styles/index.styl#L91-L158

#### Result

|Before|After|
|---|---|
|![ShareX_2nMno2GTXT](https://user-images.githubusercontent.com/42867097/175506534-abc91ccb-44bf-47d9-b986-d7238ca9be98.png)|![ShareX_B2SVszq6Ly](https://user-images.githubusercontent.com/42867097/175506550-fab2dae7-98bf-4b9f-be7c-aa2f5cc55291.png)|

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
