### PR TITLE
Fix sort field assignment in relationships

### DIFF
--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -26,6 +26,14 @@ export type ChangesItem = {
 	delete: (string | number)[];
 };
 
+function getSortMax(...values: (number | null)[]) {
+	return values.reduce<null | number>((max, v) => {
+		if (max === null) return v;
+		if (v === null) return max;
+		return Math.max(max, v);
+	}, null);
+}
+
 export function useRelationMultiple(
 	value: Ref<Record<string, any> | any[] | undefined>,
 	previewQuery: Ref<RelationQueryMultiple>,
@@ -35,6 +43,7 @@ export function useRelationMultiple(
 	const loading = ref(false);
 	const fetchedItems = ref<Record<string, any>[]>([]);
 	const existingItemCount = ref(0);
+	const existingSortMax = ref<number | null>(null);
 
 	const { cleanItem, getPage, localDelete } = useUtil();
 
@@ -74,6 +83,18 @@ export function useRelationMultiple(
 		}
 
 		return existingItemCount.value + _value.value.create.length;
+	});
+
+	const totalSortMax = computed(() => {
+		const sortField = relation.value?.sortField;
+		if (!sortField) return null;
+
+		const createdSorts = _value.value.create.map((v) => v[sortField]);
+		if (relation.value?.type === 'o2m') {
+			return getSortMax(existingSortMax.value, ...createdSorts, ...selected.value.map((v) => v[sortField]));
+		}
+
+		return getSortMax(existingSortMax.value, ...createdSorts);
 	});
 
 	const createdItems = computed(() => {
@@ -177,6 +198,7 @@ export function useRelationMultiple(
 		select,
 		displayItems,
 		totalItemCount,
+		totalSortMax,
 		loading,
 		selected,
 		fetchedSelectItems,
@@ -191,8 +213,19 @@ export function useRelationMultiple(
 		return { create, update, remove, select, clear };
 
 		function create(...items: Record<string, any>[]) {
+			const sortField = relation.value?.sortField;
+
 			for (const item of items) {
-				target.value.create.push(cleanItem(item));
+				target.value.create.push(
+					cleanItem(
+						sortField && (item[sortField] === undefined || item[sortField] === null)
+							? {
+									...item,
+									[sortField]: (totalSortMax.value || 0) + 1,
+							  }
+							: item
+					)
+				);
 			}
 			updateValue();
 		}
@@ -345,6 +378,9 @@ export function useRelationMultiple(
 
 			await updateItemCount(targetCollection, targetPKField, reverseJunctionField);
 
+			const sortField = relation.value?.sortField;
+			if (sortField) await updateSortMax(targetCollection, sortField, reverseJunctionField);
+
 			const response = await api.get(getEndpoint(targetCollection), {
 				params: {
 					fields: Array.from(fields),
@@ -377,6 +413,21 @@ export function useRelationMultiple(
 		});
 
 		existingItemCount.value = Number(response.data.data[0].count[targetPKField]);
+	}
+
+	async function updateSortMax(targetCollection: string, sortField: string, reverseJunctionField: string) {
+		const response = await api.get(getEndpoint(targetCollection), {
+			params: {
+				aggregate: {
+					max: sortField,
+				},
+				filter: {
+					[reverseJunctionField]: itemId.value,
+				},
+			},
+		});
+
+		existingSortMax.value = response.data.data[0].max[sortField] as number | null;
 	}
 
 	function useSelected() {


### PR DESCRIPTION
## Description

Fixes #11430 and related issues. 

There have been other reports of the same issue (#4280 for M2A, #10657 for O2M, #6111 for M2M) which have been addressed in individual PRs addressing a specific relationship type (#4294 M2A, #10703 for M2M). Since then the issue reappeared and more fixes were suggested (#9832, and recently #12506). 

The proposed solution here is generic:
 * Logic is implemented in `useRelationMultiple` which is used in all relationship interfaces.
 * Uses an aggregation to fetch the current maximum and then keeps track of the changes made (analogous to `totalItemCount`).
 * New items will always be inserted at the end.
 * Manual sort field assignments are kept.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
