### PR TITLE
Allow Autocomplete-API-interface for m2o fields

### DIFF
--- a/app/src/interfaces/input-autocomplete-api/index.ts
+++ b/app/src/interfaces/input-autocomplete-api/index.ts
@@ -8,8 +8,8 @@ export default defineInterface({
 	description: '$t:interfaces.input-autocomplete-api.description',
 	icon: 'find_in_page',
 	component: InterfaceInputAutocompleteAPI,
-	types: ['string', 'text'],
-	localTypes: ['standard'],
+	types: ['uuid', 'string', 'text', 'integer', 'bigInteger'],
+	localTypes: ['standard', 'm2o'],
 	group: 'standard',
 	recommendedDisplays: ['formatted-value'],
 	options: [


### PR DESCRIPTION
## Description

Adds the Autocompleter-Api as interface for m2o fields, as we can use it with directus own api.

**IMPORTANT: 
I haven't checked the changes, as I don't have a local copy of directus since the switch to pnpm.** 

Fixes #

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
