### PR TITLE
Add documentation for auth create and update hooks

### DIFF
--- a/.changeset/pretty-lobsters-look.md
+++ b/.changeset/pretty-lobsters-look.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Added documentation for auth create and update hooks

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -188,22 +188,30 @@ export default ({ embed }, { env }) => {
 
 ### Filter Events
 
-| Name                          | Payload                         | Meta                                 |
-| ----------------------------- | ------------------------------- | ------------------------------------ |
-| `request.not_found`           | `false`                         | `request`, `response`                |
-| `request.error`               | The request errors              | --                                   |
-| `database.error`              | The database error              | `client`                             |
-| `auth.login`                  | The login payload               | `status`, `user`, `provider`         |
-| `auth.jwt`                    | The auth token                  | `status`, `user`, `provider`, `type` |
-| `authenticate`                | The empty accountability object | `req`                                |
-| `(<collection>.)items.query`  | The items query                 | `collection`                         |
-| `(<collection>.)items.read`   | The read item                   | `query`, `collection`                |
-| `(<collection>.)items.create` | The new item                    | `collection`                         |
-| `(<collection>.)items.update` | The updated item                | `keys`, `collection`                 |
-| `(<collection>.)items.delete` | The keys of the item            | `collection`                         |
-| `<system-collection>.create`  | The new item                    | `collection`                         |
-| `<system-collection>.update`  | The updated item                | `keys`, `collection`                 |
-| `<system-collection>.delete`  | The keys of the item            | `collection`                         |
+| Name                          | Payload                              | Meta                                        |
+| ----------------------------- | ------------------------------------ | ------------------------------------------- |
+| `request.not_found`           | `false`                              | `request`, `response`                       |
+| `request.error`               | The request errors                   | --                                          |
+| `database.error`              | The database error                   | `client`                                    |
+| `auth.login`                  | The login payload                    | `status`, `user`, `provider`                |
+| `auth.jwt`                    | The auth token                       | `status`, `user`, `provider`, `type`        |
+| `auth.create`<sup>[1]</sup>   | The created user                     | `identifier`, `provider`, `providerPayload` |
+| `auth.update`<sup>[2]</sup>   | The updated auth token<sup>[3]</sup> | `identifier`, `provider`, `providerPayload` |
+| `authenticate`                | The empty accountability object      | `req`                                       |
+| `(<collection>.)items.query`  | The items query                      | `collection`                                |
+| `(<collection>.)items.read`   | The read item                        | `query`, `collection`                       |
+| `(<collection>.)items.create` | The new item                         | `collection`                                |
+| `(<collection>.)items.update` | The updated item                     | `keys`, `collection`                        |
+| `(<collection>.)items.delete` | The keys of the item                 | `collection`                                |
+| `<system-collection>.create`  | The new item                         | `collection`                                |
+| `<system-collection>.update`  | The updated item                     | `keys`, `collection`                        |
+| `<system-collection>.delete`  | The keys of the item                 | `collection`                                |
+
+<sup>[1]</sup> Available for `ldap`, `oauth2`, `openid` and `saml` driver.
+
+<sup>[2]</sup> Available for `ldap`, `oauth2` and `openid` driver.
+
+<sup>[3]</sup> Available for `oauth2` and `openid` driver, only if set by provider.
 
 ::: tip System Collections
 


### PR DESCRIPTION
Add documentation for the `auth.create` and `auth.update` hooks introduced in #18310 considering follow-up fix from #18310. 

Closes ENG-923