### PR TITLE
Always expand first item when sidebar is open

### DIFF
--- a/app/src/views/private/components/sidebar-detail-group.vue
+++ b/app/src/views/private/components/sidebar-detail-group.vue
@@ -32,7 +32,8 @@ export default defineComponent({
 					// Still allow the user to manually close it afterwards
 					mandatory.value = false;
 				}
-			}
+			},
+			{ immediate: true }
 		);
 
 		return {


### PR DESCRIPTION
## Description

On page changes with an already opened sidebar, currently no item is expanded by default.
Unlike this, the first item is automatically expanded when the sidebar is opened manually.
This became more apparent after #15861, as the sidebar can now be in open state after a page reload as well.
With this pull request the first item will always be expanded (on page change and reload) when the sidebar is in open state.

WDYT? Maybe we could omit the transition when the sidebar is not manually opened.

https://user-images.githubusercontent.com/5363448/203595131-61160ef6-f17e-46b7-9de6-0f1918bdf3c4.mp4

https://user-images.githubusercontent.com/5363448/203595145-513d1c9e-b88f-4732-b9d9-29b4457d3010.mp4

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
