### PR TITLE
Fix workspace size logic

### DIFF
--- a/app/src/components/v-workspace.vue
+++ b/app/src/components/v-workspace.vue
@@ -71,9 +71,9 @@ const paddingSize = computed(() => Number(cssVar('--content-padding', mainElemen
 const workspaceSize = computed(() => {
 	const furthestTileX = props.tiles.reduce(
 		(aggr, tile) => {
-			if (tile.x! > aggr.x!) {
-				aggr.x = tile.x!;
-				aggr.width = tile.width!;
+			if (tile.x + tile.width > aggr.x + aggr.width) {
+				aggr.x = tile.x;
+				aggr.width = tile.width;
 			}
 
 			return aggr;
@@ -81,11 +81,11 @@ const workspaceSize = computed(() => {
 		{ x: 0, width: 0 }
 	);
 
-	const furthestPanelY = props.tiles.reduce(
+	const furthestTileY = props.tiles.reduce(
 		(aggr, tile) => {
-			if (tile.y! > aggr.y!) {
-				aggr.y = tile.y!;
-				aggr.height = tile.height!;
+			if (tile.y + tile.height > aggr.y + aggr.height) {
+				aggr.y = tile.y;
+				aggr.height = tile.height;
 			}
 
 			return aggr;
@@ -95,14 +95,14 @@ const workspaceSize = computed(() => {
 
 	if (props.editMode === true) {
 		return {
-			width: (furthestTileX.x! + furthestTileX.width! + 25) * 20,
-			height: (furthestPanelY.y! + furthestPanelY.height! + 25) * 20,
+			width: (furthestTileX.x + furthestTileX.width + 25) * 20,
+			height: (furthestTileY.y + furthestTileY.height + 25) * 20,
 		};
 	}
 
 	return {
-		width: (furthestTileX.x! + furthestTileX.width! - 1) * 20,
-		height: (furthestPanelY.y! + furthestPanelY.height! - 1) * 20,
+		width: (furthestTileX.x + furthestTileX.width - 1) * 20,
+		height: (furthestTileY.y + furthestTileY.height - 1) * 20,
 	};
 });
 


### PR DESCRIPTION
## Description

Fixes #14281

Ref https://github.com/directus/directus/issues/14281#issuecomment-1250631736 for more context.

Currently when determining the furthest X panel, it checks for the X values for each tile via `tile.x > aggr.x`:

https://github.com/directus/directus/blob/54cd2d47da982a011d1b49ff6ddc474ea4607973/app/src/components/v-workspace.vue#L72-L82

However when there are 2 tiles for example:

- Tile A: `{ x: 5, width: 5 }`
- Tile B: `{ x: 1, width: 30 }`

Tile B is _not_ furthest in terms of X position, but it is the furthest X "point" as it is way wider than Tile A. ("point" as in the combination of x + width)

So this PR accounts for height/width when checking the furthest X/Y point.

### Changes

- account for width/height when determining furthest X/Y tile
- remove unneeded `!` non-null assertions
- rename `furthestPanelY` to `furthestTileY` for consistency

### Before/After

- Before (Width)

    https://user-images.githubusercontent.com/42867097/190966289-c1931bd5-b7dc-496e-ab9d-ed86eb6afbd2.mp4

- After

    https://user-images.githubusercontent.com/42867097/190966390-8a29c8a2-247f-43ae-9e51-caec7a59620d.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
