### PR TITLE
Update discussion/issue links

### DIFF
--- a/.changeset/metal-chairs-push.md
+++ b/.changeset/metal-chairs-push.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Updated the direct links to discussions/issues to drop the pre-chosen template

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Request a new feature
-    url: https://github.com/directus/directus/discussions/new?category=feature-requests
+    url: https://github.com/directus/directus/discussions/new
     about: Share your ideas on how to make Directus better.
   - name: Suggest improvements for the docs
-    url: https://github.com/directus/directus/discussions/new?category=docs-suggestions
+    url: https://github.com/directus/directus/discussions/new
     about: Share your ideas on how to improve the documentation of Directus.
   - name: Ask a question
     url: https://directus.chat/

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -76,12 +76,12 @@ const externalItems = computed(() => {
 		{
 			icon: 'bug_report',
 			name: t('report_bug'),
-			href: 'https://github.com/directus/directus/issues/new?template=bug_report.yml',
+			href: 'https://github.com/directus/directus/issues/new',
 		},
 		{
 			icon: 'new_releases',
 			name: t('request_feature'),
-			href: 'https://github.com/directus/directus/discussions/new?category=feature-requests',
+			href: 'https://github.com/directus/directus/discussions/new',
 		},
 	];
 });


### PR DESCRIPTION
We're continuously evolving the exact category / template names, so it makes more sense for now to use the generic "selection" page instead of deep-linking to the exact hardcoded name