### PR TITLE
Don't clear terminal screen on dev mode

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -67,7 +67,7 @@
 	"scripts": {
 		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid}\" -u 1 dist",
 		"cli": "NODE_ENV=development SERVE_APP=false tsx src/cli/run.ts",
-		"dev": "NODE_ENV=development SERVE_APP=false tsx watch src/start.ts",
+		"dev": "NODE_ENV=development SERVE_APP=false tsx watch --clear-screen=false src/start.ts",
 		"start": "node cli.js start",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",

--- a/app/package.json
+++ b/app/package.json
@@ -22,8 +22,7 @@
 	"scripts": {
 		"build": "vite build",
 		"build-storybook": "storybook build",
-		"dev": "vite",
-		"serve": "vite preview",
+		"dev": "vite --clearScreen false",
 		"storybook": "storybook dev -p 6006",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",


### PR DESCRIPTION
This is fully an opinionated change. I prefer not to have my terminal screen cleared when the server auto-restarts. Happy to revert if this upsets people beyond reason