### PR TITLE
Set sourceMap to true on TS extension template

### DIFF
--- a/packages/extensions-sdk/templates/common/typescript/tsconfig.json
+++ b/packages/extensions-sdk/templates/common/typescript/tsconfig.json
@@ -22,7 +22,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"allowSyntheticDefaultImports": true,
 		"isolatedModules": true,
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"sourceMap": true
 	},
 	"include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->
Modify tsconfig file of new extensions to set the `sourceMap` option to true. This will make sure mapping to typescript file will be done correctly when building with the `--sourcemap` flag.
 
Fixes #14880

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
