### PR TITLE
WIP: use transformer preset key name if defined

### DIFF
--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -186,6 +186,6 @@ export class AssetsService {
 
 const getAssetSuffix = (transformation: TransformationParams | TransformationPreset, transforms: Transformation[]) => {
 	if (Object.keys(transforms).length === 0) return '';
-	if (transformation.key && transformation.key.length > 0) return transformation.key;
+	if (transformation.key && transformation.key.length > 0) return `__${transformation.key}`;
 	return `__${hash(transforms)}`;
 };

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -118,7 +118,7 @@ export class AssetsService {
 
 			const assetFilename =
 				path.basename(file.filename_disk, path.extname(file.filename_disk)) +
-				getAssetSuffix(transforms) +
+				getAssetSuffix(transformation, transforms) +
 				(maybeNewFormat ? `.${maybeNewFormat}` : path.extname(file.filename_disk));
 
 			const exists = await storage.location(file.storage).exists(assetFilename);
@@ -184,7 +184,8 @@ export class AssetsService {
 	}
 }
 
-const getAssetSuffix = (transforms: Transformation[]) => {
+const getAssetSuffix = (transformation: TransformationParams | TransformationPreset, transforms: Transformation[]) => {
 	if (Object.keys(transforms).length === 0) return '';
+	if (transformation.key && transformation.key.length > 0) return transformation.key;
 	return `__${hash(transforms)}`;
 };


### PR DESCRIPTION
## Description

context:
- #8065
- #9079
- #7612

This is just idea with code.

It's good to have predictable name for file entity name which is transformed by assets preset for serverless architecture imho.
For example, transforming image into webp 2x ratio with assets preset named `webp-2x`, file entity expected to be `${file key}__webp-2x`; so that, we would be able to use it via storage service like s3 directly.

I don't understand whole the directus system yet, especially why is it named with hash than key of `storage assets preset`. I beg your pardon if this idea is not good at all perhaps.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
