### PR TITLE
Make default folder more clear

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1652,7 +1652,7 @@ interfaces:
   system-folder:
     folder: Folder
     description: Select a folder
-    field_hint: Folder for uploaded files. Does not affect existing files.
+    field_hint: Default folder for uploaded files without a folder specified. Does not affect existing files.
     root_name: File Library Root
     system_default: System Defaults
   select-radio:


### PR DESCRIPTION
Makes it more clear when setting a default folder, that it only applies when you don't have any folder specified.

This mainly applies when uplaoding files to fields in the data model if you didn't set the default upload folder for such file field.

Fixes #17518