### PR TITLE
:scroll: fix typo : missing tag closing sign

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -62,3 +62,4 @@
 - be7DOTis
 - BlackDahlia313
 - belov38
+- NebojsaKrtolica

--- a/docs/app/flows/operations.md
+++ b/docs/app/flows/operations.md
@@ -359,7 +359,7 @@ This operation makes a request to another URL.
 
 **Payload**
 
-When an operation completes successfully, the `response` is appended under its `<operationKey`.
+When an operation completes successfully, the `response` is appended under its `<operationKey>`.
 
 ## Sleep
 


### PR DESCRIPTION
Hi!

Just a fix for a typo in the docs, currently to be seen [here](https://docs.directus.io/app/flows/operations.html#webhook-request-url:~:text=appended%20under%20its-,%3CoperationKey,-.)

Please accept this humble pull request 🍀 