### PR TITLE
Remove TZ conversion for timestamps in MySQL

### DIFF
--- a/api/src/database/helpers/fn/dialects/mysql.ts
+++ b/api/src/database/helpers/fn/dialects/mysql.ts
@@ -1,44 +1,37 @@
 import { FnHelper, FnHelperOptions } from '../types';
 import { Knex } from 'knex';
 
-const parseLocaltime = (columnType?: string) => {
-	if (columnType === 'timestamp') {
-		return `CONVERT_TZ(??.??, @@GLOBAL.time_zone, '+00:00')`;
-	}
-	return '??.??';
-};
-
 export class FnHelperMySQL extends FnHelper {
-	year(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`YEAR(${parseLocaltime(options?.type)})`, [table, column]);
+	year(table: string, column: string): Knex.Raw {
+		return this.knex.raw('YEAR(??.??)', [table, column]);
 	}
 
-	month(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`MONTH(${parseLocaltime(options?.type)})`, [table, column]);
+	month(table: string, column: string): Knex.Raw {
+		return this.knex.raw('MONTH(??.??)', [table, column]);
 	}
 
-	week(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`WEEK(${parseLocaltime(options?.type)})`, [table, column]);
+	week(table: string, column: string): Knex.Raw {
+		return this.knex.raw('WEEK(??.??)', [table, column]);
 	}
 
-	day(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DAYOFMONTH(${parseLocaltime(options?.type)})`, [table, column]);
+	day(table: string, column: string): Knex.Raw {
+		return this.knex.raw('DAYOFMONTH(??.??)', [table, column]);
 	}
 
-	weekday(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`DAYOFWEEK(${parseLocaltime(options?.type)})`, [table, column]);
+	weekday(table: string, column: string): Knex.Raw {
+		return this.knex.raw('DAYOFWEEK(??.??)', [table, column]);
 	}
 
-	hour(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`HOUR(${parseLocaltime(options?.type)})`, [table, column]);
+	hour(table: string, column: string): Knex.Raw {
+		return this.knex.raw('HOUR(??.??)', [table, column]);
 	}
 
-	minute(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`MINUTE(${parseLocaltime(options?.type)})`, [table, column]);
+	minute(table: string, column: string): Knex.Raw {
+		return this.knex.raw('MINUTE(??.??)', [table, column]);
 	}
 
-	second(table: string, column: string, options: FnHelperOptions): Knex.Raw {
-		return this.knex.raw(`SECOND(${parseLocaltime(options?.type)})`, [table, column]);
+	second(table: string, column: string): Knex.Raw {
+		return this.knex.raw('SECOND(??.??)', [table, column]);
 	}
 
 	count(table: string, column: string, options?: FnHelperOptions): Knex.Raw {


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #16619. The timestamp processed with date functions in MySQL do not include the timezone `+00:00` value. Hence the casting to UTC should be removed. Fixes ENG-129

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
