### PR TITLE
Don't show language select when there is only one language to choose from

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="translations" :class="{ split: splitViewEnabled }">
 		<div class="primary" :class="splitViewEnabled ? 'half' : 'full'">
-			<language-select v-model="firstLang" :items="languageOptions">
+			<language-select v-if="showLanguageSelect" v-model="firstLang" :items="languageOptions">
 				<template #append>
 					<v-icon
 						v-if="splitViewAvailable && !splitViewEnabled"
@@ -183,6 +183,10 @@ const splitViewAvailable = computed(() => {
 
 const splitViewEnabled = computed(() => {
 	return splitViewAvailable.value && splitView.value;
+});
+
+const showLanguageSelect = computed(() => {
+	return languageOptions.value.length > 1;
 });
 
 function useLanguages() {


### PR DESCRIPTION
## Description

When you use a translations interface, but only have a single language to translate, hide the language selector dropdown.

Closes #14243

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
