### PR TITLE
Graphql: Fix required PK on create / update

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -414,7 +414,8 @@ export class GraphQLService {
 						}
 
 						if (collection.primary === field.field) {
-							type = GraphQLNonNull(GraphQLID);
+							if (['create', 'update'].includes(action)) type = GraphQLID;
+							else type = GraphQLNonNull(GraphQLID);
 						}
 
 						acc[field.field] = {

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -407,6 +407,7 @@ export class GraphQLService {
 						// submitted on updates
 						if (
 							field.nullable === false &&
+							!field.defaultValue &&
 							!GENERATE_SPECIAL.some((flag) => field.special.includes(flag)) &&
 							action !== 'update'
 						) {

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -415,7 +415,8 @@ export class GraphQLService {
 						}
 
 						if (collection.primary === field.field) {
-							if (['create', 'update'].includes(action)) type = GraphQLID;
+							if (!field.defaultValue && action === 'create') type = GraphQLNonNull(GraphQLID);
+							else if (['create', 'update'].includes(action)) type = GraphQLID;
 							else type = GraphQLNonNull(GraphQLID);
 						}
 

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -415,7 +415,8 @@ export class GraphQLService {
 						}
 
 						if (collection.primary === field.field) {
-							if (!field.defaultValue && action === 'create') type = GraphQLNonNull(GraphQLID);
+							if (!field.defaultValue && !field.special.includes('uuid') && action === 'create')
+								type = GraphQLNonNull(GraphQLID);
 							else if (['create', 'update'].includes(action)) type = GraphQLID;
 							else type = GraphQLNonNull(GraphQLID);
 						}


### PR DESCRIPTION
## Description
Fixes https://github.com/directus/directus/issues/15691 by allowing the primary key to be nullable.

The same work was done twice at the same time as this one:
https://github.com/directus/directus/pull/15692

I just wanted to put this one here, since it handles default values (eg. auto increment Primary Keys vs manually entered Primary Keys)

## Type of Change

- [x] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
