### PR TITLE
Add blackbox test for assets with format=auto query parameter

### DIFF
--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -149,13 +149,15 @@ router.get(
 			  )
 			: res.locals['transformation'];
 
-		if (transformation.format === 'auto' && req.headers.accept) {
-			let format: Exclude<TransformationParams['format'], 'auto'> = 'jpg';
+		if (transformation.format === 'auto') {
+			let format: Exclude<TransformationParams['format'], 'auto'>;
 
-			if (req.headers.accept.includes('image/webp')) {
-				format = 'webp';
-			} else if (req.headers.accept.includes('image/avif')) {
+			if (req.headers.accept?.includes('image/avif')) {
 				format = 'avif';
+			} else if (req.headers.accept?.includes('image/webp')) {
+				format = 'webp';
+			} else {
+				format = 'jpg';
 			}
 
 			transformation.format = format;

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -149,15 +149,13 @@ router.get(
 			  )
 			: res.locals['transformation'];
 
-		if (transformation.format === 'auto') {
-			let format: Exclude<TransformationParams['format'], 'auto'>;
+		if (transformation.format === 'auto' && req.headers.accept) {
+			let format: Exclude<TransformationParams['format'], 'auto'> = 'jpg';
 
-			if (req.headers.accept?.includes('image/avif')) {
-				format = 'avif';
-			} else if (req.headers.accept?.includes('image/webp')) {
+			if (req.headers.accept.includes('image/webp')) {
 				format = 'webp';
-			} else {
-				format = 'jpg';
+			} else if (req.headers.accept.includes('image/avif')) {
+				format = 'avif';
 			}
 
 			transformation.format = format;

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -36,7 +36,7 @@ describe('/assets', () => {
 
 						// Assert
 						expect(response.statusCode).toBe(200);
-						expect(response.headers['content-type']).toBe('image/jpg'); // Expect fallback to jpg as default
+						expect(response.headers['content-type']).toBe('image/jpeg'); // Expect fallback to jpg as default
 					});
 				});
 			});
@@ -45,7 +45,7 @@ describe('/assets', () => {
 				{ requestHeaderAccept: 'image/avif,image/webp,image/*,*/*;q=0.8', responseHeaderContentType: 'image/avif' },
 				{ requestHeaderAccept: 'image/avif', responseHeaderContentType: 'image/avif' },
 				{ requestHeaderAccept: 'image/webp', responseHeaderContentType: 'image/webp' },
-				{ requestHeaderAccept: '*/*', responseHeaderContentType: 'image/jpg' },
+				{ requestHeaderAccept: '*/*', responseHeaderContentType: 'image/jpeg' },
 			])('with "$requestHeaderAccept" Accept request header', ({ requestHeaderAccept, responseHeaderContentType }) => {
 				describe.each(storages)('Storage: %s', (storage) => {
 					it.each(vendors)('%s', async (vendor) => {

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -31,7 +31,7 @@ describe('/assets', () => {
 
 						// Action
 						const response = await request(getUrl(vendor))
-							.get(`/assets/${insertResponse.body.data.id}`)
+							.get(`/assets/${insertResponse.body.data.id}?format=auto`)
 							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
 
 						// Assert
@@ -58,7 +58,7 @@ describe('/assets', () => {
 
 						// Action
 						const response = await request(getUrl(vendor))
-							.get(`/assets/${insertResponse.body.data.id}`)
+							.get(`/assets/${insertResponse.body.data.id}?format=auto`)
 							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
 							.set('Accept', requestHeaderAccept);
 

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -1,0 +1,73 @@
+import { getUrl } from '@common/config';
+import request from 'supertest';
+import vendors from '@common/get-dbs-to-test';
+import { createReadStream } from 'fs';
+import path from 'path';
+import * as common from '@common/index';
+
+const assetsDirectory = [__dirname, '..', '..', 'assets'];
+const storages = ['local', 'minio'];
+
+const imageFile = {
+	name: 'directus.png',
+	type: 'image/png',
+	filesize: '7136',
+};
+
+const imageFilePath = path.join(...assetsDirectory, imageFile.name);
+
+describe('/assets', () => {
+	describe('GET /assets/:id', () => {
+		describe('format=auto Tests', () => {
+			describe('without Accept request header', () => {
+				describe.each(storages)('Storage: %s', (storage) => {
+					it.each(vendors)('%s', async (vendor) => {
+						// Setup
+						const insertResponse = await request(getUrl(vendor))
+							.post('/files')
+							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+							.field('storage', storage)
+							.attach('file', createReadStream(imageFilePath));
+
+						// Action
+						const response = await request(getUrl(vendor))
+							.get(`/assets/${insertResponse.body.data.id}`)
+							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+						// Assert
+						expect(response.statusCode).toBe(200);
+						expect(response.headers['content-type']).toBe('image/jpg'); // Expect fallback to jpg as default
+					});
+				});
+			});
+
+			describe.each([
+				{ requestHeaderAccept: 'image/avif,image/webp,image/*,*/*;q=0.8', responseHeaderContentType: 'image/avif' },
+				{ requestHeaderAccept: 'image/avif', responseHeaderContentType: 'image/avif' },
+				{ requestHeaderAccept: 'image/webp', responseHeaderContentType: 'image/webp' },
+				{ requestHeaderAccept: '*/*', responseHeaderContentType: 'image/jpg' },
+			])('with "$requestHeaderAccept" Accept request header', ({ requestHeaderAccept, responseHeaderContentType }) => {
+				describe.each(storages)('Storage: %s', (storage) => {
+					it.each(vendors)('%s', async (vendor) => {
+						// Setup
+						const insertResponse = await request(getUrl(vendor))
+							.post('/files')
+							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+							.field('storage', storage)
+							.attach('file', createReadStream(imageFilePath));
+
+						// Action
+						const response = await request(getUrl(vendor))
+							.get(`/assets/${insertResponse.body.data.id}`)
+							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+							.set('Accept', requestHeaderAccept);
+
+						// Assert
+						expect(response.statusCode).toBe(200);
+						expect(response.headers['content-type']).toBe(responseHeaderContentType);
+					});
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
An attempt to add test for #18012 and it's follow up fix #18235.