### PR TITLE
Add `axios` as a dependency to `@directus/composables`

### DIFF
--- a/.changeset/pretty-feet-trade.md
+++ b/.changeset/pretty-feet-trade.md
@@ -1,0 +1,5 @@
+---
+"@directus/composables": patch
+---
+
+Add `axios` as a dependency to `@directus/composables`

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- abdonrd
 - benhaynes
 - rijkvanzanten
 - Paiman-Rasoli

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -34,13 +34,13 @@
 		"@types/lodash-es": "4.17.7",
 		"@vitest/coverage-c8": "0.31.0",
 		"@vue/test-utils": "2.3.2",
-		"axios": "1.3.6",
 		"typescript": "5.0.4",
 		"vitest": "0.31.0"
 	},
 	"dependencies": {
 		"@directus/constants": "workspace:*",
 		"@directus/utils": "workspace:*",
+		"axios": "1.3.6",
 		"lodash-es": "4.17.21",
 		"nanoid": "4.0.2",
 		"vue": "3.2.47"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -908,6 +908,9 @@ importers:
       '@directus/utils':
         specifier: workspace:*
         version: link:../utils
+      axios:
+        specifier: 1.3.6
+        version: 1.3.6
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -933,9 +936,6 @@ importers:
       '@vue/test-utils':
         specifier: 2.3.2
         version: 2.3.2(vue@3.2.47)
-      axios:
-        specifier: 1.3.6
-        version: 1.3.6
       typescript:
         specifier: 5.0.4
         version: 5.0.4


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! Please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

`axios` is used in the `use-items.ts`:

https://github.com/directus/directus/blob/d5823bd4c1b19d82281296d26e863f865b421a31/packages/composables/src/use-items.ts#L3

I found this importing types in an extension like this:

`import type { AbstractServiceOptions } from '@directus/api/types';`

And it showed me this warning:

> ⠙ Building Directus extension..."axios" is imported by "../../node_modules/@directus/composables/dist/use-items.js", but could not be resolved – treating it as an external dependency.
> ✔ Done