### PR TITLE
Fix AllowList checking only when defined

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
@@ -94,7 +94,7 @@ export default defineComponent({
 					!!field.schema?.is_primary_key ||
 					props.disabledFields.includes(field.field) ||
 					props.typeDenyList.includes(field.type) ||
-					!props.typeAllowList?.includes(field.type),
+					(props.typeAllowList && !props.typeAllowList.includes(field.type)),
 			}));
 		});
 


### PR DESCRIPTION
The problem was that we were checking for `!props.typeAllowList.includes(field.type)` which evaluates to true if `props.typeAllowList` is undefined, instead, it should evaluate to false.
This is a regression from #17186. (nice number coincidence 😄 )

Fixes #17681 