### PR TITLE
Throttle idle event listeners

### DIFF
--- a/app/src/idle.test.ts
+++ b/app/src/idle.test.ts
@@ -1,0 +1,95 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, SpyInstance, test, vi } from 'vitest';
+import { DefineComponent, defineComponent, h, onMounted, onUnmounted } from 'vue';
+
+const timeoutDuration = 5 * 60 * 1000; // 5 min in ms
+
+vi.mock('lodash', () => ({
+	throttle: vi.fn((fn, _wait) => fn),
+}));
+
+describe('idle', () => {
+	let testComponent: DefineComponent<any>;
+	let idleTrackerEmitSpy: SpyInstance;
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+
+		const { idleTracker, startIdleTracking, stopIdleTracking } = await import('./idle');
+
+		testComponent = defineComponent({
+			setup() {
+				onMounted(() => startIdleTracking());
+				onUnmounted(() => stopIdleTracking());
+			},
+			render: () => h('div'),
+		});
+
+		idleTrackerEmitSpy = vi.spyOn(idleTracker, 'emit');
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+
+		// Ensure the internal visible & idle variables in the imported idle
+		// are reset before every test
+		vi.resetModules();
+	});
+
+	test('should emit "hide"/"show" when document visibility changes', () => {
+		mount(testComponent);
+
+		// mock document visibility state
+		Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+
+		document.dispatchEvent(new Event('visibilitychange'));
+
+		expect(idleTrackerEmitSpy).toHaveBeenCalledWith('hide');
+
+		// mock document visibility state
+		Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+
+		document.dispatchEvent(new Event('visibilitychange'));
+
+		expect(idleTrackerEmitSpy).toHaveBeenCalledWith('show');
+	});
+
+	test('should not emit "idle" before the timeout has passed', () => {
+		mount(testComponent);
+
+		document.dispatchEvent(new PointerEvent('pointerdown'));
+
+		// advance less than the idle timeout duration
+		vi.advanceTimersByTime(1000);
+
+		expect(idleTrackerEmitSpy).not.toHaveBeenCalledWith('idle');
+	});
+
+	test('should emit "idle" after the timeout has passed', () => {
+		mount(testComponent);
+
+		document.dispatchEvent(new PointerEvent('pointerdown'));
+
+		// advance past the idle timeout duration (added 1000 just in case there's timing issues)
+		vi.advanceTimersByTime(timeoutDuration + 1000);
+
+		expect(idleTrackerEmitSpy).toHaveBeenCalledWith('idle');
+	});
+
+	test('should emit "active" after being idle', () => {
+		mount(testComponent);
+
+		document.dispatchEvent(new PointerEvent('pointerdown'));
+
+		// advance past the idle timeout duration (added 1000 just in case there's timing issues)
+		vi.advanceTimersByTime(timeoutDuration + 1000);
+
+		// stop the current idle state
+		document.dispatchEvent(new PointerEvent('pointerdown'));
+
+		// advance past the throttle duration (500)
+		vi.advanceTimersByTime(1000);
+
+		expect(idleTrackerEmitSpy).toHaveBeenCalledWith('active');
+	});
+});

--- a/app/src/idle.test.ts
+++ b/app/src/idle.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, SpyInstance, test, vi } from 'vitest';
 import { DefineComponent, defineComponent, h, onMounted, onUnmounted } from 'vue';
 
-const timeoutDuration = 5 * 60 * 1000; // 5 min in ms
+import { time as timeoutDuration } from './idle';
 
 vi.mock('lodash', () => ({
 	throttle: vi.fn((fn, _wait) => fn),

--- a/app/src/idle.ts
+++ b/app/src/idle.ts
@@ -2,7 +2,7 @@ import { throttle } from 'lodash';
 import mitt from 'mitt';
 
 const events = ['pointermove', 'pointerdown', 'keydown'];
-const time = 5 * 60 * 1000; // 5 min in ms
+export const time = 5 * 60 * 1000; // 5 min in ms
 
 let timeout: number | null;
 

--- a/app/src/idle.ts
+++ b/app/src/idle.ts
@@ -1,20 +1,23 @@
+import { throttle } from 'lodash';
 import mitt from 'mitt';
 
 const events = ['pointermove', 'pointerdown', 'keydown'];
 const time = 5 * 60 * 1000; // 5 min in ms
 
-let timeout: NodeJS.Timeout;
+let timeout: number | null;
 
 let visible = true;
 let idle = false;
 
 export const idleTracker = mitt();
 
+const throttledOnIdleEvents = throttle(onIdleEvents, 500);
+
 export function startIdleTracking(): void {
 	document.addEventListener('visibilitychange', onVisibilityChange);
 
 	for (const event of events) {
-		document.addEventListener(event, onIdleEvents);
+		document.addEventListener(event, throttledOnIdleEvents);
 	}
 
 	resetTimeout();
@@ -24,7 +27,7 @@ export function stopIdleTracking(): void {
 	document.removeEventListener('visibilitychange', onVisibilityChange);
 
 	for (const event of events) {
-		document.removeEventListener(event, onIdleEvents);
+		document.removeEventListener(event, throttledOnIdleEvents);
 	}
 }
 
@@ -51,10 +54,11 @@ function onVisibilityChange() {
 
 function resetTimeout() {
 	if (timeout) {
-		clearTimeout(timeout);
+		window.clearTimeout(timeout);
+		timeout = null;
 	}
 
-	timeout = setTimeout(() => {
+	timeout = window.setTimeout(() => {
 		idle = true;
 		idleTracker.emit('idle');
 	}, time);


### PR DESCRIPTION
## Description

Currently when either of the following event is fired:

https://github.com/directus/directus/blob/12786728ed3d2c1808863fca3fcdda588d0e2c0f/app/src/idle.ts#L3

it'll call `resetTimeout` function within `onIdleEvents`:

https://github.com/directus/directus/blob/12786728ed3d2c1808863fca3fcdda588d0e2c0f/app/src/idle.ts#L31-L38

Which then calls window `clearTimeout`:

https://github.com/directus/directus/blob/12786728ed3d2c1808863fca3fcdda588d0e2c0f/app/src/idle.ts#L53-L55

However this is happening quite a number of times particularly with `pointermove` event as seen here:

https://user-images.githubusercontent.com/42867097/203023698-328536f4-a90a-47ee-b231-f2a72f2866ca.mp4

This PR adds a throttle to reduce the `clearTimeout` calls a little.

### After PR

https://user-images.githubusercontent.com/42867097/203023744-835d2a26-d18b-49e6-b553-b9569541c5ed.mp4

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
