### PR TITLE
Fix decompression when floats are used, but no integers are present

### DIFF
--- a/packages/shared/src/utils/compress.test.ts
+++ b/packages/shared/src/utils/compress.test.ts
@@ -20,6 +20,22 @@ const deep = {
 
 const arr = ['directus', false, deep];
 
+const geoJSON = {
+	data: [
+		{
+			id: 'f36431ea-0d25-4747-8b37-185eb3ba66d0',
+			point1: {
+				type: 'Point',
+				coordinates: [-107.57812499999984, 34.30714385628873],
+			},
+			point2: {
+				type: 'Point',
+				coordinates: [-91.25923790168956, 42.324763327278106],
+			},
+		},
+	],
+};
+
 describe('compress', () => {
 	test('Compresses plain objects', () => {
 		expect(compress(plain)).toBe(
@@ -36,6 +52,12 @@ describe('compress', () => {
 	test('Compresses array input', () => {
 		expect(compress(arr)).toBe(
 			'directus|another|string|true|false|null|empty|integer|float|undefined|nested|arr^1K6^12.34^@0|-2|$1|$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]|A|$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]|B|@$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]|$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]]]]'
+		);
+	});
+
+	test('Compresses GeoJSON format reliably', () => {
+		expect(compress(geoJSON)).toBe(
+			'data|id|f36431ea-0d25-4747-8b37-185eb3ba66d0|point1|type|Point|coordinates|point2^^-107.57812499999984|34.30714385628873|-91.25923790168956|42.324763327278106^$0|@$1|2|3|$4|5|6|@8|9]]|7|$4|5|6|@A|B]]]]]'
 		);
 	});
 
@@ -67,6 +89,14 @@ describe('decompress', () => {
 				'directus|another|string|true|false|null|empty|integer|float|undefined|nested|arr^1K6^12.34^@0|-2|$1|$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]|A|$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]|B|@$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]|$2|0|3|-1|4|-2|5|-3|6|-4|7|C|8|D|9|-5]]]]'
 			)
 		).toEqual(arr);
+	});
+
+	test('Decompresses GeoJSON properly', () => {
+		expect(
+			decompress(
+				'data|id|f36431ea-0d25-4747-8b37-185eb3ba66d0|point1|type|Point|coordinates|point2^^-107.57812499999984|34.30714385628873|-91.25923790168956|42.324763327278106^$0|@$1|2|3|$4|5|6|@8|9]]|7|$4|5|6|@A|B]]]]]'
+			)
+		).toEqual(geoJSON);
 	});
 
 	test('Errors when not enough parts exist', () => {

--- a/packages/shared/src/utils/compress.ts
+++ b/packages/shared/src/utils/compress.ts
@@ -171,11 +171,19 @@ export function decompress(input: string): unknown {
 	const parts = input.split('^');
 	if (parts.length !== 4) throw new Error(`Invalid input string given`);
 
-	const values: (string | number)[] = [
-		...parts[0]!.split('|').map((part) => decode(part)),
-		...parts[1]!.split('|').map((part) => to10(part)),
-		...parts[2]!.split('|').map((part) => parseFloat(part)),
-	];
+	const values: (string | number)[] = [];
+
+	if (parts[0]) {
+		values.push(...parts[0]!.split('|').map((part) => decode(part)));
+	}
+
+	if (parts[1]) {
+		values.push(...parts[1]!.split('|').map((part) => to10(part)));
+	}
+
+	if (parts[2]) {
+		values.push(...parts[2]!.split('|').map((part) => parseFloat(part)));
+	}
 
 	let num36Buffer = '';
 	const tokens: (string | number)[] = [];


### PR DESCRIPTION
## Description

The compression algorithm would get confused if no integers were used, but floats are present. This would call the lookup to start with it's index offset, which causes problems like #14980.

Fixes #14980

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
