### PR TITLE
Updated vitest

### DIFF
--- a/.changeset/late-tables-call.md
+++ b/.changeset/late-tables-call.md
@@ -1,0 +1,17 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+"@directus/composables": patch
+"@directus/exceptions": patch
+"@directus/extensions-sdk": patch
+"@directus/storage-driver-azure": patch
+"@directus/storage-driver-cloudinary": patch
+"@directus/storage-driver-gcs": patch
+"@directus/storage-driver-local": patch
+"@directus/storage-driver-s3": patch
+"@directus/storage": patch
+"@directus/update-check": patch
+"@directus/utils": patch
+---
+
+Updated vitest to `0.31.0`

--- a/api/package.json
+++ b/api/package.json
@@ -204,13 +204,13 @@
 		"@types/uuid": "9.0.1",
 		"@types/uuid-validate": "0.0.1",
 		"@types/wellknown": "0.5.4",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"copyfiles": "2.4.1",
 		"form-data": "4.0.0",
 		"knex-mock-client": "2.0.0",
 		"supertest": "6.3.3",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	},
 	"optionalDependencies": {
 		"@keyv/redis": "2.5.7",

--- a/app/package.json
+++ b/app/package.json
@@ -127,7 +127,7 @@
 		"tinymce": "6.4.1",
 		"typescript": "5.0.4",
 		"vite": "4.3.1",
-		"vitest": "0.30.1",
+		"vitest": "0.31.0",
 		"vue": "3.2.47",
 		"vue-i18n": "9.2.2",
 		"vue-router": "4.1.6",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -33,11 +33,11 @@
 		"@directus/tsconfig": "0.0.7",
 		"@directus/types": "workspace:*",
 		"@types/lodash-es": "4.17.7",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"@vue/test-utils": "2.3.2",
 		"axios": "1.3.6",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	},
 	"dependencies": {
 		"@directus/constants": "workspace:*",

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -33,9 +33,9 @@
 		"@directus/tsconfig": "0.0.7",
 		"@directus/types": "workspace:*",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"joi": "17.9.1",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -61,9 +61,9 @@
 		"@directus/tsconfig": "0.0.7",
 		"@types/fs-extra": "11.0.1",
 		"@types/inquirer": "9.0.3",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	},
 	"engines": {
 		"node": ">=12.20.0"

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -36,8 +36,8 @@
 	"devDependencies": {
 		"@directus/tsconfig": "0.0.7",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -37,8 +37,8 @@
 	"devDependencies": {
 		"@directus/tsconfig": "0.0.7",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -36,8 +36,8 @@
 	"devDependencies": {
 		"@directus/tsconfig": "0.0.7",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -35,8 +35,8 @@
 	"devDependencies": {
 		"@directus/tsconfig": "0.0.7",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -38,8 +38,8 @@
 	"devDependencies": {
 		"@directus/tsconfig": "0.0.7",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,8 +30,8 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "0.0.7",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -36,8 +36,8 @@
 		"@directus/tsconfig": "0.0.7",
 		"@ngneat/falso": "6.4.0",
 		"@types/semver": "7.3.13",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -59,9 +59,9 @@
 		"@types/lodash-es": "4.17.7",
 		"@types/node": "18.15.13",
 		"@types/tmp": "0.2.3",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "0.31.0",
 		"concurrently": "8.0.1",
 		"typescript": "5.0.4",
-		"vitest": "0.30.1"
+		"vitest": "0.31.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,8 +463,8 @@ importers:
         specifier: 0.5.4
         version: 0.5.4
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -481,8 +481,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   app:
     dependencies:
@@ -785,8 +785,8 @@ importers:
         specifier: 4.3.1
         version: 4.3.1(@types/node@18.15.13)(sass@1.62.0)
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
       vue:
         specifier: 3.2.47
         version: 3.2.47
@@ -865,8 +865,8 @@ importers:
         specifier: 4.17.7
         version: 4.17.7
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       '@vue/test-utils':
         specifier: 2.3.2
         version: 2.3.2(vue@3.2.47)
@@ -877,8 +877,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/constants:
     dependencies:
@@ -917,8 +917,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       joi:
         specifier: 17.9.1
         version: 17.9.1
@@ -926,8 +926,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/extensions-sdk:
     dependencies:
@@ -1008,14 +1008,14 @@ importers:
         specifier: 9.0.3
         version: 9.0.3
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/schema:
     dependencies:
@@ -1055,14 +1055,14 @@ importers:
         specifier: 0.0.7
         version: 0.0.7
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/storage-driver-azure:
     dependencies:
@@ -1083,14 +1083,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/storage-driver-cloudinary:
     dependencies:
@@ -1114,14 +1114,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/storage-driver-gcs:
     dependencies:
@@ -1142,14 +1142,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/storage-driver-local:
     dependencies:
@@ -1167,14 +1167,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/storage-driver-s3:
     dependencies:
@@ -1201,14 +1201,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/types:
     devDependencies:
@@ -1271,14 +1271,14 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   packages/utils:
     dependencies:
@@ -1332,8 +1332,8 @@ importers:
         specifier: 0.2.3
         version: 0.2.3
       '@vitest/coverage-c8':
-        specifier: 0.30.1
-        version: 0.30.1(vitest@0.30.1)
+        specifier: 0.31.0
+        version: 0.31.0(vitest@0.31.0)
       concurrently:
         specifier: 8.0.1
         version: 8.0.1
@@ -1341,8 +1341,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 0.30.1
-        version: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+        specifier: 0.31.0
+        version: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
 
   tests/blackbox:
     devDependencies:
@@ -7406,50 +7406,52 @@ packages:
       vue: 3.2.47
     dev: true
 
-  /@vitest/coverage-c8@0.30.1(vitest@0.30.1):
-    resolution: {integrity: sha512-/Wa3dtSuckpdngAmiCwowaEXXgJkqPrtfvrs9HTB9QoEfNbZWPu4E4cjEn4lJZb4qcGf4fxFtUA2f9DnDNAzBA==}
+  /@vitest/coverage-c8@0.31.0(vitest@0.31.0):
+    resolution: {integrity: sha512-h72qN1D962AO7UefQVulm9JFP5ACS7OfhCdBHioXU8f7ohH/+NTZCgAqmgcfRNHHO/8wLFxx+93YVxhodkEJVA==}
     peerDependencies:
       vitest: '>=0.30.0 <1'
     dependencies:
+      '@ampproject/remapping': 2.2.1
       c8: 7.13.0
+      magic-string: 0.30.0
       picocolors: 1.0.0
       std-env: 3.3.2
-      vitest: 0.30.1(happy-dom@9.8.4)(sass@1.62.0)
+      vitest: 0.31.0(happy-dom@9.8.4)(sass@1.62.0)
     dev: true
 
-  /@vitest/expect@0.30.1:
-    resolution: {integrity: sha512-c3kbEtN8XXJSeN81iDGq29bUzSjQhjES2WR3aColsS4lPGbivwLtas4DNUe0jD9gg/FYGIteqOenfU95EFituw==}
+  /@vitest/expect@0.31.0:
+    resolution: {integrity: sha512-Jlm8ZTyp6vMY9iz9Ny9a0BHnCG4fqBa8neCF6Pk/c/6vkUk49Ls6UBlgGAU82QnzzoaUs9E/mUhq/eq9uMOv/g==}
     dependencies:
-      '@vitest/spy': 0.30.1
-      '@vitest/utils': 0.30.1
+      '@vitest/spy': 0.31.0
+      '@vitest/utils': 0.31.0
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner@0.30.1:
-    resolution: {integrity: sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==}
+  /@vitest/runner@0.31.0:
+    resolution: {integrity: sha512-H1OE+Ly7JFeBwnpHTrKyCNm/oZgr+16N4qIlzzqSG/YRQDATBYmJb/KUn3GrZaiQQyL7GwpNHVZxSQd6juLCgw==}
     dependencies:
-      '@vitest/utils': 0.30.1
+      '@vitest/utils': 0.31.0
       concordance: 5.0.4
       p-limit: 4.0.0
       pathe: 1.1.0
     dev: true
 
-  /@vitest/snapshot@0.30.1:
-    resolution: {integrity: sha512-fJZqKrE99zo27uoZA/azgWyWbFvM1rw2APS05yB0JaLwUIg9aUtvvnBf4q7JWhEcAHmSwbrxKFgyBUga6tq9Tw==}
+  /@vitest/snapshot@0.31.0:
+    resolution: {integrity: sha512-5dTXhbHnyUMTMOujZPB0wjFjQ6q5x9c8TvAsSPUNKjp1tVU7i9pbqcKPqntyu2oXtmVxKbuHCqrOd+Ft60r4tg==}
     dependencies:
       magic-string: 0.30.0
       pathe: 1.1.0
       pretty-format: 27.5.1
     dev: true
 
-  /@vitest/spy@0.30.1:
-    resolution: {integrity: sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==}
+  /@vitest/spy@0.31.0:
+    resolution: {integrity: sha512-IzCEQ85RN26GqjQNkYahgVLLkULOxOm5H/t364LG0JYb3Apg0PsYCHLBYGA006+SVRMWhQvHlBBCyuByAMFmkg==}
     dependencies:
       tinyspy: 2.1.0
     dev: true
 
-  /@vitest/utils@0.30.1:
-    resolution: {integrity: sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==}
+  /@vitest/utils@0.31.0:
+    resolution: {integrity: sha512-kahaRyLX7GS1urekRXN2752X4gIgOGVX4Wo8eDUGUkTWlGpXzf5ZS6N9RUUS+Re3XEE8nVGqNyxkSxF5HXlGhQ==}
     dependencies:
       concordance: 5.0.4
       loupe: 2.3.6
@@ -17978,8 +17980,8 @@ packages:
     resolution: {integrity: sha512-+/cS2AM9l6p72IBs2uolHbGsBUztLs0WslqNgFaTXtmMksTNUOhh8p08xtA/fa03UGlWEC6/EJoeV95/QDXa2A==}
     dev: true
 
-  /tinypool@0.4.0:
-    resolution: {integrity: sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==}
+  /tinypool@0.5.0:
+    resolution: {integrity: sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -18707,8 +18709,8 @@ packages:
       vfile-message: 3.1.4
     dev: true
 
-  /vite-node@0.30.1(@types/node@18.15.13)(sass@1.62.0):
-    resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
+  /vite-node@0.31.0(@types/node@18.15.13)(sass@1.62.0):
+    resolution: {integrity: sha512-8x1x1LNuPvE2vIvkSB7c1mApX5oqlgsxzHQesYF7l5n1gKrEmrClIiZuOFbFDQcjLsmcWSwwmrWrcGWm9Fxc/g==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
@@ -18791,8 +18793,8 @@ packages:
       - terser
     dev: true
 
-  /vitest@0.30.1(happy-dom@9.8.4)(sass@1.62.0):
-    resolution: {integrity: sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==}
+  /vitest@0.31.0(happy-dom@9.8.4)(sass@1.62.0):
+    resolution: {integrity: sha512-JwWJS9p3GU9GxkG7eBSmr4Q4x4bvVBSswaCFf1PBNHiPx00obfhHRJfgHcnI0ffn+NMlIh9QGvG75FlaIBdKGA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
@@ -18825,11 +18827,11 @@ packages:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
       '@types/node': 18.15.13
-      '@vitest/expect': 0.30.1
-      '@vitest/runner': 0.30.1
-      '@vitest/snapshot': 0.30.1
-      '@vitest/spy': 0.30.1
-      '@vitest/utils': 0.30.1
+      '@vitest/expect': 0.31.0
+      '@vitest/runner': 0.31.0
+      '@vitest/snapshot': 0.31.0
+      '@vitest/spy': 0.31.0
+      '@vitest/utils': 0.31.0
       acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
@@ -18841,13 +18843,12 @@ packages:
       magic-string: 0.30.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      source-map: 0.6.1
       std-env: 3.3.2
       strip-literal: 1.0.1
       tinybench: 2.4.0
-      tinypool: 0.4.0
+      tinypool: 0.5.0
       vite: 4.3.1(@types/node@18.15.13)(sass@1.62.0)
-      vite-node: 0.30.1(@types/node@18.15.13)(sass@1.62.0)
+      vite-node: 0.31.0(@types/node@18.15.13)(sass@1.62.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
In PR https://github.com/directus/directus/pull/17873 we ran into a vitest limitation (https://github.com/vitest-dev/vitest/issues/453) which has been fixed since.

This PR updates all `vitest` dependencies to `0.31.0` so we can Mock node internals.