### PR TITLE
Remove unused isBatch check

### DIFF
--- a/.changeset/nasty-nails-grab.md
+++ b/.changeset/nasty-nails-grab.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that would prevent items with a comma in the ID from being rendered in the app

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -4,18 +4,18 @@ import { i18n } from '@/lang';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { APIError } from '@/types/error';
+import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { notify } from '@/utils/notify';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
 import { useCollection } from '@directus/composables';
+import { Field, Query, Relation } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
 import { AxiosResponse } from 'axios';
 import { mergeWith } from 'lodash';
-import { computed, ComputedRef, isRef, Ref, ref, unref, watch } from 'vue';
+import { ComputedRef, Ref, computed, isRef, ref, unref, watch } from 'vue';
 import { usePermissions } from './use-permissions';
-import { Field, Query, Relation } from '@directus/types';
-import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 
 type UsableItem = {
 	edits: Ref<Record<string, any>>;
@@ -54,7 +54,6 @@ export function useItem(
 	const edits = ref<Record<string, any>>({});
 	const hasEdits = computed(() => Object.keys(edits.value).length > 0);
 	const isNew = computed(() => primaryKey.value === '+');
-	const isBatch = computed(() => typeof primaryKey.value === 'string' && primaryKey.value.includes(','));
 	const isSingle = computed(() => !!collectionInfo.value?.meta?.singleton);
 
 	const isArchived = computed(() => {
@@ -97,7 +96,6 @@ export function useItem(
 		isArchived,
 		archiving,
 		saveAsCopy,
-		isBatch,
 		getItem,
 		validationErrors,
 	};
@@ -147,13 +145,13 @@ export function useItem(
 				response = await api.post(getEndpoint(collection.value), edits.value);
 
 				notify({
-					title: i18n.global.t('item_create_success', isBatch.value ? 2 : 1),
+					title: i18n.global.t('item_create_success', 1),
 				});
 			} else {
 				response = await api.patch(itemEndpoint.value, edits.value);
 
 				notify({
-					title: i18n.global.t('item_update_success', isBatch.value ? 2 : 1),
+					title: i18n.global.t('item_update_success', 1),
 				});
 			}
 
@@ -403,9 +401,7 @@ export function useItem(
 
 			notify({
 				title:
-					value === archiveValue
-						? i18n.global.t('item_delete_success', isBatch.value ? 2 : 1)
-						: i18n.global.t('item_update_success', isBatch.value ? 2 : 1),
+					value === archiveValue ? i18n.global.t('item_delete_success', 1) : i18n.global.t('item_update_success', 1),
 			});
 		} catch (err: any) {
 			unexpectedError(err);
@@ -424,7 +420,7 @@ export function useItem(
 			item.value = null;
 
 			notify({
-				title: i18n.global.t('item_delete_success', isBatch.value ? 2 : 1),
+				title: i18n.global.t('item_delete_success', 1),
 			});
 		} catch (err: any) {
 			unexpectedError(err);
@@ -455,20 +451,6 @@ export function useItem(
 			response.data.data = translate(response.data.data);
 		}
 
-		if (isBatch.value === false) {
-			item.value = response.data.data;
-		} else {
-			const valuesThatAreEqual = { ...response.data.data[0] };
-
-			response.data.data.forEach((existingItem: any) => {
-				for (const [key, value] of Object.entries(existingItem)) {
-					if (valuesThatAreEqual[key] !== value) {
-						delete valuesThatAreEqual[key];
-					}
-				}
-			});
-
-			item.value = valuesThatAreEqual;
-		}
+		item.value = response.data.data;
 	}
 }


### PR DESCRIPTION
Fixes #11679

Batch editing used to be done by having a comma separated value in the URL in the very early versions (rc.8), but was replaced with the drawer style which uses a memory reference to the primary keys. This isBatch check in `useItem` was still looking for the `,` in the PK, causing #11679 in the process.