### PR TITLE
Translations: Fix missing `tfa_setup`

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -582,6 +582,7 @@ select_an_item: Select an item...
 edit: Edit
 enabled: Enabled
 disable_tfa: Disable 2FA
+tfa_setup: Setup 2FA
 tfa_scan_code: Scan the code in your authenticator app to finish setting up 2FA
 enter_otp_to_disable_tfa: Enter the OTP to disable 2FA
 create_account: Create Account

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -582,6 +582,7 @@ select_an_item: Select an item...
 edit: Edit
 enabled: Enabled
 disable_tfa: Disable 2FA
+admin_disable_tfa_text: Are you sure you want to disable 2FA for this user?
 tfa_setup: Setup 2FA
 tfa_scan_code: Scan the code in your authenticator app to finish setting up 2FA
 enter_otp_to_disable_tfa: Enter the OTP to disable 2FA


### PR DESCRIPTION
## Description

Currently when role is configured with TFA enabled and when user don't have it configured yet, user is redirected to the TFA setup view.
In this view there's a big title `tfa_setup` and that's because there's no entry in translations for it.

This PR just adds that label so it shows `Setup 2FA` or the respective translation for other languages.

|Before|After|
|-|-|
| <img width="300" alt="Screenshot 2022-12-04 at 11 11 23" src="https://user-images.githubusercontent.com/14039341/205487223-27b2d9d7-77ac-4470-bd5f-be15960fb955.png"> | <img width="300" alt="Screenshot 2022-12-04 at 11 10 50" src="https://user-images.githubusercontent.com/14039341/205487240-9aac56f5-b776-49e3-af17-fa9798823cba.png"> |

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
