### PR TITLE
Use warn log levels for unexpected oid/oa2 errors

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -244,23 +244,23 @@ const handleError = (e: any) => {
 	if (e instanceof errors.OPError) {
 		if (e.error === 'invalid_grant') {
 			// Invalid token
-			logger.trace(e, `[OAuth2] Invalid grant`);
+			logger.warn(e, `[OAuth2] Invalid grant`);
 			return new InvalidTokenError();
 		}
 
 		// Server response error
-		logger.trace(e, `[OAuth2] Unknown OP error`);
+		logger.warn(e, `[OAuth2] Unknown OP error`);
 		return new ServiceUnavailableError({
 			service: 'oauth2',
 			reason: `Service returned unexpected response: ${e.error_description}`,
 		});
 	} else if (e instanceof errors.RPError) {
 		// Internal client error
-		logger.trace(e, `[OAuth2] Unknown RP error`);
+		logger.warn(e, `[OAuth2] Unknown RP error`);
 		return new InvalidCredentialsError();
 	}
 
-	logger.trace(e, `[OAuth2] Unknown error`);
+	logger.warn(e, `[OAuth2] Unknown error`);
 	return e;
 };
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -275,23 +275,23 @@ const handleError = (e: any) => {
 	if (e instanceof errors.OPError) {
 		if (e.error === 'invalid_grant') {
 			// Invalid token
-			logger.trace(e, `[OpenID] Invalid grant`);
+			logger.warn(e, `[OpenID] Invalid grant`);
 			return new InvalidTokenError();
 		}
 
 		// Server response error
-		logger.trace(e, `[OpenID] Unknown OP error`);
+		logger.warn(e, `[OpenID] Unknown OP error`);
 		return new ServiceUnavailableError({
 			service: 'openid',
 			reason: `Service returned unexpected response: ${e.error_description}`,
 		});
 	} else if (e instanceof errors.RPError) {
 		// Internal client error
-		logger.trace(e, `[OpenID] Unknown RP error`);
+		logger.warn(e, `[OpenID] Unknown RP error`);
 		return new InvalidCredentialsError();
 	}
 
-	logger.trace(e, `[OpenID] Unknown error`);
+	logger.warn(e, `[OpenID] Unknown error`);
 	return e;
 };
 

--- a/api/src/auth/drivers/saml.ts
+++ b/api/src/auth/drivers/saml.ts
@@ -57,7 +57,7 @@ export class SAMLAuthDriver extends LocalAuthDriver {
 		if (userID) return userID;
 
 		if (!allowPublicRegistration) {
-			logger.trace(`[SAML] User doesn't exist, and public registration not allowed for provider "${provider}"`);
+			logger.warn(`[SAML] User doesn't exist, and public registration not allowed for provider "${provider}"`);
 			throw new InvalidCredentialsError();
 		}
 


### PR DESCRIPTION
#19003 contained a hard to find config problem, as the unexpected error was silenced in a trace log, which are hidden by default. Using a `warn` log level makes more sense for those unexpected errors.