### PR TITLE
Fix input-code height in form-field-raw-editor

### DIFF
--- a/app/src/components/v-form/__snapshots__/form-field-raw-editor.test.ts.snap
+++ b/app/src/components/v-form/__snapshots__/form-field-raw-editor.test.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1
 
 exports[`should render 1`] = `
-"<v-dialog model-value=\\"true\\" persistent=\\"\\">
-  <v-card>
-    <v-card-title>edit_raw_value</v-card-title>
-    <v-card-text>
-      <interface-system-raw-editor type=\\"undefined\\" disabled=\\"false\\" language=\\"plaintext\\" placeholder=\\"enter_raw_value\\"></interface-system-raw-editor>
+"<v-dialog model-value=\\"true\\" persistent=\\"\\" data-v-33a4ea83=\\"\\">
+  <v-card data-v-33a4ea83=\\"\\">
+    <v-card-title data-v-33a4ea83=\\"\\">edit_raw_value</v-card-title>
+    <v-card-text data-v-33a4ea83=\\"\\">
+      <interface-system-raw-editor type=\\"undefined\\" disabled=\\"false\\" language=\\"plaintext\\" placeholder=\\"enter_raw_value\\" data-v-33a4ea83=\\"\\"></interface-system-raw-editor>
     </v-card-text>
-    <v-card-actions>
-      <v-button secondary=\\"\\">cancel</v-button>
-      <v-button>done</v-button>
+    <v-card-actions data-v-33a4ea83=\\"\\">
+      <v-button secondary=\\"\\" data-v-33a4ea83=\\"\\">cancel</v-button>
+      <v-button data-v-33a4ea83=\\"\\">done</v-button>
     </v-card-actions>
   </v-card>
 </v-dialog>"

--- a/app/src/components/v-form/form-field-raw-editor.vue
+++ b/app/src/components/v-form/form-field-raw-editor.vue
@@ -97,3 +97,14 @@ const setRawValue = () => {
 	}
 };
 </script>
+
+<style lang="scss" scoped>
+.v-card-text {
+	.input-code {
+		:deep(.CodeMirror),
+		:deep(.CodeMirror-scroll) {
+			max-height: var(--input-height-tall);
+		}
+	}
+}
+</style>


### PR DESCRIPTION
## Description

### Bug

#15868 improved raw value editor with conditionally using `<input-code>` for json values, however the height is currently not being constrained so it overflows:

![](https://user-images.githubusercontent.com/42867097/197454862-aba11f73-7ed2-4707-a32f-35fc4ba27a60.png)

### Solution

Uses similar max-height approach in `<system-raw-editor>`:

https://github.com/directus/directus/blob/228a5ca15f981f01c7072b641d53e1edf562629a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue#L133-L136

### Result

![](https://user-images.githubusercontent.com/42867097/197454837-5ec8d894-f6e3-4b7c-a4b3-46f967cb0670.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
