### PR TITLE
Nested forms get out of sync on unset

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -387,7 +387,11 @@ export default defineComponent({
 
 			if (field.field in (props.modelValue || {})) {
 				const newEdits = { ...props.modelValue };
-				delete newEdits[field.field];
+				if (field.field in props.initialValues) {
+					newEdits[field.field] = props.initialValues[field.field];
+				} else {
+					delete newEdits[field.field];
+				}
 				emit('update:modelValue', newEdits);
 			}
 		}


### PR DESCRIPTION
## Description

When undoing changes the value was getting deleted and emitted with the assumption that the value would default back to the `initialValue` which was not happening.
The solution chosen here is to explicitly emit the initialValue back to the root `v-form` if it exists else fall back to deleting the value.

Fixes #14495 

Sidenote:
I found a bug where the drawer v-form is marking all fields as edited while they're not. It's a bit out of the scope of this pr so i'll create a separate one for that

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
