### PR TITLE
Don't double-root file ref

### DIFF
--- a/packages/storage-driver-gcs/src/index.test.ts
+++ b/packages/storage-driver-gcs/src/index.test.ts
@@ -165,11 +165,6 @@ describe('#file', () => {
 		} as unknown as Bucket;
 	});
 
-	test('Uses fullPath to inject root', () => {
-		driver['file'](sample.path.input);
-		expect(driver['fullPath']).toHaveBeenCalledWith(sample.path.input);
-	});
-
 	test('Returns file instance', () => {
 		const file = driver['file']('/path/to/file');
 		expect(file).toBe(mockFile);

--- a/packages/storage-driver-gcs/src/index.ts
+++ b/packages/storage-driver-gcs/src/index.ts
@@ -30,7 +30,7 @@ export class DriverGCS implements Driver {
 	}
 
 	private file(filepath: string) {
-		return this.bucket.file(this.fullPath(filepath));
+		return this.bucket.file(filepath);
 	}
 
 	async read(filepath: string, range?: Range) {


### PR DESCRIPTION
## Description

The GCS driver abstraction was prepending `root` twice when the `file` method was used. 

Fixes #17022, fixes ENG-392

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
