### PR TITLE
Fix foreign key constraint errors for nested operations when deleting a Flow

### DIFF
--- a/api/src/services/flows.ts
+++ b/api/src/services/flows.ts
@@ -56,6 +56,9 @@ export class FlowsService extends ItemsService<FlowRaw> {
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
 		const flowManager = getFlowManager();
 
+		// this is to prevent foreign key constraint error on directus_operations resolve/reject during cascade deletion
+		await this.knex('directus_operations').update({ resolve: null, reject: null }).where('flow', key);
+
 		const result = await super.deleteOne(key, opts);
 		await flowManager.reload();
 
@@ -64,6 +67,9 @@ export class FlowsService extends ItemsService<FlowRaw> {
 
 	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const flowManager = getFlowManager();
+
+		// this is to prevent foreign key constraint error on directus_operations resolve/reject during cascade deletion
+		await this.knex('directus_operations').update({ resolve: null, reject: null }).whereIn('flow', keys);
 
 		const result = await super.deleteMany(keys, opts);
 		await flowManager.reload();


### PR DESCRIPTION
## Description

Fixes #14550

When deleting a flow, the nested operations will also get deleted as `directus_operations`'s `flow` column has ON DELETE CASCADE:

https://github.com/directus/directus/blob/c16455a10ba66e5c2d8a19fc9e07df7f49d33b13/api/src/database/migrations/20220429A-add-flows.ts#L31

However when the order is incorrect, it will trigger the foreign key constraint of linked operations via resolve/reject:

https://github.com/directus/directus/blob/c16455a10ba66e5c2d8a19fc9e07df7f49d33b13/api/src/database/migrations/20220429A-add-flows.ts#L29-L30

This PR uses a similar approach used here:

https://github.com/directus/directus/blob/9c0f806ed832c0491e43db09daf2f4ce4197008e/api/src/services/users.ts#L269-L271

to nullify all the nested operations' resolve and reject first before going through with the deletion.

### Before

https://user-images.githubusercontent.com/42867097/184894392-2ae6255b-1d04-48ee-b389-071cd1890191.mp4

### After

https://user-images.githubusercontent.com/42867097/184894784-99157957-6a40-4ef2-b21b-b61f46090190.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
