### PR TITLE
Remove named timezone usage on MySQL

### DIFF
--- a/api/src/database/helpers/fn/dialects/mysql.ts
+++ b/api/src/database/helpers/fn/dialects/mysql.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 
 const parseLocaltime = (columnType?: string) => {
 	if (columnType === 'timestamp') {
-		return `CONVERT_TZ(??.??, @@GLOBAL.time_zone, 'UTC')`;
+		return `CONVERT_TZ(??.??, @@GLOBAL.time_zone, '+00:00')`;
 	}
 	return '??.??';
 };


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Resolves #16494. The usage of named timezones in MySQL may require manual population depending on how / where it's installed. 

When tested in the MySQL Docker container, issue did not surface.

![image](https://user-images.githubusercontent.com/26413686/202645852-373cc882-df2f-43ab-9339-08a97dbfd60f.png)

Ref: https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
