### PR TITLE
Add auto-closer for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+# Auto-closes issues marked as "Needs More Info" after 7 days of no response
+
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: -1
+          days-before-close: 7
+          stale-issue-label: 'Needs More Info'
+          close-issue-message: "Heya! The core team doesn't have enough information to keep investigating this issue at present time, so it'll be closed until more information becomes available. Thanks!"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
           days-before-stale: -1
           days-before-close: 7
           stale-issue-label: 'Needs More Info'
-          close-issue-message: "Heya! The core team doesn't have enough information to keep investigating this issue at present time, so it'll be closed until more information becomes available. Thanks!"
+          close-issue-message: "Heya! There isn't enough information available to keep investigating this issue at present time, so it'll be closed until more information becomes available. Thanks!"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # Auto-closes issues marked as "Needs More Info" after 7 days of no response
 
-name: 'Close stale issues and PRs'
+name: 'Close stale issues'
 on:
   schedule:
     - cron: '30 1 * * *'


### PR DESCRIPTION
Oftentimes issues need more information from the OP before we can go over to triage / implementation. However, sometimes that information isn't given and the issue just.. hangs. This PR aims to resolve that by adding a "Needs More Info" label which will automatically close the issue if no response has been given after 7 days of the label being added. This should hopefully allow us to keep those stale issues under control.

**NOTE**: this is _not_ an auto-closer for _all_ issues. Only issues marked as "Need More Info" will be closed after a week of inactivity.