### PR TITLE
Add bottom margin to Slider interface to account for field note

### DIFF
--- a/app/src/components/v-slider.vue
+++ b/app/src/components/v-slider.vue
@@ -3,7 +3,7 @@
 		<div v-if="$slots.prepend" class="prepend">
 			<slot name="prepend" :value="modelValue" />
 		</div>
-		<div class="slider" :class="{ disabled }">
+		<div class="slider" :class="{ disabled, 'thumb-label-visible': showThumbLabel && alwaysShowValue }">
 			<input
 				:disabled="disabled"
 				type="range"
@@ -111,6 +111,10 @@ body {
 		&.disabled {
 			--v-slider-thumb-color: var(--foreground-subdued);
 			--v-slider-fill-color: var(--foreground-subdued);
+		}
+
+		&.thumb-label-visible {
+			margin-bottom: 30px;
 		}
 
 		input {

--- a/app/src/components/v-slider.vue
+++ b/app/src/components/v-slider.vue
@@ -223,6 +223,7 @@ body {
 		}
 
 		.thumb-label {
+			z-index: 1;
 			position: absolute;
 			top: 0px;
 			left: calc(var(--_v-slider-percentage) * 1%);


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #17021

Adds bottom margin when slider interface option `Always Show Value` is enabled:

|Before|After|
|---|---|
|![](https://user-images.githubusercontent.com/42867097/210764697-e77c3ed6-9b86-4c3d-bdef-d010ae725aa1.png)|![](https://user-images.githubusercontent.com/42867097/210764867-3fda6558-9ffd-4956-9883-c803d03d3239.png)|

However, I've also noticed that even if we were to not add bottom margin when it's not always shown, the label is still placed under/behind the field note, so I've added `z-index: 1` to fix this:

|Before|After|
|---|---|
|![](https://user-images.githubusercontent.com/42867097/210764373-710d9efe-24c0-4b8e-9e5c-e30a3117b08b.gif)|![](https://user-images.githubusercontent.com/42867097/210764634-941af1c2-909c-4e98-93c4-1739e547d00f.gif)|


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
