### PR TITLE
Fix translation syntax for zh-CN

### DIFF
--- a/app/src/lang/translations/zh-CN.yaml
+++ b/app/src/lang/translations/zh-CN.yaml
@@ -2030,7 +2030,7 @@ triggers:
     item_only: 仅条目页面
 any_string_or_json: 任意字符串或JSON对象...
 item_payload_placeholder: 这是用于更新条目字段值的 JSON对象...
-operation_variables_note: 您可以通过变量引用访问流程数据，例如**{{'}{'{'}$last{'}'}{'}'}**， **{{'}{{'}$trigger{'}'}{'}'}** 和 **{{'}{'{'}$accountability{'}'}{'}'}**, 或使用 **{'{'}{'{'} operation_key{'}'}{'}'}**引用之前的操作。
+operation_variables_note: 您可以通过变量引用访问流程数据，例如 **{'{'}{'{'}$last{'}'}{'}'}** ， **{'{'}{'{'}$trigger{'}'}{'}'}** 和 **{'{'}{'{'}$accountability{'}'}{'}'}**, 或使用 **{'{'}{'{'} operation_key{'}'}{'}'}** 引用之前的操作。
 operations:
   condition:
     name: 条件


### PR DESCRIPTION
Fixes wrong syntax in translation, which resulted vue-i8n to fail loading of page in production
![image](https://user-images.githubusercontent.com/3369571/199179015-54b6bf43-04b3-4bf0-be88-32a478305e5b.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
