### PR TITLE
White space rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,16 @@ const defaultRules = {
 	'no-debugger': process.env.NODE_ENV !== 'development' ? 'error' : 'off',
 	// Enforce prettier formatting
 	'prettier/prettier': 'error',
+	'padding-line-between-statements': [
+		'error',
+		{
+			blankLine: 'always',
+			prev: ['block', 'block-like', 'cjs-export', 'class', 'export', 'import'],
+			next: '*',
+		},
+		{ blankLine: 'any', prev: ['export', 'import'], next: ['export', 'import'] },
+	],
+	'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
 };
 
 module.exports = {

--- a/api/src/__utils__/items-utils.ts
+++ b/api/src/__utils__/items-utils.ts
@@ -7,11 +7,13 @@ export const sqlFieldFormatter = (schema: Record<string, any>, table: string) =>
 			fields.push(field);
 		}
 	}
+
 	let sql = '';
 
 	for (const field of fields.slice(0, fields.length - 1)) {
 		sql += `"${table}"."${field}", `;
 	}
+
 	sql += `"${table}"."${fields[fields.length - 1]}"`;
 	return sql;
 };
@@ -24,11 +26,13 @@ export const sqlFieldList = (schema: Record<string, any>, table: string) => {
 			fields.push(field);
 		}
 	}
+
 	let sql = '';
 
 	for (const field of fields.slice(0, fields.length - 1)) {
 		sql += `"${field}", `;
 	}
+
 	sql += `"${fields[fields.length - 1]}"`;
 	return sql;
 };

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -219,6 +219,7 @@ export default async function createApp(): Promise<express.Application> {
 	if (env['RATE_LIMITER_GLOBAL_ENABLED'] === true) {
 		app.use(rateLimiterGlobal);
 	}
+
 	if (env['RATE_LIMITER_ENABLED'] === true) {
 		app.use(rateLimiter);
 	}

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -318,6 +318,7 @@ export class LDAPAuthDriver extends AuthDriver {
 				logger.warn(e, '[LDAP] Failed to register user. User not unique');
 				throw new InvalidProviderException();
 			}
+
 			throw e;
 		}
 
@@ -347,6 +348,7 @@ export class LDAPAuthDriver extends AuthDriver {
 				} else {
 					resolve();
 				}
+
 				client.destroy();
 			});
 		});
@@ -375,6 +377,7 @@ const handleError = (e: Error) => {
 	) {
 		return new InvalidCredentialsException();
 	}
+
 	return new ServiceUnavailableException('Service returned unexpected error', {
 		service: 'ldap',
 		message: e.message,

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -198,6 +198,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 				logger.warn(e, '[OAuth2] Failed to register user. User not unique');
 				throw new InvalidProviderException();
 			}
+
 			throw e;
 		}
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -223,6 +223,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				logger.warn(e, '[OpenID] Failed to register user. User not unique');
 				throw new InvalidProviderException();
 			}
+
 			throw e;
 		}
 

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -10,6 +10,7 @@ import { getMilliseconds } from './utils/get-milliseconds.js';
 import { validateEnv } from './utils/validate-env.js';
 
 import { createRequire } from 'node:module';
+
 const require = createRequire(import.meta.url);
 
 let cache: Keyv | null = null;

--- a/api/src/cli/commands/database/migrate.ts
+++ b/api/src/cli/commands/database/migrate.ts
@@ -15,6 +15,7 @@ export default async function migrate(direction: 'latest' | 'up' | 'down'): Prom
 		} else {
 			logger.info('Database up to date');
 		}
+
 		database.destroy();
 		process.exit();
 	} catch (err: any) {

--- a/api/src/controllers/not-found.ts
+++ b/api/src/controllers/not-found.ts
@@ -29,6 +29,7 @@ const notFound: RequestHandler = async (req, res, next) => {
 		if (hooksResult) {
 			return next();
 		}
+
 		next(new RouteNotFoundException(req.path));
 	} catch (err: any) {
 		next(err);

--- a/api/src/controllers/permissions.ts
+++ b/api/src/controllers/permissions.ts
@@ -46,6 +46,7 @@ router.post(
 
 			throw error;
 		}
+
 		return next();
 	}),
 	respond

--- a/api/src/database/helpers/date/types.ts
+++ b/api/src/database/helpers/date/types.ts
@@ -7,14 +7,18 @@ export abstract class DateHelper extends DatabaseHelper {
 		if (date instanceof Date) {
 			return date.toISOString();
 		}
+
 		return date;
 	}
+
 	readTimestampString(date: string): string {
 		return date;
 	}
+
 	writeTimestamp(date: string): Date {
 		return parseISO(date);
 	}
+
 	fieldFlagForField(_fieldType: string): string {
 		return '';
 	}

--- a/api/src/database/helpers/fn/dialects/mssql.ts
+++ b/api/src/database/helpers/fn/dialects/mssql.ts
@@ -5,6 +5,7 @@ const parseLocaltime = (columnType?: string) => {
 	if (columnType === 'timestamp') {
 		return ` AT TIME ZONE 'UTC'`;
 	}
+
 	return '';
 };
 

--- a/api/src/database/helpers/fn/dialects/oracle.ts
+++ b/api/src/database/helpers/fn/dialects/oracle.ts
@@ -5,6 +5,7 @@ const parseLocaltime = (columnType?: string) => {
 	if (columnType === 'timestamp') {
 		return ` AT TIME ZONE 'UTC'`;
 	}
+
 	return '';
 };
 

--- a/api/src/database/helpers/fn/dialects/postgres.ts
+++ b/api/src/database/helpers/fn/dialects/postgres.ts
@@ -5,6 +5,7 @@ const parseLocaltime = (columnType?: string) => {
 	if (columnType === 'timestamp') {
 		return ` AT TIME ZONE 'UTC'`;
 	}
+
 	return '';
 };
 

--- a/api/src/database/helpers/fn/dialects/sqlite.ts
+++ b/api/src/database/helpers/fn/dialects/sqlite.ts
@@ -5,6 +5,7 @@ const parseLocaltime = (columnType?: string) => {
 	if (columnType === 'timestamp') {
 		return '';
 	}
+
 	return `, 'localtime'`;
 };
 

--- a/api/src/database/helpers/geometry/dialects/mssql.ts
+++ b/api/src/database/helpers/geometry/dialects/mssql.ts
@@ -16,6 +16,7 @@ export class GeometryHelperMSSQL extends GeometryHelper {
 		if (field.type.split('.')[1]) {
 			field.meta!.special = [field.type];
 		}
+
 		return table.specificType(field.field, 'geometry');
 	}
 

--- a/api/src/database/helpers/geometry/dialects/oracle.ts
+++ b/api/src/database/helpers/geometry/dialects/oracle.ts
@@ -16,6 +16,7 @@ export class GeometryHelperOracle extends GeometryHelper {
 		if (field.type.split('.')[1]) {
 			field.meta!.special = [field.type];
 		}
+
 		return table.specificType(field.field, 'sdo_geometry');
 	}
 

--- a/api/src/database/helpers/geometry/dialects/redshift.ts
+++ b/api/src/database/helpers/geometry/dialects/redshift.ts
@@ -7,6 +7,7 @@ export class GeometryHelperRedshift extends GeometryHelper {
 		if (field.type.split('.')[1]) {
 			field.meta!.special = [field.type];
 		}
+
 		return table.specificType(field.field, 'geometry');
 	}
 

--- a/api/src/database/helpers/geometry/types.ts
+++ b/api/src/database/helpers/geometry/types.ts
@@ -7,45 +7,58 @@ export abstract class GeometryHelper extends DatabaseHelper {
 	supported(): boolean | Promise<boolean> {
 		return true;
 	}
+
 	isTrue(expression: Knex.Raw) {
 		return expression;
 	}
+
 	isFalse(expression: Knex.Raw) {
 		return expression.wrap('NOT ', '');
 	}
+
 	createColumn(table: Knex.CreateTableBuilder, field: RawField | Field) {
 		const type = field.type.split('.')[1] ?? 'geometry';
 		return table.specificType(field.field, type);
 	}
+
 	asText(table: string, column: string): Knex.Raw {
 		return this.knex.raw('st_astext(??.??) as ??', [table, column, column]);
 	}
+
 	fromText(text: string): Knex.Raw {
 		return this.knex.raw('st_geomfromtext(?, 4326)', text);
 	}
+
 	fromGeoJSON(geojson: GeoJSONGeometry): Knex.Raw {
 		return this.fromText(geojsonToWKT(geojson));
 	}
+
 	_intersects(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		const geometry = this.fromGeoJSON(geojson);
 		return this.knex.raw('st_intersects(??, ?)', [key, geometry]);
 	}
+
 	intersects(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		return this.isTrue(this._intersects(key, geojson));
 	}
+
 	nintersects(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		return this.isFalse(this._intersects(key, geojson));
 	}
+
 	_intersects_bbox(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		const geometry = this.fromGeoJSON(geojson);
 		return this.knex.raw('st_intersects(??, ?)', [key, geometry]);
 	}
+
 	intersects_bbox(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		return this.isTrue(this._intersects_bbox(key, geojson));
 	}
+
 	nintersects_bbox(key: string, geojson: GeoJSONGeometry): Knex.Raw {
 		return this.isFalse(this._intersects_bbox(key, geojson));
 	}
+
 	collect(table: string, column: string): Knex.Raw {
 		return this.knex.raw('st_astext(st_collect(??.??))', [table, column]);
 	}

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -49,6 +49,7 @@ export default function getDatabase(): Knex {
 			} else {
 				requiredEnvVars.push('DB_USER', 'DB_PASSWORD', 'DB_CONNECT_STRING');
 			}
+
 			break;
 
 		case 'cockroachdb':
@@ -58,11 +59,13 @@ export default function getDatabase(): Knex {
 			} else {
 				requiredEnvVars.push('DB_CONNECTION_STRING');
 			}
+
 			break;
 		case 'mssql':
 			if (!env['DB_TYPE'] || env['DB_TYPE'] === 'default') {
 				requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');
 			}
+
 			break;
 		default:
 			requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');

--- a/api/src/database/migrations/20210805B-change-image-metadata-structure.ts
+++ b/api/src/database/migrations/20210805B-change-image-metadata-structure.ts
@@ -29,17 +29,21 @@ export async function up(knex: Knex): Promise<void> {
 				newMetadata.ifd0 = newMetadata.image;
 				delete newMetadata.image;
 			}
+
 			if (newMetadata.thumbnail) {
 				newMetadata.ifd1 = newMetadata.thumbnail;
 				delete newMetadata.thumbnail;
 			}
+
 			if (newMetadata.interoperability) {
 				newMetadata.interop = newMetadata.interoperability;
 				delete newMetadata.interoperability;
 			}
+
 			if (prevMetadata.icc) {
 				newMetadata.icc = prevMetadata.icc;
 			}
+
 			if (prevMetadata.iptc) {
 				newMetadata.iptc = prevMetadata.iptc;
 			}
@@ -70,18 +74,22 @@ export async function down(knex: Knex): Promise<void> {
 				newMetadata.exif['image'] = newMetadata.exif['ifd0'];
 				delete newMetadata.exif['ifd0'];
 			}
+
 			if (newMetadata.exif['ifd1']) {
 				newMetadata.exif['thumbnail'] = newMetadata.exif['ifd1'];
 				delete newMetadata.exif['ifd1'];
 			}
+
 			if (newMetadata.exif['interop']) {
 				newMetadata.exif['interoperability'] = newMetadata.exif['interop'];
 				delete newMetadata.exif['interop'];
 			}
+
 			if (newMetadata.exif['icc']) {
 				newMetadata.icc = newMetadata.exif['icc'];
 				delete newMetadata.exif['icc'];
 			}
+
 			if (newMetadata.exif['iptc']) {
 				newMetadata.iptc = newMetadata.exif['iptc'];
 				delete newMetadata.exif['iptc'];

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -313,6 +313,7 @@ async function getDBQuery(
 					orderByString += `?? ${sortRecord.order}`;
 					orderByFields.push(getColumn(knex, table, sortRecord.column, false, schema));
 				}
+
 				innerQuerySortRecords.push({ alias: sortAlias, order: sortRecord.order });
 			});
 

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import { requireYAML } from './utils/require-yaml.js';
 
 import { createRequire } from 'node:module';
+
 const require = createRequire(import.meta.url);
 
 // keeping this here for now to prevent a circular import to constants.ts
@@ -405,6 +406,7 @@ function getEnvironmentValueWithPrefix(envArray: Array<string>): Array<string | 
 		if (isEnvSyntaxPrefixPresent(item)) {
 			return getEnvironmentValueByType(item);
 		}
+
 		return item;
 	});
 }
@@ -446,6 +448,7 @@ function processValues(env: Record<string, any>) {
 						`Duplicate environment variable encountered: you can't use "${newKey}" and "${key}" simultaneously.`
 					);
 				}
+
 				try {
 					value = fs.readFileSync(value, { encoding: 'utf8' });
 					key = newKey;
@@ -480,6 +483,7 @@ function processValues(env: Record<string, any>) {
 				case 'boolean':
 					env[key] = toBoolean(value);
 			}
+
 			continue;
 		}
 

--- a/api/src/exceptions/forbidden.ts
+++ b/api/src/exceptions/forbidden.ts
@@ -1,4 +1,5 @@
 import * as exceptions from '@directus/exceptions';
+
 const { BaseException } = exceptions;
 
 export class ForbiddenException extends BaseException {

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -181,6 +181,7 @@ class ExtensionManager {
 				if (addedExtensions.length > 0) {
 					logger.info(`Added extensions: ${addedExtensions.join(', ')}`);
 				}
+
 				if (removedExtensions.length > 0) {
 					logger.info(`Removed extensions: ${removedExtensions.join(', ')}`);
 				}
@@ -566,9 +567,11 @@ class ExtensionManager {
 					logger.warn(`Couldn't register embed hook. Provided code is empty!`);
 					return;
 				}
+
 				if (position === 'head') {
 					this.hookEmbedsHead.push(content);
 				}
+
 				if (position === 'body') {
 					this.hookEmbedsBody.push(content);
 				}

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -45,6 +45,7 @@ if (env['LOG_STYLE'] !== 'raw') {
 		},
 	};
 }
+
 if (env['LOG_STYLE'] === 'raw') {
 	httpLoggerOptions.redact = {
 		paths: ['req.headers.authorization', 'req.headers.cookie', 'res.headers'],
@@ -54,8 +55,10 @@ if (env['LOG_STYLE'] === 'raw') {
 				if ('set-cookie' in value) {
 					value['set-cookie'] = REDACT_TEXT;
 				}
+
 				return value;
 			}
+
 			return REDACT_TEXT;
 		},
 	};

--- a/api/src/mailer.ts
+++ b/api/src/mailer.ts
@@ -4,6 +4,7 @@ import logger from './logger.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
 
 import { createRequire } from 'node:module';
+
 const require = createRequire(import.meta.url);
 
 let transporter: Transporter;

--- a/api/src/middleware/check-ip.ts
+++ b/api/src/middleware/check-ip.ts
@@ -12,6 +12,7 @@ export const checkIP: RequestHandler = asyncHandler(async (req, _res, next) => {
 	} else {
 		query.whereNull('id');
 	}
+
 	const role = await query.first();
 
 	const ipAllowlist = (role?.ip_access || '').split(',').filter((ip: string) => ip);

--- a/api/src/middleware/rate-limiter-global.ts
+++ b/api/src/middleware/rate-limiter-global.ts
@@ -43,6 +43,7 @@ function validateConfiguration() {
 		logger.error(`The IP based rate limiter needs to be enabled when using the global rate limiter.`);
 		process.exit(1);
 	}
+
 	const globalPointsPerSec =
 		Number(env['RATE_LIMITER_GLOBAL_POINTS']) / Math.max(Number(env['RATE_LIMITER_GLOBAL_DURATION']), 1);
 	const regularPointsPerSec = Number(env['RATE_LIMITER_POINTS']) / Math.max(Number(env['RATE_LIMITER_DURATION']), 1);

--- a/api/src/rate-limiter.ts
+++ b/api/src/rate-limiter.ts
@@ -11,6 +11,7 @@ import env from './env.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
 
 import { createRequire } from 'node:module';
+
 const require = createRequire(import.meta.url);
 
 type IRateLimiterOptionsOverrides = Partial<IRateLimiterOptions> | Partial<IRateLimiterStoreOptions>;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -102,6 +102,7 @@ export async function createServer(): Promise<http.Server> {
 		if (env['NODE_ENV'] !== 'development') {
 			logger.info('Shutting down...');
 		}
+
 		SERVER_ONLINE = false;
 	}
 

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -239,8 +239,10 @@ export class AuthorizationService {
 										result = mergeRequiredFieldPermissions(result, requiredPermissions);
 									}
 								}
+
 								return result;
 							}
+
 							// Filter value is not a filter, so we should skip it
 							return result;
 						}
@@ -352,6 +354,7 @@ export class AuthorizationService {
 						current[collection] = new Set([...current[collection]!, ...child[collection]!]);
 					}
 				}
+
 				return current;
 			}
 

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -176,18 +176,22 @@ export class FilesService extends ItemsService {
 							if (image) {
 								fullMetadata.ifd0 = image;
 							}
+
 							if (thumbnail) {
 								fullMetadata.ifd1 = thumbnail;
 							}
+
 							if (interoperability) {
 								fullMetadata.interop = interoperability;
 							}
+
 							Object.assign(fullMetadata, rest);
 						} catch (err) {
 							logger.warn(`Couldn't extract EXIF metadata from file`);
 							logger.warn(err);
 						}
 					}
+
 					if (sharpMetadata.icc) {
 						try {
 							fullMetadata.icc = parseIcc(sharpMetadata.icc);
@@ -196,6 +200,7 @@ export class FilesService extends ItemsService {
 							logger.warn(err);
 						}
 					}
+
 					if (sharpMetadata.iptc) {
 						try {
 							fullMetadata.iptc = parseIptc(sharpMetadata.iptc);
@@ -204,6 +209,7 @@ export class FilesService extends ItemsService {
 							logger.warn(err);
 						}
 					}
+
 					if (sharpMetadata.xmp) {
 						try {
 							fullMetadata.xmp = parseXmp(sharpMetadata.xmp);
@@ -216,9 +222,11 @@ export class FilesService extends ItemsService {
 					if (fullMetadata?.iptc?.['Caption'] && typeof fullMetadata.iptc['Caption'] === 'string') {
 						metadata.description = fullMetadata.iptc?.['Caption'];
 					}
+
 					if (fullMetadata?.iptc?.['Headline'] && typeof fullMetadata.iptc['Headline'] === 'string') {
 						metadata.title = fullMetadata.iptc['Headline'];
 					}
+
 					if (fullMetadata?.iptc?.['Keywords']) {
 						metadata.tags = fullMetadata.iptc['Keywords'];
 					}

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -208,6 +208,7 @@ export class GraphQLService {
 				if (collection.collection.startsWith('directus_') === false) return false;
 				if (SYSTEM_DENY_LIST.includes(collection.collection)) return false;
 			}
+
 			return true;
 		};
 
@@ -1334,6 +1335,7 @@ export class GraphQLService {
 				collection = collection.slice(0, -6);
 			}
 		}
+
 		if (args['id']) {
 			query.filter = {
 				_and: [
@@ -1723,6 +1725,7 @@ export class GraphQLService {
 			set(error[0]!, 'extensions.code', error[0]!.code);
 			return new GraphQLError(error[0]!.message, undefined, undefined, undefined, undefined, error[0]);
 		}
+
 		set(error, 'extensions.code', error.code);
 		return new GraphQLError(error.message, undefined, undefined, undefined, undefined, error);
 	}
@@ -2072,6 +2075,7 @@ export class GraphQLService {
 							sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
 						});
 					}
+
 					return {
 						access_token: result['accessToken'],
 						expires: result['expires'],
@@ -2104,6 +2108,7 @@ export class GraphQLService {
 					if (!currentRefreshToken) {
 						throw new InvalidPayloadException(`"refresh_token" is required in either the JSON payload or Cookie`);
 					}
+
 					const result = await authenticationService.refresh(currentRefreshToken);
 					if (args['mode'] === 'cookie') {
 						res?.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], result['refreshToken'], {
@@ -2114,6 +2119,7 @@ export class GraphQLService {
 							sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
 						});
 					}
+
 					return {
 						access_token: result['accessToken'],
 						expires: result['expires'],
@@ -2145,6 +2151,7 @@ export class GraphQLService {
 					if (!currentRefreshToken) {
 						throw new InvalidPayloadException(`"refresh_token" is required in either the JSON payload or Cookie`);
 					}
+
 					await authenticationService.logout(currentRefreshToken);
 					return true;
 				},
@@ -2258,6 +2265,7 @@ export class GraphQLService {
 					if (otpValid === false) {
 						throw new InvalidPayloadException(`"otp" is invalid`);
 					}
+
 					await service.disableTFA(this.accountability.user);
 					return true;
 				},
@@ -2788,6 +2796,7 @@ export class GraphQLService {
 
 							return await service.readOne(this.accountability.user, query);
 						}
+
 						return true;
 					},
 				},

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -265,6 +265,7 @@ export class PayloadService {
 
 		return payloads;
 	}
+
 	/**
 	 * Knex returns `datetime` and `date` columns as Date.. This is wrong for date / datetime, as those
 	 * shouldn't return with time / timezone info respectively
@@ -331,6 +332,7 @@ export class PayloadService {
 							if (!isValid(parsedDate)) {
 								throw new InvalidPayloadException(`Invalid Date format in field "${dateColumn.field}"`);
 							}
+
 							payload[name] = parsedDate;
 						}
 
@@ -339,6 +341,7 @@ export class PayloadService {
 							if (!isValid(parsedDate)) {
 								throw new InvalidPayloadException(`Invalid DateTime format in field "${dateColumn.field}"`);
 							}
+
 							payload[name] = parsedDate;
 						}
 

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -60,6 +60,7 @@ export class ServerService {
 			} else {
 				info['rateLimit'] = false;
 			}
+
 			if (env['RATE_LIMITER_GLOBAL_ENABLED']) {
 				info['rateLimitGlobal'] = {
 					points: env['RATE_LIMITER_GLOBAL_POINTS'],

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -256,6 +256,7 @@ export class UsersService extends ItemsService {
 						invalid: data['email'],
 					});
 				}
+
 				await this.checkUniqueEmails([data['email']], keys[0]);
 			}
 

--- a/api/src/utils/get-milliseconds.ts
+++ b/api/src/utils/get-milliseconds.ts
@@ -8,5 +8,6 @@ export function getMilliseconds(value: unknown, fallback = undefined): number | 
 	if ((typeof value !== 'string' && typeof value !== 'number') || value === '') {
 		return fallback;
 	}
+
 	return ms(String(value)) ?? fallback;
 }

--- a/api/src/utils/get-relation-info.ts
+++ b/api/src/utils/get-relation-info.ts
@@ -10,6 +10,7 @@ function checkImplicitRelation(field: string) {
 	if (field.startsWith('$FOLLOW(') && field.endsWith(')')) {
 		return field.slice(8, -1).split(',');
 	}
+
 	return null;
 }
 

--- a/api/src/utils/parse-image-metadata.ts
+++ b/api/src/utils/parse-image-metadata.ts
@@ -73,6 +73,7 @@ export function parseXmp(buffer: Buffer): Record<string, unknown> {
 
 				match = r.exec(value);
 			}
+
 			xmp[x] = result;
 		} else {
 			xmp[x] = value?.replace(/<[^>]*>?/gm, '').trim();

--- a/api/src/utils/validate-diff.test.ts
+++ b/api/src/utils/validate-diff.test.ts
@@ -41,6 +41,7 @@ describe('should throw accurate error', () => {
 			},
 		};
 	};
+
 	const baseSnapshot = (partialSnapshot?: Partial<Snapshot>) => {
 		return {
 			hash: 'xyz',

--- a/api/src/utils/validate-diff.ts
+++ b/api/src/utils/validate-diff.ts
@@ -96,6 +96,7 @@ export function validateApplyDiff(applyDiff: SnapshotDiffWithHash, currentSnapsh
 			}
 		}
 	}
+
 	for (const diffField of applyDiff.diff.fields) {
 		const field = `${diffField.collection}.${diffField.field}`;
 
@@ -121,6 +122,7 @@ export function validateApplyDiff(applyDiff: SnapshotDiffWithHash, currentSnapsh
 			}
 		}
 	}
+
 	for (const diffRelation of applyDiff.diff.relations) {
 		let relation = `${diffRelation.collection}.${diffRelation.field}`;
 		if (diffRelation.related_collection) relation += `-> ${diffRelation.related_collection}`;

--- a/app/src/components/transition/transition-bounce.stories.ts
+++ b/app/src/components/transition/transition-bounce.stories.ts
@@ -1,4 +1,5 @@
 import TransitionBounce from './bounce.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -16,4 +17,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/transition/transition-dialog.stories.ts
+++ b/app/src/components/transition/transition-dialog.stories.ts
@@ -1,4 +1,5 @@
 import TransitionDialog from './dialog.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -16,4 +17,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/transition/transition-expand.stories.ts
+++ b/app/src/components/transition/transition-expand.stories.ts
@@ -1,4 +1,5 @@
 import TransitionExpand from './expand.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -16,4 +17,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-avatar.stories.ts
+++ b/app/src/components/v-avatar.stories.ts
@@ -1,4 +1,5 @@
 import VAvatar from './v-avatar.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,4 +16,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-badge.stories.ts
+++ b/app/src/components/v-badge.stories.ts
@@ -1,4 +1,5 @@
 import VBadge from './v-badge.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	value: '+9',
 };

--- a/app/src/components/v-breadcrumb.stories.ts
+++ b/app/src/components/v-breadcrumb.stories.ts
@@ -1,4 +1,5 @@
 import VBreadcrumb from './v-breadcrumb.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	items: [
 		{

--- a/app/src/components/v-button.stories.ts
+++ b/app/src/components/v-button.stories.ts
@@ -19,4 +19,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-card.stories.ts
+++ b/app/src/components/v-card.stories.ts
@@ -1,4 +1,5 @@
 import VCard from './v-card.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -25,4 +26,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-checkbox-tree.stories.ts
+++ b/app/src/components/v-checkbox-tree.stories.ts
@@ -1,4 +1,5 @@
 import VCheckboxTree from './v-checkbox-tree/v-checkbox-tree.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	choices: [
 		{

--- a/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
@@ -149,6 +149,7 @@ function findSelectedChoices(choices: Record<string, any>[], checked: (string | 
 				}
 			}
 		}
+
 		return result;
 	}
 

--- a/app/src/components/v-checkbox.stories.ts
+++ b/app/src/components/v-checkbox.stories.ts
@@ -1,4 +1,5 @@
 import VCheckbox from './v-checkbox.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -17,6 +18,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: true,
 };

--- a/app/src/components/v-chip.stories.ts
+++ b/app/src/components/v-chip.stories.ts
@@ -1,4 +1,5 @@
 import VChip from './v-chip.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -17,4 +18,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-detail.vue
+++ b/app/src/components/v-detail.vue
@@ -41,6 +41,7 @@ const internalActive = computed({
 		if (props.modelValue !== undefined) {
 			return props.modelValue;
 		}
+
 		return localActive.value;
 	},
 	set(newActive: boolean) {

--- a/app/src/components/v-divider.stories.ts
+++ b/app/src/components/v-divider.stories.ts
@@ -1,4 +1,5 @@
 import VDivider from './v-divider.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,4 +16,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-emoji-picker.stories.ts
+++ b/app/src/components/v-emoji-picker.stories.ts
@@ -1,4 +1,5 @@
 import VEmojiPicker from './v-emoji-picker.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,4 +16,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-fancy-select.stories.ts
+++ b/app/src/components/v-fancy-select.stories.ts
@@ -1,4 +1,5 @@
 import VFancySelect from './v-fancy-select.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	items: [
 		{

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -270,6 +270,7 @@ function setContent() {
 				if (part.startsWith('{{') === false) {
 					return `<span class="text">${part}</span>`;
 				}
+
 				const fieldKey = part.replace(/({|})/g, '').trim();
 				const fieldPath = fieldKey.split('.');
 

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -184,6 +184,7 @@ function useRaw() {
 		} catch (e) {
 			internalValue.value = pastedValue;
 		}
+
 		emitValue(internalValue.value);
 	}
 

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -183,6 +183,7 @@ const firstEditableFieldIndex = computed(() => {
 			return i;
 		}
 	}
+
 	return null;
 });
 
@@ -193,6 +194,7 @@ const firstVisibleFieldIndex = computed(() => {
 			return i;
 		}
 	}
+
 	return null;
 });
 
@@ -289,6 +291,7 @@ function useForm() {
 		if (props.collection) {
 			return fieldsStore.getFieldsForCollection(props.collection);
 		}
+
 		if (props.fields) {
 			return props.fields;
 		}

--- a/app/src/components/v-highlight.stories.ts
+++ b/app/src/components/v-highlight.stories.ts
@@ -1,4 +1,5 @@
 import VHighlight from './v-highlight.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	text: 'The cake is a lie.',
 	query: ['cake', 'lie'],

--- a/app/src/components/v-hover.stories.ts
+++ b/app/src/components/v-hover.stories.ts
@@ -1,4 +1,5 @@
 import VHover from './v-hover.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -16,4 +17,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-icon-file.stories.ts
+++ b/app/src/components/v-icon-file.stories.ts
@@ -1,4 +1,5 @@
 import VIconFile from './v-icon-file.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	ext: 'png',
 };

--- a/app/src/components/v-icon.stories.ts
+++ b/app/src/components/v-icon.stories.ts
@@ -1,4 +1,5 @@
 import VIcon from './v-icon/v-icon.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	name: 'delete',
 };

--- a/app/src/components/v-info.stories.ts
+++ b/app/src/components/v-info.stories.ts
@@ -1,4 +1,5 @@
 import VInfo from './v-info.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	title: 'No more cookies',
 	icon: 'cookie',

--- a/app/src/components/v-input.stories.ts
+++ b/app/src/components/v-input.stories.ts
@@ -1,4 +1,5 @@
 import VInput from './v-input.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: 'Shut up and take my money. 💸',
 	disabled: false,

--- a/app/src/components/v-item-group.stories.ts
+++ b/app/src/components/v-item-group.stories.ts
@@ -1,4 +1,5 @@
 import VItemGroup from './v-item-group.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -16,6 +17,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: ['item1'],
 };

--- a/app/src/components/v-list-group.stories.ts
+++ b/app/src/components/v-list-group.stories.ts
@@ -1,4 +1,5 @@
 import VListGroup from './v-list-group.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -31,6 +32,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	open: true,
 };

--- a/app/src/components/v-list-item.stories.ts
+++ b/app/src/components/v-list-item.stories.ts
@@ -1,4 +1,5 @@
 import VListItem from './v-list-item.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -17,4 +18,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-list.stories.ts
+++ b/app/src/components/v-list.stories.ts
@@ -1,4 +1,5 @@
 import VList from './v-list.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -21,6 +22,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: [1],
 };

--- a/app/src/components/v-menu.stories.ts
+++ b/app/src/components/v-menu.stories.ts
@@ -1,4 +1,5 @@
 import VMenu from './v-menu.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -35,4 +36,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -222,6 +222,7 @@ function useActiveState() {
 				},
 			};
 		}
+
 		isActive.value = true;
 	}
 

--- a/app/src/components/v-notice.stories.ts
+++ b/app/src/components/v-notice.stories.ts
@@ -1,4 +1,5 @@
 import VNotice from './v-notice.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -20,4 +21,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-overlay.stories.ts
+++ b/app/src/components/v-overlay.stories.ts
@@ -1,4 +1,5 @@
 import VOverlay from './v-overlay.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	active: true,
 };

--- a/app/src/components/v-pagination.stories.ts
+++ b/app/src/components/v-pagination.stories.ts
@@ -1,4 +1,5 @@
 import VPagination from './v-pagination.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	length: 7,
 	totalVisible: 4,

--- a/app/src/components/v-progress-circular.stories.ts
+++ b/app/src/components/v-progress-circular.stories.ts
@@ -1,4 +1,5 @@
 import VProgressCircular from './v-progress-circular.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	value: 70,
 };

--- a/app/src/components/v-progress-linear.stories.ts
+++ b/app/src/components/v-progress-linear.stories.ts
@@ -1,4 +1,5 @@
 import VProgressLinear from './v-progress-linear.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	value: 70,
 	colorful: true,

--- a/app/src/components/v-radio.stories.ts
+++ b/app/src/components/v-radio.stories.ts
@@ -1,4 +1,5 @@
 import VRadio from './v-radio.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	value: '1',
 	label: 'My Radio',

--- a/app/src/components/v-select.stories.ts
+++ b/app/src/components/v-select.stories.ts
@@ -16,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	items: [
 		{

--- a/app/src/components/v-select/select-list-item-group.vue
+++ b/app/src/components/v-select/select-list-item-group.vue
@@ -72,6 +72,7 @@ const isActive = computed(() => {
 		if (!Array.isArray(props.modelValue) || !props.item.value) {
 			return false;
 		}
+
 		return props.modelValue.includes(props.item.value);
 	} else {
 		return props.modelValue === props.item.value;

--- a/app/src/components/v-select/select-list-item.vue
+++ b/app/src/components/v-select/select-list-item.vue
@@ -51,6 +51,7 @@ const isActive = computed(() => {
 		if (!Array.isArray(props.modelValue) || !props.item.value) {
 			return false;
 		}
+
 		return props.modelValue.includes(props.item.value);
 	} else {
 		return props.modelValue === props.item.value;

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -291,6 +291,7 @@ function useItems() {
 				if (item?.children) {
 					acc += countItems(item.children);
 				}
+
 				return acc + 1;
 			}, 0);
 

--- a/app/src/components/v-sheet.stories.ts
+++ b/app/src/components/v-sheet.stories.ts
@@ -1,4 +1,5 @@
 import VSheet from './v-sheet.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -16,4 +17,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-skeleton-loader.stories.ts
+++ b/app/src/components/v-skeleton-loader.stories.ts
@@ -1,4 +1,5 @@
 import VSkeletonLoader from './v-skeleton-loader.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -20,4 +21,5 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {};

--- a/app/src/components/v-slider.stories.ts
+++ b/app/src/components/v-slider.stories.ts
@@ -24,6 +24,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 // More on args: https://storybook.js.org/docs/vue/writing-stories/args
 Primary.args = {
 	modelValue: 50,

--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -331,6 +331,7 @@ function onSortChange(event: EndEvent) {
 
 	emit('manual-sort', { item, to });
 }
+
 function updateSort(newSort: Sort) {
 	emit('update:sort', newSort?.by ? newSort : null);
 }

--- a/app/src/components/v-tabs.stories.ts
+++ b/app/src/components/v-tabs.stories.ts
@@ -1,4 +1,5 @@
 import VTabs from './v-tabs.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -34,6 +35,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: [1],
 };

--- a/app/src/components/v-template-input.stories.ts
+++ b/app/src/components/v-template-input.stories.ts
@@ -1,4 +1,5 @@
 import VTemplateInput from './v-template-input.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: 'Hey ho everyone, I am a new comment!',
 	multiline: true,

--- a/app/src/components/v-template-input.vue
+++ b/app/src/components/v-template-input.vue
@@ -171,6 +171,7 @@ function checkClick(event: any) {
 		} else {
 			position(input.value!, caretPos + 1);
 		}
+
 		event.preventDefault();
 	}
 }

--- a/app/src/components/v-text-overflow.stories.ts
+++ b/app/src/components/v-text-overflow.stories.ts
@@ -1,4 +1,5 @@
 import VTextOverflow from './v-text-overflow.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	text: 'This text should not wrap to a new line!',
 };

--- a/app/src/components/v-textarea.stories.ts
+++ b/app/src/components/v-textarea.stories.ts
@@ -1,4 +1,5 @@
 import VTextarea from './v-textarea.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	modelValue: `This is some text that will be displayed in the textarea.
 This is a new line.`,

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -134,6 +134,7 @@ function validFiles(files: FileList) {
 	for (const file of files) {
 		if (file.size === 0) return false;
 	}
+
 	return true;
 }
 
@@ -154,6 +155,7 @@ function useUpload() {
 		if (props.folder) {
 			folderPreset.folder = props.folder;
 		}
+
 		try {
 			if (!validFiles(files)) {
 				throw new Error('An error has occurred while uploading the files.');

--- a/app/src/components/v-workspace-tile.stories.ts
+++ b/app/src/components/v-workspace-tile.stories.ts
@@ -1,4 +1,5 @@
 import VWorkspaceTile from './v-workspace-tile.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	name: 'My Tile',
 	id: '1',

--- a/app/src/components/v-workspace.stories.ts
+++ b/app/src/components/v-workspace.stories.ts
@@ -1,4 +1,5 @@
 import VWorkspace from './v-workspace.vue';
+
 document.body.classList.add('light');
 
 export default {
@@ -15,6 +16,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+
 Primary.args = {
 	editMode: false,
 	tiles: [

--- a/app/src/composables/use-field-tree.test.ts
+++ b/app/src/composables/use-field-tree.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { ref, unref } from 'vue';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 beforeEach(() => {

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -175,6 +175,7 @@ export function useFieldTree(
 					if (node.group === true && node.children && node.children.length > 0) {
 						acc.push(...node.children);
 					}
+
 					return acc;
 				}, [])
 				.find((node) => node.field === field);

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -243,6 +243,7 @@ export function useItem(
 					for (const item of existingItems) {
 						updateExistingRelatedItems(updatedRelatedItems, item, relatedPrimaryKeyField, relation);
 					}
+
 					updatedRelatedItems.length = 0;
 
 					for (const item of existingItems) {
@@ -296,6 +297,7 @@ export function useItem(
 				});
 				existingItems = response.data.data;
 			}
+
 			return existingItems;
 		}
 
@@ -361,6 +363,7 @@ export function useItem(
 		} else {
 			unexpectedError(err);
 		}
+
 		throw err;
 	}
 
@@ -447,6 +450,7 @@ export function useItem(
 		) {
 			response.data.data = translate(response.data.data);
 		}
+
 		if (isBatch.value === false) {
 			item.value = response.data.data;
 		} else {

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -57,6 +57,7 @@ export function useRelationMultiple(
 				value.value = undefined;
 				return;
 			}
+
 			value.value = newValue;
 		},
 	});
@@ -187,6 +188,7 @@ export function useRelationMultiple(
 				const field = sortField.substring(1);
 				return get(b, field) - get(a, field);
 			}
+
 			return get(a, sortField) - get(b, sortField);
 		});
 	});
@@ -200,6 +202,7 @@ export function useRelationMultiple(
 			for (const item of items) {
 				target.value.create.push(cleanItem(item));
 			}
+
 			updateValue();
 		}
 
@@ -223,6 +226,7 @@ export function useRelationMultiple(
 					}
 				}
 			}
+
 			updateValue();
 		}
 
@@ -249,6 +253,7 @@ export function useRelationMultiple(
 					target.value.delete.splice(item.$index, 1);
 				}
 			}
+
 			updateValue();
 		}
 
@@ -314,6 +319,7 @@ export function useRelationMultiple(
 					const pkField = relation.value.relationPrimaryKeyFields[collection.collection];
 					fields.add(`${relation.value.junctionField.field}:${collection.collection}.${pkField.field}`);
 				}
+
 				break;
 			case 'm2m':
 				targetCollection = relation.value.junctionCollection.collection;
@@ -691,6 +697,7 @@ export function useRelationMultiple(
 						$edits: item.$edits,
 					};
 			}
+
 			return {};
 		}
 

--- a/app/src/composables/use-shortcut.test.ts
+++ b/app/src/composables/use-shortcut.test.ts
@@ -45,6 +45,7 @@ describe('useShortcut', () => {
 		for (const key of keys) {
 			await wrapper.trigger('keydown', { key });
 		}
+
 		await wrapper.trigger('keyup', { key: keys[0] });
 
 		expect(shortcutHandler).toHaveBeenCalledOnce();

--- a/app/src/composables/use-tfa-setup.ts
+++ b/app/src/composables/use-tfa-setup.ts
@@ -75,6 +75,7 @@ export function useTFASetup(initialEnabled: boolean) {
 		} finally {
 			loading.value = false;
 		}
+
 		return success;
 	}
 
@@ -94,6 +95,7 @@ export function useTFASetup(initialEnabled: boolean) {
 		} finally {
 			loading.value = false;
 		}
+
 		return success;
 	}
 
@@ -112,6 +114,7 @@ export function useTFASetup(initialEnabled: boolean) {
 		} finally {
 			loading.value = false;
 		}
+
 		return success;
 	}
 }

--- a/app/src/displays/boolean/boolean.vue
+++ b/app/src/displays/boolean/boolean.vue
@@ -50,6 +50,7 @@ export default defineComponent({
 				style['color'] = props.value ? props.colorOn : props.colorOff;
 				style['--v-icon-color'] = props.value ? props.colorOn : props.colorOff;
 			}
+
 			return style;
 		});
 

--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -85,6 +85,7 @@ const displayItem = computed(() => {
 		const user = useUserStore();
 		item = props.value.find((val) => val?.[langField]?.[langPkField] === user.currentUser?.language) ?? item;
 	}
+
 	return item ?? {};
 });
 

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -162,6 +162,7 @@ export default defineComponent({
 				} else {
 					value = newVal;
 				}
+
 				emit('update:field', fieldToFilter(fieldPath, comparator.value, value));
 			},
 		});

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -274,6 +274,7 @@ function updateComparator(index: number, operator: keyof FieldFilterOperator) {
 			} else {
 				update(null);
 			}
+
 			break;
 		default:
 			// avoid setting value as string 'true'/'false' when switching from null/empty operators
@@ -282,6 +283,7 @@ function updateComparator(index: number, operator: keyof FieldFilterOperator) {
 			} else {
 				update(Array.isArray(value) ? value[0] : value);
 			}
+
 			break;
 	}
 

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -193,6 +193,7 @@ function addNode(key: string) {
 				}
 			}
 		}
+
 		let filterOperators = getFilterOperatorsForType(type, { includeValidation: props.includeValidation });
 		const operator = field?.meta?.options?.choices && filterOperators.includes('eq') ? 'eq' : filterOperators[0];
 		const node = set({}, key, { ['_' + operator]: null });

--- a/app/src/interfaces/_system/system-folder/folder.vue
+++ b/app/src/interfaces/_system/system-folder/folder.vue
@@ -79,6 +79,7 @@ export default defineComponent({
 			if (!props.value || !folders.value) {
 				return t('interfaces.system-folder.root_name');
 			}
+
 			const folder = folders.value.find((folder) => folder.id === props.value);
 			return folder
 				? folderParentPath(folder as Folder, folders.value)

--- a/app/src/interfaces/_system/system-inline-fields/system-inline-fields.vue
+++ b/app/src/interfaces/_system/system-inline-fields/system-inline-fields.vue
@@ -15,6 +15,7 @@ import { Field } from '@directus/types';
 import { set } from 'lodash';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+
 const { t } = useI18n();
 
 interface Props {

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -169,6 +169,7 @@ export default defineComponent({
 					if (fieldValue === null || fieldValue === undefined || fieldValue === '') return true;
 				}
 			}
+
 			return false;
 		});
 

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -84,6 +84,7 @@ export default defineComponent({
 					displayValue.value = null;
 					return;
 				}
+
 				let timeFormat = props.includeSeconds ? 'date-fns_time' : 'date-fns_time_no_seconds';
 				if (props.use24) timeFormat = props.includeSeconds ? 'date-fns_time_24hour' : 'date-fns_time_no_seconds_24hour';
 				let format = `${t('date-fns_date')} ${t(timeFormat)}`;

--- a/app/src/interfaces/datetime/index.ts
+++ b/app/src/interfaces/datetime/index.ts
@@ -15,6 +15,7 @@ export default defineInterface({
 			if (field.meta?.options) {
 				field.meta.options = {};
 			}
+
 			return [];
 		}
 

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -143,6 +143,7 @@ const src = computed(() => {
 	if (image.value.type.includes('svg')) {
 		return '/assets/' + image.value.id;
 	}
+
 	if (image.value.type.includes('image')) {
 		const fit = props.crop ? 'cover' : 'contain';
 		const url = `/assets/${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}`;

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -263,6 +263,7 @@ function sortItems(items: DisplayItem[]) {
 		if (!isNil(junctionId)) {
 			changes[info.junctionPrimaryKeyField.field] = junctionId;
 		}
+
 		if (!isNil(relatedId)) {
 			set(changes, info.junctionField.field + '.' + info.relatedPrimaryKeyField.field, relatedId);
 		}

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -109,6 +109,7 @@ export default defineComponent({
 			if (props.field.meta?.special?.includes('group')) {
 				fields.push(...getFieldsForGroup(props.field.meta?.field));
 			}
+
 			return fields;
 		});
 

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -150,6 +150,7 @@ export default defineComponent({
 						).toLowerCase()}`
 					);
 				}
+
 				return acc;
 			}, [] as string[]);
 

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -180,6 +180,7 @@ export default defineComponent({
 								// Do nothing
 							}
 						}
+
 						return found;
 					});
 				} else if (lang === 'plaintext') {
@@ -203,15 +204,19 @@ export default defineComponent({
 					// @ts-ignore - @types/codemirror is missing this export
 					imports.push(import('codemirror/addon/selection/mark-selection.js'));
 				}
+
 				if (optionsObj.highlightSelectionMatches) {
 					imports.push(import('codemirror/addon/search/match-highlighter.js'));
 				}
+
 				if (optionsObj.autoRefresh) {
 					imports.push(import('codemirror/addon/display/autorefresh.js'));
 				}
+
 				if (optionsObj.matchBrackets) {
 					imports.push(import('codemirror/addon/edit/matchbrackets.js'));
 				}
+
 				if (optionsObj.hintOptions || optionsObj.showHint) {
 					imports.push(import('codemirror/addon/hint/show-hint.js'));
 					// @ts-ignore - @types/codemirror is missing this export
@@ -219,6 +224,7 @@ export default defineComponent({
 					// @ts-ignore - @types/codemirror is missing this export
 					imports.push(import('codemirror/addon/hint/javascript-hint.js'));
 				}
+
 				await Promise.all(imports);
 			}
 		}
@@ -227,6 +233,7 @@ export default defineComponent({
 			if (codemirror) {
 				return codemirror.lineCount();
 			}
+
 			return 0;
 		});
 

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -328,6 +328,7 @@ export default defineComponent({
 				if (props.value !== value) {
 					contentUpdated();
 				}
+
 				return;
 			},
 		});

--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -163,6 +163,7 @@ export default function useImage(
 		if (!url.includes(getPublicURL() + 'assets/')) {
 			return url;
 		}
+
 		try {
 			const parsedUrl = new URL(url);
 			const params = new URLSearchParams(parsedUrl.search);

--- a/app/src/interfaces/input-rich-text-html/useLink.ts
+++ b/app/src/interfaces/input-rich-text-html/useLink.ts
@@ -115,8 +115,10 @@ export default function useLink(editor: Ref<any>): UsableLink {
 				editor.value.selection.setContent(linkNode.value.innerText);
 				closeLinkDrawer();
 			}
+
 			return;
 		}
+
 		const linkHtml = `<a href="${link.url}" ${link.title ? `title="${link.title}"` : ''} target="${
 			link.newTab ? '_blank' : '_self'
 		}" >${link.displayText || link.url}</a>`;

--- a/app/src/interfaces/input-rich-text-html/useMedia.ts
+++ b/app/src/interfaces/input-rich-text-html/useMedia.ts
@@ -193,6 +193,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 		} else {
 			editor.value.selection.setContent(embed.value);
 		}
+
 		editor.value.undoManager.add();
 		closeMediaDrawer();
 	}
@@ -202,6 +203,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 		if (!url.includes(getPublicURL() + 'assets/')) {
 			return url;
 		}
+
 		try {
 			const parsedUrl = new URL(url);
 			const params = new URLSearchParams(parsedUrl.search);

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -277,9 +277,11 @@ function sortItems(items: DisplayItem[]) {
 		if (!isNil(junctionId)) {
 			changes[info.junctionPrimaryKeyField.field] = junctionId;
 		}
+
 		if (!isNil(collection)) {
 			changes[info.collectionField.field] = collection;
 		}
+
 		if (!isNil(relatedId)) {
 			set(changes, info.junctionField.field + '.' + pkField, relatedId);
 		}

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -328,12 +328,15 @@ const query = computed<RelationQueryMultiple>(() => {
 	if (!relationInfo.value) {
 		return q;
 	}
+
 	if (searchFilter.value) {
 		q.filter = searchFilter.value;
 	}
+
 	if (search.value) {
 		q.search = search.value;
 	}
+
 	if (sort.value) {
 		q.sort = [`${sort.value.desc ? '-' : ''}${sort.value.by}`];
 	}
@@ -388,6 +391,7 @@ watch(
 				if (!contentWidth[key]) {
 					contentWidth[key] = 5;
 				}
+
 				if (String(item[key]).length > contentWidth[key]) {
 					contentWidth[key] = String(item[key]).length;
 				}
@@ -457,6 +461,7 @@ function sortItems(items: DisplayItem[]) {
 		if (!isNil(junctionId)) {
 			changes[info.junctionPrimaryKeyField.field] = junctionId;
 		}
+
 		if (!isNil(relatedId)) {
 			set(changes, info.junctionField.field + '.' + info.relatedPrimaryKeyField.field, relatedId);
 		}

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -102,6 +102,7 @@ const itemsMoved = computed(() => {
 		if (typeof item === 'object') {
 			return item[pkField] as string | number;
 		}
+
 		return item;
 	});
 });

--- a/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
@@ -238,6 +238,7 @@ function change(event: ChangeEvent) {
 				});
 				break;
 			}
+
 			default:
 				update({
 					...event.added.element,

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -303,12 +303,15 @@ const query = computed<RelationQueryMultiple>(() => {
 	if (!relationInfo.value) {
 		return q;
 	}
+
 	if (searchFilter.value) {
 		q.filter = searchFilter.value;
 	}
+
 	if (search.value) {
 		q.search = search.value;
 	}
+
 	if (sort.value) {
 		q.sort = [`${sort.value.desc ? '-' : ''}${sort.value.by}`];
 	}
@@ -363,6 +366,7 @@ watch(
 				if (!contentWidth[key]) {
 					contentWidth[key] = 5;
 				}
+
 				if (String(item[key]).length > contentWidth[key]) {
 					contentWidth[key] = String(item[key]).length;
 				}

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -173,6 +173,7 @@ export default defineComponent({
 					return true;
 				}
 			}
+
 			return false;
 		});
 

--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -174,6 +174,7 @@ export default defineComponent({
 		function updateProjection() {
 			projection.value = !location.value ? null : map.project(location.value as any);
 		}
+
 		watch(location, updateProjection);
 
 		const controls = {
@@ -262,6 +263,7 @@ export default defineComponent({
 					location.value = null;
 				});
 			}
+
 			controls.geolocate.on('geolocate', (event: any) => {
 				const { longitude, latitude } = event.coords;
 				location.value = [longitude, latitude];
@@ -286,6 +288,7 @@ export default defineComponent({
 					map.on('mousemove', layer, updateTooltip);
 					map.on('mouseleave', layer, updateTooltip);
 				}
+
 				window.addEventListener('keydown', handleKeyDown);
 			});
 
@@ -314,6 +317,7 @@ export default defineComponent({
 					controls.draw.changeMode('simple_select');
 				}
 			}
+
 			if (props.disabled) {
 				controls.draw.changeMode('static');
 			}
@@ -356,6 +360,7 @@ export default defineComponent({
 			if (props.disabled) {
 				return options;
 			}
+
 			if (!type) {
 				options.controls.line_string = true;
 				options.controls.polygon = true;
@@ -374,9 +379,11 @@ export default defineComponent({
 			if (!a || !b) {
 				return true;
 			}
+
 			if (a.startsWith('Multi')) {
 				return a.replace('Multi', '') == b.replace('Multi', '');
 			}
+
 			return a == b;
 		}
 
@@ -387,16 +394,19 @@ export default defineComponent({
 				if (!initialValue) {
 					return;
 				}
+
 				if (!props.disabled && !isTypeCompatible(geometryType, initialValue!.type)) {
 					geometryParsingError.value = t('interfaces.map.unexpected_geometry', {
 						expected: geometryType,
 						got: initialValue!.type,
 					});
 				}
+
 				const flattened = flatten(initialValue);
 				for (const geometry of flattened) {
 					controls.draw.add(geometry);
 				}
+
 				currentGeometry = getCurrentGeometry();
 				currentGeometry!.bbox = getBBox(currentGeometry!);
 
@@ -431,6 +441,7 @@ export default defineComponent({
 			} else {
 				result = geometries[geometries.length - 1];
 			}
+
 			return result;
 		}
 

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -289,6 +289,7 @@ function useColor() {
 			alpha = alpha.padStart(2, '0');
 			return color.value.rgb().array().length === 4 ? `${color.value.hex()}${alpha}` : color.value.hex();
 		}
+
 		return null;
 	};
 
@@ -342,6 +343,7 @@ function useColor() {
 			if (newAlpha === null) {
 				return;
 			}
+
 			const newColor = color.value !== null ? color.value.rgb().array() : [0, 0, 0];
 			setColor(Color(newColor).alpha(newAlpha / 100));
 		},

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -214,6 +214,7 @@ const selection = computed<(number | string)[]>(() => {
 	if (typeof props.value === 'object' && pkField in props.value) {
 		return [props.value[pkField]];
 	}
+
 	return [props.value];
 });
 

--- a/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
+++ b/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
@@ -123,6 +123,7 @@ export default defineComponent({
 			if (showAll.value || hideChoices.value === false) {
 				return props.choices;
 			}
+
 			return props.choices.slice(0, props.itemsShown);
 		});
 

--- a/app/src/interfaces/translations/index.ts
+++ b/app/src/interfaces/translations/index.ts
@@ -25,6 +25,7 @@ export default defineInterface({
 				value: field.field,
 			}));
 		}
+
 		return [
 			{
 				field: 'languageField',

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -56,12 +56,14 @@ export default defineLayout<LayoutOptions>({
 			if (!calendar.value || !startDateField.value) {
 				return;
 			}
+
 			const start = formatISO(calendar.value.view.activeStart);
 			const end = formatISO(calendar.value.view.activeEnd);
 			const startsHere = { [startDateField.value]: { _between: [start, end] } };
 			if (!endDateField.value) {
 				return startsHere;
 			}
+
 			const endsHere = { [endDateField.value]: { _between: [start, end] } };
 			const startsBefore = { [startDateField.value]: { _lte: start } };
 			const endsAfter = { [endDateField.value]: { _gte: end } };
@@ -324,6 +326,7 @@ export default defineLayout<LayoutOptions>({
 			if (type === 'dateTime') {
 				return dateString.substring(0, 19);
 			}
+
 			return dateString;
 		}
 	},

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -113,6 +113,7 @@ export default defineComponent({
 				placeholder: t('layouts.map.find_location'),
 			});
 		}
+
 		onMounted(() => {
 			setupMap();
 		});
@@ -135,6 +136,7 @@ export default defineComponent({
 			if (geocoderControl) {
 				map.addControl(geocoderControl as any, 'top-right');
 			}
+
 			map.addControl(attributionControl, 'bottom-left');
 			map.addControl(navigationControl, 'top-left');
 			map.addControl(geolocateControl, 'top-left');
@@ -150,6 +152,7 @@ export default defineComponent({
 					map.on('mousemove', layer, updatePopup);
 					map.on('mouseleave', layer, updatePopup);
 				}
+
 				map.on('move', updatePopupLocation);
 				map.on('click', '__directus_clusters', expandCluster);
 				map.on('mousemove', '__directus_clusters', hoverCluster);
@@ -221,14 +224,17 @@ export default defineComponent({
 					map.removeLayer(layer.id);
 				}
 			}
+
 			if (props.featureId) {
 				(newSource as any).promoteId = props.featureId;
 			} else {
 				(newSource as any).generateId = true;
 			}
+
 			if (map.getStyle().sources?.['__directus']) {
 				map.removeSource('__directus');
 			}
+
 			map.addSource('__directus', { ...newSource, data: props.data });
 			map.once('sourcedata', () => {
 				setTimeout(() => props.layers.forEach((layer) => map.addLayer(layer)));
@@ -277,6 +283,7 @@ export default defineComponent({
 			if (previousId && featureChanged) {
 				map.setFeatureState({ id: previousId, source: '__directus' }, { hovered: false });
 			}
+
 			if (feature && feature.properties) {
 				if (feature.geometry.type === 'Point') {
 					const { x, y } = map.project(feature.geometry.coordinates as LngLatLike);
@@ -286,6 +293,7 @@ export default defineComponent({
 					const { clientX: x, clientY: y } = event.originalEvent;
 					emit('updateitempopup', { position: { x, y } });
 				}
+
 				if (featureChanged) {
 					map.setFeatureState({ id: feature.id, source: '__directus' }, { hovered: true });
 					hoveredFeature.value = feature;

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -71,12 +71,14 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			if (!field) {
 				return;
 			}
+
 			const geometryField = field.field;
 			const geometryFormat = getGeometryFormatForType(field.type);
 			const geometryType = field.type.split('.')[1] ?? field.meta?.options?.geometryType;
 			if (!geometryFormat) {
 				return;
 			}
+
 			return { geometryField, geometryFormat, geometryType } as GeometryOptions;
 		});
 
@@ -133,6 +135,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			if (isGeometryFieldNative.value) {
 				return;
 			}
+
 			if (geojson.value?.features.length) {
 				geojsonBounds.value = cloneDeep(geojson.value.bbox);
 			}
@@ -241,6 +244,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				const field = primaryKeyField.value?.field;
 				update.item = !field ? null : items.value.find((i) => i[field] === update.item) ?? null;
 			}
+
 			itemPopup.value = merge({}, itemPopup.value, update);
 		}
 

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -351,6 +351,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				if (newSort.desc === true) {
 					sortString = '-' + sortString;
 				}
+
 				sort.value = [sortString];
 			}
 

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -295,6 +295,7 @@ function getDisplayValue(item: Item, key: string) {
 		} else {
 			result[key] = item[key];
 		}
+
 		return result;
 	}, {});
 

--- a/app/src/modules/files/components/file-info-sidebar-detail.vue
+++ b/app/src/modules/files/components/file-info-sidebar-detail.vue
@@ -274,6 +274,7 @@ export default defineComponent({
 				if (folder.value === null) {
 					return `/files`;
 				}
+
 				return `/files/folders/${folder.value.id}`;
 			});
 

--- a/app/src/modules/files/components/navigation-folder.vue
+++ b/app/src/modules/files/components/navigation-folder.vue
@@ -269,6 +269,7 @@ export default defineComponent({
 							},
 						});
 					}
+
 					if (newParent) {
 						router.replace(`/files/folders/${newParent}`);
 					} else {

--- a/app/src/modules/insights/components/dashboard-dialog.vue
+++ b/app/src/modules/insights/components/dashboard-dialog.vue
@@ -96,6 +96,7 @@ export default defineComponent({
 					await insightsStore.hydrate();
 					router.push(`/insights/${response.data.data.id}`);
 				}
+
 				emit('update:modelValue', false);
 			} catch (err: any) {
 				unexpectedError(err);

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -214,6 +214,7 @@ export default defineComponent({
 				const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
 				fields.push(...relations.map((field) => field.field));
 			}
+
 			return fields;
 		});
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -274,6 +274,7 @@ export default defineComponent({
 				const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
 				fields.push(...relations.map((field) => field.field));
 			}
+
 			return fields;
 		});
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -148,6 +148,7 @@ export default defineComponent({
 				const relations = relationsStore.getRelationsForCollection(relatedCollection.value);
 				fields.push(...relations.map((field) => field.field));
 			}
+
 			return fields;
 		});
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -361,6 +361,7 @@ export default defineComponent({
 						},
 					];
 				}
+
 				return [];
 			});
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -131,6 +131,7 @@ export default defineComponent({
 				unexpectedError(err);
 				return;
 			}
+
 			router.push(`/settings/data-model/${props.collection}`);
 			fieldDetail.$reset();
 		}

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.test.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 import { useFieldsStore } from '@/stores/fields';

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -177,12 +177,14 @@ export const useFieldDetailStore = defineStore({
 				) {
 					throw new Error('Field key cannot be the same as foreign key');
 				}
+
 				// Track fields used for M2M & M2A
 				if (this.collection === relation.related_collection && relation.meta?.one_field) {
 					aliasesFromRelation.push(`${relation.collection}:${relation.field}`);
 					aliasesFromRelation.push(`${this.collection}:${relation.meta.one_field}`);
 				}
 			}
+
 			// Duplicate field check for M2A
 			const addedFields = Object.values(this.fields)
 				.map((field) => (field && field.collection && field.field ? `${field.collection}:${field.field}` : null))

--- a/app/src/modules/settings/routes/flows/components/arrows.vue
+++ b/app/src/modules/settings/routes/flows/components/arrows.vue
@@ -48,6 +48,7 @@ const size = computed(() => {
 		width = Math.max(width, (panel.x + PANEL_WIDTH) * 20);
 		height = Math.max(height, (panel.y + PANEL_HEIGHT) * 20);
 	}
+
 	if (props.arrowInfo) {
 		width = Math.max(width, props.arrowInfo.pos.x + 10);
 		height = Math.max(height, props.arrowInfo.pos.y + 10);
@@ -123,6 +124,7 @@ const arrows = computed(() => {
 	if (props.arrowInfo) {
 		arrows.push();
 	}
+
 	return arrows;
 
 	function getPoints(panel: Record<string, any>, offset: Vector2, to?: Record<string, any>) {
@@ -176,6 +178,7 @@ const arrows = computed(() => {
 				path += generateCorner(points[i - 1], points[i], points[i + 1]);
 			}
 		}
+
 		const arrowSize = 8;
 		const arrow = `M ${points.at(-1)} L ${points
 			.at(-1)
@@ -223,6 +226,7 @@ const arrows = computed(() => {
 		for (let i = min; i < max; i += step) {
 			points.push(i);
 		}
+
 		points.push(max);
 		return points;
 	}

--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -177,6 +177,7 @@ const operationOptions = computed(() => {
 	} else if (typeof selectedOperation.value?.options === 'object') {
 		return selectedOperation.value.options;
 	}
+
 	return undefined;
 });
 

--- a/app/src/modules/settings/routes/flows/components/operation.vue
+++ b/app/src/modules/settings/routes/flows/components/operation.vue
@@ -289,6 +289,7 @@ function pointerEnter() {
 	if (!props.editMode) return;
 	emit('show-hint', props.panel.id);
 }
+
 function pointerLeave() {
 	if (!props.editMode) return;
 	emit('hide-hint');

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -389,6 +389,7 @@ const parentPanels = computed(() => {
 			if (parent === undefined) return false;
 			parent = parents[parent.id];
 		}
+
 		return true;
 	}
 });
@@ -631,6 +632,7 @@ function arrowStop() {
 		arrowInfo.value = undefined;
 		return;
 	}
+
 	const nearPanel = getNearAttachment(arrowInfo.value?.pos);
 
 	if (nearPanel && isLoop(arrowInfo.value.id, nearPanel)) {
@@ -686,6 +688,7 @@ function getNearAttachment(pos: Vector2) {
 		);
 		if (attachmentPos.distanceTo(pos) <= 40) return panel.id as string;
 	}
+
 	return undefined;
 }
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -297,6 +297,7 @@ export default defineComponent({
 				if (!isNew.value && ['provider', 'external_identifier'].includes(field.field) && !userStore.isAdmin) {
 					field.meta.readonly = true;
 				}
+
 				return !fieldsDenyList.includes(field.field);
 			});
 		});

--- a/app/src/operations/exec/index.test.ts
+++ b/app/src/operations/exec/index.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 import { useServerStore } from '@/stores/server';

--- a/app/src/panels/relational-variable/panel-relational-variable.vue
+++ b/app/src/panels/relational-variable/panel-relational-variable.vue
@@ -79,6 +79,7 @@ function onSelection(data: (number | string)[]) {
 		value.value = [];
 		return;
 	}
+
 	if (props.multiple) {
 		const items = Array.from(new Set(data.concat(value.value)));
 		if (items.length > props.limit) {

--- a/app/src/router.ts
+++ b/app/src/router.ts
@@ -121,6 +121,7 @@ export const onBeforeEach: NavigationGuard = async (to) => {
 				) {
 					return userStore.currentUser.last_page || '/login';
 				}
+
 				return to.fullPath;
 			} else {
 				if (to.fullPath) {

--- a/app/src/routes/accept-invite.vue
+++ b/app/src/routes/accept-invite.vue
@@ -57,6 +57,7 @@ export default defineComponent({
 			if (error.value) {
 				return translateAPIError(error.value);
 			}
+
 			return null;
 		});
 

--- a/app/src/routes/login/components/login-form/ldap-form.vue
+++ b/app/src/routes/login/components/login-form/ldap-form.vue
@@ -70,6 +70,7 @@ export default defineComponent({
 			if (error.value) {
 				return translateAPIError(error.value);
 			}
+
 			return null;
 		});
 

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -76,6 +76,7 @@ export default defineComponent({
 			if (error.value) {
 				return translateAPIError(error.value);
 			}
+
 			return null;
 		});
 

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -75,6 +75,7 @@ export default defineComponent({
 			if (router.currentRoute.value.query.reason && !validReasons.includes(router.currentRoute.value.query.reason)) {
 				return translateAPIError(router.currentRoute.value.query.reason);
 			}
+
 			return null;
 		});
 

--- a/app/src/routes/reset-password/request.vue
+++ b/app/src/routes/reset-password/request.vue
@@ -33,6 +33,7 @@ export default defineComponent({
 			if (error.value) {
 				return translateAPIError(error.value);
 			}
+
 			return null;
 		});
 

--- a/app/src/routes/reset-password/reset.vue
+++ b/app/src/routes/reset-password/reset.vue
@@ -46,6 +46,7 @@ export default defineComponent({
 			if (error.value) {
 				return translateAPIError(error.value);
 			}
+
 			return null;
 		});
 

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -129,6 +129,7 @@ export const useFieldsStore = defineStore({
 				if (i18n.global.te(`fields.${field.collection}.${field.field}`)) {
 					field.name = i18n.global.t(`fields.${field.collection}.${field.field}`);
 				}
+
 				if (field.meta?.note) field.meta.note = translateLiteral(field.meta.note);
 				if (field.meta?.options) field.meta.options = translate(field.meta.options);
 				if (field.meta?.display_options) field.meta.display_options = translate(field.meta.display_options);
@@ -262,6 +263,7 @@ export const useFieldsStore = defineStore({
 				) {
 					return false;
 				}
+
 				return true;
 			});
 

--- a/app/src/stores/insights.ts
+++ b/app/src/stores/insights.ts
@@ -189,12 +189,14 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 			.map(({ options }) => options.field)
 			.filter((fieldName) => typeof fieldName === 'string' && fieldName.length > 0);
 	}
+
 	function hasEmptyRelation(panel: Pick<Panel, 'options' | 'type'>) {
 		const stringOptions = JSON.stringify(panel.options);
 		for (const relationVar of emptyRelations()) {
 			const fieldRegex = new RegExp(`{{\\s*?${escapeStringRegexp(relationVar)}\\s*?}}`);
 			if (fieldRegex.test(stringOptions)) return true;
 		}
+
 		return false;
 	}
 

--- a/app/src/stores/notifications.ts
+++ b/app/src/stores/notifications.ts
@@ -117,6 +117,7 @@ export const useNotificationsStore = defineStore({
 						...updates,
 					};
 				}
+
 				return notification;
 			}
 		},

--- a/app/src/utils/add-related-primary-key-to-fields.test.ts
+++ b/app/src/utils/add-related-primary-key-to-fields.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 import { useFieldsStore } from '@/stores/fields';

--- a/app/src/utils/flatten-field-groups.ts
+++ b/app/src/utils/flatten-field-groups.ts
@@ -13,8 +13,10 @@ export function flattenFieldGroups(tree: FieldNode[]): FieldNode[] {
 					item.children = flattenGroups(item.children);
 				}
 			}
+
 			return item;
 		});
 	}
+
 	return flattenGroups(tree);
 }

--- a/app/src/utils/format-field-function.test.ts
+++ b/app/src/utils/format-field-function.test.ts
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { createI18n } from 'vue-i18n';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 import { useFieldsStore } from '@/stores/fields';

--- a/app/src/utils/geometry/basemap.ts
+++ b/app/src/utils/geometry/basemap.ts
@@ -44,9 +44,11 @@ export function getStyleFromBasemapSource(basemap: BasemapSource): Style | strin
 			source.tiles = expandUrl(basemap.url);
 			source.tileSize = basemap.tileSize || 512;
 		}
+
 		if (basemap.type == 'tile') {
 			source.url = basemap.url;
 		}
+
 		style.layers = [{ id: basemap.name, source: basemap.name, type: 'raster' }];
 		style.sources = { [basemap.name]: source };
 		return style;
@@ -64,8 +66,10 @@ function expandUrl(url: string): string[] {
 		for (charCode = startCharCode; charCode <= stopCharCode; ++charCode) {
 			urls.push(url.replace(match[0], String.fromCharCode(charCode)));
 		}
+
 		return urls;
 	}
+
 	match = /\{(\d+)-(\d+)\}/.exec(url);
 	if (match) {
 		// number range
@@ -73,8 +77,10 @@ function expandUrl(url: string): string[] {
 		for (let i = parseInt(match[1], 10); i <= stop; i++) {
 			urls.push(url.replace(match[0], i.toString()));
 		}
+
 		return urls;
 	}
+
 	match = /\{(([a-z0-9]+)(,([a-z0-9]+))+)\}/.exec(url);
 	if (match) {
 		// csv
@@ -82,8 +88,10 @@ function expandUrl(url: string): string[] {
 		for (const subdomain of subdomains) {
 			urls.push(url.replace(match[0], subdomain));
 		}
+
 		return urls;
 	}
+
 	urls.push(url);
 	return urls;
 }

--- a/app/src/utils/geometry/controls.ts
+++ b/app/src/utils/geometry/controls.ts
@@ -10,22 +10,27 @@ export class ButtonControl {
 		this.element.onpointerdown = callback;
 		this.active = false;
 	}
+
 	click(...args: any[]): void {
 		this.callback(...args);
 	}
+
 	activate(yes: boolean): void {
 		this.element.classList[yes ? 'add' : 'remove']('active');
 		this.active = yes;
 	}
+
 	show(yes: boolean): void {
 		this.element.classList[yes ? 'remove' : 'add']('hidden');
 	}
+
 	onAdd(): HTMLElement {
 		this.groupElement = document.createElement('div');
 		this.groupElement.className = 'mapboxgl-ctrl mapboxgl-ctrl-group';
 		this.groupElement.appendChild(this.element);
 		return this.groupElement;
 	}
+
 	onRemove(): void {
 		this.element.remove();
 		this.groupElement?.remove();
@@ -111,6 +116,7 @@ export class BoxSelectControl {
 		if (event.key == 'Shift') {
 			this.activate(true);
 		}
+
 		if (event.key == 'Escape') {
 			this.reset();
 			this.activate(false);
@@ -134,6 +140,7 @@ export class BoxSelectControl {
 		if (!this.shiftPressed) {
 			return;
 		}
+
 		if (event.button === 0) {
 			this.selecting = true;
 			this.map!.dragPan.disable();
@@ -162,6 +169,7 @@ export class BoxSelectControl {
 		if (!this.active()) {
 			return;
 		}
+
 		const features = this.map!.queryRenderedFeatures([this.startPos!, this.lastPos!], {
 			layers: this.layers,
 		});

--- a/app/src/utils/geometry/index.ts
+++ b/app/src/utils/geometry/index.ts
@@ -106,9 +106,11 @@ export function toGeoJSON(entries: any[], options: GeometryOptions): FeatureColl
 		const feature = { type: 'Feature', properties, geometry };
 		geojson.features.push(feature as Feature);
 	}
+
 	if (geojson.features.length == 0) {
 		delete geojson.bbox;
 	}
+
 	return geojson;
 }
 
@@ -117,9 +119,11 @@ export function flatten(geometry?: AnyGeometry): SimpleGeometry[] {
 	if (geometry.type == 'GeometryCollection') {
 		return geometry.geometries.flatMap(flatten);
 	}
+
 	if (geometry.type.startsWith('Multi')) {
 		const type = geometry.type.replace('Multi', '');
 		return (geometry.coordinates as any).map((coordinates: any) => ({ type, coordinates } as SimpleGeometry));
 	}
+
 	return [geometry as SimpleGeometry];
 }

--- a/app/src/utils/get-default-values-from-fields.ts
+++ b/app/src/utils/get-default-values-from-fields.ts
@@ -15,6 +15,7 @@ export function getDefaultValuesFromFields(fields: Field[] | Ref<Field[]>): Comp
 			) {
 				acc[field.field] = field.schema.default_value;
 			}
+
 			return acc;
 		}, {} as Record<string, any>);
 	});

--- a/app/src/utils/get-local-type.test.ts
+++ b/app/src/utils/get-local-type.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 beforeEach(() => {

--- a/app/src/utils/get-local-type.ts
+++ b/app/src/utils/get-local-type.ts
@@ -34,6 +34,7 @@ export function getLocalTypeForField(collection: string, field: string): LocalTy
 		if ((fieldInfo.meta?.special || []).includes('translations')) {
 			return 'translations';
 		}
+
 		if ((fieldInfo.meta?.special || []).includes('m2a')) {
 			return 'm2a';
 		}

--- a/app/src/utils/get-related-collection.test.ts
+++ b/app/src/utils/get-related-collection.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 beforeEach(() => {

--- a/app/src/utils/get-theme.test.ts
+++ b/app/src/utils/get-theme.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
 import { cryptoStub } from '@/__utils__/crypto';
+
 vi.stubGlobal('crypto', cryptoStub);
 
 beforeEach(() => {

--- a/app/src/utils/get-vue-component-name.ts
+++ b/app/src/utils/get-vue-component-name.ts
@@ -15,5 +15,6 @@ export function getVueComponentName(vm: ComponentPublicInstance | null): string 
 		const match = file.match(/([^/\\]+)\.vue$/);
 		name = match && match[1];
 	}
+
 	return name ? kebabCase(name) : `component`;
 }

--- a/app/src/utils/validate-item.test.ts
+++ b/app/src/utils/validate-item.test.ts
@@ -52,6 +52,7 @@ beforeEach(() => {
 				if (field === 'role') {
 					return [{ some: 'relation' }];
 				}
+
 				return [];
 			},
 		})

--- a/app/src/utils/vector2.ts
+++ b/app/src/utils/vector2.ts
@@ -25,6 +25,7 @@ export class Vector2 {
 			this.x *= val;
 			this.y *= val;
 		}
+
 		return this;
 	}
 
@@ -62,6 +63,7 @@ export class Vector2 {
 	static from(vector: { x: number; y: number }) {
 		return new Vector2(vector.x, vector.y);
 	}
+
 	static fromMany(...vectors: { x: number; y: number }[]) {
 		return vectors.map(Vector2.from);
 	}

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -197,6 +197,7 @@ const fields = computed(() => {
 			if (field.field === props.circularField) {
 				set(field, 'meta.readonly', true);
 			}
+
 			return field;
 		});
 	} else {

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -375,6 +375,7 @@ const getItemCount = debounce(async () => {
 				if (response.data.data?.[0]?.count) {
 					return Number(response.data.data[0].count);
 				}
+
 				if (response.data.data?.[0]?.countDistinct) {
 					return Number(response.data.data[0].countDistinct[primaryKeyField.value!.field]);
 				}

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -118,6 +118,7 @@ const isConfirmButtonDisabled = computed(() => {
 			return true;
 		}
 	}
+
 	return false;
 });
 

--- a/app/src/views/private/components/folder-picker.vue
+++ b/app/src/views/private/components/folder-picker.vue
@@ -106,6 +106,7 @@ export default defineComponent({
 				startOpenFolders.push(folderID);
 			}
 		}
+
 		const selectedFolder = computed(() => {
 			return folders.value.find((folder) => folder.id === props.modelValue) || {};
 		});

--- a/app/src/views/private/components/refresh-sidebar-detail.vue
+++ b/app/src/views/private/components/refresh-sidebar-detail.vue
@@ -41,6 +41,7 @@ export default defineComponent({
 				if (activeInterval.value !== null) {
 					clearInterval(activeInterval.value);
 				}
+
 				if (newInterval !== null && newInterval > 0) {
 					activeInterval.value = setInterval(() => {
 						emit('refresh');

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -59,6 +59,7 @@ export default defineComponent({
 			if (data.value.avatar?.id) {
 				return `/assets/${data.value.avatar.id}?key=system-medium-cover`;
 			}
+
 			return null;
 		});
 

--- a/packages/composables/src/use-filter-fields.ts
+++ b/packages/composables/src/use-filter-fields.ts
@@ -16,6 +16,7 @@ export function useFilterFields<T extends string>(
 				if (filters[name](field) === false) continue;
 				acc[name].push(field);
 			}
+
 			return acc;
 		}, acc);
 	});

--- a/packages/composables/src/use-items.test.ts
+++ b/packages/composables/src/use-items.test.ts
@@ -26,10 +26,12 @@ function isGetItemsRequest(config: AxiosRequestConfig) {
 	if (!config.params) return false;
 	return Object.keys(config.params).includes('fields');
 }
+
 function isTotalCountRequest(config: AxiosRequestConfig) {
 	if (!config.params) return false;
 	return isEqual(Object.keys(config.params), ['aggregate']);
 }
+
 function isFilterCountRequest(config: AxiosRequestConfig) {
 	if (!config.params) return false;
 	return isEqual(Object.keys(config.params), ['filter', 'search', 'aggregate']);

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -284,6 +284,7 @@ function getLanguageFromEntries(entries: ExtensionOptionsBundleEntry[]): Languag
 				log(`App language ${chalk.bold(languageApp)} is not supported.`, 'error');
 				process.exit(1);
 			}
+
 			if (!isLanguage(languageApi)) {
 				log(`API language ${chalk.bold(languageApi)} is not supported.`, 'error');
 				process.exit(1);

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -140,6 +140,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 			log(`Extension entrypoint has to be specified using the ${chalk.blue('[-i, --input <file>]')} option.`, 'error');
 			process.exit(1);
 		}
+
 		if (!output) {
 			log(
 				`Extension output file has to be specified using the ${chalk.blue('[-o, --output <file>]')} option.`,
@@ -161,6 +162,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				);
 				process.exit(1);
 			}
+
 			if (!validateSplitEntrypointOption(splitOutput)) {
 				log(
 					`Output option needs to be of the format ${chalk.blue(
@@ -192,6 +194,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				);
 				process.exit(1);
 			}
+
 			if (!validateSplitEntrypointOption(splitOutput)) {
 				log(
 					`Output option needs to be of the format ${chalk.blue(
@@ -292,6 +295,7 @@ async function buildHybridExtension({
 		log(`App entrypoint ${chalk.bold(inputApp)} does not exist.`, 'error');
 		process.exit(1);
 	}
+
 	if (!(await fse.pathExists(inputApi)) || !(await fse.stat(inputApi)).isFile()) {
 		log(`API entrypoint ${chalk.bold(inputApi)} does not exist.`, 'error');
 		process.exit(1);
@@ -301,6 +305,7 @@ async function buildHybridExtension({
 		log(`App output file can not be empty.`, 'error');
 		process.exit(1);
 	}
+
 	if (outputApi.length === 0) {
 		log(`API output file can not be empty.`, 'error');
 		process.exit(1);
@@ -313,6 +318,7 @@ async function buildHybridExtension({
 		log(`App language ${chalk.bold(languageApp)} is not supported.`, 'error');
 		process.exit(1);
 	}
+
 	if (!isLanguage(languageApi)) {
 		log(`API language ${chalk.bold(languageApi)} is not supported.`, 'error');
 		process.exit(1);
@@ -371,6 +377,7 @@ async function buildBundleExtension({
 		log(`App output file can not be empty.`, 'error');
 		process.exit(1);
 	}
+
 	if (outputApi.length === 0) {
 		log(`API output file can not be empty.`, 'error');
 		process.exit(1);
@@ -388,6 +395,7 @@ async function buildBundleExtension({
 				log(`App entrypoint ${chalk.bold(inputApp)} does not exist.`, 'error');
 				process.exit(1);
 			}
+
 			if (!(await fse.pathExists(inputApi)) || !(await fse.stat(inputApi)).isFile()) {
 				log(`API entrypoint ${chalk.bold(inputApi)} does not exist.`, 'error');
 				process.exit(1);
@@ -400,6 +408,7 @@ async function buildBundleExtension({
 				log(`App language ${chalk.bold(languageApp)} is not supported.`, 'error');
 				process.exit(1);
 			}
+
 			if (!isLanguage(languageApi)) {
 				log(`API language ${chalk.bold(languageApi)} is not supported.`, 'error');
 				process.exit(1);
@@ -532,6 +541,7 @@ async function watchExtension(config: RollupConfig | RollupConfig[]) {
 						spinner.succeed(chalk.bold('Done'));
 						log(chalk.bold.green('Watching files for changes...'));
 					}
+
 					break;
 				case 'ERROR': {
 					buildCount--;
@@ -542,6 +552,7 @@ async function watchExtension(config: RollupConfig | RollupConfig[]) {
 					if (buildCount > 0) {
 						spinner.start();
 					}
+
 					break;
 				}
 			}

--- a/packages/schema/src/dialects/cockroachdb.ts
+++ b/packages/schema/src/dialects/cockroachdb.ts
@@ -195,15 +195,18 @@ export default class CockroachDB implements SchemaInspector {
 			if (column.table_name in overview === false) {
 				overview[column.table_name] = { columns: {}, primary: <any>undefined };
 			}
+
 			if (['point', 'polygon'].includes(column.data_type)) {
 				column.data_type = 'unknown';
 			}
+
 			overview[column.table_name]!.columns[column.column_name] = column;
 		}
 
 		for (const { table_name, column_name } of primaryKeys) {
 			overview[table_name]!.primary = column_name;
 		}
+
 		for (const { table_name, column_name, data_type } of geometryColumns) {
 			overview[table_name]!.columns[column_name]!.data_type = data_type;
 		}

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -190,15 +190,18 @@ export default class Postgres implements SchemaInspector {
 			if (column.table_name in overview === false) {
 				overview[column.table_name] = { columns: {}, primary: <any>undefined };
 			}
+
 			if (['point', 'polygon'].includes(column.data_type)) {
 				column.data_type = 'unknown';
 			}
+
 			overview[column.table_name]!.columns[column.column_name] = column;
 		}
 
 		for (const { table_name, column_name } of primaryKeys) {
 			overview[table_name]!.primary = column_name;
 		}
+
 		for (const { table_name, column_name, data_type } of geometryColumns) {
 			overview[table_name]!.columns[column_name]!.data_type = data_type;
 		}

--- a/packages/schema/src/dialects/sqlite.ts
+++ b/packages/schema/src/dialects/sqlite.ts
@@ -71,6 +71,7 @@ export default class SQLite implements SchemaInspector {
 				};
 			}
 		}
+
 		return overview;
 	}
 
@@ -228,6 +229,7 @@ export default class SQLite implements SchemaInspector {
 		if (resultsVal !== 0) {
 			isColumn = true;
 		}
+
 		return isColumn;
 	}
 

--- a/packages/types/src/flows.ts
+++ b/packages/types/src/flows.ts
@@ -1,4 +1,5 @@
 export type TriggerType = 'event' | 'schedule' | 'operation' | 'webhook' | 'manual';
+
 type Status = 'active' | 'inactive';
 
 export interface Flow {

--- a/packages/utils/shared/deep-map.test.ts
+++ b/packages/utils/shared/deep-map.test.ts
@@ -5,6 +5,7 @@ describe('deepMap', () => {
 	const mockIterator = (val: any, _key: string | number) => {
 		return `Test ${val}`;
 	};
+
 	it('returns an object mapped where values are the return of the iterator', () => {
 		const mockObject = { _and: [{ field: { _eq: 'field' } }] };
 		expect(deepMap(mockObject, mockIterator)).toStrictEqual({ _and: [{ field: { _eq: 'Test field' } }] });

--- a/packages/utils/shared/define-extension.test.ts
+++ b/packages/utils/shared/define-extension.test.ts
@@ -17,6 +17,7 @@ const mockComponent = defineComponent({});
 const mockHandler = () => {
 	return '';
 };
+
 describe('define-extensions', () => {
 	const types = [] as readonly Type[];
 	const mockRecord = () => {
@@ -59,6 +60,7 @@ describe('define-extensions', () => {
 	const hookHandler = () => {
 		return { test: (..._values: any[]) => undefined };
 	};
+
 	const endpointConfig = { id: '1', handler: mockHandler };
 
 	const operationAppConfig = {

--- a/packages/utils/shared/generate-joi.ts
+++ b/packages/utils/shared/generate-joi.ts
@@ -31,6 +31,7 @@ export const Joi: typeof BaseJoi = BaseJoi.extend({
 				if (value.includes(substring) === false) {
 					return helpers.error('string.contains', { substring });
 				}
+
 				return value;
 			},
 		},

--- a/packages/utils/shared/parse-filter-function-path.ts
+++ b/packages/utils/shared/parse-filter-function-path.ts
@@ -20,5 +20,6 @@ export function parseFilterFunctionPath(path: string): string {
 			return `${preColumns}${columns}${functionName}(${field})`;
 		}
 	}
+
 	return path;
 }

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -22,6 +22,7 @@ export function parseFilter(
 	if (parsedFilter) {
 		parsedFilter = shiftLogicalOperatorsUp(parsedFilter);
 	}
+
 	return parsedFilter;
 }
 
@@ -36,6 +37,7 @@ function shiftLogicalOperatorsUp(filter: any): any {
 		for (const childKey of Object.keys(filter[key])) {
 			filter[key][childKey] = shiftLogicalOperatorsUp(filter[key][childKey]);
 		}
+
 		return filter;
 	} else {
 		const childKey = Object.keys(filter[key])[0];

--- a/packages/utils/shared/validate-payload.ts
+++ b/packages/utils/shared/validate-payload.ts
@@ -44,6 +44,7 @@ export function validatePayload(
 				swallowErrors.push(...nestedErrors);
 				return false;
 			}
+
 			return true;
 		});
 

--- a/tests/blackbox/common/functions.ts
+++ b/tests/blackbox/common/functions.ts
@@ -86,6 +86,7 @@ export async function CreateUser(vendor: string, options: Partial<OptionsCreateU
 	if (!options.token) {
 		throw new Error('Missing required field: token');
 	}
+
 	if (!options.email) {
 		throw new Error('Missing required field: email');
 	}

--- a/tests/blackbox/common/seed-functions.ts
+++ b/tests/blackbox/common/seed-functions.ts
@@ -176,9 +176,11 @@ function generateString(options: OptionsSeedGenerateString) {
 		if (options.startsWith) {
 			value = options.startsWith + value;
 		}
+
 		if (options.endsWith) {
 			value = value + options.endsWith;
 		}
+
 		values.push(value);
 	}
 

--- a/tests/blackbox/query/filter/index.ts
+++ b/tests/blackbox/query/filter/index.ts
@@ -212,12 +212,14 @@ function processValidation(
 					continue;
 				}
 			}
+
 			if (assert) {
 				if (data.length === 0) {
 					if (filter.emptyAllowedFunction(filter.value, possibleValues)) {
 						expect(true).toBe(true);
 						return false;
 					}
+
 					expect(found).toBe(true);
 					return false;
 				} else {
@@ -254,11 +256,13 @@ function processValidation(
 					break;
 				}
 			}
+
 			if (assert) {
 				if (filter.emptyAllowedFunction(filter.value, possibleValues)) {
 					expect(true).toBe(true);
 					return true;
 				}
+
 				expect(found).toBe(true);
 				return true;
 			} else {

--- a/tests/blackbox/routes/fields/crud.test.ts
+++ b/tests/blackbox/routes/fields/crud.test.ts
@@ -427,6 +427,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/fields', (pkType) => {
 							} else {
 								expect(response.statusCode).toBe(403);
 							}
+
 							expect(response2.statusCode).toBe(403);
 						});
 					});
@@ -458,6 +459,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/fields', (pkType) => {
 							} else {
 								expect(response.statusCode).toBe(403);
 							}
+
 							expect(response2.statusCode).toBe(403);
 						});
 					});

--- a/tests/blackbox/routes/items/m2a.test.ts
+++ b/tests/blackbox/routes/items/m2a.test.ts
@@ -1053,6 +1053,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 										lastIndex = foundIndex;
 									}
 								}
+
 								return;
 							}
 
@@ -1500,6 +1501,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 										lastIndex = foundIndex;
 									}
 								}
+
 								return;
 							}
 

--- a/tests/blackbox/routes/items/m2m.test.ts
+++ b/tests/blackbox/routes/items/m2m.test.ts
@@ -857,6 +857,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 										lastIndex = foundIndex;
 									}
 								}
+
 								return;
 							}
 
@@ -1298,6 +1299,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 										lastIndex = foundIndex;
 									}
 								}
+
 								return;
 							}
 

--- a/tests/blackbox/routes/items/m2o.test.ts
+++ b/tests/blackbox/routes/items/m2o.test.ts
@@ -1256,6 +1256,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 									if (i >= countCreate) {
 										state.country_id = createCountry(pkType);
 									}
+
 									statesID.push((await CreateItem(vendor, { collection: localCollectionStates, item: state })).id);
 
 									const state2: any = createState(pkType);
@@ -1263,6 +1264,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 									if (i >= countCreate) {
 										state2.country_id = createCountry(pkType);
 									}
+
 									statesID2.push((await CreateItem(vendor, { collection: localCollectionStates, item: state2 })).id);
 								}
 
@@ -1342,6 +1344,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 									if (i >= countCreate) {
 										state.country_id = createCountry(pkType);
 									}
+
 									statesID.push((await CreateItem(vendor, { collection: localCollectionStates, item: state })).id);
 
 									const state2: any = createState(pkType);
@@ -1349,6 +1352,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 									if (i >= countCreate) {
 										state2.country_id = createCountry(pkType);
 									}
+
 									statesID2.push((await CreateItem(vendor, { collection: localCollectionStates, item: state2 })).id);
 								}
 

--- a/tests/blackbox/routes/items/no-relation.test.ts
+++ b/tests/blackbox/routes/items/no-relation.test.ts
@@ -106,6 +106,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 								} else {
 									expect(gqlResponse.body.errors).toBeDefined();
 								}
+
 								break;
 							default:
 								if (pkType !== 'integer') {
@@ -113,6 +114,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 								} else {
 									expect(gqlResponse.body.errors).toBeDefined();
 								}
+
 								break;
 						}
 					});
@@ -264,6 +266,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 					for (let i = 0; i < artistsCount; i++) {
 						artists.push(createArtist(pkType));
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action
@@ -483,6 +486,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 							name: 'Johnny Cash',
 						});
 					}
+
 					expect(response.body.data.length).toBe(keys.length);
 
 					expect(gqlResponse.statusCode).toEqual(200);
@@ -491,6 +495,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 							name: 'updated',
 						});
 					}
+
 					expect(gqlResponse.body.data[mutationKey].length).toBe(keys.length);
 				});
 			});
@@ -619,6 +624,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.company = artistCompany;
 						artists.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action
@@ -667,12 +673,14 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.name = artistName;
 						artists1.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists1 });
 					for (let i = 0; i < count; i++) {
 						const artist = createArtist(pkType);
 						artist.company = artistCompany;
 						artists2.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists2 });
 
 					// Action
@@ -721,6 +729,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.name = artistName;
 						artists.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action
@@ -776,6 +785,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.name = artistName;
 						artists.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action
@@ -831,6 +841,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.name = `${i}-${artistName}`;
 						artists.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action
@@ -930,6 +941,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.name = `${i}-${artistName}`;
 						artists.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action
@@ -1049,6 +1061,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						artist.name = `${i}-${artistName}`;
 						artists.push(artist);
 					}
+
 					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
 
 					// Action

--- a/tests/blackbox/routes/items/o2m.test.ts
+++ b/tests/blackbox/routes/items/o2m.test.ts
@@ -828,6 +828,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 										lastIndex = foundIndex;
 									}
 								}
+
 								return;
 							}
 
@@ -1255,6 +1256,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 										lastIndex = foundIndex;
 									}
 								}
+
 								return;
 							}
 

--- a/tests/blackbox/routes/items/singleton.test.ts
+++ b/tests/blackbox/routes/items/singleton.test.ts
@@ -188,6 +188,7 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 							seed: `${localCollectionSingletonO2M}_update_o2m2`,
 						})[0];
 					}
+
 					updatedO2M.push(newO2mItem);
 					updatedO2M[0].name = o2mNameUpdated2;
 

--- a/tests/blackbox/schema/big-integer/index.ts
+++ b/tests/blackbox/schema/big-integer/index.ts
@@ -162,6 +162,7 @@ const _eq = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) === possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -169,6 +170,7 @@ const _neq = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) !== possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -176,6 +178,7 @@ const _lt = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) < possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -183,6 +186,7 @@ const _lte = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) <= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -190,6 +194,7 @@ const _gt = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) > possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -197,6 +202,7 @@ const _gte = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) >= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -204,6 +210,7 @@ const _between = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) >= possibleValues[0] && BigInt(inputValue) <= possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -211,6 +218,7 @@ const _nbetween = (inputValue: any, possibleValues: any): boolean => {
 	if (BigInt(inputValue) < possibleValues[0] || BigInt(inputValue) > possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -218,6 +226,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -225,6 +234,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -232,6 +242,7 @@ const _in = (inputValue: any, possibleValues: any): boolean => {
 	if (possibleValues.includes(BigInt(inputValue))) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -239,6 +250,7 @@ const _nin = (inputValue: any, possibleValues: any): boolean => {
 	if (!possibleValues.includes(BigInt(inputValue))) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -270,6 +282,7 @@ const empty_lt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return BigInt(inputValue) >= possibleValues;
@@ -283,6 +296,7 @@ const empty_gt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return BigInt(inputValue) <= possibleValues;
@@ -296,6 +310,7 @@ const empty_nbetween = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return BigInt(inputValue[0]) >= possibleValues && BigInt(inputValue[1]) <= possibleValues;

--- a/tests/blackbox/schema/boolean/index.ts
+++ b/tests/blackbox/schema/boolean/index.ts
@@ -83,6 +83,7 @@ const _eq = (inputValue: any, possibleValues: any): boolean => {
 	} else if (inputValue === false || inputValue === 0 || inputValue === '0') {
 		return possibleValues === false;
 	}
+
 	return false;
 };
 
@@ -90,6 +91,7 @@ const _neq = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue !== possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -97,6 +99,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -104,6 +107,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 

--- a/tests/blackbox/schema/date-time/index.ts
+++ b/tests/blackbox/schema/date-time/index.ts
@@ -166,6 +166,7 @@ const _eq = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue === possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -176,6 +177,7 @@ const _neq = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue !== possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -186,6 +188,7 @@ const _lt = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue < possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -196,6 +199,7 @@ const _lte = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue <= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -206,6 +210,7 @@ const _gt = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue > possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -216,6 +221,7 @@ const _gte = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue >= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -226,6 +232,7 @@ const _between = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue >= possibleValues[0] && inputValue <= possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -236,6 +243,7 @@ const _nbetween = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue < possibleValues[0] || inputValue > possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -243,6 +251,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -250,6 +259,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -326,6 +336,7 @@ const empty_gt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		possibleValues = parseDatetimeString(possibleValues);
@@ -344,6 +355,7 @@ const empty_nbetween = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		possibleValues = [parseDatetimeString(possibleValues[0]), parseDatetimeString(possibleValues[1])];

--- a/tests/blackbox/schema/float/index.ts
+++ b/tests/blackbox/schema/float/index.ts
@@ -169,6 +169,7 @@ const _eq = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) === possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -176,6 +177,7 @@ const _neq = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) !== possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -183,6 +185,7 @@ const _lt = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) < possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -190,6 +193,7 @@ const _lte = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) <= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -197,6 +201,7 @@ const _gt = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) > possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -204,6 +209,7 @@ const _gte = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) >= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -211,6 +217,7 @@ const _between = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) >= possibleValues[0] && Number(inputValue) <= possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -218,6 +225,7 @@ const _nbetween = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) < possibleValues[0] || Number(inputValue) > possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -225,6 +233,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -232,6 +241,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -239,6 +249,7 @@ const _in = (inputValue: any, possibleValues: any): boolean => {
 	if (possibleValues.includes(Number(inputValue))) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -246,6 +257,7 @@ const _nin = (inputValue: any, possibleValues: any): boolean => {
 	if (!possibleValues.includes(Number(inputValue))) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -279,6 +291,7 @@ const empty_lt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return Number(inputValue) >= possibleValues;
@@ -292,6 +305,7 @@ const empty_gt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return Number(inputValue) <= possibleValues;
@@ -305,6 +319,7 @@ const empty_nbetween = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return Number(inputValue[0]) >= possibleValues && Number(inputValue[1]) <= possibleValues;
@@ -318,6 +333,7 @@ const empty_null = (_inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return possibleValues !== null;

--- a/tests/blackbox/schema/geometry/index.ts
+++ b/tests/blackbox/schema/geometry/index.ts
@@ -58,6 +58,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -65,6 +66,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 

--- a/tests/blackbox/schema/integer/index.ts
+++ b/tests/blackbox/schema/integer/index.ts
@@ -163,6 +163,7 @@ const _eq = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) === possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -170,6 +171,7 @@ const _neq = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) !== possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -177,6 +179,7 @@ const _lt = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) < possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -184,6 +187,7 @@ const _lte = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) <= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -191,6 +195,7 @@ const _gt = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) > possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -198,6 +203,7 @@ const _gte = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) >= possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -205,6 +211,7 @@ const _between = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) >= possibleValues[0] && Number(inputValue) <= possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -212,6 +219,7 @@ const _nbetween = (inputValue: any, possibleValues: any): boolean => {
 	if (Number(inputValue) < possibleValues[0] || Number(inputValue) > possibleValues[1]) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -219,6 +227,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -226,6 +235,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -233,6 +243,7 @@ const _in = (inputValue: any, possibleValues: any): boolean => {
 	if (possibleValues.includes(Number(inputValue))) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -240,6 +251,7 @@ const _nin = (inputValue: any, possibleValues: any): boolean => {
 	if (!possibleValues.includes(Number(inputValue))) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -273,6 +285,7 @@ const empty_lt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return Number(inputValue) >= possibleValues;
@@ -286,6 +299,7 @@ const empty_gt = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return Number(inputValue) <= possibleValues;
@@ -299,6 +313,7 @@ const empty_nbetween = (inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return Number(inputValue[0]) >= possibleValues && Number(inputValue[1]) <= possibleValues;
@@ -312,6 +327,7 @@ const empty_null = (_inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return possibleValues !== null;

--- a/tests/blackbox/schema/json/index.ts
+++ b/tests/blackbox/schema/json/index.ts
@@ -50,6 +50,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -57,6 +58,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 

--- a/tests/blackbox/schema/string/index.ts
+++ b/tests/blackbox/schema/string/index.ts
@@ -145,6 +145,7 @@ const _contains = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue.includes(possibleValues)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -152,6 +153,7 @@ const _ncontains = (inputValue: any, possibleValues: any): boolean => {
 	if (!inputValue.includes(possibleValues)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -159,6 +161,7 @@ const _icontains = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue.toLowerCase().includes(possibleValues.toLowerCase())) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -166,6 +169,7 @@ const _nicontains = (inputValue: any, possibleValues: any): boolean => {
 	if (!inputValue.toLowerCase().includes(possibleValues.toLowerCase())) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -173,6 +177,7 @@ const _starts_with = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue.startsWith(possibleValues)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -180,6 +185,7 @@ const _nstarts_with = (inputValue: any, possibleValues: any): boolean => {
 	if (!inputValue.startsWith(possibleValues)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -187,6 +193,7 @@ const _ends_with = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue.endsWith(possibleValues)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -194,6 +201,7 @@ const _nends_with = (inputValue: any, possibleValues: any): boolean => {
 	if (!inputValue.endsWith(possibleValues)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -201,6 +209,7 @@ const _eq = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue === possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -208,6 +217,7 @@ const _neq = (inputValue: any, possibleValues: any): boolean => {
 	if (inputValue !== possibleValues) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -215,6 +225,7 @@ const _empty = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === '') {
 		return true;
 	}
+
 	return _null(inputValue, _possibleValues);
 };
 
@@ -222,6 +233,7 @@ const _nempty = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== '') {
 		return true;
 	}
+
 	return _nnull(inputValue, _possibleValues);
 };
 
@@ -229,6 +241,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -236,6 +249,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -243,6 +257,7 @@ const _in = (inputValue: any, possibleValues: any): boolean => {
 	if (possibleValues.includes(inputValue)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -250,6 +265,7 @@ const _nin = (inputValue: any, possibleValues: any): boolean => {
 	if (!possibleValues.includes(inputValue)) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -279,6 +295,7 @@ const empty_empty = (_inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return possibleValues !== '';
@@ -292,6 +309,7 @@ const empty_null = (_inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return possibleValues !== null;

--- a/tests/blackbox/schema/uuid/index.ts
+++ b/tests/blackbox/schema/uuid/index.ts
@@ -140,6 +140,7 @@ const _null = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue === undefined || inputValue === null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -147,6 +148,7 @@ const _nnull = (inputValue: any, _possibleValues: any): boolean => {
 	if (inputValue !== undefined && inputValue !== null) {
 		return true;
 	}
+
 	return false;
 };
 
@@ -160,6 +162,7 @@ const _in = (inputValue: any, possibleValues: any): boolean => {
 			}
 		}
 	}
+
 	return false;
 };
 
@@ -173,6 +176,7 @@ const _nin = (inputValue: any, possibleValues: any): boolean => {
 			}
 		}
 	}
+
 	return true;
 };
 
@@ -200,6 +204,7 @@ const empty_null = (_inputValue: any, possibleValues: any): boolean => {
 				return false;
 			}
 		}
+
 		return true;
 	} else {
 		return possibleValues !== null;

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -36,10 +36,12 @@ exports.getReversedTestIndex = function (testFilePath) {
 			return index;
 		}
 	}
+
 	for (let index = 0; index < this.list.after.length; index++) {
 		if (testFilePath.includes(this.list.after[index].testFilePath)) {
 			return 0 - this.list.after.length + index;
 		}
 	}
+
 	return this.list.before.length;
 };

--- a/tests/blackbox/setup/setup.ts
+++ b/tests/blackbox/setup/setup.ts
@@ -37,6 +37,7 @@ export default async (): Promise<void> => {
 								if (vendor === 'sqlite3') {
 									writeFileSync(path.join(paths.cwd, 'test.db'), '');
 								}
+
 								const bootstrap = spawnSync('node', [paths.cli, 'bootstrap'], {
 									cwd: paths.cwd,
 									env: config.envs[vendor],
@@ -44,6 +45,7 @@ export default async (): Promise<void> => {
 								if (bootstrap.stderr.length > 0) {
 									throw new Error(`Directus-${vendor} bootstrap failed: \n ${bootstrap.stderr.toString()}`);
 								}
+
 								await database.migrate.latest();
 								await database.seed.run();
 								await database.destroy();
@@ -63,6 +65,7 @@ export default async (): Promise<void> => {
 										if (process.env.TEST_SAVE_LOGS) {
 											writeFileSync(path.join(paths.cwd, `server-log-${vendor}.txt`), serverOutput);
 										}
+
 										if (code !== null) throw new Error(`Directus-${vendor} server failed: \n ${serverOutput}`);
 									});
 									// Give the server some time to start
@@ -84,6 +87,7 @@ export default async (): Promise<void> => {
 										if (process.env.TEST_SAVE_LOGS) {
 											writeFileSync(__dirname + `/../server-log-${vendor}-no-cache.txt`, serverNoCacheOutput);
 										}
+
 										if (code !== null)
 											throw new Error(`Directus-${vendor}-no-cache server failed: \n ${serverNoCacheOutput}`);
 									});
@@ -154,9 +158,11 @@ export default async (): Promise<void> => {
 			for (const server of Object.values(global.directus)) {
 				server?.kill();
 			}
+
 			for (const serverNoCache of Object.values(global.directusNoCache)) {
 				serverNoCache?.kill();
 			}
+
 			throw new Error(reason);
 		});
 

--- a/tests/blackbox/utils/await-connection.ts
+++ b/tests/blackbox/utils/await-connection.ts
@@ -12,6 +12,7 @@ export async function awaitDatabaseConnection(database: Knex, checkSQL: string):
 			continue;
 		}
 	}
+
 	throw new Error(`Couldn't connect to DB`);
 }
 
@@ -25,5 +26,6 @@ export async function awaitDirectusConnection(port: number): Promise<void | null
 			continue;
 		}
 	}
+
 	throw new Error(`Couldn't connect to Directus`);
 }

--- a/tests/blackbox/utils/prepare-request.ts
+++ b/tests/blackbox/utils/prepare-request.ts
@@ -15,8 +15,10 @@ export const PrepareRequest = (vendor: string, requestOptions: RequestOptions) =
 	if (requestOptions.token) {
 		req.set('Authorization', `Bearer ${requestOptions.token}`);
 	}
+
 	if (requestOptions.body) {
 		req.send(requestOptions.body);
 	}
+
 	return req;
 };


### PR DESCRIPTION
Enforce white line usage to keep code style consistent. This effectively makes sure that blocks like:

```js
const a = 1;
const b = 2;
let c;
if (c) {
    c = 'example';
}
return a + b;
```

are enforced to be written as:

```js
const a = 1;
const b = 2;
let c;

if (c) {
    c = 'example';
}

return a + b;
```