### PR TITLE
Fixed hiding of modals after failing to delete item

### DIFF
--- a/.changeset/nervous-dolls-roll.md
+++ b/.changeset/nervous-dolls-roll.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed hiding of modals after failing to delete item

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -465,11 +465,10 @@ function useBatch() {
 
 			selection.value = [];
 			await refresh();
-
-			confirmDelete.value = false;
 		} catch (err: any) {
 			error.value = err;
 		} finally {
+			confirmDelete.value = false;
 			deleting.value = false;
 		}
 	}

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -531,6 +531,8 @@ async function deleteAndQuit() {
 		router.replace(`/content/${props.collection}`);
 	} catch {
 		// `remove` will show the unexpected error dialog
+	} finally {
+		confirmDelete.value = false;
 	}
 }
 


### PR DESCRIPTION
fixes #19376 

Quick question: Please see the changeset - this time I used the cli for the creation and was wondering if I should use the patch or minor bump? 

Also included handling in the item view:

[Screencast from 09.08.2023 17:39:56.webm](https://github.com/directus/directus/assets/14810858/9f84795e-00cc-4bcb-8082-1277fa75279d)
