### PR TITLE
GraphQLID is always Non-Nullable

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -414,7 +414,7 @@ export class GraphQLService {
 						}
 
 						if (collection.primary === field.field) {
-							type = GraphQLID;
+							type = GraphQLNonNull(GraphQLID);
 						}
 
 						acc[field.field] = {


### PR DESCRIPTION
## Description

I believe that primary keys should always be marked as Non-Nullable. We have to type a lot of unnecessary code currently to take benefits of generated types (i.e. in TypeScript or in my case ReScript).

This is super naive attempt to fix this problem, which to my surprise worked. I'm definitely not sure this is correct, but I would love this or better fix merged.

There is long open bug #10610 which had been partially fixed in #10857 but primary keys are still not marked as non-null and this PR is trying to fix it.

I hasn't been able to make tests running even on clean repo (cannot find module oracledb) so no tests has been run yet :/

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Partial bugfix for ID only. Ref #10610

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated