### PR TITLE
Add autocomplete menu to related-collection-select and related-field-select

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -276,10 +276,6 @@ export default defineComponent({
 	}
 }
 
-.v-input.matches {
-	--v-input-color: var(--primary);
-}
-
 .type-label {
 	margin-bottom: 8px;
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -335,10 +335,6 @@ export default defineComponent({
 	}
 }
 
-.v-input.matches {
-	--v-input-color: var(--primary);
-}
-
 .type-label {
 	margin-bottom: 8px;
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2o.vue
@@ -185,10 +185,6 @@ export default defineComponent({
 	gap: 12px 32px;
 	margin-top: 48px;
 
-	.v-input.matches {
-		--v-input-color: var(--primary);
-	}
-
 	.arrow {
 		--v-icon-color: var(--primary);
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -191,10 +191,6 @@ export default defineComponent({
 	}
 }
 
-.v-input.matches {
-	--v-input-color: var(--primary);
-}
-
 .v-list {
 	--v-list-item-content-font-family: var(--family-monospace);
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-translations.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-translations.vue
@@ -265,10 +265,6 @@ export default defineComponent({
 	gap: 12px 28px;
 	margin-top: 48px;
 
-	.v-input.matches {
-		--v-input-color: var(--primary);
-	}
-
 	.v-icon.arrow {
 		--v-icon-color: var(--primary);
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -129,9 +129,5 @@ export default defineComponent({
 	&:not(:empty) {
 		margin-bottom: 20px;
 	}
-
-	.v-input.matches {
-		--v-input-color: var(--primary);
-	}
 }
 </style>

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/collection-select-menu.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/collection-select-menu.vue
@@ -4,7 +4,7 @@
 			<slot name="activator" :toggle="toggle" :activate="activate" :deactivate="deactivate" />
 		</template>
 
-		<v-list v-if="filteredCollections?.length > 0 || filteredSystemCollections > 0" class="monospace">
+		<v-list v-if="filteredCollections?.length > 0 || filteredSystemCollections?.length > 0" class="monospace">
 			<v-list-item
 				v-for="collection in filteredCollections"
 				:key="collection.collection"

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/collection-select-menu.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/collection-select-menu.vue
@@ -1,0 +1,84 @@
+<template>
+	<v-menu :show-arrow="showArrow" :attached="attached" :placement="placement">
+		<template #activator="{ toggle, activate, deactivate }">
+			<slot name="activator" :toggle="toggle" :activate="activate" :deactivate="deactivate" />
+		</template>
+
+		<v-list v-if="filteredCollections?.length > 0 || filteredSystemCollections > 0" class="monospace">
+			<v-list-item
+				v-for="collection in filteredCollections"
+				:key="collection.collection"
+				:active="modelValue === collection.collection"
+				clickable
+				@click="$emit('update:modelValue', collection.collection)"
+			>
+				<v-list-item-content>
+					{{ collection.collection }}
+				</v-list-item-content>
+			</v-list-item>
+
+			<v-divider v-if="filteredCollections.length > 0 && filteredSystemCollections.length > 0" />
+
+			<v-list-group v-if="filteredSystemCollections.length > 0">
+				<template #activator>{{ t('system') }}</template>
+				<v-list-item
+					v-for="systemCollection in filteredSystemCollections"
+					:key="systemCollection.collection"
+					:active="modelValue === systemCollection.collection"
+					clickable
+					@click="$emit('update:modelValue', systemCollection.collection)"
+				>
+					<v-list-item-content>
+						{{ systemCollection.collection }}
+					</v-list-item-content>
+				</v-list-item>
+			</v-list-group>
+		</v-list>
+	</v-menu>
+</template>
+
+<script lang="ts" setup>
+import type { Collection } from '@/types/collections';
+import type { Placement } from '@popperjs/core';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = withDefaults(
+	defineProps<{
+		showArrow?: boolean;
+		attached?: boolean;
+		placement?: Placement;
+		collections: Collection[];
+		systemCollections: Collection[];
+		filter?: string | null;
+		modelValue: string;
+	}>(),
+	{
+		showArrow: false,
+		attached: false,
+		placement: 'bottom',
+		filter: null,
+	}
+);
+
+defineEmits<{
+	(e: 'update:modelValue', collection: Collection): void;
+}>();
+
+const { t } = useI18n();
+
+const filteredCollections = computed(() =>
+	props.filter ? props.collections.filter(({ collection }) => collection.startsWith(props.filter!)) : props.collections
+);
+const filteredSystemCollections = computed(() =>
+	props.filter
+		? props.systemCollections.filter(({ collection }) => collection.startsWith(props.filter!))
+		: props.systemCollections
+);
+</script>
+
+<style lang="scss" scoped>
+.monospace {
+	--v-list-item-content-font-family: var(--family-monospace);
+}
+</style>

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/field-select-menu.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/field-select-menu.vue
@@ -1,0 +1,59 @@
+<template>
+	<v-menu :show-arrow="showArrow" :attached="attached" :placement="placement">
+		<template #activator="{ toggle, activate, deactivate }">
+			<slot name="activator" :toggle="toggle" :activate="activate" :deactivate="deactivate" />
+		</template>
+
+		<v-list v-if="filteredFields?.length > 0" class="monospace">
+			<v-list-item
+				v-for="field in filteredFields"
+				:key="field.value"
+				:active="modelValue === field.value"
+				:disabled="field.disabled"
+				clickable
+				@click="$emit('update:modelValue', field.value)"
+			>
+				<v-list-item-content>
+					{{ field.text }}
+				</v-list-item-content>
+			</v-list-item>
+		</v-list>
+	</v-menu>
+</template>
+
+<script lang="ts" setup>
+import type { Field } from '@directus/shared/types';
+import type { Placement } from '@popperjs/core';
+import { computed } from 'vue';
+
+const props = withDefaults(
+	defineProps<{
+		showArrow?: boolean;
+		attached?: boolean;
+		placement?: Placement;
+		fields: { text: string; value: string; disabled: boolean }[];
+		filter?: string | null;
+		modelValue: string;
+	}>(),
+	{
+		showArrow: false,
+		attached: false,
+		placement: 'bottom',
+		filter: null,
+	}
+);
+
+defineEmits<{
+	(e: 'update:modelValue', field: Field): void;
+}>();
+
+const filteredFields = computed(() =>
+	props.filter ? props.fields.filter(({ value }) => value.startsWith(props.filter!)) : props.fields
+);
+</script>
+
+<style lang="scss" scoped>
+.monospace {
+	--v-list-item-content-font-family: var(--family-monospace);
+}
+</style>


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Fixes #18022

Adds a simple auto complete to the related-collection-select and related-field-select components.

This is in addition to keeping the existing menu that opens when clicking the "select" icon. 
The autocomplete menu closes itself if the input loses focus or the menu on the right side of the input is clicked.

Additionally I moved the style for the `matches` class to the correct component such that it actually takes effect and an existing collection or field name is highlighted.

![Screenshot 2023-04-02 at 13 22 22](https://user-images.githubusercontent.com/4376726/229355423-cd9ce211-c41c-482a-ba83-a9b049cf6512.png)

![Screenshot 2023-04-02 at 13 22 31](https://user-images.githubusercontent.com/4376726/229355422-7c368c36-3d99-4c8d-a6f3-c7a57801eef6.png)

![Screenshot 2023-04-02 at 13 22 38](https://user-images.githubusercontent.com/4376726/229355419-2d1c3935-747f-4fe7-b09e-2428c7d986a4.png)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
