### PR TITLE
m2a drawer throwing errors for alternate layouts

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -111,7 +111,7 @@
 		</div>
 
 		<drawer-collection
-			v-if="!disabled"
+			v-if="!disabled && selectingFrom"
 			multiple
 			:active="!!selectingFrom"
 			:collection="selectingFrom"


### PR DESCRIPTION
## Description

The issue here is that that the `drawer-collection` component gets initialized with a `null` collection and when selecting a collection that collection gets updated but it takes `drawer-collection` a couple of ticks to update its internal state. In this time the component will fall back to its defaults being a `tabular` layout but it doesnt have the required properties for the layout as the collection info has not been hydrated. This race condition occurs because it tries to render the drawer instantly after updating the `selectingFrom` variable.

Adding the `selectingFrom` in the `v-if` prevents the component from being initialized before a collection is selected to open in the drawer. This effectively prevents the error from happening.

Fixes #14792 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
