### PR TITLE
Add related collection link to data model settings

### DIFF
--- a/.changeset/six-emus-joke.md
+++ b/.changeset/six-emus-joke.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Add crosslink to data model settings for relational fields

--- a/.changeset/six-emus-joke.md
+++ b/.changeset/six-emus-joke.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Add crosslink to data model settings for relational fields
+Added a shortcut link in settings for relational fields in the data model

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -219,6 +219,7 @@ export default defineComponent({
 		const showRelatedCollectionLink = computed(
 			() =>
 				relatedCollectionInfo.value !== null &&
+				props.field.collection !== relatedCollectionInfo.value.relatedCollection &&
 				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(localType.value as string)
 		);
 

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -219,7 +219,7 @@ export default defineComponent({
 		const showRelatedCollectionLink = computed(
 			() =>
 				unref(relatedCollectionInfo) !== null &&
-				props.field.collection !== unref(relatedCollectionInfo).relatedCollection &&
+				props.field.collection !== unref(relatedCollectionInfo)?.relatedCollection &&
 				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(unref(localType) as string)
 		);
 

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -92,6 +92,14 @@
 							small
 						/>
 						<v-icon v-if="hidden" v-tooltip="t('hidden_field')" name="visibility_off" class="hidden-icon" small />
+
+						<router-link
+							v-if="showRelatedCollectionLink"
+							:to="`/settings/data-model/${relatedCollectionInfo!.relatedCollection}`"
+						>
+							<v-icon name="open_in_new" class="link-icon" small />
+						</router-link>
+
 						<field-select-menu
 							:field="field"
 							@toggle-visibility="toggleVisibility"
@@ -160,6 +168,7 @@ import { hideDragImage } from '@/utils/hide-drag-image';
 import Draggable from 'vuedraggable';
 import formatTitle from '@directus/format-title';
 import { useExtension } from '@/composables/use-extension';
+import { getRelatedCollection } from '@/utils/get-related-collection';
 
 export default defineComponent({
 	name: 'FieldSelect',
@@ -205,6 +214,14 @@ export default defineComponent({
 
 		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.field));
 
+		const relatedCollectionInfo = computed(() => getRelatedCollection(props.field.collection, props.field.field));
+
+		const showRelatedCollectionLink = computed(
+			() =>
+				relatedCollectionInfo.value !== null &&
+				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(localType.value as string)
+		);
+
 		return {
 			t,
 			interfaceName,
@@ -224,6 +241,8 @@ export default defineComponent({
 			hidden,
 			toggleVisibility,
 			localType,
+			showRelatedCollectionLink,
+			relatedCollectionInfo,
 			hideDragImage,
 			onGroupSortChange,
 			nestedFields,
@@ -376,6 +395,10 @@ export default defineComponent({
 		--v-icon-color: var(--warning);
 		--v-icon-color-hover: var(--warning);
 	}
+
+	&.link-icon:hover {
+		--v-icon-color: var(--foreground-normal);
+	}
 }
 
 .drag-handle {
@@ -522,7 +545,7 @@ export default defineComponent({
 }
 
 .icons {
-	.v-icon + .v-icon:not(:last-child) {
+	* + *:not(:last-child) {
 		margin-left: 8px;
 	}
 }

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -153,7 +153,7 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed } from 'vue';
+import { defineComponent, PropType, ref, computed, unref } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRouter } from 'vue-router';
@@ -218,9 +218,9 @@ export default defineComponent({
 
 		const showRelatedCollectionLink = computed(
 			() =>
-				relatedCollectionInfo.value !== null &&
-				props.field.collection !== relatedCollectionInfo.value.relatedCollection &&
-				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(localType.value as string)
+				unref(relatedCollectionInfo) !== null &&
+				props.field.collection !== unref(relatedCollectionInfo).relatedCollection &&
+				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(unref(localType) as string)
 		);
 
 		return {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->
Closes #18344

It does not make sense to display this for `m2a` relations, since normally you don't want to view the junction collection.

After:

![Screenshot 2023-04-27 at 18 53 28](https://user-images.githubusercontent.com/4376726/234954253-fac1b0ee-2e01-490f-99fb-0a57a56f1cc7.png)
