### PR TITLE
Update gh-action-linear to v0.3.1

### DIFF
--- a/.github/workflows/linear-auto.yml
+++ b/.github/workflows/linear-auto.yml
@@ -8,7 +8,7 @@ jobs:
   linear:
     runs-on: ubuntu-latest
     steps:
-      - uses: rijkvanzanten/gh-action-linear@v0.3.0
+      - uses: rijkvanzanten/gh-action-linear@v0.3.1
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}

--- a/.github/workflows/linear-dispatch.yaml
+++ b/.github/workflows/linear-dispatch.yaml
@@ -2,12 +2,12 @@ on:
   repository_dispatch:
     types:
       - linear-command
-      
+
 jobs:
   create_issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: rijkvanzanten/gh-action-linear@v0.3.0
+      - uses: rijkvanzanten/gh-action-linear@v0.3.1
         with:
           github-repo: ${{ github.event.client_payload.github.payload.repository.full_name }}
           github-issue: ${{ github.event.client_payload.github.payload.issue.number }}


### PR DESCRIPTION
## Description

Update `gh-action-linear` to v0.3.1 in order to get rid of a warning, see https://github.com/rijkvanzanten/gh-action-linear/releases/tag/v0.3.1.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
