### PR TITLE
fix: :bug: When the key doesn't exist it should return null, not an e…

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -452,12 +452,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		const queryWithKey = assign({}, query, { filter: filterWithKey });
 
 		const results = await this.readByQuery(queryWithKey, opts);
-
-		if (results.length === 0) {
-			throw new ForbiddenError();
-		}
-
-		return results[0]!;
+		return results?.[0]!;
 	}
 
 	/**


### PR DESCRIPTION
ReadOne: When the key doesn't exist it should return null, not an an exception "ForbiddenError", it is then interpreted by the client as an authentication error.

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->
