### PR TITLE
Remove duplicated type for interfaceConfig group

### DIFF
--- a/packages/shared/src/types/interfaces.ts
+++ b/packages/shared/src/types/interfaces.ts
@@ -20,7 +20,7 @@ export interface InterfaceConfig {
 		| null;
 	types: readonly Type[];
 	localTypes?: readonly LocalType[];
-	group?: 'standard' | 'selection' | 'relational' | 'presentation' | 'presentation' | 'group' | 'other';
+	group?: 'standard' | 'selection' | 'relational' | 'presentation' | 'group' | 'other';
 	order?: number;
 	relational?: boolean;
 	hideLabel?: boolean;


### PR DESCRIPTION
## Description

Currently `presentation` is duplicated in the following union type:

https://github.com/directus/directus/blob/9405e87a3495de47754100328fa04debf062af0a/packages/shared/src/types/interfaces.ts#L23

Additional note: PR prompted by directus/docs#229.

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
