### PR TITLE
AST: Fix fetch related items when more than 100 (M2A)

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -63,8 +63,8 @@ export default async function runAST(
 
 				const nestedItems = await run(collection, ast.children[collection], query);
 
-				if (Array.isArray(nestedItems)) results[collection]?.push(...nestedItems);
-				else results[collection]?.push(nestedItems);
+				if (Array.isArray(nestedItems)) results[collection]!.push(...nestedItems);
+				else results[collection]!.push(nestedItems);
 
 				if (!nestedItems || nestedItems.length < env.RELATIONAL_BATCH_SIZE) {
 					hasMore = false;


### PR DESCRIPTION
## Description

When querying nested M2A (or A2O) items, we found that some relations were not being loaded and the related item was set to `null`.
After some investigation we found that this happens for items that have more than 100 related items.
Since all queries are limited to `100` if no `limit` is specified, that was the reason for some to not being loaded. That happened for each related collection.

In order to fix this we just follow the same example as O2M: fetch items by "page" and append to the results.

Fixes https://github.com/directus/directus/issues/14190

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
