### PR TITLE
Add extra type check in apply-diff

### DIFF
--- a/.changeset/nine-masks-explode.md
+++ b/.changeset/nine-masks-explode.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Added extra type check in apply-diff

--- a/api/src/utils/apply-diff.ts
+++ b/api/src/utils/apply-diff.ts
@@ -181,9 +181,11 @@ export async function applyDiff(
 
 		// delete top level collections (no group) first, then continue with nested collections recursively
 		await deleteCollections(
-			snapshotDiff.collections.filter(
-				({ diff }) => diff[0]?.kind === DiffKind.DELETE && (diff[0] as DiffDeleted<Collection>).lhs.meta?.group === null
-			)
+			snapshotDiff.collections.filter(({ diff }) => {
+				if (diff.length === 0 || diff[0] === undefined) return false;
+				const collectionDiff = diff[0] as DiffDeleted<Collection>;
+				return collectionDiff.kind === DiffKind.DELETE && collectionDiff.lhs?.meta?.group === null;
+			})
 		);
 
 		for (const { collection, diff } of snapshotDiff.collections) {


### PR DESCRIPTION
Fixes #18774

Added extra `null`/`undefined` checks to applyDiff which are throwing errors when applying a snapshot twice.

> Wanted to get some extra tests in here for this specific issue but can't find a way to do so without refactoring apply-diff significantly