### PR TITLE
Remove invalid exported type in app

### DIFF
--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -3,5 +3,4 @@ export * from './error';
 export * from './insights';
 export * from './notifications';
 export * from './login';
-export * from './shares';
 export * from './insights';


### PR DESCRIPTION
## Description

(Was somehow getting this error from Vite when reviewing #12820 which prevented loading of the app in dev. Maybe because the PR affected this file by exporting another type)

This line was added in #10663 over here: https://github.com/directus/directus/pull/10663/files#diff-de086547c687d4af10d62905afc999162ca1130edd9228421a13e0197ad8d171, but `app/src/types/shares.ts` does not exist.

It should be because it was moved to `packages/shared/src/types/shares.ts` and was not removed from this file accordingly.

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
