### PR TITLE
Fix useCustomSelectionMultiple #18553

### DIFF
--- a/.changeset/mighty-tomatoes-visit.md
+++ b/.changeset/mighty-tomatoes-visit.md
@@ -1,0 +1,5 @@
+---
+'@directus/composables': patch
+---
+
+Improved `select-multiple-checkbox` behavior when modifying a custom value

--- a/packages/composables/src/use-custom-selection.ts
+++ b/packages/composables/src/use-custom-selection.ts
@@ -64,19 +64,19 @@ export function useCustomSelectionMultiple(
 		currentValues,
 		(newValue) => {
 			if (newValue === null) return;
-			if (Array.isArray(newValue) === false) return;
+			if (!Array.isArray(newValue)) return;
 			if (items.value === null) return;
 
 			(newValue as string[]).forEach((value) => {
 				if (items.value === null) return;
 				const values = items.value.map((item) => item.value);
-				const existsInValues = values.includes(value) === true;
+				const existsInValues = values.includes(value);
 
-				if (existsInValues === false) {
+				if (!existsInValues) {
 					const other = otherValues.value.map((o) => o.value);
-					const existsInOtherValues = other.includes(value) === true;
+					const existsInOtherValues = other.includes(value);
 
-					if (existsInOtherValues === false) {
+					if (!existsInOtherValues) {
 						addOtherValue(value);
 					}
 				}
@@ -118,9 +118,11 @@ export function useCustomSelectionMultiple(
 				return otherValue;
 			});
 
-			const newEmitValue = [...valueWithoutPrevious, newValue];
-
-			emit(newEmitValue);
+			if (valueWithoutPrevious.length === currentValues.value?.length) {
+				emit(valueWithoutPrevious);
+			} else {
+				emit([...valueWithoutPrevious, newValue]);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Fixed #18553

`useCustomSelectionMultiple` now only emits updated values if the `previousValue` was included in the `currentValues`.
This prevents an update from happening if an unselected item in modified.

If also took the liberty of removing the explicit `=== true` and `=== false` comparisons since they seem to be dying out across the codebase?