### PR TITLE
Remove deprecated npm flag in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   build-base \
   && ln -sf /usr/bin/python3 /usr/bin/python \
   ; fi
-RUN npm i --only=production --no-package-lock
+RUN npm install --no-package-lock
 RUN rm *.tgz
 
 # Directus image


### PR DESCRIPTION
## Description

Tiny fix / enhancement: The npm [`--only`](https://docs.npmjs.com/cli/v9/using-npm/config#only) flag has been deprecated a long time ago. Removing it just to make sure nothing breaks in the future and to get rid of the following warning currently shown during the image build process:
```console
 => => # npm WARN config only Use `--omit=dev` to omit dev dependencies from the install.
```

Since we only define production dependencies in the corresponding `package.json` file anyway, we can completely remove the flag. 
I've confirmed that the exact same amount of packages are installed as without this change (running `npm list --all`).

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
