### PR TITLE
Specify oracledb version for blackbox tests

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt update -y && sudo apt install -y alien libaio1 && \
           wget https://download.oracle.com/otn_software/linux/instantclient/214000/$ORACLE_DL && \
           sudo alien -i $ORACLE_DL && \
-          pnpm -w -D add oracledb
+          pnpm -w -D add oracledb@5
         env:
           ORACLE_DL: oracle-instantclient-basic-21.4.0.0.0-1.el8.x86_64.rpm
 


### PR DESCRIPTION
A very recent release of `node-oracledb` to version `6.0.0` from `5.5.0` had caused issues with our OracleDB blackbox tests.
Ref: https://node-oracledb.readthedocs.io/en/latest/release_notes.html#node-oracledb-v6-0-0-24-may-2023