### PR TITLE
Only pass singleton prop in CollectionOrItem component when necessary

### DIFF
--- a/app/src/modules/content/routes/collection-or-item.vue
+++ b/app/src/modules/content/routes/collection-or-item.vue
@@ -3,8 +3,8 @@
 		:is="isSingleton ? 'item-route' : 'collection-route'"
 		:collection="collection"
 		:bookmark="bookmark"
-		:singleton="isSingleton"
 		:archive="archive"
+		v-bind="isSingleton ? { singleton: isSingleton } : {}"
 	/>
 </template>
 

--- a/packages/shared/src/composables/use-layout.ts
+++ b/packages/shared/src/composables/use-layout.ts
@@ -14,6 +14,7 @@ function isWritableProp(prop: string): prop is WritableProp {
 function createLayoutWrapper<Options, Query>(layout: LayoutConfig): Component {
 	return defineComponent({
 		name: `${layout.id}-${NAME_SUFFIX}`,
+		inheritAttrs: false,
 		props: {
 			collection: {
 				type: String,

--- a/packages/shared/src/composables/use-layout.ts
+++ b/packages/shared/src/composables/use-layout.ts
@@ -14,7 +14,6 @@ function isWritableProp(prop: string): prop is WritableProp {
 function createLayoutWrapper<Options, Query>(layout: LayoutConfig): Component {
 	return defineComponent({
 		name: `${layout.id}-${NAME_SUFFIX}`,
-		inheritAttrs: false,
 		props: {
 			collection: {
 				type: String,


### PR DESCRIPTION
## Description

Sort of a follow up to #7749.

layout wrappers such as TabularWrapper, CardsWrapper etc are inheriting non-props attributes, `singleton` in particular:

https://user-images.githubusercontent.com/42867097/190145219-bbcd8412-45ce-4b5c-a2ef-6fa0a6742c89.mp4

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
