### PR TITLE
GraphQL return original error (#17168)

### DIFF
--- a/tests-blackbox/routes/auth/login.test.ts
+++ b/tests-blackbox/routes/auth/login.test.ts
@@ -104,9 +104,9 @@ describe('/auth', () => {
 							expect(gqlResponse.body).toMatchObject({
 								errors: [
 									{
-										message: 'An unexpected error occurred.',
+										message: 'Invalid user credentials.',
 										extensions: {
-											code: 'INTERNAL_SERVER_ERROR',
+											code: 'INVALID_CREDENTIALS',
 										},
 									},
 								],
@@ -160,9 +160,9 @@ describe('/auth', () => {
 							expect(gqlResponse.body).toMatchObject({
 								errors: [
 									{
-										message: 'An unexpected error occurred.',
+										message: 'Invalid user credentials.',
 										extensions: {
-											code: 'INTERNAL_SERVER_ERROR',
+											code: 'INVALID_CREDENTIALS',
 										},
 									},
 								],
@@ -216,9 +216,9 @@ describe('/auth', () => {
 							expect(gqlResponse.body).toMatchObject({
 								errors: [
 									{
-										message: 'An unexpected error occurred.',
+										message: 'Invalid user credentials.',
 										extensions: {
-											code: 'INTERNAL_SERVER_ERROR',
+											code: 'INVALID_CREDENTIALS',
 										},
 									},
 								],


### PR DESCRIPTION
## Description

Change GraphQL error processor so that it returns the original error when it extends BaseException, similar to how REST error middleware does.

Fixes #17168 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
