### PR TITLE
Add allow duplicates option to M2A and M2M interfaces

### DIFF
--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -117,8 +117,8 @@ export function useRelationMultiple(
 			return updatedItem;
 		});
 
-		const selectedOnPage = fetchedSelectItems.value.map((item) => {
-			const edits = selected.value.find((edit) => {
+		const selectedOnPage = selected.value.map((item) => {
+			const edits = fetchedSelectItems.value.find((edit) => {
 				switch (relation.value?.type) {
 					case 'o2m':
 						return edit[targetPKField] === item[targetPKField];

--- a/app/src/interfaces/list-m2a/index.ts
+++ b/app/src/interfaces/list-m2a/index.ts
@@ -52,6 +52,17 @@ export default defineInterface({
 				default_value: 15,
 			},
 		},
+		{
+			field: 'allowDuplicates',
+			name: '$t:allow_duplicates',
+			schema: {
+				default_value: false,
+			},
+			meta: {
+				interface: 'boolean',
+				width: 'half',
+			},
+		},
 	],
 	preview: PreviewSVG,
 });

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -160,6 +160,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		limit?: number;
+		allowDuplicates?: boolean;
 	}>(),
 	{
 		value: () => [],
@@ -167,6 +168,7 @@ const props = withDefaults(
 		enableCreate: true,
 		enableSelect: true,
 		limit: 15,
+		allowDuplicates: false,
 	}
 );
 
@@ -329,7 +331,7 @@ function getCollectionName(item: DisplayItem) {
 const customFilter = computed(() => {
 	const info = relationInfo.value;
 
-	if (!info || !selectingFrom.value) return {};
+	if (!info || !selectingFrom.value || props.allowDuplicates) return {};
 
 	const filter: Filter = {
 		_and: [],

--- a/app/src/interfaces/list-m2m/index.ts
+++ b/app/src/interfaces/list-m2m/index.ts
@@ -75,6 +75,17 @@ export default defineInterface({
 				},
 			},
 			{
+				field: 'allowDuplicates',
+				name: '$t:allow_duplicates',
+				schema: {
+					default_value: false,
+				},
+				meta: {
+					interface: 'boolean',
+					width: 'half',
+				},
+			},
+			{
 				field: 'filter',
 				name: '$t:filter',
 				type: 'json',

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -110,6 +110,7 @@ const props = withDefaults(
 		enableSelect?: boolean;
 		filter?: Filter | null;
 		limit?: number;
+		allowDuplicates?: boolean;
 	}>(),
 	{
 		value: () => [],
@@ -119,6 +120,7 @@ const props = withDefaults(
 		enableSelect: true,
 		filter: () => null,
 		limit: 15,
+		allowDuplicates: false,
 	}
 );
 
@@ -287,7 +289,7 @@ const customFilter = computed(() => {
 
 	if (!isEmpty(customFilter)) filter._and.push(customFilter);
 
-	if (!relationInfo.value) return filter;
+	if (!relationInfo.value || props.allowDuplicates) return filter;
 
 	const reverseRelation = `$FOLLOW(${relationInfo.value.junctionCollection.collection},${relationInfo.value.junctionField.field})`;
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -488,6 +488,7 @@ creating_items: Creating Items
 enable_create_button: Enable Create Button
 selecting_items: Selecting Items
 enable_select_button: Enable Select Button
+allow_duplicates: Allow Duplicates
 comments: Comments
 no_comments: No Comments Yet
 click_to_expand: Click to Expand


### PR DESCRIPTION
## Description

Implements #14938

Adds a new field `Allow duplicates` to M2M and M2A interfaces that disables filtering of lists when adding existing items.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
