### PR TITLE
Added some cross links with main website

### DIFF
--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -4,6 +4,7 @@
 (A|a)utocomplete
 (A|a)xios
 (B|b)ackend
+(B|b)ackend-as-a-(S|s)ervice
 (B|b)alancer
 (B|b)asemap
 (B|b)ugfixes

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -59,6 +59,15 @@ Extensive configuration options are also available as global variables in the co
 authentication method, caching details, default file storage location (local, S3, google, etc.) for digital assets, emails,
 _and much more._
 
+### What Do Teams Use Directus For?
+
+- [Headless CMS](https://directus.io/headless-cms)
+- [Learning Management System](https://directus.io/headless-cms) 
+- [Product Inventory Management](https://directus.io/studio)
+- [No-Code Data Platform](https://directus.io/studio)
+- [Backend-as-a-Service](https://directus.io/engine) 
+- [Full API-Based Data Architecture](https://directus.io/engine)
+
 :::tip Ready to dive in?
 
 Get a project running in minutes. Learn Directus hands-on in the [Quickstart Guide](/getting-started/quickstart).


### PR DESCRIPTION
As requested in MARK-969, this adds some cross-links near the top of our landing page for the docs. There is some repetition, but this page will be revised/removed as part of building a new landing page for docs in the coming weeks.