### PR TITLE
Disable TinyMCE only after editor has been initialized

### DIFF
--- a/.changeset/old-zoos-relax.md
+++ b/.changeset/old-zoos-relax.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Disabled TinyMCE only after editor has been initialized

--- a/.changeset/old-zoos-relax.md
+++ b/.changeset/old-zoos-relax.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Disabled TinyMCE only after editor has been initialized
+Fixed an issue where the WYSIWYG editor could wrongly end up in read-only mode

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -4,7 +4,7 @@
 			ref="editorElement"
 			v-model="internalValue"
 			:init="editorOptions"
-			:disabled="disabled"
+			:disabled="editorDisabled"
 			model-events="change keydown blur focus paste ExecCommand SetContent"
 			@focusin="setFocus(true)"
 			@focusout="setFocus(false)"
@@ -305,6 +305,14 @@ const internalValue = computed({
 	},
 });
 
+const editorInitialized = ref(false);
+
+const editorDisabled = computed(() => {
+	if (!editorInitialized.value) return false;
+
+	return props.disabled;
+});
+
 watch(
 	() => [props.direction, editorRef],
 	() => {
@@ -429,6 +437,8 @@ function setup(editor: any) {
 		});
 
 		setCount();
+
+		editorInitialized.value = true;
 	});
 
 	editor.on('OpenWindow', function (e: any) {


### PR DESCRIPTION
Closes #19314 by re-evaluating disabled state of TinyMCE editor after it has been initialized.