### PR TITLE
Add missing filter operators for case sensitivity #18739

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -44,3 +44,5 @@
 - ched-dev
 - anantakrishna
 - Philippe-cheype
+- gitstart
+- RubensRafael

--- a/docs/reference/filter-rules.md
+++ b/docs/reference/filter-rules.md
@@ -50,32 +50,33 @@ readTime: 5 min read
 
 ## Filter Operators
 
-| Operator Title _(in app)_      | Operator                           | Description                            |
-| ------------------------------ | ---------------------------------- | -------------------------------------- |
-| Equals                         | `_eq`                              | Equal to                               |
-| Doesn't equal                  | `_neq`                             | Not equal to                           |
-| Less than                      | `_lt`                              | Less than                              |
-| Less than or equal to          | `_lte`                             | Less than or equal to                  |
-| Greater than                   | `_gt`                              | Greater than                           |
-| Greater than or equal to       | `_gte`                             | Greater than or equal to               |
-| Is one of                      | `_in`                              | Matches any of the values              |
-| Is not one of                  | `_nin`                             | Doesn't match any of the values        |
-| Is null                        | `_null`                            | Is `null`                              |
-| Isn't null                     | `_nnull`                           | Is not `null`                          |
-| Contains                       | `_contains`                        | Contains the substring                 |
-| Doesn't contain                | `_ncontains`                       | Doesn't contain the substring          |
-| Starts with                    | `_starts_with`                     | Starts with                            |
-| Doesn't start with             | `_nstarts_with`                    | Doesn't start with                     |
-| Ends with                      | `_ends_with`                       | Ends with                              |
-| Doesn't end with               | `_nends_with`                      | Doesn't end with                       |
-| Is between                     | `_between`                         | Is between two values (inclusive)      |
-| Isn't between                  | `_nbetween`                        | Is not between two values (inclusive)  |
-| Is empty                       | `_empty`                           | Is empty (`null` or falsy)             |
-| Isn't empty                    | `_nempty`                          | Is not empty (`null` or falsy)         |
-| Intersects                     | `_intersects` <sup>[1]</sup>       | Value intersects a given point         |
-| Doesn't intersect              | `_nintersects` <sup>[1]</sup>      | Value does not intersect a given point |
-| Intersects Bounding box        | `_intersects_bbox` <sup>[1]</sup>  | Value is in a bounding box             |
-| Doesn't intersect bounding box | `_nintersects_bbox` <sup>[1]</sup> | Value is not in a bounding box         |
+| Operator Title _(in app)_      | Operator                           | Description                             |
+| ------------------------------ | ---------------------------------- | --------------------------------------- |
+| Equals                         | `_eq`                              | Equal to                                |
+| Doesn't equal                  | `_neq`                             | Not equal to                            |
+| Less than                      | `_lt`                              | Less than                               |
+| Less than or equal to          | `_lte`                             | Less than or equal to                   |
+| Greater than                   | `_gt`                              | Greater than                            |
+| Greater than or equal to       | `_gte`                             | Greater than or equal to                |
+| Is one of                      | `_in`                              | Matches any of the values               |
+| Is not one of                  | `_nin`                             | Doesn't match any of the values         |
+| Is null                        | `_null`                            | Is `null`                               |
+| Isn't null                     | `_nnull`                           | Is not `null`                           |
+| Contains                       | `_contains`                        | Contains the substring                  |
+| Contains (case-insensitive)    | `_icontains`                       | Contains the case-insensitive substring |
+| Doesn't contain                | `_ncontains`                       | Doesn't contain the substring           |
+| Starts with                    | `_starts_with`                     | Starts with                             |
+| Doesn't start with             | `_nstarts_with`                    | Doesn't start with                      |
+| Ends with                      | `_ends_with`                       | Ends with                               |
+| Doesn't end with               | `_nends_with`                      | Doesn't end with                        |
+| Is between                     | `_between`                         | Is between two values (inclusive)       |
+| Isn't between                  | `_nbetween`                        | Is not between two values (inclusive)   |
+| Is empty                       | `_empty`                           | Is empty (`null` or falsy)              |
+| Isn't empty                    | `_nempty`                          | Is not empty (`null` or falsy)          |
+| Intersects                     | `_intersects` <sup>[1]</sup>       | Value intersects a given point          |
+| Doesn't intersect              | `_nintersects` <sup>[1]</sup>      | Value does not intersect a given point  |
+| Intersects Bounding box        | `_intersects_bbox` <sup>[1]</sup>  | Value is in a bounding box              |
+| Doesn't intersect bounding box | `_nintersects_bbox` <sup>[1]</sup> | Value is not in a bounding box          |
 
 The following operator has no Title on the Filter Interface as it is **only available in validation permissions**:
 


### PR DESCRIPTION
Fixes: #18739

## Demo
![image](https://github.com/GitStartHQ/client-directus/assets/70234898/0943b836-55e6-41e5-95f3-9d957cb04d0b)
![image](https://github.com/GitStartHQ/client-directus/assets/70234898/7f58a6c7-a511-476f-a34e-b2b41177caf5)


## How to test
- Build and run docs
  ```
  cd docs
  pnpm build
  pnpm dev
  ```
- Compare [local changes](http://localhost:5173/reference/filter-rules.html#filter-operators) with [deployed changes](https://docs.directus.io/reference/filter-rules.html#filter-operators)

___
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
