### PR TITLE
Make "Schedule Hook" test more stable

### DIFF
--- a/tests/blackbox/flows/schedule-hook.seed.ts
+++ b/tests/blackbox/flows/schedule-hook.seed.ts
@@ -1,39 +1,11 @@
 import { getUrl } from '@common/config';
 import vendors from '@common/get-dbs-to-test';
 import * as common from '@common/index';
-import { CreateCollection, CreateField, DeleteCollection } from '@common/index';
 import request from 'supertest';
 
-export const collection = 'test_flows_schedule_hook';
-export const fieldData = 'field_data';
 export const flowName = 'Schedule Hook Test';
+export const logPrefix = 'flow-executed-on-';
 export const envTargetVariable = 'FLOWS_SCHEDULE_HOOK_NAME';
-
-export const seedDBStructure = () => {
-	it.each(vendors)(
-		'%s',
-		async (vendor) => {
-			try {
-				await DeleteCollection(vendor, { collection });
-
-				await CreateCollection(vendor, {
-					collection,
-				});
-
-				await CreateField(vendor, {
-					collection,
-					field: fieldData,
-					type: 'string',
-				});
-
-				expect(true).toBeTruthy();
-			} catch (error) {
-				expect(error).toBeFalsy();
-			}
-		},
-		300000
-	);
-};
 
 export const seedDBValues = async () => {
 	let isSeeded = true;
@@ -54,14 +26,10 @@ export const seedDBValues = async () => {
 			const payloadOperationCreate = {
 				position_x: 19,
 				position_y: 1,
-				name: 'Create Record',
-				key: 'op_create',
-				type: 'item-create',
-				options: {
-					payload: { [fieldData]: `{{ $env.${envTargetVariable} }}` },
-					collection,
-					permissions: '$full',
-				},
+				name: 'Log to Console',
+				key: 'log_to_console',
+				type: 'log',
+				options: { message: `${logPrefix}{{ $env.${envTargetVariable} }}` },
 			};
 
 			const flowId = (

--- a/tests/blackbox/flows/schedule-hook.test.ts
+++ b/tests/blackbox/flows/schedule-hook.test.ts
@@ -100,7 +100,7 @@ describe('Flows Schedule Hook Tests', () => {
 			const env = envs[vendor][0]; // All instances are connected via MESSENGER
 			const flowId = flowIds[vendor];
 
-			// Create delayed sleep, set to 9s (4 flow executions, execution every 2 sec + a small delay)
+			// Create delayed sleep, set to 9s (4 flow executions, execution every 2s + a small delay)
 			const { sleep, sleepStart, sleepIsRunning } = delayedSleep(9000);
 
 			const flowExecutions: string[] = [];
@@ -109,7 +109,7 @@ describe('Flows Schedule Hook Tests', () => {
 				const logLine = String(chunk);
 
 				if (logLine.includes(logPrefix)) {
-					// Start timer as soon as first flow run has been executed
+					// Start sleep timer as soon as first flow has been executed
 					if (!sleepIsRunning()) {
 						sleepStart();
 					}

--- a/tests/blackbox/flows/schedule-hook.test.ts
+++ b/tests/blackbox/flows/schedule-hook.test.ts
@@ -110,7 +110,7 @@ describe('Flows Schedule Hook Tests', () => {
 
 				if (logLine.includes(logPrefix)) {
 					// Start timer as soon as first flow run has been executed
-					if (!sleepIsRunning) {
+					if (!sleepIsRunning()) {
 						sleepStart();
 					}
 

--- a/tests/blackbox/flows/schedule-hook.test.ts
+++ b/tests/blackbox/flows/schedule-hook.test.ts
@@ -110,7 +110,7 @@ describe('Flows Schedule Hook Tests', () => {
 				}
 			};
 
-			// Fetch log output of all instances
+			// Process logs of all instances
 			for (const instance of directusInstances[vendor]) {
 				// Discard data up to this point
 				instance.stdout?.read();
@@ -130,7 +130,7 @@ describe('Flows Schedule Hook Tests', () => {
 				.send({ status: 'inactive' })
 				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
 
-			// Stop fetching log output
+			// Stop processing logs
 			for (const instance of directusInstances[vendor]) {
 				instance.stdout?.off('data', processLogLine);
 			}

--- a/tests/blackbox/flows/schedule-hook.test.ts
+++ b/tests/blackbox/flows/schedule-hook.test.ts
@@ -123,17 +123,17 @@ describe('Flows Schedule Hook Tests', () => {
 				.send({ status: 'active' })
 				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
 
-			await sleep(10000);
-
-			await request(getUrl(vendor, env))
-				.patch(`/flows/${flowId}`)
-				.send({ status: 'inactive' })
-				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+			await sleep(11000);
 
 			// Stop processing logs
 			for (const instance of directusInstances[vendor]) {
 				instance.stdout?.off('data', processLogLine);
 			}
+
+			await request(getUrl(vendor, env))
+				.patch(`/flows/${flowId}`)
+				.send({ status: 'inactive' })
+				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
 
 			const redisExecutionCount = flowExecutions.filter((execution) => execution.includes('redis-')).length;
 			const memoryExecutionCount = flowExecutions.filter((execution) => execution.includes('memory-')).length;

--- a/tests/blackbox/flows/schedule-hook.test.ts
+++ b/tests/blackbox/flows/schedule-hook.test.ts
@@ -100,7 +100,7 @@ describe('Flows Schedule Hook Tests', () => {
 			const env = envs[vendor][0]; // All instances are connected via MESSENGER
 			const flowId = flowIds[vendor];
 
-			// Create delayed sleep, set to 8s (4 flow executions + a small delay)
+			// Create delayed sleep, set to 9s (4 flow executions, execution every 2 sec + a small delay)
 			const { sleep, sleepStart, sleepIsRunning } = delayedSleep(9000);
 
 			const flowExecutions: string[] = [];

--- a/tests/blackbox/utils/sleep.ts
+++ b/tests/blackbox/utils/sleep.ts
@@ -7,18 +7,22 @@ export function sleep(ms: number) {
 }
 
 export function delayedSleep(ms: number) {
-	let sleepIsRunning = false;
+	let isRunning = false;
 	let resolve: (value?: unknown) => void;
 
 	const sleep = new Promise((r) => {
 		resolve = r;
 	});
 
+	const sleepIsRunning = () => {
+		return isRunning;
+	};
+
 	const sleepStart = () => {
-		sleepIsRunning = true;
+		isRunning = true;
 
 		const timeout = setTimeout(() => {
-			sleepIsRunning = false;
+			isRunning = false;
 			resolve();
 		}, ms);
 

--- a/tests/blackbox/utils/sleep.ts
+++ b/tests/blackbox/utils/sleep.ts
@@ -8,25 +8,29 @@ export function sleep(ms: number) {
 
 export function delayedSleep(ms: number) {
 	let isRunning = false;
+	let done = false;
 	let resolve: (value?: unknown) => void;
 
 	const sleep = new Promise((r) => {
 		resolve = r;
 	});
 
-	const sleepIsRunning = () => {
-		return isRunning;
-	};
-
 	const sleepStart = () => {
+		if (done) {
+			return;
+		}
+
 		isRunning = true;
 
-		const timeout = setTimeout(() => {
+		setTimeout(() => {
 			isRunning = false;
+			done = true;
 			resolve();
 		}, ms);
+	};
 
-		timeout.unref();
+	const sleepIsRunning = () => {
+		return isRunning;
 	};
 
 	return { sleep, sleepStart, sleepIsRunning };

--- a/tests/blackbox/utils/sleep.ts
+++ b/tests/blackbox/utils/sleep.ts
@@ -5,3 +5,25 @@ export function sleep(ms: number) {
 		}, ms);
 	});
 }
+
+export function delayedSleep(ms: number) {
+	let sleepIsRunning = false;
+	let resolve: (value?: unknown) => void;
+
+	const sleep = new Promise((r) => {
+		resolve = r;
+	});
+
+	const sleepStart = () => {
+		sleepIsRunning = true;
+
+		const timeout = setTimeout(() => {
+			sleepIsRunning = false;
+			resolve();
+		}, ms);
+
+		timeout.unref();
+	};
+
+	return { sleep, sleepStart, sleepIsRunning };
+}


### PR DESCRIPTION
Lately, the "Schedule Hook" test has failed quite often. Assuming this happens when the GH runners are under high load, this an attempt to increase stability of the test by making it less load dependent (working with "log" instead of "create item" operation, removing the DB factor).

<img width="1076" src="https://github.com/directus/directus/assets/5363448/3a7c75b1-7a15-44a9-a38d-afe9494ab43e">
