### PR TITLE
Passthrough all package.json data

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -41,7 +41,7 @@ export default async function add(): Promise<void> {
 
 	try {
 		const extensionManifestFile = await fse.readFile(packagePath, 'utf8');
-		extensionManifest = ExtensionManifest.parse(JSON.parse(extensionManifestFile));
+		extensionManifest = ExtensionManifest.passthrough().parse(JSON.parse(extensionManifestFile));
 		indent = detectJsonIndent(extensionManifestFile);
 	} catch (e) {
 		log(`Current directory is not a valid Directus extension.`, 'error');


### PR DESCRIPTION
## Description

https://github.com/colinhacks/zod#passthrough
By default, zod strips out any unknown keys which caused modifications to the package.json of an extension that wheren't intended. 

Fixes #17152 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code
