### PR TITLE
Prevent duplicate emit from CodeMirror editors

### DIFF
--- a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
+++ b/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
@@ -40,6 +40,7 @@ const { width } = useWindowSize();
 
 const codemirrorEl = ref<HTMLTextAreaElement | null>();
 let codemirror: CodeMirror.Editor | null;
+let previousContent: string | null = null;
 
 const isMultiLine = computed(() => ['text', 'json'].includes(props.type));
 
@@ -84,8 +85,14 @@ onMounted(async () => {
 		}
 
 		codemirror.on('change', (doc, { origin }) => {
-			if (origin === 'setValue') return;
 			const content = doc.getValue();
+
+			// prevent duplicate emits with same content
+			if (content === previousContent) return;
+			previousContent = content;
+
+			if (origin === 'setValue') return;
+
 			if (typeof props.value === 'object') {
 				try {
 					emit('input', content !== '' ? parseJSON(content) : null);

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -77,6 +77,7 @@ export default defineComponent({
 
 		const codemirrorEl = ref<HTMLTextAreaElement | null>(null);
 		let codemirror: CodeMirror.Editor | null;
+		let previousContent: string | null = null;
 
 		onMounted(async () => {
 			if (codemirrorEl.value) {
@@ -94,9 +95,13 @@ export default defineComponent({
 				await setLanguage();
 
 				codemirror.on('change', (cm, { origin }) => {
-					if (origin === 'setValue') return;
-
 					const content = cm.getValue();
+
+					// prevent duplicate emits with same content
+					if (content === previousContent) return;
+					previousContent = content;
+
+					if (origin === 'setValue') return;
 
 					if (props.type === 'json') {
 						if (content.length === 0) {

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -289,6 +289,7 @@ export default defineComponent({
 		const markdownInterface = ref<HTMLElement>();
 		const codemirrorEl = ref<HTMLTextAreaElement>();
 		let codemirror: CodeMirror.Editor | null = null;
+		let previousContent: string | null = null;
 
 		const view = ref(['editor']);
 
@@ -321,9 +322,13 @@ export default defineComponent({
 				});
 
 				codemirror.on('change', (cm, { origin }) => {
-					if (origin === 'setValue') return;
-
 					const content = cm.getValue();
+
+					// prevent duplicate emits with same content
+					if (content === previousContent) return;
+					previousContent = content;
+
+					if (origin === 'setValue') return;
 
 					emit('input', content);
 				});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Second attempt at fixing #18150. This time I went with the [suggestion](https://github.com/directus/directus/pull/18159#issuecomment-1507319162)  from #18159 and deduplicated the duplicate emits at the source.

Overall I could find 3 usages of the CodeMirror editor.

`previousContent` is always kept in sync with the actual editor content (that's why I had to move it before the `origin === 'setValue'` check and verifies that we only emit a value that is actually different from the value that has either been set through the props or emitted previously.

I could not reproduce any duplication in any of the cases shown in the original issue.


Fixes #18150