### PR TITLE
Sanitize value in comment-input

### DIFF
--- a/app/src/views/private/components/comment-input.vue
+++ b/app/src/views/private/components/comment-input.vue
@@ -68,6 +68,7 @@
 <script setup lang="ts">
 import api from '@/api';
 import { useShortcut } from '@/composables/use-shortcut';
+import { md } from '@/utils/md';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { userName } from '@/utils/user-name';
@@ -109,7 +110,7 @@ watch(
 	() => props.existingComment,
 	() => {
 		if (props.existingComment?.comment) {
-			newCommentContent.value = props.existingComment.comment;
+			newCommentContent.value = md(props.existingComment.comment);
 		}
 	},
 	{ immediate: true }


### PR DESCRIPTION
## Description

Fixes #16469

https://github.com/directus/directus/blob/45eb4941fc415a9a02dc08b2c8cfb062406475f0/app/src/views/private/components/comment-item.vue#L5-L15

Currently when a comment is being displayed, it is sanitized within the `v-md` directive, however when it's passed to `<comment-input>` as is. The passed value should be sanitized as well.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
