### PR TITLE
Fix apply snapshot for UUID primary keys

### DIFF
--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -51,7 +51,12 @@ export async function applySnapshot(
 						.map((fieldDiff) => {
 							// Casts field type to UUID when applying non-PostgreSQL schema onto PostgreSQL database.
 							// This is needed because they snapshots UUID fields as char with length 36.
-							if (fieldDiff.schema?.data_type === 'char' && fieldDiff.schema?.max_length === 36) {
+							if (
+								fieldDiff.schema?.data_type === 'char' &&
+								fieldDiff.schema?.max_length === 36 &&
+								(fieldDiff.schema?.is_primary_key ||
+									(fieldDiff.schema?.foreign_key_table && fieldDiff.schema?.foreign_key_column))
+							) {
 								return merge(fieldDiff, { type: 'uuid', schema: { data_type: 'uuid', max_length: null } });
 							} else {
 								return fieldDiff;

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -49,26 +49,13 @@ export async function applySnapshot(
 						.filter((fieldDiff) => fieldDiff.collection === collection)
 						.map((fieldDiff) => (fieldDiff.diff[0] as DiffNew<Field>).rhs)
 						.map((fieldDiff) => {
-							// Casts field type to UUID when applying SQLite-based schema on other databases.
-							// This is needed because SQLite snapshots UUID fields as char with length 36, and
-							// it will fail when trying to create relation between char field to UUID field
-							if (
-								!fieldDiff.schema ||
-								fieldDiff.schema.data_type !== 'char' ||
-								fieldDiff.schema.max_length !== 36 ||
-								!fieldDiff.schema.foreign_key_table ||
-								!fieldDiff.schema.foreign_key_column
-							) {
+							// Casts field type to UUID when applying non-PostgreSQL schema onto PostgreSQL database.
+							// This is needed because they snapshots UUID fields as char with length 36.
+							if (fieldDiff.schema?.data_type === 'char' && fieldDiff.schema?.max_length === 36) {
+								return merge(fieldDiff, { type: 'uuid', schema: { data_type: 'uuid', max_length: null } });
+							} else {
 								return fieldDiff;
 							}
-
-							const matchingForeignKeyTable = schema.collections[fieldDiff.schema.foreign_key_table];
-							if (!matchingForeignKeyTable) return fieldDiff;
-
-							const matchingForeignKeyField = matchingForeignKeyTable.fields[fieldDiff.schema.foreign_key_column];
-							if (!matchingForeignKeyField || matchingForeignKeyField.type !== 'uuid') return fieldDiff;
-
-							return merge(fieldDiff, { type: 'uuid', schema: { data_type: 'uuid', max_length: null } });
 						});
 
 					try {


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #13988

### Changes

Previously in #12723, aside from checking `data_type: char` and `max_length: 36`, it also checks `fieldDiff.schema.foreign_key_table` and `fieldDiff.schema.foreign_key_column` to avoid false positives in the event that a user intentionally creates a char field with length of 36, not necessarily as an UUID. 

This works for relationships to UUID foreign keys, however it wasn't accounting for when the collection's primary key itself is an UUID (so it doesn't have `foreign_key_table` or `foreign_key_column`).

This PR added the check of `is_primary_key` to fix such scenario. The logic is flipped just to simplify things. Technically now it also removes the previous checks on whether `foreign_key_table` and `foreign_key_column` exists, but I believe they were actually redundant unless the user tampers with the snapshot file manually (I could be wrong here).

Also updated the comment a little to not only specify SQLite as that's not really correct, as described in Knex's docs: 

> this uses the built-in uuid type in PostgreSQL, and falling back to a char(36) in other databases by default.
>([link to above quote](http://knexjs.org/guide/schema-builder.html#uuid))

### Before

![WindowsTerminal_LNMcs9t71L](https://user-images.githubusercontent.com/42867097/179707081-8e66ed16-b74c-4101-8b04-ba71eddf4771.png)

### After

![WindowsTerminal_DUJMBgDzj9](https://user-images.githubusercontent.com/42867097/179707097-357aa59a-dec5-4377-a791-cb8a222afa78.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
