### PR TITLE
Fix literal interpolation for curly brackets for Translation Strings

### DIFF
--- a/app/src/composables/use-translation-strings.ts
+++ b/app/src/composables/use-translation-strings.ts
@@ -127,7 +127,7 @@ export function useTranslationStrings(): UsableTranslationStrings {
 			if (!cur.key || !cur.translations) return acc;
 			const translationForCurrentLang = cur.translations.find((t) => t.language === lang);
 			if (!translationForCurrentLang || !translationForCurrentLang.translation) return acc;
-			return { ...acc, [cur.key]: getLiteralInterpolatedTranslation(translationForCurrentLang.translation) };
+			return { ...acc, [cur.key]: getLiteralInterpolatedTranslation(translationForCurrentLang.translation, true) };
 		}, {});
 		i18n.global.mergeLocaleMessage(lang, localeMessages);
 	}

--- a/app/src/utils/get-literal-interpolated-translation.test.ts
+++ b/app/src/utils/get-literal-interpolated-translation.test.ts
@@ -8,3 +8,11 @@ test('No special characters', () => {
 test('With special characters', () => {
 	expect(getLiteralInterpolatedTranslation('folding@home')).toBe(`folding{'@'}home`);
 });
+
+test('Should not keep curly brackets', () => {
+	expect(getLiteralInterpolatedTranslation('my {custom} string')).toBe(`my {'{'}custom{'}'} string`);
+});
+
+test('Should keep curly brackets', () => {
+	expect(getLiteralInterpolatedTranslation('my {custom} string', true)).toBe(`my {custom} string`);
+});

--- a/app/src/utils/get-literal-interpolated-translation.ts
+++ b/app/src/utils/get-literal-interpolated-translation.ts
@@ -2,10 +2,12 @@
  * Literal interpolation to use special characters such as "{", "}", "@", "$", and "|" in app translations
  *
  * @param translation - vue i18n translation string
+ * @param keepCurlyBrackets - whether to skip interpolation for curly brackets. Defaults to false.
  * @returns - literal interpolated translation string
  *
  * @see {@link https://github.com/directus/directus/pull/11287}
  */
-export function getLiteralInterpolatedTranslation(translation: string) {
-	return translation.replace(/([{}@$|])/g, "{'$1'}");
+export function getLiteralInterpolatedTranslation(translation: string, keepCurlyBrackets = false) {
+	const interpolatedCharacters = keepCurlyBrackets ? '@$|' : '{}@$|';
+	return translation.replace(new RegExp(`([${interpolatedCharacters}])`, 'g'), "{'$1'}");
 }


### PR DESCRIPTION
## Description

Fixes #16164

#15872 applied the general literal interpolation fix for Translation Strings. However as we can use them in custom extensions and have the flexibility of using named formatting (eg. `my {custom} string`), this PR opts to keep curly brackets intact for Translations Strings.

For example, when we have the following translation string setup:

![](https://user-images.githubusercontent.com/42867097/198960696-925a8167-0c77-4d0b-98db-240c115a8f40.png)

and when we subsequently use named formatting in our extension such as `t("custom_string", { first: "My", second: "test here" })`, it will now be formatted correctly:

|Before|After|
|---|---|
|![](https://user-images.githubusercontent.com/42867097/198960657-b9f1af43-c0cd-41f0-8db1-7d0203cbece3.png)|![](https://user-images.githubusercontent.com/42867097/198960671-95db59a1-8f61-424a-8796-1995030ede2b.png)|

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
