### PR TITLE
Fix Edit Flow/Trigger not updating in Flow Editor

### DIFF
--- a/.changeset/ten-taxis-divide.md
+++ b/.changeset/ten-taxis-divide.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fix Edit Flow/Trigger not updating in Flow Editor

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -249,7 +249,7 @@ async function save() {
 
 		await flowsStore.hydrate();
 
-		emit('done', id);
+		emit('done', values);
 	} catch (err: any) {
 		unexpectedError(err);
 	} finally {

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -113,7 +113,7 @@
 			:primary-key="flow.id"
 			:start-tab="'trigger_setup'"
 			@cancel="triggerDetailOpen = false"
-			@done="triggerDetailOpen = false"
+			@done="triggerDetailPanelDone"
 		/>
 
 		<v-dialog v-model="confirmLeave" @esc="confirmLeave = false">
@@ -594,6 +594,13 @@ function duplicatePanel(panel: OperationRaw) {
 function editPanel(panel: AppTile) {
 	if (panel.id === '$trigger') triggerDetailOpen.value = true;
 	else router.push(`/settings/flows/${props.primaryKey}/${panel.id}`);
+}
+
+async function triggerDetailPanelDone() {
+	triggerDetailOpen.value = false;
+
+	await flowsStore.hydrate();
+	await loadCurrentFlow();
 }
 
 // ------------- Move Panel To ------------- //

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -182,7 +182,7 @@
 </template>
 
 <script setup lang="ts">
-import { FlowRaw, OperationRaw } from '@directus/types';
+import { Flow, FlowRaw, OperationRaw } from '@directus/types';
 import { useI18n } from 'vue-i18n';
 
 import { computed, ref, watch } from 'vue';
@@ -596,8 +596,10 @@ function editPanel(panel: AppTile) {
 	else router.push(`/settings/flows/${props.primaryKey}/${panel.id}`);
 }
 
-async function triggerDetailPanelDone() {
+async function triggerDetailPanelDone(values: Flow) {
 	triggerDetailOpen.value = false;
+
+	stagedFlow.value = merge({}, stagedFlow.value, values);
 
 	await flowsStore.hydrate();
 	await loadCurrentFlow();

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -136,7 +136,7 @@ import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { usePermissionsStore } from '@/stores/permissions';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { FlowRaw } from '@directus/types';
+import { Flow, FlowRaw } from '@directus/types';
 import { sortBy } from 'lodash';
 import { computed, ref, Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -252,9 +252,9 @@ async function toggleFlowStatusById(id: string, value: string) {
 	}
 }
 
-function onFlowDrawerCompletion(id: string) {
+function onFlowDrawerCompletion(values: Flow) {
 	if (editFlow.value === '+') {
-		router.push(`/settings/flows/${id}`);
+		router.push(`/settings/flows/${values.id}`);
 	}
 
 	editFlow.value = undefined;


### PR DESCRIPTION
- Updates FlowDrawer `done` emitter to emit `values` instead of just `id`.
- Adds a function `triggerDetailPanelDone(values: Flow)`
  - Merge emitted `values` into stagedFlow so it is updated with saved flow/trigger values
  - Hydrate and call loadCurrentFlow to update fetchedFlow with saved flow/trigger values

Fixes #18903