### PR TITLE
Optimize number of times cache is being cleared in ItemsService `updateBatch`

### DIFF
--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,16 +1,39 @@
 import { Query } from '@directus/shared/types';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { cloneDeep } from 'lodash';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { ItemsService } from '../../src/services';
 import { sqlFieldFormatter, sqlFieldList } from '../__utils__/items-utils';
 import { systemSchema, userSchema } from '../__utils__/schemas';
-import { cloneDeep } from 'lodash';
-import { describe, beforeAll, afterEach, it, expect, vi } from 'vitest';
+
+vi.mock('../env', async () => {
+	const actual = (await vi.importActual('../env')) as { default: Record<string, any> };
+
+	return {
+		default: {
+			...actual.default,
+			CACHE_AUTO_PURGE: true,
+		},
+	};
+});
 
 vi.mock('../../src/database/index', () => {
-	return { getDatabaseClient: vi.fn().mockReturnValue('postgres') };
+	return { default: vi.fn(), getDatabaseClient: vi.fn().mockReturnValue('postgres') };
 });
-vi.mock('../../src/database/index');
+
+vi.mock('../cache', () => {
+	return {
+		getCache: vi.fn().mockReturnValue({
+			cache: {
+				clear: vi.fn(),
+			},
+			systemCache: {
+				clear: vi.fn(),
+			},
+		}),
+	};
+});
 
 describe('Integration Tests', () => {
 	let db: Knex;
@@ -970,5 +993,35 @@ describe('Integration Tests', () => {
 				expect(response).toStrictEqual(item.id);
 			}
 		);
+	});
+
+	describe('updateBatch', () => {
+		const items = [
+			{ id: '6107c897-9182-40f7-b22e-4f044d1258d2', name: 'Item 1' },
+			{ id: '6e7d4a2c-e62f-43b4-a343-9196f4b1783f', name: 'Item 2' },
+		];
+
+		it.each(Object.keys(schemas))('%s batch update should only clear cache once', async (schema) => {
+			const table = schemas[schema].tables[0];
+			schemas[schema].accountability = null;
+
+			tracker.on.select(table).response(items);
+			tracker.on.update(table).response(items);
+
+			const itemsService = new ItemsService(table, {
+				knex: db,
+				accountability: {
+					role: 'admin',
+					admin: true,
+				},
+				schema: schemas[schema].schema,
+			});
+
+			const itemsServiceCacheClearSpy = vi.spyOn(itemsService.cache, 'clear' as never).mockResolvedValue(() => vi.fn());
+
+			await itemsService.updateBatch(items);
+
+			expect(itemsServiceCacheClearSpy).toHaveBeenCalledOnce();
+		});
 	});
 });

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -441,18 +441,25 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 		const keys: PrimaryKey[] = [];
 
-		await this.knex.transaction(async (trx) => {
-			const service = new ItemsService(this.collection, {
-				accountability: this.accountability,
-				knex: trx,
-				schema: this.schema,
-			});
+		try {
+			await this.knex.transaction(async (trx) => {
+				const service = new ItemsService(this.collection, {
+					accountability: this.accountability,
+					knex: trx,
+					schema: this.schema,
+				});
 
-			for (const item of data) {
-				if (!item[primaryKeyField]) throw new InvalidPayloadException(`Item in update misses primary key.`);
-				keys.push(await service.updateOne(item[primaryKeyField]!, omit(item, primaryKeyField), opts));
+				for (const item of data) {
+					if (!item[primaryKeyField]) throw new InvalidPayloadException(`Item in update misses primary key.`);
+					const combinedOpts = Object.assign({ autoPurgeCache: false }, opts);
+					keys.push(await service.updateOne(item[primaryKeyField]!, omit(item, primaryKeyField), combinedOpts));
+				}
+			});
+		} finally {
+			if (this.cache && env.CACHE_AUTO_PURGE && opts?.autoPurgeCache !== false) {
+				await this.cache.clear();
 			}
-		});
+		}
 
 		return keys;
 	}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -437,6 +437,10 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	 * Update multiple items in a single transaction
 	 */
 	async updateBatch(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		if (!Array.isArray(data)) {
+			throw new InvalidPayloadException('Input should be an array of items.');
+		}
+
 		const primaryKeyField = this.schema.collections[this.collection].primary;
 
 		const keys: PrimaryKey[] = [];


### PR DESCRIPTION
## Description

Closes #16318

Generally referred to CollectionsService's `updateBatch`:

https://github.com/directus/directus/blob/7899f6a2679ea5f0ffcdb29e1d722be41ca0e5c3/api/src/services/collections.ts#L360-L399

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
