### PR TITLE
Patch following files max upload size

### DIFF
--- a/.changeset/good-ligers-teach.md
+++ b/.changeset/good-ligers-teach.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+---
+
+Fixed `FILES_MAX_UPLOAD_SIZE` crashing bug and files interface error when the upload request errors

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -99,7 +99,6 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 
 		fileStream.on('limit', () => {
 			const error = new ContentTooLargeException(`Uploaded file is too large`);
-			fileStream.emit('error', error);
 			next(error);
 		});
 

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -328,9 +328,9 @@ function deleteItem(item: DisplayItem) {
 
 const showUpload = ref(false);
 
-function onUpload(files: Record<string, any>[]) {
+function onUpload(files: Record<string, any>[] | null) {
 	showUpload.value = false;
-	if (files.length === 0 || !relationInfo.value) return;
+	if (!files || files.length === 0 || !relationInfo.value) return;
 
 	const fileIds = files.map((file) => file.id);
 

--- a/app/src/utils/upload-files.ts
+++ b/app/src/utils/upload-files.ts
@@ -16,17 +16,19 @@ export async function uploadFiles(
 	const progressForFiles = files.map(() => 0);
 
 	try {
-		const uploadedFiles = await Promise.all(
-			files.map((file, index) =>
-				uploadFile(file, {
-					...options,
-					onProgressChange: (percentage: number) => {
-						progressForFiles[index] = percentage;
-						progressHandler(progressForFiles);
-					},
-				})
+		const uploadedFiles = (
+			await Promise.all(
+				files.map((file, index) =>
+					uploadFile(file, {
+						...options,
+						onProgressChange: (percentage: number) => {
+							progressForFiles[index] = percentage;
+							progressHandler(progressForFiles);
+						},
+					})
+				)
 			)
-		);
+		).filter((v) => v);
 
 		if (options?.notifications) {
 			notify({


### PR DESCRIPTION
Follow-up to #18735.

1. There is no need to emit the error as the limit event is triggered, tested with local storage driver.

2. Updated type + condition because when `<v-upload>` fails, it returns `null`.

3. For the `files` interface, the upload promise array will contain `undefined` should an upload fail, which is now filtered.