### PR TITLE
Fix exported fields reactivity in export drawer

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -282,6 +282,15 @@ const exportSettings = reactive({
 });
 
 watch(
+	fields,
+	() => {
+		if (props.layoutQuery?.fields) return;
+		exportSettings.fields = fields.value?.map((field) => field.field);
+	},
+	{ immediate: true }
+);
+
+watch(
 	() => props.layoutQuery,
 	() => {
 		exportSettings.limit = props.layoutQuery?.limit ?? 25;


### PR DESCRIPTION
## Description

Fixes #14660

Previously #12715 was meant to fix this by watching `props.layoutQuery`:

https://github.com/directus/directus/blob/263ee74408a52fe6d302a004e38dd16d6e6e4055/app/src/views/private/components/export-sidebar-detail.vue#L289-L291

however it was not accounting for when there is _no_ presets, thus `layoutQuery` will always be null, so the exported fields will stay the same.

Added watcher to computed ref `fields` from:

https://github.com/directus/directus/blob/263ee74408a52fe6d302a004e38dd16d6e6e4055/app/src/views/private/components/export-sidebar-detail.vue#L274 

Also return early to not update the fields when there is layoutQuery fields (based on user's current preset/bookmark).

### Before

https://user-images.githubusercontent.com/42867097/181231683-af5844e5-109b-435b-92a5-c2f3235d6f50.mp4

## After

https://user-images.githubusercontent.com/42867097/181230906-7962054f-2257-4b60-a8aa-821994b3ce8a.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
