### PR TITLE
Prevent empty title attribute in WYSIWYG links

### DIFF
--- a/app/src/interfaces/input-rich-text-html/useLink.ts
+++ b/app/src/interfaces/input-rich-text-html/useLink.ts
@@ -110,9 +110,9 @@ export default function useLink(editor: Ref<any>): UsableLink {
 
 		const link = linkSelection.value;
 		if (link.url === null) return;
-		const linkHtml = `<a href="${link.url}" title="${link.title || ''}" target="${link.newTab ? '_blank' : '_self'}" >${
-			link.displayText || link.url
-		}</a>`;
+		const linkHtml = `<a href="${link.url}" ${link.title ? `title="${link.title}"` : ''} target="${
+			link.newTab ? '_blank' : '_self'
+		}" >${link.displayText || link.url}</a>`;
 
 		// New anchor tag or current selection node is an anchor tag
 		if (!linkNode.value || currentSelectionNode.value === linkNode.value) {
@@ -123,7 +123,7 @@ export default function useLink(editor: Ref<any>): UsableLink {
 			currentSelectionNode.value.innerHTML = link.displayText || link.url;
 			linkNode.value.setAttribute('data-mce-href', link.url); // Required for tinymce to update changes
 			linkNode.value.setAttribute('href', link.url);
-			linkNode.value.setAttribute('title', link.title || '');
+			if (link.title) linkNode.value.setAttribute('title', link.title);
 			linkNode.value.setAttribute('target', link.newTab ? '_blank' : '_self');
 			editor.value.selection.select(linkNode.value);
 			editor.value.selection.setNode(linkNode.value);


### PR DESCRIPTION
## Description

Fixes #14317

### Problem

When we add a link in the WYSIWYG editor without specifying the tooltip (which is the `title` HTML attribute for the links), it will be `title=""` instead. This will impact the accessibility of said links.

https://user-images.githubusercontent.com/42867097/177911888-071ab0c6-5991-4bf3-ab99-5b85515ef95d.mp4

### Solution

Also added the same logic in line 126 to prevent empty title attributes.

https://user-images.githubusercontent.com/42867097/177911784-657f7a77-4b36-4d59-be37-1916857ac28b.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
