### PR TITLE
security update in the vm2 dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -162,7 +162,7 @@
 		"tsx": "3.12.6",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
-		"vm2": "3.9.15",
+		"vm2": "3.9.16",
 		"wellknown": "0.5.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,8 +311,8 @@ importers:
         specifier: 0.0.3
         version: 0.0.3
       vm2:
-        specifier: 3.9.15
-        version: 3.9.15
+        specifier: 3.9.16
+        version: 3.9.16
       wellknown:
         specifier: 0.5.0
         version: 0.5.0
@@ -18685,8 +18685,8 @@ packages:
       - terser
     dev: true
 
-  /vm2@3.9.15:
-    resolution: {integrity: sha512-XqNqknHGw2avJo13gbIwLNZUumvrSHc9mLqoadFZTpo3KaNEJoe1I0lqTFhRXmXD7WkLyG01aaraXdXT0pa4ag==}
+  /vm2@3.9.16:
+    resolution: {integrity: sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==}
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Updating the vm2 dependency to patch https://github.com/patriksimek/vm2/security/advisories/GHSA-xj72-wvfv-8985
