### PR TITLE
Revert list style for O2M and M2M interfaces

### DIFF
--- a/app/src/interfaces/list-m2m/index.ts
+++ b/app/src/interfaces/list-m2m/index.ts
@@ -195,6 +195,17 @@ export default defineInterface({
 						label: '$t:enable_search_filter',
 					},
 					width: 'half',
+					hidden: true,
+					conditions: [
+						{
+							rule: {
+								layout: {
+									_eq: 'table',
+								},
+							},
+							hidden: false,
+						},
+					],
 				},
 			},
 			{

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -4,7 +4,7 @@
 	</v-notice>
 	<div v-else class="many-to-many">
 		<div :class="[`layout-${layout}`, { bordered: layout === LAYOUTS.TABLE }]">
-			<div class="actions" :class="width">
+			<div v-if="layout === LAYOUTS.TABLE" class="actions" :class="width">
 				<div class="spacer" />
 
 				<div v-if="totalItemCount" class="item-count">
@@ -143,20 +143,34 @@
 				</draggable>
 			</v-list>
 
-			<div v-if="totalItemCount > 10" class="actions">
-				<v-pagination
-					v-if="pageCount > 1"
-					v-model="page"
-					:length="pageCount"
-					:total-visible="width.includes('half') ? 3 : 5"
-				/>
+			<div class="actions" :class="layout">
+				<template v-if="layout === LAYOUTS.TABLE">
+					<template v-if="totalItemCount > 10">
+						<v-pagination
+							v-if="pageCount > 1"
+							v-model="page"
+							:length="pageCount"
+							:total-visible="width.includes('half') ? 3 : 5"
+						/>
 
-				<div class="spacer" />
+						<div class="spacer" />
 
-				<div v-if="loading === false" class="per-page">
-					<span>{{ t('per_page') }}</span>
-					<v-select v-model="limit" :items="['10', '20', '30', '50', '100']" inline />
-				</div>
+						<div v-if="loading === false" class="per-page">
+							<span>{{ t('per_page') }}</span>
+							<v-select v-model="limit" :items="['10', '20', '30', '50', '100']" inline />
+						</div>
+					</template>
+				</template>
+				<template v-else>
+					<v-button v-if="enableCreate && createAllowed" :disabled="disabled" @click="createItem">
+						{{ t('create_new') }}
+					</v-button>
+					<v-button v-if="enableSelect && selectAllowed" :disabled="disabled" @click="selectModalActive = true">
+						{{ t('add_existing') }}
+					</v-button>
+					<div class="spacer" />
+					<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="5" />
+				</template>
 			</div>
 		</div>
 
@@ -649,11 +663,13 @@ const selectAllowed = computed(() => {
 	gap: var(--v-sheet-padding);
 
 	.v-pagination {
-		margin-top: var(--v-sheet-padding);
-
 		:deep(.v-button) {
 			display: inline-flex;
 		}
+	}
+
+	.table.v-pagination {
+		margin-top: var(--v-sheet-padding);
 	}
 
 	.spacer {
@@ -683,6 +699,10 @@ const selectAllowed = computed(() => {
 				width: 100% !important;
 			}
 		}
+	}
+
+	&.list {
+		margin-top: 8px;
 	}
 }
 

--- a/app/src/interfaces/list-o2m/index.ts
+++ b/app/src/interfaces/list-o2m/index.ts
@@ -169,6 +169,17 @@ export default defineInterface({
 						label: '$t:enable_search_filter',
 					},
 					width: 'half',
+					hidden: true,
+					conditions: [
+						{
+							rule: {
+								layout: {
+									_eq: 'table',
+								},
+							},
+							hidden: false,
+						},
+					],
 				},
 			},
 			{

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -4,7 +4,7 @@
 	</v-notice>
 	<div v-else class="one-to-many">
 		<div :class="{ bordered: layout === LAYOUTS.TABLE }">
-			<div class="actions" :class="width">
+			<div v-if="layout === LAYOUTS.TABLE" class="actions" :class="width">
 				<div class="spacer" />
 
 				<div v-if="totalItemCount" class="item-count">
@@ -142,20 +142,34 @@
 				</draggable>
 			</v-list>
 
-			<div v-if="totalItemCount > 10" class="actions">
-				<v-pagination
-					v-if="pageCount > 1"
-					v-model="page"
-					:length="pageCount"
-					:total-visible="width.includes('half') ? 3 : 5"
-				/>
+			<div class="actions" :class="layout">
+				<template v-if="layout === LAYOUTS.TABLE">
+					<template v-if="totalItemCount > 10">
+						<v-pagination
+							v-if="pageCount > 1"
+							v-model="page"
+							:length="pageCount"
+							:total-visible="width.includes('half') ? 3 : 5"
+						/>
 
-				<div class="spacer" />
+						<div class="spacer" />
 
-				<div v-if="loading === false" class="per-page">
-					<span>{{ t('per_page') }}</span>
-					<v-select v-model="limit" :items="['10', '20', '30', '50', '100']" inline />
-				</div>
+						<div v-if="loading === false" class="per-page">
+							<span>{{ t('per_page') }}</span>
+							<v-select v-model="limit" :items="['10', '20', '30', '50', '100']" inline />
+						</div>
+					</template>
+				</template>
+				<template v-else>
+					<v-button v-if="enableCreate && createAllowed && updateAllowed" :disabled="disabled" @click="createItem">
+						{{ t('create_new') }}
+					</v-button>
+					<v-button v-if="enableSelect && updateAllowed" :disabled="disabled" @click="selectModalActive = true">
+						{{ t('add_existing') }}
+					</v-button>
+					<div class="spacer" />
+					<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="5" />
+				</template>
 			</div>
 		</div>
 
@@ -601,11 +615,13 @@ const updateAllowed = computed(() => {
 	gap: var(--v-sheet-padding);
 
 	.v-pagination {
-		margin-top: var(--v-sheet-padding);
-
 		:deep(.v-button) {
 			display: inline-flex;
 		}
+	}
+
+	.table.v-pagination {
+		margin-top: var(--v-sheet-padding);
 	}
 
 	.spacer {
@@ -635,6 +651,10 @@ const updateAllowed = computed(() => {
 				width: 100% !important;
 			}
 		}
+	}
+
+	&.list {
+		margin-top: 8px;
 	}
 }
 


### PR DESCRIPTION
## Description

Ref https://github.com/directus/directus/discussions/15225#discussioncomment-3469474

This PR reverts the new style for lists layout which was updated by #12820 in Directus `9.16.0` after further discussions since then.

|Before|After|
|---|---|
|![chrome_ABakNk988g](https://user-images.githubusercontent.com/42867097/186674678-f4d81752-3c01-4f3b-95a7-3cfaf9f94056.png)|![chrome_ctaEttUEt3](https://user-images.githubusercontent.com/42867097/186674650-e872f208-1a1e-4958-8465-020242f7d39c.png)|

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
