### PR TITLE
Fix archive field reactivity for new collection

### DIFF
--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -384,7 +384,7 @@ export default defineComponent({
 					},
 				});
 
-				archiveField.value = 'status';
+				archiveField.value = systemFields.status.name;
 				archiveValue.value = 'archived';
 				unarchiveValue.value = 'draft';
 			}


### PR DESCRIPTION
## Description

Currently `archiveField` is hardcoded to `'status'`, even after we edit the status field name before saving the new collection:

https://github.com/directus/directus/blob/9526b4e5b222acc8f58aa3ad61fb15393dca74e8/app/src/modules/settings/routes/data-model/new-collection.vue#L387

This causes the archive field to be saved incorrectly even when we changed the default `'status'` name to something else:

https://user-images.githubusercontent.com/42867097/226565353-c181cb41-1a76-4036-bfbc-9c2fc78c7362.mp4

<br />

The `TypeError: Cannot read properties of undefined (reading 'type')` error itself is being addressed in #17802, so this PR only ensures the archive field name is actually depending on the status field name, similar to the solution used for sort field:

https://github.com/directus/directus/blob/9526b4e5b222acc8f58aa3ad61fb15393dca74e8/app/src/modules/settings/routes/data-model/new-collection.vue#L404

Fixes ENG-833

### Result

https://user-images.githubusercontent.com/42867097/226565769-b5362268-a62c-4fcb-affe-8efff941564a.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
