### PR TITLE
Fix-up for "Add support for deep in useItems"

### DIFF
--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -40,10 +40,9 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	const api = useApi();
 	const { primaryKeyField } = useCollection(collection);
 
-	const { fields, limit, sort, search, filter, page } = query;
-	let { alias, deep } = query;
-	alias = alias ?? ref();
-	deep = deep ?? ref();
+	const { fields, limit, sort, search, filter, page, alias: queryAlias, deep: queryDeep } = query;
+	const alias = queryAlias ?? ref();
+	const deep = queryDeep ?? ref();
 
 	const endpoint = computed(() => {
 		if (!collection.value) return null;

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -27,12 +27,12 @@ export type UsableItems = {
 
 export type ComputedQuery = {
 	fields: Ref<Query['fields']> | ComputedRef<Query['fields']> | WritableComputedRef<Query['fields']>;
-	alias?: Ref<Query['alias']> | ComputedRef<Query['alias']> | WritableComputedRef<Query['alias']>;
 	limit: Ref<Query['limit']> | ComputedRef<Query['limit']> | WritableComputedRef<Query['limit']>;
 	sort: Ref<Query['sort']> | ComputedRef<Query['sort']> | WritableComputedRef<Query['sort']>;
 	search: Ref<Query['search']> | ComputedRef<Query['search']> | WritableComputedRef<Query['search']>;
 	filter: Ref<Query['filter']> | ComputedRef<Query['filter']> | WritableComputedRef<Query['filter']>;
 	page: Ref<Query['page']> | WritableComputedRef<Query['page']>;
+	alias?: Ref<Query['alias']> | ComputedRef<Query['alias']> | WritableComputedRef<Query['alias']>;
 	deep?: Ref<Query['deep']> | ComputedRef<Query['deep']> | WritableComputedRef<Query['deep']>;
 };
 
@@ -40,7 +40,10 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	const api = useApi();
 	const { primaryKeyField } = useCollection(collection);
 
-	const { fields, alias, limit, sort, search, filter, page, deep } = query;
+	const { fields, limit, sort, search, filter, page } = query;
+	let { alias, deep } = query;
+	alias = alias ?? ref();
+	deep = deep ?? ref();
 
 	const endpoint = computed(() => {
 		if (!collection.value) return null;
@@ -71,12 +74,12 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	const fetchItems = throttle(getItems, 500);
 
 	watch(
-		[collection, limit, sort, search, filter, fields, page, deep],
+		[collection, limit, sort, search, filter, fields, page, alias, deep],
 		async (after, before) => {
 			if (isEqual(after, before)) return;
 
-			const [newCollection, newLimit, newSort, newSearch, newFilter, _newFields, _newPage] = after;
-			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter, _oldFields, _oldPage] = before;
+			const [newCollection, newLimit, newSort, newSearch, newFilter] = after;
+			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter] = before;
 
 			if (!newCollection || !query) return;
 


### PR DESCRIPTION
Fix-up for #18713

- Fix TypeScript issue by making `deep` & `alias` refs when not given as parameters
- Add `alias` to watch list too
