### PR TITLE
Fix path for packages in package.json used for Docker image 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Skip this step in forks
-    if: ${{ github.repository_owner == 'directus' }}
+    if: github.repository_owner == 'directus'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -67,20 +67,10 @@ jobs:
           path: '**/dist'
           key: build-artifacts-${{ github.sha }}
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
+      - name: Prepare
+        uses: ./.github/actions/prepare
         with:
-          node-version: 16
-
-      - uses: pnpm/action-setup@v2.2.2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 7
-          run_install: false
-
-      - name: Install dependencies
-        run: pnpm i
+          build: false
 
       - name: Publish packages to NPM
         env:
@@ -131,14 +121,14 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: ${{ env.DOCKERHUB_IMAGE }}
+        if: env.DOCKERHUB_IMAGE
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GHCR
         uses: docker/login-action@v2
-        if: ${{ env.GHCR_IMAGE }}
+        if: env.GHCR_IMAGE
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/docker/pack.js
+++ b/docker/pack.js
@@ -17,16 +17,17 @@ const projectPackageJson = {
 
 const directusPackage = list.find((list) => list.name === 'directus');
 
-if (!existsSync('dist')) {
-	mkdirSync('dist');
+const distFolder = path.resolve(__dirname, '..', 'dist');
+if (!existsSync(distFolder)) {
+	mkdirSync(distFolder);
 }
 
-const distFolder = path.resolve(__dirname, '..', 'dist');
-
 function addPackageRecursive(package) {
-	const tarName = String(execSync(`pnpm -F ${package.name} exec pnpm pack --pack-destination ${distFolder}`)).trim();
+	const tarName = path.basename(
+		String(execSync(`pnpm -F ${package.name} exec pnpm pack --pack-destination ${distFolder}`)).trim()
+	);
 
-	projectPackageJson.dependencies[package.name] = `file:${tarName}`;
+	projectPackageJson.dependencies[package.name] = `file:./${tarName}`;
 
 	const packageJson = require(path.join(package.path, 'package.json'));
 


### PR DESCRIPTION
## Description

Due to a recent change in PNPM (https://github.com/pnpm/pnpm/pull/5472) the paths to the tarball of the packages in the `package.json` file generated by the `docker/pack.js` script are no longer relative but absolute and therefore dependent on the executing system (in this case the GitHub runner).
This resulted in the tarballs not being found within the Docker image build process because the paths were invalid inside the Docker context.

With the fix provided in this pull request, the release process is going to work again (refs: https://github.com/directus/directus/releases/tag/v9.19.1 & https://github.com/directus/directus/pull/16083#issuecomment-1288751711).
The fix is backwards-compatible with older PNPM versions.
I've tested it in a forked repository (https://github.com/paescuj/directus/actions/runs/3312870014).

Also included revert of revert of #16083 😄

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
