### PR TITLE
Add max height to CodeMirror scroller

### DIFF
--- a/app/src/styles/lib/_codemirror.scss
+++ b/app/src/styles/lib/_codemirror.scss
@@ -2,7 +2,6 @@
 
 .CodeMirror {
 	width: 100%;
-	height: 300px;
 	height: auto;
 	color: var(--foreground-normal);
 	font-weight: inherit;
@@ -338,6 +337,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 	position: relative;
 	height: 100%;
 	min-height: var(--input-height-tall);
+	max-height: 1000px; // matches wysiwyg
 	margin-right: -50px;
 
 	/* 50px is the magic margin used to hide the element's real scrollbars */


### PR DESCRIPTION
## Description

Matches max height of input-rich-text-html

Fixes #15279

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
