### PR TITLE
Fix deselecting options for kanban layout

### DIFF
--- a/.changeset/sixty-snakes-happen.md
+++ b/.changeset/sixty-snakes-happen.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix deselecting options for kanban layout

--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -141,7 +141,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
 				return computed<T>({
 					get() {
-						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value?.[key] : defaultValue;
+						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value[key] : defaultValue;
 					},
 					set(newValue: T) {
 						layoutOptions.value = {

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -353,7 +353,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
 				return computed<T>({
 					get() {
-						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value?.[key] : defaultValue;
+						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value[key] : defaultValue;
 					},
 					set(newValue: T) {
 						layoutOptions.value = {

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -353,7 +353,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
 				return computed<T>({
 					get() {
-						return layoutOptions.value?.[key] ?? defaultValue;
+						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value?.[key] : defaultValue;
 					},
 					set(newValue: T) {
 						layoutOptions.value = {


### PR DESCRIPTION
Fix issue by adding an `undefined` check. The same implementation can be found in the `cards` layout.
https://github.com/directus/directus/blob/9bc3b745fbb014e55444857e774701ae6b936519/app/src/layouts/cards/index.ts#L143-L145

| Before | After |
| - | - |
| <video src="https://github.com/directus/directus/assets/26413686/dfce4710-70b4-4afb-9ce7-7833947488fc"> | <video src="https://github.com/directus/directus/assets/26413686/37df9ba5-b41a-4a55-b5c2-05389e1a1f04"> |