### PR TITLE
Resend user invites

### DIFF
--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -79,7 +79,6 @@ describe('Integration Tests', () => {
 		let checkPasswordPolicySpy: SpyInstance;
 		let checkRemainingAdminExistenceSpy: SpyInstance;
 		let checkRemainingActiveAdminSpy: SpyInstance;
-		let inviteUrlSpy: SpyInstance;
 
 		beforeEach(() => {
 			service = new UsersService({
@@ -131,7 +130,8 @@ describe('Integration Tests', () => {
 			checkRemainingActiveAdminSpy = vi
 				.spyOn(UsersService.prototype as any, 'checkRemainingActiveAdmin')
 				.mockResolvedValue(() => vi.fn());
-			inviteUrlSpy = vi.spyOn(UsersService.prototype as any, 'inviteUrl').mockImplementation(() => vi.fn());
+
+			vi.spyOn(UsersService.prototype as any, 'inviteUrl').mockImplementation(() => vi.fn());
 
 			mailService = new MailService({
 				schema: testSchema,

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -79,6 +79,7 @@ describe('Integration Tests', () => {
 		let checkPasswordPolicySpy: SpyInstance;
 		let checkRemainingAdminExistenceSpy: SpyInstance;
 		let checkRemainingActiveAdminSpy: SpyInstance;
+		let inviteUrlSpy: SpyInstance;
 
 		beforeEach(() => {
 			service = new UsersService({
@@ -130,6 +131,7 @@ describe('Integration Tests', () => {
 			checkRemainingActiveAdminSpy = vi
 				.spyOn(UsersService.prototype as any, 'checkRemainingActiveAdmin')
 				.mockResolvedValue(() => vi.fn());
+			inviteUrlSpy = vi.spyOn(UsersService.prototype as any, 'inviteUrl').mockImplementation(() => vi.fn());
 
 			mailService = new MailService({
 				schema: testSchema,

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -2,7 +2,7 @@ import type { SchemaOverview } from '@directus/shared/types';
 import knex, { Knex } from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, MockedFunction, SpyInstance, vi } from 'vitest';
-import { ItemsService, UsersService } from '.';
+import { ItemsService, MailService, UsersService } from '.';
 import { ForbiddenException, InvalidPayloadException } from '../exceptions';
 import { RecordNotUniqueException } from '../exceptions/database/record-not-unique';
 
@@ -65,6 +65,8 @@ describe('Integration Tests', () => {
 
 	describe('Services / Users', () => {
 		let service: UsersService;
+		let mailService: SpyInstance;
+		let superCreateManySpy: SpyInstance;
 		let superUpdateManySpy: SpyInstance;
 		let checkUniqueEmailsSpy: SpyInstance;
 		let checkPasswordPolicySpy: SpyInstance;
@@ -105,6 +107,7 @@ describe('Integration Tests', () => {
 				},
 			});
 
+			superCreateManySpy = vi.spyOn(ItemsService.prototype, 'createMany');
 			superUpdateManySpy = vi.spyOn(ItemsService.prototype, 'updateMany');
 
 			// "as any" are needed since these are private methods
@@ -120,6 +123,8 @@ describe('Integration Tests', () => {
 			checkRemainingActiveAdminSpy = vi
 				.spyOn(UsersService.prototype as any, 'checkRemainingActiveAdmin')
 				.mockResolvedValue(() => vi.fn());
+
+			mailService = vi.spyOn(MailService.prototype, 'send').mockResolvedValue(undefined);
 		});
 
 		afterEach(() => {
@@ -127,6 +132,8 @@ describe('Integration Tests', () => {
 			checkPasswordPolicySpy.mockClear();
 			checkRemainingAdminExistenceSpy.mockClear();
 			checkRemainingActiveAdminSpy.mockClear();
+
+			mailService.mockClear();
 		});
 
 		describe('createOne', () => {
@@ -600,6 +607,95 @@ describe('Integration Tests', () => {
 				}
 
 				expect(checkRemainingAdminExistenceSpy).toBeCalledTimes(1);
+			});
+		});
+
+		describe('invite', () => {
+			it('should invite new users', async () => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'test', admin: true },
+				});
+
+				const promise = service.inviteUser('user@example.com', 'invite-role', null);
+
+				await expect(promise).resolves.not.toThrow();
+
+				expect(superCreateManySpy).toBeCalledWith(
+					[
+						expect.objectContaining({
+							email: 'user@example.com',
+							status: 'invited',
+							role: 'invite-role',
+						}),
+					],
+					{}
+				);
+
+				expect(mailService).toBeCalledTimes(1);
+			});
+
+			it('should re-send invites for invited users', async () => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'test', admin: true },
+				});
+
+				// mock an invited user
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					status: 'invited',
+					role: 'invite-role',
+				});
+
+				const promise = service.inviteUser('user@example.com', 'invite-role', null);
+				await expect(promise).resolves.not.toThrow();
+
+				expect(superCreateManySpy).not.toBeCalled();
+				expect(mailService).toBeCalledTimes(1);
+			});
+
+			it('should not re-send invites for users in state other than invited', async () => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'test', admin: true },
+				});
+
+				// mock an active user
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					status: 'active',
+					role: 'invite-role',
+				});
+
+				const promise = service.inviteUser('user@example.com', 'invite-role', null);
+				await expect(promise).resolves.not.toThrow();
+
+				expect(superCreateManySpy).not.toBeCalled();
+				expect(mailService).not.toBeCalled();
+			});
+
+			it('should update role when re-sent invite contains different role than user has', async () => {
+				const service = new UsersService({
+					knex: db,
+					schema: testSchema,
+					accountability: { role: 'test', admin: true },
+				});
+
+				tracker.on.select(/select "admin_access" from "directus_roles"/).response({ admin_access: true });
+
+				// mock an invited user with different role
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 1,
+					status: 'invited',
+					role: 'existing-role',
+				});
+
+				const promise = service.inviteUser('user@example.com', 'invite-role', null);
+				await expect(promise).resolves.not.toThrow();
+
+				expect(superUpdateManySpy).toBeCalledWith([1], { role: 'invite-role' }, {});
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -137,9 +137,9 @@ export class UsersService extends ItemsService {
 	/**
 	 * Get basic information of user identified by email
 	 */
-	private async getUserByEmail(email: string): Promise<{ id: string; role: string; status: string }> {
+	private async getUserByEmail(email: string): Promise<{ id: string; role: string; status: string; password: string }> {
 		return await this.knex
-			.select('id', 'role', 'status')
+			.select('id', 'role', 'status', 'password')
 			.from('directus_users')
 			.whereRaw(`LOWER(??) = ?`, ['email', email.toLowerCase()])
 			.first();
@@ -377,7 +377,7 @@ export class UsersService extends ItemsService {
 
 		if (scope !== 'invite') throw new ForbiddenException();
 
-		const user = await this.knex.select('id', 'status').from('directus_users').where({ email }).first();
+		const user = await this.getUserByEmail(email);
 
 		if (user?.status !== 'invited') {
 			throw new InvalidPayloadException(`Email address ${email} hasn't been invited.`);
@@ -396,11 +396,7 @@ export class UsersService extends ItemsService {
 		const STALL_TIME = 500;
 		const timeStart = performance.now();
 
-		const user = await this.knex
-			.select('status', 'password')
-			.from('directus_users')
-			.whereRaw('LOWER(??) = ?', ['email', email.toLowerCase()])
-			.first();
+		const user = await this.getUserByEmail(email);
 
 		if (user?.status !== 'active') {
 			await stall(STALL_TIME, timeStart);
@@ -456,7 +452,7 @@ export class UsersService extends ItemsService {
 			opts.preMutationException = err;
 		}
 
-		const user = await this.knex.select('id', 'status', 'password').from('directus_users').where({ email }).first();
+		const user = await this.getUserByEmail(email);
 
 		if (user?.status !== 'active' || hash !== getSimpleHash('' + user.password)) {
 			throw new ForbiddenException();


### PR DESCRIPTION
## Description

As discussed in #17856 with @rijkvanzanten, this PR allows to re-send invitations for users marked as invited (`status: invited`). If role send wiht the (re-)invite differs to the one in the database, the database is updated - which requires appropriate update permissions.

Regarding the behavior in Directus Studio: If a user has `active` status (or any other status than `invited`) and a (re-)invite is created the UI does not give an error message. The user is gracefully ignored, to allow processing other users if multiple are (re-)invited at once.

A bit out of scope are the little changes made in commit 08c9513069fda8a2d0e2b7c637aa46621837afaa. Here I reuse the newly added helper for getting a user by its email to reduce duplicate code. We can keep this out of this PR if preferred.

Regarding documentation: Should something be added? I did not find a section which becomes wrong with this change.

Fixes #17994

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
