### PR TITLE
Fix "require shares fields" migration for strict MySQL

### DIFF
--- a/.changeset/sixty-taxis-fix.md
+++ b/.changeset/sixty-taxis-fix.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed "require shares fields" migration for strict MySQL instances

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -2,14 +2,36 @@ import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_shares', (table) => {
+		if (knex.client.constructor.name === 'Client_MySQL') {
+			// Temporary drop foreign key constraint, see https://github.com/directus/directus/issues/19399
+			table.dropForeign('collection', 'directus_shares_collection_foreign');
+		}
+
 		table.dropNullable('collection');
+
+		if (knex.client.constructor.name === 'Client_MySQL') {
+			// Recreate foreign key constraint, from 20211211A-add-shares.ts
+			table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
+		}
+
 		table.dropNullable('item');
 	});
 }
 
 export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_shares', (table) => {
+		if (knex.client.constructor.name === 'Client_MySQL') {
+			// Temporary drop foreign key constraint, see https://github.com/directus/directus/issues/19399
+			table.dropForeign('collection', 'directus_shares_collection_foreign');
+		}
+
 		table.setNullable('collection');
+
+		if (knex.client.constructor.name === 'Client_MySQL') {
+			// Recreate foreign key constraint, from 20211211A-add-shares.ts
+			table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
+		}
+
 		table.setNullable('item');
 	});
 }


### PR DESCRIPTION
Fixes #19399 (also reported in #19306 and #19335)

Some MySQL instances (strict mode?) are blocking the alter statement of the `collection` column in the `20230721A-require-shares-fields` migration because the column has a foreign key constraint.
Therefore adjusting the migration so that in case of MySQL the constraint is dropped temporarily and recreated after altering the column.