### PR TITLE
Do not override metadata

### DIFF
--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -97,12 +97,12 @@ export class FilesService extends ItemsService {
 			const stream = await storage.location(data.storage).read(payload.filename_disk);
 			const { height, width, description, title, tags, metadata } = await this.getMetadata(stream);
 
-			payload.height = height ?? null;
-			payload.width = width ?? null;
-			payload.description = description ?? null;
-			payload.title = title ?? null;
-			payload.tags = tags ?? null;
-			payload.metadata = metadata ?? null;
+			payload.height ??= height ?? null;
+			payload.width ??= width ?? null;
+			payload.description ??= description ?? null;
+			payload.title ??= title ?? null;
+			payload.tags ??= tags ?? null;
+			payload.metadata ??= metadata ?? null;
 		}
 
 		// We do this in a service without accountability. Even if you don't have update permissions to the file,

--- a/tests-blackbox/routes/files/storage.test.ts
+++ b/tests-blackbox/routes/files/storage.test.ts
@@ -6,11 +6,13 @@ import path from 'path';
 import * as common from '@common/index';
 
 const assetsDirectory = [__dirname, '..', '..', 'assets'];
-const storages = ['local'];
+const storages = ['local', 'minio'];
 const imageFile = {
 	name: 'directus.png',
 	type: 'image/png',
 	filesize: '7136',
+	title: 'Directus',
+	description: 'The Directus Logo',
 };
 const imageFilePath = path.join(...assetsDirectory, imageFile.name);
 
@@ -22,8 +24,10 @@ describe('/files', () => {
 				const response = await request(getUrl(vendor))
 					.post('/files')
 					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
-					.attach('file', createReadStream(imageFilePath))
-					.field('storage', storage);
+					.field('storage', storage)
+					.field('title', imageFile.title)
+					.field('description', imageFile.description)
+					.attach('file', createReadStream(imageFilePath));
 
 				// Normalize filesize to string as bigint returns as a string
 				response.body.data.filesize = String(response.body.data.filesize);
@@ -37,6 +41,8 @@ describe('/files', () => {
 						filename_download: imageFile.name,
 						filename_disk: expect.any(String),
 						storage: storage,
+						title: imageFile.title,
+						description: imageFile.description,
 						id: expect.any(String),
 					})
 				);
@@ -51,8 +57,8 @@ describe('/files', () => {
 				const insertResponse = await request(getUrl(vendor))
 					.post('/files')
 					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
-					.attach('file', createReadStream(imageFilePath))
-					.field('storage', storage);
+					.field('storage', storage)
+					.attach('file', createReadStream(imageFilePath));
 
 				// Action
 				const response = await request(getUrl(vendor))


### PR DESCRIPTION
@rijkvanzanten changed `payload.height ??= height` to `payload.height = height ?? null` but the proper change would have been `payload.height ??= height ?? null`. The `??=` operator only assigns a value when the `playload.height` is null/undefined so by removing it, we always set it to `height ?? null`.

Fixes #17970 

https://github.com/directus/directus/commit/fe74c43bc05e77357759ab018fd56e8ae143b4bd#diff-989e6837090c2d3ad803a8b7c8bd70c3b1d7706ce90732839b0d61eb1dd82dccL100-R105