### PR TITLE
Cast numeric filter values as number for _eq and _neq operators

### DIFF
--- a/packages/shared/src/utils/generate-joi.test.ts
+++ b/packages/shared/src/utils/generate-joi.test.ts
@@ -127,6 +127,26 @@ describe(`generateJoi`, () => {
 		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
 	});
 
+	it(`returns the correct schema for an empty string _eq match`, () => {
+		const mockFieldFilter = { field: { _eq: '' } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().equal(''),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for an empty string _neq match`, () => {
+		const mockFieldFilter = { field: { _neq: '' } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().not(''),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
 	it(`returns the correct schema for an _ncontains contain match`, () => {
 		const mockFieldFilter = { field: { _ncontains: 'field' } } as FieldFilter;
 		const mockSchema = Joi.object({

--- a/packages/shared/src/utils/generate-joi.test.ts
+++ b/packages/shared/src/utils/generate-joi.test.ts
@@ -147,6 +147,46 @@ describe(`generateJoi`, () => {
 		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
 	});
 
+	it(`returns the correct schema for a true _eq match`, () => {
+		const mockFieldFilter = { field: { _eq: true } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().equal(true),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a true _neq match`, () => {
+		const mockFieldFilter = { field: { _neq: true } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().not(true),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a false _eq match`, () => {
+		const mockFieldFilter = { field: { _eq: false } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().equal(false),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a false _neq match`, () => {
+		const mockFieldFilter = { field: { _neq: false } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().not(false),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
 	it(`returns the correct schema for an _ncontains contain match`, () => {
 		const mockFieldFilter = { field: { _ncontains: 'field' } } as FieldFilter;
 		const mockSchema = Joi.object({

--- a/packages/shared/src/utils/generate-joi.test.ts
+++ b/packages/shared/src/utils/generate-joi.test.ts
@@ -67,6 +67,66 @@ describe(`generateJoi`, () => {
 		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
 	});
 
+	it(`returns the correct schema for an integer _eq match`, () => {
+		const mockFieldFilter = { field: { _eq: '123' } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().equal('123', 123),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for an integer _neq match`, () => {
+		const mockFieldFilter = { field: { _neq: '123' } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().not('123', 123),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a float _eq match`, () => {
+		const mockFieldFilter = { field: { _eq: '123.456' } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().equal('123.456', 123.456),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a float _neq match`, () => {
+		const mockFieldFilter = { field: { _neq: '123.456' } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().not('123.456', 123.456),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a null _eq match`, () => {
+		const mockFieldFilter = { field: { _eq: null } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().equal(null),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
+	it(`returns the correct schema for a null _neq match`, () => {
+		const mockFieldFilter = { field: { _neq: null } } as FieldFilter;
+		const mockSchema = Joi.object({
+			field: Joi.any().not(null),
+		})
+			.unknown()
+			.describe();
+		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
+	});
+
 	it(`returns the correct schema for an _ncontains contain match`, () => {
 		const mockFieldFilter = { field: { _ncontains: 'field' } } as FieldFilter;
 		const mockSchema = Joi.object({

--- a/packages/shared/src/utils/generate-joi.ts
+++ b/packages/shared/src/utils/generate-joi.ts
@@ -104,7 +104,7 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 		const getDateSchema = () => (schema[key] ?? Joi.date()) as DateSchema;
 
 		if (operator === '_eq') {
-			const numericValue = compareValue !== null ? Number(compareValue) : NaN;
+			const numericValue = compareValue === null || compareValue === '' ? NaN : Number(compareValue);
 			if (isNaN(numericValue)) {
 				schema[key] = getAnySchema().equal(compareValue);
 			} else {
@@ -113,7 +113,7 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 		}
 
 		if (operator === '_neq') {
-			const numericValue = compareValue !== null ? Number(compareValue) : NaN;
+			const numericValue = compareValue === null || compareValue === '' ? NaN : Number(compareValue);
 			if (isNaN(numericValue)) {
 				schema[key] = getAnySchema().not(compareValue);
 			} else {

--- a/packages/shared/src/utils/generate-joi.ts
+++ b/packages/shared/src/utils/generate-joi.ts
@@ -104,11 +104,21 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 		const getDateSchema = () => (schema[key] ?? Joi.date()) as DateSchema;
 
 		if (operator === '_eq') {
-			schema[key] = getAnySchema().equal(compareValue);
+			const numericValue = compareValue !== null ? Number(compareValue) : NaN;
+			if (isNaN(numericValue)) {
+				schema[key] = getAnySchema().equal(compareValue);
+			} else {
+				schema[key] = getAnySchema().equal(compareValue, numericValue);
+			}
 		}
 
 		if (operator === '_neq') {
-			schema[key] = getAnySchema().not(compareValue);
+			const numericValue = compareValue !== null ? Number(compareValue) : NaN;
+			if (isNaN(numericValue)) {
+				schema[key] = getAnySchema().not(compareValue);
+			} else {
+				schema[key] = getAnySchema().not(compareValue, numericValue);
+			}
 		}
 
 		if (operator === '_contains') {

--- a/packages/shared/src/utils/generate-joi.ts
+++ b/packages/shared/src/utils/generate-joi.ts
@@ -104,7 +104,10 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 		const getDateSchema = () => (schema[key] ?? Joi.date()) as DateSchema;
 
 		if (operator === '_eq') {
-			const numericValue = compareValue === null || compareValue === '' ? NaN : Number(compareValue);
+			const numericValue =
+				compareValue === null || compareValue === '' || compareValue === true || compareValue === false
+					? NaN
+					: Number(compareValue);
 			if (isNaN(numericValue)) {
 				schema[key] = getAnySchema().equal(compareValue);
 			} else {
@@ -113,7 +116,10 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 		}
 
 		if (operator === '_neq') {
-			const numericValue = compareValue === null || compareValue === '' ? NaN : Number(compareValue);
+			const numericValue =
+				compareValue === null || compareValue === '' || compareValue === true || compareValue === false
+					? NaN
+					: Number(compareValue);
 			if (isNaN(numericValue)) {
 				schema[key] = getAnySchema().not(compareValue);
 			} else {


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #16649 by allowing equality with the corresponding numeric values.

The filter value in filters are stored in the string format.
For example: `{ "year(updated_on)": { "_eq": "2023" } }`

Hence when using `_eq` with `year()`, it fails validation as `2023 !== '2023'`.

Added checks for `null`, `""` and boolean values as such `Number(<value>)` becomes `0`. 

Fixes ENG-126

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
