### PR TITLE
Remove obsolete `webmanifest` extension from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ insert_final_newline = true
 charset = utf-8
 trim_trailing_whitespace = true
 
-[*.{mjs,cjs,js,mts,cts,ts,json,vue,html,scss,css,toml,webmanifest,md}]
+[*.{mjs,cjs,js,mts,cts,ts,json,vue,html,scss,css,toml,md}]
 indent_style = tab
 
 [*.md]


### PR DESCRIPTION
File removed in https://github.com/directus/directus/pull/19141.
