### PR TITLE
Fix unexpected modelValue emit if no checkbox value is set

### DIFF
--- a/.changeset/smart-countries-admire.md
+++ b/.changeset/smart-countries-admire.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed v-checkbox emit behavior when used with array model-value and the custom-value flag

--- a/app/src/components/v-checkbox.vue
+++ b/app/src/components/v-checkbox.vue
@@ -12,8 +12,8 @@
 		<div v-if="$slots.prepend" class="prepend"><slot name="prepend" /></div>
 		<v-icon class="checkbox" :name="icon" :disabled="disabled" />
 		<span class="label type-text">
-			<slot v-if="customValue === false">{{ label }}</slot>
-			<input v-else v-model="internalValue" class="custom-input" />
+			<slot v-if="!customValue">{{ label }}</slot>
+			<input v-else v-model="internalValue" class="custom-input" @click.stop="" />
 		</span>
 		<div v-if="$slots.append" class="append"><slot name="append" /></div>
 	</component>
@@ -92,16 +92,18 @@ function toggleInput(): void {
 		emit('update:indeterminate', false);
 	}
 
-	if (props.modelValue instanceof Array && props.value) {
-		const newValue = [...props.modelValue];
+	if (props.modelValue instanceof Array) {
+		if (props.value) {
+			const newValue = [...props.modelValue];
 
-		if (props.modelValue.includes(props.value) === false) {
-			newValue.push(props.value);
-		} else {
-			newValue.splice(newValue.indexOf(props.value), 1);
+			if (!props.modelValue.includes(props.value)) {
+				newValue.push(props.value);
+			} else {
+				newValue.splice(newValue.indexOf(props.value), 1);
+			}
+
+			emit('update:modelValue', newValue);
 		}
-
-		emit('update:modelValue', newValue);
 	} else {
 		emit('update:modelValue', !props.modelValue);
 	}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Fixes #18550 

When using a checkbox with a custom value in `select-multiple-checkbox` that does not yet have a value set the checkbox component previously emitted an `update:modelValue` event with `false` as payload, even though it was used with an array `modelValue` because of the else branch in L106.

I also included a small usability fix that prevents focusing (by clicking) the input from toggling the checkbox.