### PR TITLE
Fix field name error in Headless CMS Next 13 guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -31,3 +31,4 @@
 - danielduckworth
 - JonathanSchndr
 - ArthurYidi
+- lucasdon

--- a/docs/guides/headless-cms/build-static-website/next-13.md
+++ b/docs/guides/headless-cms/build-static-website/next-13.md
@@ -154,7 +154,7 @@ Create the following fields in your `posts` data model:
 - a text input field called `title`
 - a WYSIWYG input field called `content`
 - an image relational field called `image`
-- a datetime selection field called `published` - set the type to 'date'
+- a datetime selection field called `publish_date` - set the type to 'date'
 - a many-to-one relational field called `author` with the related collection set to `authors`
 
 In Roles & Permissions, give the Public role read access to the `authors`, `posts`, and `directus_files` collections.


### PR DESCRIPTION
Fix the guide's field name of `publish_date` to match the example [query code](website-next13/app/blog/page.tsx) from the repo.

