### PR TITLE
Fix duplicate logic for retrieving system collections in related-collection-select

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
@@ -90,15 +90,7 @@ export default defineComponent({
 			);
 		});
 
-		const systemCollections = computed(() => {
-			return orderBy(
-				collectionsStore.crudSafeSystemCollections.filter((collection) => {
-					return collection.collection.startsWith('directus_') === true;
-				}),
-				['collection'],
-				['asc']
-			);
-		});
+		const systemCollections = collectionsStore.crudSafeSystemCollections;
 
 		return { t, collectionExists, availableCollections, systemCollections };
 	},


### PR DESCRIPTION
## Description

The `systemCollections` variable in related-collection-select has duplicate filter-and-sort logic since the same logic is done in the collections store with `crudSafeSystemCollections`.

`crudSafeSystemCollections` reference:

https://github.com/directus/directus/blob/750e9d9969b9d0af61048d99ec4bd611fd39e4cf/app/src/stores/collections.ts#L29-L36

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
