### PR TITLE
Only hide v-select options

### DIFF
--- a/app/src/components/v-select/select-list-item-group.vue
+++ b/app/src/components/v-select/select-list-item-group.vue
@@ -1,5 +1,6 @@
 <template>
 	<v-list-group
+		v-show="!item.hidden"
 		:active="isActive"
 		:clickable="groupSelectable || item.selectable"
 		:value="item.value"

--- a/app/src/components/v-select/select-list-item.vue
+++ b/app/src/components/v-select/select-list-item.vue
@@ -3,6 +3,7 @@
 
 	<v-list-item
 		v-else
+		v-show="!item.hidden"
 		:active="isActive"
 		:disabled="item.disabled"
 		clickable

--- a/app/src/components/v-select/types.ts
+++ b/app/src/components/v-select/types.ts
@@ -6,4 +6,5 @@ export type Option = {
 	children?: Option[];
 	divider?: boolean;
 	selectable?: boolean;
+	hidden?: boolean;
 };

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -258,6 +258,7 @@ function useItems() {
 				disabled: get(item, props.itemDisabled),
 				selectable: get(item, props.itemSelectable),
 				children: children ? children.filter(filterItem) : children,
+				hidden: internalSearch.value ? !filterItem(item) : false,
 			};
 		};
 
@@ -281,9 +282,7 @@ function useItems() {
 			}
 		};
 
-		const items = internalSearch.value ? props.items.filter(filterItem).map(parseItem) : props.items.map(parseItem);
-
-		return items;
+		return props.items.map(parseItem);
 	});
 
 	const internalItemsCount = computed<number>(() => {


### PR DESCRIPTION
## Description

Before, we would filter all non matching options out of the possible select options, meaning when we alread had something selected that couldn't be matched anymore, we would show only the value. By hiding the options instead of filtering them, we prevent this issue.

Fixes #17931