### PR TITLE
Always transform rollup-styles plugin. 

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -395,13 +395,16 @@ function getRollupOptions({
 	plugins: Plugin[];
 }): RollupOptions {
 	if (mode === 'browser') {
+		const stylesPlugin = styles();
+		stylesPlugin.shouldTransformCachedModule = () => true;
+
 		return {
 			input,
 			external: APP_SHARED_DEPS,
 			plugins: [
 				vue({ preprocessStyles: true }),
 				language === 'typescript' ? typescript({ check: false }) : null,
-				styles(),
+				stylesPlugin,
 				...plugins,
 				nodeResolve({ browser: true }),
 				commonjs({ esmExternals: true, sourceMap: sourcemap }),


### PR DESCRIPTION
Fixes styles not updating during watch.

At first I thought it was a tailwind/postcss issue, but found out in the end it that the styles-plugin was being cached and not being transformed again on every change.

![beforeFix14739](https://user-images.githubusercontent.com/6641242/181722127-e0bfbd52-2b55-4939-b241-fec0fb030419.gif)

![afterFix](https://user-images.githubusercontent.com/6641242/181721951-eb019afd-81cf-445a-b295-b57ed43bc2cb.gif)

Fixes #14739 

## Type of Change

- [x] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [ ] Performed a self-review of the submitted code