### PR TITLE
Fix shares sidebar drawer's close event

### DIFF
--- a/app/src/views/private/components/shares-sidebar-detail.vue
+++ b/app/src/views/private/components/shares-sidebar-detail.vue
@@ -21,7 +21,7 @@
 			collection="directus_shares"
 			:primary-key="shareToEdit"
 			:active="!!shareToEdit"
-			@cancel="unselect"
+			@update:active="unselect"
 			@input="input"
 		/>
 


### PR DESCRIPTION
## Description

Currently the `<drawer-item>` is listening for `@cancel` event to unselect and close the drawer itself:

https://github.com/directus/directus/blob/7bf90efa6243f60fa4128a82540f2995df2ce9f5/app/src/views/private/components/shares-sidebar-detail.vue#L20-L26

However `<drawer-item>` does not emit such event, so there is a warning shown, as well as it is currently not possible to close a shares drawer if we want to back out from it:

https://user-images.githubusercontent.com/42867097/202407504-bc36d239-b31a-45bc-a5fd-d1090f2a4e60.mp4

This PR uses the same `@update:active` event used by other `<drawer-item>` usages to close the drawer:

https://github.com/directus/directus/blob/7bf90efa6243f60fa4128a82540f2995df2ce9f5/app/src/panels/list/panel-list.vue#L17-L24

https://github.com/directus/directus/blob/7bf90efa6243f60fa4128a82540f2995df2ce9f5/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue#L60-L69

### Result

https://user-images.githubusercontent.com/42867097/202407629-bffe4cd0-43a2-476c-8a4a-f0c297d56dbd.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
