### PR TITLE
Fix drawer item empty form for o2m/treeview

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -20,42 +20,40 @@
 		</template>
 
 		<div class="drawer-item-content">
-			<template v-if="junctionField">
-				<file-preview
-					v-if="file"
-					:src="file.src"
-					:mime="file.type"
-					:width="file.width"
-					:height="file.height"
-					:title="file.title"
-					:in-modal="true"
+			<file-preview
+				v-if="junctionField && file"
+				:src="file.src"
+				:mime="file.type"
+				:width="file.width"
+				:height="file.height"
+				:title="file.title"
+				:in-modal="true"
+			/>
+			<div class="drawer-item-order" :class="{ swap: swapFormOrder }">
+				<v-form
+					v-if="junctionField"
+					:disabled="disabled"
+					:loading="loading"
+					:initial-values="initialValues?.[junctionField]"
+					:primary-key="relatedPrimaryKey"
+					:model-value="internalEdits?.[junctionField]"
+					:fields="relatedCollectionFields"
+					:validation-errors="junctionField ? validationErrors : undefined"
+					autofocus
+					:show-divider="!swapFormOrder"
+					@update:model-value="setRelationEdits"
 				/>
-				<div class="drawer-item-order" :class="{ swap: swapFormOrder }">
-					<v-form
-						:disabled="disabled"
-						:loading="loading"
-						:initial-values="initialValues?.[junctionField]"
-						:primary-key="relatedPrimaryKey"
-						:model-value="internalEdits?.[junctionField]"
-						:fields="relatedCollectionFields"
-						:validation-errors="junctionField ? validationErrors : undefined"
-						autofocus
-						:show-divider="!swapFormOrder"
-						@update:model-value="setRelationEdits"
-					/>
-
-					<v-form
-						v-model="internalEdits"
-						:disabled="disabled"
-						:loading="loading"
-						:initial-values="initialValues"
-						:show-divider="swapFormOrder"
-						:primary-key="primaryKey"
-						:fields="fields"
-						:validation-errors="!junctionField ? validationErrors : undefined"
-					/>
-				</div>
-			</template>
+				<v-form
+					v-model="internalEdits"
+					:disabled="disabled"
+					:loading="loading"
+					:initial-values="initialValues"
+					:show-divider="swapFormOrder"
+					:primary-key="primaryKey"
+					:fields="fields"
+					:validation-errors="!junctionField ? validationErrors : undefined"
+				/>
+			</div>
 		</div>
 	</v-drawer>
 </template>


### PR DESCRIPTION
## Description

Fixes #15407

Ref https://github.com/directus/directus/issues/15407#issuecomment-1237663617

#14605 moved the non-junction `<v-form>` into the template `v-if="junctionField"`, which in turn causes the related collection's form to not show anymore in O2M/treeview, unless there's a junctionField such as in M2M.

Removed the `<template>` wrapper and opt to use `v-if` junction field directly on `<file-preview>` and junction `<v-form>` instead.

### Before

https://user-images.githubusercontent.com/42867097/188555828-af8904bc-c13b-444a-b8d1-d69f1056b3de.mp4

### After

https://user-images.githubusercontent.com/42867097/188555812-25ac3e51-cf8e-4ac5-a6e8-777e7c31eb93.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
