### PR TITLE
Fix refreshing on save

### DIFF
--- a/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
@@ -154,14 +154,9 @@ const props = withDefaults(
 const { t } = useI18n();
 const emit = defineEmits(['update:modelValue']);
 
-const value = computed<ChangesItem>({
+const value = computed<ChangesItem | any[]>({
 	get() {
-		if (props.modelValue === undefined)
-			return {
-				create: [],
-				update: [],
-				delete: [],
-			};
+		if (props.modelValue === undefined) return [];
 		return props.modelValue as ChangesItem;
 	},
 	set: (val) => {


### PR DESCRIPTION
The problem was that we were only refreshing the display items when the value turned from the update object back to an empty array. But why enforcing it to always be an update object, we where not triggering the update function.

fixes #18250