### PR TITLE
Fix files interface's drawer download button

### DIFF
--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -260,6 +260,7 @@ function editItem(item: DisplayItem) {
 	if (!relationInfo.value) return;
 
 	const relationPkField = relationInfo.value.relatedPrimaryKeyField.field;
+	const junctionField = relationInfo.value.junctionField.field;
 	const junctionPkField = relationInfo.value.junctionPrimaryKeyField.field;
 
 	editsAtStart.value = item;
@@ -271,7 +272,7 @@ function editItem(item: DisplayItem) {
 		relatedPrimaryKey.value = null;
 	} else {
 		currentlyEditing.value = get(item, [junctionPkField], null);
-		relatedPrimaryKey.value = get(item, [junctionPkField, relationPkField], null);
+		relatedPrimaryKey.value = get(item, [junctionField, relationPkField], null);
 	}
 }
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #14686

Same solution used in #12840 for list-m2m and list-m2a.

The reason why the download button becomes a button instead of an `<a>` tag is because the downloadUrl was undefined due to `relatedPrimaryKey.value` being null:

https://github.com/directus/directus/blob/263ee74408a52fe6d302a004e38dd16d6e6e4055/app/src/interfaces/files/files.vue#L314-L317

### Before

https://user-images.githubusercontent.com/42867097/181185640-1bdc2fbf-655b-49b2-b2cf-fd50b7c97b1b.mp4

### After

https://user-images.githubusercontent.com/42867097/181185618-9eda2c40-6e24-4797-b9db-99a8bf182011.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
