### PR TITLE
User Roles not loading

### DIFF
--- a/app/src/modules/users/components/navigation-role.vue
+++ b/app/src/modules/users/components/navigation-role.vue
@@ -21,13 +21,13 @@
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { computed, defineComponent, PropType } from 'vue';
-import { Role } from '@directus/shared/types';
 import { useUserStore } from '@/stores/user';
+import { BasicRole } from '../composables/use-navigation';
 
 export default defineComponent({
 	props: {
 		role: {
-			type: Object as PropType<Role>,
+			type: Object as PropType<BasicRole>,
 			required: true,
 		},
 		lastAdmin: {

--- a/app/src/modules/users/composables/use-navigation.ts
+++ b/app/src/modules/users/composables/use-navigation.ts
@@ -3,12 +3,14 @@ import { unexpectedError } from '@/utils/unexpected-error';
 import { Role } from '@directus/shared/types';
 import { ref, Ref } from 'vue';
 
-let roles: Ref<Role[] | null> | null = null;
+let roles: Ref<BasicRole[] | null> | null = null;
 let loading: Ref<boolean> | null = null;
 
-export default function useNavigation(): { roles: Ref<Role[] | null>; loading: Ref<boolean> } {
+export type BasicRole = Pick<Role, 'id' | 'name' | 'icon' | 'admin_access'>;
+
+export default function useNavigation(): { roles: Ref<BasicRole[] | null>; loading: Ref<boolean> } {
 	if (roles === null) {
-		roles = ref<Role[] | null>(null);
+		roles = ref<BasicRole[] | null>(null);
 	}
 
 	if (loading === null) {
@@ -29,6 +31,7 @@ export default function useNavigation(): { roles: Ref<Role[] | null>; loading: R
 			const rolesResponse = await api.get(`/roles`, {
 				params: {
 					sort: 'name',
+					fields: ['id', 'name', 'icon', 'admin_access'],
 				},
 			});
 			roles.value = rolesResponse.data.data;


### PR DESCRIPTION
## Description

When populating the user sidebar with roles a lot of extra information was requested including all users in that group which could cause the proxy to timeout for a huge number of users.

This fix changes the request from (tested with ~500k users)
`GET /users?sort=name`  Taking 5.99 s / 5.70 s / 6.45 s to respond
To only requested the needed info to render the sidebar
`GET /roles?sort=name&fields[]=id&fields[]=name&fields[]=icon&fields[]=admin_access`
Taking only 12ms / 14ms / 16ms

Fixes #16207 

## Type of Change

- [X] Bugfix
- [X] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
