### PR TITLE
Update gh-action-linear to fix workflow failure

### DIFF
--- a/.github/workflows/linear-auto.yml
+++ b/.github/workflows/linear-auto.yml
@@ -8,7 +8,7 @@ jobs:
   linear:
     runs-on: ubuntu-latest
     steps:
-      - uses: rijkvanzanten/gh-action-linear@v0.3.1
+      - uses: rijkvanzanten/gh-action-linear@v0.3.2
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}

--- a/.github/workflows/linear-dispatch.yaml
+++ b/.github/workflows/linear-dispatch.yaml
@@ -7,7 +7,7 @@ jobs:
   create_issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: rijkvanzanten/gh-action-linear@v0.3.1
+      - uses: rijkvanzanten/gh-action-linear@v0.3.2
         with:
           github-repo: ${{ github.event.client_payload.github.payload.repository.full_name }}
           github-issue: ${{ github.event.client_payload.github.payload.issue.number }}


### PR DESCRIPTION
Update `@rijkvanzanten/gh-action-linear` to `v0.3.2` to fix workflow failure for runs that do not have a Linear comment. Ref: https://github.com/rijkvanzanten/gh-action-linear/pull/4

<img width="761" alt="image" src="https://github.com/directus/directus/assets/26413686/e46e3656-5505-4e38-87b6-d4fa5acd9971">
