### PR TITLE
Move serializers option to the right place for pino-http

### DIFF
--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -46,19 +46,17 @@ const logger = pino(Object.assign(pinoOptions, loggerEnvConfig));
 
 const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', ['LOGGER_HTTP_LOGGER']);
 
-export const expressLogger = pinoHTTP(
-	{
-		logger,
-		...httpLoggerEnvConfig,
-		serializers: {
-			req(request: Request) {
-				const output = stdSerializers.req(request);
-				output.url = redactQuery(output.url);
-				return output;
-			},
+export const expressLogger = pinoHTTP({
+	logger,
+	...httpLoggerEnvConfig,
+	serializers: {
+		req(request: Request) {
+			const output = stdSerializers.req(request);
+			output.url = redactQuery(output.url);
+			return output;
 		},
-	}
-) as RequestHandler;
+	},
+}) as RequestHandler;
 
 export default logger;
 

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -50,8 +50,6 @@ export const expressLogger = pinoHTTP(
 	{
 		logger,
 		...httpLoggerEnvConfig,
-	},
-	{
 		serializers: {
 			req(request: Request) {
 				const output = stdSerializers.req(request);


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

According to the pino-http [documentation](https://github.com/pinojs/pino-http#custom-serializers), the current serializers for the loggerExpress middleware is not set in the proper place. This issue causes showing the  access_token from the logged request all the time. 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
