### PR TITLE
Fix issue with expand transition not working on initial collapse

### DIFF
--- a/app/src/components/transition/expand.vue
+++ b/app/src/components/transition/expand.vue
@@ -24,6 +24,7 @@ const emit = defineEmits([
 	'enter',
 	'afterEnter',
 	'enterCancelled',
+	'beforeLeave',
 	'leave',
 	'afterLeave',
 	'leaveCancelled',


### PR DESCRIPTION
## Description

In the expand transition component, transfer the logic from the enter functions to the leave functions and appropriately invert the logic.

The primary issue this PR fixes is that the CSS `transition` attribute is not applied initially when collapsing this component. It's applied on the expand and stays there. Thus, this issue only occurs on the initial collapse of the component **iff** the component starts expanded.

**Note: I'm not too confident in this PR being the best approach.**

### Before

[before1.webm](https://user-images.githubusercontent.com/1342819/215182289-2616c427-5d4d-486a-a7a5-239aea9f334c.webm)

### After

[after1.webm](https://user-images.githubusercontent.com/1342819/215182322-02870273-ecba-436f-aeb3-2d48350163c9.webm)

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #17324

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
