### PR TITLE
Fix `dev` script in `api` for Windows

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -67,7 +67,7 @@
 	"scripts": {
 		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid}\" -u 1 dist",
 		"cli": "NODE_ENV=development SERVE_APP=false node --loader @esbuild-kit/esm-loader src/cli/run.ts",
-		"dev": "NODE_ENV=development SERVE_APP=false node --loader @esbuild-kit/esm-loader --watch --inspect=0 src/start.ts",
+		"dev": "NODE_ENV=development SERVE_APP=false node --loader @esbuild-kit/esm-loader --watch src/start.ts",
 		"start": "node cli.js start",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",

--- a/api/package.json
+++ b/api/package.json
@@ -66,8 +66,8 @@
 	],
 	"scripts": {
 		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid}\" -u 1 dist",
-		"cli": "NODE_ENV=development SERVE_APP=false node --loader @esbuild-kit/esm-loader src/cli/run.ts",
-		"dev": "NODE_ENV=development SERVE_APP=false node --loader @esbuild-kit/esm-loader --watch src/start.ts",
+		"cli": "NODE_ENV=development SERVE_APP=false node --no-warnings=ExperimentalWarning --loader @esbuild-kit/esm-loader src/cli/run.ts",
+		"dev": "NODE_ENV=development SERVE_APP=false node --no-warnings=ExperimentalWarning --loader @esbuild-kit/esm-loader --watch src/start.ts",
 		"start": "node cli.js start",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Description

Apparently, the `--inspect` flag causes the process to be restarted endlessly on Windows.
Therefore we remove it for now. It can be added on demand with `NODE_OPTIONS="--inspect=0" pnpm run dev`.

Also we suppress the experimental warnings (coming from `--watch` & `--loader` options) for now for a cleaner output (similar how `tsx` is doing this as well).

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Documentation
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated
