### PR TITLE
Update Docs Config For SSO Example Link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -60,3 +60,4 @@
 - juliuste
 - amerkay
 - be7DOTis
+- BlackDahlia313

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -631,13 +631,12 @@ function sidebar() {
 					text: 'CLI',
 				},
 				{
-                    			text: 'Single Sign-On (SSO)',
-                    			items: [
-                        			{ link: '/self-hosted/sso', text: 'Quickstart' },
-                        			{ link: '/contributing/sso-examples', text: 'SSO Examples' },
-
-                    				],
-                		},
+					text: 'Single Sign-On (SSO)',
+					items: [
+						{ link: '/self-hosted/sso', text: 'Quickstart' },
+						{ link: '/contributing/sso-examples', text: 'SSO Examples' },
+					],
+				},
 				{
 					type: 'page',
 					link: '/self-hosted/upgrades-migrations',

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -629,11 +629,14 @@ function sidebar() {
 				{
 					link: '/self-hosted/cli',
 					text: 'CLI',
-				},
 				{
-					link: '/self-hosted/sso',
-					text: 'Single Sign-On (SSO)',
-				},
+                    			text: 'Single Sign-On (SSO)',
+                    			items: [
+                        			{ link: '/self-hosted/sso', text: 'Quickstart' },
+                        			{ link: '/contributing/sso-examples', text: 'SSO Examples' },
+
+                    				],
+                		},
 				{
 					type: 'page',
 					link: '/self-hosted/upgrades-migrations',

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -629,6 +629,7 @@ function sidebar() {
 				{
 					link: '/self-hosted/cli',
 					text: 'CLI',
+				},
 				{
                     			text: 'Single Sign-On (SSO)',
                     			items: [


### PR DESCRIPTION
Just a small update to the docs that will show SSO examples as a sidebar item for SSO documentation. 