### PR TITLE
Fix fallback icon styling for interfaces

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -14,7 +14,7 @@
 					<div class="preview">
 						<template v-if="inter.preview">
 							<!-- eslint-disable-next-line vue/no-v-html -->
-							<span v-if="isSVG(inter.preview)" v-html="inter.preview" />
+							<span v-if="isSVG(inter.preview)" class="svg" v-html="inter.preview" />
 							<img v-else :src="inter.preview" alt="" />
 						</template>
 
@@ -222,7 +222,7 @@ export default defineComponent({
 	object-fit: cover;
 }
 
-.preview span {
+.preview .svg {
 	display: contents;
 }
 


### PR DESCRIPTION
## Description

`.preview span` was targeting the fallback span as well:

```vue
<span v-else class="fallback">
  <v-icon large :name="inter.icon" />
</span>
```

even though (I believe) it's meant to target the span within the v-if:

```vue
<span v-if="isSVG(inter.preview)" v-html="inter.preview" />
```

So I added a class to the latter as the target to prevent it from affecting the fallback span.

| Before                                                                                                                      | After                                                                                                                       |
| --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| ![chrome_hsz5y93Ugd](https://user-images.githubusercontent.com/42867097/181195357-66dcd925-7a22-4200-91af-9f0d2a8c9de2.png) | ![chrome_Tmx16yeTR4](https://user-images.githubusercontent.com/42867097/181195371-859d1bf1-aa19-4ac2-894d-0096c38e7944.png) |

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
