### PR TITLE
Remove disabled override

### DIFF
--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -266,7 +266,6 @@ export default defineComponent({
 	--v-button-background-color: var(--background-normal);
 	--v-button-background-color-active: var(--background-normal);
 	--v-button-background-color-hover: var(--background-normal-alt);
-	--v-button-color-disabled: var(--foreground-normal);
 }
 
 .warning.rounded {


### PR DESCRIPTION
## Description

Before:

<img width="493" alt="Screenshot 2022-08-07 at 10 02 46" src="https://user-images.githubusercontent.com/6641242/183281396-211c5b3e-d8f0-4c57-86f6-4d7eef2709cb.png">

After this fix:

<img width="481" alt="Screenshot 2022-08-07 at 10 03 17" src="https://user-images.githubusercontent.com/6641242/183281426-2d27a141-5890-4adf-9955-47d745821428.png">

@benhaynes  What do you think about actually hiding these options for roles that have readonly permissions? Doesn't make sense for them to ever see delete, edit and create.

- [x] Improvement