### PR TITLE
Send error status only if no data is written

### DIFF
--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -187,7 +187,12 @@ router.get(
 			return res.end();
 		}
 
-		stream.on('data', (chunk) => res.write(chunk));
+		let isDataSent = false;
+
+		stream.on('data', (chunk) => {
+			isDataSent = true;
+			res.write(chunk);
+		});
 
 		stream.on('end', () => {
 			res.status(200).send();
@@ -196,23 +201,22 @@ router.get(
 		stream.on('error', (e) => {
 			logger.error(e, `Couldn't stream file ${file.id} to the client`);
 
-			stream.unpipe(res);
+			if (!isDataSent) {
+				res.removeHeader('Content-Type');
+				res.removeHeader('Content-Disposition');
+				res.removeHeader('Cache-Control');
 
-			res.removeHeader('Content-Disposition');
-			res.removeHeader('Content-Type');
-			res.removeHeader('Content-Disposition');
-			res.removeHeader('Cache-Control');
-
-			res.status(500).json({
-				errors: [
-					{
-						message: 'An unexpected error occurred.',
-						extensions: {
-							code: 'INTERNAL_SERVER_ERROR',
+				res.status(500).json({
+					errors: [
+						{
+							message: 'An unexpected error occurred.',
+							extensions: {
+								code: 'INTERNAL_SERVER_ERROR',
+							},
 						},
-					},
-				],
-			});
+					],
+				});
+			}
 		});
 	})
 );


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #14888. Headers cannot be changed after they are sent.

Removed `stream.unpipe(res)` as the stream isn't piped.
Removed the duplicated `res.removeHeader('Content-Disposition')`.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
