### PR TITLE
Fix `@directus/types` dependency in SDK

### DIFF
--- a/.changeset/fresh-carrots-deny.md
+++ b/.changeset/fresh-carrots-deny.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Marked `@directus/types` as a dependency of the SDK

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1832,13 +1832,14 @@ importers:
         version: 0.31.1(happy-dom@9.18.3)(sass@1.62.1)
 
   sdk:
+    dependencies:
+      '@directus/types':
+        specifier: workspace:*
+        version: link:../packages/types
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
         version: link:../packages/tsconfig
-      '@directus/types':
-        specifier: workspace:*
-        version: link:../packages/types
       '@types/node-fetch':
         specifier: 2.6.4
         version: 2.6.4

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -46,9 +46,11 @@
 		"dev": "NODE_ENV=development tsup",
 		"test": "vitest --watch=false"
 	},
+	"dependencies": {
+		"@directus/types": "workspace:*"
+	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
-		"@directus/types": "workspace:*",
 		"@types/node-fetch": "2.6.4",
 		"@vitest/coverage-c8": "0.31.1",
 		"tsup": "7.1.0",

--- a/sdk/tsup.config.js
+++ b/sdk/tsup.config.js
@@ -9,7 +9,6 @@ export default defineConfig(() => ({
 	format: ['cjs', 'esm'], // generate cjs and esm files
 	minify: env === 'production',
 	bundle: env === 'production',
-	skipNodeModulesBundle: true,
 	watch: env === 'development',
 	target: 'es2020',
 	entry: [


### PR DESCRIPTION
Fixes #19260

Another solution _could_ be to bundle `@directus/types` so the SDK would be dependency free, but that would require the `respectExternal` option from `rollup-plugin-dts` being exposed to `tsup`, see https://github.com/Swatinem/rollup-plugin-dts#what-to-expect & https://github.com/egoist/tsup/pull/827.