### PR TITLE
Set readonly value during initialisation of raw editor

### DIFF
--- a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
+++ b/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
@@ -62,6 +62,7 @@ onMounted(async () => {
 			extraKeys: { Ctrl: 'autocomplete' },
 			cursorBlinkRate: props.disabled ? -1 : 530,
 			placeholder: props.placeholder !== undefined ? props.placeholder : t('raw_editor_placeholder'),
+			readOnly: readOnly.value,
 		});
 
 		// prevent new lines for single lines


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #16162. Sets the readOnly option during initialisation of CodeMirror.

A similar configuration is already in place for `input-code`. 

https://github.com/directus/directus/blob/8fcca49ac1e2c3348b29e58562831564c9661789/app/src/interfaces/input-code/input-code.vue#L257-L264

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
