### PR TITLE
Remove docs CDN from the base CSP config

### DIFF
--- a/.changeset/tricky-pants-shake.md
+++ b/.changeset/tricky-pants-shake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Removed cdn.directus.io from imgSrc and mediaSrc in the base CSP configuration

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -142,11 +142,10 @@ export default async function createApp(): Promise<express.Application> {
 						upgradeInsecureRequests: null,
 
 						// These are required for MapLibre
-						// https://cdn.directus.io is required for images/videos in the official docs
 						workerSrc: ["'self'", 'blob:'],
 						childSrc: ["'self'", 'blob:'],
-						imgSrc: ["'self'", 'data:', 'blob:', 'https://cdn.directus.io'],
-						mediaSrc: ["'self'", 'https://cdn.directus.io'],
+						imgSrc: ["'self'", 'data:', 'blob:'],
+						mediaSrc: ["'self'"],
 						connectSrc: ["'self'", 'https://*'],
 					},
 				},


### PR DESCRIPTION
In-app docs was removed in #17434, so this PR cleans up the CSP entries for `cdn.directus.io` that is no longer needed.