### PR TITLE
Make role required

### DIFF
--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -136,6 +136,7 @@ fields:
     special:
       - m2o
     width: half
+    required: true
     display: related-values
     display_options:
       template: '{{ name }}'


### PR DESCRIPTION
By making the role field required we can make sure that you can't accidentally end up with a user that has no role and thus no access to directus. The only way to set the role to null is by deleting a role but then the outcome also makes sense.

Fixes #15761