### PR TITLE
Remove property="og:url" from email base template

### DIFF
--- a/api/src/services/mail/templates/base.liquid
+++ b/api/src/services/mail/templates/base.liquid
@@ -103,7 +103,6 @@ blockquote > p {
 </style>
 
 <meta name="generator" content="Directus">
-<meta property="og:url" content="http://directus-20534155.hs-sites.com/7dea362b-3fac-3e00-956a-4952a3d4f474">
 <meta name="x-apple-disable-message-reformatting">
 <meta name="robots" content="noindex,follow">
 


### PR DESCRIPTION
## Description
Removed a unlogical property="og:url" url from base.liquid email template

## Type of Change
- [*] Bugfix

## Requirements Checklist
- [*] Performed a self-review of the submitted code

