### PR TITLE
Fixes data missing after sort in m2a interface

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -147,6 +147,7 @@ import Draggable from 'vuedraggable';
 import adjustFieldsForDisplays from '@/utils/adjust-fields-for-displays';
 import { get, clamp } from 'lodash';
 import { hideDragImage } from '@/utils/hide-drag-image';
+import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 
 const props = withDefaults(
 	defineProps<{
@@ -197,12 +198,12 @@ const fields = computed(() => {
 	const fields: string[] = [];
 
 	for (const collection of relationInfo.value.allowedCollections) {
-		fields.push(
-			...adjustFieldsForDisplays(
-				getFieldsFromTemplate(templates.value[collection.collection]),
-				relationInfo.value?.junctionCollection.collection ?? ''
-			).map((field) => `${relationInfo.value?.junctionField.field}:${collection.collection}.${field}`)
-		);
+		const displayFields: string[] = adjustFieldsForDisplays(
+			getFieldsFromTemplate(templates.value[collection.collection]),
+			relationInfo.value?.junctionCollection.collection ?? ''
+		).map((field) => `${relationInfo.value?.junctionField.field}:${collection.collection}.${field}`);
+
+		fields.push(...addRelatedPrimaryKeyToFields(collection.collection, displayFields));
 	}
 
 	return fields;


### PR DESCRIPTION
## Description

Sorting data in a m2a field with nested relations results in duplicate records being created in the related collection.
Added the `addRelatedPrimaryKeyToFields` utility when the interface is loading its fields.
Applied the same fix to m2a as was done to o2m/m2m in pr #13151 

Refs #14290, #13042 and #13058

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code
