### PR TITLE
App: Hydrate `serverStore` once

### DIFF
--- a/.changeset/modern-boxes-sin.md
+++ b/.changeset/modern-boxes-sin.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fix issue where App was not fully taking rate limit into consideration

--- a/.changeset/modern-boxes-sin.md
+++ b/.changeset/modern-boxes-sin.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Fix issue where App was not fully taking rate limit into consideration
+Fixed issue where App was not fully taking rate limit into consideration

--- a/app/src/hydrate.ts
+++ b/app/src/hydrate.ts
@@ -73,7 +73,7 @@ export async function hydrate(): Promise<void> {
 		if (currentUser?.role) {
 			await Promise.all([permissionsStore.hydrate(), fieldsStore.hydrate({ skipTranslation: true })]);
 
-			const hydratedStores = ['userStore', 'permissionsStore', 'fieldsStore'];
+			const hydratedStores = ['userStore', 'permissionsStore', 'fieldsStore', 'serverStore'];
 			await Promise.all(stores.filter(({ $id }) => !hydratedStores.includes($id)).map((store) => store.hydrate?.()));
 
 			await onHydrateExtensions();


### PR DESCRIPTION
## Fixes
Fixes #18939

## Motivation
When having a low rate limit and multiple relationships in an item, App is not currently able to properly throttle the requests:
https://github.com/directus/directus/assets/14039341/60eb53de-dc42-4008-b5e3-6beebb6062c2

## Solution
After some investigation I found that `useServerStore().hydrate()` was being called twice causing `replaceQueue()` to be fired twice and finally causing issues with timers on PQueue.

1. First call to `useServerStore().hydrate()`:
https://github.com/directus/directus/blob/5ad28818a21fdce17a9868b2931efe03e67e0d0b/app/src/router.ts#L106

2. Second call to `useServerStore().hydrate()`:
https://github.com/directus/directus/blob/5ad28818a21fdce17a9868b2931efe03e67e0d0b/app/src/hydrate.ts#L76-L77

3. Calls to `replaceQueue()`:
https://github.com/directus/directus/blob/5ad28818a21fdce17a9868b2931efe03e67e0d0b/app/src/stores/server.ts#L106

Since we already hydrate `serverStore` on 1. and since we are already preventing other stores from being hydrated (because they are already hydrated) on 2., we can also skip the hydration of `serverStore` on 2.
This way, `replaceQueue()` is called once and timers on PQueue are all in sync.

I was able to detect this while logging all requests with timestamp and notice that the first burst of requests were not on a cadence of 1 sec while the others were.