### PR TITLE
converted abstract sort modifier

### DIFF
--- a/.changeset/nervous-carrots-cover.md
+++ b/.changeset/nervous-carrots-cover.md
@@ -3,4 +3,4 @@
 '@directus/data': minor
 ---
 
-Sort conversion in SQL middleware
+Implemented sort conversion in SQL middleware

--- a/.changeset/nervous-carrots-cover.md
+++ b/.changeset/nervous-carrots-cover.md
@@ -1,0 +1,6 @@
+---
+'@directus/data-sql': minor
+'@directus/data': minor
+---
+
+Sort conversion in SQL middleware

--- a/packages/data-sql/src/converter/convert-sort.test.ts
+++ b/packages/data-sql/src/converter/convert-sort.test.ts
@@ -1,0 +1,70 @@
+import type { AbstractQueryNodeSort } from '@directus/data';
+import { beforeEach, expect, test } from 'vitest';
+import { randomIdentifier } from '@directus/random';
+import { convertSort } from './convert-sort.js';
+
+let sample: {
+	sort: AbstractQueryNodeSort[];
+};
+
+beforeEach(() => {
+	sample = {
+		sort: [
+			{
+				type: 'sort',
+				direction: 'ascending',
+				target: {
+					type: 'primitive',
+					field: randomIdentifier(),
+				},
+			},
+		],
+	};
+});
+
+test('convert ascending sort with a single field', () => {
+	const res = convertSort(sample.sort);
+
+	expect(res).toStrictEqual([
+		{
+			orderBy: sample.sort[0]!.target,
+			direction: 'ASC',
+		},
+	]);
+});
+
+test('convert descending sort with a single field', () => {
+	sample.sort[0]!.direction = 'descending';
+	const res = convertSort(sample.sort);
+
+	expect(res).toStrictEqual([
+		{
+			orderBy: sample.sort[0]!.target,
+			direction: 'DESC',
+		},
+	]);
+});
+
+test('convert ascending sort with multiple fields', () => {
+	sample.sort.push({
+		type: 'sort',
+		direction: 'ascending',
+		target: {
+			type: 'primitive',
+			field: randomIdentifier(),
+		},
+	});
+
+	const res = convertSort(sample.sort);
+
+	expect(res).toStrictEqual([
+		{
+			orderBy: sample.sort[0]!.target,
+			direction: 'ASC',
+		},
+		{
+			orderBy: sample.sort[1]!.target,
+			direction: 'ASC',
+		},
+	]);
+});

--- a/packages/data-sql/src/converter/convert-sort.ts
+++ b/packages/data-sql/src/converter/convert-sort.ts
@@ -1,12 +1,12 @@
 import type { AbstractQueryNodeSort } from '@directus/data';
-import type { SqlOrder } from '../types.js';
+import type { AbstractSqlOrder } from '../types.js';
 
 /**
  * @param abstractPrimitive
  * @param collection
  * @returns the converted primitive node
  */
-export const convertSort = (abstractSorts: AbstractQueryNodeSort[]): SqlOrder[] => {
+export const convertSort = (abstractSorts: AbstractQueryNodeSort[]): AbstractSqlOrder[] => {
 	return abstractSorts.map((abstractSort) => {
 		return {
 			orderBy: abstractSort.target,

--- a/packages/data-sql/src/converter/convert-sort.ts
+++ b/packages/data-sql/src/converter/convert-sort.ts
@@ -2,9 +2,8 @@ import type { AbstractQueryNodeSort } from '@directus/data';
 import type { AbstractSqlOrder } from '../types.js';
 
 /**
- * @param abstractPrimitive
- * @param collection
- * @returns the converted primitive node
+ * @param abstractSorts
+ * @returns the converted sort nodes
  */
 export const convertSort = (abstractSorts: AbstractQueryNodeSort[]): AbstractSqlOrder[] => {
 	return abstractSorts.map((abstractSort) => {

--- a/packages/data-sql/src/converter/convert-sort.ts
+++ b/packages/data-sql/src/converter/convert-sort.ts
@@ -1,0 +1,16 @@
+import type { AbstractQueryNodeSort } from '@directus/data';
+import type { SqlOrder } from '../types.js';
+
+/**
+ * @param abstractPrimitive
+ * @param collection
+ * @returns the converted primitive node
+ */
+export const convertSort = (abstractSorts: AbstractQueryNodeSort[]): SqlOrder[] => {
+	return abstractSorts.map((abstractSort) => {
+		return {
+			orderBy: abstractSort.target,
+			direction: abstractSort.direction === 'descending' ? 'DESC' : 'ASC',
+		};
+	});
+};

--- a/packages/data-sql/src/converter/index.test.ts
+++ b/packages/data-sql/src/converter/index.test.ts
@@ -117,3 +117,97 @@ test('Get selects with a limit and offset', () => {
 
 	expect(res).toStrictEqual(expected);
 });
+
+test('Get selects with a sort', () => {
+	sample.query.modifiers = {
+		sort: [
+			{
+				type: 'sort',
+				direction: 'ascending',
+				target: {
+					type: 'primitive',
+					field: randomIdentifier(),
+				},
+			},
+		],
+	};
+
+	const res = convertAbstractQueryToAbstractSqlQuery(sample.query);
+
+	const expected: AbstractSqlQuery = {
+		select: [
+			{
+				type: 'primitive',
+				table: sample.query.collection,
+				column: (sample.query.nodes[0] as AbstractQueryFieldNodePrimitive).field,
+			},
+			{
+				type: 'primitive',
+				table: sample.query.collection,
+				column: (sample.query.nodes[1] as AbstractQueryFieldNodePrimitive).field,
+			},
+		],
+		from: sample.query.collection,
+		order: [
+			{
+				orderBy: sample.query.modifiers.sort![0]!.target,
+				direction: 'ASC',
+			},
+		],
+		parameters: [],
+	};
+
+	expect(res).toStrictEqual(expected);
+});
+
+test('Convert a complex abstract query', () => {
+	sample.query.modifiers = {
+		limit: {
+			type: 'limit',
+			value: randomInteger(1, 100),
+		},
+		offset: {
+			type: 'offset',
+			value: randomInteger(1, 100),
+		},
+		sort: [
+			{
+				type: 'sort',
+				direction: 'ascending',
+				target: {
+					type: 'primitive',
+					field: randomIdentifier(),
+				},
+			},
+		],
+	};
+
+	const res = convertAbstractQueryToAbstractSqlQuery(sample.query);
+
+	const expected: AbstractSqlQuery = {
+		select: [
+			{
+				type: 'primitive',
+				table: sample.query.collection,
+				column: (sample.query.nodes[0] as AbstractQueryFieldNodePrimitive).field,
+			},
+			{
+				type: 'primitive',
+				table: sample.query.collection,
+				column: (sample.query.nodes[1] as AbstractQueryFieldNodePrimitive).field,
+			},
+		],
+		from: sample.query.collection,
+		order: [
+			{
+				orderBy: sample.query.modifiers.sort![0]!.target,
+				direction: 'ASC',
+			},
+		],
+		limit: { parameterIndex: 0 },
+		offset: { parameterIndex: 1 },
+		parameters: [sample.query.modifiers.limit!.value, sample.query.modifiers.offset!.value],
+	};
+
+	expect(res).toStrictEqual(expected);
+});

--- a/packages/data-sql/src/converter/index.test.ts
+++ b/packages/data-sql/src/converter/index.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 	};
 });
 
-test('Get all selects', () => {
+test('Convert simple query', () => {
 	const res = convertAbstractQueryToAbstractSqlQuery(sample.query);
 
 	const expected: AbstractSqlQuery = {
@@ -51,7 +51,7 @@ test('Get all selects', () => {
 	expect(res).toStrictEqual(expected);
 });
 
-test('Get selects with a limit', () => {
+test('Convert query with a limit', () => {
 	sample.query.modifiers = {
 		limit: {
 			type: 'limit',
@@ -82,7 +82,7 @@ test('Get selects with a limit', () => {
 	expect(res).toStrictEqual(expected);
 });
 
-test('Get selects with a limit and offset', () => {
+test('Convert query with limit and offset', () => {
 	sample.query.modifiers = {
 		limit: {
 			type: 'limit',
@@ -118,7 +118,7 @@ test('Get selects with a limit and offset', () => {
 	expect(res).toStrictEqual(expected);
 });
 
-test('Get selects with a sort', () => {
+test('Convert query with a sort', () => {
 	sample.query.modifiers = {
 		sort: [
 			{
@@ -160,7 +160,7 @@ test('Get selects with a sort', () => {
 	expect(res).toStrictEqual(expected);
 });
 
-test('Convert a complex abstract query', () => {
+test('Convert a query with all possible modifiers', () => {
 	sample.query.modifiers = {
 		limit: {
 			type: 'limit',

--- a/packages/data-sql/src/converter/index.ts
+++ b/packages/data-sql/src/converter/index.ts
@@ -2,6 +2,7 @@ import type { AbstractQuery } from '@directus/data';
 import type { AbstractSqlQuery } from '../types.js';
 import { convertPrimitive } from './convert-primitive.js';
 import { parameterIndexGenerator } from '../utils/param-index-generator.js';
+import { convertSort } from './convert-sort.js';
 
 /**
  * @param abstractQuery the abstract query to convert
@@ -42,6 +43,10 @@ export const convertAbstractQueryToAbstractSqlQuery = (abstractQuery: AbstractQu
 		const idx = idGen.next().value;
 		statement.offset = { parameterIndex: idx };
 		statement.parameters[idx] = abstractQuery.modifiers.offset.value;
+	}
+
+	if (abstractQuery.modifiers?.sort) {
+		statement.order = convertSort(abstractQuery.modifiers.sort);
 	}
 
 	return statement;

--- a/packages/data-sql/src/converter/index.ts
+++ b/packages/data-sql/src/converter/index.ts
@@ -29,9 +29,7 @@ export const convertAbstractQueryToAbstractSqlQuery = (abstractQuery: AbstractQu
 
 	const idGen = parameterIndexGenerator();
 
-	// TODO:
-	// The next functions look very similar.
-	// Depending on how the other conversions will look like, we can introduce a generic function for this.
+	// TODO: Create a generic function for this and add unit tests. This way we might can save some tests in index.test.ts
 
 	if (abstractQuery.modifiers?.limit) {
 		const idx = idGen.next().value;

--- a/packages/data-sql/src/types.ts
+++ b/packages/data-sql/src/types.ts
@@ -50,11 +50,11 @@ export interface AbstractSqlQuery {
 	from: string;
 	limit?: ParameterIndex;
 	offset?: ParameterIndex;
-	order?: SqlOrder[];
+	order?: AbstractSqlOrder[];
 	parameters: (string | boolean | number)[];
 }
 
-export type SqlOrder = {
+export type AbstractSqlOrder = {
 	orderBy: AbstractQueryNodeSortTargets;
 	direction: 'ASC' | 'DESC';
 };

--- a/packages/data-sql/src/types.ts
+++ b/packages/data-sql/src/types.ts
@@ -1,3 +1,5 @@
+import type { AbstractQueryNodeSortTargets } from '@directus/data';
+
 export interface SqlStatementSelectPrimitive {
 	type: 'primitive';
 	table: string;
@@ -48,8 +50,14 @@ export interface AbstractSqlQuery {
 	from: string;
 	limit?: ParameterIndex;
 	offset?: ParameterIndex;
+	order?: SqlOrder[];
 	parameters: (string | boolean | number)[];
 }
+
+export type SqlOrder = {
+	orderBy: AbstractQueryNodeSortTargets;
+	direction: 'ASC' | 'DESC';
+};
 
 /**
  * An actual vendor specific SQL statement with its parameters.

--- a/packages/data/src/types/abstract-query.ts
+++ b/packages/data/src/types/abstract-query.ts
@@ -29,7 +29,7 @@ interface AbstractQueryNode {
 }
 
 /**
- * The A group of all possible field types.
+ * A group of all possible field types.
  * This can be used within the `nodes` array of the `AbstractQuery`.
  */
 export type AbstractQueryFieldNode =
@@ -207,11 +207,38 @@ interface AbstractQueryNodeOffset extends AbstractQueryModifierNode {
 export type AbstractQueryNodeSortTargets =
 	| AbstractQueryFieldNodePrimitive
 	| AbstractQueryFieldNodeFn
+	// TDB when we implement relations:
 	| AbstractQueryFieldNodeRelatedManyToOne
 	| AbstractQueryFieldNodeRelatedAnyToOne;
 
 /**
- * Specifies the order of the results
+ * Specifies the order of the result, f.e. for a primitive field.
+ * @example
+ * ```js
+ * const sortNode = {
+ * 		type: 'sort',
+ * 		direction: 'ascending',
+ * 		target: {
+ * 			type: 'primitive',
+ * 			field: 'attribute_xy'
+ * 		}
+ * }
+ * ```
+ * Alternatively a function can be applied a the field.
+ * The result is then used for sorting.
+ * @example
+ * ```js
+ * const sortNode = {
+ * 		type: 'sort',
+ * 		direction: 'ascending',
+ * 		target: {
+ * 			type: 'fn',
+ * 			fn: 'year',
+ * 			targetNode: {
+ * 				type: 'primitive'
+ * 				field: 'date_created'
+ * 		}
+ * }
  */
 export interface AbstractQueryNodeSort extends AbstractQueryModifierNode {
 	type: 'sort';

--- a/packages/data/src/types/abstract-query.ts
+++ b/packages/data/src/types/abstract-query.ts
@@ -180,7 +180,7 @@ export interface AbstractQueryFieldNodeRelatedOneToAny extends AbstractQueryNode
 export interface AbstractQueryModifiers {
 	limit?: AbstractQueryNodeLimit;
 	offset?: AbstractQueryNodeOffset;
-	sort?: AbstractQueryNodeSort;
+	sort?: AbstractQueryNodeSort[];
 	filter?: AbstractQueryNodeLogical | AbstractQueryNodeCondition;
 }
 
@@ -204,21 +204,23 @@ interface AbstractQueryNodeOffset extends AbstractQueryModifierNode {
 	value: number;
 }
 
+export type AbstractQueryNodeSortTargets =
+	| AbstractQueryFieldNodePrimitive
+	| AbstractQueryFieldNodeFn
+	| AbstractQueryFieldNodeRelatedManyToOne
+	| AbstractQueryFieldNodeRelatedAnyToOne;
+
 /**
  * Specifies the order of the results
  */
-interface AbstractQueryNodeSort extends AbstractQueryModifierNode {
+export interface AbstractQueryNodeSort extends AbstractQueryModifierNode {
 	type: 'sort';
 
 	/** the desired order */
 	direction: 'ascending' | 'descending';
 
 	/** the node on which the sorting should be applied */
-	target:
-		| AbstractQueryFieldNodePrimitive
-		| AbstractQueryFieldNodeFn
-		| AbstractQueryFieldNodeRelatedManyToOne
-		| AbstractQueryFieldNodeRelatedAnyToOne;
+	target: AbstractQueryNodeSortTargets;
 }
 
 /**


### PR DESCRIPTION
With this, the `sort` modifier of the abstract query will be converted into an abstract ORDER BY for SQL drivers.

It's also possible to specify multiple sorts.

The implementation of sort within the PostgreSQL driver is also done already, but I want to keep the PRs as small as possible for a fast review.