### PR TITLE
Allow fields nested in groups to be visible

### DIFF
--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -87,7 +87,11 @@ const treeList = computed(() => {
 });
 
 function filter(field: Field): boolean {
-	if (!includeRelations.value && (field.collection !== collection.value || field.type === 'alias')) return false;
+	if (
+		!includeRelations.value &&
+		(field.collection !== collection.value || (field.type === 'alias' && !field.meta?.special?.includes('group')))
+	)
+		return false;
 	if (!search.value) return true;
 	const children = fieldsStore.getFieldGroupChildren(collection.value, field.field);
 	return children?.some((field) => matchesSearch(field)) || matchesSearch(field);


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #15021 by allowing fields with the `group` special.

### Before


https://user-images.githubusercontent.com/26413686/184368667-e2c95df7-6a0a-4e67-8026-333aa8fe7e8b.mov


### After



https://user-images.githubusercontent.com/26413686/184368692-a535a67e-ca9f-4987-b637-42d6cd59620d.mov


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
