### PR TITLE
Fix storage root and filename formatting to sync Cloudinary uploads and deletes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -51,3 +51,4 @@
 - v1b3m
 - ceptonit
 - luochuanyuewu
+- sethkaufee

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -398,6 +398,9 @@ export class DriverCloudinary implements Driver {
 				next_cursor: string;
 				resources: {
 					public_id: string;
+					format: string;
+					resource_type: string;
+					filename: string;
 				}[];
 			};
 
@@ -409,7 +412,11 @@ export class DriverCloudinary implements Driver {
 			nextCursor = json.next_cursor;
 
 			for (const file of json.resources) {
-				yield file.public_id.substring(this.root.length);
+				const filename = file.public_id.substring(this.root.length);
+				if (file.resource_type === 'image' || file.resource_type === 'video')
+					yield `${filename}.${file.format}`;
+				else
+					yield filename;
 			}
 		} while (nextCursor);
 	}

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -95,9 +95,10 @@ export class DriverCloudinary implements Driver {
 	 * on the other hand requires the extension to be present.
 	 */
 	private getPublicId(filepath: string) {
+		const { base, name } = parse(filepath);
 		const resourceType = this.getResourceType(filepath);
-		if (resourceType === 'raw') return filepath;
-		return parse(filepath).name;
+		if (resourceType === 'raw') return base;
+		return name;
 	}
 
 	/**
@@ -231,6 +232,7 @@ export class DriverCloudinary implements Driver {
 	async write(filepath: string, content: Readable) {
 		const fullPath = this.fullPath(filepath);
 		const resourceType = this.getResourceType(fullPath);
+		const folderPath = this.getFolderPath(fullPath);
 
 		const uploadParameters = {
 			timestamp: this.getTimestamp(),
@@ -238,8 +240,11 @@ export class DriverCloudinary implements Driver {
 			type: 'upload',
 			access_mode: this.accessMode,
 			public_id: this.getPublicId(fullPath),
-			asset_folder: this.getFolderPath(fullPath),
-			use_asset_folder_as_public_id_prefix: true,
+			...(folderPath ? {
+					asset_folder: folderPath,
+					use_asset_folder_as_public_id_prefix: 'true'
+				} : {}
+			)
 		};
 
 		const signature = this.getFullSignature(uploadParameters);

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -238,7 +238,8 @@ export class DriverCloudinary implements Driver {
 			type: 'upload',
 			access_mode: this.accessMode,
 			public_id: this.getPublicId(fullPath),
-			folder: this.getFolderPath(fullPath),
+			asset_folder: this.getFolderPath(fullPath),
+			use_asset_folder_as_public_id_prefix: true,
 		};
 
 		const signature = this.getFullSignature(uploadParameters);


### PR DESCRIPTION
When the `@directus/storage-driver-cloudinary` is enabled, file deletes are not being reflected and the "root" folder configuration will break.

The Cloudinary API has undergone changes with regard to formatting/handling of the Public ID (filename) and folders in API requests. This PR is to address those changes and to fix #18146 and fix #19219.