### PR TITLE
Fix context menu

### DIFF
--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -122,8 +122,6 @@ const emit = defineEmits(['update:modelValue']);
 const activator = ref<HTMLElement | null>(null);
 const reference = ref<HTMLElement | null>(null);
 
-defineExpose({ activator });
-
 const virtualReference = ref({
 	getBoundingClientRect() {
 		return {
@@ -159,6 +157,8 @@ const {
 );
 
 const { isActive, activate, deactivate, toggle } = useActiveState();
+
+defineExpose({ activator, id, activate, deactivate });
 
 watch(isActive, (newActive) => {
 	if (newActive === true) {


### PR DESCRIPTION
## Description

Fixes #15375, #15383

When trying to open context menu, it does not work and an error will be logged in browser console.

`<v-menu>` component was change to `script setup` in #15094, which in turn meant the component properties became private by default, hence the directive was not able to call `activate()` or `deactivate()`.

Added `id` to `defineExpose()` so that deactivation can find the element to close:

https://github.com/directus/directus/blob/39c8c6aa830cb362259c8f306ca4ff4d82bcf54d/app/src/directives/context-menu.ts#L39

and also `activate` and `deactivate` for activating/deactivating said context menu:

https://github.com/directus/directus/blob/39c8c6aa830cb362259c8f306ca4ff4d82bcf54d/app/src/directives/context-menu.ts#L30

https://github.com/directus/directus/blob/39c8c6aa830cb362259c8f306ca4ff4d82bcf54d/app/src/directives/context-menu.ts#L41

### Before

https://user-images.githubusercontent.com/42867097/188241060-4f5e23c6-9f22-477c-8739-59b2eb6603ed.mp4

### After

https://user-images.githubusercontent.com/42867097/188241185-bffc7033-f354-47cc-8e7a-a941ca65e679.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
