### PR TITLE
Add Pie Chart panel

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -582,6 +582,8 @@ select_an_item: Select an item...
 edit: Edit
 enabled: Enabled
 disable_tfa: Disable 2FA
+admin_disable_tfa_text: Are you sure you want to disable 2FA for this user?
+tfa_setup: Setup 2FA
 tfa_scan_code: Scan the code in your authenticator app to finish setting up 2FA
 enter_otp_to_disable_tfa: Enter the OTP to disable 2FA
 create_account: Create Account

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -582,8 +582,6 @@ select_an_item: Select an item...
 edit: Edit
 enabled: Enabled
 disable_tfa: Disable 2FA
-admin_disable_tfa_text: Are you sure you want to disable 2FA for this user?
-tfa_setup: Setup 2FA
 tfa_scan_code: Scan the code in your authenticator app to finish setting up 2FA
 enter_otp_to_disable_tfa: Enter the OTP to disable 2FA
 create_account: Create Account
@@ -2045,10 +2043,14 @@ panels:
     donut: Donut
     show_labels: Show Labels
     show_legend: Show Legend
+    show_percentage: Show Percentage
     right: Right
     bottom: Bottom
     monochrome: Monochrome
     monochrome_color: Monochrome Color
+    shade_intensity: Shade Intensity
+    group_field: Group Field
+    aggregation_field: Aggregation Field
   variable:
     name: Global Variable
     description: Set a global value for use in other Panels' filters

--- a/app/src/panels/pie/index.ts
+++ b/app/src/panels/pie/index.ts
@@ -1,0 +1,198 @@
+import { useCollectionsStore } from '@/stores/collections';
+import { Filter } from '@directus/shared/types';
+import { definePanel } from '@directus/shared/utils';
+import PanelPie from './panel-pie.vue';
+
+export default definePanel({
+	id: 'pie',
+	name: '$t:panels.piechart.name',
+	description: '$t:panels.piechart.description',
+	icon: 'pie_chart',
+	query(options) {
+		if (!options?.groupField || !options?.function || !options?.aggregationField) {
+			return;
+		}
+
+		const collectionsStore = useCollectionsStore();
+		const collectionInfo = collectionsStore.getCollection(options.collection);
+
+		if (!collectionInfo) return;
+		if (collectionInfo?.meta?.singleton) return;
+
+		const filter: Filter = {
+			_and: [getParsedOptionsFilter(options.filter)],
+		};
+
+		return {
+			collection: options.collection,
+			query: {
+				group: options.groupField,
+				aggregate: {
+					[options.function]: [options.aggregationField],
+				},
+				filter,
+				limit: -1,
+			},
+		};
+
+		function getParsedOptionsFilter(filter: string | undefined) {
+			if (!filter) return {};
+			try {
+				return JSON.parse(filter);
+			} catch {
+				return filter;
+			}
+		}
+	},
+	component: PanelPie,
+	options: [
+		{
+			field: 'collection',
+			type: 'string',
+			name: '$t:collection',
+			meta: {
+				interface: 'system-collection',
+				options: {
+					includeSystem: true,
+					includeSingleton: false,
+				},
+				width: 'half',
+			},
+		},
+		{
+			field: 'groupField',
+			type: 'string',
+			name: '$t:panels.piechart.group_field',
+			meta: {
+				interface: 'system-field',
+				width: 'half',
+				options: {
+					allowForeignKeys: true,
+					collectionField: 'collection',
+					typeAllowList: ['integer', 'bigInteger', 'uuid', 'string', 'boolean'],
+				},
+			},
+		},
+		{
+			field: 'aggregationField',
+			type: 'string',
+			name: '$t:panels.piechart.aggregation_field',
+			meta: {
+				interface: 'system-field',
+				width: 'half',
+				options: {
+					allowForeignKeys: false,
+					collectionField: 'collection',
+					typeAllowList: ['integer', 'bigInteger', 'float', 'decimal'],
+				},
+				conditions: [
+					{
+						rule: {
+							function: {
+								_in: ['count', 'countDistinct'],
+							},
+						},
+						options: {
+							allowPrimaryKey: true,
+							allowForeignKeys: true,
+							typeAllowList: ['integer', 'bigInteger', 'uuid', 'string'],
+						},
+					},
+				],
+			},
+		},
+		{
+			field: 'function',
+			type: 'string',
+			name: '$t:group_aggregation',
+			meta: {
+				width: 'half',
+				interface: 'select-dropdown',
+				options: {
+					choices: [
+						{
+							text: 'Count',
+							value: 'count',
+						},
+						{
+							text: 'Count (Distinct)',
+							value: 'countDistinct',
+						},
+						{
+							text: 'Average',
+							value: 'avg',
+						},
+						{
+							text: 'Average (Distinct)',
+							value: 'avgDistinct',
+						},
+						{
+							text: 'Sum',
+							value: 'sum',
+						},
+						{
+							text: 'Sum (Distinct)',
+							value: 'sumDistinct',
+						},
+						{
+							text: 'Minimum',
+							value: 'min',
+						},
+						{
+							text: 'Maximum',
+							value: 'max',
+						},
+					],
+				},
+			},
+		},
+		{
+			field: 'filter',
+			type: 'json',
+			name: '$t:filter',
+			meta: {
+				interface: 'system-filter',
+				options: {
+					collectionField: 'collection',
+				},
+			},
+		},
+		{
+			field: 'showPercentage',
+			type: 'boolean',
+			name: '$t:panels.piechart.show_percentage',
+			meta: {
+				interface: 'boolean',
+				width: 'half',
+			},
+			schema: {
+				default_value: false,
+			},
+		},
+		{
+			field: 'color',
+			name: '$t:color',
+			type: 'string',
+			meta: {
+				interface: 'select-color',
+				width: 'half',
+			},
+		},
+		{
+			field: 'shadeIntensity',
+			name: '$t:panels.piechart.shade_intensity',
+			type: 'float',
+			meta: {
+				interface: 'input',
+				width: 'half',
+				options: {
+					min: 0,
+					max: 1,
+					placeholder: '0.35',
+				},
+			},
+		},
+	],
+	minWidth: 12,
+	minHeight: 12,
+});

--- a/app/src/panels/pie/panel-pie.vue
+++ b/app/src/panels/pie/panel-pie.vue
@@ -1,0 +1,138 @@
+<template>
+	<div class="pie">
+		<div ref="chartEl" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import Color from 'color';
+import { useFieldsStore } from '@/stores/fields';
+import { Filter } from '@directus/shared/types';
+import { cssVar } from '@directus/shared/utils/browser';
+import ApexCharts from 'apexcharts';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+
+const props = withDefaults(
+	defineProps<{
+		height: number;
+		showHeader?: boolean;
+		data?: object[];
+		id: string;
+		collection: string;
+		groupField: string;
+		aggregationField: string;
+		function: string;
+		filter?: Filter;
+		showPercentage?: boolean;
+		color?: string;
+		shadeIntensity?: number;
+	}>(),
+	{
+		showHeader: false,
+		data: () => [],
+		filter: () => ({}),
+		showPercentage: false,
+		color: () => cssVar('--primary'),
+		shadeIntensity: 0.35,
+	}
+);
+
+const fieldsStore = useFieldsStore();
+
+const chartEl = ref();
+const chart = ref<ApexCharts>();
+
+const value2Label = computed(() => {
+	const v2l: Record<string, string> = {};
+	const field = fieldsStore.getField(props.collection, props.groupField)!;
+	(field.meta?.options?.choices || []).forEach((c) => {
+		v2l[c.value] = c.text;
+	});
+	return v2l;
+});
+
+const labelTexts = computed(() => {
+	return props.data.map((d) => value2Label.value[d.group[props.groupField]] || String(d.group[props.groupField]));
+});
+
+const colors = computed(() => {
+	return labelTexts.value.map((l, i) => {
+		let c = Color(props.color);
+		c = c.lighten((props.shadeIntensity * i * (100 - c.lightness())) / c.lightness());
+		return c.hex();
+	});
+});
+
+const labelColors = computed(() => {
+	return colors.value.map((c) => {
+		const color = Color(c);
+		return color.isLight() ? '#000' : '#fff';
+	});
+});
+
+watch(
+	[() => props.data, () => props.showPercentage, () => props.color, () => props.shadeIntensity],
+	() => {
+		chart.value?.destroy();
+		setupChart();
+	},
+	{ deep: true }
+);
+
+onMounted(setupChart);
+
+onUnmounted(() => {
+	chart.value?.destroy();
+});
+
+function setupChart() {
+	const dataLabels = props.showPercentage
+		? {}
+		: {
+				formatter: function (val, opts) {
+					return opts.w.config.series[opts.seriesIndex];
+				},
+		  };
+	chart.value = new ApexCharts(chartEl.value, {
+		series: props.data.map((d) => d[props.function][props.aggregationField] ?? 0),
+		labels: labelTexts.value,
+		colors: colors.value,
+		chart: {
+			width: '100%',
+			height: '100%',
+			type: 'pie',
+			fontFamily: 'var(--family-sans-serif)',
+			foreColor: 'var(--foreground-subdued)',
+		},
+		legend: {
+			position: 'bottom',
+			fontFamily: 'var(--family-sans-serif)',
+			fontWeight: 600,
+		},
+		tooltip: {
+			theme: 'light',
+			style: {
+				fontFamily: 'var(--family-sans-serif)',
+			},
+		},
+		dataLabels: {
+			...dataLabels,
+			style: {
+				colors: labelColors.value,
+			},
+			dropShadow: {
+				enabled: false,
+			},
+		},
+	});
+
+	chart.value.render();
+}
+</script>
+
+<style scoped>
+.pie {
+	width: 100%;
+	height: 100%;
+}
+</style>


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

This will add a new panel that shows a pie chart. It uses a Group Field to group data and aggregate values using an Aggregation Field + a Function (i.e. count, sum) and displays the aggregated values. For example, you can set up a pie chart showing the ratio of each status of a column.

Common use cases:
- Show the ratio of published, draft, and archived blog posts.
- Show the ratio of paid, canceled, and unpaid orders.

Available options:
- **Collection**
- **Group Field**: used in `group` of GraphQL query.
- **Aggregation Field**: used in the value of `aggregate` of GraphQL query.
- **Function**: used in the key of `aggregate` of GraphQL query.
- **Filter**: filter out unwanted data.
- **Show Percentage**: if checked, shows percentage values on each slice instead of aggregated values.
- **Color**: the background color of the first slice.
- **Shade Intensity**: the background colors of the next slices are based on **Color** and **Shade Intensity**. **Shade Intensity** controls how much the colors will be lightened.

Screenshots:

![image](https://user-images.githubusercontent.com/23261928/209420041-8ca1079c-f499-40da-b89b-ef54ca2d7494.png)

![image](https://user-images.githubusercontent.com/23261928/209420067-a1a24fca-f31d-4aaa-992c-955f297c63ad.png)


## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
