### PR TITLE
Skip checking of virtual alias fields

### DIFF
--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -365,7 +365,7 @@ export class FieldsService {
 				(hookAdjustedField.type === 'alias' ||
 					this.schema.collections[collection].fields[field.field]?.type === 'alias') &&
 				hookAdjustedField.type &&
-				hookAdjustedField.type !== this.schema.collections[collection].fields[field.field]?.type
+				hookAdjustedField.type !== (this.schema.collections[collection].fields[field.field]?.type ?? 'alias')
 			) {
 				throw new InvalidPayloadException('Alias type cannot be changed');
 			}

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -365,7 +365,7 @@ export class FieldsService {
 				((hookAdjustedField.type === 'alias' && this.schema.collections[collection].fields[field.field]) ||
 					this.schema.collections[collection].fields[field.field]?.type === 'alias') &&
 				hookAdjustedField.type &&
-				hookAdjustedField.type !== this.schema.collections[collection].fields[field.field]?.type
+				hookAdjustedField.type !== this.schema.collections[collection].fields[field.field].type
 			) {
 				throw new InvalidPayloadException('Alias type cannot be changed');
 			}

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -362,10 +362,10 @@ export class FieldsService {
 				: null;
 
 			if (
-				((hookAdjustedField.type === 'alias' && this.schema.collections[collection].fields[field.field]) ||
+				(hookAdjustedField.type === 'alias' ||
 					this.schema.collections[collection].fields[field.field]?.type === 'alias') &&
 				hookAdjustedField.type &&
-				hookAdjustedField.type !== this.schema.collections[collection].fields[field.field].type
+				hookAdjustedField.type !== (this.schema.collections[collection].fields[field.field]?.type ?? 'alias')
 			) {
 				throw new InvalidPayloadException('Alias type cannot be changed');
 			}

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -362,9 +362,9 @@ export class FieldsService {
 				: null;
 
 			if (
+				hookAdjustedField.type &&
 				(hookAdjustedField.type === 'alias' ||
 					this.schema.collections[collection].fields[field.field]?.type === 'alias') &&
-				hookAdjustedField.type &&
 				hookAdjustedField.type !== (this.schema.collections[collection].fields[field.field]?.type ?? 'alias')
 			) {
 				throw new InvalidPayloadException('Alias type cannot be changed');

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -362,10 +362,10 @@ export class FieldsService {
 				: null;
 
 			if (
-				(hookAdjustedField.type === 'alias' ||
+				((hookAdjustedField.type === 'alias' && this.schema.collections[collection].fields[field.field]) ||
 					this.schema.collections[collection].fields[field.field]?.type === 'alias') &&
 				hookAdjustedField.type &&
-				hookAdjustedField.type !== (this.schema.collections[collection].fields[field.field]?.type ?? 'alias')
+				hookAdjustedField.type !== this.schema.collections[collection].fields[field.field]?.type
 			) {
 				throw new InvalidPayloadException('Alias type cannot be changed');
 			}

--- a/tests-blackbox/routes/fields/change-fields.seed.ts
+++ b/tests-blackbox/routes/fields/change-fields.seed.ts
@@ -12,8 +12,8 @@ import {
 import { CachedTestsSchema, TestsSchema, TestsSchemaVendorValues } from '@query/filter';
 import { set } from 'lodash';
 
-export const collectionCountries = 'test_fields_delete_field_countries';
-export const collectionStates = 'test_fields_delete_field_states';
+export const collectionCountries = 'test_fields_change_field_countries';
+export const collectionStates = 'test_fields_change_field_states';
 
 export type Country = {
 	id?: number | string;

--- a/tests-blackbox/routes/fields/change-fields.test.ts
+++ b/tests-blackbox/routes/fields/change-fields.test.ts
@@ -117,6 +117,119 @@ describe.each(common.PRIMARY_KEY_TYPES)('/fields', (pkType) => {
 					expect(existingData).toStrictEqual(updatedData);
 				});
 			});
+
+			describe('can create new virtual alias field', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const fieldName = 'test_divider';
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.post(`/fields/${localCollectionCountries}`)
+						.send({
+							field: fieldName,
+							type: 'alias',
+							meta: {
+								interface: 'presentation-divider',
+								special: ['alias', 'no-data'],
+								options: { title: 'Test Divider' },
+							},
+							collection: localCollectionCountries,
+						})
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					const response2 = await request(getUrl(vendor))
+						.get(`/fields/${localCollectionCountries}/${fieldName}`)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toEqual(200);
+					expect(response2.statusCode).toEqual(200);
+					expect(response2.body.data).toEqual(
+						expect.objectContaining({
+							field: fieldName,
+							type: 'alias',
+							collection: localCollectionCountries,
+						})
+					);
+				});
+			});
+		});
+
+		describe('PATCH /:collection', () => {
+			describe('can sort virtual alias field', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const fieldName = 'test_divider';
+					const updatedSort = 100;
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.patch(`/fields/${localCollectionCountries}`)
+						.send([{ field: 'test_divider', meta: { sort: updatedSort, group: null } }])
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					const response2 = await request(getUrl(vendor))
+						.get(`/fields/${localCollectionCountries}/${fieldName}`)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toEqual(200);
+					expect(response2.statusCode).toEqual(200);
+					expect(response2.body.data).toEqual(
+						expect.objectContaining({
+							field: fieldName,
+							type: 'alias',
+							meta: expect.objectContaining({
+								sort: updatedSort,
+							}),
+							collection: localCollectionCountries,
+						})
+					);
+				});
+			});
+		});
+
+		describe('PATCH /:collection/:field', () => {
+			describe('can update virtual alias field', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const fieldName = 'test_divider';
+					const updatedTitle = 'Updated Divider';
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.patch(`/fields/${localCollectionCountries}/${fieldName}`)
+						.send({
+							collection: localCollectionCountries,
+							field: fieldName,
+							type: 'alias',
+							schema: null,
+							meta: {
+								options: { title: updatedTitle },
+							},
+						})
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					const response2 = await request(getUrl(vendor))
+						.get(`/fields/${localCollectionCountries}/${fieldName}`)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toEqual(200);
+					expect(response2.statusCode).toEqual(200);
+					expect(response2.body.data).toEqual(
+						expect.objectContaining({
+							field: fieldName,
+							type: 'alias',
+							meta: expect.objectContaining({
+								options: expect.objectContaining({ title: updatedTitle }),
+							}),
+							collection: localCollectionCountries,
+						})
+					);
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #16315. Default missing field in schema as `alias` if field doesn't exist in the schema.

`alias` type fields with the `no-data` flag are removed from the schema, hence the defaulting to `alias` type.

https://github.com/directus/directus/blob/4b5c0e1022d5fd342ce660a5cb7dd0354acc4512/api/src/utils/get-schema.ts#L130

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
