### PR TITLE
Make DrawerItem, DrawerBatch global components

### DIFF
--- a/app/src/components/register.ts
+++ b/app/src/components/register.ts
@@ -5,6 +5,8 @@ import SidebarDetail from '@/views/private/components/sidebar-detail.vue';
 import UserPopover from '@/views/private/components/user-popover.vue';
 import ValueNull from '@/views/private/components/value-null.vue';
 import DocsWrapper from '@/views/private/components/docs-wrapper.vue';
+import DrawerItem from '@/views/private/components/drawer-item.vue';
+import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import { App } from 'vue';
 import TransitionBounce from './transition/bounce';
 import TransitionDialog from './transition/dialog';
@@ -145,4 +147,6 @@ export function registerComponents(app: App): void {
 	app.component('UserPopover', UserPopover);
 	app.component('ValueNull', ValueNull);
 	app.component('DocsWrapper', DocsWrapper);
+	app.component('DrawerItem', DrawerItem);
+	app.component('DrawerBatch', DrawerBatch);
 }

--- a/app/src/views/register.ts
+++ b/app/src/views/register.ts
@@ -3,13 +3,9 @@ import PublicView from './public/';
 import SharedView from './shared/shared-view.vue';
 
 const PrivateView = defineAsyncComponent(() => import('./private'));
-const DrawerItem = defineAsyncComponent(() => import('./private/components/drawer-item.vue'));
-const DrawerBatch = defineAsyncComponent(() => import('./private/components/drawer-batch.vue'));
 
 export function registerViews(app: App): void {
 	app.component('PublicView', PublicView);
 	app.component('PrivateView', PrivateView);
 	app.component('SharedView', SharedView);
-	app.component('DrawerItem', DrawerItem);
-	app.component('DrawerBatch', DrawerBatch);
 }

--- a/app/src/views/register.ts
+++ b/app/src/views/register.ts
@@ -3,9 +3,13 @@ import PublicView from './public/';
 import SharedView from './shared/shared-view.vue';
 
 const PrivateView = defineAsyncComponent(() => import('./private'));
+const DrawerItem = defineAsyncComponent(() => import('./private/components/drawer-item.vue'));
+const DrawerBatch = defineAsyncComponent(() => import('./private/components/drawer-batch.vue'));
 
 export function registerViews(app: App): void {
 	app.component('PublicView', PublicView);
 	app.component('PrivateView', PrivateView);
 	app.component('SharedView', SharedView);
+	app.component('DrawerItem', DrawerItem);
+	app.component('DrawerBatch', DrawerBatch);
 }


### PR DESCRIPTION
## Description

It is very comfortable to use this private views in custom extensions, like custom modules, created a different way of looking at collections, but use the same drawers for editing. Are there will be some breaking changes with this views for extensions?
Like was said here? https://github.com/directus/directus/discussions/13139
Tested it with my custom npm package for "@directus/app".

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
