### PR TITLE
broken image display for null assets

### DIFF
--- a/app/src/displays/image/image.vue
+++ b/app/src/displays/image/image.vue
@@ -39,7 +39,7 @@ export default defineComponent({
 		const imageError = ref(false);
 
 		const src = computed(() => {
-			if (props.value === null) return null;
+			if (props.value?.id === null || props.value?.id === undefined) return null;
 			const url = getRootPath() + `assets/${props.value.id}?key=system-small-cover`;
 			return addTokenToURL(url);
 		});


### PR DESCRIPTION
## Description

Added extra undefined checks to prevent the image display from trying to show `null` or `undefined` results

Fixes #14239 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code
