### PR TITLE
Add `return` to complete promise rejection

### DIFF
--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -139,7 +139,10 @@ export class FilesService extends ItemsService {
 			pipeline(
 				stream,
 				sharp().metadata(async (err, sharpMetadata) => {
-					if (err) reject(err);
+					if (err) {
+						reject(err);
+						return;
+					}
 
 					const metadata: Metadata = {};
 


### PR DESCRIPTION
## Description

The promise rejection missed a `return` statement, which lead to the rest of the code being executed, even if it should stop after the `reject` call. This lead to exceptions and API crashes. See https://github.com/directus/directus/pull/17303#issuecomment-1405070369
<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
