### PR TITLE
Move get-with-arrays to shared

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -185,7 +185,7 @@ import { useSync } from '@directus/shared/composables';
 import { Field, Filter, Item, ShowSelect } from '@directus/shared/types';
 import { ComponentPublicInstance, inject, ref, Ref, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { get } from '@/utils/get-with-arrays';
+import { get } from '@directus/shared/utils';
 import { useAliasFields, AliasField } from '@/composables/use-alias-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { isEmpty, merge } from 'lodash';

--- a/app/src/utils/save-as-csv.ts
+++ b/app/src/utils/save-as-csv.ts
@@ -1,7 +1,7 @@
 import { useAliasFields } from '@/composables/use-alias-fields';
 import { getDisplay } from '@/displays';
 import { useFieldsStore } from '@/stores/fields';
-import { get } from '@/utils/get-with-arrays';
+import { get } from '@directus/shared/utils';
 import { DisplayConfig, Field, Item } from '@directus/shared/types';
 import { saveAs } from 'file-saver';
 import { parse } from 'json2csv';

--- a/packages/shared/src/utils/get-with-arrays.test.ts
+++ b/packages/shared/src/utils/get-with-arrays.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-import { get } from '@/utils/get-with-arrays';
+import { get } from './get-with-arrays';
 
 test('Returns static value from object', () => {
 	const input = { test: { path: 'example' } };

--- a/packages/shared/src/utils/get-with-arrays.ts
+++ b/packages/shared/src/utils/get-with-arrays.ts
@@ -11,9 +11,7 @@
 export function get(object: Record<string, any> | any[], path: string, defaultValue?: unknown): any {
 	const [key, ...follow] = path.split('.');
 
-	const result = Array.isArray(object)
-		? object.map((entry) => entry?.[key!]).filter((val) => val !== undefined)
-		: object?.[key!];
+	const result = Array.isArray(object) ? object.map((entry) => entry?.[key!]) : object?.[key!];
 
 	if (follow.length > 0) {
 		return get(result, follow.join('.'), defaultValue);

--- a/packages/shared/src/utils/get-with-arrays.ts
+++ b/packages/shared/src/utils/get-with-arrays.ts
@@ -8,10 +8,12 @@
  * // => [1, 2]
  * ```
  */
-export function get(object: Record<string, any> | any[], path: string, defaultValue?: any): any {
+export function get(object: Record<string, any> | any[], path: string, defaultValue?: unknown): any {
 	const [key, ...follow] = path.split('.');
 
-	const result = Array.isArray(object) ? object.map((entry) => entry[key!]) : object?.[key!];
+	const result = Array.isArray(object)
+		? object.map((entry) => entry?.[key!]).filter((val) => val !== undefined)
+		: object?.[key!];
 
 	if (follow.length > 0) {
 		return get(result, follow.join('.'), defaultValue);

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './get-functions-for-type';
 export * from './get-output-type-for-function';
 export * from './get-relation-type';
 export * from './get-simple-hash';
+export * from './get-with-arrays';
 export * from './is-dynamic-variable';
 export * from './merge-filters';
 export * from './move-in-array';

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -1,8 +1,9 @@
-import { get, isObjectLike } from 'lodash';
+import { isObjectLike } from 'lodash';
 import { REGEX_BETWEEN_PARENS } from '../constants';
 import { Accountability, Filter, Role, User } from '../types';
 import { adjustDate } from './adjust-date';
 import { deepMap } from './deep-map';
+import { get } from './get-with-arrays';
 import { isDynamicVariable } from './is-dynamic-variable';
 import { toArray } from './to-array';
 


### PR DESCRIPTION
Follow up to https://github.com/directus/directus/pull/15276. Moves `get` from the App's `get-with-arrays` to `@directus/shared`, and re-uses it in the shared `parse-filter` instance. Also implements a fallback to undefined to avoid the problem that #15276 aimed to solve in https://github.com/directus/directus/issues/15275