### PR TITLE
Fix cleanup of unused `isBatch`

### DIFF
--- a/.changeset/twelve-shoes-serve.md
+++ b/.changeset/twelve-shoes-serve.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed cleanup of unused `isBatch` variable. Solves missing file preview in file page.

--- a/.changeset/twelve-shoes-serve.md
+++ b/.changeset/twelve-shoes-serve.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Fixed cleanup of unused `isBatch` variable. Solves missing file preview in file page.
+Fixed cleanup of unused `isBatch` variable to solve missing file preview in file item page

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -33,7 +33,6 @@ type UsableItem = {
 	isArchived: ComputedRef<boolean | null>;
 	archiving: Ref<boolean>;
 	saveAsCopy: () => Promise<any>;
-	isBatch: ComputedRef<boolean>;
 	getItem: () => Promise<void>;
 	validationErrors: Ref<any[]>;
 };

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -114,7 +114,7 @@
 		</template>
 
 		<div class="file-item">
-			<div v-if="isBatch === false && item" class="preview">
+			<div v-if="item" class="preview">
 				<file-preview :src="fileSrc" :mime="item.type" :width="item.width" :height="item.height" :title="item.title" />
 
 				<button class="replace-toggle" @click="replaceFileDialogActive = true">
@@ -135,7 +135,6 @@
 				:fields="fieldsFiltered"
 				:loading="loading"
 				:initial-values="item"
-				:batch-mode="isBatch"
 				:primary-key="primaryKey"
 				:disabled="updateAllowed === false"
 				:validation-errors="validationErrors"
@@ -158,16 +157,12 @@
 		<template #sidebar>
 			<file-info-sidebar-detail :file="item" />
 			<revisions-drawer-detail
-				v-if="isBatch === false && isNew === false && revisionsAllowed"
+				v-if="isNew === false && revisionsAllowed"
 				ref="revisionsDrawerDetailRef"
 				collection="directus_files"
 				:primary-key="primaryKey"
 			/>
-			<comments-sidebar-detail
-				v-if="isBatch === false && isNew === false"
-				collection="directus_files"
-				:primary-key="primaryKey"
-			/>
+			<comments-sidebar-detail v-if="isNew === false" collection="directus_files" :primary-key="primaryKey" />
 		</template>
 
 		<replace-file v-model="replaceFileDialogActive" :file="item" @replaced="refresh" />
@@ -215,21 +210,8 @@ const replaceFileDialogActive = ref(false);
 
 const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
-const {
-	isNew,
-	edits,
-	hasEdits,
-	item,
-	saving,
-	loading,
-	save,
-	remove,
-	deleting,
-	saveAsCopy,
-	isBatch,
-	refresh,
-	validationErrors,
-} = useItem(ref('directus_files'), primaryKey);
+const { isNew, edits, hasEdits, item, saving, loading, save, remove, deleting, saveAsCopy, refresh, validationErrors } =
+	useItem(ref('directus_files'), primaryKey);
 
 const isSavable = computed(() => saveAllowed.value && hasEdits.value);
 

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -72,7 +72,6 @@
 				collection="directus_collections"
 				:loading="loading"
 				:initial-values="item && item.meta"
-				:batch-mode="isBatch"
 				:primary-key="collection"
 				:disabled="item && item.collection.startsWith('directus_')"
 			/>
@@ -128,10 +127,7 @@ const { info: collectionInfo } = useCollection(collection);
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
 
-const { edits, item, saving, loading, save, remove, deleting, isBatch } = useItem(
-	ref('directus_collections'),
-	collection
-);
+const { edits, item, saving, loading, save, remove, deleting } = useItem(ref('directus_collections'), collection);
 
 const hasEdits = computed<boolean>(() => {
 	if (!edits.value.meta) return false;

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -81,7 +81,6 @@
 				:primary-key="primaryKey"
 				:loading="loading"
 				:initial-values="item"
-				:batch-mode="isBatch"
 			/>
 		</div>
 
@@ -139,11 +138,9 @@ const { primaryKey } = toRefs(props);
 
 const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
-const { edits, hasEdits, item, saving, loading, save, remove, deleting, isBatch } = useItem(
-	ref('directus_roles'),
-	primaryKey,
-	{ deep: { users: { _limit: 0 } } }
-);
+const { edits, hasEdits, item, saving, loading, save, remove, deleting } = useItem(ref('directus_roles'), primaryKey, {
+	deep: { users: { _limit: 0 } },
+});
 
 const confirmDelete = ref(false);
 

--- a/app/src/modules/settings/routes/webhooks/item.vue
+++ b/app/src/modules/settings/routes/webhooks/item.vue
@@ -56,7 +56,6 @@
 			:loading="loading"
 			:initial-values="item"
 			collection="directus_webhooks"
-			:batch-mode="isBatch"
 			:primary-key="primaryKey"
 			:validation-errors="validationErrors"
 		/>
@@ -111,8 +110,10 @@ const { primaryKey } = toRefs(props);
 
 const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
-const { isNew, edits, hasEdits, item, saving, loading, save, remove, deleting, saveAsCopy, isBatch, validationErrors } =
-	useItem(ref('directus_webhooks'), primaryKey);
+const { isNew, edits, hasEdits, item, saving, loading, save, remove, deleting, saveAsCopy, validationErrors } = useItem(
+	ref('directus_webhooks'),
+	primaryKey
+);
 
 const confirmDelete = ref(false);
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -144,7 +144,6 @@
 				:fields="formFields"
 				:loading="loading"
 				:initial-values="item"
-				:batch-mode="isBatch"
 				:primary-key="primaryKey"
 				:validation-errors="validationErrors"
 			/>
@@ -166,17 +165,13 @@
 		<template #sidebar>
 			<user-info-sidebar-detail :is-new="isNew" :user="item" />
 			<revisions-drawer-detail
-				v-if="isBatch === false && isNew === false && revisionsAllowed"
+				v-if="isNew === false && revisionsAllowed"
 				ref="revisionsDrawerDetail"
 				collection="directus_users"
 				:primary-key="primaryKey"
 				@revert="revert"
 			/>
-			<comments-sidebar-detail
-				v-if="isBatch === false && isNew === false"
-				collection="directus_users"
-				:primary-key="primaryKey"
-			/>
+			<comments-sidebar-detail v-if="isNew === false" collection="directus_users" :primary-key="primaryKey" />
 		</template>
 	</private-view>
 </template>
@@ -239,7 +234,6 @@ const {
 	remove,
 	deleting,
 	saveAsCopy,
-	isBatch,
 	archive,
 	archiving,
 	isArchived,


### PR DESCRIPTION
Fixes #19080

## Motivation
With the removal of `isBatch` on https://github.com/directus/directus/pull/18978 somethings are not working as expected like File Preview within Item in File Library.

## Solution
Continue with the cleanup of unused `isBatch` variable, since it will always be `undefined`

| Before | After |
| - | - | 
| <img width="610" alt="Screenshot 2023-07-10 at 19 26 58" src="https://github.com/directus/directus/assets/14039341/4945a23c-54df-406a-beed-0853febecb74"> | <img width="610" alt="Screenshot 2023-07-10 at 19 27 37" src="https://github.com/directus/directus/assets/14039341/519408ef-3126-4970-8aab-f796ae585147"> |
