### PR TITLE
Schema cache auto-purge

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -245,7 +245,7 @@ const defaults: Record<string, any> = {
 	CACHE_STORE: 'memory',
 	CACHE_TTL: '5m',
 	CACHE_NAMESPACE: 'system-cache',
-	CACHE_AUTO_PURGE: false,
+	CACHE_AUTO_PURGE: true,
 	CACHE_CONTROL_S_MAXAGE: '0',
 	CACHE_SCHEMA: true,
 	CACHE_PERMISSIONS: true,


### PR DESCRIPTION
With 9.25+ schema cache has been enabled for memory which is enabled out of the box while auto purge is disabled resulting in the default configuration not reflecting changes as expected.

The proposed solution is to enable `CACHE_AUTO_PURGE` by default which seems like a better approach than disabling `SCHEMA_CACHE` by default.

Fixes https://github.com/directus/directus/issues/18110
