### PR TITLE
Fix flow operations staged edits

### DIFF
--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -404,7 +404,7 @@ function stageOperationEdits(event: { edits: Partial<OperationRaw>; id?: string 
 		if (stagedPanels.value.some((panel) => panel.id === key)) {
 			stagedPanels.value = stagedPanels.value.map((panel) => {
 				if (panel.id === key) {
-					return merge({ id: key, flow: props.primaryKey }, panel, event.edits);
+					return Object.assign({ id: key, flow: props.primaryKey }, panel, event.edits);
 				}
 
 				return panel;


### PR DESCRIPTION
## Description

### Bug

When updating a Flow operation's options by editing it, then editing again back to the original value, the value will become "duplicated":

https://user-images.githubusercontent.com/42867097/191246117-1b06c6b0-f8c6-4760-8ab4-31d0e35213b1.mp4

This seems to be similar to #14998 and #15221 where the lodash `merge()` is causing this unintended behavior.

### After PR

https://user-images.githubusercontent.com/42867097/191246087-7b6367ea-0256-466f-b005-f441de62f220.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
