### PR TITLE
Fall back to "other" group if interface has none

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -117,7 +117,7 @@ export default defineComponent({
 			return groupsWithInterfaces.filter((group) => group.interfaces.length > 0);
 
 			function filterInterfacesByGroup(group: string) {
-				const filteredInterfaces = interfacesSorted.value.filter((inter) => inter.group === group);
+				const filteredInterfaces = interfacesSorted.value.filter((inter) => (inter.group ?? 'other') === group);
 				if (!search.value) return filteredInterfaces;
 				const searchValue = search.value!.toLowerCase();
 				return filteredInterfaces.filter(

--- a/contributors.yml
+++ b/contributors.yml
@@ -24,3 +24,4 @@
 - aidenfoxx
 - phazonoverload
 - akshay-sood
+- nickrum

--- a/docs/extensions/interfaces.md
+++ b/docs/extensions/interfaces.md
@@ -43,7 +43,7 @@ export default {
 - `localTypes` — An array of local types. Accepts `standard`, `file`, `files`, `m2o`, `o2m`, `m2m`, `m2a`,
   `presentation`, `translations` and `group`. Defaults to `standard`.
 - `group` — The group this interface is shown at when creating a field. Accepts `standard`, `selection`, `relational`,
-  `presentation`, `group` or `other`.
+  `presentation`, `group` or `other`. Defaults to `other`.
 - `relational` — A boolean that indicates if this interface is a relational interface.
 - `recommendedDisplays` — An array of display names which are recommended to be used with this interface.
 
@@ -95,7 +95,7 @@ component, it should be emitted to the Directus App by using the `input` emit.
 #### Available Emits
 
 - `input` — Update the value of the field.
-- `setFieldValue` - Used to set the value of other fields. 
+- `setFieldValue` - Used to set the value of other fields.
 
 Other than this simple API to communicate with the Directus App, the interface component is a blank canvas, allowing you
 to create anything you need.


### PR DESCRIPTION
This is based on this discussion with @azrikahar: https://github.com/directus/directus/discussions/13753#discussioncomment-4076717. It makes interface extensions appear in the advanced field creation flow even if they do not have a group set.

I've chosen to fall back to the `other` group because the `standard` group is shown as "Text & Numbers".