### PR TITLE
Consolidate same condition in file item route to prevent render issue

### DIFF
--- a/.changeset/forty-baboons-flash.md
+++ b/.changeset/forty-baboons-flash.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed render issue in file item route

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -114,17 +114,10 @@
 		</template>
 
 		<div class="file-item">
-			<div class="preview">
-				<file-preview
-					v-if="isBatch === false && item"
-					:src="fileSrc"
-					:mime="item.type"
-					:width="item.width"
-					:height="item.height"
-					:title="item.title"
-				/>
+			<div v-if="isBatch === false && item" class="preview">
+				<file-preview :src="fileSrc" :mime="item.type" :width="item.width" :height="item.height" :title="item.title" />
 
-				<button v-if="isBatch === false && item" class="replace-toggle" @click="replaceFileDialogActive = true">
+				<button class="replace-toggle" @click="replaceFileDialogActive = true">
 					{{ t('replace_file') }}
 				</button>
 			</div>


### PR DESCRIPTION
Fixes #18569

Somehow Vue runs into issues with these two consecutive components having the same `v-if` condition, probably because it wants to insert one of the component into the DOM before the other one is there while relating on the position of the other one at the same time.

Interestingly, according to `git bisect` this issue has been introduced with #18320 although nothing really changed in this regard (or at least I fail to see what could have caused this). Might be a side effect of other "unrelated" changes. Also this only happens in the production build of the app.
