### PR TITLE
Allow user to send a WYSIWYG email body

### DIFF
--- a/api/src/operations/mail/index.ts
+++ b/api/src/operations/mail/index.ts
@@ -3,9 +3,7 @@ import { MailService } from '../../services';
 import { md } from '../../utils/md';
 
 type Options = {
-	body_markdown: string;
-	body_wysiwyg: string;
-	use_wysiwyg_editor: boolean;
+	body: string;
 	to: string;
 	subject: string;
 };
@@ -13,14 +11,11 @@ type Options = {
 export default defineOperationApi<Options>({
 	id: 'mail',
 
-	handler: async (
-		{ body_markdown, body_wysiwyg, use_wysiwyg_editor, to, subject },
-		{ accountability, database, getSchema }
-	) => {
+	handler: async ({ body, to, subject }, { accountability, database, getSchema }) => {
 		const mailService = new MailService({ schema: await getSchema({ database }), accountability, knex: database });
 
 		await mailService.send({
-			html: use_wysiwyg_editor ? body_wysiwyg : md(body_markdown),
+			html: md(body),
 			to,
 			subject,
 		});

--- a/api/src/operations/mail/index.ts
+++ b/api/src/operations/mail/index.ts
@@ -5,7 +5,7 @@ import { md } from '../../utils/md';
 type Options = {
 	body: string;
 	to: string;
-	type: string;
+	type: 'wysiwyg' | 'markdown';
 	subject: string;
 };
 
@@ -16,7 +16,7 @@ export default defineOperationApi<Options>({
 		const mailService = new MailService({ schema: await getSchema({ database }), accountability, knex: database });
 
 		await mailService.send({
-			html: type === 'input-rich-text-html' ? body : md(body),
+			html: type === 'wysiwyg' ? body : md(body),
 			to,
 			subject,
 		});

--- a/api/src/operations/mail/index.ts
+++ b/api/src/operations/mail/index.ts
@@ -3,7 +3,9 @@ import { MailService } from '../../services';
 import { md } from '../../utils/md';
 
 type Options = {
-	body: string;
+	body_markdown: string;
+	body_wysiwyg: string;
+	use_wysiwyg_editor: boolean;
 	to: string;
 	subject: string;
 };
@@ -11,11 +13,14 @@ type Options = {
 export default defineOperationApi<Options>({
 	id: 'mail',
 
-	handler: async ({ body, to, subject }, { accountability, database, getSchema }) => {
+	handler: async (
+		{ body_markdown, body_wysiwyg, use_wysiwyg_editor, to, subject },
+		{ accountability, database, getSchema }
+	) => {
 		const mailService = new MailService({ schema: await getSchema({ database }), accountability, knex: database });
 
 		await mailService.send({
-			html: md(body),
+			html: use_wysiwyg_editor ? body_wysiwyg : md(body_markdown),
 			to,
 			subject,
 		});

--- a/api/src/operations/mail/index.ts
+++ b/api/src/operations/mail/index.ts
@@ -5,17 +5,18 @@ import { md } from '../../utils/md';
 type Options = {
 	body: string;
 	to: string;
+	type: string;
 	subject: string;
 };
 
 export default defineOperationApi<Options>({
 	id: 'mail',
 
-	handler: async ({ body, to, subject }, { accountability, database, getSchema }) => {
+	handler: async ({ body, to, type, subject }, { accountability, database, getSchema }) => {
 		const mailService = new MailService({ schema: await getSchema({ database }), accountability, knex: database });
 
 		await mailService.send({
-			html: md(body),
+			html: type === 'input-rich-text-html' ? body : md(body),
 			to,
 			subject,
 		});

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -93,7 +93,6 @@ invite_users: Invite Users
 invite: Invite
 email_already_invited: Email "{email}" has already been invited
 subject: Subject
-use_wysiwyg_editor: Use WYSIWYG Editor
 inbox: Inbox
 emails: Emails
 connection_excellent: Excellent Connection
@@ -2116,6 +2115,7 @@ operations:
     message_placeholder: Enter a message to show in the console...
   mail:
     name: Send Email
+    description: Send an email to one or more people
     to: To
     to_placeholder: Add e-mail addresses and press enter...
     body: Body

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -93,6 +93,7 @@ invite_users: Invite Users
 invite: Invite
 email_already_invited: Email "{email}" has already been invited
 subject: Subject
+use_wysiwyg_editor: Use WYSIWYG Editor
 inbox: Inbox
 emails: Emails
 connection_excellent: Excellent Connection
@@ -2115,7 +2116,6 @@ operations:
     message_placeholder: Enter a message to show in the console...
   mail:
     name: Send Email
-    description: Send an email to one or more people
     to: To
     to_placeholder: Add e-mail addresses and press enter...
     body: Body

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -16,7 +16,7 @@ export default defineOperationApp({
 		},
 		{
 			label: '$t:type',
-			text: type,
+			text: type || 'markdown',
 		},
 		{
 			label: '$t:operations.mail.body',
@@ -55,21 +55,20 @@ export default defineOperationApp({
 				name: '$t:type',
 				type: 'string',
 				schema: {
-					default_value: 'input-rich-text-md',
+					default_value: 'markdown',
 				},
 				meta: {
 					interface: 'select-dropdown',
-					width: 'full',
-					required: true,
+					width: 'half',
 					options: {
 						choices: [
 							{
 								text: '$t:interfaces.input-rich-text-md.markdown',
-								value: 'input-rich-text-md',
+								value: 'markdown',
 							},
 							{
 								text: '$t:interfaces.input-rich-text-html.wysiwyg',
-								value: 'input-rich-text-html',
+								value: 'wysiwyg',
 							},
 						],
 					},
@@ -81,7 +80,7 @@ export default defineOperationApp({
 				type: 'text',
 				meta: {
 					width: 'full',
-					interface: panel.type || 'input-rich-text-md',
+					interface: panel.type === 'wysiwyg' ? 'input-rich-text-html' : 'input-rich-text-md',
 				},
 			},
 		];

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -5,7 +5,7 @@ export default defineOperationApp({
 	icon: 'mail',
 	name: '$t:operations.mail.name',
 	description: '$t:operations.mail.description',
-	overview: ({ subject, to, body_wysiwyg, body_markdown, use_wysiwyg_editor }) => [
+	overview: ({ subject, to, body }) => [
 		{
 			label: '$t:subject',
 			text: subject,
@@ -16,7 +16,7 @@ export default defineOperationApp({
 		},
 		{
 			label: '$t:operations.mail.body',
-			text: use_wysiwyg_editor ? body_wysiwyg : body_markdown,
+			text: body,
 		},
 	],
 	options: [
@@ -46,76 +46,12 @@ export default defineOperationApp({
 			},
 		},
 		{
-			field: 'use_wysiwyg_editor',
-			name: '$t:use_wysiwyg_editor',
-			type: 'boolean',
-			schema: {
-				default_value: false,
-			},
-			meta: {
-				width: 'full',
-				interface: 'boolean',
-				options: {
-					label: 'Yes',
-				},
-			},
-		},
-		{
-			field: 'body_markdown',
+			field: 'body',
 			name: '$t:operations.mail.body',
 			type: 'text',
 			meta: {
 				width: 'full',
 				interface: 'input-rich-text-md',
-				required: true,
-				hidden: false,
-				conditions: [
-					{
-						name: 'If NOT Use WYSIWYG Editor',
-						rule: {
-							_and: [
-								{
-									use_wysiwyg_editor: {
-										_eq: true,
-									},
-								},
-							],
-						},
-						hidden: true,
-						required: false,
-						options: {},
-						readonly: false,
-					},
-				],
-			},
-		},
-		{
-			field: 'body_wysiwyg',
-			name: '$t:operations.mail.body',
-			type: 'text',
-			meta: {
-				width: 'full',
-				interface: 'input-rich-text-html',
-				required: false,
-				hidden: true,
-				conditions: [
-					{
-						name: 'If Use WYSIWYG Editor',
-						rule: {
-							_and: [
-								{
-									use_wysiwyg_editor: {
-										_eq: true,
-									},
-								},
-							],
-						},
-						hidden: false,
-						required: true,
-						options: {},
-						readonly: false,
-					},
-				],
 			},
 		},
 	],

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -5,7 +5,7 @@ export default defineOperationApp({
 	icon: 'mail',
 	name: '$t:operations.mail.name',
 	description: '$t:operations.mail.description',
-	overview: ({ subject, to, body }) => [
+	overview: ({ subject, to, type, body }) => [
 		{
 			label: '$t:subject',
 			text: subject,
@@ -15,44 +15,75 @@ export default defineOperationApp({
 			text: Array.isArray(to) ? to.join(', ') : to,
 		},
 		{
+			label: '$t:type',
+			text: type,
+		},
+		{
 			label: '$t:operations.mail.body',
 			text: body,
 		},
 	],
-	options: [
-		{
-			field: 'to',
-			name: '$t:operations.mail.to',
-			type: 'csv',
-			meta: {
-				width: 'full',
-				interface: 'tags',
-				options: {
-					placeholder: '$t:operations.mail.to_placeholder',
-					iconRight: 'alternate_email',
+	options: (panel) => {
+		return [
+			{
+				field: 'to',
+				name: '$t:operations.mail.to',
+				type: 'csv',
+				meta: {
+					width: 'full',
+					interface: 'tags',
+					options: {
+						placeholder: '$t:operations.mail.to_placeholder',
+						iconRight: 'alternate_email',
+					},
 				},
 			},
-		},
-		{
-			field: 'subject',
-			name: '$t:subject',
-			type: 'string',
-			meta: {
-				width: 'full',
-				interface: 'input',
-				options: {
-					iconRight: 'title',
+			{
+				field: 'subject',
+				name: '$t:subject',
+				type: 'string',
+				meta: {
+					width: 'full',
+					interface: 'input',
+					options: {
+						iconRight: 'title',
+					},
 				},
 			},
-		},
-		{
-			field: 'body',
-			name: '$t:operations.mail.body',
-			type: 'text',
-			meta: {
-				width: 'full',
-				interface: 'input-rich-text-md',
+			{
+				field: 'type',
+				name: '$t:type',
+				type: 'string',
+				schema: {
+					default_value: 'input-rich-text-md',
+				},
+				meta: {
+					interface: 'select-dropdown',
+					width: 'full',
+					required: true,
+					options: {
+						choices: [
+							{
+								text: '$t:interfaces.input-rich-text-md.markdown',
+								value: 'input-rich-text-md',
+							},
+							{
+								text: '$t:interfaces.input-rich-text-html.wysiwyg',
+								value: 'input-rich-text-html',
+							},
+						],
+					},
+				},
 			},
-		},
-	],
+			{
+				field: 'body',
+				name: '$t:operations.mail.body',
+				type: 'text',
+				meta: {
+					width: 'full',
+					interface: panel.type || 'input-rich-text-md',
+				},
+			},
+		];
+	},
 });

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -5,7 +5,7 @@ export default defineOperationApp({
 	icon: 'mail',
 	name: '$t:operations.mail.name',
 	description: '$t:operations.mail.description',
-	overview: ({ subject, to, body }) => [
+	overview: ({ subject, to, body_wysiwyg, body_markdown, use_wysiwyg_editor }) => [
 		{
 			label: '$t:subject',
 			text: subject,
@@ -16,7 +16,7 @@ export default defineOperationApp({
 		},
 		{
 			label: '$t:operations.mail.body',
-			text: body,
+			text: use_wysiwyg_editor ? body_wysiwyg : body_markdown,
 		},
 	],
 	options: [
@@ -46,12 +46,76 @@ export default defineOperationApp({
 			},
 		},
 		{
-			field: 'body',
+			field: 'use_wysiwyg_editor',
+			name: '$t:use_wysiwyg_editor',
+			type: 'boolean',
+			schema: {
+				default_value: false,
+			},
+			meta: {
+				width: 'full',
+				interface: 'boolean',
+				options: {
+					label: 'Yes',
+				},
+			},
+		},
+		{
+			field: 'body_markdown',
 			name: '$t:operations.mail.body',
 			type: 'text',
 			meta: {
 				width: 'full',
 				interface: 'input-rich-text-md',
+				required: true,
+				hidden: false,
+				conditions: [
+					{
+						name: 'If NOT Use WYSIWYG Editor',
+						rule: {
+							_and: [
+								{
+									use_wysiwyg_editor: {
+										_eq: true,
+									},
+								},
+							],
+						},
+						hidden: true,
+						required: false,
+						options: {},
+						readonly: false,
+					},
+				],
+			},
+		},
+		{
+			field: 'body_wysiwyg',
+			name: '$t:operations.mail.body',
+			type: 'text',
+			meta: {
+				width: 'full',
+				interface: 'input-rich-text-html',
+				required: false,
+				hidden: true,
+				conditions: [
+					{
+						name: 'If Use WYSIWYG Editor',
+						rule: {
+							_and: [
+								{
+									use_wysiwyg_editor: {
+										_eq: true,
+									},
+								},
+							],
+						},
+						hidden: false,
+						required: true,
+						options: {},
+						readonly: false,
+					},
+				],
 			},
 		},
 	],


### PR DESCRIPTION
## Description

Ref #14363, #14473 and #14478

This update will allow user to choose between WYSIWYG and Markdown editor in the Flows -> Send Mail Operation, user will toggle the `type` field to choose between them.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated: directus/docs#136
