### PR TITLE
Fix translations interface and use-relation-multiple empty edits

### DIFF
--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -283,17 +283,25 @@ export function useRelationMultiple(
 		function clear() {
 			if (!relation.value) return;
 
-			value.value = itemId.value === '+' ? undefined : [];
-			existingItemCount.value = 0;
-			fetchedItems.value = [];
-
 			target.value.create = [];
 			target.value.update = [];
 			target.value.delete = [];
+
+			reset();
+		}
+
+		function reset() {
+			value.value = itemId.value === '+' ? undefined : [];
+			existingItemCount.value = 0;
+			fetchedItems.value = [];
 		}
 
 		function updateValue() {
 			target.value = cloneDeep(target.value);
+
+			if (target.value.create.length === 0 && target.value.update.length === 0 && target.value.delete.length === 0) {
+				reset();
+			}
 		}
 	}
 

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -142,7 +142,7 @@ const query = ref<RelationQueryMultiple>({
 	page: 1,
 });
 
-const { create, update, displayItems, loading, fetchedItems } = useRelationMultiple(
+const { create, update, remove, displayItems, loading, fetchedItems } = useRelationMultiple(
 	value,
 	query,
 	relationInfo,
@@ -168,19 +168,24 @@ function updateValue(item: DisplayItem, lang: string | undefined) {
 
 	const itemInfo = getItemWithLang(displayItems.value, lang);
 
-	if (itemInfo) {
-		update({
-			...item,
-			$type: itemInfo?.$type,
-			$index: itemInfo?.$index,
-		});
-	} else {
+	if (!itemInfo) {
 		create({
 			...item,
 			[info.junctionField.field]: {
 				[info.relatedPrimaryKeyField.field]: lang,
 			},
 		});
+		return;
+	}
+
+	if (Object.keys(item).some((key) => ![info.junctionField.field, '$type', '$index'].includes(key))) {
+		update({
+			...item,
+			$type: itemInfo?.$type,
+			$index: itemInfo?.$index,
+		});
+	} else {
+		remove(item);
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #14427

The reported issue was primarily with translations interface, where when we undo any edits of a new language, it will still remain as an edit but just with the language code, such as:

```json
{
	"create": [
		{
			"languages_id": {
				"code": "de-DE"
			}
		}
	],
	"update": [],
	"delete": []
}
```

The fix in translations interface resolves this by making use of the existing `remove()` function when it only contains said language code. However, now translations interface, or all use-relation-multiple interfaces in general, still has a similar issue where they will contain an empty create-update-delete object, such as:

- translations

   https://user-images.githubusercontent.com/42867097/185070965-d1d9b516-3f8e-45b8-9681-cd357414e2ad.mp4
   
- O2M as another example

   https://user-images.githubusercontent.com/42867097/185070999-413ee5b7-bf3c-4b9b-8f6b-930a21b37ba9.mp4

After making sure use-relation-multiple will clean up in such scenario, now it'll remove any unnecessary edits properly:

https://user-images.githubusercontent.com/42867097/185071049-f1722e52-4c3a-4ff0-861c-310f7d43daac.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
