### PR TITLE
Fix the ownership of the workdir in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN : \
 
 FROM node:18-alpine AS runtime
 
+USER node
+
 WORKDIR /directus
 
 EXPOSE 8055
@@ -45,8 +47,6 @@ ENV \
 	NPM_CONFIG_UPDATE_NOTIFIER="false"
 
 COPY --from=builder --chown=node:node /directus/dist .
-
-USER node
 
 CMD : \
 	&& node /directus/cli.js bootstrap \


### PR DESCRIPTION
The workdir itself in the docker image should be owned by `node` as well, so modifications like installing additional packages work out of the box, see https://github.com/directus/directus/issues/18081#issuecomment-1500089734.