### PR TITLE
Comments not getting loaded properly

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -179,7 +179,13 @@
 				<div v-md="t('page_help_collections_item')" class="page-description" />
 			</sidebar-detail>
 			<revisions-drawer-detail
-				v-if="isNew === false && internalPrimaryKey && revisionsAllowed && accountabilityScope === 'all'"
+				v-if="
+					isNew === false &&
+					loading === false &&
+					internalPrimaryKey &&
+					revisionsAllowed &&
+					accountabilityScope === 'all'
+				"
 				ref="revisionsDrawerDetailRef"
 				:collection="collection"
 				:primary-key="internalPrimaryKey"
@@ -187,18 +193,18 @@
 				@revert="revert"
 			/>
 			<comments-sidebar-detail
-				v-if="isNew === false && internalPrimaryKey"
+				v-if="isNew === false && loading === false && internalPrimaryKey"
 				:collection="collection"
 				:primary-key="internalPrimaryKey"
 			/>
 			<shares-sidebar-detail
-				v-if="isNew === false && internalPrimaryKey"
+				v-if="isNew === false && loading === false && internalPrimaryKey"
 				:collection="collection"
 				:primary-key="internalPrimaryKey"
 				:allowed="shareAllowed"
 			/>
 			<flow-sidebar-detail
-				v-if="isNew === false && internalPrimaryKey"
+				v-if="isNew === false && loading === false && internalPrimaryKey"
 				location="item"
 				:collection="collection"
 				:primary-key="internalPrimaryKey"


### PR DESCRIPTION
## Description

As Azri mentioned the `internalPrimaryKey` defaults to `+` when still loading which is passed to the sidebar components. 
This solution waits for the item to be fully loaded and the `internalPrimaryKey` correctly updated before rendering the sidebar components.

Fixes #14608


## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
