### PR TITLE
fix: long arrays in query converted to objects

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -99,7 +99,7 @@ export default async function createApp(): Promise<express.Application> {
 
 	app.disable('x-powered-by');
 	app.set('trust proxy', env.IP_TRUST_PROXY);
-	app.set('query parser', (str: string) => qs.parse(str, { depth: 10 }));
+	app.set('query parser', (str: string) => qs.parse(str, { depth: 10, arrayLimit: Infinity }));
 
 	app.use(
 		helmet.contentSecurityPolicy(


### PR DESCRIPTION
## Description

I issued same issue as explained here https://github.com/expressjs/body-parser/issues/289

When using more that `20` fileds, directus don't get the query and return unrelevent results (ex: requested id when using items.readOne controller)

```ts
await directus
  .items('xxx')
  .readOne('xxx', {
    fields: [
      'field_1',
      // ...
      'field_21', // <- this one breaks
    ]
  })
```

Another solution that allowing `Infinite` in body-parser would be to update [`sanitizeFields`](https://github.com/directus/directus/blob/main/api/src/utils/sanitize-query.ts#L71) to allow parsing objects


## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
