### PR TITLE
fix redudant message in unexpected error

### DIFF
--- a/app/src/utils/unexpected-error.ts
+++ b/app/src/utils/unexpected-error.ts
@@ -13,14 +13,11 @@ export function unexpectedError(error: Error | RequestError | APIError): void {
 		(error as APIError)?.extensions?.code ||
 		'UNKNOWN';
 
-	const message = (error as RequestError).response?.data?.errors?.[0]?.message || error.message || undefined;
-
 	// eslint-disable-next-line no-console
 	console.warn(error);
 
 	store.add({
 		title: i18n.global.t(`errors.${code}`),
-		text: message,
 		type: 'error',
 		dialog: true,
 		error,


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

-->
I couldn't really reproduce the error in this `unexpected-error.vue`, but this is about the message itself.

The message in the `unexpected-error.vue` was redundant as the `code` and `error message` are already shown.


Fixes #14972

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
