### PR TITLE
Replace depreacted "create-release" action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "$GITHUB_REF_NAME" --target "$GITHUB_REF_NAME" --notes "Directus $GITHUB_REF_NAME"
+        run: gh release create "$GITHUB_REF_NAME" --notes "Directus $GITHUB_REF_NAME"
 
   build:
     name: Build Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-       - name: Create release
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         run: gh release create "$GITHUB_REF_NAME" --target "$GITHUB_REF_NAME" --notes "Directus $GITHUB_REF_NAME"
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --target "$GITHUB_REF_NAME" --notes "Directus $GITHUB_REF_NAME"
 
   build:
     name: Build Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,10 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: |
-            Directus ${{ github.ref }}
-          draft: false
-          prerelease: false
+       - name: Create release
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         run: gh release create "$GITHUB_REF_NAME" --target "$GITHUB_REF_NAME" --notes "Directus $GITHUB_REF_NAME"
 
   build:
     name: Build Packages


### PR DESCRIPTION
## Description

Replacing the deprecated [create-release](https://github.com/actions/create-release) action in the release workflow with simple usage of the [`gh`](https://github.com/cli/cli) CLI tool.

To get rid of the deprecation warnings (follow-up to #16081, #16080):
<img width="704" alt="Screenshot 2022-10-24 at 15 57 51" src="https://user-images.githubusercontent.com/5363448/197543532-1c51f3d0-9e92-4fec-9b33-af672fe811c1.png">

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
