### PR TITLE
Load Bundle Extension Types for local development

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -9,6 +9,7 @@ import {
 	generateExtensionsEntrypoint,
 	getLocalExtensions,
 	getPackageExtensions,
+	resolvePackageExtensions,
 } from '@directus/utils/node';
 import yaml from '@rollup/plugin-yaml';
 import vue from '@vitejs/plugin-vue';
@@ -121,9 +122,10 @@ function directusExtensions() {
 	async function loadExtensions() {
 		await ensureExtensionDirs(EXTENSIONS_PATH, NESTED_EXTENSION_TYPES);
 		const packageExtensions = await getPackageExtensions(API_PATH, APP_OR_HYBRID_EXTENSION_PACKAGE_TYPES);
+		const localPackageExtensions = await resolvePackageExtensions(EXTENSIONS_PATH);
 		const localExtensions = await getLocalExtensions(EXTENSIONS_PATH, APP_OR_HYBRID_EXTENSION_TYPES);
 
-		const extensions = [...packageExtensions, ...localExtensions];
+		const extensions = [...packageExtensions, ...localPackageExtensions, ...localExtensions];
 
 		extensionsEntrypoint = generateExtensionsEntrypoint(extensions);
 	}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

This resolve issues with modules from the bundle extension type not being loaded in the UI for local development.

This fixes: #18155
