### PR TITLE
Graphql: Fix geometry type in arguments

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1477,7 +1477,11 @@ export class GraphQLService {
 				const values: any = [];
 
 				for (const valueNode of argument.value.values) {
-					if (valueNode.kind === 'ObjectValue') {
+					if (valueNode.kind === 'ListValue') {
+						const node = { value: valueNode, kind: 'ListValue', name: { value: 'result' } };
+						const { result } = this.parseArgs([node], variableValues);
+						values.push(result);
+					} else if (valueNode.kind === 'ObjectValue') {
 						values.push(this.parseArgs(valueNode.fields, variableValues));
 					} else {
 						if (valueNode.kind === 'Variable') {

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -3,7 +3,6 @@ import { Accountability, Action, Aggregate, Filter, Query, SchemaOverview } from
 import argon2 from 'argon2';
 import {
 	ArgumentNode,
-	BooleanValueNode,
 	execute,
 	ExecutionResult,
 	FieldNode,
@@ -26,14 +25,11 @@ import {
 	GraphQLString,
 	GraphQLUnionType,
 	InlineFragmentNode,
-	IntValueNode,
 	NoSchemaIntrospectionCustomRule,
-	ObjectFieldNode,
-	ObjectValueNode,
 	SelectionNode,
 	specifiedRules,
-	StringValueNode,
 	validate,
+	ValueNode,
 } from 'graphql';
 import {
 	GraphQLJSON,
@@ -1456,47 +1452,33 @@ export class GraphQLService {
 	 * In order to do that, we'll parse over all ArgumentNodes and ObjectFieldNodes to manually recreate an object structure
 	 * of arguments
 	 */
-	parseArgs(
-		args: readonly ArgumentNode[] | readonly ObjectFieldNode[],
-		variableValues: GraphQLResolveInfo['variableValues']
-	): Record<string, any> {
+	parseArgs(args: readonly ArgumentNode[], variableValues: GraphQLResolveInfo['variableValues']): Record<string, any> {
 		if (!args || args.length === 0) return {};
 
-		const parseObjectValue = (arg: ObjectValueNode) => {
-			return this.parseArgs(arg.fields, variableValues);
+		const parse = (node: ValueNode): any => {
+			switch (node.kind) {
+				case 'Variable':
+					return variableValues[node.name.value];
+				case 'ListValue':
+					return node.values.map(parse);
+				case 'ObjectValue':
+					return Object.fromEntries(node.fields.map((node) => [node.name.value, parse(node.value)]));
+				case 'NullValue':
+					return null;
+				case 'StringValue':
+					return String(node.value);
+				case 'IntValue':
+				case 'FloatValue':
+					return Number(node.value);
+				case 'BooleanValue':
+					return Boolean(node.value);
+				case 'EnumValue':
+				default:
+					return node.value;
+			}
 		};
 
-		const argsObject: any = {};
-
-		for (const argument of args) {
-			if (argument.value.kind === 'ObjectValue') {
-				argsObject[argument.name.value] = parseObjectValue(argument.value);
-			} else if (argument.value.kind === 'Variable') {
-				argsObject[argument.name.value] = variableValues[argument.value.name.value];
-			} else if (argument.value.kind === 'ListValue') {
-				const values: any = [];
-
-				for (const valueNode of argument.value.values) {
-					if (valueNode.kind === 'ListValue') {
-						const node = { value: valueNode, kind: 'ListValue', name: { value: 'result' } };
-						const { result } = this.parseArgs([node], variableValues);
-						values.push(result);
-					} else if (valueNode.kind === 'ObjectValue') {
-						values.push(this.parseArgs(valueNode.fields, variableValues));
-					} else {
-						if (valueNode.kind === 'Variable') {
-							values.push(variableValues[valueNode.name.value]);
-						} else {
-							values.push((valueNode as any).value);
-						}
-					}
-				}
-
-				argsObject[argument.name.value] = values;
-			} else {
-				argsObject[argument.name.value] = (argument.value as IntValueNode | StringValueNode | BooleanValueNode).value;
-			}
-		}
+		const argsObject = Object.fromEntries(args.map((arg) => [arg.name.value, parse(arg.value)]));
 
 		return argsObject;
 	}

--- a/app/src/panels/variable/panel-variable.vue
+++ b/app/src/panels/variable/panel-variable.vue
@@ -3,6 +3,7 @@
 		<component
 			:is="`interface-${inter}`"
 			v-bind="options"
+			:disabled="true"
 			:value="value"
 			:width="fieldWidth"
 			:type="type"

--- a/app/src/utils/query-to-gql-string.ts
+++ b/app/src/utils/query-to-gql-string.ts
@@ -59,5 +59,14 @@ export function formatQuery({ collection, query }: QueryInfo): Record<string, an
 		// TBD @TODO
 	}
 
+	if (query.filter) {
+		try {
+			const json = String(query.filter);
+			formattedQuery.__args.filter = JSON.parse(json);
+		} catch {
+			// Keep current value there
+		}
+	}
+
 	return formattedQuery;
 }


### PR DESCRIPTION
## Description

While trying to use Global Variable with Map interface in Insights I faced some issues:
1. Use variable in filter argument throws invalid request error
2. Nested arrays (matrixes) are not parsed correctly for arguments
3. When Default View and  Default Value geometry types in Global Variable panel are different throws Geometry type mismatch

These issues are shown in the following screen recording:

https://user-images.githubusercontent.com/14039341/184395194-b0eadcd3-eb52-4de7-a42e-af030037b67a.mov

In order to fix those:
1. Try to use object instead of a string for object otherwise `json-to-graphql-query` will send it as string instead of object
~~2. Use same logic as `parseArgs` for arrays too. Though use a specific key for it since it's expecting this to be set. This solution is a bit _hacky_ and may need to be refactored. But for the sake of simplicity, I've just reused the same logic~~
2. Change how `parseArgs` works and handle more types on it
3. Disable all Global Variable panels, since the error is not shown when the interface is disabled

Here's the same flow after changes:

https://user-images.githubusercontent.com/14039341/184396021-1cce6f2f-e422-4c39-8a55-0a9dfd63251b.mov



## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
