### PR TITLE
docs: Fix typo in permissions attribute list

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -54,3 +54,4 @@
 - magnus-bb
 - ZeyarPaing
 - mrbarletta
+- juliuste

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -31,7 +31,7 @@ What rules the item must pass before the role is allowed to alter it. Follows [t
 `validation` **object**\
 What rules the provided values must pass before the role is allowed to submit them for insertion/update. Follows [the Filter Rules spec](/reference/filter-rules).
 
-`preset` **object**\
+`presets` **object**\
 Additional default values for the role.
 
 `fields` **array**\


### PR DESCRIPTION
Hey everyone 🙂 This PR fixes #19196. I hope I did everything correctly, otherwise please let me know and I'll update the request.