### PR TITLE
Unify download icon

### DIFF
--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -36,7 +36,7 @@
 					<v-icon name="zoom_in" />
 				</v-button>
 				<v-button v-tooltip="t('download')" icon rounded :href="downloadSrc" :download="image.filename_download">
-					<v-icon name="get_app" />
+					<v-icon name="file_download" />
 				</v-button>
 				<v-button v-tooltip="t('edit')" icon rounded @click="editImageDetails = true">
 					<v-icon name="open_in_new" />

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -67,7 +67,7 @@
 			</v-dialog>
 
 			<v-button v-tooltip.bottom="t('download')" rounded icon secondary @click="downloadFile">
-				<v-icon name="save_alt" />
+				<v-icon name="file_download" />
 			</v-button>
 
 			<v-button


### PR DESCRIPTION
## Description

Currently the image interface uses a different download icon than the download button in the file library. I guess it would make sense to use the same icon for it.

Before (Image Interface - File Library):

![grafik](https://user-images.githubusercontent.com/45203603/185239145-493ba5b1-28b9-4c02-ae18-6fc93cc6a103.png) ![grafik](https://user-images.githubusercontent.com/45203603/185239193-ab704da2-4219-4022-b21d-8340241d20f0.png)

After (Image Interface - File Library):

![grafik](https://user-images.githubusercontent.com/45203603/185239079-e0561d80-3930-4869-b8b8-e68587102508.png) ![grafik](https://user-images.githubusercontent.com/45203603/185239107-d9a4be34-af86-4ef9-a442-97f1c76cf05b.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code