### PR TITLE
Fix v-list-group active state

### DIFF
--- a/app/src/components/v-list-group.vue
+++ b/app/src/components/v-list-group.vue
@@ -45,6 +45,8 @@ interface Props {
 	multiple?: boolean;
 	/** To what route the item should link to */
 	to?: string;
+	/** If the item should be active or not */
+	active?: boolean;
 	/** Renders an active state if the route matches exactly */
 	exact?: boolean;
 	/** Renders an active state it the route matches the query  */
@@ -68,6 +70,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
 	multiple: true,
 	to: '',
+	active: undefined,
 	exact: false,
 	query: false,
 	disabled: false,
@@ -81,12 +84,12 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits(['click']);
 
-const { active, toggle } = useGroupable({
+const { active: groupableActive, toggle } = useGroupable({
 	group: props.scope,
 	value: props.value,
 });
 
-const groupActive = computed(() => active.value || props.open);
+const groupActive = computed(() => groupableActive.value || props.open);
 
 function onClick(event: MouseEvent) {
 	if (props.to) return null;


### PR DESCRIPTION
## Description

Fixes #15416

`<v-list-group>` was refactored to script setup in https://github.com/directus/directus/pull/15094/files#diff-6c142ec962a7880f93e68f1b6b3630357054a81ffb8c77bec84df1bdaf1d0189, but the `active` _prop_ was removed in favor of the `active` _ref_ from `useGroupable()`.

However the `<v-list-item>` was actually using the `active` prop to determine the active "highlighted" state:

https://github.com/directus/directus/blob/4d465764a19c6ca7482239f94dc7b27e10bd9484/app/src/components/v-list-group.vue#L5

not the `active` ref that determines whether the group is open:

https://github.com/directus/directus/blob/4d465764a19c6ca7482239f94dc7b27e10bd9484/app/src/components/v-list-group.vue#L84

This PR attempts to "revert" it to the original state.

### Comparisons

||Before|After|
|---|---|---|
| Content Module Nav | ![][before-content] | ![][after-content] |
| Files Module Folders Nav | ![][before-folder] | ![][after-folder] |

[before-content]: https://user-images.githubusercontent.com/42867097/188828476-c0d0fbf3-3bf7-4474-bcce-87de9dde4ac3.gif
[after-content]: https://user-images.githubusercontent.com/42867097/188828431-434a0507-b211-4e46-9e17-8db52f775874.gif
[before-folder]: https://user-images.githubusercontent.com/42867097/188828377-cdbb4b7f-fd51-4645-9ba6-727ecf4abe99.gif
[after-folder]: https://user-images.githubusercontent.com/42867097/188828317-cfd0e7ec-70a5-4ccb-b145-aeffd24faa84.gif

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
