### PR TITLE
Prevent thumbnail duplication

### DIFF
--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -3,6 +3,28 @@ import { resolvePreset } from './transformations.js';
 import type { File } from '../types/files.js';
 import type { TransformationParams } from '../types/assets.js';
 
+const inputFile: File = {
+	id: '43a15f67-84a7-4e07-880d-e46a9f33c542',
+	storage: 'local',
+	filename_disk: 'test',
+	filename_download: 'test',
+	title: null,
+	type: null,
+	folder: null,
+	uploaded_by: null,
+	uploaded_on: new Date(),
+	charset: null,
+	filesize: 123,
+	width: null,
+	height: null,
+	duration: null,
+	embed: null,
+	description: null,
+	location: null,
+	tags: null,
+	metadata: null,
+};
+
 describe('resolvePreset', () => {
 	test('Prevent input mutation #18301', () => {
 		const inputData: TransformationParams = {
@@ -17,30 +39,7 @@ describe('resolvePreset', () => {
 						fit: 'cover',
 					},
 				],
-				['toFormat', 'jpg', {}],
 			],
-		};
-
-		const inputFile: File = {
-			id: '43a15f67-84a7-4e07-880d-e46a9f33c542',
-			storage: 'local',
-			filename_disk: 'test',
-			filename_download: 'test',
-			title: null,
-			type: null,
-			folder: null,
-			uploaded_by: null,
-			uploaded_on: new Date(),
-			charset: null,
-			filesize: 123,
-			width: null,
-			height: null,
-			duration: null,
-			embed: null,
-			description: null,
-			location: null,
-			tags: null,
-			metadata: null,
 		};
 
 		resolvePreset(inputData, inputFile);
@@ -54,7 +53,61 @@ describe('resolvePreset', () => {
 					fit: 'cover',
 				},
 			],
-			['toFormat', 'jpg', {}],
+		]);
+	});
+
+	test('Add toFormat transformation', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			format: 'jpg',
+			quality: 80,
+			transforms: [
+				[
+					'resize',
+					{
+						width: 64,
+						height: 64,
+						fit: 'cover',
+					},
+				],
+			],
+		};
+
+		const output = resolvePreset(inputData, inputFile);
+
+		expect(output).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+				},
+			],
+			['toFormat', 'jpg', { quality: 80 }],
+		]);
+	});
+
+	test('Add resize transformation', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			width: 64,
+			height: 64,
+			fit: 'cover',
+		};
+
+		const output = resolvePreset(inputData, inputFile);
+
+		expect(output).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+					withoutEnlargement: undefined,
+				},
+			],
 		]);
 	});
 });

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -1,0 +1,60 @@
+import { expect, test, describe } from 'vitest';
+import { resolvePreset } from './transformations.js';
+import type { File } from '../types/files.js';
+import type { TransformationParams } from '../types/assets.js';
+
+describe('resolvePreset', () => {
+	test('Prevent input mutation #18301', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			format: 'jpg',
+			transforms: [
+				[
+					'resize',
+					{
+						width: 64,
+						height: 64,
+						fit: 'cover',
+					},
+				],
+				['toFormat', 'jpg', {}],
+			],
+		};
+
+		const inputFile: File = {
+			id: '43a15f67-84a7-4e07-880d-e46a9f33c542',
+			storage: 'local',
+			filename_disk: 'test',
+			filename_download: 'test',
+			title: null,
+			type: null,
+			folder: null,
+			uploaded_by: null,
+			uploaded_on: new Date(),
+			charset: null,
+			filesize: 123,
+			width: null,
+			height: null,
+			duration: null,
+			embed: null,
+			description: null,
+			location: null,
+			tags: null,
+			metadata: null,
+		};
+
+		resolvePreset(inputData, inputFile);
+
+		expect(inputData.transforms).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+				},
+			],
+			['toFormat', 'jpg', {}],
+		]);
+	});
+});

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe } from 'vitest';
-import { resolvePreset } from './transformations.js';
+import { maybeExtractFormat, resolvePreset } from './transformations.js';
 import type { File } from '../types/files.js';
-import type { TransformationParams } from '../types/assets.js';
+import type { Transformation, TransformationParams } from '../types/assets.js';
 
 const inputFile: File = {
 	id: '43a15f67-84a7-4e07-880d-e46a9f33c542',
@@ -109,5 +109,26 @@ describe('resolvePreset', () => {
 				},
 			],
 		]);
+	});
+});
+
+describe('maybeExtractFormat', () => {
+	test('get last format', () => {
+		const inputTransformations: Transformation[] = [
+			['toFormat', 'jpg', { quality: 80 }],
+			['toFormat', 'webp', { quality: 80 }],
+		];
+
+		const output = maybeExtractFormat(inputTransformations);
+
+		expect(output).toBe('webp');
+	});
+
+	test('get undefined', () => {
+		const inputTransformations: Transformation[] = [];
+
+		const output = maybeExtractFormat(inputTransformations);
+
+		expect(output).toBe(undefined);
 	});
 });

--- a/api/src/utils/transformations.ts
+++ b/api/src/utils/transformations.ts
@@ -1,7 +1,7 @@
 import type { File, Transformation, TransformationParams } from '../types/index.js';
 
 export function resolvePreset(input: TransformationParams, file: File): Transformation[] {
-	const transforms = input.transforms ?? [];
+	const transforms = input.transforms ? [...input.transforms] : [];
 
 	if (input.format || input.quality)
 		transforms.push([


### PR DESCRIPTION
## Description

Because the `resolvePreset` utility accidentally mutates its input it kept adding new "toFormat" transformations to the input resulting in a new hash every run. This fix makes a shallow copy of the input to prevent mutating the variable in the parent context.
![Code_Muy3jcrYb4](https://user-images.githubusercontent.com/9389634/234288844-08fcf55c-2788-45f6-9c34-8382455ab1e6.png)
![Code_9Bpc54tceM](https://user-images.githubusercontent.com/9389634/234288855-3b10be44-3754-4bf4-a9ba-f5b6fde60b04.png)

Fixes #18301 

## Type of Change

- [x] Bugfix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [x] Tests are included
- [ ] Documentation was added/updated
