### PR TITLE
[Take 2] Register <drawer-collection> in Vue app for relational interface extensions

### DIFF
--- a/app/src/components/register.ts
+++ b/app/src/components/register.ts
@@ -4,6 +4,7 @@ import RenderTemplate from '@/views/private/components/render-template.vue';
 import SidebarDetail from '@/views/private/components/sidebar-detail.vue';
 import UserPopover from '@/views/private/components/user-popover.vue';
 import ValueNull from '@/views/private/components/value-null.vue';
+import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import { App } from 'vue';
@@ -145,6 +146,7 @@ export function registerComponents(app: App): void {
 	app.component('SidebarDetail', SidebarDetail);
 	app.component('UserPopover', UserPopover);
 	app.component('ValueNull', ValueNull);
+	app.component('DrawerCollection', DrawerCollection);
 	app.component('DrawerItem', DrawerItem);
 	app.component('DrawerBatch', DrawerBatch);
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - denkhaus
 - joselcvarela
 - knulpi
+- JoshTheDerf


### PR DESCRIPTION
## Description

This PR registers the `<drawer-collection>` component in the Vue app to allow extensions to provide custom relational interfaces. `<drawer-item>`, the main other component needed for this purpose, is already registered.

Same changes as #17235, but with the correct GitHub user associated with the commit.

From Discussion #17234
(Should I open an issue for this sort of change?)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [ ] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:
