### PR TITLE
Support address type of node mailer

### DIFF
--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -11,7 +11,6 @@ import { Accountability, SchemaOverview } from '@directus/shared/types';
 import getMailer from '../../mailer';
 import { Transporter, SendMailOptions } from 'nodemailer';
 import { Url } from '../../utils/url';
-import { object } from 'joi';
 import { Address } from 'nodemailer/lib/mailer/index';
 
 const liquidEngine = new Liquid({


### PR DESCRIPTION
## Description

Add support for node mailer [from address](https://nodemailer.com/message/addresses/)
This would allow sending an address object in the `from` field
```
{
    name: 'Michael',
    address: 'michael@example.com'
}
```

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
