### PR TITLE
Remove free plan for cloud from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Directus is a real-time API and App dashboard for managing SQL database content.
 - **Manage pure SQL.** Works with new or existing SQL databases, no migration required.
 - **Choose your database.** Supports PostgreSQL, MySQL, SQLite, OracleDB, CockroachDB, MariaDB, and MS-SQL.
 - **On-Prem or Cloud.** Run locally, install on-premises, or use our
-  [self-service Cloud service](https://directus.io/pricing) (free tier available).
+  [self-service Cloud service](https://directus.io/pricing).
 - **Completely extensible.** Built to white-label, it is easy to customize our modular platform.
 - **A modern dashboard.** Our no-code Vue.js app is safe and intuitive for non-technical users, no training required.
 


### PR DESCRIPTION
## Description

Since directus is removing it's free cloud tier plan, removing the line from your readme about it.

cc https://directus.io/blog/cloud-update

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: Git readme update no code changed

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
