### PR TITLE
Insights: Fix query primary field for system tables

### DIFF
--- a/app/src/stores/insights.ts
+++ b/app/src/stores/insights.ts
@@ -215,9 +215,8 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 				.filter(({ collection }) => {
 					return collection.startsWith('directus_') === true;
 				})
-				.map(({ key, collection, ...rest }) => ({
+				.map(({ key, ...rest }) => ({
 					key: `query_${key}`,
-					collection: collection.substring(9),
 					...rest,
 				}))
 		);

--- a/app/src/utils/query-to-gql-string.ts
+++ b/app/src/utils/query-to-gql-string.ts
@@ -23,15 +23,17 @@ export function queryToGqlString(queries: QueryInfo | QueryInfo[]): string | nul
 export function formatQuery({ collection, query }: QueryInfo): Record<string, any> {
 	const queryKeysInArguments: (keyof Query)[] = ['limit', 'sort', 'filter', 'offset', 'page', 'search'];
 
+	const alias = collection.startsWith('directus_') ? collection.substring(9) : collection;
+
 	const formattedQuery: Record<string, any> = {
 		__args: omitBy(pick(query, ...queryKeysInArguments), isUndefined),
-		__aliasFor: collection,
+		__aliasFor: alias,
 	};
 
 	const fields = query.fields ?? [useFieldsStore().getPrimaryKeyFieldForCollection(collection)!.field];
 
 	if (query?.aggregate && !isEmpty(query.aggregate)) {
-		formattedQuery.__aliasFor = collection + '_aggregated';
+		formattedQuery.__aliasFor = alias + '_aggregated';
 
 		for (const [aggregateFunc, fields] of Object.entries(query.aggregate)) {
 			if (!formattedQuery[aggregateFunc]) {


### PR DESCRIPTION
## Description

When querying data from system tables it does not show any other panels, because we are doing all requests in a single query.
This happens because we remove the prefix `directus_` before we ask for primary key on fields store, leading to not finding it and causing JS error.

Fixes #14397

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
