### PR TITLE
Allow disabling same width for attached dropdown menu

### DIFF
--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -83,8 +83,8 @@ interface Props {
 	closeOnContentClick?: boolean;
 	/** Attach the menu to an input */
 	attached?: boolean;
-	/** Make the menu have the same width as the input when attached */
-	isSameWidthWhenAttached?: boolean;
+	/** Should the menu have the same width as the input when attached */
+	isSameWidth?: boolean;
 	/** Show an arrow pointer */
 	showArrow?: boolean;
 	/** Menu does not appear */
@@ -109,7 +109,7 @@ const props = withDefaults(defineProps<Props>(), {
 	closeOnClick: true,
 	closeOnContentClick: true,
 	attached: false,
-	isSameWidthWhenAttached: true,
+	isSameWidth: true,
 	showArrow: false,
 	disabled: false,
 	trigger: null,
@@ -153,7 +153,7 @@ const {
 	computed(() => ({
 		placement: props.placement,
 		attached: props.attached,
-		isSameWidthWhenAttached: props.isSameWidthWhenAttached,
+		isSameWidth: props.isSameWidth,
 		arrow: props.showArrow,
 		offsetY: props.offsetY,
 		offsetX: props.offsetX,
@@ -286,7 +286,7 @@ function usePopper(
 			Readonly<{
 				placement: Placement;
 				attached: boolean;
-				isSameWidthWhenAttached: boolean;
+				isSameWidth: boolean;
 				arrow: boolean;
 				offsetY: number;
 				offsetX: number;
@@ -391,10 +391,10 @@ function usePopper(
 			});
 		}
 
-		if (options.value.attached === true && options.value.isSameWidthWhenAttached === true) {
+		if (options.value.attached === true) {
 			modifiers.push({
 				name: 'sameWidth',
-				enabled: true,
+				enabled: options.value.isSameWidth,
 				fn: ({ state }) => {
 					state.styles.popper.width = `${state.rects.reference.width}px`;
 				},

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -83,6 +83,8 @@ interface Props {
 	closeOnContentClick?: boolean;
 	/** Attach the menu to an input */
 	attached?: boolean;
+	/** Make the menu have the same width as the input when attached */
+	isSameWidthWhenAttached?: boolean;
 	/** Show an arrow pointer */
 	showArrow?: boolean;
 	/** Menu does not appear */
@@ -107,6 +109,7 @@ const props = withDefaults(defineProps<Props>(), {
 	closeOnClick: true,
 	closeOnContentClick: true,
 	attached: false,
+	isSameWidthWhenAttached: true,
 	showArrow: false,
 	disabled: false,
 	trigger: null,
@@ -150,6 +153,7 @@ const {
 	computed(() => ({
 		placement: props.placement,
 		attached: props.attached,
+		isSameWidthWhenAttached: props.isSameWidthWhenAttached,
 		arrow: props.showArrow,
 		offsetY: props.offsetY,
 		offsetX: props.offsetX,
@@ -278,7 +282,16 @@ function usePopper(
 	reference: Ref<HTMLElement | null>,
 	popper: Ref<HTMLElement | null>,
 	options: Readonly<
-		Ref<Readonly<{ placement: Placement; attached: boolean; arrow: boolean; offsetY: number; offsetX: number }>>
+		Ref<
+			Readonly<{
+				placement: Placement;
+				attached: boolean;
+				isSameWidthWhenAttached: boolean;
+				arrow: boolean;
+				offsetY: number;
+				offsetX: number;
+			}>
+		>
 	>
 ): Record<string, any> {
 	const popperInstance = ref<Instance | null>(null);
@@ -378,7 +391,7 @@ function usePopper(
 			});
 		}
 
-		if (options.value.attached === true) {
+		if (options.value.attached === true && options.value.isSameWidthWhenAttached === true) {
 			modifiers.push({
 				name: 'sameWidth',
 				enabled: true,

--- a/app/src/components/v-select/__snapshots__/v-select.test.ts.snap
+++ b/app/src/components/v-select/__snapshots__/v-select.test.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1
 
-exports[`Mount component 1`] = `"<v-menu-stub class=\\"v-select\\" disabled=\\"false\\" attached=\\"true\\" show-arrow=\\"false\\" close-on-content-click=\\"true\\" placement=\\"bottom\\" data-v-cdcb6889=\\"\\"></v-menu-stub>"`;
+exports[`Mount component 1`] = `"<v-menu-stub class=\\"v-select\\" disabled=\\"false\\" attached=\\"true\\" is-same-width=\\"true\\" show-arrow=\\"false\\" close-on-content-click=\\"true\\" placement=\\"bottom\\" data-v-cdcb6889=\\"\\"></v-menu-stub>"`;

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -3,6 +3,7 @@
 		class="v-select"
 		:disabled="disabled"
 		:attached="inline === false"
+		:is-same-width-when-attached="isMenuSameWidth"
 		:show-arrow="inline === true"
 		:close-on-content-click="closeOnContentClick"
 		:placement="placement"
@@ -182,6 +183,8 @@ interface Props {
 	multiplePreviewThreshold?: number;
 	/** The direction the menu should open */
 	placement?: Placement;
+	/** Should the menu be the same width as the select element */
+	isMenuSameWidth?: true;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -205,6 +208,7 @@ const props = withDefaults(defineProps<Props>(), {
 	label: false,
 	multiplePreviewThreshold: 3,
 	placement: 'bottom',
+	isMenuSameWidth: true,
 });
 
 const emit = defineEmits(['update:modelValue', 'group-toggle']);

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -3,7 +3,7 @@
 		class="v-select"
 		:disabled="disabled"
 		:attached="inline === false"
-		:is-same-width-when-attached="isMenuSameWidth"
+		:is-same-width="isMenuSameWidth"
 		:show-arrow="inline === true"
 		:close-on-content-click="closeOnContentClick"
 		:placement="placement"

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -24,6 +24,7 @@
 					item-text="name"
 					item-disabled="meta.singleton"
 					multiple
+					:is-same-width-when-attached="false"
 					:multiple-preview-threshold="0"
 				/>
 			</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -24,7 +24,7 @@
 					item-text="name"
 					item-disabled="meta.singleton"
 					multiple
-					:is-same-width-when-attached="false"
+					:is-menu-same-width="false"
 					:multiple-preview-threshold="0"
 				/>
 			</div>


### PR DESCRIPTION
## Description

Fixes #16364

Currently when a v-menu is `attached`, it will always be the same width as the input due to the following modifier to the popover:

https://github.com/directus/directus/blob/6e730956afbba37832b49587cc06049d99b68937/app/src/components/v-menu.vue#L381-L391

This PR allows disabling the same width only when it's attached to account for edge cases such as this. 

### Before

![](https://user-images.githubusercontent.com/42867097/200726067-a5b0d430-a7c4-4f51-9b11-f7b30fd3a2f6.png)

### After

![](https://user-images.githubusercontent.com/42867097/200726074-6412562e-af4c-4a3a-86e7-79546f94449c.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
