### PR TITLE
Render calendar and map layouts correctly

### DIFF
--- a/.changeset/blue-impalas-smell.md
+++ b/.changeset/blue-impalas-smell.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed CSS to render calendar and map layouts correctly

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -444,6 +444,7 @@ function getWidth(input: unknown, fallback: number): number {
 		font-size: 15px;
 		line-height: 24px;
 
+		.content-wrapper,
 		main {
 			display: contents;
 		}


### PR DESCRIPTION
Fix CSS to render calendar and map layouts correctly.
Closes #18848, closes #18757.