### PR TITLE
Use Node.js 18 for Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16-alpine
+ARG NODE_VERSION=18-alpine
 
 FROM node:${NODE_VERSION} as builder
 


### PR DESCRIPTION
## Description

Since v18 is the current active LTS of [Node.js](https://nodejs.dev/en/about/releases/) we should move to this version in the Docker image as well.

I'm not aware of any breaking changes from v16 -> v18 which could lead to issues, but I'd like to have this confirmed by others.
On the other hand v18 comes with a few interesting updates and features, see the [release announcement](https://nodejs.org/en/blog/announcements/v18-release-announce/).
For example the update of the V8 engine and things like `FormData` which became available (ref #16777).

Built and tested locally ✅ 

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
