### PR TITLE
Fix v-select search & selection of groups

### DIFF
--- a/app/src/components/v-select/select-list-item-group.vue
+++ b/app/src/components/v-select/select-list-item-group.vue
@@ -29,7 +29,7 @@
 				:model-value="modelValue"
 				:multiple="multiple"
 				:allow-other="allowOther"
-				:group-clickable="groupSelectable"
+				:group-selectable="groupSelectable"
 				@update:model-value="$emit('update:modelValue', $event)"
 			/>
 			<select-list-item

--- a/app/src/components/v-select/select-list-item-group.vue
+++ b/app/src/components/v-select/select-list-item-group.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-list-group
-		:active="multiple ? (modelValue || []).includes(item.value) : modelValue === item.value"
+		:active="isActive"
 		:clickable="groupSelectable || item.selectable"
 		:open="item.children?.length === 1"
 		:value="item.value"
@@ -46,7 +46,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { computed, defineComponent, PropType } from 'vue';
 import { Option } from './types';
 import SelectListItem from './select-list-item.vue';
 
@@ -77,7 +77,18 @@ export default defineComponent({
 	},
 	emits: ['update:modelValue'],
 	setup(props, { emit }) {
-		return { onGroupClick };
+		const isActive = computed(() => {
+			if (props.multiple) {
+				if (!Array.isArray(props.modelValue) || !props.item.value) {
+					return false;
+				}
+				return props.modelValue.includes(props.item.value);
+			} else {
+				return props.modelValue === props.item.value;
+			}
+		});
+
+		return { isActive, onGroupClick };
 
 		function onGroupClick(item: Option) {
 			if (!props.groupSelectable) return;

--- a/app/src/components/v-select/select-list-item-group.vue
+++ b/app/src/components/v-select/select-list-item-group.vue
@@ -1,5 +1,6 @@
 <template>
 	<v-list-group
+		:active="multiple ? (modelValue || []).includes(item.value) : modelValue === item.value"
 		:clickable="groupSelectable || item.selectable"
 		:open="item.children?.length === 1"
 		:value="item.value"

--- a/app/src/components/v-select/select-list-item-group.vue
+++ b/app/src/components/v-select/select-list-item-group.vue
@@ -1,5 +1,10 @@
 <template>
-	<v-list-group :clickable="item.selectable" :open="item.children?.length === 1" :value="item.value">
+	<v-list-group
+		:clickable="groupSelectable || item.selectable"
+		:open="item.children?.length === 1"
+		:value="item.value"
+		@click="onGroupClick(item)"
+	>
 		<template #activator>
 			<v-list-item-icon v-if="multiple === false && allowOther === false && item.icon">
 				<v-icon :name="item.icon" />
@@ -24,6 +29,7 @@
 				:model-value="modelValue"
 				:multiple="multiple"
 				:allow-other="allowOther"
+				:group-clickable="groupSelectable"
 				@update:model-value="$emit('update:modelValue', $event)"
 			/>
 			<select-list-item
@@ -63,7 +69,20 @@ export default defineComponent({
 			type: Boolean,
 			required: true,
 		},
+		groupSelectable: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	emits: ['update:modelValue'],
+	setup(props, { emit }) {
+		return { onGroupClick };
+
+		function onGroupClick(item: Option) {
+			if (!props.groupSelectable) return;
+
+			emit('update:modelValue', item.value);
+		}
+	},
 });
 </script>

--- a/app/src/components/v-select/select-list-item.vue
+++ b/app/src/components/v-select/select-list-item.vue
@@ -3,7 +3,7 @@
 
 	<v-list-item
 		v-else
-		:active="multiple ? (modelValue || []).includes(item.value) : modelValue === item.value"
+		:active="isActive"
 		:disabled="item.disabled"
 		clickable
 		:value="item.value"
@@ -27,7 +27,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { computed, defineComponent, PropType } from 'vue';
 import { Option } from './types';
 
 export default defineComponent({
@@ -51,5 +51,20 @@ export default defineComponent({
 		},
 	},
 	emits: ['update:modelValue'],
+	setup(props) {
+		const isActive = computed(() => {
+			if (props.multiple) {
+				if (!Array.isArray(props.modelValue) || !props.item.value) {
+					return false;
+				}
+				return props.modelValue.includes(props.item.value);
+			} else {
+				return props.modelValue === props.item.value;
+			}
+		});
+		return {
+			isActive,
+		};
+	},
 });
 </script>

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -65,6 +65,7 @@
 					:model-value="modelValue"
 					:multiple="multiple"
 					:allow-other="allowOther"
+					:group-selectable="groupSelectable"
 					@update:model-value="$emit('update:modelValue', $event)"
 				/>
 				<select-list-item
@@ -175,6 +176,10 @@ export default defineComponent({
 			default: null,
 		},
 		multiple: {
+			type: Boolean,
+			default: false,
+		},
+		groupSelectable: {
 			type: Boolean,
 			default: false,
 		},

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -292,8 +292,13 @@ export default defineComponent({
 					const searchValue = internalSearch.value.toLowerCase();
 
 					return item?.children
-						? item.children.some((item: Record<string, any>) => filterItem(item))
-						: item.text?.toLowerCase().includes(searchValue) || item.value?.toLowerCase().includes(searchValue);
+						? isMatchingCurrentItem(item, searchValue) ||
+								item.children.some((item: Record<string, any>) => filterItem(item))
+						: isMatchingCurrentItem(item, searchValue);
+
+					function isMatchingCurrentItem(item: Record<string, any>, searchValue: string): boolean {
+						return item.text?.toLowerCase().includes(searchValue) || item.value?.toLowerCase().includes(searchValue);
+					}
 				};
 
 				const items = internalSearch.value ? props.items.filter(filterItem).map(parseItem) : props.items.map(parseItem);

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -24,6 +24,7 @@
 		:model-value="value"
 		:placeholder="t('select')"
 		allow-other
+		group-selectable
 		@update:model-value="emitValue($event)"
 	/>
 	<template v-else-if="is === 'interface-datetime'">


### PR DESCRIPTION
## Description

Follow up to #13867, implements/fixes points brought up over here: https://github.com/directus/directus/pull/13867#issuecomment-1168202136

- [x] **It's still not possible to select a parent item in a Checkbox Tree field**. Clicking the label expands/collapses the node, but doesn't allow selection. We'd need to allow selection of the node by clicking the label, and expand/collapse of the node by clicking the arrow icon. 

   Added `groupSelectable` prop to v-select and defaulted it to `false` to not affect existing v-select usages. It uses the `clickable` and subsequently `@click` event (which will fire when it is clickable) to emit the group when it's selectable.
   
   ![chrome_clOmHMUbxV](https://user-images.githubusercontent.com/42867097/176197404-4a32c982-37df-4b3c-b21c-552aaafba900.gif)


- [x] **Searching only finds bottom-level nodes in a Checkbox Tree**. Nodes that have children are not found in a search. 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
