### PR TITLE
#18930 - Fix to v-table show-select='one'

### DIFF
--- a/.changeset/fair-years-itch.md
+++ b/.changeset/fair-years-itch.md
@@ -2,4 +2,4 @@
 '@directus/extensions-sdk': patch
 ---
 
-Fix to v-table show-select behaviour allow for radio buttons to have multi-select (unexpected behaviour)
+Fixed `v-table` allowing radio buttons to have multiple selection values when the `show-select` prop was set to `one`

--- a/.changeset/fair-years-itch.md
+++ b/.changeset/fair-years-itch.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+Fix to v-table show-select behaviour allow for radio buttons to have multi-select (unexpected behaviour)

--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -292,6 +292,10 @@ function onItemSelected(event: ItemSelectEvent) {
 		});
 	}
 
+	if (props.showSelect === 'one') {
+		selection = selection.slice(-1);
+	}
+
 	emit('update:modelValue', selection);
 }
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -43,3 +43,4 @@
 - ninogjoni
 - ched-dev
 - anantakrishna
+- Philippe-cheype


### PR DESCRIPTION
## Linked Issue

#18930 

## About unit tests

I was looking around for a test file for `v-table` or a `v-table.test.js` but I couldn't find any? Is this normal? If needed I can create one.

## About the docs/wiki

I don't believe it's necessary to specify how radio buttons behave, but I can add a line to the wiki if needed.
