### PR TITLE
Reset selections for Flows manual trigger in collection page

### DIFF
--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -228,7 +228,7 @@
 				v-model:active="batchEditActive"
 				:primary-keys="selection"
 				:collection="collection"
-				@refresh="drawerBatchRefresh"
+				@refresh="batchRefresh"
 			/>
 
 			<template #sidebar>
@@ -252,7 +252,12 @@
 					@download="download"
 					@refresh="refresh"
 				/>
-				<flow-sidebar-detail location="collection" :collection="collection" :selection="selection" @refresh="refresh" />
+				<flow-sidebar-detail
+					location="collection"
+					:collection="collection"
+					:selection="selection"
+					@refresh="batchRefresh"
+				/>
 			</template>
 
 			<v-dialog :model-value="deleteError !== null">
@@ -465,7 +470,7 @@ export default defineComponent({
 			bookmarkIsMine,
 			bookmarkSaving,
 			clearLocalSave,
-			drawerBatchRefresh,
+			batchRefresh,
 			refresh,
 			refreshInterval,
 			currentLayout,
@@ -483,7 +488,7 @@ export default defineComponent({
 			await layoutRef.value?.state?.download?.();
 		}
 
-		async function drawerBatchRefresh() {
+		async function batchRefresh() {
 			selection.value = [];
 			await refresh();
 		}


### PR DESCRIPTION
## Description

Fixes #16065

When triggering manual flows, the selections aren't being reset:

https://user-images.githubusercontent.com/42867097/196862688-3f345be7-e4f2-4b84-82a2-36274b75696a.mp4

This PR reuses the `drawerBatchRefresh()` function added in #9798 which includes resetting of selections, but also renamed said function to `batchRefresh()` to be more "agnostic".

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
