### PR TITLE
Fix delete and quit opening save changes drawer

### DIFF
--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -350,7 +350,7 @@ async function saveAsCopyAndNavigate() {
 async function deleteAndQuit() {
 	try {
 		await remove();
-		edits.value = {}
+		edits.value = {};
 		router.replace(to.value);
 	} catch {
 		// `remove` will show the unexpected error dialog

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -350,6 +350,7 @@ async function saveAsCopyAndNavigate() {
 async function deleteAndQuit() {
 	try {
 		await remove();
+		edits.value = {}
 		router.replace(to.value);
 	} catch {
 		// `remove` will show the unexpected error dialog

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -186,6 +186,7 @@ export default defineComponent({
 		async function deleteAndQuit() {
 			await remove();
 			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+			edits.value = {};
 			router.replace(`/settings/data-model`);
 		}
 

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -273,6 +273,7 @@ function useDelete() {
 
 		try {
 			await presetsStore.delete([Number(props.id)]);
+			edits.value = {};
 			router.replace(`/settings/presets`);
 		} catch (err: any) {
 			unexpectedError(err);

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -240,7 +240,7 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
-			edits.value = {}
+			edits.value = {};
 			router.replace(`/settings/roles`);
 		}
 

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -240,6 +240,7 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
+			edits.value = {}
 			router.replace(`/settings/roles`);
 		}
 

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -191,7 +191,7 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
-			edits.value = {}
+			edits.value = {};
 			router.replace(`/settings/webhooks`);
 		}
 

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -191,6 +191,7 @@ export default defineComponent({
 
 		async function deleteAndQuit() {
 			await remove();
+			edits.value = {}
 			router.replace(`/settings/webhooks`);
 		}
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -432,6 +432,7 @@ export default defineComponent({
 		async function deleteAndQuit() {
 			try {
 				await remove();
+				edits.value = {};
 				router.replace(`/users`);
 			} catch {
 				// `remove` will show the unexpected error dialog


### PR DESCRIPTION
The problem was that when running `await remove(); await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);` edits got added to the view thus opening the prompt of unsaved changes. By reseting the edits after it, we pevent it from having any changes.

Fixes #17538, fixes ENG-702