### PR TITLE
Fix drag & drop upload to the root folder in the file library

### DIFF
--- a/.changeset/happy-months-dream.md
+++ b/.changeset/happy-months-dream.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed drag & drop upload to the root folder in the file library

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -543,10 +543,10 @@ function useFileUpload() {
 			loading: true,
 		});
 
+		const preset = props.folder ? { folder: props.folder } : undefined;
+
 		await uploadFiles(files, {
-			preset: {
-				folder: props.folder,
-			},
+			preset,
 			onProgressChange: (progress) => {
 				const percentageDone = progress.reduce((val, cur) => (val += cur)) / progress.length;
 


### PR DESCRIPTION
Read the fix from #18473 (https://github.com/directus/directus/pull/18473/files#diff-a0669cdce5c6d9c0616f315839f8e61f6f8b743a9baa4dd6b798daec856decc7), accidentally removed in merge of #18320
