### PR TITLE
Fix `cast-csv` read action for csv field's first revision

### DIFF
--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -61,6 +61,19 @@ describe('Integration Tests', () => {
 					expect(result).toMatchObject([]);
 				});
 
+				it('Returns array values as is', async () => {
+					const result = await service.transformers['cast-csv']({
+						value: ['test', 'directus'],
+						action: 'read',
+						payload: {},
+						accountability: { role: null },
+						specials: [],
+						helpers,
+					});
+
+					expect(result).toEqual(['test', 'directus']);
+				});
+
 				it('Splits the CSV string', async () => {
 					const result = await service.transformers['cast-csv']({
 						value: 'test,directus',

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -121,7 +121,9 @@ export class PayloadService {
 		async 'cast-csv'({ action, value }) {
 			if (Array.isArray(value) === false && typeof value !== 'string') return;
 
-			if (action === 'read' && Array.isArray(value) === false) {
+			if (action === 'read') {
+				if (Array.isArray(value)) return value;
+
 				if (value === '') return [];
 
 				return value.split(',');


### PR DESCRIPTION
## Description

Fixes #16303

currently when reading a field with `cast-csv` special flag, the logic isn't accounting for value that is already an array + `read` action:

(note the condition `if (action === 'read' && Array.isArray(value) === false)` which will not be true for array value even if it's read)

https://github.com/directus/directus/blob/692b8c48073ad90bd43f82636bb433135e2f023e/api/src/services/payload.ts#L121-L135

hence now it'll always join an array for payload service's `prepareDelta` even for read action:

https://github.com/directus/directus/blob/692b8c48073ad90bd43f82636bb433135e2f023e/api/src/services/payload.ts#L785

so CSV field's first revision is always incorrect.

### Before

https://user-images.githubusercontent.com/42867097/201665533-dc7cc4af-84bc-4da5-868b-1f5aa36da7d4.mp4

### After

https://user-images.githubusercontent.com/42867097/201665547-1edc339e-4eb8-44b6-b0ea-cc8c27ce50af.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
