### PR TITLE
Set `auth_data` to null when updating user `provider` or `external_identifier`

### DIFF
--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,7 +1,7 @@
 import { SchemaOverview } from '@directus/shared/types';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { afterEach, beforeAll, describe, it, vi, expect, MockedFunction } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, MockedFunction, SpyInstance, vi } from 'vitest';
 import { ItemsService, UsersService } from '.';
 import { InvalidPayloadException } from '../exceptions';
 
@@ -54,6 +54,12 @@ describe('Integration Tests', () => {
 	});
 
 	describe('Services / Users', () => {
+		let superUpdateManySpy: SpyInstance;
+
+		beforeEach(() => {
+			superUpdateManySpy = vi.spyOn(ItemsService.prototype, 'updateMany');
+		});
+
 		describe('updateOne', () => {
 			it.each(['provider', 'external_identifier'])(
 				'should throw InvalidPayloadException for non-admin users when updating "%s" field',
@@ -87,6 +93,7 @@ describe('Integration Tests', () => {
 				const promise = service.updateOne(1, { [field]: 'test' });
 
 				await expect(promise).resolves.not.toThrow();
+				expect(superUpdateManySpy).toBeCalledWith([1], expect.objectContaining({ auth_data: null }), undefined);
 			});
 
 			it.each(['provider', 'external_identifier'])(
@@ -100,6 +107,7 @@ describe('Integration Tests', () => {
 					const promise = service.updateOne(1, { [field]: 'test' });
 
 					await expect(promise).resolves.not.toThrow();
+					expect(superUpdateManySpy).toBeCalledWith([1], expect.objectContaining({ auth_data: null }), undefined);
 				}
 			);
 		});
@@ -137,6 +145,7 @@ describe('Integration Tests', () => {
 				const promise = service.updateMany([1], { [field]: 'test' });
 
 				await expect(promise).resolves.not.toThrow();
+				expect(superUpdateManySpy).toBeCalledWith([1], expect.objectContaining({ auth_data: null }), undefined);
 			});
 
 			it.each(['provider', 'external_identifier'])(
@@ -150,6 +159,7 @@ describe('Integration Tests', () => {
 					const promise = service.updateMany([1], { [field]: 'test' });
 
 					await expect(promise).resolves.not.toThrow();
+					expect(superUpdateManySpy).toBeCalledWith([1], expect.objectContaining({ auth_data: null }), undefined);
 				}
 			);
 		});
@@ -191,6 +201,7 @@ describe('Integration Tests', () => {
 				const promise = service.updateByQuery({}, { [field]: 'test' });
 
 				await expect(promise).resolves.not.toThrow();
+				expect(superUpdateManySpy).toBeCalledWith([1], expect.objectContaining({ auth_data: null }), undefined);
 			});
 
 			it.each(['provider', 'external_identifier'])(
@@ -206,6 +217,7 @@ describe('Integration Tests', () => {
 					const promise = service.updateByQuery({}, { [field]: 'test' });
 
 					await expect(promise).resolves.not.toThrow();
+					expect(superUpdateManySpy).toBeCalledWith([1], expect.objectContaining({ auth_data: null }), undefined);
 				}
 			);
 		});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -241,12 +241,20 @@ export class UsersService extends ItemsService {
 			throw new InvalidPayloadException(`You can't change the "tfa_secret" value manually.`);
 		}
 
-		if (data.provider !== undefined && this.accountability && this.accountability.admin !== true) {
-			throw new InvalidPayloadException(`You can't change the "provider" value manually.`);
+		if (data.provider !== undefined) {
+			if (this.accountability && this.accountability.admin !== true) {
+				throw new InvalidPayloadException(`You can't change the "provider" value manually.`);
+			}
+
+			data.auth_data = null;
 		}
 
-		if (data.external_identifier !== undefined && this.accountability && this.accountability.admin !== true) {
-			throw new InvalidPayloadException(`You can't change the "external_identifier" value manually.`);
+		if (data.external_identifier !== undefined) {
+			if (this.accountability && this.accountability.admin !== true) {
+				throw new InvalidPayloadException(`You can't change the "external_identifier" value manually.`);
+			}
+
+			data.auth_data = null;
 		}
 
 		return await super.updateMany(keys, data, opts);


### PR DESCRIPTION
## Description

Addresses https://github.com/directus/directus/pull/16436#issuecomment-1315630944

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
