### PR TITLE
Apply relevant deep filters on top level query when sorting with multi-relational fields

### DIFF
--- a/api/src/utils/apply-parent-field-to-filter.ts
+++ b/api/src/utils/apply-parent-field-to-filter.ts
@@ -1,0 +1,80 @@
+import type { Filter } from '@directus/types';
+
+/**
+ * Apply a top level parent field to a Directus Filter, ignoring any _ prefixed properties until it is applied
+ *
+ * @example
+ *
+ * ```js
+ * const filter = {
+ * 	_and: [
+ * 		{
+ * 			language_id: {
+ * 				_eq: 'English',
+ * 			},
+ * 		},
+ * 		{
+ * 			status: {
+ * 				_eq: 'Published',
+ * 			},
+ * 		},
+ * 	],
+ * };
+ *
+ * const result = applyParentFieldToFilter(filter, 'translations');
+ * // => {
+ * //	_and: [
+ * //		{
+ * //			translations: {
+ * //				language_id: {
+ * //					_eq: 'English',
+ * //				},
+ * //			},
+ * //		},
+ * //		{
+ * //			translations: {
+ * //				status: {
+ * //					_eq: 'Published',
+ * //				},
+ * //			},
+ * //		},
+ * // 	],
+ * // };
+ * ```
+ */
+export function applyParentFieldToFilter(parentPath: string, filter?: Filter | null) {
+	if (!filter) {
+		return filter;
+	}
+
+	return processFilter(filter, true);
+
+	function processFilter(obj: Record<string, any>, isRoot: boolean) {
+		const processedFilter: Record<string, any> = isRoot ? { _and: [] } : {};
+		const paths = Object.keys(obj);
+
+		for (const path of paths) {
+			const nestedFilter = obj[path];
+
+			if (path.startsWith('_')) {
+				if (Array.isArray(nestedFilter)) {
+					processedFilter[path] = nestedFilter.map((val) => processFilter(val, false));
+				} else {
+					processedFilter[path] = processFilter(nestedFilter, false);
+				}
+
+				continue;
+			}
+
+			if (isRoot) {
+				processedFilter['_and']!.push({
+					[parentPath]: { [path]: nestedFilter },
+				});
+			} else {
+				processedFilter[parentPath] = { [path]: nestedFilter };
+			}
+		}
+
+		return processedFilter as Filter;
+	}
+}

--- a/api/src/utils/get-field-paths-from-filter.ts
+++ b/api/src/utils/get-field-paths-from-filter.ts
@@ -1,0 +1,63 @@
+import type { Filter } from '@directus/types';
+import { isPlainObject, isArray } from 'lodash-es';
+
+/**
+ * Get the dot notation field paths of a Directus Filter, ignoring any _ prefixed properties
+ *
+ * @example
+ *
+ * ```js
+ * const filter = {
+ * 	_and: [
+ * 		{
+ * 			translations: {
+ * 				language_id: {
+ * 					_eq: 'English',
+ * 				},
+ * 			},
+ * 		},
+ * 		{
+ * 			status: {
+ * 				_eq: 'Published',
+ * 			},
+ * 		},
+ * 	],
+ * };
+ *
+ * const result = getFieldPathsFromFilter(filter); // => ['translations.language_id', 'status']
+ * ```
+ */
+export function getFieldPathsFromFilter(filter?: Filter | null, parentPath = ''): string[] {
+	if (!filter) {
+		return [];
+	}
+
+	const fieldPaths: string[] = [];
+	const paths = Object.keys(filter);
+
+	for (const path of paths) {
+		const nestedFilter = (filter as Record<string, any>)[path];
+
+		let currentPath = '';
+
+		if (path.startsWith('_')) {
+			currentPath = parentPath;
+		} else {
+			currentPath = parentPath ? `${parentPath}.${path}` : path;
+		}
+
+		if (!isPlainObject(nestedFilter) && !isArray(nestedFilter)) {
+			fieldPaths.push(currentPath);
+			continue;
+		}
+
+		if (Array.isArray(nestedFilter)) {
+			const nestedKeys = nestedFilter.flatMap((val) => getFieldPathsFromFilter(val, currentPath));
+			fieldPaths.push(...nestedKeys);
+		} else {
+			fieldPaths.push(...getFieldPathsFromFilter(nestedFilter, currentPath));
+		}
+	}
+
+	return fieldPaths;
+}


### PR DESCRIPTION
WIP. Apply relevant deep filters on top level query, when performing multi-relational (O2M) sort with fields where the relational tables has deep filters applied.

- [ ] Pending confirmation if a documentation update should be done instead
- [ ] Tests.

Closes #19397.