### PR TITLE
Remove extension config import workaround

### DIFF
--- a/.changeset/quiet-eagles-reflect.md
+++ b/.changeset/quiet-eagles-reflect.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+Removed extension config import workaround that is no longer necessary since we are building to ESM

--- a/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
@@ -6,14 +6,12 @@ import type { Config } from '../../types.js';
 
 export const CONFIG_FILE_NAMES = ['extension.config.js', 'extension.config.mjs', 'extension.config.cjs'];
 
-// This is needed to work around Typescript always transpiling import() to require() for CommonJS targets.
-const _import = new Function('url', 'return import(url)');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default async function loadConfig(): Promise<Config> {
 	for (const fileName of CONFIG_FILE_NAMES) {
 		if (await fse.pathExists(fileName)) {
-			const configFile = await _import(pathToRelativeUrl(path.resolve(fileName), __dirname));
+			const configFile = await import(pathToRelativeUrl(path.resolve(fileName), __dirname));
 
 			return configFile.default;
 		}


### PR DESCRIPTION
This workaround is no longer necessary since we are building to ESM.