### PR TITLE
Revising Docker Guides

### DIFF
--- a/.changeset/kind-needles-itch.md
+++ b/.changeset/kind-needles-itch.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Revised Docker Guides

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -691,7 +691,7 @@ function sidebar() {
 			],
 		},
 		{
-			text: 'Self Hosted',
+			text: 'Self-Hosted',
 			collapsible: true,
 			collapsed: true,
 			items: [

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -313,6 +313,8 @@ px.
 reactively
 readonly
 readTime
+(R|r)ealtime
+(R|r)eal-(T|t)ime
 rebase
 reconfigurations
 reconnection

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -7,7 +7,7 @@ readTime: 3 min read
 
 ::: info Non-Docker Guides
 
-We only publish and maintain self hosting guides using Docker as this removes many environment-specific configuration
+We only publish and maintain self-hosting guides using Docker as this removes many environment-specific configuration
 problems. If you can't or don't want to use Docker, we also publish an
 [npm package](https://www.npmjs.com/package/directus) without guides.
 

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -65,7 +65,7 @@ services:
 
 ## Example Docker Compose
 
-Whiel the [Self-Hosting Quickstart](/self-hosted/quickstart.html) aims to show you the minimum-viable `docker-compose.yml` file, here is a more complete one that spins up a Postgres database, Redis cache, and Directus project:
+While the [Self-Hosting Quickstart](/self-hosted/quickstart.html) aims to show you the minimum-viable `docker-compose.yml` file, here is a more complete one that spins up a Postgres database, Redis cache, and Directus project:
 
 ```yaml
 version: '3'

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -13,19 +13,9 @@ problems. If you can't or don't want to use Docker, we also publish an
 
 :::
 
-Directus is published to [Docker Hub](https://hub.docker.com/r/directus/directus) under `directus/directus`. To use the
-latest Directus image from Docker Hub, run:
+Directus is published to [Docker Hub](https://hub.docker.com/r/directus/directus) under `directus/directus`. If you're just getting started, check out our [Self-Hosting Quickstart](/self-hosted/quickstart.html).
 
-```bash
-# Make sure to change sensitive values (KEY, SECRET, ...) in production
-docker run \
-  -p 8055:8055 \
-  -e KEY=255d861b-5ea1-5996-9aa3-922530ec40b1 \
-  -e SECRET=6116487b-cda1-52c2-b5b5-c8022c45e263 \
-  directus/directus
-```
-
-### Installing Specific Versions
+## Installing Specific Versions
 
 To stick to a more specific version of Directus you can use one of the following tags:
 
@@ -33,21 +23,19 @@ To stick to a more specific version of Directus you can use one of the following
 - Minor releases, e.g. `10.0`
 - Major releases, e.g. `10`
 
-To use a specific version of Directus, run:
+To use a specific version of Directus, include the version number in your `services.directus.image` value:
 
-```bash
-# Make sure to change sensitive values (KEY, SECRET, ...) in production
-docker run \
-  -p 8055:8055 \
-  -e KEY=255d861b-5ea1-5996-9aa3-922530ec40b1 \
-  -e SECRET=6116487b-cda1-52c2-b5b5-c8022c45e263 \
-  directus/directus:10.0.0
+```yml
+services:
+  directus:
+    image: directus/directus // [!code --]
+    image: directus/directus:10.0.0 // [!code ++]
 ```
 
-### Configure Admin User
+## Configure Admin User
 
-The published Docker image will automatically populate the database and create an admin user. To configure the
-email/password for this first user, pass the following env vars:
+The `ADMIN_EMAIL` and `ADMIN_PASSWORD` variables, while shown in the quickstart, are optional. If omitted, the published Docker image will automatically populate the database and create an admin user. To configure the
+email/password for this first user, include the following environment variables:
 
 ```bash
 ADMIN_EMAIL="admin@example.com"
@@ -56,21 +44,28 @@ ADMIN_PASSWORD="d1r3ctu5"
 
 ## Persistence
 
-Containers are ephemeral, and this means that whenever you stop a container, all the data associated with it is going to
-be removed [unless you persist them](https://docs.docker.com/storage) when creating your container.
+Containers are ephemeral, and this means that whenever you stop a container, all the data associated with it is going to be removed [unless you persist them](https://docs.docker.com/storage) when creating your container.
 
-Directus image by default
-[will use the following locations](https://github.com/directus/directus/blob/main/docker/Dockerfile#L56-L60) for data
-persistence (note that these can be changed through environment variables)
+Directus image by default will use the following locations for data persistence (note that these can be changed through environment variables):
 
 - `/directus/uploads` for uploads
 - `/directus/database` (only when using SQLite and not configured to a different folder)
 - `/directus/extensions` for loading extensions
 
-## Docker Compose
+The `services.directus.volumes` section in your docker-compose.yml is optional. To persist data to your local machine, include a list of persisted directories:
 
-When using Docker Compose, you can use the following setup to get you started - make sure to change all sensitive values
-(`SECRET`, `DB_PASSWORD`, ...) in production:
+```yml
+services:
+  directus:
+    volumes:
+      - ./database:/directus/database
+      - ./uploads:/directus/uploads
+      - ./extensions:/directus/extensions
+```
+
+## Example Docker Compose
+
+Whiel the [Self-Hosting Quickstart](/self-hosted/quickstart.html) aims to show you the minimum-viable `docker-compose.yml` file, here is a more complete one that spins up a Postgres database, Redis cache, and Directus project:
 
 ```yaml
 version: '3'
@@ -101,12 +96,7 @@ services:
     ports:
       - 8055:8055
     volumes:
-      # By default, uploads are stored in /directus/uploads
-      # Always make sure your volumes matches the storage root when using
-      # local driver
       - ./uploads:/directus/uploads
-      # Make sure to also mount the volume when using SQLite
-      # - ./database:/directus/database
       # If you want to load extensions from the host
       # - ./extensions:/directus/extensions
     networks:
@@ -135,9 +125,6 @@ services:
       # Make sure to set this in production
       # (see https://docs.directus.io/self-hosted/config-options#general)
       # PUBLIC_URL: 'https://directus.example.com'
-
-networks:
-  directus:
 ```
 
 ### Updating With Docker Compose
@@ -157,10 +144,9 @@ docker-compose pull
 docker-compose up -d
 ```
 
-The images will be pulled and the containers recreated. Migrations will happen automatically so once the containers have
-started you will be on the latest version (or the version you specified).
+The images will be pulled and the containers recreated. Migrations will happen automatically so once the containers have started you will be on the latest version (or the version you specified).
 
-### Adding packages to use in Flows scripts
+### Adding Packages to Use in Flows Scripts
 
 If you need third-party packages in a script of one of your flows, the recommended way is to create a new Docker image
 extending from the official image and installing the packages there.

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -23,7 +23,7 @@ To stick to a more specific version of Directus you can use one of the following
 - Minor releases, e.g. `10.0`
 - Major releases, e.g. `10`
 
-To use a specific version of Directus, include the version number in your `services.directus.image` value:
+It is recommended to explicitly specify a Directus version in your `docker-compose.yml` file. Include the version number in your `services.directus.image` value:
 
 ```yml
 services:
@@ -34,13 +34,14 @@ services:
 
 ## Configure Admin User
 
-The `ADMIN_EMAIL` and `ADMIN_PASSWORD` variables, while shown in the quickstart, are optional. If omitted, the published Docker image will automatically populate the database and create an admin user. To configure the
-email/password for this first user, include the following environment variables:
+The `ADMIN_EMAIL` and `ADMIN_PASSWORD` variables, while shown in the quickstart, are optional. If omitted, the published Docker image will automatically populate the database and create an admin user, and these will only be shown in the Docker bootstrap logs when starting Directus for the first time. To configure the email/password for this first user, include the following environment variables:
 
 ```bash
 ADMIN_EMAIL="admin@example.com"
 ADMIN_PASSWORD="d1r3ctu5"
 ```
+
+Once you've started Directus for the first time, assuming your database is persisted, you can remove these values from your compose file. 
 
 ## Persistence
 

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -142,7 +142,7 @@ You can then issue the following two commands (from your docker-compose root):
 
 ```bash
 docker compose pull
-docker compose up -d
+docker compose up
 ```
 
 The images will be pulled and the containers recreated. Migrations will happen automatically so once the containers have started you will be on the latest version (or the version you specified).

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -41,7 +41,7 @@ ADMIN_EMAIL="admin@example.com"
 ADMIN_PASSWORD="d1r3ctu5"
 ```
 
-Once you've started Directus for the first time, assuming your database is persisted, you can remove these values from your compose file. 
+Once you've started Directus for the first time, assuming your database is persisted, you can remove these values from your compose file.
 
 ## Persistence
 
@@ -141,8 +141,8 @@ increment the tag version number, e.g.:
 You can then issue the following two commands (from your docker-compose root):
 
 ```bash
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 The images will be pulled and the containers recreated. Migrations will happen automatically so once the containers have started you will be on the latest version (or the version you specified).

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -28,7 +28,7 @@ It is recommended to explicitly specify a Directus version in your `docker-compo
 ```yml
 services:
   directus:
-    image: directus/directus // [!code --]
+    image: directus/directus:latest // [!code --]
     image: directus/directus:10.0.0 // [!code ++]
 ```
 
@@ -93,7 +93,7 @@ services:
 
   directus:
     container_name: directus
-    image: directus/directus:latest
+    image: directus/directus:10.0.0
     ports:
       - 8055:8055
     volumes:
@@ -138,14 +138,13 @@ increment the tag version number, e.g.:
 +   image: directus/directus:10.1.0
 ```
 
-You can then issue the following two commands (from your docker-compose root):
+Then run the following from your docker-compose root:
 
 ```bash
-docker compose pull
 docker compose up
 ```
 
-The images will be pulled and the containers recreated. Migrations will happen automatically so once the containers have started you will be on the latest version (or the version you specified).
+The specified image will be pulled and the containers recreated. Migrations will happen automatically so once the containers have started you will be on the latest version (or the version you specified).
 
 ### Adding Packages to Use in Flows Scripts
 

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -1,28 +1,29 @@
 ---
 description:
-  If you're looking for the fastest way to get up-and-running with Directus, this guide will walk you through getting
-  things installed, configured, and modeled.
-readTime: 5 min read
+  If you're looking for the fastest way to get up-and-running with Directus locally, this guide will get you there in minutes.
 ---
 
-# Quickstart Guide
+# Self-Hosting Quickstart
 
-> If you're looking for the fastest way to get up-and-running with Directus, this guide will walk you through getting
-> things installed, configured, and modeled.
+<iframe style="width:100%; aspect-ratio:16/9; margin-top: 2em;" src="https://www.youtube.com/embed/-UASj_6WmMQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-## Requirements
+## Install Docker
 
-- [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/) (often included with newer Docker installations)
+You should have [Docker](https://docs.docker.com/get-docker/) installed and running on your machine.
 
-It can be easy to under-provision resources to run a self-hosted instance of Directus. For Directus' container resources, the required minimum system requirements are 1x 0.25 vCPU / 512 MB, although the recommended minimum is 2x 1 vCPU / 2GB.
+:::info What Is Docker?
 
-## 1. Installation
+Docker is a developer tool that allows software-creators to distribute their work along with all dependencies and required environment settings. This means that applications can run reliably and consistently, making it the perfect way to use Directus both locally and in-production.
 
-You can use the following configuration to get started using Docker Compose. Make sure to change all sensitive values
-like `KEY`, `SECRET`, `ADMIN_PASSWORD`, _etc._
+As soon as there are new releases of Directus, we publish them on [Docker Hub](https://hub.docker.com/r/directus/directus).
 
-```yaml
+:::
+
+## Create a Docker Compose File
+
+Create a new empty directory, and open it in a text editor. Create a `docker-compose.yml` file and paste the following:
+
+```yml
 version: '3'
 services:
   directus:
@@ -30,129 +31,34 @@ services:
     ports:
       - 8055:8055
     volumes:
-      - ./uploads:/directus/uploads
       - ./database:/directus/database
+      - ./uploads:/directus/uploads
     environment:
-      KEY: '255d861b-5ea1-5996-9aa3-922530ec40b1'
-      SECRET: '6116487b-cda1-52c2-b5b5-c8022c45e263'
-
-      DB_CLIENT: 'sqlite3'
-      DB_FILENAME: './database/data.db'
-
-      ADMIN_EMAIL: 'admin@example.com'
-      ADMIN_PASSWORD: 'd1r3ctu5'
+      KEY: 'replace-with-random-value'
+      SECRET: 'replace-with-random-value'
+      ADMIN_EMAIL: 'admin@example.com' 
+      ADMIN_PASSWORD: 'd1r3ctu5' 
+      WEBSOCKETS_ENABLED: true
 ```
 
-Save this in your project as a file named `docker-compose.yml` and run:
+Save the file. Let's step through it:
+
+- This file defines a single Docker container that will use the latest version of the `directus/directus` image. 
+- The `ports` list maps internal port `8055` is made available to our machine using the same port number, meaning we can access it from our computer's browser.
+- The`volumes` section maps internal `directus/database` and `directus/uploads` to our local file system alongside the `docker-compose.yml` - meaning data is backed up outside of Docker containers.
+- The `environment` section contains any [configuration variables](/self-hosted/config-options.html) we wish to set. 
+  - `KEY` and `SECRET` are required and should be random values.
+  - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch. 
+  - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html). 
+
+The volumes section is not requires, but without this, our database and file uploads will be destroyed when the Docker container stops running. The default database is SQLite - a self-contained server-less database that stores data to a file.
+
+## Run Directus 
+
+Run the following in your terminal:
 
 ```
-docker-compose up -d
+docker-compose up
 ```
 
-::: tip More Info on Docker
-
-To learn more, visit the [Docker Guide](/self-hosted/docker-guide).
-
-:::
-
-## 2. Login to App
-
-With the server running, you're now able to login to your new Directus project and start using it.
-
-Our start command stated that the server started at port `8055`, which means we can navigate to `http://localhost:8055`
-to open Directus in the browser.
-
-Login using the admin credentials you configured during the installation in Step 1.
-
-## 3. Create a Collection
-
-Once logged in, you're greeted with the option to create your first Collection:
-
-![Directus Empty State](https://cdn.directus.io/docs/v9/getting-started/quickstart/quickstart-20220217A/empty-state-20220217A.webp)
-
-Follow the prompts and create a Collection. For the sake of this demo, we'll be calling ours `articles`, but feel free
-to make it your own!
-
-::: tip More Info on Collections
-
-To learn more, see our documentation [Collections](/app/content/collections).
-
-:::
-
-## 4. Create a Field
-
-With the Collection created, it's time to start adding some Fields. Click the **"Create Field"** button, and select
-**"Input"**:
-
-<video autoplay playsinline muted loop controls>
-<source src="https://cdn.directus.io/docs/v9/getting-started/quickstart/quickstart-20220217A/add-field-20220217A.mp4" type="video/mp4" />
-</video>
-
-We'll be calling our Field `title`. While Directus offers a range of powerful field customization options, we'll be
-sticking to the defaults for now. These defaults use the "String" datatype.
-
-::: tip More Info on Fields
-
-To learn more, see our documentation on [Fields](/getting-started/glossary#fields).
-
-:::
-
-## 5. Create an Item
-
-Now that we have a Collection with a Field configured, it's time to start adding some content. Navigate to the Content
-Module (top left), and click <span mi btn>add</span> in the top-right to get started. This will take you to the
-Create/Edit Item page:
-
-![Directus Create Item](https://cdn.directus.io/docs/v9/getting-started/quickstart/quickstart-20220217A/create-item-20220217A.webp)
-
-Once you're happy with your creation, click <span mi btn>check</span> in the top-right to save your Item to the
-database.
-
-::: tip More Info on Items
-
-To learn more, see our documentation on [Items](/app/content/items).
-
-:::
-
-## 6. Set Role/Public Permissions
-
-By default, all content entered into Directus is considered private. This means that no data will be returned by the
-API, unless requested by an authenticated user that has the correct permissions. In order to have the API return our
-items, we'll have to setup some permissions. Navigate to **Settings Module <span mi icon dark>chevron_right</span> Roles
-& Permissions**.
-
-Directus ships with a special **"Public"** role that controls what data is returned to non-authenticated users. Select
-the Public Role, find your Collection, and click the icon under the <span mi icon>visibility</span> icon (read/view
-permission) to allow the Public Role to read the Items in your Collection.
-
-![Directus Permissions](https://cdn.directus.io/docs/v9/getting-started/quickstart/quickstart-20220217A/permissions-20220217A.webp)
-
-::: tip More Info on Roles & Permissions
-
-Roles & Permissions are extremely powerful and can get pretty in-depth. To learn all about the nuances in setting these
-up, see [Roles](/reference/system/roles) & [Permissions](/reference/system/permissions).
-
-:::
-
-## 7. Connect to the API
-
-Now that your project has some content in it, it's time to start using this content externally. Data can be accessed in
-a number of ways, including the REST API, GraphQL, the CLI, or even straight from the database. In this case, we'll use
-[the `/items/` REST API endpoint](/reference/items) to retrieve the item we just created.
-
-Use your browser or an API tool like [Postman](http://postman.com) or [Paw](https://paw.cloud) to open
-`http://localhost:8055/items/articles`.
-
-And there it is! The Article Item you just created is being served in beautiful JSON, ready to be used anywhere and
-everywhere!
-
-```json
-{
-	"data": [
-		{
-			"id": 1,
-			"title": "Hello World!"
-		}
-	]
-}
-```
+Directus should now be available at http://0.0.0.0:8055

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -47,7 +47,7 @@ Save the file. Let's step through it:
 - The `ports` list maps internal port `8055` is made available to our machine using the same port number, meaning we can access it from our computer's browser.
 - The`volumes` section maps internal `directus/database` and `directus/uploads` to our local file system alongside the `docker-compose.yml` - meaning data is backed up outside of Docker containers.
 - The `environment` section contains any [configuration variables](/self-hosted/config-options.html) we wish to set.
-  - `KEY` and `SECRET` are required and should be long random values. `KEY` is used for telemetery and health tracking, and `SECRET` is used to sign access tokens.
+  - `KEY` and `SECRET` are required and should be long random values. `KEY` is used for telemetry and health tracking, and `SECRET` is used to sign access tokens.
   - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch.
   - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html).
 

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -47,7 +47,7 @@ Save the file. Let's step through it:
 - The `ports` list maps internal port `8055` is made available to our machine using the same port number, meaning we can access it from our computer's browser.
 - The`volumes` section maps internal `directus/database` and `directus/uploads` to our local file system alongside the `docker-compose.yml` - meaning data is backed up outside of Docker containers.
 - The `environment` section contains any [configuration variables](/self-hosted/config-options.html) we wish to set.
-  - `KEY` and `SECRET` are required and should be random values.
+  - `KEY` and `SECRET` are required and should be long random values. `KEY` is used for telemetery and health tracking, and `SECRET` is used to sign access tokens.
   - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch.
   - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html).
 

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -36,29 +36,29 @@ services:
     environment:
       KEY: 'replace-with-random-value'
       SECRET: 'replace-with-random-value'
-      ADMIN_EMAIL: 'admin@example.com' 
-      ADMIN_PASSWORD: 'd1r3ctu5' 
+      ADMIN_EMAIL: 'admin@example.com'
+      ADMIN_PASSWORD: 'd1r3ctu5'
       WEBSOCKETS_ENABLED: true
 ```
 
 Save the file. Let's step through it:
 
-- This file defines a single Docker container that will use the latest version of the `directus/directus` image. 
+- This file defines a single Docker container that will use the latest version of the `directus/directus` image.
 - The `ports` list maps internal port `8055` is made available to our machine using the same port number, meaning we can access it from our computer's browser.
 - The`volumes` section maps internal `directus/database` and `directus/uploads` to our local file system alongside the `docker-compose.yml` - meaning data is backed up outside of Docker containers.
-- The `environment` section contains any [configuration variables](/self-hosted/config-options.html) we wish to set. 
+- The `environment` section contains any [configuration variables](/self-hosted/config-options.html) we wish to set.
   - `KEY` and `SECRET` are required and should be random values.
-  - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch. 
-  - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html). 
+  - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch.
+  - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html).
 
 The volumes section is not requires, but without this, our database and file uploads will be destroyed when the Docker container stops running. The default database is SQLite - a self-contained server-less database that stores data to a file.
 
-## Run Directus 
+## Run Directus
 
 Run the following in your terminal:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 Directus should now be available at http://0.0.0.0:8055

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -5,7 +5,7 @@ description:
 
 # Self-Hosting Quickstart
 
-<iframe style="width:100%; aspect-ratio:16/9; margin-top: 2em;" src="https://www.youtube.com/embed/-UASj_6WmMQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="width:100%; aspect-ratio:16/9; margin-top: 2em;" src="https://www.youtube.com/embed/J7tFWxAGkh4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Install Docker
 

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -51,7 +51,7 @@ Save the file. Let's step through it:
   - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch.
   - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html).
 
-The volumes section is not requires, but without this, our database and file uploads will be destroyed when the Docker container stops running. The default database is SQLite - a self-contained server-less database that stores data to a file.
+The volumes section is not required, but without this, our database and file uploads will be destroyed when the Docker container stops running. The default database is SQLite - a self-contained server-less database that stores data to a file.
 
 ## Run Directus
 

--- a/packages/schema/readme.md
+++ b/packages/schema/readme.md
@@ -198,7 +198,7 @@ Please make sure to update tests as appropriate.
 First start docker containers:
 
 ```shell
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 Then run tests:

--- a/packages/schema/readme.md
+++ b/packages/schema/readme.md
@@ -198,7 +198,7 @@ Please make sure to update tests as appropriate.
 First start docker containers:
 
 ```shell
-$ docker compose up -d
+$ docker compose up
 ```
 
 Then run tests:

--- a/tests/blackbox/readme.md
+++ b/tests/blackbox/readme.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Make sure the containers for the databases are running by running `docker compose up -d` in this folder.
+Make sure the containers for the databases are running by running `docker compose up` in this folder.
 
 Directus needs to be deployed with `pnpm --filter directus deploy --prod dist`. When using the `test:blackbox` script in the workspace root (`pnpm -w run test:blackbox`) this is already done.
 


### PR DESCRIPTION
This PR does not create new content, but instead adjusts the existing two docker guides - Quickstart and 'Docker Guide'. 

1. The Quickstart now follows the same brief flow as our latest video, and embeds it at the top. It also removes steps after the project is successfully running (create collection, etc).
2. The Docker Guide now follows-on to add more context to steps. It also standardizes on docker-compose.yml (and briefly mentioning a Dockerfile for including npm modules for flows). It no longer talks about running it from a command line and passing in vars as arguments. 