### PR TITLE
Show search results for mapbox

### DIFF
--- a/app/src/styles/lib/_mapbox.scss
+++ b/app/src/styles/lib/_mapbox.scss
@@ -134,7 +134,6 @@
 	font-family: inherit !important;
 	line-height: inherit !important;
 	background-color: var(--background-page);
-	overflow: hidden;
 
 	&,
 	&.suggestions {


### PR DESCRIPTION
I wasn't able to find a reason why we would want to set the overflow to hidden so let's get rid of it.

Fixes #17369, Fixes ENG-614