### PR TITLE
Prevent parsing non-decimal values in search

### DIFF
--- a/.changeset/rare-deers-clap.md
+++ b/.changeset/rare-deers-clap.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+---
+
+Prevented parsing non-decimal values in search query.

--- a/.changeset/rare-deers-clap.md
+++ b/.changeset/rare-deers-clap.md
@@ -3,4 +3,4 @@
 "@directus/api": patch
 ---
 
-Prevented parsing non-decimal values in search query.
+Prevented parsing non-decimal values in search query

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -1,0 +1,122 @@
+import { expect, vi, test, describe } from 'vitest';
+import { applySearch } from './apply-query.js';
+import type { SchemaOverview } from '@directus/types';
+
+function mockDatabase() {
+	const self: Record<string, any> = {
+		andWhere: vi.fn(() => self),
+		orWhere: vi.fn(() => self),
+		orWhereRaw: vi.fn(() => self),
+	};
+
+	return self;
+}
+
+describe('applySearch', () => {
+	const FAKE_SCHEMA: SchemaOverview = {
+		collections: {
+			test: {
+				collection: 'test',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					text: {
+						field: 'text',
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						type: 'text',
+						dbType: null,
+						precision: null,
+						scale: null,
+						special: [],
+						note: null,
+						validation: null,
+						alias: false,
+					},
+					float: {
+						field: 'float',
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						type: 'float',
+						dbType: null,
+						precision: null,
+						scale: null,
+						special: [],
+						note: null,
+						validation: null,
+						alias: false,
+					},
+					integer: {
+						field: 'integer',
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						type: 'integer',
+						dbType: null,
+						precision: null,
+						scale: null,
+						special: [],
+						note: null,
+						validation: null,
+						alias: false,
+					},
+					id: {
+						field: 'id',
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						type: 'uuid',
+						dbType: null,
+						precision: null,
+						scale: null,
+						special: [],
+						note: null,
+						validation: null,
+						alias: false,
+					},
+				},
+			},
+		},
+		relations: [],
+	};
+
+	test.each(['0x56071c902718e681e274DB0AaC9B4Ed2d027924d', '0b11111', '0.42e3', 'Infinity'])(
+		'Prevent %s from being cast to number',
+		async (number) => {
+			const db = mockDatabase();
+
+			db['andWhere'].mockImplementation((callback: () => void) => {
+				// detonate the andWhere function
+				callback.call(db);
+				return db;
+			});
+
+			await applySearch(FAKE_SCHEMA, db as any, number, 'test');
+
+			expect(db['andWhere']).toBeCalledTimes(1);
+			expect(db['orWhere']).toBeCalledTimes(0);
+			expect(db['orWhereRaw']).toBeCalledTimes(1);
+		}
+	);
+
+	test.each(['1234', '-128', '12.34', '42.000'])('Casting number %s', async (number) => {
+		const db = mockDatabase();
+
+		db['andWhere'].mockImplementation((callback: () => void) => {
+			// detonate the andWhere function
+			callback.call(db);
+			return db;
+		});
+
+		await applySearch(FAKE_SCHEMA, db as any, number, 'test');
+
+		expect(db['andWhere']).toBeCalledTimes(1);
+		expect(db['orWhere']).toBeCalledTimes(2);
+		expect(db['orWhereRaw']).toBeCalledTimes(1);
+	});
+});

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -85,7 +85,7 @@ describe('applySearch', () => {
 		relations: [],
 	};
 
-	test.each(['0x56071c902718e681e274DB0AaC9B4Ed2d027924d', '0b11111', '0.42e3', 'Infinity'])(
+	test.each(['0x56071c902718e681e274DB0AaC9B4Ed2d027924d', '0b11111', '0.42e3', 'Infinity', '42.000'])(
 		'Prevent %s from being cast to number',
 		async (number) => {
 			const db = mockDatabase();
@@ -104,7 +104,7 @@ describe('applySearch', () => {
 		}
 	);
 
-	test.each(['1234', '-128', '12.34', '42.000'])('Casting number %s', async (number) => {
+	test.each(['1234', '-128', '12.34'])('Casting number %s', async (number) => {
 		const db = mockDatabase();
 
 		db['andWhere'].mockImplementation((callback: () => void) => {

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -786,6 +786,8 @@ function validateNumber(value: string, parsed: number) {
 		parsed = Number(value);
 	}
 
+	// casting parsed value back to string should be equal the original value
+	// (prevent unintended number parsing, e.g. String(7) !== "ob111")
 	return String(parsed) === value;
 }
 

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -779,13 +779,6 @@ export async function applySearch(
 
 function validateNumber(value: string, parsed: number) {
 	if (isNaN(parsed) || !Number.isFinite(parsed)) return false;
-
-	// compare without the decimal point
-	if (value.includes('.')) {
-		value = value.replace('.', '');
-		parsed = Number(value);
-	}
-
 	return String(parsed) === value;
 }
 


### PR DESCRIPTION
For numeric fields we are parsing the search value to a number however this includes all numeric formats. I don't think we should be actively searching for the numeric value of binary or hexidecimal formats. This PR tries to prevent number casting for the following formats:
- hexadecimal `0xFFFF`
- binary `0b11111111`
- exponential `0.42e2`
- infinite `Infinity`

Fixes #18356 
