### PR TITLE
Add active state to file interface

### DIFF
--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -1,13 +1,14 @@
 <template>
 	<div class="file">
 		<v-menu attached :disabled="loading">
-			<template #activator="{ toggle }">
+			<template #activator="{ toggle, active }">
 				<div>
 					<v-skeleton-loader v-if="loading" type="input" />
 					<v-input
 						v-else
 						clickable
 						readonly
+						:active="active"
 						:disabled="disabled"
 						:placeholder="t('no_file_selected')"
 						:model-value="file && file.title"


### PR DESCRIPTION
## Description

Currently the file interface doesn't have an active border when focused, whereas other similar "dropdown" interfaces does have it:

https://user-images.githubusercontent.com/42867097/229117706-a7621bb4-eb96-4dd1-8429-3ab0a4cb38e2.mp4

### After Fix

![](https://user-images.githubusercontent.com/42867097/229117665-1c3bc8c2-3c84-4d5a-b9dd-8cace4696680.gif)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
