### PR TITLE
Fix "create an item" requestBody schema in OAS

### DIFF
--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -32,69 +32,120 @@ describe('Integration Tests', () => {
 					service = new SpecificationService({
 						knex: db,
 						schema: { collections: {}, relations: [] },
+						accountability: { role: 'admin', admin: true },
 					});
 				});
 
-				it('returns untyped schema for json fields', async () => {
-					jest.spyOn(CollectionsService.prototype, 'readByQuery').mockImplementation(
-						jest.fn().mockReturnValue([
-							{
-								collection: 'test_table',
-								meta: {
-									accountability: 'all',
+				describe('schema', () => {
+					it('returns untyped schema for json fields', async () => {
+						jest.spyOn(CollectionsService.prototype, 'readByQuery').mockImplementation(
+							jest.fn().mockReturnValue([
+								{
 									collection: 'test_table',
-									group: null,
-									hidden: false,
-									icon: null,
-									item_duplication_fields: null,
-									note: null,
-									singleton: false,
-									translations: null,
+									meta: {
+										accountability: 'all',
+										collection: 'test_table',
+										group: null,
+										hidden: false,
+										icon: null,
+										item_duplication_fields: null,
+										note: null,
+										singleton: false,
+										translations: null,
+									},
+									schema: {
+										name: 'test_table',
+									},
 								},
-								schema: {
-									name: 'test_table',
-								},
-							},
-						])
-					);
+							])
+						);
 
-					jest.spyOn(FieldsService.prototype, 'readAll').mockImplementation(
-						jest.fn().mockReturnValue([
-							{
-								collection: 'test_table',
-								field: 'id',
-								type: 'integer',
-								schema: {
-									is_nullable: false,
-								},
-							},
-							{
-								collection: 'test_table',
-								field: 'blob',
-								type: 'json',
-								schema: {
-									is_nullable: true,
-								},
-							},
-						])
-					);
-					jest.spyOn(RelationsService.prototype, 'readAll').mockImplementation(jest.fn().mockReturnValue([]));
-
-					const spec = await service.oas.generate();
-					expect(spec.components?.schemas).toEqual({
-						ItemsTestTable: {
-							type: 'object',
-							properties: {
-								id: {
-									nullable: false,
+						jest.spyOn(FieldsService.prototype, 'readAll').mockImplementation(
+							jest.fn().mockReturnValue([
+								{
+									collection: 'test_table',
+									field: 'id',
 									type: 'integer',
+									schema: {
+										is_nullable: false,
+									},
 								},
-								blob: {
-									nullable: true,
+								{
+									collection: 'test_table',
+									field: 'blob',
+									type: 'json',
+									schema: {
+										is_nullable: true,
+									},
 								},
+							])
+						);
+						jest.spyOn(RelationsService.prototype, 'readAll').mockImplementation(jest.fn().mockReturnValue([]));
+
+						const spec = await service.oas.generate();
+						expect(spec.components?.schemas).toEqual({
+							ItemsTestTable: {
+								type: 'object',
+								properties: {
+									id: {
+										nullable: false,
+										type: 'integer',
+									},
+									blob: {
+										nullable: true,
+									},
+								},
+								'x-collection': 'test_table',
 							},
-							'x-collection': 'test_table',
-						},
+						});
+					});
+				});
+
+				describe('path', () => {
+					it('requestBody for CreateItems POST path should not have type in schema', async () => {
+						const collection = {
+							collection: 'test_table',
+							meta: {
+								accountability: 'all',
+								collection: 'test_table',
+								group: null,
+								hidden: false,
+								icon: null,
+								item_duplication_fields: null,
+								note: null,
+								singleton: false,
+								translations: null,
+							},
+							schema: {
+								name: 'test_table',
+							},
+						};
+
+						jest
+							.spyOn(CollectionsService.prototype, 'readByQuery')
+							.mockImplementation(jest.fn().mockReturnValue([collection]));
+
+						jest.spyOn(FieldsService.prototype, 'readAll').mockImplementation(
+							jest.fn().mockReturnValue([
+								{
+									collection: collection.collection,
+									field: 'id',
+									type: 'integer',
+									schema: {
+										is_nullable: false,
+									},
+								},
+							])
+						);
+						jest.spyOn(RelationsService.prototype, 'readAll').mockImplementation(jest.fn().mockReturnValue([]));
+
+						const spec = await service.oas.generate();
+
+						const targetSchema =
+							spec.paths[`/items/${collection.collection}`].post.requestBody.content['application/json'].schema;
+
+						expect(targetSchema).toHaveProperty('oneOf');
+						expect(targetSchema).not.toHaveProperty('type');
 					});
 				});
 			});

--- a/packages/specs/src/paths/items/items.yaml
+++ b/packages/specs/src/paths/items/items.yaml
@@ -44,7 +44,6 @@ post:
     content:
       application/json:
         schema:
-          type: object
   responses:
     '200':
       description: Successful request


### PR DESCRIPTION
## Description

Fixes #16275

Currently for POST request to create an item for custom collections, the requestBody content schema contains `type: object`:

https://github.com/directus/directus/blob/c70211c48dee133dbf7f19785dcbf5ea9bba158c/packages/specs/src/paths/items/items.yaml#L43-L47

However when merging the path over here:

https://github.com/directus/directus/blob/c70211c48dee133dbf7f19785dcbf5ea9bba158c/api/src/services/specifications.ts#L219-L231

schema now has `type: object` _but_ it's supposed to be `oneOf` which should not contain explicit type, but the type should depend on the nested children of `oneOf`.

Additional live edit in swagger editor to verify `type: object` _with_ `oneOf` is the root cause:

https://user-images.githubusercontent.com/42867097/199656053-e3948251-05d5-43ac-82ac-d48381ff1ac7.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
