### PR TITLE
Enable usage of `Home` and `End` keys in input fields

### DIFF
--- a/.changeset/friendly-mails-lick.md
+++ b/.changeset/friendly-mails-lick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Enable Home and End keys do in all inputs

--- a/.changeset/friendly-mails-lick.md
+++ b/.changeset/friendly-mails-lick.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Enable Home and End keys do in all inputs
+Enabled usage of `Home` and `End` keys in input fields

--- a/app/src/composables/use-shortcut.ts
+++ b/app/src/composables/use-shortcut.ts
@@ -7,7 +7,7 @@ export const keyMap: Record<string, string> = {
 	Command: 'meta',
 };
 
-export const systemKeys = ['meta', 'shift', 'alt', 'backspace', 'delete', 'tab', 'capslock', 'enter'];
+export const systemKeys = ['meta', 'shift', 'alt', 'backspace', 'delete', 'tab', 'capslock', 'enter', 'home', 'end'];
 
 const keysDown: Set<string> = new Set([]);
 const handlers: Record<string, ShortcutHandler[]> = {};


### PR DESCRIPTION
Fixes: #19097 

Demo: https://www.loom.com/share/c04c9bac651b4c3f9140daffeff815e2?sid=f585d188-9e08-4949-a7ba-20e3cee5bd46

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
