### PR TITLE
Only create CLA message if there are actually missing contributors returned

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - id: check
         uses: directus/cla-bot@v0.0.1
-      - if: failure()
+      - if: failure() && steps.check.outputs.missing
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |


### PR DESCRIPTION
If the CLA check fails for some other reason than missing contributors (e.g. failed to read file) the message still gets created at the moment with no actual usernames in it. Therefore adding additional check whether there is actually some data returned by the action.