### PR TITLE
App: Don't mix fields from other groups

### DIFF
--- a/app/src/composables/use-form-fields.ts
+++ b/app/src/composables/use-form-fields.ts
@@ -15,7 +15,11 @@ export function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<F
 			return systemFake === false;
 		});
 
-		formFields = orderBy(formFields, [(field) => !!field.meta?.system, 'meta.sort', 'meta.id'], ['desc', 'asc', 'asc']);
+		formFields = orderBy(
+			formFields,
+			[(field) => !!field.meta?.system, 'meta.group', 'meta.sort', 'meta.id'],
+			['desc', 'desc', 'asc', 'asc']
+		);
 
 		formFields = formFields.map((field, index) => {
 			if (!field.meta) return field;


### PR DESCRIPTION
## Description

There's some weird scenarios where fields are mixed up ending in an unexpected UI when using half width fields and groups.
For example:

https://user-images.githubusercontent.com/14039341/182922593-6eb5e32c-7737-4b16-91f4-7d5f8b676492.mov

I found that fields were order but didn't include group on criteria. By including group on this sort, fixes this issue:

https://user-images.githubusercontent.com/14039341/182922789-d5943cf5-135a-4a20-a0f6-79d2abf8064b.mov

Fixes https://github.com/directus/cloud/issues/555

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
