### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,11 @@
-## Description
-
 <!--
 
-A summary of the changes and a reference to the Issue that was fixed / implemented.
+Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:
 
-NOTE: All Pull Requests require a corresponding open Issue.
+- The PR closes an Issue (not Discussion)
+- Tests are added/updated and are passing locally if applicable
+- Documentation was added/updated if applicable
 
-Please reference the Issue number below:
+Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
 
 -->
-
-Fixes #
-
-## Type of Change
-
-- [ ] Bugfix
-- [ ] Improvement
-- [ ] New Feature
-- [ ] Refactor / codestyle updates
-- [ ] Documentation
-- [ ] Other, please describe:
-
-## Requirements Checklist
-
-- [ ] New / updated tests are included
-- [ ] All tests are passing locally
-- [ ] Performed a self-review of the submitted code
-
-If adding a new feature:
-
-- [ ] Documentation was added/updated


### PR DESCRIPTION
The "Type of Change" is already tracked on the linked issue, so is redundant on the PR, the requirements checklist isn't really a "todo", which is currently causing GitHub to show the PR with "tasks" that aren't completed yet: 
<img width="116" alt="CleanShot 2023-04-05 at 17 28 41@2x" src="https://user-images.githubusercontent.com/9141017/230216016-5a8b5fa0-09d8-4133-ba1f-52d2db3fb0ea.png">

The point of the requirements list is to make sure people read the requirements, but just showing the requirements should have the same effect. We'll tweak as we go!