### PR TITLE
Add discussion template for feature requests

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,0 +1,98 @@
+# This is based on Vue's great RFC template https://github.com/vuejs/rfcs/blob/master/0000-template.md
+name: Feature Request
+description: Share ideas for new Core features
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi, thank you for taking the time to create a feature request!
+
+        In order to make sure this feature request has the biggest chance of being implemented, please fill out the following sections in as much detail as you can.
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Brief explanation of the feature
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Basic Example
+      description: If the proposal involves a new or changed API, include a basic code example.
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: |
+        Why are we doing this? What use cases does it support? What is the expected outcome?
+
+        Please focus on explaining the motivation so that if this RFC is not accepted, the motivation could be used to develop alternative solutions. In other words, enumerate the constraints you are trying to solve without coupling them too closely to the solution you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: |
+        This is the bulk of the RFC. Explain the design in enough detail for somebody familiar with Directus to understand, and for somebody familiar with the implementation to implement. This should get into specifics and corner-cases, and include examples of how the feature is used. Any new terminology should be defined here.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Requirements List
+      value: |
+        ### Must Have:
+        - A
+        - B
+
+        ### Should Have:
+        - C
+
+        ### Could Have:
+        - D
+
+        ### Won't Have:
+        - E
+      description: |
+        What is required to make this feature a success? Please use [the MoSCoW method](https://en.wikipedia.org/wiki/MoSCoW_method) to describe the requirements.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Drawbacks
+      description: |
+        Why should we **not** do this? Please consider:
+          - implementation cost, both in term of code size and complexity
+          - whether the proposed feature can be implemented in user space
+          - the impact on teaching people Directus
+          - integration of this feature with other existing and planned features
+          - cost of migrating existing Directus applications (is it a breaking change?)
+
+          There are tradeoffs to choosing any path. Attempt to identify them here.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives
+      description: |
+        What other designs have been considered? What is the impact of not doing this?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Adoption Strategy
+      description: |
+        If we implement this proposal, how will existing Directus developers adopt it? Is this a breaking change? Can we write a migration? How will this affect other projects in the Directus ecosystem?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Unresolved Questions
+      description: |
+        What parts of this request are still unknown?


### PR DESCRIPTION
Currently, Feature Requests in Discussions are a free-for-all. This means that a lot of feature requests don't include the necessary detail to really start implementing the ideas presented. GitHub just launched Discussion Templates (thanks for the heads up @paescuj!) which means we can ensure that new feature requests are created with sufficient detail (just like we do with Bug Reports). 