### PR TITLE
Increase table sticky header offset

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="layout-tabular">
+	<div :class="$attrs.class" class="layout-tabular">
 		<v-table
 			v-if="loading || (itemCount && itemCount > 0)"
 			ref="table"

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -687,7 +687,7 @@ export default defineComponent({
 }
 
 .layout {
-	--layout-offset-top: 64px;
+	--layout-offset-top: calc(var(--header-bar-height) - 1px);
 }
 
 .bookmark-controls {

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -670,7 +670,7 @@ export default defineComponent({
 }
 
 .layout {
-	--layout-offset-top: 64px;
+	--layout-offset-top: calc(var(--header-bar-height) - 1px);
 }
 
 .drop-border {

--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -319,6 +319,6 @@ export default defineComponent({
 }
 
 .layout {
-	--layout-offset-top: 64px;
+	--layout-offset-top: calc(var(--header-bar-height) - 1px);
 }
 </style>

--- a/app/src/modules/settings/routes/webhooks/collection.vue
+++ b/app/src/modules/settings/routes/webhooks/collection.vue
@@ -200,6 +200,6 @@ export default defineComponent({
 }
 
 .layout {
-	--layout-offset-top: 64px;
+	--layout-offset-top: calc(var(--header-bar-height) - 1px);
 }
 </style>

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -371,6 +371,6 @@ function usePermissions() {
 }
 
 .layout {
-	--layout-offset-top: 64px;
+	--layout-offset-top: calc(var(--header-bar-height) - 1px);
 }
 </style>


### PR DESCRIPTION
## Description

Sticky table headers are not visible while scrolling

Fixes #16960

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
