### PR TITLE
Allow query string to update the cache key

### DIFF
--- a/api/src/utils/get-cache-key.test.ts
+++ b/api/src/utils/get-cache-key.test.ts
@@ -86,6 +86,12 @@ describe('get cache key', () => {
 		expect(getCacheKey(params as unknown as Request)).toEqual(key);
 	});
 
+	test.each(cases)('should create a different cache key for %s having a query string', (_, params: any, key) => {
+		expect(getCacheKey({ ...params, originalUrl: `${params.originalUrl}?test` } as unknown as Request)).not.toEqual(
+			key
+		);
+	});
+
 	test('should create a unique key for each request', () => {
 		const keys = cases.map(([, params]) => getCacheKey(params as unknown as Request));
 		const hasDuplicate = keys.some((key) => keys.indexOf(key) !== keys.lastIndexOf(key));

--- a/api/src/utils/get-cache-key.ts
+++ b/api/src/utils/get-cache-key.ts
@@ -5,7 +5,7 @@ import { getGraphqlQueryAndVariables } from './get-graphql-query-and-variables.j
 import { version } from './package.js';
 
 export function getCacheKey(req: Request): string {
-	const path = url.parse(req.originalUrl).pathname;
+	const path = url.parse(req.originalUrl).path;
 	const isGraphQl = path?.startsWith('/graphql');
 
 	const info = {


### PR DESCRIPTION
The existing `pathname` had stripped the query string out.

Fixes #18271, Closes ENG-912