### PR TITLE
Tweak add-to-project GitHub action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-name: Add issues to Projects (beta)
+name: Add issues to Projects
 
 on:
   issues:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,7 +13,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.0.3
+      - uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/directus/projects/6
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/directus/projects/6
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: Automerge
+          label-operator: NOT


### PR DESCRIPTION
## Description

This is to prevent Crowdin updates PRs from being added to the project board.

### Changes

- Ignore PRs with `Automerge` labels from Crowdin updates
- Update the GH action's version from `0.0.3` to `0.3.0`

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
