### PR TITLE
fix hero background showing over content

### DIFF
--- a/docs/home.css
+++ b/docs/home.css
@@ -7,6 +7,10 @@
 	margin-inline: auto;
 }
 
+.sectionContainerHero {
+	position: relative;
+}
+
 .sectionPaddingHero {
 	padding-block: 108px;
 }
@@ -49,7 +53,6 @@
 
 .heroContent {
 	max-width: 580px;
-	position: relative;
 }
 
 .heroContent h1 {
@@ -76,7 +79,6 @@
 	box-shadow: 0 0 100px 24px rgba(255, 255, 255, 0.3);
 	backdrop-filter: blur(4px);
 	margin-left: 20px;
-	z-index: 1;
 }
 
 .flex {

--- a/docs/home.css
+++ b/docs/home.css
@@ -49,6 +49,7 @@
 
 .heroContent {
 	max-width: 580px;
+	position: relative;
 }
 
 .heroContent h1 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ import Github from './.vitepress/components/home/icons/Github.vue';
 	<div :class="$style.heroPattern">
 		 <Pattern />
 	</div>
-	<div :class="[$style.sectionContainer, $style.flex]">
+	<div :class="[$style.sectionContainer, $style.sectionContainerHero, $style.flex]">
 		<div :class="[$style.heroContent, $style.sectionPaddingHero]">
 			<div :class="$style.heroBadge">Resource Hub</div>
 			<h1>Directus Documentation</h1>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,9 @@ import Github from './.vitepress/components/home/icons/Github.vue';
 </script>
 
 <section :class="[$style.hero, $style.paddingBox]">
+	<div :class="$style.heroPattern">
+		 <Pattern />
+	</div>
 	<div :class="[$style.sectionContainer, $style.flex]">
 		<div :class="[$style.heroContent, $style.sectionPaddingHero]">
 			<div :class="$style.heroBadge">Resource Hub</div>
@@ -67,9 +70,7 @@ await directus.items('articles').readOne(4, {
 </SnippetToggler>
 		</div>
 	</div>
-	<div :class="$style.heroPattern">
-		 <Pattern />
-	</div>
+
 </section>
 
 <section :class="[$style.sectionPaddingLg, $style.paddingBox]">


### PR DESCRIPTION
The background for the hero was showing over top of the content in the hero section.

Example
![ScreenShot 2023-06-30 at 12 24 41@2x](https://github.com/directus/directus/assets/23302570/9950a4e5-eb76-402a-8712-fa4cd11bf0ef)

Should be all fixed now!
