### PR TITLE
Fix filter by folder for file and files interface

### DIFF
--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -96,6 +96,7 @@ import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import api from '@/api';
 import emitter, { Events } from '@/events';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { Filter } from '@directus/shared/types';
 
 export default defineComponent({
 	components: { DrawerCollection },
@@ -136,8 +137,8 @@ export default defineComponent({
 		const activeDialog = ref<'choose' | 'url' | null>(null);
 
 		const filterByFolder = computed(() => {
-			if (!props.folder) return null;
-			return { folder: { id: { _eq: props.folder } } };
+			if (!props.folder) return undefined;
+			return { folder: { id: { _eq: props.folder } } } as Filter;
 		});
 
 		return {

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -108,6 +108,7 @@
 			v-if="activeDialog === 'choose'"
 			collection="directus_files"
 			:active="activeDialog === 'choose'"
+			:filter="filterByFolder"
 			@update:active="activeDialog = null"
 			@input="setSelection"
 		/>
@@ -147,6 +148,7 @@ import DrawerItem from '@/views/private/components/drawer-item.vue';
 import { addQueryToPath } from '@/utils/add-query-to-path';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
 import { useRelationSingle, RelationQuerySingle } from '@/composables/use-relation-single';
+import { Filter } from '@directus/shared/types';
 
 type FileInfo = {
 	id: string;
@@ -189,6 +191,11 @@ const { displayItem: file, loading, update, remove } = useRelationSingle(value, 
 const { t } = useI18n();
 
 const activeDialog = ref<'upload' | 'choose' | 'url' | null>(null);
+
+const filterByFolder = computed(() => {
+	if (!props.folder) return undefined;
+	return { folder: { id: { _eq: props.folder } } } as Filter;
+});
 
 const fileExtension = computed(() => {
 	if (file.value === null) return null;

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -336,6 +336,14 @@ const customFilter = computed(() => {
 		_and: [],
 	};
 
+	if (props.folder) {
+		filter._and.push({
+			folder: {
+				id: { _eq: props.folder },
+			},
+		});
+	}
+
 	if (!relationInfo.value) return filter;
 
 	const reverseRelation = `$FOLLOW(${relationInfo.value.junctionCollection.collection},${relationInfo.value.junctionField.field})`;


### PR DESCRIPTION
## Description

Fixes #15058

As mentioned by https://github.com/directus/directus/issues/15058#issuecomment-1214178332, this works for `image`, `wysiwyg`, and `markdown` interfaces, but not `file` or `files`. 

This is because the ones that are working are via `<drawer-collection>` within `<v-upload>` which does pass a filter with folder to the `filter` prop:

https://github.com/directus/directus/blob/0bffb2b0f5a56449434cd34bc6e96109b0656bea/app/src/components/v-upload.vue#L55-L62

### Before

The bunny image shouldn't show up as it's on a parent folder:

https://user-images.githubusercontent.com/42867097/184636807-3a8700c5-3ed5-4017-a20a-9c5a59de86d5.mp4

### After

https://user-images.githubusercontent.com/42867097/184636850-843e34b9-53c8-448d-bf7d-315917bc1791.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
