### PR TITLE
Fix duplicate env keys

### DIFF
--- a/api/src/cli/utils/create-env/env-stub.liquid
+++ b/api/src/cli/utils/create-env/env-stub.liquid
@@ -296,10 +296,10 @@ EMAIL_SENDMAIL_PATH="/usr/sbin/sendmail"
 ## Email (Sendmail Transport)
 
 # What new line style to use in sendmail ["unix"]
-EMAIL_SENDMAIL_NEW_LINE="unix"
+# EMAIL_SENDMAIL_NEW_LINE="unix"
 
 # Path to your sendmail executable ["/usr/sbin/sendmail"]
-EMAIL_SENDMAIL_PATH="/usr/sbin/sendmail"
+# EMAIL_SENDMAIL_PATH="/usr/sbin/sendmail"
 
 ## Email (SMTP Transport)
 # EMAIL_SMTP_HOST="localhost"


### PR DESCRIPTION
## Description

The default .env contains a couple of duplicate keys:
* EMAIL_SENDMAIL_NEW_LINE
* EMAIL_SENDMAIL_PATH

It looks like it was supposed to be a commented example, but it's missing the `#` in front.

This can lead to an error if you are trying to create a secret in Kubernetes via kubectl.

I ran this command>
`kubectl create secret generic dot-env --from-env-file=$DOT_ENV`

Which gave me this error:
`error: cannot add key EMAIL_SENDMAIL_NEW_LINE, another key by that name already exists`.

This PR comments out the example so that no keys are duplicate.

Fixes #

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
