### PR TITLE
Prevent app crash on empty manual flow config

### DIFF
--- a/app/src/stores/flows.ts
+++ b/app/src/stores/flows.ts
@@ -31,7 +31,7 @@ export const useFlowsStore = defineStore({
 			this.$reset();
 		},
 		getManualFlowsForCollection(collection: string): FlowRaw[] {
-			return this.flows.filter((flow) => flow.trigger === 'manual' && flow.options?.collections.includes(collection));
+			return this.flows.filter((flow) => flow.trigger === 'manual' && flow.options?.collections?.includes(collection));
 		},
 	},
 });


### PR DESCRIPTION
## Description

When a manual flow was used, without any options, the app crashes on startup, as it tries to read the configured collections on startup

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
