### PR TITLE
Revert #18303

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -245,7 +245,7 @@ const defaults: Record<string, any> = {
 	CACHE_STORE: 'memory',
 	CACHE_TTL: '5m',
 	CACHE_NAMESPACE: 'system-cache',
-	CACHE_AUTO_PURGE: true,
+	CACHE_AUTO_PURGE: false,
 	CACHE_CONTROL_S_MAXAGE: '0',
 	CACHE_SCHEMA: true,
 	CACHE_PERMISSIONS: true,


### PR DESCRIPTION
The original issue #18110 stems from the incoming request having a different url from the `PUBLIC_URL`. Hence, a cached response was provided.

Additionally, turning on `CACHE_AUTO_PURGE` may be a breaking change for instances that do not currently expect this behaviour.

This reverts commit 4ccfd2a4ae4a874142652eaf3961ce66bb29885c.