### PR TITLE
Fix: Added a condition to handle validation errors related to non-unique fields

### DIFF
--- a/.changeset/strange-pans-grab.md
+++ b/.changeset/strange-pans-grab.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added a condition to handle validation errors related to non-unique fields.

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -62,7 +62,7 @@
 
 		<small v-if="validationError" class="validation-error selectable">
 			<template v-if="field.meta?.validation_message">
-				{{ field.meta?.validation_message }}
+				{{ validationError.code === 'RECORD_NOT_UNIQUE' ? validationMessage : field.meta?.validation_message }}
 				<v-icon v-tooltip="validationMessage" small right name="help" />
 			</template>
 			<template v-else>{{ validationPrefix }}{{ validationMessage }}</template>

--- a/app/src/components/v-form/validation-errors.vue
+++ b/app/src/components/v-form/validation-errors.vue
@@ -19,7 +19,11 @@
 					</strong>
 					<span>:&nbsp;</span>
 					<template v-if="validationError.customValidationMessage">
-						{{ validationError.customValidationMessage }}
+						{{
+							validationError.code === 'RECORD_NOT_UNIQUE'
+								? t('validationError.unique', validationError)
+								: validationError.customValidationMessage
+						}}
 						<v-icon
 							v-tooltip="
 								validationError.code === 'RECORD_NOT_UNIQUE'


### PR DESCRIPTION
Closes: #18298 

In a sense, it can be argued that the bug is not technically valid. We already display a 'unique field error' message in the help icon when there is custom validation available. However, the issue lies in the fact that the custom validation field is free text, allowing users to enter any text. This can potentially mislead users, as illustrated in the mentioned example (#18298).

In this pull request, my intention is to specifically filter out the 'unique field error' in order to prevent any potential confusion.