### PR TITLE
Fix non-admin role creation via cli for SQLite

### DIFF
--- a/api/src/cli/commands/roles/create.ts
+++ b/api/src/cli/commands/roles/create.ts
@@ -15,7 +15,7 @@ export default async function rolesCreate({ role: name, admin }: { role: string;
 		const schema = await getSchema();
 		const service = new RolesService({ schema: schema, knex: database });
 
-		const id = await service.createOne({ name, admin_access: admin ?? false });
+		const id = await service.createOne(admin ? { name, admin_access: admin } : { name });
 		process.stdout.write(`${String(id)}\n`);
 		database.destroy();
 		process.exit(0);

--- a/api/src/cli/commands/roles/create.ts
+++ b/api/src/cli/commands/roles/create.ts
@@ -15,7 +15,7 @@ export default async function rolesCreate({ role: name, admin }: { role: string;
 		const schema = await getSchema();
 		const service = new RolesService({ schema: schema, knex: database });
 
-		const id = await service.createOne({ name, admin_access: admin });
+		const id = await service.createOne({ name, admin_access: admin ?? false });
 		process.stdout.write(`${String(id)}\n`);
 		database.destroy();
 		process.exit(0);


### PR DESCRIPTION
## Description

Fixes #15721

When we're not passing the `--admin` flag, the following createOne will receive `{ name: "my-role-name", admin: undefined }`:

https://github.com/directus/directus/blob/324b549d9de6dcbcac6670b1764f930b0bd71e71/api/src/cli/commands/roles/create.ts#L18

since admin is undefined, it will/should fallback to the default value which is `false`:

https://github.com/directus/directus/blob/324b549d9de6dcbcac6670b1764f930b0bd71e71/api/src/database/seeds/02-roles.yaml#L29-L32

However for sqlite3 specifically, when the same field is not nullable, passing undefined values will still violate NOT NULL constraint as noted by this comment over in Knex: https://github.com/knex/knex/issues/332#issuecomment-220447144

Technically doing `admin: admin ?? false` will also work, but opted to use the "more correct" approach in case the `admin_access` field's default value ever changes (even if this is very much unlikely).


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
