### PR TITLE
fix item-dropdown interface text overflowing

### DIFF
--- a/.changeset/dull-elephants-carry.md
+++ b/.changeset/dull-elephants-carry.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed text overflow in collection item interface

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -140,6 +140,9 @@ function onSelection(selectedIds: (number | string)[] | null) {
 
 <style lang="scss" scoped>
 .preview {
+	display: block;
 	flex-grow: 1;
+	height: calc(100% - 16px);
+	overflow: hidden;
 }
 </style>


### PR DESCRIPTION
fixes #19393

image showing o2m, item-dropdown, m2o fields
![grafik](https://github.com/directus/directus/assets/22577866/1e9b079f-44c5-49a4-8cfc-f717f38e41e7)
