### PR TITLE
use correct collection for translation

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -83,7 +83,7 @@
 						},
 						{
 							text: t('referential_action_cascade', {
-								collection: collection,
+								collection: relatedCollection,
 								field: relatedField,
 							}),
 							value: 'CASCADE',


### PR DESCRIPTION
The problem was that for the o2m relation we displayed the wrong collection to cascade delete.
E.g. Collections A --o2m--> B showing `On cascade delete A item` where it should be `B item` when you delete an item in A.

Fixes #16187 