### PR TITLE
Fix EditorJS Styling

### DIFF
--- a/.changeset/hip-beans-wink.md
+++ b/.changeset/hip-beans-wink.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+fixed editorjs icon styling

--- a/app/src/interfaces/input-block-editor/editorjs-overrides.css
+++ b/app/src/interfaces/input-block-editor/editorjs-overrides.css
@@ -21,13 +21,6 @@
 	fill: var(--foreground-normal) !important;
 }
 
-.codex-editor .cdx-settings-button svg,
-.codex-editor .ce-inline-toolbar__dropdown svg,
-.codex-editor .ce-inline-toolbar .ce-inline-tool svg,
-.codex-editor .ce-settings .ce-settings__button svg {
-	fill: var(--v-list-color) !important;
-}
-
 .codex-editor .ce-inline-toolbar .ce-inline-tool--active svg,
 .codex-editor .ce-settings .cdx-settings-button--active svg {
 	fill: var(--primary) !important;


### PR DESCRIPTION
This PR removes a style that applied a fill to icons that should only have a stroke. Fixes #19001