### PR TITLE
Fix Websocket GraphQL public auth

### DIFF
--- a/api/src/websocket/controllers/graphql.ts
+++ b/api/src/websocket/controllers/graphql.ts
@@ -55,7 +55,7 @@ export class GraphQLSubscriptionController extends SocketController {
 					client.on('parsed-message', async (message: WebSocketMessage) => {
 						try {
 							if (getMessageType(message) === 'connection_init' && this.authentication.mode !== 'strict') {
-								const params = ConnectionParams.parse(message['payload']);
+								const params = ConnectionParams.parse(message['payload'] ?? {});
 
 								if (this.authentication.mode === 'handshake') {
 									if (typeof params.access_token === 'string') {


### PR DESCRIPTION
Auth mode `public` didn't work for GraphQL, because the message payload was expected to be an object in every case, resulting in the cryptic error message:
```
WebSocketException [Error]: Validation error: Required
```

Fixed by falling back to an empty object if no payload is given.