### PR TITLE
Fix unsupported date_part() in CrDB

### DIFF
--- a/api/src/database/helpers/fn/dialects/postgres.ts
+++ b/api/src/database/helpers/fn/dialects/postgres.ts
@@ -10,35 +10,35 @@ const parseLocaltime = (columnType?: string) => {
 
 export class FnHelperPostgres extends FnHelper {
 	year(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('year', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(YEAR FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	month(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('month', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(MONTH FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	week(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('week', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(WEEK FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	day(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('day', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(DAY FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	weekday(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('dow', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(DOW FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	hour(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('hour', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(HOUR FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	minute(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('minute', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(MINUTE FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	second(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DATE_PART('second', ??.??${parseLocaltime(options?.type)})`, [table, column]);
+		return this.knex.raw(`EXTRACT(SECOND FROM ??.??${parseLocaltime(options?.type)})`, [table, column]);
 	}
 
 	count(table: string, column: string, options?: FnHelperOptions): Knex.Raw {


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Follow-up of #16027.
`date_part()` isn't supported in CrDB v21 https://www.cockroachlabs.com/docs/v21.2/functions-and-operators
Support is only added in CrDB v22 https://www.cockroachlabs.com/docs/stable/functions-and-operators.html

- [x] Pending test results in https://github.com/directus/directus/actions/runs/3473604480/jobs/5805806348 as fix was cherry-picked from https://github.com/directus/directus/pull/14798/commits/5735bee5a898527b29fa3d662330e383e0334dff.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
