### PR TITLE
App: Do not validate circular fields

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -189,6 +189,16 @@ export default defineComponent({
 			}
 		});
 
+		const fieldsWithoutCircular = computed(() => {
+			if (props.circularField) {
+				return fields.value.filter((field) => {
+					return field.field !== props.circularField;
+				});
+			} else {
+				return fields.value;
+			}
+		});
+
 		const templatePrimaryKey = computed(() =>
 			junctionFieldInfo.value ? String(props.relatedPrimaryKey) : String(props.primaryKey)
 		);
@@ -396,7 +406,9 @@ export default defineComponent({
 
 			function save() {
 				const editsToValidate = props.junctionField ? internalEdits.value[props.junctionField] : internalEdits.value;
-				const fieldsToValidate = props.junctionField ? junctionRelatedCollectionFields.value : fields.value;
+				const fieldsToValidate = props.junctionField
+					? junctionRelatedCollectionFields.value
+					: fieldsWithoutCircular.value;
 				let errors = validateItem(editsToValidate || {}, fieldsToValidate, isNew.value);
 
 				if (errors.length > 0) {


### PR DESCRIPTION
## Description
In #14834 we have a regression since it caused circular fields to be validated. Though, when the item is about to being created this field is null which causes the validation to fail preventing the creation of the relationship.

Fixes #14992

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
