### PR TITLE
fix list-folders test on Windows

### DIFF
--- a/packages/shared/src/utils/node/list-folders.test.ts
+++ b/packages/shared/src/utils/node/list-folders.test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { DirResult, dirSync } from 'tmp';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { listFolders } from './list-folders';
@@ -14,8 +15,9 @@ describe('', () => {
 	afterEach(() => {
 		rootDir.removeCallback();
 	});
+
 	it('returns all the subdirectories of the current directory', async () => {
-		const childPath = childDir.name.split('/');
+		const childPath = childDir.name.split(path.sep);
 		expect(await listFolders(rootDir.name)).toStrictEqual([childPath[childPath?.length - 1]]);
 	});
 });


### PR DESCRIPTION
## Description

The path value for `childDir.name` on Windows is using backward slashes `\`, but the current test is splitting the path using hardcoded forward slash `/`, hence the test is failing for Windows machines. Opted to use `path.sep` which will use the correct slash depending on the platform.

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: fix test

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
