### PR TITLE
Skip fetching items when id = '+'

### DIFF
--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -345,18 +345,20 @@ export function useRelationMultiple(
 
 			await updateItemCount(targetCollection, targetPKField, reverseJunctionField);
 
-			const response = await api.get(getEndpoint(targetCollection), {
-				params: {
-					fields: Array.from(fields),
-					filter: {
-						[reverseJunctionField]: itemId.value,
+			if (itemId.value !== '+') {
+				const response = await api.get(getEndpoint(targetCollection), {
+					params: {
+						fields: Array.from(fields),
+						filter: {
+							[reverseJunctionField]: itemId.value,
+						},
+						page: previewQuery.value.page,
+						limit: previewQuery.value.limit,
 					},
-					page: previewQuery.value.page,
-					limit: previewQuery.value.limit,
-				},
-			});
+				});
 
-			fetchedItems.value = response.data.data;
+				fetchedItems.value = response.data.data;
+			}
 		} catch (err: any) {
 			unexpectedError(err);
 		} finally {


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #14944. The value of `itemId` changes when the `updateItemCount()` runs, due to the updating of numerous computed fields. The primaryKey props is being updated to `+`, leading to the invalid request.

https://github.com/directus/directus/blob/65d8fa3735584ea825d322eedae05cc68556ef30/app/src/composables/use-relation-multiple.ts#L346-L347

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
