### PR TITLE
Skip serialization for empty or string bigint values in GraphQL

### DIFF
--- a/api/src/services/graphql/types/bigint.ts
+++ b/api/src/services/graphql/types/bigint.ts
@@ -4,6 +4,8 @@ export const GraphQLBigInt = new GraphQLScalarType({
 	name: 'GraphQLBigInt',
 	description: 'BigInt value',
 	serialize(value) {
+		if (!value) return value;
+		if (typeof value === 'string') return value;
 		if (typeof value !== 'number') {
 			throw new Error('Value must be a Number');
 		}


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Hotfix for serializing of BigInt values in GraphQL. 
Returns empty or string big values as is.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
