### PR TITLE
Handle Date objects in compress util

### DIFF
--- a/packages/shared/src/utils/compress.test.ts
+++ b/packages/shared/src/utils/compress.test.ts
@@ -36,6 +36,14 @@ const geoJSON = {
 	],
 };
 
+const dateString = '2022-02-14T01:02:11.000Z';
+const dateInput = {
+	date_created: new Date(dateString),
+};
+const dateOutput = {
+	date_created: dateString,
+};
+
 describe('compress', () => {
 	test('Compresses plain objects', () => {
 		expect(compress(plain)).toBe(
@@ -59,6 +67,10 @@ describe('compress', () => {
 		expect(compress(geoJSON)).toBe(
 			'data|id|f36431ea-0d25-4747-8b37-185eb3ba66d0|point1|type|Point|coordinates|point2^^-107.57812499999984|34.30714385628873|-91.25923790168956|42.324763327278106^$0|@$1|2|3|$4|5|6|@8|9]]|7|$4|5|6|@A|B]]]]]'
 		);
+	});
+
+	test('Compresses Date objects into strings', () => {
+		expect(compress(dateInput)).toBe('date_created|2022-02-14T01:02:11.000Z^^^$0|1]');
 	});
 
 	test('Throws error on non-supported types', () => {
@@ -97,6 +109,10 @@ describe('decompress', () => {
 				'data|id|f36431ea-0d25-4747-8b37-185eb3ba66d0|point1|type|Point|coordinates|point2^^-107.57812499999984|34.30714385628873|-91.25923790168956|42.324763327278106^$0|@$1|2|3|$4|5|6|@8|9]]|7|$4|5|6|@A|B]]]]]'
 			)
 		).toEqual(geoJSON);
+	});
+
+	test('Decompresses Date strings', () => {
+		expect(decompress('date_created|2022-02-14T01:02:11.000Z^^^$0|1]')).toEqual(dateOutput);
 	});
 
 	test('Errors when not enough parts exist', () => {

--- a/packages/shared/src/utils/compress.ts
+++ b/packages/shared/src/utils/compress.ts
@@ -51,6 +51,26 @@ export function compress(obj: Record<string, any> | Record<string, any>[]) {
 			return ['@', ...part.map((subPart) => getAst(subPart))];
 		}
 
+		if (part instanceof Date) {
+			const value = encode(part.toJSON());
+
+			if (strings.has(value)) {
+				return {
+					type: Types.STRING,
+					index: strings.get(value)!,
+				};
+			}
+
+			const index = strings.size;
+
+			strings.set(value, index);
+
+			return {
+				type: Types.STRING,
+				index,
+			};
+		}
+
 		if (typeof part === 'object') {
 			return [
 				'$',


### PR DESCRIPTION
## Description

Fixes #15415

Ref https://github.com/directus/directus/issues/15415#issuecomment-1240293499

### Before

(Cached result)

![firefox_iStvrZXtdm](https://user-images.githubusercontent.com/42867097/189828372-766ce43c-ddff-4b50-8e61-e8b970b33a92.png)

### After

![firefox_XCgVPSW7CZ](https://user-images.githubusercontent.com/42867097/189828391-275a837c-c39c-4e5b-a1df-c943e2ea5a13.png)

### Others

This might be another tangent here, but I was wondering why this issue isn't present in typical timestamps, but I believe it's because they are being processed into string here:

https://github.com/directus/directus/blob/551f1d82b42c16b7101b028c0b020a03bea6ae41/api/src/services/payload.ts#L259-L263

whereas when we use aggregates, they aren't "processed" (not 100% sure). This results in date-only aggregates being an iso string:

![image](https://user-images.githubusercontent.com/42867097/189828919-033d89e9-a4e8-4d2b-83c2-29cc7e8ad28d.png)

rather than being the typical date-only string after being processed:

![image](https://user-images.githubusercontent.com/42867097/189829050-09169d2d-0316-49c6-9008-b4eff2384e2b.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
