### PR TITLE
Fallback to just get a value especially for translations

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -28,8 +28,8 @@
 				<render-display
 					:value="
 						!aliasFields || item[header.value] !== undefined
-							? get(item, header.value)
-							: getAliasedValue(item, header.value)
+							? get(item, header.value) ?? get(item, header.value.replace('.', '.[0]'))
+							: getAliasedValue(item, header.value) ?? getAliasedValue(item, header.value.replace('.', '.[0]'))
 					"
 					:display="header.field.display"
 					:options="header.field.displayOptions"

--- a/app/src/views/private/components/render-template/render-template.vue
+++ b/app/src/views/private/components/render-template/render-template.vue
@@ -83,8 +83,11 @@ export default defineComponent({
 							.join('.');
 					}
 
-					// Try getting the value from the item, return some question marks if it doesn't exist
-					const value = get(props.item, fieldKey);
+					// Try getting the value from the item, else try the first element if it is an array
+					let value = get(props.item, fieldKey);
+					if (value === undefined && fieldKey.includes('.')) {
+						value = get(props.item, fieldKey.replace('.', '.[0]'));
+					}
 
 					if (value === undefined) return null;
 


### PR DESCRIPTION
## Description

A start to fix translations display in template and displays.

It isn't the most elegant of solutions, but at least it shows something. Basically it when a value is undefined, it tries to get a value from the first element in the array, which is how translations tend to be loaded.

The order of the translations is completely random even per item, but that could be the next part to fix.

Totally understand if the PR gets closed, just wanted to put it out there as a possible fix for the time being. Seems like translations need some meta property so they can be loaded slightly differently.


Possibly Fixes #11385 

## Type of Change

- [x] Bugfix
- [x] Improvement

