### PR TITLE
Encode webhook url only if it does not contain encoded values

### DIFF
--- a/api/src/operations/request/index.ts
+++ b/api/src/operations/request/index.ts
@@ -17,7 +17,13 @@ export default defineOperationApi<Options>({
 			return acc;
 		}, {} as Record<string, string>);
 
-		const result = await axios({ url: encodeURI(url), method, data: body, headers: customHeaders });
+		const shouldEncode = decodeURI(url) === url;
+		const result = await axios({
+			url: shouldEncode ? encodeURI(url) : url,
+			method,
+			data: body,
+			headers: customHeaders,
+		});
 
 		return { status: result.status, statusText: result.statusText, headers: result.headers, data: result.data };
 	},


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #14971.
Note: The request will fail if there are invalid unescaped characters alongside a url with encoded values.
The "Script" flow operation discussed in https://github.com/directus/directus/discussions/13944 could be a potential solution to encode certain values.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
