### PR TITLE
Always show error in tabular layout

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="layout-tabular">
 		<v-table
-			v-if="loading || (itemCount && itemCount > 0)"
+			v-if="loading || (itemCount && itemCount > 0 && !error)"
 			ref="table"
 			v-model="selectionWritable"
 			v-model:headers="tableHeadersWritable"


### PR DESCRIPTION
The problem was that `itemCount` was larger than 0 because that request is not using the sort param that you can configure thus not failing but the main request failed. To fix this we are now also checking if the error hasn't been set meaning the main request must have been successful too.

Fixes #17004