### PR TITLE
Fix limit in nested a2o queries

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -117,9 +117,18 @@ export default async function runAST(
 					batchCount++;
 				}
 			} else {
-				const node = merge({}, nestedNode, {
-					query: { limit: -1 },
-				});
+				let node;
+
+				if (nestedNode.type === 'a2o') {
+					node = merge({}, nestedNode);
+					for (const nestedCollection of nestedNode.names) {
+						node.query[nestedCollection].limit = -1;
+					}
+				} else {
+					node = merge({}, nestedNode, {
+						query: { limit: -1 },
+					});
+				}
 
 				nestedItems = (await runAST(node, schema, { knex, nested: true })) as Item[] | null;
 

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -117,18 +117,9 @@ export default async function runAST(
 					batchCount++;
 				}
 			} else {
-				let node;
-
-				if (nestedNode.type === 'a2o') {
-					node = merge({}, nestedNode);
-					for (const nestedCollection of nestedNode.names) {
-						node.query[nestedCollection].limit = -1;
-					}
-				} else {
-					node = merge({}, nestedNode, {
-						query: { limit: -1 },
-					});
-				}
+				const node = merge({}, nestedNode, {
+					query: { limit: -1 },
+				});
 
 				nestedItems = (await runAST(node, schema, { knex, nested: true })) as Item[] | null;
 
@@ -315,7 +306,7 @@ function applyParentFilters(
 				const foreignIds = uniq(keysPerCollection[relatedCollection]);
 
 				merge(nestedNode, {
-					query: { [relatedCollection]: { filter: { [foreignField]: { _in: foreignIds } } } },
+					query: { [relatedCollection]: { filter: { [foreignField]: { _in: foreignIds } }, limit: foreignIds.length } },
 				});
 			}
 		}


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #14190. The root cause is the limit for `a2o` fields not being set within each collection's query. Hence, the default limit of `100` is applied, leading to the `null` items.

https://github.com/directus/directus/blob/baf5d7bde6755649171634f888ba9892cd540b34/api/src/database/run-ast.ts#L259

On the other hand, the `a2o` actually works correctly in the main branch if the `RELATIONAL_BATCH_SIZE` is reduced to a value below `100`, as the limit of `100` doesn't clip the result.

@rijkvanzanten Should the default `RELATIONAL_BATCH_SIZE` be reduced?
Agree that `25000` is a good default value set in #11246 for the top level query.
However, this value also directly ties to the number of items within the `WHERE IN()` when fetching nested items. 

1x `WHERE IN (25000 PKs)` vs 50x `WHERE IN (500 PKs)`. 🤔 
I'm thinking if might be more efficient / faster to run smaller `WHERE IN()` queries, albeit having additional latencies.
Or should there be another environment variable that splits such `WHERE IN()` queries up?

Side note, Oracle supports a maximum of `999` values in an `IN()` query. Ref: ORA-01795 https://support.oracle.com/knowledge/More%20Applications%20and%20Technologies/2228062_1.html

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
