### PR TITLE
Fix using strings for flow trigger collections

### DIFF
--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -144,26 +144,28 @@ class FlowManager {
 
 		for (const flow of flowTrees) {
 			if (flow.trigger === 'event') {
-				const events: string[] = flow.options?.scope
-					? toArray(flow.options.scope)
-							.map((scope: string) => {
-								if (['items.create', 'items.update', 'items.delete'].includes(scope)) {
-									return (
-										flow.options?.collections?.map((collection: string) => {
-											if (collection.startsWith('directus_')) {
-												const action = scope.split('.')[1];
-												return collection.substring(9) + '.' + action;
-											}
+				let events: string[] = [];
 
-											return `${collection}.${scope}`;
-										}) ?? []
-									);
-								}
+				if (flow.options?.scope) {
+					events = toArray(flow.options.scope)
+						.map((scope: string) => {
+							if (['items.create', 'items.update', 'items.delete'].includes(scope)) {
+								if (!flow.options?.collections) return [];
 
-								return scope;
-							})
-							.flat()
-					: [];
+								return toArray(flow.options.collections).map((collection: string) => {
+									if (collection.startsWith('directus_')) {
+										const action = scope.split('.')[1];
+										return collection.substring(9) + '.' + action;
+									}
+
+									return `${collection}.${scope}`;
+								});
+							}
+
+							return scope;
+						})
+						.flat();
+				}
 
 				if (flow.options.type === 'filter') {
 					const handler: FilterHandler = (payload, meta, context) =>

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -94,6 +94,7 @@ export function getTriggers() {
 					{
 						field: 'collections',
 						name: t('collections'),
+						type: 'csv',
 						meta: {
 							interface: 'system-collections',
 							width: 'full' as Width,


### PR DESCRIPTION
The problem was that we didn't make sure that the collections list is always an array. By setting the field type to `csv` we make sure you can only send arrays and even if you manage to send an string, it does work with strings now.

Fixes #17352