### PR TITLE
Don't use locales in generated camelCased values from env

### DIFF
--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -38,7 +38,7 @@ export function getConfigFromEnv(
 
 	function transform(key: string): string {
 		if (type === 'camelcase') {
-			return camelcase(key);
+			return camelcase(key, { locale: false });
 		} else if (type === 'underscore') {
 			return key.toLowerCase();
 		}


### PR DESCRIPTION
## Description

The camelCasing library we rely on for generating env objects from `__` env vars uses the system locale to decide what characters to use for upper/lowercase. That causes issues in certain languages (like Turkish), where `I` might be converted to `ı` instead of `i`

Ref https://github.com/directus/directus/discussions/14122

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
