### PR TITLE
API: Do count distinct since `left join` duplicates results

### DIFF
--- a/.changeset/angry-suits-compete.md
+++ b/.changeset/angry-suits-compete.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixes incorrect `filter_count` meta field when query applies to relationships
+Fixed incorrect `filter_count` meta field when query applies to relationships

--- a/.changeset/angry-suits-compete.md
+++ b/.changeset/angry-suits-compete.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixes incorrect `filter_count` meta field when query applies to relationships

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -88,9 +88,7 @@ export class MetaService {
 		if (hasJoins) {
 			const primaryKeyName = this.schema.collections[collection]!.primary;
 
-			dbQuery.countDistinct(this.knex.raw('??.??', [collection, primaryKeyName]), {
-				as: 'count',
-			});
+			dbQuery.countDistinct({ count: [`${collection}.${primaryKeyName}`] });
 		} else {
 			dbQuery.count('*', { as: 'count' });
 		}

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -90,6 +90,6 @@ export class MetaService {
 
 		const records = await dbQuery;
 
-		return Number(records[0]!.count);
+		return Number(records[0]!['count']);
 	}
 }

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -56,7 +56,11 @@ export class MetaService {
 	}
 
 	async filterCount(collection: string, query: Query): Promise<number> {
-		const dbQuery = this.knex(collection).count('*', { as: 'count' });
+		const primaryKeyName = this.schema.collections[collection]!.primary;
+
+		const dbQuery = this.knex(collection).countDistinct(this.knex.raw('??.??', [collection, primaryKeyName]), {
+			as: 'count',
+		});
 
 		let filter = query.filter || {};
 

--- a/tests/blackbox/routes/items/m2o.test.ts
+++ b/tests/blackbox/routes/items/m2o.test.ts
@@ -1958,5 +1958,63 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 				vendorSchemaValues
 			);
 		});
+
+		describe('Meta Service Tests', () => {
+			describe('retrieves filter count correctly', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const name = 'test-meta-service-count';
+					const country = createCountry(pkType);
+					const country2 = createCountry(pkType);
+
+					country.name = name;
+					country2.name = name;
+
+					const insertedCountry = await CreateItem(vendor, {
+						collection: localCollectionCountries,
+						item: country,
+					});
+
+					const insertedCountry2 = await CreateItem(vendor, {
+						collection: localCollectionCountries,
+						item: country2,
+					});
+
+					const state = createState(pkType);
+					const state2 = createState(pkType);
+
+					state.name = name;
+					state2.name = name;
+					state.country_id = insertedCountry.id;
+					state2.country_id = insertedCountry2.id;
+
+					await CreateItem(vendor, {
+						collection: localCollectionStates,
+						item: [state, state2],
+					});
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionStates}`)
+						.query({
+							filter: JSON.stringify({
+								name: { _eq: name },
+								country_id: {
+									name: {
+										_eq: name,
+									},
+								},
+							}),
+							meta: '*',
+						})
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.meta.filter_count).toBe(2);
+					expect(response.body.data.length).toBe(2);
+				});
+			});
+		});
 	});
 });

--- a/tests/blackbox/routes/items/no-relation.test.ts
+++ b/tests/blackbox/routes/items/no-relation.test.ts
@@ -2186,5 +2186,40 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 				});
 			});
 		});
+
+		describe('Meta Service Tests', () => {
+			describe('retrieves filter count correctly', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const name = 'test-meta-service-count';
+					const artist = createArtist(pkType);
+					const artist2 = createArtist(pkType);
+
+					artist.name = name;
+					artist2.name = name;
+
+					await CreateItem(vendor, {
+						collection: localCollectionArtists,
+						item: [artist, artist2],
+					});
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArtists}`)
+						.query({
+							filter: JSON.stringify({
+								name: { _eq: name },
+							}),
+							meta: '*',
+						})
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.meta.filter_count).toBe(2);
+					expect(response.body.data.length).toBe(2);
+				});
+			});
+		});
 	});
 });

--- a/tests/blackbox/routes/items/o2m.test.ts
+++ b/tests/blackbox/routes/items/o2m.test.ts
@@ -2699,5 +2699,77 @@ describe.each(common.PRIMARY_KEY_TYPES)('/items', (pkType) => {
 				});
 			});
 		});
+
+		describe('Meta Service Tests', () => {
+			describe('retrieves filter count correctly', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const name = 'test-meta-service-count';
+					const country = createCountry(pkType);
+					const country2 = createCountry(pkType);
+					const states = [];
+					const states2 = [];
+
+					country.name = name;
+					country2.name = name;
+
+					for (let count = 0; count < 2; count++) {
+						const state = createState(pkType);
+						const state2 = createState(pkType);
+						state.name = name;
+						state2.name = name;
+						states.push(state);
+						states2.push(state2);
+					}
+
+					await CreateItem(vendor, {
+						collection: localCollectionCountries,
+						item: [
+							{
+								...country,
+								states: {
+									create: states,
+									update: [],
+									delete: [],
+								},
+							},
+							{
+								...country2,
+								states: {
+									create: states2,
+									update: [],
+									delete: [],
+								},
+							},
+						],
+					});
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionCountries}`)
+						.query({
+							filter: JSON.stringify({
+								name: { _eq: name },
+								states: {
+									name: {
+										_eq: name,
+									},
+								},
+							}),
+							meta: '*',
+						})
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.meta.filter_count).toBe(2);
+					expect(response.body.data.length).toBe(2);
+
+					for (const item of response.body.data) {
+						expect(item.states.length).toBe(2);
+					}
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Motivation
In some scenarios, `filter_count` returns the result of the amount of relationships instead of just the amount records on current collection.
This happens because the results are duplicated since a `left join` is being used.

## Solution
In order to solve this, we can just do a `countDistinct` using the primary key of the current collection.
That will remove the duplicated results and `filter_count` will have proper value

Fixes #18608