### PR TITLE
Fix translations-display width

### DIFF
--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -127,6 +127,7 @@ const translations = computed(() => {
 
 .display-translations {
 	display: inline-flex;
+	max-width: 100%;
 	align-items: center;
 
 	.icon {


### PR DESCRIPTION
## Description
Fixes #16521
The issue was related with translations display. Setting max-width: 100%; on .display-translations was solved the problem.

## Before
![image](https://user-images.githubusercontent.com/26179694/202808187-d40b2a8a-5ee9-4782-84d8-42c65dbcb009.png)
![image](https://user-images.githubusercontent.com/26179694/202808892-21e3e61f-50f9-4390-9189-5679eb43653a.png)

## After
![image](https://user-images.githubusercontent.com/26179694/202808201-b70a58a6-bc40-4ea0-8bdc-d7cb8d1dbc3e.png)
![image](https://user-images.githubusercontent.com/26179694/202808921-eb3087dc-beb2-4520-8c53-c3e210b26d79.png)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
