### PR TITLE
Add alias to always have the same name

### DIFF
--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -679,7 +679,7 @@ export class PayloadService {
 							.from(relation.collection)
 							.where({ [relation.field]: parent })
 							.whereNotNull(sortField)
-							.max(sortField)
+							.max(sortField, { as: 'max' })
 							.first();
 
 						createPayload = alterations.create.map((item, index) => {


### PR DESCRIPTION
The problems was that postgres possibly names the column just `max` where as other vendors use `max('sort')` which causes problems.

Fixes #15954

Related to #15241