### PR TITLE
Don't reset body on singleton non-SEARCH reqs

### DIFF
--- a/api/src/middleware/validate-batch.test.ts
+++ b/api/src/middleware/validate-batch.test.ts
@@ -26,10 +26,10 @@ test('Sets body to empty, calls next on GET requests', async () => {
 test(`Short circuits on singletons that aren't queried through SEARCH`, async () => {
 	mockRequest.method = 'PATCH';
 	mockRequest.singleton = true;
+	mockRequest.body = { title: 'test' };
 
 	await validateBatch('update')(mockRequest as Request, mockResponse as Response, nextFunction);
 
-	expect(mockRequest.body).toEqual({});
 	expect(nextFunction).toHaveBeenCalledTimes(1);
 });
 

--- a/api/src/middleware/validate-batch.ts
+++ b/api/src/middleware/validate-batch.ts
@@ -12,7 +12,6 @@ export const validateBatch = (scope: 'read' | 'update' | 'delete') =>
 		}
 
 		if (req.method.toLowerCase() !== 'search' && scope !== 'read' && req.singleton) {
-			req.body = {};
 			return next();
 		}
 


### PR DESCRIPTION
## Description

The request body was erroneously set to `{}` on non-search methods, killing `PATCH` support.

Fixes #15364

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
