### PR TITLE
Use example.com instead of directus.io

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -244,7 +244,7 @@ const defaults: Record<string, any> = {
 	EXTENSIONS_PATH: './extensions',
 	EXTENSIONS_AUTO_RELOAD: false,
 
-	EMAIL_FROM: 'no-reply@directus.io',
+	EMAIL_FROM: 'no-reply@example.com',
 	EMAIL_VERIFY_SETUP: true,
 	EMAIL_TRANSPORT: 'sendmail',
 	EMAIL_SENDMAIL_NEW_LINE: 'unix',


### PR DESCRIPTION
The `directus.io` domain has all sorts of email protections enabled that'd mean that a lot of Directus-sent emails won't arrive when using the defaults values. Switching the default to `@example.com` makes more sense in this case