### PR TITLE
Fix preset resetting itself

### DIFF
--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -94,7 +94,9 @@ export function usePreset(
 
 	// update current bookmark title when it is edited in navigation-bookmark
 	presetsStore.$subscribe(() => {
-		initLocalPreset();
+		if (!bookmarkExists.value) return;
+		const newBookmark = presetsStore.getBookmark(Number(bookmark.value));
+		localPreset.value.bookmark = newBookmark?.bookmark;
 	});
 
 	const layoutOptions = computed<Record<string, any>>({


### PR DESCRIPTION
The Problem was that the response from the api would update the localPreset and delete all changes that happened after the request started.

Fixes #13157 