### PR TITLE
App: Do not allow to link collection `folders` to M2A relationship

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -191,7 +191,7 @@ export default defineComponent({
 		const availableCollections = computed(() => {
 			return orderBy(
 				[
-					...collectionsStore.allCollections,
+					...collectionsStore.databaseCollections,
 					{
 						divider: true,
 					},

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -97,7 +97,7 @@ export default defineComponent({
 		const availableCollections = computed(() => {
 			return orderBy(
 				[
-					...collectionsStore.allCollections,
+					...collectionsStore.databaseCollections,
 					{
 						divider: true,
 					},

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
@@ -81,13 +81,7 @@ export default defineComponent({
 		});
 
 		const availableCollections = computed(() => {
-			return orderBy(
-				collectionsStore.collections.filter((collection) => {
-					return collection.collection.startsWith('directus_') === false && collection.schema;
-				}),
-				['sort', 'collection'],
-				['asc']
-			);
+			return orderBy(collectionsStore.databaseCollections, ['sort', 'collection'], ['asc']);
 		});
 
 		const systemCollections = collectionsStore.crudSafeSystemCollections;

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
@@ -96,11 +96,7 @@ export default defineComponent({
 
 		const collectionsStore = useCollectionsStore();
 
-		const regularCollections = computed(() =>
-			collectionsStore.collections.filter(
-				(collection) => collection.collection.startsWith('directus_') === false && collection.schema
-			)
-		);
+		const regularCollections = computed(() => collectionsStore.databaseCollections);
 
 		const systemCollections = computed(() =>
 			orderBy(

--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -26,6 +26,9 @@ export const useCollectionsStore = defineStore({
 		allCollections(): Collection[] {
 			return this.collections.filter(({ collection }) => collection.startsWith('directus_') === false);
 		},
+		databaseCollections(): Collection[] {
+			return this.allCollections.filter((collection) => collection.type === 'table');
+		},
 		crudSafeSystemCollections(): Collection[] {
 			return orderBy(
 				this.collections.filter((collection) => {

--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -27,7 +27,7 @@ export const useCollectionsStore = defineStore({
 			return this.collections.filter(({ collection }) => collection.startsWith('directus_') === false);
 		},
 		databaseCollections(): Collection[] {
-			return this.allCollections.filter((collection) => collection.type === 'table');
+			return this.allCollections.filter((collection) => collection.schema);
 		},
 		crudSafeSystemCollections(): Collection[] {
 			return orderBy(


### PR DESCRIPTION
## Description
Do not allow to link `folders` to M2A relationship.
In other words, only allow database tables to be linked to M2A relationship.

##### Motivation
I had an issue with Insights / Grapqhl query preventing to retrieve the results. The error was the following:
```
Cannot read properties of undefined (reading 'getType')
```
Following the stack trace I found that I had an M2A relation with a `folder` in allowed collections.
Since Graphql looks up every relation, I had issues with all Graphql queries.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
