### PR TITLE
Merge with M2M junction value when validating in drawer-item

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -358,6 +358,8 @@ function useActions() {
 		if (errors.length > 0) {
 			validationErrors.value = errors;
 			return;
+		} else {
+			validationErrors.value = [];
 		}
 
 		if (props.junctionField && props.relatedPrimaryKey !== '+' && relatedPrimaryKeyField.value) {

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -348,8 +348,15 @@ function useActions() {
 		const editsToValidate = props.junctionField ? internalEdits.value[props.junctionField] : internalEdits.value;
 		const fieldsToValidate = props.junctionField ? relatedCollectionFields.value : fieldsWithoutCircular.value;
 		const defaultValues = getDefaultValuesFromFields(fieldsToValidate);
+		const existingValues = initialValues
+			? props.junctionField
+				? initialValues.value
+					? initialValues.value[props.junctionField] ?? {}
+					: {}
+				: initialValues.value
+			: {};
 		let errors = validateItem(
-			merge({}, defaultValues.value, initialValues.value, editsToValidate),
+			merge({}, defaultValues.value, existingValues, editsToValidate),
 			fieldsToValidate,
 			isNew.value
 		);

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -348,13 +348,7 @@ function useActions() {
 		const editsToValidate = props.junctionField ? internalEdits.value[props.junctionField] : internalEdits.value;
 		const fieldsToValidate = props.junctionField ? relatedCollectionFields.value : fieldsWithoutCircular.value;
 		const defaultValues = getDefaultValuesFromFields(fieldsToValidate);
-		const existingValues = initialValues
-			? props.junctionField
-				? initialValues.value
-					? initialValues.value[props.junctionField] ?? {}
-					: {}
-				: initialValues.value
-			: {};
+		const existingValues = props.junctionField ? initialValues?.value?.[props.junctionField] : initialValues?.value;
 		let errors = validateItem(
 			merge({}, defaultValues.value, existingValues, editsToValidate),
 			fieldsToValidate,


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes https://github.com/directus/directus/issues/15379#issuecomment-1238384783 by merging with the initial values within the junction field.
Follow-up of https://github.com/directus/directus/pull/15386 where the PR fixed issue for O2M only.

Also clears the validation messages on save to prevent error from displaying when reopening drawer.

### O2M 
https://user-images.githubusercontent.com/26413686/188708012-590b1106-cdd9-4d86-97d5-fcfe9cf9a1bb.mov

### M2M
https://user-images.githubusercontent.com/26413686/188708064-4712c231-c9a9-4c58-b5f4-44e8f2ba1b7b.mov

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
