### PR TITLE
fixed incorrectly mocked endpoint

### DIFF
--- a/.changeset/olive-toys-fail.md
+++ b/.changeset/olive-toys-fail.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed incorrectly mocked endpoint in SDK tests

--- a/packages/sdk/tests/base/auth.test.ts
+++ b/packages/sdk/tests/base/auth.test.ts
@@ -102,7 +102,7 @@ describe('auth', function () {
 
 	it(`invalid credentials token should not set the token`, async () => {
 		mockServer.use(
-			rest.get(URL + '/users/me', (_req, res, ctx) =>
+			rest.post(URL + '/auth/login', (_req, res, ctx) =>
 				res(
 					ctx.status(401),
 					ctx.json({
@@ -121,21 +121,14 @@ describe('auth', function () {
 
 		const sdk = new Directus(URL);
 
-		let failed: false | string = false;
-
-		try {
-			await sdk.auth.login({
+		await expect(
+			sdk.auth.login({
 				email: 'invalid@email.com',
 				password: 'invalid_password',
-			});
-
-			failed = 'Should have thrown due to error response';
-		} catch {
-			//
-		}
+			})
+		).rejects.toThrowError();
 
 		expect(await sdk.auth.token).toBeNull();
-		expect(failed).toBe(false);
 	});
 
 	it(`invalid static token should not set the token`, async () => {
@@ -159,16 +152,8 @@ describe('auth', function () {
 
 		const sdk = new Directus(URL);
 
-		let failed: false | string = false;
-
-		try {
-			await sdk.auth.static('token');
-			failed = 'Should have thrown due to error response';
-		} catch {
-			//
-		}
+		await expect(sdk.auth.static('token')).rejects.toThrowError();
 
 		expect(await sdk.auth.token).toBeNull();
-		expect(failed).toBe(false);
 	});
 });

--- a/packages/sdk/tests/base/transport.test.ts
+++ b/packages/sdk/tests/base/transport.test.ts
@@ -43,16 +43,11 @@ describe('default transport', function () {
 
 			const transport = new Transport({ url: URL }) as any;
 
-			let failed = false;
-
 			try {
-				await transport[method](route);
-				failed = true;
+				await expect(transport[method](route)).rejects.toThrowError();
 			} catch (err: any) {
 				expect(err).toBeInstanceOf(TransportError);
 			}
-
-			expect(failed).toBe(false);
 		});
 
 		it(`${method} should carry response error information`, async function () {
@@ -78,11 +73,8 @@ describe('default transport', function () {
 
 			const transport = new Transport({ url: URL }) as any;
 
-			let failed = false;
-
 			try {
-				await transport[method](route);
-				failed = true;
+				await expect(transport[method](route)).rejects.toThrowError();
 			} catch (err: any) {
 				const terr = err as TransportError;
 				expect(terr).toBeInstanceOf(TransportError);
@@ -92,8 +84,6 @@ describe('default transport', function () {
 				expect(terr.errors[0]?.message).toBe('You don\'t have permission access to "contacts" collection.');
 				expect(terr.errors[0]?.extensions?.code).toBe('FORBIDDEN');
 			}
-
-			expect(failed).toBe(false);
 		});
 
 		// I am unsure how to mock this with msw
@@ -133,11 +123,8 @@ describe('default transport', function () {
 			throw new Error('this is not an axios error');
 		});
 
-		let failed = false;
-
 		try {
-			await transport.get('/route');
-			failed = true;
+			await expect(transport.get('/route')).rejects.toThrowError();
 		} catch (err: any) {
 			const terr = err as TransportError;
 			expect(terr).toBeInstanceOf(TransportError);
@@ -146,7 +133,5 @@ describe('default transport', function () {
 			expect(terr.parent).not.toBeUndefined();
 			expect(terr.parent?.message).toBe('this is not an axios error');
 		}
-
-		expect(failed).toBe(false);
 	});
 });


### PR DESCRIPTION
Fixes 2 small issue with the migrated SDK tests
- an incorrectly updated mock throwing a warning
- fixed incorrect replacement of the `fail` function in try-catches
