### PR TITLE
Allow usage of tupels of arbitrary length with DeepPartial

### DIFF
--- a/packages/shared/src/types/misc.ts
+++ b/packages/shared/src/types/misc.ts
@@ -1,16 +1,12 @@
 type Primitive = undefined | null | string | number | boolean | bigint | symbol;
 type Builtin = Primitive | Date | Error | RegExp | ((...args: any[]) => unknown);
-type Tuple =
-	| [unknown]
-	| [unknown, unknown]
-	| [unknown, unknown, unknown]
-	| [unknown, unknown, unknown, unknown]
-	| [unknown, unknown, unknown, unknown, unknown];
 
 export type DeepPartial<T> = T extends Builtin
 	? T
-	: T extends Tuple
-	? { [K in keyof T]?: DeepPartial<T[K]> }
+	: T extends []
+	? []
+	: T extends [infer U, ...infer R]
+	? [DeepPartial<U>, ...DeepPartial<R>]
 	: T extends Array<infer U>
 	? Array<DeepPartial<U>>
 	: T extends ReadonlyArray<infer U>


### PR DESCRIPTION
## Description

Not that it matters at all for our usage of `DeepPartial`, but I stumbled upon this while working on something else. So, might as well make it nice ✨

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
