### PR TITLE
Remove res.status calculation as it is set later

### DIFF
--- a/.changeset/rare-buckets-walk.md
+++ b/.changeset/rare-buckets-walk.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved http status code handling when multiple errors are thrown

--- a/api/src/middleware/error-handler.ts
+++ b/api/src/middleware/error-handler.ts
@@ -16,20 +16,8 @@ const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
 
 	const errors = toArray(err);
 
-	if (errors.some((err) => isDirectusError(err) === false)) {
+	if (!errors.length) {
 		res.status(500);
-	} else {
-		let status = errors[0].status;
-
-		for (const err of errors) {
-			if (status !== err.status) {
-				// If there's multiple different status codes in the errors, use 500
-				status = 500;
-				break;
-			}
-		}
-
-		res.status(status);
 	}
 
 	for (const err of errors) {


### PR DESCRIPTION
res.status is anyways set in either flow later in this function, so no need to loop through errors just for this.

Only edge case is when there are no errors, which would anyways just mean 500 as you can see.
