### PR TITLE
Introduce new `directus` wrapper package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN pnpm install --recursive --offline --frozen-lockfile
 
 RUN : \
-	&& pnpm --recursive --workspace-concurrency=1 run build \
+	&& npm_config_workspace_concurrency=1 pnpm run build \
 	&& pnpm --filter directus deploy --prod dist \
 	&& cd dist \
 	&& pnpm pack \
@@ -49,6 +49,6 @@ COPY --from=builder --chown=node:node /directus/dist .
 USER node
 
 CMD : \
-	&& node /directus/dist/cli/run.js bootstrap \
-	&& node /directus/dist/cli/run.js start \
+	&& node /directus/cli.js bootstrap \
+	&& node /directus/cli.js start \
 	;

--- a/api/cli.js
+++ b/api/cli.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import './dist/cli/run.js';

--- a/api/package.json
+++ b/api/package.json
@@ -53,7 +53,8 @@
 	"exports": {
 		".": "./dist/index.js",
 		"./*": "./dist/*.js",
-		"./package.json": "./package.json"
+		"./package.json": "./package.json",
+		"./cli/run.js": "./dist/cli/run.js"
 	},
 	"main": "dist/index.js",
 	"files": [

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "directus",
+	"name": "@directus/api",
 	"version": "9.24.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"type": "module",
@@ -56,9 +56,6 @@
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"bin": {
-		"directus": "cli.js"
-	},
 	"files": [
 		"dist",
 		"!**/*.test.js",

--- a/api/package.json
+++ b/api/package.json
@@ -53,8 +53,8 @@
 	"exports": {
 		".": "./dist/index.js",
 		"./*": "./dist/*.js",
-		"./package.json": "./package.json",
-		"./cli/run.js": "./dist/cli/run.js"
+		"./cli/run.js": "./dist/cli/run.js",
+		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
 	"files": [
@@ -66,7 +66,6 @@
 		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid}\" -u 1 dist",
 		"cli": "NODE_ENV=development SERVE_APP=false tsx src/cli/run.ts",
 		"dev": "NODE_ENV=development SERVE_APP=false tsx watch --clear-screen=false src/start.ts",
-		"start": "node cli.js start",
 		"test": "vitest --watch=false"
 	},
 	"dependencies": {
@@ -227,6 +226,6 @@
 		"tedious": "15.1.3"
 	},
 	"engines": {
-		"node": ">=12.20.0"
+		"node": ">=18.0.0"
 	}
 }

--- a/app/package.json
+++ b/app/package.json
@@ -95,6 +95,7 @@
 		"date-fns": "2.29.3",
 		"diacritics": "1.3.0",
 		"diff": "5.1.0",
+		"directus": "workspace:*",
 		"dompurify": "3.0.1",
 		"escape-string-regexp": "5.0.0",
 		"file-saver": "2.0.5",

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -28,7 +28,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { version } from '../../../../package.json';
+import { version } from 'directus/package.json';
 
 export default defineComponent({
 	setup() {

--- a/directus/cli.js
+++ b/directus/cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('@directus/api/dist/cli/run.js');

--- a/directus/cli.js
+++ b/directus/cli.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('@directus/api/dist/cli/run.js');
+require('@directus/api/cli/run.js');

--- a/directus/cli.js
+++ b/directus/cli.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('@directus/api/cli/run.js');
+import '@directus/api/cli/run.js';

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,0 +1,64 @@
+{
+	"name": "directus",
+	"version": "10.0.0",
+	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
+	"keywords": [
+		"directus",
+		"realtime",
+		"database",
+		"content",
+		"api",
+		"rest",
+		"graphql",
+		"app",
+		"dashboard",
+		"headless",
+		"cms",
+		"mysql",
+		"postgresql",
+		"cockroachdb",
+		"sqlite",
+		"framework",
+		"vue"
+	],
+	"homepage": "https://directus.io",
+	"bugs": {
+		"url": "https://github.com/directus/directus/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/directus/directus.git",
+		"directory": "api"
+	},
+	"funding": "https://github.com/directus/directus?sponsor=1",
+	"license": "GPL-3.0-only",
+	"author": {
+		"name": "Monospace Inc",
+		"email": "info@monospace.io",
+		"url": "https://monospace.io"
+	},
+	"maintainers": [
+		{
+			"name": "Rijk van Zanten",
+			"email": "rijkvanzanten@me.com",
+			"url": "https://github.com/rijkvanzanten"
+		},
+		{
+			"name": "Ben Haynes",
+			"email": "ben@rngr.org",
+			"url": "https://github.com/benhaynes"
+		}
+	],
+	"exports": {
+		".": "./dist/index.js",
+		"./*": "./dist/*.js",
+		"./package.json": "./package.json"
+	},
+	"main": "dist/index.js",
+	"bin": {
+		"directus": "cli.js"
+	},
+	"dependencies": {
+		"@directus/api": "workspace:9.23.3"
+	}
+}

--- a/directus/package.json
+++ b/directus/package.json
@@ -2,7 +2,7 @@
 	"name": "directus",
 	"version": "9.24.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
-  "type": "module",
+	"type": "module",
 	"keywords": [
 		"directus",
 		"realtime",
@@ -57,5 +57,8 @@
 	},
 	"dependencies": {
 		"@directus/api": "workspace:*"
+	},
+	"engines": {
+		"node": ">=18.0.0"
 	}
 }

--- a/directus/package.json
+++ b/directus/package.json
@@ -29,7 +29,6 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git"
-		"directory": "directus"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
 	"license": "GPL-3.0-only",

--- a/directus/package.json
+++ b/directus/package.json
@@ -28,7 +28,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/directus/directus.git",
+		"url": "https://github.com/directus/directus.git"
 		"directory": "directus"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "directus",
-	"version": "10.0.0",
+	"version": "9.24.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
+  "type": "module",
 	"keywords": [
 		"directus",
 		"realtime",
@@ -28,7 +29,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",
-		"directory": "api"
+		"directory": "directus"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
 	"license": "GPL-3.0-only",
@@ -50,15 +51,12 @@
 		}
 	],
 	"exports": {
-		".": "./dist/index.js",
-		"./*": "./dist/*.js",
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
 	"bin": {
 		"directus": "cli.js"
 	},
 	"dependencies": {
-		"@directus/api": "workspace:9.23.3"
+		"@directus/api": "workspace:9.24.0"
 	}
 }

--- a/directus/package.json
+++ b/directus/package.json
@@ -57,6 +57,6 @@
 		"directus": "cli.js"
 	},
 	"dependencies": {
-		"@directus/api": "workspace:9.24.0"
+		"@directus/api": "workspace:*"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,7 +812,7 @@ importers:
   directus:
     dependencies:
       '@directus/api':
-        specifier: workspace:9.24.0
+        specifier: workspace:*
         version: link:../api
 
   docs:
@@ -12434,7 +12434,7 @@ packages:
       jest-util: 29.5.0
       jest-validate: 29.5.0
       resolve: 1.22.1
-      resolve.exports: 2.0.2
+      resolve.exports: 2.0.0
       slash: 3.0.0
     dev: true
 
@@ -16313,8 +16313,8 @@ packages:
       protocol-buffers-schema: 3.6.0
     dev: true
 
-  /resolve.exports@2.0.2:
-    resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
+  /resolve.exports@2.0.0:
+    resolution: {integrity: sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==}
     engines: {node: '>=10'}
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,12 @@ importers:
         specifier: 4.9.5
         version: 4.9.5
 
+  directus:
+    specifiers:
+      '@directus/api': workspace:9.23.3
+    dependencies:
+      '@directus/api': link:../api
+
   packages/create-directus-extension:
     dependencies:
       '@directus/constants':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,12 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
 
+  directus:
+    dependencies:
+      '@directus/api':
+        specifier: workspace:9.24.0
+        version: link:../api
+
   docs:
     dependencies:
       node-fetch:
@@ -886,12 +892,6 @@ importers:
       typescript:
         specifier: 4.9.5
         version: 4.9.5
-
-  directus:
-    specifiers:
-      '@directus/api': workspace:9.23.3
-    dependencies:
-      '@directus/api': link:../api
 
   packages/create-directus-extension:
     dependencies:
@@ -1393,7 +1393,7 @@ importers:
         version: 2.2.5
       knex:
         specifier: 2.4.2
-        version: 2.4.2
+        version: 2.4.2(mysql@2.18.1)(pg@8.10.0)(sqlite3@5.1.6)(tedious@15.1.3)
       listr2:
         specifier: 5.0.8
         version: 5.0.8
@@ -12960,52 +12960,6 @@ packages:
     dependencies:
       knex: 2.4.2(mysql@2.18.1)(pg@8.10.0)(sqlite3@5.1.6)(tedious@15.1.3)
       lodash.clonedeep: 4.5.0
-    dev: true
-
-  /knex@2.4.2:
-    resolution: {integrity: sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    peerDependencies:
-      better-sqlite3: '*'
-      mysql: '*'
-      mysql2: '*'
-      pg: '*'
-      pg-native: '*'
-      sqlite3: '*'
-      tedious: '*'
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      mysql:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      sqlite3:
-        optional: true
-      tedious:
-        optional: true
-    dependencies:
-      colorette: 2.0.19
-      commander: 9.5.0
-      debug: 4.3.4
-      escalade: 3.1.1
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.5.0
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /knex@2.4.2(mysql@2.18.1)(pg@8.10.0)(sqlite3@5.1.6)(tedious@15.1.3):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,6 +697,9 @@ importers:
       diff:
         specifier: 5.1.0
         version: 5.1.0
+      directus:
+        specifier: workspace:*
+        version: link:../directus
       dompurify:
         specifier: 3.0.1
         version: 3.0.1
@@ -5694,7 +5697,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2
+      '@rollup/pluginutils': 5.0.2(rollup@3.19.1)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
     dev: true
@@ -5706,20 +5709,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: false
-
-  /@rollup/pluginutils@5.0.2:
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.0
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: true
 
   /@rollup/pluginutils@5.0.2(rollup@3.19.1):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
@@ -5734,7 +5723,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.19.1
-    dev: false
 
   /@sendgrid/client@6.5.5:
     resolution: {integrity: sha512-Nbfgo94gbWSL8PIgJfuHoifyOJJepvV8NQkkglctAEfb1hyozKhrzE6v1kPG/z4j0RodaTtXD5LJj/t0q/VhLA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - directus
   - app
   - api
   - docs


### PR DESCRIPTION
Introducing a new `directus` wrapper package while renaming the old `directus` package to `@directus/api`.
This gives us more flexibility in versioning the sub-packages individually, keeping the main version in `directus` and enables us to adhere to separation of concerns (also making it more obvious that `@directus/api` contains - you name it - the api). 