### PR TITLE
New "Create Default" Modal and "Create Bookmark" Modal Upgrades

### DIFF
--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -214,7 +214,7 @@ export function usePreset(
 			...localPreset.value,
 			...overrides,
 		};
-//create_default: Create Default
+
 		if (data.id) delete data.id;
 
 		return await savePreset(data);

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -62,7 +62,7 @@ export function usePreset(
 
 		localPreset.value = {
 			...localPreset.value,
-			id: updatedValues.id
+			id: updatedValues.id,
 		};
 
 		bookmarkSaved.value = true;
@@ -182,7 +182,7 @@ export function usePreset(
 		busy,
 		clearLocalSave,
 		localPreset,
-		saveCurrentAsDefault
+		saveCurrentAsDefault,
 	};
 
 	/**
@@ -210,10 +210,10 @@ export function usePreset(
 
 	function initLocalPreset() {
 		if (bookmarkExists.value) {
-			return localPreset.value =  presetsStore.getBookmark(Number(bookmark.value))!;
+			return (localPreset.value = presetsStore.getBookmark(Number(bookmark.value))!);
 		}
 
-		return localPreset.value =  presetsStore.getPresetForCollection(collection.value)!;
+		return (localPreset.value = presetsStore.getPresetForCollection(collection.value)!);
 	}
 
 	/**
@@ -314,7 +314,7 @@ export function usePreset(
 			});
 		}
 
-		if(filterOptions.length > 0) {
+		if (filterOptions.length > 0) {
 			// if we need to delete presets, we need to get their keys
 
 			const response = await api.get(`/presets`, {
@@ -328,9 +328,9 @@ export function usePreset(
 						},
 						_or: filterOptions,
 					},
-					fields: ['id']
-				}
-			})
+					fields: ['id'],
+				},
+			});
 
 			const keys = response.data.data.map((preset: any) => preset.id);
 
@@ -340,6 +340,6 @@ export function usePreset(
 		return await saveCurrentAsPreset({
 			user: defaultPreset.user,
 			role: defaultPreset.role,
-		})
+		});
 	}
 }

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -15,7 +15,7 @@ type UsablePreset = {
 	search: Ref<string | null>;
 	refreshInterval: Ref<number | null>;
 	savePreset: (preset?: Partial<Preset> | undefined) => Promise<any>;
-	saveCurrentAsBookmark: (overrides: Partial<Preset>) => Promise<any>;
+	saveCurrentAsPreset: (overrides: Partial<Preset>) => Promise<any>;
 	bookmarkTitle: Ref<string | null>;
 	resetPreset: () => Promise<void>;
 	bookmarkSaved: Ref<boolean>;
@@ -60,8 +60,7 @@ export function usePreset(
 
 		localPreset.value = {
 			...localPreset.value,
-			id: updatedValues.id,
-			user: updatedValues.user,
+			id: updatedValues.id
 		};
 
 		bookmarkSaved.value = true;
@@ -156,7 +155,7 @@ export function usePreset(
 		search,
 		refreshInterval,
 		savePreset,
-		saveCurrentAsBookmark,
+		saveCurrentAsPreset,
 		bookmarkTitle,
 		resetPreset,
 		bookmarkSaved,
@@ -190,7 +189,7 @@ export function usePreset(
 	}
 
 	function initLocalPreset() {
-		const preset = { layout: 'tabular' };
+		const preset = { layout: 'tabular', user: (userStore.currentUser as User).id };
 
 		if (bookmark.value === null) {
 			assign(preset, presetsStore.getPresetForCollection(collection.value));
@@ -202,23 +201,21 @@ export function usePreset(
 	}
 
 	/**
-	 * Saves the current state of localPreset as a bookmark. The parameter allows you to override
+	 * Saves the current state of localPreset as a preset. The parameter allows you to override
 	 * any of the values of the collection preset on save.
 	 *
-	 * This will set the user of the bookmark to the current user, and is therefore only meant to be
-	 * used to create bookmarks for yourself.
+	 * This will no longer automatically set the user, that logic has been moved into
+	 * useBookmark so this function can be used for useDefault as well.
 	 *
 	 * @param overrides Individual overrides for the collection preset
 	 */
-	async function saveCurrentAsBookmark(overrides: Partial<Preset>) {
+	async function saveCurrentAsPreset(overrides: Partial<Preset>) {
 		const data = {
 			...localPreset.value,
 			...overrides,
 		};
-
+//create_default: Create Default
 		if (data.id) delete data.id;
-
-		data.user = (userStore.currentUser as User).id;
 
 		return await savePreset(data);
 	}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -648,6 +648,13 @@ cannot_edit_global_bookmarks: Can't Edit Global Bookmarks
 bookmarks: Bookmarks
 presets: Presets
 create_default: Create Default
+create_default_delete_warning: Are you sure you want to delete existing presets? This action can not be undone.
+create_default_options:
+  all_users: Delete All User Presets for this collection
+  all_roles: Delete All Role Presets for this collection
+  all_role_users: Delete All User Presets in Selected Role for this collection
+  all_role: Delete Selected Role Presets for this collection
+  all_user: Delete Selected Users Presets for this collection
 unexpected_error: Unexpected Error
 unexpected_error_copy: An unexpected error has occurred. Please try again later.
 copy_details: Copy Details

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -647,6 +647,7 @@ cannot_edit_role_bookmarks: Can't Edit Role Bookmarks
 cannot_edit_global_bookmarks: Can't Edit Global Bookmarks
 bookmarks: Bookmarks
 presets: Presets
+create_default: Create Default
 unexpected_error: Unexpected Error
 unexpected_error_copy: An unexpected error has occurred. Please try again later.
 copy_details: Copy Details

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -80,6 +80,20 @@
 						@click="clearLocalSave"
 					/>
 				</div>
+				<div class="bookmark-controls">
+					<default-add
+						v-if="!bookmark"
+						v-model="defaultDialogActive"
+						class="add"
+						:saving="creatingDefault"
+						@save="createDefault"
+					>
+						<template #activator="{ on }">
+							<v-icon v-tooltip.right="t('create_default')" class="toggle" clickable name="star" @click="on" />
+						</template>
+					</default-add>
+
+				</div>
 			</template>
 
 			<template #actions:prepend>
@@ -280,6 +294,7 @@ import { useUserStore } from '@/stores/user';
 import { unexpectedError } from '@/utils/unexpected-error';
 import ArchiveSidebarDetail from '@/views/private/components/archive-sidebar-detail.vue';
 import BookmarkAdd from '@/views/private/components/bookmark-add.vue';
+import DefaultAdd from '@/views/private/components/default-add.vue';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import ExportSidebarDetail from '@/views/private/components/export-sidebar-detail.vue';
 import FlowSidebarDetail from '@/views/private/components/flow-sidebar-detail.vue';
@@ -329,7 +344,7 @@ const {
 	search,
 	savePreset,
 	bookmarkExists,
-	saveCurrentAsBookmark,
+	saveCurrentAsPreset,
 	bookmarkTitle,
 	resetPreset,
 	bookmarkSaved,
@@ -353,6 +368,8 @@ const {
 } = useBatch();
 
 const { bookmarkDialogActive, creatingBookmark, createBookmark } = useBookmarks();
+
+const { defaultDialogActive, creatingDefault, createDefault } = useDefaults();
 
 const currentLayout = useExtension('layout', layout);
 
@@ -529,10 +546,12 @@ function useBookmarks() {
 		creatingBookmark.value = true;
 
 		try {
-			const newBookmark = await saveCurrentAsBookmark({
+			const newBookmark = await saveCurrentAsPreset({
 				bookmark: bookmark.name,
 				icon: bookmark.icon,
 				color: bookmark.color,
+				user: bookmark.user,
+				role: bookmark.role,
 			});
 
 			router.push(`/content/${newBookmark.collection}?bookmark=${newBookmark.id}`);
@@ -542,6 +561,201 @@ function useBookmarks() {
 			unexpectedError(err);
 		} finally {
 			creatingBookmark.value = false;
+		}
+	}
+}
+
+function useDefaults() {
+	const defaultDialogActive = ref(false);
+	const creatingDefault = ref(false);
+
+	return {
+		defaultDialogActive,
+		creatingDefault,
+		createDefault,
+	};
+
+	function determineDeleteFilters(defaultPreset: any){
+
+		const { user, role, purge } = defaultPreset;
+
+		const filterOptions = [];
+
+		for( const option of purge){
+			switch(option) {
+
+				case 'all_users':
+					// Delete all users presets for this collection
+					filterOptions.push(
+						{
+							_and: [
+								{
+									collection: {
+										_eq: collection
+									}
+								},
+								{
+									user: {
+										_nnull: true
+									}
+								}
+							]
+						}
+					);
+
+					break;
+
+
+				case 'all_roles':
+					// Delete all roles presets for this collection
+					filterOptions.push(
+						{
+							_and: [
+								{
+									collection: {
+										_eq: collection
+									}
+								},
+								{
+									role: {
+										_nnull: true
+									}
+								}
+							]
+						}
+					);
+
+					break;
+				case 'all_role_users':
+					// Delete all user presets for users in this role for this collection
+					filterOptions.push(
+						{
+							_and: [
+								{
+									collection: {
+										_eq: collection
+									}
+								},
+								{
+									user: {
+										role: {
+											_eq: role
+										}
+									}
+								}
+							]
+						}
+					);
+
+					break;
+				case 'all_role':
+					// Delete all role presets for this role for this collection
+					filterOptions.push(
+						{
+							_and: [
+								{
+									collection: {
+										_eq: collection
+									}
+								},
+								{
+									role: {
+										_eq: role
+									}
+								}
+							]
+						}
+					);
+
+					break;
+				case 'all_user':
+					// Delete all user presets for this user for this collection
+					filterOptions.push(
+						{
+							_and: [
+								{
+									collection: {
+										_eq: collection
+									}
+								},
+								{
+									user: {
+										_eq: user
+									}
+								}
+							]
+						}
+					);
+
+					break;
+				default:
+					break;
+			}
+		}
+
+		// If we are creating a new global default, we need to delete all other global defaults.
+		if(!user && !role){
+			filterOptions.push(
+				{
+					_and: [
+						{
+							user: {
+								_null: true
+							}
+						},
+						{
+							role: {
+								_null: true
+							}
+						}
+					]
+				}
+			);
+		}
+
+		if(filterOptions.length > 0){
+			// If we have any filters, we need to only delete presets (not bookmarks) and apply the filters.
+			return {
+				_and : [
+					{
+						bookmark: {
+							_null: true
+						}
+					},
+					{
+						_or: filterOptions
+					}
+				]
+			}
+		}
+
+		return null;
+	}
+
+	async function createDefault(defaultPreset: any) {
+		creatingDefault.value = true;
+
+		try {
+			await saveCurrentAsPreset({
+				user: defaultPreset.user,
+				role: defaultPreset.role,
+			});
+
+			const deleteFilters = determineDeleteFilters(defaultPreset);
+
+			if(deleteFilters){
+				await api.delete(`/presets`, {
+					data: {
+						filter: deleteFilters
+					}
+				});
+			}
+
+			defaultDialogActive.value = false;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			creatingDefault.value = false;
 		}
 	}
 }

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -598,6 +598,7 @@ function discardAndLeave() {
 
 	position: relative;
 	width: 100%;
+	margin-top: 48px;
 	overflow: auto;
 }
 

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -598,7 +598,6 @@ function discardAndLeave() {
 
 	position: relative;
 	width: 100%;
-	margin-top: 48px;
 	overflow: auto;
 }
 

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -202,7 +202,7 @@ export const usePresetsStore = defineStore({
 					const updatedPreset = {
 						...response.data.data,
 						id: id,
-					}
+					};
 
 					if (preset.id === updatedPreset.id) {
 						return updatedPreset;

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -281,30 +281,17 @@ export const usePresetsStore = defineStore({
 		async savePreset(preset: Partial<Preset>) {
 			const userStore = useUserStore();
 			if (userStore.currentUser === null) return null;
-			const { id: userID } = userStore.currentUser;
 
 			// Clone the preset to make sure the future deletes don't affect the original object
 			preset = cloneDeep(preset);
 
 			if (preset.id === undefined || preset.id === null) {
-				return await this.create({
-					...preset,
-					user: userID,
-				});
+				return await this.create(preset);
 			}
 
-			if (preset.user !== userID) {
-				if ('id' in preset) delete preset.id;
-
-				return await this.create({
-					...preset,
-					user: userID,
-				});
-			} else {
-				const id = preset.id;
-				delete preset.id;
-				return await this.update(id, preset);
-			}
+			const id = preset.id;
+			delete preset.id;
+			return await this.update(id, preset);
 		},
 
 		saveLocal(updatedPreset: Preset) {

--- a/app/src/views/private/components/bookmark-add.vue
+++ b/app/src/views/private/components/bookmark-add.vue
@@ -6,28 +6,27 @@
 
 		<v-card>
 			<v-card-title>
-				{{t('create_bookmark')}}
+				{{ t('create_bookmark') }}
 			</v-card-title>
 
 			<v-card-text>
-
-						<div class="fields">
-							<interface-system-input-translated-string
-								:value="bookmarkValue.name"
-								class="full"
-								autofocus
-								trim
-								:placeholder="t('bookmark_name')"
-								@input="bookmarkValue.name = $event"
-								@keyup.enter="$emit('save', bookmarkValue)"
-							/>
-							<interface-select-icon width="half" :value="bookmarkValue.icon" @input="setIcon" />
-							<interface-select-color width="half" :value="bookmarkValue.color" @input="setColor" />
-							<interface-system-scope class="full" :value="bookmarkValue.scope" @input="setScope"  />
-							<small class="full">
-								<p class="type-note">Create a personal, role, or global bookmark.</p>
-							</small>
-						</div>
+				<div class="fields">
+					<interface-system-input-translated-string
+						:value="bookmarkValue.name"
+						class="full"
+						autofocus
+						trim
+						:placeholder="t('bookmark_name')"
+						@input="bookmarkValue.name = $event"
+						@keyup.enter="$emit('save', bookmarkValue)"
+					/>
+					<interface-select-icon width="half" :value="bookmarkValue.icon" @input="setIcon" />
+					<interface-select-color width="half" :value="bookmarkValue.color" @input="setColor" />
+					<interface-system-scope class="full" :value="bookmarkValue.scope" @input="setScope" />
+					<small class="full">
+						<p class="type-note">Create a personal, role, or global bookmark.</p>
+					</small>
+				</div>
 			</v-card-text>
 			<v-card-actions>
 				<v-button secondary @click="cancel">
@@ -58,34 +57,35 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(e: 'save', value: { name: string | null; icon: string | null; color: string | null; user : string | null; role : string | null; }): void;
+	(
+		e: 'save',
+		value: { name: string | null; icon: string | null; color: string | null; user: string | null; role: string | null }
+	): void;
 	(e: 'update:modelValue', value: boolean): void;
 }>();
 
 const { t } = useI18n();
 
 const saveBookmarkValue = computed(() => {
-
-	if (bookmarkValue?.scope?.startsWith('user_')){
+	if (bookmarkValue?.scope?.startsWith('user_')) {
 		return {
 			...bookmarkValue,
 			user: bookmarkValue.scope.replace('user_', ''),
 			role: null,
-		}
-	} else if (bookmarkValue?.scope?.startsWith('role_')){
+		};
+	} else if (bookmarkValue?.scope?.startsWith('role_')) {
 		return {
 			...bookmarkValue,
 			user: null,
 			role: bookmarkValue.scope.replace('role_', ''),
-		}
+		};
 	} else {
 		return {
 			...bookmarkValue,
 			user: null,
 			role: null,
-		}
+		};
 	}
-
 });
 
 const bookmarkValue = reactive({

--- a/app/src/views/private/components/bookmark-add.vue
+++ b/app/src/views/private/components/bookmark-add.vue
@@ -6,7 +6,7 @@
 
 		<v-card>
 			<v-card-title>
-				Create Bookmark or Default
+				{{t('create_bookmark')}}
 			</v-card-title>
 
 			<v-card-text>

--- a/app/src/views/private/components/bookmark-add.vue
+++ b/app/src/views/private/components/bookmark-add.vue
@@ -64,13 +64,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-interface bookmarkValue {
-	name: string | null;
-	icon: string | null;
-	color: string | null;
-	scope: string | null;
-}
-
 const saveBookmarkValue = computed(() => {
 
 	if (bookmarkValue?.scope?.startsWith('user_')){
@@ -100,7 +93,7 @@ const bookmarkValue = reactive({
 	icon: 'bookmark',
 	color: null,
 	scope: currentUser ? `user_${currentUser.id}` : 'all',
-}) as bookmarkValue;
+});
 
 function setIcon(icon: any) {
 	bookmarkValue.icon = icon;
@@ -115,7 +108,7 @@ function setScope(scope: any) {
 }
 
 function cancel() {
-	bookmarkValue.name = null;
+	bookmarkValue.name = 'My Bookmark';
 	bookmarkValue.icon = 'bookmark';
 	bookmarkValue.color = null;
 	bookmarkValue.scope = currentUser ? `user_${currentUser.id}` : 'all';
@@ -132,26 +125,5 @@ function cancel() {
 	.full {
 		grid-column: 1 / span 2;
 	}
-}
-
-.bookmark-tabs {
-	width: 100%;
-	background-color: var(--background-normal-alt);
-	padding: 8px;
-	border-radius: var(--border-radius);
-	gap: 12px;
-}
-
-.bookmark-tab {
-	color: var(--foreground-normal) !important;
-	border-radius: var(--border-radius) !important;
-	height: 56px !important;
-}
-
-.bookmark-tab.active {
-	color: var(--white) !important;
-	background-color: var(--primary) !important;
-	box-shadow: 0 0 16px -8px var(--v-input-box-shadow-color-focus) !important;
-	font-weight: 600 !important;
 }
 </style>

--- a/app/src/views/private/components/default-add.vue
+++ b/app/src/views/private/components/default-add.vue
@@ -31,6 +31,10 @@
 								<p class="type-note">Deleting existing presets allows you to override users/roles current presets.</p>
 							</small>
 
+							<v-notice v-if="bookmarkValue.purge.length > 0" class="full" type="danger">
+								{{ t('create_default_delete_warning') }}
+							</v-notice>
+
 						</div>
 
 			</v-card-text>
@@ -39,8 +43,8 @@
 				<v-button secondary @click="cancel">
 					{{ t('cancel') }}
 				</v-button>
-				<v-button :loading="saving" @click="$emit('save', saveBookmarkValue)">
-					{{ t('save') }}
+				<v-button :loading="saving" :kind="bookmarkValue.purge.length > 0 ? 'danger' : 'normal'" @click="$emit('save', saveBookmarkValue)" >
+					{{ bookmarkValue.purge.length == 0 ? t('save') : 'Save and Delete' }}
 				</v-button>
 			</v-card-actions>
 		</v-card>
@@ -90,7 +94,6 @@ const saveBookmarkValue = computed(() => {
 			purge: bookmarkValue.purge,
 		}
 	}
-
 });
 
 
@@ -99,29 +102,29 @@ const availablePurgeOptions = computed(() => {
 	if(bookmarkValue.scope == "all"){
 		return [
 		{
-			text: 'Delete All User Presets for this collection',
+			text: t('create_default_options.all_users'),
 			value: 'all_users',
 		},
 		{
-			text: 'Delete All Role Presets for this collection',
+			text: t('create_default_options.all_roles'),
 			value: 'all_roles',
 		}
 	];
 	} else if(bookmarkValue.scope.startsWith('role')) {
 		return [
 		{
-			text: 'Delete All User Presets in Selected Role for this collection',
+			text: t('create_default_options.all_role_users'),
 			value: 'all_role_users',
 		},
 		{
-			text: 'Delete Selected Role Presets for this collection',
+			text: t('create_default_options.all_role'),
 			value: 'all_role',
 		},
 	];
 	} else if(bookmarkValue.scope.startsWith('user')) {
 		return [
 		{
-			text: 'Delete Selected Users Presets for this collection',
+			text: t('create_default_options.all_user'),
 			value: 'all_user',
 		}
 	];

--- a/app/src/views/private/components/default-add.vue
+++ b/app/src/views/private/components/default-add.vue
@@ -28,7 +28,7 @@
 							/>
 
 							<small class="full">
-								<p class="type-note">Deleting existing presets allows you to override users/roles current views.</p>
+								<p class="type-note">Deleting existing presets allows you to override users/roles current presets.</p>
 							</small>
 
 						</div>
@@ -93,6 +93,7 @@ const saveBookmarkValue = computed(() => {
 
 });
 
+
 const availablePurgeOptions = computed(() => {
 
 	if(bookmarkValue.scope == "all"){
@@ -130,6 +131,7 @@ const availablePurgeOptions = computed(() => {
 });
 
 function setScope(scope: any) {
+	setPurge([]);
 	bookmarkValue.scope = scope;
 }
 

--- a/app/src/views/private/components/default-add.vue
+++ b/app/src/views/private/components/default-add.vue
@@ -31,7 +31,7 @@
 								<p class="type-note">Deleting existing presets allows you to override users/roles current presets.</p>
 							</small>
 
-							<v-notice v-if="bookmarkValue.purge.length > 0" class="full" type="danger">
+							<v-notice v-if="bookmarkValue.purge.length > 0" class="full" type="warning">
 								{{ t('create_default_delete_warning') }}
 							</v-notice>
 
@@ -43,7 +43,7 @@
 				<v-button secondary @click="cancel">
 					{{ t('cancel') }}
 				</v-button>
-				<v-button :loading="saving" :kind="bookmarkValue.purge.length > 0 ? 'danger' : 'normal'" @click="$emit('save', saveBookmarkValue)" >
+				<v-button :loading="saving" :kind="bookmarkValue.purge.length > 0 ? 'warning' : 'normal'" @click="$emit('save', saveBookmarkValue)" >
 					{{ bookmarkValue.purge.length == 0 ? t('save') : 'Save and Delete' }}
 				</v-button>
 			</v-card-actions>

--- a/app/src/views/private/components/default-add.vue
+++ b/app/src/views/private/components/default-add.vue
@@ -6,44 +6,41 @@
 
 		<v-card>
 			<v-card-title>
-				{{t('create_default')}}
+				{{ t('create_default') }}
 			</v-card-title>
 
 			<v-card-text>
+				<div class="fields">
+					<interface-system-scope class="full" :value="bookmarkValue.scope" @input="setScope" />
 
-						<div class="fields">
+					<v-divider class="full">Delete Existing Presets</v-divider>
 
-							<interface-system-scope class="full" :value="bookmarkValue.scope" @input="setScope"  />
+					<interface-select-multiple-checkbox
+						class="full"
+						:choices="availablePurgeOptions"
+						:value="bookmarkValue.purge"
+						@input="setPurge"
+					/>
 
-							<v-divider   class="full">
-								Delete Existing Presets
-							</v-divider>
+					<small class="full">
+						<p class="type-note">Deleting existing presets allows you to override users/roles current presets.</p>
+					</small>
 
-							<interface-select-multiple-checkbox
-								class="full"
-								:choices="availablePurgeOptions"
-								:value="bookmarkValue.purge"
-								@input="setPurge"
-
-							/>
-
-							<small class="full">
-								<p class="type-note">Deleting existing presets allows you to override users/roles current presets.</p>
-							</small>
-
-							<v-notice v-if="bookmarkValue.purge.length > 0" class="full" type="warning">
-								{{ t('create_default_delete_warning') }}
-							</v-notice>
-
-						</div>
-
+					<v-notice v-if="bookmarkValue.purge.length > 0" class="full" type="warning">
+						{{ t('create_default_delete_warning') }}
+					</v-notice>
+				</div>
 			</v-card-text>
 
 			<v-card-actions>
 				<v-button secondary @click="cancel">
 					{{ t('cancel') }}
 				</v-button>
-				<v-button :loading="saving" :kind="bookmarkValue.purge.length > 0 ? 'warning' : 'normal'" @click="$emit('save', saveBookmarkValue)" >
+				<v-button
+					:loading="saving"
+					:kind="bookmarkValue.purge.length > 0 ? 'warning' : 'normal'"
+					@click="$emit('save', saveBookmarkValue)"
+				>
 					{{ bookmarkValue.purge.length == 0 ? t('save') : 'Save and Delete' }}
 				</v-button>
 			</v-card-actions>
@@ -55,14 +52,13 @@
 import { reactive, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-
 defineProps<{
 	modelValue?: boolean;
 	saving?: boolean;
 }>();
 
 const emit = defineEmits<{
-	(e: 'save', value: { user : string | null; role : string | null; }): void;
+	(e: 'save', value: { user: string | null; role: string | null }): void;
 	(e: 'update:modelValue', value: boolean): void;
 }>();
 
@@ -74,60 +70,57 @@ const bookmarkValue = reactive({
 });
 
 const saveBookmarkValue = computed(() => {
-
-	if (bookmarkValue?.scope?.startsWith('user_')){
+	if (bookmarkValue?.scope?.startsWith('user_')) {
 		return {
 			user: bookmarkValue.scope.replace('user_', ''),
 			role: null,
 			purge: bookmarkValue.purge,
-		}
-	} else if (bookmarkValue?.scope?.startsWith('role_')){
+		};
+	} else if (bookmarkValue?.scope?.startsWith('role_')) {
 		return {
 			user: null,
 			role: bookmarkValue.scope.replace('role_', ''),
 			purge: bookmarkValue.purge,
-		}
+		};
 	} else {
 		return {
 			user: null,
 			role: null,
 			purge: bookmarkValue.purge,
-		}
+		};
 	}
 });
 
-
 const availablePurgeOptions = computed(() => {
-
-	if(bookmarkValue.scope == "all"){
+	if (bookmarkValue.scope == 'all') {
 		return [
-		{
-			text: t('create_default_options.all_users'),
-			value: 'all_users',
-		},
-		{
-			text: t('create_default_options.all_roles'),
-			value: 'all_roles',
-		}
-	];
-	} else if(bookmarkValue.scope.startsWith('role')) {
+			{
+				text: t('create_default_options.all_users'),
+				value: 'all_users',
+			},
+			{
+				text: t('create_default_options.all_roles'),
+				value: 'all_roles',
+			},
+		];
+	} else if (bookmarkValue.scope.startsWith('role')) {
 		return [
-		{
-			text: t('create_default_options.all_role_users'),
-			value: 'all_role_users',
-		},
-		{
-			text: t('create_default_options.all_role'),
-			value: 'all_role',
-		},
-	];
-	} else if(bookmarkValue.scope.startsWith('user')) {
+			{
+				text: t('create_default_options.all_role_users'),
+				value: 'all_role_users',
+			},
+			{
+				text: t('create_default_options.all_role'),
+				value: 'all_role',
+			},
+		];
+	} else if (bookmarkValue.scope.startsWith('user')) {
 		return [
-		{
-			text: t('create_default_options.all_user'),
-			value: 'all_user',
-		}
-	];
+			{
+				text: t('create_default_options.all_user'),
+				value: 'all_user',
+			},
+		];
 	}
 
 	return [];


### PR DESCRIPTION
This PR adds a scope field to **Create Bookmark** and a new **Create Default** modal to create default presets for certain scopes. This new modal also provides options to delete existing users/roles presets so you can easily override users current presets to your new default.

![image](https://github.com/directus/directus/assets/12714889/3b6ab24e-6ed6-4964-b120-25de0eae5ca2)
![image](https://github.com/directus/directus/assets/12714889/150df504-4536-47ce-ab81-b61af8ca93b0)

**TODO**
- [ ] Move bookmark logic to useBookmarks composable
- [ ] Move defaults logic to useDefaults composable
- [ ] Move presets logic that snuck its way into presetStore back to preset composable
- [ ] Ensure that presetStore is agnostic, moving function specific code to their respective composables/components
