### PR TITLE
Fix api call for insights list panel

### DIFF
--- a/.changeset/many-shoes-pull.md
+++ b/.changeset/many-shoes-pull.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed api endpoint for insights list panel

--- a/app/src/panels/list/panel-list.vue
+++ b/app/src/panels/list/panel-list.vue
@@ -31,6 +31,7 @@ import api from '@/api';
 import { useFieldsStore } from '@/stores/fields';
 import { useInsightsStore } from '@/stores/insights';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { getEndpoint } from '@directus/utils';
 
 const props = withDefaults(
 	defineProps<{
@@ -70,7 +71,7 @@ function cancelEdit() {
 
 async function saveEdits(item: Record<string, any>) {
 	try {
-		await api.patch(`/items/${props.collection}/${currentlyEditing.value}`, item);
+		await api.patch(`${getEndpoint(props.collection)}/${currentlyEditing.value}`, item);
 	} catch (err: any) {
 		unexpectedError(err);
 	}


### PR DESCRIPTION
The list panel was still making calls directly to `/items/${collection}` but this errors for system collections. Solution to use the shared `getEndpoint(collection)` utility.

Fixes #18621
Fixes ENG-1024