### PR TITLE
Add Client_MySQL2 to supported database clients

### DIFF
--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -13,7 +13,7 @@ on:
       - .github/workflows/blackbox-pr.yml
 
 concurrency:
-  group: blackbox-pr-${{ github.ref }}
+  group: blackbox-pr-mysql2-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -21,8 +21,15 @@ env:
 
 jobs:
   test:
-    name: SQLite Only
+    name: ${{ matrix.vendor }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        vendor:
+          - mysql
+          - mysql5
+          - maria
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -30,9 +37,13 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
 
+      - name: Install mysql2
+        run: pnpm --filter api add -O -E mysql2
+
       - name: Start services
         run:
-          docker compose -f tests/blackbox/docker-compose.yml up auth-saml redis minio minio-mc -d --quiet-pull --wait
+          docker compose -f tests/blackbox/docker-compose.yml up ${{ matrix.vendor }} auth-saml redis minio minio-mc -d
+          --quiet-pull --wait
 
       - name: Run tests
-        run: TEST_DB=sqlite3 pnpm run test:blackbox
+        run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -215,6 +215,7 @@ export function getDatabaseClient(database?: Knex): DatabaseClient {
 	database = database ?? getDatabase();
 
 	switch (database.client.constructor.name) {
+		case 'Client_MySQL2':
 		case 'Client_MySQL':
 			return 'mysql';
 		case 'Client_PG':

--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -112,7 +112,7 @@ const config: Config = {
 			...knexConfig,
 		},
 		mysql: {
-			client: 'mysql',
+			client: 'mysql2',
 			connection: {
 				database: 'directus',
 				user: 'root',
@@ -123,7 +123,7 @@ const config: Config = {
 			...knexConfig,
 		},
 		mysql5: {
-			client: 'mysql',
+			client: 'mysql2',
 			connection: {
 				database: 'directus',
 				user: 'root',
@@ -134,7 +134,7 @@ const config: Config = {
 			...knexConfig,
 		},
 		maria: {
-			client: 'mysql',
+			client: 'mysql2',
 			connection: {
 				database: 'directus',
 				user: 'root',
@@ -235,7 +235,7 @@ const config: Config = {
 		},
 		mysql: {
 			...directusConfig,
-			DB_CLIENT: 'mysql',
+			DB_CLIENT: 'mysql2',
 			DB_HOST: `127.0.0.1`,
 			DB_PORT: '6102',
 			DB_USER: 'root',
@@ -245,7 +245,7 @@ const config: Config = {
 		},
 		mysql5: {
 			...directusConfig,
-			DB_CLIENT: 'mysql',
+			DB_CLIENT: 'mysql2',
 			DB_HOST: `127.0.0.1`,
 			DB_PORT: '6103',
 			DB_USER: 'root',
@@ -255,7 +255,7 @@ const config: Config = {
 		},
 		maria: {
 			...directusConfig,
-			DB_CLIENT: 'mysql',
+			DB_CLIENT: 'mysql2',
 			DB_HOST: `localhost`,
 			DB_PORT: '6104',
 			DB_USER: 'root',


### PR DESCRIPTION
I noticed that mysql2 is actually supported in knex and is already added to @directus/schema
But when I tried using it, it failed due to it not matching database client in directus.
This fixes that and have tested it, so far everything seems to work.

Fixes #19361 