### PR TITLE
Fix rotating called twice

### DIFF
--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -151,7 +151,10 @@ export class AssetsService {
 				const transformer = sharp({
 					limitInputPixels: Math.pow(env.ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION, 2),
 					sequentialRead: true,
-				}).rotate();
+				});
+
+				if(transforms.find((transform) => transform[0] === 'rotate') === undefined)
+					transformer.rotate()
 
 				transforms.forEach(([method, ...args]) => (transformer[method] as any).apply(transformer, args));
 

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -153,8 +153,7 @@ export class AssetsService {
 					sequentialRead: true,
 				});
 
-				if(transforms.find((transform) => transform[0] === 'rotate') === undefined)
-					transformer.rotate()
+				if (transforms.find((transform) => transform[0] === 'rotate') === undefined) transformer.rotate();
 
 				transforms.forEach(([method, ...args]) => (transformer[method] as any).apply(transformer, args));
 


### PR DESCRIPTION
## Description

It seems that `sharp` doesn't like to have `rotate` called multiple times.

Fixes #15490 