### PR TITLE
Check for null on `_empty` and `_nempty` filters

### DIFF
--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -550,13 +550,13 @@ export function applyFilter(
 
 			if (operator === '_empty' || (operator === '_nempty' && compareValue === false)) {
 				dbQuery[logical].andWhere((query) => {
-					query.where(key, '=', '');
+					query.whereNull(key).orWhere(key, '=', '');
 				});
 			}
 
 			if (operator === '_nempty' || (operator === '_empty' && compareValue === false)) {
 				dbQuery[logical].andWhere((query) => {
-					query.where(key, '!=', '');
+					query.whereNotNull(key).orWhere(key, '!=', '');
 				});
 			}
 

--- a/tests-blackbox/schema/string/index.ts
+++ b/tests-blackbox/schema/string/index.ts
@@ -214,14 +214,14 @@ const _empty = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === '') {
 		return true;
 	}
-	return false;
+	return _null(inputValue, _possibleValues);
 };
 
 const _nempty = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== '') {
 		return true;
 	}
-	return false;
+	return _nnull(inputValue, _possibleValues);
 };
 
 const _null = (inputValue: any, _possibleValues: any): boolean => {


### PR DESCRIPTION
## Description

The documentation states that `_empty` should be checking for `null` and `falsy` values which was not happening. This PR updates the `_empty` and `_nempty` filters to check for `NULL` too. Tests have been updated to include null values.

Fixes #17106 

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
