### PR TITLE
Cast values to string when matching in v-select

### DIFF
--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -302,7 +302,10 @@ export default defineComponent({
 						: isMatchingCurrentItem(item, searchValue);
 
 					function isMatchingCurrentItem(item: Record<string, any>, searchValue: string): boolean {
-						return item.text?.toLowerCase().includes(searchValue) || item.value?.toLowerCase().includes(searchValue);
+						return (
+							(item.text ? String(item.text).toLowerCase().includes(searchValue) : false) ||
+							(item.value ? String(item.value).toLowerCase().includes(searchValue) : false)
+						);
 					}
 				};
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #14683.
`item.text` and `item.value` can be set by users manually through the raw editor and may not be of string type.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
