### PR TITLE
Allow offset and page args for GraphQL aggregated queries

### DIFF
--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1016,6 +1016,12 @@ export class GraphQLService {
 						limit: {
 							type: GraphQLInt,
 						},
+						offset: {
+							type: GraphQLInt,
+						},
+						page: {
+							type: GraphQLInt,
+						},
 						search: {
 							type: GraphQLString,
 						},


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Adds the missing `offset` and `page` args for GraphQL aggregated queries.
The offset or paging should be usable when `groupBy` is used. 

`limit` in aggregated queries was added in https://github.com/directus/directus/pull/10077

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
