### PR TITLE
Fix M2M drawer autofocusing the wrong field with junction field location `top`

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -39,7 +39,7 @@
 					:model-value="internalEdits?.[junctionField]"
 					:fields="relatedCollectionFields"
 					:validation-errors="junctionField ? validationErrors : undefined"
-					autofocus
+					:autofocus="!swapFormOrder"
 					:show-divider="!swapFormOrder"
 					@update:model-value="setRelationEdits"
 				/>
@@ -48,6 +48,7 @@
 					:disabled="disabled"
 					:loading="loading"
 					:initial-values="initialValues"
+					:autofocus="swapFormOrder"
 					:show-divider="swapFormOrder"
 					:primary-key="primaryKey"
 					:fields="fields"


### PR DESCRIPTION
## Description

fix the autofocus when changing the junction field direction to TOP on the m2m interface.

Fixes #15440 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated