### PR TITLE
strip function from fields for validation

### DIFF
--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -395,7 +395,10 @@ export class AuthorizationService {
 
 					for (const field of requiredPermissions[collection]) {
 						if (field.startsWith('$FOLLOW')) continue;
-						if (!allowedFields.includes(field)) throw new ForbiddenException();
+						const fieldName = stripFunction(field);
+						if (!allowedFields.includes(fieldName)) {
+							throw new ForbiddenException();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Description

Field validation was failing for filters using functions. This fix strips the function before validating.

Fixes #16148

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
