### PR TITLE
Use import.meta.url instead of __dirname

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
@@ -1,12 +1,14 @@
 import { pathToRelativeUrl } from '@directus/utils/node';
 import fse from 'fs-extra';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import type { Config } from '../../types.js';
 
 const CONFIG_FILE_NAMES = ['extension.config.js', 'extension.config.mjs', 'extension.config.cjs'];
 
 // This is needed to work around Typescript always transpiling import() to require() for CommonJS targets.
 const _import = new Function('url', 'return import(url)');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default async function loadConfig(): Promise<Config> {
 	for (const fileName of CONFIG_FILE_NAMES) {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

`__dirname` doesn't work in ES modules.

Fixes #18201.

I verified that I can build my extension with this fix in the recent SDK version.
