### PR TITLE
Fix Project Background Image URL Resolution

### DIFF
--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -60,6 +60,7 @@
 import { computed } from 'vue';
 import { useServerStore } from '@/stores/server';
 import { storeToRefs } from 'pinia';
+import { getRootPath } from '@/utils/get-root-path';
 import { useI18n } from 'vue-i18n';
 import { cssVar } from '@directus/shared/utils/browser';
 import Color from 'color';
@@ -130,7 +131,7 @@ const hasCustomBackground = computed(() => {
 const artStyles = computed(() => {
 	if (!hasCustomBackground.value) return null;
 
-	const url = `/assets/${info.value!.project?.public_background}`;
+	const url = getRootPath() + `assets/${info.value!.project?.public_background}`;
 
 	return {
 		background: `url(${url})`,


### PR DESCRIPTION
## Description

Fix Root URL for Background Image on Public Page

Added `getRootPath()` back for the Project Background since it does not use `v-image`.

Fixes #16032

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
