### PR TITLE
Delay retrieving context for conditions

### DIFF
--- a/.changeset/spotty-pans-kick.md
+++ b/.changeset/spotty-pans-kick.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Resolved browser freeze in field conditions by delaying the retrieving of field context 

--- a/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
+++ b/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
@@ -40,7 +40,7 @@ const props = defineProps<{
 	interface?: string;
 	collection?: string;
 	disabled?: boolean;
-	context?: ExtensionOptionsContext;
+	context?: () => ExtensionOptionsContext;
 }>();
 
 const emit = defineEmits<{
@@ -76,7 +76,7 @@ const optionsFields = computed(() => {
 
 	if (typeof selectedInterface.value.options === 'function') {
 		optionsObjectOrArray = selectedInterface.value.options(
-			props.context ?? {
+			props.context?.() ?? {
 				field: {
 					type: 'unknown',
 				},

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -92,7 +92,7 @@ const repeaterFields = computed<DeepPartial<Field>[]>(() => [
 			interface: 'system-interface-options',
 			options: {
 				interface: interfaceId.value,
-				context: fieldDetailStore,
+				context: useFieldDetailStore,
 			},
 		},
 	},


### PR DESCRIPTION
Fixes #19259

In the production build of the app the browser freezed when the context of field store was retrieved and then passed to the system interface options component. Passing the function instead and do the retrieving in the interface component itself fixes the issue.