### PR TITLE
Use native concurrency option to cancel outdated workflow runs

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -11,6 +11,10 @@ on:
       - pnpm-lock.yaml
       - .github/workflows/blackbox-main.yml
 
+concurrency:
+  group: blackbox-main
+  cancel-in-progress: true
+
 env:
   NODE_OPTIONS: --max_old_space_size=6144
 

--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -10,6 +10,10 @@ on:
       - package.json
       - pnpm-lock.yaml
 
+concurrency:
+  group: blackbox-pr-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_OPTIONS: --max_old_space_size=6144
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,20 +8,14 @@ on:
     branches:
       - main
 
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_OPTIONS: --max_old_space_size=6144
 
 jobs:
-  cancel:
-    name: Cancel Previous Runs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          workflow_id: all
-          access_token: ${{ github.token }}
-
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

As much as I appreciate the work done in the [cancel-workflow-action](https://github.com/styfle/cancel-workflow-action), I suggest switching to the native [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) option provided by GitHub to cancel outdated workflow runs for the following reasons:

* It's faster
* More verbose message on cancelled workflow runs
* Also works on pull requests from forks (no need for a GitHub token)
* Supported by GitHub

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
