### PR TITLE
Exclude relationship fields on field validation

### DIFF
--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -36,11 +36,13 @@ interface Props {
 	field?: string;
 	disabledFields?: string[];
 	includeFunctions?: boolean;
+	excludeRelations?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
 	disabledFields: () => [],
 	includeFunctions: false,
+	excludeRelations: false,
 	field: undefined,
 });
 
@@ -48,7 +50,7 @@ defineEmits(['select-field']);
 
 const fieldsStore = useFieldsStore();
 
-const { collection } = toRefs(props);
+const { collection, excludeRelations } = toRefs(props);
 
 const fieldsCount = computed(() => fieldsStore.getFieldsForCollection(collection.value)?.length ?? 0);
 
@@ -85,6 +87,7 @@ const treeList = computed(() => {
 });
 
 function filter(field: Field): boolean {
+	if (excludeRelations.value && (field.collection !== collection.value || field.type === 'alias')) return false;
 	if (!search.value) return true;
 	const children = fieldsStore.getFieldGroupChildren(collection.value, field.field);
 	return children?.some((field) => matchesSearch(field)) || matchesSearch(field);

--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -36,13 +36,13 @@ interface Props {
 	field?: string;
 	disabledFields?: string[];
 	includeFunctions?: boolean;
-	excludeRelations?: boolean;
+	includeRelations?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
 	disabledFields: () => [],
 	includeFunctions: false,
-	excludeRelations: false,
+	includeRelations: true,
 	field: undefined,
 });
 
@@ -50,7 +50,7 @@ defineEmits(['select-field']);
 
 const fieldsStore = useFieldsStore();
 
-const { collection, excludeRelations } = toRefs(props);
+const { collection, includeRelations } = toRefs(props);
 
 const fieldsCount = computed(() => fieldsStore.getFieldsForCollection(collection.value)?.length ?? 0);
 
@@ -87,7 +87,7 @@ const treeList = computed(() => {
 });
 
 function filter(field: Field): boolean {
-	if (excludeRelations.value && (field.collection !== collection.value || field.type === 'alias')) return false;
+	if (!includeRelations.value && (field.collection !== collection.value || field.type === 'alias')) return false;
 	if (!search.value) return true;
 	const children = fieldsStore.getFieldGroupChildren(collection.value, field.field);
 	return children?.some((field) => matchesSearch(field)) || matchesSearch(field);

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -28,6 +28,7 @@
 								:collection="collection"
 								:field="field"
 								include-functions
+								:include-relations="includeRelations"
 								@select-field="updateField(index, $event)"
 							/>
 						</v-menu>
@@ -139,6 +140,7 @@ interface Props {
 	depth?: number;
 	inline?: boolean;
 	includeValidation?: boolean;
+	includeRelations?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -146,6 +148,7 @@ const props = withDefaults(defineProps<Props>(), {
 	depth: 1,
 	inline: false,
 	includeValidation: false,
+	includeRelations: true,
 });
 
 const emit = defineEmits(['remove-node', 'update:filter', 'change']);

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -19,6 +19,7 @@
 				:field="fieldName"
 				:depth="1"
 				:include-validation="includeValidation"
+				:include-relations="includeRelations"
 				@remove-node="removeNode($event)"
 				@change="emitValue"
 			/>
@@ -42,7 +43,7 @@
 					v-if="collectionRequired"
 					:collection="collection"
 					include-functions
-					:exclude-relations="includeValidation"
+					:include-relations="includeRelations"
 					@select-field="addNode($event)"
 				>
 					<template #prepend>
@@ -97,6 +98,7 @@ interface Props {
 	fieldName?: string;
 	inline?: boolean;
 	includeValidation?: boolean;
+	includeRelations?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -108,6 +110,7 @@ const props = withDefaults(defineProps<Props>(), {
 	fieldName: undefined,
 	inline: false,
 	includeValidation: false,
+	includeRelations: true,
 });
 
 const emit = defineEmits(['input']);

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -42,6 +42,7 @@
 					v-if="collectionRequired"
 					:collection="collection"
 					include-functions
+					:exclude-relations="includeValidation"
 					@select-field="addNode($event)"
 				>
 					<template #prepend>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -44,6 +44,7 @@ export default defineComponent({
 					interface: 'system-filter',
 					options: {
 						collectionName: collection.value,
+						includeRelations: false,
 					},
 				},
 			},

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/validation.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/validation.vue
@@ -46,6 +46,7 @@ export default defineComponent({
 					options: {
 						collectionName: permissionSync.value.collection,
 						includeValidation: true,
+						includeRelations: false,
 					},
 				},
 			},


### PR DESCRIPTION
## Description

UX improvement until the feature for checking relationship fields is actually implemented.
Until then relationship fields shouldn't be selectable on the field validation tab.

Improves #11775 

## Type of Change

- [ ] Bugfix (not really depending on how you look at it)
- [x] Improvement

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [ ] Performed a self-review of the submitted code