### PR TITLE
Fix displaying of thumbnail in O2M/M2O/M2A interfaces

### DIFF
--- a/.changeset/chilly-fishes-own.md
+++ b/.changeset/chilly-fishes-own.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed displaying of thumbnail in O2M/M2O/M2A interfaces

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -134,7 +134,7 @@ function handleObject(fieldKey: string) {
 			.join('.');
 	}
 
-	const value = get(props.item, fieldKey);
+	const value = fieldKey ? get(props.item, fieldKey) : props.item;
 
 	if (value === undefined) return null;
 


### PR DESCRIPTION
For those relations, `fieldKey` is empty because `$thumbnail` is stripped away and no "sub-key" is left (as opposed to M2M (file / files) where sub-key points to `directus_files`), which means the `get()` call should be omitted. 

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img src="https://github.com/directus/directus/assets/5363448/1b4134b9-c65b-4f73-9b06-7e6104902dba"></td><td><img src="https://github.com/directus/directus/assets/5363448/11b872d6-b650-41b6-816c-4037d75914c6"></td></tr>
</table>



