### PR TITLE
POST /items, /files: Return items in provided order

### DIFF
--- a/api/src/controllers/collections.ts
+++ b/api/src/controllers/collections.ts
@@ -17,8 +17,8 @@ router.post(
 		});
 
 		if (Array.isArray(req.body)) {
-			const collectionKey = await collectionsService.createMany(req.body);
-			const records = await collectionsService.readMany(collectionKey);
+			const collectionKeys = await collectionsService.createMany(req.body);
+			const records = await collectionsService.readMany(collectionKeys);
 			res.locals.payload = { data: records || null };
 		} else {
 			const collectionKey = await collectionsService.createOne(req.body);

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -65,7 +65,7 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 		if (!filename) {
 			return busboy.emit('error', new InvalidPayloadException(`File is missing filename`));
 		}
-
+		const fileIndex = fileCount;
 		fileCount++;
 
 		if (!payload.title) {
@@ -88,7 +88,7 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 
 		try {
 			const primaryKey = await service.uploadOne(fileStream, payloadWithRequiredFields, existingPrimaryKey);
-			savedFiles.push(primaryKey);
+			savedFiles[fileIndex] = primaryKey;
 			tryDone();
 		} catch (error: any) {
 			busboy.emit('error', error);
@@ -106,7 +106,7 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 	req.pipe(busboy);
 
 	function tryDone() {
-		if (savedFiles.length === fileCount) {
+		if (savedFiles.reduce((cnt: number) => cnt + 1, 0) === fileCount) {
 			if (fileCount === 0) {
 				return next(new InvalidPayloadException(`No files where included in the body`));
 			}

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -108,7 +108,7 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 	function tryDone() {
 		if (savedFiles.reduce((cnt: number) => cnt + 1, 0) === fileCount) {
 			if (fileCount === 0) {
-				return next(new InvalidPayloadException(`No files where included in the body`));
+				return next(new InvalidPayloadException(`No files were included in the body`));
 			}
 
 			res.locals.savedFiles = savedFiles;

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -406,6 +406,13 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		}
 
 		const results = await this.readByQuery(queryWithKey, opts);
+		if (!query.sort) {
+			const pkMap = new Map();
+			keys.forEach((key, index) => {
+				pkMap.set(key, index);
+			});
+			results.sort((a, b) => pkMap.get(a[primaryKeyField]) - pkMap.get(b[primaryKeyField]));
+		}
 
 		return results;
 	}


### PR DESCRIPTION
## Description

When uploading files or creating items the created objects are returned. The default order is sorted by primary key, which means it's hard to know which upload lead to which file object.
With this PR the default ordering is the order in which the files/items were found in the payload.
One can still get the old behaviour back by adding ?sort=id

Fixes [#](https://github.com/directus/directus/discussions/16170)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
