### PR TITLE
Don't set edits at start in List Panel

### DIFF
--- a/app/src/panels/list/panel-list.vue
+++ b/app/src/panels/list/panel-list.vue
@@ -61,7 +61,6 @@ const primaryKeyField = computed(() => fieldsStore.getPrimaryKeyFieldForCollecti
 function startEditing(item: Record<string, any>) {
 	if (!props.linkToItem) return;
 	currentlyEditing.value = item[primaryKeyField.value];
-	editsAtStart.value = item;
 }
 
 function cancelEdit() {


### PR DESCRIPTION
The problem was that we were setting the starting edits to the display object, even though that is not nessesary.

Fixes #17623