### PR TITLE
Stop groups from rendering before the conditions are applied

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -282,6 +282,7 @@ export default defineComponent({
 			const { formFields } = useFormFields(fields);
 
 			const fieldsMap = computed(() => {
+				if (Object.keys(values.value).length === 0) return {};
 				const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
 				return formFields.value.reduce((result: Record<string, Field>, field: Field) => {
 					const newField = applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field));

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -121,6 +121,7 @@ export default defineComponent({
 	emits: ['apply'],
 	setup(props) {
 		const { t } = useI18n();
+
 		const detailOpen = ref(props.start === 'open');
 
 		const edited = computed(() => {

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -161,12 +161,6 @@ export default defineComponent({
 			if (isEqual(newVal, oldVal)) return;
 			detailOpen.value = validationMessages.value.length > 0;
 		});
-		watch(
-			() => props.start,
-			(startOpen) => {
-				detailOpen.value = startOpen === 'open';
-			}
-		);
 
 		return { t, edited, validationMessages, detailOpen };
 	},

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -121,7 +121,6 @@ export default defineComponent({
 	emits: ['apply'],
 	setup(props) {
 		const { t } = useI18n();
-
 		const detailOpen = ref(props.start === 'open');
 
 		const edited = computed(() => {
@@ -162,6 +161,12 @@ export default defineComponent({
 			if (isEqual(newVal, oldVal)) return;
 			detailOpen.value = validationMessages.value.length > 0;
 		});
+		watch(
+			() => props.start,
+			(startOpen) => {
+				detailOpen.value = startOpen === 'open';
+			}
+		);
 
 		return { t, edited, validationMessages, detailOpen };
 	},


### PR DESCRIPTION
## Description

Groups were getting rendered before the form values were completely loaded causing the group to use default values preventing the "start open"/"start closed" options from being applied by conditions .

Fixes #15030 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
