### PR TITLE
Automatically assign next release milestone

### DIFF
--- a/.github/workflows/assign-next-release-milestone.yml
+++ b/.github/workflows/assign-next-release-milestone.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: 'Next Release'
-      - uses: zoispag/action-assign-milestone@v1
+      - uses: zoispag/action-assign-milestone@v1.1.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           milestone: 'Next Release'

--- a/.github/workflows/assign-next-release-milestone.yml
+++ b/.github/workflows/assign-next-release-milestone.yml
@@ -6,7 +6,8 @@ on:
       - closed
 
 jobs:
-  check-if-merged:
+  assign:
+    name: Assign Milestone
     if: github.event.pull_request.merged == true && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/assign-next-release-milestone.yml
+++ b/.github/workflows/assign-next-release-milestone.yml
@@ -1,0 +1,16 @@
+name: Assign Next Release Milestone
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  check-if-merged:
+    if: github.event.pull_request.merged == true && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zoispag/action-assign-milestone@v1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          milestone: 'Next Release'

--- a/.github/workflows/assign-next-release-milestone.yml
+++ b/.github/workflows/assign-next-release-milestone.yml
@@ -10,6 +10,10 @@ jobs:
     if: github.event.pull_request.merged == true && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
+      - uses: sv-tools/create-milestone-action@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 'Next Release'
       - uses: zoispag/action-assign-milestone@v1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
The workflow will run when a PR is closed and merged into `main`. 
It creates a `Next Release` milestone if it does not exist and assigns the PR to the milestone.

https://github.com/directus/directus/assets/26413686/c2d53d3b-678f-433c-8f3a-346289dc9d00

Refs:
https://github.com/marketplace/actions/create-milestone-js
https://github.com/marketplace/actions/assign-a-milestone-to-pull-requests