### PR TITLE
Recursively check permissions in isAllowed utility function

### DIFF
--- a/.changeset/heavy-kiwis-return.md
+++ b/.changeset/heavy-kiwis-return.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added recursive check for permissions in app side


### PR DESCRIPTION
Fixes #16731, fixes ENG-1258

### Description

Currently within isAllowed, `generateJoi` util function is used:

https://github.com/directus/directus/blob/0c5123ab9665229b3cbd906af19970074dddd463/app/src/utils/is-allowed.ts#L35

However, permissions similar to Filters can be nested in AND/OR group, whereas `generateJoi` itself doesn't support logical operators:

https://github.com/directus/directus/blob/0c5123ab9665229b3cbd906af19970074dddd463/packages/utils/shared/generate-joi.ts#L73

This PR follows a similar recursive logic in filterItems:

https://github.com/directus/directus/blob/0c5123ab9665229b3cbd906af19970074dddd463/api/src/utils/filter-items.ts#L19-L36

and implement it within isAllowed to recursively check permissions.

### Before

A user should only be able to edit their own Last Name, and not any other users. Although the API itself prevents the user from doing so once they click save, the app still shows it as editable in another user's page:

https://github.com/directus/directus/assets/42867097/e867b88c-8443-4c4c-8a96-49bba936fda0

### After

It is now disabled when they view another user's page:

https://github.com/directus/directus/assets/42867097/8d36dda3-2ca4-4b8f-9b9d-0176059a6210

