### PR TITLE
nested user properties are now allowed in regular filter

### DIFF
--- a/app/src/utils/parse-filter.ts
+++ b/app/src/utils/parse-filter.ts
@@ -11,6 +11,7 @@ export function parseFilter(filter: Filter | null): Filter {
 	const accountability: Accountability = {
 		role: userStore.currentUser.role.id,
 		user: userStore.currentUser.id,
+		userDetail: userStore.currentUser,
 	};
 
 	return parseFilterShared(filter, accountability) ?? {};

--- a/packages/shared/src/types/accountability.ts
+++ b/packages/shared/src/types/accountability.ts
@@ -1,4 +1,5 @@
 import { Permission } from './permissions';
+import { User } from './users';
 
 export type ShareScope = {
 	collection: string;
@@ -8,6 +9,7 @@ export type ShareScope = {
 export type Accountability = {
 	role: string | null;
 	user?: string | null;
+	userDetail?: User;
 	admin?: boolean;
 	app?: boolean;
 	permissions?: Permission[];

--- a/packages/shared/src/utils/parse-filter.ts
+++ b/packages/shared/src/utils/parse-filter.ts
@@ -1,4 +1,4 @@
-import { isObjectLike } from 'lodash';
+import { isObjectLike, get as getObj } from 'lodash';
 import { REGEX_BETWEEN_PARENS } from '../constants';
 import { Accountability, Filter, Role, User } from '../types';
 import { adjustDate } from './adjust-date';
@@ -124,6 +124,12 @@ function parseDynamicVariable(value: any, accountability: Accountability | null,
 		}
 
 		return new Date();
+	}
+
+	if (value.startsWith('$CURRENT_USER.')) {
+		if (accountability?.userDetail) {
+			return getObj(accountability.userDetail, value.replace('$CURRENT_USER.', ''));
+		}
 	}
 
 	if (value.startsWith('$CURRENT_USER')) {


### PR DESCRIPTION
## Description

As mention in the Docs [Filter Rules](https://docs.directus.io/reference/filter-rules.html) 
> Note: This feature is only available for permissions, validation, and presets. Regular filters and conditional fields currently only support the root ID.

You can't use nested properties of user inside regular filter like in M2O interface. You can't use like this `$CURRENT_USER.first_name`

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
