### PR TITLE
#15395  fix: date-fns date format for tr-TR translations

### DIFF
--- a/app/src/lang/translations/tr-TR.yaml
+++ b/app/src/lang/translations/tr-TR.yaml
@@ -395,9 +395,9 @@ date-fns_time: 's:dd:ss a'
 date-fns_time_no_seconds: 's:dd a'
 date-fns_time_24hour: 'SS:dd:ss'
 date-fns_time_no_seconds_24hour: 'SS:dd'
-date-fns_date_short: 'AAA d, u'
+date-fns_date_short: 'MMM d, u'
 date-fns_time_short: 's:aa a'
-date-fns_date_short_no_year: AAA d
+date-fns_date_short_no_year: MMM d
 minutes: Dakika
 hours: Saat
 month: Ay


### PR DESCRIPTION
## Description

<!--

Problem is due to date-fns package. There is no formatter like ```AAA``` in date-fns. Changing date format strings ```AAA``` to ```MMM``` in tr-TR.yaml has fixed the issue.

-->

Fixes #15395

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
