### PR TITLE
Update pt-BR.yaml

### DIFF
--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -62,6 +62,7 @@ show_archived_items: Exibir Itens Arquivados
 show_all_items: Exibir Todos os Itens
 edited: Valor Editado
 required: Obrigatório
+require_value_to_be_set_on_creation: Exigir que o valor seja definido na criação
 required_for_app_access: Obrigatório para Acesso ao App
 requires_value: Requer valor
 create_preset: Criar Predefinição


### PR DESCRIPTION
Whenever a new field is created, there's no translation for the "require value to be set on creation". The translation to it should be "Exigir que o valor seja definido na criação".

## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ X] Other, please describe: translation

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
