### PR TITLE
Revert "Small `Release` workflow clean-up"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Skip this step in forks
-    if: github.repository_owner == 'directus'
+    if: ${{ github.repository_owner == 'directus' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -67,10 +67,20 @@ jobs:
           path: '**/dist'
           key: build-artifacts-${{ github.sha }}
 
-      - name: Prepare
-        uses: ./.github/actions/prepare
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
-          build: false
+          node-version: 16
+
+      - uses: pnpm/action-setup@v2.2.2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm i
 
       - name: Publish packages to NPM
         env:
@@ -121,14 +131,14 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: env.DOCKERHUB_IMAGE
+        if: ${{ env.DOCKERHUB_IMAGE }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GHCR
         uses: docker/login-action@v2
-        if: env.GHCR_IMAGE
+        if: ${{ env.GHCR_IMAGE }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Reverts directus/directus#16083

Somehow, the usage of the cache seems to make npm think (correctly or otherwise) that the tarball packed versions of the packages are corrupt, preventing the docker images from being built. We'll revert this optimization until we figure out what's going on there