### PR TITLE
Prevent v-highlight infinite loop

### DIFF
--- a/app/src/components/v-highlight.vue
+++ b/app/src/components/v-highlight.vue
@@ -44,7 +44,7 @@ const parts = computed<HighlightPart[]>(() => {
 
 	const matches = flatten(
 		queries.reduce<number[][][]>((acc, query) => {
-			if (query === null) return acc;
+			if (!query) return acc;
 
 			query = removeDiacritics(query.toLowerCase());
 


### PR DESCRIPTION
## Description

Fixes #15434

In #15094, `<v-highlight>` was refactored here:

https://github.com/directus/directus/pull/15094/files#diff-f1a285feff41d11bda6ada4bb01cb25885943b6a446c24e7ffc57b4e43c6e036L46-L65

```js
			const matches = flatten(
				queries
					.filter((query) => query)
					.map((query) => {
						query = removeDiacritics(query.toLowerCase());
						const indices = [];
						let startIndex = 0;
						let index = searchText.indexOf(query, startIndex);
						while (index > -1) {
							startIndex = index + query.length;
							indices.push([index, startIndex]);
							index = searchText.indexOf(query, index + 1);
						}
						return indices;
					})
			);
```

here the `.filter` filters not only null values, but also empty string `""` which is also falsy.

However the refactor was only catching `null`:

https://github.com/directus/directus/blob/41995dbd4560e4610ef4a100758b3f133d01c941/app/src/components/v-highlight.vue#L47

thus the `index` in the following lines became `0`, and `while (index > -1)` turns into an infinite loop.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
