### PR TITLE
Missing headers for invalid json requests

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -137,6 +137,15 @@ export default async function createApp(): Promise<express.Application> {
 
 	app.use(expressLogger);
 
+	app.use((_req, res, next) => {
+		res.setHeader('X-Powered-By', 'Directus');
+		next();
+	});
+
+	if (env.CORS_ENABLED === true) {
+		app.use(cors);
+	}
+
 	app.use((req, res, next) => {
 		(
 			express.json({
@@ -154,15 +163,6 @@ export default async function createApp(): Promise<express.Application> {
 	app.use(cookieParser());
 
 	app.use(extractToken);
-
-	app.use((_req, res, next) => {
-		res.setHeader('X-Powered-By', 'Directus');
-		next();
-	});
-
-	if (env.CORS_ENABLED === true) {
-		app.use(cors);
-	}
 
 	app.get('/', (_req, res, next) => {
 		if (env.ROOT_REDIRECT) {


### PR DESCRIPTION
## Description

The JSON body was being parsed before the CORS headers were set so when it runs into a JSON parse error it is missing the required headers for a browser. The solution is to first set the cors headers and then parse the body.

Fixes #15194

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
