### PR TITLE
Fix empty image selection error for file-image interface

### DIFF
--- a/.changeset/shaggy-mugs-kick.md
+++ b/.changeset/shaggy-mugs-kick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed empty image selection error for file-image interface

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -186,7 +186,7 @@ async function imageErrorHandler() {
 }
 
 function onUpload(image: any) {
-	if (image) update(image.id);
+	if (image?.id) update(image.id);
 }
 
 function deselect() {

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -80,7 +80,7 @@
 
 			<file-lightbox :id="image.id" v-model="lightboxActive" />
 		</div>
-		<v-upload v-else from-library from-url :from-user="createAllowed" :folder="folder" @input="update($event.id)" />
+		<v-upload v-else from-library from-url :from-user="createAllowed" :folder="folder" @input="onUpload" />
 	</div>
 </template>
 
@@ -183,6 +183,10 @@ async function imageErrorHandler() {
 			imageError.value = 'UNKNOWN';
 		}
 	}
+}
+
+function onUpload(image: any) {
+	if (image) update(image.id);
 }
 
 function deselect() {


### PR DESCRIPTION
Fix image selection error for file-image interface when selection is empty.

### Before

https://github.com/directus/directus/assets/26413686/0ba13542-6dd5-4c71-8bf4-55eb62c572f1

### After

https://github.com/directus/directus/assets/26413686/265fe8a3-568f-4470-8f58-e9770048ddc6
