### PR TITLE
Fix websocket with $CURRENT_USER permissions

### DIFF
--- a/.changeset/swift-eyes-rule.md
+++ b/.changeset/swift-eyes-rule.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed resolving $CURRENT_USER in permissions for websocket authentication

--- a/api/src/websocket/authenticate.test.ts
+++ b/api/src/websocket/authenticate.test.ts
@@ -2,11 +2,11 @@ import type { Accountability } from '@directus/types';
 import { describe, expect, test, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { InvalidCredentialsException } from '../index.js';
-import { getAccountabilityForRole } from '../utils/get-accountability-for-role.js';
 import { getAccountabilityForToken } from '../utils/get-accountability-for-token.js';
 import { authenticateConnection, authenticationSuccess, refreshAccountability } from './authenticate.js';
 import type { WebSocketAuthMessage } from './messages.js';
 import { getExpiresAtForToken } from './utils/get-expires-at-for-token.js';
+import { getPermissions } from '../utils/get-permissions.js';
 
 vi.mock('../utils/get-accountability-for-token', () => ({
 	getAccountabilityForToken: vi.fn().mockReturnValue({
@@ -14,8 +14,8 @@ vi.mock('../utils/get-accountability-for-token', () => ({
 	} as Accountability),
 }));
 
-vi.mock('../utils/get-accountability-for-role', () => ({
-	getAccountabilityForRole: vi.fn(),
+vi.mock('../utils/get-permissions', () => ({
+	getPermissions: vi.fn(),
 }));
 
 vi.mock('./utils/get-expires-at-for-token', () => ({
@@ -107,19 +107,18 @@ describe('authenticateConnection', () => {
 });
 
 describe('refreshAccountability', () => {
-	test('should just work', async () => {
-		(getAccountabilityForRole as Mock).mockReturnValue({
-			role: '123-456-789',
-		} as Accountability);
+	test('update permissions', async () => {
+		(getPermissions as Mock).mockReturnValue([]);
 
 		const result = await refreshAccountability({
-			role: null,
+			role: '123-456-789',
 			user: 'abc-def-ghi',
 		});
 
 		expect(result).toStrictEqual({
 			role: '123-456-789',
 			user: 'abc-def-ghi',
+			permissions: [],
 		});
 	});
 });


### PR DESCRIPTION
When refreshing the accountability on incoming requests i was using the `getAccountabilityForRole` function. This function explicitly sets the provided `user` to `null` before fetching the permissions resulting in the $CURRENT_USER variable not being resolved correctly.

The fix here removes the usages of `getAccountabilityForRole()` and instead directly fetches the permissions.


Fixes #18891
