### PR TITLE
Additionally check for varchar when casting UUID in apply diff

### DIFF
--- a/api/src/utils/apply-diff.ts
+++ b/api/src/utils/apply-diff.ts
@@ -60,9 +60,9 @@ export async function applyDiff(
 						.map((fieldDiff) => (fieldDiff.diff[0] as DiffNew<Field>).rhs)
 						.map((fieldDiff) => {
 							// Casts field type to UUID when applying non-PostgreSQL schema onto PostgreSQL database.
-							// This is needed because they snapshots UUID fields as char with length 36.
+							// This is needed because they snapshots UUID fields as char/varchar with length 36.
 							if (
-								String(fieldDiff.schema?.data_type).toLowerCase() === 'char' &&
+								['char', 'varchar'].includes(String(fieldDiff.schema?.data_type).toLowerCase()) &&
 								fieldDiff.schema?.max_length === 36 &&
 								(fieldDiff.schema?.is_primary_key ||
 									(fieldDiff.schema?.foreign_key_table && fieldDiff.schema?.foreign_key_column))

--- a/api/src/utils/apply-snapshot.test.ts
+++ b/api/src/utils/apply-snapshot.test.ts
@@ -11,7 +11,7 @@ import {
 	snapshotCreateCollectionNotNested,
 	snapshotBeforeDeleteCollection,
 } from '../__utils__/snapshots';
-import { Snapshot } from '../types';
+import { Snapshot, SnapshotField } from '../types';
 import { describe, afterEach, it, expect, vi, beforeEach, MockedFunction } from 'vitest';
 
 class Client_PG extends MockClient {}
@@ -258,6 +258,165 @@ describe('applySnapshot', () => {
 			// they will get filtered in createCollections
 			expect(createFieldSpy).toHaveBeenCalledTimes(0);
 		});
+	});
+
+	describe('Creating new collection with UUID primary key field', () => {
+		const fieldSchemaMaxLength = 36;
+
+		it.each(['char', 'varchar'])(
+			'casts non-postgres schema snapshots of UUID fields as %s(36) to UUID type',
+			async (fieldSchemaDataType) => {
+				const snapshotToApply: Snapshot = {
+					version: 1,
+					directus: '0.0.0',
+					collections: [
+						{
+							collection: 'test_uuid_table',
+							meta: {
+								accountability: 'all',
+								collection: 'test_uuid_table',
+								group: null,
+								hidden: true,
+								icon: 'box',
+								item_duplication_fields: null,
+								note: null,
+								singleton: false,
+								translations: {},
+							},
+							schema: { name: 'test_uuid_table' },
+						},
+					],
+					fields: [
+						{
+							collection: 'test_uuid_table',
+							field: 'id',
+							meta: {
+								collection: 'test_uuid_table',
+								conditions: null,
+								display: null,
+								display_options: null,
+								field: 'id',
+								group: null,
+								hidden: true,
+								interface: null,
+								note: null,
+								options: null,
+								readonly: false,
+								required: false,
+								sort: null,
+								special: null,
+								translations: {},
+								validation: null,
+								validation_message: null,
+								width: 'full',
+							},
+							schema: {
+								comment: null,
+								data_type: fieldSchemaDataType,
+								default_value: null,
+								foreign_key_column: null,
+								foreign_key_schema: null,
+								foreign_key_table: null,
+								generation_expression: null,
+								has_auto_increment: false,
+								is_generated: false,
+								is_nullable: false,
+								is_primary_key: true,
+								is_unique: true,
+								max_length: fieldSchemaMaxLength,
+								name: 'id',
+								numeric_precision: null,
+								numeric_scale: null,
+								table: 'test_uuid_table',
+							},
+							type: 'uuid',
+						} as SnapshotField,
+					],
+					relations: [],
+				};
+
+				const expected = {
+					collection: 'test_uuid_table',
+					meta: {
+						accountability: 'all',
+						collection: 'test_uuid_table',
+						group: null,
+						hidden: true,
+						icon: 'box',
+						item_duplication_fields: null,
+						note: null,
+						singleton: false,
+						translations: {},
+					},
+					schema: { name: 'test_uuid_table' },
+					fields: [
+						{
+							collection: 'test_uuid_table',
+							field: 'id',
+							meta: {
+								collection: 'test_uuid_table',
+								conditions: null,
+								display: null,
+								display_options: null,
+								field: 'id',
+								group: null,
+								hidden: true,
+								interface: null,
+								note: null,
+								options: null,
+								readonly: false,
+								required: false,
+								sort: null,
+								special: null,
+								translations: {},
+								validation: null,
+								validation_message: null,
+								width: 'full',
+							},
+							schema: {
+								data_type: 'uuid',
+								default_value: null,
+								foreign_key_column: null,
+								foreign_key_table: null,
+								generation_expression: null,
+								has_auto_increment: false,
+								is_generated: false,
+								is_nullable: false,
+								is_primary_key: true,
+								is_unique: true,
+								max_length: null,
+								name: 'id',
+								numeric_precision: null,
+								numeric_scale: null,
+								table: 'test_uuid_table',
+							},
+							type: 'uuid',
+						},
+					],
+				};
+
+				// Stop call to db later on in apply-snapshot
+				vi.spyOn(getSchema, 'getSchema').mockReturnValue(Promise.resolve(snapshotApplyTestSchema));
+				// We are not actually testing that createOne works, just that is is called with the right data type
+				const createOneCollectionSpy = vi.spyOn(CollectionsService.prototype, 'createOne').mockResolvedValue('test');
+				vi.spyOn(FieldsService.prototype, 'createField').mockResolvedValue();
+
+				await applySnapshot(snapshotToApply, {
+					database: db,
+					current: {
+						version: 1,
+						directus: '0.0.0',
+						collections: [],
+						fields: [],
+						relations: [],
+					},
+					schema: snapshotApplyTestSchema,
+				});
+
+				expect(createOneCollectionSpy).toHaveBeenCalledOnce();
+				expect(createOneCollectionSpy).toHaveBeenCalledWith(expected, mutationOptions);
+			}
+		);
 	});
 
 	describe('Delete collections', () => {


### PR DESCRIPTION
## Description

Ref https://github.com/directus/directus/issues/17385#issuecomment-1442061354

Previously #12723 added a check for non-postgres schema which snapshots UUID field type as `char(36)`. However there seems to be cases where it can be `varchar(36)` as well. There was a prior internal discussion regarding this change in past.

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
