### PR TITLE
Improve contributing guidelines

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,9 +1,109 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other
-method with the owners of this repository before making a change.
+Heya! Welcome to Directus, and thank you for taking the time to contribute back to Open Source Software! ❤️ We want
+everybody to be able to contribute to Directus, no matter your background or expertise. In order to facilitate that,
+we've put together a couple ticks and tricks below. Our team truly appreciates every single contributor, community
+member, GitHub star, pull-request, bug report, and feature request. Keeping Directus completely free and open-source is
+our way of saying: **Thank you!**
 
-Please note we have a [code of conduct](./code_of_conduct.md), please follow it in all your interactions with the
+> We're here to help!
+>
+> If you have _any_ questions along your contributor journey, please feel free to come chat with us on
+> [our Discord server](https://directus.chat).
+
+## Code of Conduct
+
+**The Directus [Code of Conduct](https://github.com/directus/directus/blob/main/code_of_conduct.md) is one of the ways
+we put our values into practice. We expect all of our staff, contractors and contributors to know and follow this
+code.**
+
+**Our contributors and maintainers work extremely hard to build Directus as premium open-source software. Please be
+respectful of those efforts throughout our ecosystem. Trolling, harassing, insulting, or other unacceptable behavior by
+participants will not be tolerated.**
+
+In the interest of fostering an open and welcoming environment, we as pledge to make participation in our project and
+community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+**Before continuing, please take a moment to read our full
+[Code of Conduct](https://github.com/directus/directus/blob/main/code_of_conduct.md).**
+
+## Ways to Contribute
+
+### Reporting Bugs
+
+If you happen to run into a bug, please post an Issue on our main GitHub Issue board:
+https://github.com/directus/directus/issues
+
+Please be as explicit and detailed as you can in the bug report. The more information is available, the easier it is for
+other contributors to help you find the solution or fix.
+
+### Leaving Feedback
+
+If you have a great idea for an improvement of the platform, or any other feedback, please make sure to open a new
+Discussion on our GitHub Discussions board: https://github.com/directus/directus/discussions
+
+### Document the Project
+
+[The Directus Docs](https://github.com/directus/docs) are a living document that can always be improved on. Any parts of
+the docs in dire need of some tender love and care? Feel free to open a Pull Request!
+
+### Helping Others
+
+The Directus community is growing quickly, which also means there's more and more people that have questions. Helping
+out your fellow developers by answering questions on [Discord](https://directus.chat) or
+[GitHub Discussions](https://github.com/directus/directus/discussions/categories/q-a) is a great way to help the
 project.
 
-Learn more about contributing to the platform: https://docs.directus.io/contributing/introduction/
+### Pull Requests
+
+#### Bug Fixes
+
+We treat Issues on the main repo as actionable items we want to get done. This also means that we welcome PRs for any
+Issue that has been labeled. Labeled issues are bugs of new features that have been triaged, accepted, and are ready to
+be implemented.
+
+#### Implementing Features
+
+With the continuous growth of Directus, more and more people are relying on Directus for (critical) data workloads in
+various use cases. This means we need to be careful with any changes that might affect the stability, security,
+performance, or scalability of Directus. For this reason, it's important that any new feature is properly thought
+through and discussed before being implemented.
+
+Before you start writing code to implement your new feature idea, please read through and understand our triaging
+process for new features before diving in. While we encourage and appreciate every code contribution, please understand
+that we can't merge every suggested code change.
+
+##### Triaging Process
+
+Each Pull Request that comes in is required to resolve [an open Issue](https://github.com/directus/directus/issues).
+This ensures that any code change made implements a known actionable item, be it a feature or otherwise.
+
+Feature Request Discussions that are deemed ready to be implemented with the discussed implementation details are marked
+"Accepted" and converted into an Issue, at which point the feature is ready to be implemented.
+
+New feature ideas reported directly to issues might be converted into a Discussion for further triaging at
+[the core team](https://github.com/orgs/directus/people)'s discretion first. This is often due to a lack of detail, or
+lack of proven interest.
+
+### Reporting Security Vulnerabilities
+
+If you believe you have discovered a security issue within a Directus product or service, please reach out to us
+directly over email: [security@directus.io](mailto:security@directus.io). We will then open a
+[GitHub Security Advisory](https://github.com/directus/directus/security/advisories) for tracking the fix.
+
+We value the members of the independent security research community who find security vulnerabilities and work with our
+team so that proper fixes can be issued to users. Our policy is to credit all researchers in the fix's release notes. In
+order to receive credit, security researchers must follow responsible disclosure practices, including:
+
+- They do not publish the vulnerability prior to the Directus team releasing a fix for it
+- They do not divulge exact details of the issue, e.g., through exploits or proof-of-concepts

--- a/contributing.md
+++ b/contributing.md
@@ -69,8 +69,8 @@ project.
 #### Bug Fixes
 
 We treat Issues on the main repo as actionable items we want to get done. This also means that we welcome PRs for any
-Issue that has been labeled. Labeled issues are bugs of new features that have been triaged, accepted, and are ready to
-be implemented.
+Issue that has been labeled either "Bug", "Improvement", or "New Feature". Labeled issues are bugs or new features that
+have been triaged, accepted, and are ready to be implemented.
 
 #### Implementing Features
 

--- a/contributing.md
+++ b/contributing.md
@@ -44,8 +44,8 @@ Examples of behavior that contributes to creating a positive environment include
 If you happen to run into a bug, please post an Issue on our main GitHub Issue board:
 https://github.com/directus/directus/issues
 
-Please be as explicit and detailed as you can in the bug report. The more information is available, the easier it is for
-other contributors to help you find the solution or fix.
+Please be as explicit and detailed as you can in the bug report. The more information available, the easier it is for
+other contributors to help you find the solution or fix. Consider adding a schema snapshot file, or a database dump.
 
 ### Leaving Feedback
 

--- a/contributing.md
+++ b/contributing.md
@@ -54,8 +54,8 @@ Discussion on our GitHub Discussions board: https://github.com/directus/directus
 
 ### Document the Project
 
-[The Directus Docs](https://github.com/directus/docs) are a living document that can always be improved on. Any parts of
-the docs in dire need of some tender love and care? Feel free to open a Pull Request!
+[The Directus Docs](https://github.com/directus/docs) are a living document that can always be improved on. Notice any
+parts of the docs in dire need of some tender love and care? Feel free to open a Pull Request!
 
 ### Helping Others
 

--- a/contributing.md
+++ b/contributing.md
@@ -2,7 +2,7 @@
 
 Heya! Welcome to Directus, and thank you for taking the time to contribute back to Open Source Software! ❤️ We want
 everybody to be able to contribute to Directus, no matter your background or expertise. In order to facilitate that,
-we've put together a couple ticks and tricks below. Our team truly appreciates every single contributor, community
+we've put together a couple tips and tricks below. Our team truly appreciates every single contributor, community
 member, GitHub star, pull-request, bug report, and feature request. Keeping Directus completely free and open-source is
 our way of saying: **Thank you!**
 

--- a/contributing.md
+++ b/contributing.md
@@ -92,8 +92,9 @@ New feature ideas reported directly to issues might be converted into a Discussi
 [the core team](https://github.com/orgs/directus/people)'s discretion first. This is often due to a lack of detail, or
 lack of proven interest.
 
-Each Pull Request that comes in is required to resolve [an open Issue](https://github.com/directus/directus/issues).
-This ensures that any code change made implements a known actionable item, be it a feature or otherwise.
+Each Pull Request that comes in is required to resolve [an open Issue](https://github.com/directus/directus/issues) that
+is labeled "Bug", "Improvement", or "New Feature". This ensures that any code change made implements a known actionable
+item, be it a feature or otherwise.
 
 ### Reporting Security Vulnerabilities
 

--- a/contributing.md
+++ b/contributing.md
@@ -54,7 +54,7 @@ Discussion on our GitHub Discussions board: https://github.com/directus/directus
 
 ### Document the Project
 
-[The Directus Docs](https://github.com/directus/docs) are a living document that can always be improved on. Notice any
+The [Directus Docs](https://github.com/directus/docs) are living documents that can always be improved on. Notice any
 parts of the docs in dire need of some tender love and care? Feel free to open a Pull Request!
 
 ### Helping Others

--- a/contributing.md
+++ b/contributing.md
@@ -85,15 +85,15 @@ that we can't merge every suggested code change.
 
 ##### Triaging Process
 
-Each Pull Request that comes in is required to resolve [an open Issue](https://github.com/directus/directus/issues).
-This ensures that any code change made implements a known actionable item, be it a feature or otherwise.
-
 Feature Request Discussions that are deemed ready to be implemented with the discussed implementation details are marked
 "Accepted" and converted into an Issue, at which point the feature is ready to be implemented.
 
 New feature ideas reported directly to issues might be converted into a Discussion for further triaging at
 [the core team](https://github.com/orgs/directus/people)'s discretion first. This is often due to a lack of detail, or
 lack of proven interest.
+
+Each Pull Request that comes in is required to resolve [an open Issue](https://github.com/directus/directus/issues).
+This ensures that any code change made implements a known actionable item, be it a feature or otherwise.
 
 ### Reporting Security Vulnerabilities
 

--- a/contributing.md
+++ b/contributing.md
@@ -21,10 +21,10 @@ code.**
 respectful of those efforts throughout our ecosystem. Trolling, harassing, insulting, or other unacceptable behavior by
 participants will not be tolerated.**
 
-In the interest of fostering an open and welcoming environment, we as pledge to make participation in our project and
-community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex
-characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality,
-personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making
+participation in our project and community a harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 Examples of behavior that contributes to creating a positive environment include:
 


### PR DESCRIPTION
Our previous contributing guidelines were a little light on details. With the recent rapid growth of the open source core project, we have to put some more guardrails in place to make sure the project remains maintainable at scale.

@erondpowell This is roughly based on some of the existing content on the docs page. Once we reach concession on the final contents here, we should put the same content on the website docs.
