### PR TITLE
Send null for `auth_data` if undefined

### DIFF
--- a/.changeset/ninety-mails-heal.md
+++ b/.changeset/ninety-mails-heal.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed issue preventing user from authenticating with external auth drivers when user info didn't change

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -159,7 +159,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{ auth_data: userPayload.auth_data },
+				{ auth_data: userPayload.auth_data ?? null },
 				{
 					identifier,
 					provider: this.config['provider'],

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -185,7 +185,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{ auth_data: userPayload.auth_data },
+				{ auth_data: userPayload.auth_data ?? null },
 				{
 					identifier,
 					provider: this.config['provider'],


### PR DESCRIPTION
This solves an error on the Knex side when sending an empty (keyed) update. Issue here: https://github.com/directus/directus/issues/18595

See: https://github.com/knex/knex/issues/3591#issuecomment-628753558