### PR TITLE
fix (display-filesize): adjust handler argument to be read as `value`

### DIFF
--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -7,7 +7,7 @@ export default defineDisplay({
 	description: '$t:displays.filesize.description',
 	icon: 'description',
 	component: ({ value }: { value: number }) => formatFilesize(value),
-	handler: ({ value }: { value: number }) => formatFilesize(value),
+	handler: ( value: number) => formatFilesize(value),
 	options: [],
 	types: ['integer', 'bigInteger'],
 });

--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -7,7 +7,7 @@ export default defineDisplay({
 	description: '$t:displays.filesize.description',
 	icon: 'description',
 	component: ({ value }: { value: number }) => formatFilesize(value),
-	handler: ( value: number) => formatFilesize(value),
+	handler: (value: number) => formatFilesize(value),
 	options: [],
 	types: ['integer', 'bigInteger'],
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/directus/directus/issues/15837

Adjust handler argument to be read as `value`; before it was read as an object from which the key `value` was tried to be extracted (the expected way how the arguments for the `component` function are to be read; suspecting a simple copy/paste mistake as origin of this bug).

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
