### PR TITLE
App: Fix show Tinymce style formats

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -364,7 +364,7 @@ export default defineComponent({
 				.join(' ');
 
 			if (styleFormats) {
-				toolbarString += ' styleselect';
+				toolbarString += ' styles';
 			}
 
 			return {

--- a/app/src/interfaces/input-rich-text-html/tinymce-overrides.css
+++ b/app/src/interfaces/input-rich-text-html/tinymce-overrides.css
@@ -151,6 +151,10 @@ body.dark .tox .tox-toolbar__overflow {
 	background: var(--border-normal);
 }
 
+.tox .tox-tbtn--bespoke {
+	background: inherit;
+}
+
 .tox .tox-tbtn + .tox .tox-tbtn {
 	margin-left: 2px;
 }


### PR DESCRIPTION
Because we upgraded TinyMCE to version 5:
https://github.com/directus/directus/pull/18107

And there's a breaking change:
https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/CHANGELOG.md#:~:text=Renamed%20the%20styleselect%20toolbar%20button%20and%20formats%20menu%20item%20to%20styles.%20%23TINY%2D8328
|Before|After|
| - | - |
| <video src="https://user-images.githubusercontent.com/14039341/233997426-820fad55-51f3-4417-93b1-8816fa6ee3b5.mov"></video> | <video src="https://user-images.githubusercontent.com/14039341/233997473-173e1aa5-6244-4413-878f-1f49fc0f1156.mov"></video> |