### PR TITLE
Fix show hidden collections for nested collections

### DIFF
--- a/app/src/modules/content/components/navigation-item.vue
+++ b/app/src/modules/content/components/navigation-item.vue
@@ -20,6 +20,7 @@
 		<navigation-item
 			v-for="childCollection in childCollections"
 			:key="childCollection.collection"
+			:show-hidden="showHidden"
 			:collection="childCollection"
 			:search="search"
 		/>


### PR DESCRIPTION
## Description

Fixes #14910

The `showHidden` prop was used in the "root" navigation-item here:

https://github.com/directus/directus/blob/896c5a2b5678514d360e4f545c23ccbb21b3d5cd/app/src/modules/content/components/navigation.vue#L17-L23

but not in the nested navigation-item components:

https://github.com/directus/directus/blob/896c5a2b5678514d360e4f545c23ccbb21b3d5cd/app/src/modules/content/components/navigation-item.vue#L20-L25

## Before

![chrome_i7JPo09HlV](https://user-images.githubusercontent.com/42867097/183357199-e8e2fd6a-e45a-4c7e-9577-c656c8520106.gif)

## After

![chrome_ZIshRM8zOz](https://user-images.githubusercontent.com/42867097/183357232-c76f2c0c-1ce5-4fb8-b5a3-74df3be639f5.gif)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
