### PR TITLE
Ship docker image with custom libvips (full `AVIF` support)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
   build:
     name: Build Packages
     runs-on: ubuntu-latest
+    outputs:
+      libvips-version: ${{ steps.libvips.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -34,8 +36,11 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Build
-        run: |
-          node docker/pack
+        run: node docker/pack
+
+      - name: Get libvips version
+        id: libvips
+        run: echo "version=$(node docker/get-libvips-version)" >> $GITHUB_OUTPUT
 
       - name: Cache build artifacts
         uses: actions/cache@v3
@@ -133,6 +138,9 @@ jobs:
           file: ./docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            LIBVIPS_VERSION=${{ needs.build.outputs.libvips-version }}
           platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,26 +1,29 @@
+### Builder
 ARG NODE_VERSION=18-alpine
-
 FROM node:${NODE_VERSION} as builder
 
-ARG TARGETPLATFORM
+ARG LIBVIPS_VERSION
+
+RUN apk --no-cache add \
+  # Deps required to compile some Node.js packages
+  python3 \
+  build-base \
+  # Use custom build of libvips (dev files required to build sharp)
+  "vips-dev=~${LIBVIPS_VERSION}"
+RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 WORKDIR /directus
 COPY /dist .
-RUN \
-  if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then \
-  apk --no-cache add \
-  python3 \
-  build-base \
-  && ln -sf /usr/bin/python3 /usr/bin/python \
-  ; fi
+
 RUN npm install --no-package-lock
 RUN rm *.tgz
 
-# Directus image
+### Directus Image
 FROM node:${NODE_VERSION}
 
 ARG VERSION
 ARG REPOSITORY=directus/directus
+ARG LIBVIPS_VERSION
 
 LABEL directus.version="${VERSION}"
 
@@ -32,13 +35,17 @@ ENV \
   EXTENSIONS_PATH="/directus/extensions" \
   STORAGE_LOCAL_ROOT="/directus/uploads"
 
-RUN \
-  # Upgrade system and install 'ssmtp' to be able to send mails
-  apk upgrade --no-cache && apk add --no-cache \
+# Upgrade system and install additionals packages
+RUN apk upgrade --no-cache && apk add --no-cache \
+  # To be able to send mails
   ssmtp \
-  # Add support for specifying the timezone of the container
-  # using the "TZ" environment variable.
+  # Support for specifying the timezone (via "TZ" env variable)
   tzdata \
+  # Custom libvips (C++ bindings for sharp)
+  # with heif and magick (PPM, FITS, JP2K) support
+  "vips-cpp=~${LIBVIPS_VERSION}" \
+  "vips-magick=~${LIBVIPS_VERSION}" \
+  "vips-heif=~${LIBVIPS_VERSION}" \
   # Create directory for Directus with corresponding ownership
   # (can be omitted on newer Docker versions since WORKDIR below will do the same)
   && mkdir /directus && chown node:node /directus
@@ -47,17 +54,16 @@ RUN \
 USER node
 WORKDIR /directus
 
-# disable npm update warnings
+# Disable npm update warnings
 RUN echo "update-notifier=false" >> ~/.npmrc
 
 COPY --from=builder --chown=node:node /directus .
 
-RUN \
-  # Create data directories
-  mkdir -p \
-    database \
-    extensions \
-    uploads
+# Create data directories
+RUN mkdir -p \
+  database \
+  extensions \
+  uploads
 
 # Expose data directories as volumes
 VOLUME \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,40 +2,53 @@
 
 SHELL=bash
 
-image=directus-test
-version=$(shell git rev-parse HEAD)
-tag=latest
+IMAGE=directus-test
+VERSION=$(shell git rev-parse HEAD)
+TAG=latest
+# Currently it's only possible to target a single platform locally in one run
+PLATFORM?=linux/amd64
 
-.PHONY: build-image test-image
+all : prepare build-image
+.PHONY: all prepare build-image test-image
 
-build-image:
+prepare:
 	pnpm install
 	pnpm -r build
 	node pack.js
-	docker build \
-		--build-arg VERSION=$(version) \
-		--build-arg REPOSITORY=$(image) \
-		-t $(image):$(version) \
-		-f ./Dockerfile \
-		..
-	docker tag $(image):$(version) $(image):$(tag)
 
-# To override or pass additional arguments:
+build-image:
+	docker buildx create --use
+	docker buildx build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg REPOSITORY=$(IMAGE) \
+		--build-arg LIBVIPS_VERSION=$$(node get-libvips-version.js) \
+		--platform $(PLATFORM) \
+		--tag $(IMAGE):$(VERSION) \
+		--tag $(IMAGE):$(TAG) \
+		--output type=docker \
+	  --file Dockerfile \
+		..
+	docker buildx rm
+
+# To override or set additional arguments:
 # DOCKER_ARGS='-p 8051:8055 -e LOG_STYLE=raw' make test-image
 test-image:
 	ARGS=($$DOCKER_ARGS); docker run \
+		--platform $(PLATFORM) \
 		--rm \
-		-t \
-		-p 8055:8055 \
-		-e "KEY=$$(uuidgen | tr '[:upper:]' '[:lower:]')" \
-		-e "SECRET=$$(uuidgen | tr '[:upper:]' '[:lower:]')" \
+		--tty \
+		--publish 8055:8055 \
+		--env "KEY=$$(uuidgen | tr '[:upper:]' '[:lower:]')" \
+		--env "SECRET=$$(uuidgen | tr '[:upper:]' '[:lower:]')" \
 		"$${ARGS[@]}" \
-		$(image):$(tag)
+		$(IMAGE):$(TAG)
 
 enter-image:
 	ARGS=($$DOCKER_ARGS); docker run \
+		--platform $(PLATFORM) \
 		--rm \
-		-it \
+		--interactive \
+		--tty \
 		"$${ARGS[@]}" \
-		$(image):$(tag) \
+		$(IMAGE):$(TAG) \
 		/bin/sh

--- a/docker/get-libvips-version.js
+++ b/docker/get-libvips-version.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-console */
+const { execSync } = require('child_process');
+
+// Get path to package.json file of sharp
+const sharpPackageJsonPath = execSync(
+	'pnpm --filter directus exec node -e "console.log(require.resolve(\'sharp/package.json\'))"'
+);
+
+// Load the package.json file
+const sharpPackageJson = require(String(sharpPackageJsonPath).trim());
+
+// Print the required version of libvips
+console.log(sharpPackageJson.config.libvips);


### PR DESCRIPTION
## Description

The prebuilt version of libvips from sharp comes with limited support for `AVIF`, see https://github.com/lovell/sharp/pull/3541.
The limited support might be confusing for users (non-meaningful error message), which is why we prefer having full `AVIF` support. Therefore we include a custom build of libvips (Alpine package) in the docker image.

Tested locally with both amd64 & arm64 ✅ 
The resulting image is about ~60 MB larger.

Addressing #17076 (together with #17303)

- [ ] Documentation, see https://github.com/directus/directus/pull/17303#issuecomment-1411075732

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
