### PR TITLE
Enhance usage of dynamic user/role variables

### DIFF
--- a/.changeset/nine-wombats-breathe.md
+++ b/.changeset/nine-wombats-breathe.md
@@ -1,0 +1,7 @@
+---
+"@directus/utils": patch
+"@directus/app": patch
+"@directus/api": patch
+---
+
+Enabled usage of dynamic user/role variable with paths targeting multi-level relations and fixed catching of non-existing paths

--- a/packages/utils/shared/get-with-arrays.test.ts
+++ b/packages/utils/shared/get-with-arrays.test.ts
@@ -2,14 +2,24 @@ import { test, expect } from 'vitest';
 
 import { get } from './get-with-arrays.js';
 
-test('Returns static value from object', () => {
+test('Returns static value', () => {
 	const input = { test: { path: 'example' } };
 	expect(get(input, 'test.path')).toBe('example');
 });
 
-test('Returns default value if path does not exist in object', () => {
+test('Returns static array', () => {
+	const input = { test: [] };
+	expect(get(input, 'test')).toEqual([]);
+});
+
+test('Returns default value if path inside object does not exist', () => {
 	const input = { test: { path: 'example' } };
 	expect(get(input, 'test.wrong', 'default value')).toBe('default value');
+});
+
+test('Returns default value if path inside array does not exist', () => {
+	const input = { test: [{ path: 'example' }] };
+	expect(get(input, 'test.wrong', 'default value')).toEqual('default value');
 });
 
 test('Returns values in array path as flattened array', () => {
@@ -20,4 +30,14 @@ test('Returns values in array path as flattened array', () => {
 test('Returns values in array path as flattened array', () => {
 	const input = { test: [{ path: 'example' }, { falsePath: 'another' }] };
 	expect(get(input, 'test:collection.path')).toEqual(['example']);
+});
+
+test('Returns values in multi-array path as flattened array', () => {
+	const input = { test: [{ path: [{ test: 'example' }, { falsePath: 'another' }] }, { falsePath: 'falseAnother' }] };
+	expect(get(input, 'test.path.test')).toEqual(['example']);
+});
+
+test('Returns values spread across multiple places in multi-array path as flattened array', () => {
+	const input = { test: [{ path: [{ test: 'example' }, { test: 'example2' }] }, { path: [{ test: 'another' }] }] };
+	expect(get(input, 'test.path.test')).toEqual(['example', 'example2', 'another']);
 });

--- a/packages/utils/shared/get-with-arrays.ts
+++ b/packages/utils/shared/get-with-arrays.ts
@@ -14,11 +14,17 @@ export function get(object: Record<string, any> | any[], path: string, defaultVa
 
 	if (key.includes(':')) key = key.split(':')[0]!;
 
-	const result = Array.isArray(object) ? object.map((entry) => entry?.[key]).filter((entry) => entry) : object?.[key];
+	const result = Array.isArray(object) ? getArrayResult(object, key) : object?.[key];
 
-	if (follow.length > 0) {
+	if (result !== undefined && follow.length > 0) {
 		return get(result, follow.join('.'), defaultValue);
 	}
 
 	return result ?? defaultValue;
+}
+
+function getArrayResult(object: unknown[], key: string): unknown[] | undefined {
+	const result = object.map((entry) => entry?.[key as keyof unknown]).filter((entry) => entry);
+
+	return result.length > 0 ? result.flat() : undefined;
 }


### PR DESCRIPTION
Closes #19337

- Enable usage of dynamic user/role variable with paths targeting multi-level relations by flattening results
  - for example `$CURRENT_USER.workspaces.folders.id` as used in #19337
  - also prevents the `ERROR: Method no longer accepts array arguments: valid` error mentioned in #19337
- Ensures default value (`null` for filters/permissions) is returned in case path cannot be found inside relation/array
  - for example `$CURRENT_USER.workspaces.folders.fake_column_name` as outlined in #19337