### PR TITLE
Fix Save and Stay to refresh revisions detail for roles and webhooks

### DIFF
--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -87,7 +87,7 @@
 
 		<template #sidebar>
 			<role-info-sidebar-detail :role="item" />
-			<revisions-drawer-detail collection="directus_roles" :primary-key="primaryKey" />
+			<revisions-drawer-detail ref="revisionsDrawerDetailRef" collection="directus_roles" :primary-key="primaryKey" />
 		</template>
 
 		<v-dialog v-model="confirmLeave" @esc="confirmLeave = false">
@@ -149,6 +149,8 @@ export default defineComponent({
 		const serverStore = useServerStore();
 		const userInviteModalActive = ref(false);
 		const { primaryKey } = toRefs(props);
+
+		const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
 		const { edits, hasEdits, item, saving, loading, error, save, remove, deleting, isBatch } = useItem(
 			ref('directus_roles'),
@@ -218,6 +220,7 @@ export default defineComponent({
 			leaveTo,
 			discardAndLeave,
 			canInviteUsers,
+			revisionsDrawerDetailRef,
 		};
 
 		/**
@@ -230,6 +233,7 @@ export default defineComponent({
 		async function saveAndStay() {
 			await save();
 			await userStore.hydrate();
+			revisionsDrawerDetailRef.value?.refresh?.();
 		}
 
 		async function saveAndQuit() {

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -65,7 +65,12 @@
 			<sidebar-detail icon="info_outline" :title="t('information')" close>
 				<div v-md="t('page_help_settings_webhooks_item')" class="page-description" />
 			</sidebar-detail>
-			<revisions-drawer-detail v-if="isNew === false" collection="directus_webhooks" :primary-key="primaryKey" />
+			<revisions-drawer-detail
+				v-if="isNew === false"
+				ref="revisionsDrawerDetailRef"
+				collection="directus_webhooks"
+				:primary-key="primaryKey"
+			/>
 		</template>
 
 		<v-dialog v-model="confirmLeave" @esc="confirmLeave = false">
@@ -110,6 +115,8 @@ export default defineComponent({
 		const router = useRouter();
 
 		const { primaryKey } = toRefs(props);
+
+		const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
 		const {
 			isNew,
@@ -168,6 +175,7 @@ export default defineComponent({
 			confirmLeave,
 			leaveTo,
 			discardAndLeave,
+			revisionsDrawerDetailRef,
 		};
 
 		async function saveAndQuit() {
@@ -177,6 +185,7 @@ export default defineComponent({
 
 		async function saveAndStay() {
 			await save();
+			revisionsDrawerDetailRef.value?.refresh?.();
 		}
 
 		async function saveAndAddNew() {


### PR DESCRIPTION
## Description

Currently when we Save and Stay within content items, files items and user items, the revisions drawer detail in the sidebar will be refreshed via `revisionsDrawerDetail.value?.refresh?.()`:

- https://github.com/directus/directus/blob/fa44632c7151363a7be39398d42f3b505926abce/app/src/modules/content/routes/item.vue#L400-L406

- https://github.com/directus/directus/blob/fa44632c7151363a7be39398d42f3b505926abce/app/src/modules/files/routes/item.vue#L336-L339

- https://github.com/directus/directus/blob/fa44632c7151363a7be39398d42f3b505926abce/app/src/modules/users/routes/item.vue#L396-L401

However this logic is missing from role items and webhook items page.

Fixes ENG-840

### Before

https://user-images.githubusercontent.com/42867097/227131764-37df1dc1-41a0-4178-8b81-5f1dda98777f.mp4

### After

https://user-images.githubusercontent.com/42867097/227131713-5e79c1dd-9053-425e-8b89-d785ebfe0102.mp4

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
