### PR TITLE
Remove authorization header from token refresh request

### DIFF
--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -109,8 +109,8 @@ export async function refresh({ navigate }: LogoutOptions = { navigate: true }):
 	try {
 		const response = await api.post<any>('/auth/refresh', undefined, {
 			transformRequest(data, headers) {
-				// This seems wrongly typed in Axios itself..
-				delete (headers?.common as unknown as Record<string, string>)?.['Authorization'];
+				// Remove Authorization header from request
+				headers.set('Authorization');
 				return data;
 			},
 		});


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #16188. Remove the `Authorization` header by setting `undefined` to prevent the default symbol value from being applied. 
Note: this issue surfaces only on the production build.

![image](https://user-images.githubusercontent.com/26413686/198278410-fe9221c8-f7a5-4360-8dd4-fe2d22cfc330.png)


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
