### PR TITLE
Skip parsing of date strings that only contain zeros

### DIFF
--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -210,7 +210,7 @@ describe('Integration Tests', () => {
 						{
 							[dateFieldId]: '2022-01-10',
 							[dateTimeFieldId]: '2021-10-01T12:34:56',
-							[timestampFieldId]: '1980-12-07T16:41:22.333Z',
+							[timestampFieldId]: new Date('1980-12-08 00:11:22.333').toISOString(),
 						},
 					]);
 				});

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -101,5 +101,120 @@ describe('Integration Tests', () => {
 				});
 			});
 		});
+
+		describe('processDates', () => {
+			let service: PayloadService;
+
+			const dateFieldId = 'date_field';
+			const dateTimeFieldId = 'datetime_field';
+			const timestampFieldId = 'timestamp_field';
+
+			beforeEach(() => {
+				service = new PayloadService('test', {
+					knex: db,
+					schema: {
+						collections: {
+							test: {
+								collection: 'test',
+								primary: 'id',
+								singleton: false,
+								sortField: null,
+								note: null,
+								accountability: null,
+								fields: {
+									[dateFieldId]: {
+										field: dateFieldId,
+										defaultValue: null,
+										nullable: true,
+										generated: false,
+										type: 'date',
+										dbType: 'date',
+										precision: null,
+										scale: null,
+										special: [],
+										note: null,
+										validation: null,
+										alias: false,
+									},
+									[dateTimeFieldId]: {
+										field: dateTimeFieldId,
+										defaultValue: null,
+										nullable: true,
+										generated: false,
+										type: 'dateTime',
+										dbType: 'datetime',
+										precision: null,
+										scale: null,
+										special: [],
+										note: null,
+										validation: null,
+										alias: false,
+									},
+									[timestampFieldId]: {
+										field: timestampFieldId,
+										defaultValue: null,
+										nullable: true,
+										generated: false,
+										type: 'timestamp',
+										dbType: 'timestamp',
+										precision: null,
+										scale: null,
+										special: [],
+										note: null,
+										validation: null,
+										alias: false,
+									},
+								},
+							},
+						},
+						relations: [],
+					},
+				});
+			});
+
+			describe('processes dates', () => {
+				it('with zero values', async () => {
+					const result = await service.processDates(
+						[
+							{
+								[dateFieldId]: '0000-00-00',
+								[dateTimeFieldId]: '0000-00-00 00:00:00',
+								[timestampFieldId]: '0000-00-00 00:00:00.000',
+							},
+						],
+						'read'
+					);
+
+					expect(result).toMatchObject([
+						{
+							[dateFieldId]: null,
+							[dateTimeFieldId]: null,
+							[timestampFieldId]: null,
+						},
+					]);
+				});
+
+				it('with typical values', async () => {
+					const result = await service.processDates(
+						[
+							{
+								[dateFieldId]: '2022-01-10',
+								[dateTimeFieldId]: '2021-09-31 12:34:56',
+								[timestampFieldId]: '1980-12-08 00:11:22.333',
+							},
+						],
+						'read'
+					);
+
+					expect(result).toMatchObject([
+						{
+							[dateFieldId]: '2022-01-10',
+							[dateTimeFieldId]: '2021-10-01T12:34:56',
+							[timestampFieldId]: '1980-12-07T16:41:22.333Z',
+						},
+					]);
+				});
+			});
+		});
 	});
 });

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -277,7 +277,7 @@ export class PayloadService {
 			for (const payload of payloads) {
 				let value: number | string | Date = payload[name];
 
-				if (value === null || value === '0000-00-00') {
+				if (value === null || (typeof value === 'string' && /^[0 :-]+$/.test(value))) {
 					payload[name] = null;
 					continue;
 				}

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -277,7 +277,7 @@ export class PayloadService {
 			for (const payload of payloads) {
 				let value: number | string | Date = payload[name];
 
-				if (value === null || (typeof value === 'string' && /^[0 :-]+$/.test(value))) {
+				if (value === null || (typeof value === 'string' && /^[.0 :-]{10,}$/.test(value))) {
 					payload[name] = null;
 					continue;
 				}


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #14497.
Improve on previous bypass which only filters for `0000-00-00`.
Now it also works for values `0000-00-00 00:00:00` or `0000-00-00 00:00:00.000`.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
