### PR TITLE
Fix running npm init directus-extension

### DIFF
--- a/packages/create-directus-extension/lib/index.js
+++ b/packages/create-directus-extension/lib/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const inquirer = require('inquirer');
-const { EXTENSION_LANGUAGES, EXTENSION_PACKAGE_TYPES, EXTENSION_TYPES } = require('@directus/shared/constants');
+const { EXTENSION_LANGUAGES, EXTENSION_TYPES, BUNDLE_EXTENSION_TYPES } = require('@directus/shared/constants');
 const { create } = require('@directus/extensions-sdk/cli');
 
 run();
@@ -16,7 +16,7 @@ async function run() {
 			type: 'list',
 			name: 'type',
 			message: 'Choose the extension type',
-			choices: EXTENSION_PACKAGE_TYPES,
+			choices: EXTENSION_TYPES,
 		},
 		{
 			type: 'input',
@@ -28,7 +28,7 @@ async function run() {
 			name: 'language',
 			message: 'Choose the language to use',
 			choices: EXTENSION_LANGUAGES,
-			when: ({ type }) => EXTENSION_TYPES.includes(type),
+			when: ({ type }) => BUNDLE_EXTENSION_TYPES.includes(type) === false,
 		},
 	]);
 


### PR DESCRIPTION
The problem was that the `create-directus-extension` project still used old imports.