### PR TITLE
Add contextual info for hook handlers

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -28,6 +28,12 @@ export type QueryOptions = {
 	stripNonRequested?: boolean;
 	permissionsAction?: PermissionsAction;
 	emitEvents?: boolean;
+
+	/**
+	 * Contextual info for the database query to pass on to `context.info` in action and filter hooks.
+	 * Allows hook handlers to perform context-aware custom logic.
+	 */
+	info?: any;
 };
 
 export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractService {
@@ -113,6 +119,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 								database: trx,
 								schema: this.schema,
 								accountability: this.accountability,
+								info: opts?.info,
 							}
 					  )
 					: payload;
@@ -241,6 +248,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					database: getDatabase(),
 					schema: this.schema,
 					accountability: this.accountability,
+					info: opts?.info,
 				},
 			};
 
@@ -324,6 +332,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 							database: this.knex,
 							schema: this.schema,
 							accountability: this.accountability,
+							info: opts?.info,
 						}
 				  )
 				: query;
@@ -370,6 +379,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 							database: this.knex,
 							schema: this.schema,
 							accountability: this.accountability,
+							info: opts?.info,
 						}
 				  )
 				: records;
@@ -386,6 +396,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					database: this.knex || getDatabase(),
 					schema: this.schema,
 					accountability: this.accountability,
+					info: opts?.info,
 				}
 			);
 		}
@@ -528,6 +539,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 							database: this.knex,
 							schema: this.schema,
 							accountability: this.accountability,
+							info: opts?.info,
 						}
 				  )
 				: payload;
@@ -674,6 +686,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					database: getDatabase(),
 					schema: this.schema,
 					accountability: this.accountability,
+					info: opts?.info,
 				},
 			};
 
@@ -796,6 +809,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					database: this.knex,
 					schema: this.schema,
 					accountability: this.accountability,
+					info: opts?.info,
 				}
 			);
 		}
@@ -842,6 +856,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					database: getDatabase(),
 					schema: this.schema,
 					accountability: this.accountability,
+					info: opts?.info,
 				},
 			};
 

--- a/api/src/types/items.ts
+++ b/api/src/types/items.ts
@@ -45,6 +45,12 @@ export type MutationOptions = {
 	 * Can be used to queue up the nested events from item service's create, update and delete
 	 */
 	bypassEmitAction?: (params: ActionEventParams) => void;
+
+	/**
+	 * Contextual info for the database action to pass on to `context.info` in action and filter hooks.
+	 * Allows hook handlers to perform context-aware custom logic.
+	 */
+	info?: any;
 };
 
 export type ActionEventParams = {

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -6,6 +6,11 @@ export type EventContext = {
 	database: Knex;
 	schema: SchemaOverview | null;
 	accountability: Accountability | null;
+	/**
+	 * Contextual info passed with the performed database action.
+	 * Allows hook handlers to perform context-aware custom logic.
+	 */
+	info?: any;
 };
 
 export type FilterHandler<T = unknown> = (


### PR DESCRIPTION
## Description

Adds the ability to provide contextual info with database updates/reads that are passed on to hook handlers. Contrary to the `emitEvents` switch, this allows `action` and `filter` hook handlers themselves to decide *whether* and *how* to handle emitted events.

This is similar to contexts used in AceBase database updates (see [Get triggering context of events](https://github.com/appy-one/acebase#get-triggering-context-of-events)): it eliminates the need to add fields to the database schema and passing arbitrary info in the payload. It also enables contextual info to be added to read hooks, which would otherwise not be possible because there is no payload.

Example:

_my-service.js_:
```js
await itemService.updateOne(id, updates, { info: { source: 'my-service' } });
```
_remote_api_service.js_:
```js
await itemService.updateOne(id, updates, { info: { source: 'remote-api' } });
```
_my-hook.js_:
```js
action('mycollection.items.update', (meta, context) => {
   switch (context.info?.source) {
     case 'my-service':
       // update caused by "my-service"
       return handleMyServiceUpdate(meta, context);
     case 'remote-api':
       // update caused by sync from remote service
       return handleRemoteApiUpdate(meta, context);
     default: 
        // update from Directus UI / other reason. Sync to remote service
       return syncToRemoteApi(meta, context);
   }
});
```

_other-hook.js_:
```js
filter('mycollection.items.update', async (payload, meta, context) => {
  if (payload.content && context.info?.source === 'remote-api') {
    payload.md5 = await createHash(payload.content);
  }
  return payload;
});
```

There is no open issue for this, let me know if you'd want me to create one.

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally (`pnpm vitest run` in `api` succeeds)
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
