### PR TITLE
Add try/catch block to Users Module navigation and system-scope interface

### DIFF
--- a/app/src/interfaces/_system/system-scope/system-scope.vue
+++ b/app/src/interfaces/_system/system-scope/system-scope.vue
@@ -18,6 +18,7 @@ import { computed, defineComponent, ref, watch } from 'vue';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import api from '@/api';
 import { userName } from '@/utils/user-name';
+import { unexpectedError } from '@/utils/unexpected-error';
 
 export default defineComponent({
 	components: {
@@ -103,25 +104,29 @@ export default defineComponent({
 
 			const [endpoint, id] = props.value.split('_');
 
-			if (endpoint === 'role') {
-				const result = await api.get('/roles/' + id, {
-					params: {
-						fields: ['id', 'name'],
-					},
-				});
+			try {
+				if (endpoint === 'role') {
+					const result = await api.get('/roles/' + id, {
+						params: {
+							fields: ['id', 'name'],
+						},
+					});
 
-				itemName.value = result.data.data.name;
-			} else if (endpoint === 'user') {
-				const result = await api.get('/users/' + id, {
-					params: {
-						fields: ['id', 'first_name', 'last_name', 'email'],
-					},
-				});
+					itemName.value = result.data.data.name;
+				} else if (endpoint === 'user') {
+					const result = await api.get('/users/' + id, {
+						params: {
+							fields: ['id', 'first_name', 'last_name', 'email'],
+						},
+					});
 
-				itemName.value = userName(result.data.data);
+					itemName.value = userName(result.data.data);
+				}
+			} catch (error: any) {
+				unexpectedError(error);
+			} finally {
+				loading.value = false;
 			}
-
-			loading.value = false;
 		}
 	},
 });

--- a/app/src/modules/users/composables/use-navigation.ts
+++ b/app/src/modules/users/composables/use-navigation.ts
@@ -1,4 +1,5 @@
 import api from '@/api';
+import { unexpectedError } from '@/utils/unexpected-error';
 import { Role } from '@directus/shared/types';
 import { ref, Ref } from 'vue';
 
@@ -24,12 +25,17 @@ export default function useNavigation(): { roles: Ref<Role[] | null>; loading: R
 		if (!loading || !roles) return;
 		if (!roles.value) loading.value = true;
 
-		const rolesResponse = await api.get(`/roles`, {
-			params: {
-				sort: 'name',
-			},
-		});
-		roles.value = rolesResponse.data.data;
-		loading.value = false;
+		try {
+			const rolesResponse = await api.get(`/roles`, {
+				params: {
+					sort: 'name',
+				},
+			});
+			roles.value = rolesResponse.data.data;
+		} catch (error: any) {
+			unexpectedError(error);
+		} finally {
+			loading.value = false;
+		}
 	}
 }


### PR DESCRIPTION
## Description

Currently there is no try/catch statement wrapping the role fetching within the navigation in Users Module, so whenever there is an issue with said API, the loading state never stops:

(This is just an example to induce the error by manually changing it to an invalid endpoint `/roles123`)

https://user-images.githubusercontent.com/42867097/196340734-9594188c-078a-418b-9c27-1c8acfb6f7c4.mp4

Same issue applies for system-scope interface (it will show loading perpetually in case it errors), so this PR includes it as well.

### Result

https://user-images.githubusercontent.com/42867097/196340816-c165989a-8f6e-4045-a44e-788f4c8b6cb6.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
