### PR TITLE
Fix Emit Events for item CRUD operations in Flows

### DIFF
--- a/api/src/operations/item-create/index.ts
+++ b/api/src/operations/item-create/index.ts
@@ -42,7 +42,7 @@ export default defineOperationApi<Options>({
 		if (!payloadObject) {
 			result = null;
 		} else {
-			result = await itemsService.createMany(toArray(payloadObject), { emitEvents });
+			result = await itemsService.createMany(toArray(payloadObject), { emitEvents: !!emitEvents });
 		}
 
 		return result;

--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -47,9 +47,9 @@ export default defineOperationApi<Options>({
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.deleteOne(keys[0], { emitEvents });
+				result = await itemsService.deleteOne(keys[0], { emitEvents: !!emitEvents });
 			} else {
-				result = await itemsService.deleteMany(keys, { emitEvents });
+				result = await itemsService.deleteMany(keys, { emitEvents: !!emitEvents });
 			}
 		}
 

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -48,9 +48,9 @@ export default defineOperationApi<Options>({
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.readOne(keys[0], sanitizedQueryObject, { emitEvents });
+				result = await itemsService.readOne(keys[0], sanitizedQueryObject, { emitEvents: !!emitEvents });
 			} else {
-				result = await itemsService.readMany(keys, sanitizedQueryObject, { emitEvents });
+				result = await itemsService.readMany(keys, sanitizedQueryObject, { emitEvents: !!emitEvents });
 			}
 		}
 

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -53,14 +53,14 @@ export default defineOperationApi<Options>({
 		let result: PrimaryKey | PrimaryKey[] | null;
 
 		if (!key || (Array.isArray(key) && key.length === 0)) {
-			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents });
+			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
 		} else {
 			const keys = toArray(key);
 
 			if (keys.length === 1) {
-				result = await itemsService.updateOne(keys[0], payloadObject, { emitEvents });
+				result = await itemsService.updateOne(keys[0], payloadObject, { emitEvents: !!emitEvents });
 			} else {
-				result = await itemsService.updateMany(keys, payloadObject, { emitEvents });
+				result = await itemsService.updateMany(keys, payloadObject, { emitEvents: !!emitEvents });
 			}
 		}
 


### PR DESCRIPTION
## Description

Fixes the issue brought up in discussion #14720

Since the default value for Emit Events in the app is `false`, the option was never passed to the API.  However, this meant the `{ emitEvents }` here:

https://github.com/directus/directus/blob/6c77b8d00379c2068769c302601cf799667c1c6b/api/src/operations/item-update/index.ts#L56

will still be sent as `{ emitEvents: undefined }`, which still satisfies the logic here:

https://github.com/directus/directus/blob/6c77b8d00379c2068769c302601cf799667c1c6b/api/src/services/items.ts#L429

so _not_ sending emitEvents turns out to still make it true as well.

Since the typical usage in other places is `{ emitEvents: false }` to opt out of emitting event:

https://github.com/directus/directus/blob/6c77b8d00379c2068769c302601cf799667c1c6b/api/src/services/files.ts#L49

This PR uses double negation to turn `!!undefined` to `false`, which prevents it from firing.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
