### PR TITLE
Add name to routes with empty path

### DIFF
--- a/app/src/modules/docs/index.ts
+++ b/app/src/modules/docs/index.ts
@@ -10,10 +10,12 @@ export default defineModule({
 	icon: 'help_outline',
 	routes: [
 		{
+			name: 'docs-routes',
 			path: '',
 			component: StaticDocs,
 			children: [
 				{
+					name: 'docs-app-overview',
 					path: '',
 					redirect: '/docs/app/overview',
 				},

--- a/app/src/modules/docs/index.ts
+++ b/app/src/modules/docs/index.ts
@@ -15,7 +15,7 @@ export default defineModule({
 			component: StaticDocs,
 			children: [
 				{
-					name: 'docs-app-overview',
+					name: 'docs-app-overview-redirect',
 					path: '',
 					redirect: '/docs/app/overview',
 				},

--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -31,7 +31,7 @@ export default defineModule({
 	color: 'var(--primary)',
 	routes: [
 		{
-			name: 'settings-redirect-to-data-model',
+			name: 'settings-data-model-redirect',
 			path: '',
 			redirect: '/settings/data-model',
 		},

--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -31,6 +31,7 @@ export default defineModule({
 	color: 'var(--primary)',
 	routes: [
 		{
+			name: 'settings-redirect-to-data-model',
 			path: '',
 			redirect: '/settings/data-model',
 		},


### PR DESCRIPTION
## Description

Fixes vue router warnings for routes with empty path `''` and no name. 

#16052 bumped vue-router from `4.0.15` to `4.1.5`, and this warning is added in [vue-router `4.1.0`](https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#410-2022-07-04).

![chrome_vxmLRW36zw](https://user-images.githubusercontent.com/42867097/197937265-44de4eb5-c9ae-4edc-8019-4e1ff52477f7.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
