### PR TITLE
Add database afterCreate pool init hook

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -95,6 +95,8 @@ export default async function createApp(): Promise<express.Application> {
 
 	const app = express();
 
+	await emitter.emitInit('app.afterCreate', { app });
+
 	app.disable('x-powered-by');
 	app.set('trust proxy', env.IP_TRUST_PROXY);
 	app.set('query parser', (str: string) => qs.parse(str, { depth: 10 }));


### PR DESCRIPTION
## Description

Added a new emitter hook 'app.afterCreate' to ./api/src/app.ts to allow user to run extension on a hook after the database pool is created.

Fixes #14310

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
