### PR TITLE
Remove VS Code autoformat / autofix for now

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-	"editor.defaultFormatter": "esbenp.prettier-vscode",
-	"editor.formatOnSave": true,
-	"editor.codeActionsOnSave": ["source.formatDocument", "source.fixAll.eslint"]
+	"editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
Let's remove it for now to avoid conflicts with personal settings & confusion.
We might revisit that at a later point 👍 

---

Also should be this:
```json
{
	"editor.defaultFormatter": "esbenp.prettier-vscode",
	"editor.formatOnSave": true,
	"editor.codeActionsOnSave": ["source.fixAll.eslint"]
}
```