### PR TITLE
Exclude unnecessary files from packages

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -72,8 +72,8 @@
 	},
 	"files": [
 		"dist",
-		"!dist/**/*.test.js",
-		"!dist/__*__/"
+		"!**/*.test.js",
+		"!**/__*__/"
 	],
 	"dependencies": {
 		"@authenio/samlify-node-xmllint": "2.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -59,7 +59,7 @@
 	"scripts": {
 		"start": "npx directus start",
 		"prebuild": "pnpm cleanup",
-		"build": "tsc --build && copyfiles \"src/**/*.*\" -e \"src/**/*.ts\" -u 1 dist",
+		"build": "tsc --build",
 		"cleanup": "rimraf dist",
 		"dev": "cross-env NODE_ENV=development SERVE_APP=false ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect=0 --exit-child -- src/start.ts",
 		"cli": "cross-env NODE_ENV=development SERVE_APP=false ts-node --script-mode --transpile-only src/cli/run.ts",
@@ -72,8 +72,8 @@
 	},
 	"files": [
 		"dist",
-		"LICENSE",
-		"README.md"
+		"!dist/**/*.test.js",
+		"!dist/__*__/"
 	],
 	"dependencies": {
 		"@authenio/samlify-node-xmllint": "2.0.0",
@@ -221,7 +221,6 @@
 		"@types/uuid": "8.3.4",
 		"@types/uuid-validate": "0.0.1",
 		"@types/wellknown": "0.5.3",
-		"copyfiles": "2.4.1",
 		"cross-env": "7.0.3",
 		"form-data": "4.0.0",
 		"jest": "29.2.1",

--- a/api/package.json
+++ b/api/package.json
@@ -59,7 +59,7 @@
 	"scripts": {
 		"start": "npx directus start",
 		"prebuild": "pnpm cleanup",
-		"build": "tsc --build",
+		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid}\" -u 1 dist",
 		"cleanup": "rimraf dist",
 		"dev": "cross-env NODE_ENV=development SERVE_APP=false ts-node-dev --files --transpile-only --respawn --watch \".env\" --inspect=0 --exit-child -- src/start.ts",
 		"cli": "cross-env NODE_ENV=development SERVE_APP=false ts-node --script-mode --transpile-only src/cli/run.ts",
@@ -221,6 +221,7 @@
 		"@types/uuid": "8.3.4",
 		"@types/uuid-validate": "0.0.1",
 		"@types/wellknown": "0.5.3",
+		"copyfiles": "2.4.1",
 		"cross-env": "7.0.3",
 		"form-data": "4.0.0",
 		"jest": "29.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -10,9 +10,7 @@
 		"./package.json": "./package.json"
 	},
 	"files": [
-		"dist",
-		"LICENSE",
-		"README.md"
+		"dist"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -8,6 +8,9 @@
 		".": "./lib/index.js",
 		"./package.json": "./package.json"
 	},
+	"files": [
+		"lib/index.js"
+	],
 	"bin": {
 		"create-directus-extension": "./lib/index.js",
 		"cde": "./lib/index.js"

--- a/packages/drive-azure/package.json
+++ b/packages/drive-azure/package.json
@@ -8,7 +8,6 @@
 		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
-	"types": "dist/index.d.ts",
 	"keywords": [
 		"storage",
 		"filesystem",
@@ -35,7 +34,8 @@
 		"Rijk van Zanten <rijkvanzanten@me.com>"
 	],
 	"files": [
-		"dist"
+		"dist",
+		"!**/*.d.ts?(.map)"
 	],
 	"dependencies": {
 		"@azure/storage-blob": "12.12.0",

--- a/packages/drive-gcs/package.json
+++ b/packages/drive-gcs/package.json
@@ -8,7 +8,6 @@
 		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
-	"types": "dist/index.d.ts",
 	"keywords": [
 		"storage",
 		"filesystem",
@@ -25,7 +24,8 @@
 		"Rijk van Zanten <rijkvanzanten@me.com>"
 	],
 	"files": [
-		"dist"
+		"dist",
+		"!**/*.d.ts?(.map)"
 	],
 	"scripts": {
 		"build": "tsc --project ./tsconfig.json",

--- a/packages/drive-s3/package.json
+++ b/packages/drive-s3/package.json
@@ -8,7 +8,6 @@
 		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
-	"types": "dist/index.d.ts",
 	"keywords": [
 		"storage",
 		"filesystem",
@@ -26,7 +25,8 @@
 		"Rijk van Zanten <rijkvanzanten@me.com>"
 	],
 	"files": [
-		"dist"
+		"dist",
+		"!**/*.d.ts?(.map)"
 	],
 	"scripts": {
 		"build": "tsc --project ./tsconfig.json",

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -8,7 +8,6 @@
 		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
-	"types": "dist/index.d.ts",
 	"keywords": [
 		"storage",
 		"filesystem",
@@ -27,7 +26,8 @@
 		"Rijk van Zanten <rijkvanzanten@me.com>"
 	],
 	"files": [
-		"dist"
+		"dist",
+		"!**/*.d.ts?(.map)"
 	],
 	"scripts": {
 		"build": "tsc --project ./tsconfig.json",

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -15,6 +15,10 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"files": [
+		"dist",
+		"templates"
+	],
 	"types": "dist/esm/index.d.ts",
 	"bin": {
 		"directus-extension": "cli.js"

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -17,7 +17,8 @@
 	},
 	"files": [
 		"dist",
-		"templates"
+		"templates",
+		"!**/*.d.ts.map"
 	],
 	"types": "dist/esm/index.d.ts",
 	"bin": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -8,6 +8,9 @@
 		"./package.json": "./package.json"
 	},
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build": "tsc --build && echo \"Built successfully\"",
 		"dev": "npm-watch build"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,7 +35,8 @@
 	},
 	"files": [
 		"dist",
-		"!dist/**/*.test.js"
+		"!**/*.test.js",
+		"!**/*.d.ts.map"
 	],
 	"sideEffects": false,
 	"scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,6 +33,10 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"files": [
+		"dist",
+		"!dist/**/*.test.js"
+	],
 	"sideEffects": false,
 	"scripts": {
 		"build": "run-p \"build:* {@}\"",

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -36,8 +36,6 @@
 	"homepage": "https://github.com/directus/directus#readme",
 	"files": [
 		"dist",
-		"LICENSE",
-		"README.md",
 		"index.d.ts",
 		"index.js"
 	],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,6 @@ importers:
       chokidar: 3.5.3
       commander: 9.4.1
       cookie-parser: 1.4.6
-      copyfiles: 2.4.1
       cors: 2.8.5
       cross-env: 7.0.3
       csv-parser: 3.0.0
@@ -360,7 +359,6 @@ importers:
       '@types/uuid': 8.3.4
       '@types/uuid-validate': 0.0.1
       '@types/wellknown': 0.5.3
-      copyfiles: 2.4.1
       cross-env: 7.0.3
       form-data: 4.0.0
       jest: 29.2.1_5uyhgycj63wuqgvl4exdnr442q

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
       chokidar: 3.5.3
       commander: 9.4.1
       cookie-parser: 1.4.6
+      copyfiles: 2.4.1
       cors: 2.8.5
       cross-env: 7.0.3
       csv-parser: 3.0.0
@@ -359,6 +360,7 @@ importers:
       '@types/uuid': 8.3.4
       '@types/uuid-validate': 0.0.1
       '@types/wellknown': 0.5.3
+      copyfiles: 2.4.1
       cross-env: 7.0.3
       form-data: 4.0.0
       jest: 29.2.1_5uyhgycj63wuqgvl4exdnr442q


### PR DESCRIPTION
## Description

I noticed that there are quite a few files in the published packages which aren't necessary.
For example test files, but also whole `src` folders or files like `.editorconfig`.
This pull request updates the [files](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files) field in the `package.json` files to exclude those.

Note: Files like `README.md` and `LICENSE` are always included, therefore they don't have to be specified explicitly.

Also there are some packages with source map files. I wonder whether we really want these files in the published package or if it is sufficient if they are available in the local development environment?

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
