### PR TITLE
[Bug Fix] utils/url.js removing trailing slashes

### DIFF
--- a/.changeset/amazing-flying-monkey.md
+++ b/.changeset/amazing-flying-monkey.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+[Bug Fix] utils/url.js removing trailing slashes. It now preserves them.

--- a/.changeset/amazing-flying-monkey.md
+++ b/.changeset/amazing-flying-monkey.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-[Bug Fix] utils/url.js removing trailing slashes. It now preserves them.
+Fixed URL util to preserve trailing slashes

--- a/api/src/utils/url.test.ts
+++ b/api/src/utils/url.test.ts
@@ -1,24 +1,6 @@
 import { expect, test, describe } from 'vitest';
 import { Url } from './url.js';
 
-describe('path handling', () => {
-	test('parse and serialize an URL without path', () => {
-		expect(new Url('https://example.com').toString()).toStrictEqual('https://example.com');
-	});
-
-	test('parse and serialize an URL without path, removing trailing slash', () => {
-		expect(new Url('https://example.com/').toString()).toStrictEqual('https://example.com');
-	});
-
-	test('parse and serialize an URL with path component', () => {
-		expect(new Url('https://example.com/path').toString()).toStrictEqual('https://example.com/path');
-	});
-
-	test('parse and serialize an URL with path component, removing trailing slash', () => {
-		expect(new Url('https://example.com/path/').toString()).toStrictEqual('https://example.com/path');
-	});
-});
-
 describe('relative URL handling', () => {
 	test('parse and serialize a relative path', () => {
 		expect(new Url('/sample-path').toString()).toStrictEqual('/sample-path');
@@ -136,6 +118,14 @@ describe('isRootRelative', () => {
 });
 
 describe('trailing slash handling', () => {
+	test('parse and serialize an URL without path', () => {
+		expect(new Url('https://example.com').toString()).toStrictEqual('https://example.com');
+	});
+
+	test('parse and serialize an URL without path, keeping trailing slash', () => {
+		expect(new Url('https://example.com/').toString()).toStrictEqual('https://example.com/');
+	});
+	
 	test('parse and serialize an URL preserving trailing slash with no query params', () => {
 		expect(new Url('https://example.com/path/').toString()).toStrictEqual('https://example.com/path/');
 	});

--- a/api/src/utils/url.test.ts
+++ b/api/src/utils/url.test.ts
@@ -134,3 +134,45 @@ describe('isRootRelative', () => {
 		expect(new Url('//example.com/sample-path').isRootRelative()).toStrictEqual(false);
 	});
 });
+
+describe('trailing slash handling', () => {
+	test('parse and serialize an URL preserving trailing slash with no query params', () => {
+		expect(new Url('https://example.com/path/').toString()).toStrictEqual('https://example.com/path/');
+	});
+
+	test('parse and serialize an URL preserving trailing slash with query params', () => {
+		expect(new Url('https://example.com/path/?foo=bar').toString()).toStrictEqual('https://example.com/path/?foo=bar');
+	});
+
+	test('parse, add query param, and serialize an URL preserving trailing slash', () => {
+		const testUrl = new Url('https://example.com/path/');
+		testUrl.setQuery('token', '123123');
+		expect(testUrl.toString()).toStrictEqual('https://example.com/path/?token=123123');
+	});
+
+	test('parse, add query param, and serialize an URL preserving trailing slash with existing query params', () => {
+		const testUrl = new Url('https://example.com/path/?foo=bar');
+		testUrl.setQuery('token', '123123');
+		expect(testUrl.toString()).toStrictEqual('https://example.com/path/?foo=bar&token=123123');
+	});
+
+	test('parse and serialize an URL without trailing slash with no query params', () => {
+		expect(new Url('https://example.com/path').toString()).toStrictEqual('https://example.com/path');
+	});
+
+	test('parse and serialize an URL without trailing slash with query params', () => {
+		expect(new Url('https://example.com/path?foo=bar').toString()).toStrictEqual('https://example.com/path?foo=bar');
+	});
+
+	test('parse, add query param, and serialize an URL without trailing slash', () => {
+		const testUrl = new Url('https://example.com/path');
+		testUrl.setQuery('token', '123123');
+		expect(testUrl.toString()).toStrictEqual('https://example.com/path?token=123123');
+	});
+
+	test('parse, add query param, and serialize an URL without trailing slash with existing query params', () => {
+		const testUrl = new Url('https://example.com/path?foo=bar');
+		testUrl.setQuery('token', '123123');
+		expect(testUrl.toString()).toStrictEqual('https://example.com/path?foo=bar&token=123123');
+	});
+});

--- a/api/src/utils/url.test.ts
+++ b/api/src/utils/url.test.ts
@@ -125,7 +125,7 @@ describe('trailing slash handling', () => {
 	test('parse and serialize an URL without path, keeping trailing slash', () => {
 		expect(new Url('https://example.com/').toString()).toStrictEqual('https://example.com/');
 	});
-	
+
 	test('parse and serialize an URL preserving trailing slash with no query params', () => {
 		expect(new Url('https://example.com/path/').toString()).toStrictEqual('https://example.com/path/');
 	});

--- a/api/src/utils/url.ts
+++ b/api/src/utils/url.ts
@@ -27,8 +27,7 @@ export class Url {
 		this.query = Object.fromEntries(parsedUrl.searchParams.entries());
 		this.hash = parsedUrl.hash !== '' ? parsedUrl.hash.substring(1) : null;
 
-		this.hasTrailingSlash = parsedUrl.pathname.length > 1
-			? parsedUrl.pathname.endsWith('/') : url.endsWith('/');
+		this.hasTrailingSlash = parsedUrl.pathname.length > 1 ? parsedUrl.pathname.endsWith('/') : url.endsWith('/');
 	}
 
 	public isAbsolute(): boolean {

--- a/api/src/utils/url.ts
+++ b/api/src/utils/url.ts
@@ -26,7 +26,9 @@ export class Url {
 		this.path = parsedUrl.pathname.split('/').filter((p) => p !== '');
 		this.query = Object.fromEntries(parsedUrl.searchParams.entries());
 		this.hash = parsedUrl.hash !== '' ? parsedUrl.hash.substring(1) : null;
-		this.hasTrailingSlash = parsedUrl.pathname.endsWith('/');
+
+		this.hasTrailingSlash = parsedUrl.pathname.length > 1
+			? parsedUrl.pathname.endsWith('/') : url.endsWith('/');
 	}
 
 	public isAbsolute(): boolean {
@@ -69,7 +71,7 @@ export class Url {
 
 		const path = this.path.length ? `/${this.path.join('/')}` : '';
 
-		const trailingSlash = this.hasTrailingSlash && this.path.length ? '/' : '';
+		const trailingSlash = this.hasTrailingSlash ? '/' : '';
 
 		const query = Object.keys(this.query).length !== 0 ? `?${new URLSearchParams(this.query).toString()}` : '';
 

--- a/api/src/utils/url.ts
+++ b/api/src/utils/url.ts
@@ -7,6 +7,7 @@ export class Url {
 	path: string[];
 	query: Record<string, string>;
 	hash: string | null;
+	hasTrailingSlash: boolean;
 
 	constructor(url: string) {
 		const parsedUrl = new URL(url, 'http://localhost');
@@ -25,6 +26,7 @@ export class Url {
 		this.path = parsedUrl.pathname.split('/').filter((p) => p !== '');
 		this.query = Object.fromEntries(parsedUrl.searchParams.entries());
 		this.hash = parsedUrl.hash !== '' ? parsedUrl.hash.substring(1) : null;
+		this.hasTrailingSlash = parsedUrl.pathname.endsWith('/');
 	}
 
 	public isAbsolute(): boolean {
@@ -67,10 +69,12 @@ export class Url {
 
 		const path = this.path.length ? `/${this.path.join('/')}` : '';
 
+		const trailingSlash = this.hasTrailingSlash && this.path.length ? '/' : '';
+
 		const query = Object.keys(this.query).length !== 0 ? `?${new URLSearchParams(this.query).toString()}` : '';
 
 		const hash = this.hash !== null ? `#${this.hash}` : '';
 
-		return `${!rootRelative ? origin : ''}${path}${query}${hash}`;
+		return `${!rootRelative ? origin : ''}${path}${trailingSlash}${query}${hash}`;
 	}
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -55,3 +55,4 @@
 - ZeyarPaing
 - mrbarletta
 - juliuste
+- amerkay


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Hi!

TLDR; `Url("https://example.com/verify/").toString()` returns `https://example.com/verify`, it removes the trailing slash. It should preserve it. This PR fixes that.

- PR closes this issue https://github.com/directus/directus/issues/19207
- Tests added.

Cheers!

Fixes #19207