### PR TITLE
500 error when using scoped fields query when not applicable

### DIFF
--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -106,7 +106,7 @@ export default async function getASTFromQuery(
 
 		fields = await convertWildcards(parentCollection, fields);
 
-		if (!fields) return [];
+		if (!fields || !Array.isArray(fields)) return [];
 
 		const children: (NestedCollectionNode | FieldNode | FunctionFieldNode)[] = [];
 

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -259,7 +259,9 @@ export default async function getASTFromQuery(
 					relatedKey: schema.collections[relatedCollection].primary,
 					relation: relation,
 					query: getDeepQuery(deep?.[fieldKey] || {}),
-					children: await parseFields(relatedCollection, nestedFields as string[], deep?.[fieldKey] || {}),
+					children: Array.isArray(nestedFields)
+						? await parseFields(relatedCollection, nestedFields, deep?.[fieldKey] || {})
+						: [],
 				};
 
 				if (relationType === 'o2m' && !child!.query.sort) {

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -259,9 +259,7 @@ export default async function getASTFromQuery(
 					relatedKey: schema.collections[relatedCollection].primary,
 					relation: relation,
 					query: getDeepQuery(deep?.[fieldKey] || {}),
-					children: Array.isArray(nestedFields)
-						? await parseFields(relatedCollection, nestedFields, deep?.[fieldKey] || {})
-						: [],
+					children: await parseFields(relatedCollection, nestedFields as string[], deep?.[fieldKey] || {}),
 				};
 
 				if (relationType === 'o2m' && !child!.query.sort) {


### PR DESCRIPTION
## Description

This fix only prevents the 500 error from being thrown when scoped fields are used inappropriately and will gracefully ignore the scoped part when applied to non m2a fields.

Fixes #14607

I would have preferred to actually check the field type and perhaps throw a descriptive error but could not get that to work at this stage.

## before
`GET http://localhost:8055/items/collection_a?fields=test,author:languages.code`
```json
{
    "errors": [
        {
            "message": "fields is not iterable",
            "extensions": {
                "code": "INTERNAL_SERVER_ERROR",
                "stack": "TypeError: fields is not iterable\n    at parseFields (D:\\Directus\\triage-repo\\api\\src\\utils\\get-ast-from-query.ts:115:26)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at parseFields (D:\\Directus\\triage-repo\\api\\src\\utils\\get-ast-from-query.ts:262:16)\n    at getASTFromQuery (D:\\Directus\\triage-repo\\api\\src\\utils\\get-ast-from-query.ts:100:17)\n    at ItemsService.readByQuery (D:\\Directus\\triage-repo\\api\\src\\services\\items.ts:255:13)\n    at D:\\Directus\\triage-repo\\api\\src\\controllers\\items.ts:78:12"
            }
        }
    ]
}
```

## after
`GET http://localhost:8055/items/collection_a?fields=test,author:languages.code`
```json
{
    "data": [
        {
            "test": null,
            "author": "80510679-8186-4b12-b1b0-6504f34249a6"
        },
        {
            "test": null,
            "author": null
        },
        {
            "test": null,
            "author": null
        }
    ]
}
```
## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
