### PR TITLE
Sort in pg driver

### DIFF
--- a/.changeset/little-rivers-report.md
+++ b/.changeset/little-rivers-report.md
@@ -2,4 +2,4 @@
 '@directus/data-driver-postgres': minor
 ---
 
-Implented support for sorting in PostgreSQL driver
+Implemented sorting in PostgreSQL driver

--- a/.changeset/little-rivers-report.md
+++ b/.changeset/little-rivers-report.md
@@ -1,0 +1,5 @@
+---
+'@directus/data-driver-postgres': minor
+---
+
+Implented support for sorting in PostgreSQL driver

--- a/packages/data-driver-postgres/src/query/from.test.ts
+++ b/packages/data-driver-postgres/src/query/from.test.ts
@@ -1,10 +1,10 @@
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 import { beforeEach, expect, test } from 'vitest';
 import { from } from './from.js';
 import { randomIdentifier } from '@directus/random';
 
 let sample: {
-	statement: SqlStatement;
+	statement: AbstractSqlQuery;
 };
 
 beforeEach(() => {

--- a/packages/data-driver-postgres/src/query/from.ts
+++ b/packages/data-driver-postgres/src/query/from.ts
@@ -1,4 +1,4 @@
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 import { escapeIdentifier } from '../utils/escape-identifier.js';
 
 /**
@@ -6,6 +6,6 @@ import { escapeIdentifier } from '../utils/escape-identifier.js';
  * @param from - The table to select data from
  * @returns The `FROM x` part of a SQL statement
  */
-export function from({ from }: SqlStatement): string {
+export function from({ from }: AbstractSqlQuery): string {
 	return `FROM ${escapeIdentifier(from)}`;
 }

--- a/packages/data-driver-postgres/src/query/index.test.ts
+++ b/packages/data-driver-postgres/src/query/index.test.ts
@@ -75,3 +75,29 @@ test('statement with order', () => {
 		parameters: sample.statement.parameters,
 	});
 });
+
+test('statement with all possible modifiers', () => {
+	sample.statement.limit = { parameterIndex: 0 };
+	sample.statement.offset = { parameterIndex: 1 };
+	sample.statement.parameters = [randomInteger(1, 100), randomInteger(1, 100)];
+
+	sample.statement.order = [
+		{
+			orderBy: {
+				type: 'primitive',
+				field: randomIdentifier(),
+			},
+			direction: 'ASC',
+		},
+	];
+
+	expect(constructSqlQuery(sample.statement)).toEqual({
+		statement: `SELECT "${sample.statement.select[0]!.table}"."${sample.statement.select[0]!.column}", "${
+			sample.statement.select[1]!.table
+		}"."${sample.statement.select[1]!.column}" FROM "${sample.statement.from}" ORDER BY "${
+			// @ts-ignore
+			sample.statement.order[0].orderBy.field
+		}" ASC LIMIT $1 OFFSET $2;`,
+		parameters: sample.statement.parameters,
+	});
+});

--- a/packages/data-driver-postgres/src/query/index.test.ts
+++ b/packages/data-driver-postgres/src/query/index.test.ts
@@ -1,7 +1,8 @@
+import type { AbstractQueryFieldNodePrimitive } from '@directus/data';
 import type { AbstractSqlQuery } from '@directus/data-sql';
+import { randomIdentifier, randomInteger } from '@directus/random';
 import { beforeEach, expect, test } from 'vitest';
 import { constructSqlQuery } from './index.js';
-import { randomIdentifier, randomInteger } from '@directus/random';
 
 let sample: {
 	statement: AbstractSqlQuery;
@@ -69,8 +70,7 @@ test('statement with order', () => {
 		statement: `SELECT "${sample.statement.select[0]!.table}"."${sample.statement.select[0]!.column}", "${
 			sample.statement.select[1]!.table
 		}"."${sample.statement.select[1]!.column}" FROM "${sample.statement.from}" ORDER BY "${
-			// @ts-ignore
-			sample.statement.order[0].orderBy.field
+			(sample.statement.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field
 		}" ASC;`,
 		parameters: sample.statement.parameters,
 	});
@@ -95,8 +95,7 @@ test('statement with all possible modifiers', () => {
 		statement: `SELECT "${sample.statement.select[0]!.table}"."${sample.statement.select[0]!.column}", "${
 			sample.statement.select[1]!.table
 		}"."${sample.statement.select[1]!.column}" FROM "${sample.statement.from}" ORDER BY "${
-			// @ts-ignore
-			sample.statement.order[0].orderBy.field
+			(sample.statement.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field
 		}" ASC LIMIT $1 OFFSET $2;`,
 		parameters: sample.statement.parameters,
 	});

--- a/packages/data-driver-postgres/src/query/index.test.ts
+++ b/packages/data-driver-postgres/src/query/index.test.ts
@@ -53,3 +53,25 @@ test('statement with limit and offset', () => {
 		parameters: sample.statement.parameters,
 	});
 });
+
+test('statement with order', () => {
+	sample.statement.order = [
+		{
+			orderBy: {
+				type: 'primitive',
+				field: randomIdentifier(),
+			},
+			direction: 'ASC',
+		},
+	];
+
+	expect(constructSqlQuery(sample.statement)).toEqual({
+		statement: `SELECT "${sample.statement.select[0]!.table}"."${sample.statement.select[0]!.column}", "${
+			sample.statement.select[1]!.table
+		}"."${sample.statement.select[1]!.column}" FROM "${sample.statement.from}" ORDER BY "${
+			// @ts-ignore
+			sample.statement.order[0].orderBy.field
+		}" ASC;`,
+		parameters: sample.statement.parameters,
+	});
+});

--- a/packages/data-driver-postgres/src/query/index.ts
+++ b/packages/data-driver-postgres/src/query/index.ts
@@ -28,7 +28,7 @@ export function constructSqlQuery(query: AbstractSqlQuery): ParameterizedSQLStat
 	const actualParts = [base, orderByPart, limitPart, offsetPart].filter((p) => p !== null);
 
 	return {
-		statement: actualParts.join(' ').trim() + ';',
+		statement: actualParts.join(' ') + ';',
 		parameters: query.parameters,
 	};
 }

--- a/packages/data-driver-postgres/src/query/index.ts
+++ b/packages/data-driver-postgres/src/query/index.ts
@@ -4,9 +4,15 @@ import { select } from './select.js';
 import type { ParameterizedSQLStatement } from '@directus/data-sql';
 import { limit } from './limit.js';
 import { offset } from './offset.js';
+import { orderBy } from './orderBy.js';
 
 /**
  * Constructs an actual PostgreSQL query statement from a given abstract SQL query.
+ *
+ * @remarks
+ * To create a PostgreSQL statement each part is constructed in separate functions.
+ * Those functions check if the part should needs to be created.
+ * If not they return null.
  *
  * @param query - The abstract SQL statement
  * @returns An actual SQL with parameters
@@ -17,8 +23,12 @@ export function constructSqlQuery(query: AbstractSqlQuery): ParameterizedSQLStat
 	const limitPart = limit(query);
 	const offsetPart = offset(query);
 
+	const orderByPart = orderBy(query);
+
+	const actualParts = [base, limitPart, offsetPart, orderByPart].filter((p) => p !== null);
+
 	return {
-		statement: `${base} ${limitPart} ${offsetPart}`.trimEnd() + ';',
+		statement: actualParts.join(' ').trim() + ';',
 		parameters: query.parameters,
 	};
 }

--- a/packages/data-driver-postgres/src/query/index.ts
+++ b/packages/data-driver-postgres/src/query/index.ts
@@ -11,7 +11,7 @@ import { orderBy } from './orderBy.js';
  *
  * @remarks
  * To create a PostgreSQL statement each part is constructed in a separate function.
- * In those functions it will be check if the part is actually should be created.
+ * In those functions it will be checked if the part should actually be created.
  * If not, the functions return null.
  *
  * @param query - The abstract SQL statement

--- a/packages/data-driver-postgres/src/query/index.ts
+++ b/packages/data-driver-postgres/src/query/index.ts
@@ -10,22 +10,22 @@ import { orderBy } from './orderBy.js';
  * Constructs an actual PostgreSQL query statement from a given abstract SQL query.
  *
  * @remarks
- * To create a PostgreSQL statement each part is constructed in separate functions.
- * Those functions check if the part should needs to be created.
- * If not they return null.
+ * To create a PostgreSQL statement each part is constructed in a separate function.
+ * In those functions it will be check if the part is actually should be created.
+ * If not, the functions return null.
  *
  * @param query - The abstract SQL statement
- * @returns An actual SQL with parameters
+ * @returns An actual SQL query with parameters
  */
 export function constructSqlQuery(query: AbstractSqlQuery): ParameterizedSQLStatement {
 	const base = [select(query), from(query)].join(' ');
 
+	const orderByPart = orderBy(query);
+
 	const limitPart = limit(query);
 	const offsetPart = offset(query);
 
-	const orderByPart = orderBy(query);
-
-	const actualParts = [base, limitPart, offsetPart, orderByPart].filter((p) => p !== null);
+	const actualParts = [base, orderByPart, limitPart, offsetPart].filter((p) => p !== null);
 
 	return {
 		statement: actualParts.join(' ').trim() + ';',

--- a/packages/data-driver-postgres/src/query/index.ts
+++ b/packages/data-driver-postgres/src/query/index.ts
@@ -1,7 +1,7 @@
 import type { AbstractSqlQuery } from '@directus/data-sql';
-import { from } from './from.js';
-import { select } from './select.js';
 import type { ParameterizedSQLStatement } from '@directus/data-sql';
+import { select } from './select.js';
+import { from } from './from.js';
 import { limit } from './limit.js';
 import { offset } from './offset.js';
 import { orderBy } from './orderBy.js';
@@ -18,17 +18,15 @@ import { orderBy } from './orderBy.js';
  * @returns An actual SQL query with parameters
  */
 export function constructSqlQuery(query: AbstractSqlQuery): ParameterizedSQLStatement {
-	const base = [select(query), from(query)].join(' ');
+	const statementParts = [select, from, orderBy, limit, offset];
 
-	const orderByPart = orderBy(query);
-
-	const limitPart = limit(query);
-	const offsetPart = offset(query);
-
-	const actualParts = [base, orderByPart, limitPart, offsetPart].filter((p) => p !== null);
+	const statement = `${statementParts
+		.map((part) => part(query))
+		.filter((p) => p !== null)
+		.join(' ')};`;
 
 	return {
-		statement: actualParts.join(' ') + ';',
+		statement,
 		parameters: query.parameters,
 	};
 }

--- a/packages/data-driver-postgres/src/query/limit.test.ts
+++ b/packages/data-driver-postgres/src/query/limit.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 });
 
 test('Empty parametrized statement when limit is not defined', () => {
-	expect(limit(sample.statement)).toStrictEqual('');
+	expect(limit(sample.statement)).toStrictEqual(null);
 });
 
 test('Returns limit part with one parameter', () => {

--- a/packages/data-driver-postgres/src/query/limit.test.ts
+++ b/packages/data-driver-postgres/src/query/limit.test.ts
@@ -1,10 +1,10 @@
 import { test, expect, beforeEach } from 'vitest';
 import { limit } from './limit.js';
 import { randomInteger, randomIdentifier } from '@directus/random';
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 
 let sample: {
-	statement: SqlStatement;
+	statement: AbstractSqlQuery;
 };
 
 beforeEach(() => {

--- a/packages/data-driver-postgres/src/query/limit.ts
+++ b/packages/data-driver-postgres/src/query/limit.ts
@@ -1,4 +1,4 @@
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 
 /**
  * Generate the `LIMIT x` part of a SQL statement.
@@ -6,7 +6,7 @@ import type { SqlStatement } from '@directus/data-sql';
  * @param query The abstract query
  * @returns The `LIMIT x` part of a SQL statement
  */
-export function limit({ limit }: SqlStatement): string {
+export function limit({ limit }: AbstractSqlQuery): string | null {
 	if (limit === undefined) {
 		return '';
 	}

--- a/packages/data-driver-postgres/src/query/limit.ts
+++ b/packages/data-driver-postgres/src/query/limit.ts
@@ -8,7 +8,7 @@ import type { AbstractSqlQuery } from '@directus/data-sql';
  */
 export function limit({ limit }: AbstractSqlQuery): string | null {
 	if (limit === undefined) {
-		return '';
+		return null;
 	}
 
 	return `LIMIT $${limit.parameterIndex + 1}`;

--- a/packages/data-driver-postgres/src/query/offset.test.ts
+++ b/packages/data-driver-postgres/src/query/offset.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 });
 
 test('Empty string when offset is not defined', () => {
-	expect(offset(sample.statement)).toStrictEqual('');
+	expect(offset(sample.statement)).toStrictEqual(null);
 });
 
 test('Returns offset', () => {

--- a/packages/data-driver-postgres/src/query/offset.test.ts
+++ b/packages/data-driver-postgres/src/query/offset.test.ts
@@ -1,10 +1,10 @@
 import { test, expect, beforeEach } from 'vitest';
 import { offset } from './offset.js';
 import { randomIdentifier } from '@directus/random';
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 
 let sample: {
-	statement: SqlStatement;
+	statement: AbstractSqlQuery;
 };
 
 beforeEach(() => {

--- a/packages/data-driver-postgres/src/query/offset.ts
+++ b/packages/data-driver-postgres/src/query/offset.ts
@@ -1,4 +1,4 @@
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 
 /**
  * Generate the `OFFSET x` part of a SQL statement.
@@ -6,7 +6,7 @@ import type { SqlStatement } from '@directus/data-sql';
  * @param query The abstract query
  * @returns The `OFFSET x` part of a SQL statement
  */
-export function offset({ offset }: SqlStatement): string {
+export function offset({ offset }: AbstractSqlQuery): string | null {
 	if (offset === undefined) {
 		return '';
 	}

--- a/packages/data-driver-postgres/src/query/offset.ts
+++ b/packages/data-driver-postgres/src/query/offset.ts
@@ -8,7 +8,7 @@ import type { AbstractSqlQuery } from '@directus/data-sql';
  */
 export function offset({ offset }: AbstractSqlQuery): string | null {
 	if (offset === undefined) {
-		return '';
+		return null;
 	}
 
 	return `OFFSET $${offset.parameterIndex + 1}`;

--- a/packages/data-driver-postgres/src/query/orderBy.test.ts
+++ b/packages/data-driver-postgres/src/query/orderBy.test.ts
@@ -1,7 +1,8 @@
-import { test, expect, beforeEach } from 'vitest';
-import { orderBy } from './orderBy.js';
-import { randomIdentifier } from '@directus/random';
+import type { AbstractQueryFieldNodePrimitive } from '@directus/data';
 import type { AbstractSqlQuery } from '@directus/data-sql';
+import { randomIdentifier } from '@directus/random';
+import { beforeEach, expect, test } from 'vitest';
+import { orderBy } from './orderBy.js';
 
 let sample: {
 	statement: AbstractSqlQuery;
@@ -40,8 +41,7 @@ test('Returns order part for one primitive field', () => {
 		},
 	];
 
-	// @ts-ignore
-	const expected = `ORDER BY "${sample.statement.order[0].orderBy.field}" ASC`;
+	const expected = `ORDER BY "${(sample.statement.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field}" ASC`;
 
 	expect(orderBy(sample.statement)).toStrictEqual(expected);
 });
@@ -64,8 +64,9 @@ test('Returns order part for multiple primitive fields', () => {
 		},
 	];
 
-	// @ts-ignore
-	const expected = `ORDER BY "${sample.statement.order[0].orderBy.field}" ASC, "${sample.statement.order[1].orderBy.field}" DESC`;
+	const expected = `ORDER BY "${(sample.statement.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field}" ASC, "${
+		(sample.statement.order[1]!.orderBy as AbstractQueryFieldNodePrimitive).field
+	}" DESC`;
 
 	expect(orderBy(sample.statement)).toStrictEqual(expected);
 });

--- a/packages/data-driver-postgres/src/query/orderBy.test.ts
+++ b/packages/data-driver-postgres/src/query/orderBy.test.ts
@@ -1,0 +1,71 @@
+import { test, expect, beforeEach } from 'vitest';
+import { orderBy } from './orderBy.js';
+import { randomIdentifier } from '@directus/random';
+import type { AbstractSqlQuery } from '@directus/data-sql';
+
+let sample: {
+	statement: AbstractSqlQuery;
+};
+
+beforeEach(() => {
+	sample = {
+		statement: {
+			select: [
+				{
+					type: 'primitive',
+					column: randomIdentifier(),
+					table: randomIdentifier(),
+					as: randomIdentifier(),
+				},
+				{ type: 'primitive', column: randomIdentifier(), table: randomIdentifier() },
+			],
+			from: randomIdentifier(),
+			parameters: [],
+		},
+	};
+});
+
+test('Empty parametrized statement when order is not defined', () => {
+	expect(orderBy(sample.statement)).toStrictEqual(null);
+});
+
+test('Returns order part for one primitive field', () => {
+	sample.statement.order = [
+		{
+			orderBy: {
+				type: 'primitive',
+				field: randomIdentifier(),
+			},
+			direction: 'ASC',
+		},
+	];
+
+	// @ts-ignore
+	const expected = `ORDER BY "${sample.statement.order[0].orderBy.field}" ASC`;
+
+	expect(orderBy(sample.statement)).toStrictEqual(expected);
+});
+
+test('Returns order part for multiple primitive fields', () => {
+	sample.statement.order = [
+		{
+			orderBy: {
+				type: 'primitive',
+				field: randomIdentifier(),
+			},
+			direction: 'ASC',
+		},
+		{
+			orderBy: {
+				type: 'primitive',
+				field: randomIdentifier(),
+			},
+			direction: 'DESC',
+		},
+	];
+
+	// @ts-ignore
+	const expected = `ORDER BY "${sample.statement.order[0].orderBy.field}" ASC, "${sample.statement.order[1].orderBy.field}" DESC`;
+
+	expect(orderBy(sample.statement)).toStrictEqual(expected);
+});

--- a/packages/data-driver-postgres/src/query/orderBy.ts
+++ b/packages/data-driver-postgres/src/query/orderBy.ts
@@ -1,0 +1,29 @@
+import type { AbstractSqlQuery } from '@directus/data-sql';
+import { escapeIdentifier } from '../utils/escape-identifier.js';
+
+/**
+ * Generates the `ORDER BY x` part of a SQL statement.
+ * The order direction is always set explicitly, although Postgres defaults to `ASC`.
+ *
+ * @param query - The abstract query
+ * @returns The `ORDER BY x` part of a SQL statement
+ */
+export function orderBy({ order }: AbstractSqlQuery): string | null {
+	if (order === undefined) {
+		return null;
+	}
+
+	const sortExpressions = order.map((o) => {
+		switch (o.orderBy.type) {
+			case 'primitive':
+				return `${escapeIdentifier(o.orderBy.field)} ${o.direction}`;
+			case 'fn':
+			case 'm2o':
+			case 'a2o':
+			default:
+				throw new Error(`Type ${o.orderBy.type} hasn't been implemented yet`);
+		}
+	});
+
+	return `ORDER BY ${sortExpressions.join(', ')}`;
+}

--- a/packages/data-driver-postgres/src/query/select.test.ts
+++ b/packages/data-driver-postgres/src/query/select.test.ts
@@ -1,10 +1,10 @@
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 import { beforeEach, expect, test } from 'vitest';
 import { select } from './select.js';
 import { randomIdentifier } from '@directus/random';
 
 let sample: {
-	statement: SqlStatement;
+	statement: AbstractSqlQuery;
 };
 
 beforeEach(() => {

--- a/packages/data-driver-postgres/src/query/select.ts
+++ b/packages/data-driver-postgres/src/query/select.ts
@@ -1,11 +1,11 @@
-import type { SqlStatement } from '@directus/data-sql';
+import type { AbstractSqlQuery } from '@directus/data-sql';
 import { wrapColumn } from '../utils/wrap-column.js';
 
 /**
  * Generates the `SELECT x, y` part of a SQL statement.
  * The fields are always prefixed with the table name.
  */
-export const select = ({ select }: SqlStatement): string => {
+export const select = ({ select }: AbstractSqlQuery): string => {
 	const escapedColumns = select.map(({ table, column, as }) => wrapColumn(table, column, as));
 	return `SELECT ${escapedColumns.join(', ')}`;
 };


### PR DESCRIPTION
- Added support for sort in PostgreSQL driver
- Now functions to create the statement part will return `null` when the part is not needed - this makes it easier to concatenate the final string
- Fix: Used the new interface name `AbstractSqlQuery` everywhere. `SqlStatement` was too generic considering that sooner or later we will introduce more SQL statements of other kinds - so not only for querying but also for modifications. So I wanted to highlights that the type represents a _query_.  
