### PR TITLE
Clean-up changesets

### DIFF
--- a/.changeset/chilled-wolves-double.md
+++ b/.changeset/chilled-wolves-double.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed reverse usage of null, nnull, empty and nempty filter operator
+Fixed reverse usage of _null, _nnull, _empty and _nempty filter operators

--- a/.changeset/clean-wasps-build.md
+++ b/.changeset/clean-wasps-build.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Move useAppStore to @directus/stores
+Moved useAppStore to @directus/stores

--- a/.changeset/eleven-cougars-sparkle.md
+++ b/.changeset/eleven-cougars-sparkle.md
@@ -5,4 +5,4 @@
 '@directus/random': patch
 ---
 
-Start work on @directus/data
+Added initial implementation of @directus/data

--- a/.changeset/eleven-cougars-sparkle.md
+++ b/.changeset/eleven-cougars-sparkle.md
@@ -5,4 +5,4 @@
 '@directus/random': patch
 ---
 
-Added initial implementation of @directus/data
+Started initial work on @directus/data

--- a/.changeset/lazy-cows-happen.md
+++ b/.changeset/lazy-cows-happen.md
@@ -3,7 +3,7 @@
 "directus": minor
 ---
 
-Integrating Websockets Subscriptions for REST and GraphQL in Directus 🕸️🧦 
+Integrated Websockets Subscriptions for REST and GraphQL in Directus 🕸️🧦
 - A CRUD implementation over WebSockets
 - A REST Subscriptions implementation
 - GraphQL Subscriptions over WebSockets

--- a/.changeset/warm-spiders-double.md
+++ b/.changeset/warm-spiders-double.md
@@ -6,11 +6,10 @@
 "@directus/extensions-sdk": patch
 "@directus/pressure": patch
 "@directus/random": patch
-"@directus/sdk": patch
 "@directus/stores": patch
 "@directus/types": patch
 "@directus/update-check": patch
 "@directus/utils": patch
 ---
 
-Add TypeDocs to Docs
+Added TypeDocs to Docs


### PR DESCRIPTION
Removal of `@directus/sdk` bump in `warm-spiders-double.md` is required to prevent a conflict when running `pnpm version` (since the SDK package is currently ignored).