### PR TITLE
Enhance version comparison in the update notifier

### DIFF
--- a/.changeset/twelve-ghosts-juggle.md
+++ b/.changeset/twelve-ghosts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@directus/update-check": patch
+---
+
+Enhanced version comparison in the update notifier

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -28,13 +28,15 @@
 		"boxen": "7.1.0",
 		"chalk": "5.2.0",
 		"find-cache-dir": "4.0.0",
-		"node-fetch-cache": "3.1.3"
+		"node-fetch-cache": "3.1.3",
+		"semver": "7.5.1"
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"@npm/types": "1.0.2",
 		"@types/find-cache-dir": "3.2.1",
 		"@types/node-fetch-cache": "3.0.0",
+		"@types/semver": "7.5.0",
 		"typescript": "5.0.4"
 	}
 }

--- a/packages/update-check/src/index.ts
+++ b/packages/update-check/src/index.ts
@@ -3,12 +3,11 @@ import chalk from 'chalk';
 import type { Manifest } from '@npm/types';
 import findCacheDirectory from 'find-cache-dir';
 import { fetchBuilder, FileSystemCache } from 'node-fetch-cache';
+import { gte, prerelease } from 'semver';
 
 const cacheDirectory = findCacheDirectory({ name: 'directus' });
 
-const fetch = fetchBuilder.withCache(
-	new FileSystemCache({ ttl: 60 * 60 * 60, ...(cacheDirectory && { cacheDirectory }) })
-);
+const fetch = fetchBuilder.withCache(new FileSystemCache({ ttl: 60 * 60, ...(cacheDirectory && { cacheDirectory }) }));
 
 export async function updateCheck(currentVersion: string) {
 	let packageManifest: Manifest | undefined = undefined;
@@ -34,11 +33,11 @@ export async function updateCheck(currentVersion: string) {
 
 	const latestVersion = packageManifest['dist-tags']['latest'];
 
-	if (!latestVersion || currentVersion === latestVersion) {
+	if (!latestVersion || gte(currentVersion, latestVersion)) {
 		return;
 	}
 
-	const allVersions = Object.keys(packageManifest.versions);
+	const allVersions = Object.keys(packageManifest.versions).filter((version) => !prerelease(version));
 	const indexOfCurrent = allVersions.indexOf(currentVersion);
 	const indexOfLatest = allVersions.indexOf(latestVersion);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1474,6 +1474,9 @@ importers:
       node-fetch-cache:
         specifier: 3.1.3
         version: 3.1.3
+      semver:
+        specifier: 7.5.1
+        version: 7.5.1
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -1487,6 +1490,9 @@ importers:
       '@types/node-fetch-cache':
         specifier: 3.0.0
         version: 3.0.0
+      '@types/semver':
+        specifier: 7.5.0
+        version: 7.5.0
       typescript:
         specifier: 5.0.4
         version: 5.0.4


### PR DESCRIPTION
Use `semver` to do proper version comparison

- Handle the case when the local version is higher than the last published version (e.g. in tests)
- Filter out pre-releases for the "version behind" check - could be relevant in the future again when we release beta versions or similar

Also reduces TTL for cache (supposed to be 1h already at the beginning)