### PR TITLE
Fix vite error when pre-bundling docs package

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -118,6 +118,9 @@ export default defineConfig({
 			},
 		}),
 	],
+	optimizeDeps: {
+		exclude: ['@directus/docs'],
+	},
 	resolve: {
 		alias: [
 			{ find: '@', replacement: path.resolve(__dirname, 'src') },


### PR DESCRIPTION
## Description

Fixes the issue with loading the docs after the migration to external repo:

![WindowsTerminal_OHTKBSbmm3](https://user-images.githubusercontent.com/42867097/176675290-13f582f2-cd5a-4882-9576-492ede2150ae.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
