### PR TITLE
Flush cache when applying diff

### DIFF
--- a/.changeset/strange-peaches-heal.md
+++ b/.changeset/strange-peaches-heal.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Flushed cache when applying diff
+Ensured all caches are flushed when applying diff

--- a/.changeset/strange-peaches-heal.md
+++ b/.changeset/strange-peaches-heal.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Flushed cache when applying diff

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -86,7 +86,7 @@ export async function clearSystemCache(opts?: {
 	forced?: boolean | undefined;
 	autoPurgeCache?: false | undefined;
 }): Promise<void> {
-	const { systemCache, localSchemaCache, lockCache } = getCache();
+	const { systemCache, localSchemaCache, lockCache, sharedSchemaCache } = getCache();
 
 	// Flush system cache when forced or when system cache lock not set
 	if (opts?.forced || !(await lockCache.get('system-cache-lock'))) {
@@ -95,6 +95,7 @@ export async function clearSystemCache(opts?: {
 		await lockCache.delete('system-cache-lock');
 	}
 
+	await sharedSchemaCache.clear();
 	await localSchemaCache.clear();
 	messenger.publish('schemaChanged', { autoPurgeCache: opts?.autoPurgeCache });
 }

--- a/api/src/utils/apply-diff.ts
+++ b/api/src/utils/apply-diff.ts
@@ -3,7 +3,7 @@ import type { Diff, DiffDeleted, DiffNew } from 'deep-diff';
 import deepDiff from 'deep-diff';
 import type { Knex } from 'knex';
 import { cloneDeep, merge, set } from 'lodash-es';
-import { clearSystemCache } from '../cache.js';
+import { flushCaches } from '../cache.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase from '../database/index.js';
 import emitter from '../emitter.js';
@@ -324,7 +324,7 @@ export async function applyDiff(
 		await helpers.schema.postColumnChange();
 	}
 
-	await clearSystemCache();
+	await flushCaches();
 
 	if (nestedActionEvents.length > 0) {
 		const updatedSchema = await getSchema({ database, bypassCache: true });


### PR DESCRIPTION
The `cache` isn't cleared when applying diff, only the `systemCache` is cleared. 
`flushCaches` is used instead to ensure that all caches are cleared.

https://github.com/directus/directus/blob/28e33a67e9646ad034cdf274bfeeaec7eb1bff34/api/src/utils/apply-diff.ts#L327

In addition, when applying diff in a node balanced environment, a different node will not regenerate the schema until a `getSchema` request is run on the node that applied the diff.
`sharedSchemaCache` is cleared to ensure that a new schema regenerates.