### PR TITLE
v-form error: Cannot read properties of undefined (reading 'meta')

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -47,7 +47,7 @@
 				"
 				:key="fieldName + '_field'"
 				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
-				:field="fieldsMap[fieldName]"
+				:field="fieldsMap[fieldName] || {}"
 				:autofocus="index === firstEditableFieldIndex && autofocus"
 				:model-value="(values || {})[fieldName]"
 				:initial-value="(initialValues || {})[fieldName]"
@@ -282,7 +282,7 @@ export default defineComponent({
 			const { formFields } = useFormFields(fields);
 
 			const fieldsMap = computed(() => {
-				if (Object.keys(values.value).length === 0) return {};
+				if (props.loading) return {};
 				const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
 				return formFields.value.reduce((result: Record<string, Field>, field: Field) => {
 					const newField = applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field));
@@ -306,7 +306,8 @@ export default defineComponent({
 
 			return { fieldNames, fieldsMap, isDisabled, getFieldsForGroup, fieldsForGroup };
 
-			function isDisabled(field: Field) {
+			function isDisabled(field: Field | undefined) {
+				if (!field) return true;
 				const meta = fieldsMap.value?.[field.field]?.meta;
 				return (
 					props.loading ||

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -8,9 +8,9 @@
 		/>
 		<template v-for="(fieldName, index) in fieldNames">
 			<component
-				:is="`interface-${fieldsMap[fieldName].meta?.interface || 'group-standard'}`"
-				v-if="fieldsMap[fieldName].meta?.special?.includes('group')"
-				v-show="!fieldsMap[fieldName].meta?.hidden"
+				:is="`interface-${fieldsMap[fieldName]?.meta?.interface || 'group-standard'}`"
+				v-if="fieldsMap[fieldName]?.meta?.special?.includes('group')"
+				v-show="!fieldsMap[fieldName]?.meta?.hidden"
 				:ref="
 					(el: Element) => {
 						formFieldEls[fieldName] = el;
@@ -18,7 +18,7 @@
 				"
 				:key="fieldName + '_group'"
 				:class="[
-					fieldsMap[fieldName].meta?.width || 'full',
+					fieldsMap[fieldName]?.meta?.width || 'full',
 					index === firstVisibleFieldIndex ? 'first-visible-field' : '',
 				]"
 				:field="fieldsMap[fieldName]"
@@ -34,12 +34,12 @@
 				:badge="badge"
 				:raw-editor-enabled="rawEditorEnabled"
 				:direction="direction"
-				v-bind="fieldsMap[fieldName].meta?.options || {}"
+				v-bind="fieldsMap[fieldName]?.meta?.options || {}"
 				@apply="apply"
 			/>
 
 			<form-field
-				v-else-if="!fieldsMap[fieldName].meta?.hidden"
+				v-else-if="!fieldsMap[fieldName]?.meta?.hidden"
 				:ref="
 					(el: Element) => {
 						formFieldEls[fieldName] = el;
@@ -195,7 +195,7 @@ export default defineComponent({
 		const firstEditableFieldIndex = computed(() => {
 			for (let i = 0; i < fieldNames.value.length; i++) {
 				const field = fieldsMap.value[fieldNames.value[i]];
-				if (field.meta && !field.meta?.readonly && !field.meta?.hidden) {
+				if (field?.meta && !field.meta?.readonly && !field.meta?.hidden) {
 					return i;
 				}
 			}
@@ -205,7 +205,7 @@ export default defineComponent({
 		const firstVisibleFieldIndex = computed(() => {
 			for (let i = 0; i < fieldNames.value.length; i++) {
 				const field = fieldsMap.value[fieldNames.value[i]];
-				if (field.meta && !field.meta?.hidden) {
+				if (field?.meta && !field.meta?.hidden) {
 					return i;
 				}
 			}
@@ -307,7 +307,7 @@ export default defineComponent({
 			return { fieldNames, fieldsMap, isDisabled, getFieldsForGroup, fieldsForGroup };
 
 			function isDisabled(field: Field) {
-				const meta = fieldsMap.value?.[field.field].meta;
+				const meta = fieldsMap.value?.[field.field]?.meta;
 				return (
 					props.loading ||
 					props.disabled === true ||
@@ -319,12 +319,12 @@ export default defineComponent({
 
 			function getFieldsForGroup(group: null | string, passed: string[] = []): Field[] {
 				const fieldsInGroup: Field[] = fields.value.filter((field) => {
-					const meta = fieldsMap.value?.[field.field].meta;
+					const meta = fieldsMap.value?.[field.field]?.meta;
 					return meta?.group === group || (group === null && isNil(meta));
 				});
 
 				for (const field of fieldsInGroup) {
-					const meta = fieldsMap.value?.[field.field].meta;
+					const meta = fieldsMap.value?.[field.field]?.meta;
 					if (meta?.special?.includes('group') && !passed.includes(meta!.field)) {
 						passed.push(meta!.field);
 						fieldsInGroup.push(...getFieldsForGroup(meta!.field, passed));

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -85,7 +85,7 @@ import { applyConditions } from '@/utils/apply-conditions';
 import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
 import { Field, ValidationError } from '@directus/shared/types';
 import { assign, cloneDeep, isEqual, isNil, omit, pick } from 'lodash';
-import { computed, defineComponent, onBeforeUpdate, PropType, provide, ref, watch } from 'vue';
+import { computed, ComputedRef, defineComponent, onBeforeUpdate, PropType, provide, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import FormField from './form-field.vue';
 import ValidationErrors from './validation-errors.vue';
@@ -281,8 +281,8 @@ export default defineComponent({
 
 			const { formFields } = useFormFields(fields);
 
-			const fieldsMap = computed(() => {
-				if (props.loading) return {};
+			const fieldsMap: ComputedRef<Record<string, Field | undefined>> = computed(() => {
+				if (props.loading) return {} as Record<string, undefined>;
 				const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
 				return formFields.value.reduce((result: Record<string, Field>, field: Field) => {
 					const newField = applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field));
@@ -390,7 +390,8 @@ export default defineComponent({
 			}
 		}
 
-		function unsetValue(field: Field) {
+		function unsetValue(field: Field | undefined) {
+			if (!field) return;
 			if (!props.batchMode && isDisabled(field)) return;
 
 			if (field.field in (props.modelValue || {})) {
@@ -409,7 +410,8 @@ export default defineComponent({
 
 			return { batchActiveFields, toggleBatchField };
 
-			function toggleBatchField(field: Field) {
+			function toggleBatchField(field: Field | undefined) {
+				if (!field) return;
 				if (batchActiveFields.value.includes(field.field)) {
 					batchActiveFields.value = batchActiveFields.value.filter((fieldKey) => fieldKey !== field.field);
 
@@ -432,7 +434,8 @@ export default defineComponent({
 
 			return { rawActiveFields, toggleRawField };
 
-			function toggleRawField(field: Field) {
+			function toggleRawField(field: Field | undefined) {
+				if (!field) return;
 				if (rawActiveFields.value.has(field.field)) {
 					rawActiveFields.value.delete(field.field);
 				} else {


### PR DESCRIPTION
## Description

The fix for #15144 was not properly tested for all `v-form` use-cases. The chosen solution had situations where the field was propagated as `undefined` causing errors when accessing properties of it. 
This pr fixes that by adding optional chaining where appropriate and making sure that situations where the field is still loading are handled gracefully by adding defaults to fall back on or early returns in functions. 

Fixes #15157

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
