### PR TITLE
Fix NPM publishing in release workflow

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: Build the production bundle of the platform
     required: false
     default: true
+  registry:
+    description: NPM registry to set up for auth
+    required: false
 
 runs:
   using: 'composite'
@@ -13,6 +16,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        registry-url: ${{ inputs.registry }}
 
     - uses: pnpm/action-setup@v2.2.4
       name: Install pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,12 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           build: false
+          registry: https://registry.npmjs.org
 
       - name: Publish packages to NPM
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          pnpm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-          pnpm -r publish --access=public --no-git-checks
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --access=public --no-git-checks
 
   build-images:
     name: Build Images


### PR DESCRIPTION
## Description

Fix publishing of packages to NPM in release workflow by using the NPM auth set-up from `setup-node` action. This is the officially recommended way to publish packages from within GitHub workflows, see https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry.

Tested in another repo ✅ 

Honestly, I'm not entirely sure what the problem is, but it seems like the publish command doesn't pick up the token anymore with the current workflow set-up. This is not specific to `pnpm` but also the case with `npm`.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
