### PR TITLE
Support for role hierarchy (including public)

### DIFF
--- a/api/src/database/seeds/02-roles.yaml
+++ b/api/src/database/seeds/02-roles.yaml
@@ -5,6 +5,12 @@ columns:
     type: uuid
     primary: true
     nullable: false
+  parent_role:
+    type: uuid
+    nullable: true
+    references:
+      table: directus_roles
+      column: id
   name:
     type: string
     length: 100

--- a/api/src/database/system-data/fields/roles.yaml
+++ b/api/src/database/system-data/fields/roles.yaml
@@ -7,6 +7,17 @@ fields:
     special:
       - uuid
 
+  - field: parent_role
+    interface: select-dropdown-m2o
+    options:
+      template: '{{ name }}'
+    special:
+      - m2o
+    width: half
+    display: related-values
+    display_options:
+      template: '{{ name }}'
+
   - field: name
     interface: input
     options:

--- a/api/src/database/system-data/relations/relations.yaml
+++ b/api/src/database/system-data/relations/relations.yaml
@@ -123,3 +123,7 @@ data:
   - many_collection: directus_shares
     many_field: user_created
     one_collection: directus_users
+  - many_collection: directus_roles
+    many_field: parent_role
+    one_collection: directus_roles
+    one_field: child_roles


### PR DESCRIPTION
## Description

Added a parent_role field to the role collection, and changed the getPermissions function to use the role hierarchy to enumerate and merge the tree of permissions together. Also changed it to include the null role (public role in the GUI).

Not a final solution, but a decent workaround for now to this:
https://github.com/directus/directus/discussions/4959

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [X] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
