### PR TITLE
Add support for `FILES_MIME_TYPE_ALLOW_LIST` env var

### DIFF
--- a/.changeset/weak-bottles-travel.md
+++ b/.changeset/weak-bottles-travel.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Added support for `FILES_MIME_TYPE_ALLOW_LIST` environment variable.

--- a/api/package.json
+++ b/api/package.json
@@ -130,6 +130,7 @@
 		"marked": "5.0.2",
 		"micromustache": "8.0.3",
 		"mime-types": "2.1.35",
+		"minimatch": "9.0.1",
 		"ms": "2.1.3",
 		"nanoid": "4.0.2",
 		"node-machine-id": "1.1.12",

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -110,6 +110,7 @@ const allowedEnvironmentVars = [
 
 	// files
 	'FILES_MAX_UPLOAD_SIZE',
+	'FILES_CONTENT_TYPE_ALLOW_LIST',
 
 	// assets
 	'ASSETS_CACHE_TTL',
@@ -315,6 +316,8 @@ const defaults: Record<string, any> = {
 	PRESSURE_LIMITER_MAX_MEMORY_RSS: false,
 	PRESSURE_LIMITER_MAX_MEMORY_HEAP_USED: false,
 	PRESSURE_LIMITER_RETRY_AFTER: false,
+
+	FILES_MIME_TYPE_ALLOW_LIST: '*/*',
 };
 
 // Allows us to force certain environment variable into a type, instead of relying

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -682,9 +682,10 @@ purposes, collection of additional metadata must be configured:
 
 ### Upload Limits
 
-| Variable                | Description                                                         | Default Value |
-| ----------------------- | ------------------------------------------------------------------- | ------------- |
-| `FILES_MAX_UPLOAD_SIZE` | Maximum file upload size allowed. For example `10mb`, `1gb`, `10kb` |               |
+| Variable                     | Description                                                                      | Default Value |
+| ---------------------------- | -------------------------------------------------------------------------------- | ------------- |
+| `FILES_MAX_UPLOAD_SIZE`      | Maximum file upload size allowed. For example `10mb`, `1gb`, `10kb`              |               |
+| `FILES_MIME_TYPE_ALLOW_LIST` | Allow list of mime types that are allowed to be uploaded. Supports `glob` syntax | `*/*`         |
 
 ## Assets
 

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -684,7 +684,7 @@ purposes, collection of additional metadata must be configured:
 
 | Variable                     | Description                                                                      | Default Value |
 | ---------------------------- | -------------------------------------------------------------------------------- | ------------- |
-| `FILES_MAX_UPLOAD_SIZE`      | Maximum file upload size allowed. For example `10mb`, `1gb`, `10kb`              |               |
+| `FILES_MAX_UPLOAD_SIZE`      | Maximum file upload size allowed. For example `10mb`, `1gb`, `10kb`              | --            |
 | `FILES_MIME_TYPE_ALLOW_LIST` | Allow list of mime types that are allowed to be uploaded. Supports `glob` syntax | `*/*`         |
 
 ## Assets

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       mime-types:
         specifier: 2.1.35
         version: 2.1.35
+      minimatch:
+        specifier: 9.0.1
+        version: 9.0.1
       ms:
         specifier: 2.1.3
         version: 2.1.3
@@ -8204,7 +8207,7 @@ packages:
       '@vue/compiler-sfc': 3.3.4
       '@vue/reactivity': 3.3.4
       '@vue/shared': 3.3.4
-      minimatch: 9.0.0
+      minimatch: 9.0.1
       muggle-string: 0.2.2
       vue-template-compiler: 2.7.14
     dev: true
@@ -14988,12 +14991,11 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
 
-  /minimatch@9.0.0:
-    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
+  /minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}


### PR DESCRIPTION
Allows limiting file uploads to an allow list of mime types. Supports `glob` style configuration for easier setup, like `image/*`.