### PR TITLE
From now a user who has readonly rights on a collection should not be allowed to activate the manual sort

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -15,7 +15,7 @@
 			:loading="loading"
 			:row-height="tableRowHeight"
 			:item-key="primaryKeyField?.field"
-			:show-manual-sort="sortField !== null"
+			:show-manual-sort="sortField !== null && !checkPermission(collection, 'read')"
 			:manual-sort-key="sortField"
 			allow-header-reorder
 			selection-use-keys
@@ -188,6 +188,7 @@ import { get } from '@directus/shared/utils';
 import { useAliasFields, AliasField } from '@/composables/use-alias-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { isEmpty, merge } from 'lodash';
+import { usePermissionsStore } from '@/stores/permissions';
 
 interface Props {
 	collection: string;
@@ -233,6 +234,14 @@ const props = withDefaults(defineProps<Props>(), {
 	onSortChange: () => undefined,
 	onAlignChange: () => undefined,
 });
+
+const permissionsStore = usePermissionsStore();
+
+const checkPermission = (collection: string, action: string) => {
+	const permissionOfCollection = permissionsStore.permissions.filter((item) => item.collection === collection);
+	const permissionOfAction = permissionOfCollection.filter((item) => item.action === action);
+	return permissionOfAction.length && permissionOfCollection.length === 1;
+};
 
 const emit = defineEmits(['update:selection', 'update:tableHeaders', 'update:limit', 'update:fields']);
 


### PR DESCRIPTION
This PR solves issue #16807: A user who has readonly rights on a collection should not be allowed to activate the manual sort  @rijkvanzanten 
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 

Final output:
![image](https://user-images.githubusercontent.com/113751840/211793912-bd6b8ea1-fd27-4826-b08f-b67b18ef34b3.png)

