### PR TITLE
Update pt-BR.yaml

### DIFF
--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -63,6 +63,7 @@ show_all_items: Exibir Todos os Itens
 edited: Valor Editado
 required: Obrigatório
 required_for_app_access: Obrigatório para Acesso ao App
+require_value_to_be_set_at_creation: Exigir que o valor seja definido na criação
 requires_value: Requer valor
 create_preset: Criar Predefinição
 create_panel: Criar Painel


### PR DESCRIPTION
## Description

<!--

Whenever a new field is created, there's no translation for the "require value to be set on creation". The translation to it should be "Exigir que o valor seja definido na criação".

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #
Whenever a new field is created, there's no translation for the "require value to be set on creation". The translation to it should be "Exigir que o valor seja definido na criação".

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [X ] Other, please describe: Translation to PT-BR
Whenever a new field is created, there's no translation for the "require value to be set on creation". The translation to it should be "Exigir que o valor seja definido na criação".

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [X ] Performed a self-review of the submitted code

If adding a new feature:

- [ X] Documentation was added/updated

![image](https://user-images.githubusercontent.com/108586700/180620913-c3311ba2-37d3-4c9d-ad50-0d30eaf22185.png)

