### PR TITLE
Prevent sending the primary key for newly created relational items

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -361,7 +361,7 @@ function useActions() {
 			set(internalEdits.value, [props.junctionField, relatedPrimaryKeyField.value.field], props.relatedPrimaryKey);
 		}
 
-		if (props.primaryKey && primaryKeyField.value) {
+		if (props.primaryKey && props.primaryKey !== '+' && primaryKeyField.value) {
 			internalEdits.value[primaryKeyField.value.field] = props.primaryKey;
 		}
 


### PR DESCRIPTION
## Description

Follow up on PR #15336 

The primaryKeys of newly created relational items were getting sent to the API as `+` creating type errors.

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
