### PR TITLE
Security update vm2

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -165,7 +165,7 @@
 		"tsx": "3.12.6",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
-		"vm2": "3.9.14",
+		"vm2": "3.9.15",
 		"wellknown": "0.5.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 0.0.3
         version: 0.0.3
       vm2:
-        specifier: 3.9.14
-        version: 3.9.14
+        specifier: 3.9.15
+        version: 3.9.15
       wellknown:
         specifier: 0.5.0
         version: 0.5.0
@@ -18724,8 +18724,8 @@ packages:
       - terser
     dev: true
 
-  /vm2@3.9.14:
-    resolution: {integrity: sha512-HgvPHYHeQy8+QhzlFryvSteA4uQLBCOub02mgqdR+0bN/akRZ48TGB1v0aCv7ksyc0HXx16AZtMHKS38alc6TA==}
+  /vm2@3.9.15:
+    resolution: {integrity: sha512-XqNqknHGw2avJo13gbIwLNZUumvrSHc9mLqoadFZTpo3KaNEJoe1I0lqTFhRXmXD7WkLyG01aaraXdXT0pa4ag==}
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Updating the vm2 dependency to patch https://nvd.nist.gov/vuln/detail/CVE-2023-29017
