### PR TITLE
Reset page when changing pageSize

### DIFF
--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -313,7 +313,7 @@ const query = computed<RelationQueryMultiple>(() => {
 	return q;
 });
 
-watch([search, searchFilter], () => {
+watch([search, searchFilter, limit], () => {
 	page.value = 1;
 });
 


### PR DESCRIPTION
When changing the pageSize while on the last page, it would mess up the current page and you would have been stuck with a view of no items.

Fixes #16389 