### PR TITLE
Fix crash on logout due to `te` missing

### DIFF
--- a/app/src/routes/login/login.vue
+++ b/app/src/routes/login/login.vue
@@ -46,7 +46,7 @@ withDefaults(defineProps<Props>(), {
 	logoutReason: null,
 });
 
-const { t } = useI18n();
+const { t, te } = useI18n();
 
 const appStore = useAppStore();
 const driver = ref('local');


### PR DESCRIPTION
## Description

i18n function `te` is missing from login component. This logic is executed when there's a `reason` query parameter and causes a crash.

Bug was introduced in https://github.com/directus/directus/pull/14229

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
