### PR TITLE
Optimise export sidebar aggregation call

### DIFF
--- a/.changeset/smart-files-protect.md
+++ b/.changeset/smart-files-protect.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Optimised export sidebar aggregation call

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -53,7 +53,7 @@
 			</template>
 
 			<div class="field full">
-				<v-button small full-width @click="exportDialogActive = true">
+				<v-button small full-width @click="openExportDialog">
 					{{ t('export_items') }}
 				</v-button>
 
@@ -138,7 +138,10 @@
 				<v-notice class="full" :type="lockedToFiles ? 'warning' : 'normal'">
 					<div>
 						<p>
-							<template v-if="exportSettings.limit === 0 || itemCount === 0">
+							<template v-if="itemCountLoading">
+								{{ t('loading') }}
+							</template>
+							<template v-else-if="exportSettings.limit === 0 || itemCount === 0">
 								{{ t('exporting_no_items_to_export') }}
 							</template>
 							<template
@@ -388,10 +391,10 @@ const getItemCount = debounce(async () => {
 	}
 }, 250);
 
-getItemCount();
-
 watch(exportSettings, () => {
-	getItemCount();
+	if (exportDialogActive.value) {
+		getItemCount();
+	}
 });
 
 watch(primaryKeyField, (newVal) => {
@@ -426,6 +429,11 @@ const sortField = computed({
 });
 
 const exporting = ref(false);
+
+function openExportDialog() {
+	getItemCount();
+	exportDialogActive.value = true;
+}
 
 function onChange(event: Event) {
 	const files = (event.target as HTMLInputElement)?.files;

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -246,7 +246,7 @@ import { useCollection } from '@directus/composables';
 import { Filter } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
 import type { AxiosProgressEvent } from 'axios';
-import { debounce } from 'lodash';
+import { debounce, pick } from 'lodash';
 import { computed, reactive, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -371,7 +371,7 @@ const getItemCount = debounce(async () => {
 		const count = await api
 			.get(getEndpoint(collection.value), {
 				params: {
-					...exportSettings,
+					...pick(exportSettings, ['search', 'filter']),
 					aggregate,
 				},
 			})

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -368,22 +368,22 @@ const getItemCount = debounce(async () => {
 					count: ['*'],
 			  };
 
-		const count = await api
-			.get(getEndpoint(collection.value), {
-				params: {
-					...pick(exportSettings, ['search', 'filter']),
-					aggregate,
-				},
-			})
-			.then((response) => {
-				if (response.data.data?.[0]?.count) {
-					return Number(response.data.data[0].count);
-				}
+		const response = await api.get(getEndpoint(collection.value), {
+			params: {
+				...pick(exportSettings, ['search', 'filter']),
+				aggregate,
+			},
+		});
 
-				if (response.data.data?.[0]?.countDistinct) {
-					return Number(response.data.data[0].countDistinct[primaryKeyField.value!.field]);
-				}
-			});
+		let count;
+
+		if (response.data.data?.[0]?.count) {
+			count = Number(response.data.data[0].count);
+		}
+
+		if (response.data.data?.[0]?.countDistinct) {
+			count = Number(response.data.data[0].countDistinct[primaryKeyField.value!.field]);
+		}
 
 		itemCount.value = count;
 	} finally {


### PR DESCRIPTION
Optimise export sidebar aggregation call.

1. Fetch count only when needed and not upon load.
2. Remove redundant fields when aggregating to improve caching. (`sort` and `limit` will be needed when aggregation has grouping)

Closes ENG-1087