### PR TITLE
Follow-up fix after TS error fixes in routes

### DIFF
--- a/app/src/routes/login/login.vue
+++ b/app/src/routes/login/login.vue
@@ -15,15 +15,18 @@
 
 		<sso-links v-if="!authenticated" :providers="auth.providers" />
 
-		<template v-if="authenticated" #notice>
-			<v-icon name="lock_open" left />
-			{{ t('authenticated') }}
-		</template>
-		<template v-else #notice>
-			<v-icon name="lock" left />
-			{{
-				logoutReason && te(`logoutReason.${logoutReason}`) ? t(`logoutReason.${logoutReason}`) : t('not_authenticated')
-			}}
+		<template #notice>
+			<div v-if="authenticated">
+				<v-icon name="lock_open" left />
+				{{ t('authenticated') }}
+			</div>
+			<div v-else>
+				{{
+					logoutReason && te(`logoutReason.${logoutReason}`)
+						? t(`logoutReason.${logoutReason}`)
+						: t('not_authenticated')
+				}}
+			</div>
 		</template>
 	</public-view>
 </template>
@@ -47,7 +50,7 @@ withDefaults(defineProps<Props>(), {
 	logoutReason: null,
 });
 
-const { t } = useI18n();
+const { t, te } = useI18n();
 
 const appStore = useAppStore();
 const serverStore = useServerStore();


### PR DESCRIPTION
Follow-up on #18468.

Apparently, Volar doesn't check the content of `<template v-else` and therefore was under the impression that `te` is not needed.
(Honestly, not quite sure why this is the case 🤔)
