### PR TITLE
Ensure case insensitive email checks for password reset requests

### DIFF
--- a/api/src/cli/commands/users/passwd.ts
+++ b/api/src/cli/commands/users/passwd.ts
@@ -17,7 +17,11 @@ export default async function usersPasswd({ email, password }: { email?: string;
 		const schema = await getSchema();
 		const service = new UsersService({ schema, knex: database });
 
-		const user = await service.knex.select('id').from('directus_users').where({ email }).first();
+		const user = await service.knex
+			.select('id')
+			.from('directus_users')
+			.whereRaw('LOWER(??) = ?', ['email', email.toLowerCase()])
+			.first();
 		if (user) {
 			await service.knex('directus_users').update({ password: passwordHashed }).where({ id: user.id });
 			logger.info(`Password is updated for user ${user.id}`);

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -357,7 +357,11 @@ export class UsersService extends ItemsService {
 		const STALL_TIME = 500;
 		const timeStart = performance.now();
 
-		const user = await this.knex.select('status', 'password').from('directus_users').where({ email }).first();
+		const user = await this.knex
+			.select('status', 'password')
+			.from('directus_users')
+			.whereRaw('LOWER(??) = ?', ['email', email.toLowerCase()])
+			.first();
 
 		if (user?.status !== 'active') {
 			await stall(STALL_TIME, timeStart);


### PR DESCRIPTION
## Description

Fixes #15418

When logging in via the local auth driver, email is lowercased during the check:

https://github.com/directus/directus/blob/fd9c75b27cf795c4864fb61d5d5b5ecd3a65942e/api/src/auth/drivers/local.ts#L22-L26

as well as when checking for unique mails:

https://github.com/directus/directus/blob/fd9c75b27cf795c4864fb61d5d5b5ecd3a65942e/api/src/services/users.ts#L38-L39

https://github.com/directus/directus/blob/fd9c75b27cf795c4864fb61d5d5b5ecd3a65942e/api/src/services/users.ts#L51-L54

However not when requesting password reset.

Updated API password reset request and also CLI password reset command to use the same lowercase logic.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
