### PR TITLE
Correctly set user "auth_data" after auth.update hook

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -159,7 +159,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{},
+				{ auth_data: userPayload.auth_data },
 				{
 					identifier,
 					provider: this.config['provider'],

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -185,7 +185,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{},
+				{ auth_data: userPayload.auth_data },
 				{
 					identifier,
 					provider: this.config['provider'],


### PR DESCRIPTION
Some auth providers include a "refresh_token" on authentication, revoking previously used tokens. We need to update the users "auth_data" to include this token or the now invalidated token will throw an error when checked.

Solves: https://github.com/directus/directus/issues/18304

Caused by an oversight in this merge: https://github.com/directus/directus/commit/b2204138191f00e4c81acc8e3efe39b78ba2e199#diff-249d6560e108f61fab7c1b235ece9adcf3880369803d990f7771a680888fb408L145