### PR TITLE
Docs: Update Quickstart guide

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,19 +8,19 @@ readTime: 7 min read
 # Quickstart Guide
 
 > This quickstart guide is designed to get you up and running with a Directus Cloud Project in a snap. Along the way,
-> you will better understand what Directus is, setup your Directus Cloud Account, get a _hands-on introduction_ to
-> the App and API, and find more resources to deep-dive into.
+> you will better understand what Directus is, setup your Directus Cloud Account, get a _hands-on introduction_ to the
+> App and API, and find more resources to deep-dive into.
 
 ## 1. Create Cloud Account and Login
 
 First, you'll need to create an Account and log in on [Directus Cloud](https://directus.cloud/login).
 
 Your Directus Cloud Account allows you to create and manage any number of Projects. We've made life easier by giving you
-the option to create and log in to your Cloud Account automatically with GitHub. If you don't have a GitHub account
-or prefer not to use this login method, email-and-password login is available as well.
+the option to create and log in to your Cloud Account automatically with GitHub. If you don't have a GitHub account or
+prefer not to use this login method, email-and-password login is available as well.
 
-The very first time you log in to your Cloud Account, you will be prompted to create a Team. Each Directus Cloud Project exists within the scope of one Team. They allow you to organize Team Members,
-Projects and Project Billing as desired.
+The very first time you log in to your Cloud Account, you will be prompted to create a Team. Each Directus Cloud Project
+exists within the scope of one Team. They allow you to organize Team Members, Projects and Project Billing as desired.
 
 Once your Team is created, it's time to create your Directus Cloud Project!
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,7 +8,7 @@ readTime: 7 min read
 # Quickstart Guide
 
 > This quickstart guide is designed to get you up and running with a Directus Cloud Project in a snap. Along the way,
-> you will better understand what Directus is, setup your free Directus Cloud Account, get a _hands-on introduction_ to
+> you will better understand what Directus is, setup your Directus Cloud Account, get a _hands-on introduction_ to
 > the App and API, and find more resources to deep-dive into.
 
 ## 1. Create Cloud Account and Login
@@ -16,11 +16,10 @@ readTime: 7 min read
 First, you'll need to create an Account and log in on [Directus Cloud](https://directus.cloud/login).
 
 Your Directus Cloud Account allows you to create and manage any number of Projects. We've made life easier by giving you
-the option to create and log in to your free Cloud Account automatically with GitHub. If you don't have a GitHub account
+the option to create and log in to your Cloud Account automatically with GitHub. If you don't have a GitHub account
 or prefer not to use this login method, email-and-password login is available as well.
 
-The very first time you log in to your Cloud Account, you will be prompted to create a Team. Teams are totally free to
-create. Each Directus Cloud Project exists within the scope of one Team. They allow you to organize Team Members,
+The very first time you log in to your Cloud Account, you will be prompted to create a Team. Each Directus Cloud Project exists within the scope of one Team. They allow you to organize Team Members,
 Projects and Project Billing as desired.
 
 Once your Team is created, it's time to create your Directus Cloud Project!

--- a/docs/user-guide/overview/quickstart.md
+++ b/docs/user-guide/overview/quickstart.md
@@ -8,20 +8,19 @@ readTime: 7 min read
 # Quickstart Guide
 
 > This quickstart guide is designed to get you up and running with a Directus Cloud Project in a snap. Along the way,
-> you will better understand what Directus is, setup your free Directus Cloud Account, get a _hands-on introduction_ to
-> the App and API, and find more resources to deep-dive into.
+> you will better understand what Directus is, setup your Directus Cloud Account, and get a _hands-on introduction_ to
+> the App.
 
 ## 1. Create Cloud Account and Login
 
 First, you'll need to create an Account and log in on [Directus Cloud](https://directus.cloud/login).
 
 Your Directus Cloud Account allows you to create and manage any number of Projects. We've made life easier by giving you
-the option to create and log in to your free Cloud Account automatically with GitHub. If you don't have a GitHub account
-or prefer not to use this login method, email-and-password login is available as well.
+the option to create and log in to your Cloud Account automatically with GitHub. If you don't have a GitHub account or
+prefer not to use this login method, email-and-password login is available as well.
 
-The very first time you log in to your Cloud Account, you will be prompted to create a Team. Teams are totally free to
-create. Each Directus Cloud Project exists within the scope of one Team. They allow you to organize Team Members,
-Projects and Project Billing as desired.
+The very first time you log in to your Cloud Account, you will be prompted to create a Team. Each Directus Cloud Project
+exists within the scope of one Team. They allow you to organize Team Members, Projects and Project Billing as desired.
 
 Once your Team is created, it's time to create your Directus Cloud Project!
 


### PR DESCRIPTION

This PR removes the reference to a 'Free' cloud account that was in our Quickstart guide.