### PR TITLE
Fix GraphQL server health output

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1949,7 +1949,7 @@ export class GraphQLService {
 						accountability: this.accountability,
 						schema: this.schema,
 					});
-					return await service.serverInfo();
+					return await service.health();
 				},
 			},
 		});

--- a/tests-blackbox/routes/server/health.test.ts
+++ b/tests-blackbox/routes/server/health.test.ts
@@ -1,0 +1,47 @@
+import { getUrl } from '@common/config';
+import * as common from '@common/index';
+import request from 'supertest';
+import vendors from '@common/get-dbs-to-test';
+import { requestGraphQL } from '@common/transport';
+
+describe('/server', () => {
+	describe('GET /health', () => {
+		common.TEST_USERS.forEach((userKey) => {
+			describe(common.USER[userKey].NAME, () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Action
+					const response = await request(getUrl(vendor))
+						.get('/server/health')
+						.set('Authorization', `Bearer ${common.USER[userKey].TOKEN}`);
+
+					const gqlResponse = await requestGraphQL(getUrl(vendor), true, common.USER[userKey].TOKEN, {
+						query: {
+							server_health: true,
+						},
+					});
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(gqlResponse.statusCode).toBe(200);
+
+					if (userKey === common.USER.ADMIN.KEY) {
+						const adminResult = {
+							status: 'ok',
+							releaseId: expect.any(String),
+							serviceId: expect.any(String),
+							checks: expect.anything(),
+						};
+
+						expect(response.body).toEqual(adminResult);
+						expect(gqlResponse.body.data.server_health).toEqual(adminResult);
+					} else {
+						const nonAdminResult = { status: 'ok' };
+
+						expect(response.body).toEqual(nonAdminResult);
+						expect(gqlResponse.body.data.server_health).toEqual(nonAdminResult);
+					}
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Description

Corrected the resolver for `server_health` request using GraphQL.
```gql
query {
    server_health 
}
```

Fixes #16975 
Fixes ENG-371

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
