### PR TITLE
Fix Material Symbols in timycme & mapbox

### DIFF
--- a/app/src/interfaces/input-rich-text-html/tinymce-overrides.css
+++ b/app/src/interfaces/input-rich-text-html/tinymce-overrides.css
@@ -31,7 +31,7 @@
 	margin-top: 4px;
 	color: var(--foreground-normal);
 	font-size: 24px;
-	font-family: 'Material Icons';
+	font-family: 'Material Symbols';
 	content: 'format_bold';
 	font-feature-settings: 'liga';
 }
@@ -45,7 +45,7 @@
 	margin-top: 4px;
 	color: var(--foreground-normal);
 	font-size: 24px;
-	font-family: 'Material Icons';
+	font-family: 'Material Symbols';
 	content: 'format_italic';
 	font-feature-settings: 'liga';
 }
@@ -59,7 +59,7 @@
 	margin-top: 4px;
 	color: var(--foreground-normal);
 	font-size: 24px;
-	font-family: 'Material Icons';
+	font-family: 'Material Symbols';
 	content: 'format_underlined';
 	font-feature-settings: 'liga';
 }
@@ -73,7 +73,7 @@
 	margin-top: 4px;
 	color: var(--foreground-normal);
 	font-size: 24px;
-	font-family: 'Material Icons';
+	font-family: 'Material Symbols';
 	content: 'insert_link';
 	font-feature-settings: 'liga';
 }

--- a/app/src/styles/lib/_mapbox.scss
+++ b/app/src/styles/lib/_mapbox.scss
@@ -43,7 +43,7 @@
 		display: flex;
 		justify-content: center;
 		font-size: 24px;
-		font-family: 'Material Icons Outline', sans-serif;
+		font-family: 'Material Symbols', sans-serif;
 		font-style: normal;
 		font-variant: normal;
 		text-rendering: auto;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Fixes #18184.

So much for only 2 typos...

I searched for all occurrences of `Material Icons` to identify any more missed font-families. Couldn't find any.