### PR TITLE
Fix Flow Status not being included in Staged Changes

### DIFF
--- a/.changeset/lovely-spies-yawn.md
+++ b/.changeset/lovely-spies-yawn.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed Flow Status not saving in editor

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -233,6 +233,7 @@ const flow = computed<FlowRaw | undefined>({
 		if (!existing) return undefined;
 
 		return merge({}, existing, {
+			status: stagedFlow.value?.status ?? existing.status,
 			operation: stagedFlow.value?.operation ?? existing.operation,
 			operations: stagedFlow.value?.operations ?? existing.operations,
 		});


### PR DESCRIPTION
Fixes #19086 , when flows was changed to use the flowsStores the flow `status` was not included when merging staged and existing changes. This adds status to the merge.
