### PR TITLE
Require 'collection' & 'item' fields for shares

### DIFF
--- a/.changeset/smooth-paws-jog.md
+++ b/.changeset/smooth-paws-jog.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+---
+
+Ensured shares cannot be created without 'collection' and 'item' field

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_shares', (table) => {
+		table.dropNullable('collection');
+		table.dropNullable('item');
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_shares', (table) => {
+		table.setNullable('collection');
+		table.setNullable('item');
+	});
+}

--- a/api/src/database/system-data/fields/shares.yaml
+++ b/api/src/database/system-data/fields/shares.yaml
@@ -35,7 +35,7 @@ fields:
       iconRight: lock
       masked: true
     width: half
-    note: $t:shared_leave_blank_for_unlimited
+    note: $t:shared_leave_blank_for_passwordless_access
 
   - field: date_start
     width: half

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1385,6 +1385,7 @@ share: Share
 share_item: Share Item
 shared_with_you: An item has been shared with you
 shared_enter_passcode: Enter your passcode to continue...
+shared_leave_blank_for_passwordless_access: Leave blank for passwordless access
 shared_leave_blank_for_unlimited: Leave blank for unlimited
 shared_times_remaining: This link can only be used {n} times
 shared_last_remaining: This link can only be used once


### PR DESCRIPTION
It doesn't make sense to create shares without these two fields.

Also enhancing the hint on the password field.