### PR TITLE
Update of all vitest snapshots

### DIFF
--- a/app/src/components/__snapshots__/v-avatar.test.ts.snap
+++ b/app/src/components/__snapshots__/v-avatar.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-8dd7c482=\\"\\" class=\\"v-avatar\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-badge.test.ts.snap
+++ b/app/src/components/__snapshots__/v-badge.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-a39517a7=\\"\\" class=\\"v-badge\\"><span data-v-a39517a7=\\"\\" class=\\"badge\\"><span data-v-a39517a7=\\"\\"></span></span>Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-breadcrumb.test.ts.snap
+++ b/app/src/components/__snapshots__/v-breadcrumb.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<span data-v-273d8978=\\"\\" class=\\"v-breadcrumb\\"><span data-v-273d8978=\\"\\" class=\\"section\\"><!--v-if--><router-link-stub data-v-273d8978=\\"\\" to=\\"hi\\" class=\\"section-link\\"></router-link-stub></span><span data-v-273d8978=\\"\\" class=\\"section\\"><v-icon-stub data-v-273d8978=\\"\\" name=\\"chevron_right\\" small=\\"\\"></v-icon-stub><router-link-stub data-v-273d8978=\\"\\" to=\\"wow\\" class=\\"section-link\\"></router-link-stub></span><span data-v-273d8978=\\"\\" class=\\"section disabled\\"><v-icon-stub data-v-273d8978=\\"\\" name=\\"chevron_right\\" small=\\"\\"></v-icon-stub><span data-v-273d8978=\\"\\" class=\\"section-link\\"><!--v-if--> Disabled</span></span></span>"`;

--- a/app/src/components/__snapshots__/v-button.test.ts.snap
+++ b/app/src/components/__snapshots__/v-button.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-28d526fe=\\"\\" class=\\"v-button\\"><button data-v-28d526fe=\\"\\" class=\\"button align-center normal\\" type=\\"button\\"><span data-v-28d526fe=\\"\\" class=\\"content\\"></span>

--- a/app/src/components/__snapshots__/v-card-actions.test.ts.snap
+++ b/app/src/components/__snapshots__/v-card-actions.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-b9233e5b=\\"\\" class=\\"v-card-actions\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-card-subtitle.test.ts.snap
+++ b/app/src/components/__snapshots__/v-card-subtitle.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-f6658148=\\"\\" class=\\"v-card-subtitle\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-card-text.test.ts.snap
+++ b/app/src/components/__snapshots__/v-card-text.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-de36d604=\\"\\" class=\\"v-card-text\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-card-title.test.ts.snap
+++ b/app/src/components/__snapshots__/v-card-title.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-0768f50f=\\"\\" class=\\"v-card-title type-label\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-card.test.ts.snap
+++ b/app/src/components/__snapshots__/v-card.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-12731031=\\"\\" class=\\"v-card\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-checkbox.test.ts.snap
+++ b/app/src/components/__snapshots__/v-checkbox.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<button data-v-61c33115=\\"\\" class=\\"v-checkbox\\" type=\\"button\\" role=\\"checkbox\\" aria-pressed=\\"false\\">

--- a/app/src/components/__snapshots__/v-chip.test.ts.snap
+++ b/app/src/components/__snapshots__/v-chip.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<span data-v-0ab7ac28=\\"\\" class=\\"v-chip label\\"><span data-v-0ab7ac28=\\"\\" class=\\"chip-content\\"><!--v-if--></span></span>"`;

--- a/app/src/components/__snapshots__/v-divider.test.ts.snap
+++ b/app/src/components/__snapshots__/v-divider.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-51167fde=\\"\\" class=\\"v-divider inlineTitle\\"><span data-v-51167fde=\\"\\" class=\\"wrapper\\"><span data-v-51167fde=\\"\\" class=\\"type-text\\">Default slot</span></span>

--- a/app/src/components/__snapshots__/v-error-boundary.test.ts.snap
+++ b/app/src/components/__snapshots__/v-error-boundary.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `""`;

--- a/app/src/components/__snapshots__/v-fancy-select.test.ts.snap
+++ b/app/src/components/__snapshots__/v-fancy-select.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-167e9f7d=\\"\\" class=\\"v-fancy-select\\">

--- a/app/src/components/__snapshots__/v-highlight.test.ts.snap
+++ b/app/src/components/__snapshots__/v-highlight.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "Th

--- a/app/src/components/__snapshots__/v-hover.test.ts.snap
+++ b/app/src/components/__snapshots__/v-hover.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div>hidden</div>"`;

--- a/app/src/components/__snapshots__/v-icon-file.test.ts.snap
+++ b/app/src/components/__snapshots__/v-icon-file.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-a90644d4=\\"\\" class=\\"icon\\">

--- a/app/src/components/__snapshots__/v-info.test.ts.snap
+++ b/app/src/components/__snapshots__/v-info.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-30215bfa=\\"\\" class=\\"v-info info\\">

--- a/app/src/components/__snapshots__/v-input.test.ts.snap
+++ b/app/src/components/__snapshots__/v-input.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-418390f4=\\"\\" class=\\"v-input full-width\\">

--- a/app/src/components/__snapshots__/v-menu.test.ts.snap
+++ b/app/src/components/__snapshots__/v-menu.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-41b8fe03=\\"\\" class=\\"v-menu\\">

--- a/app/src/components/__snapshots__/v-notice.test.ts.snap
+++ b/app/src/components/__snapshots__/v-notice.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-f0538e61=\\"\\" class=\\"v-notice normal\\">

--- a/app/src/components/__snapshots__/v-overlay.test.ts.snap
+++ b/app/src/components/__snapshots__/v-overlay.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-500f2fb5=\\"\\" class=\\"v-overlay active has-click\\">

--- a/app/src/components/__snapshots__/v-pagination.test.ts.snap
+++ b/app/src/components/__snapshots__/v-pagination.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-278b16a4=\\"\\" class=\\"v-pagination\\">

--- a/app/src/components/__snapshots__/v-progress-circular.test.ts.snap
+++ b/app/src/components/__snapshots__/v-progress-circular.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-0b5afddc=\\"\\" class=\\"v-progress-circular\\"><svg data-v-0b5afddc=\\"\\" class=\\"circle\\" viewBox=\\"0 0 30 30\\">

--- a/app/src/components/__snapshots__/v-progress-linear.test.ts.snap
+++ b/app/src/components/__snapshots__/v-progress-linear.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-f02f7ebf=\\"\\" class=\\"v-progress-linear danger\\">

--- a/app/src/components/__snapshots__/v-radio.test.ts.snap
+++ b/app/src/components/__snapshots__/v-radio.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<button data-v-2b39bf8c=\\"\\" class=\\"v-radio\\" type=\\"button\\" aria-pressed=\\"false\\">

--- a/app/src/components/__snapshots__/v-sheet.test.ts.snap
+++ b/app/src/components/__snapshots__/v-sheet.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-7bdf141c=\\"\\" class=\\"v-sheet\\">Slot Content</div>"`;

--- a/app/src/components/__snapshots__/v-skeleton-loader.test.ts.snap
+++ b/app/src/components/__snapshots__/v-skeleton-loader.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-b5d05879=\\"\\" class=\\"list-item-icon v-skeleton-loader\\">

--- a/app/src/components/__snapshots__/v-slider.test.ts.snap
+++ b/app/src/components/__snapshots__/v-slider.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-de7fe070=\\"\\" class=\\"v-slider\\" style=\\"--_v-slider-percentage: 0;\\">

--- a/app/src/components/__snapshots__/v-tabs.test.ts.snap
+++ b/app/src/components/__snapshots__/v-tabs.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-21b3cbb9=\\"\\" class=\\"v-tabs horizontal\\">Some value</div>"`;

--- a/app/src/components/__snapshots__/v-text-overflow.test.ts.snap
+++ b/app/src/components/__snapshots__/v-text-overflow.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<div data-v-dcb797ca=\\"\\" class=\\"v-text-overflow\\">My text</div>"`;

--- a/app/src/components/__snapshots__/v-textarea.test.ts.snap
+++ b/app/src/components/__snapshots__/v-textarea.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-6a3718b7=\\"\\" class=\\"v-textarea full-width has-content\\">

--- a/app/src/components/__snapshots__/v-workspace-tile.test.ts.snap
+++ b/app/src/components/__snapshots__/v-workspace-tile.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-a110deb5=\\"\\" class=\\"v-workspace-tile draggable br-tl br-tr br-br br-bl\\" style=\\"--pos-x: 1; --pos-y: 1; --width: 10; --height: 10;\\" data-move=\\"\\">

--- a/app/src/components/__snapshots__/v-workspace.test.ts.snap
+++ b/app/src/components/__snapshots__/v-workspace.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `
 "<div data-v-c965220a=\\"\\" class=\\"v-workspace\\" style=\\"width: 480px; height: 280px;\\">

--- a/app/src/components/v-checkbox-tree/__snapshots__/v-checkbox-tree.test.ts.snap
+++ b/app/src/components/v-checkbox-tree/__snapshots__/v-checkbox-tree.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<ul data-v-ff20e609=\\"\\" class=\\"v-list\\"></ul>"`;

--- a/app/src/components/v-form/__snapshots__/form-field-raw-editor.test.ts.snap
+++ b/app/src/components/v-form/__snapshots__/form-field-raw-editor.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should render 1`] = `
 "<v-dialog data-v-33a4ea83=\\"\\" model-value=\\"true\\" persistent=\\"\\">

--- a/app/src/components/v-icon/__snapshots__/v-icon.test.ts.snap
+++ b/app/src/components/v-icon/__snapshots__/v-icon.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<span data-v-23a4d650=\\"\\" class=\\"v-icon\\"><i data-v-23a4d650=\\"\\" class=\\"\\" data-icon=\\"close\\"></i></span>"`;

--- a/app/src/components/v-select/__snapshots__/v-select.test.ts.snap
+++ b/app/src/components/v-select/__snapshots__/v-select.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Mount component 1`] = `"<v-menu-stub data-v-cdcb6889=\\"\\" class=\\"v-select\\" disabled=\\"false\\" attached=\\"true\\" is-same-width=\\"true\\" show-arrow=\\"false\\" close-on-content-click=\\"true\\" placement=\\"bottom\\"></v-menu-stub>"`;


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Due to a breaking change in [vitest 0.29.0](https://github.com/vitest-dev/vitest/releases/tag/v0.29.0) it now [inserts a link to their docs](https://github.com/vitest-dev/vitest/pull/2867) when *running* the testsuite into snapshot files. This has definitely caused me to add those updated snapshots to a commit by accident before.

Since the pinned vitest version is 0.29.3 I think it is reasonable to update those snapshots. (Done by simply running the test suite).

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe:
Update of test snapshots 

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
