### PR TITLE
Add Auto Cache Purging to Sorting Utility

### DIFF
--- a/.changeset/nervous-onions-relate.md
+++ b/.changeset/nervous-onions-relate.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+added auto cache purging to sorting utility

--- a/.changeset/nervous-onions-relate.md
+++ b/.changeset/nervous-onions-relate.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-added auto cache purging to sorting utility
+Added auto cache purging to sorting utility

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -129,7 +129,7 @@ export class UtilsService {
 		// check if cache should be cleared
 		const cache = getCache().cache;
 
-		if(shouldClearCache(cache, undefined, collection)){
+		if (shouldClearCache(cache, undefined, collection)) {
 			await cache.clear();
 		}
 

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -127,7 +127,7 @@ export class UtilsService {
 		}
 
 		// check if cache should be cleared
-		const cache = getCache().cache;
+		const { cache } = getCache();
 
 		if (shouldClearCache(cache, undefined, collection)) {
 			await cache.clear();

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -5,7 +5,6 @@ import { systemCollectionRows } from '../database/system-data/collections/index.
 import emitter from '../emitter.js';
 import { ForbiddenError, InvalidPayloadError } from '../errors/index.js';
 import type { AbstractServiceOptions, PrimaryKey } from '../types/index.js';
-import { getEnv } from '../env.js';
 import { getCache } from '../cache.js';
 import { shouldClearCache } from '../utils/should-clear-cache.js';
 
@@ -127,15 +126,11 @@ export class UtilsService {
 				.andWhereNot({ [primaryKeyField]: item });
 		}
 
-		// auto purge cache if enabled, there is a cache, and the collection is not in the ignore list
-		const env = getEnv();
+		// check if cache should be cleared
+		const cache = getCache().cache;
 
-		if (env['CACHE_AUTO_PURGE']) {
-			const cache = getCache().cache;
-
-			if(shouldClearCache(cache, undefined, collection)){
-				await cache.clear();
-			}
+		if(shouldClearCache(cache, undefined, collection)){
+			await cache.clear();
 		}
 
 		emitter.emitAction(

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -7,6 +7,7 @@ import { ForbiddenError, InvalidPayloadError } from '../errors/index.js';
 import type { AbstractServiceOptions, PrimaryKey } from '../types/index.js';
 import { getEnv } from '../env.js';
 import { getCache } from '../cache.js';
+import { shouldClearCache } from '../utils/should-clear-cache.js';
 
 export class UtilsService {
 	knex: Knex;
@@ -132,7 +133,7 @@ export class UtilsService {
 		if (env['CACHE_AUTO_PURGE']) {
 			const cache = getCache().cache;
 
-			if (cache && !env['CACHE_AUTO_PURGE_IGNORE_LIST'].includes(collection)) {
+			if(shouldClearCache(cache, undefined, collection)){
 				await cache.clear();
 			}
 		}

--- a/api/src/utils/should-clear-cache.ts
+++ b/api/src/utils/should-clear-cache.ts
@@ -16,12 +16,16 @@ export function shouldClearCache(
 ): cache is Keyv<any> {
 	const env = getEnv();
 
-	if (collection && env['CACHE_AUTO_PURGE_IGNORE_LIST'].includes(collection)) {
-		return false;
-	}
+	if(env['CACHE_AUTO_PURGE']){
 
-	if (cache && env['CACHE_AUTO_PURGE'] && opts?.autoPurgeCache !== false) {
-		return true;
+		if (collection && env['CACHE_AUTO_PURGE_IGNORE_LIST'].includes(collection)) {
+			return false;
+		}
+
+		if (cache && opts?.autoPurgeCache !== false) {
+			return true;
+		}
+
 	}
 
 	return false;

--- a/api/src/utils/should-clear-cache.ts
+++ b/api/src/utils/should-clear-cache.ts
@@ -16,8 +16,7 @@ export function shouldClearCache(
 ): cache is Keyv<any> {
 	const env = getEnv();
 
-	if(env['CACHE_AUTO_PURGE']){
-
+	if (env['CACHE_AUTO_PURGE']) {
 		if (collection && env['CACHE_AUTO_PURGE_IGNORE_LIST'].includes(collection)) {
 			return false;
 		}
@@ -25,7 +24,6 @@ export function shouldClearCache(
 		if (cache && opts?.autoPurgeCache !== false) {
 			return true;
 		}
-
 	}
 
 	return false;


### PR DESCRIPTION
The sort utility does not use the ItemService, rather it uses knex directly so it bypassed the typical checks/purging if `CACHE_AUTO_PURGE` was enabled.

This PR adds the cache purging logic to the sorting utility, reusing `shouldClearCache` from the ItemService fixing #18788.

Fixes #18788