### PR TITLE
Use light primary border color for fields when they are inside groups

### DIFF
--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -459,6 +459,12 @@ export default defineComponent({
 	& + & {
 		margin-top: 8px;
 	}
+
+	&.nested {
+		.field :deep(.input) {
+			border: var(--border-width) solid var(--primary-25) !important;
+		}
+	}
 }
 
 .field {

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -462,19 +462,19 @@ export default defineComponent({
 
 	&.nested {
 		.field :deep(.input) {
-			border: var(--border-width) solid var(--primary-25) !important;
+			border: var(--border-width) solid var(--primary-25);
 		}
 	}
 }
 
 .field {
-	:deep(.input) {
-		border: var(--border-width) solid var(--border-subdued) !important;
+	&.v-input :deep(.input) {
+		border: var(--border-width) solid var(--border-subdued);
 	}
 
-	:deep(.input:hover) {
-		background-color: var(--card-face-color) !important;
-		border: var(--border-width) solid var(--border-normal-alt) !important;
+	&.v-input :deep(.input:hover) {
+		background-color: var(--card-face-color);
+		border: var(--border-width) solid var(--border-normal-alt);
 	}
 
 	.label {


### PR DESCRIPTION
## Description

Currently fields within a collection in Data Model has a light gray border. However when they are inside a group with a tinted primary background color, the light gray border becomes "blurry" and less defined:

![](https://user-images.githubusercontent.com/42867097/224766516-e1c494b4-a5b7-42c0-9dcb-f596f518505d.png)

This PR proposes to use a light primary color for the border instead, so they can mesh better when they're inside groups.

### Before

![](https://user-images.githubusercontent.com/42867097/224766258-c7668fa5-e4e4-4d51-b5cc-7a5ff58bfac0.png)

### After

![](https://user-images.githubusercontent.com/42867097/224766322-9d11585b-a9d9-48a8-ab2b-667a49296af6.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
