### PR TITLE
skip interface options for variable panel

### DIFF
--- a/app/src/panels/variable/index.ts
+++ b/app/src/panels/variable/index.ts
@@ -84,4 +84,5 @@ export default definePanel({
 	},
 	minWidth: 12,
 	minHeight: 6,
+	skipUndefinedKeys: ['options'],
 });


### PR DESCRIPTION
## Description

This excludes all interface options for the variable panel from being parsed before they're passed to the panel.
For auto-complete the URL template was being parsed into `/items/test?search=undefined` before the interface gets it.
Not sure if this is too broad of a solution but i couldnt find any usecases yet for having variables used directly in interface options.

Fixes #15592

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
