### PR TITLE
Add emitEvents flag to item reads in service

### DIFF
--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -9,13 +9,14 @@ type Options = {
 	collection: string;
 	key?: PrimaryKey | PrimaryKey[] | null;
 	query?: Record<string, any> | string | null;
+	emitEvents: boolean;
 	permissions: string; // $public, $trigger, $full, or UUID of a role
 };
 
 export default defineOperationApi<Options>({
 	id: 'item-read',
 
-	handler: async ({ collection, key, query, permissions }, { accountability, database, getSchema }) => {
+	handler: async ({ collection, key, query, emitEvents, permissions }, { accountability, database, getSchema }) => {
 		const schema = await getSchema({ database });
 
 		let customAccountability: Accountability | null;
@@ -47,9 +48,9 @@ export default defineOperationApi<Options>({
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.readOne(keys[0], sanitizedQueryObject);
+				result = await itemsService.readOne(keys[0], sanitizedQueryObject, { emitEvents });
 			} else {
-				result = await itemsService.readMany(keys, sanitizedQueryObject);
+				result = await itemsService.readMany(keys, sanitizedQueryObject, { emitEvents });
 			}
 		}
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2042,6 +2042,7 @@ operations:
     description: Read items from the database
     key: IDs
     query: Query
+    emit_events: Emit Events
   item-update:
     name: Update Data
     description: Update items in the database

--- a/app/src/operations/item-read/index.ts
+++ b/app/src/operations/item-read/index.ts
@@ -105,5 +105,17 @@ export default defineOperationApp({
 				},
 			},
 		},
+		{
+			field: 'emitEvents',
+			name: '$t:operations.item-create.emit_events',
+			type: 'boolean',
+			meta: {
+				width: 'half',
+				interface: 'boolean',
+			},
+			schema: {
+				default_value: false,
+			},
+		},
 	],
 });


### PR DESCRIPTION
## Description

Adds the `emitEvents` flag to the ItemsService read operations.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
