### PR TITLE
Allow for custom robots.txt

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -3,7 +3,6 @@ import request from 'supertest';
 import { describe, expect, test, vi } from 'vitest';
 
 import createApp from './app';
-import { ROBOTSTXT } from './constants';
 
 vi.mock('./database', () => ({
 	default: vi.fn(),
@@ -97,7 +96,7 @@ describe('createApp', async () => {
 			const app = await createApp();
 			const response = await request(app).get('/robots.txt');
 
-			expect(response.text).toEqual(ROBOTSTXT);
+			expect(response.text).toEqual('User-agent: *\nDisallow: /');
 		});
 	});
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -50,7 +50,6 @@ import extractToken from './middleware/extract-token';
 import rateLimiter from './middleware/rate-limiter';
 import sanitizeQuery from './middleware/sanitize-query';
 import schema from './middleware/schema';
-import { ROBOTSTXT } from './constants';
 
 import { track } from './utils/track';
 import { validateEnv } from './utils/validate-env';
@@ -177,7 +176,7 @@ export default async function createApp(): Promise<express.Application> {
 	app.get('/robots.txt', (_, res) => {
 		res.set('Content-Type', 'text/plain');
 		res.status(200);
-		res.send(ROBOTSTXT);
+		res.send(env.ROBOTS_TXT);
 	});
 
 	if (env.SERVE_APP) {

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -60,9 +60,4 @@ export const COOKIE_OPTIONS = {
 	sameSite: (env.REFRESH_TOKEN_COOKIE_SAME_SITE as 'lax' | 'strict' | 'none') || 'strict',
 };
 
-export const ROBOTSTXT = `
-User-agent: *
-Disallow: /
-`.trim();
-
 export const OAS_REQUIRED_SCHEMAS = ['Query', 'x-metadata'];

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -24,6 +24,7 @@ const allowedEnvironmentVars = [
 	'SERVE_APP',
 	'GRAPHQL_INTROSPECTION',
 	'LOGGER_.+',
+	'ROBOTS_TXT',
 	// server
 	'SERVER_.+',
 	// database
@@ -192,6 +193,7 @@ const defaults: Record<string, any> = {
 	PUBLIC_URL: '/',
 	MAX_PAYLOAD_SIZE: '1mb',
 	MAX_RELATIONAL_DEPTH: 10,
+	ROBOTS_TXT: 'User-agent: *\nDisallow: /',
 
 	DB_EXCLUDE_TABLES: 'spatial_ref_sys,sysdiagrams',
 


### PR DESCRIPTION
Allow for setting the robots.txt like so: `ROBOTS_TXT="User-agent: *\nDisallow: /whatever"`

Fixes #15421

Docs: directus/docs#285