### PR TITLE
Use filled star for required asterisks & rating display

### DIFF
--- a/app/src/components/v-form/form-field-label.vue
+++ b/app/src/components/v-form/form-field-label.vue
@@ -9,7 +9,14 @@
 			/>
 			<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>
 			<v-text-overflow :text="field.name" />
-			<v-icon v-if="field.meta?.required === true" class="required" :class="{ 'has-badge': badge }" sup name="star" />
+			<v-icon
+				v-if="field.meta?.required === true"
+				class="required"
+				:class="{ 'has-badge': badge }"
+				sup
+				name="star"
+				filled
+			/>
 			<v-chip v-if="badge" x-small>{{ badge }}</v-chip>
 			<v-icon
 				v-if="!disabled && rawEditorEnabled"

--- a/app/src/displays/rating/rating.vue
+++ b/app/src/displays/rating/rating.vue
@@ -1,11 +1,11 @@
 <template>
 	<span v-if="simple" class="rating simple">
-		<v-icon small name="star" />
+		<v-icon small name="star" filled />
 		{{ value }}
 	</span>
 	<div v-else v-tooltip.bottom.start="value" class="rating detailed">
 		<div class="active" :style="ratingPercentage">
-			<v-icon v-for="index in starCount" :key="index" small name="star" />
+			<v-icon v-for="index in starCount" :key="index" small name="star" filled />
 		</div>
 		<div class="inactive">
 			<v-icon v-for="index in starCount" :key="index" small name="star" />

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -5,7 +5,7 @@
 				<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>
 				<v-icon class="icon" :class="{ active }" name="expand_more" />
 				<span class="field-name">{{ field.name }}</span>
-				<v-icon v-if="field.meta?.required === true" class="required" sup name="star" />
+				<v-icon v-if="field.meta?.required === true" class="required" sup name="star" filled />
 				<v-chip v-if="badge" x-small>{{ badge }}</v-chip>
 				<v-icon v-if="!active && validationMessage" v-tooltip="validationMessage" class="warning" name="error" small />
 			</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -4,7 +4,7 @@
 			<div class="field">
 				<div class="label type-label">
 					{{ t('key') }}
-					<v-icon class="required" sup name="star" />
+					<v-icon class="required" sup name="star" filled />
 				</div>
 
 				<v-input
@@ -23,7 +23,7 @@
 			<div class="field half">
 				<div class="label type-label">
 					{{ t('type') }}
-					<v-icon class="required" sup name="star" />
+					<v-icon class="required" sup name="star" filled />
 				</div>
 				<v-input v-if="isAlias" :model-value="t('alias')" disabled />
 				<v-select

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -6,7 +6,7 @@
 					<div class="field half-left">
 						<div class="label type-label">
 							{{ t('key') }}
-							<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+							<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 						</div>
 
 						<v-input v-model="key" autofocus class="monospace" db-safe :placeholder="t('a_unique_column_name')" />

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -3,7 +3,7 @@
 		<div v-if="localType === 'm2o'" class="field full">
 			<div class="label type-label">
 				{{ t('related_collection') }}
-				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 			</div>
 
 			<related-collection-select v-model="relatedCollectionM2O" />
@@ -13,7 +13,7 @@
 			<div class="field half-left">
 				<div class="label type-label">
 					{{ t('related_collection') }}
-					<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+					<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 				</div>
 
 				<related-collection-select v-model="o2mCollection" />
@@ -22,7 +22,7 @@
 			<div class="field half-right">
 				<div class="label type-label">
 					{{ t('foreign_key') }}
-					<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+					<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 				</div>
 
 				<related-field-select v-model="o2mField" :collection="o2mCollection" :disabled="!o2mCollection" />
@@ -32,7 +32,7 @@
 		<div v-if="localType === 'm2m'" class="field full">
 			<div class="label type-label">
 				{{ t('related_collection') }}
-				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 			</div>
 
 			<related-collection-select v-model="relatedCollectionM2O" />
@@ -41,7 +41,7 @@
 		<div v-if="localType === 'translations'" class="field full">
 			<div class="label type-label">
 				{{ t('languages_collection') }}
-				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 			</div>
 
 			<related-collection-select v-model="relatedCollectionM2O" />
@@ -50,7 +50,7 @@
 		<div v-if="localType === 'm2a'" class="field full">
 			<div class="label type-label">
 				{{ t('related_collections') }}
-				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" />
+				<v-icon v-tooltip="t('required')" class="required-mark" sup name="star" filled />
 			</div>
 
 			<v-select

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -68,7 +68,7 @@
 						<div class="label-inner">
 							<span class="name">
 								{{ field.field }}
-								<v-icon v-if="field.meta?.required === true" name="star" class="required" sup />
+								<v-icon v-if="field.meta?.required === true" name="star" class="required" sup filled />
 							</span>
 							<span v-if="field.meta" class="interface">{{ interfaceName }}</span>
 							<span v-else class="interface">{{ t('db_only_click_to_configure') }}</span>

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -24,7 +24,7 @@
 					<div class="field half">
 						<div class="type-label">
 							{{ t('name') }}
-							<v-icon v-tooltip="t('required')" class="required" name="star" sup />
+							<v-icon v-tooltip="t('required')" class="required" name="star" sup filled />
 						</div>
 						<v-input
 							v-model="collectionName"

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -23,7 +23,7 @@
 					<div class="field half">
 						<div class="type-label">
 							{{ t('flow_name') }}
-							<v-icon v-tooltip="t('required')" class="required" name="star" sup />
+							<v-icon v-tooltip="t('required')" class="required" name="star" sup filled />
 						</div>
 						<v-input v-model="values.name" autofocus :placeholder="t('flow_name')" />
 					</div>


### PR DESCRIPTION
Previously the codebase was using the `star` Material Icons Outlined, which actually isn't technically in outline style:

![](https://user-images.githubusercontent.com/42867097/232928865-e9039f41-c791-4efe-86e4-f2331de23183.png)

After the upgrade to Material Symbols in #18004, it is now _correctly_ showing an outlined star:

![](https://user-images.githubusercontent.com/42867097/232928878-aac42acc-8e2a-42df-87cd-90e5a28765f7.png)

but I presume our existing `star` usage is intended to be _filled_ instead of outlined, hence this PR aims to change the following:

- update the required asterisk (which was using `star`) to use the filled variant

    | Before this PR | After this PR |
    |---|---|
    |![](https://user-images.githubusercontent.com/42867097/232929509-f060866b-a346-4cd8-b283-b13383f14041.png)|![](https://user-images.githubusercontent.com/42867097/232929515-1ad75e3b-337e-4205-9ccb-5e828c1906ad.png)|

- update the rating display's active state to use the filled variant, but currently intentionally kept inactive state to keep the outlined variant, similar to GitHub stars. We can change it to filled as well if deemed necessary.

    | Before this PR | After this PR |
    |---|---|
    |![](https://user-images.githubusercontent.com/42867097/232929627-c4837555-13ac-4001-9831-4bce9d57bb61.png)|![](https://user-images.githubusercontent.com/42867097/232929745-5dc958bd-2a88-4ee7-bf10-c61dfbcc5f01.png)|
