### PR TITLE
Allow node builtins to be whitelisted in Exec flow

### DIFF
--- a/api/src/operations/exec/index.ts
+++ b/api/src/operations/exec/index.ts
@@ -9,6 +9,7 @@ export default defineOperationApi<Options>({
 	id: 'exec',
 	handler: async ({ code }, { data, env }) => {
 		const allowedModules = env.FLOWS_EXEC_ALLOWED_MODULES ? toArray(env.FLOWS_EXEC_ALLOWED_MODULES) : [];
+		const allowedBuiltins = env.FLOWS_EXEC_ALLOWED_BUILTINS ? toArray(env.FLOWS_EXEC_ALLOWED_BUILTINS) : [];
 		const allowedEnv = data.$env ?? {};
 
 		const opts: NodeVMOptions = {
@@ -24,6 +25,11 @@ export default defineOperationApi<Options>({
 					transitive: false,
 				},
 			};
+		}
+		
+		if (allowedBuiltins.length > 0) {
+			opts.require ?? {};
+			opts.require.builtin = allowedBuiltins;
 		}
 
 		const vm = new NodeVM(opts);


### PR DESCRIPTION
Introduce the `FLOWS_EXEC_ALLOWED_BUILTINS` environment variable that is passed to the `require.builtin` option for vm2

## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
