### PR TITLE
Fix macos-release error in server info

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -132,7 +132,6 @@
 		"ldapjs": "^2.3.3",
 		"liquidjs": "^9.37.0",
 		"lodash": "^4.17.21",
-		"macos-release": "^2.4.1",
 		"marked": "^4.0.16",
 		"micromustache": "^8.0.3",
 		"mime-types": "^2.1.35",

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -1,6 +1,5 @@
 import { Knex } from 'knex';
 import { merge } from 'lodash';
-import macosRelease from 'macos-release';
 import { nanoid } from 'nanoid';
 import os from 'os';
 import { performance } from 'perf_hooks';
@@ -17,6 +16,7 @@ import { Accountability, SchemaOverview } from '@directus/shared/types';
 import { toArray } from '@directus/shared/utils';
 import getMailer from '../mailer';
 import { SettingsService } from './settings';
+import { getOSInfo } from '../utils/get-os-info';
 
 export class ServerService {
 	knex: Knex;
@@ -62,9 +62,7 @@ export class ServerService {
 		}
 
 		if (this.accountability?.admin === true) {
-			const osType = os.type() === 'Darwin' ? 'macOS' : os.type();
-
-			const osVersion = osType === 'macOS' ? `${macosRelease().name} (${macosRelease().version})` : os.release();
+			const { osType, osVersion } = getOSInfo();
 
 			info.directus = {
 				version,

--- a/api/src/utils/get-os-info.ts
+++ b/api/src/utils/get-os-info.ts
@@ -1,0 +1,47 @@
+import os from 'os';
+
+/**
+ * Get current host OS information
+ *
+ * @returns Object of OS type and version
+ */
+export function getOSInfo() {
+	const osType = os.type() === 'Darwin' ? 'macOS' : os.type();
+
+	const osVersion = osType === 'macOS' ? macosRelease() : os.release();
+
+	return { osType, osVersion };
+}
+
+/**
+ * Get the name and version of a macOS release from the Darwin version.
+ * Lifted from `macos-release`.
+ */
+function macosRelease() {
+	const release = Number(os.release().split('.')[0]);
+
+	const nameMap = new Map<number, [name: string, version: string]>([
+		[22, ['Ventura', '13']],
+		[21, ['Monterey', '12']],
+		[20, ['Big Sur', '11']],
+		[19, ['Catalina', '10.15']],
+		[18, ['Mojave', '10.14']],
+		[17, ['High Sierra', '10.13']],
+		[16, ['Sierra', '10.12']],
+		[15, ['El Capitan', '10.11']],
+		[14, ['Yosemite', '10.10']],
+		[13, ['Mavericks', '10.9']],
+		[12, ['Mountain Lion', '10.8']],
+		[11, ['Lion', '10.7']],
+		[10, ['Snow Leopard', '10.6']],
+		[9, ['Leopard', '10.5']],
+		[8, ['Tiger', '10.4']],
+		[7, ['Panther', '10.3']],
+		[6, ['Jaguar', '10.2']],
+		[5, ['Puma', '10.1']],
+	]);
+
+	const current = nameMap.get(release);
+
+	return current ? `${current[0]} (${current[1]})` : 'Unknown';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,6 @@ importers:
       ldapjs: ^2.3.3
       liquidjs: ^9.37.0
       lodash: ^4.17.21
-      macos-release: ^2.4.1
       marked: ^4.0.16
       memcached: ^2.2.2
       micromustache: ^8.0.3
@@ -269,7 +268,6 @@ importers:
       ldapjs: 2.3.3
       liquidjs: 9.39.1
       lodash: 4.17.21
-      macos-release: 2.5.0
       marked: 4.0.18
       micromustache: 8.0.3
       mime-types: 2.1.35
@@ -11046,12 +11044,6 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /macos-release/2.5.0:
-    resolution:
-      { integrity: sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g== }
-    engines: { node: '>=6' }
-    dev: false
-
   /magic-string/0.25.9:
     resolution:
       { integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ== }
@@ -14995,7 +14987,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.2
+      jest: 28.1.2_dyhfsldgbafx4up6nvciefunqu
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Description

Fixes #14830

`macos-release` v3 does resolve this, but we weren't able to directly upgrade it due to v3 being ESM. It was already upgraded in #7381 and subsequently downgraded in #7389 for the same reason.

This PR removes `macos-release` package in favor of lifting the code directly alongside a more general utility function `getOSInfo`.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
