### PR TITLE
Allow removing existing link in WYSIWYG editor by clearing the URL

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -51,7 +51,7 @@
 				</v-card-text>
 				<v-card-actions>
 					<v-button secondary @click="closeLinkDrawer">{{ t('cancel') }}</v-button>
-					<v-button :disabled="linkSelection.url === null" @click="saveLink">{{ t('save') }}</v-button>
+					<v-button :disabled="linkSelection.url === null && !linkNode" @click="saveLink">{{ t('save') }}</v-button>
 				</v-card-actions>
 			</v-card>
 		</v-dialog>
@@ -319,7 +319,7 @@ export default defineComponent({
 			mediaButton,
 		} = useMedia(editorRef, imageToken);
 
-		const { linkButton, linkDrawerOpen, closeLinkDrawer, saveLink, linkSelection } = useLink(editorRef);
+		const { linkButton, linkDrawerOpen, closeLinkDrawer, saveLink, linkSelection, linkNode } = useLink(editorRef);
 
 		const { codeDrawerOpen, code, closeCodeDrawer, saveCode, sourceCodeButton } = useSourceCode(editorRef);
 
@@ -428,6 +428,7 @@ export default defineComponent({
 			closeLinkDrawer,
 			saveLink,
 			linkSelection,
+			linkNode,
 			codeDrawerOpen,
 			code,
 			closeCodeDrawer,

--- a/app/src/interfaces/input-rich-text-html/useLink.ts
+++ b/app/src/interfaces/input-rich-text-html/useLink.ts
@@ -18,6 +18,7 @@ type LinkButton = {
 type UsableLink = {
 	linkDrawerOpen: Ref<boolean>;
 	linkSelection: Ref<LinkSelection>;
+	linkNode: Ref<HTMLLinkElement | null>;
 	closeLinkDrawer: () => void;
 	saveLink: () => void;
 	linkButton: LinkButton;
@@ -94,7 +95,7 @@ export default function useLink(editor: Ref<any>): UsableLink {
 		},
 	};
 
-	return { linkDrawerOpen, linkSelection, closeLinkDrawer, saveLink, linkButton };
+	return { linkDrawerOpen, linkSelection, linkNode, closeLinkDrawer, saveLink, linkButton };
 
 	function setLinkSelection(overrideLinkSelection: Partial<LinkSelection> = {}) {
 		linkSelection.value = Object.assign({}, defaultLinkSelection, overrideLinkSelection);
@@ -109,7 +110,13 @@ export default function useLink(editor: Ref<any>): UsableLink {
 		editor.value.fire('focus');
 
 		const link = linkSelection.value;
-		if (link.url === null) return;
+		if (link.url === null) {
+			if (linkNode.value) {
+				editor.value.selection.setContent(linkNode.value.innerText);
+				closeLinkDrawer();
+			}
+			return;
+		}
 		const linkHtml = `<a href="${link.url}" ${link.title ? `title="${link.title}"` : ''} target="${
 			link.newTab ? '_blank' : '_self'
 		}" >${link.displayText || link.url}</a>`;


### PR DESCRIPTION
## Description

Fixes #15670

TinyMCE's original implementation allows the removal of existing links by clearing the URL and saving it. This PR aims to support the same interaction in the custom link implementation.

### Result

https://user-images.githubusercontent.com/42867097/194022909-b6ad2c39-b2eb-41cb-816a-08294ba3ddb0.mp4

### Additional thoughts

Technically it is also currently possible to remove links via context menu, so it does depends on whether the custom link drawer should behave the same as TinyMCE's own link drawer or not.

![chrome_SWrnITjM2h](https://user-images.githubusercontent.com/42867097/194023516-20cade2f-e9ef-4aa5-9216-526b1065354d.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
