### PR TITLE
Fix date-fns format to use hours (HH) instead of era (GG) in polish translation

### DIFF
--- a/app/src/lang/translations/pl-PL.yaml
+++ b/app/src/lang/translations/pl-PL.yaml
@@ -395,8 +395,8 @@ functions:
 date-fns_date: PPP
 date-fns_time: 'h:mm:ss a'
 date-fns_time_no_seconds: 'h:mm a'
-date-fns_time_24hour: 'GG:mm:ss'
-date-fns_time_no_seconds_24hour: 'GG:mm'
+date-fns_time_24hour: 'HH:mm:ss'
+date-fns_time_no_seconds_24hour: 'HH:mm'
 date-fns_date_short: 'd MMM u'
 date-fns_time_short: 'h:mma'
 date-fns_date_short_no_year: MMM d


### PR DESCRIPTION
## Description

Polish translation uses `GG` instead of `HH` format:

```yaml
date-fns_time_24hour: 'GG:mm:ss'
date-fns_time_no_seconds_24hour: 'GG:mm'
```
Reference: date-fns.org docs > [format](https://date-fns.org/v2.24.0/docs/format)

Fixes #15031

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
