### PR TITLE
Support multiline summaries in release notes generator

### DIFF
--- a/.changeset/cool-laws-share.md
+++ b/.changeset/cool-laws-share.md
@@ -1,0 +1,5 @@
+---
+"@directus/release-notes-generator": minor
+---
+
+Added support for multiline summaries

--- a/packages/release-notes-generator/src/utils/generate-markdown.test.ts
+++ b/packages/release-notes-generator/src/utils/generate-markdown.test.ts
@@ -4,10 +4,10 @@ import type { Change, Notice, PackageVersion, Type, UntypedPackage } from '../ty
 import { generateMarkdown } from './generate-markdown';
 
 const change1: Change = {
-	summary: 'Made Directus even more magical',
+	summary: "Made Directus even more magical\nAnd here's some additional context",
 	commit: 'abcd123',
 	githubInfo: {
-		user: '@directus',
+		user: 'directus',
 		pull: 1,
 		links: {
 			commit: '[`abcd123`](https://github.com/directus/directus/commit/abcd123)',
@@ -21,7 +21,7 @@ const change2: Change = {
 	summary: 'Improved some things a little',
 	commit: 'efgh456',
 	githubInfo: {
-		user: '@directus',
+		user: 'directus',
 		pull: 1,
 		links: {
 			commit: '[`efgh456`](https://github.com/directus/directus/commit/efgh456)',
@@ -32,8 +32,6 @@ const change2: Change = {
 };
 
 test('should generate basic release notes', () => {
-	const notices: Notice[] = [];
-
 	const types: Type[] = [
 		{
 			title: TYPE_MAP.minor,
@@ -65,28 +63,32 @@ test('should generate basic release notes', () => {
 		{ name: '@directus/app', version: '10.0.0' },
 	];
 
-	const markdown = generateMarkdown(notices, types, untypedPackages, packageVersions);
+	const markdown = generateMarkdown([], types, untypedPackages, packageVersions);
 
 	expect(markdown).toMatchInlineSnapshot(`
 		"### ✨ New Features & Improvements
 
 		- **@directus/api**
-		  - Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @@directus)
+		  - Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @directus)
+		    And here's some additional context
 
 		### 🐛 Bug Fixes & Optimizations
 
 		- **@directus/app**
-		  - Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @@directus)
-		  - Improved some things a little ([#2](https://github.com/directus/directus/pull/2) by @@directus)
+		  - Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @directus)
+		    And here's some additional context
+		  - Improved some things a little ([#2](https://github.com/directus/directus/pull/2) by @directus)
 
 		### 📝 Documentation
 
-		- Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @@directus)
-		- Improved some things a little ([#2](https://github.com/directus/directus/pull/2) by @@directus)
+		- Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @directus)
+		  And here's some additional context
+		- Improved some things a little ([#2](https://github.com/directus/directus/pull/2) by @directus)
 
 		### 🧪 Blackbox Tests
 
-		- Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @@directus)
+		- Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @directus)
+		  And here's some additional context
 
 		### 📦 Published Versions
 
@@ -107,7 +109,7 @@ describe('notices', () => {
 		expect(markdown).toMatchInlineSnapshot(`
 			"### ⚠️ Potential Breaking Changes
 
-			**Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1))**
+			**Made Directus even more magical... ([#1](https://github.com/directus/directus/pull/1))**
 			This is an example notice.
 
 			**Improved some things a little ([#2](https://github.com/directus/directus/pull/2))**
@@ -133,14 +135,15 @@ describe('notices', () => {
 		expect(markdown).toMatchInlineSnapshot(`
 			"### ⚠️ Potential Breaking Changes
 
-			**Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1))**
+			**Made Directus even more magical... ([#1](https://github.com/directus/directus/pull/1))**
 			This is an example notice.
 
 			**Improved some things a little ([#2](https://github.com/directus/directus/pull/2))**
 			This is another notice.
 
 			- **@directus/api**
-			  - Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @@directus)"
+			  - Made Directus even more magical ([#1](https://github.com/directus/directus/pull/1) by @directus)
+			    And here's some additional context"
 		`);
 	});
 });

--- a/packages/release-notes-generator/src/utils/generate-markdown.ts
+++ b/packages/release-notes-generator/src/utils/generate-markdown.ts
@@ -64,7 +64,7 @@ function formatSections(sections: Section[]): string {
 
 function formatNotices(notices: Notice[]): string {
 	const output = notices.map((notice) => {
-		let lines = `**${formatChange(notice.change, false)}**\n`;
+		let lines = `**${formatChange(notice.change, true)}**\n`;
 		return (lines += `${notice.notice}`);
 	});
 
@@ -79,7 +79,12 @@ function formatPackages(packages: Package[]): string {
 			lines += `- **${name}**\n`;
 
 			lines += formatChanges(changes)
-				.map((change) => `  ${change}`)
+				.map((change) =>
+					change
+						.split('\n')
+						.map((line) => `  ${line}`)
+						.join('\n')
+				)
 				.join('\n');
 		}
 
@@ -107,10 +112,22 @@ function formatUntypedPackages(untypedPackages: UntypedPackage[]): string {
 }
 
 function formatChanges(changes: Change[]): string[] {
-	return changes.map((change) => `- ${formatChange(change)}`);
+	return changes.map((change) => {
+		const lines = [];
+
+		const [firstLine, ...remainingLines] = formatChange(change).split('\n');
+
+		lines.push(`- ${firstLine}`);
+
+		if (remainingLines.length > 0) {
+			lines.push(...remainingLines.map((line) => `  ${line}`));
+		}
+
+		return lines.join('\n');
+	});
 }
 
-function formatChange(change: Change, includeUser = true): string {
+function formatChange(change: Change, short?: boolean): string {
 	let refUser = '';
 	const refUserContent = [];
 
@@ -122,7 +139,7 @@ function formatChange(change: Change, includeUser = true): string {
 		refUserContent.push(`[${change.commit}](https://github.com/${REPO}/commit/${change.commit})`);
 	}
 
-	if (includeUser && change.githubInfo?.user) {
+	if (!short && change.githubInfo?.user) {
 		refUserContent.push(`by @${change.githubInfo.user}`);
 	}
 
@@ -132,7 +149,12 @@ function formatChange(change: Change, includeUser = true): string {
 		refUser += ')';
 	}
 
-	return `${change.summary}${refUser}`;
+	const [firstSummaryLine, ...remainingSummaryLines] = change.summary.split('\n');
+
+	const title = short && remainingSummaryLines.length > 0 ? `${firstSummaryLine}...` : firstSummaryLine;
+	const additionalLines = !short && remainingSummaryLines.length > 0 ? `\n${remainingSummaryLines.join('\n')}` : '';
+
+	return `${title}${refUser}${additionalLines}`;
 }
 
 function formatPackageVersions(packageVersions: PackageVersion[]): string {


### PR DESCRIPTION
For the [changeset](https://github.com/directus/directus/blob/bc7e92e4b0512735821aa43aa67280c963184bca/.changeset/lazy-cows-happen.md) from the WebSocket PR in particular but also for such cases in the future:

<table><tr><td>
<img width="700" src="https://github.com/directus/directus/assets/5363448/1bfe0d4d-d87e-4b1a-ae09-ff179e73f350">
</td></tr></table>
