### PR TITLE
Do not report utf8mb4_bin inconsistencies on MariaDB

### DIFF
--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -273,7 +273,7 @@ async function validateDatabaseCharset(database?: Knex): Promise<void> {
 
 	if (getDatabaseClient(database) === 'mysql') {
 		const { version } = await database.select(database.raw('VERSION() as version')).first();
-		const isMariaDB = version.split('-').includes('MariaDB')
+		const isMariaDB = version.split('-').includes('MariaDB');
 
 		const { collation } = await database.select(database.raw(`@@collation_database as collation`)).first();
 


### PR DESCRIPTION
## Description

When database column with `json` type is created on MariaDB, in reality it's type becomes `LONGTEXT` and it's collation becomes `utf8mb4_bin`.
This is reported by Directus as a mismatch with default database collation.

This PR skips columns inconsistency checks when conditions described above are met.

As far as I know AWS RDS/ Aurora instances are using MariaDB (not MySQL) so this issue comes up for every AWS installation.

I'm not sure if this is proper way to handle the issue, but it's something to start with.

For more information, see:
- MariaDB > [JSON Data Type](https://mariadb.com/kb/en/json-data-type/))
- MariaDB > [Making MariaDB understand MySQL JSON](https://mariadb.org/making-mariadb-understand-mysql-json/)

Fixes #11786

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code
