### PR TITLE
Allow form of drawer to show validation errors

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -52,7 +52,6 @@
 					v-model="internalEdits"
 					:disabled="disabled"
 					:loading="loading"
-					:nested="true"
 					:initial-values="initialValues"
 					:autofocus="swapFormOrder"
 					:show-divider="swapFormOrder"


### PR DESCRIPTION
## Description

Fixes #16091

Setting `nested:true` for v-form inside drawer-item, was preventing validation errors was being show inside the drawer

I could not figure out why this value was set in #14778 because the fallback message still shows properly if `nested` is not set.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
