### PR TITLE
Add register and update hooks for oauth2 and openid drivers

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -154,9 +154,13 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			// Run hook so the end user has the chance to augment the
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
-				`auth.oauth2.update`,
+				`auth.update`,
 				{},
-				{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo, userPayload },
+				{
+					identifier,
+					provider: this.config.provider,
+					providerPayload: { accessToken: tokenSet.access_token, userInfo },
+				},
 				{ database: getDatabase(), schema: this.schema, accountability: null }
 			);
 
@@ -175,9 +179,13 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		// Run hook so the end user has the chance to augment the
 		// user that is about to be created
 		const updatedUserPayload = await emitter.emitFilter(
-			`auth.oauth2.create`,
+			`auth.create`,
 			userPayload,
-			{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo },
+			{
+				identifier,
+				provider: this.config.provider,
+				providerPayload: { accessToken: tokenSet.access_token, userInfo },
+			},
 			{ database: getDatabase(), schema: this.schema, accountability: null }
 		);
 

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -5,6 +5,8 @@ import flatten from 'flat';
 import jwt from 'jsonwebtoken';
 import { Client, errors, generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth';
+import getDatabase from '../../database/index';
+import emitter from '../../emitter';
 import env from '../../env';
 import {
 	InvalidConfigException,
@@ -136,15 +138,31 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsException();
 		}
 
+		const userPayload = {
+			provider,
+			first_name: userInfo[this.config.firstNameKey],
+			last_name: userInfo[this.config.lastNameKey],
+			email: email,
+			external_identifier: identifier,
+			role: this.config.defaultRoleId,
+			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
+		};
+
 		const userId = await this.fetchUserId(identifier);
 
 		if (userId) {
-			// Update user refreshToken if provided
-			if (tokenSet.refresh_token) {
-				await this.usersService.updateOne(userId, {
-					auth_data: JSON.stringify({ refreshToken: tokenSet.refresh_token }),
-				});
-			}
+			// Run hook so the end user has the chance to augment the
+			// user that is about to be updated
+			const updatedUserPayload = await emitter.emitFilter(
+				`auth.oauth2.update`,
+				{},
+				{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo, userPayload },
+				{ database: getDatabase(), schema: this.schema, accountability: null }
+			);
+
+			// Update user to update refresh_token and other properties that might have changed
+			await this.usersService.updateOne(userId, updatedUserPayload);
+
 			return userId;
 		}
 
@@ -154,16 +172,17 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsException();
 		}
 
+		// Run hook so the end user has the chance to augment the
+		// user that is about to be created
+		const updatedUserPayload = await emitter.emitFilter(
+			`auth.oauth2.create`,
+			userPayload,
+			{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo },
+			{ database: getDatabase(), schema: this.schema, accountability: null }
+		);
+
 		try {
-			await this.usersService.createOne({
-				provider,
-				first_name: userInfo[this.config.firstNameKey],
-				last_name: userInfo[this.config.lastNameKey],
-				email: email,
-				external_identifier: identifier,
-				role: this.config.defaultRoleId,
-				auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
-			});
+			await this.usersService.createOne(updatedUserPayload);
 		} catch (e) {
 			if (e instanceof RecordNotUniqueException) {
 				logger.warn(e, '[OAuth2] Failed to register user. User not unique');

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -177,9 +177,13 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// Run hook so the end user has the chance to augment the
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
-				`auth.openid.update`,
+				`auth.update`,
 				{},
-				{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo, userPayload },
+				{
+					identifier,
+					provider: this.config.provider,
+					providerPayload: { accessToken: tokenSet.access_token, userInfo },
+				},
 				{ database: getDatabase(), schema: this.schema, accountability: null }
 			);
 
@@ -200,9 +204,13 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		// Run hook so the end user has the chance to augment the
 		// user that is about to be created
 		const updatedUserPayload = await emitter.emitFilter(
-			`auth.openid.create`,
+			`auth.create`,
 			userPayload,
-			{ identifier, provider: this.config.provider, accessToken: tokenSet.access_token, userInfo },
+			{
+				identifier,
+				provider: this.config.provider,
+				providerPayload: { accessToken: tokenSet.access_token, userInfo },
+			},
 			{ database: getDatabase(), schema: this.schema, accountability: null }
 		);
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

To create the correct User Roles, based on the access_token from oauth and openid providers, we require access to the access_token within the event. This used to be possible but isn't anymore as described in this issue here:

https://github.com/directus/directus/issues/10414

I discovered that there was already a PR open for this but it became stale. I created a new one, based on the existing one (https://github.com/directus/directus/pull/11306). Upon implementation I noticed that it's not just necessary to create users but also to update them when they return.

These new hooks allow it to assign correct roles to newly and returning users if the openid or oauth provider has roles added to the access_token. In our case this is keycloak.

Fixes #

## Type of Change

- [ ] Bugfix
- [X] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated. PR: https://github.com/directus/docs/pull/233
