### PR TITLE
Only show message on just request/exec flow operations

### DIFF
--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -19,6 +19,7 @@ import getDatabase from './database/index.js';
 import emitter from './emitter.js';
 import env from './env.js';
 import * as exceptions from './exceptions/index.js';
+import { BaseException } from '@directus/exceptions';
 import logger from './logger.js';
 import { getMessenger } from './messenger.js';
 import { ActivityService } from './services/activity.js';
@@ -420,13 +421,10 @@ class FlowManager {
 		} catch (error) {
 			let data;
 
-			if (error instanceof Error) {
-				// If the error is from a request or exec operation, use the message of it as the error data
-				if (operation.type == 'request' || operation.type == 'exec') {
-					data = { message: error.message };
-				} else {
-					data = error;
-				}
+			if (error instanceof BaseException) {
+				data = { message: error.message, code: error.code, extensions: error.extensions, status: error.status };
+			} else if (error instanceof Error) {
+				data = { message: error.message };
 			} else if (typeof error === 'string') {
 				// If the error is a JSON string, parse it and use that as the error data
 				data = isValidJSON(error) ? parseJSON(error) : error;

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -421,8 +421,12 @@ class FlowManager {
 			let data;
 
 			if (error instanceof Error) {
-				// If the error is instance of Error, use the message of it as the error data
-				data = { message: error.message };
+				// If the error is from a request or exec operation, use the message of it as the error data
+				if (operation.type == 'request' || operation.type == 'exec') {
+					data = { message: error.message };
+				} else {
+					data = error;
+				}
 			} else if (typeof error === 'string') {
 				// If the error is a JSON string, parse it and use that as the error data
 				data = isValidJSON(error) ? parseJSON(error) : error;

--- a/contributors.yml
+++ b/contributors.yml
@@ -19,3 +19,4 @@
 - david-zacharias
 - hanneskuettner
 - JoshTheDerf
+- ConnorSimply


### PR DESCRIPTION
This fixes #18161 which was caused by errors being swallowed by #17519.

We had changed the flows to only return `error.message` to prevent sensitive information being released from Run Scripts, however, it was not limited to run scripts which resulted in other operations also being stripped of information.

@br41nslug Can you confirm that this is acceptable from a security stand point? Should any other operations also return only `error.message`?
