### PR TITLE
Silence prefer builtins and circular dependency warnings when building extensions

### DIFF
--- a/.changeset/chilly-pugs-pay.md
+++ b/.changeset/chilly-pugs-pay.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+Silenced prefer builtins and circular dependency warnings when building extensions

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -602,6 +602,11 @@ function getRollupOptions({
 			}),
 			minify ? terser() : null,
 		],
+		onwarn(warning, warn) {
+			if (warning.code === 'CIRCULAR_DEPENDENCY' && warning.ids?.every((id) => /\bnode_modules\b/.test(id))) return;
+
+			warn(warning);
+		},
 	};
 }
 

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -591,7 +591,7 @@ function getRollupOptions({
 			languages.includes('typescript') ? esbuild({ include: /\.tsx?$/, sourceMap: sourcemap }) : null,
 			mode === 'browser' ? styles() : null,
 			...plugins,
-			nodeResolve({ browser: mode === 'browser' }),
+			nodeResolve({ browser: mode === 'browser', preferBuiltins: mode === 'node' }),
 			commonjs({ esmExternals: mode === 'browser', sourceMap: sourcemap }),
 			json(),
 			replace({


### PR DESCRIPTION
Those warnings come up when bundling API extensions. Circular dependency warnings are only silenced when only external files are involved. Unfortunately, the prefer builtins warning can't be disabled for external files only, enabling the option and thus silencing the warning should still be rasonably safe for API extensions as this is rollup's default.