### PR TITLE
Remove handleObject default value in render-template

### DIFF
--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -120,7 +120,7 @@ function handleObject(fieldKey: string) {
 			.join('.');
 	}
 
-	const value = get(props.item, fieldKey, field?.schema?.default_value);
+	const value = get(props.item, fieldKey);
 
 	if (value === undefined) return null;
 


### PR DESCRIPTION
## Description

This sort of partially reverts the change in #15736, specifically only the addition of default value in `get()` in this line: https://github.com/directus/directus/pull/15736/files#diff-798c8805bfccc41091f17de4fc330a22c42700e5938e2f5bb8d299c464e7d756R123

This is because for autoincrement in Postgres for example (the video below shows the default value for Postgres, but should hold true for other vendors as well) is now displaying the default value such as `nextval('b_id_seq'::regclass)` which seems odd personally. Quick comparison:

### With default value

https://user-images.githubusercontent.com/42867097/195780706-0cded360-9f86-4b4b-bd1f-c803c8773450.mp4

### Without default value (how it used to work)

https://user-images.githubusercontent.com/42867097/195780655-df239735-ec73-42ab-92c7-789373c4071f.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
