### PR TITLE
Add option to use pnpm during extension scaffold installation

### DIFF
--- a/packages/create-directus-extension/lib/index.js
+++ b/packages/create-directus-extension/lib/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const inquirer = require('inquirer');
-const { EXTENSION_TYPES, EXTENSION_LANGUAGES } = require('@directus/shared/constants');
+const { EXTENSION_TYPES, EXTENSION_LANGUAGES, EXTENSION_PACKAGE_MANAGERS } = require('@directus/shared/constants');
 const { create } = require('@directus/extensions-sdk/cli');
 
 run();
@@ -11,7 +11,7 @@ async function run() {
 	// eslint-disable-next-line no-console
 	console.log('This utility will walk you through creating a Directus extension.\n');
 
-	const { type, name, language } = await inquirer.prompt([
+	const { type, name, language, packageManager } = await inquirer.prompt([
 		{
 			type: 'list',
 			name: 'type',
@@ -29,7 +29,14 @@ async function run() {
 			message: 'Choose the language to use',
 			choices: EXTENSION_LANGUAGES,
 		},
+		{
+			type: 'list',
+			name: 'packageManager',
+			message: 'Choose the package manager used to install dependencies',
+			choices: EXTENSION_PACKAGE_MANAGERS,
+			default: 'npm',
+		},
 	]);
 
-	await create(type, name, { language });
+	await create(type, name, { language, packageManager });
 }

--- a/packages/shared/src/constants/extensions.ts
+++ b/packages/shared/src/constants/extensions.ts
@@ -22,6 +22,8 @@ export const API_OR_HYBRID_EXTENSION_PACKAGE_TYPES = [
 
 export const EXTENSION_LANGUAGES = ['javascript', 'typescript'] as const;
 
+export const EXTENSION_PACKAGE_MANAGERS = ['npm', 'pnpm'] as const;
+
 export const EXTENSION_NAME_REGEX = /^(?:(?:@[^/]+\/)?directus-extension-|@directus\/extension-).+$/;
 
 export const EXTENSION_PKG_KEY = 'directus:extension';


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

This is a suuuuper tiny PR that adds an option to the create extension flow to specify the desired package manager.

`pnpm` (for the most part) is a drop-in replacement for `npm`, and can be easily swapped in this context without fear of complication, given we don't need to change `package.json`/`package-lock.json` at all.

### Notes
- The `packageManager` option is defined as optional in the method signature, allowing this to be fully backwards compatible with any code calling `create()` elsewhere
- Added a check against available package managers to protect against any nasties in the shell execution

Fixes #16142.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included (none present before)
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
