### PR TITLE
Wrap mime-type display in `span` node

### DIFF
--- a/app/src/displays/mime-type/index.ts
+++ b/app/src/displays/mime-type/index.ts
@@ -1,6 +1,7 @@
 import { defineDisplay } from '@directus/shared/utils';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import mime from 'mime/lite';
+import { h } from 'vue';
 
 export default defineDisplay({
 	id: 'mime-type',
@@ -26,10 +27,10 @@ export default defineDisplay({
 	types: ['string'],
 	component: ({ value, showAsExtension }: { value: string; showAsExtension: boolean }) => {
 		if (showAsExtension) {
-			return mime.getExtension(value);
+			return h('span', mime.getExtension(value));
 		}
 
-		return readableMimeType(value);
+		return h('span', readableMimeType(value));
 	},
 	handler: (value, options) => {
 		if (options.showAsExtension) {


### PR DESCRIPTION
## Description

Fixes #17073, fixes ENG-447

Uses the same solution used in #15841 for `filesize` display (but I've omitted the 2nd param in `h()` since it is also valid. Reference: https://vuejs.org/guide/extras/render-function.html#creating-vnodes).

### Before

![](https://user-images.githubusercontent.com/42867097/211783692-05ef8ad6-a423-4c2d-a42b-b2e01f8fc018.png)

### After

![](https://user-images.githubusercontent.com/42867097/211783701-891d50f6-f17e-410c-9c30-bb0b2436d9bc.png)


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
