### PR TITLE
Fix warning block accessibility for dark theme

### DIFF
--- a/docs/.vitepress/theme/vars.css
+++ b/docs/.vitepress/theme/vars.css
@@ -29,8 +29,6 @@
 	--vp-c-purple-dimm-1: rgba(102, 68, 255, 0.5);
 	--vp-c-purple-dimm-2: rgba(102, 68, 255, 0.25);
 	--vp-c-purple-dimm-3: rgba(102, 68, 255, 0.05);
-
-	--vp-custom-block-warning-text: #876717;
 }
 
 /**
@@ -61,9 +59,13 @@
 	--vp-custom-block-tip-text: var(--vp-c-purple-darker);
 	--vp-custom-block-tip-bg: var(--vp-c-purple-dimm-3);
 	--vp-custom-block-tip-code-bg: var(--vp-custom-block-tip-bg);
+
+	--vp-custom-block-warning-text: var(--vp-c-yellow-darker);
 }
 
 .dark {
 	--vp-custom-block-tip-border: var(--vp-c-purple-dimm-2);
 	--vp-custom-block-tip-text: var(--vp-c-purple-light);
+
+	--vp-custom-block-warning-text: var(--vp-c-yellow);
 }


### PR DESCRIPTION
Minor follow up tweak to https://github.com/directus/docs/commit/e732053d9d3732968bf2a8b03840ba6d7bc3501d.

I've opted to use `var(--vp-c-yellow-darker)` over the previous `#876717` for light theme, though it technically brought down the contrast ratio from `5.08` to `4.74` (shown above each images below), hopefully that still suffices. As for dark theme, it'll remain as the default `var(--vp-c-yellow)`.

### Before

|Light|Dark|
|---|---|
|![](https://user-images.githubusercontent.com/42867097/230917845-fcc9ed47-1761-4b57-8b6f-24beddc59ce7.png)|![](https://user-images.githubusercontent.com/42867097/230917874-112b1382-7786-4bf0-9597-d04ac4c94116.png)|
|Contrast ratio: 5.08|Contrast ratio: 2.89|

### After

|Light|Dark|
|---|---|
|![](https://user-images.githubusercontent.com/42867097/230918014-3dea75a1-eb52-497e-aac6-f7764b32508b.png)|![chrome_APwsG6ZE0A](https://user-images.githubusercontent.com/42867097/230918035-e57e4421-0e5a-473c-b546-2f588e3c2aaf.png)|
|Contrast ratio: 4.74|Contrast ratio: 7.97|

