### PR TITLE
Publish all types from packages/*

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,15 +7,5 @@ charset = utf-8
 indent_style = tab
 trim_trailing_whitespace = true
 
-[{*.yml,*.yaml}]
+[*.{yml,yaml}]
 indent_style = space
-indent_size = 2
-
-[package.json]
-indent_size = 2
-
-[Dockerfile]
-indent_style = tab
-
-[Makefile]
-indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,11 @@ charset = utf-8
 indent_style = tab
 trim_trailing_whitespace = true
 
-[{package.json,*.yml,*.yaml}]
+[{*.yml,*.yaml}]
 indent_style = space
+indent_size = 2
+
+[package.json]
 indent_size = 2
 
 [Dockerfile]

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,5 @@ module.exports = {
 	htmlWhitespaceSensitivity: 'ignore',
 	printWidth: 120,
 	singleQuote: true,
-	useTabs: true,
 	proseWrap: 'always',
 };

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -17,17 +17,13 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
+		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
-		"!**/*.d.ts.map"
+		"!**/*.test.{js,d.ts}"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -17,12 +17,15 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"!**/*.d.ts.map"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -23,6 +23,8 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"!**/*.d.ts.map"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -16,13 +16,15 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
 	"files": [
 		"dist",
-		"!**/*.d.ts?(.map)"
+		"!**/*.d.ts.map"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -22,6 +22,8 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"!**/*.d.ts.map"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -16,17 +16,12 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
+		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
-		"dist",
-		"!**/*.d.ts.map"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -17,13 +17,15 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
 	"files": [
 		"dist",
-		"!**/*.d.ts?(.map)"
+		"!**/*.d.ts.map"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -17,17 +17,13 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
+		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
-		"!**/*.d.ts.map"
+		"!**/*.test.{js,d.ts}"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -23,6 +23,8 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"!**/*.d.ts.map"

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -15,22 +15,18 @@
 	"funding": "https://github.com/directus/directus?sponsor=1",
 	"author": "Nicola Krumschmidt",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
+		".": "./dist/index.js",
 		"./cli": "./dist/cli/index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"bin": {
 		"directus-extension": "cli.js"
 	},
 	"files": [
 		"dist",
 		"templates",
-		"!**/*.d.ts.map"
+		"!**/*.test.{js,d.ts}"
 	],
 	"scripts": {
 		"build": "tsc --build",

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -15,12 +15,13 @@
 	"funding": "https://github.com/directus/directus?sponsor=1",
 	"author": "Nicola Krumschmidt",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
 		"./cli": "./dist/cli/index.js",
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"bin": {
 		"directus-extension": "cli.js"
 	},

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -22,6 +22,8 @@
 		"./cli": "./dist/cli/index.js",
 		"./package.json": "./package.json"
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"bin": {
 		"directus-extension": "cli.js"
 	},

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -36,6 +36,8 @@
 			"default": "./dist/types/overview.js"
 		}
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"!**/*.d.ts.map"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -26,10 +26,7 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
+		".": "./dist/index.js",
 		"./package.json": "./package.json",
 		"./types/overview": {
 			"types": "./dist/types/overview.d.ts",
@@ -37,10 +34,9 @@
 		}
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
-		"!**/*.d.ts.map"
+		"!**/*.test.{js,d.ts}"
 	],
 	"scripts": {
 		"build": "tsc --build",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -35,8 +35,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"scripts": {
 		"build": "tsc --build",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -26,17 +26,19 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
 		"./package.json": "./package.json",
 		"./types/overview": {
 			"types": "./dist/types/overview.d.ts",
 			"default": "./dist/types/overview.js"
 		}
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
-		"dist"
+		"dist",
+		"!**/*.d.ts.map"
 	],
 	"scripts": {
 		"build": "tsc --build",

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -21,6 +21,8 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"main": "index.js",
+	"types": "index.d.ts",
 	"files": [
 		"dist",
 		"index.d.ts",

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -15,10 +15,12 @@
 	"license": "GPL-3.0",
 	"author": "Nils Twelker",
 	"exports": {
-		".": "./index.js",
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.js"
+		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"files": [
 		"dist",
 		"index.d.ts",

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -15,14 +15,10 @@
 	"license": "GPL-3.0",
 	"author": "Nils Twelker",
 	"exports": {
-		".": {
-			"types": "./index.d.ts",
-			"import": "./index.js"
-		},
+		".": "./index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "index.js",
-	"types": "index.d.ts",
 	"files": [
 		"dist",
 		"index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -17,13 +17,15 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
 	"files": [
 		"dist",
-		"!**/*.d.ts?(.map)"
+		"!**/*.d.ts.map"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -17,17 +17,13 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
+		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
-		"!**/*.d.ts.map"
+		"!**/*.test.{js,d.ts}"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -23,6 +23,8 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"!**/*.d.ts.map"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,13 +16,15 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": "./dist/index.js",
+		".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
 		"./package.json": "./package.json"
 	},
-	"main": "dist/index.js",
 	"files": [
 		"dist",
-		"!**/*.d.ts?(.map)"
+    "!**/*.d.ts.map"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,6 +22,8 @@
     },
 		"./package.json": "./package.json"
 	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
     "!**/*.d.ts.map"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,17 +16,12 @@
 	"license": "GPL-3.0",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"exports": {
-		".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
+		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
 	"files": [
-		"dist",
-    "!**/*.d.ts.map"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,6 +31,8 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"main": "dist/shared/index.js",
+	"types": "dist/shared/index.d.ts",
 	"files": [
 		"dist",
 		"!**/*.d.ts.map"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,10 +32,9 @@
 		"./package.json": "./package.json"
 	},
 	"main": "dist/shared/index.js",
-	"types": "dist/shared/index.d.ts",
 	"files": [
 		"dist",
-		"!**/*.d.ts.map"
+		"!**/*.test.{js,d.ts}"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,10 +31,9 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "dist/shared/index.js",
 	"files": [
 		"dist",
-		"!**/*.d.ts?(.map)"
+		"!**/*.d.ts.map"
 	],
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Fixes #18209
This is basically a continuation of #18180

~Additionally this PR removes the `main` entrypoint and replaces them with a proper `exports` field as this project is now ESM only anyways and the exports field takes precedence over the `main` field as per https://nodejs.org/api/packages.html#package-entry-points~

> ~For new packages targeting the currently supported versions of Node.js, the ["exports"](https://nodejs.org/api/packages.html#exports) field is recommended. For packages supporting Node.js 10 and below, the ["main"](https://nodejs.org/api/packages.html#main) field is required. If both ["exports"](https://nodejs.org/api/packages.html#exports) and ["main"](https://nodejs.org/api/packages.html#main) are defined, the ["exports"](https://nodejs.org/api/packages.html#exports) field takes precedence over ["main"](https://nodejs.org/api/packages.html#main) in supported versions of Node.js.~

Edit: Turns out TypeScript needs to have [`"moduleResolution": "nodenext"`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html) enabled for the exports to work (which is available since TS 4.7). So this would mean a breaking change in extensions. I've left the `main` entrypoint intact and added an additional `types` entrypoint in addition to the future proof `exports`.



I also removed the 2 spaces rule for `package.json` from the `.editorconfig` since my editor seemed to be the only one respecting it and all of the `package.json` files used tabs so far.

Open Questions:
- Was there any reason to not publish the types before?
- Should the `storage-driver-*` types also be exported?
