### PR TITLE
GraphQL Subscriptions update

### DIFF
--- a/.changeset/hungry-points-rescue.md
+++ b/.changeset/hungry-points-rescue.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"docs": patch
+---
+
+Updated GraphQL Subscriptions structure

--- a/.changeset/hungry-points-rescue.md
+++ b/.changeset/hungry-points-rescue.md
@@ -1,6 +1,0 @@
----
-"@directus/api": patch
-"docs": patch
----
-
-Updated GraphQL Subscriptions structure

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -190,6 +190,15 @@ export class GraphQLService {
 					: reduceSchema(this.schema, this.accountability?.permissions || null, ['delete']),
 		};
 
+		const subscriptionEventType = schemaComposer.createEnumTC({
+			name: 'EventEnum',
+			values: {
+				create: { value: 'create' },
+				update: { value: 'update' },
+				delete: { value: 'delete' },
+			},
+		});
+
 		const { ReadCollectionTypes } = getReadableTypes();
 
 		const { CreateCollectionTypes, UpdateCollectionTypes, DeleteCollectionTypes } = getWritableTypes();
@@ -1060,16 +1069,23 @@ export class GraphQLService {
 				}
 
 				const eventName = `${collection.collection}_mutated`;
-				const subscriptionType = ReadCollectionTypes[collection.collection]?.clone(collection.collection + '_mutation');
 
-				if (subscriptionType) {
-					subscriptionType.addFields({
-						_event: GraphQLString,
+				if (collection.collection in ReadCollectionTypes) {
+					const subscriptionType = schemaComposer.createObjectTC({
+						name: eventName,
+						fields: {
+							id: new GraphQLNonNull(GraphQLID),
+							event: subscriptionEventType,
+							data: ReadCollectionTypes[collection.collection]!,
+						},
 					});
 
 					schemaComposer.Subscription.addFields({
 						[eventName]: {
 							type: subscriptionType,
+							args: {
+								event: subscriptionEventType,
+							},
 							subscribe: createSubscriptionGenerator(self, eventName),
 						},
 					});

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1074,7 +1074,7 @@ export class GraphQLService {
 					const subscriptionType = schemaComposer.createObjectTC({
 						name: eventName,
 						fields: {
-							id: new GraphQLNonNull(GraphQLID),
+							key: new GraphQLNonNull(GraphQLID),
 							event: subscriptionEventType,
 							data: ReadCollectionTypes[collection.collection]!,
 						},

--- a/api/src/services/graphql/subscription.ts
+++ b/api/src/services/graphql/subscription.ts
@@ -34,7 +34,7 @@ export function createSubscriptionGenerator(self: GraphQLService, event: string)
 				const { collection, key } = eventData;
 				const service = new ItemsService(collection, { schema });
 				const data = await service.readOne(key, { fields } as Query);
-				yield { [event]: { id: key, data, event: 'create' } };
+				yield { [event]: { key, data, event: 'create' } };
 			}
 
 			if (eventData['action'] === 'update') {
@@ -43,7 +43,7 @@ export function createSubscriptionGenerator(self: GraphQLService, event: string)
 
 				for (const key of keys) {
 					const data = await service.readOne(key, { fields } as Query);
-					yield { [event]: { id: key, data, event: 'update' } };
+					yield { [event]: { key, data, event: 'update' } };
 				}
 			}
 
@@ -51,7 +51,7 @@ export function createSubscriptionGenerator(self: GraphQLService, event: string)
 				const { keys } = eventData;
 
 				for (const key of keys) {
-					yield { [event]: { id: key, data: {}, event: 'delete' } };
+					yield { [event]: { key, data: {}, event: 'delete' } };
 				}
 			}
 		}

--- a/api/src/services/graphql/subscription.ts
+++ b/api/src/services/graphql/subscription.ts
@@ -51,7 +51,7 @@ export function createSubscriptionGenerator(self: GraphQLService, event: string)
 				const { keys } = eventData;
 
 				for (const key of keys) {
-					yield { [event]: { key, data: {}, event: 'delete' } };
+					yield { [event]: { key, data: null, event: 'delete' } };
 				}
 			}
 		}

--- a/api/src/services/graphql/subscription.ts
+++ b/api/src/services/graphql/subscription.ts
@@ -4,7 +4,7 @@ import type { GraphQLService } from './index.js';
 import { getSchema } from '../../utils/get-schema.js';
 import { ItemsService } from '../items.js';
 import type { Query } from '@directus/types';
-import type { GraphQLResolveInfo } from 'graphql';
+import type { GraphQLResolveInfo, SelectionNode } from 'graphql';
 
 const messages = createPubSub(new EventEmitter());
 
@@ -18,18 +18,23 @@ export function bindPubSub() {
 
 export function createSubscriptionGenerator(self: GraphQLService, event: string) {
 	return async function* (_x: unknown, _y: unknown, _z: unknown, request: GraphQLResolveInfo) {
-		const selections = request.fieldNodes[0]?.selectionSet?.selections || [];
-		const { fields } = self.getQuery({}, selections, {});
+		const fields = parseFields(self, request);
+		const args = parseArguments(request);
 
 		for await (const payload of messages.subscribe(event)) {
 			const eventData = payload as Record<string, any>;
+
+			if ('event' in args && eventData['action'] !== args['event']) {
+				continue; // skip filtered events
+			}
+
 			const schema = await getSchema();
 
 			if (eventData['action'] === 'create') {
 				const { collection, key } = eventData;
 				const service = new ItemsService(collection, { schema });
 				const data = await service.readOne(key, { fields } as Query);
-				yield { [event]: { ...data, _event: 'create' } };
+				yield { [event]: { id: key, data, event: 'create' } };
 			}
 
 			if (eventData['action'] === 'update') {
@@ -38,7 +43,7 @@ export function createSubscriptionGenerator(self: GraphQLService, event: string)
 
 				for (const key of keys) {
 					const data = await service.readOne(key, { fields } as Query);
-					yield { [event]: { ...data, _event: 'update' } };
+					yield { [event]: { id: key, data, event: 'update' } };
 				}
 			}
 
@@ -46,18 +51,7 @@ export function createSubscriptionGenerator(self: GraphQLService, event: string)
 				const { keys } = eventData;
 
 				for (const key of keys) {
-					const result: Record<string, any> = {};
-
-					if (fields) {
-						for (const field of fields) {
-							result[field] = null;
-						}
-					}
-
-					const pk = schema.collections[eventData['collection']]?.primary;
-					if (pk) result[pk] = key;
-					result['_event'] = 'delete';
-					yield { [event]: result };
+					yield { [event]: { id: key, data: {}, event: 'delete' } };
 				}
 			}
 		}
@@ -76,4 +70,34 @@ function createPubSub<P extends { [key: string]: unknown }>(emitter: EventEmitte
 			}
 		},
 	};
+}
+
+function parseFields(service: GraphQLService, request: GraphQLResolveInfo) {
+	const selections = request.fieldNodes[0]?.selectionSet?.selections ?? [];
+
+	const dataSelections = selections.reduce((result: readonly SelectionNode[], selection: SelectionNode) => {
+		if (
+			selection.kind === 'Field' &&
+			selection.name.value === 'data' &&
+			selection.selectionSet?.kind === 'SelectionSet'
+		) {
+			return selection.selectionSet.selections;
+		}
+
+		return result;
+	}, []);
+
+	const { fields } = service.getQuery({}, dataSelections, request.variableValues);
+	return fields ?? [];
+}
+
+function parseArguments(request: GraphQLResolveInfo) {
+	const args = request.fieldNodes[0]?.arguments ?? [];
+	return args.reduce((result, current) => {
+		if ('value' in current.value && typeof current.value.value === 'string') {
+			result[current.name.value] = current.value.value;
+		}
+
+		return result;
+	}, {} as Record<string, string>);
 }

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -210,10 +210,10 @@ export class SubscribeHandler {
 
 		if (subscription.collection === 'directus_collections') {
 			const service = new CollectionsService({ schema, accountability });
-			result['payload'] = await service.readOne(String(id));
+			result['data'] = await service.readOne(String(id));
 		} else {
 			const service = getService(subscription.collection, { schema, accountability });
-			result['payload'] = await service.readOne(id, query);
+			result['data'] = await service.readOne(id, query);
 		}
 
 		if ('meta' in query) {
@@ -237,16 +237,16 @@ export class SubscribeHandler {
 
 		switch (subscription.collection) {
 			case 'directus_collections':
-				result['payload'] = await this.getCollectionPayload(accountability, schema, event);
+				result['data'] = await this.getCollectionPayload(accountability, schema, event);
 				break;
 			case 'directus_fields':
-				result['payload'] = await this.getFieldsPayload(accountability, schema, event);
+				result['data'] = await this.getFieldsPayload(accountability, schema, event);
 				break;
 			case 'directus_relations':
-				result['payload'] = event?.payload;
+				result['data'] = event?.payload;
 				break;
 			default:
-				result['payload'] = await this.getItemsPayload(subscription, accountability, schema, event);
+				result['data'] = await this.getItemsPayload(subscription, accountability, schema, event);
 				break;
 		}
 

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -11,7 +11,7 @@ import { refreshAccountability } from '../authenticate.js';
 import { WebSocketException, handleWebSocketException } from '../exceptions.js';
 import type { WebSocketEvent } from '../messages.js';
 import { WebSocketSubscribeMessage } from '../messages.js';
-import type { Subscription, WebSocketClient } from '../types.js';
+import type { Subscription, SubscriptionEvent, WebSocketClient } from '../types.js';
 import { fmtMessage, getMessageType } from '../utils/message.js';
 
 /**
@@ -116,6 +116,10 @@ export class SubscribeHandler {
 		for (const subscription of subscriptions) {
 			const { client } = subscription;
 
+			if (subscription.event !== undefined && event.action !== subscription.event) {
+				continue; // skip filtered events
+			}
+
 			try {
 				client.accountability = await refreshAccountability(client.accountability);
 
@@ -157,6 +161,10 @@ export class SubscribeHandler {
 					collection,
 				};
 
+				if ('event' in message) {
+					subscription.event = message.event as SubscriptionEvent;
+				}
+
 				if ('query' in message) {
 					subscription.query = sanitizeQuery(message.query!, accountability);
 				}
@@ -176,8 +184,11 @@ export class SubscribeHandler {
 
 				// if no errors were thrown register the subscription
 				this.subscribe(subscription);
+
 				// send an initial response
-				client.send(fmtMessage('subscription', data, subscription.uid));
+				if (subscription.event === undefined) {
+					client.send(fmtMessage('subscription', data, subscription.uid));
+				}
 			} catch (err) {
 				handleWebSocketException(client, err, 'subscribe');
 			}

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -124,7 +124,7 @@ export class SubscribeHandler {
 						? await this.getSinglePayload(subscription, client.accountability, schema, event)
 						: await this.getMultiPayload(subscription, client.accountability, schema, event);
 
-				if (Array.isArray(result?.['payload']) && result?.['payload']?.length === 0) return;
+				if (Array.isArray(result?.['data']) && result?.['data']?.length === 0) return;
 
 				client.send(fmtMessage('subscription', result, subscription.uid));
 			} catch (err) {

--- a/api/src/websocket/messages.ts
+++ b/api/src/websocket/messages.ts
@@ -46,6 +46,7 @@ export const WebSocketSubscribeMessage = z.discriminatedUnion('type', [
 	WebSocketMessage.extend({
 		type: z.literal('subscribe'),
 		collection: z.string(),
+		event: z.union([z.literal('create'), z.literal('update'), z.literal('delete')]).optional(),
 		item: zodStringOrNumber.optional(),
 		query: z.custom<Query>().optional(),
 	}),

--- a/api/src/websocket/types.ts
+++ b/api/src/websocket/types.ts
@@ -13,11 +13,13 @@ export type WebSocketClient = WebSocket &
 	AuthenticationState & { uid: string | number; auth_timer: NodeJS.Timer | null };
 export type UpgradeRequest = IncomingMessage & AuthenticationState;
 
+export type SubscriptionEvent = 'create' | 'update' | 'delete';
+
 export type Subscription = {
 	uid?: string | number;
 	query?: Query;
 	item?: string | number;
-	status?: boolean;
+	event?: SubscriptionEvent;
 	collection: string;
 	client: WebSocketClient;
 };

--- a/docs/guides/real-time/chat/javascript.md
+++ b/docs/guides/real-time/chat/javascript.md
@@ -177,7 +177,7 @@ In your `receiveMessage` function, listen for new `create` events on the `Messag
 
 ```js
 if (data.type == 'subscription' && data.event == 'create') {
-	addMessageToList(data.payload[0]);
+	addMessageToList(data.data[0]);
 }
 ```
 
@@ -192,7 +192,7 @@ Replace the `console.log()` you created when the subscription is initialized:
 ```js
 if (data.type == 'subscription' && data.event == 'init') {
 	console.log('subscription started'); // [!code --]
-	for (const message of data.payload) { // [!code ++]
+	for (const message of data.data) { // [!code ++]
 		addMessageToList(message); // [!code ++]
 	} // [!code ++]
 }
@@ -277,12 +277,12 @@ This guide covers authentication, item creation, and subscription using WebSocke
 				}));
 			}
 			if (data.type == 'subscription' && data.event == 'init') {
-				for (const message of data.payload) { 
+				for (const message of data.data) { 
 					addMessageToList(message); 
 				} 
 			}
 			if (data.type == 'subscription' && data.event == 'create') {
-				addMessageToList(data.payload[0]);
+				addMessageToList(data.data[0]);
 			}
 		};
 

--- a/docs/guides/real-time/chat/react.md
+++ b/docs/guides/real-time/chat/react.md
@@ -277,7 +277,7 @@ In your `receiveMessage` function, listen for new `create` events on the `Messag
 
 ```js
 if (data.type === 'subscription' && data.event === 'create') {
-	setMessageHistory((history) => [...history, data.payload[0]]);
+	setMessageHistory((history) => [...history, data.data[0]]);
 }
 ```
 
@@ -305,7 +305,7 @@ Replace the `console.log()` you created when the subscription is initialized:
 ```js
 if (data.type === 'subscription' && data.event === 'init') {
 	console.log('subscription started'); // [!code --]
-	for (const message of data.payload) { // [!code ++]
+	for (const message of data.data) { // [!code ++]
 		setMessageHistory((history) => [...history, message]); // [!code ++]
 	} // [!code ++]
 }
@@ -363,12 +363,12 @@ export default function App() {
 			);
 		}
 		if (data.type === 'subscription' && data.event === 'init') {
-			for (const message of data.payload) {
+			for (const message of data.data) {
 				setMessageHistory((history) => [...history, message]);
 			}
 		}
 		if (data.type === 'subscription' && data.event === 'create') {
-			setMessageHistory((history) => [...history, data.payload[0]]);
+			setMessageHistory((history) => [...history, data.data[0]]);
 		}
 	};
 

--- a/docs/guides/real-time/chat/vue.md
+++ b/docs/guides/real-time/chat/vue.md
@@ -267,7 +267,7 @@ In your `receiveMessage` function, listen for new `create` events on the `Messag
 
 ```js
 if (data.type == 'subscription' && data.event == 'create') {
-	this.messages.history.push(data.payload[0]);
+	this.messages.history.push(data.data[0]);
 }
 ```
 
@@ -292,7 +292,7 @@ Replace the `console.log()` you created when the subscription is initialized:
 ```js
 if (data.type == 'subscription' && data.event == 'init') {
 	console.log('subscription started'); // [!code --]
-	for (const message of data.payload) { // [!code ++]
+	for (const message of data.data) { // [!code ++]
 		this.messages.history.push(message); // [!code ++]
 	} // [!code ++]
 }
@@ -384,12 +384,12 @@ This guide covers authentication, item creation, and subscription using WebSocke
 						})); 
 					} 
 					if (data.type == 'subscription' && data.event == 'init') { 
-						for (const message of data.payload) { 
+						for (const message of data.data) { 
 							this.messages.history.push(message); 
 						} 
 					} 
 					if (data.type == 'subscription' && data.event == 'create') {
-						this.messages.history.push(data.payload[0]);
+						this.messages.history.push(data.data[0]);
 					}
 				}
 			}

--- a/docs/guides/real-time/getting-started/graphql.md
+++ b/docs/guides/real-time/getting-started/graphql.md
@@ -60,8 +60,8 @@ client.subscribe(
 		query: `
 				subscription {
 					messages_mutated {
-						id,
-						event,
+						key
+						event
 						data {
 							text
 						}

--- a/docs/guides/real-time/getting-started/graphql.md
+++ b/docs/guides/real-time/getting-started/graphql.md
@@ -61,7 +61,10 @@ client.subscribe(
 				subscription {
 					messages_mutated {
 						id,
-						text
+						event,
+						data {
+							text
+						}
 					}
 				}`,
 	},

--- a/docs/guides/real-time/live-poll.md
+++ b/docs/guides/real-time/live-poll.md
@@ -150,7 +150,7 @@ A message is sent over the connection when a connection is initialized with data
 
 ```js
 if (data.type == 'subscription' && data.event == 'init') {
-	for (const item of data.payload) {	// [!code	++]
+	for (const item of data.data) {	// [!code	++]
 		chart.data.labels.push(item.choice);	// [!code	++]
 		chart.data.datasets[0].data.push(item.count.choice);	// [!code	++]
 	}	// [!code	++]
@@ -168,7 +168,7 @@ When a new vote is cast, update the chart’s dataset and update it:
 
 ```js
 if (data.type == 'subscription' && data.event == 'create') {
-  const vote = data.payload[0]; // [!code  ++]
+  const vote = data.data[0]; // [!code  ++]
   const itemToUpdate = chart.data.labels.indexOf(vote.choice); // [!code  ++]
   chart.data.datasets[0].data[itemToUpdate]++; // [!code  ++]
   chart.update(); // [!code  ++]
@@ -253,7 +253,7 @@ There are many ways to improve the project built in this guide:
 				}
 
 				if (data.type == 'subscription' && data.event == 'init') {
-					for (const item of data.payload) {
+					for (const item of data.data) {
 						chart.data.labels.push(item.choice);
 						chart.data.datasets[0].data.push(item.count.choice);
 					}
@@ -261,7 +261,7 @@ There are many ways to improve the project built in this guide:
 				}
 
 				if (data.type == 'subscription' && data.event == 'create') {
-					const vote = data.payload[0];
+					const vote = data.data[0];
 					const itemToUpdate = chart.data.labels.indexOf(vote.choice); 
 					chart.data.datasets[0].data[itemToUpdate]++;
 					chart.update();

--- a/docs/guides/real-time/operations.md
+++ b/docs/guides/real-time/operations.md
@@ -75,13 +75,13 @@ Instead of using an object as the value of `data`, you can provide an array of o
 }
 ```
 
-Regardless of how many items are updated, the `payload` in the returned data will always be an array.
+Regardless of how many items are updated, the `data` in the returned object will always be an array.
 
 ```json
 {
 	"type": "subscription",
 	"event": "update",
-	"payload": [...]
+	"data": [...]
 }
 ```
 
@@ -100,13 +100,13 @@ Instead of using an `id` property, you can use an `ids` property with an array o
 }
 ```
 
-Regardless of how many items are updated, the `payload` in the returned data will always be an array containing all IDs from deleted items:
+Regardless of how many items are updated, the `data` in the returned data will always be an array containing all IDs from deleted items:
 
 ```json
 {
 	"type": "items",
 	"event": "delete",
-	"payload": ["single_item_id", "single_item_id_2"]
+	"data": ["single_item_id", "single_item_id_2"]
 }
 ```
 

--- a/docs/guides/real-time/subscriptions/graphql.md
+++ b/docs/guides/real-time/subscriptions/graphql.md
@@ -22,6 +22,7 @@ subscription {
 		key
 		event
 		data {
+			id
 			text
 		}
 	}
@@ -41,9 +42,10 @@ When a change happens to an item in a collection with an active subscription, it
 ```json
 {
 	"messages_mutated": {
-		"id": "1",
+		"key": "1",
 		"event": "create",
 		"data": {
+			"id": "1",
 			"text": "Hello world!",
 		}
 	}
@@ -51,7 +53,7 @@ When a change happens to an item in a collection with an active subscription, it
 ```
 
 An event will be either `create`, `update`, or `delete`. If the event is `create` or `update`, the payload will
-contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be filled the other requested fields will be `null`.
+contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `key` will be filled the other requested fields will be `null`.
 
 ## Working With Specific CRUD Operations
 

--- a/docs/guides/real-time/subscriptions/graphql.md
+++ b/docs/guides/real-time/subscriptions/graphql.md
@@ -20,7 +20,10 @@ subscribe to a `messages` collection, the query would look like this:
 subscription {
 	messages_mutated {
 		id
-		text
+		event
+		data {
+			text
+		}
 	}
 }
 ```
@@ -39,33 +42,31 @@ When a change happens to an item in a collection with an active subscription, it
 {
 	"messages_mutated": {
 		"id": "1",
-		"text": "Hello world!",
-		"_event": "create"
+		"event": "create",
+		"data": {
+			"text": "Hello world!",
+		}
 	}
 }
 ```
 
 An event will be either `create`, `update`, or `delete`. If the event is `create` or `update`, the payload will
-contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be
-returned.
+contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be filled the other requested fields will be `null`.
 
 ## Working With Specific CRUD Operations
 
-Using the `_event` value, you can implement your own conditional logic to execute different logic for `create`,
+Using the `event` argument, you can filter for specific `create`,
 `update`, and `delete` events. Here's an example of how to do this:
 
-```js
-next: ({ data }) => {
-	const { text, id, _event } = data?.messages_mutated || {};
-
-	if (_event === 'create') {
-		setMessageData((messages) => [...messages, { id, text }]);
-	} else if (_event === 'delete') {
-		setMessageData((messages) => messages.filter((m) => m.id !== id));
-	} else if (_event === 'update') {
-		setMessageData((messages) => messages.map((message) => (message.id === id ? { ...message, text } : message)));
+```graphql
+subscription {
+	messages_mutated(event: create) {
+		id
+		data {
+			text
+		}
 	}
-};
+}
 ```
 
 ## Unsubscribing From Changes

--- a/docs/guides/real-time/subscriptions/graphql.md
+++ b/docs/guides/real-time/subscriptions/graphql.md
@@ -61,7 +61,7 @@ Using the `event` argument, you can filter for specific `create`,
 ```graphql
 subscription {
 	messages_mutated(event: create) {
-		id
+		key
 		data {
 			text
 		}

--- a/docs/guides/real-time/subscriptions/graphql.md
+++ b/docs/guides/real-time/subscriptions/graphql.md
@@ -19,7 +19,7 @@ subscribe to a `messages` collection, the query would look like this:
 ```graphql
 subscription {
 	messages_mutated {
-		id
+		key
 		event
 		data {
 			text

--- a/docs/guides/real-time/subscriptions/graphql.md
+++ b/docs/guides/real-time/subscriptions/graphql.md
@@ -57,7 +57,7 @@ contain the full item objects (or specific fields, if specified). If the event i
 
 ## Working With Specific CRUD Operations
 
-Using the `event` argument, you can filter for specific `create`,
+Using the `event` argument you can filter for specific `create`,
 `update`, and `delete` events. Here's an example of how to do this:
 
 ```graphql

--- a/docs/guides/real-time/subscriptions/websockets.md
+++ b/docs/guides/real-time/subscriptions/websockets.md
@@ -41,7 +41,7 @@ When a change happens to an item in a collection with an active subscription, it
 }
 ```
 
-The `event` will be one of `create`, `update`, or `delete`. If the event is `create` or `update`, `data` will contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be returned.
+The `event` will be one of `create`, `update`, or `delete`. If the event is `create` or `update`, the `data` will contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be returned.
 
 ## Working With Specific CRUD Operations
 

--- a/docs/guides/real-time/subscriptions/websockets.md
+++ b/docs/guides/real-time/subscriptions/websockets.md
@@ -37,11 +37,11 @@ When a change happens to an item in a collection with an active subscription, it
 {
 	"type": "subscription",
 	"event": "create",
-	"payload": [...]
+	"data": [...]
 }
 ```
 
-The `event` will be one of `create`, `update`, or `delete`. If the event is `create` or `update`, the payload will contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be returned.
+The `event` will be one of `create`, `update`, or `delete`. If the event is `create` or `update`, `data` will contain the full item objects (or specific fields, if specified). If the event is `delete`, just the `id` will be returned.
 
 ## Working With Specific CRUD Operations
 
@@ -79,7 +79,7 @@ When you receive responses, the same `uid` will be included as a property:
 {
 	"type": "subscription",
 	"event": "create",
-	"payload": [...],
+	"data": [...],
 	"uid": "any-string-value"
 }
 ```

--- a/docs/guides/real-time/subscriptions/websockets.md
+++ b/docs/guides/real-time/subscriptions/websockets.md
@@ -45,7 +45,16 @@ The `event` will be one of `create`, `update`, or `delete`. If the event is `cre
 
 ## Working With Specific CRUD Operations
 
-There is no way to only subscribe to specific events within a collection - it’s all or nothing. Using the `event` value, you should implement your own conditional logic to execute different logic for `create`, `update`, and `delete` events.
+Using the optional `event` argument you can filter for specific `create`, `update`, and `delete` events. When filtering for an event the `init` response will no longer be sent.
+
+Here's an example of how to do this:
+```json
+{
+	"type": "subscribe",
+	"collection": "messages",
+	"event": "create"
+}
+```
 
 ## Specifying Fields To Return
 


### PR DESCRIPTION
Fixes ENG-1053

This slightly alters the GraphQL Subscription format.

Before: 
```graphql
subscription {
	messages_mutated {
		id
                _event
		text
	}
}
```

After:
```graphql
subscription {
	messages_mutated {
		key
		event
		data {
                        id
			text
		}
	}
}
```

With the added option to filter a specific event:
```graphql
subscription {
	messages_mutated(event: update) {
		key
		data {
                        id
			text
		}
	}
}
```

And updates the REST subscriptions slightly for consistency:
- added optional `event` filter like was added for graphql
- renamed `payload` to `data` for consistency between the http api, graphql and rest