### PR TITLE
Mention Node.js LTS requirement in CLI documentation

### DIFF
--- a/docs/self-hosted/cli.md
+++ b/docs/self-hosted/cli.md
@@ -11,6 +11,10 @@ readTime: 7 min read
 > actions that relate to your on-prem instance, like migrating the database or resetting a user, while the other allows
 > you to interact with a Directus instance as you would with an SDK.
 
+## Requirements
+
+- Node.js [active LTS](https://nodejs.dev/en/about/releases/)
+
 ## Server
 
 For server-side CLI, all functionality can be accessed by running `npx directus <command>` in your project folder.

--- a/docs/self-hosted/cli.md
+++ b/docs/self-hosted/cli.md
@@ -13,7 +13,7 @@ readTime: 7 min read
 
 ## Requirements
 
-- Node.js [active LTS](https://nodejs.dev/en/about/releases/)
+- Node.js [Active LTS](https://nodejs.dev/en/about/releases/)
 
 ## Server
 


### PR DESCRIPTION
## Description

We moved installation instructions along with requirements from the `readme.md` into the docs in #17019.
However the requirement of Node.js active LTS version has been removed in the meantime (or has never actually made it into the docs).
I feel like we should mention it somewhere in order to make it clear / official and to avoid related issues (e.g. #18049).

## Type of Change

- [ ] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [x] Other, please describe: docs

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
