### PR TITLE
Fix problems with manual sort

### DIFF
--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -1,4 +1,4 @@
-import { HeaderRaw, Item } from '@/components/v-table/types';
+import { HeaderRaw, Item, Sort } from '@/components/v-table/types';
 import { useFieldsStore } from '@/stores/fields';
 import { useAliasFields } from '@/composables/use-alias-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
@@ -309,12 +309,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				}
 			}
 
-			function onSortChange(newSort: { by: string; desc: boolean }) {
-				let sortString = newSort.by;
-				if (!newSort.by) {
+			function onSortChange(newSort: Sort | null) {
+				if (!newSort?.by) {
 					sort.value = [];
 					return;
 				}
+
+				let sortString = newSort.by;
 				if (newSort.desc === true) {
 					sortString = '-' + sortString;
 				}

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -46,7 +46,7 @@
 						:disabled="!header.sortable"
 						:active="tableSort?.by === header.value && tableSort?.desc === false"
 						clickable
-						@click="onSortChange?.({ by: header.value, desc: false })"
+						@click="onSortChange({ by: header.value, desc: false })"
 					>
 						<v-list-item-icon>
 							<v-icon name="sort" class="flip" />
@@ -60,7 +60,7 @@
 						:active="tableSort?.by === header.value && tableSort?.desc === true"
 						:disabled="!header.sortable"
 						clickable
-						@click="onSortChange?.({ by: header.value, desc: true })"
+						@click="onSortChange({ by: header.value, desc: true })"
 					>
 						<v-list-item-icon>
 							<v-icon name="sort" />
@@ -215,7 +215,7 @@ interface Props {
 	selectAll: () => void;
 	filterUser?: Filter;
 	search?: string;
-	onSortChange?: (newSort: { by: string; desc: boolean }) => void;
+	onSortChange: (newSort: { by: string; desc: boolean }) => void;
 	onAlignChange?: (field: 'string', align: 'left' | 'center' | 'right') => void;
 }
 
@@ -230,7 +230,6 @@ const props = withDefaults(defineProps<Props>(), {
 	sortField: undefined,
 	filterUser: undefined,
 	search: undefined,
-	onSortChange: () => undefined,
 	onAlignChange: () => undefined,
 });
 

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -262,22 +262,22 @@ useShortcut(
 const permissionsStore = usePermissionsStore();
 const userStore = useUserStore();
 
-
 const showManualSort = computed(() => {
-	if(!props.sortField) return false;
+	if (!props.sortField) return false;
 
 	const isAdmin = userStore.currentUser?.role?.admin_access;
 
-	if(isAdmin) return true;
+	if (isAdmin) return true;
 
 	const permission = permissionsStore.getPermissionsForUser(props.collection, 'update');
 
-	if(!permission) return false;
+	if (!permission) return false;
 
-	if(Array.isArray(permission.fields) && permission.fields.length > 0) return permission.fields.includes(props.sortField)
+	if (Array.isArray(permission.fields) && permission.fields.length > 0)
+		return permission.fields.includes(props.sortField);
 
 	return true;
-})
+});
 
 const fieldsWritable = useSync(props, 'fields', emit);
 


### PR DESCRIPTION
There where 2 bugs to fix here:
- You couldn't disable manual drag&drop.
- It showed the manual drag&drop even if you didn't have update permissions to the sort field.

Fixes #16807
Fixes #17445