### PR TITLE
Fix infinite recursion

### DIFF
--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -95,7 +95,9 @@ export function useFieldTree(
 			if (children) {
 				for (const child of children) {
 					if (child.relatedCollection) {
-						child.children = [{ name: 'Loading...', field: '', collection: '', key: '', path: '', type: 'alias', _loading: true }];
+						child.children = [
+							{ name: 'Loading...', field: '', collection: '', key: '', path: '', type: 'alias', _loading: true },
+						];
 					}
 				}
 			}
@@ -193,7 +195,7 @@ export function useFieldTree(
 
 			const node = getNodeAtPath(path.split('.'), treeList.value);
 
-			if(node && node.children?.length === 1 && node.children[0]._loading) {
+			if (node && node.children?.length === 1 && node.children[0]._loading) {
 				node.children = getTree(node.relatedCollection, node);
 			}
 

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -15,6 +15,7 @@ export type FieldNode = {
 	type: Type;
 	children?: FieldNode[];
 	group?: boolean;
+	_loading?: boolean;
 };
 
 export type FieldTreeContext = {
@@ -94,7 +95,7 @@ export function useFieldTree(
 			if (children) {
 				for (const child of children) {
 					if (child.relatedCollection) {
-						child.children = getTree(child.relatedCollection, child);
+						child.children = [{ name: 'Loading...', field: '', collection: '', key: '', path: '', type: 'alias', _loading: true }];
 					}
 				}
 			}
@@ -191,6 +192,10 @@ export function useFieldTree(
 			visitedPaths.value.add(path);
 
 			const node = getNodeAtPath(path.split('.'), treeList.value);
+
+			if(node && node.children?.length === 1 && node.children[0]._loading) {
+				node.children = getTree(node.relatedCollection, node);
+			}
 
 			for (const child of node?.children || []) {
 				if (child?.relatedCollection) {


### PR DESCRIPTION
## Description

The problem was that on groups, we not only had to load it's children but also the children of the children in a group in order to display the open icon on a field. Where it went wrong is when you had a field that would link to the same collection meaning: By loading all children->children of a collection, it would also want to load the inner copy of the current collection, and that is where the infinite recursion started.

```
field_a
m2o_to_somewhere    <-- Would load all of it's children and then stop.
group               <-- Would not only load all of it's children but also those children as well.
  m2o_to_self       <-- Meaning, this field would have had to load all of it's children too.
    field_a
    m2o_to_somewhere
    group           <-- By doing so, this group would also load it's children, and the infinite recursion would begin.
```

I also noticed that I can rework the logic of the use-field-tree to be way simpler by inserting fake children for the time being which I didn't think of before and am using to fix this bug now. But those changes will happen in a separate PR.

Fixes #17587 
Fixes #17591
Fixes ENG-729
Fixes ENG-733