### PR TITLE
Remove unnecessary key props

### DIFF
--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :key="field.field" class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
+	<div class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
 		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow>
 			<template #activator="{ toggle, active }">
 				<form-field-label

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -22,7 +22,6 @@
 				<div
 					v-if="isActive"
 					:id="id"
-					:key="id"
 					v-click-outside="{
 						handler: deactivate,
 						middleware: onClickOutsideMiddleware,

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -150,7 +150,6 @@
 
 		<v-form
 			ref="form"
-			:key="collection"
 			v-model="edits"
 			:autofocus="isNew"
 			:disabled="isNew ? false : updateAllowed === false"

--- a/docs/.vitepress/theme/DocLayout.vue
+++ b/docs/.vitepress/theme/DocLayout.vue
@@ -14,7 +14,7 @@ const path = computed(() => route.path);
 <template>
 	<Layout>
 		<template #doc-footer-before>
-			<ArticleFeedback :key="path" :url="path" :title="title" />
+			<ArticleFeedback :url="path" :title="title" />
 		</template>
 	</Layout>
 </template>


### PR DESCRIPTION
Since Vue 3, key props aren't necessary on `v-if`s and are only really useful in combination with `v-for` or to force-rerender a component (see the [vue docs](https://vuejs.org/api/built-in-special-attributes.html#key)).