### PR TITLE
Support running prod locally through ./api/cli.js

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -179,7 +179,7 @@ export default async function createApp(): Promise<express.Application> {
 	});
 
 	if (env.SERVE_APP) {
-		const adminPath = require.resolve('@directus/app');
+		const adminPath = require.resolve('@directus/app', require.main ? { paths: [require.main.filename] } : undefined);
 		const adminUrl = new Url(env.PUBLIC_URL).addPath('admin');
 
 		// Set the App's base path according to the APIs public URL

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -310,7 +310,9 @@ class ExtensionManager {
 	}
 
 	private async getSharedDepsMapping(deps: string[]) {
-		const appDir = await fse.readdir(path.join(resolvePackage('@directus/app'), 'dist', 'assets'));
+		const appDir = await fse.readdir(
+			path.join(resolvePackage('@directus/app', require.main?.filename), 'dist', 'assets')
+		);
 
 		const depsMapping: Record<string, string> = {};
 		for (const dep of deps) {


### PR DESCRIPTION
## Description

`./api/cli.js <command>` used to work, as it would resolve to the `dist` folders. Since the switch to `pnpm`, this throws an error, as `pnpm` incorrectly resolves the `@directus/app` package. This PR fixes that by resolving the package import from the current require context.

Fixes #14706

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Not really a bug, as 14706 was never officially supported. This aims to actually support that.

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
