### PR TITLE
Update handler response format for manual flows

### DIFF
--- a/.changeset/olive-ligers-tie.md
+++ b/.changeset/olive-ligers-tie.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Updated handler response format for manual flows

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -119,7 +119,7 @@ class FlowManager {
 		id: string,
 		data: unknown,
 		context: Record<string, unknown>
-	): Promise<{ result: unknown; cacheEnabled: boolean }> {
+	): Promise<{ result: unknown; cacheEnabled?: boolean }> {
 		if (!(id in this.webhookFlowHandlers)) {
 			logger.warn(`Couldn't find webhook or manual triggered flow with id "${id}"`);
 			throw new exceptions.ForbiddenException();
@@ -240,7 +240,7 @@ class FlowManager {
 
 				this.webhookFlowHandlers[`${method}-${flow.id}`] = handler;
 			} else if (flow.trigger === 'manual') {
-				const handler = (data: unknown, context: Record<string, unknown>) => {
+				const handler = async (data: unknown, context: Record<string, unknown>) => {
 					const enabledCollections = flow.options?.['collections'] ?? [];
 					const targetCollection = (data as Record<string, any>)?.['body'].collection;
 
@@ -261,9 +261,9 @@ class FlowManager {
 
 					if (flow.options['async']) {
 						this.executeFlow(flow, data, context);
-						return undefined;
+						return { result: undefined };
 					} else {
-						return this.executeFlow(flow, data, context);
+						return { result: await this.executeFlow(flow, data, context) };
 					}
 				};
 


### PR DESCRIPTION
Follow-up of #18277 to update the handler response format for manual flows as it is stored in `webhookFlowHandlers` and triggered via `runWebhookFlow()` alongside other webhooks.

### Background

A destructure error surfaced when running a manual flow with an `undefined` result in its response handler.

https://github.com/directus/directus/blob/21d7f99002734d29396d3ea05bc8424d371fd1bc/api/src/controllers/flows.ts#L21-L34