### PR TITLE
Only show tooltips when sidebar is not open

### DIFF
--- a/app/src/views/private/components/notifications-preview.vue
+++ b/app/src/views/private/components/notifications-preview.vue
@@ -14,7 +14,7 @@
 		</transition-expand>
 
 		<sidebar-button
-			v-tooltip.left="t('activity_log')"
+			v-tooltip.left="!sidebarOpen && t('activity_log')"
 			:active="modelValue"
 			class="toggle"
 			icon="pending_actions"

--- a/app/src/views/private/components/sidebar-detail.vue
+++ b/app/src/views/private/components/sidebar-detail.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="sidebar-detail" :class="{ open: sidebarOpen }">
-		<button v-tooltip.left="title" class="toggle" :class="{ open: active }" @click="toggle">
+		<button v-tooltip.left="!sidebarOpen && title" class="toggle" :class="{ open: active }" @click="toggle">
 			<div class="icon">
 				<v-badge :dot="badge === true" bordered :value="badge" :disabled="!badge">
 					<v-icon :name="icon" />


### PR DESCRIPTION
Fixes #18253

Added a condition to ensure the tooltip only appears when the sidebar is closed. Also added the same change for Activity Log (at the bottom right corner of sidebar).

Based on other similar conditional tooltip usages such as:

- https://github.com/directus/directus/blob/ae68a6ee9aa54ccbb222f77e679b26afa2b130ee/app/src/components/v-text-overflow.vue#L2

- https://github.com/directus/directus/blob/ae68a6ee9aa54ccbb222f77e679b26afa2b130ee/app/src/modules/content/components/navigation-bookmark.vue#L17

- https://github.com/directus/directus/blob/ae68a6ee9aa54ccbb222f77e679b26afa2b130ee/app/src/modules/settings/routes/flows/components/operation.vue#L37