### PR TITLE
Cache: Fix check if endpoint is `/graphql` or not

### DIFF
--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -9,7 +9,9 @@ import logger from '../logger';
 const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next) => {
 	const { cache } = getCache();
 
-	if (req.method.toLowerCase() !== 'get' && req.path?.startsWith('/graphql') === false) return next();
+	const isGraphql = /^\/(system\/)?graphql/.test(req.originalUrl);
+
+	if (req.method.toLowerCase() !== 'get' && !isGraphql) return next();
 	if (env.CACHE_ENABLED !== true) return next();
 	if (!cache) return next();
 

--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -9,9 +9,7 @@ import logger from '../logger';
 const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next) => {
 	const { cache } = getCache();
 
-	const isGraphql = /^\/(system\/)?graphql/.test(req.originalUrl);
-
-	if (req.method.toLowerCase() !== 'get' && !isGraphql) return next();
+	if (req.method.toLowerCase() !== 'get' && req.originalUrl?.startsWith('/graphql') === false) return next();
 	if (env.CACHE_ENABLED !== true) return next();
 	if (!cache) return next();
 

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -22,10 +22,8 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		exceedsMaxSize = valueSize > maxSize;
 	}
 
-	const isGraphql = /^\/(system\/)?graphql/.test(req.originalUrl);
-
 	if (
-		(req.method.toLowerCase() === 'get' || isGraphql) &&
+		(req.method.toLowerCase() === 'get' || req.originalUrl?.startsWith('/graphql')) &&
 		env.CACHE_ENABLED === true &&
 		cache &&
 		!req.sanitizedQuery.export &&

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -22,8 +22,10 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		exceedsMaxSize = valueSize > maxSize;
 	}
 
+	const isGraphql = /^\/(system\/)?graphql/.test(req.originalUrl);
+
 	if (
-		(req.method.toLowerCase() === 'get' || req.path?.startsWith('/graphql')) &&
+		(req.method.toLowerCase() === 'get' || isGraphql) &&
 		env.CACHE_ENABLED === true &&
 		cache &&
 		!req.sanitizedQuery.export &&

--- a/api/src/utils/get-cache-key.test.ts
+++ b/api/src/utils/get-cache-key.test.ts
@@ -4,32 +4,38 @@ import { getCacheKey } from '../../src/utils/get-cache-key';
 const restUrl = 'http://localhost/items/example';
 const graphQlUrl = 'http://localhost/graphql';
 const accountability = { user: '00000000-0000-0000-0000-000000000000' };
+const method = 'GET';
 
 const requests = [
 	{
 		name: 'as unauthenticated request',
-		params: { originalUrl: restUrl },
+		params: { method, originalUrl: restUrl },
 		key: '17da8272c9a0ec6eea38a37d6d78bddeb7c79045',
 	},
 	{
 		name: 'as authenticated request',
-		params: { originalUrl: restUrl, accountability },
+		params: { method, originalUrl: restUrl, accountability },
 		key: '99a6394222a3d7d149ac1662fc2fff506932db58',
 	},
 	{
 		name: 'a request with a fields query',
-		params: { originalUrl: restUrl, sanitizedQuery: { fields: ['id', 'name'] } },
+		params: { method, originalUrl: restUrl, sanitizedQuery: { fields: ['id', 'name'] } },
 		key: 'aa6e2d8a78de4dfb4af6eaa230d1cd9b7d31ed19',
 	},
 	{
 		name: 'a request with a filter query',
-		params: { originalUrl: restUrl, sanitizedQuery: { filter: { name: { _eq: 'test' } } } },
+		params: { method, originalUrl: restUrl, sanitizedQuery: { filter: { name: { _eq: 'test' } } } },
 		key: 'd7eb8970f0429e1cf85e12eb5bb8669f618b09d3',
 	},
 	{
-		name: 'a GraphQL query request',
-		params: { originalUrl: graphQlUrl, query: { query: 'query { test { id } }' } },
+		name: 'a GraphQL GET query request',
+		params: { method, originalUrl: graphQlUrl, query: { query: 'query { test { id } }' } },
 		key: '201731b75c627c60554512d819b6935b54c73814',
+	},
+	{
+		name: 'a GraphQL POST query request',
+		params: { method: 'POST', originalUrl: graphQlUrl, body: { query: 'query { test { name } }' } },
+		key: '64eb0c48ea69d0863ff930398f29b5c7884f88f7',
 	},
 ];
 
@@ -41,7 +47,7 @@ describe('get cache key', () => {
 	});
 
 	test('should create a unique key for each request', () => {
-		const keys = requests.map((r) => r.key);
+		const keys = cases.map(([, params]) => getCacheKey(params as unknown as Request));
 		const hasDuplicate = keys.some((key) => keys.indexOf(key) !== keys.lastIndexOf(key));
 
 		expect(hasDuplicate).toBeFalsy();
@@ -52,8 +58,12 @@ describe('get cache key', () => {
 		const operationName = 'test';
 		const variables1 = JSON.stringify({ name: 'test 1' });
 		const variables2 = JSON.stringify({ name: 'test 2' });
-		const req1: any = { originalUrl: graphQlUrl, query: { query, operationName, variables: variables1 } };
-		const req2: any = { originalUrl: graphQlUrl, query: { query, operationName, variables: variables2 } };
+		const req1: any = { method, originalUrl: graphQlUrl, query: { query, operationName, variables: variables1 } };
+		const req2: any = {
+			method: 'POST',
+			originalUrl: graphQlUrl,
+			query: { query, operationName, variables: variables2 },
+		};
 
 		expect(getCacheKey(req1)).not.toEqual(getCacheKey(req2));
 	});

--- a/api/src/utils/get-cache-key.test.ts
+++ b/api/src/utils/get-cache-key.test.ts
@@ -59,12 +59,13 @@ describe('get cache key', () => {
 		const variables1 = JSON.stringify({ name: 'test 1' });
 		const variables2 = JSON.stringify({ name: 'test 2' });
 		const req1: any = { method, originalUrl: graphQlUrl, query: { query, operationName, variables: variables1 } };
-		const req2: any = {
-			method: 'POST',
-			originalUrl: graphQlUrl,
-			query: { query, operationName, variables: variables2 },
-		};
+		const req2: any = { method, originalUrl: graphQlUrl, query: { query, operationName, variables: variables2 } };
+		const postReq1: any = { method: 'POST', originalUrl: req1.originalUrl, body: req1.query };
+		const postReq2: any = { method: 'POST', originalUrl: req2.originalUrl, body: req2.query };
 
 		expect(getCacheKey(req1)).not.toEqual(getCacheKey(req2));
+		expect(getCacheKey(postReq1)).not.toEqual(getCacheKey(postReq2));
+		expect(getCacheKey(req1)).toEqual(getCacheKey(postReq1));
+		expect(getCacheKey(req2)).toEqual(getCacheKey(postReq2));
 	});
 });

--- a/api/src/utils/get-cache-key.test.ts
+++ b/api/src/utils/get-cache-key.test.ts
@@ -37,6 +37,16 @@ const requests = [
 		params: { method: 'POST', originalUrl: graphQlUrl, body: { query: 'query { test { name } }' } },
 		key: '64eb0c48ea69d0863ff930398f29b5c7884f88f7',
 	},
+	{
+		name: 'an authenticated GraphQL GET query request',
+		params: { method, originalUrl: graphQlUrl, accountability, query: { query: 'query { test { id } }' } },
+		key: '9bc52c98dcf2de04c64589f52e0ada1e38d53a90',
+	},
+	{
+		name: 'an authenticated GraphQL POST query request',
+		params: { method: 'POST', originalUrl: graphQlUrl, accountability, body: { query: 'query { test { name } }' } },
+		key: '051ea77ce5ba71bbc88bcb567b9ddc602b585c13',
+	},
 ];
 
 const cases = requests.map(({ name, params, key }) => [name, params, key]);

--- a/api/src/utils/get-cache-key.ts
+++ b/api/src/utils/get-cache-key.ts
@@ -10,7 +10,7 @@ export function getCacheKey(req: Request): string {
 	const info = {
 		user: req.accountability?.user || null,
 		path,
-		query: isGraphQl ? pick(req.query, ['query', 'variables']) : req.sanitizedQuery,
+		query: isGraphQl ? pick(req.body, ['query', 'variables']) : req.sanitizedQuery,
 	};
 
 	const key = hash(info);

--- a/api/src/utils/get-cache-key.ts
+++ b/api/src/utils/get-cache-key.ts
@@ -6,7 +6,7 @@ import { pick } from 'lodash';
 export function getCacheKey(req: Request): string {
 	const path = url.parse(req.originalUrl).pathname;
 	const isGraphQl = path?.includes('/graphql');
-	const isGet = req.method.toLowerCase() === 'get';
+	const isGet = req.method?.toLowerCase() === 'get';
 
 	const info = {
 		user: req.accountability?.user || null,

--- a/api/src/utils/get-cache-key.ts
+++ b/api/src/utils/get-cache-key.ts
@@ -6,11 +6,12 @@ import { pick } from 'lodash';
 export function getCacheKey(req: Request): string {
 	const path = url.parse(req.originalUrl).pathname;
 	const isGraphQl = path?.includes('/graphql');
+	const isGet = req.method === 'GET';
 
 	const info = {
 		user: req.accountability?.user || null,
 		path,
-		query: isGraphQl ? pick(req.body, ['query', 'variables']) : req.sanitizedQuery,
+		query: isGraphQl ? pick(isGet ? req.query : req.body, ['query', 'variables']) : req.sanitizedQuery,
 	};
 
 	const key = hash(info);

--- a/api/src/utils/get-cache-key.ts
+++ b/api/src/utils/get-cache-key.ts
@@ -6,7 +6,7 @@ import { pick } from 'lodash';
 export function getCacheKey(req: Request): string {
 	const path = url.parse(req.originalUrl).pathname;
 	const isGraphQl = path?.includes('/graphql');
-	const isGet = req.method === 'GET';
+	const isGet = req.method.toLowerCase() === 'get';
 
 	const info = {
 		user: req.accountability?.user || null,


### PR DESCRIPTION
## Description
By using `CACHE_STATUS_HEADER` we were able to check that Graphql requests always reported `MISS` which means that Graphql requests were not being cached.
The source of the issue is that Express reports on `req.path` the route we defined for the controller.
For example, we have a router for entire application where we define `router.post('/graphl', graphqlRouter)`.
Then we define `graphqlRouter.post('/', handler)`. In this case, inside handler our `req.path` will be `/` because ` /graphql` was defined on parent.

In order to solve the issue we take `req.originalUrl` which contains the entire path of the request.

~~Also, it seems that System Graphql was not being cached, so I added those too, but let me know if that's intended and I can remove it.~~

After fixing the initial issue I found that every request was responding with the Grapqhl Introspection.
This was cause by retrieving the same key every time because `req.query` for Grapqhl requests does/should not exist.
So fixed the key to be based on `req.body`

## Type of Change

- [x] Bugfix (ref: https://github.com/directus/directus/issues/14371)
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
