### PR TITLE
Declare `null` as valid value type for v-radio

### DIFF
--- a/app/src/components/v-radio.vue
+++ b/app/src/components/v-radio.vue
@@ -19,7 +19,7 @@ import { computed } from 'vue';
 
 interface Props {
 	/** What value to represent when selected */
-	value: string | number;
+	value: string | number | null;
 	/** If `value` and `modelValue` match, the radio is selected */
 	modelValue?: string | number | null;
 	/** Label to render next to the radio */


### PR DESCRIPTION
## Description

The archive sidebar uses `null` as the default value for the radio input (representing "Show Active Items").
While this works flawlessly, the following warning is thrown because `null` is currently not allowed as value type:
```
[Vue warn]: Invalid prop: type check failed for prop "value". Expected String | Number, got Null  
  at <VRadio key=null value=null label="Show Active Items"  ... > 
  at <BaseTransition mode="in-out" onBeforeEnter=fn<onBeforeEnter> onEnter=fn  ... > 
  at <Transition name="expand-transition" mode="in-out" onBeforeEnter=fn<beforeEnter>  ... > 
  at <Expand class="scroll-container" > 
  at <SidebarDetail icon="archive" title="Archive" badge=false > 
  at <ArchiveSidebarDetail key=0 collection="article" archive=null > 
  at <VItemGroup modelValue= 
Array []
 onUpdate:modelValue=fn class="sidebar-detail-group"  ... > 
  at <SidebarDetailGroup sidebar-open=true > 
  at <PrivateView key=1 title="Article" small-header=undefined > 
  at <AsyncComponentWrapper key=1 title="Article" small-header=undefined > 
  at <TabularWrapper ref="layoutRef" selection= 
Array []
 onUpdate:selection=fn  ... > 
  at <ContentCollection collection="article" bookmark=null archive=null > 
  at <CollectionOrItem collection="article" bookmark=undefined archive=null  ... > 
  at <RouterView> 
  at <RouterPassthrough onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< 
#text ""
 > > 
  at <RouterView> 
  at <RouterPassthrough onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< 
#text ""
 > > 
  at <RouterView key=1 > 
  at <App> chunk-2GTISQ3F.js:1641:13
```

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [x] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
