### PR TITLE
Fix using alias fields function for non alias field

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -26,7 +26,7 @@
 			<template v-for="header in tableHeaders" :key="header.value" #[`item.${header.value}`]="{ item }">
 				<render-display
 					:value="
-						!aliasFields || item[header.value] !== undefined
+						!aliasFields || item[header.value] !== undefined || aliasFields[header.value] === undefined
 							? get(item, header.value)
 							: getAliasedValue(item, header.value)
 					"


### PR DESCRIPTION
The problem was that we were relying on the `getAliasedValue` function even if the field wasn't aliased.

Fixes #17506 Fixes: ENG-690
