### PR TITLE
Fix sortField selection

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -64,6 +64,7 @@
 			<v-divider large :inline-title="false">{{ t('sort_field') }}</v-divider>
 			<related-field-select
 				v-model="sortField"
+				:type-allow-list="['integer', 'bigInteger', 'float', 'decimal']"
 				:disabled-fields="unsortableJunctionFields"
 				:collection="junctionCollection"
 				:placeholder="t('add_sort_field')"

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -71,6 +71,7 @@
 			<related-field-select
 				v-model="sortField"
 				:collection="junctionCollection"
+				:type-allow-list="['integer', 'bigInteger', 'float', 'decimal']"
 				:disabled-fields="unsortableJunctionFields"
 				:placeholder="t('add_sort_field') + '...'"
 				:nullable="true"

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -24,6 +24,7 @@
 			<related-field-select
 				v-model="sortField"
 				:collection="relatedCollection"
+				:type-allow-list="['integer', 'bigInteger', 'float', 'decimal']"
 				:disabled-fields="unsortableJunctionFields"
 				:placeholder="t('add_sort_field') + '...'"
 				:nullable="true"
@@ -142,7 +143,7 @@ export default defineComponent({
 		const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
 
 		const unsortableJunctionFields = computed(() => {
-			let fields = ['item', 'collection'];
+			let fields = [];
 			if (relatedCollection.value) {
 				const relations = relationsStore.getRelationsForCollection(relatedCollection.value);
 				fields.push(...relations.map((field) => field.field));

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
@@ -65,6 +65,10 @@ export default defineComponent({
 			type: Array as PropType<string[]>,
 			default: () => [],
 		},
+		typeAllowList: {
+			type: Array as PropType<string[]>,
+			default: () => [],
+		},
 		placeholder: {
 			type: String,
 			default: () => i18n.global.t('foreign_key') + '...',
@@ -89,7 +93,8 @@ export default defineComponent({
 					!field.schema ||
 					!!field.schema?.is_primary_key ||
 					props.disabledFields.includes(field.field) ||
-					props.typeDenyList.includes(field.type),
+					props.typeDenyList.includes(field.type) ||
+					!props.typeAllowList.includes(field.type),
 			}));
 		});
 


### PR DESCRIPTION
Only allow for selecting integer type fields in the sortField dropdown and fix a minor bug caused by #14303 where you would not have been able to select a field with the name `collection` or `item` in the o2m sortField dropdown.

![grafik](https://user-images.githubusercontent.com/22577866/200856197-495a74ae-67a1-4690-a16e-016cfcf9a09c.png)


Fixes #16376