### PR TITLE
API/Graphql: Use same types as `count` for `countDistinct`

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -834,6 +834,18 @@ export class GraphQLService {
 					}, {} as ObjectTypeComposerFieldConfigMapDefinition<any, any>),
 				});
 
+				const countType = schemaComposer.createObjectTC({
+					name: `${collection.collection}_aggregated_count`,
+					fields: Object.values(collection.fields).reduce((acc, field) => {
+						acc[field.field] = {
+							type: GraphQLInt,
+							description: field.note,
+						};
+
+						return acc;
+					}, {} as ObjectTypeComposerFieldConfigMapDefinition<any, any>),
+				});
+
 				AggregateMethods[collection.collection] = {
 					group: {
 						name: 'group',
@@ -845,17 +857,11 @@ export class GraphQLService {
 					},
 					count: {
 						name: 'count',
-						type: schemaComposer.createObjectTC({
-							name: `${collection.collection}_aggregated_count`,
-							fields: Object.values(collection.fields).reduce((acc, field) => {
-								acc[field.field] = {
-									type: GraphQLInt,
-									description: field.note,
-								};
-
-								return acc;
-							}, {} as ObjectTypeComposerFieldConfigMapDefinition<any, any>),
-						}),
+						type: countType,
+					},
+					countDistinct: {
+						name: 'countDistinct',
+						type: countType,
 					},
 				};
 
@@ -877,10 +883,6 @@ export class GraphQLService {
 						},
 						sum: {
 							name: 'sum',
-							type: AggregatedFields[collection.collection],
-						},
-						countDistinct: {
-							name: 'countDistinct',
 							type: AggregatedFields[collection.collection],
 						},
 						avgDistinct: {


### PR DESCRIPTION
## Description
Right now, `countDistinct` in Graphql only supports Int or Floats field types.
Since `count` already supports all types, just reuse the same approach for  `countDistinct`

Related #14420

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
