### PR TITLE
Pass accountability to activity and revision services

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -19,6 +19,7 @@ import {
 	PrimaryKey,
 } from '../types';
 import getASTFromQuery from '../utils/get-ast-from-query';
+import { setAdmin } from '../utils/set-admin';
 import { validateKeys } from '../utils/validate-keys';
 import { AuthorizationService } from './authorization';
 import { ActivityService, RevisionsService } from './index';
@@ -183,7 +184,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
-					accountability: this.accountability,
+					accountability: setAdmin(this.accountability),
 				});
 
 				const activity = await activityService.createOne({
@@ -201,7 +202,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					const revisionsService = new RevisionsService({
 						knex: trx,
 						schema: this.schema,
-						accountability: this.accountability,
+						accountability: setAdmin(this.accountability),
 					});
 
 					const revision = await revisionsService.createOne({
@@ -594,7 +595,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
-					accountability: this.accountability,
+					accountability: setAdmin(this.accountability),
 				});
 
 				const activity = await activityService.createMany(
@@ -620,7 +621,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					const revisionsService = new RevisionsService({
 						knex: trx,
 						schema: this.schema,
-						accountability: this.accountability,
+						accountability: setAdmin(this.accountability),
 					});
 
 					const revisions = (
@@ -811,7 +812,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
-					accountability: this.accountability,
+					accountability: setAdmin(this.accountability),
 				});
 
 				await activityService.createMany(

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -183,6 +183,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
+					accountability: this.accountability,
 				});
 
 				const activity = await activityService.createOne({
@@ -200,6 +201,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					const revisionsService = new RevisionsService({
 						knex: trx,
 						schema: this.schema,
+						accountability: this.accountability,
 					});
 
 					const revision = await revisionsService.createOne({
@@ -592,6 +594,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
+					accountability: this.accountability,
 				});
 
 				const activity = await activityService.createMany(
@@ -617,6 +620,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					const revisionsService = new RevisionsService({
 						knex: trx,
 						schema: this.schema,
+						accountability: this.accountability,
 					});
 
 					const revisions = (
@@ -807,6 +811,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
+					accountability: this.accountability,
 				});
 
 				await activityService.createMany(

--- a/api/src/types/services.ts
+++ b/api/src/types/services.ts
@@ -5,6 +5,7 @@ import { Item, PrimaryKey } from './items';
 export type AbstractServiceOptions = {
 	knex?: Knex;
 	accountability?: Accountability | null;
+	elevatedPrivileges?: boolean;
 	schema: SchemaOverview;
 };
 

--- a/api/src/utils/set-admin.ts
+++ b/api/src/utils/set-admin.ts
@@ -1,7 +1,0 @@
-import { Accountability } from '@directus/shared/types';
-
-export function setAdmin(accountability: Accountability | null = null) {
-	if (accountability === null) return null;
-	accountability.admin = true;
-	return accountability;
-}

--- a/api/src/utils/set-admin.ts
+++ b/api/src/utils/set-admin.ts
@@ -1,0 +1,7 @@
+import { Accountability } from '@directus/shared/types';
+
+export function setAdmin(accountability: Accountability | null = null) {
+	if (accountability === null) return null;
+	accountability.admin = true;
+	return accountability;
+}


### PR DESCRIPTION
## Description

The accountability object was not getting passed down to the `ActivityService` and `RevisionService` user by the `ItemsService`.
This PR adds the `accountability` object to the constructors of these services falling back to `null` when not applicable.

Fixes #17266 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [X] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
