### PR TITLE
Add auth.register hook for oauth2 and openid drivers

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -6,6 +6,8 @@ import jwt from 'jsonwebtoken';
 import ms from 'ms';
 import { Client, errors, generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth';
+import getDatabase from '../../database/index';
+import emitter from '../../emitter';
 import env from '../../env';
 import {
 	InvalidConfigException,
@@ -154,16 +156,27 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsException();
 		}
 
+		const userPayload = {
+			provider,
+			first_name: userInfo[this.config.firstNameKey],
+			last_name: userInfo[this.config.lastNameKey],
+			email: email,
+			external_identifier: identifier,
+			role: this.config.defaultRoleId,
+			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
+		};
+
+		// Run hook so the end user has the chance to augment the
+		// user that is about to be created
+		const updatedUserPayload = await emitter.emitFilter(
+			`auth.register`,
+			userPayload,
+			{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo },
+			{ database: getDatabase(), schema: this.schema, accountability: null }
+		);
+
 		try {
-			await this.usersService.createOne({
-				provider,
-				first_name: userInfo[this.config.firstNameKey],
-				last_name: userInfo[this.config.lastNameKey],
-				email: email,
-				external_identifier: identifier,
-				role: this.config.defaultRoleId,
-				auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
-			});
+			await this.usersService.createOne(updatedUserPayload);
 		} catch (e) {
 			if (e instanceof RecordNotUniqueException) {
 				logger.warn(e, '[OAuth2] Failed to register user. User not unique');


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

To create the correct User Roles, based on the access_token from oauth and openid providers, we require access to the access_token within the event. This used to be possible but isn't anymore as described in this issue here:

https://github.com/directus/directus/issues/10414

I discovered that there was already a PR open for this but it became stale. I created a new one, based on the existing one (https://github.com/directus/directus/pull/11306) 

Running the e2e tests locally seems to be a problem for me. Does the compose file work with M1 macs? I get warnings regarding the databases not being platform compatible and 2 of them never finish booting.

Fixes #

## Type of Change

- [ ] Bugfix
- [X] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally (see note above)
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated. PR: https://github.com/directus/docs/pull/233
