### PR TITLE
Fix incorrect skipping of m2m tests

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -1,6 +1,9 @@
 name: Blackbox Tests
 
 on:
+  pull_request: # Remove block before marking PR as ready for review
+    branches:
+      - main
   push:
     branches:
       - main
@@ -13,7 +16,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main
+  group: blackbox-main-test-only # Revert line before marking PR as ready for review
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -1,9 +1,6 @@
 name: Blackbox Tests
 
 on:
-  pull_request: # Remove block before marking PR as ready for review
-    branches:
-      - main
   push:
     branches:
       - main
@@ -16,7 +13,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main-test-only # Revert line before marking PR as ready for review
+  group: blackbox-main
   cancel-in-progress: true
 
 env:

--- a/tests-blackbox/routes/items/m2m.test.ts
+++ b/tests-blackbox/routes/items/m2m.test.ts
@@ -1501,7 +1501,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 			);
 		});
 
-		describe.only('Depth Tests', () => {
+		describe('Depth Tests', () => {
 			describe('allow queries up to the field depth limit', () => {
 				it.each(vendors)('%s', async (vendor) => {
 					// Setup

--- a/tests-blackbox/routes/schema/schema.test.ts
+++ b/tests-blackbox/routes/schema/schema.test.ts
@@ -107,7 +107,7 @@ describe('Schema Snapshots', () => {
 
 						await assertCollectionsDeleted(vendor, pkType);
 					},
-					300000
+					1200000
 				);
 			});
 		});


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

M2M tests are incorrectly skipped due to the `.only`.
Also increasing the timeout in the schema test as the existing duration was exceeded.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
