### PR TITLE
Foreign tables discoverability for postgresql

### DIFF
--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -42,7 +42,7 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
         LEFT JOIN information_schema.tables t
           ON c.table_name = t.table_name
         WHERE
-          t.table_type = 'BASE TABLE'
+          t.table_type IN ('BASE TABLE', 'FOREIGN')
           AND c.table_schema IN (${bindings});
       `,
 				this.explodedSchema
@@ -93,7 +93,7 @@ export default class Postgres extends KnexPostgres implements SchemaInspector {
 				FROM geometries g
 				JOIN information_schema.tables t
 					ON g.f_table_name = t.table_name
-					AND t.table_type = 'BASE TABLE'
+					AND t.table_type IN ('BASE TABLE', 'FOREIGN')
 				WHERE f_table_schema in (${bindings})
 				`,
 				this.explodedSchema


### PR DESCRIPTION
## Description

PostgresQL natively allows creating [foreign tables](https://www.postgresql.org/docs/current/sql-createforeigntable.html) since version 11.

This is useful in the context of a Directus-powered CMS where the data can be located on multiple sites yet can be accessed from a single database root instance.

Yet the current implementation restricts to using base tables.

It would be neat to also support foreign tables.

Fixes #

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
