### PR TITLE
File Storage 2.0: Make metadata extraction backward-compatible

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -119,6 +119,7 @@
 		"graphql": "16.6.0",
 		"graphql-compose": "9.0.10",
 		"helmet": "6.0.0",
+		"icc": "2.0.0",
 		"inquirer": "8.2.4",
 		"ioredis": "5.2.4",
 		"joi": "17.7.0",

--- a/api/src/types/shims.d.ts
+++ b/api/src/types/shims.d.ts
@@ -11,3 +11,8 @@ declare module 'pino-http' {
 		req: (req: any) => Record<string, any>;
 	};
 }
+
+declare module 'icc' {
+	const parse: (buf: Buffer) => Record<string, string>;
+	export { parse };
+}

--- a/api/src/utils/parse-image-metadata.ts
+++ b/api/src/utils/parse-image-metadata.ts
@@ -1,0 +1,83 @@
+const IPTC_ENTRY_TYPES = new Map([
+	[0x78, 'caption'],
+	[0x6e, 'credit'],
+	[0x19, 'keywords'],
+	[0x37, 'dateCreated'],
+	[0x50, 'byline'],
+	[0x55, 'bylineTitle'],
+	[0x7a, 'captionWriter'],
+	[0x69, 'headline'],
+	[0x74, 'copyright'],
+	[0x0f, 'category'],
+]);
+
+const IPTC_ENTRY_MARKER = Buffer.from([0x1c, 0x02]);
+
+export function parseIptc(buffer: Buffer): Record<string, unknown> {
+	if (!Buffer.isBuffer(buffer)) return {};
+
+	const iptc: Record<string, any> = {};
+	let lastIptcEntryPos = buffer.indexOf(IPTC_ENTRY_MARKER);
+
+	while (lastIptcEntryPos !== -1) {
+		lastIptcEntryPos = buffer.indexOf(IPTC_ENTRY_MARKER, lastIptcEntryPos + IPTC_ENTRY_MARKER.byteLength);
+
+		const iptcBlockTypePos = lastIptcEntryPos + IPTC_ENTRY_MARKER.byteLength;
+		const iptcBlockSizePos = iptcBlockTypePos + 1;
+		const iptcBlockDataPos = iptcBlockSizePos + 2;
+
+		const iptcBlockType = buffer.readUInt8(iptcBlockTypePos);
+		const iptcBlockSize = buffer.readUInt16BE(iptcBlockSizePos);
+
+		if (!IPTC_ENTRY_TYPES.has(iptcBlockType)) {
+			continue;
+		}
+
+		const iptcBlockTypeId = IPTC_ENTRY_TYPES.get(iptcBlockType);
+		const iptcData = buffer.subarray(iptcBlockDataPos, iptcBlockDataPos + iptcBlockSize).toString();
+
+		if (iptcBlockTypeId) {
+			if (iptc[iptcBlockTypeId] == null) {
+				iptc[iptcBlockTypeId] = iptcData;
+			} else if (Array.isArray(iptc[iptcBlockTypeId])) {
+				iptc[iptcBlockTypeId].push(iptcData);
+			} else {
+				iptc[iptcBlockTypeId] = [iptc[iptcBlockTypeId], iptcData];
+			}
+		}
+	}
+
+	return iptc;
+}
+
+export function parseXmp(buffer: Buffer): Record<string, unknown> {
+	const xmp: Record<string, unknown> = {};
+
+	['title', 'description', 'rights', 'creator', 'subject'].forEach((x) => {
+		const tagRegex = new RegExp(`<dc:${x}>(.*?)</dc:${x}>`, 'smig'),
+			tagMatches = tagRegex.exec(buffer.toString());
+
+		if (!tagMatches || tagMatches.length === 0) {
+			return;
+		}
+
+		const value = tagMatches[1].trim();
+
+		if (value.toLowerCase().indexOf('<rdf:bag>') === 0) {
+			const r = new RegExp('<rdf:li>(.*?)</rdf:li>', 'smig');
+			let match = r.exec(value);
+			const result = [];
+
+			while (match) {
+				result.push(match[1]);
+
+				match = r.exec(value);
+			}
+			xmp[x] = result;
+		} else {
+			xmp[x] = value.replace(/<[^>]*>?/gm, '').trim();
+		}
+	});
+
+	return xmp;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,7 @@ importers:
       graphql: 16.6.0
       graphql-compose: 9.0.10
       helmet: 6.0.0
+      icc: 2.0.0
       inquirer: 8.2.4
       ioredis: 5.2.4
       joi: 17.7.0
@@ -257,6 +258,7 @@ importers:
       graphql: 16.6.0
       graphql-compose: 9.0.10_graphql@16.6.0
       helmet: 6.0.0
+      icc: 2.0.0
       inquirer: 8.2.4
       ioredis: 5.2.4
       joi: 17.7.0
@@ -10028,7 +10030,7 @@ packages:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
       tar: 6.1.13
@@ -14033,6 +14035,11 @@ packages:
     dependencies:
       ms: 2.1.3
     optional: true
+
+  /icc/2.0.0:
+    resolution: {integrity: sha512-VSTak7UAcZu1E24YFvcoHVpVg/ZUVyb0G1v0wUIibfz5mHvcFeI/Gpn8C0cAUKw5jCCGx5JBcV4gULu6hX97mA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -18392,6 +18399,14 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /promise-inflight/1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
   /promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
     peerDependencies:
@@ -18401,6 +18416,7 @@ packages:
         optional: true
     dependencies:
       bluebird: 3.7.2
+    dev: true
 
   /promise-retry/2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}


### PR DESCRIPTION
## Description

Extract & parse image metadata in a backward-compatible way (same layout as it used to be with `exifr`)

**Note:** The tag names itself may vary a bit

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
