### PR TITLE
(Draft) M2A Template Values

### DIFF
--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -33,7 +33,7 @@ import { toRefs, ref, watch, onMounted, onUnmounted, computed } from 'vue';
 import FieldListItem from './field-list-item.vue';
 import { FieldTree } from './types';
 import { Field, Relation } from '@directus/shared/types';
-import { useFieldTree } from '@/composables/use-field-tree';
+import { FieldNode, useFieldTree } from '@/composables/use-field-tree';
 import { flattenFieldGroups } from '@/utils/flatten-field-groups';
 
 interface Props {
@@ -41,6 +41,8 @@ interface Props {
 	modelValue?: string | null;
 	nullable?: boolean;
 	collection?: string | null;
+	m2aCollectionField: string | null;
+	m2aCollectionScope: string | null;
 	depth?: number;
 	placeholder?: string | null;
 	inject?: {
@@ -54,6 +56,8 @@ const props = withDefaults(defineProps<Props>(), {
 	modelValue: null,
 	nullable: true,
 	collection: null,
+	m2aCollectionField: null,
+	m2aCollectionScope: null,
 	depth: undefined,
 	placeholder: null,
 	inject: null,
@@ -65,8 +69,10 @@ const contentEl = ref<HTMLElement | null>(null);
 
 const menuActive = ref(false);
 
-const { collection, inject } = toRefs(props);
-const { treeList, loadFieldRelations } = useFieldTree(collection, inject);
+const { collection, inject, m2aCollectionField, m2aCollectionScope } = toRefs(props);
+const blankFilter = () => true;
+
+const { treeList, loadFieldRelations } = useFieldTree(collection, inject, blankFilter, m2aCollectionScope.value);
 
 watch(() => props.modelValue, setContent, { immediate: true });
 

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -27,7 +27,8 @@ export type FieldTreeContext = {
 export function useFieldTree(
 	collection: Ref<string | null>,
 	inject?: Ref<{ fields: Field[]; relations: Relation[] } | null>,
-	filter: (field: Field, parent?: FieldNode) => boolean = () => true
+	filter: (field: Field, parent?: FieldNode) => boolean = () => true,
+	m2aCollectionScope: string | null = null
 ): FieldTreeContext {
 	const fieldsStore = useFieldsStore();
 	const relationsStore = useRelationsStore();
@@ -51,7 +52,7 @@ export function useFieldTree(
 	}
 
 	function getTree(collection?: string | null, parent?: FieldNode) {
-		const injectedFields = inject?.value?.fields.filter((field) => field.collection === collection);
+		const injectedFields = inject?.value?.fields?.filter((field) => field.collection === collection);
 
 		const allFields = fieldsStore
 			.getFieldsForCollectionSorted(collection!)
@@ -120,6 +121,19 @@ export function useFieldTree(
 			};
 		}
 
+		if (m2aCollectionScope) {
+			const scopedCollection = relatedCollections.find((collection) => collection === m2aCollectionScope);
+
+			return {
+				name: `${field.name} (${scopedCollection})`,
+				field: `${field.field}:${scopedCollection}`,
+				collection: field.collection,
+				relatedCollection: scopedCollection,
+				key: keyContext + `${field.field}:${scopedCollection}`,
+				path: pathContext + `${field.field}:${scopedCollection}`,
+				type: field.type,
+			};
+		}
 		return relatedCollections.map((collection) => {
 			return {
 				name: `${field.name} (${collection})`,

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -1,7 +1,7 @@
 <template>
 	<value-null v-if="!relatedCollection" />
 	<v-menu
-		v-else-if="['o2m', 'm2m', 'm2a', 'translations', 'files'].includes(localType.toLowerCase())"
+		v-else-if="localType && ['o2m', 'm2m', 'm2a', 'translations', 'files'].includes(localType.toLowerCase())"
 		show-arrow
 		:disabled="value.length === 0"
 	>
@@ -16,10 +16,17 @@
 		</template>
 
 		<v-list class="links">
-			<v-list-item v-for="item in value" :key="item[primaryKeyFieldPath]">
+			<v-list-item
+				v-for="item in value"
+				:key="
+					collectionField
+						? item[primaryKeyFieldPaths[item[collectionField]]]
+						: item[primaryKeyFieldPaths[relatedCollection as string]]
+				"
+			>
 				<v-list-item-content>
 					<render-template
-						:template="internalTemplate"
+						:template="getTemplate(item)"
 						:item="item"
 						:collection="junctionCollection ?? relatedCollection"
 					/>
@@ -30,16 +37,18 @@
 			</v-list-item>
 		</v-list>
 	</v-menu>
-	<render-template v-else :template="internalTemplate" :item="value" :collection="relatedCollection" />
+	<render-template v-else :template="getTemplate(value)" :item="value" :collection="relatedCollection" />
 </template>
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
 import { defineComponent, computed, PropType } from 'vue';
 import { getRelatedCollection } from '@/utils/get-related-collection';
-import { useCollection } from '@directus/shared/composables';
+import { useFieldsStore } from '@/stores/fields';
 import { getLocalTypeForField } from '@/utils/get-local-type';
 import { get } from 'lodash';
+import { useCollectionsStore } from '@/stores/collections';
+import { Field } from '@directus/shared/types';
 
 export default defineComponent({
 	props: {
@@ -56,51 +65,68 @@ export default defineComponent({
 			default: null,
 		},
 		template: {
-			type: String,
+			type: [String, Object] as PropType<string | Record<string, string>>,
 			default: null,
 		},
 	},
 	setup(props) {
 		const { t, te } = useI18n();
+		const fieldsStore = useFieldsStore();
+		const collectionsStore = useCollectionsStore();
 
 		const relatedCollectionData = computed(() => {
 			return getRelatedCollection(props.collection, props.field);
 		});
 
 		const relatedCollection = computed(() => {
-			return relatedCollectionData.value.relatedCollection;
+			return relatedCollectionData.value?.relatedCollection;
 		});
 
 		const junctionCollection = computed(() => {
-			return relatedCollectionData.value.junctionCollection;
+			return relatedCollectionData.value?.junctionCollection;
+		});
+
+		const path = computed(() => {
+			return relatedCollectionData.value?.path;
+		});
+
+		const collectionField = computed(() => {
+			return relatedCollectionData.value?.collectionField;
 		});
 
 		const localType = computed(() => {
 			return getLocalTypeForField(props.collection, props.field);
 		});
 
-		const { primaryKeyField } = useCollection(relatedCollection);
+		const primaryKeyFields = computed(() =>
+			Array.isArray(relatedCollection.value)
+				? (relatedCollection.value
+						.map((collection) => fieldsStore.getPrimaryKeyFieldForCollection(collection))
+						.filter((f) => f != null) as Field[])
+				: ([fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value!)] as Field[])
+		);
 
-		const primaryKeyFieldPath = computed(() => {
-			return relatedCollectionData.value.path
-				? [...relatedCollectionData.value.path, primaryKeyField.value?.field].join('.')
-				: primaryKeyField.value?.field;
-		});
+		const primaryKeyFieldPaths = computed(() => {
+			const initialValue = {} as Record<string, string>;
 
-		const internalTemplate = computed(() => {
-			return props.template || `{{ ${primaryKeyFieldPath.value!} }}`;
+			return primaryKeyFields.value.reduce((obj, pkField) => {
+				return {
+					...obj,
+					[pkField!.collection]: path.value ? [path.value, pkField?.field].join('.') : pkField?.field,
+				};
+			}, initialValue);
 		});
 
 		const unit = computed(() => {
 			if (Array.isArray(props.value)) {
 				if (props.value.length === 1) {
-					if (te(`collection_names_singular.${relatedCollection.value}`)) {
+					if (!Array.isArray(relatedCollection.value) && te(`collection_names_singular.${relatedCollection.value}`)) {
 						return t(`collection_names_singular.${relatedCollection.value}`);
 					} else {
 						return t('item');
 					}
 				} else {
-					if (te(`collection_names_plural.${relatedCollection.value}`)) {
+					if (!Array.isArray(relatedCollection.value) && te(`collection_names_plural.${relatedCollection.value}`)) {
 						return t(`collection_names_plural.${relatedCollection.value}`);
 					} else {
 						return t('items');
@@ -114,18 +140,47 @@ export default defineComponent({
 		return {
 			relatedCollection,
 			junctionCollection,
-			primaryKeyFieldPath,
+			primaryKeyFieldPaths,
+			collectionField,
 			getLinkForItem,
-			internalTemplate,
+			getTemplate,
 			unit,
 			localType,
 		};
 
 		function getLinkForItem(item: any) {
-			if (!relatedCollectionData.value || !primaryKeyFieldPath.value) return null;
-			const primaryKey = get(item, primaryKeyFieldPath.value);
+			if (!relatedCollectionData.value || !primaryKeyFields.value || primaryKeyFields.value.length === 0) return '';
+			if (collectionField.value) {
+				const itemCollection = item[collectionField.value];
+				const pkFieldPath = primaryKeyFieldPaths.value[itemCollection];
+				if (pkFieldPath) {
+					const primaryKey = get(item, pkFieldPath);
+					return `/content/${itemCollection}/${encodeURIComponent(primaryKey)}`;
+				}
+			} else {
+				const primaryKey = get(item, primaryKeyFieldPaths.value[relatedCollection.value as string]!);
+				return `/content/${relatedCollection.value as string}/${encodeURIComponent(primaryKey)}`;
+			}
+			return '';
+		}
 
-			return `/content/${relatedCollection.value}/${encodeURIComponent(primaryKey)}`;
+		function getTemplate(item: any): string {
+			if (Array.isArray(relatedCollection.value) && collectionField.value && typeof props.template === 'object') {
+				return (
+					props.template[item[collectionField.value]] ?? getDefaultTemplateForCollection(item[collectionField.value])
+				);
+			}
+			return (props.template as string) ?? getDefaultTemplateForCollection(relatedCollection.value as string);
+		}
+
+		function getDefaultTemplateForCollection(collection: string): string {
+			const col = collectionsStore.getCollection(collection);
+			if (col?.meta?.display_template) {
+				return col.meta.display_template;
+			} else {
+				const pkFieldPath = primaryKeyFieldPaths.value[collection];
+				return `{{${pkFieldPath}}}`;
+			}
 		}
 	},
 });

--- a/app/src/interfaces/_system/system-display-template-m2a/index.ts
+++ b/app/src/interfaces/_system/system-display-template-m2a/index.ts
@@ -1,0 +1,13 @@
+import { defineInterface } from '@directus/shared/utils';
+import InterfaceSystemDisplayTemplateM2A from './system-display-template-m2a.vue';
+
+export default defineInterface({
+	id: 'system-display-template-m2a',
+	name: '$t:interfaces.system-display-template.display-template',
+	description: '$t:interfaces.system-display-template.description',
+	icon: 'arrow_drop_down_circle',
+	component: InterfaceSystemDisplayTemplateM2A,
+	types: ['json'],
+	system: true,
+	options: [],
+});

--- a/app/src/interfaces/_system/system-display-template-m2a/system-display-template-m2a.vue
+++ b/app/src/interfaces/_system/system-display-template-m2a/system-display-template-m2a.vue
@@ -85,13 +85,15 @@ export default defineComponent({
 			internalValue.value = { ...internalValue.value, [collection]: event };
 		};
 
+		// TODO: move to gettree for nested m2as
+
 		const injectedFields = computed(() => {
 			const singularField: Field = {
 				name: `${t('field_options.directus_collections.collection_name')} (${t(
 					'field_options.directus_collections.singular_unit'
 				)})`,
 				collection: collectionName.value,
-				field: `$t:collection_names_singular.${collectionField.value}`,
+				field: `$collection_name_singular`,
 				type: 'string',
 				schema: null,
 				meta: null,
@@ -101,12 +103,20 @@ export default defineComponent({
 					'field_options.directus_collections.plural_unit'
 				)})`,
 				collection: collectionName.value,
-				field: `$t:collection_names_plural.${collectionField.value}`,
+				field: `$collection_name_plural`,
 				type: 'string',
 				schema: null,
 				meta: null,
 			};
-			return [singularField, pluralField];
+			const itemDefaultField: Field = {
+				name: `${t('item')} (${t('default_label')} ${t('fields.directus_collections.display_template')})`,
+				collection: collectionName.value,
+				field: `$item_default_display_template`,
+				type: 'string',
+				schema: null,
+				meta: null,
+			};
+			return [singularField, pluralField, itemDefaultField];
 		});
 
 		return { t, allowedCollectionsInfo, handleUpdate, internalValue, injectedFields };

--- a/app/src/interfaces/_system/system-display-template-m2a/system-display-template-m2a.vue
+++ b/app/src/interfaces/_system/system-display-template-m2a/system-display-template-m2a.vue
@@ -1,0 +1,126 @@
+<template>
+	<div class="system-display-template">
+		<v-notice v-if="collectionName === null" type="info">
+			{{ t('interfaces.system-display-template.select_a_collection') }}
+		</v-notice>
+
+		<template v-else>
+			<template v-for="collection in allowedCollectionsInfo" :key="collection.collection">
+				<v-text-overflow :text="collection.name" />
+				<v-field-template
+					:collection="collectionName"
+					:m2a-collection-field="collectionField"
+					:m2a-collection-scope="collection.collection"
+					:model-value="internalValue[collection.collection]"
+					:disabled="disabled"
+					:inject="{ fields: injectedFields }"
+					@update:model-value="handleUpdate(collection.collection, $event)"
+				/>
+			</template>
+		</template>
+	</div>
+</template>
+
+<script lang="ts">
+import { useI18n } from 'vue-i18n';
+import { defineComponent, inject, ref, computed, PropType, toRefs } from 'vue';
+import { useCollectionsStore } from '@/stores/collections';
+import { Collection } from '@/types/collections';
+import { Field } from '@directus/shared/types';
+
+export default defineComponent({
+	props: {
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+		value: {
+			type: Object as PropType<Record<string, string>>,
+			default: null,
+		},
+		collectionField: {
+			type: String,
+			required: true,
+		},
+		allowedCollections: {
+			type: Array as PropType<string[]>,
+			required: true,
+		},
+		collectionName: {
+			type: String,
+			required: true,
+		},
+	},
+	emits: ['input'],
+	setup(props, { emit }) {
+		const { t } = useI18n();
+		const { allowedCollections, collectionField, collectionName } = toRefs(props);
+
+		const internalValue = computed({
+			get: () => {
+				if (typeof props.value === 'string' || !props.value) {
+					let obj = {} as Record<string, string>;
+					for (let col of allowedCollections.value) {
+						obj[col] = props.value;
+					}
+					return obj;
+				}
+				return props.value;
+			},
+			set: (val) => {
+				emit('input', val);
+			},
+		});
+
+		const collectionsStore = useCollectionsStore();
+
+		const allowedCollectionsInfo = computed<Collection[]>(
+			() =>
+				allowedCollections.value
+					.map((collection) => collectionsStore.getCollection(collection))
+					.filter((collection) => collection != null) as Collection[]
+		);
+
+		const handleUpdate = (collection: string, event: string) => {
+			internalValue.value = { ...internalValue.value, [collection]: event };
+		};
+
+		const injectedFields = computed(() => {
+			const singularField: Field = {
+				name: `${t('field_options.directus_collections.collection_name')} (${t(
+					'field_options.directus_collections.singular_unit'
+				)})`,
+				collection: collectionName.value,
+				field: `$t:collection_names_singular.${collectionField.value}`,
+				type: 'string',
+				schema: null,
+				meta: null,
+			};
+			const pluralField: Field = {
+				name: `${t('field_options.directus_collections.collection_name')} (${t(
+					'field_options.directus_collections.plural_unit'
+				)})`,
+				collection: collectionName.value,
+				field: `$t:collection_names_plural.${collectionField.value}`,
+				type: 'string',
+				schema: null,
+				meta: null,
+			};
+			return [singularField, pluralField];
+		});
+
+		return { t, allowedCollectionsInfo, handleUpdate, internalValue, injectedFields };
+	},
+});
+</script>
+<style lang="scss" scoped>
+.system-display-template {
+	::v-deep(.v-text-overflow) {
+		margin-bottom: 8px;
+	}
+
+	::v-deep(.v-input) {
+		margin-bottom: 16px;
+	}
+}
+</style>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
@@ -30,6 +30,7 @@ import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import ExtensionOptions from '../shared/extension-options.vue';
 import { useExtension } from '@/composables/use-extension';
+import { FancySelectItem } from '@/components/v-fancy-select.vue';
 
 export default defineComponent({
 	components: { ExtensionOptions },

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -80,7 +80,7 @@ export const useFieldDetailStore = defineStore({
 		items: {} as Record<string, Record<string, any>[]>,
 
 		// Various flags that alter the operations of watchers and getters
-		localType: 'standard' as (typeof LOCAL_TYPES)[number],
+		localType: 'standard' as typeof LOCAL_TYPES[number],
 		autoGenerateJunctionRelation: true,
 		saving: false,
 	}),
@@ -108,7 +108,7 @@ export const useFieldDetailStore = defineStore({
 				) as DeepPartial<Relation> | undefined;
 
 				if (['files', 'm2m', 'translations', 'm2a'].includes(this.localType)) {
-					// These types rely on directus_relations fields being said, so meta should exist for these particular relations
+					// These types rely on directus_relations fields being set, so meta should exist for these particular relations
 					this.relations.m2o = relations.find((relation) => relation.meta?.id !== this.relations.o2m?.meta?.id) as
 						| DeepPartial<Relation>
 						| undefined;
@@ -161,7 +161,7 @@ export const useFieldDetailStore = defineStore({
 				alterations.global.setSpecialForLocalType(updates);
 			}
 
-			const localType = getCurrent('localType') as (typeof LOCAL_TYPES)[number] | undefined;
+			const localType = getCurrent('localType') as typeof LOCAL_TYPES[number] | undefined;
 			if (localType) {
 				alterations[localType].applyChanges(updates, this, helperFn);
 			}

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -321,7 +321,7 @@ export const useFieldsStore = defineStore({
 		 * Retrieve field info for a field or a related field
 		 */
 		getField(collection: string, fieldKey: string): Field | null {
-			if (fieldKey.includes('.')) {
+			if (fieldKey.includes('.') || fieldKey.includes(':')) {
 				return this.getRelationalField(collection, fieldKey) || null;
 			} else {
 				return this.fields.find((field) => field.collection === collection && field.field === fieldKey) || null;
@@ -342,8 +342,8 @@ export const useFieldsStore = defineStore({
 			const relationsStore = useRelationsStore();
 			const [field, ...path] = fields.split('.');
 			if (field.includes(':')) {
-				const [_, collection] = field.split(':');
-				return this.getField(collection, path.join('.'));
+				const [key, scopedCollection] = field.split(':');
+				return path.length > 0 ? this.getField(scopedCollection, path.join('.')) : this.getField(collection, key);
 			}
 
 			const relations = relationsStore.getRelationsForField(collection, field);

--- a/app/src/stores/relations.ts
+++ b/app/src/stores/relations.ts
@@ -63,13 +63,13 @@ export const useRelationsStore = defineStore({
 
 			const relations: Relation[] = this.getRelationsForCollection(collection).filter((relation: Relation) => {
 				return (
-					(relation.collection === collection && relation.field === field) ||
-					(relation.related_collection === collection && relation.meta?.one_field === field)
+					(relation.collection === collection && relation.field === fieldInfo.field) ||
+					(relation.related_collection === collection && relation.meta?.one_field === fieldInfo.field)
 				);
 			});
 
 			if (relations.length > 0) {
-				const isM2M = relations[0].meta?.junction_field !== null;
+				const isM2M = relations[0].meta?.junction_field !== null && relations[0].meta?.one_allowed_collections === null;
 
 				// If the relation matching the field has a junction field, it's a m2m (OR M2A). In that case,
 				// we also want to return the secondary relationship (from the jt to the related(s))

--- a/app/src/stores/relations.ts
+++ b/app/src/stores/relations.ts
@@ -71,8 +71,8 @@ export const useRelationsStore = defineStore({
 			if (relations.length > 0) {
 				const isM2M = relations[0].meta?.junction_field !== null;
 
-				// If the relation matching the field has a junction field, it's a m2m. In that case,
-				// we also want to return the secondary relationship (from the jt to the related)
+				// If the relation matching the field has a junction field, it's a m2m (OR M2A). In that case,
+				// we also want to return the secondary relationship (from the jt to the related(s))
 				// so any ui elements (interfaces) can utilize the full relationship
 				if (isM2M) {
 					const secondaryRelation = this.relations.find((relation) => {

--- a/app/src/utils/get-related-collection.ts
+++ b/app/src/utils/get-related-collection.ts
@@ -31,10 +31,22 @@ export function getRelatedCollection(collection: string, field: string): Related
 	 * return whichever collection isn't the current one
 	 */
 	if (relations.length === 1) {
-		return {
-			relatedCollection:
-				relations[0].collection === collection ? relations[0].related_collection! : relations[0].collection,
-		};
+		if (relations[0].collection === collection) {
+			if (relations[0].related_collection) {
+				return {
+					relatedCollection: relations[0].related_collection,
+				};
+			} else if (field.includes(':')) {
+				const [_, collectionScope] = field.split(':');
+				if (relations[0].meta?.one_allowed_collections?.includes(collectionScope)) {
+					return { relatedCollection: collectionScope };
+				}
+			}
+			return null;
+		} else {
+			return { relatedCollection: relations[0].collection };
+		}
+
 		/* Else it must be a junction collection, either m2m or m2a
 		 * (translations is also an m2m)
 		 */

--- a/app/src/utils/render-string-template.ts
+++ b/app/src/utils/render-string-template.ts
@@ -7,6 +7,7 @@ import { computed, ComputedRef, Ref, ref, unref } from 'vue';
 import { set } from 'lodash';
 import { useExtension } from '@/composables/use-extension';
 
+//TODO: test for m2a fields
 type StringTemplate = {
 	fieldsInTemplate: ComputedRef<string[]>;
 	displayValue: ComputedRef<string | false>;


### PR DESCRIPTION
## Description

Allows M2A Template values to be entered and rendered in display templates on a per-related-collection basis
Also adds a few special fields for m2a fields

I had to implement this for a job and thought I'd submit it here. It's messy and not complete (see: `render-string-template.vue` and rendering m2a fields nested under other fields), but it works for rendering m2a values in `related-values` displays on tables. I don't really have time to keep working on this so please take it over if you want. Happy to answer any questions too. Just thought I'd give you this work as is :)

Ok I'm now realizing the special `item_default_display_template` doesn't work because `adjust-fields-for-display` doesn't recognize it and get the appropriate fields to be fetched. 

Fixes #10601, #16517

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
