### PR TITLE
Allow admin to update Directus User `provider` and `external_identifier`

### DIFF
--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,0 +1,218 @@
+import { SchemaOverview } from '@directus/shared/types';
+import knex, { Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { UsersService, ItemsService } from '.';
+import { InvalidPayloadException } from '../exceptions';
+
+jest.mock('../../src/database/index', () => {
+	return { __esModule: true, default: jest.fn(), getDatabaseClient: jest.fn().mockReturnValue('postgres') };
+});
+
+const testSchema = {
+	collections: {
+		directus_users: {
+			collection: 'directus_users',
+			primary: 'id',
+			singleton: false,
+			sortField: null,
+			note: null,
+			accountability: null,
+			fields: {
+				id: {
+					field: 'id',
+					defaultValue: null,
+					nullable: false,
+					generated: true,
+					type: 'integer',
+					dbType: 'integer',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+			},
+		},
+	},
+	relations: [],
+} as SchemaOverview;
+
+describe('Integration Tests', () => {
+	let db: jest.Mocked<Knex>;
+	let tracker: Tracker;
+
+	beforeAll(async () => {
+		db = knex({ client: MockClient }) as jest.Mocked<Knex>;
+		tracker = getTracker();
+	});
+
+	// beforeEach(() => {
+	// 	tracker.on.any('directus_users').response({});
+
+	// 	// mock notifications update query in deleteOne/deleteMany/deleteByQuery methods
+	// 	tracker.on.update('directus_notifications').response({});
+	// });
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	describe('Services / Users', () => {
+		describe('updateOne', () => {
+			it.each(['provider', 'external_identifier'])(
+				'should throw InvalidPayloadException for non-admin users when updating "%s" field',
+				async (field) => {
+					const service = new UsersService({
+						knex: db,
+						schema: testSchema,
+						accountability: { role: 'test', admin: false },
+					});
+
+					const promise = service.updateOne(1, { [field]: 'test' });
+
+					expect.assertions(2); // to ensure both assertions in the catch block are reached
+
+					try {
+						await promise;
+					} catch (err: any) {
+						expect(err.message).toBe(`You can't change the "${field}" value manually.`);
+						expect(err).toBeInstanceOf(InvalidPayloadException);
+					}
+				}
+			);
+
+			it.each(['provider', 'external_identifier'])('should allow admin users to update "%s" field', async (field) => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'admin', admin: true },
+				});
+
+				const promise = service.updateOne(1, { [field]: 'test' });
+
+				await expect(promise).resolves.not.toThrow();
+			});
+
+			it.each(['provider', 'external_identifier'])(
+				'should allow null accountability to update "%s" field',
+				async (field) => {
+					const service = new UsersService({
+						knex: db,
+						schema: testSchema,
+					});
+
+					const promise = service.updateOne(1, { [field]: 'test' });
+
+					await expect(promise).resolves.not.toThrow();
+				}
+			);
+		});
+
+		describe('updateMany', () => {
+			it.each(['provider', 'external_identifier'])(
+				'should throw InvalidPayloadException for non-admin users when updating "%s" field',
+				async (field) => {
+					const service = new UsersService({
+						knex: db,
+						schema: testSchema,
+						accountability: { role: 'test', admin: false },
+					});
+
+					const promise = service.updateMany([1], { [field]: 'test' });
+
+					expect.assertions(2); // to ensure both assertions in the catch block are reached
+
+					try {
+						await promise;
+					} catch (err: any) {
+						expect(err.message).toBe(`You can't change the "${field}" value manually.`);
+						expect(err).toBeInstanceOf(InvalidPayloadException);
+					}
+				}
+			);
+
+			it.each(['provider', 'external_identifier'])('should allow admin users to update "%s" field', async (field) => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'admin', admin: true },
+				});
+
+				const promise = service.updateMany([1], { [field]: 'test' });
+
+				await expect(promise).resolves.not.toThrow();
+			});
+
+			it.each(['provider', 'external_identifier'])(
+				'should allow null accountability to update "%s" field',
+				async (field) => {
+					const service = new UsersService({
+						knex: db,
+						schema: testSchema,
+					});
+
+					const promise = service.updateMany([1], { [field]: 'test' });
+
+					await expect(promise).resolves.not.toThrow();
+				}
+			);
+		});
+
+		describe('updateByQuery', () => {
+			it.each(['provider', 'external_identifier'])(
+				'should throw InvalidPayloadException for non-admin users when updating "%s" field',
+				async (field) => {
+					const service = new UsersService({
+						knex: db,
+						schema: testSchema,
+						accountability: { role: 'test', admin: false },
+					});
+
+					jest.spyOn(ItemsService.prototype, 'getKeysByQuery').mockImplementation(jest.fn(() => Promise.resolve([1])));
+
+					const promise = service.updateByQuery({}, { [field]: 'test' });
+
+					expect.assertions(2); // to ensure both assertions in the catch block are reached
+
+					try {
+						await promise;
+					} catch (err: any) {
+						expect(err.message).toBe(`You can't change the "${field}" value manually.`);
+						expect(err).toBeInstanceOf(InvalidPayloadException);
+					}
+				}
+			);
+
+			it.each(['provider', 'external_identifier'])('should allow admin users to update "%s" field', async (field) => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'admin', admin: true },
+				});
+
+				jest.spyOn(ItemsService.prototype, 'getKeysByQuery').mockImplementation(jest.fn(() => Promise.resolve([1])));
+
+				const promise = service.updateByQuery({}, { [field]: 'test' });
+
+				await expect(promise).resolves.not.toThrow();
+			});
+
+			it.each(['provider', 'external_identifier'])(
+				'should allow null accountability to update "%s" field',
+				async (field) => {
+					const service = new UsersService({
+						knex: db,
+						schema: testSchema,
+					});
+
+					jest.spyOn(ItemsService.prototype, 'getKeysByQuery').mockImplementation(jest.fn(() => Promise.resolve([1])));
+
+					const promise = service.updateByQuery({}, { [field]: 'test' });
+
+					await expect(promise).resolves.not.toThrow();
+				}
+			);
+		});
+	});
+});

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -47,13 +47,6 @@ describe('Integration Tests', () => {
 		tracker = getTracker();
 	});
 
-	// beforeEach(() => {
-	// 	tracker.on.any('directus_users').response({});
-
-	// 	// mock notifications update query in deleteOne/deleteMany/deleteByQuery methods
-	// 	tracker.on.update('directus_notifications').response({});
-	// });
-
 	afterEach(() => {
 		tracker.reset();
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -241,11 +241,11 @@ export class UsersService extends ItemsService {
 			throw new InvalidPayloadException(`You can't change the "tfa_secret" value manually.`);
 		}
 
-		if (data.provider !== undefined) {
+		if (data.provider !== undefined && this.accountability && this.accountability.admin !== true) {
 			throw new InvalidPayloadException(`You can't change the "provider" value manually.`);
 		}
 
-		if (data.external_identifier !== undefined) {
+		if (data.external_identifier !== undefined && this.accountability && this.accountability.admin !== true) {
 			throw new InvalidPayloadException(`You can't change the "external_identifier" value manually.`);
 		}
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -289,16 +289,7 @@ export default defineComponent({
 			usePermissions(ref('directus_users'), item, isNew);
 
 		// These fields will be shown in the sidebar instead
-		const fieldsDenyList = [
-			'id',
-			'external_id',
-			'last_page',
-			'created_on',
-			'created_by',
-			'modified_by',
-			'modified_on',
-			'last_access',
-		];
+		const fieldsDenyList = ['id', 'last_page', 'created_on', 'created_by', 'modified_by', 'modified_on', 'last_access'];
 
 		const fieldsFiltered = computed(() => {
 			return fields.value.filter((field: Field) => {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -302,8 +302,8 @@ export default defineComponent({
 
 		const fieldsFiltered = computed(() => {
 			return fields.value.filter((field: Field) => {
-				// These fields should only be editable when creating new users
-				if (!isNew.value && ['provider', 'external_identifier'].includes(field.field)) {
+				// These fields should only be editable when creating new users or by administrators
+				if (!isNew.value && ['provider', 'external_identifier'].includes(field.field) && !userStore.isAdmin) {
 					field.meta.readonly = true;
 				}
 				return !fieldsDenyList.includes(field.field);


### PR DESCRIPTION
## Description

Fixes #16240

Currently both the App and API prevents update to both `provider` and `external_identifier` fields. This PR makes it possible for admin users to update them when the need arises.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
