### PR TITLE
 Re-add entrypoint type definition files in `@directus/shared`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,6 +50,7 @@
 	},
 	"files": [
 		"dist",
+		"*.d.ts",
 		"!**/*.test.js",
 		"!**/*.d.ts.map"
 	],


### PR DESCRIPTION
## Description

Closes #16602, also mentioned in discussion #16601

The "entrypoint type definition files" in `@directus/shared` have accidentally been excluded in #16374. Although I carefully reviewed the changes at the time, I must have overlooked them. I'm sorry about that!

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
