### PR TITLE
Workaround fixing `pnpm deploy` in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN pnpm install --recursive --offline --frozen-lockfile
 
 RUN : \
 	&& pnpm --recursive --workspace-concurrency=1 run build \
+	&& printf 'dedupe-peer-dependents=false\npublic-hoist-pattern[]=' >> .npmrc \
 	&& pnpm --filter directus deploy --prod dist \
 	&& cd dist \
 	&& pnpm pack \


### PR DESCRIPTION
## Description

With the upgrade to pnpm 8 the `pnpm deploy` command used in the docker image wasn't working properly anymore.
This is related to the following change introduced in v8:
> ### Other Changes
> * [...]
> * Direct dependencies are deduped. If a dependency is present in both a project and the workspace root, it will only be linked to the workspace root.

This pull request should only be considered as a workaround for now. It's most likely a bug as the above change shouldn't apply for `pnpm deploy`. See https://github.com/pnpm/pnpm/issues/6303 for a similar issue report.

Without this workaround, `pnpm pack` fails with
```console
 ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL  Cannot resolve workspace protocol of dependency "@directus/app" because this dependency is not installed. Try running "pnpm install".
```
since this dep (as well as the others) are deduped and thus not available in `node_modules`.

**TODO** Check with pnpm 8.1.0

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
