### PR TITLE
Allow explicit region configuration

### DIFF
--- a/packages/storage-driver-s3/src/index.test.ts
+++ b/packages/storage-driver-s3/src/index.test.ts
@@ -70,6 +70,7 @@ beforeEach(() => {
 			serverSideEncryption: randWord(),
 			root: randDirectoryPath(),
 			endpoint: randDomainName(),
+			region: randWord(),
 		},
 		path: {
 			input: randUnique() + randFilePath(),
@@ -196,6 +197,23 @@ describe('#constructor', () => {
 				protocol: 'https:',
 				path: '/',
 			},
+			credentials: {
+				accessKeyId: sample.config.key,
+				secretAccessKey: sample.config.secret,
+			},
+		});
+	});
+
+	test('Sets region', () => {
+		new DriverS3({
+			key: sample.config.key,
+			secret: sample.config.secret,
+			bucket: sample.config.bucket,
+			region: sample.config.region,
+		});
+
+		expect(S3Client).toHaveBeenCalledWith({
+			region: sample.config.region,
 			credentials: {
 				accessKeyId: sample.config.key,
 				secretAccessKey: sample.config.secret,

--- a/packages/storage-driver-s3/src/index.ts
+++ b/packages/storage-driver-s3/src/index.ts
@@ -28,6 +28,7 @@ export type DriverS3Config = {
 	acl?: string;
 	serverSideEncryption?: string;
 	endpoint?: string;
+	region?: string;
 };
 
 export class DriverS3 implements Driver {
@@ -56,6 +57,10 @@ export class DriverS3 implements Driver {
 			};
 
 			s3ClientConfig.forcePathStyle = true;
+		}
+
+		if (config.region) {
+			s3ClientConfig.region = config.region;
 		}
 
 		this.client = new S3Client(s3ClientConfig);


### PR DESCRIPTION
## Description

Certain S3 compatible services will throw errors if the region isn't explicitly passed to the S3 client, even if the region is already provided through the endpoint. This change allows the region to be overwritten again, which resolves the discrepancies for those provider types.

Fixes #16876, fixes ENG-318

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
