### PR TITLE
Fix npm usage in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,8 @@ RUN pnpm --recursive run build \
 	&& cd pruned \
 	&& pnpm pack \
 	&& tar -zxvf *.tgz package/package.json \
-	&& rm package.json \
 	&& mv package/package.json package.json \
-	&& rm *.tgz
+	&& rm -r *.tgz package
 
 ####################################################################################################
 ## Create Production Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,13 @@ WORKDIR /workspace
 ENV NODE_OPTIONS=--max-old-space-size=8192
 
 RUN pnpm --recursive run build \
-	&& pnpm --filter directus deploy --prod pruned
+	&& pnpm --filter directus deploy --prod pruned \
+	&& cd pruned \
+	&& pnpm pack \
+	&& tar -zxvf *.tgz package/package.json \
+	&& rm package.json \
+	&& mv package/package.json package.json \
+	&& rm *.tgz
 
 ####################################################################################################
 ## Create Production Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ FROM node:18-alpine
 
 RUN mkdir /directus \
 	&& mkdir -p /directus/database /directus/extensions /directus/uploads \
-	&& chown node:node /directus/database /directus/extensions /directus/uploads;
+	&& chown -R node:node /directus
 
 WORKDIR /directus
 
@@ -55,10 +55,10 @@ VOLUME /directus/database
 VOLUME /directus/extensions
 VOLUME /directus/uploads
 
-COPY --from=pruned /workspace/pruned/dist dist
-COPY --from=pruned /workspace/pruned/package.json package.json
-COPY --from=pruned /workspace/pruned/cli.js cli.js
-COPY --from=pruned /workspace/pruned/node_modules node_modules
+COPY --from=pruned --chown=node:node /workspace/pruned/cli.js cli.js
+COPY --from=pruned --chown=node:node /workspace/pruned/dist dist
+COPY --from=pruned --chown=node:node /workspace/pruned/package.json package.json
+COPY --from=pruned --chown=node:node /workspace/pruned/node_modules node_modules
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ COPY --from=pruned /workspace/pruned/package.json package.json
 COPY --from=pruned /workspace/pruned/node_modules node_modules
 
 RUN mkdir /directus/database /directus/extensions /directus/uploads \
-	&& chown -R node:node /directus
+	&& chown -R node:node /directus \
+	&& corepack enable \
+	&& corepack prepare pnpm@7.30.0 --activate
 
 VOLUME /directus/database
 VOLUME /directus/extensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ VOLUME /directus/uploads
 
 COPY --from=pruned /workspace/pruned/dist dist
 COPY --from=pruned /workspace/pruned/package.json package.json
+COPY --from=pruned /workspace/pruned/cli.js cli.js
 COPY --from=pruned /workspace/pruned/node_modules node_modules
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,6 @@ RUN pnpm --recursive run build \
 
 FROM node:18-alpine
 
-RUN mkdir /directus \
-	&& mkdir -p /directus/database /directus/extensions /directus/uploads \
-	&& chown -R node:node /directus
-
 WORKDIR /directus
 
 EXPOSE 8055
@@ -51,14 +47,17 @@ ENV STORAGE_LOCAL_ROOT="/directus/uploads"
 ENV NODE_ENV="production"
 ENV NPM_CONFIG_UPDATE_NOTIFIER="false"
 
+COPY --from=pruned /workspace/pruned/cli.js cli.js
+COPY --from=pruned /workspace/pruned/dist dist
+COPY --from=pruned /workspace/pruned/package.json package.json
+COPY --from=pruned /workspace/pruned/node_modules node_modules
+
+RUN mkdir /directus/database /directus/extensions /directus/uploads \
+	&& chown -R node:node /directus
+
 VOLUME /directus/database
 VOLUME /directus/extensions
 VOLUME /directus/uploads
-
-COPY --from=pruned --chown=node:node /workspace/pruned/cli.js cli.js
-COPY --from=pruned --chown=node:node /workspace/pruned/dist dist
-COPY --from=pruned --chown=node:node /workspace/pruned/package.json package.json
-COPY --from=pruned --chown=node:node /workspace/pruned/node_modules node_modules
 
 USER node
 


### PR DESCRIPTION
`pnpm deploy` doesn't seem to properly rewrite the `package.json` file (see https://github.com/pnpm/pnpm/issues/6269), so this PR works around that by copying over the package.json generated by `pnpm pack` into the final dists

Fixes #17902