### PR TITLE
SSO / OpenID: Add `nonce` to request

### DIFF
--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -99,6 +99,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				code_challenge_method: 'S256',
 				// Some providers require state even with PKCE
 				state: codeChallenge,
+				nonce: codeChallenge,
 			});
 		} catch (e) {
 			throw handleError(e);
@@ -126,10 +127,11 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 
 		try {
 			const client = await this.client;
+			const codeChallenge = generators.codeChallenge(payload.codeVerifier);
 			tokenSet = await client.callback(
 				this.redirectUrl,
 				{ code: payload.code, state: payload.state },
-				{ code_verifier: payload.codeVerifier, state: generators.codeChallenge(payload.codeVerifier) }
+				{ code_verifier: payload.codeVerifier, state: codeChallenge, nonce: codeChallenge }
 			);
 			userInfo = tokenSet.claims();
 


### PR DESCRIPTION
## Description
### Issue
When using Amazon Cognito as OpenID provider, we found that it failed at first login attempt but succeeded at second attempt to login.

After some research we found that Amazon Cognito sends a `nonce` field and because Directus does not set any, it throws an error.
We also found that other users were facing the same issue: https://github.com/panva/node-openid-client/discussions/456

### Solution
Because Amazon Cognito is creating it's own `nonce`, when `openid-client` tries to compare with Directus `nonce` value, it fails because Directus does not set any.
The solution is just to provide a `nonce` value on request. The third party should resend the same value and when comparing it should succeed. This is similar to `state` value (required by Okta).

Note: In order to test this, I have set up an Amazon Cognito app and an Azure AD app. Here's a tutorial how to set it up:
https://aws.amazon.com/blogs/security/how-to-set-up-amazon-cognito-for-federated-authentication-using-azure-ad/

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
