### PR TITLE
Update the Makefile for testing the Docker image build process

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,27 +1,41 @@
+# For testing purposes only!
+
 SHELL=bash
 
-version=$(shell git describe --tags --abbrev=0)
+image=directus-test
+version=$(shell git rev-parse HEAD)
 tag=latest
-cmd=
-user=directus
-registry=docker.io
-repository=directus/directus
 
-.PHONY: build-images
+.PHONY: build-image test-image
 
-build-images:
-	npm run build
-	npm run pack
+build-image:
+	pnpm install
+	pnpm -r build
+	node pack.js
 	docker build \
 		--build-arg VERSION=$(version) \
-		--build-arg REPOSITORY=$(repository) \
-		-t directus:temp \
+		--build-arg REPOSITORY=$(image) \
+		-t $(image):$(version) \
 		-f ./Dockerfile \
 		..
+	docker tag $(image):$(version) $(image):$(tag)
 
-	docker tag directus:temp $(registry)/$(repository):$(version)
-	docker tag directus:temp $(registry)/$(repository):$(tag)
-	docker image rm directus:temp
-
+# To override or pass additional arguments:
+# DOCKER_ARGS='-p 8051:8055 -e LOG_STYLE=raw' make test-image
 test-image:
-	docker run --rm -it $(registry)/$(repository):$(tag) $(cmd)
+	ARGS=($$DOCKER_ARGS); docker run \
+		--rm \
+		-t \
+		-p 8055:8055 \
+		-e "KEY=$$(uuidgen | tr '[:upper:]' '[:lower:]')" \
+		-e "SECRET=$$(uuidgen | tr '[:upper:]' '[:lower:]')" \
+		"$${ARGS[@]}" \
+		$(image):$(tag)
+
+enter-image:
+	ARGS=($$DOCKER_ARGS); docker run \
+		--rm \
+		-it \
+		"$${ARGS[@]}" \
+		$(image):$(tag) \
+		/bin/sh


### PR DESCRIPTION
## Description

The Makefile hasn't been updated for a while and therefore no longer worked (pnpm, envs, ...).
As far as I remember the file used to be a part of the actual build process at an earlier stage. Now, I've adapted it so that it is to be clearly used for testing purposes instead. This comes in very handy if you want to briefly test the development state in a Docker container context.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
