### PR TITLE
Fix relational fields for Download Page as CSV & relevant displays' handler improvements

### DIFF
--- a/app/src/displays/formatted-value/formatted-value.vue
+++ b/app/src/displays/formatted-value/formatted-value.vue
@@ -25,6 +25,7 @@ import formatTitle from '@directus/format-title';
 import { decode } from 'html-entities';
 import { useI18n } from 'vue-i18n';
 import { isNil } from 'lodash';
+import dompurify from 'dompurify';
 
 export default defineComponent({
 	props: {
@@ -152,7 +153,7 @@ export default defineComponent({
 			let value = String(props.value);
 
 			// Strip out all HTML tags
-			value = value.replace(/(<([^>]+)>)/gi, '');
+			value = dompurify.sanitize(value, { ALLOWED_TAGS: [] });
 
 			// Decode any HTML encoded characters (like &copy;)
 			value = decode(value);

--- a/app/src/displays/formatted-value/index.ts
+++ b/app/src/displays/formatted-value/index.ts
@@ -2,6 +2,7 @@ import { defineDisplay } from '@directus/shared/utils';
 import { DisplayConfig } from '@directus/shared/types';
 import DisplayFormattedValue from './formatted-value.vue';
 import formatTitle from '@directus/format-title';
+import { decode } from 'html-entities';
 
 export default defineDisplay({
 	id: 'formatted-value',
@@ -13,7 +14,16 @@ export default defineDisplay({
 	handler: (value, options) => {
 		const prefix = options.prefix ?? '';
 		const suffix = options.suffix ?? '';
-		const formattedValue = options.format ? formatTitle(value) : value;
+
+		let sanitizedValue = String(value);
+
+		// Strip out all HTML tags
+		sanitizedValue = value.replace(/(<([^>]+)>)/gi, '');
+
+		// Decode any HTML encoded characters (like &copy;)
+		sanitizedValue = decode(sanitizedValue);
+
+		const formattedValue = options.format ? formatTitle(sanitizedValue) : sanitizedValue;
 
 		return `${prefix}${formattedValue}${suffix}`;
 	},

--- a/app/src/displays/formatted-value/index.ts
+++ b/app/src/displays/formatted-value/index.ts
@@ -3,6 +3,7 @@ import { DisplayConfig } from '@directus/shared/types';
 import DisplayFormattedValue from './formatted-value.vue';
 import formatTitle from '@directus/format-title';
 import { decode } from 'html-entities';
+import dompurify from 'dompurify';
 
 export default defineDisplay({
 	id: 'formatted-value',
@@ -18,7 +19,7 @@ export default defineDisplay({
 		let sanitizedValue = String(value);
 
 		// Strip out all HTML tags
-		sanitizedValue = value.replace(/(<([^>]+)>)/gi, '');
+		sanitizedValue = dompurify.sanitize(value, { ALLOWED_TAGS: [] });
 
 		// Decode any HTML encoded characters (like &copy;)
 		sanitizedValue = decode(sanitizedValue);

--- a/app/src/displays/labels/index.ts
+++ b/app/src/displays/labels/index.ts
@@ -23,7 +23,7 @@ export default defineDisplay({
 
 			if (configuredChoice) {
 				const { text } = translate(configuredChoice);
-				return text;
+				return text && text !== '' ? text : val;
 			}
 
 			return val;

--- a/app/src/displays/labels/index.ts
+++ b/app/src/displays/labels/index.ts
@@ -10,16 +10,24 @@ export default defineDisplay({
 	icon: 'flag',
 	component: DisplayLabels,
 	handler: (value, options, { interfaceOptions }) => {
-		const configuredChoice =
-			options?.choices?.find((choice: { value: string }) => choice.value === value) ??
-			interfaceOptions?.choices?.find((choice: { value: string }) => choice.value === value);
-
-		if (configuredChoice) {
-			const { text } = translate(configuredChoice);
-			return text;
+		if (Array.isArray(value)) {
+			return value.map((val) => getConfiguredChoice(val)).join(', ');
+		} else {
+			return getConfiguredChoice(value);
 		}
 
-		return value;
+		function getConfiguredChoice(val: string) {
+			const configuredChoice =
+				options?.choices?.find((choice: { value: string }) => choice.value === val) ??
+				interfaceOptions?.choices?.find((choice: { value: string }) => choice.value === val);
+
+			if (configuredChoice) {
+				const { text } = translate(configuredChoice);
+				return text;
+			}
+
+			return val;
+		}
 	},
 	options: [
 		{

--- a/app/src/displays/labels/index.ts
+++ b/app/src/displays/labels/index.ts
@@ -23,7 +23,7 @@ export default defineDisplay({
 
 			if (configuredChoice) {
 				const { text } = translate(configuredChoice);
-				return text && text !== '' ? text : val;
+				return text ? text : val;
 			}
 
 			return val;


### PR DESCRIPTION
## Description

Fixes #13791

### Issues, Investigation and Solution used

- > - Adding related organizations.title_english makes permits.title_english disappear
  > - Relational data to the m2m fields doesn't export

   There's 2 primary bugs causing this:

     - The value retrieval was not accounting for the recently added aliasing (so relational fields are aliased/hashed rather than the original relational table name)

        (`key` can be aliased)
     https://github.com/directus/directus/blob/efa64dc4aa7f631d9eb6ee942bc5302667b35ea2/app/src/utils/save-as-csv.ts#L27
   
     - Here we are using `parsedItem[name]` ("name" being field name) to generate the csv columns. However, `Title English` and relational `orgs -> organization ID -> Title English` both resolves into `Title English`, hence whichever comes later will override the previous value and make the column/field seemingly disappear.

       https://github.com/directus/directus/blob/efa64dc4aa7f631d9eb6ee942bc5302667b35ea2/app/src/utils/save-as-csv.ts#L35-L45
   
   The relevant solution were applied to `save-as-csv.ts` only.

- > - checkbox tree field just dumps the raw value, rather than using the Display that is shown in the table layout.
  > - Display for Checkbox Tree is configured to mirror the configured Choices (Labels display)

   For checkbox tree (json or csv), the `value` in the handler is an array, hence the "finding of choice" will always not match as it's comparing to an array. 
   
   Added an additional check and map over the array with `getConfiguredChoice`.

- > - Noticed when testing on a dropdown field -- if the Display "Text" entry is blank, then no data will be exported 

   This was added in the above solution as well, specifically `return text && text !== '' ? text : val;` to fallback to value.

- > - wysywyg field exports the raw HTML which is not how it's displayed in the Table Layout
  > - Display for Wysiwyg is set as "Formatted Value"
  
   formatted value display additionally does replacing of HTML tags and decoding:
   
   https://github.com/directus/directus/blob/efa64dc4aa7f631d9eb6ee942bc5302667b35ea2/app/src/displays/formatted-value/formatted-value.vue#L154-L158
   
   Added the same logic to formatted-value display's handler.
   
## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
