### PR TITLE
Add app name to identify session

### DIFF
--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -403,6 +403,7 @@ export function createLDAPAuthRouter(provider: string): Router {
 		password: Joi.string().required(),
 		mode: Joi.string().valid('cookie', 'json'),
 		otp: Joi.string(),
+		app_name: Joi.string(),
 	}).unknown();
 
 	router.post(
@@ -435,6 +436,7 @@ export function createLDAPAuthRouter(provider: string): Router {
 			const { accessToken, refreshToken, expires } = await authenticationService.login(
 				provider,
 				req.body,
+				req.body?.app_name,
 				req.body?.otp
 			);
 

--- a/api/src/auth/drivers/local.ts
+++ b/api/src/auth/drivers/local.ts
@@ -52,6 +52,7 @@ export function createLocalAuthRouter(provider: string): Router {
 		password: Joi.string().required(),
 		mode: Joi.string().valid('cookie', 'json'),
 		otp: Joi.string(),
+		app_name: Joi.string(),
 	}).unknown();
 
 	router.post(
@@ -88,6 +89,7 @@ export function createLocalAuthRouter(provider: string): Router {
 			const { accessToken, refreshToken, expires } = await authenticationService.login(
 				provider,
 				req.body,
+				req.body?.app_name,
 				req.body?.otp
 			);
 

--- a/api/src/database/migrations/20230801A-add-app-name.ts
+++ b/api/src/database/migrations/20230801A-add-app-name.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_sessions', (table) => {
+		table.string('app_name').nullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_sessions', (table) => {
+		table.dropColumn('app_name');
+	});
+}

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -43,6 +43,7 @@ export class AuthenticationService {
 	async login(
 		providerName: string = DEFAULT_AUTH_PROVIDER,
 		payload: Record<string, any>,
+		appName?: string,
 		otp?: string
 	): Promise<LoginResult> {
 		const { nanoid } = await import('nanoid');
@@ -182,6 +183,7 @@ export class AuthenticationService {
 			role: user.role,
 			app_access: user.app_access,
 			admin_access: user.admin_access,
+			app_name: appName,
 		};
 
 		const customClaims = await emitter.emitFilter(
@@ -215,6 +217,7 @@ export class AuthenticationService {
 			ip: this.accountability?.ip,
 			user_agent: this.accountability?.userAgent,
 			origin: this.accountability?.origin,
+			app_name: appName,
 		});
 
 		await this.knex('directus_sessions').delete().where('expires', '<', new Date());
@@ -261,6 +264,7 @@ export class AuthenticationService {
 		const record = await this.knex
 			.select({
 				session_expires: 's.expires',
+				app_name: 's.app_name',
 				user_id: 'u.id',
 				user_first_name: 'u.first_name',
 				user_last_name: 'u.last_name',
@@ -338,6 +342,7 @@ export class AuthenticationService {
 			role: record.role_id,
 			app_access: record.role_app_access,
 			admin_access: record.role_admin_access,
+			app_name: record.app_name,
 		};
 
 		if (record.share_id) {

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -2079,6 +2079,7 @@ export class GraphQLService {
 					password: new GraphQLNonNull(GraphQLString),
 					mode: AuthMode,
 					otp: GraphQLString,
+					app_name: GraphQLString,
 				},
 				resolve: async (_, args, { req, res }) => {
 					const accountability: Accountability = { role: null };
@@ -2096,7 +2097,7 @@ export class GraphQLService {
 						schema: this.schema,
 					});
 
-					const result = await authenticationService.login(DEFAULT_AUTH_PROVIDER, args, args?.otp);
+					const result = await authenticationService.login(DEFAULT_AUTH_PROVIDER, args, args?.app_name, args?.otp);
 
 					if (args['mode'] === 'cookie') {
 						res?.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], result['refreshToken'], {

--- a/api/src/types/auth.ts
+++ b/api/src/types/auth.ts
@@ -39,6 +39,7 @@ export type DirectusTokenPayload = {
 		collection: string;
 		item: string;
 	};
+	app_name?: string;
 };
 
 export type ShareData = {

--- a/api/src/utils/get-accountability-for-token.ts
+++ b/api/src/utils/get-accountability-for-token.ts
@@ -29,6 +29,7 @@ export async function getAccountabilityForToken(
 			if (payload.share) accountability.share = payload.share;
 			if (payload.share_scope) accountability.share_scope = payload.share_scope;
 			if (payload.id) accountability.user = payload.id;
+			if (payload.app_name) accountability.app_name = payload.app_name;
 		} else {
 			// Try finding the user with the provided token
 			const database = getDatabase();

--- a/api/src/utils/jwt.ts
+++ b/api/src/utils/jwt.ts
@@ -23,11 +23,11 @@ export function verifyJWT(token: string, secret: string): Record<string, any> {
 }
 
 export function verifyAccessJWT(token: string, secret: string): DirectusTokenPayload {
-	const { id, role, app_access, admin_access, share, share_scope } = verifyJWT(token, secret);
+	const { id, role, app_access, admin_access, share, share_scope, app_name } = verifyJWT(token, secret);
 
 	if (role === undefined || app_access === undefined || admin_access === undefined) {
 		throw new InvalidTokenError();
 	}
 
-	return { id, role, app_access, admin_access, share, share_scope };
+	return { id, role, app_access, admin_access, share, share_scope, app_name };
 }

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -1,8 +1,7 @@
-import type { Request } from 'express';
-import { getEnv } from '../env.js';
-import { Url } from './url.js';
-import url from 'url';
 import { getEndpoint } from '@directus/utils';
+import type { Request } from 'express';
+import url from 'url';
+import { getEnv } from '../env.js';
 
 /**
  * Whether to skip caching for the current request
@@ -13,18 +12,9 @@ import { getEndpoint } from '@directus/utils';
 export function shouldSkipCache(req: Request): boolean {
 	const env = getEnv();
 
-	// Always skip cache for requests coming from the data studio based on Referer header
-	const referer = req.get('Referer');
-
-	if (referer) {
-		const adminUrl = new Url(env['PUBLIC_URL']).addPath('admin');
-
-		if (adminUrl.isRootRelative()) {
-			const refererUrl = new Url(referer);
-			if (refererUrl.path.join('/').startsWith(adminUrl.path.join('/')) && checkAutoPurge()) return true;
-		} else if (referer.startsWith(adminUrl.toString()) && checkAutoPurge()) {
-			return true;
-		}
+	// Always skip cache for requests coming from the data studio
+	if (req.accountability && req.accountability.app_name === 'directus-data-studio' && checkAutoPurge()) {
+		return true;
 	}
 
 	if (env['CACHE_SKIP_ALLOWED'] && req.get('cache-control')?.includes('no-store')) return true;

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -32,6 +32,7 @@ export async function login({ credentials, provider, share }: LoginParams): Prom
 	const response = await api.post<any>(getAuthEndpoint(provider, share), {
 		...credentials,
 		mode: 'cookie',
+		app_name: 'directus-data-studio',
 	});
 
 	const accessToken = response.data.data.access_token;

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -50,6 +50,7 @@ watch(
 				ssoLoginLink.pathname = `${getRootPath()}auth/login/${provider.name}`;
 
 				const redirectToLink = new URL(window.location.href);
+				redirectToLink.searchParams.set('app_name', 'directus-data-studio');
 				redirectToLink.searchParams.set('continue', '');
 
 				ssoLoginLink.searchParams.set('redirect', redirectToLink.toString());

--- a/packages/types/src/accountability.ts
+++ b/packages/types/src/accountability.ts
@@ -17,4 +17,5 @@ export type Accountability = {
 	ip?: string;
 	userAgent?: string;
 	origin?: string;
+	app_name?: string;
 };


### PR DESCRIPTION
WIP.

An application name can be provided during login which can be accessed in the accountability.

This PR removes the usage of `Referer` header to identify when requests from the data studio. The application name is set as `directus-data-studio` when logging in from the data studio.

A migration is added to add a `app_name` field to `directus_sessions` which is required to retain the `app_name` during token refresh. The `app_name` is not added to `directus_activity` for now as it is not necessary.

Fixes #19166.