### PR TITLE
Fix Flow operations update bug

### DIFF
--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -280,7 +280,7 @@ const panels = computed(() => {
 			const updates = stagedPanels.value.find((updatedPanel) => updatedPanel.id === panel.id);
 
 			if (updates) {
-				return merge({}, panel, updates);
+				return Object.assign({}, panel, updates);
 			}
 
 			return panel;


### PR DESCRIPTION
## Description

Fixes #14986

### Before

Due to the usage of lodash `merge()` here:

https://github.com/directus/directus/blob/e9a02cdf85b81b13c850ee6aedb8ef784570b14e/app/src/modules/settings/routes/flows/flow.vue#L282-L284

it is producing wrong result for array values, even if it's technically doing what it's supposed to do.

For example:

```js
// panel
{
    "headers": [
        {
            "header": "Content-Type",
            "value": "application/json"
        },
        {
            "header": "Authorization",
            "value": "Bearer token"
        }
    ]
}

// updates
{
    "headers": [
        {
            "header": "Authorization",
            "value": "Bearer token"
        }
    ]
}

// result
{
    "headers": [
        {
            "header": "Authorization",
            "value": "Bearer token"
        },
        {
            "header": "Authorization",
            "value": "Bearer token"
        }
    ]
}
```

https://user-images.githubusercontent.com/42867097/183833172-7c93cc83-8263-4ad8-8394-f4521e1c0444.mp4

### After

Use `Object.assign()` instead to prevent this.

https://user-images.githubusercontent.com/42867097/183833146-5895505f-b73b-4127-bc7a-9cd84468e468.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
