### PR TITLE
Use singular/plural collection translations in M2A interface

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -172,7 +172,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits(['input']);
-const { t } = useI18n();
+const { t, te } = useI18n();
 const { collection, field, primaryKey, limit } = toRefs(props);
 const { relationInfo } = useRelationM2A(collection, field);
 
@@ -336,7 +336,13 @@ function hasAllowedCollection(item: DisplayItem) {
 function getCollectionName(item: DisplayItem) {
 	const info = relationInfo.value;
 	if (!info) return false;
-	return info.allowedCollections.find((coll) => coll.collection === item[info.collectionField.field])?.name;
+
+	const collection = info.allowedCollections.find((coll) => coll.collection === item[info.collectionField.field]);
+	if (te(`collection_names_singular.${collection?.collection}`))
+		return t(`collection_names_singular.${collection?.collection}`);
+	if (te(`collection_names_plural.${collection?.collection}`))
+		return t(`collection_names_plural.${collection?.collection}`);
+	return collection?.name;
 }
 
 const customFilter = computed(() => {


### PR DESCRIPTION
## Description

Fixes #15675

M2A interface shows collection name as prefix, but it's not using the singular or plural translation when showing it.

This PR refers the implementation in related-values display: https://github.com/directus/directus/blob/d6fce8d92a48a5983293ca0c04f9de84201ec405/app/src/displays/related-values/related-values.vue#L96-L108.

### Before

![chrome_525jygxadd](https://user-images.githubusercontent.com/42867097/191432123-888cc7dc-7a4b-48be-b441-fbe91c5866db.png)

### After

![chrome_j0GtUw3sBw](https://user-images.githubusercontent.com/42867097/191432142-4484208c-9e05-47f6-865b-e15c07f607f7.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
