### PR TITLE
Prevents selecting relational fields as sort field

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -64,6 +64,7 @@
 			<v-divider large :inline-title="false">{{ t('sort_field') }}</v-divider>
 			<related-field-select
 				v-model="sortField"
+				:disabled-fields="unsortableJunctionFields"
 				:collection="junctionCollection"
 				:placeholder="t('add_sort_field')"
 				:nullable="true"
@@ -157,7 +158,7 @@ import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
 import RelatedFieldSelect from '../shared/related-field-select.vue';
-import { useFieldsStore, useCollectionsStore } from '@/stores';
+import { useFieldsStore, useCollectionsStore, useRelationsStore } from '@/stores';
 import { orderBy } from 'lodash';
 
 export default defineComponent({
@@ -167,6 +168,7 @@ export default defineComponent({
 
 		const fieldDetailStore = useFieldDetailStore();
 		const collectionsStore = useCollectionsStore();
+		const relationsStore = useRelationsStore();
 		const fieldsStore = useFieldsStore();
 
 		const { collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
@@ -202,6 +204,15 @@ export default defineComponent({
 			);
 		});
 
+		const unsortableJunctionFields = computed(() => {
+			let fields = ['item', 'collection'];
+			if (junctionCollection.value) {
+				const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
+				fields.push(...relations.map((field) => field.field));
+			}
+			return fields;
+		});
+
 		return {
 			t,
 			availableCollections,
@@ -218,6 +229,7 @@ export default defineComponent({
 			sortField,
 			onDelete,
 			onDeselect,
+			unsortableJunctionFields,
 		};
 	},
 });

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -71,6 +71,7 @@
 			<related-field-select
 				v-model="sortField"
 				:collection="junctionCollection"
+				:disabled-fields="unsortableJunctionFields"
 				:placeholder="t('add_sort_field') + '...'"
 				:nullable="true"
 			/>
@@ -203,7 +204,7 @@ import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
 import RelatedFieldSelect from '../shared/related-field-select.vue';
-import { useFieldsStore } from '@/stores';
+import { useFieldsStore, useRelationsStore } from '@/stores';
 
 export default defineComponent({
 	components: { RelatedCollectionSelect, RelatedFieldSelect },
@@ -211,6 +212,7 @@ export default defineComponent({
 		const { t } = useI18n();
 
 		const fieldDetailStore = useFieldDetailStore();
+		const relationsStore = useRelationsStore();
 		const fieldsStore = useFieldsStore();
 
 		const { field, collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
@@ -265,6 +267,15 @@ export default defineComponent({
 			return t('add_field_related');
 		});
 
+		const unsortableJunctionFields = computed(() => {
+			let fields = [];
+			if (junctionCollection.value) {
+				const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
+				fields.push(...relations.map((field) => field.field));
+			}
+			return fields;
+		});
+
 		return {
 			t,
 			autoGenerateJunctionRelation,
@@ -285,6 +296,7 @@ export default defineComponent({
 			correspondingLabel,
 			correspondingFieldKey,
 			generationInfo,
+			unsortableJunctionFields,
 		};
 	},
 });

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -24,6 +24,7 @@
 			<related-field-select
 				v-model="sortField"
 				:collection="relatedCollection"
+				:disabled-fields="unsortableJunctionFields"
 				:placeholder="t('add_sort_field') + '...'"
 				:nullable="true"
 			/>
@@ -117,7 +118,7 @@ import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
 import RelatedFieldSelect from '../shared/related-field-select.vue';
-import { useFieldsStore } from '@/stores';
+import { useFieldsStore, useRelationsStore } from '@/stores';
 
 export default defineComponent({
 	components: { RelatedCollectionSelect, RelatedFieldSelect },
@@ -125,6 +126,7 @@ export default defineComponent({
 		const { t } = useI18n();
 
 		const fieldDetailStore = useFieldDetailStore();
+		const relationsStore = useRelationsStore();
 		const fieldsStore = useFieldsStore();
 
 		const relatedCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
@@ -138,6 +140,15 @@ export default defineComponent({
 		const isExisting = computed(() => editing.value !== '+');
 		const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
 
+		const unsortableJunctionFields = computed(() => {
+			let fields = ['item', 'collection'];
+			if (relatedCollection.value) {
+				const relations = relationsStore.getRelationsForCollection(relatedCollection.value);
+				fields.push(...relations.map((field) => field.field));
+			}
+			return fields;
+		});
+
 		return {
 			t,
 			isExisting,
@@ -149,6 +160,7 @@ export default defineComponent({
 			sortField,
 			onDelete,
 			onDeselect,
+			unsortableJunctionFields,
 		};
 	},
 });

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
@@ -57,6 +57,10 @@ export default defineComponent({
 			type: String,
 			default: null,
 		},
+		disabledFields: {
+			type: Array as PropType<string[]>,
+			default: () => [],
+		},
 		typeDenyList: {
 			type: Array as PropType<string[]>,
 			default: () => [],
@@ -81,7 +85,11 @@ export default defineComponent({
 			return fieldsStore.getFieldsForCollectionAlphabetical(props.collection).map((field) => ({
 				text: field.field,
 				value: field.field,
-				disabled: !field.schema || !!field.schema?.is_primary_key || !!props.typeDenyList.includes(field.type),
+				disabled:
+					!field.schema ||
+					!!field.schema?.is_primary_key ||
+					props.disabledFields.includes(field.field) ||
+					props.typeDenyList.includes(field.type),
 			}));
 		});
 


### PR DESCRIPTION
## Description

Re-implements the fix done here #11444 and here #12463 which were reverted in #13014 because the fix was also preventing relational fields to be selected as foreign keys for o2m/m2o.

This fix only adds a new property to the widely used `related-field-select.vue` which allows for an array of disabled fields to be passed. Added logic to the m2a, o2m and m2m field detail sidebars to disable relational fields or essential fields from being selected as sort field.

Fixes #14290 

## Type of Change

- [X] Bugfix
- [X] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
