### PR TITLE
Fix typo for operation component in OAS

### DIFF
--- a/packages/specs/src/components/operation.yaml
+++ b/packages/specs/src/components/operation.yaml
@@ -25,11 +25,11 @@ properties:
     example: null
     nullable: true
   position_x:
-    descripton: Position of the operation on the X axis within the flow workspace.
+    description: Position of the operation on the X axis within the flow workspace.
     type: integer
     example: 12
   position_y:
-    descripton: Position of the operation on the Y axis within the flow workspace.
+    description: Position of the operation on the Y axis within the flow workspace.
     type: integer
     example: 12
   date_created:


### PR DESCRIPTION
## Description

Fixes typo causing structural error for generated OAS:

![image](https://user-images.githubusercontent.com/42867097/182370609-df21224f-a05c-40ee-ab26-f2dcc0579b3c.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
