### PR TITLE
Feat/improve cli commands for first time starts

### DIFF
--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -47,7 +47,7 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 	process.exit(0);
 }
 
-async function waitForDatabase(database: Knex) {
+export async function waitForDatabase(database: Knex) {
 	const tries = 5;
 	const secondsBetweenTries = 5;
 

--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -10,7 +10,13 @@ import getDatabase, { isInstalled, validateDatabaseConnection, hasDatabaseConnec
 import { SchemaOverview } from '@directus/shared/types';
 import { defaultAdminRole, defaultAdminUser } from '../../utils/defaults';
 
-export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boolean }): Promise<void> {
+export default async function bootstrap({
+	skipAdminInit,
+	systemOnlyMigrations = false,
+}: {
+	skipAdminInit?: boolean;
+	systemOnlyMigrations?: boolean;
+}): Promise<void> {
 	logger.info('Initializing bootstrap...');
 
 	const database = getDatabase();
@@ -23,7 +29,7 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 		await installDatabase(database);
 
 		logger.info('Running migrations...');
-		await runMigrations(database, 'latest');
+		await runMigrations(database, 'latest', systemOnlyMigrations);
 
 		const schema = await getSchema();
 
@@ -40,7 +46,7 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 	} else {
 		logger.info('Database already initialized, skipping install');
 		logger.info('Running migrations...');
-		await runMigrations(database, 'latest');
+		await runMigrations(database, 'latest', systemOnlyMigrations);
 	}
 
 	logger.info('Done');

--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -29,7 +29,7 @@ export default async function bootstrap({
 		await installDatabase(database);
 
 		logger.info('Running migrations...');
-		await runMigrations(database, 'latest', systemOnlyMigrations);
+		await runMigrations(database, 'latest', true, systemOnlyMigrations);
 
 		const schema = await getSchema();
 
@@ -46,7 +46,7 @@ export default async function bootstrap({
 	} else {
 		logger.info('Database already initialized, skipping install');
 		logger.info('Running migrations...');
-		await runMigrations(database, 'latest', systemOnlyMigrations);
+		await runMigrations(database, 'latest', true, systemOnlyMigrations);
 	}
 
 	logger.info('Done');

--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -1,11 +1,26 @@
 import installSeeds from '../../../database/seeds/run';
-import getDatabase from '../../../database';
+import getDatabase, { isInstalled } from '../../../database';
 import logger from '../../../logger';
+import { waitForDatabase } from '../../commands/bootstrap';
+import { Knex } from 'knex';
 
-export default async function start(): Promise<void> {
-	const database = getDatabase();
+export default async function start({
+	ignoreAlreadyInstalled = false,
+}: {
+	ignoreAlreadyInstalled?: boolean;
+}): Promise<void> {
+	const database: Knex = getDatabase();
 
 	try {
+		await waitForDatabase(database);
+		if ((await isInstalled()) === true) {
+			if (ignoreAlreadyInstalled) {
+				logger.info('The database is already installed');
+			}
+			database.destroy();
+			process.exit(0);
+		}
+
 		await installSeeds(database);
 		database.destroy();
 		process.exit(0);

--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -3,11 +3,16 @@ import getDatabase, { isInstalled } from '../../../database';
 import logger from '../../../logger';
 import { waitForDatabase } from '../../commands/bootstrap';
 import { Knex } from 'knex';
+import bootstrap from '../../commands/bootstrap';
 
 export default async function start({
 	ignoreAlreadyInstalled = false,
+	bootstrapWithSystemMigrations = false,
+	skipAdminInit,
 }: {
 	ignoreAlreadyInstalled?: boolean;
+	bootstrapWithSystemMigrations?: boolean;
+	skipAdminInit?: boolean;
 }): Promise<void> {
 	const database: Knex = getDatabase();
 
@@ -21,7 +26,13 @@ export default async function start({
 			process.exit(0);
 		}
 
-		await installSeeds(database);
+		if (bootstrapWithSystemMigrations) {
+			bootstrap({ skipAdminInit });
+		} else {
+			logger.info('Skipping system migrations...');
+			await installSeeds(database);
+		}
+
 		database.destroy();
 		process.exit(0);
 	} catch (err: any) {

--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -1,4 +1,4 @@
-import installSeeds from '../../../database/seeds/run';
+import installDatabase from '../../../database/seeds/run';
 import getDatabase, { isInstalled } from '../../../database';
 import logger from '../../../logger';
 import { waitForDatabase } from '../../commands/bootstrap';
@@ -30,7 +30,7 @@ export default async function start({
 			bootstrap({ skipAdminInit });
 		} else {
 			logger.info('Skipping system migrations...');
-			await installSeeds(database);
+			await installDatabase(database);
 		}
 
 		database.destroy();

--- a/api/src/cli/commands/database/install.ts
+++ b/api/src/cli/commands/database/install.ts
@@ -27,7 +27,7 @@ export default async function start({
 		}
 
 		if (bootstrapWithSystemMigrations) {
-			bootstrap({ skipAdminInit });
+			bootstrap({ skipAdminInit, systemOnlyMigrations: bootstrapWithSystemMigrations });
 		} else {
 			logger.info('Skipping system migrations...');
 			await installDatabase(database);

--- a/api/src/cli/commands/database/migrate.ts
+++ b/api/src/cli/commands/database/migrate.ts
@@ -2,13 +2,13 @@ import run from '../../../database/migrations/run';
 import getDatabase from '../../../database';
 import logger from '../../../logger';
 
-export default async function migrate(direction: 'latest' | 'up' | 'down'): Promise<void> {
+export default async function migrate(direction: 'latest' | 'up' | 'down', systemOnly: false): Promise<void> {
 	const database = getDatabase();
 
 	try {
 		logger.info('Running migrations...');
 
-		await run(database, direction);
+		await run(database, direction, systemOnly);
 
 		if (direction === 'down') {
 			logger.info('Downgrade successful');

--- a/api/src/cli/commands/database/migrate.ts
+++ b/api/src/cli/commands/database/migrate.ts
@@ -8,7 +8,7 @@ export default async function migrate(direction: 'latest' | 'up' | 'down', syste
 	try {
 		logger.info('Running migrations...');
 
-		await run(database, direction, systemOnly);
+		await run(database, direction, true, systemOnly);
 
 		if (direction === 'down') {
 			logger.info('Downgrade successful');

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -42,15 +42,18 @@ export async function createCli(): Promise<Command> {
 	dbCommand
 		.command('migrate:latest')
 		.description('Upgrade the database')
-		.action(() => dbMigrate('latest'));
+		.option('-s, --system-only, run directus system migrations only')
+		.action((options) => dbMigrate('latest', options.systemOnly));
 	dbCommand
 		.command('migrate:up')
 		.description('Upgrade the database')
-		.action(() => dbMigrate('up'));
+		.option('-s, --system-only, run directus system migrations only')
+		.action((options) => dbMigrate('up', options.systemOnly));
 	dbCommand
 		.command('migrate:down')
 		.description('Downgrade the database')
-		.action(() => dbMigrate('down'));
+		.option('-s, --system-only, run directus system migrations only')
+		.action((options) => dbMigrate('down', options.systemOnly));
 
 	const usersCommand = program.command('users');
 

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -42,6 +42,13 @@ export async function createCli(): Promise<Command> {
 		.command('install')
 		.description('Install the database')
 		.option('-i, --ignore-already-installed, ignore if the database is already installed')
+		.option(
+			'-b, --bootstrap-with-system-migrations, if the database needs to be installed, seed the admin user, project name, and apply system migrations'
+		)
+		.option(
+			'--skipAdminInit',
+			'Skips the creation of the default Admin Role and User when the --bootstrap-with-system-migrations flag is used'
+		)
 		.action(dbInstall);
 	dbCommand
 		.command('migrate:latest')

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -38,7 +38,11 @@ export async function createCli(): Promise<Command> {
 	securityCommand.command('secret:generate').description('Generate the app secret').action(secretGenerate);
 
 	const dbCommand = program.command('database');
-	dbCommand.command('install').description('Install the database').action(dbInstall);
+	dbCommand
+		.command('install')
+		.description('Install the database')
+		.option('-i, --ignore-already-installed, ignore if the database is already installed')
+		.action(dbInstall);
 	dbCommand
 		.command('migrate:latest')
 		.description('Upgrade the database')

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -13,8 +13,8 @@ import formatTitle from '@directus/format-title';
 export default async function run(
 	database: Knex,
 	direction: 'up' | 'down' | 'latest',
-	systemOnly = false,
-	log = true
+	log = true,
+	systemOnly = false
 ): Promise<void> {
 	let migrationFiles = await fse.readdir(__dirname);
 	migrationFiles = migrationFiles.filter((file: string) => /^[0-9]+[A-Z]-[^.]+\.(?:js|ts)$/.test(file));


### PR DESCRIPTION
## Description

This PR adds some improvements to the CLI database commands. The idea of the PR is to implement a few use-cases:
- Be able to deploy as a docker container without having modify deploy scripts to run one-time database install/bootstrap script
- Be able to apply system migrations independently of custom migrations

Example start script in a docker container:

```Dockerfile
CMD npx directus database install --ignore-already-installed --bootstrap-with-system-migrations && \
    npx directus database migrate:latest --system-only && \
    if test -f /directus/schema/schema.yaml; then npx directus schema apply /directus/schema/schema.yaml --yes; fi && \
    npx directus bootstrap && \
    npx directus start
```

Fixes #11798

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
