### PR TITLE
Fix manually typed o2m sort field

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/o2m.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/o2m.ts
@@ -166,20 +166,15 @@ export function updateGeneratedRelatedField(updates: StateUpdates, state: State)
 	}
 }
 
+function fieldExists(collection: string, field: string) {
+	return !!useFieldsStore().getField(collection, field);
+}
+
 export function generateSortField(updates: StateUpdates, state: State, { getCurrent }: HelperFunctions) {
+	const relatedCollection = getCurrent('relations.o2m.collection');
 	const sort = getCurrent('relations.o2m.meta.sort_field');
 
-	if (!sort) return;
-
-	const fieldsStore = useFieldsStore();
-
-	const relatedCollection = getCurrent('relations.o2m.collection');
-
-	const exists = !!fieldsStore.getField(relatedCollection, sort);
-
-	if (exists) {
-		set(updates, 'fields.sort', undefined);
-	} else {
+	if (relatedCollection && sort && fieldExists(relatedCollection, sort) === false) {
 		set(updates, 'fields.sort', {
 			collection: relatedCollection,
 			field: sort,
@@ -189,5 +184,7 @@ export function generateSortField(updates: StateUpdates, state: State, { getCurr
 				hidden: false,
 			},
 		});
+	} else {
+		set(updates, 'fields.sort', undefined);
 	}
 }


### PR DESCRIPTION
## Description

Fixes #15061

When trying to remove a manually typed O2M via backspace, the first character still remains as a field that will be created.

This is because for o2m relation's `generateSortField()`, when there's no sort which is when we fully clear the input, it'll get early returned:

https://github.com/directus/directus/blob/0bffb2b0f5a56449434cd34bc6e96109b0656bea/app/src/modules/settings/routes/data-model/field-detail/store/alterations/o2m.ts#L172

but it didn't update the sort field to undefined like how it's being done further down the logic:

https://github.com/directus/directus/blob/0bffb2b0f5a56449434cd34bc6e96109b0656bea/app/src/modules/settings/routes/data-model/field-detail/store/alterations/o2m.ts#L181

This solutions tries to mirror the following similar logic used in other relations such as m2m, translations etc for consistency sake:

https://github.com/directus/directus/blob/0bffb2b0f5a56449434cd34bc6e96109b0656bea/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts#L184-L186

https://github.com/directus/directus/blob/0bffb2b0f5a56449434cd34bc6e96109b0656bea/app/src/modules/settings/routes/data-model/field-detail/store/alterations/m2m.ts#L291-L303

### Before

https://user-images.githubusercontent.com/42867097/184564168-376798ab-d92b-4c4a-8c9f-4fec3755adce.mp4

### After

https://user-images.githubusercontent.com/42867097/184564179-5ce6825c-de9d-4a37-b681-0820e6aa8c30.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
