### PR TITLE
App: Allow to select  checkbox entry when children is `null`

### DIFF
--- a/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
@@ -122,7 +122,7 @@ const treeValue = computed({
 		const added = difference(newValue, props.modelValue);
 		const removed = difference(props.modelValue, newValue);
 
-		if (props.children.length > 0) {
+		if (Array.isArray(props.children) && props.children.length > 0) {
 			switch (props.valueCombining) {
 				case 'all':
 					return emitAll(newValue, { added, removed });


### PR DESCRIPTION
## Description
When using Checkbox Tree interfaces, if `children` is set to `null` it fails to set that item.
Children is set to null when using Clear Value option in interface or when removing all children items.

https://user-images.githubusercontent.com/14039341/224924932-572f3913-87ab-450a-af1e-8bf2ef11cbf4.mov

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
