### PR TITLE
Fix schedule hook test

### DIFF
--- a/tests/blackbox/flows/schedule-hook.test.ts
+++ b/tests/blackbox/flows/schedule-hook.test.ts
@@ -143,8 +143,8 @@ describe('Flows Schedule Hook Tests', () => {
 			).body.data[0].count.id;
 
 			// Assert
-			expect(redisRunCount).toBe(5);
-			expect(memoryRunCount).toBe(5);
+			expect(parseInt(redisRunCount)).toBe(5);
+			expect(parseInt(memoryRunCount)).toBe(5);
 		});
 	});
 });


### PR DESCRIPTION
Fix schedule hook test as the count aggregation result is a string in Postgres and CockroachDB.