### PR TITLE
Cast special in system fields as array

### DIFF
--- a/api/src/database/system-data/fields/activity.yaml
+++ b/api/src/database/system-data/fields/activity.yaml
@@ -74,7 +74,8 @@ fields:
 
   - field: revisions
     interface: list-o2m
-    special: o2m
+    special:
+      - o2m
     options:
       fields:
         - collection

--- a/api/src/database/system-data/fields/collections.yaml
+++ b/api/src/database/system-data/fields/collections.yaml
@@ -42,21 +42,24 @@ fields:
     width: full
 
   - field: hidden
-    special: cast-boolean
+    special:
+      - cast-boolean
     interface: boolean
     options:
       label: $t:field_options.directus_collections.hidden_label
     width: half
 
   - field: singleton
-    special: cast-boolean
+    special:
+      - cast-boolean
     interface: boolean
     options:
       label: $t:singleton_label
     width: half
 
   - field: translations
-    special: cast-json
+    special:
+      - cast-json
     interface: list
     options:
       template: '{{ translation }} ({{ language }})'
@@ -115,7 +118,8 @@ fields:
 
   - field: archive_app_filter
     interface: boolean
-    special: cast-boolean
+    special:
+      - cast-boolean
     options:
       label: $t:field_options.directus_collections.archive_app_filter
     width: half

--- a/api/src/database/system-data/fields/dashboards.yaml
+++ b/api/src/database/system-data/fields/dashboards.yaml
@@ -2,16 +2,19 @@ table: directus_dashboards
 
 fields:
   - field: id
-    special: uuid
+    special:
+      - uuid
   - field: name
   - field: icon
   - field: panels
-    special: o2m
+    special:
+      - o2m
   - field: date_created
     special:
       - date-created
       - cast-timestamp
   - field: user_created
-    special: user-created
+    special:
+      - user-created
   - field: note
   - field: color

--- a/api/src/database/system-data/fields/fields.yaml
+++ b/api/src/database/system-data/fields/fields.yaml
@@ -17,7 +17,8 @@ fields:
   - collection: directus_fields
     field: special
     hidden: true
-    special: cast-csv
+    special:
+      - cast-csv
     width: half
 
   - collection: directus_fields
@@ -27,7 +28,8 @@ fields:
   - collection: directus_fields
     field: options
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
     width: half
 
   - collection: directus_fields
@@ -37,25 +39,29 @@ fields:
   - collection: directus_fields
     field: display_options
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
     width: half
 
   - collection: directus_fields
     field: readonly
     hidden: true
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
 
   - collection: directus_fields
     field: hidden
     hidden: true
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
 
   - collection: directus_fields
     field: required
     hidden: true
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
 
   - collection: directus_fields
@@ -73,7 +79,8 @@ fields:
   - collection: directus_fields
     field: translations
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
     width: half
 
   - collection: directus_fields
@@ -83,12 +90,14 @@ fields:
   - collection: directus_fields
     field: conditions
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - collection: directus_fields
     field: validation
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - collection: directus_fields
     field: validation_message

--- a/api/src/database/system-data/fields/files.yaml
+++ b/api/src/database/system-data/fields/files.yaml
@@ -4,7 +4,8 @@ fields:
   - field: id
     hidden: true
     interface: input
-    special: uuid
+    special:
+      - uuid
 
   - field: title
     interface: input
@@ -23,7 +24,8 @@ fields:
     interface: tags
     options:
       iconRight: local_offer
-    special: cast-json
+    special:
+      - cast-json
     width: full
     display: labels
     display_options:
@@ -71,7 +73,8 @@ fields:
 
   - field: metadata
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - field: type
     display: mime-type
@@ -83,7 +86,8 @@ fields:
 
   - field: modified_by
     interface: select-dropdown-m2o
-    special: user-updated
+    special:
+      - user-updated
     width: half
     display: user
     readonly: true
@@ -92,7 +96,8 @@ fields:
 
   - field: modified_on
     interface: datetime
-    special: date-updated
+    special:
+      - date-updated
     width: half
     display: datetime
     readonly: true
@@ -105,7 +110,8 @@ fields:
     display: user
     width: half
     hidden: true
-    special: user-created
+    special:
+      - user-created
 
   - field: uploaded_on
     display: datetime
@@ -115,7 +121,8 @@ fields:
   - field: folder
     width: half
     readonly: true
-    special: m2o
+    special:
+      - m2o
     display: related-values
     display_options:
       template: '{{ name }}'

--- a/api/src/database/system-data/fields/flows.yaml
+++ b/api/src/database/system-data/fields/flows.yaml
@@ -2,7 +2,8 @@ table: directus_flows
 
 fields:
   - field: id
-    special: uuid
+    special:
+      - uuid
   - field: name
   - field: icon
   - field: color
@@ -11,11 +12,15 @@ fields:
   - field: trigger
   - field: accountability
   - field: options
-    special: cast-json
+    special:
+      - cast-json
   - field: operation
   - field: operations
-    special: o2m
+    special:
+      - o2m
   - field: date_created
-    special: date-created
+    special:
+      - date-created
   - field: user_created
-    special: user-created
+    special:
+      - user-created

--- a/api/src/database/system-data/fields/folders.yaml
+++ b/api/src/database/system-data/fields/folders.yaml
@@ -3,7 +3,8 @@ table: directus_folders
 fields:
   - field: id
     interface: input
-    special: uuid
+    special:
+      - uuid
     width: half
 
   - field: parent

--- a/api/src/database/system-data/fields/operations.yaml
+++ b/api/src/database/system-data/fields/operations.yaml
@@ -2,18 +2,22 @@ table: directus_operations
 
 fields:
   - field: id
-    special: uuid
+    special:
+      - uuid
   - field: name
   - field: key
   - field: type
   - field: position_x
   - field: position_y
   - field: options
-    special: cast-json
+    special:
+      - cast-json
   - field: resolve
   - field: reject
   - field: flow
   - field: date_created
-    special: date-created
+    special:
+      - date-created
   - field: user_created
-    special: user-created
+    special:
+      - user-created

--- a/api/src/database/system-data/fields/panels.yaml
+++ b/api/src/database/system-data/fields/panels.yaml
@@ -2,24 +2,28 @@ table: directus_panels
 
 fields:
   - field: id
-    special: uuid
+    special:
+      - uuid
   - field: name
   - field: icon
   - field: color
   - field: note
   - field: type
   - field: show_header
-    special: cast-boolean
+    special:
+      - cast-boolean
   - field: position_x
   - field: position_y
   - field: width
   - field: height
   - field: options
-    special: cast-json
+    special:
+      - cast-json
   - field: date_created
     special:
       - date-created
       - cast-timestamp
   - field: user_created
-    special: user-created
+    special:
+      - user-created
   - field: dashboard

--- a/api/src/database/system-data/fields/permissions.yaml
+++ b/api/src/database/system-data/fields/permissions.yaml
@@ -4,12 +4,14 @@ table: directus_permissions
 fields:
   - field: permissions
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
     width: half
 
   - field: presets
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
     width: half
 
   - field: role
@@ -23,11 +25,13 @@ fields:
 
   - field: fields
     width: half
-    special: cast-csv
+    special:
+      - cast-csv
 
   - field: action
     width: half
 
   - field: validation
     width: half
-    special: cast-json
+    special:
+      - cast-json

--- a/api/src/database/system-data/fields/presets.yaml
+++ b/api/src/database/system-data/fields/presets.yaml
@@ -3,26 +3,31 @@ table: directus_presets
 fields:
   - field: filter
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - field: layout_query
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - field: layout_options
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - field: role
     width: half
-    special: m2o
+    special:
+      - m2o
     display: related-values
     display_options:
       template: '{{ name }}'
 
   - field: user
     width: half
-    special: m2o
+    special:
+      - m2o
     display: related-values
     display_options:
       template: '{{ email }}'

--- a/api/src/database/system-data/fields/relations.yaml
+++ b/api/src/database/system-data/fields/relations.yaml
@@ -20,7 +20,8 @@ fields:
     width: half
 
   - field: one_allowed_collections
-    special: cast-csv
+    special:
+      - cast-csv
     width: half
 
   - field: junction_field

--- a/api/src/database/system-data/fields/revisions.yaml
+++ b/api/src/database/system-data/fields/revisions.yaml
@@ -15,11 +15,13 @@ fields:
 
   - field: data
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - field: delta
     hidden: true
-    special: cast-json
+    special:
+      - cast-json
 
   - field: parent
     width: half

--- a/api/src/database/system-data/fields/roles.yaml
+++ b/api/src/database/system-data/fields/roles.yaml
@@ -4,7 +4,8 @@ fields:
   - field: id
     hidden: true
     interface: input
-    special: uuid
+    special:
+      - uuid
 
   - field: name
     interface: input
@@ -25,29 +26,34 @@ fields:
 
   - field: app_access
     interface: boolean
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
 
   - field: admin_access
     interface: boolean
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
 
   - field: ip_access
     interface: tags
     options:
       placeholder: $t:field_options.directus_roles.ip_access
-    special: cast-csv
+    special:
+      - cast-csv
     width: full
 
   - field: enforce_tfa
     interface: boolean
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
 
   - field: users
     interface: list-o2m
-    special: o2m
+    special:
+      - o2m
     options:
       fields:
         - first_name

--- a/api/src/database/system-data/fields/settings.yaml
+++ b/api/src/database/system-data/fields/settings.yaml
@@ -131,7 +131,8 @@ fields:
 
   - field: module_bar
     interface: system-modules
-    special: cast-json
+    special:
+      - cast-json
 
   - field: security_divider
     interface: presentation-divider
@@ -307,7 +308,8 @@ fields:
                 ]
             width: full
       template: '{{key}}'
-    special: cast-json
+    special:
+      - cast-json
     width: full
 
   - field: map_divider
@@ -332,7 +334,8 @@ fields:
 
   - field: basemaps
     interface: list
-    special: cast-json
+    special:
+      - cast-json
     options:
       template: '{{name}}'
       fields:
@@ -390,7 +393,8 @@ fields:
               placeholder: $t:fields.directus_settings.attribution_placeholder
 
   - field: translation_strings
-    special: cast-json
+    special:
+      - cast-json
     hidden: true
 
   - field: image_editor
@@ -405,7 +409,8 @@ fields:
 
   - field: custom_aspect_ratios
     interface: list
-    special: cast-json
+    special:
+      - cast-json
     options:
       template: '{{text}}'
       fields:

--- a/api/src/database/system-data/fields/shares.yaml
+++ b/api/src/database/system-data/fields/shares.yaml
@@ -2,7 +2,8 @@ table: directus_shares
 
 fields:
   - field: id
-    special: uuid
+    special:
+      - uuid
     readonly: true
     hidden: true
 
@@ -26,7 +27,9 @@ fields:
           _eq: false
 
   - field: password
-    special: hash,conceal
+    special:
+      - hash
+      - conceal
     interface: input-hash
     options:
       iconRight: lock
@@ -64,7 +67,8 @@ fields:
         hidden: true
 
   - field: user_created
-    special: user-created
+    special:
+      - user-created
     interface: select-dropdown-m2o
     width: half
     display: user

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -20,7 +20,9 @@ fields:
     width: half
 
   - field: password
-    special: hash,conceal
+    special:
+      - hash
+      - conceal
     interface: input-hash
     options:
       iconRight: lock
@@ -50,7 +52,8 @@ fields:
 
   - field: tags
     interface: tags
-    special: cast-json
+    special:
+      - cast-json
     width: full
     options:
       iconRight: local_offer
@@ -89,13 +92,15 @@ fields:
 
   - field: tfa_secret
     interface: system-mfa-setup
-    special: conceal
+    special:
+      - conceal
     width: half
 
   - field: email_notifications
     interface: boolean
     width: half
-    special: cast-boolean
+    special:
+      - cast-boolean
 
   - field: admin_divider
     interface: presentation-divider
@@ -128,7 +133,8 @@ fields:
     interface: select-dropdown-m2o
     options:
       template: '{{ name }}'
-    special: m2o
+    special:
+      - m2o
     width: half
     display: related-values
     display_options:
@@ -136,11 +142,13 @@ fields:
 
   - field: token
     interface: system-token
-    special: conceal
+    special:
+      - conceal
     width: full
 
   - field: id
-    special: uuid
+    special:
+      - uuid
     interface: input
     options:
       iconRight: vpn_key

--- a/api/src/database/system-data/fields/webhooks.yaml
+++ b/api/src/database/system-data/fields/webhooks.yaml
@@ -60,12 +60,14 @@ fields:
     interface: boolean
     options:
       label: $t:fields.directus_webhooks.data_label
-    special: cast-boolean
+    special:
+      - cast-boolean
     width: half
     display: boolean
 
   - field: headers
-    special: cast-json
+    special:
+      - cast-json
     interface: list
     options:
       template: '{{ header }}: {{ value }}'
@@ -105,7 +107,8 @@ fields:
           value: update
         - text: $t:delete_label
           value: delete
-    special: cast-csv
+    special:
+      - cast-csv
     width: full
     display: labels
     display_options:
@@ -129,7 +132,8 @@ fields:
 
   - field: collections
     interface: system-collections
-    special: cast-csv
+    special:
+      - cast-csv
     width: full
     display: labels
     display_options:


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #15643. The `special` field is correctly typed as `string[]`, but the result from API is a `string`.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
