### PR TITLE
Fix interface options that use a code editor

### DIFF
--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -30,7 +30,7 @@ import 'codemirror/keymap/sublime.js';
 
 const props = withDefaults(
 	defineProps<{
-		value: string | Record<string, unknown> | unknown[] | boolean | number | null;
+		value?: string | Record<string, unknown> | unknown[] | boolean | number | null;
 		disabled?: boolean;
 		altOptions?: Record<string, any>;
 		template?: string;
@@ -99,8 +99,8 @@ onMounted(async () => {
 	}
 });
 
-const stringValue = computed<string>(() => {
-	if (props.value === null) return '';
+const stringValue = computed(() => {
+	if (props.value === null || props.value === undefined) return '';
 
 	if (props.type === 'json' || typeof props.value === 'object') {
 		return JSON.stringify(props.value, null, 4);


### PR DESCRIPTION
Prior to #18415, `input-code`'s `value` prop had a default value of `null`. This broke the WYSIWYG editor interface's `customFormats` and `tinymceOverrides` options.