### PR TITLE
Pass emitEvents to query methods in item-read & item-delete operations

### DIFF
--- a/api/src/operations/item-delete/index.test.ts
+++ b/api/src/operations/item-delete/index.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { ItemsService } from '../../services';
+import config from './index';
+
+vi.mock('../../services', () => {
+	const ItemsService = vi.fn();
+	ItemsService.prototype.deleteByQuery = vi.fn();
+	ItemsService.prototype.deleteOne = vi.fn();
+	ItemsService.prototype.deleteMany = vi.fn();
+	return { ItemsService };
+});
+
+const getSchema = vi.fn().mockResolvedValue({});
+
+vi.mock('../../utils/get-accountability-for-role', () => ({
+	getAccountabilityForRole: vi.fn((role: string | null, _context) => Promise.resolve(role)),
+}));
+
+const testCollection = 'test';
+const testQuery = { limit: -1 };
+const testId = '00000000-0000-0000-0000-000000000000';
+const testAccountability = { user: testId, role: testId };
+
+describe('Operations / Item Delete', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test.each([
+		{ permissions: undefined, expected: testAccountability },
+		{ permissions: '$trigger', expected: testAccountability },
+		{ permissions: '$full', expected: 'system' },
+		{ permissions: '$public', expected: null },
+		{ permissions: 'test', expected: 'test' },
+	])('accountability for permissions "$permissions" should be $expected', async ({ permissions, expected }) => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, permissions } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService).toHaveBeenCalledWith(
+			testCollection,
+			expect.objectContaining({ schema: {}, accountability: expected, knex: undefined })
+		);
+	});
+
+	test('should have fallback when query is not defined', async () => {
+		await config.handler(
+			{ collection: testCollection } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteByQuery).toHaveBeenCalledWith({}, expect.anything());
+	});
+
+	test.each([undefined, []])('should call deleteByQuery with correct query when key is $payload', async (key) => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, key } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteByQuery).toHaveBeenCalledWith(testQuery, expect.anything());
+		expect(ItemsService.prototype.deleteOne).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.deleteMany).not.toHaveBeenCalled();
+	});
+
+	test('should emit events for deleteByQuery when true', async () => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, emitEvents: true } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteByQuery).toHaveBeenCalledWith(testQuery, { emitEvents: true });
+	});
+
+	test.each([undefined, false])('should not emit events for deleteByQuery when %s', async (emitEvents) => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, emitEvents } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteByQuery).toHaveBeenCalledWith(testQuery, { emitEvents: false });
+	});
+
+	test.each([1, [1]])('should call deleteOne when key is $payload', async (key) => {
+		await config.handler(
+			{ collection: testCollection, key } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteByQuery).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.deleteOne).toHaveBeenCalled();
+		expect(ItemsService.prototype.deleteMany).not.toHaveBeenCalled();
+	});
+
+	test('should emit events for deleteOne when true', async () => {
+		const key = 1;
+		await config.handler(
+			{ collection: testCollection, key, emitEvents: true } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteOne).toHaveBeenCalledWith(key, { emitEvents: true });
+	});
+
+	test.each([undefined, false])('should not emit events for deleteOne when %s', async (emitEvents) => {
+		const key = 1;
+		await config.handler(
+			{ collection: testCollection, key, emitEvents } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteOne).toHaveBeenCalledWith(key, { emitEvents: false });
+	});
+
+	test('should call deleteMany when key is an array with more than one item', async () => {
+		await config.handler(
+			{ collection: testCollection, key: [1, 2, 3] } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteByQuery).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.deleteOne).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.deleteMany).toHaveBeenCalled();
+	});
+
+	test('should emit events for deleteMany when true', async () => {
+		const keys = [1, 2, 3];
+		await config.handler(
+			{ collection: testCollection, key: keys, emitEvents: true } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteMany).toHaveBeenCalledWith(keys, { emitEvents: true });
+	});
+
+	test.each([undefined, false])('should not emit events for deleteMany when %s', async (emitEvents) => {
+		const keys = [1, 2, 3];
+		await config.handler(
+			{ collection: testCollection, key: keys, emitEvents } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.deleteMany).toHaveBeenCalledWith(keys, { emitEvents: false });
+	});
+});

--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -41,7 +41,7 @@ export default defineOperationApi<Options>({
 		let result: PrimaryKey | PrimaryKey[] | null;
 
 		if (!key || (Array.isArray(key) && key.length === 0)) {
-			result = await itemsService.deleteByQuery(sanitizedQueryObject);
+			result = await itemsService.deleteByQuery(sanitizedQueryObject, { emitEvents: !!emitEvents });
 		} else {
 			const keys = toArray(key);
 

--- a/api/src/operations/item-read/index.test.ts
+++ b/api/src/operations/item-read/index.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { ItemsService } from '../../services';
+import config from './index';
+
+vi.mock('../../services', () => {
+	const ItemsService = vi.fn();
+	ItemsService.prototype.readByQuery = vi.fn();
+	ItemsService.prototype.readOne = vi.fn();
+	ItemsService.prototype.readMany = vi.fn();
+	return { ItemsService };
+});
+
+const getSchema = vi.fn().mockResolvedValue({});
+
+vi.mock('../../utils/get-accountability-for-role', () => ({
+	getAccountabilityForRole: vi.fn((role: string | null, _context) => Promise.resolve(role)),
+}));
+
+const testCollection = 'test';
+const testQuery = { limit: -1 };
+const testId = '00000000-0000-0000-0000-000000000000';
+const testAccountability = { user: testId, role: testId };
+
+describe('Operations / Item Read', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test.each([
+		{ permissions: undefined, expected: testAccountability },
+		{ permissions: '$trigger', expected: testAccountability },
+		{ permissions: '$full', expected: 'system' },
+		{ permissions: '$public', expected: null },
+		{ permissions: 'test', expected: 'test' },
+	])('accountability for permissions "$permissions" should be $expected', async ({ permissions, expected }) => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, permissions } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService).toHaveBeenCalledWith(
+			testCollection,
+			expect.objectContaining({ schema: {}, accountability: expected, knex: undefined })
+		);
+	});
+
+	test('should have fallback when query is not defined', async () => {
+		await config.handler(
+			{ collection: testCollection } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readByQuery).toHaveBeenCalledWith({}, expect.anything());
+	});
+
+	test.each([undefined, []])('should call readByQuery with correct query when key is $payload', async (key) => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, key } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readByQuery).toHaveBeenCalledWith(testQuery, expect.anything());
+		expect(ItemsService.prototype.readOne).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.readMany).not.toHaveBeenCalled();
+	});
+
+	test('should emit events for readByQuery when true', async () => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, emitEvents: true } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readByQuery).toHaveBeenCalledWith(testQuery, { emitEvents: true });
+	});
+
+	test.each([undefined, false])('should not emit events for readByQuery when %s', async (emitEvents) => {
+		await config.handler(
+			{ collection: testCollection, query: testQuery, emitEvents } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readByQuery).toHaveBeenCalledWith(testQuery, { emitEvents: false });
+	});
+
+	test.each([1, [1]])('should call readOne when key is $payload', async (key) => {
+		await config.handler(
+			{ collection: testCollection, key } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readByQuery).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.readOne).toHaveBeenCalled();
+		expect(ItemsService.prototype.readMany).not.toHaveBeenCalled();
+	});
+
+	test('should emit events for readOne when true', async () => {
+		const key = 1;
+		await config.handler(
+			{ collection: testCollection, key, emitEvents: true } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readOne).toHaveBeenCalledWith(key, {}, { emitEvents: true });
+	});
+
+	test.each([undefined, false])('should not emit events for readOne when %s', async (emitEvents) => {
+		const key = 1;
+		await config.handler(
+			{ collection: testCollection, key, emitEvents } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readOne).toHaveBeenCalledWith(key, {}, { emitEvents: false });
+	});
+
+	test('should call readMany when key is an array with more than one item', async () => {
+		await config.handler(
+			{ collection: testCollection, key: [1, 2, 3] } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readByQuery).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.readOne).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.readMany).toHaveBeenCalled();
+	});
+
+	test('should emit events for readMany when true', async () => {
+		const keys = [1, 2, 3];
+		await config.handler(
+			{ collection: testCollection, key: keys, emitEvents: true } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readMany).toHaveBeenCalledWith(keys, {}, { emitEvents: true });
+	});
+
+	test.each([undefined, false])('should not emit events for readMany when %s', async (emitEvents) => {
+		const keys = [1, 2, 3];
+		await config.handler(
+			{ collection: testCollection, key: keys, emitEvents } as any,
+			{ accountability: testAccountability, getSchema } as any
+		);
+
+		expect(ItemsService.prototype.readMany).toHaveBeenCalledWith(keys, {}, { emitEvents: false });
+	});
+});

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -42,7 +42,7 @@ export default defineOperationApi<Options>({
 		let result: Item | Item[] | null;
 
 		if (!key || (Array.isArray(key) && key.length === 0)) {
-			result = await itemsService.readByQuery(sanitizedQueryObject);
+			result = await itemsService.readByQuery(sanitizedQueryObject, { emitEvents: !!emitEvents });
 		} else {
 			const keys = toArray(key);
 


### PR DESCRIPTION
## Description

Currently `deleteByQuery` in item-delete flows operation is not passing `emitEvents` to it's options, but `deleteOne` and `deleteMany` does have it:

https://github.com/directus/directus/blob/8a3dc4b68b36217b97110e2e3dabaaf20be59648/api/src/operations/item-delete/index.ts#L43-L53

Similar issue can be seen for `readByQuery` in item-read flows operation:

https://github.com/directus/directus/blob/8a3dc4b68b36217b97110e2e3dabaaf20be59648/api/src/operations/item-read/index.ts#L44-L54

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
