### PR TITLE
revisions for CRUD operations with $full

### DIFF
--- a/api/src/operations/item-create/index.ts
+++ b/api/src/operations/item-create/index.ts
@@ -22,7 +22,7 @@ export default defineOperationApi<Options>({
 		if (!permissions || permissions === '$trigger') {
 			customAccountability = accountability;
 		} else if (permissions === '$full') {
-			customAccountability = null;
+			customAccountability = await getAccountabilityForRole('system', { database, schema, accountability });
 		} else if (permissions === '$public') {
 			customAccountability = await getAccountabilityForRole(null, { database, schema, accountability });
 		} else {

--- a/api/src/operations/item-create/index.ts
+++ b/api/src/operations/item-create/index.ts
@@ -16,7 +16,6 @@ export default defineOperationApi<Options>({
 
 	handler: async ({ collection, payload, emitEvents, permissions }, { accountability, database, getSchema }) => {
 		const schema = await getSchema({ database });
-
 		let customAccountability: Accountability | null;
 
 		if (!permissions || permissions === '$trigger') {

--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -17,7 +17,6 @@ export default defineOperationApi<Options>({
 
 	handler: async ({ collection, key, query, emitEvents, permissions }, { accountability, database, getSchema }) => {
 		const schema = await getSchema({ database });
-
 		let customAccountability: Accountability | null;
 
 		if (!permissions || permissions === '$trigger') {

--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -23,7 +23,7 @@ export default defineOperationApi<Options>({
 		if (!permissions || permissions === '$trigger') {
 			customAccountability = accountability;
 		} else if (permissions === '$full') {
-			customAccountability = null;
+			customAccountability = await getAccountabilityForRole('system', { database, schema, accountability });
 		} else if (permissions === '$public') {
 			customAccountability = await getAccountabilityForRole(null, { database, schema, accountability });
 		} else {

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -24,7 +24,7 @@ export default defineOperationApi<Options>({
 		if (!permissions || permissions === '$trigger') {
 			customAccountability = accountability;
 		} else if (permissions === '$full') {
-			customAccountability = null;
+			customAccountability = await getAccountabilityForRole('system', { database, schema, accountability });
 		} else if (permissions === '$public') {
 			customAccountability = await getAccountabilityForRole(null, { database, schema, accountability });
 		} else {

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -18,7 +18,6 @@ export default defineOperationApi<Options>({
 
 	handler: async ({ collection, key, query, emitEvents, permissions }, { accountability, database, getSchema }) => {
 		const schema = await getSchema({ database });
-
 		let customAccountability: Accountability | null;
 
 		if (!permissions || permissions === '$trigger') {

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -26,13 +26,7 @@ export default defineOperationApi<Options>({
 		if (!permissions || permissions === '$trigger') {
 			customAccountability = accountability;
 		} else if (permissions === '$full') {
-			customAccountability = {
-				user: null,
-				role: null,
-				admin: true,
-				app: true,
-				permissions: [],
-			};
+			customAccountability = await getAccountabilityForRole('system', { database, schema, accountability });
 		} else if (permissions === '$public') {
 			customAccountability = await getAccountabilityForRole(null, { database, schema, accountability });
 		} else {

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -31,11 +31,6 @@ export default defineOperationApi<Options>({
 				role: null,
 				admin: true,
 				app: true,
-				ip: '',
-				userAgent: '',
-				origin: '',
-				share: undefined,
-				share_scope: undefined,
 				permissions: [],
 			};
 		} else if (permissions === '$public') {

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -23,6 +23,7 @@ export default defineOperationApi<Options>({
 	) => {
 		const schema = await getSchema({ database });
 		let customAccountability: Accountability | null;
+
 		if (!permissions || permissions === '$trigger') {
 			customAccountability = accountability;
 		} else if (permissions === '$full') {

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -22,13 +22,22 @@ export default defineOperationApi<Options>({
 		{ accountability, database, getSchema }
 	) => {
 		const schema = await getSchema({ database });
-
 		let customAccountability: Accountability | null;
-
 		if (!permissions || permissions === '$trigger') {
 			customAccountability = accountability;
 		} else if (permissions === '$full') {
-			customAccountability = null;
+			customAccountability = {
+				user: null,
+				role: null,
+				admin: true,
+				app: true,
+				ip: '',
+				userAgent: '',
+				origin: '',
+				share: undefined,
+				share_scope: undefined,
+				permissions: [],
+			};
 		} else if (permissions === '$public') {
 			customAccountability = await getAccountabilityForRole(null, { database, schema, accountability });
 		} else {

--- a/api/src/operations/notification/index.ts
+++ b/api/src/operations/notification/index.ts
@@ -15,7 +15,6 @@ export default defineOperationApi<Options>({
 
 	handler: async ({ recipient, subject, message, permissions }, { accountability, database, getSchema }) => {
 		const schema = await getSchema({ database });
-
 		let customAccountability: Accountability | null;
 
 		if (!permissions || permissions === '$trigger') {

--- a/api/src/utils/get-accountability-for-role.ts
+++ b/api/src/utils/get-accountability-for-role.ts
@@ -22,6 +22,14 @@ export async function getAccountabilityForRole(
 		};
 
 		generatedAccountability.permissions = await getPermissions(generatedAccountability, context.schema);
+	} else if (role === 'system') {
+		generatedAccountability = {
+			user: null,
+			role: null,
+			admin: true,
+			app: true,
+			permissions: [],
+		};
 	} else {
 		const roleInfo = await context.database
 			.select(['app_access', 'admin_access'])


### PR DESCRIPTION
## Description

This PR addresses the fact that when no user is set in flows aka system or `$full` permissions operations, then the app didn't store revisions to track the changes.

Originally, it set the `customAccountability` to null, now it will set it as follows:

```jsx
customAccountability = {
  user: null,
  role: null,
  admin: true,
  app: true,
  ip: '',
  userAgent: '',
  origin: '',
  share: undefined,
  share_scope: undefined,
  permissions: [],
};
```
This leads to revisions being created by the flow so we can track the changes.

Addresses #15345, fixes #15346

## Type of Change

- [X] Bugfix
- [X] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
