### PR TITLE
Move tsconfig package to monorepo

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -163,7 +163,7 @@
 		"wellknown": "0.5.0"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@types/async": "3.2.20",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -29,7 +29,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@types/lodash-es": "4.17.7",
 		"@vitest/coverage-c8": "0.31.1",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"typescript": "5.0.4"
 	},
 	"dependencies": {

--- a/packages/data-driver-postgres/package.json
+++ b/packages/data-driver-postgres/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -29,7 +29,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-c8": "0.31.1",

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -58,7 +58,7 @@
 		"vue": "3.3.4"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/fs-extra": "11.0.1",
 		"@types/inquirer": "9.0.3",
 		"@vitest/coverage-c8": "0.31.1",

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -29,7 +29,7 @@
 	},
 	"devDependencies": {
 		"@directus/random": "workspace:*",
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/express": "4.17.17",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",
 		"vitest": "0.31.1"

--- a/packages/release-notes-generator/package.json
+++ b/packages/release-notes-generator/package.json
@@ -16,7 +16,7 @@
 	],
 	"devDependencies": {
 		"@changesets/types": "5.2.1",
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/node": "20.2.0",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -45,7 +45,7 @@
 		"knex": "2.4.2"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"typescript": "5.0.4"
 	},
 	"publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,7 +50,7 @@
 		"axios": "^0.27.2"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/node": "^18.0.3",
 		"@typescript-eslint/eslint-plugin": "^5.30.5",
 		"@typescript-eslint/parser": "^5.30.5",

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -33,7 +33,7 @@
 		"@directus/utils": "workspace:*"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -34,7 +34,7 @@
 		"undici": "5.22.1"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -33,7 +33,7 @@
 		"@google-cloud/storage": "6.10.1"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -32,7 +32,7 @@
 		"@directus/utils": "workspace:*"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -35,7 +35,7 @@
 		"@directus/utils": "workspace:*"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-c8": "0.31.1",
 		"typescript": "5.0.4",

--- a/packages/tsconfig/license
+++ b/packages/tsconfig/license
@@ -1,0 +1,16 @@
+MIT License
+
+Copyright 2023 Monospace, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/tsconfig/node18-esm.json
+++ b/packages/tsconfig/node18-esm.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"display": "Node 18 ESM",
+	"compilerOptions": {
+		"lib": ["es2022"],
+		"module": "es2022",
+		"target": "es2022",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"moduleResolution": "NodeNext",
+		"allowUnusedLabels": false,
+		"allowUnreachableCode": false,
+		"exactOptionalPropertyTypes": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"verbatimModuleSyntax": true,
+		"checkJs": true,
+		"allowSyntheticDefaultImports": true,
+		"declaration": true
+	}
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "@directus/tsconfig",
+	"version": "0.0.7",
+	"description": "TS Config used in Directus projects",
+	"main": "index.js",
+	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
+	"license": "MIT",
+	"files": [
+		"./node18-esm.json"
+	]
+}

--- a/packages/tsconfig/readme.md
+++ b/packages/tsconfig/readme.md
@@ -1,0 +1,17 @@
+# @directus/tsconfig
+
+The shared TS Config files used by the projects in the Directus ecosystem.
+
+## Usage
+
+```
+pnpm add @directus/tsconfig
+```
+
+In your `tsconfig.json`:
+
+```json
+{
+	"extends": "@directus/tsconfig/node18-esm.json"
+}
+```

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,7 +29,7 @@
 	"devDependencies": {
 		"@directus/constants": "workspace:*",
 		"@directus/schema": "workspace:*",
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@types/express": "4.17.17",
 		"@types/geojson": "7946.0.10",
 		"express": "4.18.2",

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -32,7 +32,7 @@
 		"undici": "5.22.1"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@types/semver": "7.5.0",
 		"@vitest/coverage-c8": "0.31.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,7 @@
 		"vue": "3.3.4"
 	},
 	"devDependencies": {
-		"@directus/tsconfig": "0.0.7",
+		"@directus/tsconfig": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@types/fs-extra": "11.0.1",
 		"@types/lodash-es": "4.17.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,8 +349,8 @@ importers:
         version: 16.1.0
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../packages/tsconfig
       '@directus/types':
         specifier: workspace:*
         version: link:../packages/types
@@ -910,8 +910,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@directus/types':
         specifier: workspace:*
         version: link:../types
@@ -938,8 +938,8 @@ importers:
         version: 3.21.4
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -959,8 +959,8 @@ importers:
   packages/data:
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 18.16.12
         version: 18.16.12
@@ -977,8 +977,8 @@ importers:
   packages/data-driver-postgres:
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 18.16.12
         version: 18.16.12
@@ -995,8 +995,8 @@ importers:
   packages/exceptions:
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@directus/types':
         specifier: workspace:*
         version: link:../types
@@ -1089,8 +1089,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1
@@ -1117,8 +1117,8 @@ importers:
         specifier: workspace:*
         version: link:../random
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -1135,8 +1135,8 @@ importers:
   packages/random:
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@vitest/coverage-c8':
         specifier: 0.31.1
         version: 0.31.1(vitest@0.31.1)
@@ -1163,8 +1163,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 20.2.0
         version: 20.2.0
@@ -1185,8 +1185,8 @@ importers:
         version: 2.4.2(mysql@2.18.1)(pg@8.11.0)(sqlite3@5.1.6)(tedious@16.1.0)
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1198,8 +1198,8 @@ importers:
         version: 0.27.2
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: ^18.0.3
         version: 18.16.12
@@ -1247,8 +1247,8 @@ importers:
   packages/storage:
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 18.16.12
         version: 18.16.12
@@ -1275,8 +1275,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
@@ -1306,8 +1306,8 @@ importers:
         version: 5.22.1
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
@@ -1334,8 +1334,8 @@ importers:
         version: 6.10.1
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
@@ -1359,8 +1359,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
@@ -1393,8 +1393,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
@@ -1408,6 +1408,8 @@ importers:
         specifier: 0.31.1
         version: 0.31.1(happy-dom@9.18.3)(sass@1.62.1)
 
+  packages/tsconfig: {}
+
   packages/types:
     devDependencies:
       '@directus/constants':
@@ -1417,8 +1419,8 @@ importers:
         specifier: workspace:*
         version: link:../schema
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -1460,8 +1462,8 @@ importers:
         version: 5.22.1
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
@@ -1506,8 +1508,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@directus/tsconfig':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../tsconfig
       '@directus/types':
         specifier: workspace:*
         version: link:../types
@@ -4498,10 +4500,6 @@ packages:
   /@directus/format-title@10.0.0:
     resolution: {integrity: sha512-iMXP8yQb0UKAMGRHAY7IkNXEGdUqQDvlu1aAkPARYah4lMhEU8E5KgkXdOCPQaxt6Wy0gXb7DPMjeSlKyBKCxg==}
     engines: {node: '>=6.0.0'}
-
-  /@directus/tsconfig@0.0.7:
-    resolution: {integrity: sha512-0h9GOyLFl1ylcZYLi3zNik+/DorFTtywsJl7RIVsy9pdL1cL/jewKT9L0yShDvbmN/kenPSlXC8qmqmz1NPhHA==}
-    dev: true
 
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}


### PR DESCRIPTION
As the title suggests! 

Now that version numbers are individual, we can (finally) bring home some of the other sub-dependencies, like the tsconfig file we use. This'll make it way easier to make changes to tsconfig that propagate across all properties, instead of having to deal with multiple repos and individual PRs in the right order