### PR TITLE
Align ASSETS_CACHE_TTL default value in .env stub

### DIFF
--- a/api/src/cli/utils/create-env/env-stub.liquid
+++ b/api/src/cli/utils/create-env/env-stub.liquid
@@ -149,8 +149,8 @@ CACHE_ENABLED=false
 # memory | redis | memcache
 CACHE_STORE=memory
 
-# How long assets will be cached for in the browser. Sets the max-age value of the Cache-Control header ["30m"]
-ASSETS_CACHE_TTL="30m"
+# How long assets will be cached for in the browser. Sets the max-age value of the Cache-Control header ["30d"]
+ASSETS_CACHE_TTL="30d"
 
 # CACHE_REDIS="redis://@127.0.0.1:5105"
 # CACHE_MEMCACHE="localhost:5109"


### PR DESCRIPTION
## Description

It was updated to `30d` in https://github.com/directus/directus/commit/f512ba5c1dcc85ac204c99d6a6ed612b0b878057, so aligning the value in `.env` file stub to it. PR prompted by directus/docs#222

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Tweak

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
