### PR TITLE
System fields not properly filtered when editing images

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -285,7 +285,7 @@ export default defineComponent({
 			});
 
 			const fieldsInGroup = computed(() =>
-				fields.value.filter(
+				formFields.value.filter(
 					(field: Field) => field.meta?.group === props.group || (props.group === null && isNil(field.meta?.group))
 				)
 			);


### PR DESCRIPTION
## Description

Not all system fields we're being filtered before looping. This fix uses the `formFields` instead of the `fields` property for making the `fieldNames` array used in the field render loop.
Fixes #14568 

**Before**
![image](https://user-images.githubusercontent.com/9389634/180412576-8dfc1546-da2c-4319-a72b-ec65498673a8.png)

**After**
![image](https://user-images.githubusercontent.com/9389634/180412806-698efcbc-3f9c-43c2-b68f-da76cd5d938c.png)


## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
