### PR TITLE
Fix map interface controls for non-native geometry types

### DIFF
--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -151,7 +151,7 @@ export default defineComponent({
 		const geometryOptionsError = ref<string | null>();
 		const geometryParsingError = ref<string | TranslateResult>();
 
-		const geometryType = props.geometryType || (props.fieldData?.type.split('.')[1] as GeometryType);
+		const geometryType = props.fieldData?.type.split('.')[1] as GeometryType;
 		const geometryFormat = getGeometryFormatForType(props.type)!;
 
 		const settingsStore = useSettingsStore();


### PR DESCRIPTION
## Description

Fixes #15006

In https://github.com/directus/directus/pull/14096/files#diff-b813187d23ee3e6e9d5b66a408e1e6b80ed96abb8ec92d85d2d02f974daa93ecR49, `geometryType` now defaults to `Point` even for non-native geometry types like `geometry` (Geometry (All)), `json`, `csv` etc. I assume this is to fix it from breaking when being used as a global variable panel.

However I believe it is _intentionally_ turned to `undefined`, as it's explicitly defined here:

https://github.com/directus/directus/blob/e9a02cdf85b81b13c850ee6aedb8ef784570b14e/packages/shared/src/types/fields.ts#L19

We can also see the differences of `geometryType` here:

|before the change|after the change|
|---|---|
|![chrome_sCTHWU0xff](https://user-images.githubusercontent.com/42867097/183898522-18df163a-fd49-4148-b921-44496b62754a.png)|![chrome_TqTUNTyS5j](https://user-images.githubusercontent.com/42867097/183898977-125790e3-a32f-4129-b3c6-806f0c130d88.png)|

As it now always defaults to `Point`, the logic to determine what controls to show will now always default to Point:

https://github.com/directus/directus/blob/e9a02cdf85b81b13c850ee6aedb8ef784570b14e/app/src/interfaces/map/map.vue#L154

https://github.com/directus/directus/blob/e9a02cdf85b81b13c850ee6aedb8ef784570b14e/app/src/interfaces/map/map.vue#L353-L378

note that `getDrawOptions()` function above has `if(!type)` to show all controls when they are non-native geometry types.

This PR opts to follow the existing notion and allow it to turn to `undefined` when the `split('.')[1]` results in undefined.

### Before

![chrome_Juta1y2v9V](https://user-images.githubusercontent.com/42867097/183901298-28e9d058-abdc-421c-ac34-6675c978b089.png)

### After

![chrome_6cJ6daZv8M](https://user-images.githubusercontent.com/42867097/183900938-c9326e36-7fc0-4529-8196-8cbd57993120.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
