### PR TITLE
Map cluster and calendar drag highlight color tweak

### DIFF
--- a/app/src/layouts/map/style.ts
+++ b/app/src/layouts/map/style.ts
@@ -96,7 +96,15 @@ export function getMapStyle() {
 			filter: ['has', 'point_count'],
 			paint: {
 				'circle-radius': ['step', ['get', 'point_count'], 20, 100, 30, 750, 40],
-				'circle-color': ['step', ['get', 'point_count'], '#7fe3ca', 100, '#fde2a7', 750, '#f0a7b3'],
+				'circle-color': [
+					'step',
+					['get', 'point_count'],
+					cssVar('--primary-50'),
+					100,
+					cssVar('--yellow-50'),
+					750,
+					cssVar('--red-50'),
+				],
 				'circle-opacity': 0.7,
 			},
 		},

--- a/app/src/layouts/map/style.ts
+++ b/app/src/layouts/map/style.ts
@@ -96,15 +96,7 @@ export function getMapStyle() {
 			filter: ['has', 'point_count'],
 			paint: {
 				'circle-radius': ['step', ['get', 'point_count'], 20, 100, 30, 750, 40],
-				'circle-color': [
-					'step',
-					['get', 'point_count'],
-					cssVar('--primary-50'),
-					100,
-					cssVar('--yellow-50'),
-					750,
-					cssVar('--red-50'),
-				],
+				'circle-color': ['step', ['get', 'point_count'], '#b3a2ff', 100, '#fde2a7', 750, '#f1a8b4'],
 				'circle-opacity': 0.7,
 			},
 		},

--- a/app/src/styles/lib/_fullcalendar.scss
+++ b/app/src/styles/lib/_fullcalendar.scss
@@ -10,6 +10,7 @@
 	--fc-button-hover-border-color: transparent;
 	--fc-button-text-color: var(--foreground-subdued);
 	--fc-border-color: var(--border-normal);
+	--fc-highlight-color: var(--primary-10);
 	--fc-neutral-bg-color: var(--background-normal);
 	--fc-list-event-hover-bg-color: var(--background-subdued);
 


### PR DESCRIPTION
## Description

Fixes #15679

### Map cluster

By referring to the older css variable values: https://github.com/directus/directus/commit/a466503265458fcfa442a963aa59e0a38fbc0a2b#diff-c07f157e9f73f2e82177c933e5404a24d96e8ae01b522b3bbae7fb429b8fd4d0, seems like it is using the old light mode `--green-50`, `--yellow-50` and `--red-50` (or primary, warning, danger).

Also tried using `cssVar()`, but realized it would not work for dark mode since dark mode inverts the colors:

<details>
<summary>Why we can't use cssVar() due to dark mode</summary>

![chrome_uGI1ptvmQb](https://user-images.githubusercontent.com/42867097/191425302-d8191502-4e93-4da3-adec-473290c8c414.png)

</details>

So this PR uses the current updated light mode `--purple-50`, `--yellow-50` (remained the same), and `--red-50`.

|Before|After|
|---|---|
|![chrome_Yyh0XTNvH2](https://user-images.githubusercontent.com/42867097/191425403-ce0e4f3d-2c05-4a14-9167-d021c56740d1.png)|![chrome_PqbWJDL5oB](https://user-images.githubusercontent.com/42867097/191425422-b9157709-b80d-4d8b-9441-5990b8263023.png)|

### Calendar Drag Highlight

Seems like it was never defined, so it fallback to the original fullcalendar color, which coincidentally is green hue'd.

|Before|After|
|---|---|
|![chrome_kAx6BKqBSH](https://user-images.githubusercontent.com/42867097/191425613-e197a558-bb89-4b80-b8fb-321a2a48b678.png)|![chrome_4C0gZcFsQI](https://user-images.githubusercontent.com/42867097/191425632-76c3a16c-d3dd-4970-b04d-ee05f83bce75.png)|

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
