### PR TITLE
Fix cache skipping when PUBLIC_URL is relative

### DIFF
--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -5,24 +5,30 @@ import { shouldSkipCache } from './should-skip-cache';
 
 vi.mock('../env');
 
-test('should always skip cache for requests coming from data studio', () => {
-	const publicURL = 'http://admin.example.com';
+// test('should always skip cache for requests coming from data studio', () => {
+test.each([
+	{ scenario: 'not relative', publicURL: 'http://admin.example.com', refererHost: '' },
+	{ scenario: 'relative', publicURL: '/', refererHost: 'http://ignore.domain' },
+	{ scenario: 'relative with subdirectory', publicURL: '/test/subfolder', refererHost: 'http://ignore.domain' },
+])(
+	'should always skip cache for requests coming from data studio when public URL is $scenario',
+	({ publicURL, refererHost }) => {
+		vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: publicURL, CACHE_SKIP_ALLOWED: false });
 
-	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: publicURL, CACHE_SKIP_ALLOWED: false });
+		const req = {
+			get: vi.fn((str) => {
+				switch (str) {
+					case 'Referer':
+						return `${refererHost}${publicURL}/admin/settings/data-model`;
+					default:
+						return undefined;
+				}
+			}),
+		} as unknown as Request;
 
-	const req = {
-		get: vi.fn((str) => {
-			switch (str) {
-				case 'Referer':
-					return `${publicURL}/admin/settings/data-model`;
-				default:
-					return undefined;
-			}
-		}),
-	} as unknown as Request;
-
-	expect(shouldSkipCache(req)).toBe(true);
-});
+		expect(shouldSkipCache(req)).toBe(true);
+	}
+);
 
 test('should not skip cache for requests coming outside of data studio', () => {
 	vi.mocked(getEnv).mockReturnValue({ PUBLIC_URL: 'http://admin.example.com', CACHE_SKIP_ALLOWED: false });

--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -5,7 +5,6 @@ import { shouldSkipCache } from './should-skip-cache';
 
 vi.mock('../env');
 
-// test('should always skip cache for requests coming from data studio', () => {
 test.each([
 	{ scenario: 'not relative', publicURL: 'http://admin.example.com', refererHost: '' },
 	{ scenario: 'relative', publicURL: '/', refererHost: 'http://ignore.domain' },

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -12,8 +12,16 @@ export function shouldSkipCache(req: Request): boolean {
 	const env = getEnv();
 
 	// Always skip cache for requests coming from the data studio based on Referer header
-	const adminUrl = new Url(env['PUBLIC_URL']).addPath('admin').toString();
-	if (req.get('Referer')?.startsWith(adminUrl)) return true;
+	const referer = req.get('Referer');
+	if (referer) {
+		const adminUrl = new Url(env['PUBLIC_URL']).addPath('admin');
+		if (adminUrl.isRootRelative()) {
+			const refererUrl = new Url(referer);
+			if (refererUrl.path.join('/').startsWith(adminUrl.path.join('/'))) return true;
+		} else if (referer.startsWith(adminUrl.toString())) {
+			return true;
+		}
+	}
 
 	if (env['CACHE_SKIP_ALLOWED'] && req.get('cache-control')?.includes('no-store')) return true;
 


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

`PUBLIC_URL` defaults to `/` which resulted in the admin app not skipping cache as `Referer` urls include the host.

Fixes #18026, Closes ENG-863.

Follow-up to #17642.

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
