### PR TITLE
Add perPage and page props to support local pagination

### DIFF
--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -130,6 +130,8 @@ interface Props {
 	inline?: boolean;
 	disabled?: boolean;
 	clickable?: boolean;
+	perPage?: number;
+	page?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -152,6 +154,8 @@ const props = withDefaults(defineProps<Props>(), {
 	inline: false,
 	disabled: false,
 	clickable: true,
+	perPage: 0,
+	page: 1,
 });
 
 const emit = defineEmits([
@@ -233,17 +237,22 @@ const fullColSpan = computed<string>(() => {
 	return `1 / span ${length}`;
 });
 
+const sortedItems = computed(() => {
+	if (props.serverSort === true || internalSort.value.by === props.manualSortKey) {
+		return props.items;
+	}
+
+	if (internalSort.value.by === null) return props.items;
+
+	const itemsSorted = sortBy(props.items, [internalSort.value.by]);
+	if (internalSort.value.desc === true) itemsSorted.reverse();
+	return itemsSorted;
+});
+
 const internalItems = computed({
 	get: () => {
-		if (props.serverSort === true || internalSort.value.by === props.manualSortKey) {
-			return props.items;
-		}
-
-		if (internalSort.value.by === null) return props.items;
-
-		const itemsSorted = sortBy(props.items, [internalSort.value.by]);
-		if (internalSort.value.desc === true) return itemsSorted.reverse();
-		return itemsSorted;
+		const { perPage, page } = props;
+		return perPage > 0 ? sortedItems.value.slice(perPage * page - perPage, perPage) : sortedItems.value;
 	},
 	set: (value: Item[]) => {
 		emit('update:items', value);


### PR DESCRIPTION
## Description

`v-table` is a great reusable component with sorting and selecting. However I find with a static list of items I would like to paginate it but still make use of v-tables sorting feature.

This PR adds page and perPage as optional props that can be set to reduce the number of items shown. In tests this has huge performance benefits when limiting how many items are shown at a time, even though there are many more items.

Using this in combination with `v-pagination` works awesomely

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated **_Will add this once PR is merge_**

