### PR TITLE
Fix app hydration for users with null language

### DIFF
--- a/app/src/hydrate.test.ts
+++ b/app/src/hydrate.test.ts
@@ -1,0 +1,69 @@
+import { setLanguage } from '@/lang/set-language';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useUserStore } from '@/stores/user';
+import { useServerStore } from '@/stores/server';
+import { useSettingsStore } from '@/stores/settings';
+import { useAppStore } from '@/stores/app';
+
+import { hydrate } from './hydrate';
+import { defaultBasemap } from './utils/geometry/basemap';
+
+vi.mock('@/lang/set-language', () => ({
+	setLanguage: vi.fn(),
+}));
+
+beforeEach(() => {
+	setActivePinia(
+		createTestingPinia({
+			createSpy: vi.fn,
+		})
+	);
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('setLanguage', () => {
+	test('should not be called with null project default language (in runtime)', async () => {
+		const serverStore = useServerStore();
+		serverStore.info = { project: { default_language: null } } as any;
+
+		await hydrate();
+
+		expect(vi.mocked(setLanguage).mock.calls[0][0]).not.toBeNull();
+	});
+
+	test('should not be called with null user language (in runtime)', async () => {
+		const userStore = useUserStore();
+		userStore.currentUser = { language: null } as any;
+
+		await hydrate();
+
+		expect(vi.mocked(setLanguage).mock.calls[0][0]).not.toBeNull();
+	});
+});
+
+describe('basemap', () => {
+	test('should use default basemap when there is no mapbox key', async () => {
+		const appStore = useAppStore();
+		const settingsStore = useSettingsStore();
+		settingsStore.settings = { mapbox_key: null } as any;
+
+		await hydrate();
+
+		expect(appStore.basemap).toBe(defaultBasemap.name);
+	});
+
+	test('should use default mapbox basemap when there is mapbox key', async () => {
+		const appStore = useAppStore();
+		const settingsStore = useSettingsStore();
+		settingsStore.settings = { mapbox_key: 'sample_mapbox_key' } as any;
+
+		await hydrate();
+
+		expect(appStore.basemap).toBe('Mapbox');
+	});
+});

--- a/app/src/hydrate.ts
+++ b/app/src/hydrate.ts
@@ -69,11 +69,13 @@ export async function hydrate(): Promise<void> {
 		 */
 		await userStore.hydrate();
 
+		const currentUser = userStore.currentUser;
+
 		let lang = 'en-US';
 		if (serverStore.info?.project?.default_language) lang = serverStore.info.project.default_language;
-		if (userStore.currentUser && 'language' in userStore.currentUser) lang = userStore.currentUser.language;
+		if (currentUser && 'language' in currentUser && currentUser.language) lang = currentUser.language;
 
-		if (userStore.currentUser?.role) {
+		if (currentUser?.role) {
 			await Promise.all([permissionsStore.hydrate(), fieldsStore.hydrate({ skipTranslation: true })]);
 
 			const hydratedStores = ['userStore', 'permissionsStore', 'fieldsStore'];

--- a/app/src/utils/geometry/basemap.ts
+++ b/app/src/utils/geometry/basemap.ts
@@ -10,7 +10,7 @@ export type BasemapSource = {
 	attribution?: string;
 };
 
-const defaultBasemap: BasemapSource = {
+export const defaultBasemap: BasemapSource = {
 	name: 'OpenStreetMap',
 	type: 'raster',
 	url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -32,7 +32,7 @@ export type User = {
 	role: Role;
 	password_reset_token: string | null;
 	timezone: string;
-	language: string;
+	language: string | null;
 	avatar: null | Avatar;
 	company: string | null;
 	title: string | null;


### PR DESCRIPTION
## Description

Fixes the bug mentioned in https://github.com/directus/directus/pull/18489#discussion_r1185608991.

The app breaks when we are logging in with a user that has `null` language (which is by default):

![](https://user-images.githubusercontent.com/42867097/236382721-fbb061fa-1f47-499d-b4c4-8fee76d58652.png)

This is because the absence of null check now causes `setLanguage` to be called with `null` instead of a string value, `loadDateFNSLocale` is then subsequently called with `null`, causing the `.split('-')` here to throw the error:

https://github.com/directus/directus/blob/88861f8fceda8265a9e4fcd78b204573c156d21b/app/src/utils/get-date-fns-locale.ts#L12

## Changes

- added `&& currentUser.language` check to ensure null value no longer passes the condition. Also "extracted" `userStore.currentUser` into a variable to keep the conditions tiny bit shorter.
- updated the User type's `language` to include null, so it can be caught earlier when applicable:

    ![](https://user-images.githubusercontent.com/42867097/236382886-c7222576-8af7-463b-a882-6b3498ae39ef.png)

- added unit test for this, but had to export `defaultBasemap` from the basemap utils for basemap-related test cases included in the new unit test.