### PR TITLE
Hide accordion section if field is hidden

### DIFF
--- a/.changeset/blue-spiders-admire.md
+++ b/.changeset/blue-spiders-admire.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed bug where section of a group inside according would still be displayed in detail view even if hidden

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -258,9 +258,19 @@ function useForm() {
 		return fieldsInGroup.value.map((f) => f.field);
 	});
 
-	const fieldsForGroup = computed(() =>
-		fieldNames.value.map((name: string) => getFieldsForGroup(fieldsMap.value[name]?.meta?.field || null))
-	);
+	const fieldsForGroup = computed(() => {
+		const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
+
+		return fieldNames.value.map((name: string) => {
+			const fields = getFieldsForGroup(fieldsMap.value[name]?.meta?.field || null);
+
+			return fields.reduce((result: Field[], field: Field) => {
+				const newField = applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field));
+				if (newField.field) result.push(newField);
+				return result;
+			}, [] as Field[]);
+		});
+	});
 
 	return { fieldNames, fieldsMap, isDisabled, getFieldsForGroup, fieldsForGroup };
 

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-item :value="field.field" scope="group-accordion" class="accordion-section">
+	<v-item v-if="!field.meta?.hidden" :value="field.field" scope="group-accordion" class="accordion-section">
 		<template #default="{ active, toggle }">
 			<div class="label type-title" :class="{ active, edited }" @click="handleModifier($event, toggle)">
 				<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>


### PR DESCRIPTION
fixes #18934 
This PR does the 2 following things: Hide the accordion group if it is set to hidden and calculate if it is hidden before passing it to a group.
