### PR TITLE
Do not show inactive manual flows in flows sidebar

### DIFF
--- a/app/src/stores/flows.ts
+++ b/app/src/stores/flows.ts
@@ -32,7 +32,10 @@ export const useFlowsStore = defineStore({
 			this.$reset();
 		},
 		getManualFlowsForCollection(collection: string): FlowRaw[] {
-			return this.flows.filter((flow) => flow.trigger === 'manual' && flow.options?.collections?.includes(collection));
+			return this.flows.filter(
+				(flow) =>
+					flow.trigger === 'manual' && flow.status === 'active' && flow.options?.collections?.includes(collection)
+			);
 		},
 	},
 });


### PR DESCRIPTION
## Description

Currently the Flows sidebar in collections/items still shows inactive manual flows, which will (correctly) error out when clicked:

https://user-images.githubusercontent.com/42867097/182086795-f37ed2e8-e4ba-491d-a62a-dccfbe0dda62.mp4

This PR ensures only _active_ manual flows will be shown.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
