### PR TITLE
Support storages from extensions

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -61,6 +61,7 @@ import { registerAuthProviders } from './auth';
 import { Url } from './utils/url';
 import { getConfigFromEnv } from './utils/get-config-from-env';
 import { merge } from 'lodash';
+import { registerDrivers } from './storage';
 
 export default async function createApp(): Promise<express.Application> {
 	validateEnv(['KEY', 'SECRET']);
@@ -92,6 +93,8 @@ export default async function createApp(): Promise<express.Application> {
 
 	await extensionManager.initialize();
 	await flowManager.initialize();
+
+	registerDrivers();
 
 	const app = express();
 

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -8,12 +8,12 @@ import sharp from 'sharp';
 import getDatabase from '../database';
 import env from '../env';
 import { IllegalAssetTransformation, RangeNotSatisfiableException, ForbiddenException } from '../exceptions';
-import storage from '../storage';
 import { AbstractServiceOptions, File, Transformation, TransformationParams, TransformationPreset } from '../types';
 import { Accountability } from '@directus/shared/types';
 import { AuthorizationService } from './authorization';
 import * as TransformationUtils from '../utils/transformations';
 import validateUUID from 'uuid-validate';
+import storage from '../storage';
 
 sharp.concurrency(1);
 
@@ -154,11 +154,12 @@ export class AssetsService {
 
 				transforms.forEach(([method, ...args]) => (transformer[method] as any).apply(transformer, args));
 
-				await storage.disk(file.storage).put(assetFilename, readStream.pipe(transformer), type);
+				const response = await storage.disk(file.storage).put(assetFilename, readStream.pipe(transformer), type);
+				const assetLocation = response.location;
 
 				return {
-					stream: storage.disk(file.storage).getStream(assetFilename, range),
-					stat: await storage.disk(file.storage).getStat(assetFilename),
+					stream: storage.disk(file.storage).getStream(assetLocation, range),
+					stat: await storage.disk(file.storage).getStat(assetLocation),
 					file,
 				};
 			});

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -68,19 +68,21 @@ export class FilesService extends ItemsService {
 			payload.type = 'application/octet-stream';
 		}
 
+		let fileLocation;
 		try {
-			await storage.disk(data.storage).put(payload.filename_disk, stream, payload.type);
+			const response = await storage.disk(data.storage).put(payload.filename_disk, stream, payload.type);
+			fileLocation = response.location;
 		} catch (err: any) {
 			logger.warn(`Couldn't save file ${payload.filename_disk}`);
 			logger.warn(err);
 			throw new ServiceUnavailableException(`Couldn't save file ${payload.filename_disk}`, { service: 'files' });
 		}
 
-		const { size } = await storage.disk(data.storage).getStat(payload.filename_disk);
+		const { size } = await storage.disk(data.storage).getStat(fileLocation);
 		payload.filesize = size;
 
 		if (['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/tiff'].includes(payload.type)) {
-			const buffer = await storage.disk(data.storage).getBuffer(payload.filename_disk);
+			const buffer = await storage.disk(data.storage).getBuffer(fileLocation);
 			const { height, width, description, title, tags, metadata } = await this.getMetadata(buffer.content);
 
 			payload.height ??= height;

--- a/packages/drive-azure/src/AzureBlobWebServices.ts
+++ b/packages/drive-azure/src/AzureBlobWebServices.ts
@@ -5,6 +5,7 @@ import {
 	SignedUrlOptions,
 	Response,
 	ExistsResponse,
+	PutResponse,
 	ContentResponse,
 	SignedUrlResponse,
 	StatResponse,
@@ -217,23 +218,23 @@ export class AzureBlobWebServicesStorage extends Storage {
 		location: string,
 		content: Buffer | NodeJS.ReadableStream | string,
 		type?: string
-	): Promise<Response> {
-		location = this._fullPath(location);
+	): Promise<PutResponse> {
+		const locationFullPath = this._fullPath(location);
 
-		const blockBlobClient = this.$containerClient.getBlockBlobClient(location);
+		const blockBlobClient = this.$containerClient.getBlockBlobClient(locationFullPath);
 
 		try {
 			if (isReadableStream(content)) {
 				const result = await blockBlobClient.uploadStream(content as Readable, undefined, undefined, {
 					blobHTTPHeaders: { blobContentType: type ?? 'application/octet-stream' },
 				});
-				return { raw: result };
+				return { location, raw: result };
 			}
 
 			const result = await blockBlobClient.upload(content, content.length);
-			return { raw: result };
+			return { location, raw: result };
 		} catch (e: any) {
-			throw handleError(e, location);
+			throw handleError(e, locationFullPath);
 		}
 	}
 

--- a/packages/drive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/drive-gcs/src/GoogleCloudStorage.ts
@@ -12,6 +12,7 @@ import {
 	pipeline,
 	Response,
 	ExistsResponse,
+	PutResponse,
 	ContentResponse,
 	SignedUrlResponse,
 	SignedUrlOptions,
@@ -221,18 +222,18 @@ export class GoogleCloudStorage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
+	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<PutResponse> {
 		const file = this._file(location);
 
 		try {
 			if (isReadableStream(content)) {
 				const destStream = file.createWriteStream({ resumable: false });
 				await pipeline(content, destStream);
-				return { raw: undefined };
+				return { location, raw: undefined };
 			}
 
 			const result = await file.save(content, { resumable: false });
-			return { raw: result };
+			return { location, raw: result };
 		} catch (e: any) {
 			throw handleError(e, location);
 		}

--- a/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/drive-s3/src/AmazonWebServicesS3Storage.ts
@@ -8,6 +8,7 @@ import {
 	SignedUrlOptions,
 	Response,
 	ExistsResponse,
+	PutResponse,
 	ContentResponse,
 	SignedUrlResponse,
 	StatResponse,
@@ -251,11 +252,11 @@ export class AmazonWebServicesS3Storage extends Storage {
 		location: string,
 		content: Buffer | NodeJS.ReadableStream | string,
 		type?: string
-	): Promise<Response> {
-		location = this._fullPath(location);
+	): Promise<PutResponse> {
+		const locationFullPath = this._fullPath(location);
 
 		const params = {
-			Key: location,
+			Key: locationFullPath,
 			Body: content,
 			Bucket: this.$bucket,
 			ACL: this.$acl,
@@ -264,9 +265,9 @@ export class AmazonWebServicesS3Storage extends Storage {
 
 		try {
 			const result = await this.$driver.upload(params).promise();
-			return { raw: result };
+			return { location, raw: result };
 		} catch (e: any) {
-			throw handleError(e, location, this.$bucket);
+			throw handleError(e, locationFullPath, this.$bucket);
 		}
 	}
 

--- a/packages/drive/src/LocalFileSystemStorage.ts
+++ b/packages/drive/src/LocalFileSystemStorage.ts
@@ -12,6 +12,7 @@ import {
 	FileListResponse,
 	DeleteResponse,
 	Range,
+	PutResponse,
 } from './types';
 
 function handleError(err: Error & { code: string; path?: string }, location: string): Error {
@@ -183,7 +184,7 @@ export class LocalFileSystemStorage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
+	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<PutResponse> {
 		const fullPath = this._fullPath(location);
 
 		try {
@@ -192,11 +193,11 @@ export class LocalFileSystemStorage extends Storage {
 				await fse.ensureDir(dir);
 				const ws = fse.createWriteStream(fullPath);
 				await pipeline(content, ws);
-				return { raw: undefined };
+				return { location, raw: undefined };
 			}
 
 			const result = await fse.outputFile(fullPath, content);
-			return { raw: result };
+			return { location, raw: result };
 		} catch (e: any) {
 			throw handleError(e, location);
 		}

--- a/packages/drive/src/Storage.ts
+++ b/packages/drive/src/Storage.ts
@@ -1,6 +1,7 @@
 import { MethodNotSupported } from './exceptions';
 import {
 	Response,
+	PutResponse,
 	SignedUrlResponse,
 	ContentResponse,
 	ExistsResponse,
@@ -131,7 +132,7 @@ export default abstract class Storage {
 	 *
 	 * Supported drivers: "local", "s3", "gcs", "azure"
 	 */
-	put(_location: string, _content: Buffer | NodeJS.ReadableStream | string, _type?: string): Promise<Response> {
+	put(_location: string, _content: Buffer | NodeJS.ReadableStream | string, _type?: string): Promise<PutResponse> {
 		throw new MethodNotSupported('put', this.constructor.name);
 	}
 

--- a/packages/drive/src/types.ts
+++ b/packages/drive/src/types.ts
@@ -28,6 +28,10 @@ export interface Response {
 	raw: unknown;
 }
 
+export interface PutResponse extends Response {
+	location: string;
+}
+
 export interface ExistsResponse extends Response {
 	exists: boolean;
 }

--- a/packages/extensions-sdk/templates/storage/javascript/src/index.js
+++ b/packages/extensions-sdk/templates/storage/javascript/src/index.js
@@ -1,0 +1,100 @@
+import { Storage } from '@directus/drive';
+
+export default class CustomStorage extends Storage {
+	/**
+	 * Appends content to a file.
+	 */
+	append(_location, _content) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Copy a file to a location.
+	 */
+	copy(_src, _dest) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Delete existing file.
+	 * The value returned by this method will have a `wasDeleted` property that
+	 * can be either a boolean (`true` if a file was deleted, `false` if there was
+	 * no file to delete) or `null` (if no information about the file is available).
+	 */
+	delete(_location) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the driver.
+	 */
+	driver() {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Determines if a file or folder already exists.
+	 */
+	exists(_location) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the file contents as a string.
+	 */
+	get(_location, _encoding) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the file contents as a Buffer.
+	 */
+	getBuffer(_location) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns signed url for an existing file.
+	 */
+	getSignedUrl(_location, _options) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns file's size and modification date.
+	 */
+	getStat(_location) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the stream for the given file.
+	 */
+	getStream(_location, _range) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns url for a given key. Note this method doesn't
+	 * validates the existence of file or it's visibility
+	 * status.
+	 */
+	getUrl(_location) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Move file to a new location.
+	 */
+	move(_src, _dest) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Creates a new file.
+	 * This method will create missing directories on the fly.
+	 */
+	put(_location, _content, _type) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Prepends content to a file.
+	 */
+	prepend(_location, _content) {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * List files with a given prefix.
+	 */
+	flatList(_prefix) {
+		throw new Error('Function not implemented.');
+	}
+}

--- a/packages/extensions-sdk/templates/storage/typescript/src/index.ts
+++ b/packages/extensions-sdk/templates/storage/typescript/src/index.ts
@@ -1,0 +1,109 @@
+import { Storage } from '@directus/drive';
+import {
+	ContentResponse,
+	DeleteResponse,
+	ExistsResponse,
+	FileListResponse,
+	SignedUrlOptions,
+	SignedUrlResponse,
+	StatResponse,
+} from '@directus/drive';
+
+export default class CustomStorage extends Storage {
+	/**
+	 * Appends content to a file.
+	 */
+	append(_location: string, _content: Buffer | string): Promise<Response> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Copy a file to a location.
+	 */
+	copy(_src: string, _dest: string): Promise<Response> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Delete existing file.
+	 * The value returned by this method will have a `wasDeleted` property that
+	 * can be either a boolean (`true` if a file was deleted, `false` if there was
+	 * no file to delete) or `null` (if no information about the file is available).
+	 */
+	delete(_location: string): Promise<DeleteResponse> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the driver.
+	 */
+	driver(): unknown {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Determines if a file or folder already exists.
+	 */
+	exists(_location: string): Promise<ExistsResponse> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the file contents as a string.
+	 */
+	get(_location: string, _encoding?: string): Promise<ContentResponse<string>> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the file contents as a Buffer.
+	 */
+	getBuffer(_location: string): Promise<ContentResponse<Buffer>> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns signed url for an existing file.
+	 */
+	getSignedUrl(_location: string, _options?: SignedUrlOptions): Promise<SignedUrlResponse> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns file's size and modification date.
+	 */
+	getStat(_location: string): Promise<StatResponse> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns the stream for the given file.
+	 */
+	getStream(_location: string, _range?: Range): NodeJS.ReadableStream {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Returns url for a given key. Note this method doesn't
+	 * validates the existence of file or it's visibility
+	 * status.
+	 */
+	getUrl(_location: string): string {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Move file to a new location.
+	 */
+	move(_src: string, _dest: string): Promise<Response> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Creates a new file.
+	 * This method will create missing directories on the fly.
+	 */
+	put(_location: string, _content: Buffer | NodeJS.ReadableStream | string, _type?: string): Promise<Response> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * Prepends content to a file.
+	 */
+	prepend(_location: string, _content: Buffer | string): Promise<Response> {
+		throw new Error('Function not implemented.');
+	}
+	/**
+	 * List files with a given prefix.
+	 */
+	flatList(_prefix?: string): AsyncIterable<FileListResponse> {
+		throw new Error('Function not implemented.');
+	}
+}

--- a/packages/shared/src/constants/extensions.ts
+++ b/packages/shared/src/constants/extensions.ts
@@ -2,7 +2,7 @@ export const APP_SHARED_DEPS = ['@directus/extensions-sdk', 'vue', 'vue-router',
 export const API_SHARED_DEPS = ['directus'];
 
 export const APP_WITHOUT_HYBRID_EXTENSION_TYPES = ['interface', 'display', 'layout', 'module', 'panel'] as const;
-export const API_WITHOUT_HYBRID_EXTENSION_TYPES = ['hook', 'endpoint'] as const;
+export const API_WITHOUT_HYBRID_EXTENSION_TYPES = ['hook', 'endpoint', 'storage'] as const;
 export const HYBRID_EXTENSION_TYPES = ['operation'] as const;
 export const APP_EXTENSION_TYPES = [...APP_WITHOUT_HYBRID_EXTENSION_TYPES, ...HYBRID_EXTENSION_TYPES] as const;
 export const API_EXTENSION_TYPES = [...API_WITHOUT_HYBRID_EXTENSION_TYPES, ...HYBRID_EXTENSION_TYPES] as const;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -25,4 +25,5 @@ export * from './relations';
 export * from './schema';
 export * from './settings';
 export * from './shares';
+export * from './storages';
 export * from './users';

--- a/packages/shared/src/types/storages.ts
+++ b/packages/shared/src/types/storages.ts
@@ -1,0 +1,4 @@
+export type StorageConfig = {
+	id: string;
+	driver: any;
+};


### PR DESCRIPTION
## Description

Basic support of loading storages via extensions.

Notes:
- existing storages were modified to return a location on creation (using put()), because some storage APIs will return a generated location/id upon creation, which we sometimes can't specify
- please tell me if there is tests to make
- please tell me if I need to add some documentation

Fixes #3946

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [?] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [?] Documentation was added/updated
