### PR TITLE
Translate module link name in project settings

### DIFF
--- a/.changeset/stale-kiwis-greet.md
+++ b/.changeset/stale-kiwis-greet.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Translate module link name in project settings

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -69,6 +69,7 @@ import { nanoid } from 'nanoid';
 import { Field, DeepPartial } from '@directus/types';
 import { MODULE_BAR_DEFAULT } from '@/constants';
 import { useExtensions } from '@/extensions';
+import { translate } from '@/utils/translate-object-values';
 
 type PreviewExtra = {
 	to: string;
@@ -200,7 +201,7 @@ export default defineComponent({
 							...part,
 							to: part.url,
 							icon: part.icon,
-							name: part.name,
+							name: translate(part.name),
 						};
 					}
 


### PR DESCRIPTION
Closes #18341.

### Before

<img width="273" alt="image" src="https://user-images.githubusercontent.com/26413686/234938094-33cf2429-2d5d-4df1-bc91-933588f20e0f.png">

### After

<img width="273" alt="image" src="https://user-images.githubusercontent.com/26413686/234937995-ac259ca9-0e3e-4f7e-97a2-2b2fa184db7b.png">