### PR TITLE
Removed (old) MIT-License information

### DIFF
--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -212,7 +212,3 @@ Standard mocha filter (grep) can be used:
 ```shell
 $ npm test -- -g '.tableInfo'
 ```
-
-## License
-
-[MIT](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
## Description

The README.md in the schema package still said "MIT" license. But the package.json said GPL so I removed the part stating it would be MIT.

Fixes #

## Type of Change

- [x] Refactor / codestyle updates

## Requirements Checklist

If adding a new feature:

- [x] Documentation was added/updated. PR:
