### PR TITLE
Feat/interface presentation external images

### DIFF
--- a/app/src/interfaces/presentation-external-images/index.ts
+++ b/app/src/interfaces/presentation-external-images/index.ts
@@ -1,0 +1,53 @@
+import { defineInterface } from '@directus/shared/utils';
+import InterfacePresentationExternalImages from './presentation-external-images.vue';
+import PreviewSVG from './preview.svg?raw';
+
+export default defineInterface({
+	id: 'presentation-external-images',
+	name: '$t:interfaces.presentation-external-images.presentation-external-images',
+	description: '$t:interfaces.presentation-external-images.description',
+	icon: 'smart_button',
+	component: InterfacePresentationExternalImages,
+	hideLabel: true,
+	hideLoader: true,
+	types: ['alias'],
+	localTypes: ['presentation'],
+	group: 'presentation',
+	options: ({ collection }) => [
+		{
+			field: 'images',
+			name: '$t:interfaces.presentation-external-images.images',
+			type: 'json',
+			meta: {
+				interface: 'list',
+				options: {
+					fields: [
+						{
+							field: 'src',
+							type: 'string',
+							name: '$t:interfaces.presentation-external-images.src',
+							meta: {
+								width: 'half',
+								options: {
+									placeholder: '$t:interfaces.presentation-external-images.src-placeholder',
+								},
+							},
+						},
+						{
+							field: 'width',
+							type: 'string',
+							name: '$t:interfaces.presentation-external-images.width',
+							meta: {
+								width: 'half',
+								options: {
+									placeholder: '$t:interfaces.presentation-external-images.width-placeholder',
+								},
+							},
+						},
+					],
+				},
+			},
+		},
+	],
+	preview: PreviewSVG,
+});

--- a/app/src/interfaces/presentation-external-images/presentation-external-images.vue
+++ b/app/src/interfaces/presentation-external-images/presentation-external-images.vue
@@ -1,0 +1,33 @@
+<template>
+	<div class="presentation-external-images">
+		<!-- <img v-for="(image, index) in images" :key="index" :src="image.src" :style="{ width: image.width ?? 'auto' }" /> -->
+		<v-image v-for="(image, index) in images" :key="index" :src="image.src" :style="{ width: image.width ?? 'auto' }" />
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+
+type Image = {
+	src: string;
+	width?: string;
+};
+
+export default defineComponent({
+	props: {
+		images: {
+			type: Array as PropType<Image[]>,
+			default: null,
+		},
+	},
+});
+</script>
+
+<style lang="scss" scoped>
+.presentation-external-images {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: start;
+	gap: 8px;
+}
+</style>

--- a/app/src/interfaces/presentation-external-images/presentation-external-images.vue
+++ b/app/src/interfaces/presentation-external-images/presentation-external-images.vue
@@ -1,7 +1,6 @@
 <template>
 	<div class="presentation-external-images">
-		<!-- <img v-for="(image, index) in images" :key="index" :src="image.src" :style="{ width: image.width ?? 'auto' }" /> -->
-		<v-image v-for="(image, index) in images" :key="index" :src="image.src" :style="{ width: image.width ?? 'auto' }" />
+		<img v-for="(image, index) in images" :key="index" :src="image.src" :style="{ width: image.width ?? 'auto' }" />
 	</div>
 </template>
 

--- a/app/src/interfaces/presentation-external-images/preview.svg
+++ b/app/src/interfaces/presentation-external-images/preview.svg
@@ -1,0 +1,7 @@
+<svg width="156" height="96" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<rect x="18" y="13" width="120" height="70" rx="6" fill="var(--background-page)" class="glow"/>
+	<rect x="19" y="14" width="118" height="68" rx="5" stroke="var(--primary)" stroke-width="2"/>
+	<rect x="24" y="19" width="108" height="58" rx="2" fill="var(--primary)" fill-opacity=".25"/>
+	<path fill-rule="evenodd" clip-rule="evenodd" d="m125.294 69-35-29-25.213 20.891L52 49 30 69h95.294Z" fill="var(--primary)"/>
+	<path d="M50 35a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z" fill="var(--primary)"/>
+</svg>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1455,6 +1455,14 @@ interfaces:
     all_opened: All Opened
     accordion_mode: Accordion Mode
     max_one_section_open: Max 1 Section Open
+  presentation-external-images:
+    presentation-external-images: External Images
+    description: Display images from external sources
+    images: Images
+    src: URL
+    src-placeholder: https://example.com/image.png
+    width: Width
+    width-placeholder: 200px or 100%
   presentation-links:
     presentation-links: Button Links
     links: Links


### PR DESCRIPTION
## Description

With this extension it is possible to add dynamic images to a record. This can be useful when an external image provides dynamic info or it needs a visual explanation. Example Shield.io Badges. An entry can have X images. Each image needs a URL and optionally the width. If you like the feature, it would also make sense to create a new panel for the dashboard.

<img width="1211" alt="1" src="https://user-images.githubusercontent.com/922406/184316462-2fec715d-781c-4ad2-9459-ebce8480cee6.png">
<img width="927" alt="2" src="https://user-images.githubusercontent.com/922406/184316477-cbca172f-aced-4aba-9770-b484e94ea5ae.png">
<img width="1220" alt="3" src="https://user-images.githubusercontent.com/922406/184316479-7b25b349-19d9-44a7-9ca8-f5c5c97f9bff.png">

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
