### PR TITLE
Add tests for translate-shortcut

### DIFF
--- a/app/src/utils/translate-shortcut.test.ts
+++ b/app/src/utils/translate-shortcut.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from 'vitest';
+
+import { translateShortcut } from '@/utils/translate-shortcut';
+
+test('Windows/Linux', () => {
+	window.navigator.platform = 'test';
+	expect(translateShortcut(['meta', 's'])).toBe('Ctrl+S');
+	expect(translateShortcut(['option', 's'])).toBe('Option+S');
+	expect(translateShortcut(['alt', 's'])).toBe('Alt+S');
+	expect(translateShortcut(['shift', 's'])).toBe('Shift+S');
+});
+
+test('macOS/iOS', () => {
+	window.navigator.platform = 'MacIntel';
+
+	expect(translateShortcut(['meta', 's'])).toBe('⌘S');
+	expect(translateShortcut(['option', 's'])).toBe('⌥S');
+	expect(translateShortcut(['alt', 's'])).toBe('⌥S');
+	expect(translateShortcut(['shift', 's'])).toBe('⇧S');
+
+	window.navigator.platform = 'iPad';
+
+	expect(translateShortcut(['meta', 's'])).toBe('⌘S');
+	expect(translateShortcut(['option', 's'])).toBe('⌥S');
+	expect(translateShortcut(['alt', 's'])).toBe('⌥S');
+	expect(translateShortcut(['shift', 's'])).toBe('⇧S');
+});


### PR DESCRIPTION
Add some basic unit tests to `translate-shortcut` util. 100% coverage