### PR TITLE
Use pnpm 7.29.1 for now to circumvent dep regression

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -22,7 +22,7 @@ runs:
       name: Install pnpm
       id: pnpm-install
       with:
-        version: 7
+        version: 7.29.1
         run_install: false
 
     - name: Get pnpm store directory


### PR DESCRIPTION
## Description

The unit test workflow has started to fail with pnpm@7.29.2.
Seems to be related to https://github.com/pnpm/pnpm/issues/6213.
Therefore we pin the version to 7.29.1 until this issue has been fixed.

Fixes ENG-811

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
