### PR TITLE
refactor: Adds support for additional parameters when logging in via openid

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -131,6 +131,7 @@ const allowedEnvironmentVars = [
 	'AUTH_.+_ICON',
 	'AUTH_.+_LABEL',
 	'AUTH_.+_PARAMS',
+	'AUTH_.+_CUSTOM_URL_PARAMS',
 	'AUTH_.+_ISSUER_URL',
 	'AUTH_.+_AUTH_REQUIRE_VERIFIED_EMAIL',
 	'AUTH_.+_CLIENT_URL',

--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -39,7 +39,8 @@ if (process.env.TEST_SAVE_LOGS) {
 }
 
 const directusAuthConfig = {
-	AUTH_PROVIDERS: 'saml',
+	// SAM
+	AUTH_PROVIDERS: 'saml,directus',
 	AUTH_SAML_DRIVER: 'saml',
 	AUTH_SAML_ALLOW_PUBLIC_REGISTRATION: 'true',
 	AUTH_SAML_SP_metadata:
@@ -49,6 +50,13 @@ const directusAuthConfig = {
 	AUTH_SAML_DEFAULT_ROLE_ID: 'd70c0943-5b55-4c5d-a613-f539a27a57f5',
 	AUTH_SAML_IDENTIFIER_KEY: 'uid',
 	AUTH_SAML_EMAIL_KEY: 'email',
+
+	// OAuth2 and OpenId
+	AUTH_DIRECTUS_DRIVER: 'openid',
+	AUTH_DIRECTUS_CLIENT_ID: '000000000000-abcdefvaldeirpsrbcdefabcdefabcdefab.apps.directususercontent.com',
+	AUTH_DIRECTUS_CLIENT_SECRET: 'ABCDEF-abcdefghijklmnopqrstuvwxyz',
+	AUTH_DIRECTUS_ISSUER_URL: 'https://accounts-fake.directus.com',
+	AUTH_DIRECTUS_DEFAULT_ROLE_ID: 'd70c0943-5b55-4c5d-a613-f539a27a57f5'
 };
 
 const directusStorageConfig = {

--- a/tests/blackbox/routes/auth/openid.test.ts
+++ b/tests/blackbox/routes/auth/openid.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import vendors from '@common/get-dbs-to-test';
+
+describe('/auth/login/directus', () => {
+	describe('GET /', () => {
+		describe('when correct params', () => {
+			describe('The redirection URL must have the informed URL parameters', () => {
+				it.each(vendors)('%s', async () => {
+					const customParams = {
+						login_hint: 'example@directus.com',
+						display: 'wap'
+					};
+
+					const params = new URLSearchParams(customParams).toString();
+
+					// Actions
+					const response = await request('http://127.0.0.1:8880')
+						.get(`/auth/login/directus?${params}`);
+
+					// Assert Status Code
+					expect(response.statusCode).toBe(302);
+					expect(response.headers).toHaveProperty('location');
+
+					const location = new URL(response.headers['location']);
+
+					// Assert URL Params
+					expect(location.searchParams.get('login_hint')).toBe(customParams.login_hint);
+					expect(location.searchParams.get('display')).toBe(customParams.display);
+				});
+			});
+		});
+
+		describe('when incorrect params', () => {
+			describe('The redirection URL should NOT contain the URL parameters not allowed in the environment variable', () => {
+				it.each(vendors)('%s', async () => {
+					const customParams = {
+						invalid_query: 'mc-sid',
+						display: 'wap' // Valid param
+					};
+
+					const params = new URLSearchParams(customParams).toString();
+
+					// Actions
+					const response = await request('http://127.0.0.1:8880')
+						.get(`/auth/login/directus?${params}`);
+
+					// Assert Status Code
+					expect(response.statusCode).toBe(302);
+					expect(response.headers).toHaveProperty('location');
+
+					const location = new URL(response.headers['location']);
+
+					// Assert URL Params
+					expect(location.searchParams.get('invalid_query')).toBe(null);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
Currently, some websites such as Google allow the developer to use
various URL parameters in addition to the required ones
(client_id, scope, etc).

The modification allows the user to enable a list via .env and enables
the front-end developer to enhance the integration between the website
and Directus.

**Exemplo de parâmetros**

| Parameter  | Description                                                                                                                     |
|------------|---------------------------------------------------------------------------------------------------------------------------------|
| display    | An ASCII string value for specifying how the authorization server displays the authentication and consent user interface pages. |
| hd         | Streamline the login process for accounts owned by a Google Cloud organization.                                                 |
| login_hint | Enables the front-end to inform the user's email to facilitate login when the user has multiple logged-in accounts.             |

**Configurando parâmetros**

1. Open `.env` file
2. Enter config

```env
AUTH_PROVIDERS=directus

AUTH_DIRECTUS_DRIVER=openid
AUTH_DIRECTUS_CLIENT_ID=000000000000-abcdefvaldeirpsrbcdefabcdefabcdefab.apps.directususercontent.com
AUTH_DIRECTUS_CLIENT_SECRET=ABCDEF-abcdefghijklmnopqrstuvwxyz
AUTH_DIRECTUS_ISSUER_URL=https://accounts.google.com
AUTH_DIRECTUS_DEFAULT_ROLE_ID=eddfce8d-36e9-4cba-90a4-6b8b2004a3cc

AUTH_DIRECTUS_CUSTOM_URL_PARAMS=login_hint,display
```

**Sites that use custom parameters**

https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters

https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#send-the-sign-in-request

Signed-off-by: Valdeir S.