### PR TITLE
fix wrong default ip

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -146,7 +146,7 @@ export default defineConfig({
 		port: 8080,
 		proxy: {
 			'^/(?!admin)': {
-				target: process.env.API_URL ? process.env.API_URL : 'http://0.0.0.0:8055/',
+				target: process.env.API_URL ? process.env.API_URL : 'http://localhost:8055/',
 				changeOrigin: true,
 			},
 		},

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -146,7 +146,7 @@ export default defineConfig({
 		port: 8080,
 		proxy: {
 			'^/(?!admin)': {
-				target: process.env.API_URL ? process.env.API_URL : 'http://localhost:8055/',
+				target: process.env.API_URL ? process.env.API_URL : 'http://127.0.0.1:8055/',
 				changeOrigin: true,
 			},
 		},


### PR DESCRIPTION
Fix Vite default proxy to be an allowed ip. @rijkvanzanten why did you change that to `http://0.0.0.0:8055` as that is not a valid ip in that context?

https://github.com/directus/directus/blame/8a3dc4b68b36217b97110e2e3dabaaf20be59648/app/vite.config.js#L149