### PR TITLE
Tweak datetime picker styles

### DIFF
--- a/app/src/styles/lib/_flatpickr.scss
+++ b/app/src/styles/lib/_flatpickr.scss
@@ -276,7 +276,7 @@ span.flatpickr-weekday {
 
 .flatpickr-time input {
 	color: var(--v-input-color);
-	background: var(--v-input-background-color);
+	background: var(--background-subdued);
 	transition: var(--fast) var(--transition);
 	transition-property: color, background;
 }
@@ -311,6 +311,8 @@ span.flatpickr-weekday {
 
 .flatpickr-time input:focus,
 .flatpickr-time .flatpickr-am-pm:focus {
+	border: var(--border-width) solid var(--primary);
+	border-radius: var(--border-radius);
 	background-color: var(--background-input);
 }
 
@@ -327,5 +329,5 @@ span.flatpickr-weekday {
 }
 
 .flatpickr-calendar .set-to-now-button:hover {
-	background-color: var(--background-highlight);
+	background-color: var(--background-normal);
 }


### PR DESCRIPTION
## Description

Closes #16709

CUrrently the hour and minute inputs has the same background color when not focused _and_ when focused, so it can be hard to tell which one is being focused. Added a similar "rounded primary-colored-border on focus" input style to them.

Also opted to tweak the "Set Now" button's highlight color on hover, as the dark theme in particular had a slightly different colored highlight.

### Comparisons

|Theme|Before|After|
|---|---|---|
|Light|![](https://user-images.githubusercontent.com/42867097/205552058-f2629a2b-0e99-4283-a240-190905303816.gif)|![](https://user-images.githubusercontent.com/42867097/205552226-65398aca-17c7-4132-aa1a-3f56034c59a7.gif)|
|Dark|![](https://user-images.githubusercontent.com/42867097/205552271-ed9d3ba5-c8ba-4d40-8554-106867c60ac7.gif)|![](https://user-images.githubusercontent.com/42867097/205552281-7ba80e04-b53e-4009-ba8e-8a4a3c06e714.gif)|

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
