### PR TITLE
Add GraphQLBigInt type

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -90,6 +90,7 @@ import { PrimaryKey } from '@directus/shared/types';
 
 import { addPathToValidationError } from './utils/add-path-to-validation-error';
 import { GraphQLHash } from './types/hash';
+import { GraphQLBigInt } from './types/bigint';
 
 const validationRules = Array.from(specifiedRules);
 
@@ -821,6 +822,7 @@ export class GraphQLService {
 							case GraphQLBoolean:
 								filterOperatorType = BooleanFilterOperators;
 								break;
+							case GraphQLBigInt:
 							case GraphQLInt:
 							case GraphQLFloat:
 								filterOperatorType = NumberFilterOperators;
@@ -879,6 +881,7 @@ export class GraphQLService {
 						const graphqlType = getGraphQLType(field.type, field.special);
 
 						switch (graphqlType) {
+							case GraphQLBigInt:
 							case GraphQLInt:
 							case GraphQLFloat:
 								acc[field.field] = {

--- a/api/src/services/graphql/types/bigint.ts
+++ b/api/src/services/graphql/types/bigint.ts
@@ -1,0 +1,39 @@
+import { GraphQLScalarType, Kind } from 'graphql';
+
+export const GraphQLBigInt = new GraphQLScalarType({
+	name: 'GraphQLBigInt',
+	description: 'BigInt value',
+	serialize(value) {
+		if (typeof value !== 'number') {
+			throw new Error('Value must be a Number');
+		}
+
+		return value.toString();
+	},
+	parseValue(value) {
+		if (typeof value !== 'string') {
+			throw new Error('Value must be a String');
+		}
+
+		return parseNumberValue(value);
+	},
+	parseLiteral(ast) {
+		if (ast.kind !== Kind.STRING) {
+			throw new Error('Value must be a String');
+		}
+
+		return parseNumberValue(ast.value);
+	},
+});
+
+function parseNumberValue(input: string) {
+	if (!/[+-]?([0-9]+[.])?[0-9]+/.test(input)) return input;
+
+	const value = parseInt(input);
+
+	if (isNaN(value) || value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
+		throw new Error('Invalid GraphQLBigInt');
+	}
+
+	return value;
+}

--- a/api/src/utils/get-graphql-type.ts
+++ b/api/src/utils/get-graphql-type.ts
@@ -12,6 +12,7 @@ import { GraphQLDate } from '../services/graphql/types/date';
 import { GraphQLGeoJSON } from '../services/graphql/types/geojson';
 import { Type } from '@directus/shared/types';
 import { GraphQLHash } from '../services/graphql/types/hash';
+import { GraphQLBigInt } from '../services/graphql/types/bigint';
 
 export function getGraphQLType(
 	localType: Type | 'alias' | 'unknown',
@@ -25,7 +26,7 @@ export function getGraphQLType(
 		case 'boolean':
 			return GraphQLBoolean;
 		case 'bigInteger':
-			return GraphQLString;
+			return GraphQLBigInt;
 		case 'integer':
 			return GraphQLInt;
 		case 'decimal':


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #15663. BigInt values remains to be of string output type as per #12688.

GraphQLBigInt has the same max value of `9007199254740991`, which is the `Number.MAX_SAFE_INTEGER`, which has to be passed as a string.
GraphQLInt has a max value of `2147483647`.

BigInt fields can be aggregated in GraphQL.

https://user-images.githubusercontent.com/26413686/197800204-ba31092c-d616-4dc6-b521-fa1cf2b35b33.mov


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
