### PR TITLE
Sanitize column only when applying snapshot diff

### DIFF
--- a/.changeset/six-chairs-peel.md
+++ b/.changeset/six-chairs-peel.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"tests-blackbox": patch
+---
+
+Sanitize column only when applying snapshot diff

--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -1,6 +1,9 @@
 name: Blackbox Tests
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -13,7 +16,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main
+  group: blackbox-main-fix-sanitize-column
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -1,9 +1,6 @@
 name: Blackbox Tests
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -16,7 +13,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main-fix-sanitize-column
+  group: blackbox-main
   cancel-in-progress: true
 
 env:

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -399,7 +399,7 @@ export class FieldsService {
 			if (hookAdjustedField.schema) {
 				const existingColumn = await this.schemaInspector.columnInfo(collection, hookAdjustedField.field);
 
-				// Sanitize column only when applying snapshot diff
+				// Sanitize column only when applying snapshot diff as opts is only passed from /utils/apply-diff.ts
 				const columnToCompare =
 					opts?.bypassLimits && opts.autoPurgeSystemCache === false ? sanitizeColumn(existingColumn) : existingColumn;
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -400,7 +400,8 @@ export class FieldsService {
 				const existingColumn = await this.schemaInspector.columnInfo(collection, hookAdjustedField.field);
 
 				// Sanitize column only when applying snapshot diff
-				const columnToCompare = opts?.bypassLimits ? sanitizeColumn(existingColumn) : existingColumn;
+				const columnToCompare =
+					opts?.bypassLimits && opts.autoPurgeSystemCache === false ? sanitizeColumn(existingColumn) : existingColumn;
 
 				if (!isEqual(columnToCompare, hookAdjustedField.schema)) {
 					try {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -399,7 +399,10 @@ export class FieldsService {
 			if (hookAdjustedField.schema) {
 				const existingColumn = await this.schemaInspector.columnInfo(collection, hookAdjustedField.field);
 
-				if (!isEqual(sanitizeColumn(existingColumn), hookAdjustedField.schema)) {
+				// Sanitize column only when applying snapshot diff
+				const columnToCompare = opts?.bypassLimits ? sanitizeColumn(existingColumn) : existingColumn;
+
+				if (!isEqual(columnToCompare, hookAdjustedField.schema)) {
 					try {
 						await this.knex.schema.alterTable(collection, (table) => {
 							if (!hookAdjustedField.schema) return;

--- a/tests/blackbox/routes/fields/change-fields.test.ts
+++ b/tests/blackbox/routes/fields/change-fields.test.ts
@@ -234,6 +234,36 @@ describe.each(common.PRIMARY_KEY_TYPES)('/fields', (pkType) => {
 					);
 				});
 			});
+
+			describe('can update meta only without schema changes for relational field', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const fieldName = 'country_id';
+
+					const payload = (
+						await request(getUrl(vendor))
+							.get(`/fields/${localCollectionStates}/${fieldName}`)
+							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					).body.data;
+
+					payload.meta.options = { template: 'updated' };
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.patch(`/fields/${localCollectionStates}/${fieldName}`)
+						.send(payload)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					const response2 = await request(getUrl(vendor))
+						.get(`/fields/${localCollectionStates}/${fieldName}`)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toEqual(200);
+					expect(response2.statusCode).toEqual(200);
+					expect(response2.body.data).toEqual(payload);
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
`sanitizeColumn` was introduced in #18048 to remove vendor specific properties when applying diffs. 
It resulted the incorrect "dirty" identification of schema when updating via `/fields/{collection}`.  

> **Warning**
> - [x] Revert testing for all vendors before merging

Fixes #18247
Fixes #18472
Fixes #18379
Fixes #18299
Closes ENG-902
