### PR TITLE
Fix bug with v-checkbox-tree where leaf nodes are treated like branch nodes with no children

### DIFF
--- a/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
@@ -112,7 +112,7 @@ const groupShown = computed(() => {
 	return !props.hidden;
 });
 
-const childrenValues = computed(() => props.children?.map((child) => child[props.itemValue]) || []);
+const childrenValues = computed(() => props.children.map((child) => child[props.itemValue]));
 
 const treeValue = computed({
 	get() {
@@ -122,7 +122,7 @@ const treeValue = computed({
 		const added = difference(newValue, props.modelValue);
 		const removed = difference(props.modelValue, newValue);
 
-		if (props.children) {
+		if (props.children.length > 0) {
 			switch (props.valueCombining) {
 				case 'all':
 					return emitAll(newValue, { added, removed });
@@ -264,7 +264,7 @@ function emitBranch(rawValue: (string | number)[], { added, removed }: Delta) {
 
 		const newValue = [
 			...rawValue.filter((val) => val !== props.value),
-			...(props.children || [])
+			...props.children
 				.filter((child) => {
 					if (!child[props.itemChildren]) return true;
 					return child[props.itemValue] !== childThatContainsSelection?.[props.itemValue];


### PR DESCRIPTION
## Description

Leaf nodes in the choices of `v-checkbox-tree` are treated like branch nodes with no children. This causes issues depending on the `valueCombining` prop. For example, if you set the `valueCombining` prop to `leaf`, then it won't let you select individual leaf nodes.

The default value of `children` changed from `null` to `[]`. A nullish check for `children` caused the bug.

Bug was introduced here: #15094

### Before

[before2.webm](https://user-images.githubusercontent.com/1342819/215180029-ad792c87-d803-4639-9458-c899158ce0d4.webm)


### After

[after2.webm](https://user-images.githubusercontent.com/1342819/215180057-9850305c-56b8-47ac-8889-d12f3a68e6f7.webm)

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #17322

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
