### PR TITLE
Improve IDs field interaction for Flows item read/update/delete operations when empty

### DIFF
--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -42,7 +42,7 @@ export default defineOperationApi<Options>({
 
 		let result: PrimaryKey | PrimaryKey[] | null;
 
-		if (!key) {
+		if (!key || (Array.isArray(key) && key.length === 0)) {
 			result = await itemsService.deleteByQuery(sanitizedQueryObject);
 		} else {
 			const keys = toArray(key);

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -42,7 +42,7 @@ export default defineOperationApi<Options>({
 
 		let result: Item | Item[] | null;
 
-		if (!key) {
+		if (!key || (Array.isArray(key) && key.length === 0)) {
 			result = await itemsService.readByQuery(sanitizedQueryObject);
 		} else {
 			const keys = toArray(key);

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -53,7 +53,7 @@ export default defineOperationApi<Options>({
 
 		let result: PrimaryKey | PrimaryKey[] | null;
 
-		if (!key) {
+		if (!key || (Array.isArray(key) && key.length === 0)) {
 			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents });
 		} else {
 			const keys = toArray(key);

--- a/app/src/operations/item-delete/index.ts
+++ b/app/src/operations/item-delete/index.ts
@@ -14,7 +14,7 @@ export default defineOperationApp({
 			},
 			{
 				label: '$t:operations.item-delete.key',
-				text: key ? toArray(key).join(', ') : '--',
+				text: toArray(key).length > 0 ? toArray(key).join(', ') : '--',
 			},
 		];
 

--- a/app/src/operations/item-read/index.ts
+++ b/app/src/operations/item-read/index.ts
@@ -14,7 +14,7 @@ export default defineOperationApp({
 			},
 			{
 				label: '$t:operations.item-read.key',
-				text: key ? toArray(key).join(', ') : '--',
+				text: toArray(key).length > 0 ? toArray(key).join(', ') : '--',
 			},
 		];
 

--- a/app/src/operations/item-update/index.ts
+++ b/app/src/operations/item-update/index.ts
@@ -13,7 +13,7 @@ export default defineOperationApp({
 			},
 			{
 				label: '$t:operations.item-update.key',
-				text: key ? toArray(key).join(', ') : '--',
+				text: toArray(key).length > 0 ? toArray(key).join(', ') : '--',
 			},
 		];
 


### PR DESCRIPTION
## Description

Ref: https://github.com/directus/directus/issues/14084#issuecomment-1165600116.

When a user unset value for IDs field, it becomes an empty array, which will end up being used and ignore filter query even if IDs field "looks" empty.

This PR implements recommendation in https://github.com/directus/directus/issues/14084#issuecomment-1165607189.

Also added `toArray(key).length > 0` logic for App side so that it'll display `--` instead of blank for this scenario.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
