### PR TITLE
Show field data type & interface on hover for system collections' fields

### DIFF
--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -55,7 +55,7 @@
 
 				<template #input>
 					<div
-						v-tooltip="interfaceName ? `${field.name} (${formatTitle(field.type)}) - ${interfaceName}` : field.name"
+						v-tooltip="`${field.name} (${formatTitle(field.type)})${interfaceName ? ` - ${interfaceName}` : ''}`"
 						class="label"
 						@click="openFieldDetail"
 					>

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -6,8 +6,14 @@
 			</template>
 
 			<template #input>
-				<div class="label">
-					<span class="name">{{ field.field }}</span>
+				<div
+					v-tooltip="`${field.name} (${formatTitle(field.type)})${interfaceName ? ` - ${interfaceName}` : ''}`"
+					class="label"
+				>
+					<div class="label-inner">
+						<span class="name">{{ field.field }}</span>
+						<span v-if="interfaceName" class="interface">{{ interfaceName }}</span>
+					</div>
 				</div>
 			</template>
 		</v-input>


### PR DESCRIPTION
## Description

Fixes #14313

### Problem

> The fields aren't in monospace, and aren't showing the data types.

### Solution

Used the general existing code in normal collections' fields:

https://github.com/directus/directus/blob/7ad51b29254e37b569cfe08e522d37115977b604/app/src/modules/settings/routes/data-model/fields/components/field-select.vue#L57-L69

Result:

![chrome_8qaHsLzywZ](https://user-images.githubusercontent.com/42867097/177909835-83665559-87da-4f10-958f-594f7bef6a1e.gif)

(Nesting the `.name` span inside `.label-inner` is what set it as monospace font)

Additionally, the original tooltip were actually not showing `field.type` when there are no interface set (`interfaceName`), so tweaked that in this PR as well.

|Before|After|
|---|---|
|![chrome_k2w7DWdMs4](https://user-images.githubusercontent.com/42867097/177909724-b2184179-9a90-4c75-a4f9-0f9af47eae91.png)|![chrome_XevcDhVla3](https://user-images.githubusercontent.com/42867097/177909746-d91f1586-fe89-49c9-93a2-6b414c88e8ca.png)|


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
