### PR TITLE
Fix for unknown filter fields

### DIFF
--- a/.changeset/lucky-falcons-collect.md
+++ b/.changeset/lucky-falcons-collect.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed error handling for unknown fields used in filters

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -372,7 +372,7 @@ export function applyFilter(
 
 			if (
 				filterPath.length > 1 ||
-				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]!.fields[key]!.type === 'alias')
+				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]?.fields[key]?.type === 'alias')
 			) {
 				const hasMultiRelational = addJoin({
 					path: filterPath,
@@ -429,7 +429,7 @@ export function applyFilter(
 
 			if (
 				filterPath.length > 1 ||
-				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]!.fields[key]!.type === 'alias')
+				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]?.fields[key]?.type === 'alias')
 			) {
 				if (!relation) continue;
 


### PR DESCRIPTION
Using optional chaining `?.` instead of non-null asserting `.!` so the API gracefully handles non-existing fields in filters.

Before:
![image](https://github.com/directus/directus/assets/9389634/a88cfdd3-397a-4c36-b523-ab92d3eb4eab)


After:
![image](https://github.com/directus/directus/assets/9389634/a4e5dc2b-c3ed-4ad4-a962-df279bdfe9d1)


Fixes #18514
Fixes ENG-959
