### PR TITLE
Handle server hydration errors on first load

### DIFF
--- a/app/src/router.ts
+++ b/app/src/router.ts
@@ -101,7 +101,11 @@ export const onBeforeEach: NavigationGuard = async (to) => {
 	}
 
 	if (serverStore.info.project === null) {
-		await serverStore.hydrate();
+		try {
+			await serverStore.hydrate();
+		} catch (error: any) {
+			appStore.error = error;
+		}
 	}
 
 	if (to.meta?.public !== true) {


### PR DESCRIPTION
## Description

Currently whenever we first load the Data Studio, there's an `onBeforeEach` router guard that kicks in:

https://github.com/directus/directus/blob/0154878f2746809896738a1cfb73edcaa3dceace/app/src/router.ts#L87

However before the `hydrate()` is called (line 111), there is also a call to `serverStore.hydrate()` (line 104):

https://github.com/directus/directus/blob/0154878f2746809896738a1cfb73edcaa3dceace/app/src/router.ts#L103-L111

but the serverStore hydration does not have try/catch in place, so when it has unexpected error(s0, it "crashes" the router and nothing gets rendered.

Within the `hydrate()` function mentioned above (which hydrates all the stores), there is try/catch in place:

https://github.com/directus/directus/blob/0154878f2746809896738a1cfb73edcaa3dceace/app/src/hydrate.ts#L63-L93

and it will set `appStore.error` as the caught error to display the global error page.

This PR applies a similar logic and catch any error from serverStore hydration to `appStore.error`.

Fixes ENG-556

### Before

https://user-images.githubusercontent.com/42867097/224013929-44a7c6d2-887e-479b-ac98-4d746b778ddf.mp4

### After

https://user-images.githubusercontent.com/42867097/224013881-0f10b47f-f5f0-47b9-9934-c4bb80725f78.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
