### PR TITLE
Allow for rendering lists in template string

### DIFF
--- a/app/src/utils/render-string-template.ts
+++ b/app/src/utils/render-string-template.ts
@@ -1,10 +1,10 @@
 import { useAliasFields } from '@/composables/use-alias-fields';
 import { useFieldsStore } from '@/stores/fields';
 import { Field } from '@directus/shared/types';
-import { getFieldsFromTemplate } from '@directus/shared/utils';
+import { get, getFieldsFromTemplate } from '@directus/shared/utils';
 import { render, renderFn } from 'micromustache';
 import { computed, ComputedRef, Ref, ref, unref } from 'vue';
-import { get, set } from 'lodash';
+import { set } from 'lodash';
 import { useExtension } from '@/composables/use-extension';
 
 type StringTemplate = {


### PR DESCRIPTION
## Description

By using our internal `get` method that also supports arrays, we are able to display relations with multiple results for the event name.

Fixes #15832

![grafik](https://user-images.githubusercontent.com/22577866/216950580-9a3c7361-51ed-406b-963e-e2307bca9133.png)
