### PR TITLE
Persist existing global variable values on save

### DIFF
--- a/app/src/stores/insights.ts
+++ b/app/src/stores/insights.ts
@@ -133,7 +133,7 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 			}
 		});
 
-		variables.value = variableDefaults;
+		variables.value = assign({}, variableDefaults, variables.value);
 	}
 
 	function dehydrate() {


### PR DESCRIPTION
## Description

Fixes #14219

### Before

Currently the global variables are being reset on hydrate (i.e. whenever we save):

https://user-images.githubusercontent.com/42867097/176760875-c128d602-4527-4372-bb97-0702681091dd.mp4

### After

Use assign to ensure the existing values are kept intact:

https://user-images.githubusercontent.com/42867097/176760862-915461e4-e39e-4b23-b5dd-722d52b57007.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
