### PR TITLE
Fix field configuration view not updating when navigating between different fields in New Field drawer

### DIFF
--- a/app/src/composables/use-extension.ts
+++ b/app/src/composables/use-extension.ts
@@ -4,16 +4,13 @@ import { useExtensions } from '@/extensions';
 import { pluralize } from '@directus/shared/utils';
 
 export function useExtension<T extends AppExtensionType | HybridExtensionType>(
-	type: T,
+	type: T | Ref<T>,
 	name: string | Ref<string | null>
 ): Ref<AppExtensionConfigs[Plural<T>][number] | null> {
 	const extensions = useExtensions();
 
 	return computed(() => {
-		const nameRaw = unref(name);
-
-		if (nameRaw === null) return null;
-
-		return (extensions[pluralize(type)].value as any[]).find(({ id }) => id === nameRaw) ?? null;
+		if (unref(name) === null) return null;
+		return (extensions[pluralize(unref(type))].value as any[]).find(({ id }) => id === unref(name)) ?? null;
 	});
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+import { defineComponent, PropType, computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useFieldDetailStore } from '../store';
 import { storeToRefs } from 'pinia';
@@ -69,11 +69,9 @@ export default defineComponent({
 		const fieldDetailStore = useFieldDetailStore();
 
 		const { collection, field } = storeToRefs(fieldDetailStore);
+		const { extension } = toRefs(props);
 
-		const extensionInfo = useExtension(
-			props.type,
-			computed(() => props.extension)
-		);
+		const extensionInfo = useExtension(props.type, extension);
 
 		const usesCustomComponent = computed(() => {
 			if (!extensionInfo.value) return false;

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -69,9 +69,9 @@ export default defineComponent({
 		const fieldDetailStore = useFieldDetailStore();
 
 		const { collection, field } = storeToRefs(fieldDetailStore);
-		const { extension } = toRefs(props);
+		const { extension, type } = toRefs(props);
 
-		const extensionInfo = useExtension(props.type, extension);
+		const extensionInfo = useExtension(type, extension);
 
 		const usesCustomComponent = computed(() => {
 			if (!extensionInfo.value) return false;

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -70,7 +70,10 @@ export default defineComponent({
 
 		const { collection, field } = storeToRefs(fieldDetailStore);
 
-		const extensionInfo = useExtension(props.type, props.extension);
+		const extensionInfo = useExtension(
+			props.type,
+			computed(() => props.extension)
+		);
 
 		const usesCustomComponent = computed(() => {
 			if (!extensionInfo.value) return false;


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #17128. I have mentioned the **explanation** of issue and **solution** below. Please have a look.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:

## Explanation of issue 
`extension-options` component containing extensionInfo variable which had `useExtension` composable value was not updating when different fields were selected. Due to which old object value was there and not getting updated in component. Its not reactive. To make it reactive, we have one solution i.e making argument `props.extension` computed. 

## Solution 
I made the `extensionInfo` object reactive by making `props.extension` to computed which then was updated. 
Screenshots attached. 
![image](https://user-images.githubusercontent.com/93135924/212836088-78637b2b-a09c-4972-b21f-a23c947347b7.png)
![image](https://user-images.githubusercontent.com/93135924/212836145-f397b001-d82a-44b0-a1ce-d5414c720ab7.png)

