### PR TITLE
Allow to pass type to `useItem` & fix `User` type

### DIFF
--- a/.changeset/wild-flowers-occur.md
+++ b/.changeset/wild-flowers-occur.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/types": patch
+---
+
+Improved types for `User` & fixed bug with user detail page not displaying for users not associated to a role

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -17,7 +17,7 @@ import { mergeWith } from 'lodash';
 import { ComputedRef, Ref, computed, isRef, ref, unref, watch } from 'vue';
 import { usePermissions } from './use-permissions';
 
-type UsableItem<T> = {
+type UsableItem<T extends Record<string, any>> = {
 	edits: Ref<Record<string, any>>;
 	hasEdits: Ref<boolean>;
 	item: Ref<T | null>;

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -43,7 +43,7 @@ export function useItem<T extends Record<string, any>>(
 	query: Ref<Query> | Query = {}
 ): UsableItem<T> {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
-	const item = ref<Record<string, any> | null>(null);
+	const item: Ref<T | null> = ref(null);
 	const error = ref<any>(null);
 	const validationErrors = ref<any[]>([]);
 	const loading = ref(false);

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -82,8 +82,6 @@ export function useItem<T extends Record<string, any>>(
 	return {
 		edits,
 		hasEdits,
-		// TODO Find way to fix warning:
-		// 'T' could be instantiated with a different subtype of constraint 'Record<string, any>'
 		item,
 		error,
 		loading,
@@ -124,7 +122,7 @@ export function useItem<T extends Record<string, any>>(
 			defaultValues.value,
 			item.value,
 			edits.value,
-			function (from: any, to: any) {
+			function (_from: any, to: any) {
 				if (typeof to !== 'undefined') {
 					return to;
 				}
@@ -325,7 +323,10 @@ export function useItem<T extends Record<string, any>>(
 
 				for (const col of columns) {
 					const colName = col.split('.')[1];
-					item[colName] = updatedItem[colName];
+
+					if (colName !== undefined) {
+						item[colName] = updatedItem[colName];
+					}
 				}
 			}
 		}
@@ -396,7 +397,7 @@ export function useItem<T extends Record<string, any>>(
 			});
 
 			item.value = {
-				...item.value,
+				...(item.value as T),
 				[field]: value,
 			};
 

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -17,10 +17,10 @@ import { mergeWith } from 'lodash';
 import { ComputedRef, Ref, computed, isRef, ref, unref, watch } from 'vue';
 import { usePermissions } from './use-permissions';
 
-type UsableItem = {
+type UsableItem<T> = {
 	edits: Ref<Record<string, any>>;
 	hasEdits: Ref<boolean>;
-	item: Ref<Record<string, any> | null>;
+	item: Ref<T | null>;
 	error: Ref<any>;
 	loading: Ref<boolean>;
 	saving: Ref<boolean>;
@@ -37,11 +37,11 @@ type UsableItem = {
 	validationErrors: Ref<any[]>;
 };
 
-export function useItem(
+export function useItem<T extends Record<string, any>>(
 	collection: Ref<string>,
 	primaryKey: Ref<string | number | null>,
 	query: Ref<Query> | Query = {}
-): UsableItem {
+): UsableItem<T> {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 	const item = ref<Record<string, any> | null>(null);
 	const error = ref<any>(null);
@@ -82,6 +82,8 @@ export function useItem(
 	return {
 		edits,
 		hasEdits,
+		// TODO Find way to fix warning:
+		// 'T' could be instantiated with a different subtype of constraint 'Record<string, any>'
 		item,
 		error,
 		loading,

--- a/app/src/modules/users/components/user-info-sidebar-detail.vue
+++ b/app/src/modules/users/components/user-info-sidebar-detail.vue
@@ -23,18 +23,6 @@
 				<dt>{{ t('last_access') }}</dt>
 				<dd>{{ lastAccessDate }}</dd>
 			</div>
-			<div v-if="user.created_on">
-				<dt>{{ t('created_on') }}</dt>
-				<dd>{{ user.created_on }}</dd>
-			</div>
-			<div v-if="user.created_by">
-				<dt>{{ t('created_by') }}</dt>
-				<dd>{{ user.created_by }}</dd>
-			</div>
-			<div v-if="user.modified_on">
-				<dt>{{ t('modified_on') }}</dt>
-				<dd>{{ user.modified_on }}</dd>
-			</div>
 		</dl>
 
 		<v-divider />
@@ -46,11 +34,12 @@
 <script setup lang="ts">
 import { useClipboard } from '@/composables/use-clipboard';
 import { localizedFormat } from '@/utils/localized-format';
+import type { User } from '@directus/types';
 import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-	user?: Record<string, any>;
+	user: User | null;
 	isNew?: boolean;
 }>();
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -98,7 +98,7 @@
 		</template>
 
 		<template #navigation>
-			<users-navigation :current-role="item?.role.id || role" />
+			<users-navigation :current-role="item?.role?.id ?? role" />
 		</template>
 
 		<div class="user-item">
@@ -132,7 +132,7 @@
 							<v-icon name="place" small />
 							{{ item.location }}
 						</div>
-						<v-chip v-if="item.role.name" :class="item.status" small>{{ item.role.name }}</v-chip>
+						<v-chip v-if="item.role?.name" :class="item.status" small>{{ item.role.name }}</v-chip>
 					</template>
 				</div>
 			</div>
@@ -192,7 +192,7 @@ import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-d
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
 import { useCollection } from '@directus/composables';
-import { Field } from '@directus/types';
+import type { Field, User } from '@directus/types';
 import { computed, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
@@ -237,7 +237,7 @@ const {
 	isArchived,
 	validationErrors,
 	refresh,
-} = useItem(
+} = useItem<User>(
 	ref('directus_users'),
 	primaryKey,
 	props.primaryKey !== '+'
@@ -247,7 +247,7 @@ const {
 		: undefined
 );
 
-const user = computed(() => ({ ...item.value, role: item.value?.role.id }));
+const user = computed(() => ({ ...item.value, role: item.value?.role?.id }));
 
 if (props.role) {
 	edits.value = {

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -14,27 +14,27 @@ export type Avatar = {
 	id: string;
 };
 
-// There's more data returned in thumbnails and the avatar data, but we
-// only care about the thumbnails in this context
-
 export type User = {
 	id: string;
-	status: string;
-	first_name: string;
-	last_name: string;
-	email: string;
-	token: string;
-	last_login: string;
-	last_page: string;
-	external_id: string;
-	tfa_secret: string;
-	theme: 'auto' | 'dark' | 'light';
-	role: Role;
-	password_reset_token: string | null;
-	timezone: string;
+	status: 'draft' | 'invited' | 'active' | 'suspended' | 'archived';
+	first_name: string | null;
+	last_name: string | null;
+	email: string | null;
+	password: string | null;
+	token: string | null;
+	last_access: string | null;
+	last_page: string | null;
+	external_identifier: string | null;
+	tfa_secret: string | null;
+	auth_data: Record<string, any> | null;
+	provider: string;
+	theme: string | null;
+	role: Role | null;
 	language: string | null;
-	avatar: null | Avatar;
-	company: string | null;
+	avatar: Avatar | null;
 	title: string | null;
+	description: string | null;
+	location: string | null;
+	tags: string[] | null;
 	email_notifications: boolean;
 };


### PR DESCRIPTION
- More accurate types would have prevented this regression introduced in #19257 in the first place, therefore this PR intends to improve accuracy by enabling to pass types to `useItem`
- Type of `User` was pretty outdated

Account for users with no role associated, fixes #19303
