### PR TITLE
Replace Array.prototype.at() usage for browser compatibility

### DIFF
--- a/app/src/components/v-image.vue
+++ b/app/src/components/v-image.vue
@@ -28,7 +28,7 @@ let loaded = false;
 const observer = new IntersectionObserver((entries) => {
 	if (entries.length === 0) return;
 
-	const isIntersecting = entries.at(-1)!.isIntersecting;
+	const isIntersecting = entries[entries.length - 1].isIntersecting;
 
 	inView.value = isIntersecting;
 

--- a/app/src/modules/settings/routes/flows/components/arrows.vue
+++ b/app/src/modules/settings/routes/flows/components/arrows.vue
@@ -177,15 +177,14 @@ const arrows = computed(() => {
 			}
 		}
 		const arrowSize = 8;
-		const arrow = `M ${points.at(-1)} L ${points
-			.at(-1)
+		const lastPoint = points[points.length - 1];
+		const arrow = `M ${lastPoint} L ${lastPoint
 			?.clone()
-			.add(new Vector2(-arrowSize, -arrowSize))} M ${points.at(-1)} L ${points
-			.at(-1)
+			.add(new Vector2(-arrowSize, -arrowSize))} M ${lastPoint} L ${lastPoint
 			?.clone()
 			.add(new Vector2(-arrowSize, arrowSize))}`;
 
-		return path + ` L ${points.at(-1)} ${arrow}`;
+		return path + ` L ${lastPoint} ${arrow}`;
 	}
 
 	function generateCorner(start: Vector2, middle: Vector2, end: Vector2) {


### PR DESCRIPTION
## Description

Ref https://github.com/directus/directus/issues/15219#issuecomment-1226853282

Technically the linked issue _should_ be a browser version issue, however this PR attempts to replace the "get last item in an array" logic, `arr.at(-1)` used in #15082 with `arr[arr.length - 1]` for better browser compatibility.

Closes #15219

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
