### PR TITLE
Graphql: Do not try to convert Dates (considered an object)

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1575,7 +1575,7 @@ export class GraphQLService {
 
 						result[currentKey] = Object.values(value)[0]!;
 					} else {
-						result[currentKey] = isObject(value) ? replaceFuncDeep(value) : value;
+						result[currentKey] = value?.constructor === Object ? replaceFuncDeep(value) : value;
 					}
 				});
 			}


### PR DESCRIPTION
## Description

When using date dynamic variables in Graphql, the server returns with errors telling the field is not a date (1).
The most interesting part of this issue is after the first issue occurred the next Graphql request always hang and if we try to make the request again it crash with 500 Internal Server Error (2).
<details><summary>The Internal Server Error has the following message:</summary>
<pre>
'select "directus_users"."id", "directus_users"."role", "directus_roles"."admin_access", "directus_roles"."app_access" from "directus_users" left join "directus_roles" on "directus_users"."role" = "directus_roles"."id" where "directus_users"."token" = $1 and "status" = $2 limit $3 - invalid message format'
</pre>
</details>

I am not sure what causes the (2) issue, but this PR only fixes (1) which prevents (2) from happening on this context.

Fixes #14480
Fixes https://github.com/directus/cloud/issues/500

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
