### PR TITLE
Fix GraphQL aggregate query

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1250,7 +1250,7 @@ export class GraphQLService {
 		if (!selections) return null;
 		const args: Record<string, any> = this.parseArgs(info.fieldNodes[0].arguments || [], info.variableValues);
 
-		let query: Record<string, any>;
+		let query: Query;
 
 		const isAggregate = collection.endsWith('_aggregated') && collection in this.schema.collections === false;
 
@@ -1280,13 +1280,15 @@ export class GraphQLService {
 		}
 
 		// Transform count(a.b.c) into a.b.count(c)
-		for (let fieldIndex = 0; fieldIndex < (query.fields || []).length; fieldIndex++) {
-			if (query.fields[fieldIndex].includes('(') && query.fields[fieldIndex].includes(')')) {
-				const functionName = query.fields[fieldIndex].split('(')[0];
-				const columnNames = query.fields[fieldIndex].match(REGEX_BETWEEN_PARENS)![1].split('.');
-				if (columnNames.length > 1) {
-					const column = columnNames.pop();
-					query.fields[fieldIndex] = columnNames.join('.') + '.' + functionName + '(' + column + ')';
+		if (query.fields?.length) {
+			for (let fieldIndex = 0; fieldIndex < query.fields.length; fieldIndex++) {
+				if (query.fields[fieldIndex].includes('(') && query.fields[fieldIndex].includes(')')) {
+					const functionName = query.fields[fieldIndex].split('(')[0];
+					const columnNames = query.fields[fieldIndex].match(REGEX_BETWEEN_PARENS)![1].split('.');
+					if (columnNames.length > 1) {
+						const column = columnNames.pop();
+						query.fields[fieldIndex] = columnNames.join('.') + '.' + functionName + '(' + column + ')';
+					}
 				}
 			}
 		}

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1280,7 +1280,7 @@ export class GraphQLService {
 		}
 
 		// Transform count(a.b.c) into a.b.count(c)
-		for (let fieldIndex = 0; fieldIndex < query.fields.length; fieldIndex++) {
+		for (let fieldIndex = 0; fieldIndex < (query.fields || []).length; fieldIndex++) {
 			if (query.fields[fieldIndex].includes('(') && query.fields[fieldIndex].includes(')')) {
 				const functionName = query.fields[fieldIndex].split('(')[0];
 				const columnNames = query.fields[fieldIndex].match(REGEX_BETWEEN_PARENS)![1].split('.');

--- a/tests/api/items/aggregate.test.ts
+++ b/tests/api/items/aggregate.test.ts
@@ -1,0 +1,84 @@
+import config, { getUrl } from '../../config';
+import vendors from '../../get-dbs-to-test';
+import request from 'supertest';
+import knex, { Knex } from 'knex';
+import { createGuest, seedTable, createMany } from '../../setup/utils/factories';
+
+describe('/items', () => {
+	const databases = new Map<string, Knex>();
+
+	beforeAll(async () => {
+		for (const vendor of vendors) {
+			databases.set(vendor, knex(config.knexConfig[vendor]!));
+		}
+	});
+
+	afterAll(async () => {
+		for (const [_vendor, connection] of databases) {
+			await connection.destroy();
+		}
+	});
+
+	beforeEach(async () => {
+		for (const [, connection] of databases) {
+			await connection('guests').delete();
+		}
+	});
+
+	describe('/:collection GET', () => {
+		describe('returns count correctly', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const count = 10;
+				const guests: any[] = createMany(createGuest, count);
+				await seedTable(databases.get(vendor)!, 1, 'guests', guests);
+
+				const response = await request(getUrl(vendor))
+					.get(`/items/guests?aggregate[count]=id`)
+					.set('Authorization', 'Bearer AdminToken')
+					.expect('Content-Type', /application\/json/)
+					.expect(200);
+
+				const { data } = response.body;
+				expect(data[0]).toMatchObject({
+					count: {
+						id: guests.length,
+					},
+				});
+			});
+		});
+	});
+
+	describe('/:collection GraphQL Query', () => {
+		describe('returns count correctly', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const count = 10;
+				const guests: any[] = createMany(createGuest, count);
+				await seedTable(databases.get(vendor)!, 1, 'guests', guests);
+
+				const query = `
+				{
+					guests_aggregated {
+						count {
+							id
+						}
+					}
+				}`;
+
+				const response = await request(getUrl(vendor))
+					.post('/graphql')
+					.send({ query })
+					.set('Authorization', 'Bearer AdminToken')
+					.expect('Content-Type', /application\/json/)
+					.expect(200);
+
+				const { data } = response.body;
+
+				expect(data.guests_aggregated[0]).toMatchObject({
+					count: {
+						id: guests.length,
+					},
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Description

Fixes #14557

#13870 added the following for loop on `query.fields` which accesses `query.fields.length` in the condition expression:

https://github.com/directus/directus/blob/3d03291c310c6d30a6cde1323f5298379a48fec3/api/src/services/graphql/index.ts#L1283

However when it is an aggregate query, it uses `getAggregatedQuery` instead of `getQuery`:

https://github.com/directus/directus/blob/3d03291c310c6d30a6cde1323f5298379a48fec3/api/src/services/graphql/index.ts#L1257-L1261

and `getAggregatedQuery`, unlike `getQuery`, never assigns value to `query.fields`, hence accessing `.length` throws `Cannot read properties of undefined (reading 'length')` error.

### Solution

Changed type from `Record<string, any>` to `Query` since both `getAggregatedQuery` and `getQuery` return types are Query, because the `any` type was probably why this was uncaught.

Initially used `(query.fields || []).length` like how it's used in other parts of the code, but end up wrapping with IF statement to satisfy `query.fields[fieldIndex]` typechecks within the for loop.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
