### PR TITLE
Allow triggering manual flow without selection(s)

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -795,7 +795,7 @@ select_a_flow: Select a Flow
 run_flow_on_current_collection: Run flow on Current Collection
 run_flow_on_current: Run flow on Current Item
 run_flow_on_current_edited_confirm: This item may be updated by this flow, are you sure you want to execute it?
-run_flow_on_selected: No Items Selected | Run flow on 1 Selected Item | Run flow on {n} Selected Items
+run_flow_on_selected: Select One or More Items First | Run flow on 1 Selected Item | Run flow on {n} Selected Items
 run_flow_success: Flow "{flow}" ran successfully
 trigger: Trigger
 trigger_options: Trigger Options

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -792,6 +792,7 @@ label: Label
 flows: Flows
 flow: Flow
 select_a_flow: Select a Flow
+run_flow_on_current_collection: Run flow on Current Collection
 run_flow_on_current: Run flow on Current Item
 run_flow_on_current_edited_confirm: This item may be updated by this flow, are you sure you want to execute it?
 run_flow_on_selected: No Items Selected | Run flow on 1 Selected Item | Run flow on {n} Selected Items
@@ -2082,6 +2083,8 @@ triggers:
     collection_and_item: Collection & Item Pages
     collection_only: Collection Page Only
     item_only: Item Page Only
+    collection_page: Collection Page
+    require_selection: Requires Selection
 a_flow_uuid: Select a Flow to trigger...
 any_string_or_json: Any string or JSON...
 item_payload_placeholder: This is the JSON used to update the item's field values...

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -380,6 +380,32 @@ export function getTriggers() {
 						default_value: false,
 					},
 				},
+				{
+					field: 'requireSelection',
+					name: t('triggers.manual.collection_page'),
+					type: 'boolean',
+					meta: {
+						interface: 'boolean',
+						width: 'half' as Width,
+						options: {
+							label: t('triggers.manual.require_selection'),
+						},
+						hidden: false,
+						conditions: [
+							{
+								rule: {
+									location: {
+										_eq: 'item',
+									},
+								},
+								hidden: true,
+							},
+						],
+					},
+					schema: {
+						default_value: true,
+					},
+				},
 			],
 		},
 	];

--- a/app/src/stores/flows.test.ts
+++ b/app/src/stores/flows.test.ts
@@ -1,0 +1,126 @@
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+	setActivePinia(
+		createTestingPinia({
+			createSpy: vi.fn,
+			stubActions: false,
+		})
+	);
+});
+
+import { useFlowsStore } from './flows';
+import { useUserStore } from './user';
+
+const mockFlows = [
+	{
+		name: 'Flow 1',
+		status: 'active',
+		trigger: 'manual',
+		accountability: 'all',
+		options: {
+			collections: ['a'],
+		},
+	},
+	{
+		name: 'Flow 2',
+		status: 'inactive',
+		trigger: 'event',
+		accountability: 'all',
+		options: {
+			type: 'action',
+			scope: ['items.create'],
+			collections: ['a'],
+		},
+	},
+	{
+		name: 'Flow 3',
+		status: 'inactive',
+		trigger: 'manual',
+		accountability: 'all',
+		options: {
+			collections: ['a'],
+		},
+	},
+	{
+		name: 'Flow 4',
+		status: 'active',
+		trigger: 'manual',
+		accountability: 'all',
+		options: {
+			collections: ['b'],
+		},
+	},
+];
+
+const mockAdminUser = { role: { admin_access: true } } as any;
+
+const mockNonAdminUser = { role: { admin_access: false } } as any;
+
+vi.mock('@/api', () => {
+	return {
+		default: {
+			get: (path: string) => {
+				if (path === '/flows') {
+					return Promise.resolve({
+						data: {
+							data: mockFlows,
+						},
+					});
+				}
+
+				return Promise.reject(new Error(`Path "${path}" is not mocked in this test`));
+			},
+		},
+	};
+});
+
+test('hydrate action for admin', async () => {
+	const userStore = useUserStore();
+	userStore.currentUser = mockAdminUser;
+
+	const flowsStore = useFlowsStore();
+	await flowsStore.hydrate();
+
+	expect(flowsStore.flows).toEqual(mockFlows);
+});
+
+test('hydrate action for non-admin', async () => {
+	const userStore = useUserStore();
+	userStore.currentUser = mockNonAdminUser;
+
+	const flowsStore = useFlowsStore();
+	await flowsStore.hydrate();
+
+	expect(flowsStore.flows).toEqual([]);
+});
+
+test('dehydrate action resets store', async () => {
+	const userStore = useUserStore();
+	userStore.currentUser = mockAdminUser;
+
+	const flowsStore = useFlowsStore();
+	await flowsStore.hydrate();
+	await flowsStore.dehydrate();
+
+	expect(flowsStore.flows).toEqual([]);
+});
+
+test('getManualFlowsForCollection action returns active manual flows of specified collection only', async () => {
+	const userStore = useUserStore();
+	userStore.currentUser = mockAdminUser;
+
+	const flowsStore = useFlowsStore();
+	await flowsStore.hydrate();
+
+	const testCollection = 'a';
+
+	expect(flowsStore.getManualFlowsForCollection(testCollection)).toEqual(
+		mockFlows.filter(
+			(flow) =>
+				flow.trigger === 'manual' && flow.status === 'active' && flow.options?.collections?.includes(testCollection)
+		)
+	);
+});


### PR DESCRIPTION
## Description

Addresses https://github.com/directus/directus/discussions/15746#discussioncomment-3863358 and implements #15794

- Added new option in Manual Trigger to allow triggering in Collection Page without having to select any items

     https://user-images.githubusercontent.com/42867097/195519376-9479fc73-9641-4210-ad7a-d02e7cb39e33.mp4
     
- Added (unrelated) test for flows store

- Updated tooltip for No Items Selected as discussed in https://github.com/directus/directus/discussions/15746#discussioncomment-3775709

    ![chrome_tr7u9iKXQV](https://user-images.githubusercontent.com/42867097/195519960-7f9a0518-e1a2-4c4e-b101-178621983633.png)

### Result

https://user-images.githubusercontent.com/42867097/195519195-cdcf2cfe-0f95-4dff-999f-12f2d6a5fbf0.mp4

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated. PR: directus/docs#170
