### PR TITLE
Terminate Directus if OpenID discovery fails

### DIFF
--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -71,7 +71,10 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 						})
 					);
 				})
-				.catch(reject);
+				.catch((e) => {
+					logger.error(e, '[OpenID] Failed to fetch provider config');
+					process.exit(1);
+				});
 		});
 	}
 


### PR DESCRIPTION
## Description

Currently Directus can launch if OpenID discovery fails, leaving the auth provider in a broken state. We should terminate and warn the user, or force the deamon to retry.

See discussion here https://github.com/directus/directus/discussions/14284

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
