### PR TITLE
Fix collection name in quickstart.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -40,3 +40,4 @@
 - craigharman
 - ninogjoni
 - ched-dev
+- anantakrishna

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -119,7 +119,7 @@ of creating a new Role.
 
 1. Navigate to **Settings Module > Roles & Permissions > Public**.
 2. Click <span mi icon dngr>block</span> under the <span mi icon>visibility</span> icon on the desired Collection.\
-   In our case, the Collection name is `article`.
+   In our case, the Collection name is `articles`.
 3. Click **"All Access"** to give the Public Role full read permissions to the Items in this Collection.
 
 ::: tip Learn More About Roles & Permissions


### PR DESCRIPTION
It was created as `articles` in the guide, but later referred to as `article`.