### PR TITLE
Current items cleared in o2m/m2m when selecting nothing with "add existing"

### DIFF
--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -37,7 +37,7 @@
 		</v-list-item>
 		<v-list-item
 			v-if="!restricted && (defaultValue === null || !isRequired)"
-			:disabled="modelValue === null"
+			:disabled="modelValue === null || relational"
 			clickable
 			@click="$emit('update:modelValue', null)"
 		>
@@ -87,7 +87,14 @@ export default defineComponent({
 			return props.field?.schema?.is_nullable === false;
 		});
 
-		return { t, defaultValue, isRequired, isCopySupported, isPasteSupported };
+		const relational = computed(
+			() =>
+				props.field.meta?.special?.find((type) =>
+					['file', 'files', 'm2o', 'o2m', 'm2m', 'm2a', 'translations'].includes(type)
+				) !== undefined
+		);
+
+		return { t, defaultValue, isRequired, isCopySupported, isPasteSupported, relational };
 	},
 });
 </script>

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -251,7 +251,7 @@ export function useRelationMultiple(
 
 		function select(items: (string | number)[], collection?: string) {
 			const info = relation.value;
-			if (!info) return;
+			if (!info || items.length === 0) return;
 
 			const selected = items.map((item) => {
 				switch (info.type) {

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -63,8 +63,6 @@ export function useRelationMultiple(
 			(Array.isArray(newValue) && Array.isArray(oldValue) && oldValue.length === 0)
 		) {
 			updateFetchedItems();
-		} else if (newValue === null) {
-			clear();
 		}
 	});
 
@@ -173,7 +171,7 @@ export function useRelationMultiple(
 		});
 	});
 
-	const { create, remove, select, update, clear } = useActions(_value);
+	const { create, remove, select, update } = useActions(_value);
 
 	return {
 		create,
@@ -193,7 +191,7 @@ export function useRelationMultiple(
 	};
 
 	function useActions(target: Ref<Item>) {
-		return { create, update, remove, select, clear };
+		return { create, update, remove, select };
 
 		function create(...items: Record<string, any>[]) {
 			for (const item of items) {
@@ -251,7 +249,7 @@ export function useRelationMultiple(
 
 		function select(items: (string | number)[], collection?: string) {
 			const info = relation.value;
-			if (!info || items.length === 0) return;
+			if (!info) return;
 
 			const selected = items.map((item) => {
 				switch (info.type) {
@@ -285,28 +283,8 @@ export function useRelationMultiple(
 			else create(...selected);
 		}
 
-		function clear() {
-			if (!relation.value) return;
-
-			target.value.create = [];
-			target.value.update = [];
-			target.value.delete = [];
-
-			reset();
-		}
-
-		function reset() {
-			value.value = itemId.value === '+' ? undefined : [];
-			existingItemCount.value = 0;
-			fetchedItems.value = [];
-		}
-
 		function updateValue() {
 			target.value = cloneDeep(target.value);
-
-			if (target.value.create.length === 0 && target.value.update.length === 0 && target.value.delete.length === 0) {
-				reset();
-			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Reproduce:
- create any o2m/m2m fields with "add existing" enabled
- select one or more items
- (optional) save and reopen that
- click "add existing" and click save without selecting anything

Result:
The originally selected items are gone but won't be selectable again if duplicates is disabled until you save and re-open

Solution:
Added an early return to stop the `select` function from updating the state if nothing has been selected.
Because when the rest of the update logic fires it will eventually up at this reset with an empty target:
https://github.com/directus/directus/blob/d7b8ef297e1389d648cd7b7ed7d9db3b8eca57b0/app/src/composables/use-relation-multiple.ts#L307-L309

Fixes #15324 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
