### PR TITLE
Mark shared packages as side effects free

### DIFF
--- a/.changeset/loud-otters-destroy.md
+++ b/.changeset/loud-otters-destroy.md
@@ -1,6 +1,8 @@
 ---
 '@directus/constants': patch
 '@directus/utils': patch
+'@directus/composables': patch
+'@directus/exceptions': patch
 ---
 
-Marked the constant and utils packages as side effects free to shrink size of API extensions using Typescript
+Marked the `constant`, `utils`, `composables` and `exceptions` packages as side effects free to shrink size of API extensions using Typescript

--- a/.changeset/loud-otters-destroy.md
+++ b/.changeset/loud-otters-destroy.md
@@ -1,0 +1,6 @@
+---
+'@directus/constants': patch
+'@directus/utils': patch
+---
+
+Marked the constant and utils packages as side effects free to shrink size of API extensions using Typescript

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -2,6 +2,7 @@
 	"name": "@directus/composables",
 	"version": "10.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --build",
 		"dev": "tsc --watch",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,6 +2,7 @@
 	"name": "@directus/constants",
 	"version": "10.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --build",
 		"dev": "tsc --watch"

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -2,6 +2,7 @@
 	"name": "@directus/exceptions",
 	"version": "10.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --build",
 		"dev": "tsc --watch",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,7 @@
 	"name": "@directus/utils",
 	"version": "10.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --project browser/tsconfig.json && tsc --project node/tsconfig.json && tsc --project shared/tsconfig.json",
 		"dev": "concurrently \"tsc --watch --project browser/tsconfig.json\" \"tsc --watch --project node/tsconfig.json\" \"tsc --watch --project shared/tsconfig.json\"",


### PR DESCRIPTION
API extensions using Typescript import one of the `define*()` from `@directus/extensions-sdk`. Rollup's tree-shaking heuristics aren't prefect. So in order for this import to be properly tree-shaken away by rollup, the package from which the function is imported (`@directus/utils`) must be marked as side effects free. Due to reasons not clear to me, `@directus/constants` also needs to be marked as side effects free.

This was also present in the old `@directus/shared` package, so this PR essentially only reverts to the previous behavior.