### PR TITLE
Fix back button on content/files/users item page after login

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -42,7 +42,7 @@
 				icon
 				secondary
 				exact
-				@click="router.back()"
+				@click="navigateBack"
 			>
 				<v-icon name="arrow_back" />
 			</v-button>
@@ -364,6 +364,16 @@ const disabledOptions = computed(() => {
 	if (isNew.value) return ['save-as-copy'];
 	return [];
 });
+
+function navigateBack() {
+	const backState = router.options.history.state.back;
+	if (typeof backState !== 'string' || !backState.startsWith('/login')) {
+		router.back();
+		return;
+	}
+
+	router.push(`/content/${props.collection}`);
+}
 
 function useBreadcrumb() {
 	const breadcrumb = computed(() => [

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -2,7 +2,7 @@
 	<files-not-found v-if="!loading && !item" />
 	<private-view v-else :title="loading || !item ? t('loading') : item.title">
 		<template #title-outer:prepend>
-			<v-button class="header-icon" rounded icon secondary exact @click="router.back()">
+			<v-button class="header-icon" rounded icon secondary exact @click="navigateBack">
 				<v-icon name="arrow_back" />
 			</v-button>
 		</template>
@@ -287,6 +287,20 @@ const { createAllowed, deleteAllowed, saveAllowed, updateAllowed, fields, revisi
 const fieldsFiltered = computed(() => {
 	return fields.value.filter((field: Field) => fieldsDenyList.includes(field.field) === false);
 });
+
+function navigateBack() {
+	const backState = router.options.history.state.back;
+	if (typeof backState !== 'string' || !backState.startsWith('/login')) {
+		router.back();
+		return;
+	}
+
+	if (item?.value?.folder) {
+		router.push(`/files/folders/${item.value.folder}`);
+	} else {
+		router.push('/files');
+	}
+}
 
 function useBreadcrumb() {
 	const breadcrumb = computed(() => {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -1,7 +1,7 @@
 <template>
 	<private-view :title="title">
 		<template #title-outer:prepend>
-			<v-button class="header-icon" rounded icon secondary exact @click="router.back()">
+			<v-button class="header-icon" rounded icon secondary exact @click="navigateBack">
 				<v-icon name="arrow_back" />
 			</v-button>
 		</template>
@@ -328,6 +328,7 @@ export default defineComponent({
 			item,
 			loading,
 			isNew,
+			navigateBack,
 			breadcrumb,
 			edits,
 			hasEdits,
@@ -368,6 +369,16 @@ export default defineComponent({
 			avatarError,
 			isSavable,
 		};
+
+		function navigateBack() {
+			const backState = router.options.history.state.back;
+			if (typeof backState !== 'string' || !backState.startsWith('/login')) {
+				router.back();
+				return;
+			}
+
+			router.push('/users');
+		}
 
 		function useBreadcrumb() {
 			const breadcrumb = computed(() => [


### PR DESCRIPTION
## Description

Fixes #16210

When a user has an item as their `last_page`, they will be brought back to the login page when they click on the Back button in the header. This is because of the usage of `router.back()` which (albeit correctly) brings the user back to the login page which would be an odd UX.

Technically we could opt to use ``:to="`/content/${collection}`"`` for content item, however we can also navigate to a content item via relational displays, so in that case, `router.back()` would still be the correct approach. 

This is why this PR opts to check the router history's back state and only goes back to content/users/files page _if_ they were previously coming from the login page.

Additional examples of why `router.back()` is still beneficial for these pages:

- Content item page: When we have a M2M relationship between collection A and collection B, we can navigate to collection B's item(s) by clicking the M2M display. But then the back button should still bring us back to collection A, not collection B.

- File page: A file can be nested in a folder, so clicking back should bring us back to the specific folder instead of the Files module's root page.

- User page: As we can click on the bottom left button to view our own profile anytime, the back button should bring us back to where we were, rather than to the Users module. 

### Comparison for file item being the last page after logging in

#### Before

https://user-images.githubusercontent.com/42867097/198519004-c1fa9e29-c30b-4952-bc3e-370ee3578a4f.mp4

#### After

https://user-images.githubusercontent.com/42867097/198519084-3eeb88eb-881c-4c50-9ef2-b3e9e868ff98.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
