### PR TITLE
Add example for `_null`

### DIFF
--- a/.changeset/rare-seas-tap.md
+++ b/.changeset/rare-seas-tap.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Added example for `_null` filter rule

--- a/docs/reference/filter-rules.md
+++ b/docs/reference/filter-rules.md
@@ -48,6 +48,14 @@ readTime: 5 min read
 }
 ```
 
+```json
+{
+	"category": {
+		"_null": true
+	}
+}
+```
+
 ## Filter Operators
 
 | Operator Title _(in app)_      | Operator                           | Description                             |


### PR DESCRIPTION
Adding an example for `_null` filter rule to show how boolean filters are used.