### PR TITLE
fix: Use Cloudinary explicit endpoint

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -19,3 +19,4 @@
 - david-zacharias
 - hanneskuettner
 - JoshTheDerf
+- jbmolle

--- a/packages/storage-driver-cloudinary/src/index.test.ts
+++ b/packages/storage-driver-cloudinary/src/index.test.ts
@@ -630,15 +630,40 @@ describe('#stat', () => {
 		expect(driver['getPublicId']).toHaveBeenCalledWith(sample.path.inputFull);
 	});
 
-	test('Calls fetch with constructed URL and auth header', async () => {
+	test('Creates signature for body parameters', async () => {
 		await driver.stat(sample.path.input);
+
+		expect(driver['getFullSignature']).toHaveBeenCalledWith({
+			type: 'upload',
+			public_id: sample.publicId.input,
+			api_key: sample.config.apiKey,
+			timestamp: sample.timestamp,
+		});
+	});
+
+	test('Creates form url encoded body ', async () => {
+		await driver.stat(sample.path.input);
+
+		expect(driver['toFormUrlEncoded']).toHaveBeenCalledWith({
+			type: 'upload',
+			public_id: sample.publicId.input,
+			api_key: sample.config.apiKey,
+			timestamp: sample.timestamp,
+			signature: sample.fullSignature,
+		});
+	});
+
+	test('Fetches URL with url encoded body', async () => {
+		await driver.stat(sample.path.input);
+
 		expect(fetch).toHaveBeenCalledWith(
-			`https://api.cloudinary.com/v1_1/${sample.config.cloudName}/resources/${sample.resourceType}/upload/${sample.publicId.input}`,
+			`https://api.cloudinary.com/v1_1/${sample.config.cloudName}/${sample.resourceType}/explicit`,
 			{
-				method: 'GET',
+				method: 'POST',
 				headers: {
-					Authorization: sample.basicAuth,
+					'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
 				},
+				body: sample.formUrlEncoded,
 			}
 		);
 	});

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -136,12 +136,29 @@ export class DriverCloudinary implements Driver {
 		const fullPath = this.fullPath(filepath);
 		const resourceType = this.getResourceType(fullPath);
 		const publicId = this.getPublicId(fullPath);
-		const url = `https://api.cloudinary.com/v1_1/${this.cloudName}/resources/${resourceType}/upload/${publicId}`;
+
+		const parameters = {
+			public_id: publicId,
+			type: 'upload',
+			api_key: this.apiKey,
+			timestamp: this.getTimestamp(),
+		};
+
+		const signature = this.getFullSignature(parameters);
+
+		const body = this.toFormUrlEncoded({
+			...parameters,
+			signature,
+		});
+
+		const url = `https://api.cloudinary.com/v1_1/${this.cloudName}/${resourceType}/explicit`;
+
 		const response = await fetch(url, {
-			method: 'GET',
+			method: 'POST',
 			headers: {
-				Authorization: this.getBasicAuth(),
+				'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
 			},
+			body,
 		});
 
 		if (response.status >= 400) {


### PR DESCRIPTION
Use explicit endpoint instead of Cloudinary Admin API to avoid reaching rate limit of 500 requests / hour

## Description

When using Cloudinary Driver, we reach quite quickly the Admin API rate limit because every call to an asset performs a call to the Admin API through the stat function.
This pull request changes the stat function so it uses the Cloudinary explicit endpoint which is not rate limited.

Fixes #17447 
Related to discussion #17452 
(Replaces previous pull request #17715)

## Type of Change

- [ ] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] New / updated tests are included
- [x] All tests are passing locally
- [ ] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR:

