### PR TITLE
Fixes infinite fetch all loop

### DIFF
--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
@@ -101,8 +101,6 @@ const { permissions, fetchPermissions, refreshing } = usePermissions();
 
 const { resetActive, resetSystemPermissions, resetting } = useReset();
 
-fetchPermissions();
-
 watch(() => props.permission, fetchPermissions, { immediate: true });
 
 provide('refresh-permissions', fetchPermissions);

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
@@ -124,7 +124,8 @@ function usePermissions() {
 				params.filter.role = { _eq: props.role };
 			}
 
-			permissions.value = await fetchAll('/permissions', { params });
+			const response = await api.get('/permissions', { params });
+			permissions.value = response.data.data;
 		} catch (err: any) {
 			unexpectedError(err);
 		} finally {

--- a/contributors.yml
+++ b/contributors.yml
@@ -46,3 +46,4 @@
 - Philippe-cheype
 - gitstart
 - RubensRafael
+- ps73


### PR DESCRIPTION
This pr fixes issue #18961 by using api.get instead of fetchAll since permissions controller overrides pagination which was implemented as temporary fix in #18655

Removes also the initial request and only runs the request as watch handler since this was running with immediate effect anyway which causes double request.