### PR TITLE
Input and textarea fields are always getting trimmed

### DIFF
--- a/app/src/interfaces/input-multiline/input-multiline.vue
+++ b/app/src/interfaces/input-multiline/input-multiline.vue
@@ -45,7 +45,7 @@ export default defineComponent({
 		},
 		trim: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		font: {
 			type: String as PropType<'sans-serif' | 'serif' | 'monospace'>,

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -72,7 +72,7 @@ export default defineComponent({
 		},
 		trim: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		font: {
 			type: String as PropType<'sans-serif' | 'serif' | 'monospace'>,


### PR DESCRIPTION
## Description

Because the interface settings are saved to the database as `null` when sticking to the defaults this was getting overwritten by the `input` and `textarea` property defaults which were set to `trim=true`. 
I've opted to update the component default properties to be in sync with the interface options defaults.


Fixes #14702 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
