### PR TITLE
Fix revisions drawer detail ref type

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -208,7 +208,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ComponentPublicInstance, computed, ref, unref, toRefs } from 'vue';
+import { computed, ref, unref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { useEditsGuard } from '@/composables/use-edits-guard';
@@ -248,7 +248,7 @@ const form = ref<HTMLElement>();
 const { collection, primaryKey } = toRefs(props);
 const { breadcrumb } = useBreadcrumb();
 
-const revisionsDrawerDetailRef = ref<ComponentPublicInstance | null>(null);
+const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
 const { info: collectionInfo, defaults, primaryKeyField, isSingleton, accountabilityScope } = useCollection(collection);
 

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -191,7 +191,7 @@ import ImageEditor from '@/views/private/components/image-editor.vue';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
 import { Field } from '@directus/shared/types';
-import { ComponentPublicInstance, computed, ref, toRefs, watch } from 'vue';
+import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import FileInfoSidebarDetail from '../components/file-info-sidebar-detail.vue';
@@ -214,7 +214,7 @@ const { primaryKey } = toRefs(props);
 const { breadcrumb } = useBreadcrumb();
 const replaceFileDialogActive = ref(false);
 
-const revisionsDrawerDetailRef = ref<ComponentPublicInstance | null>(null);
+const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
 const {
 	isNew,

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -182,7 +182,7 @@
 </template>
 
 <script lang="ts">
-import { ComponentPublicInstance, computed, defineComponent, ref, toRefs, watch } from 'vue';
+import { computed, defineComponent, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import api from '@/api';
@@ -237,7 +237,7 @@ export default defineComponent({
 
 		const { info: collectionInfo } = useCollection('directus_users');
 
-		const revisionsDrawerDetail = ref<ComponentPublicInstance | null>(null);
+		const revisionsDrawerDetail = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
 		const {
 			isNew,

--- a/app/src/views/private/components/revisions-drawer-detail.vue
+++ b/app/src/views/private/components/revisions-drawer-detail.vue
@@ -76,6 +76,10 @@ function openModal(id: number) {
 	modalCurrentRevision.value = id;
 	modalActive.value = true;
 }
+
+defineExpose({
+	refresh,
+});
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Description

### Before

The type of `revisionsDrawerDetailRef` were incorrect, hence affecting the type & autocomplete for the child method `refresh()`:

![Code_YgqAQC12U9](https://user-images.githubusercontent.com/42867097/180712879-c2a88b66-4701-4d51-8b86-72032228b4da.png)

### Solution

Uses the approach shared in the Vue.js docs' [Typing Component Template Refs](https://vuejs.org/guide/typescript/composition-api.html#typing-component-template-refs), which adds [defineExpose()](https://vuejs.org/api/sfc-script-setup.html#defineexpose) and uses `InstanceType<typeof ComponentHere>`.

### After

![Code_pvNQo03hhA](https://user-images.githubusercontent.com/42867097/180712938-149c26b9-6643-4e2e-9e57-df8b64f37b20.png)


## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
