### PR TITLE
Check original field name when aliased

### DIFF
--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -397,11 +397,11 @@ export class AuthorizationService {
 					for (const field of requiredPermissions[collection]) {
 						if (field.startsWith('$FOLLOW')) continue;
 						const fieldName = stripFunction(field);
-let originalFieldName = fieldName;
+						let originalFieldName = fieldName;
 
-if (collection === rootCollection && aliasMap?.[fieldName]) {
-  originalFieldName = aliasMap[fieldName];
-}
+						if (collection === rootCollection && aliasMap?.[fieldName]) {
+							originalFieldName = aliasMap[fieldName];
+						}
 
 						if (!allowedFields.includes(originalFieldName)) {
 							throw new ForbiddenException();

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -397,12 +397,9 @@ export class AuthorizationService {
 					for (const field of requiredPermissions[collection]) {
 						if (field.startsWith('$FOLLOW')) continue;
 						const fieldName = stripFunction(field);
+						const originalFieldName = collection === rootCollection ? aliasMap?.[fieldName] ?? fieldName : fieldName;
 
-						if (collection === rootCollection && aliasMap && aliasMap[fieldName]) {
-							if (!allowedFields.includes(aliasMap[fieldName])) {
-								throw new ForbiddenException();
-							}
-						} else if (!allowedFields.includes(fieldName)) {
+						if (!allowedFields.includes(originalFieldName)) {
 							throw new ForbiddenException();
 						}
 					}

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -212,7 +212,7 @@ export class AuthorizationService {
 
 			if (ast.type === 'root') {
 				// Validate all required permissions once at the root level
-				checkFieldPermissions(ast.name, schema, action, requiredFieldPermissions);
+				checkFieldPermissions(ast.name, schema, action, requiredFieldPermissions, ast.query.alias);
 			}
 
 			return requiredFieldPermissions;
@@ -359,7 +359,8 @@ export class AuthorizationService {
 				rootCollection: string,
 				schema: SchemaOverview,
 				action: PermissionsAction,
-				requiredPermissions: Record<string, Set<string>>
+				requiredPermissions: Record<string, Set<string>>,
+				alias?: Record<string, string> | null
 			) {
 				if (accountability?.admin === true) return;
 
@@ -396,7 +397,12 @@ export class AuthorizationService {
 					for (const field of requiredPermissions[collection]) {
 						if (field.startsWith('$FOLLOW')) continue;
 						const fieldName = stripFunction(field);
-						if (!allowedFields.includes(fieldName)) {
+
+						if (collection === rootCollection && alias && alias[fieldName]) {
+							if (!allowedFields.includes(alias[fieldName])) {
+								throw new ForbiddenException();
+							}
+						} else if (!allowedFields.includes(fieldName)) {
 							throw new ForbiddenException();
 						}
 					}

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -360,7 +360,7 @@ export class AuthorizationService {
 				schema: SchemaOverview,
 				action: PermissionsAction,
 				requiredPermissions: Record<string, Set<string>>,
-				alias?: Record<string, string> | null
+				aliasMap?: Record<string, string> | null
 			) {
 				if (accountability?.admin === true) return;
 
@@ -398,8 +398,8 @@ export class AuthorizationService {
 						if (field.startsWith('$FOLLOW')) continue;
 						const fieldName = stripFunction(field);
 
-						if (collection === rootCollection && alias && alias[fieldName]) {
-							if (!allowedFields.includes(alias[fieldName])) {
+						if (collection === rootCollection && aliasMap && aliasMap[fieldName]) {
+							if (!allowedFields.includes(aliasMap[fieldName])) {
 								throw new ForbiddenException();
 							}
 						} else if (!allowedFields.includes(fieldName)) {

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -397,7 +397,11 @@ export class AuthorizationService {
 					for (const field of requiredPermissions[collection]) {
 						if (field.startsWith('$FOLLOW')) continue;
 						const fieldName = stripFunction(field);
-						const originalFieldName = collection === rootCollection ? aliasMap?.[fieldName] ?? fieldName : fieldName;
+let originalFieldName = fieldName;
+
+if (collection === rootCollection && aliasMap?.[fieldName]) {
+  originalFieldName = aliasMap[fieldName];
+}
 
 						if (!allowedFields.includes(originalFieldName)) {
 							throw new ForbiddenException();


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #16203. When a field is aliased, the original field name should be checked instead.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
