### PR TITLE
Fix display dimensions of SVG in image edit drawer

### DIFF
--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -106,11 +106,7 @@
 				<v-icon v-tooltip.top.inverted="t('reset')" name="restart_alt" clickable @click="reset" />
 
 				<div v-if="imageData" class="dimensions">
-					{{ n(imageData.width) }}x{{ n(imageData.height) }}
-					<template v-if="imageData.width !== newDimensions.width || imageData.height !== newDimensions.height">
-						->
-						{{ n(newDimensions.width ?? 0) }}x{{ n(newDimensions.height ?? 0) }}
-					</template>
+					{{ dimensionsString }}
 				</div>
 
 				<button v-show="cropping" class="toolbar-button cancel" @click="cropping = false">
@@ -211,6 +207,33 @@ export default defineComponent({
 			return addTokenToURL(`${getRootPath()}assets/${props.id}?${randomId.value}`);
 		});
 
+		const dimensionsString = computed(() => {
+			let output = '';
+			const isSVG = imageData.value?.type === 'image/svg+xml';
+
+			if (imageData.value) {
+				if (isSVG) {
+					output += 'SVG';
+				} else {
+					output += `${n(imageData.value.width ?? 0)}x${n(imageData.value.height ?? 0)}`;
+				}
+
+				if (imageData.value.width !== newDimensions.width || imageData.value.height !== newDimensions.height) {
+					if (isSVG) {
+						if (newDimensions.width || newDimensions.height) {
+							output += ` -> PNG ${n(newDimensions.width ?? 0)}x${n(newDimensions.height ?? 0)}`;
+						} else {
+							output += ' -> PNG';
+						}
+					} else {
+						output += ` -> ${isSVG ? 'PNG ' : ''}${n(newDimensions.width ?? 0)}x${n(newDimensions.height ?? 0)}`;
+					}
+				}
+			}
+
+			return output;
+		});
+
 		const customAspectRatios = settingsStore.settings?.custom_aspect_ratios ?? null;
 
 		return {
@@ -234,6 +257,7 @@ export default defineComponent({
 			dragMode,
 			cropping,
 			setAspectRatio,
+			dimensionsString,
 			customAspectRatios,
 		};
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->

Fixes #15461 where the image dimensions have `null` values.

SVG does not have a fixed resolution.
![image](https://user-images.githubusercontent.com/26413686/188941497-d385ef0f-3e2a-44b1-aa25-ead6df1e1d65.png)

When SVG is edited, it will display the PNG type conversion.
![image](https://user-images.githubusercontent.com/26413686/188941820-292713da-97d5-4746-981e-8efd634f171e.png)


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
