### PR TITLE
Fix publishing of packages to NPM in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          registry: https://registry.npmjs.org
 
       - name: Publish packages to NPM
         env:


### PR DESCRIPTION
We need to pass the `registry` prop to the `prepare` action so the NPM token is set correctly. Overlooked in #17858.

See also https://github.com/directus/directus/pull/17656.