### PR TITLE
Tweaks for datetime display options

### DIFF
--- a/app/src/displays/datetime/index.ts
+++ b/app/src/displays/datetime/index.ts
@@ -113,7 +113,7 @@ export default defineDisplay({
 					name: '$t:displays.datetime.strict',
 					type: 'boolean',
 					meta: {
-						width: 'full',
+						width: 'half',
 						interface: 'boolean',
 						options: {
 							label: '$t:displays.datetime.strict_label',

--- a/app/src/displays/datetime/index.ts
+++ b/app/src/displays/datetime/index.ts
@@ -94,15 +94,15 @@ export default defineDisplay({
 			fields.push(
 				{
 					field: 'suffix',
-					name: 'Suffix',
+					name: '$t:displays.datetime.suffix',
 					type: 'boolean',
 					meta: {
 						width: 'half',
 						interface: 'boolean',
 						options: {
-							label: 'Show relative indicator',
+							label: '$t:displays.datetime.suffix_label',
 						},
-						note: "Uses words like 'in' and 'ago'",
+						note: '$t:displays.datetime.suffix_note',
 					},
 					schema: {
 						default_value: true,
@@ -110,15 +110,15 @@ export default defineDisplay({
 				},
 				{
 					field: 'strict',
-					name: 'Strict',
+					name: '$t:displays.datetime.strict',
 					type: 'boolean',
 					meta: {
 						width: 'full',
 						interface: 'boolean',
 						options: {
-							label: 'Use strict units',
+							label: '$t:displays.datetime.strict_label',
 						},
-						note: "Removes words like 'almost', 'over', 'less than'",
+						note: '$t:displays.datetime.strict_note',
 					},
 					schema: {
 						default_value: false,

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1762,6 +1762,12 @@ displays:
     short: Short
     relative: Relative
     relative_label: 'Show relative time, eg: 5 minutes ago'
+    suffix: Suffix
+    suffix_label: Show relative indicator
+    suffix_note: Uses words like 'in' and 'ago'
+    strict: Strict
+    strict_label: Use strict units
+    strict_note: Removes words like 'almost', 'over', 'less than'
   file:
     file: File
     description: Display files


### PR DESCRIPTION
## Description

Follow up to #12804.

- Use translation keys for field names, labels, and notes
- Change `strict` option to half width

### Before

![chrome_dBdCEDxUGv](https://user-images.githubusercontent.com/42867097/176471332-2d32360e-4725-44ec-ab1d-4a878c5f004e.png)

### After

![chrome_zAl1R8mnyX](https://user-images.githubusercontent.com/42867097/176471351-de919855-0df3-40d3-a935-3088aadd9484.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
