### PR TITLE
Add ability to limit requests from using the Cache-Control header to skip cache

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -76,6 +76,7 @@ const allowedEnvironmentVars = [
 	'CACHE_REDIS_PASSWORD',
 	'CACHE_MEMCACHE',
 	'CACHE_VALUE_MAX_SIZE',
+	'CACHE_SKIP_ALLOWED',
 	'CACHE_HEALTHCHECK_THRESHOLD',
 	// storage
 	'STORAGE_LOCATIONS',
@@ -236,6 +237,7 @@ const defaults: Record<string, any> = {
 	CACHE_SCHEMA: true,
 	CACHE_PERMISSIONS: true,
 	CACHE_VALUE_MAX_SIZE: false,
+	CACHE_SKIP_ALLOWED: false,
 
 	AUTH_PROVIDERS: '',
 	AUTH_DISABLE_DEFAULT: false,

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -293,6 +293,9 @@ const typeMap: Record<string, string> = {
 	DB_PORT: 'number',
 
 	DB_EXCLUDE_TABLES: 'array',
+
+	CACHE_SKIP_ALLOWED: 'boolean',
+
 	IMPORT_IP_DENY_LIST: 'array',
 
 	FILE_METADATA_ALLOW_LIST: 'array',

--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -4,6 +4,7 @@ import env from '../env';
 import asyncHandler from '../utils/async-handler';
 import { getCacheControlHeader } from '../utils/get-cache-headers';
 import { getCacheKey } from '../utils/get-cache-key';
+import { shouldSkipCache } from '../utils/should-skip-cache';
 import logger from '../logger';
 
 const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next) => {
@@ -13,7 +14,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 	if (env.CACHE_ENABLED !== true) return next();
 	if (!cache) return next();
 
-	if (req.headers['cache-control']?.includes('no-store') || req.headers['Cache-Control']?.includes('no-store')) {
+	if (shouldSkipCache(req)) {
 		if (env.CACHE_STATUS_HEADER) res.setHeader(`${env.CACHE_STATUS_HEADER}`, 'MISS');
 		return next();
 	}

--- a/api/src/utils/get-cache-headers.test.ts
+++ b/api/src/utils/get-cache-headers.test.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import { describe, expect, vi, test } from 'vitest';
-import { getCacheControlHeader } from '../../src/utils/get-cache-headers';
+import { getCacheControlHeader } from './get-cache-headers';
 
 let factoryEnv: { [k: string]: any } = {};
 
@@ -13,26 +13,15 @@ vi.mock('../../src/env', () => ({
 			},
 		}
 	),
+	getEnv: vi.fn().mockImplementation(() => factoryEnv),
 }));
 
 const scenarios = [
 	// Test the cache-control header
 	{
-		name: 'when cache-control header includes no-store',
-		input: {
-			env: {},
-			headers: { 'cache-control': 'no-store' },
-			accountability: null,
-			ttl: 5678910,
-			globalCacheSettings: false,
-			personalized: false,
-		},
-		output: 'no-store',
-	},
-	{
 		name: 'when cache-Control header includes no-store',
 		input: {
-			env: {},
+			env: { CACHE_SKIP_ALLOWED: true },
 			headers: { 'Cache-Control': 'no-store' },
 			accountability: null,
 			ttl: 5678910,
@@ -44,7 +33,7 @@ const scenarios = [
 	{
 		name: 'when cache-Control header does not include no-store',
 		input: {
-			env: {},
+			env: { CACHE_SKIP_ALLOWED: true },
 			headers: { other: 'value' },
 			accountability: null,
 			ttl: 5678910,
@@ -210,6 +199,10 @@ describe('get cache headers', () => {
 			const mockRequest = {
 				headers: scenario.input.headers as any,
 				accountability: scenario.input.accountability,
+				get: vi.fn().mockImplementation((header) => {
+					const matchingKey = Object.keys(scenario.input.headers as any).find((key) => key.toLowerCase() === header);
+					return matchingKey ? (scenario.input.headers as any)?.[matchingKey] : undefined;
+				}),
 			} as Partial<Request>;
 			factoryEnv = scenario.input.env;
 			const { ttl, globalCacheSettings, personalized } = scenario.input;

--- a/api/src/utils/get-cache-headers.ts
+++ b/api/src/utils/get-cache-headers.ts
@@ -1,5 +1,6 @@
 import env from '../env';
 import { Request } from 'express';
+import { shouldSkipCache } from './should-skip-cache';
 
 /**
  * Returns the Cache-Control header for the current request
@@ -15,11 +16,8 @@ export function getCacheControlHeader(
 	globalCacheSettings: boolean,
 	personalized: boolean
 ): string {
-	const noCacheRequested =
-		req.headers['cache-control']?.includes('no-store') || req.headers['Cache-Control']?.includes('no-store');
-
 	// When the user explicitly asked to skip the cache
-	if (noCacheRequested) return 'no-store';
+	if (shouldSkipCache(req)) return 'no-store';
 
 	// When the resource / current request shouldn't be cached
 	if (ttl === undefined || ttl < 0) return 'no-cache';

--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -1,0 +1,29 @@
+import { Request } from 'express';
+import { expect, test, vi } from 'vitest';
+import { getEnv } from '../env';
+import { shouldSkipCache } from './should-skip-cache';
+
+vi.mock('../env');
+
+test.each([
+	{ scenario: 'accept', value: true },
+	{ scenario: 'ignore', value: false },
+])(
+	'should $scenario Cache-Control request header containing "no-store" when CACHE_SKIP_ALLOWED is $value',
+	({ value }) => {
+		vi.mocked(getEnv).mockReturnValue({ CACHE_SKIP_ALLOWED: value });
+
+		const req = {
+			get: vi.fn((str) => {
+				switch (str) {
+					case 'cache-control':
+						return 'no-store';
+					default:
+						return undefined;
+				}
+			}),
+		} as unknown as Request;
+
+		expect(shouldSkipCache(req)).toBe(value);
+	}
+);

--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -8,7 +8,7 @@ vi.mock('../env');
 test('should always skip cache for requests coming from data studio', () => {
 	const publicURL = 'http://admin.example.com';
 
-	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: publicURL, CACHE_SKIP_ALLOWED: true });
+	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: publicURL, CACHE_SKIP_ALLOWED: false });
 
 	const req = {
 		get: vi.fn((str) => {
@@ -25,7 +25,7 @@ test('should always skip cache for requests coming from data studio', () => {
 });
 
 test('should not skip cache for requests coming outside of data studio', () => {
-	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: 'http://admin.example.com', CACHE_SKIP_ALLOWED: true });
+	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: 'http://admin.example.com', CACHE_SKIP_ALLOWED: false });
 
 	const req = {
 		get: vi.fn((str) => {

--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -5,13 +5,49 @@ import { shouldSkipCache } from './should-skip-cache';
 
 vi.mock('../env');
 
+test('should always skip cache for requests coming from data studio', () => {
+	const publicURL = 'http://admin.example.com';
+
+	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: publicURL, CACHE_SKIP_ALLOWED: true });
+
+	const req = {
+		get: vi.fn((str) => {
+			switch (str) {
+				case 'Referer':
+					return `${publicURL}/admin/settings/data-model`;
+				default:
+					return undefined;
+			}
+		}),
+	} as unknown as Request;
+
+	expect(shouldSkipCache(req)).toBe(true);
+});
+
+test('should not skip cache for requests coming outside of data studio', () => {
+	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: 'http://admin.example.com', CACHE_SKIP_ALLOWED: true });
+
+	const req = {
+		get: vi.fn((str) => {
+			switch (str) {
+				case 'Referer':
+					return `http://elsewhere.example.com/admin/settings/data-model`;
+				default:
+					return undefined;
+			}
+		}),
+	} as unknown as Request;
+
+	expect(shouldSkipCache(req)).toBe(false);
+});
+
 test.each([
 	{ scenario: 'accept', value: true },
 	{ scenario: 'ignore', value: false },
 ])(
 	'should $scenario Cache-Control request header containing "no-store" when CACHE_SKIP_ALLOWED is $value',
 	({ value }) => {
-		vi.mocked(getEnv).mockReturnValue({ CACHE_SKIP_ALLOWED: value });
+		vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: '/', CACHE_SKIP_ALLOWED: value });
 
 		const req = {
 			get: vi.fn((str) => {

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -11,6 +11,7 @@ import { Url } from './url';
 export function shouldSkipCache(req: Request): boolean {
 	const env = getEnv();
 
+	// prevent skipping of cache when it is not allowed
 	if (env.CACHE_SKIP_ALLOWED === false) return false;
 
 	// always skip cache for requests coming from the data studio based on Referer header

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -18,5 +18,7 @@ export function shouldSkipCache(req: Request): boolean {
 	const adminUrl = new Url(env.PUBLIC_URL).addPath('admin').toString();
 	if (req.get('Referer')?.startsWith(adminUrl)) return true;
 
-	return req.get('cache-control')?.includes('no-store') ?? false;
+	if (req.get('cache-control')?.includes('no-store')) return true;
+
+	return false;
 }

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -11,14 +11,11 @@ import { Url } from './url';
 export function shouldSkipCache(req: Request): boolean {
 	const env = getEnv();
 
-	// prevent skipping of cache when it is not allowed
-	if (env.CACHE_SKIP_ALLOWED === false) return false;
-
 	// always skip cache for requests coming from the data studio based on Referer header
 	const adminUrl = new Url(env.PUBLIC_URL).addPath('admin').toString();
 	if (req.get('Referer')?.startsWith(adminUrl)) return true;
 
-	if (req.get('cache-control')?.includes('no-store')) return true;
+	if (env.CACHE_SKIP_ALLOWED && req.get('cache-control')?.includes('no-store')) return true;
 
 	return false;
 }

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -11,7 +11,7 @@ import { Url } from './url';
 export function shouldSkipCache(req: Request): boolean {
 	const env = getEnv();
 
-	// always skip cache for requests coming from the data studio based on Referer header
+	// Always skip cache for requests coming from the data studio based on Referer header
 	const adminUrl = new Url(env.PUBLIC_URL).addPath('admin').toString();
 	if (req.get('Referer')?.startsWith(adminUrl)) return true;
 

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -1,5 +1,6 @@
 import { Request } from 'express';
 import { getEnv } from '../env';
+import { Url } from './url';
 
 /**
  * Whether to skip caching for the current request
@@ -11,6 +12,10 @@ export function shouldSkipCache(req: Request): boolean {
 	const env = getEnv();
 
 	if (env.CACHE_SKIP_ALLOWED === false) return false;
+
+	// always skip cache for requests coming from the data studio based on Referer header
+	const adminUrl = new Url(env.PUBLIC_URL).addPath('admin').toString();
+	if (req.get('Referer')?.startsWith(adminUrl)) return true;
 
 	return req.get('cache-control')?.includes('no-store') ?? false;
 }

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -1,0 +1,16 @@
+import { Request } from 'express';
+import { getEnv } from '../env';
+
+/**
+ * Whether to skip caching for the current request
+ *
+ * @param req Express request object
+ */
+
+export function shouldSkipCache(req: Request): boolean {
+	const env = getEnv();
+
+	if (env.CACHE_SKIP_ALLOWED === false) return false;
+
+	return req.get('cache-control')?.includes('no-store') ?? false;
+}

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -8,9 +8,6 @@ import PQueue, { Options, DefaultAddOptions } from 'p-queue';
 const api = axios.create({
 	baseURL: getRootPath(),
 	withCredentials: true,
-	headers: {
-		'Cache-Control': 'no-store',
-	},
 });
 
 let queue = new PQueue({ concurrency: 5, intervalCap: 5, interval: 500, carryoverConcurrencyCount: true });


### PR DESCRIPTION
## Description

Currently users can circumvent the API cache by sending `Cache-Control` request header containing `no-store`, and it is being used by the data studio as well.

This PR adds an environment variable to make it possible to lockdown the ability to skip cache, except for requests coming from the Data Studio.

Fixes ENG-490

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [x] Documentation was added/updated. PR: directus/docs#314
