### PR TITLE
Prepare Action: Set output via new file method

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -25,7 +25,7 @@ runs:
       id: pnpm-cache
       shell: bash
       run: |
-        echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+        echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       name: Setup pnpm cache


### PR DESCRIPTION
## Description

Use the file method to set output in the prepare action.
The older command method has been deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<img width="800" src="https://user-images.githubusercontent.com/5363448/196985632-e455abd4-cf2b-47ac-b55a-dc3197d68f9d.png">

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
