### PR TITLE
Fix Refresh Token issue 

### DIFF
--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -5,7 +5,7 @@ import type { Request, RequestHandler } from 'express';
 import pinoHTTP, { stdSerializers } from 'pino-http';
 import { URL } from 'url';
 import env from './env';
-import { getConfigFromEnv } from './utils/get-config-from-env';
+import { getConfigFromEnv } from './utils/get-config-from-env';const output = pino_http_1.stdSerializers.req(request, {clone: true});
 import { redactHeaderCookie } from './utils/redact-header-cookies';
 
 const pinoOptions: LoggerOptions = {
@@ -85,7 +85,7 @@ export const expressLogger = pinoHTTP({
 	...httpLoggerEnvConfig,
 	serializers: {
 		req(request: Request) {
-			const output = stdSerializers.req(request, {clone: true});
+			const output = JSON.parse(JSON.stringify(stdSerializers.req(request)));
 			output.url = redactQuery(output.url);
 			if (output.headers?.['cookie']) {
 				output.headers['cookie'] = redactHeaderCookie(output.headers['cookie'], [

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -85,7 +85,7 @@ export const expressLogger = pinoHTTP({
 	...httpLoggerEnvConfig,
 	serializers: {
 		req(request: Request) {
-			const output = JSON.parse(JSON.stringify(stdSerializers.req(request));
+			const output = stdSerializers.req(request, {clone: true});
 			output.url = redactQuery(output.url);
 			if (output.headers?.['cookie']) {
 				output.headers['cookie'] = redactHeaderCookie(output.headers['cookie'], [

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -5,7 +5,7 @@ import type { Request, RequestHandler } from 'express';
 import pinoHTTP, { stdSerializers } from 'pino-http';
 import { URL } from 'url';
 import env from './env';
-import { getConfigFromEnv } from './utils/get-config-from-env';const output = pino_http_1.stdSerializers.req(request, {clone: true});
+import { getConfigFromEnv } from './utils/get-config-from-env';
 import { redactHeaderCookie } from './utils/redact-header-cookies';
 
 const pinoOptions: LoggerOptions = {

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -85,7 +85,7 @@ export const expressLogger = pinoHTTP({
 	...httpLoggerEnvConfig,
 	serializers: {
 		req(request: Request) {
-			const output = stdSerializers.req(request);
+			const output = JSON.parse(JSON.stringify(stdSerializers.req(request));
 			output.url = redactQuery(output.url);
 			if (output.headers?.['cookie']) {
 				output.headers['cookie'] = redactHeaderCookie(output.headers['cookie'], [

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -1,4 +1,4 @@
-import { toArray } from '@directus/shared/utils';
+import { parseJSON, toArray } from '@directus/shared/utils';
 import { merge } from 'lodash';
 import pino, { LoggerOptions, SerializedResponse } from 'pino';
 import type { Request, RequestHandler } from 'express';
@@ -85,7 +85,7 @@ export const expressLogger = pinoHTTP({
 	...httpLoggerEnvConfig,
 	serializers: {
 		req(request: Request) {
-			const output = JSON.parse(JSON.stringify(stdSerializers.req(request)));
+			const output = parseJSON(JSON.stringify(stdSerializers.req(request)));
 			output.url = redactQuery(output.url);
 			if (output.headers?.['cookie']) {
 				output.headers['cookie'] = redactHeaderCookie(output.headers['cookie'], [


### PR DESCRIPTION
## Description

The request is handled by the logger middleware before it reaches the auth controller's refresh function.

Since the logger middleware has direct access to the request object, any modifications made to it will also affect the refresh function in the auth controller. Therefore, the refresh token will be redacted in both the auth controller and the output that is logged.

To ensure that the refresh token is passed to the auth controller without any issues and the logged output has the refresh token redacted, a clone object can be created from the request object using the following code:
` const output = JSON.parse(JSON.stringify(stdSerializers.req(request)));`


<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:
https://github.com/directus/directus/issues/17901
-->

Fixes #
https://github.com/directus/directus/issues/17901https://github.com/directus/directus/issues/17901

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
