### PR TITLE
Clean-up lint / format set-up

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 node_modules
 dist
-templates
-stories
+packages/extensions-sdk/templates

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,13 +5,13 @@ body:
     attributes:
       value: |
         Hi, thank you for taking the time to create an issue!
-        
+
         Before opening this issue, please make sure that:
-        
+
         - You've completed all [Troubleshooting Steps](https://docs.directus.io/getting-started/support/#troubleshooting-steps).
         - You're using [the latest version of Directus](https://github.com/directus/directus/releases).
         - There's [no other issue](https://github.com/directus/directus/issues?q=is%3Aissue) that already describes the problem.
-        
+
         _For issues specific to Directus Cloud projects, please reach out through the Live Chat in our Cloud Dashboard._
   - type: textarea
     attributes:
@@ -22,7 +22,9 @@ body:
   - type: textarea
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce the bug.
+      description:
+        Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce
+        the bug.
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,4 @@ Fixes #
 
 If adding a new feature:
 
-- [ ] Documentation was added/updated. PR: 
+- [ ] Documentation was added/updated. PR:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 dist
+coverage
 node_modules
 pnpm-lock.yaml
 app/src/lang/translations/*.yaml

--- a/app/src/interfaces/select-icon/icons.json
+++ b/app/src/interfaces/select-icon/icons.json
@@ -1203,11 +1203,7 @@
 	},
 	{
 		"name": "home",
-		"icons": [
-			"sensor_door",
-			"sensor_window",
-			"shield_moon"
-		]
+		"icons": ["sensor_door", "sensor_window", "shield_moon"]
 	},
 	{
 		"name": "image",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	],
 	"scripts": {
 		"lint": "eslint .",
-		"format": "prettier --write \"**/*.{js,ts,vue,md,yaml}\"",
+		"format": "prettier --write \"**/*.{md,y?(a)ml,json}\"",
 		"test:e2e": "jest tests -c tests/jest.config.js",
 		"test:e2e:watch": "jest tests -c tests/jest.config.js --watch",
 		"posttest:e2e:watch": "ts-node --project ./tests/tsconfig.json --transpile-only ./tests/setup/teardown.ts",
@@ -27,7 +27,7 @@
 	},
 	"lint-staged": {
 		"*.{js,ts,vue}": "eslint --fix",
-		"*.{md,yaml}": "prettier --write"
+		"*.{md,y?(a)ml,json}": "prettier --write"
 	},
 	"volta": {
 		"node": "16.15.0",

--- a/packages/extensions-sdk/tsconfig.json
+++ b/packages/extensions-sdk/tsconfig.json
@@ -24,7 +24,7 @@
 		"forceConsistentCasingInFileNames": true,
 		"allowSyntheticDefaultImports": true,
 		"isolatedModules": true,
-		"rootDir": "./src",
+		"rootDir": "./src"
 	},
 	"include": ["./src/**/*.ts"]
 }

--- a/tests-blackbox/docker-compose.yml
+++ b/tests-blackbox/docker-compose.yml
@@ -96,4 +96,4 @@ services:
       - SIMPLESAMLPHP_SP_ENTITY_ID=saml-test
       - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=http://localhost:8080/auth/login/saml/acs
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
## Description

Small clean-up to the current lint / format set-up:

- Format `json` and all `yaml` files with prettier, don't use Prettier for code files as those are processed via ESLint.
- Adjust `.eslintignore` and `.prettierignore` files: Ignore `coverage` folders, be more specific about the `templates` folder.
- Format files with the new set-up.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
