### PR TITLE
Export redirects to wrong page when hosted in a subfolder

### DIFF
--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -221,7 +221,7 @@
 
 <script lang="ts" setup>
 import api from '@/api';
-import { getRootPath } from '@/utils/get-root-path';
+import { getPublicURL } from '@/utils/get-root-path';
 import { notify } from '@/utils/notify';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { Filter } from '@directus/shared/types';
@@ -477,8 +477,7 @@ function exportDataLocal() {
 	const endpoint = collection.value.startsWith('directus_')
 		? `${collection.value.substring(9)}`
 		: `items/${collection.value}`;
-
-	const url = getRootPath() + endpoint;
+	const url = getPublicURL() + endpoint;
 
 	let params: Record<string, unknown> = {
 		access_token: api.defaults.headers.common['Authorization'].substring(7),


### PR DESCRIPTION
## Description

When directus is hosted in a subfolder like `http://localhost:8055/proxy` then the window open call used for exports would result in a duplication of this folder like `http://localhost:8080/proxy/proxy/items/:collection?...`.

By providing the `window.open` call with an absolute url instead of a relative path this won't happen.

Fixes #16718 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
