### PR TITLE
fix name removal in Presets & Bookmarks

### DIFF
--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -241,7 +241,7 @@ export default defineComponent({
 
 				const editsParsed: Partial<Preset> = {};
 
-				if (edits.value.name) editsParsed.bookmark = edits.value.name;
+				if (edits.value.name !== undefined) editsParsed.bookmark = edits.value.name;
 				if (edits.value.name?.length === 0) editsParsed.bookmark = null;
 				if (edits.value.icon) editsParsed.icon = edits.value.icon;
 				if (edits.value.color) editsParsed.color = edits.value.color;


### PR DESCRIPTION
## Description

Fixes #15135

We should be able to remove a bookmark name to make it into a default preset when empty:

![chrome_SKu1Qse8dJ](https://user-images.githubusercontent.com/42867097/185366982-bf61d95c-306f-48e1-8f03-e727463ffac8.png)

However when removing it, it doesn't seem to be saved:

https://user-images.githubusercontent.com/42867097/185370014-6d396322-d4c4-41ad-b56a-c962e6c5c793.mp4

Fixed it by preventing `null` value being false when parsing the edits.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
