### PR TITLE
fix detailed and improve simple variants of showing rating-display on card layout

### DIFF
--- a/.changeset/calm-lions-fold.md
+++ b/.changeset/calm-lions-fold.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed showing of detailed and improved simple Rating-Display for the Card-Layout

--- a/app/src/displays/rating/rating.vue
+++ b/app/src/displays/rating/rating.vue
@@ -64,6 +64,8 @@ const ratingPercentage = computed(() => ({
 	&.detailed {
 		position: relative;
 		width: min-content;
+		display: inline-flex;
+		height: var(--v-icon-size);
 
 		.active {
 			position: relative;

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -300,7 +300,7 @@ function handleClick() {
 	display: flex;
 	align-items: center;
 	width: 100%;
-	height: 20px;
+	height: 26px;
 	margin-top: 2px;
 	overflow: hidden;
 	line-height: 1.3em;


### PR DESCRIPTION
fixes #19359 

also improves the simple variant

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/14810858/258773861-8ed019e3-76d9-4db3-85c9-fab3b732be38.png) | ![image](https://github.com/directus/directus/assets/14810858/15e33e80-e7b8-472d-9fb5-b936f9155aed) |