### PR TITLE
Update pt-BR.yaml

### DIFF
--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -64,6 +64,7 @@ edited: Valor Editado
 required: Obrigatório
 required_for_app_access: Obrigatório para Acesso ao App
 requires_value: Requer valor
+require_value_to_be_set_on_creation: Requer que valor seja definido na criação
 create_preset: Criar Predefinição
 create_panel: Criar Painel
 create_role: Criar Cargo


### PR DESCRIPTION
Whenever a new field is created, there's no translation for the "require value to be set on creation". The translation to it should be "Requer que valor seja definido na criação".

## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated
![image](https://user-images.githubusercontent.com/65249675/180621594-07f392d5-7e99-4ae0-9a5f-02e206551a00.png)
