### PR TITLE
Fix checkbox flickering

### DIFF
--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -237,7 +237,7 @@ const internalItems = computed({
 });
 
 const allItemsSelected = computed<boolean>(() => {
-	return props.loading === false && props.modelValue.length === props.items.length;
+	return props.loading === false && props.items.length > 0 && props.modelValue.length === props.items.length;
 });
 
 const someItemsSelected = computed<boolean>(() => {


### PR DESCRIPTION
## Description

The problem was that `props.loading` got to false before `props.items.length` got set to it's right value.

Fixes #17358


