### PR TITLE
Fix M2A filter scope on select existing

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -136,18 +136,18 @@
 </template>
 
 <script setup lang="ts">
-import { useRelationM2A, useRelationMultiple, RelationQueryMultiple, DisplayItem } from '@/composables/use-relation';
-import { Filter } from '@directus/shared/types';
-import { getFieldsFromTemplate } from '@directus/shared/utils';
-import { computed, ref, toRefs } from 'vue';
-import { useI18n } from 'vue-i18n';
-import DrawerItem from '@/views/private/components/drawer-item';
-import DrawerCollection from '@/views/private/components/drawer-collection';
-import Draggable from 'vuedraggable';
-import adjustFieldsForDisplays from '@/utils/adjust-fields-for-displays';
-import { get, clamp } from 'lodash';
-import { hideDragImage } from '@/utils/hide-drag-image';
+import { DisplayItem, RelationQueryMultiple, useRelationM2A, useRelationMultiple } from '@/composables/use-relation';
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
+import adjustFieldsForDisplays from '@/utils/adjust-fields-for-displays';
+import { hideDragImage } from '@/utils/hide-drag-image';
+import DrawerCollection from '@/views/private/components/drawer-collection';
+import DrawerItem from '@/views/private/components/drawer-item';
+import { Filter, FieldFilter } from '@directus/shared/types';
+import { getFieldsFromTemplate } from '@directus/shared/utils';
+import { clamp, get } from 'lodash';
+import { computed, ref, toRefs, unref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
 
 const props = withDefaults(
 	defineProps<{
@@ -328,20 +328,29 @@ function getCollectionName(item: DisplayItem) {
 const customFilter = computed(() => {
 	const info = relationInfo.value;
 
+	if (!info || !selectingFrom.value) return {};
+
 	const filter: Filter = {
 		_and: [],
 	};
-
-	if (!info || !selectingFrom.value) return filter;
 
 	const reverseRelation = `$FOLLOW(${info.junctionCollection.collection},${info.junctionField.field},${info.collectionField.field})`;
 
 	const selectFilter: Filter = {
 		[reverseRelation]: {
 			_none: {
-				[relationInfo.value.reverseJunctionField.field]: {
-					_eq: props.primaryKey,
-				},
+				_and: [
+					{
+						[relationInfo.value.reverseJunctionField.field]: {
+							_eq: props.primaryKey,
+						},
+					},
+					{
+						[info.collectionField.field]: {
+							_eq: unref(selectingFrom),
+						},
+					},
+				],
 			},
 		},
 	};

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -111,7 +111,7 @@
 		</div>
 
 		<drawer-collection
-			v-if="!disabled && !!selectingFrom"
+			v-if="!disabled"
 			multiple
 			:active="!!selectingFrom"
 			:collection="selectingFrom"

--- a/app/src/views/private/components/drawer-collection/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection/drawer-collection.vue
@@ -66,7 +66,7 @@ export default defineComponent({
 		},
 		collection: {
 			type: String,
-			required: true,
+			default: null,
 		},
 		multiple: {
 			type: Boolean,


### PR DESCRIPTION
## Description

Adds an additional collection filter scope to the m2a junction table check to ensure that the primary key isn't the only identifying data point in the collection drawer filter.

Fixes #13598

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
