### PR TITLE
Correct the documented default type for argon2

### DIFF
--- a/api/src/cli/utils/create-env/env-stub.liquid
+++ b/api/src/cli/utils/create-env/env-stub.liquid
@@ -251,7 +251,7 @@ CORS_MAX_AGE=18000
 # The amount of threads to compute the hash on. Each thread has a memory pool with HASH_MEMORY_COST size [1]
 # HASH_PARALLELISM=2
 
-# The variant of the hash function (0: argon2d, 1: argon2i, or 2: argon2id) [1]
+# The variant of the hash function (0: argon2d, 1: argon2i, or 2: argon2id) [2]
 # HASH_TYPE=2
 
 # An extra and optional non-secret value. The value will be included B64 encoded in the parameters portion of the digest []


### PR DESCRIPTION
## Description

Currently there are not default value for `HASH_TYPE` environment variable, which is passed as `argon2HashConfigOptions` to argon2:

https://github.com/directus/directus/blob/e13c8e36b0da64718a40e0f7b4f904c8eba55924/api/src/utils/generate-hash.ts#L4-L10

as there is no default `HASH_TYPE` passed, `argon2.hash()` function defaults to `argon2id` as described in it docs: https://github.com/ranisalt/node-argon2/wiki/Options#type

We can also verify this when inspecting the password hash of a Directus user, which starts with `argon2id`:

> $argon2id$v=19$m=4096,t=3,p=1$mwNWN0Bis/tFgC1sby44qg$bTLb8GLI08V+NpMpB7wS72JUxjR/B/30EeB/8NOtyGY

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Minor correction

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated. PR: directus/docs#139
