### PR TITLE
Disable vue/require-default-prop eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
 			rules: {
 				...defaultRules,
 				'vue/multi-word-component-names': 'off',
+				'vue/require-default-prop': 'off',
 				// It's recommended to turn off this rule on TypeScript projects
 				'no-undef': 'off',
 				// Allow ts-directive comments (used to suppress TypeScript compiler errors)


### PR DESCRIPTION
This rule was very useful in Vue 2 when we didn't have proper TypeScript support yet. Nowadays, it basically incentives the wrong default values from being set in components, where the default-default value (`undefined`) is often the appropriate choice. This removes that rule in favor of relying on TypeScript types to achieve the same type safety