### PR TITLE
Disable disable depreacted marked options

### DIFF
--- a/api/src/utils/md.ts
+++ b/api/src/utils/md.ts
@@ -5,5 +5,5 @@ import sanitizeHTML from 'sanitize-html';
  * Render and sanitize a markdown string
  */
 export function md(str: string): string {
-	return sanitizeHTML(marked(str));
+	return sanitizeHTML(marked(str, { headerIds: false, mangle: false }));
 }

--- a/app/src/utils/md.ts
+++ b/app/src/utils/md.ts
@@ -25,6 +25,8 @@ export function md(str: string, options: Options = { target: '_self' }): string 
 	return dompurify.sanitize(
 		marked(str, {
 			renderer,
+			headerIds: false,
+			mangle: false,
 		}),
 		{ ADD_ATTR: ['target'] }
 	);


### PR DESCRIPTION
Since the update of `marked` to v5 in #18643 the console is getting filled with the following warnings:

```console
marked(): mangle parameter is enabled by default, but is deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install https://www.npmjs.com/package/marked-mangle, or disable by setting `{mangle: false}`.

marked(): headerIds and headerPrefix parameters enabled by default, but are deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install  https://www.npmjs.com/package/marked-gfm-heading-id, or disable by setting `{headerIds: false}`.
```

I was under the impression that those options are disabled by default and we didn't enable them thus no action required. But it turns out that the options are enabled by default, see https://github.com/markedjs/marked/releases/tag/v5.0.0.

I think both options are not really of use in the app, so we can disable them.
However, we could consider whether it makes sense to install [marked-gfm-heading-id](https://www.npmjs.com/package/marked-gfm-heading-id) in the api, where marked is used for email bodies.