### PR TITLE
App: Fix saving required relational fields

### DIFF
--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -120,13 +120,19 @@ export function useItem(
 		saving.value = true;
 		validationErrors.value = [];
 
-		const payload = mergeWith({}, defaultValues.value, item.value, edits.value, function (from: any, to: any) {
-			if (typeof to !== undefined) {
-				return to;
+		const payloadToValidate = mergeWith(
+			{},
+			defaultValues.value,
+			item.value,
+			edits.value,
+			function (from: any, to: any) {
+				if (typeof to !== undefined) {
+					return to;
+				}
 			}
-		});
+		);
 
-		const errors = validateItem(payload, fieldsWithPermissions.value, isNew.value);
+		const errors = validateItem(payloadToValidate, fieldsWithPermissions.value, isNew.value);
 
 		if (errors.length > 0) {
 			validationErrors.value = errors;

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -11,7 +11,7 @@ import { validateItem } from '@/utils/validate-item';
 import { useCollection } from '@directus/shared/composables';
 import { getEndpoint } from '@directus/shared/utils';
 import { AxiosResponse } from 'axios';
-import { merge } from 'lodash';
+import { mergeWith } from 'lodash';
 import { computed, ComputedRef, Ref, ref, watch } from 'vue';
 import { usePermissions } from './use-permissions';
 import { Field, Query, Relation } from '@directus/shared/types';
@@ -120,11 +120,13 @@ export function useItem(
 		saving.value = true;
 		validationErrors.value = [];
 
-		const errors = validateItem(
-			merge({}, defaultValues.value, item.value, edits.value),
-			fieldsWithPermissions.value,
-			isNew.value
-		);
+		const payload = mergeWith({}, defaultValues.value, item.value, edits.value, function (from: any, to: any) {
+			if (typeof to !== undefined) {
+				return to;
+			}
+		});
+
+		const errors = validateItem(payload, fieldsWithPermissions.value, isNew.value);
 
 		if (errors.length > 0) {
 			validationErrors.value = errors;

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -126,7 +126,7 @@ export function useItem(
 			item.value,
 			edits.value,
 			function (from: any, to: any) {
-				if (typeof to !== undefined) {
+				if (typeof to !== 'undefined') {
 					return to;
 				}
 			}


### PR DESCRIPTION
## Description
When trying to save a required relationship an error is shown saying `<Field> cant' be null`.
After some investigation I found that when we `save` an item the following function is called:
https://github.com/directus/directus/blob/6a54e24bbafd63aa8b90038bda0fa14b95046004/app/src/composables/use-item.ts#L123-L127

As we can see, we are trying to merge `defaultValues.value`, `item.value` and `edits.value`.
Everything works as expected until we find a relationship. That's because the value of a relationship on `item.value` is an Array while on `edits.value` is an Object like `{create:...,update:...,delete:...}`. Also the result of `merge` with Array and Object is an Array with the Object properties, i.e. the indexes of the array are `create`, `update`, `delete` instead of `0`, `1`, `2` and so on. 
When it reaches here:
https://github.com/directus/directus/blob/6a54e24bbafd63aa8b90038bda0fa14b95046004/app/src/utils/validate-item.ts#L19
The `cloneDeep` does not recognize those weird indexes on array and the result is `[]` leading to the error, because the array is empty.

## Solution
Instead of using `merge`, we can just check if the next object of merge has value and if so, we just use that value. We can do so using `mergeWith`.
Since this is only to validate the payload, I believe that just overriding previous value in case the current one exists can be sufficient. 

## Preview
| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/14039341/226144832-c00dd2d1-e9d9-4122-b675-f0e36eb2e9c9.mov" /> | <video src="https://user-images.githubusercontent.com/14039341/226144839-99776452-a9c6-489e-be4a-23a6d9defb3e.mov" /> | 

Fixes ENG-822
Fixes #17897

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
