### PR TITLE
Re-add default value for notification item type

### DIFF
--- a/app/src/views/private/components/notification-item.vue
+++ b/app/src/views/private/components/notification-item.vue
@@ -18,18 +18,23 @@
 <script lang="ts" setup>
 import { useNotificationsStore } from '@/stores/notifications';
 
-const props = defineProps<{
-	id: string;
-	title: string;
-	text?: string;
-	icon?: string | null;
-	type?: 'info' | 'success' | 'warning' | 'error';
-	tail?: boolean;
-	dense?: boolean;
-	showClose?: boolean;
-	loading?: boolean;
-	progress?: number;
-}>();
+const props = withDefaults(
+	defineProps<{
+		id: string;
+		title: string;
+		text?: string;
+		icon?: string | null;
+		type?: 'info' | 'success' | 'warning' | 'error';
+		tail?: boolean;
+		dense?: boolean;
+		showClose?: boolean;
+		loading?: boolean;
+		progress?: number;
+	}>(),
+	{
+		type: 'info',
+	}
+);
 
 const notificationsStore = useNotificationsStore();
 


### PR DESCRIPTION
## Description

`<notification-item>`'s `type` prop used to have a default value of `info` so that notifications will have the default primary color as it's background color, but it was missing after the move to script[setup] via https://github.com/directus/directus/pull/18454/files#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL42.

### Before

https://github.com/directus/directus/assets/42867097/c6df0bf3-c5d4-4396-ab9c-b812d7e67f36

### After

https://github.com/directus/directus/assets/42867097/698d87c6-f8fd-4820-9de0-9d3ac2d02d3f

