### PR TITLE
Request output parsing improvement for the SDK

### DIFF
--- a/.changeset/warm-owls-sleep.md
+++ b/.changeset/warm-owls-sleep.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Improved request output parsing for the SDK

--- a/sdk/src/rest/commands/auth/logout.ts
+++ b/sdk/src/rest/commands/auth/logout.ts
@@ -13,5 +13,4 @@ export const logout =
 		path: '/auth/logout',
 		method: 'POST',
 		body: JSON.stringify({ refresh_token }),
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/auth/password-request.ts
+++ b/sdk/src/rest/commands/auth/password-request.ts
@@ -14,5 +14,4 @@ export const passwordRequest =
 		path: '/auth/password/request',
 		method: 'POST',
 		body: JSON.stringify({ email, ...(reset_url ? { reset_url } : {}) }),
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/auth/password-reset.ts
+++ b/sdk/src/rest/commands/auth/password-reset.ts
@@ -14,5 +14,4 @@ export const passwordReset =
 		path: '/auth/password/reset',
 		method: 'POST',
 		body: JSON.stringify({ token, password }),
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/activity.ts
+++ b/sdk/src/rest/commands/delete/activity.ts
@@ -11,5 +11,4 @@ export const deleteComment =
 	() => ({
 		path: `/activity/comment/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/collections.ts
+++ b/sdk/src/rest/commands/delete/collections.ts
@@ -11,5 +11,4 @@ export const deleteCollection =
 	() => ({
 		path: `/collections/${collection}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/dashboards.ts
+++ b/sdk/src/rest/commands/delete/dashboards.ts
@@ -12,7 +12,6 @@ export const deleteDashboards =
 		path: `/dashboards`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteDashboard =
 	() => ({
 		path: `/dashboards/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/fields.ts
+++ b/sdk/src/rest/commands/delete/fields.ts
@@ -15,5 +15,4 @@ export const deleteField =
 	() => ({
 		path: `/fields/${collection}/${field}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/files.ts
+++ b/sdk/src/rest/commands/delete/files.ts
@@ -12,7 +12,6 @@ export const deleteFiles =
 		path: `/files`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteFile =
 	() => ({
 		path: `/files/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/flows.ts
+++ b/sdk/src/rest/commands/delete/flows.ts
@@ -12,7 +12,6 @@ export const deleteFlows =
 		path: `/flows`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteFlow =
 	() => ({
 		path: `/flows/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/folders.ts
+++ b/sdk/src/rest/commands/delete/folders.ts
@@ -12,7 +12,6 @@ export const deleteFolders =
 		path: `/folders`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteFolder =
 	() => ({
 		path: `/folders/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/items.ts
+++ b/sdk/src/rest/commands/delete/items.ts
@@ -26,7 +26,6 @@ export const deleteItems =
 			path: `/items/${_collection}`,
 			body: JSON.stringify(Array.isArray(keysOrQuery) ? { keys: keysOrQuery } : { query: keysOrQuery }),
 			method: 'DELETE',
-			onResponse: null,
 		};
 	};
 /**
@@ -52,6 +51,5 @@ export const deleteItem =
 		return {
 			path: `/items/${_collection}/${key}`,
 			method: 'DELETE',
-			onResponse: null,
 		};
 	};

--- a/sdk/src/rest/commands/delete/notifications.ts
+++ b/sdk/src/rest/commands/delete/notifications.ts
@@ -12,7 +12,6 @@ export const deleteNotifications =
 		path: `/notifications`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteNotification =
 	() => ({
 		path: `/notifications/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/operations.ts
+++ b/sdk/src/rest/commands/delete/operations.ts
@@ -12,7 +12,6 @@ export const deleteOperations =
 		path: `/operations`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteOperation =
 	() => ({
 		path: `/operations/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/panels.ts
+++ b/sdk/src/rest/commands/delete/panels.ts
@@ -12,7 +12,6 @@ export const deletePanels =
 		path: `/panels`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deletePanel =
 	() => ({
 		path: `/panels/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/permissions.ts
+++ b/sdk/src/rest/commands/delete/permissions.ts
@@ -12,7 +12,6 @@ export const deletePermissions =
 		path: `/permissions`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deletePermission =
 	() => ({
 		path: `/permissions/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/presets.ts
+++ b/sdk/src/rest/commands/delete/presets.ts
@@ -12,7 +12,6 @@ export const deletePresets =
 		path: `/presets`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deletePreset =
 	() => ({
 		path: `/presets/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/relations.ts
+++ b/sdk/src/rest/commands/delete/relations.ts
@@ -15,5 +15,4 @@ export const deleteRelation =
 	() => ({
 		path: `/relations/${collection}/${field}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/roles.ts
+++ b/sdk/src/rest/commands/delete/roles.ts
@@ -12,7 +12,6 @@ export const deleteRoles =
 		path: `/roles`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteRole =
 	() => ({
 		path: `/roles/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/shares.ts
+++ b/sdk/src/rest/commands/delete/shares.ts
@@ -12,7 +12,6 @@ export const deleteShares =
 		path: `/shares`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteShare =
 	() => ({
 		path: `/shares/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/translations.ts
+++ b/sdk/src/rest/commands/delete/translations.ts
@@ -12,7 +12,6 @@ export const deleteTranslations =
 		path: `/translations`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteTranslation =
 	() => ({
 		path: `/translations/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/users.ts
+++ b/sdk/src/rest/commands/delete/users.ts
@@ -14,7 +14,6 @@ export const deleteUsers =
 		path: `/users`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -29,5 +28,4 @@ export const deleteUser =
 	() => ({
 		path: `/users/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/delete/webhooks.ts
+++ b/sdk/src/rest/commands/delete/webhooks.ts
@@ -12,7 +12,6 @@ export const deleteWebhooks =
 		path: `/webhooks`,
 		body: JSON.stringify(keys),
 		method: 'DELETE',
-		onResponse: null,
 	});
 
 /**
@@ -25,5 +24,4 @@ export const deleteWebhook =
 	() => ({
 		path: `/webhooks/${key}`,
 		method: 'DELETE',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/schema/apply.ts
+++ b/sdk/src/rest/commands/schema/apply.ts
@@ -12,5 +12,4 @@ export const schemaApply =
 		method: 'POST',
 		path: '/schema/apply',
 		body: JSON.stringify(diff),
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/server/graphql.ts
+++ b/sdk/src/rest/commands/server/graphql.ts
@@ -9,5 +9,4 @@ export const readGraphqlSdl =
 	() => ({
 		method: 'GET',
 		path: scope === 'item' ? '/server/specs/graphql' : '/server/specs/graphql/system',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/server/info.ts
+++ b/sdk/src/rest/commands/server/info.ts
@@ -53,5 +53,4 @@ export const serverInfo =
 	() => ({
 		method: 'GET',
 		path: '/server/info',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/server/ping.ts
+++ b/sdk/src/rest/commands/server/ping.ts
@@ -9,5 +9,4 @@ export const serverPing =
 	() => ({
 		method: 'GET',
 		path: '/server/ping',
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/utils/cache.ts
+++ b/sdk/src/rest/commands/utils/cache.ts
@@ -9,5 +9,4 @@ export const clearCache =
 	() => ({
 		method: 'POST',
 		path: `/utils/cache/clear`,
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/utils/export.ts
+++ b/sdk/src/rest/commands/utils/export.ts
@@ -19,5 +19,4 @@ export const utilsExport =
 		method: 'POST',
 		path: `/utils/export/${collection as string}`,
 		body: JSON.stringify({ format, query, file }),
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/utils/import.ts
+++ b/sdk/src/rest/commands/utils/import.ts
@@ -10,6 +10,5 @@ export const utilsImport =
 		path: `/utils/import/${collection as string}`,
 		method: 'POST',
 		body: data,
-		onResponse: null,
 		headers: { 'Content-Type': 'multipart/form-data' },
 	});

--- a/sdk/src/rest/commands/utils/shares.ts
+++ b/sdk/src/rest/commands/utils/shares.ts
@@ -40,7 +40,6 @@ export const inviteShare =
 		path: `/shares/invite`,
 		method: 'POST',
 		body: JSON.stringify({ share, emails }),
-		onResponse: null,
 	});
 
 /**

--- a/sdk/src/rest/commands/utils/sort.ts
+++ b/sdk/src/rest/commands/utils/sort.ts
@@ -10,5 +10,4 @@ export const utilitySort =
 		method: 'POST',
 		path: `/utils/sort/${collection as string}`,
 		body: JSON.stringify({ item, to }),
-		onResponse: null,
 	});

--- a/sdk/src/rest/commands/utils/users.ts
+++ b/sdk/src/rest/commands/utils/users.ts
@@ -19,7 +19,6 @@ export const inviteUser =
 			role,
 			...(invite_url ? { invite_url } : {}),
 		}),
-		onResponse: null,
 	});
 
 /**
@@ -39,7 +38,6 @@ export const acceptUserInvite =
 			token,
 			password,
 		}),
-		onResponse: null,
 	});
 
 /**
@@ -76,7 +74,6 @@ export const enableTwoFactor =
 			secret,
 			otp,
 		}),
-		onResponse: null,
 	});
 
 /**
@@ -92,5 +89,4 @@ export const disableTwoFactor =
 		path: `/users/me/tfa/disable`,
 		method: 'POST',
 		body: JSON.stringify({ otp }),
-		onResponse: null,
 	});

--- a/sdk/src/types/request.ts
+++ b/sdk/src/types/request.ts
@@ -7,7 +7,7 @@ export interface RequestOptions {
 	headers?: Record<string, string>;
 	body?: string | FormData;
 	onRequest?: RequestTransformer;
-	onResponse?: ResponseTransformer | null;
+	onResponse?: ResponseTransformer;
 }
 
 export interface RequestTransformer {


### PR DESCRIPTION
Instead of relying on hardcoded "expected result" output formatting make use of the `content-type` response header to appropriately parse results dynamically.