### PR TITLE
Fix Local Auth Provider Form being Hidden

### DIFF
--- a/app/src/routes/login/login.vue
+++ b/app/src/routes/login/login.vue
@@ -11,7 +11,7 @@
 
 		<ldap-form v-else-if="driver === 'ldap'" :provider="provider" />
 
-		<login-form v-else-if="driver === 'default'" :provider="provider" />
+		<login-form v-else-if="driver === 'default' || driver === 'local'" :provider="provider" />
 
 		<sso-links v-if="!authenticated" :providers="auth.providers" />
 


### PR DESCRIPTION
## Description

The Login form only checked for `default` provider not `default` and `local` provider when rendering the login form client side.

Fixes #17340 , Fixes #ENG-601

## Type of Change

- [X] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [X] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
