### PR TITLE
use dbSafe inputs when creating optional system fields

### DIFF
--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -82,6 +82,7 @@
 						<div class="type-label">{{ t(info.label) }}</div>
 						<v-input
 							v-model="info.name"
+							db-safe
 							class="monospace"
 							:class="{ active: info.enabled }"
 							:disabled="info.inputDisabled"


### PR DESCRIPTION
## Description

Generally when creating a new field, dbSafe is used to prevent field names with special characters or hyphens etc. However currently the inputs in Optional System Fields does not have dbSafe configured:

https://user-images.githubusercontent.com/42867097/226563455-37e9f015-7296-45fe-ae4a-af021daa40da.mp4

Fixes ENG-832

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
