### PR TITLE
Update version of pnpm & apply stricter engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
 		"eslint-plugin-vue": "9.13.0",
 		"prettier": "2.8.8"
 	},
-	"packageManager": "pnpm@8.5.1",
+	"packageManager": "pnpm@8.6.0",
 	"engines": {
 		"node": ">=18.0.0",
-		"pnpm": ">=8.5.1"
+		"pnpm": "~8.6.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 


### PR DESCRIPTION
The stricter version requirement in `engines` ensures that we don't accidentally use an newer version of `pnpm` which introduces some incompatible changes to the lockfile.