### PR TITLE
Skip deleting if relationship doesn't exist

### DIFF
--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -234,9 +234,13 @@ export async function applySnapshot(
 			if (diff?.[0].kind === 'D') {
 				try {
 					await relationsService.deleteOne(collection, field);
-				} catch (err) {
-					logger.error(`Failed to delete relation "${collection}.${field}"`);
-					throw err;
+				} catch (err: any) {
+					if (err.message?.includes("doesn't exist in collection")) {
+						logger.warn(`Skip delete relation "${collection}.${field}"`);
+					} else {
+						logger.error(`Failed to delete relation "${collection}.${field}"`);
+						throw err;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Skips over trying to delete relationships that don't exist (for what ever reason)

Goes from this:

![Screenshot 2022-08-12 at 09 31 24](https://user-images.githubusercontent.com/6641242/184306455-2dcb1d53-1e08-472d-ac99-2ac27a96d3d9.png)

to this:

![Screenshot 2022-08-12 at 09 31 33](https://user-images.githubusercontent.com/6641242/184306481-606f48f1-0003-431d-bf40-bd07de154d12.png)


## Type of Change

- [x] Bugfix
- [x] Improvement
