### PR TITLE
Parse GeoJSON raw value to object if string is passed

### DIFF
--- a/.changeset/empty-camels-worry.md
+++ b/.changeset/empty-camels-worry.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed issue that would prevent JSON string from being treated as GeoJSON in filtering operations


### PR DESCRIPTION
Fixes #10869

Geo filters now support either the params format:

```
?filter[map][_intersects][type]=Point
&filter[map][_intersects][coordinates][]=42
&filter[map][_intersects][coordinates][]=24
```

A JSON string:

```
?filter[map][_intersects]={"type":"Point","coordinates":[42,24]}
```

or the full filter object as a string:

```
?filter={"map":{"_intersects":{"type":"Point","coordinates":[42,24]}}}
```