### PR TITLE
Prevent nested ternary expressions

### DIFF
--- a/.changeset/breezy-numbers-brake.md
+++ b/.changeset/breezy-numbers-brake.md
@@ -4,4 +4,4 @@
 "tests-blackbox": patch
 ---
 
-Adds `no-nested-ternary` eslint rule
+Added `no-nested-ternary` eslint rule to ensure better readability in the code base

--- a/.changeset/breezy-numbers-brake.md
+++ b/.changeset/breezy-numbers-brake.md
@@ -1,0 +1,7 @@
+---
+"@directus/app": patch
+"@directus/extensions-sdk": patch
+"tests-blackbox": patch
+---
+
+Adds `no-nested-ternary` eslint rule

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ const defaultRules = {
 		{ blankLine: 'any', prev: ['export', 'import'], next: ['export', 'import'] },
 	],
 	'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+	'no-nested-ternary': 'error',
 };
 
 module.exports = {

--- a/app/src/components/v-template-input.vue
+++ b/app/src/components/v-template-input.vue
@@ -228,8 +228,13 @@ function parseHTML(innerText?: string, isDirectInput = false) {
 	}
 
 	let newHTML = input.value.innerText;
+	let caretPos = 0;
 
-	const caretPos = isDirectInput ? previousCaretPos : window.getSelection()?.rangeCount ? position(input.value).pos : 0;
+	if (isDirectInput) {
+		caretPos = previousCaretPos;
+	} else if (window.getSelection()?.rangeCount) {
+		caretPos = position(input.value).pos;
+	}
 
 	let lastMatchIndex = 0;
 	const matches = newHTML.match(new RegExp(`${props.captureGroup}(?!</mark>)`, 'gi'));

--- a/app/src/interfaces/input-rich-text-html/useMedia.ts
+++ b/app/src/interfaces/input-rich-text-html/useMedia.ts
@@ -124,7 +124,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 		if (newEmbed === '') {
 			mediaSelection.value = null;
 		} else {
-			const tag = /<(video|audio|iframe)/g.exec(newEmbed)?.[1];
+			const tag = /<(video|audio|iframe)/g.exec(newEmbed)?.[1] as 'video' | 'audio' | 'iframe' | undefined;
 			const sourceUrl = /src="(.*?)"/g.exec(newEmbed)?.[1] || undefined;
 			const width = Number(/width="(.*?)"/g.exec(newEmbed)?.[1]) || undefined;
 			const height = Number(/height="(.*?)"/g.exec(newEmbed)?.[1]) || undefined;
@@ -136,7 +136,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 			const previewUrl = replaceUrlAccessToken(sourceUrl, imageToken.value || getToken());
 
 			mediaSelection.value = {
-				tag: tag === 'audio' ? 'audio' : tag === 'iframe' ? 'iframe' : 'video',
+				tag,
 				sourceUrl,
 				width,
 				height,

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -304,8 +304,11 @@ function useColor() {
 
 	const rgb = computed<number[]>({
 		get() {
-			const arr = color.value !== null ? color.value.rgb().array() : props.opacity ? [0, 0, 0, 1] : [0, 0, 0];
-			return arr.length === 4 ? [...arr.slice(0, -1).map(Math.round), arr[3]] : arr.map(Math.round);
+			if (color.value !== null) {
+				return roundColorValues(color.value.rgb().array());
+			}
+
+			return roundColorValues(props.opacity ? [0, 0, 0, 1] : [0, 0, 0]);
 		},
 		set(newRGB) {
 			setColor(Color.rgb(newRGB).alpha(newRGB.length === 4 ? newRGB[3] : 1));
@@ -314,8 +317,11 @@ function useColor() {
 
 	const hsl = computed<number[]>({
 		get() {
-			const arr = color.value !== null ? color.value.hsl().array() : props.opacity ? [0, 0, 0, 1] : [0, 0, 0];
-			return arr.length === 4 ? [...arr.slice(0, -1).map(Math.round), arr[3]] : arr.map(Math.round);
+			if (color.value !== null) {
+				return roundColorValues(color.value.hsl().array());
+			}
+
+			return roundColorValues(props.opacity ? [0, 0, 0, 1] : [0, 0, 0]);
 		},
 		set(newHSL) {
 			setColor(Color.hsl(newHSL).alpha(newHSL.length === 4 ? newHSL[3] : 1));
@@ -360,6 +366,15 @@ function useColor() {
 		} else {
 			emit('input', getHexa());
 		}
+	}
+
+	function roundColorValues(arr: number[]): number[] {
+		if (arr.length === 4) {
+			// do not round the opacity
+			return [...arr.slice(0, -1).map((x) => Math.round(x)), arr[3]];
+		}
+
+		return arr.map((x) => Math.round(x));
 	}
 }
 </script>

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -370,7 +370,7 @@ function useColor() {
 
 	function roundColorValues(arr: number[]): number[] {
 		if (arr.length === 4) {
-			// do not round the opacity
+			// Do not round the opacity
 			return [...arr.slice(0, -1).map((x) => Math.round(x)), arr[3]];
 		}
 

--- a/packages/extensions-sdk/src/cli/commands/helpers/generate-bundle-entrypoint.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/generate-bundle-entrypoint.ts
@@ -9,7 +9,7 @@ export default function generateBundleEntrypoint(mode: 'app' | 'api', entries: E
 
 	const entriesForTypes = entries.filter((entry) => isIn(entry.type, types));
 
-	const imports = entriesForTypes.map((entry, i) => {
+	const imports = entriesForTypes.map((entry, index) => {
 		let entryPath: string;
 
 		if (isTypeIn(entry, HYBRID_EXTENSION_TYPES)) {
@@ -18,7 +18,7 @@ export default function generateBundleEntrypoint(mode: 'app' | 'api', entries: E
 			entryPath = entry.source;
 		}
 
-		return `import e${i} from './${pathToRelativeUrl(path.resolve(entryPath))}';`;
+		return `import e${index} from './${pathToRelativeUrl(path.resolve(entryPath))}';`;
 	});
 
 	const exports = types.map((type) => {

--- a/packages/extensions-sdk/src/cli/commands/helpers/generate-bundle-entrypoint.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/generate-bundle-entrypoint.ts
@@ -9,28 +9,33 @@ export default function generateBundleEntrypoint(mode: 'app' | 'api', entries: E
 
 	const entriesForTypes = entries.filter((entry) => isIn(entry.type, types));
 
-	const imports = entriesForTypes.map(
-		(entry, i) =>
-			`import e${i} from './${pathToRelativeUrl(
-				path.resolve(
-					isTypeIn(entry, HYBRID_EXTENSION_TYPES)
-						? mode === 'app'
-							? entry.source.app
-							: entry.source.api
-						: entry.source
-				)
-			)}';`
-	);
+	const imports = entriesForTypes.map((entry, i) => {
+		let entryPath: string;
 
-	const exports = types.map(
-		(type) =>
-			`export const ${pluralize(type)} = [${entriesForTypes
-				.map((entry, i) =>
-					entry.type === type ? (mode === 'app' ? `e${i}` : `{name:'${entry.name}',config:e${i}}`) : null
-				)
-				.filter((e): e is string => e !== null)
-				.join(',')}];`
-	);
+		if (isTypeIn(entry, HYBRID_EXTENSION_TYPES)) {
+			entryPath = mode === 'app' ? entry.source.app : entry.source.api;
+		} else {
+			entryPath = entry.source;
+		}
+
+		return `import e${i} from './${pathToRelativeUrl(path.resolve(entryPath))}';`;
+	});
+
+	const exports = types.map((type) => {
+		const entries = entriesForTypes.reduce<string[]>((result, entry, index) => {
+			if (entry.type !== type) return result;
+
+			if (mode === 'app') {
+				result.push(`e${index}`);
+			} else {
+				result.push(`{name:'${entry.name}',config:e${index}}`);
+			}
+
+			return result;
+		}, []);
+
+		return `export const ${pluralize(type)} = [${entries.join(',')}];`;
+	});
 
 	return `${imports.join('')}${exports.join('')}`;
 }

--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -32,11 +32,11 @@ const knexConfig = {
 
 const allowedLogLevels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 
-const logLevel = process.env.TEST_SAVE_LOGS
-	? allowedLogLevels.includes(process.env.TEST_SAVE_LOGS)
-		? process.env.TEST_SAVE_LOGS
-		: 'info'
-	: 'error';
+let logLevel = 'error';
+
+if (process.env.TEST_SAVE_LOGS) {
+	logLevel = allowedLogLevels.includes(process.env.TEST_SAVE_LOGS) ? process.env.TEST_SAVE_LOGS : 'info';
+}
 
 const directusAuthConfig = {
 	AUTH_PROVIDERS: 'saml',

--- a/tests/blackbox/schema/timezone/timezone-changed-node-tz-america.test.ts
+++ b/tests/blackbox/schema/timezone/timezone-changed-node-tz-america.test.ts
@@ -30,13 +30,16 @@ describe('schema', () => {
 	const currentTzOffset = new Date().getTimezoneOffset();
 	const isWindows = ['win32', 'win64'].includes(process.platform);
 	const newTzOffset = currentTzOffset !== 180 ? 180 : 360;
+	let newTz: string;
 
 	// Different timezone format for Windows
-	const newTz = isWindows
-		? String(newTzOffset * 60)
-		: newTzOffset === 180
-		? 'America/Sao_Paulo'
-		: 'America/Mexico_City';
+	if (isWindows) {
+		newTz = String(newTzOffset * 60);
+	} else if (newTzOffset === 180) {
+		newTz = 'America/Sao_Paulo';
+	} else {
+		newTz = 'America/Mexico_City';
+	}
 
 	const sampleDates: SchemaTimezoneTypesObject[] = [];
 

--- a/tests/blackbox/schema/timezone/timezone-changed-node-tz-asia.test.ts
+++ b/tests/blackbox/schema/timezone/timezone-changed-node-tz-asia.test.ts
@@ -31,9 +31,16 @@ describe('schema', () => {
 	const isWindows = ['win32', 'win64'].includes(process.platform);
 
 	const newTzOffset = currentTzOffset !== -540 ? -540 : -240;
+	let newTz: string;
 
 	// Different timezone format for Windows
-	const newTz = isWindows ? String(newTzOffset * 60) : newTzOffset === -540 ? 'Asia/Seoul' : 'Asia/Dubai';
+	if (isWindows) {
+		newTz = String(newTzOffset * 60);
+	} else if (newTzOffset === -540) {
+		newTz = 'Asia/Seoul';
+	} else {
+		newTz = 'Asia/Dubai';
+	}
 
 	const sampleDates: SchemaTimezoneTypesObject[] = [];
 


### PR DESCRIPTION
Introducing the `no-nested-ternary` linter rule for improved readability/maintainability.
https://eslint.org/docs/latest/rules/no-nested-ternary