### PR TITLE
Add Content-Type header to Flows request operation when applicable

### DIFF
--- a/api/src/operations/request/index.ts
+++ b/api/src/operations/request/index.ts
@@ -1,4 +1,4 @@
-import { defineOperationApi } from '@directus/shared/utils';
+import { defineOperationApi, parseJSON } from '@directus/shared/utils';
 import axios, { Method } from 'axios';
 
 type Options = {
@@ -12,10 +12,15 @@ export default defineOperationApi<Options>({
 	id: 'request',
 
 	handler: async ({ url, method, body, headers }) => {
-		const customHeaders = headers?.reduce((acc, { header, value }) => {
-			acc[header] = value;
-			return acc;
-		}, {} as Record<string, string>);
+		const customHeaders =
+			headers?.reduce((acc, { header, value }) => {
+				acc[header] = value;
+				return acc;
+			}, {} as Record<string, string>) ?? {};
+
+		if (!customHeaders['Content-Type'] && isValidJSON(body)) {
+			customHeaders['Content-Type'] = 'application/json';
+		}
 
 		const shouldEncode = decodeURI(url) === url;
 		const result = await axios({
@@ -26,5 +31,14 @@ export default defineOperationApi<Options>({
 		});
 
 		return { status: result.status, statusText: result.statusText, headers: result.headers, data: result.data };
+
+		function isValidJSON(value: any): boolean {
+			try {
+				parseJSON(value);
+				return true;
+			} catch {
+				return false;
+			}
+		}
 	},
 });


### PR DESCRIPTION
## Description

Fixes #14547

Ref https://github.com/directus/directus/issues/14547#issuecomment-1191275714, where JSON-like strings are sent with `application/x-www-form-urlencoded` instead of `application/json`. Manually adding the header does work, but this helps to simplify it, particularly when user is forming a custom JSON that derives values from other operations via variables.

The `!customHeaders['Content-Type']` check should still allow users to override and opt out of this behavior.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
