### PR TITLE
Allow PK to be nullable for system collections and fields in GraphQL

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -2263,9 +2263,10 @@ export class GraphQLService {
 					name: 'directus_collections_meta',
 					fields: Object.values(schema.read.collections['directus_collections'].fields).reduce((acc, field) => {
 						acc[field.field] = {
-							type: field.nullable
-								? getGraphQLType(field.type, field.special)
-								: new GraphQLNonNull(getGraphQLType(field.type, field.special)),
+							type:
+								field.nullable || field.field === schema.read.collections['directus_collections'].primary
+									? getGraphQLType(field.type, field.special)
+									: new GraphQLNonNull(getGraphQLType(field.type, field.special)),
 							description: field.note,
 						} as ObjectTypeComposerFieldConfigDefinition<any, any, any>;
 
@@ -2320,9 +2321,10 @@ export class GraphQLService {
 					name: 'directus_fields_meta',
 					fields: Object.values(schema.read.collections['directus_fields'].fields).reduce((acc, field) => {
 						acc[field.field] = {
-							type: field.nullable
-								? getGraphQLType(field.type, field.special)
-								: new GraphQLNonNull(getGraphQLType(field.type, field.special)),
+							type:
+								field.nullable || field.field === schema.read.collections['directus_fields'].primary
+									? getGraphQLType(field.type, field.special)
+									: new GraphQLNonNull(getGraphQLType(field.type, field.special)),
 							description: field.note,
 						} as ObjectTypeComposerFieldConfigDefinition<any, any, any>;
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #10451. Allow PK field, `id`, to be nullable. Closes ENG-286

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
