### PR TITLE
Fix use-items loading state when an existing request gets canceled

### DIFF
--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -111,8 +111,7 @@ export default defineLayout<LayoutOptions>({
 				fields: queryFields,
 				filter: filterWithCalendarView,
 				search: search,
-			},
-			false
+			}
 		);
 
 		const events: Ref<EventInput> = computed(

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -60,7 +60,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 		return Math.ceil(itemCount.value / (unref(limit) ?? 100));
 	});
 
-	let currentRequest: CancelTokenSource | null = null;
+	let existingRequest: CancelTokenSource | null = null;
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
 	const fetchItems = throttle(getItems, 500);
@@ -121,8 +121,8 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 		let isCurrentRequestCanceled = false;
 
-		currentRequest?.cancel();
-		currentRequest = null;
+		existingRequest?.cancel();
+		existingRequest = null;
 
 		error.value = null;
 
@@ -154,7 +154,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 		fieldsToFetch = fieldsToFetch.filter((field) => field.startsWith('$') === false);
 
 		try {
-			currentRequest = axios.CancelToken.source();
+			existingRequest = axios.CancelToken.source();
 
 			const response = await api.get<any>(endpoint.value, {
 				params: {
@@ -166,7 +166,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 					search: unref(search),
 					filter: unref(filter),
 				},
-				cancelToken: currentRequest.token,
+				cancelToken: existingRequest.token,
 			});
 
 			let fetchedItems = response.data.data;

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -69,6 +69,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 	const fetchItems = throttle(getItems, 500);
 
+	// can this be removed to prevent double fetches?
 	if (fetchOnInit) {
 		fetchItems();
 	}
@@ -83,6 +84,10 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 			if (!newCollection || !query) return;
 
+			if (newCollection !== oldCollection) {
+				reset();
+			}
+
 			if (
 				!isEqual(newFilter, oldFilter) ||
 				!isEqual(newSort, oldSort) ||
@@ -96,10 +101,6 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 
 			if (newCollection !== oldCollection || !isEqual(newFilter, oldFilter) || newSearch !== oldSearch) {
 				getItemCount();
-			}
-
-			if (newCollection !== oldCollection) {
-				reset();
 			}
 
 			fetchItems();

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -94,7 +94,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 				}
 			}
 
-			if (!isEqual(newFilter, oldFilter) || newSearch !== oldSearch) {
+			if (newCollection !== oldCollection || !isEqual(newFilter, oldFilter) || newSearch !== oldSearch) {
 				getItemCount();
 			}
 

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -34,7 +34,7 @@ type ComputedQuery = {
 	page: Ref<Query['page']> | WritableComputedRef<Query['page']>;
 };
 
-export function useItems(collection: Ref<string | null>, query: ComputedQuery, fetchOnInit = true): UsableItems {
+export function useItems(collection: Ref<string | null>, query: ComputedQuery): UsableItems {
 	const api = useApi();
 	const { primaryKeyField } = useCollection(collection);
 
@@ -68,11 +68,6 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
 	const fetchItems = throttle(getItems, 500);
-
-	// can this be removed to prevent double fetches?
-	if (fetchOnInit) {
-		fetchItems();
-	}
 
 	watch(
 		[collection, limit, sort, search, filter, fields, page],

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -205,7 +205,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 				loadingTimeout = null;
 			}
 
-			loading.value = false;
+			if (!loadingTimeout) loading.value = false;
 		}
 	}
 

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -154,8 +154,6 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 		fieldsToFetch = fieldsToFetch.filter((field) => field.startsWith('$') === false);
 
 		try {
-			// existingRequest = axios.CancelToken.source();
-
 			const response = await api.get<any>(endpoint.value, {
 				params: {
 					limit: unref(limit),
@@ -167,7 +165,6 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 					filter: unref(filter),
 				},
 				signal: existingRequests.items.signal,
-				// cancelToken: existingRequest.token,
 			});
 
 			let fetchedItems = response.data.data;

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -119,6 +119,8 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 	async function getItems() {
 		if (!endpoint.value) return;
 
+		let isCurrentRequestCanceled = false;
+
 		currentRequest?.cancel();
 		currentRequest = null;
 
@@ -192,11 +194,13 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 				page.value = 1;
 			}
 		} catch (err: any) {
-			if (!axios.isCancel(err)) {
+			if (axios.isCancel(err)) {
+				isCurrentRequestCanceled = true;
+			} else {
 				error.value = err;
 			}
 		} finally {
-			if (loadingTimeout) {
+			if (loadingTimeout && !isCurrentRequestCanceled) {
 				clearTimeout(loadingTimeout);
 				loadingTimeout = null;
 			}

--- a/packages/shared/src/composables/use-items.ts
+++ b/packages/shared/src/composables/use-items.ts
@@ -237,44 +237,56 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery, f
 	async function getTotalCount() {
 		if (!endpoint.value) return;
 
-		if (existingRequests.total) existingRequests.total.abort();
-		existingRequests.total = new AbortController();
+		try {
+			if (existingRequests.total) existingRequests.total.abort();
+			existingRequests.total = new AbortController();
 
-		const response = await api.get<any>(endpoint.value, {
-			params: {
-				aggregate: {
-					count: '*',
+			const response = await api.get<any>(endpoint.value, {
+				params: {
+					aggregate: {
+						count: '*',
+					},
 				},
-			},
-			signal: existingRequests.total.signal,
-		});
+				signal: existingRequests.total.signal,
+			});
 
-		const count = Number(response.data.data[0].count);
-		existingRequests.total = null;
+			const count = Number(response.data.data[0].count);
+			existingRequests.total = null;
 
-		totalCount.value = count;
+			totalCount.value = count;
+		} catch (err: any) {
+			if (!axios.isCancel(err)) {
+				throw err;
+			}
+		}
 	}
 
 	async function getItemCount() {
 		if (!endpoint.value) return;
 
-		if (existingRequests.filter) existingRequests.filter.abort();
-		existingRequests.filter = new AbortController();
+		try {
+			if (existingRequests.filter) existingRequests.filter.abort();
+			existingRequests.filter = new AbortController();
 
-		const response = await api.get<any>(endpoint.value, {
-			params: {
-				filter: unref(filter),
-				search: unref(search),
-				aggregate: {
-					count: '*',
+			const response = await api.get<any>(endpoint.value, {
+				params: {
+					filter: unref(filter),
+					search: unref(search),
+					aggregate: {
+						count: '*',
+					},
 				},
-			},
-			signal: existingRequests.filter.signal,
-		});
+				signal: existingRequests.filter.signal,
+			});
 
-		const count = Number(response.data.data[0].count);
-		existingRequests.filter = null;
+			const count = Number(response.data.data[0].count);
+			existingRequests.filter = null;
 
-		itemCount.value = count;
+			itemCount.value = count;
+		} catch (err: any) {
+			if (!axios.isCancel(err)) {
+				throw err;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description

Closes #16883

Within the use-items composable, whenever a request starts, it'll attempt to cancel an existing request that has yet to be completed:

https://github.com/directus/directus/blob/602f5db4f73101fda2292de3487635b2ae046b49/packages/shared/src/composables/use-items.ts#L122

However even if an **existing** request gets canceled, it will still enter it's `finally` block here and clear the loadingTimeout that is already set by the **current** request:

https://github.com/directus/directus/blob/602f5db4f73101fda2292de3487635b2ae046b49/packages/shared/src/composables/use-items.ts#L194-L205

but this causes the **current** request to not being able to set loading to true, so it's causing an odd "No Items" state when this happens, as seen below.

https://user-images.githubusercontent.com/42867097/209074826-369be24c-a14f-4a71-afa2-a57a21e18db4.mp4

### Example timeline of how this problem occurs

(`finally` below refers to the `finally` block of try/catch/finally)

1. Request A starts
2. Request A assigns loadingTimeout
3. Request A loadingTimeout finishes and set loading to true
4. Request B starts
5. Request B cancels request A
6. Request B assigns loadingTimeout
7. Request A is canceled, so it goes to Request A `finally` to clear loadingTimeout, but it shouldn't because this ends up clearing Request B's loadingTimeout, so now loading is still never set to true at all
8. Since Request B was never able to set loading to true, and it is still in pending fetching the items (`items.length` is zero), the "No Items" table body in `<v-table>` is (mistakenly) shown:

    https://github.com/directus/directus/blob/602f5db4f73101fda2292de3487635b2ae046b49/app/src/components/v-table/v-table.vue#L42-L46

9. Request B completes, and it goes to Request B `finally` to clear loadingTimeout (but it's already cleared due to Request A)

### After PR

https://user-images.githubusercontent.com/42867097/209074879-7cfa7750-69f4-44af-a5fa-739b7472b516.mp4

### Additional changes

I've also opted to rename `currentRequest` to `existingRequest`, as it feels like it's slightly more accurate to describe it is attempting to cancel a request that is already (and still) running, and not the "current" request. Another reason is partially it might be a bit confusing if `isCurrentRequestCanceled = false` is followed up directly by `currentRequest?.cancel()`.
 
## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
