### PR TITLE
Fix condition operation passing even when the checked field isn't present in the payload

### DIFF
--- a/api/src/operations/condition/index.test.ts
+++ b/api/src/operations/condition/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+
+import config from './index';
+
+describe('Operations / Condition', () => {
+	test('returns null when condition passes', () => {
+		const filter = {
+			status: {
+				_eq: true,
+			},
+		};
+		const data = {
+			status: true,
+		};
+
+		expect(config.handler({ filter }, { data } as any)).toBe(null);
+	});
+
+	test('throws error array when conditions fails', () => {
+		const filter = {
+			status: {
+				_eq: true,
+			},
+		};
+		const data = {
+			status: false,
+		};
+
+		expect.assertions(2); // ensure catch block is reached
+
+		try {
+			config.handler({ filter }, { data } as any);
+		} catch (err: any) {
+			expect(err).toHaveLength(1);
+			expect(err[0]!.message).toBe(`"status" must be [true]`);
+		}
+	});
+
+	test('throws error array when condition is checking for a field that is not included in data', () => {
+		const filter = {
+			status: {
+				_eq: true,
+			},
+		};
+		const data = {};
+
+		expect.assertions(2); // ensure catch block is reached
+
+		try {
+			config.handler({ filter }, { data } as any);
+		} catch (err: any) {
+			expect(err).toHaveLength(1);
+			expect(err[0]!.message).toBe(`"status" is required`);
+		}
+	});
+});

--- a/api/src/operations/condition/index.ts
+++ b/api/src/operations/condition/index.ts
@@ -9,7 +9,7 @@ export default defineOperationApi<Options>({
 	id: 'condition',
 
 	handler: ({ filter }, { data }) => {
-		const errors = validatePayload(filter, data);
+		const errors = validatePayload(filter, data, { requireAll: true });
 
 		if (errors.length > 0) {
 			throw errors;

--- a/packages/shared/src/utils/validate-payload.test.ts
+++ b/packages/shared/src/utils/validate-payload.test.ts
@@ -65,4 +65,21 @@ describe('validatePayload', () => {
 			})
 		).toHaveLength(0);
 	});
+	it('returns an empty array when there is no error for filter field that does not exist in payload ', () => {
+		const mockFilter = { field: { _eq: 'field' } } as Filter;
+		// intentionally empty payload to simulate "field" was never included in payload
+		const mockPayload = {};
+
+		expect(validatePayload(mockFilter, mockPayload)).toHaveLength(0);
+	});
+	it('returns an array of 1 when there is required error for filter field that does not exist in payload and requireAll option flag is true', () => {
+		const mockFilter = { field: { _eq: 'field' } } as Filter;
+		// intentionally empty payload to simulate "field" was never included in payload
+		const mockPayload = {};
+
+		const errors = validatePayload(mockFilter, mockPayload, { requireAll: true });
+
+		expect(errors).toHaveLength(1);
+		expect(errors[0]!.message).toBe(`"field" is required`);
+	});
 });


### PR DESCRIPTION
## Description

Fixes #14571

Currently `validatePayload` passes within Condition operation even when the received payload does not contain the field(s) that should be validated in the condition, for example:

This PR uses the existing `requireAll` option that will be passed to Joi to ensure the checked field(s) must be present in the payload, which is the expected outcome when users are using the conditions operation (at least from my understanding).

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
