### PR TITLE
Set limit as -1 for local exports when field is cleared

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -487,10 +487,11 @@ function exportDataLocal() {
 
 	if (exportSettings.sort && exportSettings.sort !== '') params.sort = exportSettings.sort;
 	if (exportSettings.fields) params.fields = exportSettings.fields;
-	if (exportSettings.limit) params.limit = exportSettings.limit;
 	if (exportSettings.search) params.search = exportSettings.search;
 	if (exportSettings.filter) params.filter = exportSettings.filter;
 	if (exportSettings.search) params.search = exportSettings.search;
+
+	params.limit = exportSettings.limit ?? -1;
 
 	const exportUrl = api.getUri({
 		url,


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #15377

`exportSettings.limit` is set as `null` when field is cleared, leading to the API limiting it to `100`.

https://github.com/directus/directus/blob/3d469ce0c13e652f0900b99e9e16126a6bc689b0/api/src/database/run-ast.ts#L246-L247

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
