### PR TITLE
Add tailwind option to create-extension.

### DIFF
--- a/packages/create-directus-extension/lib/index.js
+++ b/packages/create-directus-extension/lib/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const inquirer = require('inquirer');
-const { EXTENSION_TYPES, EXTENSION_LANGUAGES } = require('@directus/shared/constants');
+const { EXTENSION_TYPES, EXTENSION_LANGUAGES, APP_OR_HYBRID_EXTENSION_TYPES } = require('@directus/shared/constants');
 const { create } = require('@directus/extensions-sdk/cli');
 
 run();
@@ -11,7 +11,7 @@ async function run() {
 	// eslint-disable-next-line no-console
 	console.log('This utility will walk you through creating a Directus extension.\n');
 
-	const { type, name, language } = await inquirer.prompt([
+	const { type, name, language, tailwind } = await inquirer.prompt([
 		{
 			type: 'list',
 			name: 'type',
@@ -29,7 +29,14 @@ async function run() {
 			message: 'Choose the language to use',
 			choices: EXTENSION_LANGUAGES,
 		},
+		{
+			type: 'confirm',
+			name: 'tailwind',
+			message: 'Bootstrap with tailwindcss?',
+			default: false,
+			when: ({ type }) => APP_OR_HYBRID_EXTENSION_TYPES.includes(type),
+		},
 	]);
 
-	await create(type, name, { language });
+	await create(type, name, { language, tailwind });
 }

--- a/packages/extensions-sdk/src/cli/run.ts
+++ b/packages/extensions-sdk/src/cli/run.ts
@@ -14,6 +14,7 @@ program
 	.arguments('<type> <name>')
 	.description('Scaffold a new Directus extension')
 	.option('-l, --language <language>', 'specify the language to use', 'javascript')
+	.option('-tw, --tailwind', 'include tailwindcss in the extension')
 	.action(create);
 
 program

--- a/packages/extensions-sdk/templates/common/tailwindcss/postcss.config.js
+++ b/packages/extensions-sdk/templates/common/tailwindcss/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {},
+	},
+};

--- a/packages/extensions-sdk/templates/common/tailwindcss/src/styles.css
+++ b/packages/extensions-sdk/templates/common/tailwindcss/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/extensions-sdk/templates/common/tailwindcss/tailwind.config.js
+++ b/packages/extensions-sdk/templates/common/tailwindcss/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+	content: ['./src/**/*.{vue,js,ts,jsx,tsx}'],
+	theme: {
+		extend: {},
+	},
+	corePlugins: {
+		preflight: false,
+	},
+	plugins: [],
+};


### PR DESCRIPTION
## Description

Add an option for bootstraping UI extensions with tailwindcss.

Supports purging, (so only what tailwind classes you use in extension will be included in build)

Disabled preflight so it doesn't reset any styles by Directus.

![tailwind-support](https://user-images.githubusercontent.com/6641242/181475024-b53d265b-98eb-426b-9d31-3ad330ad9b39.gif)


## Type of Change

- [ ] Bugfix
- [x] Improvement
- [x] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:
