### PR TITLE
Reinstate language direction translations keys

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -301,6 +301,8 @@ next: Next
 field_name: Field Name
 translations: Translations
 no_translations: No Translations
+left_to_right: Left to Right
+right_to_left: Right to Left
 note: Note
 enter_a_value: Enter a value...
 enter_a_placeholder: Enter a placeholder...
@@ -1683,6 +1685,7 @@ interfaces:
     user_language: Use Current User Language
     default_language: Default Language
     language_field: Language Indicator Field
+    language_direction_field: Language Direction Field
   list-o2m-tree-view:
     description: Tree view for nested recursive one-to-many items
     recursive_only: The tree view interface only works for recursive relationships.


### PR DESCRIPTION
## Description

Seems like the new translations keys added in #14665 was removed here: https://github.com/directus/directus/pull/14983/files#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6a

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
