### PR TITLE
Optimize stores hydration calls

### DIFF
--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -185,21 +185,18 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
-			await collectionsStore.hydrate();
-			await fieldsStore.hydrate();
+			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
 			router.replace(`/settings/data-model`);
 		}
 
 		async function saveAndStay() {
 			await save();
-			await collectionsStore.hydrate();
-			await fieldsStore.hydrate();
+			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
 		}
 
 		async function saveAndQuit() {
 			await save();
-			await collectionsStore.hydrate();
-			await fieldsStore.hydrate();
+			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
 			router.push(`/settings/data-model`);
 		}
 

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -252,18 +252,18 @@ export default defineComponent({
 					},
 				});
 
+				const storeHydrations: Promise<void>[] = [];
+
 				const relations = getSystemRelations();
 
 				if (relations.length > 0) {
-					for (const relation of relations) {
-						await api.post('/relations', relation);
-					}
-
-					await relationsStore.hydrate();
+					const requests = relations.map((relation) => api.post('/relations', relation));
+					await Promise.all(requests);
+					storeHydrations.push(relationsStore.hydrate());
 				}
 
-				await collectionsStore.hydrate();
-				await fieldsStore.hydrate();
+				storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate());
+				await Promise.all(storeHydrations);
 
 				notify({
 					title: t('collection_created'),

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -446,8 +446,7 @@ export default defineComponent({
 			if (newLang && newLang !== locale.value) {
 				await setLanguage(newLang);
 
-				await fieldsStore.hydrate();
-				await collectionsStore.hydrate();
+				await Promise.all([fieldsStore.hydrate(), collectionsStore.hydrate()]);
 			}
 		}
 

--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -165,8 +165,8 @@ export const useCollectionsStore = defineStore({
 
 			try {
 				await api.delete(`/collections/${collection}`);
-				await this.hydrate();
-				await relationsStore.hydrate();
+				await Promise.all([this.hydrate(), relationsStore.hydrate()]);
+
 				notify({
 					title: i18n.global.t('delete_collection_success'),
 				});


### PR DESCRIPTION
## Description

Minor optimization for store hydration calls after a particular CRUD action relating to collections/fields/relations.

Example comparison of the waterfall when creating a new collection, where it fires 2 new `/relations` requests when user create and user update fields are added, followed up by `/relations` `/collections` `/fields` request fired by respective store hydrations:

### Before

![](https://user-images.githubusercontent.com/42867097/203584419-72908000-6c11-451a-a965-645c79dcf8a1.png)

### After

![](https://user-images.githubusercontent.com/42867097/203584437-e0611163-309d-462d-9e80-ae915ee5f666.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
