### PR TITLE
Fixed the option color of the snippet toggler 

### DIFF
--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -115,6 +115,9 @@ onBeforeMount(() => {
 	font-size: 12px;
 	padding-inline-end: 20px;
 }
+.snippet-toggler-header-lang option {
+	color: var(--vp-c-black);
+}
 
 .snippet-toggler-header-lang:focus {
 	outline: none;


### PR DESCRIPTION
This PR fixes the issue where the Dark mode snippet toggler option text is not readable because it was transparent. This behaviour is mostly visible when using Windows OS.

Issue -> https://linear.app/directus/issue/MARK-1401/dark-mode-snippet-toggler-text-is-not-readable