### PR TITLE
Use the improved get method

### DIFF
--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -23,7 +23,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useFieldsStore } from '@/stores/fields';
-import { get } from 'lodash';
+import { get } from '@directus/shared/utils';
 import { Field } from '@directus/shared/types';
 import { getDisplay } from '@/displays';
 import { getDefaultDisplayForType } from '@/utils/get-default-display-for-type';


### PR DESCRIPTION
## Description

Before, items of an m2a wouldn't show in the related-values component due to the `item:collection` syntax. The updated get method from get-array supports those so #15269 is the target branch as it introduces the updated get-array method.

Fixes #10601