### PR TITLE
Fix margin for tree view buttons

### DIFF
--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -141,16 +141,4 @@ const fields = computed(() => {
 	margin-left: 24px;
 	padding-left: 0;
 }
-
-.actions {
-	margin-top: 12px;
-}
-
-.actions .v-button + .v-button {
-	margin-left: 12px;
-}
-
-.existing {
-	margin-left: 12px;
-}
 </style>

--- a/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
@@ -311,4 +311,12 @@ function addNew(item: Record<string, any>) {
 	background-color: var(--primary-alt);
 	box-shadow: 0 !important;
 }
+
+.actions {
+	margin-top: 12px;
+}
+
+.actions .v-button + .v-button {
+	margin-left: 12px;
+}
 </style>


### PR DESCRIPTION
## Description

The buttons within tree view interface doesn't seem to have spacing between them, unlike other relational interfaces:

![chrome_jjLLCRVZWw](https://user-images.githubusercontent.com/42867097/185106246-05263f00-16ad-4bf7-a2f7-567fca659368.png)

Seems like the buttons were moved to a nested component during the relational interfaces rework here: https://github.com/directus/directus/pull/12082/files#diff-9fbb64e6f2881d20e39054cc5d484d33e515284a46c9fb93c1fab19aad0a338f

So this PR moves those classes into said `<nested-draggable>` component. The `.existing` class is also removed since it is not used anywhere, but I assume it was used in the past, before the `.actions .v-button > .v-button` solution was implemented.

### Result

![chrome_lGJfogpt6s](https://user-images.githubusercontent.com/42867097/185106390-e153930b-b7a3-43ff-a3e6-d99c8fc5af4b.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
