### PR TITLE
fix (display-filesize): wrap component value in `span` node

### DIFF
--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -1,6 +1,6 @@
 import { defineDisplay } from '@directus/shared/utils';
 import { formatFilesize } from '@/utils/format-filesize';
-import { h } from 'vue'
+import { h } from 'vue';
 
 export default defineDisplay({
 	id: 'filesize',

--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -1,12 +1,13 @@
 import { defineDisplay } from '@directus/shared/utils';
 import { formatFilesize } from '@/utils/format-filesize';
+import { h } from 'vue'
 
 export default defineDisplay({
 	id: 'filesize',
 	name: '$t:displays.filesize.filesize',
 	description: '$t:displays.filesize.description',
 	icon: 'description',
-	component: ({ value }: { value: number }) => formatFilesize(value),
+	component: ({ value }: { value: number }) => h('span', null, formatFilesize(value)),
 	handler: ({ value }: { value: number }) => formatFilesize(value),
 	options: [],
 	types: ['integer', 'bigInteger'],


### PR DESCRIPTION
## Description

Added missing `span` wrap around the `display-filesize` component so that the formatted `filesize` value can now be properly vertically aligned with other template values.

Fixes #15838

## Type of Change

- [x] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
