### PR TITLE
Fix translations setting primary key and request spamming

### DIFF
--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -440,12 +440,28 @@ export function useRelationMultiple(
 		watch(
 			selectedOnPage,
 			(newVal, oldVal) => {
-				if (!isEqual(newVal, oldVal)) loadSelectedDisplay();
+				if (newVal.length !== oldVal?.length || !isEqual(newVal.map(getRelatedIDs), (oldVal ?? []).map(getRelatedIDs)))
+					loadSelectedDisplay();
 			},
 			{ immediate: true }
 		);
 
 		return { fetchedSelectItems, selected, isItemSelected, selectedOnPage };
+
+		function getRelatedIDs(item: DisplayItem) {
+			switch (relation.value?.type) {
+				case 'o2m':
+					return item[relation.value.relatedPrimaryKeyField.field];
+				case 'm2m':
+					return item[relation.value.junctionField.field][relation.value.relatedPrimaryKeyField.field];
+				case 'm2a': {
+					const collection = item[relation.value.collectionField.field];
+					return item[relation.value.junctionPrimaryKeyField.field][
+						relation.value.relationPrimaryKeyFields[collection].field
+					];
+				}
+			}
+		}
 
 		function isItemSelected(item: DisplayItem) {
 			return relation.value !== undefined && item[relation.value.reverseJunctionField.field] !== undefined;
@@ -481,7 +497,7 @@ export function useRelationMultiple(
 					fields: Array.from(fields),
 					filter: {
 						[targetPKField]: {
-							_in: selectedOnPage.value.map((item) => item[targetPKField]),
+							_in: selectedOnPage.value.map(getRelatedIDs),
 						},
 					},
 					limit: -1,
@@ -514,7 +530,7 @@ export function useRelationMultiple(
 					fields: Array.from(fields),
 					filter: {
 						[relatedPKField]: {
-							_in: selectedOnPage.value.map((item) => item[relation.junctionField.field][relatedPKField]),
+							_in: selectedOnPage.value.map(getRelatedIDs),
 						},
 					},
 					limit: -1,

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -448,7 +448,7 @@ export function useRelationMultiple(
 
 		return { fetchedSelectItems, selected, isItemSelected, selectedOnPage };
 
-		function getRelatedIDs(item: DisplayItem) {
+		function getRelatedIDs(item: DisplayItem): string | number | undefined {
 			switch (relation.value?.type) {
 				case 'o2m':
 					return item[relation.value.relatedPrimaryKeyField.field];

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -197,7 +197,7 @@ function updateValue(item: DisplayItem, lang: string | undefined) {
 
 		if (itemInfo[info.junctionPrimaryKeyField.field] !== undefined) {
 			itemUpdates[info.junctionPrimaryKeyField.field] = itemInfo[info.junctionPrimaryKeyField.field];
-		} else {
+		} else if (primaryKey.value !== '+') {
 			itemUpdates[info.reverseJunctionField.field] = primaryKey.value;
 		}
 


### PR DESCRIPTION
## Description

This PR solves 2 Problems. The first being that the primary key gets inserted, even when creating a new item. The second bein that we would reload all selected preview data even though the selected items didn't actually change.

Fixes #17762