### PR TITLE
Add Expand/Collapse to collection items in data model

### DIFF
--- a/.changeset/silent-comics-move.md
+++ b/.changeset/silent-comics-move.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Add new toggle to collapse nested collections in the datamodel settings

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -132,10 +132,8 @@ archive_confirm_count: >-
   No Items Selected | Are you sure you want to archive this item? | Are you sure you want to archive these {count}
   items?
 reset_system_permissions_to: 'Reset System Permissions to:'
-reset_system_permissions_copy:
-  This action will overwrite any custom permissions you may have applied to the system collections. Are you sure?
-the_following_are_minimum_permissions:
-  The following minimum permissions are automatically applied when "App Access" is enabled. You can grant additional permissions if needed, but you cannot reduce permissions below this level.
+reset_system_permissions_copy: This action will overwrite any custom permissions you may have applied to the system collections. Are you sure?
+the_following_are_minimum_permissions: The following minimum permissions are automatically applied when "App Access" is enabled. You can grant additional permissions if needed, but you cannot reduce permissions below this level.
 app_access_minimum: App Access Minimum
 recommended_defaults: Recommended Defaults
 unarchive: Unarchive
@@ -363,7 +361,7 @@ revision_delta_reverted: Reverted
 revision_delta_update_message: This field has been updated but its value is being concealed for security reasons.
 revision_delta_other: Revision
 revision_delta_by: '{date} by {user}'
-presentation_text_values_cannot_be_reimported: "Uses presentation text, values can not be re-imported."
+presentation_text_values_cannot_be_reimported: 'Uses presentation text, values can not be re-imported.'
 download_page_as_csv: 'Download Page as CSV'
 private_user: Private User
 creation_preview: Creation Preview
@@ -478,8 +476,7 @@ exporting_all_items_in_collection: Exporting all {total} items within {collectio
 exporting_limited_items_in_collection: Exporting {limit} out of {total} items within {collection}.
 exporting_no_items_to_export: No items to export. Adjust the exporting configuration below.
 exporting_download_hint: Once completed, this {format} file will automatically be downloaded to your device.
-exporting_batch_hint:
-  This export will be processed in batches, and once completed, the {format} file will be saved to the File Library.
+exporting_batch_hint: This export will be processed in batches, and once completed, the {format} file will be saved to the File Library.
 exporting_batch_hint_forced:
   Due to the large number of items, this export must be processed in batches, and once completed, the {format} file will
   be saved to the File Library.
@@ -508,6 +505,7 @@ allow_duplicates: Allow Duplicates
 comments: Comments
 no_comments: No Comments Yet
 click_to_expand: Click to Expand
+click_to_collapse: Click to Collapse
 select_item: Select Item
 no_items: No items
 search_items: Search items...
@@ -1029,8 +1027,7 @@ page_help_settings_webhooks_collection: '**Browse Webhooks** — Lists all webho
 page_help_settings_webhooks_item: '**Webhook Detail** — A form for creating and managing project webhooks.'
 page_help_settings_flows_collection: '**Browse Flows** — Lists all Flows within the project.'
 page_help_settings_flows_item: '**Flow Detail** — Workspace for managing one or more operations.'
-page_help_settings_translation_strings_collection:
-  '**Browse Translation Strings** — Lists all translation strings within the project.'
+page_help_settings_translation_strings_collection: '**Browse Translation Strings** — Lists all translation strings within the project.'
 page_help_users_collection: '**User Directory** — Lists all system users within this project.'
 page_help_users_item: >-
   **User Detail** — Manage your account information, or view the details of other users.
@@ -1173,8 +1170,7 @@ fields:
     mapbox_placeholder: pk.eyJ1Ijo.....
     attribution: Attribution
     attribution_placeholder: © OpenStreetMap contributors
-    transforms_note:
-      The Sharp method name and its arguments. See https://sharp.pixelplumbing.com/api-constructor for more information.
+    transforms_note: The Sharp method name and its arguments. See https://sharp.pixelplumbing.com/api-constructor for more information.
     additional_transforms: Additional Transformations
     project_name: Project Name
     project_descriptor: Project Descriptor
@@ -1258,8 +1254,7 @@ field_options:
         fit_text: Fit inside
         outside_text: Fit outside
     additional_transforms: Additional Transformations
-    transforms_note:
-      The Sharp method name and its arguments. See https://sharp.pixelplumbing.com/api-constructor for more information.
+    transforms_note: The Sharp method name and its arguments. See https://sharp.pixelplumbing.com/api-constructor for more information.
     mapbox_key: Mapbox Access Token
     mapbox_placeholder: pk.eyJ1Ijo.....
     basemaps: Basemaps
@@ -1372,8 +1367,7 @@ shared_uses_left:
   For added security, this shared page has been configured with a limited number of views. There are currently {n} views
   remaining, after which, the page will no longer be accessible.
 share_access_page: Access Shared Page
-share_access_not_found:
-  This shared page either does not exist or has already exceeded the maximum number of allowed uses.
+share_access_not_found: This shared page either does not exist or has already exceeded the maximum number of allowed uses.
 share_access_not_found_desc: Please contact an authorized user of this project to request access.
 share_access_not_found_title: Unknown Share Page
 share_copy_link: Copy Link
@@ -2168,7 +2162,7 @@ operations:
     message: Message
   request:
     name: Webhook / Request URL
-    description: "Make a request to a URL"
+    description: 'Make a request to a URL'
     url: URL
     url_placeholder: https://example.com/example
     method: Method

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -504,8 +504,8 @@ enable_select_button: Enable Select Button
 allow_duplicates: Allow Duplicates
 comments: Comments
 no_comments: No Comments Yet
-click_to_expand: Click to Expand
-click_to_collapse: Click to Collapse
+expand: Expand
+collapse: Collapse
 select_item: Select Item
 no_items: No items
 search_items: Search items...

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -31,7 +31,12 @@
 				/>
 				<v-icon v-else :name="collapseIcon" />
 			</template>
-			<collection-options :collection="collection" />
+			<collection-options
+				:collection="collection"
+				:has-nested-collections="nestedCollections.length > 0"
+				:is-collection-expanded="!!isCollectionExpanded"
+				@collection-toggle="onCollectionToggle"
+			/>
 		</v-list-item>
 
 		<draggable
@@ -45,12 +50,14 @@
 			@update:model-value="onGroupSortChange"
 		>
 			<template #item="{ element }">
-				<collection-item
-					:collection="element"
-					:collections="collections"
-					@edit-collection="$emit('editCollection', $event)"
-					@set-nested-sort="$emit('setNestedSort', $event)"
-				/>
+				<transition-expand v-if="isCollectionExpanded" class="collection-items">
+					<collection-item
+						:collection="element"
+						:collections="collections"
+						@edit-collection="$emit('editCollection', $event)"
+						@set-nested-sort="$emit('setNestedSort', $event)"
+					/>
+				</transition-expand>
 			</template>
 		</draggable>
 	</div>
@@ -65,6 +72,7 @@ import { useCollectionsStore } from '@/stores/collections';
 import { DeepPartial } from '@directus/types';
 import { useI18n } from 'vue-i18n';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { useLocalStorage } from '@/composables/use-local-storage';
 
 const props = defineProps<{
 	collection: Collection;
@@ -76,6 +84,11 @@ const emit = defineEmits(['setNestedSort', 'editCollection']);
 
 const collectionsStore = useCollectionsStore();
 const { t } = useI18n();
+const { data: isCollectionExpanded } = useLocalStorage(props.collection.collection, true);
+
+const onCollectionToggle = () => {
+	isCollectionExpanded.value = !isCollectionExpanded.value;
+};
 
 const nestedCollections = computed(() =>
 	props.collections.filter((collection) => collection.meta?.group === props.collection.collection)

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -20,59 +20,53 @@
 				<span ref="collectionName" class="collection-name">{{ collection.collection }}</span>
 				<span v-if="collection.meta?.note" class="collection-note">{{ collection.meta.note }}</span>
 			</div>
-			<template v-if="collection.type === 'alias' || nestedCollections.length">
-				<v-progress-circular v-if="collapseLoading" small indeterminate />
-				<v-icon
-					v-else-if="nestedCollections.length"
-					v-tooltip="collapseTooltip"
-					:name="collapseIcon"
-					:clickable="nestedCollections.length > 0"
-					@click.stop.prevent="toggleCollapse"
-				/>
-				<v-icon v-else :name="collapseIcon" />
-			</template>
+
+			<v-icon
+				v-if="nestedCollections?.length"
+				v-tooltip="isCollectionExpanded ? t('collapse') : t('expand')"
+				:name="isCollectionExpanded ? 'unfold_less' : 'unfold_more'"
+				clickable
+				@click.stop.prevent="toggleCollapse"
+			/>
 			<collection-options
-				:collection="collection"
 				:has-nested-collections="nestedCollections.length > 0"
-				:is-collection-expanded="!!isCollectionExpanded"
-				@collection-toggle="onCollectionToggle"
+				:collection="collection"
+				@collection-toggle="toggleCollapse"
 			/>
 		</v-list-item>
 
-		<draggable
-			:force-fallback="true"
-			:model-value="nestedCollections"
-			:group="{ name: 'collections' }"
-			:swap-threshold="0.3"
-			class="drag-container"
-			item-key="collection"
-			handle=".drag-handle"
-			@update:model-value="onGroupSortChange"
-		>
-			<template #item="{ element }">
-				<transition-expand v-if="isCollectionExpanded" class="collection-items">
+		<transition-expand class="collection-items">
+			<draggable
+				v-if="isCollectionExpanded"
+				:force-fallback="true"
+				:model-value="nestedCollections"
+				:group="{ name: 'collections' }"
+				:swap-threshold="0.3"
+				class="drag-container"
+				item-key="collection"
+				handle=".drag-handle"
+				@update:model-value="onGroupSortChange"
+			>
+				<template #item="{ element }">
 					<collection-item
 						:collection="element"
 						:collections="collections"
 						@edit-collection="$emit('editCollection', $event)"
 						@set-nested-sort="$emit('setNestedSort', $event)"
 					/>
-				</transition-expand>
-			</template>
-		</draggable>
+				</template>
+			</draggable>
+		</transition-expand>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import CollectionOptions from './collection-options.vue';
-import { Collection } from '@/types/collections';
-import Draggable from 'vuedraggable';
-import { useCollectionsStore } from '@/stores/collections';
-import { DeepPartial } from '@directus/types';
-import { useI18n } from 'vue-i18n';
-import { unexpectedError } from '@/utils/unexpected-error';
 import { useLocalStorage } from '@/composables/use-local-storage';
+import { Collection } from '@/types/collections';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
+import CollectionOptions from './collection-options.vue';
 
 const props = defineProps<{
 	collection: Collection;
@@ -82,71 +76,16 @@ const props = defineProps<{
 
 const emit = defineEmits(['setNestedSort', 'editCollection']);
 
-const collectionsStore = useCollectionsStore();
 const { t } = useI18n();
-const { data: isCollectionExpanded } = useLocalStorage(props.collection.collection, true);
+const { data: isCollectionExpanded } = useLocalStorage(`settings-collapsed-${props.collection.collection}`, true);
 
-const onCollectionToggle = () => {
+const toggleCollapse = () => {
 	isCollectionExpanded.value = !isCollectionExpanded.value;
 };
 
 const nestedCollections = computed(() =>
 	props.collections.filter((collection) => collection.meta?.group === props.collection.collection)
 );
-
-const collapseIcon = computed(() => {
-	switch (props.collection.meta?.collapse) {
-		case 'open':
-			return 'folder_open';
-		case 'closed':
-			return 'folder';
-		case 'locked':
-			return 'folder_lock';
-	}
-
-	return undefined;
-});
-
-const collapseTooltip = computed(() => {
-	switch (props.collection.meta?.collapse) {
-		case 'open':
-			return t('start_open');
-		case 'closed':
-			return t('start_collapsed');
-		case 'locked':
-			return t('always_open');
-	}
-
-	return undefined;
-});
-
-const collapseLoading = ref(false);
-
-async function toggleCollapse() {
-	if (collapseLoading.value === true) return;
-
-	collapseLoading.value = true;
-
-	let newCollapse: 'open' | 'closed' | 'locked' = 'open';
-
-	if (props.collection.meta?.collapse === 'open') {
-		newCollapse = 'closed';
-	} else if (props.collection.meta?.collapse === 'closed') {
-		newCollapse = 'locked';
-	}
-
-	try {
-		await update({ meta: { collapse: newCollapse } });
-	} catch (err: any) {
-		unexpectedError(err);
-	} finally {
-		collapseLoading.value = false;
-	}
-}
-
-async function update(updates: DeepPartial<Collection>) {
-	await collectionsStore.updateCollection(props.collection.collection, updates);
-}
 
 function onGroupSortChange(collections: Collection[]) {
 	const updates = collections.map((collection) => ({

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -29,15 +29,50 @@
 					</template>
 				</v-list-item>
 
-				<v-list-item v-if="hasNestedCollections" clickable @click="onCollectionToggle">
-					<v-list-item-icon>
-						<v-icon v-if="isCollectionExpanded" name="unfold_less" />
-						<v-icon v-else name="unfold_more" />
-					</v-list-item-icon>
-					<v-list-item-content>
-						{{ isCollectionExpanded ? t('click_to_collapse') : t('click_to_expand') }}
-					</v-list-item-content>
-				</v-list-item>
+				<template v-if="collection.type === 'alias' || hasNestedCollections">
+					<v-divider />
+
+					<v-list-item
+						:active="collection.meta?.collapse === 'open'"
+						clickable
+						@click="update({ meta: { collapse: 'open' } })"
+					>
+						<v-list-item-icon>
+							<v-icon name="folder_open" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							{{ t('start_open') }}
+						</v-list-item-content>
+					</v-list-item>
+
+					<v-list-item
+						:active="collection.meta?.collapse === 'closed'"
+						clickable
+						@click="update({ meta: { collapse: 'closed' } })"
+					>
+						<v-list-item-icon>
+							<v-icon name="folder" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							{{ t('start_collapsed') }}
+						</v-list-item-content>
+					</v-list-item>
+
+					<v-list-item
+						:active="collection.meta?.collapse === 'locked'"
+						clickable
+						@click="update({ meta: { collapse: 'locked' } })"
+					>
+						<v-list-item-icon>
+							<v-icon name="folder_lock" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							{{ t('always_open') }}
+						</v-list-item-content>
+					</v-list-item>
+
+					<v-divider />
+				</template>
 
 				<v-list-item clickable class="danger" @click="deleteActive = true">
 					<v-list-item-icon>
@@ -85,18 +120,17 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed, ref } from 'vue';
-import { Collection } from '@/types/collections';
 import { useCollectionsStore } from '@/stores/collections';
-import { useRelationsStore } from '@/stores/relations';
 import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
+import { Collection } from '@/types/collections';
+import type { DeepPartial } from '@directus/types';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type Props = {
 	collection: Collection;
-	hasNestedCollections?: boolean;
-	isCollectionExpanded: boolean;
-	onCollectionToggle?: () => void;
+	hasNestedCollections: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {});
@@ -124,10 +158,6 @@ const peerDependencies = computed(() => {
 		}));
 });
 
-async function update(updates: Partial<Collection>) {
-	await collectionsStore.updateCollection(props.collection.collection, updates);
-}
-
 function useDelete() {
 	const deleting = ref(false);
 	const deleteActive = ref(false);
@@ -148,6 +178,10 @@ function useDelete() {
 			deleting.value = false;
 		}
 	}
+}
+
+async function update(updates: DeepPartial<Collection>) {
+	await collectionsStore.updateCollection(props.collection.collection, updates);
 }
 </script>
 

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -29,6 +29,16 @@
 					</template>
 				</v-list-item>
 
+				<v-list-item v-if="hasNestedCollections" clickable @click="onCollectionToggle">
+					<v-list-item-icon>
+						<v-icon v-if="isCollectionExpanded" name="unfold_less" />
+						<v-icon v-else name="unfold_more" />
+					</v-list-item-icon>
+					<v-list-item-content>
+						{{ isCollectionExpanded ? t('click_to_collapse') : t('click_to_expand') }}
+					</v-list-item-content>
+				</v-list-item>
+
 				<v-list-item clickable class="danger" @click="deleteActive = true">
 					<v-list-item-icon>
 						<v-icon name="delete" />
@@ -84,6 +94,9 @@ import { useFieldsStore } from '@/stores/fields';
 
 type Props = {
 	collection: Collection;
+	hasNestedCollections?: boolean;
+	isCollectionExpanded: boolean;
+	onCollectionToggle?: () => void;
 };
 
 const props = withDefaults(defineProps<Props>(), {});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

This adds the ability to collapse/expand collection items that have nested collection items.

It uses local storage to set the key of the collection, and value of true/false.

Fixes #18517 


https://github.com/directus/directus/assets/9679004/fbbffa2d-3399-4203-8be6-c048ad7e34e4


Notes:
- Based on my new experience within Vue 3, I am not sure how to get the `<transition-expand>` animations to apply instead of just closing/opening without any animations.
- I am also not sure if this is the correct way to implement this functionality, there might be a better way, or a more "best practice" option, that I am happy to update to.
- Want to add some test cases, as I am figuring out how to do that.
- I added a new translation string, not sure if this is the correct way to do that. Or if a better string would fit the `Click to Collapse` verbiage.
- I also just picked the two icons that I thought fit, if better ones exist, happy to update them.