### PR TITLE
Do not override current admin language when updating project default language

### DIFF
--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -5,6 +5,7 @@ import { setLanguage } from '@/lang/set-language';
 import formatTitle from '@directus/format-title';
 import { acceptHMRUpdate, defineStore } from 'pinia';
 import { computed, reactive, unref } from 'vue';
+import { useUserStore } from '@/stores/user';
 
 type Info = {
 	project: null | {
@@ -83,7 +84,11 @@ export const useServerStore = defineStore('serverStore', () => {
 		auth.providers = authResponse.data.data;
 		auth.disableDefault = authResponse.data.disableDefault;
 
-		await setLanguage(unref(info)?.project?.default_language ?? 'en-US');
+		const { currentUser } = useUserStore();
+
+		if (!currentUser?.language) {
+			await setLanguage(unref(info)?.project?.default_language ?? 'en-US');
+		}
 
 		if (serverInfoResponse.data.data?.rateLimit !== undefined) {
 			if (serverInfoResponse.data.data?.rateLimit === false) {


### PR DESCRIPTION
## Description

Fixes #14522

### Problem

When we update the project default language, the current admin's locale is updated to said language even when they already have another language configured. This lead to subsequent confusion when the language changes back to the user language upon refreshing the app:

https://user-images.githubusercontent.com/42867097/180957246-02d3d886-38dd-4da7-b037-bcd0a9a0d2dd.mp4

### Solution

Prevent setting the new default language as the locale when the current admin already has a configured language:

https://user-images.githubusercontent.com/42867097/180957510-128e57de-e5a8-4a35-9c9d-be6b48e4201c.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
