### PR TITLE
add missing `.toString()` for password reset accept URL object

### DIFF
--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -398,7 +398,7 @@ export class UsersService extends ItemsService {
 		const token = jwt.sign(payload, env['SECRET'] as string, { expiresIn: '1d', issuer: 'directus' });
 		const acceptURL = url
 			? new Url(url).setQuery('token', token).toString()
-			: new Url(env['PUBLIC_URL']).addPath('admin', 'reset-password').setQuery('token', token);
+			: new Url(env['PUBLIC_URL']).addPath('admin', 'reset-password').setQuery('token', token).toString();
 		const subjectLine = subject ? subject : 'Password Reset Request';
 
 		await mailService.send({


### PR DESCRIPTION
## Description

When using the util `Url` class, we need to call it's `.toString()` to properly turn it into a full url string: 

https://github.com/directus/directus/blob/bb952f93860b3e1d1d9013870977745ce43fe453/api/src/utils/url.ts#L61-L74

and it is used in several places such as:

- https://github.com/directus/directus/blob/bb952f93860b3e1d1d9013870977745ce43fe453/api/src/services/shares.ts#L143
- https://github.com/directus/directus/blob/bb952f93860b3e1d1d9013870977745ce43fe453/api/src/services/users.ts#L341
- https://github.com/directus/directus/blob/bb952f93860b3e1d1d9013870977745ce43fe453/api/src/services/mail/index.ts#L118

However there is one instance where it is missing here. I'm not 100% sure why it currently still works _without_ `.toString()` so this bug (technically) wasn't caught earlier, but my current assumption is it's somewhat due to `.toString()` will indirectly be called when casted as a string within liquidjs itself. For example:

- `String({})` outputs `'[object Object]'`
- `String({ toString: () => 'my string' })` outputs `'my string'`

Fixes ENG-866

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: It's technically a bug, but I believe it is "fixed" when passed to liquidjs so we didn't notice this earlier.

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
