### PR TITLE
Fix assets limit test

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -1,9 +1,6 @@
 name: Blackbox Tests
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -16,7 +13,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main-assets-limit-test
+  group: blackbox-main
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -1,6 +1,9 @@
 name: Blackbox Tests
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -13,7 +16,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main
+  group: blackbox-main-assets-limit-test
   cancel-in-progress: true
 
 env:

--- a/tests-blackbox/routes/assets/limit.test.ts
+++ b/tests-blackbox/routes/assets/limit.test.ts
@@ -59,7 +59,7 @@ describe('/assets', () => {
 						'%s',
 						async (vendor) => {
 							// Setup
-							const attempts = 30;
+							const attempts = 100;
 							const uploadedFileID = (
 								await request(getUrl(vendor))
 									.post('/files')

--- a/tests-blackbox/routes/assets/limit.test.ts
+++ b/tests-blackbox/routes/assets/limit.test.ts
@@ -81,10 +81,6 @@ describe('/assets', () => {
 
 							// Assert
 							const unavailableCount = responses.filter((response) => response.statusCode === 503).length;
-
-							// eslint-disable-next-line no-console
-							console.log(`Unavailable assets response count: ${unavailableCount}`);
-
 							expect(unavailableCount).toBeGreaterThanOrEqual(attempts / 2);
 							expect(responses.filter((response) => response.statusCode === 200).length).toBe(
 								attempts - unavailableCount

--- a/tests-blackbox/routes/assets/limit.test.ts
+++ b/tests-blackbox/routes/assets/limit.test.ts
@@ -81,6 +81,10 @@ describe('/assets', () => {
 
 							// Assert
 							const unavailableCount = responses.filter((response) => response.statusCode === 503).length;
+
+							// eslint-disable-next-line no-console
+							console.log(`Unavailable assets response count: ${unavailableCount}`);
+
 							expect(unavailableCount).toBeGreaterThanOrEqual(attempts / 2);
 							expect(responses.filter((response) => response.statusCode === 200).length).toBe(
 								attempts - unavailableCount


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fix random failing tests on GitHub runners.
By increasing the number of asset requests to 100, the unavailable responses ranges from around 73 to 93.

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Test optimization

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
