### PR TITLE
POC: Transform array queries received as object due to QS limit

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -388,7 +388,15 @@ export function applyFilter(
 
 					validateFilterOperator(type, filterOperator, special);
 
-					applyFilterToQuery(`${collection}.${filterPath[0]}`, filterOperator, filterValue, logical);
+					const processedFilterValue =
+						filterOperator === '_in' &&
+						typeof filterValue[0] === 'object' &&
+						!Array.isArray(filterValue[0]) &&
+						filterValue[0] !== null
+							? Object.values(filterValue[0])
+							: filterValue;
+
+					applyFilterToQuery(`${collection}.${filterPath[0]}`, filterOperator, processedFilterValue, logical);
 				}
 			} else if (subQuery === false || filterPath.length > 1) {
 				if (!relation) continue;


### PR DESCRIPTION
## Description

Veeery simple POC to address #16745 with the approach described in https://github.com/directus/directus/issues/16745#issuecomment-1342892598.

When the limit is reached the params are received as follows:
```json
"filter": {
  "test": {
    "_in": [
      {
        "1": "1",
        "2": "2",
        "3": "3",
        "4": "4",
        "9999": "9999"
      }
    ]
  }
}
```

As opposed to:
```json
"filter": {
  "test": {
    "_in": [
      "1"
      "2"
      "3"
      "4"
    ]
  }
}
```

**TODOs**:

- [ ] Clarify whether this is a reasonable approach
- [ ] Cover all cases (operators, ...), think about side cases (e.g. could `filterValue[0]` be an object even when limit is not reached?)
- [ ] Add tests
- [ ] Possibly introduce another limit so Directus cannot be flooded with unlimited filters (currently blocked "unintentionally" by the QS limit)

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
