### PR TITLE
Filter out any non existent fields

### DIFF
--- a/.changeset/short-hairs-beg.md
+++ b/.changeset/short-hairs-beg.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed issue preventing tabular layout from loading when fields are referenced that no longer exist

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -169,13 +169,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			const fields = computed({
 				get() {
 					if (layoutQuery.value?.fields) {
-						return layoutQuery.value.fields.filter(field => fieldsStore.getField(collection.value!, field))
+						return layoutQuery.value.fields.filter((field) => fieldsStore.getField(collection.value!, field));
 					} else {
 						return unref(fieldsDefaultValue);
 					}
 				},
 				set(value) {
-					layoutQuery.value.fields = value
+					layoutQuery.value.fields = value;
 				},
 			});
 

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -168,7 +168,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const fields = computed({
 				get() {
-					console.log('layoutQuery.value.fields', layoutQuery.value.fields)
 					if (layoutQuery.value.fields) {
 						return layoutQuery.value.fields.filter(field => fieldsStore.getField(collection.value!, field))
 					} else {

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -11,7 +11,7 @@ import { useCollection, useItems, useSync } from '@directus/composables';
 import { Field } from '@directus/types';
 import { defineLayout } from '@directus/utils';
 import { debounce } from 'lodash';
-import { computed, ref, toRefs, watch } from 'vue';
+import { computed, ref, toRefs, unref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import TabularActions from './actions.vue';
 import TabularOptions from './options.vue';
@@ -166,7 +166,19 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					.sort();
 			});
 
-			const fields = syncRefProperty(layoutQuery, 'fields', fieldsDefaultValue);
+			const fields = computed({
+				get() {
+					console.log('layoutQuery.value.fields', layoutQuery.value.fields)
+					if (layoutQuery.value.fields) {
+						return layoutQuery.value.fields.filter(field => fieldsStore.getField(collection.value!, field))
+					} else {
+						return unref(fieldsDefaultValue);
+					}
+				},
+				set(value) {
+					layoutQuery.value.fields = value
+				},
+			});
 
 			const fieldsWithRelational = computed(() => {
 				if (!props.collection) return [];

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -168,7 +168,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const fields = computed({
 				get() {
-					if (layoutQuery.value.fields) {
+					if (layoutQuery.value?.fields) {
 						return layoutQuery.value.fields.filter(field => fieldsStore.getField(collection.value!, field))
 					} else {
 						return unref(fieldsDefaultValue);


### PR DESCRIPTION
fixes #18912 

Problem was that we didn't check if a field was non existent anymore causing the layout to crash. Now it gets ignored and fixes itself when you update the tabs again.