### PR TITLE
Use right collection for filter

### DIFF
--- a/app/src/interfaces/list-m2m/index.ts
+++ b/app/src/interfaces/list-m2m/index.ts
@@ -13,7 +13,7 @@ export default defineInterface({
 	localTypes: ['m2m'],
 	group: 'relational',
 	options: ({ editing, relations, field: { meta } }) => {
-		const { collection, related_collection } = relations.o2m ?? {};
+		const { collection, related_collection } = relations.m2o ?? {};
 		const options = meta?.options ?? {};
 
 		const tableOptions = [


### PR DESCRIPTION
The problem was that we didn't use the related collection for filtering but the current one on m2m's.

Fixes #15994