### PR TITLE
Fix fetching from related collection in drawer item

### DIFF
--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -270,7 +270,6 @@ function useItem() {
 	const internalEdits = ref<Record<string, any>>({});
 	const loading = ref(false);
 	const initialValues = ref<Record<string, any> | null>(null);
-	const baseEndpoint = getEndpoint(props.collection);
 
 	watch(
 		() => props.active,
@@ -295,6 +294,7 @@ function useItem() {
 
 		loading.value = true;
 
+		const baseEndpoint = getEndpoint(props.collection);
 		const endpoint = props.collection.startsWith('directus_')
 			? `${baseEndpoint}/${props.primaryKey}`
 			: `${baseEndpoint}/${encodeURIComponent(props.primaryKey)}`;
@@ -323,6 +323,7 @@ function useItem() {
 
 		loading.value = true;
 
+		const baseEndpoint = getEndpoint(collection);
 		const endpoint = collection.startsWith('directus_')
 			? `${baseEndpoint}/${props.relatedPrimaryKey}`
 			: `${baseEndpoint}/${encodeURIComponent(props.relatedPrimaryKey)}`;


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

The related collection for base endpoint should be reading from the local `collection` variable and not from `props.collection`.

Fixes #17108, closes ENG-469. 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
