### PR TITLE
Fix: Add type parameter for FilterHandler to filter hook register function

### DIFF
--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -6,7 +6,7 @@ export type HookExtensionContext = ApiExtensionContext & {
 };
 
 type RegisterFunctions = {
-	filter: (event: string, handler: FilterHandler) => void;
+	filter: <T>(event: string, handler: FilterHandler<T>) => void;
 	action: (event: string, handler: ActionHandler) => void;
 	init: (event: string, handler: InitHandler) => void;
 	schedule: (cron: string, handler: ScheduleHandler) => void;


### PR DESCRIPTION
## Description

Allows to pass filter type to `FilterHandler`

Fixes #17870

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
