### PR TITLE
Fix extensions translations and time-series panel

### DIFF
--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -1885,33 +1885,33 @@ layouts:
     default_template: Verwenden des Sammlungs-Standards...
     no_compatible_fields: Keine kompatiblen Felder
   kanban:
-    name: Kanban,
-    group_field: Gruppieren nach,
-    group_field_placeholder: Feld zum Gruppieren...,
-    group_title: Gruppentitel,
-    group_title_placeholder: Feld für Gruppentitel...,
-    title: Karten-Titel,
-    title_placeholder: Optionales Titelfeld...,
-    text: Karten-Text,
-    text_placeholder: Optionales Textfeld...,
-    date: Karten-Datum,
-    date_placeholder: Optionales Datumsfeld...,
-    tags: Karten-Tags,
-    tags_placeholder: Optionales Tag-Feld...,
-    user: Karten-Benutzer,
-    user_placeholder: Optionales Benutzerfeld...,
-    image: Karten-Bild,
-    image_placeholder: Optionales Bildfeld...,
-    image_fit: Karten-Bildfüllmodus,
-    crop: Beschneiden,
-    advanced: Erweitert,
-    edit_group: Gruppe bearbeiten,
-    delete_group: Gruppe löschen,
-    add_group: Gruppe hinzufügen,
-    add_group_placeholder: Neuen Gruppentitel eingeben...,
-    show_ungrouped: Nicht gruppierte Elemente zeigen,
-    show: Anzeigen,
-    no_group: Keine Gruppe,
+    name: Kanban
+    group_field: Gruppieren nach
+    group_field_placeholder: Feld zum Gruppieren...
+    group_title: Gruppentitel
+    group_title_placeholder: Feld für Gruppentitel...
+    title: Karten-Titel
+    title_placeholder: Optionales Titelfeld...
+    text: Karten-Text
+    text_placeholder: Optionales Textfeld...
+    date: Karten-Datum
+    date_placeholder: Optionales Datumsfeld...
+    tags: Karten-Tags
+    tags_placeholder: Optionales Tag-Feld...
+    user: Karten-Benutzer
+    user_placeholder: Optionales Benutzerfeld...
+    image: Karten-Bild
+    image_placeholder: Optionales Bildfeld...
+    image_fit: Karten-Bildfüllmodus
+    crop: Beschneiden
+    advanced: Erweitert
+    edit_group: Gruppe bearbeiten
+    delete_group: Gruppe löschen
+    add_group: Gruppe hinzufügen
+    add_group_placeholder: Neuen Gruppentitel eingeben...
+    show_ungrouped: Nicht gruppierte Elemente zeigen
+    show: Anzeigen
+    no_group: Keine Gruppe
     not_all_loaded: Konnte nur die ersten 1000 Elemente laden.
 panels:
   metric:

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1934,33 +1934,33 @@ layouts:
     default_template: Using Collection Default...
     no_compatible_fields: No compatible fields
   kanban:
-    name: Kanban,
-    group_field: Group By,
-    group_field_placeholder: Field to group by...,
-    group_title: Group Title,
-    group_title_placeholder: Field for group titles...,
-    title: Card Title,
-    title_placeholder: Optional title field...,
-    text: Card Text,
-    text_placeholder: Optional text field...,
-    date: Card Date,
-    date_placeholder: Optional date field...,
-    tags: Card Tags,
-    tags_placeholder: Optional tags field...,
-    user: Card User,
-    user_placeholder: Optional user field...,
-    image: Card Image,
-    image_placeholder: Optional image field...,
-    image_fit: Card Image Fit,
-    crop: Crop,
-    advanced: Advanced,
-    edit_group: Edit Group,
-    delete_group: Delete Group,
-    add_group: Add Group,
-    add_group_placeholder: Enter a new group title...,
-    show_ungrouped: Show Ungrouped,
-    show: Show,
-    no_group: No Group,
+    name: Kanban
+    group_field: Group By
+    group_field_placeholder: Field to group by...
+    group_title: Group Title
+    group_title_placeholder: Field for group titles...
+    title: Card Title
+    title_placeholder: Optional title field...
+    text: Card Text
+    text_placeholder: Optional text field...
+    date: Card Date
+    date_placeholder: Optional date field...
+    tags: Card Tags
+    tags_placeholder: Optional tags field...
+    user: Card User
+    user_placeholder: Optional user field...
+    image: Card Image
+    image_placeholder: Optional image field...
+    image_fit: Card Image Fit
+    crop: Crop
+    advanced: Advanced
+    edit_group: Edit Group
+    delete_group: Delete Group
+    add_group: Add Group
+    add_group_placeholder: Enter a new group title...
+    show_ungrouped: Show Ungrouped
+    show: Show
+    no_group: No Group
     not_all_loaded: Could only load the first 1000 items.
 
 panels:

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2024,7 +2024,8 @@ panels:
   meter:
     description: Meter for tracking values
     name: Meter
-    arc: Arc
+    half_circle: Half Circle
+    full_circle: Full Circle
     stroke_width: Stroke Width
     select_max_value: You must select a maximum value.
     max_greater_than_zero: The maximum must be greater than 0.

--- a/app/src/panels/time-series/panel-time-series.vue
+++ b/app/src/panels/time-series/panel-time-series.vue
@@ -11,7 +11,7 @@ import { abbreviateNumber, adjustDate } from '@directus/shared/utils';
 import { cssVar } from '@directus/shared/utils/browser';
 import ApexCharts from 'apexcharts';
 import { addWeeks } from 'date-fns';
-import { isNil } from 'lodash';
+import { isNil, snakeCase } from 'lodash';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { orderBy } from 'lodash';
@@ -66,7 +66,7 @@ const chart = ref<ApexCharts>();
 
 const valueLabel = computed(() => {
 	const field = fieldsStore.getField(props.collection, props.valueField)!;
-	const operation = t(props.function);
+	const operation = t(snakeCase(props.function));
 	return `${field.name} (${operation})`;
 });
 


### PR DESCRIPTION
## Description

- Kanban `en-US` and `de-DE` translations from #12780 had trailing commas in them, presumably was unintentionally left in
- Meter
    - Removed unused `arc`
    - Translate Full and Half size
- Time Series
    - the translations for distinct functions are snake_case such as `sum_distinct`, but currently the translation is trying to do camelCase `sumDistinct` so they weren't really translated.
    
        |Before|After|
        |---|---|
        |![](https://user-images.githubusercontent.com/42867097/196192797-cf8fa402-df01-4aba-8d1f-25f8ed8de4b2.png)|![](https://user-images.githubusercontent.com/42867097/196192825-9618d208-64b7-4f78-8c15-b08cf5a8f759.png)|

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
