### PR TITLE
Remove disabled props from presentation links

### DIFF
--- a/app/src/interfaces/presentation-links/presentation-links.vue
+++ b/app/src/interfaces/presentation-links/presentation-links.vue
@@ -6,7 +6,6 @@
 			class="action"
 			:class="[link.type]"
 			:secondary="link.type !== 'primary'"
-			:disabled="disabled"
 			:icon="!link.label"
 			:href="link.href"
 			:to="link.to"
@@ -31,10 +30,6 @@ type Link = {
 
 export default defineComponent({
 	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
 		links: {
 			type: Array as PropType<Link[]>,
 			default: null,


### PR DESCRIPTION
## Description

The disabled property has been completely removed from the presentation links component, as either the link is readable and can be used or there is no read rights and thus the whole button is not displayed.

Fixes #14735

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
