### PR TITLE
Simplified generic examples and consolidated imports for sdk examples in docs.

### DIFF
--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -76,13 +76,13 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, login } from '@directus/sdk';
 
-const client = createDirectus('directus_project_url').with(authentication()).with(rest())
+const client = createDirectus('directus_project_url').with(authentication()).with(rest());
 
 // login using the authentication composable
-const result = await client.login( email,  password );
+const result = await client.login(email, password);
 
 // login http request
-const result = await client.request(login( email,  password ));
+const result = await client.request(login(email, password));
 ```
 
 </template>
@@ -158,7 +158,7 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, login } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
+const client = createDirectus('https://directus.example.com').with(authentication()).with(rest());
 
 // login using the authentication composable
 const result = await client.login('admin@example.com', 'd1r3ctu5');
@@ -208,13 +208,13 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, refresh } from '@directus/sdk';
 
-const client = createDirectus('directus_project_url').with(authentication()).with(rest())
+const client = createDirectus('directus_project_url').with(authentication()).with(rest());
 
 // refresh using the authentication composable
 const result = await client.refresh();
 
 // refresh http request
-const result = await client.request(refresh( refresh_token ));
+const result = await client.request(refresh(refresh_token));
 ```
 
 </template>
@@ -275,7 +275,7 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, refresh } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
+const client = createDirectus('https://directus.example.com').with(authentication()).with(rest());
 
 // refresh using the authentication composable
 const result = await client.refresh();
@@ -321,13 +321,13 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, logout } from '@directus/sdk';
 
-const client = createDirectus('directus_project_url').with(authentication()).with(rest())
+const client = createDirectus('directus_project_url').with(authentication()).with(rest());
 
 // logout using the authentication composable
 const result = await client.logout();
 
 // logout http request
-const result = await client.request(logout( refresh_token ));
+const result = await client.request(logout(refresh_token));
 ```
 
 </template>
@@ -369,7 +369,7 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, logout } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
+const client = createDirectus('https://directus.example.com').with(authentication()).with(rest());
 
 // logout using the authentication composable
 const result = await client.logout();
@@ -417,7 +417,7 @@ import { createDirectus, rest, passwordRequest } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(passwordRequest( user_email ));
+const result = await client.request(passwordRequest(user_email));
 ```
 
 </template>
@@ -509,7 +509,7 @@ import { createDirectus, rest, passwordReset } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(passwordReset( reset_token, new_password ));
+const result = await client.request(passwordReset(reset_token, new_password));
 ```
 
 </template>

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -51,8 +51,8 @@ Retrieve a temporary access token and refresh token.
 
 ```json
 {
-	"email": "user_email",
-	"password": "user_password"
+	"email": user_email,
+	"password": user_password
 }
 ```
 
@@ -74,17 +74,15 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/authentication';
-import { rest, login } from '@directus/sdk/rest';
+import { createDirectus, authentication, rest, login } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
+const client = createDirectus('directus_project_url').with(authentication()).with(rest())
 
 // login using the authentication composable
-const result = await client.login('email', 'password');
+const result = await client.login( email,  password );
 
 // login http request
-const result = await client.request(login('email', 'password'));
+const result = await client.request(login( email,  password ));
 ```
 
 </template>
@@ -158,9 +156,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/authentication';
-import { rest, login } from '@directus/sdk/rest';
+import { createDirectus, authentication, rest, login } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
 
@@ -187,8 +183,8 @@ Retrieve a new access token using a refresh token.
 
 ```json
 {
-	"refresh_token": "gmPd...8wuB",
-	"mode": "json"
+	"refresh_token": refresh_token_string,
+	"mode": refresh_mode
 }
 ```
 
@@ -210,17 +206,15 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/authentication';
-import { rest, refresh } from '@directus/sdk/rest';
+import { createDirectus, authentication, rest, refresh } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
+const client = createDirectus('directus_project_url').with(authentication()).with(rest())
 
 // refresh using the authentication composable
 const result = await client.refresh();
 
 // refresh http request
-const result = await client.request(refresh('refresh_token'));
+const result = await client.request(refresh( refresh_token ));
 ```
 
 </template>
@@ -279,9 +273,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/authentication';
-import { rest, refresh } from '@directus/sdk/rest';
+import { createDirectus, authentication, rest, refresh } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
 
@@ -308,7 +300,7 @@ Invalidate the refresh token thus destroying the user's session.
 
 ```json
 {
-	"refresh_token": "refresh_token"
+	"refresh_token": refresh_token
 }
 ```
 
@@ -327,17 +319,15 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/authentication';
-import { rest, logout } from '@directus/sdk/rest';
+import { createDirectus, authentication, rest, logout } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
+const client = createDirectus('directus_project_url').with(authentication()).with(rest())
 
 // logout using the authentication composable
 const result = await client.logout();
 
 // logout http request
-const result = await client.request(logout('refresh_token'));
+const result = await client.request(logout( refresh_token ));
 ```
 
 </template>
@@ -377,9 +367,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/authentication';
-import { rest, logout } from '@directus/sdk/rest';
+import { createDirectus, authentication, rest, logout } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(authentication()).with(rest())
 
@@ -406,7 +394,7 @@ Request a password reset email to be sent to the given user.
 
 ```json
 {
-	"email": "user_email"
+	"email": user_email
 }
 ```
 
@@ -425,12 +413,11 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, passwordRequest } from '@directus/sdk/rest';
+import { createDirectus, rest, passwordRequest } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(passwordRequest('user_email'));
+const result = await client.request(passwordRequest( user_email ));
 ```
 
 </template>
@@ -474,8 +461,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, passwordRequest } from '@directus/sdk/rest';
+import { createDirectus, rest, passwordRequest } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -499,8 +485,8 @@ this endpoint to allow the user to reset their password.
 
 ```json
 {
-	"token": "password_reset_token",
-	"password": "password"
+	"token": password_reset_token,
+	"password": password
 }
 ```
 
@@ -519,12 +505,11 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, passwordReset } from '@directus/sdk/rest';
+import { createDirectus, rest, passwordReset } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(passwordReset('reset_token', 'new_password'));
+const result = await client.request(passwordReset( reset_token, new_password ));
 ```
 
 </template>
@@ -567,8 +552,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, passwordReset } from '@directus/sdk/rest';
+import { createDirectus, rest, passwordReset } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -596,6 +580,22 @@ To learn more about setting up auth providers, see
 
 `GET /auth`
 
+</template>
+<template #sdk>
+
+```js
+import { createDirectus, rest, readProviders } from '@directus/sdk';
+
+const client = createDirectus('directus_project_url').with(rest());
+
+const result = await client.request(readProviders());
+```
+
+</template>
+</SnippetToggler>
+
+### Response
+
 ```json
 {
 	"data": [
@@ -617,23 +617,6 @@ To learn more about setting up auth providers, see
 	"disableDefault": false
 }
 ```
-
-</template>
-<template #sdk>
-
-```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readProviders } from '@directus/sdk/rest';
-
-const client = createDirectus('https://directus.example.com').with(rest());
-
-const result = await client.request(readProviders());
-```
-
-</template>
-</SnippetToggler>
-
-### Response
 
 `data` **Array**\
 Array of configured auth providers.
@@ -648,34 +631,11 @@ Whether or not the default authentication provider is disabled.
 
 `GET /auth`
 
-```json
-{
-	"data": [
-		{
-			"name": "GitHub",
-			"driver": "oauth2",
-			"icon": "github"
-		},
-		{
-			"name": "Google",
-			"driver": "openid",
-			"icon": "google"
-		},
-		{
-			"name": "Okta",
-			"driver": "openid"
-		}
-	],
-	"disableDefault": false
-}
-```
-
 </template>
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readProviders } from '@directus/sdk/rest';
+import { createDirectus, rest, readProviders } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -501,7 +501,7 @@ Import a file from the web
 ```json
 {
 	"url": file_url ,
-	"data": file_object 
+	"data": file_object
 }
 ```
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -262,7 +262,7 @@ List all files that exist in Directus.
 
 `GET /files` `SEARCH /files`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -283,9 +283,7 @@ import { createDirectus, rest, readFiles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readFiles( query_object )
-);
+const result = await client.request(readFiles(query_object));
 ```
 
 </template>
@@ -375,9 +373,7 @@ import { createDirectus, rest, readFiles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readFile( file_id , query_object )
-);
+const result = await client.request(readFile(file_id, query_object));
 ```
 
 </template>
@@ -500,7 +496,7 @@ Import a file from the web
 
 ```json
 {
-	"url": file_url ,
+	"url": file_url,
 	"data": file_object
 }
 ```
@@ -524,9 +520,7 @@ import { createDirectus, rest, importFile } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	importFile( file_url , file_object )
-);
+const result = await client.request(importFile(file_url, file_object));
 ```
 
 </template>
@@ -627,9 +621,7 @@ import { createDirectus, rest, updateFile } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateFile( file_id , partial_file_object )
-);
+const result = await client.request(updateFile(file_id, partial_file_object));
 ```
 
 </template>
@@ -731,9 +723,7 @@ import { createDirectus, rest, updateFiles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateFiles( file_id_array , partial_file_object )
-);
+const result = await client.request(updateFiles(file_id_array, partial_file_object));
 ```
 
 </template>
@@ -839,7 +829,7 @@ import { createDirectus, rest, deleteFile } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFile( file_id ));
+const result = await client.request(deleteFile(file_id));
 ```
 
 </template>
@@ -925,13 +915,11 @@ import { createDirectus, rest, deleteFiles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFiles( file_id_array ));
+const result = await client.request(deleteFiles(file_id_array));
 
 //or
 
-const result = await client.request(
-	deleteFiles( query_object )
-);
+const result = await client.request(deleteFiles(query_object));
 ```
 
 </template>

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -262,6 +262,8 @@ List all files that exist in Directus.
 
 `GET /files` `SEARCH /files`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -277,21 +279,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, readFiles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readFiles({
-		query: {
-			query_type: {
-				field: {
-					query_operator: 'value',
-				},
-			},
-		},
-	})
+	readFiles( query_object )
 );
 ```
 
@@ -332,8 +325,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, readFiles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -379,12 +371,13 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, readFiles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFile('file_id', query));
+const result = await client.request(
+	readFile( file_id , query_object )
+);
 ```
 
 </template>
@@ -423,8 +416,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, readFiles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -460,8 +452,7 @@ Not supported by GraphQL
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, uploadFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, uploadFiles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -509,10 +500,8 @@ Import a file from the web
 
 ```json
 {
-	"url": "file_url",
-	"data": {
-		"file_field": "value_1"
-	}
+	"url": file_url ,
+	"data": file_object 
 }
 ```
 
@@ -531,15 +520,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, importFile } from '@directus/sdk/rest';
+import { createDirectus, rest, importFile } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	importFile('file_url', {
-		file_field: 'value',
-	})
+	importFile( file_url , file_object )
 );
 ```
 
@@ -595,8 +581,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, importFile } from '@directus/sdk/rest';
+import { createDirectus, rest, importFile } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -621,11 +606,7 @@ Update an existing file, and/or replace it's file contents.
 
 `PATCH /files/:id`
 
-```json
-{
-	"field": "value"
-}
-```
+Provide a partial [file object](#the-file-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -642,15 +623,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFile } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFile } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateFile('file_id', {
-		file_field: 'value',
-	})
+	updateFile( file_id , partial_file_object )
 );
 ```
 
@@ -702,8 +680,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFile } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFile } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -730,10 +707,8 @@ Update multiple files at the same time.
 
 ```json
 {
-	"keys": ["file_id", "file_id_2"],
-	"data": {
-		"item_field": ["value"]
-	}
+	"keys": file_id_array ,
+	"data": partial_file_object
 }
 ```
 
@@ -752,15 +727,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFiles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateFiles(['file_id', 'file_id_2'], {
-		item_field: ['value'],
-	})
+	updateFiles( file_id_array , partial_file_object )
 );
 ```
 
@@ -817,8 +789,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFiles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -864,12 +835,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFile } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFile } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFile('file_id'));
+const result = await client.request(deleteFile( file_id ));
 ```
 
 </template>
@@ -907,8 +877,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFile } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFile } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -935,9 +904,7 @@ This will also delete the files from disk.
 
 `DELETE /files`
 
-```json
-["file_id", "file_id"]
-```
+Provide an array of file ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -954,23 +921,16 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFiles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFiles(['file_id_1', 'file_id_2']));
+const result = await client.request(deleteFiles( file_id_array ));
 
 //or
 
 const result = await client.request(
-	deleteFiles({
-		query_type: {
-			field: {
-				query_operator: 'value',
-			},
-		},
-	})
+	deleteFiles( query_object )
 );
 ```
 
@@ -1017,8 +977,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFiles } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFiles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -260,9 +260,13 @@ List all files that exist in Directus.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-`GET /files` `SEARCH /files`
+`GET /files`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+`SEARCH /files`
+
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -289,8 +293,6 @@ const result = await client.request(readFiles(query_object));
 </template>
 </SnippetToggler>
 
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
-
 #### Query Parameters
 
 Supports all [global query parameters](/reference/query).
@@ -305,7 +307,9 @@ be an empty array.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-`GET /files` `SEARCH /files`
+`GET /files`
+
+`SEARCH /files`
 
 </template>
 <template #graphql>
@@ -894,7 +898,7 @@ This will also delete the files from disk.
 
 `DELETE /files`
 
-Provide an array of file ids as the body of your request.
+Provide an array of file IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -46,7 +46,9 @@ List all items that exist in Directus.
 
 `SEARCH /items/:collection`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -73,8 +75,6 @@ const result = await client.request(readItems('collection_name', query_object));
 </template>
 </SnippetToggler>
 
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
-
 #### Query Parameters
 
 Supports all [global query parameters](/reference/query).
@@ -96,6 +96,8 @@ be an empty array.
 <template #rest>
 
 `GET /items/articles`
+
+`SEARCH /items/articles`
 
 </template>
 <template #graphql>

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -46,7 +46,7 @@ List all items that exist in Directus.
 
 `SEARCH /items/:collection`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -756,7 +756,7 @@ import { createDirectus, rest, updateItems } from '@directus/sdk';
 const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateItems( collection_name , item_object_array , partial_item_object )
+	updateItems( collection_name , item_id_array , partial_item_object )
 );
 ```
 
@@ -927,7 +927,7 @@ import { createDirectus, rest, deleteItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteItems( collection_name , [ item_id_1 ,  item_id_2 ]));
+const result = await client.request(deleteItems( collection_name , item_id_array ));
 
 //or
 

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -67,9 +67,7 @@ import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readItems('collection_name', query_object )
-);
+const result = await client.request(readItems('collection_name', query_object));
 ```
 
 </template>
@@ -164,7 +162,7 @@ import { createDirectus, rest, readItem } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readItem( collection_name ,  item_id ));
+const result = await client.request(readItem(collection_name, item_id));
 ```
 
 </template>
@@ -240,7 +238,7 @@ import { createDirectus, rest, readSingleton } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readSingleton( collection_name ));
+const result = await client.request(readSingleton(collection_name));
 ```
 
 </template>
@@ -332,9 +330,7 @@ import { createDirectus, rest, createItem } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createItem( collection_name , item_object )
-);
+const result = await client.request(createItem(collection_name, item_object));
 ```
 
 </template>
@@ -438,9 +434,7 @@ import { createDirectus, rest, createItems } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createItems( collection_name , item_object_array )
-);
+const result = await client.request(createItems(collection_name, item_object_array));
 ```
 
 </template>
@@ -554,9 +548,7 @@ import { createDirectus, rest, updateItem } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateItem( collection_name ,  item_id , partial_item_object )
-);
+const result = await client.request(updateItem(collection_name, item_id, partial_item_object));
 ```
 
 </template>
@@ -651,9 +643,7 @@ import { createDirectus, rest, updateSingleton } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateSingleton( collection_name , partial_item_object )
-);
+const result = await client.request(updateSingleton(collection_name, partial_item_object));
 ```
 
 </template>
@@ -755,9 +745,7 @@ import { createDirectus, rest, updateItems } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateItems( collection_name , item_id_array , partial_item_object )
-);
+const result = await client.request(updateItems(collection_name, item_id_array, partial_item_object));
 ```
 
 </template>
@@ -853,7 +841,7 @@ import { createDirectus, rest, deleteItem } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteItem( collection_name , item_id ));
+const result = await client.request(deleteItem(collection_name, item_id));
 ```
 
 </template>
@@ -927,13 +915,11 @@ import { createDirectus, rest, deleteItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteItems( collection_name , item_id_array ));
+const result = await client.request(deleteItems(collection_name, item_id_array));
 
 //or
 
-const result2 = await client.request(
-	deleteItems( collection_name , query_object )
-);
+const result = await client.request(deleteItems(collection_name, query_object));
 ```
 
 </template>

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -994,7 +994,7 @@ const result = await client.request(deleteItems('articles', ['6', '7']));
 
 //or
 
-const result2 = await client.request(
+const result = await client.request(
 	deleteItems('articles', {
 		filter: {
 			status: {

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -46,6 +46,8 @@ List all items that exist in Directus.
 
 `SEARCH /items/:collection`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -61,15 +63,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readItems('collection_name', {
-		query,
-	})
+	readItems('collection_name', query_object )
 );
 ```
 
@@ -121,8 +120,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -162,12 +160,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItem } from '@directus/sdk/rest';
+import { createDirectus, rest, readItem } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readItem('collection_name', 'item_id'));
+const result = await client.request(readItem( collection_name ,  item_id ));
 ```
 
 </template>
@@ -203,8 +200,7 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItem } from '@directus/sdk/rest';
+import { createDirectus, rest, readItem } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -240,12 +236,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readSingleton } from '@directus/sdk/rest';
+import { createDirectus, rest, readSingleton } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readSingleton('collection_name'));
+const result = await client.request(readSingleton( collection_name ));
 ```
 
 </template>
@@ -295,8 +290,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readSingleton } from '@directus/sdk/rest';
+import { createDirectus, rest, readSingleton } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -317,12 +311,7 @@ Create a new item in the given collection.
 
 `POST /items/:collection`
 
-```json
-{
-	"field": "value",
-	"field_2": "value_2"
-}
-```
+Provide an [item object](#the-item-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -339,16 +328,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createItem } from '@directus/sdk/rest';
+import { createDirectus, rest, createItem } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createItem('collection_name', {
-		field: 'value_1',
-		field_2: 'value_2',
-	})
+	createItem( collection_name , item_object )
 );
 ```
 
@@ -361,7 +346,7 @@ Supports all [global query parameters](/reference/query).
 
 #### Request Body
 
-An array of partial [item objects](#the-item-object).
+A partial [item objects](#the-item-object).
 
 ::: tip Relational Data
 
@@ -406,8 +391,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createItem } from '@directus/sdk/rest';
+import { createDirectus, rest, createItem } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -433,18 +417,7 @@ Create new items in the given collection.
 
 `POST /items/:collection`
 
-```json
-[
-	{
-		"field_1": "value_1",
-		"field_2": "value_2"
-	},
-	{
-		"field_1": "value_3",
-		"field_2": "value_4"
-	}
-]
-```
+Provide an array of [item object](#the-item-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -461,22 +434,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createItems } from '@directus/sdk/rest';
+import { createDirectus, rest, createItems } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createItems('collection_name', [
-		{
-			field_1: 'value_1',
-			field_2: 'value_2',
-		},
-		{
-			field_1: 'value_3',
-			field_2: 'value_4',
-		},
-	])
+	createItems( collection_name , item_object_array )
 );
 ```
 
@@ -538,8 +501,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createItems } from '@directus/sdk/rest';
+import { createDirectus, rest, createItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -571,11 +533,7 @@ Update an existing item.
 
 `PATCH /items/:collection/:id`
 
-```json
-{
-	"field": "value"
-}
-```
+Provide a partial [item object](#the-item-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -592,15 +550,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateItem } from '@directus/sdk/rest';
+import { createDirectus, rest, updateItem } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateItem('collection_name', 'item_id', {
-		field: 'value',
-	})
+	updateItem( collection_name ,  item_id , partial_item_object )
 );
 ```
 
@@ -650,8 +605,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateItem } from '@directus/sdk/rest';
+import { createDirectus, rest, updateItem } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -676,11 +630,7 @@ Update a singleton item.
 
 `PATCH /items/:collection`
 
-```json
-{
-	"item_field": "value"
-}
-```
+Provide a partial [item object](#the-item-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -697,15 +647,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateSingleton } from '@directus/sdk/rest';
+import { createDirectus, rest, updateSingleton } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateSingleton('collection_name', {
-		item_field: 'value',
-	})
+	updateSingleton( collection_name , partial_item_object )
 );
 ```
 
@@ -762,8 +709,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateSingleton } from '@directus/sdk/rest';
+import { createDirectus, rest, updateSingleton } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -788,14 +734,7 @@ Update multiple items at the same time.
 
 `PATCH /items/:collection`
 
-```json
-{
-	"keys": ["id_1", "id_2"],
-	"data": {
-		"field": "value"
-	}
-}
-```
+Provide a partial [item object](#the-item-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -812,15 +751,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateItems } from '@directus/sdk/rest';
+import { createDirectus, rest, updateItems } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateItems('collection_name', ['id_1', 'id_2'], {
-		field: 'value',
-	})
+	updateItems( collection_name , item_object_array , partial_item_object )
 );
 ```
 
@@ -873,8 +809,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateItems } from '@directus/sdk/rest';
+import { createDirectus, rest, updateItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -914,12 +849,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteItem } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteItem } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteItem('collection_name', 'id'));
+const result = await client.request(deleteItem( collection_name , item_id ));
 ```
 
 </template>
@@ -953,8 +887,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteItem } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteItem } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -972,31 +905,8 @@ Delete multiple existing items.
 <template #rest>
 
 `DELETE /items/:collection`
-
-```json
-// Array
-["key_1", "key_2", "key_3"]
-```
-
-```json
-// Object
-{
-	"field": ["key_1", "key_2", "key_3"]
-}
-```
-
-```json
-// Object containing query
-{
-	"query": {
-		"query_type": {
-			"field_1": {
-				"filter_condition": "value_1"
-			}
-		}
-	}
-}
-```
+ 
+Provide an array of item primary keys or an object containing either `keys` or `query` as your request body. 
 
 </template>
 <template #graphql>
@@ -1013,23 +923,16 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteItems } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteItems('collection_name', ['id_1', 'id_2']));
+const result = await client.request(deleteItems( collection_name , [ item_id_1 ,  item_id_2 ]));
 
 //or
 
 const result2 = await client.request(
-	deleteItems('collection_name', {
-		query_type: {
-			field_1: {
-				filter_condition: 'value_1',
-			},
-		},
-	})
+	deleteItems( collection_name , query_object )
 );
 ```
 
@@ -1097,8 +1000,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteItems } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -905,8 +905,8 @@ Delete multiple existing items.
 <template #rest>
 
 `DELETE /items/:collection`
- 
-Provide an array of item primary keys or an object containing either `keys` or `query` as your request body. 
+
+Provide an array of item primary keys or an object containing either `keys` or `query` as your request body.
 
 </template>
 <template #graphql>

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -81,8 +81,7 @@ In GraphQL, this can be achieved using Union Types.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -179,8 +178,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -254,8 +252,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -314,8 +311,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -368,8 +364,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -412,8 +407,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -460,8 +454,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -529,8 +522,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, aggregate } from '@directus/sdk/rest';
+import { createDirectus, rest, aggregate } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -608,8 +600,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(staticToken()).with(rest());
 
@@ -672,8 +663,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(staticToken()).with(rest());
 
@@ -794,8 +784,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/activity.md
+++ b/docs/reference/system/activity.md
@@ -69,7 +69,9 @@ Returns a list of activity actions.
 
 `SEARCH /activity`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -95,8 +97,6 @@ const result = await client.request(readActivities(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 

--- a/docs/reference/system/activity.md
+++ b/docs/reference/system/activity.md
@@ -69,6 +69,8 @@ Returns a list of activity actions.
 
 `SEARCH /activity`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -84,12 +86,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readActivities } from '@directus/sdk/rest';
+import { createDirectus, rest, readActivities } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readActivities(query));
+const result = await client.request(readActivities( query_object ));
 ```
 
 </template>
@@ -130,8 +131,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readActivities } from '@directus/sdk/rest';
+import { createDirectus, rest, readActivities } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -171,12 +171,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readActivity } from '@directus/sdk/rest';
+import { createDirectus, rest, readActivity } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readActivity('activity_id', query));
+const result = await client.request(readActivity( activity_id , query_object ));
 ```
 
 </template>
@@ -214,8 +213,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readActivity } from '@directus/sdk/rest';
+import { createDirectus, rest, readActivity } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -242,9 +240,9 @@ Creates a new comment on a given item.
 
 ```json
 {
-	"collection": "collection_name",
-	"item": "item_id",
-	"comment": "comment content"
+	"collection": collection_name,
+	"item": item_id,
+	"comment": comment_content
 }
 ```
 
@@ -263,16 +261,15 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createComment } from '@directus/sdk/rest';
+import { createDirectus, rest, createComment } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
 	createComment({
-		collection: 'collection_name',
-		item: 'item_id',
-		comment: 'value',
+		collection:  collection_name ,
+		item:  item_id ,
+		comment:  comment_content ,
 	})
 );
 ```
@@ -327,8 +324,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createComment } from '@directus/sdk/rest';
+import { createDirectus, rest, createComment } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -357,7 +353,7 @@ Updates an existing comment by activity action primary key.
 
 ```json
 {
-	"comment": "value"
+	"comment": comment_content
 }
 ```
 
@@ -376,14 +372,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateComment } from '@directus/sdk/rest';
+import { createDirectus, rest, updateComment } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateComment('comment_id', {
-		comment: 'value',
+	updateComment( comment_id , {
+		comment:  comment_content ,
 	})
 );
 ```
@@ -471,12 +466,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteComment } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteComment } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteComment('comment_id'));
+const result = await client.request(deleteComment( comment_id ));
 ```
 
 </template>

--- a/docs/reference/system/activity.md
+++ b/docs/reference/system/activity.md
@@ -90,7 +90,7 @@ import { createDirectus, rest, readActivities } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readActivities( query_object ));
+const result = await client.request(readActivities(query_object));
 ```
 
 </template>
@@ -175,7 +175,7 @@ import { createDirectus, rest, readActivity } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readActivity( activity_id , query_object ));
+const result = await client.request(readActivity(activity_id, query_object));
 ```
 
 </template>
@@ -267,9 +267,9 @@ const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
 	createComment({
-		collection:  collection_name ,
-		item:  item_id ,
-		comment:  comment_content ,
+		collection: collection_name,
+		item: item_id,
+		comment: comment_content,
 	})
 );
 ```
@@ -377,8 +377,8 @@ import { createDirectus, rest, updateComment } from '@directus/sdk';
 const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateComment( comment_id , {
-		comment:  comment_content ,
+	updateComment(comment_id, {
+		comment: comment_content,
 	})
 );
 ```
@@ -470,7 +470,7 @@ import { createDirectus, rest, deleteComment } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteComment( comment_id ));
+const result = await client.request(deleteComment(comment_id));
 ```
 
 </template>

--- a/docs/reference/system/activity.md
+++ b/docs/reference/system/activity.md
@@ -69,7 +69,7 @@ Returns a list of activity actions.
 
 `SEARCH /activity`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -317,7 +317,8 @@ Create a new Collection. This will create a new table in the database as well.
 
 `POST /collections`
 
-Provide an [collection object](#the-collection-object) as the body of your request with a `collection` name property being a required field.
+Provide an [collection object](#the-collection-object) as the body of your request with a `collection` name property
+being a required field.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -155,7 +155,7 @@ List the available collections.
 
 `SEARCH /collections`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>
@@ -317,7 +317,7 @@ Create a new Collection. This will create a new table in the database as well.
 
 `POST /collections`
 
-Provide an [collection object](#the-collection-object) as the body of your request with a `collection` name property
+Provide a [collection object](#the-collection-object) as the body of your request with a `collection` name property
 being a required field.
 
 </template>

--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -155,7 +155,9 @@ List the available collections.
 
 `SEARCH /collections`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -181,8 +183,6 @@ const result = await client.request(readCollections());
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 

--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -155,6 +155,8 @@ List the available collections.
 
 `SEARCH /collections`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -170,10 +172,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readCollections } from '@directus/sdk/rest';
+import { createDirectus, rest, readCollections } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(readCollections());
 ```
@@ -217,8 +218,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readCollections } from '@directus/sdk/rest';
+import { createDirectus, rest, readCollections } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -254,12 +254,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, readCollection } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readCollection('collection_name'));
+const result = await client.request(readCollection( collection_name ));
 ```
 
 </template>
@@ -297,8 +296,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, readCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -319,14 +317,7 @@ Create a new Collection. This will create a new table in the database as well.
 
 `POST /collections`
 
-```json
-{
-	"collection": "collection_name",
-	"field": {
-		"sub_field": "value"
-	}
-}
-```
+Provide an [collection object](#the-collection-object) as the body of your request with a `collection` name property being a required field.
 
 </template>
 <template #graphql>
@@ -343,10 +334,9 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, createCollection } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
 	createCollection({
@@ -418,8 +408,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, createCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -447,13 +436,7 @@ Update the metadata for an existing collection.
 
 `PATCH /collections/:collection`
 
-```json
-{
-	"meta": {
-		"field": "value"
-	}
-}
-```
+Provide a partial [collection object](#the-collection-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -470,17 +453,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, updateCollection } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateCollection('collection_name', {
-		meta: {
-			field: 'value',
-		},
-	})
+	updateCollection( collection_name , partial_collection_object )
 );
 ```
 
@@ -532,8 +510,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, updateCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -581,12 +558,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteCollection } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteCollection('collection_name'));
+const result = await client.request(deleteCollection( collection_name ));
 ```
 
 </template>
@@ -616,8 +592,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -258,7 +258,7 @@ import { createDirectus, rest, readCollection } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readCollection( collection_name ));
+const result = await client.request(readCollection(collection_name));
 ```
 
 </template>
@@ -458,9 +458,7 @@ import { createDirectus, rest, updateCollection } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateCollection( collection_name , partial_collection_object )
-);
+const result = await client.request(updateCollection(collection_name, partial_collection_object));
 ```
 
 </template>
@@ -563,7 +561,7 @@ import { createDirectus, rest, deleteCollection } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteCollection( collection_name ));
+const result = await client.request(deleteCollection(collection_name));
 ```
 
 </template>

--- a/docs/reference/system/dashboards.md
+++ b/docs/reference/system/dashboards.md
@@ -62,7 +62,9 @@ List all dashboards that exist in Directus.
 
 `SEARCH /dashboards`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -88,8 +90,6 @@ const result = await client.request(readDashboards(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -374,7 +374,7 @@ Returns the [dashboard object](#the-dashboard-object) for the created dashboard.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-`// POST /dashboards`
+`POST /dashboards`
 
 ```json
 [
@@ -720,7 +720,7 @@ Delete multiple existing dashboards.
 
 `DELETE /dashboards`
 
-Provide an array of dashboard ids as the body of your request.
+Provide an array of dashboard IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/dashboards.md
+++ b/docs/reference/system/dashboards.md
@@ -62,7 +62,7 @@ List all dashboards that exist in Directus.
 
 `SEARCH /dashboards`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>
@@ -233,7 +233,7 @@ Create a new dashboard.
 
 `POST /dashboards`
 
-Provide an [dashboard object](#the-dashboard-object) as the body of your request.
+Provide a [dashboard object](#the-dashboard-object) as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/dashboards.md
+++ b/docs/reference/system/dashboards.md
@@ -62,6 +62,8 @@ List all dashboards that exist in Directus.
 
 `SEARCH /dashboards`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -77,12 +79,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, readDashboards } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readDashboards(query));
+const result = await client.request(readDashboards( query_object ));
 ```
 
 </template>
@@ -126,8 +127,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, readDashboards } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -167,12 +167,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, readDashboard } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readDashboard('dashboard_id', query));
+const result = await client.request(readDashboard( dashboard_id , query_object ));
 ```
 
 </template>
@@ -209,8 +208,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, readDashboard } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -235,12 +233,7 @@ Create a new dashboard.
 
 `POST /dashboards`
 
-```json
-{
-	"dashboard_field_1": "value_1",
-	"dashboard_field_2": "value_2"
-}
-```
+Provide an [dashboard object](#the-dashboard-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -257,16 +250,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, createDashboard } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createDashboard({
-		dashboard_field_1: 'value_1',
-		dashboard_field_2: 'value_2',
-	})
+	createDashboard( dashboard_object )
 );
 ```
 
@@ -317,8 +306,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, createDashboard } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -342,20 +330,9 @@ Create multiple new dashboards.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-`// POST /dashboards`
+`POST /dashboards`
 
-```json
-[
-	{
-		"dashboard_1_object_field_1": "value_1",
-		"dashboard_1_object_field_2": "value_2"
-	},
-	{
-		"dashboard_2_object_field_1": "value_3",
-		"dashboard_2_object_field_2": "value_4"
-	}
-]
-```
+Provide an array of [dashboard objects](#the-dashboard-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -372,22 +349,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, createDashboards } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createDashboards([
-		{
-			dashboard_1_field_1: 'value_1',
-			dashboard_1_field_2: 'value_2',
-		},
-		{
-			dashboard_2_field_1: 'value_3',
-			dashboard_2_field_2: 'value_4',
-		},
-	])
+	createDashboards( dashboard_object_array )
 );
 ```
 
@@ -446,8 +413,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, createDashboards } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -479,11 +445,7 @@ Update an existing dashboard.
 
 `PATCH /dashboards/:id`
 
-```json
-{
-	"dashboard_field": "value_1"
-}
-```
+Provide a partial [dashboard object](#the-dashboard-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -500,15 +462,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, updateDashboard } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateDashboard('dashboard_id', {
-		dashboard_field: 'value',
-	})
+	updateDashboard( dashboard_id , partial_dashboard_object)
 );
 ```
 
@@ -558,8 +517,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, updateDashboard } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -586,10 +544,8 @@ Update multiple existing dashboards.
 
 ```json
 {
-	"keys": ["dashboard_key_1", "dashboard_key_2"],
-	"data": {
-		"dashboard_field": "value_1"
-	}
+	"keys": dashboard_id_array,
+	"data": partial_dashboard_object
 }
 ```
 
@@ -608,15 +564,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, updateDashboards } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateDashboards(['dashboard_1_id', 'dashboard_2_id'], {
-		dashboard_field: 'value_1',
-	})
+	updateDashboards( dashboard_id_array, partial_dashboard_object )
 );
 ```
 
@@ -676,8 +629,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, updateDashboards } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -717,12 +669,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteDashboard } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteDashboard('dashboard_id'));
+const result = await client.request(deleteDashboard( dashboard_id ));
 ```
 
 </template>
@@ -756,8 +707,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteDashboard } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteDashboard } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -778,9 +728,7 @@ Delete multiple existing dashboards.
 
 `DELETE /dashboards`
 
-```json
-["dashboard_id_1", "dashboard_id_2", "dashboard_id_3"]
-```
+Provide an array of dashboard ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -797,12 +745,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteDashboards } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteDashboards(['dashboard_id_1', 'dashboard_id_2']));
+const result = await client.request(deleteDashboards( dashboard_id_array ));
 ```
 
 </template>

--- a/docs/reference/system/dashboards.md
+++ b/docs/reference/system/dashboards.md
@@ -83,7 +83,7 @@ import { createDirectus, rest, readDashboards } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readDashboards( query_object ));
+const result = await client.request(readDashboards(query_object));
 ```
 
 </template>
@@ -171,7 +171,7 @@ import { createDirectus, rest, readDashboard } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readDashboard( dashboard_id , query_object ));
+const result = await client.request(readDashboard(dashboard_id, query_object));
 ```
 
 </template>
@@ -254,9 +254,7 @@ import { createDirectus, rest, createDashboard } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createDashboard( dashboard_object )
-);
+const result = await client.request(createDashboard(dashboard_object));
 ```
 
 </template>
@@ -353,9 +351,7 @@ import { createDirectus, rest, createDashboards } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createDashboards( dashboard_object_array )
-);
+const result = await client.request(createDashboards(dashboard_object_array));
 ```
 
 </template>
@@ -466,9 +462,7 @@ import { createDirectus, rest, updateDashboard } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateDashboard( dashboard_id , partial_dashboard_object)
-);
+const result = await client.request(updateDashboard(dashboard_id, partial_dashboard_object));
 ```
 
 </template>
@@ -568,9 +562,7 @@ import { createDirectus, rest, updateDashboards } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateDashboards( dashboard_id_array, partial_dashboard_object )
-);
+const result = await client.request(updateDashboards(dashboard_id_array, partial_dashboard_object));
 ```
 
 </template>
@@ -673,7 +665,7 @@ import { createDirectus, rest, deleteDashboard } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteDashboard( dashboard_id ));
+const result = await client.request(deleteDashboard(dashboard_id));
 ```
 
 </template>
@@ -749,7 +741,7 @@ import { createDirectus, rest, deleteDashboards } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteDashboards( dashboard_id_array ));
+const result = await client.request(deleteDashboards(dashboard_id_array));
 ```
 
 </template>

--- a/docs/reference/system/extensions.md
+++ b/docs/reference/system/extensions.md
@@ -36,12 +36,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readExtensions } from '@directus/sdk/rest';
+import { createDirectus, rest, readExtensions } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readExtensions('extension_type'));
+const result = await client.request(readExtensions( extension_type ));
 ```
 
 </template>
@@ -79,8 +78,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readExtensions } from '@directus/sdk/rest';
+import { createDirectus, rest, readExtensions } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/extensions.md
+++ b/docs/reference/system/extensions.md
@@ -40,7 +40,7 @@ import { createDirectus, rest, readExtensions } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readExtensions( extension_type ));
+const result = await client.request(readExtensions(extension_type));
 ```
 
 </template>

--- a/docs/reference/system/fields.md
+++ b/docs/reference/system/fields.md
@@ -396,8 +396,8 @@ Create a new field in the given collection.
 
 `POST /fields/:collection`
 
-Provide an [collection object](#the-collection-object) as the body of your request with `field` and `type` being
-required parameters.
+Provide a [collection object](#the-collection-object) as the body of your request with `field` and `type` being required
+parameters.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/fields.md
+++ b/docs/reference/system/fields.md
@@ -257,7 +257,7 @@ import { createDirectus, rest, readFieldsByCollection } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFieldsByCollection( collection_name ));
+const result = await client.request(readFieldsByCollection(collection_name));
 ```
 
 </template>
@@ -336,7 +336,7 @@ import { createDirectus, rest, readField } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readField( collection_name ,  field_name ));
+const result = await client.request(readField(collection_name, field_name));
 ```
 
 </template>
@@ -419,9 +419,9 @@ import { createDirectus, rest, createField } from '@directus/sdk';
 const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createField( collection_name , {
-		field:  field_name ,
-		type:  field_type ,
+	createField(collection_name, {
+		field: field_name,
+		type: field_type,
 		field_field: value,
 	})
 );
@@ -543,9 +543,7 @@ import { createDirectus, rest, updateField } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateField( collection_name ,  field_name , partial_field_object )
-);
+const result = await client.request(updateField(collection_name, field_name, partial_field_object));
 ```
 
 </template>
@@ -671,7 +669,7 @@ import { createDirectus, rest, deleteField } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteField( collection_name , field_name ));
+const result = await client.request(deleteField(collection_name, field_name));
 ```
 
 </template>

--- a/docs/reference/system/fields.md
+++ b/docs/reference/system/fields.md
@@ -174,10 +174,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFields } from '@directus/sdk/rest';
+import { createDirectus, rest, readFields } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(readFields());
 ```
@@ -218,10 +217,9 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFields } from '@directus/sdk/rest';
+import { createDirectus, rest, readFields } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(readFields());
 ```
@@ -255,12 +253,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFieldsByCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, readFieldsByCollection } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFieldsByCollection('collection_name'));
+const result = await client.request(readFieldsByCollection( collection_name ));
 ```
 
 </template>
@@ -299,8 +296,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFieldsByCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, readFieldsByCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -336,12 +332,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readField } from '@directus/sdk/rest';
+import { createDirectus, rest, readField } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readField('collection_name', 'field_name'));
+const result = await client.request(readField( collection_name ,  field_name ));
 ```
 
 </template>
@@ -380,8 +375,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readField } from '@directus/sdk/rest';
+import { createDirectus, rest, readField } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -402,15 +396,7 @@ Create a new field in the given collection.
 
 `POST /fields/:collection`
 
-```json
-{
-	"field": "field_key",
-	"type": "value_type",
-	"field_field": {
-		"field_sub_field": "value_1"
-	}
-}
-```
+Provide an [collection object](#the-collection-object) as the body of your request with `field` and `type` being required parameters.
 
 </template>
 <template #graphql>
@@ -427,18 +413,15 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createField } from '@directus/sdk/rest';
+import { createDirectus, rest, createField } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createField('collection_name', {
-		field: 'field_name',
-		type: 'field_type',
-		field_field: {
-			field_sub_field: 'value_3',
-		},
+	createField( collection_name , {
+		field:  field_name ,
+		type:  field_type ,
+		field_field: value,
 	})
 );
 ```
@@ -510,8 +493,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createField } from '@directus/sdk/rest';
+import { createDirectus, rest, createField } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -539,13 +521,7 @@ Updates the given field in the given collection.
 
 `PATCH /fields/articles/title`
 
-```json
-{
-	"field": {
-		"sub_field": "value_1"
-	}
-}
-```
+Provide a partial [field object](#the-field-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -562,17 +538,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateField } from '@directus/sdk/rest';
+import { createDirectus, rest, updateField } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateField('collection_name', 'field_name', {
-		field: {
-			sub_field: 'value',
-		},
-	})
+	updateField( collection_name ,  field_name , partial_field_object )
 );
 ```
 
@@ -647,8 +618,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateField } from '@directus/sdk/rest';
+import { createDirectus, rest, updateField } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -696,12 +666,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteField } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteField } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteField('collection_name', 'field_name'));
+const result = await client.request(deleteField( collection_name , field_name ));
 ```
 
 </template>
@@ -732,8 +701,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteField } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteField } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/fields.md
+++ b/docs/reference/system/fields.md
@@ -396,7 +396,8 @@ Create a new field in the given collection.
 
 `POST /fields/:collection`
 
-Provide an [collection object](#the-collection-object) as the body of your request with `field` and `type` being required parameters.
+Provide an [collection object](#the-collection-object) as the body of your request with `field` and `type` being
+required parameters.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -746,7 +746,7 @@ Delete multiple existing flows.
 
 `DELETE /flows`
 
-Provide an array of flow ids as your request body.
+Provide an array of flow IDs as your request body.
 
 </template>
 <template #graphql>
@@ -861,7 +861,7 @@ Result of the flow, if any.
 <SnippetToggler :choices="['REST', 'SDK']" label="API">
 <template #rest>
 
-`GET /flows/trigger/202a940b-a00b-47df-b832-369c53f13122` `// Payload here`
+`GET /flows/trigger/202a940b-a00b-47df-b832-369c53f13122`
 
 </template>
 <template #sdk>
@@ -919,7 +919,11 @@ Result of the flow, if any.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-`POST /flows/trigger/202a940b-a00b-47df-b832-369c53f13122` `// Payload here`
+`POST /flows/trigger/202a940b-a00b-47df-b832-369c53f13122`
+
+```json
+// Payload here
+```
 
 </template>
 <template #sdk>

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -570,7 +570,7 @@ Update multiple existing flows.
 ```json
 {
 	"keys": flow_id_array,
-	"data": partial_flow_object 
+	"data": partial_flow_object
 }
 ```
 
@@ -754,7 +754,7 @@ Delete multiple existing flows.
 
 `DELETE /flows`
 
-Provide an array of flow ids as your request body. 
+Provide an array of flow ids as your request body.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -250,7 +250,7 @@ Create a new flow.
 
 `POST /flows`
 
-Provide an [flow object](#the-flow-object) as the body of your request.
+Provide a [flow object](#the-flow-object) as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -185,7 +185,7 @@ import { createDirectus, rest, readFlow } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFlow( flow_id , query_object ));
+const result = await client.request(readFlow(flow_id, query_object));
 ```
 
 </template>
@@ -271,9 +271,7 @@ import { createDirectus, rest, createFlow } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createFlow( flow_object )
-);
+const result = await client.request(createFlow(flow_object));
 ```
 
 </template>
@@ -372,9 +370,7 @@ import { createDirectus, rest, createFlows } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createFlows( flow_object_array )
-);
+const result = await client.request(createFlows(flow_object_array));
 ```
 
 </template>
@@ -491,9 +487,7 @@ import { createDirectus, rest, updateFlow } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateFlow( flow_id, partial_flow_object )
-);
+const result = await client.request(updateFlow(flow_id, partial_flow_object));
 ```
 
 </template>
@@ -593,9 +587,7 @@ import { createDirectus, rest, updateFlows } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateFlows( flow_id_array, partial_flow_object )
-);
+const result = await client.request(updateFlows(flow_id_array, partial_flow_object));
 ```
 
 </template>
@@ -699,7 +691,7 @@ import { createDirectus, rest, deleteFlow } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFlow( flow_id ));
+const result = await client.request(deleteFlow(flow_id));
 ```
 
 </template>
@@ -775,7 +767,7 @@ import { createDirectus, rest, deleteFlows } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFlows( flow_id_array ));
+const result = await client.request(deleteFlows(flow_id_array));
 ```
 
 </template>
@@ -854,9 +846,7 @@ import { createDirectus, rest, triggerFlow } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	triggerFlow( 'GET', flow_id, query_object )
-);
+const result = await client.request(triggerFlow('GET', flow_id, query_object));
 ```
 
 </template>
@@ -910,9 +900,7 @@ import { createDirectus, rest, triggerFlow } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	triggerFlow( 'POST', flow_id, webhook_payload )
-);
+const result = await client.request(triggerFlow('POST', flow_id, webhook_payload));
 ```
 
 </template>

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -181,12 +181,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, readFlow } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFlow('flow_id', query));
+const result = await client.request(readFlow( flow_id , query_object ));
 ```
 
 </template>
@@ -226,8 +225,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, readFlow } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -252,13 +250,7 @@ Create a new flow.
 
 `POST /flows`
 
-```json
-{
-	"flow_object_field_1": "value_1",
-	"flow_object_field_2": "value_2",
-	"flow_object_field_3": "value_3"
-}
-```
+Provide an [flow object](#the-flow-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -275,16 +267,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, createFlow } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createFlow({
-		flow_field_1: 'value_1',
-		flow_field_2: 'value_2',
-	})
+	createFlow( flow_object )
 );
 ```
 
@@ -337,8 +325,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, createFlow } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -364,20 +351,7 @@ Create multiple new flows.
 
 `POST /flows`
 
-```json
-[
-	{
-		"flow_1_field_1": "value_1",
-		"flow_1_field_2": "value_2",
-		"flow_1_field_3": "value_3"
-	},
-	{
-		"flow_2_field_1": "value_4",
-		"flow_2_field_2": "value_5",
-		"flow_2_field_3": "value_6"
-	}
-]
-```
+Provide an array of [flow objects](#the-flow-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -394,22 +368,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, createFlows } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createFlows([
-		{
-			flow_1_field_1: 'value_1',
-			flow_1_field_2: 'value_2',
-		},
-		{
-			flow_2_field_1: 'value_3',
-			flow_2_field_2: 'value_4',
-		},
-	])
+	createFlows( flow_object_array )
 );
 ```
 
@@ -474,8 +438,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, createFlows } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -507,11 +470,7 @@ Update an existing flow.
 
 `PATCH /flows/:id`
 
-```json
-{
-	"flow_object_field": "value_1"
-}
-```
+Provide a partial [flow object](#the-flow-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -528,15 +487,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFlow } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateFlow('flow_id', {
-		flow_field: 'value',
-	})
+	updateFlow( flow_id, partial_flow_object )
 );
 ```
 
@@ -586,8 +542,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFlow } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -614,10 +569,8 @@ Update multiple existing flows.
 
 ```json
 {
-	"keys": ["flow_1_key", "flow_2_key"],
-	"data": {
-		"flow_object_field": "value_1"
-	}
+	"keys": flow_id_array,
+	"data": partial_flow_object 
 }
 ```
 
@@ -636,15 +589,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFlows } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateFlows(['flow_1_id', 'flow_2_id'], {
-		flow_field: 'value',
-	})
+	updateFlows( flow_id_array, partial_flow_object )
 );
 ```
 
@@ -705,8 +655,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFlows } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -746,12 +695,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFlow } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFlow('flow_id'));
+const result = await client.request(deleteFlow( flow_id ));
 ```
 
 </template>
@@ -785,8 +733,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFlow } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -807,9 +754,7 @@ Delete multiple existing flows.
 
 `DELETE /flows`
 
-```json
-["flow_1_key", "flow_2_key", "flow_3_key"]
-```
+Provide an array of flow ids as your request body. 
 
 </template>
 <template #graphql>
@@ -826,12 +771,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFlows } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFlows(['flow_1_id', 'flow_2_id']));
+const result = await client.request(deleteFlows( flow_id_array ));
 ```
 
 </template>
@@ -879,8 +823,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFlows } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -907,15 +850,12 @@ Start a flow with GET webhook trigger.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, triggerFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, triggerFlow } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	triggerFlow('GET', 'flow_id', {
-		fields: '*',
-	})
+	triggerFlow( 'GET', flow_id, query_object )
 );
 ```
 
@@ -937,8 +877,7 @@ Result of the flow, if any.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, triggerFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, triggerFlow } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -967,15 +906,12 @@ Start a flow with POST webhook trigger.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, triggerFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, triggerFlow } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	triggerFlow('POST', 'flow_id', {
-		field: 'value', // Payload for webhook
-	})
+	triggerFlow( 'POST', flow_id, webhook_payload )
 );
 ```
 
@@ -1001,8 +937,7 @@ Result of the flow, if any.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, triggerFlow } from '@directus/sdk/rest';
+import { createDirectus, rest, triggerFlow } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/folders.md
+++ b/docs/reference/system/folders.md
@@ -43,7 +43,9 @@ List all folders that exist in Directus.
 
 `SEARCH /folders`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -69,8 +71,6 @@ const result = await client.request(readFolders(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -708,7 +708,7 @@ Any files in these folders will be moved to the root folder.
 
 `DELETE /folders`
 
-Provide an array of item ids as your request body.
+Provide an array of item IDs as your request body.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/folders.md
+++ b/docs/reference/system/folders.md
@@ -43,7 +43,7 @@ List all folders that exist in Directus.
 
 `SEARCH /folders`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>
@@ -214,7 +214,7 @@ Create a new (virtual) folder.
 
 `POST /folders`
 
-Provide an [folder object](#the-folder-object) as the body of your request.
+Provide a [folder object](#the-folder-object) as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/folders.md
+++ b/docs/reference/system/folders.md
@@ -521,7 +521,7 @@ Update multiple existing folders.
 ```json
 {
 	"keys": folder_id_array,
-	"data": partial_folder_object 
+	"data": partial_folder_object
 }
 ```
 
@@ -716,7 +716,7 @@ Any files in these folders will be moved to the root folder.
 
 `DELETE /folders`
 
-Provide an array of item ids as your request body. 
+Provide an array of item ids as your request body.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/folders.md
+++ b/docs/reference/system/folders.md
@@ -64,7 +64,7 @@ import { createDirectus, rest, readFolders } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFolders( query_object ));
+const result = await client.request(readFolders(query_object));
 ```
 
 </template>
@@ -151,7 +151,7 @@ import { createDirectus, rest, readFolder } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFolder( folder_id , query_object ));
+const result = await client.request(readFolder(folder_id, query_object));
 ```
 
 </template>
@@ -235,9 +235,7 @@ import { createDirectus, rest, createFolder } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createFolder( folder_object )
-);
+const result = await client.request(createFolder(folder_object));
 ```
 
 </template>
@@ -332,9 +330,7 @@ import { createDirectus, rest, createFolders } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createFolders( folder_object_array )
-);
+const result = await client.request(createFolders(folder_object_array));
 ```
 
 </template>
@@ -439,9 +435,7 @@ import { createDirectus, rest, updateFolder } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateFolder( folder_id, partial_folder_object )
-);
+const result = await client.request(updateFolder(folder_id, partial_folder_object));
 ```
 
 </template>
@@ -544,9 +538,7 @@ import { createDirectus, rest, updateFolders } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateFolders( folder_id_array, partial_folder_object )
-);
+const result = await client.request(updateFolders(folder_id_array, partial_folder_object));
 ```
 
 </template>
@@ -655,7 +647,7 @@ import { createDirectus, rest, deleteFolder } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFolder( folder_id ));
+const result = await client.request(deleteFolder(folder_id));
 ```
 
 </template>
@@ -737,7 +729,7 @@ import { createDirectus, rest, deleteFolders } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFolders( folder_id_array ));
+const result = await client.request(deleteFolders(folder_id_array));
 ```
 
 </template>

--- a/docs/reference/system/folders.md
+++ b/docs/reference/system/folders.md
@@ -43,6 +43,8 @@ List all folders that exist in Directus.
 
 `SEARCH /folders`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -58,12 +60,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, readFolders } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFolders(query));
+const result = await client.request(readFolders( query_object ));
 ```
 
 </template>
@@ -106,8 +107,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, readFolders } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -147,12 +147,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, readFolder } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readFolder('folder_id', query));
+const result = await client.request(readFolder( folder_id , query_object ));
 ```
 
 </template>
@@ -190,8 +189,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, readFolder } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -216,11 +214,7 @@ Create a new (virtual) folder.
 
 `POST /folders`
 
-```json
-{
-	"name": "value_1"
-}
-```
+Provide an [folder object](#the-folder-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -237,15 +231,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, createFolder } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createFolder({
-		name: 'value',
-	})
+	createFolder( folder_object )
 );
 ```
 
@@ -295,8 +286,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, createFolder } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -321,16 +311,7 @@ Create multiple new (virtual) folders.
 
 `POST /folders`
 
-```json
-[
-	{
-		"name": "value_1"
-	},
-	{
-		"name": "value_2"
-	}
-]
-```
+Provide an array of [folder object](#the-folder-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -347,20 +328,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, createFolders } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createFolders([
-		{
-			name: 'value_1',
-		},
-		{
-			name: 'value_2',
-		},
-	])
+	createFolders( folder_object_array )
 );
 ```
 
@@ -415,8 +388,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, createFolders } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -446,11 +418,7 @@ Update an existing folder.
 
 `PATCH /folders/:id`
 
-```json
-{
-	"folder_object_field": "value_1"
-}
-```
+Provide a partial [folder object](#the-folder-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -467,15 +435,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFolder } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateFolder('folder_id', {
-		field: 'value',
-	})
+	updateFolder( folder_id, partial_folder_object )
 );
 ```
 
@@ -528,8 +493,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFolder } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -556,10 +520,8 @@ Update multiple existing folders.
 
 ```json
 {
-	"keys": ["folder_1_key", "folder_2_key"],
-	"data": {
-		"folder_object_field": "value_1"
-	}
+	"keys": folder_id_array,
+	"data": partial_folder_object 
 }
 ```
 
@@ -578,12 +540,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFolders } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(updateFolders(['folder_1_id', 'folder_2_id'], { field: 'value' }));
+const result = await client.request(
+	updateFolders( folder_id_array, partial_folder_object )
+);
 ```
 
 </template>
@@ -642,8 +605,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, updateFolders } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -689,12 +651,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFolder } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFolder('folder_id'));
+const result = await client.request(deleteFolder( folder_id ));
 ```
 
 </template>
@@ -728,8 +689,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFolder } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFolder } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -756,9 +716,7 @@ Any files in these folders will be moved to the root folder.
 
 `DELETE /folders`
 
-```json
-["folder_1_key", "folder_2_key"]
-```
+Provide an array of item ids as your request body. 
 
 </template>
 <template #graphql>
@@ -775,12 +733,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFolders } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteFolders(['folder_1_id', 'folder_2_id']));
+const result = await client.request(deleteFolders( folder_id_array ));
 ```
 
 </template>
@@ -820,8 +777,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteFolders } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteFolders } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/notifications.md
+++ b/docs/reference/system/notifications.md
@@ -85,7 +85,7 @@ import { createDirectus, rest, readNotifications } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readNotifications( query_object ));
+const result = await client.request(readNotifications(query_object));
 ```
 
 </template>
@@ -174,9 +174,7 @@ import { createDirectus, rest, readNotification } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readNotification( notification_id, query_object )
-);
+const result = await client.request(readNotification(notification_id, query_object));
 ```
 
 </template>
@@ -262,9 +260,7 @@ import { createDirectus, rest, createNotification } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createNotification( notification_object )
-);
+const result = await client.request(createNotification(notification_object));
 ```
 
 </template>
@@ -362,9 +358,7 @@ import { createDirectus, rest, createNotifications } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createNotifications( notifcation_object_array )
-);
+const result = await client.request(createNotifications(notifcation_object_array));
 ```
 
 </template>
@@ -497,9 +491,7 @@ import { createDirectus, rest, updateNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	updateNotification( notification_id, partial_notification_object )
-);
+const result = await client.request(updateNotification(notification_id, partial_notification_object));
 ```
 
 </template>
@@ -599,9 +591,7 @@ import { createDirectus, rest, updateNotifications } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	updateNotifications( notification_id_array, partial_notification_object )
-);
+const result = await client.request(updateNotifications(notification_id_array, partial_notification_object));
 ```
 
 </template>
@@ -701,7 +691,7 @@ import { createDirectus, rest, deleteNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteNotification( notification_id ));
+const result = await client.request(deleteNotification(notification_id));
 ```
 
 </template>
@@ -777,9 +767,7 @@ import { createDirectus, rest, deleteNotifications } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	deleteNotifications( notification_id_array )
-);
+const result = await client.request(deleteNotifications(notification_id_array));
 ```
 
 </template>

--- a/docs/reference/system/notifications.md
+++ b/docs/reference/system/notifications.md
@@ -64,6 +64,8 @@ List all notifications that exist in Directus.
 
 `SEARCH /notifications`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -79,12 +81,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, readNotifications } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readNotifications(query));
+const result = await client.request(readNotifications( query_object ));
 ```
 
 </template>
@@ -129,8 +130,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, readNotifications } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -170,12 +170,13 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, readNotification } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readNotification('notification_id', query));
+const result = await client.request(
+	readNotification( notification_id, query_object )
+);
 ```
 
 </template>
@@ -215,8 +216,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, readNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -241,12 +241,7 @@ Create a new notification.
 
 `POST /notifications`
 
-```json
-{
-	"notification_object_field_1": "value_1",
-	"notification_object_field_2": "value_2"
-}
-```
+Provide an [notification object](#the-notification-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -263,17 +258,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, createNotification } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createNotification({
-		notification_field: 'value_1',
-		notification_field_2: 'value_2',
-		notification_field_3: 'value_3',
-	})
+	createNotification( notification_object )
 );
 ```
 
@@ -324,8 +314,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, createNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -352,20 +341,7 @@ Create multiple new notifications.
 
 `POST /notifications`
 
-```json
-[
-	{
-		"notification_field": "value_1",
-		"notification_field_2": "value_2",
-		"notification_field_3": "value_3"
-	},
-	{
-		"notification_2_field": "value_3",
-		"notification_2_field_2": "value_4",
-		"notification_2_field_3": "value_5"
-	}
-]
-```
+Provide an array of [notification objects](#the-notification-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -382,24 +358,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, createNotifications } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createNotifications([
-		{
-			notification_field: 'value_1',
-			notification_field_2: 'value_2',
-			notification_field_3: 'value_3',
-		},
-		{
-			notification_2_field: 'value_4',
-			notification_2_field_2: 'value_5',
-			notification_2_field_3: 'value_6',
-		},
-	])
+	createNotifications( notifcation_object_array )
 );
 ```
 
@@ -471,8 +435,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, createNotifications } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -513,11 +476,8 @@ notification email to be sent.
 
 `PATCH /notifications/:id`
 
-```json
-{
-	"notification_object_field": "value_1"
-}
-```
+Provide a partial [notification object](#the-notification-object) as the body of your request.
+
 
 </template>
 <template #graphql>
@@ -534,15 +494,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, updateNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
 const result = await client.request(
-	updateNotification('notification_id', {
-		field: 'value',
-	})
+	updateNotification( notification_id, partial_notification_object )
 );
 ```
 
@@ -592,8 +549,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, updateNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -620,10 +576,8 @@ Update multiple existing notifications.
 
 ```json
 {
-	"keys": ["notification_key_1", "notification_key_2"],
-	"data": {
-		"notification_object_field": "field_1"
-	}
+	"keys": notification_id_array,
+	"data": partial_notification_object 
 }
 ```
 
@@ -642,15 +596,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, updateNotifications } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
 const result = await client.request(
-	updateNotifications(['notification_1_id', 'notification_2_id', 'notification_3_id'], {
-		field: 'value',
-	})
+	updateNotifications( notification_id_array, partial_notification_object )
 );
 ```
 
@@ -707,8 +658,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, updateNotifications } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -748,12 +698,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteNotification('notification_1_id'));
+const result = await client.request(deleteNotification( notification_id ));
 ```
 
 </template>
@@ -787,8 +736,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteNotification } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteNotification } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -807,10 +755,9 @@ Delete multiple existing notifications.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-```json
-// DELETE /notifications
-["notification_1_id", "notification_2_id", "notification_3_id"]
-```
+`DELETE /notifications`
+
+Provide an array of notification ids as your request body. 
 
 </template>
 <template #graphql>
@@ -827,13 +774,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteNotifications } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	deleteNotifications(['notification_1_id', 'notification_2_id', 'notification_3_id'])
+	deleteNotifications( notification_id_array )
 );
 ```
 
@@ -876,8 +822,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteNotifications } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteNotifications } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/notifications.md
+++ b/docs/reference/system/notifications.md
@@ -64,7 +64,7 @@ List all notifications that exist in Directus.
 
 `SEARCH /notifications`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>
@@ -241,7 +241,7 @@ Create a new notification.
 
 `POST /notifications`
 
-Provide an [notification object](#the-notification-object) as the body of your request.
+Provide a [notification object](#the-notification-object) as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/notifications.md
+++ b/docs/reference/system/notifications.md
@@ -64,7 +64,9 @@ List all notifications that exist in Directus.
 
 `SEARCH /notifications`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -90,8 +92,6 @@ const result = await client.request(readNotifications(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -746,7 +746,7 @@ Delete multiple existing notifications.
 
 `DELETE /notifications`
 
-Provide an array of notification ids as your request body.
+Provide an array of notification IDs as your request body.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/notifications.md
+++ b/docs/reference/system/notifications.md
@@ -478,7 +478,6 @@ notification email to be sent.
 
 Provide a partial [notification object](#the-notification-object) as the body of your request.
 
-
 </template>
 <template #graphql>
 
@@ -577,7 +576,7 @@ Update multiple existing notifications.
 ```json
 {
 	"keys": notification_id_array,
-	"data": partial_notification_object 
+	"data": partial_notification_object
 }
 ```
 
@@ -757,7 +756,7 @@ Delete multiple existing notifications.
 
 `DELETE /notifications`
 
-Provide an array of notification ids as your request body. 
+Provide an array of notification ids as your request body.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/operations.md
+++ b/docs/reference/system/operations.md
@@ -358,6 +358,7 @@ Create multiple new operations.
 <template #rest>
 
 `POST /operations`
+
 Provide an array of [operations objects](#the-operations-object) as the body of your request.
 
 ```json
@@ -596,7 +597,7 @@ Update multiple existing operations.
 ```json
 {
 	"keys": operation_id_array,
-	"data": partial_operation_object 
+	"data": partial_operation_object
 }
 ```
 

--- a/docs/reference/system/operations.md
+++ b/docs/reference/system/operations.md
@@ -78,7 +78,7 @@ List all operations that exist in Directus.
 
 `SEARCH /operations`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/operations.md
+++ b/docs/reference/system/operations.md
@@ -99,7 +99,7 @@ import { createDirectus, rest, readOperations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(readOperations( query_object ));
+const result = await client.request(readOperations(query_object));
 ```
 
 </template>
@@ -186,9 +186,7 @@ import { createDirectus, rest, readOperation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readOperation( operation_id, query_object )
-);
+const result = await client.request(readOperation(operation_id, query_object));
 ```
 
 </template>
@@ -274,9 +272,7 @@ import { createDirectus, rest, createOperation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createOperation( operation_object )
-);
+const result = await client.request(createOperation(operation_object));
 ```
 
 </template>
@@ -395,9 +391,7 @@ import { createDirectus, rest, createOperations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createOperations( operations_object_array )
-);
+const result = await client.request(createOperations(operations_object_array));
 ```
 
 </template>
@@ -520,9 +514,7 @@ import { createDirectus, rest, updateOperation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateOperation( operation_id, partial_operation_object )
-);
+const result = await client.request(updateOperation(operation_id, partial_operation_object));
 ```
 
 </template>
@@ -620,9 +612,7 @@ import { createDirectus, rest, updateOperations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateOperations( operations_id_array, partial_operations_object )
-);
+const result = await client.request(updateOperations(operations_id_array, partial_operations_object));
 ```
 
 </template>
@@ -726,9 +716,7 @@ import { createDirectus, rest, deleteOperation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	deleteOperation( operation_id )
-);
+const result = await client.request(deleteOperation(operation_id));
 ```
 
 </template>
@@ -802,9 +790,7 @@ import { createDirectus, rest, deleteOperations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	deleteOperations( operations_id_array )
-);
+const result = await client.request(deleteOperations(operations_id_array));
 ```
 
 </template>
@@ -883,9 +869,7 @@ import { createDirectus, rest, triggerOperation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	triggerOperation( operation_id, webhook_payload_object )
-);
+const result = await client.request(triggerOperation(operation_id, webhook_payload_object));
 ```
 
 </template>

--- a/docs/reference/system/operations.md
+++ b/docs/reference/system/operations.md
@@ -78,7 +78,9 @@ List all operations that exist in Directus.
 
 `SEARCH /operations`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -104,8 +106,6 @@ const result = await client.request(readOperations(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -769,7 +769,7 @@ Delete multiple existing operations.
 
 `DELETE /operations`
 
-Provide an array of operation ids as the body of your request.
+Provide an array of operation IDs as the body of your request.
 
 </template>
 <template #graphql>
@@ -888,7 +888,11 @@ Result of the operation, if any.
 <SnippetToggler :choices="['REST', 'SDK']" label="API">
 <template #rest>
 
-`// POST /flows/trigger/202a940b-a00b-47df-b832-369c53f13122` `// Payload here`
+`POST /flows/trigger/202a940b-a00b-47df-b832-369c53f13122`
+
+```json
+// Payload here
+```
 
 </template>
 <template #sdk>

--- a/docs/reference/system/operations.md
+++ b/docs/reference/system/operations.md
@@ -78,6 +78,8 @@ List all operations that exist in Directus.
 
 `SEARCH /operations`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -93,12 +95,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, readOperations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(readOperations(query));
+const result = await client.request(readOperations( query_object ));
 ```
 
 </template>
@@ -143,8 +144,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, readOperations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -182,12 +182,13 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, readOperation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readOperation('operation_id', query));
+const result = await client.request(
+	readOperation( operation_id, query_object )
+);
 ```
 
 </template>
@@ -229,8 +230,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, readOperation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -253,13 +253,7 @@ Create a new operation.
 
 `POST /operations`
 
-```json
-{
-	"operations_field_1": "value_1",
-	"operations_field_2": "value_2",
-	"operations_field_3": "value_3"
-}
-```
+Provide an [operation object](#the-operation-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -276,19 +270,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, createOperation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createOperation({
-		key: 'operation_key',
-		type: 'operation_log',
-		position_x: 'operation_x_pos',
-		position_y: 'operation_y_pos',
-		flow: '9flow_id',
-	})
+	createOperation( operation_object )
 );
 ```
 
@@ -343,8 +330,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, createOperation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -372,6 +358,7 @@ Create multiple new operations.
 <template #rest>
 
 `POST /operations`
+Provide an array of [operations objects](#the-operations-object) as the body of your request.
 
 ```json
 [
@@ -403,28 +390,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, createOperations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createOperations([
-		{
-			key: 'operation_key',
-			type: 'operation_log',
-			position_x: 'operation_x_pos',
-			position_y: 'operation_y_pos',
-			flow: 'flow_id',
-		},
-		{
-			key: 'operation_2_key',
-			type: 'operation_2_log',
-			position_x: 'operation_2_x_pos',
-			position_y: 'operation_2_y_pos',
-			flow: 'flow_id',
-		},
-	])
+	createOperations( operations_object_array )
 );
 ```
 
@@ -489,8 +460,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, createOperations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -528,11 +498,7 @@ Update an existing operation.
 
 `PATCH /operation/:id`
 
-```json
-{
-	"operation_object_field": "value_1"
-}
-```
+Provide a partial [operation object](#the-operation-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -549,15 +515,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, updateOperation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateOperation('operation_id', {
-		operation_field: 'value',
-	})
+	updateOperation( operation_id, partial_operation_object )
 );
 ```
 
@@ -607,8 +570,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, updateOperation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -633,10 +595,8 @@ Update multiple existing operations.
 
 ```json
 {
-	"keys": ["operation_1_key", "operation_2_key"],
-	"data": {
-		"operation_object_field": "value_1"
-	}
+	"keys": operation_id_array,
+	"data": partial_operation_object 
 }
 ```
 
@@ -655,15 +615,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, updateOperations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateOperations(['operation_1_id', 'operation_2_id'], {
-		field: 'value',
-	})
+	updateOperations( operations_id_array, partial_operations_object )
 );
 ```
 
@@ -724,8 +681,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, updateOperations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -765,12 +721,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteOperation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteOperation('operation_id'));
+const result = await client.request(
+	deleteOperation( operation_id )
+);
 ```
 
 </template>
@@ -802,8 +759,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteOperation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -824,9 +780,7 @@ Delete multiple existing operations.
 
 `DELETE /operations`
 
-```json
-["operation_1_id", "operation_2_id", "operation_2_id"]
-```
+Provide an array of operation ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -843,13 +797,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteOperations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	deleteOperations(['263b18e6-7297-4a9f-af88-15af7317d4ef', '4b220e51-5e2b-48b5-a988-0a6451624d0c'])
+	deleteOperations( operations_id_array )
 );
 ```
 
@@ -898,8 +851,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteOperations } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteOperations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -926,15 +878,12 @@ Trigger an operation based on primary key.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, triggerOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, triggerOperation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	triggerOperation('operation_id', {
-		// Payload
-	})
+	triggerOperation( operation_id, webhook_payload_object )
 );
 ```
 
@@ -960,8 +909,7 @@ Result of the operation, if any.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, triggerOperation } from '@directus/sdk/rest';
+import { createDirectus, rest, triggerOperation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/panels.md
+++ b/docs/reference/system/panels.md
@@ -91,7 +91,9 @@ List all panels that exist in Directus.
 
 `SEARCH /panels`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -117,8 +119,6 @@ const result = await client.request(readPanels(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -765,7 +765,7 @@ Delete multiple existing panels.
 
 `DELETE /panels`
 
-Provide an array of panel ids as the body of your request.
+Provide an array of panel IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/panels.md
+++ b/docs/reference/system/panels.md
@@ -112,9 +112,7 @@ import { createDirectus, rest, readPanels } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readPanels( query_object )
-);
+const result = await client.request(readPanels(query_object));
 ```
 
 </template>
@@ -202,9 +200,7 @@ import { createDirectus, rest, readPanel } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readPanel( panel_id, query_object )
-);
+const result = await client.request(readPanel(panel_id, query_object));
 ```
 
 </template>
@@ -289,9 +285,7 @@ import { createDirectus, rest, createPanel } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createPanel( panel_object )
-);
+const result = await client.request(createPanel(panel_object));
 ```
 
 </template>
@@ -393,9 +387,7 @@ import { createDirectus, rest, createPanels } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createPanels( panel_object_array )
-);
+const result = await client.request(createPanels(panel_object_array));
 ```
 
 </template>
@@ -514,9 +506,7 @@ import { createDirectus, rest, updatePanel } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updatePanel( panel_id, partial_panel_object )
-);
+const result = await client.request(updatePanel(panel_id, partial_panel_object));
 ```
 
 </template>
@@ -617,9 +607,7 @@ import { createDirectus, rest, updatePanels } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updatePanels( panel_id_array, partial_panel_object )
-);
+const result = await client.request(updatePanels(panel_id_array, partial_panel_object));
 ```
 
 </template>
@@ -722,7 +710,7 @@ import { createDirectus, rest, deletePanel } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePanel( panel_id ));
+const result = await client.request(deletePanel(panel_id));
 ```
 
 </template>
@@ -798,7 +786,7 @@ import { createDirectus, rest, deletePanels } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePanels( panel_id_array ));
+const result = await client.request(deletePanels(panel_id_array));
 ```
 
 </template>

--- a/docs/reference/system/panels.md
+++ b/docs/reference/system/panels.md
@@ -91,6 +91,8 @@ List all panels that exist in Directus.
 
 `SEARCH /panels`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -106,15 +108,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPanels } from '@directus/sdk/rest';
+import { createDirectus, rest, readPanels } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readPanels({
-		fields: ['*'],
-	})
+	readPanels( query_object )
 );
 ```
 
@@ -159,8 +158,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPanels } from '@directus/sdk/rest';
+import { createDirectus, rest, readPanels } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -200,15 +198,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPanel } from '@directus/sdk/rest';
+import { createDirectus, rest, readPanel } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readPanel('panel_id', {
-		fields: ['*'],
-	})
+	readPanel( panel_id, query_object )
 );
 ```
 
@@ -248,8 +243,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPanel } from '@directus/sdk/rest';
+import { createDirectus, rest, readPanel } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -274,12 +268,7 @@ Create a new panel.
 
 `POST /panels`
 
-```json
-{
-	"panel_field_1": "value_1",
-	"panel_field_2": "value_2"
-}
-```
+Provide a [panel object](#the-panel-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -296,21 +285,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPanel } from '@directus/sdk/rest';
+import { createDirectus, rest, createPanel } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createPanel({
-		name: 'panel_name',
-		type: 'panel_type',
-		dashboard: 'dashboard_id',
-		width: panel_width,
-		height: panel_height,
-		position_x: panel_x,
-		position_y: panel_y,
-	})
+	createPanel( panel_object )
 );
 ```
 
@@ -361,8 +341,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPanel } from '@directus/sdk/rest';
+import { createDirectus, rest, createPanel } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -393,18 +372,7 @@ Create multiple new panels.
 
 `POST /panels`
 
-```json
-[
-	{
-		"panel_1_field_1": "value_1",
-		"panel_1_field_2": "value_2"
-	},
-	{
-		"panel_2_field_1": "value_3",
-		"panel_2_field_2": "value_4"
-	}
-]
-```
+Provide an array of [panel objects](#the-panel-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -421,32 +389,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPanels } from '@directus/sdk/rest';
+import { createDirectus, rest, createPanels } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createPanels([
-		{
-			name: 'panel_name',
-			type: 'panel_type',
-			dashboard: 'dashboard_id',
-			width: panel_width,
-			height: panel_height,
-			position_x: panel_x,
-			position_y: panel_y,
-		},
-		{
-			name: 'panel_2_name',
-			type: 'panel_2_type',
-			dashboard: 'dashboard_2_id',
-			width: panel_2_width,
-			height: panel_2_height,
-			position_x: panel_2_x,
-			position_y: panel_2_y,
-		},
-	])
+	createPanels( panel_object_array )
 );
 ```
 
@@ -503,8 +451,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPanels } from '@directus/sdk/rest';
+import { createDirectus, rest, createPanels } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -546,11 +493,7 @@ Update an existing panel.
 
 `PATCH /panels/:id`
 
-```json
-{
-	"panel_field": "value"
-}
-```
+Provide a partial [panel object](#the-panel-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -567,15 +510,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePanel } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePanel } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updatePanel('panel_id', {
-		field: 'value',
-	})
+	updatePanel( panel_id, partial_panel_object )
 );
 ```
 
@@ -625,8 +565,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePanel } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePanel } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -654,10 +593,8 @@ Update multiple existing panels.
 
 ```json
 {
-	"keys": ["panel_1_id", "panel_2_id"],
-	"data": {
-		"panel_object_field": "value_1"
-	}
+	"keys": panel_id_array,
+	"data": partial_panel_object 
 }
 ```
 
@@ -676,15 +613,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePanels } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePanels } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(staticToken()).with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updatePanels(['panel_1_id', 'panel_2_id'], {
-		field: 'value',
-	})
+	updatePanels( panel_id_array, partial_panel_object )
 );
 ```
 
@@ -744,8 +678,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePanels } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePanels } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -785,12 +718,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePanel } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePanel } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePanel('panel_id'));
+const result = await client.request(deletePanel( panel_id ));
 ```
 
 </template>
@@ -824,8 +756,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePanel } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePanel } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -846,9 +777,7 @@ Delete multiple existing panels.
 
 `DELETE /panels`
 
-```json
-["panel_1_id", "panel_2_id", "panel_3_id"]
-```
+Provide an array of panel ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -865,12 +794,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePanels } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePanels } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePanels(['panel_1_id', 'panel_2_id']));
+const result = await client.request(deletePanels( panel_id_array ));
 ```
 
 </template>
@@ -918,8 +846,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePanels } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePanels } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/panels.md
+++ b/docs/reference/system/panels.md
@@ -91,7 +91,7 @@ List all panels that exist in Directus.
 
 `SEARCH /panels`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/panels.md
+++ b/docs/reference/system/panels.md
@@ -594,7 +594,7 @@ Update multiple existing panels.
 ```json
 {
 	"keys": panel_id_array,
-	"data": partial_panel_object 
+	"data": partial_panel_object
 }
 ```
 

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -74,6 +74,8 @@ other than the current user's role won't be returned.
 
 `SEARCH /permissions`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -89,15 +91,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, readPermissions } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readPermissions({
-		fields: ['*'],
-	})
+	readPermissions( query_object )
 );
 ```
 
@@ -143,8 +142,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, readPermissions } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -184,15 +182,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPermission } from '@directus/sdk/rest';
+import { createDirectus, rest, readPermission } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readPermission('41', {
-		fields: ['*'],
-	})
+	readPermission( permission_id , query_object )
 );
 ```
 
@@ -233,8 +228,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPermission } from '@directus/sdk/rest';
+import { createDirectus, rest, readPermission } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -259,14 +253,7 @@ Create a new permission rule
 
 `POST /permissions`
 
-```json
-{
-	"permission_field_1": "value_1",
-	"permission_field_2": "value_2",
-	"permission_field_3": "value_3",
-	"permission_field_4": ["value_4", "value_5"]
-}
-```
+Provide a [permission object](#the-permission-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -283,17 +270,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPermission } from '@directus/sdk/rest';
+import { createDirectus, rest, createPermission } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createPermission({
-		role: 'role_id',
-		collection: 'collection_name',
-		action: 'action_name',
-	})
+	createPermission( permission_object )
 );
 ```
 
@@ -349,8 +331,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPermission } from '@directus/sdk/rest';
+import { createDirectus, rest, createPermission } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -378,22 +359,7 @@ Create multiple new permission rules
 
 `POST /permissions`
 
-```json
-[
-	{
-		"permission_object_1_field_1": "value_1",
-		"permission_object_1_field_2": "value_2",
-		"permission_object_1_field_3": "value_3",
-		"permission_object_1_field_4": ["value_4", "value_5"]
-	},
-	{
-		"permission_object_2_field_1": "value_6",
-		"permission_object_2_field_2": "value_7",
-		"permission_object_2_field_3": "value_8",
-		"permission_object_2_field_4": ["value_9", "value_10"]
-	}
-]
-```
+Provide an array of [permission objects](#the-permission-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -410,24 +376,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, createPermissions } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createPermissions([
-		{
-			role: 'role_id',
-			collection: 'collection_name',
-			action: 'action_name',
-		},
-		{
-			role: 'role_id',
-			collection: 'collection_name',
-			action: 'action_name',
-		},
-	])
+	createPermissions( permission_object_array )
 );
 ```
 
@@ -494,8 +448,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, createPermissions } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -531,11 +484,7 @@ Update an existing permissions rule.
 
 `PATCH /permissions/:id`
 
-```json
-{
-	"permissions_object_fields": ["value_1", "value_2", "value_3"]
-}
-```
+Provide a partial [permissions object](#the-permissions-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -552,15 +501,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePermission } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePermission } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updatePermission('permission_id', {
-		permission_field: ['value_1', 'value_2'],
-	})
+	updatePermission( permission_id, partial_permission_object)
 );
 ```
 
@@ -609,8 +555,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePermission } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePermission } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -637,10 +582,8 @@ Update multiple existing permissions rules.
 
 ```json
 {
-	"keys": ["permission_1_key", "permission_2_key"],
-	"data": {
-		"permissions_object_fields": ["value_1", "value_2", "value_3"]
-	}
+	"keys": permission_id_array,
+	"data": partial_permission_object 
 }
 ```
 
@@ -659,15 +602,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePermissions } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updatePermissions(['permission_1_id', 'permission_2_id'], {
-		permission_field: ['value_1', 'value_2'],
-	})
+	updatePermissions( permission_id_array, permission_object_panel)
 );
 ```
 
@@ -723,8 +663,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePermissions } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -764,12 +703,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePermission } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePermission } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePermission('permission_1_id'));
+const result = await client.request(deletePermission( permission_id ));
 ```
 
 </template>
@@ -803,8 +741,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePermission } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePermission } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -825,9 +762,7 @@ Delete multiple existing permissions rules
 
 `DELETE /permissions`
 
-```json
-["key_1", "key_2", "key_3"]
-```
+Provide an array of permissions ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -844,12 +779,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePermissions } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePermissions(['permission_1_id', 'permission_2_id']));
+const result = await client.request(deletePermissions( permission_id_array ));
 ```
 
 </template>
@@ -889,8 +823,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePermissions } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePermissions } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -95,9 +95,7 @@ import { createDirectus, rest, readPermissions } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readPermissions( query_object )
-);
+const result = await client.request(readPermissions(query_object));
 ```
 
 </template>
@@ -186,9 +184,7 @@ import { createDirectus, rest, readPermission } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readPermission( permission_id , query_object )
-);
+const result = await client.request(readPermission(permission_id, query_object));
 ```
 
 </template>
@@ -274,9 +270,7 @@ import { createDirectus, rest, createPermission } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createPermission( permission_object )
-);
+const result = await client.request(createPermission(permission_object));
 ```
 
 </template>
@@ -380,9 +374,7 @@ import { createDirectus, rest, createPermissions } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createPermissions( permission_object_array )
-);
+const result = await client.request(createPermissions(permission_object_array));
 ```
 
 </template>
@@ -505,9 +497,7 @@ import { createDirectus, rest, updatePermission } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updatePermission( permission_id, partial_permission_object)
-);
+const result = await client.request(updatePermission(permission_id, partial_permission_object));
 ```
 
 </template>
@@ -606,9 +596,7 @@ import { createDirectus, rest, updatePermissions } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updatePermissions( permission_id_array, permission_object_panel)
-);
+const result = await client.request(updatePermissions(permission_id_array, permission_object_panel));
 ```
 
 </template>
@@ -707,7 +695,7 @@ import { createDirectus, rest, deletePermission } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePermission( permission_id ));
+const result = await client.request(deletePermission(permission_id));
 ```
 
 </template>
@@ -783,7 +771,7 @@ import { createDirectus, rest, deletePermissions } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePermissions( permission_id_array ));
+const result = await client.request(deletePermissions(permission_id_array));
 ```
 
 </template>

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -583,7 +583,7 @@ Update multiple existing permissions rules.
 ```json
 {
 	"keys": permission_id_array,
-	"data": partial_permission_object 
+	"data": partial_permission_object
 }
 ```
 

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -74,7 +74,7 @@ other than the current user's role won't be returned.
 
 `SEARCH /permissions`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/permissions.md
+++ b/docs/reference/system/permissions.md
@@ -74,7 +74,9 @@ other than the current user's role won't be returned.
 
 `SEARCH /permissions`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -100,8 +102,6 @@ const result = await client.request(readPermissions(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -750,7 +750,7 @@ Delete multiple existing permissions rules
 
 `DELETE /permissions`
 
-Provide an array of permissions ids as the body of your request.
+Provide an array of permissions IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/presets.md
+++ b/docs/reference/system/presets.md
@@ -91,6 +91,8 @@ other than the current user's role won't be returned.
 
 `SEARCH /presets`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -106,15 +108,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPresets } from '@directus/sdk/rest';
+import { createDirectus, rest, readPresets } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readPresets({
-		fields: ['*'],
-	})
+	readPresets( object_field )
 );
 ```
 
@@ -159,8 +158,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPresets } from '@directus/sdk/rest';
+import { createDirectus, rest, readPresets } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -200,15 +198,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPreset } from '@directus/sdk/rest';
+import { createDirectus, rest, readPreset } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readPreset('preset_id', {
-		fields: ['*'],
-	})
+	readPreset( preset_id, query_object )
 );
 ```
 
@@ -248,8 +243,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readPreset } from '@directus/sdk/rest';
+import { createDirectus, rest, readPreset } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -274,13 +268,7 @@ Create a new preset.
 
 `POST /presets`
 
-```json
-{
-	"preset_field_1": "value_1",
-	"preset_field_2": "value_2",
-	"preset_field_3": "value_3"
-}
-```
+Provide a [preset object](#the-preset-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -297,16 +285,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPreset } from '@directus/sdk/rest';
+import { createDirectus, rest, createPreset } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createPreset({
-		preset_field_1: 'value_1',
-		preset_field_2: 'value_2',
-	})
+	createPreset( presets_object )
 );
 ```
 
@@ -358,8 +342,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPreset } from '@directus/sdk/rest';
+import { createDirectus, rest, createPreset } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -385,20 +368,7 @@ Create multiple new presets.
 
 `POST /presets`
 
-```json
-[
-	{
-		"preset_1_field_1": "value_1",
-		"preset_1_field_2": "value_2",
-		"preset_1_field_3": "value_3"
-	},
-	{
-		"preset_2_field_1": "value_1",
-		"preset_2_field_2": "value_2",
-		"preset_2_field_3": "value_3"
-	}
-]
-```
+Provide an array of [presets objects](#the-presets-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -415,22 +385,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPresets } from '@directus/sdk/rest';
+import { createDirectus, rest, createPresets } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createPresets([
-		{
-			preset_1_field_1: 'value_1',
-			preset_1_field_2: 'value_2',
-		},
-		{
-			preset_2_field_1: 'value_3',
-			preset_2_field_2: 'value_4',
-		},
-	])
+	createPresets( presets_object_array )
 );
 ```
 
@@ -500,8 +460,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createPresets } from '@directus/sdk/rest';
+import { createDirectus, rest, createPresets } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -533,11 +492,7 @@ Update an existing preset.
 
 `PATCH /presets/:id`
 
-```json
-{
-	"preset_object_field": "value_1"
-}
-```
+Provide a partial [preset object](#the-preset-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -554,15 +509,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePresets } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePresets } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updatePreset('preset_id', {
-		field: 'value',
-	})
+	updatePreset( preset_id, partial_preset_object)
 );
 ```
 
@@ -612,8 +564,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePreset } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePreset } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -640,10 +591,8 @@ Update multiple existing presets.
 
 ```json
 {
-	"keys": ["preset_1_key", "preset_2_key"],
-	"data": {
-		"preset_object_field": "value_1"
-	}
+	"keys": preset_id_array,
+	"data": partial_preset_object 
 }
 ```
 
@@ -662,15 +611,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePresets } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePresets } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updatePresets(['preset_1_id', 'preset_2_id'], {
-		field: 'value',
-	})
+	updatePresets( preset_id_array, partial_preset_object )
 );
 ```
 
@@ -727,8 +673,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updatePresets } from '@directus/sdk/rest';
+import { createDirectus, rest, updatePresets } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -768,12 +713,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePreset } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePreset } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePreset('preset_id'));
+const result = await client.request(deletePreset( preset_id ));
 ```
 
 </template>
@@ -807,8 +751,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePreset } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePreset } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -829,9 +772,7 @@ Delete multiple existing presets.
 
 `DELETE /presets`
 
-```json
-["preset_1_key", "preset_2_key", "preset_3_key"]
-```
+Provide an array of preset ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -848,12 +789,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePresets } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePresets } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePreset(['preset_1_id', 'preset_2_id']));
+const result = await client.request(deletePreset( preset_id_array ));
 ```
 
 </template>
@@ -895,12 +835,11 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deletePresets } from '@directus/sdk/rest';
+import { createDirectus, rest, deletePresets } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deletePreset(['24', '48']));
+const result = await client.request(deletePresets(['24', '48']));
 ```
 
 </template>

--- a/docs/reference/system/presets.md
+++ b/docs/reference/system/presets.md
@@ -91,7 +91,9 @@ other than the current user's role won't be returned.
 
 `SEARCH /presets`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -117,8 +119,6 @@ const result = await client.request(readPresets(object_field));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -760,7 +760,7 @@ Delete multiple existing presets.
 
 `DELETE /presets`
 
-Provide an array of preset ids as the body of your request.
+Provide an array of preset IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/presets.md
+++ b/docs/reference/system/presets.md
@@ -91,7 +91,7 @@ other than the current user's role won't be returned.
 
 `SEARCH /presets`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/presets.md
+++ b/docs/reference/system/presets.md
@@ -592,7 +592,7 @@ Update multiple existing presets.
 ```json
 {
 	"keys": preset_id_array,
-	"data": partial_preset_object 
+	"data": partial_preset_object
 }
 ```
 

--- a/docs/reference/system/presets.md
+++ b/docs/reference/system/presets.md
@@ -112,9 +112,7 @@ import { createDirectus, rest, readPresets } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readPresets( object_field )
-);
+const result = await client.request(readPresets(object_field));
 ```
 
 </template>
@@ -202,9 +200,7 @@ import { createDirectus, rest, readPreset } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readPreset( preset_id, query_object )
-);
+const result = await client.request(readPreset(preset_id, query_object));
 ```
 
 </template>
@@ -289,9 +285,7 @@ import { createDirectus, rest, createPreset } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createPreset( presets_object )
-);
+const result = await client.request(createPreset(presets_object));
 ```
 
 </template>
@@ -389,9 +383,7 @@ import { createDirectus, rest, createPresets } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createPresets( presets_object_array )
-);
+const result = await client.request(createPresets(presets_object_array));
 ```
 
 </template>
@@ -513,9 +505,7 @@ import { createDirectus, rest, updatePresets } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updatePreset( preset_id, partial_preset_object)
-);
+const result = await client.request(updatePreset(preset_id, partial_preset_object));
 ```
 
 </template>
@@ -615,9 +605,7 @@ import { createDirectus, rest, updatePresets } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updatePresets( preset_id_array, partial_preset_object )
-);
+const result = await client.request(updatePresets(preset_id_array, partial_preset_object));
 ```
 
 </template>
@@ -717,7 +705,7 @@ import { createDirectus, rest, deletePreset } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePreset( preset_id ));
+const result = await client.request(deletePreset(preset_id));
 ```
 
 </template>
@@ -793,7 +781,7 @@ import { createDirectus, rest, deletePresets } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deletePreset( preset_id_array ));
+const result = await client.request(deletePreset(preset_id_array));
 ```
 
 </template>

--- a/docs/reference/system/relations.md
+++ b/docs/reference/system/relations.md
@@ -365,8 +365,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, readRelation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -391,13 +390,7 @@ Create a new relation.
 
 `POST /relations`
 
-```json
-{
-	"relations_field_1": "value_1",
-	"relations_field_2": "value_2",
-	"relations_field_3": "value_3"
-}
-```
+Provide a [relation object](#the-relation-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -414,17 +407,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, createRelation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createRelation({
-		relations_field_1: 'value_1',
-		relations_field_2: 'value_2',
-		relations_field_3: 'value_3',
-	})
+	createRelation( relation_object )
 );
 ```
 
@@ -479,8 +467,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, createRelation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -507,13 +494,7 @@ Update an existing relation.
 
 `PATCH /relations/:collection/:field`
 
-```json
-{
-	"relations_field": {
-		"relations_subfield": "value"
-	}
-}
-```
+Provide a partial [relation object](#the-relation-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -530,17 +511,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, updateRelation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateRelation('collection_name', 'field_name', {
-		field: {
-			sub_field: 'value',
-		},
-	})
+	updateRelation( collection_name,  field_name, partial_relation_object )
 );
 ```
 
@@ -593,8 +569,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, updateRelation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -636,12 +611,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteRelation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteRelation('collection_name', 'field_name'));
+const result = await client.request(deleteRelation( collection_name,  field_name ));
 ```
 
 </template>
@@ -676,8 +650,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteRelation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/relations.md
+++ b/docs/reference/system/relations.md
@@ -146,9 +146,7 @@ import { createDirectus, rest, readRelations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRelations( query_object )
-);
+const result = await client.request(readRelations(query_object));
 ```
 
 </template>
@@ -238,9 +236,7 @@ import { createDirectus, rest, readRelationByCollection } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRelationByCollection( collection_name, query_object )
-);
+const result = await client.request(readRelationByCollection(collection_name, query_object));
 ```
 
 </template>
@@ -323,9 +319,7 @@ import { createDirectus, rest, readRelation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRelation( collection_name, field_name, query_object )
-);
+const result = await client.request(readRelation(collection_name, field_name, query_object));
 ```
 
 </template>
@@ -411,9 +405,7 @@ import { createDirectus, rest, createRelation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createRelation( relation_object )
-);
+const result = await client.request(createRelation(relation_object));
 ```
 
 </template>
@@ -515,9 +507,7 @@ import { createDirectus, rest, updateRelation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateRelation( collection_name,  field_name, partial_relation_object )
-);
+const result = await client.request(updateRelation(collection_name, field_name, partial_relation_object));
 ```
 
 </template>
@@ -615,7 +605,7 @@ import { createDirectus, rest, deleteRelation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteRelation( collection_name,  field_name ));
+const result = await client.request(deleteRelation(collection_name, field_name));
 ```
 
 </template>

--- a/docs/reference/system/relations.md
+++ b/docs/reference/system/relations.md
@@ -142,15 +142,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRelations } from '@directus/sdk/rest';
+import { createDirectus, rest, readRelations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRelations({
-		fields: ['*'],
-	})
+	readRelations( query_object )
 );
 ```
 
@@ -190,8 +187,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRelations } from '@directus/sdk/rest';
+import { createDirectus, rest, readRelations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -238,15 +234,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRelationByCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, readRelationByCollection } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRelationByCollection('collection_name', {
-		fields: ['*'],
-	})
+	readRelationByCollection( collection_name, query_object )
 );
 ```
 
@@ -286,8 +279,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRelationByCollection } from '@directus/sdk/rest';
+import { createDirectus, rest, readRelationByCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -327,15 +319,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRelation } from '@directus/sdk/rest';
+import { createDirectus, rest, readRelation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRelation('collection_name', 'field_name', {
-		fields: ['*'],
-	})
+	readRelation( collection_name, field_name, query_object )
 );
 ```
 

--- a/docs/reference/system/revisions.md
+++ b/docs/reference/system/revisions.md
@@ -68,6 +68,8 @@ to a collection that the current user doesn't have access to are stripped out.
 
 `SEARCH /revisions`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -83,15 +85,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRevisions } from '@directus/sdk/rest';
+import { createDirectus, rest, readRevisions } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRevisions({
-		fields: ['*'],
-	})
+	readRevisions( query_object )
 );
 ```
 
@@ -137,8 +136,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRevisions } from '@directus/sdk/rest';
+import { createDirectus, rest, readRevisions } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -178,15 +176,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRevision } from '@directus/sdk/rest';
+import { createDirectus, rest, readRevision } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRevision('revision_id', {
-		fields: ['*'],
-	})
+	readRevision( revision_id, query_object )
 );
 ```
 
@@ -227,8 +222,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRevision } from '@directus/sdk/rest';
+import { createDirectus, rest, readRevision } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/revisions.md
+++ b/docs/reference/system/revisions.md
@@ -89,9 +89,7 @@ import { createDirectus, rest, readRevisions } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRevisions( query_object )
-);
+const result = await client.request(readRevisions(query_object));
 ```
 
 </template>
@@ -180,9 +178,7 @@ import { createDirectus, rest, readRevision } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRevision( revision_id, query_object )
-);
+const result = await client.request(readRevision(revision_id, query_object));
 ```
 
 </template>

--- a/docs/reference/system/revisions.md
+++ b/docs/reference/system/revisions.md
@@ -68,7 +68,9 @@ to a collection that the current user doesn't have access to are stripped out.
 
 `SEARCH /revisions`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -94,8 +96,6 @@ const result = await client.request(readRevisions(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 

--- a/docs/reference/system/revisions.md
+++ b/docs/reference/system/revisions.md
@@ -68,7 +68,7 @@ to a collection that the current user doesn't have access to are stripped out.
 
 `SEARCH /revisions`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/roles.md
+++ b/docs/reference/system/roles.md
@@ -65,7 +65,7 @@ List all roles that exist in Directus.
 
 `SEARCH /roles`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/roles.md
+++ b/docs/reference/system/roles.md
@@ -245,6 +245,7 @@ Create a new role.
 <template #rest>
 
 `POST /roles`
+
 Provide a [role object](#the-role-object) as the body of your request.
 
 </template>
@@ -354,6 +355,7 @@ Create multiple new roles.
 <template #rest>
 
 `POST /roles`
+
 Provide an array of [role objects](#the-role-object) as the body of your request.
 
 </template>
@@ -484,6 +486,7 @@ Update an existing role.
 <template #rest>
 
 `PATCH /roles/:id`
+
 Provide a partial [role object](#the-role-object) as the body of your request.
 
 </template>
@@ -587,7 +590,7 @@ Update multiple existing roles.
 ```json
 {
 	"keys": role_id_array,
-	"data": partial_role_object 
+	"data": partial_role_object
 }
 ```
 

--- a/docs/reference/system/roles.md
+++ b/docs/reference/system/roles.md
@@ -86,9 +86,7 @@ import { createDirectus, rest, readRoles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRoles( query_object )
-);
+const result = await client.request(readRoles(query_object));
 ```
 
 </template>
@@ -177,9 +175,7 @@ import { createDirectus, rest, readRole } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readRole( role_id, query_object )
-);
+const result = await client.request(readRole(role_id, query_object));
 ```
 
 </template>
@@ -267,9 +263,7 @@ import { createDirectus, rest, createRole } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createRole( role_object )
-);
+const result = await client.request(createRole(role_object));
 ```
 
 </template>
@@ -377,9 +371,7 @@ import { createDirectus, rest, createRoles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createRoles( role_object_array )
-);
+const result = await client.request(createRoles(role_object_array));
 ```
 
 </template>
@@ -508,9 +500,7 @@ import { createDirectus, rest, updateRole } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateRole( role_id, partial_role_object )
-);
+const result = await client.request(updateRole(role_id, partial_role_object));
 ```
 
 </template>
@@ -613,9 +603,7 @@ import { createDirectus, rest, updateRoles } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateRoles( role_id_array, partial_role_object )
-);
+const result = await client.request(updateRoles(role_id_array, partial_role_object));
 ```
 
 </template>
@@ -721,7 +709,7 @@ import { createDirectus, rest, deleteRole } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteRole( role_id ));
+const result = await client.request(deleteRole(role_id));
 ```
 
 </template>
@@ -797,7 +785,7 @@ import { createDirectus, rest, deleteRoles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteRoles( role_id_array ));
+const result = await client.request(deleteRoles(role_id_array));
 ```
 
 </template>

--- a/docs/reference/system/roles.md
+++ b/docs/reference/system/roles.md
@@ -65,6 +65,8 @@ List all roles that exist in Directus.
 
 `SEARCH /roles`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -80,15 +82,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, readRoles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRoles({
-		fields: ['*'],
-	})
+	readRoles( query_object )
 );
 ```
 
@@ -136,8 +135,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, readRoles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -175,15 +173,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRole } from '@directus/sdk/rest';
+import { createDirectus, rest, readRole } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readRole('role_id', {
-		fields: ['*'],
-	})
+	readRole( role_id, query_object )
 );
 ```
 
@@ -226,8 +221,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readRole } from '@directus/sdk/rest';
+import { createDirectus, rest, readRole } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -251,16 +245,7 @@ Create a new role.
 <template #rest>
 
 `POST /roles`
-
-```json
-{
-	"role_field_1": "value_1",
-	"role_field_2": "value_2",
-	"role_field_3": "value_3",
-	"role_field_4": "value_4",
-	"role_field_5": "value_5"
-}
-```
+Provide a [role object](#the-role-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -277,19 +262,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createRole } from '@directus/sdk/rest';
+import { createDirectus, rest, createRole } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createRole({
-		role_field_1: 'value_1',
-		role_field_2: 'value_2',
-		role_field_3: 'value_3',
-		role_field_4: 'value_4',
-		role_field_5: 'value_5',
-	})
+	createRole( role_object )
 );
 ```
 
@@ -348,8 +326,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createRole } from '@directus/sdk/rest';
+import { createDirectus, rest, createRole } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -377,25 +354,7 @@ Create multiple new roles.
 <template #rest>
 
 `POST /roles`
-
-```json
-[
-	{
-		"role_object_1_field_1": "value_1",
-		"role_object_1_field_2": "value_2",
-		"role_object_1_field_3": "value_3",
-		"role_object_1_field_4": "value_4",
-		"role_object_1_field_5": "value_5"
-	},
-	{
-		"role_object_2_field_1": "value_6",
-		"role_object_2_field_2": "value_7",
-		"role_object_2_field_3": "value_8",
-		"role_object_2_field_4": "value_9",
-		"role_object_2_field_5": "value_10"
-	}
-]
-```
+Provide an array of [role objects](#the-role-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -412,28 +371,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, createRoles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createRoles([
-		{
-			role_object_1_field_1: 'value_1',
-			role_object_1_field_2: 'value_2',
-			role_object_1_field_3: 'value_3',
-			role_object_1_field_4: 'value_4',
-			role_object_1_field_5: 'value_5',
-		},
-		{
-			role_object_2_field_1: 'value_6',
-			role_object_2_field_2: 'value_7',
-			role_object_2_field_3: 'value_8',
-			role_object_2_field_4: 'value_9',
-			role_object_2_field_5: 'value_10',
-		},
-	])
+	createRoles( role_object_array )
 );
 ```
 
@@ -504,8 +447,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, createRoles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -542,12 +484,7 @@ Update an existing role.
 <template #rest>
 
 `PATCH /roles/:id`
-
-```json
-{
-	"roles_object_field": "value_1"
-}
-```
+Provide a partial [role object](#the-role-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -564,15 +501,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateRole } from '@directus/sdk/rest';
+import { createDirectus, rest, updateRole } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateRole('role_id', {
-		role_field: 'value',
-	})
+	updateRole( role_id, partial_role_object )
 );
 ```
 
@@ -625,8 +559,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateRole } from '@directus/sdk/rest';
+import { createDirectus, rest, updateRole } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -653,10 +586,8 @@ Update multiple existing roles.
 
 ```json
 {
-	"keys": ["role_1_key", "role_2_key"],
-	"data": {
-		"role_object_field": "value_1"
-	}
+	"keys": role_id_array,
+	"data": partial_role_object 
 }
 ```
 
@@ -675,15 +606,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, updateRoles } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateRoles(['role_1_id', 'role_2_id'], {
-		field: 'value',
-	})
+	updateRoles( role_id_array, partial_role_object )
 );
 ```
 
@@ -746,8 +674,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, updateRoles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -787,12 +714,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteRole } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteRole } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteRole('role_id'));
+const result = await client.request(deleteRole( role_id ));
 ```
 
 </template>
@@ -826,8 +752,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteRole } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteRole } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -848,9 +773,7 @@ Delete multiple existing roles.
 
 `DELETE /roles`
 
-```json
-["role_1_key", "role_2_key"]
-```
+Provide an array of role ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -867,12 +790,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteRoles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(deleteRoles(['role_1_id', 'role_2_id']));
+const result = await client.request(deleteRoles( role_id_array ));
 ```
 
 </template>
@@ -914,8 +836,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteRoles } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteRoles } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/roles.md
+++ b/docs/reference/system/roles.md
@@ -65,7 +65,9 @@ List all roles that exist in Directus.
 
 `SEARCH /roles`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -91,8 +93,6 @@ const result = await client.request(readRoles(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -764,7 +764,7 @@ Delete multiple existing roles.
 
 `DELETE /roles`
 
-Provide an array of role ids as the body of your request.
+Provide an array of role IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/schema.md
+++ b/docs/reference/system/schema.md
@@ -36,10 +36,9 @@ GET /schema/snapshot?export=yaml
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, schemaSnapshot } from '@directus/sdk/rest';
+import { createDirectus, rest, schemaSnapshot } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(schemaSnapshot());
 ```
@@ -78,8 +77,7 @@ GET /schema/snapshot?export=yaml
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, schemaSnapshot } from '@directus/sdk/rest';
+import { createDirectus, rest, schemaSnapshot } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -170,8 +168,7 @@ relations: []
 ::: details **Toggle Open to See Request**
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, schemaDiff } from '@directus/sdk/rest';
+import { createDirectus, rest, schemaDiff } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -547,8 +544,7 @@ relations: []
 ::: details **Toggle Open to See Example Request**
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, schemaDiff } from '@directus/sdk/rest';
+import { createDirectus, rest, schemaDiff } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -882,8 +878,7 @@ POST /schema/apply
 ::: details **Toggle Open to See Example Request**
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, schemaApply } from '@directus/sdk/rest';
+import { createDirectus, rest, schemaApply } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/server.md
+++ b/docs/reference/system/server.md
@@ -123,7 +123,7 @@ import { createDirectus, rest, readGraphqlSdl } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readGraphqlSdl( scope ));
+const result = await client.request(readGraphqlSdl(scope));
 ```
 
 </template>

--- a/docs/reference/system/server.md
+++ b/docs/reference/system/server.md
@@ -41,10 +41,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readOpenApiSpec } from '@directus/sdk/rest';
+import { createDirectus, rest, readOpenApiSpec } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(readOpenApiSpec());
 ```
@@ -76,8 +75,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readOpenApiSpec } from '@directus/sdk/rest';
+import { createDirectus, rest, readOpenApiSpec } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -121,12 +119,11 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readGraphqlSdl } from '@directus/sdk/rest';
+import { createDirectus, rest, readGraphqlSdl } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readGraphqlSdl('scope'));
+const result = await client.request(readGraphqlSdl( scope ));
 ```
 
 </template>
@@ -182,8 +179,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readGraphqlSdl } from '@directus/sdk/rest';
+import { createDirectus, rest, readGraphqlSdl } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -219,10 +215,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, serverPing } from '@directus/sdk/rest';
+import { createDirectus, rest, serverPing } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(serverPing());
 ```
@@ -256,8 +251,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, serverPing } from '@directus/sdk/rest';
+import { createDirectus, rest, serverPing } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -299,10 +293,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, serverInfo } from '@directus/sdk/rest';
+import { createDirectus, rest, serverInfo } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(serverInfo());
 ```
@@ -361,8 +354,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, serverInfo } from '@directus/sdk/rest';
+import { createDirectus, rest, serverInfo } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -466,10 +458,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, serverHealth } from '@directus/sdk/rest';
+import { createDirectus, rest, serverHealth } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(serverHealth());
 ```
@@ -515,8 +506,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, serverHealth } from '@directus/sdk/rest';
+import { createDirectus, rest, serverHealth } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/settings.md
+++ b/docs/reference/system/settings.md
@@ -194,7 +194,7 @@ const result = await client.request(readSettings());
 
 `PATCH /settings`
 
-Provide a [settings object](#the-settings-object) as the body of your request.
+Provide a partial [settings object](#the-settings-object) as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/settings.md
+++ b/docs/reference/system/settings.md
@@ -215,9 +215,7 @@ import { createDirectus, rest, updateSettings } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateSettings( settings_object )
-);
+const result = await client.request(updateSettings(settings_object));
 ```
 
 </template>

--- a/docs/reference/system/settings.md
+++ b/docs/reference/system/settings.md
@@ -133,10 +133,9 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readSettings } from '@directus/sdk/rest';
+import { createDirectus, rest, readSettings } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(readSettings());
 ```
@@ -176,8 +175,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readSettings } from '@directus/sdk/rest';
+import { createDirectus, rest, readSettings } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -196,11 +194,7 @@ const result = await client.request(readSettings());
 
 `PATCH /settings`
 
-```json
-{
-	"settings_object_field": "value_1"
-}
-```
+Provide a [settings object](#the-settings-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -217,15 +211,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateSettings } from '@directus/sdk/rest';
+import { createDirectus, rest, updateSettings } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateSettings({
-		settings_field: 'value',
-	})
+	updateSettings( settings_object )
 );
 ```
 
@@ -275,8 +266,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateSettings } from '@directus/sdk/rest';
+import { createDirectus, rest, updateSettings } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/shares.md
+++ b/docs/reference/system/shares.md
@@ -76,7 +76,7 @@ List all shares that exist in Directus.
 
 `SEARCH /shares`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/shares.md
+++ b/docs/reference/system/shares.md
@@ -97,9 +97,7 @@ import { createDirectus, rest, readShares } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readShares( query_object )
-);
+const result = await client.request(readShares(query_object));
 ```
 
 </template>
@@ -187,9 +185,7 @@ import { createDirectus, rest, readShare } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readShare( share_id, query_object )
-);
+const result = await client.request(readShare(share_id, query_object));
 ```
 
 </template>
@@ -276,9 +272,7 @@ import { createDirectus, rest, createShare } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createShare( share_object )
-);
+const result = await client.request(createShare(share_object));
 ```
 
 </template>
@@ -381,9 +375,7 @@ import { createDirectus, rest, createShares } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createShares( share_object_array )
-);
+const result = await client.request(createShares(share_object_array));
 ```
 
 </template>
@@ -512,9 +504,7 @@ import { createDirectus, rest, updateShare } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateShare( share_id, partial_share_object )
-);
+const result = await client.request(updateShare(share_id, partial_share_object));
 ```
 
 </template>
@@ -616,9 +606,7 @@ import { createDirectus, rest, updateShares } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateShares( share_id_array, partial_share_object )
-);
+const result = await client.request(updateShares(share_id_array, partial_share_object));
 ```
 
 </template>
@@ -723,7 +711,7 @@ import { createDirectus, rest, deleteShare } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteShare( share_id ));
+const result = await client.request(deleteShare(share_id));
 ```
 
 </template>
@@ -799,7 +787,7 @@ import { createDirectus, rest, deleteShares } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteShares( share_id_array ));
+const result = await client.request(deleteShares(share_id_array));
 ```
 
 </template>
@@ -887,9 +875,7 @@ import { createDirectus, rest, authenticateShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	authenticateShare('share_key', 'password')
-);
+const result = await client.request(authenticateShare('share_key', 'password'));
 ```
 
 </template>
@@ -942,9 +928,7 @@ import { createDirectus, rest, authenticateShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	authenticateShare('61e8a1b6-6eba-438c-91e8-8d912ef655d3', 'd1r3ct5us')
-);
+const result = await client.request(authenticateShare('61e8a1b6-6eba-438c-91e8-8d912ef655d3', 'd1r3ct5us'));
 ```
 
 </template>
@@ -981,9 +965,7 @@ import { createDirectus, rest, inviteShare } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	inviteShare( share_id, email_address_array)
-);
+const result = await client.request(inviteShare(share_id, email_address_array));
 ```
 
 </template>
@@ -1029,7 +1011,7 @@ import { createDirectus, rest, inviteShare } from '@directus/sdk';
 const client = createDirectus('https://directus.example.com').with(rest());
 
 const result = await client.request(
-	inviteShare('653925a9-970e-487a-bfc0-ab6c96affcdc', ["allison@example.com", "mike@example.com"])
+	inviteShare('653925a9-970e-487a-bfc0-ab6c96affcdc', ['allison@example.com', 'mike@example.com'])
 );
 ```
 
@@ -1058,7 +1040,7 @@ import { createDirectus, rest, readShareInfo } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readShareInfo( share_id ));
+const result = await client.request(readShareInfo(share_id));
 ```
 
 </template>

--- a/docs/reference/system/shares.md
+++ b/docs/reference/system/shares.md
@@ -76,7 +76,9 @@ List all shares that exist in Directus.
 
 `SEARCH /shares`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -102,8 +104,6 @@ const result = await client.request(readShares(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -766,7 +766,7 @@ Delete multiple existing shares.
 
 `DELETE /shares`
 
-Provide an array of share ids as the body of your request.
+Provide an array of share IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/shares.md
+++ b/docs/reference/system/shares.md
@@ -593,7 +593,7 @@ Update multiple existing shares.
 ```json
 {
 	"keys": share_id_array,
-	"data": partial_share_object 
+	"data": partial_share_object
 }
 ```
 

--- a/docs/reference/system/shares.md
+++ b/docs/reference/system/shares.md
@@ -76,6 +76,8 @@ List all shares that exist in Directus.
 
 `SEARCH /shares`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -91,15 +93,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readShares } from '@directus/sdk/rest';
+import { createDirectus, rest, readShares } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readShares({
-		fields: ['*'],
-	})
+	readShares( query_object )
 );
 ```
 
@@ -146,8 +145,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readShares } from '@directus/sdk/rest';
+import { createDirectus, rest, readShares } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -185,15 +183,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readShare } from '@directus/sdk/rest';
+import { createDirectus, rest, readShare } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readShare('share_id', {
-		fields: ['*'],
-	})
+	readShare( share_id, query_object )
 );
 ```
 
@@ -235,8 +230,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readShare } from '@directus/sdk/rest';
+import { createDirectus, rest, readShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -261,14 +255,7 @@ Create a new share.
 
 `POST /shares`
 
-```json
-{
-	"share_field_1": "value_1",
-	"share_field_2": "value_2",
-	"share_field_3": "value_3",
-	"share_field_4": "value_4"
-}
-```
+Provide a [share object](#the-share-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -285,18 +272,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createShare } from '@directus/sdk/rest';
+import { createDirectus, rest, createShare } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createShare({
-		share_field_1: 'value_1',
-		share_field_2: 'value_2',
-		share_field_3: 'value_3',
-		share_field_4: 'value_4',
-	})
+	createShare( share_object )
 );
 ```
 
@@ -351,8 +332,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createShare } from '@directus/sdk/rest';
+import { createDirectus, rest, createShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -380,22 +360,7 @@ Create multiple new shares.
 
 `POST /shares`
 
-```json
-[
-	{
-		"share_1_field_1": "value_1",
-		"share_1_field_2": "value_2",
-		"share_1_field_3": "value_3",
-		"share_1_field_4": "value_4"
-	},
-	{
-		"share_2_field_1": "value_5",
-		"share_2_field_2": "value_6",
-		"share_2_field_3": "value_7",
-		"share_2_field_4": "value_8"
-	}
-]
-```
+Provide an array of [share objects](#the-share-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -412,26 +377,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createShares } from '@directus/sdk/rest';
+import { createDirectus, rest, createShares } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createShares([
-		{
-			share_1_field_1: 'value_1',
-			share_1_field_2: 'value_2',
-			share_1_field_3: 'value_3',
-			share_1_field_4: 'value_4',
-		},
-		{
-			share_2_field_1: 'value_5',
-			share_2_field_2: 'value_6',
-			share_2_field_3: 'value_7',
-			share_2_field_4: 'value_8',
-		},
-	])
+	createShares( share_object_array )
 );
 ```
 
@@ -504,8 +455,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createShares } from '@directus/sdk/rest';
+import { createDirectus, rest, createShares } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -541,11 +491,7 @@ Update an existing share.
 
 `PATCH /shares/:id`
 
-```json
-{
-	"share_field": "value_1"
-}
-```
+Provide a partial [share objects](#the-share-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -562,15 +508,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateShare } from '@directus/sdk/rest';
+import { createDirectus, rest, updateShare } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateShare('share_id', {
-		share_field: 'value',
-	})
+	updateShare( share_id, partial_share_object )
 );
 ```
 
@@ -622,8 +565,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateShare } from '@directus/sdk/rest';
+import { createDirectus, rest, updateShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -650,10 +592,8 @@ Update multiple existing shares.
 
 ```json
 {
-	"keys": ["share_1_id", "share_2_id"],
-	"data": {
-		"share_object_field": "value_1"
-	}
+	"keys": share_id_array,
+	"data": partial_share_object 
 }
 ```
 
@@ -672,15 +612,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateShare } from '@directus/sdk/rest';
+import { createDirectus, rest, updateShares } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateShares(['share_1_id', 'share_2_id'], {
-		field: 'value',
-	})
+	updateShares( share_id_array, partial_share_object )
 );
 ```
 
@@ -742,8 +679,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateShare } from '@directus/sdk/rest';
+import { createDirectus, rest, updateShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -780,6 +716,17 @@ type Mutation {
 ```
 
 </template>
+<template #sdk>
+
+```js
+import { createDirectus, rest, deleteShare } from '@directus/sdk';
+
+const client = createDirectus('directus_project_url').with(rest());
+
+const result = await client.request(deleteShare( share_id ));
+```
+
+</template>
 </SnippetToggler>
 
 ### Response
@@ -810,8 +757,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteShare } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(staticToken()).with(rest());
 
@@ -832,9 +778,7 @@ Delete multiple existing shares.
 
 `DELETE /shares`
 
-```json
-["share_1_id", "share_2_id"]
-```
+Provide an array of share ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -851,12 +795,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteShares } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteShares } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteShares(['share_1_id', 'share_2_id']));
+const result = await client.request(deleteShares( share_id_array ));
 ```
 
 </template>
@@ -898,8 +841,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteShares } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteShares } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -927,8 +869,8 @@ with the credentials set returned by this endpoint.
 
 ```json
 {
-	"share": "share_key",
-	"password": "password"
+	"share": share_id,
+	"password": password
 }
 ```
 
@@ -941,12 +883,13 @@ with the credentials set returned by this endpoint.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readShareInfo } from '@directus/sdk/rest';
+import { createDirectus, rest, authenticateShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(readShareInfo('share_key'));
+const result = await client.request(
+	authenticateShare('share_key', 'password')
+);
 ```
 
 </template>
@@ -995,12 +938,13 @@ as the mode in the request, the refresh token won't be returned in the JSON.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, authenticateShare } from '@directus/sdk/rest';
+import { createDirectus, rest, authenticateShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(authenticateShare('share_key', 'password'));
+const result = await client.request(
+	authenticateShare('61e8a1b6-6eba-438c-91e8-8d912ef655d3', 'd1r3ct5us')
+);
 ```
 
 </template>
@@ -1019,8 +963,8 @@ Sends an email to the provided email addresses with a link to the share.
 
 ```json
 {
-	"share": "share_key",
-	"emails": ["email_addr_1", "email_addr_2"]
+	"share": share_key,
+	"emails": email_address_array
 }
 ```
 
@@ -1033,12 +977,13 @@ Sends an email to the provided email addresses with a link to the share.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, authenticateShare } from '@directus/sdk/rest';
+import { createDirectus, rest, inviteShare } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(authenticateShare('61e8a1b6-6eba-438c-91e8-8d912ef655d3', 'd1r3ct5us'));
+const result = await client.request(
+	inviteShare( share_id, email_address_array)
+);
 ```
 
 </template>
@@ -1079,12 +1024,13 @@ Empty body.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, inviteShare } from '@directus/sdk/rest';
+import { createDirectus, rest, inviteShare } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(inviteShare('share_key', ['email_addr_1', 'email_addr_2']));
+const result = await client.request(
+	inviteShare('653925a9-970e-487a-bfc0-ab6c96affcdc', ["allison@example.com", "mike@example.com"])
+);
 ```
 
 </template>
@@ -1108,14 +1054,11 @@ Allows unauthenticated users to retrieve information about the share.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, inviteShare } from '@directus/sdk/rest';
+import { createDirectus, rest, readShareInfo } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	inviteShare('653925a9-970e-487a-bfc0-ab6c96affcdc', ['allison@example.com', 'mike@example.com'])
-);
+const result = await client.request(readShareInfo( share_id ));
 ```
 
 </template>
@@ -1141,8 +1084,7 @@ The [share objects](#the-share-object) for the given UUID, if it's still valid.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readShareInfo } from '@directus/sdk/rest';
+import { createDirectus, rest, readShareInfo } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/translations.md
+++ b/docs/reference/system/translations.md
@@ -44,7 +44,9 @@ List all translations that exist in Directus.
 
 `SEARCH /translations`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #sdk>
@@ -59,8 +61,6 @@ const result = await client.request(readTranslations(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -531,7 +531,7 @@ Delete multiple existing translations.
 
 `DELETE /translations`
 
-Provide an array of translation ids as the body of your request.
+Provide an array of translation IDs as the body of your request.
 
 </template>
 <template #sdk>

--- a/docs/reference/system/translations.md
+++ b/docs/reference/system/translations.md
@@ -44,7 +44,7 @@ List all translations that exist in Directus.
 
 `SEARCH /translations`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #sdk>

--- a/docs/reference/system/translations.md
+++ b/docs/reference/system/translations.md
@@ -412,7 +412,7 @@ Update multiple existing translations.
 ```json
 {
 	"keys": translation_id_array,
-	"data": partial_translation_object 
+	"data": partial_translation_object
 }
 ```
 

--- a/docs/reference/system/translations.md
+++ b/docs/reference/system/translations.md
@@ -54,9 +54,7 @@ import { createDirectus, rest, readTranslations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readTranslations( query_object )
-);
+const result = await client.request(readTranslations(query_object));
 ```
 
 </template>
@@ -119,9 +117,7 @@ import { createDirectus, rest, readTranslation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readTranslation( translation_id, query_object )
-);
+const result = await client.request(readTranslation(translation_id, query_object));
 ```
 
 </template>
@@ -181,9 +177,7 @@ import { createDirectus, rest, createTranslation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createTranslation( translation_object )
-);
+const result = await client.request(createTranslation(translation_object));
 ```
 
 </template>
@@ -257,9 +251,7 @@ import { createDirectus, rest, createTranslations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createTranslations( translation_object_array )
-);
+const result = await client.request(createTranslations(translation_object_array));
 ```
 
 </template>
@@ -347,9 +339,7 @@ import { createDirectus, rest, updateTranslation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateTranslation( translation_id, partial_translation_object )
-);
+const result = await client.request(updateTranslation(translation_id, partial_translation_object));
 ```
 
 </template>
@@ -424,9 +414,7 @@ import { createDirectus, rest, updateTranslations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateTranslations( translation_id_array, partial_translation_object )
-);
+const result = await client.request(updateTranslations(translation_id_array, partial_translation_object));
 ```
 
 </template>
@@ -501,7 +489,7 @@ import { createDirectus, rest, deleteTranslation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteTranslation( translation_id ));
+const result = await client.request(deleteTranslation(translation_id));
 ```
 
 </template>
@@ -553,9 +541,7 @@ import { createDirectus, rest, deleteTranslations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	deleteTranslations( translation_id_array )
-);
+const result = await client.request(deleteTranslations(translation_id_array));
 ```
 
 </template>

--- a/docs/reference/system/translations.md
+++ b/docs/reference/system/translations.md
@@ -44,19 +44,18 @@ List all translations that exist in Directus.
 
 `SEARCH /translations`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, readTranslations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readTranslations({
-		fields: ['*'],
-	})
+	readTranslations( query_object )
 );
 ```
 
@@ -87,8 +86,7 @@ available, data will be an empty array.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, readTranslations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -117,15 +115,12 @@ List an existing translation by primary key.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, readTranslation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readTranslation('translation_id', {
-		fields: ['*'],
-	})
+	readTranslation( translation_id, query_object )
 );
 ```
 
@@ -151,8 +146,7 @@ Returns the requested [translation object](#the-translations-object).
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, readTranslation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -177,29 +171,18 @@ Create a new translation.
 
 `POST /translations`
 
-```json
-{
-	"translation_field_1": "value_1",
-	"translation_field_2": "value_2",
-	"translation_field_3": "value_3"
-}
-```
+Provide a [translation object](#the-translation-object) as the body of your request.
 
 </template>
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, createTranslation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createTranslation({
-		translation_field_1: 'value_1',
-		translation_field_2: 'value_2',
-		translation_field_3: 'value_3',
-	})
+	createTranslation( translation_object )
 );
 ```
 
@@ -237,8 +220,7 @@ Returns the [translation object](#the-translations-object) for the created trans
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, createTranslation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -265,43 +247,18 @@ Create multiple new translation.
 
 `POST /translations`
 
-```json
-[
-	{
-		"translation_1_field_1": "value_1",
-		"translation_1_field_2": "value_2",
-		"translation_1_field_3": "value_3"
-	},
-	{
-		"translation_2_field_1": "value_4",
-		"translation_2_field_2": "value_5",
-		"translation_2_field_3": "value_6"
-	}
-]
-```
+Provide an array of [translation objects](#the-translation-object) as the body of your request.
 
 </template>
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, createTranslations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createTranslations([
-		{
-			translation_1_field_1: 'value_1',
-			translation_1_field_2: 'value_2',
-			translation_1_field_3: 'value_3',
-		},
-		{
-			translation_2_field_1: 'value_4',
-			translation_2_field_2: 'value_5',
-			translation_2_field_3: 'value_6',
-		},
-	])
+	createTranslations( translation_object_array )
 );
 ```
 
@@ -346,8 +303,7 @@ Returns the [translation object](#the-translations-object) for the created trans
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, createTranslations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -381,25 +337,18 @@ Update an existing translation.
 
 `PATCH /translations/:id`
 
-```json
-{
-	"translation_object_field": "value_1"
-}
-```
+Provide a partial [translation object](#the-translation-object) as the body of your request.
 
 </template>
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, updateTranslation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateTranslation('translation_id', {
-		translation_field: 'value',
-	})
+	updateTranslation( translation_id, partial_translation_object )
 );
 ```
 
@@ -435,8 +384,7 @@ Returns the [translation object](#the-translations-object) for the updated trans
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, updateTranslation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -463,10 +411,8 @@ Update multiple existing translations.
 
 ```json
 {
-	"keys": ["translation_1_key", "translation_2_key"],
-	"data": {
-		"field": "value"
-	}
+	"keys": translation_id_array,
+	"data": partial_translation_object 
 }
 ```
 
@@ -474,15 +420,12 @@ Update multiple existing translations.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, updateTranslations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateTranslations(['translation_1_id', 'translation_2_id'], {
-		field: 'value',
-	})
+	updateTranslations( translation_id_array, partial_translation_object )
 );
 ```
 
@@ -525,8 +468,7 @@ Returns the [translation objects](#the-translations-object) for the updated tran
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, updateTranslations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -555,12 +497,11 @@ Delete an existing translation.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteTranslation } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteTranslation('id'));
+const result = await client.request(deleteTranslation( translation_id ));
 ```
 
 </template>
@@ -581,8 +522,7 @@ Empty body.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteTranslation } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteTranslation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -603,21 +543,18 @@ Delete multiple existing translations.
 
 `DELETE /translations`
 
-```json
-["translation_1_key", "translation_2_key", "translation_3_key"]
-```
+Provide an array of translation ids as the body of your request.
 
 </template>
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteTranslations } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	deleteTranslations(['translation_1_key', 'translation_2_key', 'translation_3_key'])
+	deleteTranslations( translation_id_array )
 );
 ```
 
@@ -647,8 +584,7 @@ Empty body.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteTranslations } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteTranslations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -114,7 +114,9 @@ List all users that exist in Directus.
 
 `SEARCH /users`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -140,8 +142,6 @@ const result = await client.request(readUsers(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -703,7 +703,7 @@ Update an existing user.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" label="API">
 <template #rest>
 
-`PATCH /users/72a1ce24-4748-47de-a05f-ce9af3033727`
+`PATCH /users/:id`
 
 Provide a partial [user object](#the-user-object) as the body of your request.
 
@@ -984,7 +984,7 @@ Delete multiple existing users.
 
 `DELETE /users`
 
-Provide an array of user ids as the body of your request.
+Provide an array of user IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -114,7 +114,7 @@ List all users that exist in Directus.
 
 `SEARCH /users`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -114,6 +114,8 @@ List all users that exist in Directus.
 
 `SEARCH /users`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -129,15 +131,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, readUsers } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readUsers({
-		fields: ['*'],
-	})
+	readUsers( query_object )
 );
 ```
 
@@ -181,8 +180,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, readUsers } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -222,15 +220,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readUser } from '@directus/sdk/rest';
+import { createDirectus, rest, readUser } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readUser('user_id', {
-		fields: ['*'],
-	})
+	readUser( user_id, query_object )
 );
 ```
 
@@ -271,8 +266,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readUser } from '@directus/sdk/rest';
+import { createDirectus, rest, readUser } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -312,15 +306,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readMe } from '@directus/sdk/rest';
+import { createDirectus, rest, readMe } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readMe({
-		fields: ['*'],
-	})
+	readMe( query_object )
 );
 ```
 
@@ -357,8 +348,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readMe } from '@directus/sdk/rest';
+import { createDirectus, rest, readMe } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -383,11 +373,7 @@ Update the authenticated user.
 
 `PATCH /users/me`
 
-```json
-{
-	"user_object_field": "value"
-}
-```
+Provide a partial [user object](#the-user-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -404,15 +390,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateMe } from '@directus/sdk/rest';
+import { createDirectus, rest, updateMe } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateMe({
-		user_field: 'value',
-	})
+	updateMe( partial_user_object )
 );
 ```
 
@@ -457,8 +440,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateMe } from '@directus/sdk/rest';
+import { createDirectus, rest, updateMe } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -483,13 +465,7 @@ Create a new user
 
 `POST /users`
 
-```json
-{
-	"email": "user_email",
-	"password": "user_password",
-	"user_object_field": "value"
-}
-```
+Provide a [user object](#the-user-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -506,16 +482,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createUser } from '@directus/sdk/rest';
+import { createDirectus, rest, createUser } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createUser({
-		email: 'user_email',
-		password: 'user_password',
-	})
+	createUser( user_object )
 );
 ```
 
@@ -583,8 +555,7 @@ could be modified by the user call.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createUser } from '@directus/sdk/rest';
+import { createDirectus, rest, createUser } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -610,20 +581,7 @@ Create multiple new users
 
 `POST /users`
 
-```json
-[
-	{
-		"email": "user_email",
-		"password": "user_password",
-		"user_object_field": "value"
-	},
-	{
-		"email": "user_email",
-		"password": "user_password",
-		"user_object_field": "value"
-	}
-]
-```
+Provide an array of [user objects](#the-user-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -640,22 +598,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, createUsers } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createUsers([
-		{
-			email: 'user_email',
-			password: 'user_password',
-		},
-		{
-			email: 'user_email',
-			password: 'user_password',
-		},
-	])
+	createUsers( user_object_array )
 );
 ```
 
@@ -737,8 +685,7 @@ could be modified by the user call.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, createUsers } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -770,11 +717,7 @@ Update an existing user.
 
 `PATCH /users/72a1ce24-4748-47de-a05f-ce9af3033727`
 
-```json
-{
-	"user_object_field": "value"
-}
-```
+Provide a partial [user object](#the-user-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -791,15 +734,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateUser } from '@directus/sdk/rest';
+import { createDirectus, rest, updateUser } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateUser('user_id', {
-		user_fiels: 'value',
-	})
+	updateUser( user_id, partial_user_object )
 );
 ```
 
@@ -849,8 +789,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateUser } from '@directus/sdk/rest';
+import { createDirectus, rest, updateUser } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -877,10 +816,8 @@ Update multiple existing users.
 
 ```json
 {
-	"keys": ["user_1_key", "user_2_key"],
-	"data": {
-		"user_object_field": "value"
-	}
+	"keys": user_id_array,
+	"data": partial_user_object 
 }
 ```
 
@@ -899,15 +836,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, updateUsers } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateUsers(['user_1_id', 'user_2_id'], {
-		user_field: 'value',
-	})
+	updateUsers( user_id_array, partial_user_object )
 );
 ```
 
@@ -967,8 +901,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, updateUsers } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -1008,12 +941,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteUser } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteUser } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteUser('user_id'));
+const result = await client.request(deleteUser( user_id ));
 ```
 
 </template>
@@ -1047,8 +979,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteUser } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteUser } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -1069,9 +1000,7 @@ Delete multiple existing users.
 
 `DELETE /users`
 
-```json
-["user_1_key", "user_2_key"]
-```
+Provide an array of user ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -1088,12 +1017,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteUsers } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteUsers(['user_1_id', 'user_2_id']));
+const result = await client.request(deleteUsers( user_id_array ));
 ```
 
 </template>
@@ -1133,8 +1061,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteUsers } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteUsers } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -1159,8 +1086,8 @@ Invite a new user by email.
 
 ```json
 {
-	"email": "invited_user_email",
-	"role": "invited_user_role"
+	"email": invited_user_email,
+	"role": invited_user_role
 }
 ```
 
@@ -1179,12 +1106,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, inviteUser } from '@directus/sdk/rest';
+import { createDirectus, rest, inviteUser } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(inviteUser('invited_user_email', 'invited_user_role'));
+const result = await client.request(
+	inviteUser( invited_user_email,  invited_user_role )
+);
 ```
 
 </template>
@@ -1236,12 +1164,13 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, inviteUser } from '@directus/sdk/rest';
+import { createDirectus, rest, inviteUser } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(inviteUser('another@example.com', 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7'));
+const result = await client.request(
+	inviteUser('another@example.com', 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7')
+);
 ```
 
 </template>
@@ -1262,8 +1191,8 @@ This link includes a token, which is then used to activate the invited user.
 
 ```json
 {
-	"token": "invite_token",
-	"password": "user_password"
+	"token": invite_token,
+	"password": user_password
 }
 ```
 
@@ -1282,12 +1211,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, inviteUser } from '@directus/sdk/rest';
+import { createDirectus, rest, acceptUserInvite } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(inviteUser('another@example.com', 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7'));
+const reSUlt = await client.request(
+	acceptUserInvite( invite_token,  user_password )
+);
 ```
 
 </template>
@@ -1332,12 +1262,13 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, acceptUserInvite } from '@directus/sdk/rest';
+import { createDirectus, rest, acceptUserInvite } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(acceptUserInvite('invite_token', 'user_password'));
+const result = await client.request(
+	acceptUserInvite('eyJh...KmUk', 'd1r3ctu5')
+);
 ```
 
 </template>
@@ -1356,7 +1287,7 @@ Generates a secret and returns the URL to be used in an authenticator app.
 
 ```json
 {
-	"password": "user_password"
+	"password": user_password
 }
 ```
 
@@ -1375,12 +1306,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, acceptUserInvite } from '@directus/sdk/rest';
+import { createDirectus, rest, generateTwoFactorSecret } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(acceptUserInvite('eyJh...KmUk', 'd1r3ctu5'));
+const result = await client.request(generateTwoFactorSecret( user_password ));
 ```
 
 </template>
@@ -1430,12 +1360,11 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, generateTwoFactorSecret } from '@directus/sdk/rest';
+import { createDirectus, rest, generateTwoFactorSecret } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(generateTwoFactorSecret('user_password'));
+const result = await client.request(generateTwoFactorSecret('d1r3ctu5'));
 ```
 
 </template>
@@ -1454,8 +1383,8 @@ Adds a TFA secret to the user account.
 
 ```json
 {
-	"otp": "One Time Password",
-	"secret": "Two-Factor_Authorization_secret"
+	"otp": One_Time_Password,
+	"secret": Two-Factor_Authorization_secret
 }
 ```
 
@@ -1474,12 +1403,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, generateTwoFactorSecret } from '@directus/sdk/rest';
+import { createDirectus, rest, enableTwoFactor } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(generateTwoFactorSecret('d1r3ctu5'));
+const result = await client.request(
+	enableTwoFactor( secret,  otp )
+);
 ```
 
 </template>
@@ -1526,12 +1456,13 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, enableTwoFactor } from '@directus/sdk/rest';
+import { createDirectus, rest, enableTwoFactor } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(enableTwoFactor('secret', 'otp'));
+const result = await client.request(
+	enableTwoFactor('123456', '3CtiutsNBmY3szHE')
+);
 ```
 
 </template>
@@ -1550,7 +1481,7 @@ Disables two-factor authentication by removing the OTP secret from the user.
 
 ```json
 {
-	"otp": "One-time password"
+	"otp": One-Time_Password
 }
 ```
 
@@ -1569,12 +1500,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, enableTwoFactor } from '@directus/sdk/rest';
+import { createDirectus, rest, disableTwoFactor } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(enableTwoFactor('3CtiutsNBmY3szHE', '123456'));
+const result = await client.request(disableTwoFactor( otp ));
 ```
 
 </template>
@@ -1617,10 +1547,9 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, disableTwoFactor } from '@directus/sdk/rest';
+import { createDirectus, rest, disableTwoFactor } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(disableTwoFactor('591763'));
 ```

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -135,9 +135,7 @@ import { createDirectus, rest, readUsers } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readUsers( query_object )
-);
+const result = await client.request(readUsers(query_object));
 ```
 
 </template>
@@ -224,9 +222,7 @@ import { createDirectus, rest, readUser } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readUser( user_id, query_object )
-);
+const result = await client.request(readUser(user_id, query_object));
 ```
 
 </template>
@@ -310,9 +306,7 @@ import { createDirectus, rest, readMe } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readMe( query_object )
-);
+const result = await client.request(readMe(query_object));
 ```
 
 </template>
@@ -394,9 +388,7 @@ import { createDirectus, rest, updateMe } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateMe( partial_user_object )
-);
+const result = await client.request(updateMe(partial_user_object));
 ```
 
 </template>
@@ -486,9 +478,7 @@ import { createDirectus, rest, createUser } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createUser( user_object )
-);
+const result = await client.request(createUser(user_object));
 ```
 
 </template>
@@ -602,9 +592,7 @@ import { createDirectus, rest, createUsers } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createUsers( user_object_array )
-);
+const result = await client.request(createUsers(user_object_array));
 ```
 
 </template>
@@ -738,9 +726,7 @@ import { createDirectus, rest, updateUser } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateUser( user_id, partial_user_object )
-);
+const result = await client.request(updateUser(user_id, partial_user_object));
 ```
 
 </template>
@@ -840,9 +826,7 @@ import { createDirectus, rest, updateUsers } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateUsers( user_id_array, partial_user_object )
-);
+const result = await client.request(updateUsers(user_id_array, partial_user_object));
 ```
 
 </template>
@@ -945,7 +929,7 @@ import { createDirectus, rest, deleteUser } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteUser( user_id ));
+const result = await client.request(deleteUser(user_id));
 ```
 
 </template>
@@ -1021,7 +1005,7 @@ import { createDirectus, rest, deleteUsers } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteUsers( user_id_array ));
+const result = await client.request(deleteUsers(user_id_array));
 ```
 
 </template>
@@ -1110,9 +1094,7 @@ import { createDirectus, rest, inviteUser } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	inviteUser( invited_user_email,  invited_user_role )
-);
+const result = await client.request(inviteUser(invited_user_email, invited_user_role));
 ```
 
 </template>
@@ -1168,9 +1150,7 @@ import { createDirectus, rest, inviteUser } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	inviteUser('another@example.com', 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7')
-);
+const result = await client.request(inviteUser('another@example.com', 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7'));
 ```
 
 </template>
@@ -1215,9 +1195,7 @@ import { createDirectus, rest, acceptUserInvite } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const reSUlt = await client.request(
-	acceptUserInvite( invite_token,  user_password )
-);
+const result = await client.request(acceptUserInvite(invite_token, user_password));
 ```
 
 </template>
@@ -1266,9 +1244,7 @@ import { createDirectus, rest, acceptUserInvite } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	acceptUserInvite('eyJh...KmUk', 'd1r3ctu5')
-);
+const result = await client.request(acceptUserInvite('eyJh...KmUk', 'd1r3ctu5'));
 ```
 
 </template>
@@ -1310,7 +1286,7 @@ import { createDirectus, rest, generateTwoFactorSecret } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(generateTwoFactorSecret( user_password ));
+const result = await client.request(generateTwoFactorSecret(user_password));
 ```
 
 </template>
@@ -1383,8 +1359,8 @@ Adds a TFA secret to the user account.
 
 ```json
 {
-	"otp": One_Time_Password,
-	"secret": Two-Factor_Authorization_secret
+	"otp": one_time_password,
+	"secret": two_factor_authorization_secret
 }
 ```
 
@@ -1407,9 +1383,7 @@ import { createDirectus, rest, enableTwoFactor } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	enableTwoFactor( secret,  otp )
-);
+const result = await client.request(enableTwoFactor(secret, otp));
 ```
 
 </template>
@@ -1460,9 +1434,7 @@ import { createDirectus, rest, enableTwoFactor } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	enableTwoFactor('123456', '3CtiutsNBmY3szHE')
-);
+const result = await client.request(enableTwoFactor('123456', '3CtiutsNBmY3szHE'));
 ```
 
 </template>
@@ -1481,7 +1453,7 @@ Disables two-factor authentication by removing the OTP secret from the user.
 
 ```json
 {
-	"otp": One-Time_Password
+	"otp": one_time_password
 }
 ```
 
@@ -1504,7 +1476,7 @@ import { createDirectus, rest, disableTwoFactor } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(disableTwoFactor( otp ));
+const result = await client.request(disableTwoFactor(otp));
 ```
 
 </template>

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -817,7 +817,7 @@ Update multiple existing users.
 ```json
 {
 	"keys": user_id_array,
-	"data": partial_user_object 
+	"data": partial_user_object
 }
 ```
 

--- a/docs/reference/system/utilities.md
+++ b/docs/reference/system/utilities.md
@@ -21,7 +21,7 @@ Generate a hash for a given string.
 
 ```json
 {
-	"string": "hash"
+	"string": string_to_hash
 }
 ```
 
@@ -40,12 +40,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, generateHash } from '@directus/sdk/rest';
+import { createDirectus, rest, generateHash } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(generateHash('string'));
+const result = await client.request(generateHash( string_to_hash ));
 ```
 
 </template>
@@ -86,8 +85,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, generateHash } from '@directus/sdk/rest';
+import { createDirectus, rest, generateHash } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -110,8 +108,8 @@ Verify a string with a hash.
 
 ```json
 {
-	"string": "test_string",
-	"hash": "hash"
+	"string": string_to_verify,
+	"hash": hash
 }
 ```
 
@@ -130,12 +128,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, verifyHash } from '@directus/sdk/rest';
+import { createDirectus, rest, verifyHash } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(verifyHash('string_to_verify', 'hash'));
+const result = await client.request(verifyHash( string_to_verify, hash ));
 ```
 
 </template>
@@ -182,8 +179,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, verifyHash } from '@directus/sdk/rest';
+import { createDirectus, rest, verifyHash } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -211,8 +207,8 @@ If a collection has a sort field, this util can be used to move items in that ma
 
 ```json
 {
-	"item": "id_item_to_move",
-	"to": "id_item_moving_to"
+	"item": id_item_to_move,
+	"to": id_item_moving_to
 }
 ```
 
@@ -231,12 +227,13 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, utilitySort } from '@directus/sdk/rest';
+import { createDirectus, rest, utilitySort } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(utilitySort('collection_name', 'id_item_to_move', 'id_item_moving_to'));
+const result = await client.request(
+	utilitySort( collection_name,  id_item_to_move,  id_item_moving_to )
+);
 ```
 
 </template>
@@ -283,12 +280,13 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, utilitySort } from '@directus/sdk/rest';
+import { createDirectus, rest, utilitySort } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(utilitySort('things', '2', '4'));
+const result = await client.request(
+	utilitySort('things', '2', '4')
+);
 ```
 
 </template>
@@ -316,15 +314,14 @@ Body must be formatted as a `multipart/form-data` with a `file` property.
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, utilsImport } from '@directus/sdk/rest';
+import { createDirectus, rest, utilsImport } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const formData = new FormData();
 formData.append('file', raw_file);
 
-const result = await client.request(utilsImport(formData));
+const result = await client.request(utilsImport( formData ));
 ```
 
 </template>
@@ -377,10 +374,9 @@ Export a larger data set to a file in the File Library
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, utilsExport } from '@directus/sdk/rest';
+import { createDirectus, rest, utilsExport } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
 	utilsExport(
@@ -455,8 +451,7 @@ Empty body
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, utilsExport } from '@directus/sdk/rest';
+import { createDirectus, rest, utilsExport } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -507,8 +502,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, clearCache } from '@directus/sdk/rest';
+import { createDirectus, rest, clearCache } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/utilities.md
+++ b/docs/reference/system/utilities.md
@@ -44,7 +44,7 @@ import { createDirectus, rest, generateHash } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(generateHash( string_to_hash ));
+const result = await client.request(generateHash(string_to_hash));
 ```
 
 </template>
@@ -132,7 +132,7 @@ import { createDirectus, rest, verifyHash } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(verifyHash( string_to_verify, hash ));
+const result = await client.request(verifyHash(string_to_verify, hash));
 ```
 
 </template>
@@ -231,9 +231,7 @@ import { createDirectus, rest, utilitySort } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	utilitySort( collection_name,  id_item_to_move,  id_item_moving_to )
-);
+const result = await client.request(utilitySort(collection_name, id_item_to_move, id_item_moving_to));
 ```
 
 </template>
@@ -284,9 +282,7 @@ import { createDirectus, rest, utilitySort } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	utilitySort('things', '2', '4')
-);
+const result = await client.request(utilitySort('things', '2', '4'));
 ```
 
 </template>
@@ -321,7 +317,7 @@ const client = createDirectus('directus_project_url').with(rest());
 const formData = new FormData();
 formData.append('file', raw_file);
 
-const result = await client.request(utilsImport( formData ));
+const result = await client.request(utilsImport(formData));
 ```
 
 </template>

--- a/docs/reference/system/webhooks.md
+++ b/docs/reference/system/webhooks.md
@@ -63,7 +63,7 @@ List all webhooks that exist in Directus.
 
 `SEARCH /webhooks`
 
-If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request
 
 </template>
 <template #graphql>

--- a/docs/reference/system/webhooks.md
+++ b/docs/reference/system/webhooks.md
@@ -63,7 +63,9 @@ List all webhooks that exist in Directus.
 
 `SEARCH /webhooks`
 
-If using SEARCH you can provide a [query object](/reference/query) as the body of your request
+If using SEARCH you can provide a [query object](/reference/query) as the body of your request.
+
+[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 </template>
 <template #graphql>
@@ -89,8 +91,6 @@ const result = await client.request(readWebhooks(query_object));
 
 </template>
 </SnippetToggler>
-
-[Learn more about SEARCH ->](/reference/introduction#search-http-method)
 
 #### Query Parameters
 
@@ -745,7 +745,7 @@ Delete multiple existing webhooks.
 
 `DELETE /webhooks`
 
-Provide an array of webhook ids as the body of your request.
+Provide an array of webhook IDs as the body of your request.
 
 </template>
 <template #graphql>

--- a/docs/reference/system/webhooks.md
+++ b/docs/reference/system/webhooks.md
@@ -576,7 +576,7 @@ Update multiple existing webhooks.
 ```json
 {
 	"keys": webhook_id_array,
-	"data": partial_webhook_object 
+	"data": partial_webhook_object
 }
 ```
 

--- a/docs/reference/system/webhooks.md
+++ b/docs/reference/system/webhooks.md
@@ -63,6 +63,8 @@ List all webhooks that exist in Directus.
 
 `SEARCH /webhooks`
 
+If using SEARCH you can provide an [query object](/reference/query) as the body of your request
+
 </template>
 <template #graphql>
 
@@ -78,15 +80,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, readWebhooks } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readWebhooks({
-		fields: ['*'],
-	})
+	readWebhooks( query_object )
 );
 ```
 
@@ -131,8 +130,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, readWebhooks } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -172,15 +170,12 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, readWebhook } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	readWebhook('webhook_id', {
-		fields: ['*'],
-	})
+	readWebhook( webhook_id, query_object )
 );
 ```
 
@@ -221,8 +216,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, readWebhook } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -247,14 +241,7 @@ Create a new webhook.
 
 `POST /webhooks`
 
-```json
-{
-	"name": "name",
-	"actions": ["webhook_action_1", "webhook_action_2"],
-	"collections": ["collection to act on"],
-	"url": "url of webhook"
-}
-```
+Provide a [webhook object](#the-webhook-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -271,18 +258,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, createWebhook } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createWebhook({
-		name: 'webhook_name',
-		collections: 'collection_name',
-		actions: ['action_1', 'action_2', 'action_3'],
-		url: 'webhook_url',
-	})
+	createWebhook( webhook_object )
 );
 ```
 
@@ -339,8 +320,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, createWebhook } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -369,22 +349,7 @@ Create multiple new webhooks.
 
 `POST /webhooks`
 
-```json
-[
-	{
-		"name": "name_1",
-		"actions": ["webhook_action_1", "webhook_action_2"],
-		"collections": ["collection to act on"],
-		"url": "url of webhook_1"
-	},
-	{
-		"name": "name_2",
-		"actions": ["webhook_action_1", "webhook_action_2"],
-		"collections": ["collection to act on"],
-		"url": "url of webhook_2"
-	}
-]
-```
+Provide an array of [webhook objects](#the-webhook-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -401,26 +366,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, createWebhooks } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createWebhooks([
-		{
-			name: 'name_1',
-			collections: ['collection to act on'],
-			actions: ['webhook_action_1', 'webhook_action_2'],
-			url: 'url of webhook_1',
-		},
-		{
-			name: 'webhook_2_name',
-			actions: ['action_1', 'action_2', 'action_3'],
-			collections: 'collection_2_name',
-			url: 'webhook_2_url',
-		},
-	])
+	createWebhooks( webhook_object_array )
 );
 ```
 
@@ -488,8 +439,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, createWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, createWebhooks } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -527,11 +477,7 @@ Update an existing webhook.
 
 `PATCH /webhooks/:id`
 
-```json
-{
-	"webhook_field": "value"
-}
-```
+Provide a partial [webhook object](#the-webhook-object) as the body of your request.
 
 </template>
 <template #graphql>
@@ -548,15 +494,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, updateWebhook } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateWebhook('webhook_id', {
-		field: 'value',
-	})
+	updateWebhook( webhook_id, partal_webhook_object )
 );
 ```
 
@@ -605,8 +548,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, updateWebhook } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -633,10 +575,8 @@ Update multiple existing webhooks.
 
 ```json
 {
-	"keys": ["webhook_1_key", "webhook_2_key"],
-	"data": {
-		"webhook_object_field": "value_1"
-	}
+	"keys": webhook_id_array,
+	"data": partial_webhook_object 
 }
 ```
 
@@ -655,15 +595,12 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, updateWebhooks } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	updateWebhooks(['webhook_1_id', 'webhook_2_id'], {
-		webhook_field: 'value',
-	})
+	updateWebhooks( webhook_id_array, partial_webhook_object )
 );
 ```
 
@@ -721,8 +658,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, updateWebhooks } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -762,12 +698,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteWebhook } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteWebhook('webhook_id'));
+const result = await client.request(deleteWebhook( webhook_id ));
 ```
 
 </template>
@@ -801,8 +736,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteWebhook } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteWebhook } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -823,9 +757,7 @@ Delete multiple existing webhooks.
 
 `DELETE /webhooks`
 
-```json
-["webhook_1_key", "webhook_2_key", "webhook_3_key"]
-```
+Provide an array of webhook ids as the body of your request.
 
 </template>
 <template #graphql>
@@ -842,12 +774,11 @@ type Mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteWebhooks } from '@directus/sdk';
 
-const client = createDirectus('https://directus.example.com').with(rest());
+const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteWebhooks(['webhook_1_id', 'webhook_2_id']));
+const result = await client.request(deleteWebhooks( webhook_id_array ));
 ```
 
 </template>
@@ -889,8 +820,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteWebhooks } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteWebhooks } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/webhooks.md
+++ b/docs/reference/system/webhooks.md
@@ -84,9 +84,7 @@ import { createDirectus, rest, readWebhooks } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readWebhooks( query_object )
-);
+const result = await client.request(readWebhooks(query_object));
 ```
 
 </template>
@@ -174,9 +172,7 @@ import { createDirectus, rest, readWebhook } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	readWebhook( webhook_id, query_object )
-);
+const result = await client.request(readWebhook(webhook_id, query_object));
 ```
 
 </template>
@@ -262,9 +258,7 @@ import { createDirectus, rest, createWebhook } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createWebhook( webhook_object )
-);
+const result = await client.request(createWebhook(webhook_object));
 ```
 
 </template>
@@ -370,9 +364,7 @@ import { createDirectus, rest, createWebhooks } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	createWebhooks( webhook_object_array )
-);
+const result = await client.request(createWebhooks(webhook_object_array));
 ```
 
 </template>
@@ -498,9 +490,7 @@ import { createDirectus, rest, updateWebhook } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateWebhook( webhook_id, partal_webhook_object )
-);
+const result = await client.request(updateWebhook(webhook_id, partal_webhook_object));
 ```
 
 </template>
@@ -599,9 +589,7 @@ import { createDirectus, rest, updateWebhooks } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(
-	updateWebhooks( webhook_id_array, partial_webhook_object )
-);
+const result = await client.request(updateWebhooks(webhook_id_array, partial_webhook_object));
 ```
 
 </template>
@@ -702,7 +690,7 @@ import { createDirectus, rest, deleteWebhook } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteWebhook( webhook_id ));
+const result = await client.request(deleteWebhook(webhook_id));
 ```
 
 </template>
@@ -778,7 +766,7 @@ import { createDirectus, rest, deleteWebhooks } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(deleteWebhooks( webhook_id_array ));
+const result = await client.request(deleteWebhooks(webhook_id_array));
 ```
 
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: link:packages/release-notes-generator
       '@typescript-eslint/eslint-plugin':
         specifier: 5.59.6
-        version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.1.6)
+        version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4)
       '@typescript-eslint/parser':
         specifier: 5.59.6
-        version: 5.59.6(eslint@8.40.0)(typescript@5.1.6)
+        version: 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       eslint:
         specifier: 8.40.0
         version: 8.40.0
@@ -922,13 +922,13 @@ importers:
         version: 0.1.0
       eslint-plugin-markdown:
         specifier: 3.0.0
-        version: 3.0.0(eslint@8.46.0)
+        version: 3.0.0(eslint@8.40.0)
       eslint-plugin-prettier:
         specifier: npm:@paescuj/eslint-plugin-prettier@4.3.0-1
-        version: /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.46.0)(prettier@2.8.8)
+        version: /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.40.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: 7.32.2
-        version: 7.32.2(eslint@8.46.0)
+        version: 7.32.2(eslint@8.40.0)
       spellchecker-cli:
         specifier: 6.1.1
         version: 6.1.1
@@ -952,7 +952,7 @@ importers:
         version: 5.0.4
       vitepress:
         specifier: 1.0.0-alpha.75
-        version: 1.0.0-alpha.75(@algolia/client-search@4.17.0)
+        version: 1.0.0-alpha.75(@algolia/client-search@4.19.1)(search-insights@2.7.0)
       vitepress-plugin-tabs:
         specifier: 0.3.0
         version: 0.3.0(vitepress@1.0.0-alpha.75)(vue@3.3.4)
@@ -986,7 +986,7 @@ importers:
         version: 0.16.1(vite@4.3.7)
       '@rollup/plugin-node-resolve':
         specifier: 15.0.2
-        version: 15.0.2(rollup@3.27.2)
+        version: 15.0.2(rollup@3.22.0)
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.3.7)(vue@3.3.4)
@@ -998,7 +998,7 @@ importers:
         version: 0.16.1(vite@4.3.7)
       rollup-plugin-node-externals:
         specifier: 6.1.1
-        version: 6.1.1(rollup@3.27.2)
+        version: 6.1.1(rollup@3.22.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1007,7 +1007,7 @@ importers:
         version: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
       vite-plugin-dts:
         specifier: 2.3.0
-        version: 2.3.0(rollup@3.27.2)(vite@4.3.7)
+        version: 2.3.0(rollup@3.22.0)(vite@4.3.7)
       vitest:
         specifier: 0.31.1
         version: 0.31.1(happy-dom@9.18.3)(sass@1.62.1)
@@ -1893,7 +1893,7 @@ importers:
         version: 11.1.0
       graphql-ws:
         specifier: 5.12.0
-        version: 5.12.0(graphql@16.7.1)
+        version: 5.12.0(graphql@16.6.0)
       jest:
         specifier: 29.5.0
         version: 29.5.0
@@ -1923,7 +1923,7 @@ importers:
         version: 6.3.3
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.22.9)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1935,11 +1935,6 @@ importers:
         version: 8.12.1
 
 packages:
-
-  /@aashutoshrathi/word-wrap@1.2.6:
-    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /@akryum/tinypool@0.3.1:
     resolution: {integrity: sha512-nznEC1ZA/m3hQDEnrGQ4c5gkaa9pcaVnw4LFJyzBAaR7E3nfiAPEHS3otnSafpZouVnoKeITl5D+2LsnwlnK8g==}
@@ -2254,7 +2249,7 @@ packages:
   /@aws-sdk/chunked-blob-reader@3.310.0:
     resolution: {integrity: sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/client-s3@3.332.0:
@@ -2400,7 +2395,7 @@ packages:
       '@aws-sdk/util-user-agent-browser': 3.329.0
       '@aws-sdk/util-user-agent-node': 3.329.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2440,7 +2435,7 @@ packages:
       '@aws-sdk/util-user-agent-browser': 3.329.0
       '@aws-sdk/util-user-agent-node': 3.329.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2505,7 +2500,7 @@ packages:
     dependencies:
       '@aws-sdk/property-provider': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/credential-provider-imds@3.329.0:
@@ -2516,7 +2511,7 @@ packages:
       '@aws-sdk/property-provider': 3.329.0
       '@aws-sdk/types': 3.329.0
       '@aws-sdk/url-parser': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/credential-provider-ini@3.332.0:
@@ -2531,7 +2526,7 @@ packages:
       '@aws-sdk/property-provider': 3.329.0
       '@aws-sdk/shared-ini-file-loader': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2561,7 +2556,7 @@ packages:
       '@aws-sdk/property-provider': 3.329.0
       '@aws-sdk/shared-ini-file-loader': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/credential-provider-sso@3.332.0:
@@ -2573,7 +2568,7 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.329.0
       '@aws-sdk/token-providers': 3.332.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2584,7 +2579,7 @@ packages:
     dependencies:
       '@aws-sdk/property-provider': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/eventstream-codec@3.329.0:
@@ -2593,7 +2588,7 @@ packages:
       '@aws-crypto/crc32': 3.0.0
       '@aws-sdk/types': 3.329.0
       '@aws-sdk/util-hex-encoding': 3.310.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/eventstream-serde-browser@3.329.0:
@@ -2628,7 +2623,7 @@ packages:
     dependencies:
       '@aws-sdk/eventstream-codec': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/fetch-http-handler@3.329.0:
@@ -2679,7 +2674,7 @@ packages:
     resolution: {integrity: sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/lib-storage@3.332.0(@aws-sdk/abort-controller@3.329.0)(@aws-sdk/client-s3@3.332.0):
@@ -2823,7 +2818,7 @@ packages:
     dependencies:
       '@aws-sdk/middleware-signing': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/middleware-serde@3.329.0:
@@ -2908,7 +2903,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/protocol-http@3.329.0:
@@ -2933,7 +2928,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.329.0
       '@aws-sdk/util-uri-escape': 3.310.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/querystring-builder@3.342.0:
@@ -2950,7 +2945,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/service-error-classification@3.329.0:
@@ -2963,7 +2958,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/signature-v4-multi-region@3.329.0:
@@ -2991,7 +2986,7 @@ packages:
       '@aws-sdk/util-middleware': 3.329.0
       '@aws-sdk/util-uri-escape': 3.310.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/smithy-client@3.329.0:
@@ -3011,7 +3006,7 @@ packages:
       '@aws-sdk/property-provider': 3.329.0
       '@aws-sdk/shared-ini-file-loader': 3.329.0
       '@aws-sdk/types': 3.329.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -3042,7 +3037,7 @@ packages:
     resolution: {integrity: sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-base64@3.310.0:
@@ -3071,14 +3066,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/is-array-buffer': 3.310.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-config-provider@3.310.0:
     resolution: {integrity: sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-defaults-mode-browser@3.329.0:
@@ -3115,21 +3110,21 @@ packages:
     resolution: {integrity: sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-locate-window@3.310.0:
     resolution: {integrity: sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-middleware@3.329.0:
     resolution: {integrity: sha512-RhBOBaxzkTUghi4MSqr8S5qeeBCjgJ0XPJ6jIYkVkj1saCmqkuZCgl3zFaYdyhdxxPV6nflkFer+1HUoqT+Fqw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-retry@3.329.0:
@@ -3165,7 +3160,7 @@ packages:
     resolution: {integrity: sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-user-agent-browser@3.329.0:
@@ -3193,7 +3188,7 @@ packages:
   /@aws-sdk/util-utf8-browser@3.259.0:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: false
 
   /@aws-sdk/util-utf8@3.310.0:
@@ -3432,20 +3427,8 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
-  /@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.22.5
-    dev: true
-
   /@babel/compat-data@7.21.7:
     resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/compat-data@7.22.9:
-    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -3472,29 +3455,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core@7.22.9:
-    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/generator@7.21.5:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
     engines: {node: '>=6.9.0'}
@@ -3507,16 +3467,6 @@ packages:
 
   /@babel/generator@7.22.7:
     resolution: {integrity: sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
-      jsesc: 2.5.2
-    dev: true
-
-  /@babel/generator@7.22.9:
-    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
@@ -3551,20 +3501,6 @@ packages:
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
-    dev: true
-
-  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
-    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
-      '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.10
-      lru-cache: 5.1.1
-      semver: 6.3.1
     dev: true
 
   /@babel/helper-create-class-features-plugin@7.21.8(@babel/core@7.21.8):
@@ -3620,11 +3556,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-environment-visitor@7.22.5:
-    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/helper-function-name@7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
@@ -3633,26 +3564,11 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
-  /@babel/helper-function-name@7.22.5:
-    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
-    dev: true
-
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.5
-    dev: true
-
-  /@babel/helper-hoist-variables@7.22.5:
-    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.21.5:
@@ -3669,13 +3585,6 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
-  /@babel/helper-module-imports@7.22.5:
-    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: true
-
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
     engines: {node: '>=6.9.0'}
@@ -3690,20 +3599,6 @@ packages:
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
   /@babel/helper-optimise-call-expression@7.18.6:
@@ -3754,13 +3649,6 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
-  /@babel/helper-simple-access@7.22.5:
-    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: true
-
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
@@ -3775,13 +3663,6 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
-  /@babel/helper-split-export-declaration@7.22.6:
-    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: true
-
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
@@ -3792,11 +3673,6 @@ packages:
 
   /@babel/helper-validator-option@7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-validator-option@7.22.5:
-    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -3823,17 +3699,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helpers@7.22.6:
-    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
@@ -3841,15 +3706,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
-
-  /@babel/highlight@7.22.5:
-    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
 
   /@babel/parser@7.21.8:
     resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
@@ -4829,15 +4685,6 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
-  /@babel/template@7.22.5:
-    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/parser': 7.22.7
-      '@babel/types': 7.22.5
-    dev: true
-
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
     engines: {node: '>=6.9.0'}
@@ -4850,24 +4697,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.8
       '@babel/types': 7.21.5
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/traverse@7.22.8:
-    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/types': 7.22.5
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -5917,23 +5746,8 @@ packages:
       eslint-visitor-keys: 3.4.1
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.46.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.46.0
-      eslint-visitor-keys: 3.4.1
-    dev: true
-
   /@eslint-community/regexpp@4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint-community/regexpp@4.6.2:
-    resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
@@ -5954,30 +5768,8 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/eslintrc@2.1.1:
-    resolution: {integrity: sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.6.1
-      globals: 13.20.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@eslint/js@8.40.0:
     resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/js@8.46.0:
-    resolution: {integrity: sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -6208,17 +6000,6 @@ packages:
 
   /@histoire/vendors@0.16.0:
     resolution: {integrity: sha512-MVr3P2q5Q9UiLJJT99b+j2ABCSerQG4VnUeCr5+eOxyEmoIFz1a0KGJimzqQM0EoVnMQmiaNN3WhuUYG+DWh/w==}
-    dev: true
-
-  /@humanwhocodes/config-array@0.11.10:
-    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@humanwhocodes/config-array@0.11.8:
@@ -7045,7 +6826,7 @@ packages:
       '@otplib/plugin-thirty-two': 12.0.1
     dev: false
 
-  /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.46.0)(prettier@2.8.8):
+  /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.40.0)(prettier@2.8.8):
     resolution: {integrity: sha512-mIlCVXh/nfzGkgvOTtd7WxzYZf7nxgR+/4Hs/6952dowh1n/IcVOfiBK0pUuCJ/mvZORDXdn35LI6vYpTlXicQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -7059,7 +6840,7 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 8.46.0
+      eslint: 8.40.0
       eslint-config-prettier: 8.8.0(eslint@8.40.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
@@ -7513,25 +7294,6 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.2
       rollup: 3.22.0
-    dev: false
-
-  /@rollup/plugin-node-resolve@15.0.2(rollup@3.27.2):
-    resolution: {integrity: sha512-Y35fRGUjC3FaurG722uhUuG8YHOJRJQbI6/CkbRkdPotSpDj9NtIN85z1zrcyDcCQIW4qp5mgG72U+gJ0TAFEg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.78.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
-      is-module: 1.0.0
-      resolve: 1.22.2
-      rollup: 3.27.2
-    dev: true
 
   /@rollup/plugin-replace@5.0.2(rollup@3.22.0):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
@@ -7583,7 +7345,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
     dev: true
@@ -7609,22 +7371,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.22.0
-    dev: false
-
-  /@rollup/pluginutils@5.0.2(rollup@3.27.2):
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.1
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-      rollup: 3.27.2
-    dev: true
 
   /@rushstack/node-core-library@3.59.3:
     resolution: {integrity: sha512-OGk0nQc+SvDkn+IQN16co691A/96gPoRIoWdIlpUds+sYPAGWdTcNVjKMwFOAsCSASqOeF2lh1GdPtWoWJCkPQ==}
@@ -8608,7 +8354,7 @@ packages:
   /@ts-morph/common@0.19.0:
     resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
     dependencies:
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       minimatch: 7.4.6
       mkdirp: 2.1.6
       path-browserify: 1.0.1
@@ -9323,7 +9069,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4):
     resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9335,23 +9081,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.59.6
-      '@typescript-eslint/type-utils': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.40.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.1
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.6(eslint@8.40.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@5.59.6(eslint@8.40.0)(typescript@5.0.4):
     resolution: {integrity: sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9363,10 +9109,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.40.0
-      typescript: 5.1.6
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9379,7 +9125,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.6(eslint@8.40.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
     resolution: {integrity: sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9389,12 +9135,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.40.0
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9404,7 +9150,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.0.4):
     resolution: {integrity: sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9419,13 +9165,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.6(eslint@8.40.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
     resolution: {integrity: sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9436,7 +9182,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
       eslint: 8.40.0
       eslint-scope: 5.1.1
       semver: 7.5.1
@@ -9456,7 +9202,7 @@ packages:
   /@unhead/addons@1.1.30:
     resolution: {integrity: sha512-9Ule9CcL7RiqY8e6ZtJum/j2gi1UUngI3K8hFS2P1scx3Wz1rbCrI7bAhGdY03IARH/8vTaJJTIoWLBdl5GxEA==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
       '@unhead/schema': 1.1.30
       '@unhead/shared': 1.1.30
       magic-string: 0.30.1
@@ -9935,14 +9681,6 @@ packages:
       acorn: 8.8.2
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.10.0):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.10.0
-    dev: true
-
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -10373,7 +10111,7 @@ packages:
     engines: {node: '>=16.14.0'}
     dependencies:
       '@babel/parser': 7.22.7
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
@@ -10803,17 +10541,6 @@ packages:
       pako: 0.2.9
     dev: true
 
-  /browserslist@4.21.10:
-    resolution: {integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001519
-      electron-to-chromium: 1.4.485
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.11(browserslist@4.21.10)
-    dev: true
-
   /browserslist@4.21.5:
     resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -11049,10 +10776,6 @@ packages:
 
   /caniuse-lite@1.0.30001488:
     resolution: {integrity: sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==}
-
-  /caniuse-lite@1.0.30001519:
-    resolution: {integrity: sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==}
-    dev: true
 
   /capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -12187,7 +11910,7 @@ packages:
     dependencies:
       bundle-name: 3.0.0
       default-browser-id: 3.0.0
-      execa: 7.2.0
+      execa: 7.1.1
       titleize: 3.0.0
     dev: true
 
@@ -12509,10 +12232,6 @@ packages:
 
   /electron-to-chromium@1.4.401:
     resolution: {integrity: sha512-AswqHsYyEbfSn0x87n31Na/xttUqEAg7NUjpiyxC20MaWKLyadOYHMzyLdF78N1iw+FK8/2KHLpZxRdyRILgtA==}
-
-  /electron-to-chromium@1.4.485:
-    resolution: {integrity: sha512-1ndQ5IBNEnFirPwvyud69GHL+31FkE09gH/CJ6m3KCbkx3i0EVOrjwz4UNxRmN9H8OVHbC6vMRZGN1yCvjSs9w==}
-    dev: true
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -12875,19 +12594,19 @@ packages:
     resolution: {integrity: sha512-oOeA6FWU0UJT/Rxc3XF5Cq0nbIZbylm7j8+plqq0CZoE6m4u32OXJrR+9iy4srGMmF6v6pmgvP1zPxSRIGh3sg==}
     dev: true
 
-  /eslint-plugin-markdown@3.0.0(eslint@8.46.0):
+  /eslint-plugin-markdown@3.0.0(eslint@8.40.0):
     resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.46.0
+      eslint: 8.40.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@8.46.0):
+  /eslint-plugin-react@7.32.2(eslint@8.40.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12897,7 +12616,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.46.0
+      eslint: 8.40.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -12945,21 +12664,8 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-    dev: true
-
   /eslint-visitor-keys@3.4.1:
     resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /eslint-visitor-keys@3.4.2:
-    resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -13012,52 +12718,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint@8.46.0:
-    resolution: {integrity: sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
-      '@eslint-community/regexpp': 4.6.2
-      '@eslint/eslintrc': 2.1.1
-      '@eslint/js': 8.46.0
-      '@humanwhocodes/config-array': 0.11.10
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.2
-      espree: 9.6.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.20.0
-      graphemer: 1.4.0
-      ignore: 5.2.4
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
@@ -13069,15 +12729,6 @@ packages:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
       eslint-visitor-keys: 3.4.1
-    dev: true
-
-  /espree@9.6.1:
-    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      acorn: 8.10.0
-      acorn-jsx: 5.3.2(acorn@8.10.0)
-      eslint-visitor-keys: 3.4.2
     dev: true
 
   /esprima@4.0.1:
@@ -13173,22 +12824,6 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
-    dev: false
-
-  /execa@7.2.0:
-    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
-    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 4.3.1
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.1.0
-      onetime: 6.0.0
-      signal-exit: 3.0.7
-      strip-final-newline: 3.0.0
-    dev: true
 
   /exif-reader@1.2.0:
     resolution: {integrity: sha512-C9jsLWxaUh9/gNwo9Ouf9jxP0vGn/2vkhu89wbPFyFfpfl8WPbwLrvrb7h9Q6oVvkyvA+e4lXgOllW+/bAk0RQ==}
@@ -14097,10 +13732,6 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-    dev: true
-
   /graphlib@2.1.8:
     resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
     dependencies:
@@ -14131,26 +13762,10 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.6.0
-    dev: false
-
-  /graphql-ws@5.12.0(graphql@16.7.1):
-    resolution: {integrity: sha512-PA3ImUp8utrpEjoxBMhvxsjkStvFEdU0E1gEBREt8HZIWkxOUymwJBhFnBL7t/iHhUq1GVPeZevPinkZFENxTw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: '>=0.11 <=16'
-    dependencies:
-      graphql: 16.7.1
-    dev: true
 
   /graphql@16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: false
-
-  /graphql@16.7.1:
-    resolution: {integrity: sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: true
 
   /gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -17524,10 +17139,6 @@ packages:
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
 
-  /node-releases@2.0.13:
-    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
-    dev: true
-
   /node-rsa@1.1.1:
     resolution: {integrity: sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==}
     dependencies:
@@ -17948,18 +17559,6 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
-    dev: true
-
-  /optionator@0.9.3:
-    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      '@aashutoshrathi/word-wrap': 1.2.6
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.4.1
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
     dev: true
 
   /ora@5.4.1:
@@ -20121,13 +19720,13 @@ packages:
       - supports-color
     dev: false
 
-  /rollup-plugin-node-externals@6.1.1(rollup@3.27.2):
+  /rollup-plugin-node-externals@6.1.1(rollup@3.22.0):
     resolution: {integrity: sha512-127OFMkpH5rBVlRHRBDUMk1m1sGuzbGy7so5aj/IkpUb2r3+wOWjR/erUzd2ChEQWPsxsyQG6xpYYvPBAdcBRA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       rollup: ^3.0.0
     dependencies:
-      rollup: 3.27.2
+      rollup: 3.22.0
     dev: true
 
   /rollup-plugin-styles@4.0.0(rollup@3.22.0):
@@ -21796,7 +21395,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.1.0(@babel/core@7.22.9)(jest@29.5.0)(typescript@5.0.4):
+  /ts-jest@29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21817,7 +21416,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.21.8
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0
@@ -21922,14 +21521,14 @@ packages:
       - ts-node
     dev: true
 
-  /tsutils@3.21.0(typescript@5.1.6):
+  /tsutils@3.21.0(typescript@5.0.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.6
+      typescript: 5.0.4
     dev: true
 
   /tsx@3.12.7:
@@ -22146,12 +21745,6 @@ packages:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
     hasBin: true
-
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
 
   /typical@2.6.1:
     resolution: {integrity: sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==}
@@ -22389,7 +21982,7 @@ packages:
       '@antfu/utils': 0.7.5
       '@babel/generator': 7.22.7
       '@babel/parser': 7.22.7
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
       ast-kit: 0.6.7
       magic-string-ast: 0.1.3
       unplugin: 1.3.2
@@ -22418,17 +22011,6 @@ packages:
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /update-browserslist-db@1.0.11(browserslist@4.21.10):
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.10
-      escalade: 3.1.1
-      picocolors: 1.0.0
     dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.5):
@@ -22691,7 +22273,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@2.3.0(rollup@3.27.2)(vite@4.3.7):
+  /vite-plugin-dts@2.3.0(rollup@3.22.0)(vite@4.3.7):
     resolution: {integrity: sha512-WbJgGtsStgQhdm3EosYmIdTGbag5YQpZ3HXWUAPCDyoXI5qN6EY0V7NXq0lAmnv9hVQsvh0htbYcg0Or5Db9JQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -22699,7 +22281,7 @@ packages:
     dependencies:
       '@babel/parser': 7.21.8
       '@microsoft/api-extractor': 7.35.3
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
       '@rushstack/node-core-library': 3.59.3
       debug: 4.3.4
       fast-glob: 3.2.12
@@ -22820,11 +22402,11 @@ packages:
       vitepress: ^1.0.0-beta.2
       vue: ^3.3.4
     dependencies:
-      vitepress: 1.0.0-alpha.75(@algolia/client-search@4.17.0)
+      vitepress: 1.0.0-alpha.75(@algolia/client-search@4.19.1)(search-insights@2.7.0)
       vue: 3.3.4
     dev: true
 
-  /vitepress@1.0.0-alpha.75(@algolia/client-search@4.17.0):
+  /vitepress@1.0.0-alpha.75(@algolia/client-search@4.19.1)(search-insights@2.7.0):
     resolution: {integrity: sha512-twpPZ/6UnDR8X0Nmj767KwKhXlTQQM9V/J1i2BP9ryO29/w4hpxBfEum6nvfpNhJ4H3h+cIhwzAK/e9crZ6HEQ==}
     hasBin: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: link:packages/release-notes-generator
       '@typescript-eslint/eslint-plugin':
         specifier: 5.59.6
-        version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4)
+        version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: 5.59.6
-        version: 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+        version: 5.59.6(eslint@8.40.0)(typescript@5.1.6)
       eslint:
         specifier: 8.40.0
         version: 8.40.0
@@ -870,7 +870,7 @@ importers:
         version: 5.0.4
       vite:
         specifier: 4.3.7
-        version: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
+        version: 4.3.7(sass@1.62.1)
       vitest:
         specifier: 0.31.1
         version: 0.31.1(happy-dom@9.18.3)(sass@1.62.1)
@@ -922,13 +922,13 @@ importers:
         version: 0.1.0
       eslint-plugin-markdown:
         specifier: 3.0.0
-        version: 3.0.0(eslint@8.40.0)
+        version: 3.0.0(eslint@8.46.0)
       eslint-plugin-prettier:
         specifier: npm:@paescuj/eslint-plugin-prettier@4.3.0-1
-        version: /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.40.0)(prettier@2.8.8)
+        version: /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.46.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: 7.32.2
-        version: 7.32.2(eslint@8.40.0)
+        version: 7.32.2(eslint@8.46.0)
       spellchecker-cli:
         specifier: 6.1.1
         version: 6.1.1
@@ -952,7 +952,7 @@ importers:
         version: 5.0.4
       vitepress:
         specifier: 1.0.0-alpha.75
-        version: 1.0.0-alpha.75(@algolia/client-search@4.17.0)
+        version: 1.0.0-alpha.75(@algolia/client-search@4.19.1)(search-insights@2.7.0)
       vue:
         specifier: 3.3.4
         version: 3.3.4
@@ -983,7 +983,7 @@ importers:
         version: 0.16.1(vite@4.3.7)
       '@rollup/plugin-node-resolve':
         specifier: 15.0.2
-        version: 15.0.2(rollup@3.22.0)
+        version: 15.0.2(rollup@3.27.2)
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.3.7)(vue@3.3.4)
@@ -995,7 +995,7 @@ importers:
         version: 0.16.1(vite@4.3.7)
       rollup-plugin-node-externals:
         specifier: 6.1.1
-        version: 6.1.1(rollup@3.22.0)
+        version: 6.1.1(rollup@3.27.2)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1004,7 +1004,7 @@ importers:
         version: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
       vite-plugin-dts:
         specifier: 2.3.0
-        version: 2.3.0(rollup@3.22.0)(vite@4.3.7)
+        version: 2.3.0(rollup@3.27.2)(vite@4.3.7)
       vitest:
         specifier: 0.31.1
         version: 0.31.1(happy-dom@9.18.3)(sass@1.62.1)
@@ -1890,7 +1890,7 @@ importers:
         version: 11.1.0
       graphql-ws:
         specifier: 5.12.0
-        version: 5.12.0(graphql@16.6.0)
+        version: 5.12.0(graphql@16.7.1)
       jest:
         specifier: 29.5.0
         version: 29.5.0
@@ -1920,7 +1920,7 @@ importers:
         version: 6.3.3
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.22.9)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1933,120 +1933,148 @@ importers:
 
 packages:
 
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /@akryum/tinypool@0.3.1:
     resolution: {integrity: sha512-nznEC1ZA/m3hQDEnrGQ4c5gkaa9pcaVnw4LFJyzBAaR7E3nfiAPEHS3otnSafpZouVnoKeITl5D+2LsnwlnK8g==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@algolia/autocomplete-core@1.8.2:
-    resolution: {integrity: sha512-mTeshsyFhAqw/ebqNsQpMtbnjr+qVOSKXArEj4K0d7sqc8It1XD0gkASwecm9mF/jlOQ4Z9RNg1HbdA8JPdRwQ==}
+  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0):
+    resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
     dependencies:
-      '@algolia/autocomplete-shared': 1.8.2
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0)
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+      - search-insights
     dev: true
 
-  /@algolia/autocomplete-preset-algolia@1.8.2(@algolia/client-search@4.17.0)(algoliasearch@4.17.0):
-    resolution: {integrity: sha512-J0oTx4me6ZM9kIKPuL3lyU3aB8DEvpVvR6xWmHVROx5rOYJGQcZsdG4ozxwcOyiiu3qxMkIbzntnV1S1VWD8yA==}
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0):
+    resolution: {integrity: sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==}
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+    dependencies:
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+      search-insights: 2.7.0
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+    dev: true
+
+  /@algolia/autocomplete-preset-algolia@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1):
+    resolution: {integrity: sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/autocomplete-shared': 1.8.2
-      '@algolia/client-search': 4.17.0
-      algoliasearch: 4.17.0
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+      '@algolia/client-search': 4.19.1
+      algoliasearch: 4.19.1
     dev: true
 
-  /@algolia/autocomplete-shared@1.8.2:
-    resolution: {integrity: sha512-b6Z/X4MczChMcfhk6kfRmBzPgjoPzuS9KGR4AFsiLulLNRAAqhP+xZTKtMnZGhLuc61I20d5WqlId02AZvcO6g==}
-    dev: true
-
-  /@algolia/cache-browser-local-storage@4.17.0:
-    resolution: {integrity: sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==}
+  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1):
+    resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/cache-common': 4.17.0
+      '@algolia/client-search': 4.19.1
+      algoliasearch: 4.19.1
     dev: true
 
-  /@algolia/cache-common@4.17.0:
-    resolution: {integrity: sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ==}
-    dev: true
-
-  /@algolia/cache-in-memory@4.17.0:
-    resolution: {integrity: sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==}
+  /@algolia/cache-browser-local-storage@4.19.1:
+    resolution: {integrity: sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==}
     dependencies:
-      '@algolia/cache-common': 4.17.0
+      '@algolia/cache-common': 4.19.1
     dev: true
 
-  /@algolia/client-account@4.17.0:
-    resolution: {integrity: sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==}
+  /@algolia/cache-common@4.19.1:
+    resolution: {integrity: sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg==}
+    dev: true
+
+  /@algolia/cache-in-memory@4.19.1:
+    resolution: {integrity: sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==}
     dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/client-search': 4.17.0
-      '@algolia/transporter': 4.17.0
+      '@algolia/cache-common': 4.19.1
     dev: true
 
-  /@algolia/client-analytics@4.17.0:
-    resolution: {integrity: sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==}
+  /@algolia/client-account@4.19.1:
+    resolution: {integrity: sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==}
     dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/client-search': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
+      '@algolia/client-common': 4.19.1
+      '@algolia/client-search': 4.19.1
+      '@algolia/transporter': 4.19.1
     dev: true
 
-  /@algolia/client-common@4.17.0:
-    resolution: {integrity: sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==}
+  /@algolia/client-analytics@4.19.1:
+    resolution: {integrity: sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==}
     dependencies:
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
+      '@algolia/client-common': 4.19.1
+      '@algolia/client-search': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
     dev: true
 
-  /@algolia/client-personalization@4.17.0:
-    resolution: {integrity: sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==}
+  /@algolia/client-common@4.19.1:
+    resolution: {integrity: sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==}
     dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
     dev: true
 
-  /@algolia/client-search@4.17.0:
-    resolution: {integrity: sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==}
+  /@algolia/client-personalization@4.19.1:
+    resolution: {integrity: sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==}
     dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
+      '@algolia/client-common': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
     dev: true
 
-  /@algolia/logger-common@4.17.0:
-    resolution: {integrity: sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw==}
-    dev: true
-
-  /@algolia/logger-console@4.17.0:
-    resolution: {integrity: sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==}
+  /@algolia/client-search@4.19.1:
+    resolution: {integrity: sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==}
     dependencies:
-      '@algolia/logger-common': 4.17.0
+      '@algolia/client-common': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
     dev: true
 
-  /@algolia/requester-browser-xhr@4.17.0:
-    resolution: {integrity: sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==}
+  /@algolia/logger-common@4.19.1:
+    resolution: {integrity: sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw==}
+    dev: true
+
+  /@algolia/logger-console@4.19.1:
+    resolution: {integrity: sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==}
     dependencies:
-      '@algolia/requester-common': 4.17.0
+      '@algolia/logger-common': 4.19.1
     dev: true
 
-  /@algolia/requester-common@4.17.0:
-    resolution: {integrity: sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg==}
-    dev: true
-
-  /@algolia/requester-node-http@4.17.0:
-    resolution: {integrity: sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==}
+  /@algolia/requester-browser-xhr@4.19.1:
+    resolution: {integrity: sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==}
     dependencies:
-      '@algolia/requester-common': 4.17.0
+      '@algolia/requester-common': 4.19.1
     dev: true
 
-  /@algolia/transporter@4.17.0:
-    resolution: {integrity: sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==}
+  /@algolia/requester-common@4.19.1:
+    resolution: {integrity: sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ==}
+    dev: true
+
+  /@algolia/requester-node-http@4.19.1:
+    resolution: {integrity: sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==}
     dependencies:
-      '@algolia/cache-common': 4.17.0
-      '@algolia/logger-common': 4.17.0
-      '@algolia/requester-common': 4.17.0
+      '@algolia/requester-common': 4.19.1
+    dev: true
+
+  /@algolia/transporter@4.19.1:
+    resolution: {integrity: sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==}
+    dependencies:
+      '@algolia/cache-common': 4.19.1
+      '@algolia/logger-common': 4.19.1
+      '@algolia/requester-common': 4.19.1
     dev: true
 
   /@ampproject/remapping@2.2.1:
@@ -3200,7 +3228,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.5.2
+      tslib: 2.6.1
 
   /@azure/core-client@1.7.2:
     resolution: {integrity: sha512-ye5554gnVnXdfZ64hptUtETgacXoRWxYv1JF5MctoAzTSH5dXhDPZd9gOjDPyWMcLIk58pnP5+p5vGX6PYn1ag==}
@@ -3213,7 +3241,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3278,7 +3306,7 @@ packages:
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3295,14 +3323,14 @@ packages:
     engines: {node: '>=12.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
 
   /@azure/core-util@1.3.2:
     resolution: {integrity: sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.5.2
+      tslib: 2.6.1
 
   /@azure/identity@2.1.0:
     resolution: {integrity: sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==}
@@ -3323,7 +3351,7 @@ packages:
       jws: 4.0.0
       open: 8.4.2
       stoppable: 1.1.0
-      tslib: 2.5.2
+      tslib: 2.6.1
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -3343,7 +3371,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3401,8 +3429,20 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.5
+    dev: true
+
   /@babel/compat-data@7.21.7:
     resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/compat-data@7.22.9:
+    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -3429,6 +3469,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core@7.22.9:
+    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator@7.21.5:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
     engines: {node: '>=6.9.0'}
@@ -3441,6 +3504,16 @@ packages:
 
   /@babel/generator@7.22.7:
     resolution: {integrity: sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.22.9:
+    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
@@ -3475,6 +3548,20 @@ packages:
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
+    dev: true
+
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.22.9
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.10
+      lru-cache: 5.1.1
+      semver: 6.3.1
     dev: true
 
   /@babel/helper-create-class-features-plugin@7.21.8(@babel/core@7.21.8):
@@ -3530,6 +3617,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-environment-visitor@7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-function-name@7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
@@ -3538,11 +3630,26 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
+  /@babel/helper-function-name@7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/helper-hoist-variables@7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.21.5:
@@ -3559,6 +3666,13 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
+  /@babel/helper-module-imports@7.22.5:
+    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
     engines: {node: '>=6.9.0'}
@@ -3567,12 +3681,26 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-simple-access': 7.21.5
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
   /@babel/helper-optimise-call-expression@7.18.6:
@@ -3623,6 +3751,13 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
@@ -3637,26 +3772,28 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
-  /@babel/helper-string-parser@7.21.5:
-    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
 
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option@7.22.5:
+    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -3683,13 +3820,33 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers@7.22.6:
+    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
+
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
 
   /@babel/parser@7.21.8:
     resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
@@ -3697,14 +3854,22 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/parser@7.21.9:
+    resolution: {integrity: sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
 
   /@babel/parser@7.22.7:
     resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.21.5
-    dev: true
+      '@babel/types': 7.22.5
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -4306,7 +4471,7 @@ packages:
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4389,7 +4554,7 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.8)
-      '@babel/types': 7.21.5
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/plugin-transform-regenerator@7.21.5(@babel/core@7.21.8):
@@ -4661,6 +4826,15 @@ packages:
       '@babel/types': 7.21.5
     dev: true
 
+  /@babel/template@7.22.5:
+    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
     engines: {node: '>=6.9.0'}
@@ -4679,13 +4853,32 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse@7.22.8:
+    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.21.5:
     resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.22.5:
     resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
@@ -4694,7 +4887,6 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -4985,24 +5177,25 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@docsearch/css@3.3.5:
-    resolution: {integrity: sha512-NaXVp3I8LdmJ54fn038KHgG7HmbIzZlKS2FkVf6mKcW5bYMJovkx4947joQyZk5yubxOZ+ddHSh79y39Aevufg==}
+  /@docsearch/css@3.5.1:
+    resolution: {integrity: sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA==}
     dev: true
 
-  /@docsearch/js@3.3.5(@algolia/client-search@4.17.0):
-    resolution: {integrity: sha512-nZi074OCryZnzva2LNcbQkwBJIND6cvuFI4s1FIe6Ygf6n9g6B/IYUULXNx05rpoCZ+KEoEt3taROpsHBliuSw==}
+  /@docsearch/js@3.5.1(@algolia/client-search@4.19.1)(search-insights@2.7.0):
+    resolution: {integrity: sha512-EXi8de5njxgP6TV3N9ytnGRLG9zmBNTEZjR4VzwPcpPLbZxxTLG2gaFyJyKiFVQxHW/DPlMrDJA3qoRRGEkgZw==}
     dependencies:
-      '@docsearch/react': 3.3.5(@algolia/client-search@4.17.0)
-      preact: 10.14.1
+      '@docsearch/react': 3.5.1(@algolia/client-search@4.19.1)(search-insights@2.7.0)
+      preact: 10.16.0
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
       - react
       - react-dom
+      - search-insights
     dev: true
 
-  /@docsearch/react@3.3.5(@algolia/client-search@4.17.0):
-    resolution: {integrity: sha512-Zuxf4z5PZ9eIQkVCNu76v1H+KAztKItNn3rLzZa7kpBS+++TgNARITnZeUS7C1DKoAhJZFr6T/H+Lvc6h/iiYg==}
+  /@docsearch/react@3.5.1(@algolia/client-search@4.19.1)(search-insights@2.7.0):
+    resolution: {integrity: sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
       react: '>= 16.8.0 < 19.0.0'
@@ -5015,12 +5208,13 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.8.2
-      '@algolia/autocomplete-preset-algolia': 1.8.2(@algolia/client-search@4.17.0)(algoliasearch@4.17.0)
-      '@docsearch/css': 3.3.5
-      algoliasearch: 4.17.0
+      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0)
+      '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+      '@docsearch/css': 3.5.1
+      algoliasearch: 4.19.1
     transitivePeerDependencies:
       - '@algolia/client-search'
+      - search-insights
     dev: true
 
   /@editorjs/attaches@1.3.0:
@@ -5155,6 +5349,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm64@0.18.17:
+    resolution: {integrity: sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm@0.17.19:
     resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
     engines: {node: '>=12'}
@@ -5165,6 +5368,15 @@ packages:
 
   /@esbuild/android-arm@0.18.10:
     resolution: {integrity: sha512-3KClmVNd+Fku82uZJz5C4Rx8m1PPmWUFz5Zkw8jkpZPOmsq+EG1TTOtw1OXkHuX3WczOFQigrtf60B1ijKwNsg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.18.17:
+    resolution: {integrity: sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -5189,6 +5401,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64@0.18.17:
+    resolution: {integrity: sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.17.19:
     resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
     engines: {node: '>=12'}
@@ -5199,6 +5420,15 @@ packages:
 
   /@esbuild/darwin-arm64@0.18.10:
     resolution: {integrity: sha512-k2OJQ7ZxE6sVc91+MQeZH9gFeDAH2uIYALPAwTjTCvcPy9Dzrf7V7gFUQPYkn09zloWhQ+nvxWHia2x2ZLR0sQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.18.17:
+    resolution: {integrity: sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -5223,6 +5453,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-x64@0.18.17:
+    resolution: {integrity: sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.17.19:
     resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
     engines: {node: '>=12'}
@@ -5233,6 +5472,15 @@ packages:
 
   /@esbuild/freebsd-arm64@0.18.10:
     resolution: {integrity: sha512-QJluV0LwBrbHnYYwSKC+K8RGz0g/EyhpQH1IxdoFT0nM7PfgjE+aS8wxq/KFEsU0JkL7U/EEKd3O8xVBxXb2aA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.18.17:
+    resolution: {integrity: sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -5257,6 +5505,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-x64@0.18.17:
+    resolution: {integrity: sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm64@0.17.19:
     resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
     engines: {node: '>=12'}
@@ -5267,6 +5524,15 @@ packages:
 
   /@esbuild/linux-arm64@0.18.10:
     resolution: {integrity: sha512-Nz6XcfRBOO7jSrVpKAyEyFOPGhySPNlgumSDhWAspdQQ11ub/7/NZDMhWDFReE9QH/SsCOCLQbdj0atAk/HMOQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.18.17:
+    resolution: {integrity: sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -5291,6 +5557,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm@0.18.17:
+    resolution: {integrity: sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32@0.17.19:
     resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
     engines: {node: '>=12'}
@@ -5301,6 +5576,15 @@ packages:
 
   /@esbuild/linux-ia32@0.18.10:
     resolution: {integrity: sha512-otMdmSmkMe+pmiP/bZBjfphyAsTsngyT9RCYwoFzqrveAbux9nYitDTpdgToG0Z0U55+PnH654gCH2GQ1aB6Yw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.18.17:
+    resolution: {integrity: sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -5325,6 +5609,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64@0.18.17:
+    resolution: {integrity: sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.17.19:
     resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
     engines: {node: '>=12'}
@@ -5335,6 +5628,15 @@ packages:
 
   /@esbuild/linux-mips64el@0.18.10:
     resolution: {integrity: sha512-+dUkcVzcfEJHz3HEnVpIJu8z8Wdn2n/nWMWdl6FVPFGJAVySO4g3+XPzNKFytVFwf8hPVDwYXzVcu8GMFqsqZw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.18.17:
+    resolution: {integrity: sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -5359,6 +5661,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64@0.18.17:
+    resolution: {integrity: sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.17.19:
     resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
     engines: {node: '>=12'}
@@ -5369,6 +5680,15 @@ packages:
 
   /@esbuild/linux-riscv64@0.18.10:
     resolution: {integrity: sha512-JDtdbJg3yjDeXLv4lZYE1kiTnxv73/8cbPHY9T/dUKi8rYOM/k5b3W4UJLMUksuQ6nTm5c89W1nADsql6FW75A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.18.17:
+    resolution: {integrity: sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -5393,6 +5713,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x@0.18.17:
+    resolution: {integrity: sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64@0.17.19:
     resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
     engines: {node: '>=12'}
@@ -5403,6 +5732,15 @@ packages:
 
   /@esbuild/linux-x64@0.18.10:
     resolution: {integrity: sha512-wj2KRsCsFusli+6yFgNO/zmmLslislAWryJnodteRmGej7ZzinIbMdsyp13rVGde88zxJd5vercNYK9kuvlZaQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.18.17:
+    resolution: {integrity: sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -5427,6 +5765,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.18.17:
+    resolution: {integrity: sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.17.19:
     resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
     engines: {node: '>=12'}
@@ -5437,6 +5784,15 @@ packages:
 
   /@esbuild/openbsd-x64@0.18.10:
     resolution: {integrity: sha512-k8GTIIW9I8pEEfoOUm32TpPMgSg06JhL5DO+ql66aLTkOQUs0TxCA67Wi7pv6z8iF8STCGcNbm3UWFHLuci+ag==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.18.17:
+    resolution: {integrity: sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -5461,6 +5817,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.18.17:
+    resolution: {integrity: sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.17.19:
     resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
     engines: {node: '>=12'}
@@ -5471,6 +5836,15 @@ packages:
 
   /@esbuild/win32-arm64@0.18.10:
     resolution: {integrity: sha512-kRhNcMZFGMW+ZHCarAM1ypr8OZs0k688ViUCetVCef9p3enFxzWeBg9h/575Y0nsFu0ZItluCVF5gMR2pwOEpA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.18.17:
+    resolution: {integrity: sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -5495,6 +5869,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.18.17:
+    resolution: {integrity: sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.19:
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -5512,6 +5895,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-x64@0.18.17:
+    resolution: {integrity: sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@eslint-community/eslint-utils@4.4.0(eslint@8.40.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5522,8 +5914,23 @@ packages:
       eslint-visitor-keys: 3.4.1
     dev: true
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.46.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.46.0
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
   /@eslint-community/regexpp@4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint-community/regexpp@4.6.2:
+    resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
@@ -5544,8 +5951,30 @@ packages:
       - supports-color
     dev: true
 
+  /@eslint/eslintrc@2.1.1:
+    resolution: {integrity: sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 9.6.1
+      globals: 13.20.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@eslint/js@8.40.0:
     resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/js@8.46.0:
+    resolution: {integrity: sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -5776,6 +6205,17 @@ packages:
 
   /@histoire/vendors@0.16.0:
     resolution: {integrity: sha512-MVr3P2q5Q9UiLJJT99b+j2ABCSerQG4VnUeCr5+eOxyEmoIFz1a0KGJimzqQM0EoVnMQmiaNN3WhuUYG+DWh/w==}
+    dev: true
+
+  /@humanwhocodes/config-array@0.11.10:
+    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.3.4
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@humanwhocodes/config-array@0.11.8:
@@ -6301,7 +6741,7 @@ packages:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.4
       tar: 6.1.15
     transitivePeerDependencies:
       - encoding
@@ -6602,7 +7042,7 @@ packages:
       '@otplib/plugin-thirty-two': 12.0.1
     dev: false
 
-  /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.40.0)(prettier@2.8.8):
+  /@paescuj/eslint-plugin-prettier@4.3.0-1(eslint-config-prettier@8.8.0)(eslint@8.46.0)(prettier@2.8.8):
     resolution: {integrity: sha512-mIlCVXh/nfzGkgvOTtd7WxzYZf7nxgR+/4Hs/6952dowh1n/IcVOfiBK0pUuCJ/mvZORDXdn35LI6vYpTlXicQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -6616,7 +7056,7 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 8.40.0
+      eslint: 8.46.0
       eslint-config-prettier: 8.8.0(eslint@8.40.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
@@ -6640,16 +7080,16 @@ packages:
       - vue
     dev: true
 
-  /@pkgr/utils@2.4.1:
-    resolution: {integrity: sha512-JOqwkgFEyi+OROIyq7l4Jy28h/WwhDnG/cPkXG2Z1iFbubB6jsHW1NDvmyOzTBxHr3yg68YGirmh1JUgMqa+9w==}
+  /@pkgr/utils@2.4.2:
+    resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dependencies:
       cross-spawn: 7.0.3
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       is-glob: 4.0.3
       open: 9.1.0
       picocolors: 1.0.0
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /@pnpm/cli-meta@5.0.0:
@@ -6766,7 +7206,7 @@ packages:
       ramda: /@pnpm/ramda@0.28.1
       right-pad: 1.0.1
       rxjs: 7.8.1
-      semver: 7.5.1
+      semver: 7.5.4
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -6817,7 +7257,7 @@ packages:
       '@pnpm/read-project-manifest': 5.0.0
       '@pnpm/types': 9.0.0
       '@pnpm/util.lex-comparator': 1.0.0
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       p-filter: 2.1.0
     dev: false
 
@@ -6854,7 +7294,7 @@ packages:
     resolution: {integrity: sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==}
     engines: {node: '>=12.17'}
     dependencies:
-      bole: 5.0.4
+      bole: 5.0.6
       ndjson: 2.0.0
     dev: false
 
@@ -6905,7 +7345,7 @@ packages:
       detect-libc: 2.0.1
       execa: /safe-execa@0.1.2
       mem: 8.1.1
-      semver: 7.5.1
+      semver: 7.5.4
     dev: false
 
   /@pnpm/pnpmfile@5.0.6(@pnpm/logger@5.0.0):
@@ -7070,6 +7510,25 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.2
       rollup: 3.22.0
+    dev: false
+
+  /@rollup/plugin-node-resolve@15.0.2(rollup@3.27.2):
+    resolution: {integrity: sha512-Y35fRGUjC3FaurG722uhUuG8YHOJRJQbI6/CkbRkdPotSpDj9NtIN85z1zrcyDcCQIW4qp5mgG72U+gJ0TAFEg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.2
+      rollup: 3.27.2
+    dev: true
 
   /@rollup/plugin-replace@5.0.2(rollup@3.22.0):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
@@ -7121,7 +7580,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
     dev: true
@@ -7147,6 +7606,22 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.22.0
+    dev: false
+
+  /@rollup/pluginutils@5.0.2(rollup@3.27.2):
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.27.2
+    dev: true
 
   /@rushstack/node-core-library@3.59.3:
     resolution: {integrity: sha512-OGk0nQc+SvDkn+IQN16co691A/96gPoRIoWdIlpUds+sYPAGWdTcNVjKMwFOAsCSASqOeF2lh1GdPtWoWJCkPQ==}
@@ -7636,9 +8111,9 @@ packages:
       magic-string: 0.27.0
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
-      rollup: 3.22.0
+      rollup: 3.27.2
       typescript: 5.0.4
-      vite: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
+      vite: 4.3.7(sass@1.62.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7702,7 +8177,7 @@ packages:
       prompts: 2.4.2
       puppeteer-core: 2.1.1
       read-pkg-up: 7.0.1
-      semver: 7.5.1
+      semver: 7.5.4
       shelljs: 0.8.5
       simple-update-notifier: 1.1.0
       strip-json-comments: 3.1.1
@@ -7842,7 +8317,7 @@ packages:
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.1
+      semver: 7.5.4
       serve-favicon: 2.5.0
       telejson: 7.1.0
       ts-dedent: 2.2.0
@@ -7869,7 +8344,7 @@ packages:
     resolution: {integrity: sha512-EcDzKeENzs4awyjx0VxlONDLibiEtIPDP1XdOCcZGtv3nXXBFtS2WDsYhJHkwyvE37jWTyw2e4xKQmBi0Hjvbw==}
     dependencies:
       '@babel/generator': 7.21.5
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.21.9
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
       '@storybook/csf': 0.1.0
@@ -7928,7 +8403,7 @@ packages:
       memoizerific: 1.11.3
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
-      semver: 7.5.1
+      semver: 7.5.4
       store2: 2.14.2
       telejson: 7.1.0
       ts-dedent: 2.2.0
@@ -8057,7 +8532,7 @@ packages:
       magic-string: 0.27.0
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
-      vite: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
+      vite: 4.3.7(sass@1.62.1)
       vue-docgen-api: 4.72.3(vue@3.3.4)
     transitivePeerDependencies:
       - '@preact/preset-vite'
@@ -8157,8 +8632,8 @@ packages:
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.5
@@ -8167,20 +8642,20 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.22.5
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
     dev: true
 
   /@types/babel__traverse@7.18.5:
     resolution: {integrity: sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==}
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.22.5
     dev: true
 
   /@types/base-64@1.0.0:
@@ -8292,8 +8767,8 @@ packages:
       - postcss
     dev: false
 
-  /@types/debug@4.1.7:
-    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+  /@types/debug@4.1.8:
+    resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
     dependencies:
       '@types/ms': 0.7.31
     dev: true
@@ -8552,10 +9027,10 @@ packages:
     resolution: {integrity: sha512-zK4gSFMjgslsv5Lyvr3O1yCjgmnE4pr8jbG8qVn4QglMwtpvPCf4YT2Wma7Nk95OxUUJI8Z+kzdXohbM7mVpGw==}
     dev: true
 
-  /@types/mdast@3.0.11:
-    resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==}
+  /@types/mdast@3.0.12:
+    resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /@types/mdurl@1.0.2:
@@ -8588,10 +9063,10 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
 
-  /@types/nlcst@1.0.0:
-    resolution: {integrity: sha512-3TGCfOcy8R8mMQ4CNSNOe3PG66HttvjcLzCoOpvXvDtfWOTi+uT/rxeOKm/qEwbM4SNe1O/PjdiBK2YcTjU4OQ==}
+  /@types/nlcst@1.0.1:
+    resolution: {integrity: sha512-aVIyXt6pZiiMOtVByE4Y0gf+BLm1Cxc4ZLSK8VRHn1CgkO+kXbQwN/EBhQmhPdBMjFJCMBKtmNW2zWQuFywz8Q==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /@types/node-fetch-cache@3.0.0:
@@ -8810,8 +9285,8 @@ packages:
       '@types/node': 18.16.12
     dev: false
 
-  /@types/unist@2.0.6:
-    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+  /@types/unist@2.0.7:
+    resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
     dev: true
 
   /@types/uuid-validate@0.0.1:
@@ -8845,7 +9320,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8857,23 +9332,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.59.6
-      '@typescript-eslint/type-utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.40.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.1
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@5.59.6(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8885,10 +9360,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.40.0
-      typescript: 5.0.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8901,7 +9376,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.59.6(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8911,12 +9386,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.40.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8926,7 +9401,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.1.6):
     resolution: {integrity: sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8940,14 +9415,14 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.59.6(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8958,7 +9433,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.1.6)
       eslint: 8.40.0
       eslint-scope: 5.1.1
       semver: 7.5.1
@@ -8978,7 +9453,7 @@ packages:
   /@unhead/addons@1.1.30:
     resolution: {integrity: sha512-9Ule9CcL7RiqY8e6ZtJum/j2gi1UUngI3K8hFS2P1scx3Wz1rbCrI7bAhGdY03IARH/8vTaJJTIoWLBdl5GxEA==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
       '@unhead/schema': 1.1.30
       '@unhead/shared': 1.1.30
       magic-string: 0.30.1
@@ -9030,8 +9505,19 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
+      vite: 4.3.7(sass@1.62.1)
       vue: 3.3.4
+
+  /@vitejs/plugin-vue@4.2.3(vite@4.4.8)(vue@3.3.4):
+    resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 4.4.8
+      vue: 3.3.4
+    dev: true
 
   /@vitest/coverage-c8@0.31.1(vitest@0.31.1):
     resolution: {integrity: sha512-6TkjQpmgYez7e3dbAUoYdRXxWN81BojCmUILJwgCy39uZFG33DsQ0rSRSZC9beAEdCZTpxR63nOvd9hxDQcJ0g==}
@@ -9115,7 +9601,7 @@ packages:
       '@vue/compiler-sfc': 3.3.4
       '@vue/reactivity': 3.3.4
       '@vue/shared': 3.3.4
-      minimatch: 9.0.1
+      minimatch: 9.0.3
       muggle-string: 0.2.2
       vue-template-compiler: 2.7.14
     dev: true
@@ -9133,7 +9619,7 @@ packages:
   /@vue/compiler-core@3.3.4:
     resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
       source-map-js: 1.0.2
@@ -9147,15 +9633,15 @@ packages:
   /@vue/compiler-sfc@3.3.4:
     resolution: {integrity: sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@vue/compiler-core': 3.3.4
       '@vue/compiler-dom': 3.3.4
       '@vue/compiler-ssr': 3.3.4
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
-      postcss: 8.4.23
+      magic-string: 0.30.2
+      postcss: 8.4.27
       source-map-js: 1.0.2
 
   /@vue/compiler-ssr@3.3.4:
@@ -9170,11 +9656,11 @@ packages:
   /@vue/reactivity-transform@3.3.4:
     resolution: {integrity: sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.2
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -9229,8 +9715,24 @@ packages:
       - '@vue/composition-api'
       - vue
 
+  /@vueuse/core@10.3.0(vue@3.3.4):
+    resolution: {integrity: sha512-BEM5yxcFKb5btFjTSAFjTu5jmwoW66fyV9uJIP4wUXXU8aR5Hl44gndaaXp7dC5HSObmgbnR2RN+Un1p68Mf5Q==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.17
+      '@vueuse/metadata': 10.3.0
+      '@vueuse/shared': 10.3.0(vue@3.3.4)
+      vue-demi: 0.14.5(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
+
   /@vueuse/metadata@10.1.2:
     resolution: {integrity: sha512-3mc5BqN9aU2SqBeBuWE7ne4OtXHoHKggNgxZR2K+zIW4YLsy6xoZ4/9vErQs6tvoKDX6QAqm3lvsrv0mczAwIQ==}
+
+  /@vueuse/metadata@10.3.0:
+    resolution: {integrity: sha512-Ema3YhNOa4swDsV0V7CEY5JXvK19JI/o1szFO1iWxdFg3vhdFtCtSTP26PCvbUpnUtNHBY2wx5y3WDXND5Pvnw==}
+    dev: true
 
   /@vueuse/shared@10.1.2(vue@3.3.4):
     resolution: {integrity: sha512-1uoUTPBlgyscK9v6ScGeVYDDzlPSFXBlxuK7SfrDGyUTBiznb3mNceqhwvZHjtDRELZEN79V5uWPTF1VDV8svA==}
@@ -9239,6 +9741,15 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  /@vueuse/shared@10.3.0(vue@3.3.4):
+    resolution: {integrity: sha512-kGqCTEuFPMK4+fNWy6dUOiYmxGcUbtznMwBZLC1PubidF4VZY05B+Oht7Jh7/6x4VOWGpvu3R37WHi81cKpiqg==}
+    dependencies:
+      vue-demi: 0.14.5(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -9366,7 +9877,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.17.19
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /@zkochan/which@2.0.3:
@@ -9419,6 +9930,14 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.8.2
+    dev: true
+
+  /acorn-jsx@5.3.2(acorn@8.10.0):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.10.0
     dev: true
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
@@ -9543,23 +10062,23 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /algoliasearch@4.17.0:
-    resolution: {integrity: sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==}
+  /algoliasearch@4.19.1:
+    resolution: {integrity: sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==}
     dependencies:
-      '@algolia/cache-browser-local-storage': 4.17.0
-      '@algolia/cache-common': 4.17.0
-      '@algolia/cache-in-memory': 4.17.0
-      '@algolia/client-account': 4.17.0
-      '@algolia/client-analytics': 4.17.0
-      '@algolia/client-common': 4.17.0
-      '@algolia/client-personalization': 4.17.0
-      '@algolia/client-search': 4.17.0
-      '@algolia/logger-common': 4.17.0
-      '@algolia/logger-console': 4.17.0
-      '@algolia/requester-browser-xhr': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/requester-node-http': 4.17.0
-      '@algolia/transporter': 4.17.0
+      '@algolia/cache-browser-local-storage': 4.19.1
+      '@algolia/cache-common': 4.19.1
+      '@algolia/cache-in-memory': 4.19.1
+      '@algolia/client-account': 4.19.1
+      '@algolia/client-analytics': 4.19.1
+      '@algolia/client-common': 4.19.1
+      '@algolia/client-personalization': 4.19.1
+      '@algolia/client-search': 4.19.1
+      '@algolia/logger-common': 4.19.1
+      '@algolia/logger-console': 4.19.1
+      '@algolia/requester-browser-xhr': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/requester-node-http': 4.19.1
+      '@algolia/transporter': 4.19.1
     dev: true
 
   /ansi-align@3.0.1:
@@ -9604,8 +10123,8 @@ packages:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
 
-  /ansi-sequence-parser@1.1.0:
-    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
+  /ansi-sequence-parser@1.1.1:
+    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
     dev: true
 
   /ansi-split@1.0.1:
@@ -9743,7 +10262,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       get-intrinsic: 1.2.1
       is-string: 1.0.7
     dev: true
@@ -9763,7 +10282,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -9773,7 +10292,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -9782,10 +10301,21 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.1
     dev: true
+
+  /arraybuffer.prototype.slice@1.0.1:
+    resolution: {integrity: sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      get-intrinsic: 1.2.1
+      is-array-buffer: 3.0.2
+      is-shared-array-buffer: 1.0.2
 
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -9840,7 +10370,7 @@ packages:
     engines: {node: '>=16.14.0'}
     dependencies:
       '@babel/parser': 7.22.7
-      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
@@ -9850,14 +10380,14 @@ packages:
     resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /async-limiter@1.0.1:
@@ -9992,7 +10522,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.5
+      '@babel/types': 7.22.5
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.5
     dev: true
@@ -10068,7 +10598,7 @@ packages:
     resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.22.5
     dev: true
 
   /backoff@2.5.0:
@@ -10189,8 +10719,8 @@ packages:
     resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
     dev: true
 
-  /bole@5.0.4:
-    resolution: {integrity: sha512-eiT3gRFZTlC81m7Z2peYhpHYjgIt04ap91He9P44UsDg1Zf0rxdWGX8fjXSo/MbskvSFv/w9WzqzKuAQZlbVHg==}
+  /bole@5.0.6:
+    resolution: {integrity: sha512-HtZbVmxHqreaC29XVvGPShDtL2zSafkLe8vMdvFr4ppvtjrObVxtejoU/3jpRbxzxFeqDLXv5oIxUhSVw1NaAw==}
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
@@ -10268,6 +10798,17 @@ packages:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
     dependencies:
       pako: 0.2.9
+    dev: true
+
+  /browserslist@4.21.10:
+    resolution: {integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001519
+      electron-to-chromium: 1.4.485
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
 
   /browserslist@4.21.5:
@@ -10458,7 +10999,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /camelcase-keys@6.2.2:
@@ -10506,11 +11047,15 @@ packages:
   /caniuse-lite@1.0.30001488:
     resolution: {integrity: sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==}
 
+  /caniuse-lite@1.0.30001519:
+    resolution: {integrity: sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==}
+    dev: true
+
   /capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
       upper-case-first: 2.0.2
     dev: true
 
@@ -10575,7 +11120,7 @@ packages:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /char-regex@1.0.2:
@@ -10951,7 +11496,7 @@ packages:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.5.1
+      semver: 7.5.4
       well-known-symbols: 2.0.0
     dev: true
 
@@ -11166,15 +11711,15 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
       upper-case: 2.0.2
     dev: true
 
   /constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
     dependencies:
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
     dev: true
 
   /content-disposition@0.5.4:
@@ -11639,7 +12184,7 @@ packages:
     dependencies:
       bundle-name: 3.0.0
       default-browser-id: 3.0.0
-      execa: 7.1.1
+      execa: 7.2.0
       titleize: 3.0.0
     dev: true
 
@@ -11877,7 +12422,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /dotenv-expand@10.0.0:
@@ -11934,7 +12479,7 @@ packages:
     dependencies:
       commander: 2.20.3
       lru-cache: 4.1.5
-      semver: 5.7.1
+      semver: 5.7.2
       sigmund: 1.0.1
     dev: true
 
@@ -11961,6 +12506,10 @@ packages:
 
   /electron-to-chromium@1.4.401:
     resolution: {integrity: sha512-AswqHsYyEbfSn0x87n31Na/xttUqEAg7NUjpiyxC20MaWKLyadOYHMzyLdF78N1iw+FK8/2KHLpZxRdyRILgtA==}
+
+  /electron-to-chromium@1.4.485:
+    resolution: {integrity: sha512-1ndQ5IBNEnFirPwvyud69GHL+31FkE09gH/CJ6m3KCbkx3i0EVOrjwz4UNxRmN9H8OVHbC6vMRZGN1yCvjSs9w==}
+    dev: true
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -12079,11 +12628,12 @@ packages:
     dependencies:
       is-arrayish: 0.2.1
 
-  /es-abstract@1.21.2:
-    resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==}
+  /es-abstract@1.22.1:
+    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
+      arraybuffer.prototype.slice: 1.0.1
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
@@ -12104,19 +12654,23 @@ packages:
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
       is-weakref: 1.0.2
       object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.5.0
+      safe-array-concat: 1.0.0
       safe-regex-test: 1.0.0
       string.prototype.trim: 1.2.7
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
+      typed-array-buffer: 1.0.0
+      typed-array-byte-length: 1.0.0
+      typed-array-byte-offset: 1.0.0
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.9
+      which-typed-array: 1.1.11
 
   /es-aggregate-error@1.0.9:
     resolution: {integrity: sha512-fvnX40sb538wdU6r4s35cq4EY6Lr09Upj40BEVem4LEsuW8XgQep9yD5Q1U2KftokNp1rWODFJ2qwZSsAjFpbg==}
@@ -12124,7 +12678,7 @@ packages:
     requiresBuild: true
     dependencies:
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       function-bind: 1.1.1
       functions-have-names: 1.2.3
       get-intrinsic: 1.2.1
@@ -12238,6 +12792,36 @@ packages:
       '@esbuild/win32-x64': 0.18.10
     dev: true
 
+  /esbuild@0.18.17:
+    resolution: {integrity: sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.17
+      '@esbuild/android-arm64': 0.18.17
+      '@esbuild/android-x64': 0.18.17
+      '@esbuild/darwin-arm64': 0.18.17
+      '@esbuild/darwin-x64': 0.18.17
+      '@esbuild/freebsd-arm64': 0.18.17
+      '@esbuild/freebsd-x64': 0.18.17
+      '@esbuild/linux-arm': 0.18.17
+      '@esbuild/linux-arm64': 0.18.17
+      '@esbuild/linux-ia32': 0.18.17
+      '@esbuild/linux-loong64': 0.18.17
+      '@esbuild/linux-mips64el': 0.18.17
+      '@esbuild/linux-ppc64': 0.18.17
+      '@esbuild/linux-riscv64': 0.18.17
+      '@esbuild/linux-s390x': 0.18.17
+      '@esbuild/linux-x64': 0.18.17
+      '@esbuild/netbsd-x64': 0.18.17
+      '@esbuild/openbsd-x64': 0.18.17
+      '@esbuild/sunos-x64': 0.18.17
+      '@esbuild/win32-arm64': 0.18.17
+      '@esbuild/win32-ia32': 0.18.17
+      '@esbuild/win32-x64': 0.18.17
+    dev: true
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -12288,19 +12872,19 @@ packages:
     resolution: {integrity: sha512-oOeA6FWU0UJT/Rxc3XF5Cq0nbIZbylm7j8+plqq0CZoE6m4u32OXJrR+9iy4srGMmF6v6pmgvP1zPxSRIGh3sg==}
     dev: true
 
-  /eslint-plugin-markdown@3.0.0(eslint@8.40.0):
+  /eslint-plugin-markdown@3.0.0(eslint@8.46.0):
     resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.40.0
+      eslint: 8.46.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@8.40.0):
+  /eslint-plugin-react@7.32.2(eslint@8.46.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12310,9 +12894,9 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.40.0
+      eslint: 8.46.0
       estraverse: 5.3.0
-      jsx-ast-utils: 3.3.4
+      jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
       object.entries: 1.1.6
       object.fromentries: 2.0.6
@@ -12320,7 +12904,7 @@ packages:
       object.values: 1.1.6
       prop-types: 15.8.1
       resolve: 2.0.0-next.4
-      semver: 6.3.0
+      semver: 6.3.1
       string.prototype.matchall: 4.0.8
     dev: true
 
@@ -12358,8 +12942,21 @@ packages:
       estraverse: 5.3.0
     dev: true
 
+  /eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
   /eslint-visitor-keys@3.4.1:
     resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint-visitor-keys@3.4.2:
+    resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -12412,6 +13009,52 @@ packages:
       - supports-color
     dev: true
 
+  /eslint@8.46.0:
+    resolution: {integrity: sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
+      '@eslint-community/regexpp': 4.6.2
+      '@eslint/eslintrc': 2.1.1
+      '@eslint/js': 8.46.0
+      '@humanwhocodes/config-array': 0.11.10
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.2
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.20.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
@@ -12423,6 +13066,15 @@ packages:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
       eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
+      eslint-visitor-keys: 3.4.2
     dev: true
 
   /esprima@4.0.1:
@@ -12518,6 +13170,22 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
+    dev: false
+
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: true
 
   /exif-reader@1.2.0:
     resolution: {integrity: sha512-C9jsLWxaUh9/gNwo9Ouf9jxP0vGn/2vkhu89wbPFyFfpfl8WPbwLrvrb7h9Q6oVvkyvA+e4lXgOllW+/bAk0RQ==}
@@ -12641,6 +13309,17 @@ packages:
 
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
+  /fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -13067,7 +13746,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       functions-have-names: 1.2.3
 
   /functions-have-names@1.2.3:
@@ -13350,7 +14029,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
@@ -13415,6 +14094,10 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
+
   /graphlib@2.1.8:
     resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
     dependencies:
@@ -13445,10 +14128,26 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.6.0
+    dev: false
+
+  /graphql-ws@5.12.0(graphql@16.7.1):
+    resolution: {integrity: sha512-PA3ImUp8utrpEjoxBMhvxsjkStvFEdU0E1gEBREt8HZIWkxOUymwJBhFnBL7t/iHhUq1GVPeZevPinkZFENxTw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dependencies:
+      graphql: 16.7.1
+    dev: true
 
   /graphql@16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
+
+  /graphql@16.7.1:
+    resolution: {integrity: sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
 
   /gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -13608,7 +14307,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /helmet@7.0.0:
@@ -14002,7 +14701,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -14050,8 +14749,8 @@ packages:
       ci-info: 3.8.0
     dev: true
 
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+  /is-core-module@2.13.0:
+    resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
     dependencies:
       has: 1.0.3
 
@@ -14269,15 +14968,11 @@ packages:
     dependencies:
       has-symbols: 1.0.3
 
-  /is-typed-array@1.1.10:
-    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+  /is-typed-array@1.1.12:
+    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
+      which-typed-array: 1.1.11
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -14319,6 +15014,9 @@ packages:
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
+  /isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -14352,10 +15050,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14718,7 +15416,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.8)
       '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.21.8)
       '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
+      '@babel/types': 7.22.5
       '@jest/expect-utils': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
@@ -14735,7 +15433,7 @@ packages:
       jest-util: 29.5.0
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.5.1
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14912,7 +15610,7 @@ packages:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.8)
@@ -15138,8 +15836,8 @@ packages:
       promise: 7.3.1
     dev: true
 
-  /jsx-ast-utils@3.3.4:
-    resolution: {integrity: sha512-fX2TVdCViod6HwKEtSWGHs57oFhVfCMwieb9PuRDgjDPh5XeqJiHFFFJCHxU5cnTc3Bu/GRL+kPiFmw8XWOfKw==}
+  /jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.6
@@ -15554,7 +16252,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /lowercase-keys@2.0.0:
@@ -15620,6 +16318,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /magic-string@0.30.1:
     resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
@@ -15627,6 +16326,12 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
+
+  /magic-string@0.30.2:
+    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   /mailgun.js@8.2.1:
     resolution: {integrity: sha512-iKHCMehdUcWzBAp8KU2idLP7AbsTxQ8DjJev4Gvm430Dujul+ZkzKPgn40uYpb9BXGL5l8/w5jpf2pvw51df/w==}
@@ -15645,14 +16350,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 5.7.1
+      semver: 5.7.2
     dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -15851,7 +16556,7 @@ packages:
   /mdast-util-find-and-replace@2.2.2:
     resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       escape-string-regexp: 5.0.0
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
@@ -15860,7 +16565,7 @@ packages:
   /mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-to-string: 2.0.0
       micromark: 2.11.4
       parse-entities: 2.0.0
@@ -15869,19 +16574,19 @@ packages:
       - supports-color
     dev: true
 
-  /mdast-util-from-markdown@1.3.0:
-    resolution: {integrity: sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==}
+  /mdast-util-from-markdown@1.3.1:
+    resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
     dependencies:
-      '@types/mdast': 3.0.11
-      '@types/unist': 2.0.6
+      '@types/mdast': 3.0.12
+      '@types/unist': 2.0.7
       decode-named-character-reference: 1.0.2
       mdast-util-to-string: 3.2.0
-      micromark: 3.1.0
-      micromark-util-decode-numeric-character-reference: 1.0.0
-      micromark-util-decode-string: 1.0.2
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark: 3.2.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-decode-string: 1.1.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       unist-util-stringify-position: 3.0.3
       uvu: 0.5.6
     transitivePeerDependencies:
@@ -15891,41 +16596,41 @@ packages:
   /mdast-util-frontmatter@1.0.1:
     resolution: {integrity: sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-to-markdown: 1.5.0
-      micromark-extension-frontmatter: 1.1.0
+      micromark-extension-frontmatter: 1.1.1
     dev: true
 
   /mdast-util-gfm-autolink-literal@1.0.3:
     resolution: {integrity: sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       ccount: 2.0.1
       mdast-util-find-and-replace: 2.2.2
-      micromark-util-character: 1.1.0
+      micromark-util-character: 1.2.0
     dev: true
 
   /mdast-util-gfm-footnote@1.0.2:
     resolution: {integrity: sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-to-markdown: 1.5.0
-      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-normalize-identifier: 1.1.0
     dev: true
 
   /mdast-util-gfm-strikethrough@1.0.3:
     resolution: {integrity: sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-to-markdown: 1.5.0
     dev: true
 
   /mdast-util-gfm-table@1.0.7:
     resolution: {integrity: sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       markdown-table: 3.0.3
-      mdast-util-from-markdown: 1.3.0
+      mdast-util-from-markdown: 1.3.1
       mdast-util-to-markdown: 1.5.0
     transitivePeerDependencies:
       - supports-color
@@ -15934,14 +16639,14 @@ packages:
   /mdast-util-gfm-task-list-item@1.0.2:
     resolution: {integrity: sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-to-markdown: 1.5.0
     dev: true
 
   /mdast-util-gfm@2.0.2:
     resolution: {integrity: sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==}
     dependencies:
-      mdast-util-from-markdown: 1.3.0
+      mdast-util-from-markdown: 1.3.1
       mdast-util-gfm-autolink-literal: 1.0.3
       mdast-util-gfm-footnote: 1.0.2
       mdast-util-gfm-strikethrough: 1.0.3
@@ -15955,19 +16660,19 @@ packages:
   /mdast-util-phrasing@3.0.1:
     resolution: {integrity: sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       unist-util-is: 5.2.1
     dev: true
 
   /mdast-util-to-markdown@1.5.0:
     resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
     dependencies:
-      '@types/mdast': 3.0.11
-      '@types/unist': 2.0.6
+      '@types/mdast': 3.0.12
+      '@types/unist': 2.0.7
       longest-streak: 3.1.0
       mdast-util-phrasing: 3.0.1
       mdast-util-to-string: 3.2.0
-      micromark-util-decode-string: 1.0.2
+      micromark-util-decode-string: 1.1.0
       unist-util-visit: 4.1.2
       zwitch: 2.0.4
     dev: true
@@ -15975,9 +16680,9 @@ packages:
   /mdast-util-to-nlcst@5.2.1:
     resolution: {integrity: sha512-Xznpj85MsJnLQjBboajOovT2fAAvbbbmYutpFgzLi9pjZEOkgGzjq+t6fHcge8uzZ5uEkj5pigzw2QrnIVq/kw==}
     dependencies:
-      '@types/mdast': 3.0.11
-      '@types/nlcst': 1.0.0
-      '@types/unist': 2.0.6
+      '@types/mdast': 3.0.12
+      '@types/nlcst': 1.0.1
+      '@types/unist': 2.0.7
       nlcst-to-string: 3.1.1
       unist-util-position: 4.0.4
       vfile: 5.3.7
@@ -15995,7 +16700,7 @@ packages:
   /mdast-util-to-string@3.2.0:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
     dev: true
 
   /mdn-data@2.0.14:
@@ -16055,92 +16760,92 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
-  /micromark-core-commonmark@1.0.6:
-    resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
+  /micromark-core-commonmark@1.1.0:
+    resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
     dependencies:
       decode-named-character-reference: 1.0.2
-      micromark-factory-destination: 1.0.0
-      micromark-factory-label: 1.0.2
-      micromark-factory-space: 1.0.0
-      micromark-factory-title: 1.0.2
-      micromark-factory-whitespace: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-chunked: 1.0.0
-      micromark-util-classify-character: 1.0.0
-      micromark-util-html-tag-name: 1.1.0
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-resolve-all: 1.0.0
-      micromark-util-subtokenize: 1.0.2
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-factory-destination: 1.1.0
+      micromark-factory-label: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-factory-title: 1.1.0
+      micromark-factory-whitespace: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-chunked: 1.1.0
+      micromark-util-classify-character: 1.1.0
+      micromark-util-html-tag-name: 1.2.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-subtokenize: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
-  /micromark-extension-frontmatter@1.1.0:
-    resolution: {integrity: sha512-0nLelmvXR5aZ+F2IL6/Ed4cDnHLpL/VD/EELKuclsTWHrLI8UgxGHEmeoumeX2FXiM6z2WrBIOEcbKUZR8RYNg==}
+  /micromark-extension-frontmatter@1.1.1:
+    resolution: {integrity: sha512-m2UH9a7n3W8VAH9JO9y01APpPKmNNNs71P0RbknEmYSaZU5Ghogv38BYO94AI5Xw6OYfxZRdHZZ2nYjs/Z+SZQ==}
     dependencies:
       fault: 2.0.1
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
   /micromark-extension-gfm-autolink-literal@1.0.4:
     resolution: {integrity: sha512-WCssN+M9rUyfHN5zPBn3/f0mIA7tqArHL/EKbv3CZK+LT2rG77FEikIQEqBkv46fOqXQK4NEW/Pc7Z27gshpeg==}
     dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-sanitize-uri: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
   /micromark-extension-gfm-footnote@1.1.0:
     resolution: {integrity: sha512-RWYce7j8+c0n7Djzv5NzGEGitNNYO3uj+h/XYMdS/JinH1Go+/Qkomg/rfxExFzYTiydaV6GLeffGO5qcJbMPA==}
     dependencies:
-      micromark-core-commonmark: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-sanitize-uri: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-core-commonmark: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
   /micromark-extension-gfm-strikethrough@1.0.5:
     resolution: {integrity: sha512-X0oI5eYYQVARhiNfbETy7BfLSmSilzN1eOuoRnrf9oUNsPRrWOAe9UqSizgw1vNxQBfOwL+n2610S3bYjVNi7w==}
     dependencies:
-      micromark-util-chunked: 1.0.0
-      micromark-util-classify-character: 1.0.0
-      micromark-util-resolve-all: 1.0.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-chunked: 1.1.0
+      micromark-util-classify-character: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
   /micromark-extension-gfm-table@1.0.6:
     resolution: {integrity: sha512-92pq7Q+T+4kXH4M6kL+pc8WU23Z9iuhcqmtYFWdFWjm73ZscFpH2xE28+XFpGWlvgq3LUwcN0XC0PGCicYFpgA==}
     dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
   /micromark-extension-gfm-tagfilter@1.0.2:
     resolution: {integrity: sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==}
     dependencies:
-      micromark-util-types: 1.0.2
+      micromark-util-types: 1.1.0
     dev: true
 
   /micromark-extension-gfm-task-list-item@1.0.4:
     resolution: {integrity: sha512-9XlIUUVnYXHsFF2HZ9jby4h3npfX10S1coXTnV035QGPgrtNYQq3J6IfIvcCIUAJrrqBVi5BqA/LmaOMJqPwMQ==}
     dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
@@ -16153,139 +16858,138 @@ packages:
       micromark-extension-gfm-table: 1.0.6
       micromark-extension-gfm-tagfilter: 1.0.2
       micromark-extension-gfm-task-list-item: 1.0.4
-      micromark-util-combine-extensions: 1.0.0
-      micromark-util-types: 1.0.2
+      micromark-util-combine-extensions: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-factory-destination@1.0.0:
-    resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
+  /micromark-factory-destination@1.1.0:
+    resolution: {integrity: sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==}
     dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-factory-label@1.0.2:
-    resolution: {integrity: sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==}
+  /micromark-factory-label@1.1.0:
+    resolution: {integrity: sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==}
     dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
-  /micromark-factory-space@1.0.0:
-    resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
+  /micromark-factory-space@1.1.0:
+    resolution: {integrity: sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==}
     dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-types: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-factory-title@1.0.2:
-    resolution: {integrity: sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==}
+  /micromark-factory-title@1.1.0:
+    resolution: {integrity: sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==}
     dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-factory-whitespace@1.0.0:
-    resolution: {integrity: sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==}
+  /micromark-factory-whitespace@1.1.0:
+    resolution: {integrity: sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==}
     dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-util-character@1.1.0:
-    resolution: {integrity: sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==}
+  /micromark-util-character@1.2.0:
+    resolution: {integrity: sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==}
     dependencies:
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-util-chunked@1.0.0:
-    resolution: {integrity: sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==}
+  /micromark-util-chunked@1.1.0:
+    resolution: {integrity: sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==}
     dependencies:
-      micromark-util-symbol: 1.0.1
+      micromark-util-symbol: 1.1.0
     dev: true
 
-  /micromark-util-classify-character@1.0.0:
-    resolution: {integrity: sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==}
+  /micromark-util-classify-character@1.1.0:
+    resolution: {integrity: sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==}
     dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-util-combine-extensions@1.0.0:
-    resolution: {integrity: sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==}
+  /micromark-util-combine-extensions@1.1.0:
+    resolution: {integrity: sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==}
     dependencies:
-      micromark-util-chunked: 1.0.0
-      micromark-util-types: 1.0.2
+      micromark-util-chunked: 1.1.0
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-util-decode-numeric-character-reference@1.0.0:
-    resolution: {integrity: sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==}
+  /micromark-util-decode-numeric-character-reference@1.1.0:
+    resolution: {integrity: sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==}
     dependencies:
-      micromark-util-symbol: 1.0.1
+      micromark-util-symbol: 1.1.0
     dev: true
 
-  /micromark-util-decode-string@1.0.2:
-    resolution: {integrity: sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==}
+  /micromark-util-decode-string@1.1.0:
+    resolution: {integrity: sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==}
     dependencies:
       decode-named-character-reference: 1.0.2
-      micromark-util-character: 1.1.0
-      micromark-util-decode-numeric-character-reference: 1.0.0
-      micromark-util-symbol: 1.0.1
+      micromark-util-character: 1.2.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-symbol: 1.1.0
     dev: true
 
-  /micromark-util-encode@1.0.1:
-    resolution: {integrity: sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==}
+  /micromark-util-encode@1.1.0:
+    resolution: {integrity: sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==}
     dev: true
 
-  /micromark-util-html-tag-name@1.1.0:
-    resolution: {integrity: sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==}
+  /micromark-util-html-tag-name@1.2.0:
+    resolution: {integrity: sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==}
     dev: true
 
-  /micromark-util-normalize-identifier@1.0.0:
-    resolution: {integrity: sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==}
+  /micromark-util-normalize-identifier@1.1.0:
+    resolution: {integrity: sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==}
     dependencies:
-      micromark-util-symbol: 1.0.1
+      micromark-util-symbol: 1.1.0
     dev: true
 
-  /micromark-util-resolve-all@1.0.0:
-    resolution: {integrity: sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==}
+  /micromark-util-resolve-all@1.1.0:
+    resolution: {integrity: sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==}
     dependencies:
-      micromark-util-types: 1.0.2
+      micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-util-sanitize-uri@1.1.0:
-    resolution: {integrity: sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==}
+  /micromark-util-sanitize-uri@1.2.0:
+    resolution: {integrity: sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==}
     dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-encode: 1.0.1
-      micromark-util-symbol: 1.0.1
+      micromark-util-character: 1.2.0
+      micromark-util-encode: 1.1.0
+      micromark-util-symbol: 1.1.0
     dev: true
 
-  /micromark-util-subtokenize@1.0.2:
-    resolution: {integrity: sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==}
+  /micromark-util-subtokenize@1.1.0:
+    resolution: {integrity: sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==}
     dependencies:
-      micromark-util-chunked: 1.0.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-util-chunked: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     dev: true
 
-  /micromark-util-symbol@1.0.1:
-    resolution: {integrity: sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==}
+  /micromark-util-symbol@1.1.0:
+    resolution: {integrity: sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==}
     dev: true
 
-  /micromark-util-types@1.0.2:
-    resolution: {integrity: sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==}
+  /micromark-util-types@1.1.0:
+    resolution: {integrity: sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==}
     dev: true
 
   /micromark@2.11.4:
@@ -16297,25 +17001,25 @@ packages:
       - supports-color
     dev: true
 
-  /micromark@3.1.0:
-    resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
+  /micromark@3.2.0:
+    resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
-      '@types/debug': 4.1.7
+      '@types/debug': 4.1.8
       debug: 4.3.4
       decode-named-character-reference: 1.0.2
-      micromark-core-commonmark: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-chunked: 1.0.0
-      micromark-util-combine-extensions: 1.0.0
-      micromark-util-decode-numeric-character-reference: 1.0.0
-      micromark-util-encode: 1.0.1
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-resolve-all: 1.0.0
-      micromark-util-sanitize-uri: 1.1.0
-      micromark-util-subtokenize: 1.0.2
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
+      micromark-core-commonmark: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-chunked: 1.1.0
+      micromark-util-combine-extensions: 1.1.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-encode: 1.1.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-subtokenize: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
       uvu: 0.5.6
     transitivePeerDependencies:
       - supports-color
@@ -16408,6 +17112,14 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: false
+
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
 
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -16640,8 +17352,8 @@ packages:
   /nlcst-affix-emoticon-modifier@2.1.1:
     resolution: {integrity: sha512-0kOpSNwB6pFMoe5tWFZ3KrvW6ftVqvnXW+jQw3EJnXkzXdAmdhbcoG9r+NMvJ0nc37BLYlEy5A+FGlB8IOfq5A==}
     dependencies:
-      '@types/nlcst': 1.0.0
-      '@types/unist': 2.0.6
+      '@types/nlcst': 1.0.1
+      '@types/unist': 2.0.7
       nlcst-emoticon-modifier: 2.1.1
       unist-util-modify-children: 3.1.1
     dev: true
@@ -16649,7 +17361,7 @@ packages:
   /nlcst-emoji-modifier@5.2.0:
     resolution: {integrity: sha512-bxgOEDWN2hz6/JN0uiIww+28Ssktq9FRctHq3bxiBi/8G/mb72cQ99vhzrZMWZe8tKD3YYckVH1bEkzcxTJFxg==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       emoji-regex: 10.2.1
       gemoji: 8.1.0
       nlcst-emoticon-modifier: 2.1.1
@@ -16662,8 +17374,8 @@ packages:
   /nlcst-emoticon-modifier@2.1.1:
     resolution: {integrity: sha512-fDfvvmA6ziUQC+I3BYLNZ7lq0rIG3Uz6IsmhTAkdB8d9UyI5LPz1uvmk+W7fKkX1mVWGJw0PeOT9VtXISrPFbg==}
     dependencies:
-      '@types/nlcst': 1.0.0
-      '@types/unist': 2.0.6
+      '@types/nlcst': 1.0.1
+      '@types/unist': 2.0.7
       emoticon: 4.0.1
       nlcst-to-string: 3.1.1
       unist-util-modify-children: 3.1.1
@@ -16672,22 +17384,22 @@ packages:
   /nlcst-is-literal@2.1.1:
     resolution: {integrity: sha512-/PyEKNHN+SrcrmnZRwszzZYbvZSN2AVD506+rfMUzyFHB0PtUmqZOdUuXmQxQeZXv6o29pT5chLjQJdC9weOCQ==}
     dependencies:
-      '@types/nlcst': 1.0.0
-      '@types/unist': 2.0.6
+      '@types/nlcst': 1.0.1
+      '@types/unist': 2.0.7
       nlcst-to-string: 3.1.1
     dev: true
 
   /nlcst-to-string@3.1.1:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
     dev: true
 
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /node-abi@3.40.0:
@@ -16790,7 +17502,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.4
       tar: 6.1.15
       which: 2.0.2
     transitivePeerDependencies:
@@ -16808,6 +17520,10 @@ packages:
 
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
+
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: true
 
   /node-rsa@1.1.1:
     resolution: {integrity: sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==}
@@ -16916,7 +17632,7 @@ packages:
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 5.7.1
+      semver: 5.7.2
       simple-update-notifier: 1.1.0
       supports-color: 5.5.0
       touch: 3.1.0
@@ -17081,7 +17797,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
     dev: true
 
   /object.fromentries@2.0.6:
@@ -17090,14 +17806,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
     dev: true
 
   /object.hasown@1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
     dev: true
 
   /object.values@1.1.6:
@@ -17106,7 +17822,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
     dev: true
 
   /oidc-token-hash@5.0.3:
@@ -17229,6 +17945,18 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+    dev: true
+
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
     dev: true
 
   /ora@5.4.1:
@@ -17398,7 +18126,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /parent-module@1.0.1:
@@ -17471,7 +18199,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /path-absolute@1.0.1:
@@ -17487,7 +18215,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /path-exists@3.0.0:
@@ -17594,8 +18322,8 @@ packages:
     dev: false
     optional: true
 
-  /pg-cloudflare@1.1.0:
-    resolution: {integrity: sha512-tGM8/s6frwuAIyRcJ6nWcIvd3+3NmUKIs6OjviIm1HPPFEt5MzQDOTBQyhPWg/m0kCl95M6gA1JaIXtS8KovOA==}
+  /pg-cloudflare@1.1.1:
+    resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
     requiresBuild: true
     optional: true
 
@@ -17690,7 +18418,7 @@ packages:
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
-      pg-cloudflare: 1.1.0
+      pg-cloudflare: 1.1.1
 
   /pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
@@ -17988,7 +18716,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      yaml: 2.2.2
+      yaml: 2.3.1
     dev: true
 
   /postcss-merge-longhand@5.1.7(postcss@8.4.23):
@@ -18263,6 +18991,14 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /postcss@8.4.27:
+    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+
   /postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -18289,8 +19025,8 @@ packages:
     resolution: {integrity: sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==}
     dev: true
 
-  /preact@10.14.1:
-    resolution: {integrity: sha512-4XDSnUisk3YFBb3p9WeKeH1mKoxdFUsaXcvxs9wlpYR1wax/TWJVqhwmIWbByX0h7jMEJH6Zc5J6jqc58FKaNQ==}
+  /preact@10.16.0:
+    resolution: {integrity: sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==}
     dev: true
 
   /prebuild-install@7.1.1:
@@ -18901,7 +19637,7 @@ packages:
       ast-types: 0.15.2
       esprima: 4.0.1
       source-map: 0.6.1
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /recast@0.23.2:
@@ -18912,7 +19648,7 @@ packages:
       ast-types: 0.16.1
       esprima: 4.0.1
       source-map: 0.6.1
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /rechoir@0.6.2:
@@ -19017,16 +19753,16 @@ packages:
   /remark-frontmatter@4.0.1:
     resolution: {integrity: sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-frontmatter: 1.0.1
-      micromark-extension-frontmatter: 1.1.0
+      micromark-extension-frontmatter: 1.1.1
       unified: 10.1.2
     dev: true
 
   /remark-gfm@3.0.1:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-gfm: 2.0.2
       micromark-extension-gfm: 2.0.3
       unified: 10.1.2
@@ -19037,8 +19773,8 @@ packages:
   /remark-parse@10.0.2:
     resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
     dependencies:
-      '@types/mdast': 3.0.11
-      mdast-util-from-markdown: 1.3.0
+      '@types/mdast': 3.0.12
+      mdast-util-from-markdown: 1.3.1
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19047,8 +19783,8 @@ packages:
   /remark-retext@5.0.1:
     resolution: {integrity: sha512-h3kOjKNy7oJfohqXlKp+W4YDigHD3rw01x91qvQP/cUkK5nJrDl6yEYwTujQCAXSLZrsBxywlK3ntzIX6c29aA==}
     dependencies:
-      '@types/mdast': 3.0.11
-      '@types/unist': 2.0.6
+      '@types/mdast': 3.0.12
+      '@types/unist': 2.0.7
       mdast-util-to-nlcst: 5.2.1
       unified: 10.1.2
     dev: true
@@ -19064,7 +19800,7 @@ packages:
   /remark-stringify@10.0.3:
     resolution: {integrity: sha512-koyOzCMYoUHudypbj4XpnAKFbkddRMYZHwghnxd7ue5210WzGw6kOBwauJTRUMq16jsovXx8dYNvSSWP89kZ3A==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       mdast-util-to-markdown: 1.5.0
       unified: 10.1.2
     dev: true
@@ -19072,7 +19808,7 @@ packages:
   /remark@14.0.3:
     resolution: {integrity: sha512-bfmJW1dmR2LvaMJuAnE88pZP9DktIFYXazkTfOIKZzi3Knk9lT0roItIA24ydOucI3bV/g/tXBA6hzqq3FV9Ew==}
     dependencies:
-      '@types/mdast': 3.0.11
+      '@types/mdast': 3.0.12
       remark-parse: 10.0.2
       remark-stringify: 10.0.3
       unified: 10.1.2
@@ -19170,7 +19906,7 @@ packages:
   /resolve@1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.13.0
       path-parse: 1.0.7
     dev: true
 
@@ -19178,7 +19914,7 @@ packages:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.13.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -19186,7 +19922,7 @@ packages:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.13.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -19215,7 +19951,7 @@ packages:
   /retext-emoji@8.1.0:
     resolution: {integrity: sha512-cvT53Ttn6XXgNprhmI8p4qtwujxNwoHW8hHe2B0JLEMxrMzGTbxwKqnwGslLk/FDsH4dSYStmqnpE20auNSrNg==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       emoticon: 4.0.1
       gemoji: 7.1.0
       nlcst-affix-emoticon-modifier: 2.1.1
@@ -19229,7 +19965,7 @@ packages:
   /retext-indefinite-article@4.3.0:
     resolution: {integrity: sha512-NdVOT0pR68ZhC/Eph/eg2z92zwC9H3DzXkEaiaIs0aDAnNBVzJT/DeRFYDTEMDWINnEVTApuGoCl9mqciUUsAw==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       format: 0.2.2
       nlcst-to-string: 3.1.1
       number-to-words: 1.2.4
@@ -19240,7 +19976,7 @@ packages:
   /retext-latin@3.1.0:
     resolution: {integrity: sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       parse-latin: 5.0.1
       unherit: 3.0.1
       unified: 10.1.2
@@ -19249,7 +19985,7 @@ packages:
   /retext-repeated-words@4.2.0:
     resolution: {integrity: sha512-Tle40/5Xy6KxI94s4XRqGXcj6aWUeCoQZUGQto8OjZP98t4tKVDRVG3QGodF633hVOEiN1vYqj0Zegqoe8XOaw==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       nlcst-to-string: 3.1.1
       unified: 10.1.2
       unist-util-position: 4.0.4
@@ -19259,7 +19995,7 @@ packages:
   /retext-spell@5.3.0:
     resolution: {integrity: sha512-b4LLp5S7ScmE+qJ2gu7FKfJICcfIK/UYIn1L84gJNRjDJyVIXWgdqQ7kgoqduP1mH3fFiKz3YVyNS4hD3XTlWw==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       nlcst-is-literal: 2.1.1
       nlcst-to-string: 3.1.1
       nspell: 2.1.5
@@ -19271,7 +20007,7 @@ packages:
   /retext-stringify@3.1.0:
     resolution: {integrity: sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       nlcst-to-string: 3.1.1
       unified: 10.1.2
     dev: true
@@ -19279,7 +20015,7 @@ packages:
   /retext-syntax-mentions@3.1.0:
     resolution: {integrity: sha512-xcHHHOm3coErzrxtXN3S75UJ1S+WUJXKes5Mpu8WyVmMMYVC5qjSoBlYLHx1+jztq+KmYYkG3rbM3it2J4y7jA==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       nlcst-to-string: 3.1.1
       unified: 10.1.2
       unist-util-position: 4.0.4
@@ -19289,8 +20025,8 @@ packages:
   /retext-syntax-urls@3.1.2:
     resolution: {integrity: sha512-CFuqX1x7GPFQRMPTA88bjrD0l8jTN7Y5Zp8QVr9ToWyJRChIMqUlPq4HfOJbKdDfcwhTVZvh/jRyxLc/K6Tc4g==}
     dependencies:
-      '@types/nlcst': 1.0.0
-      '@types/unist': 2.0.6
+      '@types/nlcst': 1.0.1
+      '@types/unist': 2.0.7
       ccount: 2.0.1
       nlcst-to-string: 3.1.1
       unified: 10.1.2
@@ -19301,7 +20037,7 @@ packages:
   /retext@8.1.0:
     resolution: {integrity: sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==}
     dependencies:
-      '@types/nlcst': 1.0.0
+      '@types/nlcst': 1.0.1
       retext-latin: 3.1.0
       retext-stringify: 3.1.0
       unified: 10.1.2
@@ -19382,13 +20118,13 @@ packages:
       - supports-color
     dev: false
 
-  /rollup-plugin-node-externals@6.1.1(rollup@3.22.0):
+  /rollup-plugin-node-externals@6.1.1(rollup@3.27.2):
     resolution: {integrity: sha512-127OFMkpH5rBVlRHRBDUMk1m1sGuzbGy7so5aj/IkpUb2r3+wOWjR/erUzd2ChEQWPsxsyQG6xpYYvPBAdcBRA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       rollup: ^3.0.0
     dependencies:
-      rollup: 3.22.0
+      rollup: 3.27.2
     dev: true
 
   /rollup-plugin-styles@4.0.0(rollup@3.22.0):
@@ -19425,6 +20161,13 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /rollup@3.27.2:
+    resolution: {integrity: sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+
   /run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
     engines: {node: '>=12'}
@@ -19453,7 +20196,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
 
   /sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -19461,6 +20204,15 @@ packages:
     dependencies:
       mri: 1.2.0
     dev: true
+
+  /safe-array-concat@1.0.0:
+    resolution: {integrity: sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==}
+    engines: {node: '>=0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+      has-symbols: 1.0.3
+      isarray: 2.0.5
 
   /safe-buffer@5.1.1:
     resolution: {integrity: sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==}
@@ -19567,6 +20319,11 @@ packages:
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: true
 
+  /search-insights@2.7.0:
+    resolution: {integrity: sha512-GLbVaGgzYEKMvuJbHRhLi1qoBFnjXZGZ6l4LxOYPCp4lI2jDRB3jPU9/XNhMwv6kvnA9slTreq6pvK+b3o3aqg==}
+    engines: {node: '>=8.16.0'}
+    dev: true
+
   /section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
@@ -19588,8 +20345,18 @@ packages:
     hasBin: true
     dev: true
 
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: true
+
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
+    dev: true
+
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   /semver@7.0.0:
@@ -19607,6 +20374,13 @@ packages:
 
   /semver@7.5.1:
     resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -19636,7 +20410,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
       upper-case-first: 2.0.2
     dev: true
 
@@ -19735,10 +20509,10 @@ packages:
     resolution: {integrity: sha512-RbRMD+IuJJseSZljDdne9ThrUYrwBwJR04FvN4VXpfsU3MNID5VJGHLAD5je/HGThCyEKNgH+nEkSFEWKD7C3Q==}
     dev: true
 
-  /shiki@0.14.2:
-    resolution: {integrity: sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==}
+  /shiki@0.14.3:
+    resolution: {integrity: sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==}
     dependencies:
-      ansi-sequence-parser: 1.1.0
+      ansi-sequence-parser: 1.1.1
       jsonc-parser: 3.2.0
       vscode-oniguruma: 1.7.0
       vscode-textmate: 8.0.0
@@ -19762,8 +20536,8 @@ packages:
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  /signal-exit@4.0.2:
-    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
     dev: false
 
@@ -19848,7 +20622,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /snappy@7.2.2:
@@ -20267,7 +21041,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
       get-intrinsic: 1.2.1
       has-symbols: 1.0.3
       internal-slot: 1.0.5
@@ -20281,21 +21055,21 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
 
   /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.2
+      es-abstract: 1.22.1
 
   /string_decoder@0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
@@ -20454,7 +21228,7 @@ packages:
       mime: 2.6.0
       qs: 6.11.2
       readable-stream: 3.6.2
-      semver: 7.5.1
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20472,7 +21246,7 @@ packages:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.11.2
-      semver: 7.5.1
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20636,8 +21410,8 @@ packages:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
-      '@pkgr/utils': 2.4.1
-      tslib: 2.5.2
+      '@pkgr/utils': 2.4.2
+      tslib: 2.6.1
     dev: true
 
   /tabbable@4.0.0:
@@ -21019,7 +21793,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.4):
+  /ts-jest@29.1.0(@babel/core@7.22.9)(jest@29.5.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21040,7 +21814,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.21.8
+      '@babel/core': 7.22.9
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0
@@ -21069,6 +21843,9 @@ packages:
 
   /tslib@2.5.2:
     resolution: {integrity: sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==}
+
+  /tslib@2.6.1:
+    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
 
   /tsup@6.7.0(typescript@5.0.4):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
@@ -21142,14 +21919,14 @@ packages:
       - ts-node
     dev: true
 
-  /tsutils@3.21.0(typescript@5.0.4):
+  /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.1.6
     dev: true
 
   /tsx@3.12.7:
@@ -21269,12 +22046,39 @@ packages:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  /typed-array-buffer@1.0.0:
+    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+      is-typed-array: 1.1.12
+
+  /typed-array-byte-length@1.0.0:
+    resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      has-proto: 1.0.1
+      is-typed-array: 1.1.12
+
+  /typed-array-byte-offset@1.0.0:
+    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      has-proto: 1.0.1
+      is-typed-array: 1.1.12
+
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
 
   /typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -21292,7 +22096,7 @@ packages:
   /typedoc-plugin-frontmatter@0.0.2:
     resolution: {integrity: sha512-xPw76L4S4/zbd01Tt89CVsJdPiMxztlmkXaA2Wu/l0KEbIrsqSHPv/sGsPI1O+pkZrSpaFr94qLA3ls1MrpKKw==}
     dependencies:
-      yaml: 2.2.2
+      yaml: 2.3.1
     dev: true
 
   /typedoc-plugin-markdown@4.0.0-next.13(prettier@2.8.8)(typedoc@0.24.7):
@@ -21330,8 +22134,8 @@ packages:
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 9.0.1
-      shiki: 0.14.2
+      minimatch: 9.0.3
+      shiki: 0.14.3
       typescript: 5.0.4
     dev: true
 
@@ -21339,6 +22143,12 @@ packages:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
     hasBin: true
+
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /typical@2.6.1:
     resolution: {integrity: sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==}
@@ -21431,7 +22241,7 @@ packages:
   /unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       bail: 2.0.2
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -21471,20 +22281,20 @@ packages:
   /unist-util-is@5.2.1:
     resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /unist-util-modify-children@3.1.1:
     resolution: {integrity: sha512-yXi4Lm+TG5VG+qvokP6tpnk+r1EPwyYL04JWDxLvgvPV40jANh7nm3udk65OOWquvbMDe+PL9+LmkxDpTv/7BA==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       array-iterate: 2.0.1
     dev: true
 
   /unist-util-position@4.0.4:
     resolution: {integrity: sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /unist-util-stringify-position@1.1.2:
@@ -21494,19 +22304,19 @@ packages:
   /unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /unist-util-stringify-position@3.0.3:
     resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /unist-util-visit-children@2.0.2:
     resolution: {integrity: sha512-+LWpMFqyUwLGpsQxpumsQ9o9DG2VGLFrpz+rpVXYIEdPy57GSy5HioC0g3bg/8WP9oCLlapQtklOzQ8uLS496Q==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: true
 
   /unist-util-visit-parents@2.1.2:
@@ -21518,14 +22328,14 @@ packages:
   /unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-is: 4.1.0
     dev: true
 
   /unist-util-visit-parents@5.1.3:
     resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-is: 5.2.1
     dev: true
 
@@ -21538,7 +22348,7 @@ packages:
   /unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
     dev: true
@@ -21546,7 +22356,7 @@ packages:
   /unist-util-visit@4.1.2:
     resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
     dev: true
@@ -21576,7 +22386,7 @@ packages:
       '@antfu/utils': 0.7.5
       '@babel/generator': 7.22.7
       '@babel/parser': 7.22.7
-      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
       ast-kit: 0.6.7
       magic-string-ast: 0.1.3
       unplugin: 1.3.2
@@ -21607,6 +22417,17 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /update-browserslist-db@1.0.11(browserslist@4.21.10):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.10
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /update-browserslist-db@1.0.11(browserslist@4.21.5):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
@@ -21620,13 +22441,13 @@ packages:
   /upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.6.1
     dev: true
 
   /uri-js@4.4.1:
@@ -21673,8 +22494,8 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
-      which-typed-array: 1.1.9
+      is-typed-array: 1.1.12
+      which-typed-array: 1.1.11
     dev: true
 
   /utils-merge@1.0.1:
@@ -21769,7 +22590,7 @@ packages:
   /vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       vfile: 5.3.7
     dev: true
 
@@ -21782,7 +22603,7 @@ packages:
   /vfile-message@3.1.4:
     resolution: {integrity: sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-stringify-position: 3.0.3
     dev: true
 
@@ -21817,7 +22638,7 @@ packages:
   /vfile@5.3.7:
     resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
@@ -21867,7 +22688,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@2.3.0(rollup@3.22.0)(vite@4.3.7):
+  /vite-plugin-dts@2.3.0(rollup@3.27.2)(vite@4.3.7):
     resolution: {integrity: sha512-WbJgGtsStgQhdm3EosYmIdTGbag5YQpZ3HXWUAPCDyoXI5qN6EY0V7NXq0lAmnv9hVQsvh0htbYcg0Or5Db9JQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -21875,7 +22696,7 @@ packages:
     dependencies:
       '@babel/parser': 7.21.8
       '@microsoft/api-extractor': 7.35.3
-      '@rollup/pluginutils': 5.0.2(rollup@3.22.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.2)
       '@rushstack/node-core-library': 3.59.3
       debug: 4.3.4
       fast-glob: 3.2.12
@@ -21917,26 +22738,93 @@ packages:
     dependencies:
       '@types/node': 20.2.0
       esbuild: 0.17.19
+      postcss: 8.4.27
+      rollup: 3.27.2
+      sass: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /vite@4.3.7(sass@1.62.1):
+    resolution: {integrity: sha512-MTIFpbIm9v7Hh5b0wSBgkcWzSBz7SAa6K/cBTwS4kUiQJfQLFlZZRJRQgqunCVzhTPCk674tW+0Qaqh3Q00dBg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.17.19
       postcss: 8.4.23
       rollup: 3.22.0
       sass: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vitepress@1.0.0-alpha.75(@algolia/client-search@4.17.0):
+  /vite@4.4.8:
+    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.18.17
+      postcss: 8.4.27
+      rollup: 3.27.2
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitepress@1.0.0-alpha.75(@algolia/client-search@4.19.1)(search-insights@2.7.0):
     resolution: {integrity: sha512-twpPZ/6UnDR8X0Nmj767KwKhXlTQQM9V/J1i2BP9ryO29/w4hpxBfEum6nvfpNhJ4H3h+cIhwzAK/e9crZ6HEQ==}
     hasBin: true
     dependencies:
-      '@docsearch/css': 3.3.5
-      '@docsearch/js': 3.3.5(@algolia/client-search@4.17.0)
-      '@vitejs/plugin-vue': 4.2.3(vite@4.3.7)(vue@3.3.4)
+      '@docsearch/css': 3.5.1
+      '@docsearch/js': 3.5.1(@algolia/client-search@4.19.1)(search-insights@2.7.0)
+      '@vitejs/plugin-vue': 4.2.3(vite@4.4.8)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
-      '@vueuse/core': 10.1.2(vue@3.3.4)
+      '@vueuse/core': 10.3.0(vue@3.3.4)
       body-scroll-lock: 4.0.0-beta.0
       mark.js: 8.11.1
       minisearch: 6.1.0
-      shiki: 0.14.2
-      vite: 4.3.7(@types/node@20.2.0)(sass@1.62.1)
+      shiki: 0.14.3
+      vite: 4.4.8
       vue: 3.3.4
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -21944,9 +22832,11 @@ packages:
       - '@types/react'
       - '@vue/composition-api'
       - less
+      - lightningcss
       - react
       - react-dom
       - sass
+      - search-insights
       - stylus
       - sugarss
       - terser
@@ -22065,8 +22955,8 @@ packages:
   /vue-docgen-api@4.72.3(vue@3.3.4):
     resolution: {integrity: sha512-76IpEW/pnY0Lfi+NaKkjYZGpEIxqVnDbCbzfZldLt0ldaKz2wvjepvCN1lhxWYtuucziXspFEEfvOY2shrrE3w==}
     dependencies:
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
       '@vue/compiler-dom': 3.3.4
       '@vue/compiler-sfc': 3.3.4
       ast-types: 0.16.1
@@ -22334,8 +23224,8 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /which-typed-array@1.1.9:
-    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+  /which-typed-array@1.1.11:
+    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
@@ -22343,7 +23233,6 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
-      is-typed-array: 1.1.10
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -22398,8 +23287,8 @@ packages:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
       assert-never: 1.2.1
       babel-walk: 3.0.0-canary-5
     dev: true
@@ -22478,7 +23367,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       imurmurhash: 0.1.4
-      signal-exit: 4.0.2
+      signal-exit: 4.1.0
     dev: false
 
   /write-yaml-file@4.2.0:
@@ -22607,6 +23496,12 @@ packages:
   /yaml@2.2.2:
     resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
     engines: {node: '>= 14'}
+    dev: false
+
+  /yaml@2.3.1:
+    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
+    engines: {node: '>= 14'}
+    dev: true
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}


### PR DESCRIPTION
Working with @phazonoverload this makes the generic examples more generic and simple to avoid confusion with the working examples.

Also the imports for the SDK snippets have been consolidated into one root import.

A few examples have also been swapped around as they were in the wrong sections.