### PR TITLE
Inline form interface

### DIFF
--- a/app/src/interfaces/inline-form-m2o/index.ts
+++ b/app/src/interfaces/inline-form-m2o/index.ts
@@ -11,57 +11,32 @@ export default defineInterface({
 	relational: true,
 	localTypes: ['m2o'],
 	group: 'relational',
-	hideLabel: true,
 	options: ({ relations }) => {
 		const collection = relations.m2o?.related_collection;
 
 		return [
 			{
-				field: 'template',
-				name: '$t:interfaces.select-dropdown-m2o.display_template',
-				meta: {
-					interface: 'system-display-template',
-					options: {
-						collectionName: collection,
-					},
-				},
-			},
-			{
-				field: 'enableCreate',
-				name: '$t:creating_items',
+				field: 'createRelatedItem',
+				type: 'string',
+				name: '$t:interfaces.inline-form-m2o.create-related-item',
 				schema: {
-					default_value: true,
+					default_value: 'withContent',
 				},
 				meta: {
-					interface: 'boolean',
+					note: '$t:interfaces.inline-form-m2o.create-related-item-note',
+					width: 'full',
+					interface: 'select-dropdown',
 					options: {
-						label: '$t:enable_create_button',
-					},
-					width: 'half',
-				},
-			},
-			{
-				field: 'enableSelect',
-				name: '$t:selecting_items',
-				schema: {
-					default_value: true,
-				},
-				meta: {
-					interface: 'boolean',
-					options: {
-						label: '$t:enable_select_button',
-					},
-					width: 'half',
-				},
-			},
-			{
-				field: 'filter',
-				name: '$t:filter',
-				type: 'json',
-				meta: {
-					interface: 'system-filter',
-					options: {
-						collectionName: collection,
+						choices: [
+							{
+								text: '$t:interfaces.inline-form-m2o.only-with-content',
+								value: 'withContent',
+							},
+							{
+								text: '$t:interfaces.inline-form-m2o.always-create',
+								value: 'always',
+							},
+						],
 					},
 				},
 			},

--- a/app/src/interfaces/inline-form-m2o/index.ts
+++ b/app/src/interfaces/inline-form-m2o/index.ts
@@ -11,9 +11,7 @@ export default defineInterface({
 	relational: true,
 	localTypes: ['m2o'],
 	group: 'relational',
-	options: ({ relations }) => {
-		const collection = relations.m2o?.related_collection;
-
+	options: () => {
 		return [
 			{
 				field: 'createRelatedItem',

--- a/app/src/interfaces/inline-form-m2o/index.ts
+++ b/app/src/interfaces/inline-form-m2o/index.ts
@@ -1,0 +1,71 @@
+import { defineInterface } from '@directus/extensions-sdk';
+import InterfaceInlineFormM2O from './inline-form-m2o.vue';
+
+export default defineInterface({
+	id: 'inline-form-m2o',
+	name: '$t:interfaces.inline-form-m2o.inline-form',
+	description: '$t:interfaces.inline-form-m2o.description',
+	icon: 'view_agenda',
+	component: InterfaceInlineFormM2O,
+	types: ['uuid', 'string', 'text', 'integer', 'bigInteger'],
+	relational: true,
+	localTypes: ['m2o'],
+	group: 'relational',
+	hideLabel: true,
+	options: ({ relations }) => {
+		const collection = relations.m2o?.related_collection;
+
+		return [
+			{
+				field: 'template',
+				name: '$t:interfaces.select-dropdown-m2o.display_template',
+				meta: {
+					interface: 'system-display-template',
+					options: {
+						collectionName: collection,
+					},
+				},
+			},
+			{
+				field: 'enableCreate',
+				name: '$t:creating_items',
+				schema: {
+					default_value: true,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:enable_create_button',
+					},
+					width: 'half',
+				},
+			},
+			{
+				field: 'enableSelect',
+				name: '$t:selecting_items',
+				schema: {
+					default_value: true,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:enable_select_button',
+					},
+					width: 'half',
+				},
+			},
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
+					},
+				},
+			},
+		];
+	},
+	recommendedDisplays: ['related-values'],
+});

--- a/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
+++ b/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
@@ -1,37 +1,51 @@
 <template>
-	<v-form
-		v-model="internalEdits"
-		:disabled="disabled"
-		:loading="loading"
-		:show-no-visible-fields="false"
-		:initial-values="initialValues"
-		:primary-key="currentPrimaryKey"
-		:fields="fields"
-		:validation-errors="validationErrors"
-	/>
+	<v-notice v-if="!readAllowed" type="warning">
+		{{ t('interfaces.inline-form-m2o.no-read-permission') }}
+	</v-notice>
+	<v-notice v-else-if="!relationInfo" type="warning">
+		{{ t('relationship_not_setup') }}
+	</v-notice>
+	<div v-else class="wrapper">
+		<v-notice v-if="!(createAllowed || updateAllowed)" type="warning">
+			{{ t('interfaces.inline-form-m2o.no-update-permission') }}
+		</v-notice>
+		<v-form
+			v-model="internalEdits"
+			:disabled="disabled"
+			:loading="loading"
+			:show-no-visible-fields="false"
+			:initial-values="initialValues"
+			:primary-key="currentPrimaryKey"
+			:fields="fields"
+			:validation-errors="validationErrors"
+		/>
+	</div>
 </template>
 
 <script lang="ts" setup>
 import api from '@/api';
 import { computed, ref, toRefs, watch } from 'vue';
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, isNil } from 'lodash';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
 import { getEndpoint } from '@directus/shared/utils';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { useFieldsStore } from '@/stores/fields';
+import { usePermissions } from '@/composables/use-permissions';
+import { usePermissionsStore } from '@/stores/permissions';
+import { useI18n } from 'vue-i18n';
 
 interface Props {
 	value?: string | number | Record<string, any> | null;
 	collection: string;
 	field: string;
 	disabled?: boolean;
-	alwaysCreate?: boolean;
-	removeEmpty?: boolean;
+	createRelatedItem?: 'withContent' | 'always';
 }
 
 const props = withDefaults(defineProps<Props>(), {
 	value: null,
 	disabled: false,
+	createRelatedItem: 'withContent',
 });
 
 const emit = defineEmits<{
@@ -40,17 +54,11 @@ const emit = defineEmits<{
 }>();
 
 const { collection, field } = toRefs(props);
-const fieldsStore = useFieldsStore();
+const { t } = useI18n();
 
 const validationErrors = ref<any[]>([]);
 
 const { relationInfo } = useRelationM2O(collection, field);
-const fields = computed(() =>
-	relationInfo.value?.relatedCollection.collection
-		? fieldsStore.getFieldsForCollection(relationInfo.value?.relatedCollection.collection)
-		: []
-);
-
 const currentPrimaryKey = computed<string | number>(() => {
 	if (!props.value || !relationInfo.value) return '+';
 
@@ -60,25 +68,48 @@ const currentPrimaryKey = computed<string | number>(() => {
 
 	return get(props.value, relationInfo.value.relatedPrimaryKeyField.field, '+');
 });
+const isNew = computed(() => currentPrimaryKey.value === '+');
 
 const { internalEdits, loading, initialValues, fetchItem } = useItem();
+const {
+	fields: fieldsWithPermissions,
+	createAllowed,
+	updateAllowed,
+} = usePermissions(
+	computed(() => relationInfo.value?.relatedCollection.collection ?? ''),
+	initialValues,
+	isNew
+);
+
+const { hasPermission } = usePermissionsStore();
+const readAllowed = computed(() => {
+	if (!relationInfo.value) return false;
+	return hasPermission(relationInfo.value.relatedCollection.collection, 'read');
+});
+
+// don't show circular field
+const fields = computed(() =>
+	!isNil(relationInfo.value?.relation.meta?.one_field)
+		? fieldsWithPermissions.value.filter(({ field }) => field !== relationInfo.value?.relation.meta?.one_field)
+		: fieldsWithPermissions.value
+);
 
 watch(
 	internalEdits,
 	() => {
 		if (!relationInfo.value) return;
 
-		if (!isEmpty(internalEdits.value)) {
+		if (!isEmpty(internalEdits.value) || (isNew.value && props.createRelatedItem === 'always')) {
 			const item = internalEdits.value;
 
-			if (currentPrimaryKey.value !== '+') {
+			if (!isNew.value) {
 				item[relationInfo.value.relatedPrimaryKeyField.field] = currentPrimaryKey.value;
 			}
 
 			emit('input', item);
 		}
 	},
-	{ deep: true }
+	{ deep: true, immediate: true }
 );
 
 watch(
@@ -86,10 +117,7 @@ watch(
 	() => {
 		if (!relationInfo.value) return;
 
-		if (
-			get(initialValues.value, relationInfo.value.relatedPrimaryKeyField.field) === props.value &&
-			currentPrimaryKey.value !== '+'
-		) {
+		if (get(initialValues.value, relationInfo.value.relatedPrimaryKeyField.field) === props.value && !isNew.value) {
 			fetchItem();
 		}
 	}
@@ -101,9 +129,9 @@ function useItem() {
 	const initialValues = ref<Record<string, any> | null>(null);
 
 	watch(
-		[currentPrimaryKey, relationInfo],
+		[currentPrimaryKey, isNew, relationInfo],
 		() => {
-			if (currentPrimaryKey.value !== '+') fetchItem();
+			if (!isNew.value) fetchItem();
 		},
 		{ immediate: true }
 	);
@@ -135,3 +163,11 @@ function useItem() {
 	}
 }
 </script>
+
+<style lang="scss" scoped>
+.wrapper {
+	& > div + div {
+		margin-top: var(--form-vertical-gap);
+	}
+}
+</style>

--- a/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
+++ b/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
@@ -110,6 +110,8 @@ watch(
 	{ deep: true, immediate: true }
 );
 
+// watch for a discard (value will be changed back to it's initial key value)
+// refetch data if this is not a new item
 watch(
 	() => props.value,
 	() => {

--- a/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
+++ b/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
@@ -25,14 +25,13 @@
 <script lang="ts" setup>
 import api from '@/api';
 import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { get, isEmpty, isNil } from 'lodash';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
 import { getEndpoint } from '@directus/shared/utils';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { useFieldsStore } from '@/stores/fields';
 import { usePermissions } from '@/composables/use-permissions';
 import { usePermissionsStore } from '@/stores/permissions';
-import { useI18n } from 'vue-i18n';
 
 interface Props {
 	value?: string | number | Record<string, any> | null;

--- a/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
+++ b/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
@@ -49,7 +49,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
 	(e: 'input', value: Props['value']): void;
-	(e: 'setFieldValue', value: any): void;
 }>();
 
 const { collection, field } = toRefs(props);

--- a/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
+++ b/app/src/interfaces/inline-form-m2o/inline-form-m2o.vue
@@ -1,0 +1,137 @@
+<template>
+	<v-form
+		v-model="internalEdits"
+		:disabled="disabled"
+		:loading="loading"
+		:show-no-visible-fields="false"
+		:initial-values="initialValues"
+		:primary-key="currentPrimaryKey"
+		:fields="fields"
+		:validation-errors="validationErrors"
+	/>
+</template>
+
+<script lang="ts" setup>
+import api from '@/api';
+import { computed, ref, toRefs, watch } from 'vue';
+import { get, isEmpty } from 'lodash';
+import { useRelationM2O } from '@/composables/use-relation-m2o';
+import { getEndpoint } from '@directus/shared/utils';
+import { unexpectedError } from '@/utils/unexpected-error';
+import { useFieldsStore } from '@/stores/fields';
+
+interface Props {
+	value?: string | number | Record<string, any> | null;
+	collection: string;
+	field: string;
+	disabled?: boolean;
+	alwaysCreate?: boolean;
+	removeEmpty?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	value: null,
+	disabled: false,
+});
+
+const emit = defineEmits<{
+	(e: 'input', value: Props['value']): void;
+	(e: 'setFieldValue', value: any): void;
+}>();
+
+const { collection, field } = toRefs(props);
+const fieldsStore = useFieldsStore();
+
+const validationErrors = ref<any[]>([]);
+
+const { relationInfo } = useRelationM2O(collection, field);
+const fields = computed(() =>
+	relationInfo.value?.relatedCollection.collection
+		? fieldsStore.getFieldsForCollection(relationInfo.value?.relatedCollection.collection)
+		: []
+);
+
+const currentPrimaryKey = computed<string | number>(() => {
+	if (!props.value || !relationInfo.value) return '+';
+
+	if (typeof props.value === 'number' || typeof props.value === 'string') {
+		return props.value;
+	}
+
+	return get(props.value, relationInfo.value.relatedPrimaryKeyField.field, '+');
+});
+
+const { internalEdits, loading, initialValues, fetchItem } = useItem();
+
+watch(
+	internalEdits,
+	() => {
+		if (!relationInfo.value) return;
+
+		if (!isEmpty(internalEdits.value)) {
+			const item = internalEdits.value;
+
+			if (currentPrimaryKey.value !== '+') {
+				item[relationInfo.value.relatedPrimaryKeyField.field] = currentPrimaryKey.value;
+			}
+
+			emit('input', item);
+		}
+	},
+	{ deep: true }
+);
+
+watch(
+	() => props.value,
+	() => {
+		if (!relationInfo.value) return;
+
+		if (
+			get(initialValues.value, relationInfo.value.relatedPrimaryKeyField.field) === props.value &&
+			currentPrimaryKey.value !== '+'
+		) {
+			fetchItem();
+		}
+	}
+);
+
+function useItem() {
+	const internalEdits = ref<Record<string, any>>({});
+	const loading = ref(false);
+	const initialValues = ref<Record<string, any> | null>(null);
+
+	watch(
+		[currentPrimaryKey, relationInfo],
+		() => {
+			if (currentPrimaryKey.value !== '+') fetchItem();
+		},
+		{ immediate: true }
+	);
+
+	return { internalEdits, loading, initialValues, fetchItem };
+
+	async function fetchItem() {
+		if (!currentPrimaryKey.value || !relationInfo.value) return;
+
+		loading.value = true;
+
+		const baseEndpoint = getEndpoint(relationInfo.value.relatedCollection.collection);
+		const endpoint = relationInfo.value.relatedCollection.collection.startsWith('directus_')
+			? `${baseEndpoint}/${currentPrimaryKey.value}`
+			: `${baseEndpoint}/${encodeURIComponent(currentPrimaryKey.value)}`;
+
+		let fields = '*';
+
+		try {
+			const response = await api.get(endpoint, { params: { fields } });
+
+			initialValues.value = response.data.data;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			loading.value = false;
+			internalEdits.value = {};
+		}
+	}
+}
+</script>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1790,6 +1790,9 @@ interfaces:
   system-raw-editor:
     system-raw-editor: Raw Editor
     description: Allow entering of raw or mustache templating values
+  inline-form-m2o:
+    inline-form: Inline Form
+    description: Edit a single related item inline
 displays:
   translations:
     translations: Translations

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1793,6 +1793,12 @@ interfaces:
   inline-form-m2o:
     inline-form: Inline Form
     description: Edit a single related item inline
+    create-related-item: Create Related Item
+    create-related-item-note: Select if the related item should always be created or only if some data has been entered into the form
+    only-with-content: Only create with content
+    always-create: Always create
+    no-read-permission: You are not allowed to view this inline form
+    no-update-permission: You are not allowed to update this inline form
 displays:
   translations:
     translations: Translations


### PR DESCRIPTION
## Description

<!--

A summary of the changes and a reference to the Issue that was fixed / implemented.

NOTE: All Pull Requests require a corresponding open Issue.

Please reference the Issue number below:

-->

Closes #3474

Add a new m2o interface for inline form editing.
This is a WIP, though it already works and can be tried out.


Supported features:
- [x] Inline editing of a related item using the v-form component
- [x] `createRelatedItem`: `withContent` | `always` option [as suggested here](https://github.com/directus/directus/discussions/3474#discussioncomment-327660)

Missing features:

- [ ] Ability to render whole form in details section with a custom title and icon (blocked by #18025)
- [ ] Proper display of validation errors in the form (limited by missing access to validationErrors and missing `collection` property on the error returned by the backend)
- [ ] Translations (I'm able to at least contribute en-CA, en-GB and de-DE)
- [ ] preview.svg (not really something I'm able to deliver I'm afraid)



I took heavy inspiration from the select-dropdown-m2o and the drawer-item component to cover all the bases of functionality and correctness (I hope).

The component fetches the relationInfo of the related collection and the item based on the value and emits all value updates through the `input` event.
If the values are discarded in the item route it refetches the most recent item data.


## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [x] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:

I could not find any public docs repo? Is this an internal thing?
