### PR TITLE
Update quickstart

### DIFF
--- a/.changeset/short-drinks-smile.md
+++ b/.changeset/short-drinks-smile.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Updated quickstart

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -41,6 +41,8 @@ services:
       SECRET: 'replace-with-random-value'
       ADMIN_EMAIL: 'admin@example.com'
       ADMIN_PASSWORD: 'd1r3ctu5'
+      DB_CLIENT: 'sqlite3'
+      DB_FILENAME: '/directus/database/data.db'
       WEBSOCKETS_ENABLED: true
 ```
 
@@ -55,6 +57,7 @@ Save the file. Let's step through it:
   - `KEY` and `SECRET` are required and should be long random values. `KEY` is used for telemetry and health tracking,
     and `SECRET` is used to sign access tokens.
   - `ADMIN_EMAIL` and `ADMIN_PASSWORD` is the initial admin user credentials on first launch.
+  - `DB_CLIENT` and `DB_FILENAME` are defining the connection to your database.
   - `WEBSOCKETS_ENABLED` is not required, but enables [Directus Realtime](/guides/real-time/getting-started/index.html).
 
 The volumes section is not required, but without this, our database and file uploads will be destroyed when the Docker

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -72,4 +72,4 @@ Run the following in your terminal:
 docker compose up
 ```
 
-Directus should now be available at http://0.0.0.0:8055
+Directus should now be available at http://localhost:8055 or http://127.0.0.1:8055


### PR DESCRIPTION
refs #19156

A few question came in along the lines of how do i use postgres instead of sqlite. looks like relying on the fallback/default database configuration is causing some confusion. 

And `0.0.0.0` is not a broadly configured method of referring to `localhost` and is not guaranteed to work across operating systems.
