### PR TITLE
adds missing graphQL operators

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -562,6 +562,9 @@ export class GraphQLService {
 					_contains: {
 						type: GraphQLString,
 					},
+					_icontains: {
+						type: GraphQLString,
+					},
 					_ncontains: {
 						type: GraphQLString,
 					},
@@ -643,6 +646,12 @@ export class GraphQLService {
 					_nnull: {
 						type: GraphQLBoolean,
 					},
+					_in: {
+						type: new GraphQLList(GraphQLString),
+					},
+					_nin: {
+						type: new GraphQLList(GraphQLString),
+					},
 					_between: {
 						type: new GraphQLList(GraphQLStringOrFloat),
 					},
@@ -715,6 +724,12 @@ export class GraphQLService {
 					},
 					_nintersects_bbox: {
 						type: GraphQLGeoJSON,
+					},
+					_null: {
+						type: GraphQLBoolean,
+					},
+					_nnull: {
+						type: GraphQLBoolean,
 					},
 				},
 			});

--- a/packages/shared/src/utils/get-filter-operators-for-type.test.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.test.ts
@@ -120,6 +120,7 @@ describe('', () => {
 		expect(getFilterOperatorsForType('alias', { includeValidation: true })).toStrictEqual([
 			'contains',
 			'ncontains',
+			'icontains',
 			'eq',
 			'neq',
 			'lt',

--- a/packages/shared/src/utils/get-filter-operators-for-type.test.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.test.ts
@@ -6,6 +6,7 @@ describe('', () => {
 		expect(getFilterOperatorsForType('alias')).toStrictEqual([
 			'contains',
 			'ncontains',
+			'icontains',
 			'eq',
 			'neq',
 			'lt',
@@ -104,6 +105,8 @@ describe('', () => {
 
 	it('returns the filter operators for geometry', () => {
 		expect(getFilterOperatorsForType('geometry')).toStrictEqual([
+			'eq',
+			'neq',
 			'null',
 			'nnull',
 			'intersects',

--- a/packages/shared/src/utils/get-filter-operators-for-type.test.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.test.ts
@@ -6,7 +6,6 @@ describe('', () => {
 		expect(getFilterOperatorsForType('alias')).toStrictEqual([
 			'contains',
 			'ncontains',
-			'icontains',
 			'eq',
 			'neq',
 			'lt',

--- a/packages/shared/src/utils/get-filter-operators-for-type.test.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.test.ts
@@ -120,7 +120,6 @@ describe('', () => {
 		expect(getFilterOperatorsForType('alias', { includeValidation: true })).toStrictEqual([
 			'contains',
 			'ncontains',
-			'icontains',
 			'eq',
 			'neq',
 			'lt',

--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -62,7 +62,7 @@ export function getFilterOperatorsForType(
 			return ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'null', 'nnull', 'in', 'nin'];
 
 		case 'geometry':
-			return ['null', 'nnull', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'];
+			return ['eq', 'neq', 'null', 'nnull', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'];
 
 		default:
 			return [

--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -68,6 +68,7 @@ export function getFilterOperatorsForType(
 			return [
 				'contains',
 				'ncontains',
+				'icontains',
 				'eq',
 				'neq',
 				'lt',

--- a/packages/shared/src/utils/get-filter-operators-for-type.ts
+++ b/packages/shared/src/utils/get-filter-operators-for-type.ts
@@ -68,7 +68,6 @@ export function getFilterOperatorsForType(
 			return [
 				'contains',
 				'ncontains',
-				'icontains',
 				'eq',
 				'neq',
 				'lt',


### PR DESCRIPTION
## Description

This PR helps with some consistency among graphQL operators:

- adds `icontains` for string
- adds `in`, `nin` for date
- adds missing `eq`, `neq` for geo.

Fixes #15699

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
