### PR TITLE
Disable selecting alias fields to filter on

### DIFF
--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -72,7 +72,7 @@ const treeList = computed(() => {
 	function setDisabled(
 		field: typeof treeListOriginal.value[number]
 	): typeof treeListOriginal.value[number] & { disabled: boolean } {
-		let disabled = field.group || false;
+		let disabled = field.group || field.type === 'alias' || false;
 
 		if (props.disabledFields?.includes(field.key)) disabled = true;
 


### PR DESCRIPTION
## Description

Since no alias field can be searched on, I just disabled being able to select all alias fields.

Fixes #14306 

## Type of Change

- [x] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
