### PR TITLE
Fix wrong drawer opens when editing fields in data model

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -77,11 +77,9 @@ const fieldDetail = useFieldDetailStore();
 const { editing } = storeToRefs(fieldDetail);
 
 watch(
-	[field, type],
+	field,
 	() => {
-		if (!type.value) return;
-
-		fieldDetail.startEditing(collection.value, field.value, type.value);
+		fieldDetail.startEditing(collection.value, field.value, type.value ?? undefined);
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
The problem is a regression of #18249 caused by not calling `startEditing` when the type is null with an addition of an early return here: https://github.com/directus/directus/pull/18249/files#diff-6b865c53c811f41ea100622d42e1e07ff040b4ed37dac0792eab19b87a8dffacR82

fixes #18265

Reverts the changes to the way it was before:
https://github.com/directus/directus/blob/c301cfbc82d1ce3ba8dad56800552c4899895b6e/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue#L86-L90