### PR TITLE
Enhance translations in export sidebar

### DIFF
--- a/.changeset/warm-pumas-provide.md
+++ b/.changeset/warm-pumas-provide.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Enhanced translations in export sidebar

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -465,9 +465,9 @@ download_file: Download File
 open_file_in_tab: Open file in new tab
 start_export: Start Export
 not_available_for_local_downloads: Not available for local downloads
-exporting_all_items_in_collection: Exporting all {total} items within {collection}.
+exporting_all_items_in_collection: Exporting all items ({total}) within {collection}.
 exporting_limited_items_in_collection: Exporting {limit} out of {total} items within {collection}.
-exporting_no_items_to_export: No items to export. Adjust the exporting configuration below.
+exporting_no_items_to_export: No items to export. Adjust the exporting configuration.
 exporting_download_hint: Once completed, this {format} file will automatically be downloaded to your device.
 exporting_batch_hint: This export will be processed in batches, and once completed, the {format} file will be saved to the File Library.
 exporting_batch_hint_forced:

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -169,15 +169,15 @@
 
 						<p>
 							<template v-if="lockedToFiles">
-								{{ t('exporting_batch_hint_forced', { format }) }}
+								{{ t('exporting_batch_hint_forced', { format: t(format) }) }}
 							</template>
 
 							<template v-else-if="location === 'files'">
-								{{ t('exporting_batch_hint', { format }) }}
+								{{ t('exporting_batch_hint', { format: t(format) }) }}
 							</template>
 
 							<template v-else>
-								{{ t('exporting_download_hint', { format }) }}
+								{{ t('exporting_download_hint', { format: t(format) }) }}
 							</template>
 						</p>
 					</div>


### PR DESCRIPTION
## Export Count & Format

### Before

![Screenshot 2023-05-22 at 15-26-51 Presets   Bookmarks](https://github.com/directus/directus/assets/5363448/9c077a27-9f57-4c83-a07c-0214f3a1380c)

### After

![Screenshot 2023-05-22 at 15-30-09 Presets   Bookmarks](https://github.com/directus/directus/assets/5363448/214591d0-ce6c-4015-a4ef-8315e5eddb6c)

## Misleading Configuration Hint

The configuration can be adjusted **above** and below the hint

### Before

<img width="814" alt="Screenshot 2023-05-22 at 15 27 47" src="https://github.com/directus/directus/assets/5363448/10614c87-9127-4391-9b2b-34a688f427fd">

### After

<img width="817" alt="Screenshot 2023-05-22 at 15 27 23" src="https://github.com/directus/directus/assets/5363448/b83b8614-f541-4144-8517-80ee548a122c">
