### PR TITLE
Fix error processor redacting too much info

### DIFF
--- a/api/src/services/graphql/utils/process-error.test.ts
+++ b/api/src/services/graphql/utils/process-error.test.ts
@@ -5,7 +5,7 @@ import processError from './process-error';
 describe('GraphQL processError util', () => {
 	const sampleError = new GraphQLError('An error message', { path: ['test_collection'] });
 	const redactedError = {
-		message: 'An unexpected error occurred.',
+		message: 'An error message',
 		extensions: {
 			code: 'INTERNAL_SERVER_ERROR',
 		},

--- a/api/src/services/graphql/utils/process-error.ts
+++ b/api/src/services/graphql/utils/process-error.ts
@@ -14,7 +14,7 @@ const processError = (accountability: Accountability | null, error: Readonly<Gra
 		};
 	} else {
 		return {
-			message: 'An unexpected error occurred.',
+			message: error.message,
 			extensions: {
 				code: 'INTERNAL_SERVER_ERROR',
 			},

--- a/tests-blackbox/routes/auth/login.test.ts
+++ b/tests-blackbox/routes/auth/login.test.ts
@@ -104,7 +104,7 @@ describe('/auth', () => {
 							expect(gqlResponse.body).toMatchObject({
 								errors: [
 									{
-										message: 'An unexpected error occurred.',
+										message: 'Invalid user credentials.',
 										extensions: {
 											code: 'INTERNAL_SERVER_ERROR',
 										},
@@ -160,7 +160,7 @@ describe('/auth', () => {
 							expect(gqlResponse.body).toMatchObject({
 								errors: [
 									{
-										message: 'An unexpected error occurred.',
+										message: 'Invalid user credentials.',
 										extensions: {
 											code: 'INTERNAL_SERVER_ERROR',
 										},
@@ -216,7 +216,7 @@ describe('/auth', () => {
 							expect(gqlResponse.body).toMatchObject({
 								errors: [
 									{
-										message: 'An unexpected error occurred.',
+										message: 'Invalid user credentials.',
 										extensions: {
 											code: 'INTERNAL_SERVER_ERROR',
 										},


### PR DESCRIPTION
## Description

This is a proposal to expose error messages (but not the stack trace nor other details) to all users, so that client apps can properly inform their users about what is going on when an error occurs.

Fixes #17168 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
