### PR TITLE
Fix loading of relational fields in group

### DIFF
--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -89,9 +89,19 @@ export function useFieldTree(
 				type: field.type,
 			};
 
+			const children = getTree(field.collection, node);
+
+			if (children) {
+				for (const child of children) {
+					if (child.relatedCollection) {
+						child.children = getTree(child.relatedCollection, child);
+					}
+				}
+			}
+
 			return {
 				...node,
-				children: getTree(field.collection, node),
+				children,
 			};
 		}
 
@@ -154,14 +164,24 @@ export function useFieldTree(
 	}
 
 	function getNodeAtPath([field, ...path]: string[], root?: FieldNode[]): FieldNode | undefined {
-		for (const node of root || []) {
-			if (node.field === field) {
-				if (path.length) {
-					return getNodeAtPath(path, node.children);
-				} else {
-					return node;
+		let node = root?.find((node) => node.field === field);
+
+		if(!node) {
+			node = root?.reduce<FieldNode[]>((acc, node) => {
+				if (node.group === true && node.children && node.children.length > 0) {
+					acc.push(...node.children)
 				}
-			}
+				return acc;
+			}, []).find((node) => node.field === field);
+
+		}
+		
+		if(!node) return undefined;
+
+		if (path.length) {
+			return getNodeAtPath(path, node.children);
+		} else {
+			return node;
 		}
 	}
 

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -166,17 +166,18 @@ export function useFieldTree(
 	function getNodeAtPath([field, ...path]: string[], root?: FieldNode[]): FieldNode | undefined {
 		let node = root?.find((node) => node.field === field);
 
-		if(!node) {
-			node = root?.reduce<FieldNode[]>((acc, node) => {
-				if (node.group === true && node.children && node.children.length > 0) {
-					acc.push(...node.children)
-				}
-				return acc;
-			}, []).find((node) => node.field === field);
-
+		if (!node) {
+			node = root
+				?.reduce<FieldNode[]>((acc, node) => {
+					if (node.group === true && node.children && node.children.length > 0) {
+						acc.push(...node.children);
+					}
+					return acc;
+				}, [])
+				.find((node) => node.field === field);
 		}
-		
-		if(!node) return undefined;
+
+		if (!node) return undefined;
 
 		if (path.length) {
 			return getNodeAtPath(path, node.children);


### PR DESCRIPTION
## Description

The problem was that when opening the group it didn't load the children for the children in the group, thus displaying no arrows inside a group even if there are relational fields. The reason why no inner children got loaded was caused by the group not having any value which is intended as groups are `alias` fields.

The fix was to preload any children of children of groups and if we open a child in a group, to be able to find that child as the path is not matching the actual tree, and then to load it's children.

Here is the problem visualized:
```
- "field1"
- "field2"
- "" <--- Is a group but has no path as "relational-field-in-group" is top-level for the api
  - "relational-field-in-group" <--- by giving the group no path it's chidren are correct
- "field4"
```
When you now click on that group we would have to somehow find it in the tree with the path of `""` which we can't as the path is nonsense.

The solution is to do this:
```
- "field1"
- "field2"
- ""
  - "relational-field-in-group" <-- we are now able to find this even though the path would in theory be "group1.relational-field-in-group".
    - "relational-field-in-group.relational-field1"
    - "relational-field-in-group.relational-field2"
- "field4"
```

Fixes #13899