### PR TITLE
Rename `system-field[-tree]` `collection` prop to `collectionName`

### DIFF
--- a/app/src/interfaces/_system/system-field-tree/system-field-tree.vue
+++ b/app/src/interfaces/_system/system-field-tree/system-field-tree.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-notice v-if="!collectionField && !collection" type="warning">
+	<v-notice v-if="!collectionField && !collectionName" type="warning">
 		{{ t('collection_field_not_setup') }}
 	</v-notice>
 	<v-notice v-else-if="!chosenCollection" type="warning">
@@ -30,7 +30,7 @@ export default defineComponent({
 			type: String,
 			default: null,
 		},
-		collection: {
+		collectionName: {
 			type: String,
 			default: null,
 		},
@@ -57,7 +57,7 @@ export default defineComponent({
 
 		const values = inject('values', ref<Record<string, any>>({}));
 
-		const chosenCollection = computed(() => values.value[props.collectionField] || props.collection);
+		const chosenCollection = computed(() => values.value[props.collectionField] || props.collectionName);
 
 		const { treeList, loadFieldRelations } = useFieldTree(chosenCollection);
 

--- a/app/src/interfaces/_system/system-field/system-field.vue
+++ b/app/src/interfaces/_system/system-field/system-field.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-notice v-if="!collectionField && !collection" type="warning">
+	<v-notice v-if="!collectionField && !collectionName" type="warning">
 		{{ t('collection_field_not_setup') }}
 	</v-notice>
 	<v-notice v-else-if="selectItems.length === 0" type="warning">
@@ -28,7 +28,7 @@ export default defineComponent({
 			type: String,
 			default: null,
 		},
-		collection: {
+		collectionName: {
 			type: String,
 			default: null,
 		},
@@ -69,10 +69,10 @@ export default defineComponent({
 
 		const values = inject('values', ref<Record<string, any>>({}));
 
-		const collection = computed(() => values.value[props.collectionField] || props.collection);
+		const collection = computed(() => values.value[props.collectionField] || props.collectionName);
 
 		const fields = computed(() => {
-			if (!props.collectionField && !props.collection) return [];
+			if (!props.collectionField && !props.collectionName) return [];
 			return fieldsStore.getFieldsForCollection(collection.value);
 		});
 

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -189,7 +189,7 @@
 					<p class="type-label">{{ t('sort_field') }}</p>
 					<interface-system-field
 						:value="sortField"
-						:collection="collection"
+						:collection-name="collection"
 						allow-primary-key
 						@input="sortField = $event"
 					/>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Fixes #18192 

Additionally I applied the same fix to `system-field-tree`.

Internally both were always configured with `collectionField` and never with `collection` so no change needed.

Only `interface-system-field` was once used directly so I changed the prop accordingly and verified its working. It being used directly instead of through a `form-field-interface` was the only reason it worked there in the first place.

Since it definitely wasn't working before when using the interface I presume that there are no extensions using the old name.