### PR TITLE
Tweak swatch button size & position in select-color interface

### DIFF
--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -369,8 +369,9 @@ function useColor() {
 
 	position: relative;
 	box-sizing: border-box;
-	width: calc(var(--input-height) - 12px);
-	max-height: calc(var(--input-height) - 12px);
+	margin-left: -8px;
+	width: calc(var(--input-height) - 20px);
+	max-height: calc(var(--input-height) - 20px);
 	overflow: hidden;
 	border-radius: calc(var(--border-radius) + 2px);
 	cursor: pointer;
@@ -406,14 +407,16 @@ function useColor() {
 	padding-right: 0px;
 }
 
-.v-input.html-color-select {
-	width: 0;
-	height: 0;
-	visibility: hidden;
-}
+.color-input {
+	:deep(.input) {
+		padding-left: 6px;
+	}
 
-.color-input :deep(.input) {
-	padding-left: 6px;
+	.v-input.html-color-select {
+		width: 0;
+		height: 0;
+		visibility: hidden;
+	}
 }
 
 .color-data-inputs {

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -408,10 +408,6 @@ function useColor() {
 }
 
 .color-input {
-	:deep(.input) {
-		padding-left: 6px;
-	}
-
 	.v-input.html-color-select {
 		width: 0;
 		height: 0;


### PR DESCRIPTION
## Description

Currently there is an odd spacing around the swatch button in select-color interface, especially when compared to similarly designed input like File interface:

![](https://user-images.githubusercontent.com/42867097/224752308-50f43e94-9144-48fd-bee3-221e69b2a1a1.png)

When I peek on older PRs such as #10009, there didn't used to be such odd spacing either:

![](https://user-images.githubusercontent.com/42867097/224753133-3004dd90-3b2b-422d-9578-8837bc1bf769.png)

so I think this extra spacing might be an unintended side-effect of past style updates.

### Before Tweak

![](https://user-images.githubusercontent.com/42867097/224753326-55f61b0b-3b74-43cc-acc3-a72f6d725750.png)

### After Tweak

![](https://user-images.githubusercontent.com/42867097/224753355-abafc95a-9392-4e05-b7c7-b801d1837193.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
