### PR TITLE
Typo fix for codebase overview docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -52,3 +52,4 @@
 - ceptonit
 - luochuanyuewu
 - magnus-bb
+- ZeyarPaing

--- a/docs/contributing/codebase-overview.md
+++ b/docs/contributing/codebase-overview.md
@@ -44,7 +44,7 @@ Contains the Directus Data Studio App, written in Vue.js 3 w/ the Composition AP
 | `/public` | Assets that are included with the app, but not bundled. |
 | `/src`    | App source code.                                        |
 
-The source code is located in `/api/src` and the below folders are inside there.
+The source code is located in `/app/src` and the below folders are inside there.
 
 | Folder         | Content                                                                                                                                                      |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
- Fix for Documentation typo error just saw while reading where it should be `app/src` but it is `api/src`