### PR TITLE
offset should be 0 not 1 by default

### DIFF
--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -12,7 +12,7 @@ const querySchema = Joi.object({
 	sort: Joi.array().items(Joi.string()),
 	filter: Joi.object({}).unknown(),
 	limit: Joi.number().integer().min(-1),
-	offset: Joi.number().integer().min(1),
+	offset: Joi.number().integer().min(0),
 	page: Joi.number().integer().min(0),
 	meta: Joi.array().items(Joi.string().valid('total_count', 'filter_count')),
 	search: Joi.string(),


### PR DESCRIPTION
## Description

offset was set to default to 1 as a minimum value which means we skip the first record and also breaks any queries using offset as 0 now.