### PR TITLE
Add Breaking Changes page to self-hosted docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -678,9 +678,12 @@ function sidebar() {
 					],
 				},
 				{
-					type: 'page',
 					link: '/self-hosted/upgrades-migrations',
 					text: 'Upgrades & Migrations',
+				},
+				{
+					link: '/self-hosted/breaking-changes',
+					text: 'Breaking Changes',
 				},
 			],
 		},

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -63,6 +63,7 @@
 (U|u)nfilterable
 (U|u)nlink
 (U|u)psert
+(U|u)ptime
 (U|u)tils?
 (URI|URIs)
 (URL|url)

--- a/docs/self-hosted/breaking-changes.md
+++ b/docs/self-hosted/breaking-changes.md
@@ -1,0 +1,102 @@
+---
+description: A list of any actions you may need to take as you upgrade Directus versions.
+---
+
+# Breaking Changes
+
+As we continue to build Directus, we occasionally make changes that change how certain features works. We try and keep these to a minimum, but rest assured we only make them with good reason. 
+
+Starting with Directus 10.0, here is a list of potential breaking changes with remedial action you may need to take.
+
+## Version 10.4
+
+### Consolidated Environment Variables for Redis Use
+
+
+Directus had various different functionalities that required you to use Redis when running Directus in a horizontally scaled environment such as caching, rate-limiting, realtime, and flows. The configuration for these different parts have been combined into a single set of `REDIS` environment variables that are reused across the system.
+
+:::details Migration/Mitigation
+
+Combine all the `*_REDIS` environment variables into a single shared one as followed:
+
+_Before_
+
+```
+CACHE_STORE="redis"
+CACHE_REDIS_HOST="127.0.0.1"
+CACHE_REDIS_PORT="6379"
+...
+RATE_LIMITER_STORE="redis"
+RATE_LIMITER_REDIS_HOST="127.0.0.1"
+RATE_LIMITER_REDIS_PORT="6379"
+...
+SYNCHRONIZATION_STORE="redis"
+SYNCHRONIZATION_REDIS_HOST="127.0.0.1"
+SYNCHRONIZATION_REDIS_PORT="6379"
+...
+MESSENGER_STORE="redis"
+MESSENGER_REDIS_HOST="127.0.0.1"
+MESSENGER_REDIS_PORT="6379"
+```
+
+_After_
+
+```
+REDIS_HOST="127.0.0.1"
+REDIS_PORT="6379"
+
+CACHE_STORE="redis"
+RATE_LIMITER_STORE="redis"
+SYNCHRONIZATION_STORE="redis"
+MESSENGER_STORE="redis"
+```
+
+:::
+
+### Dropped Support for Memcached
+
+Directus used to support either memory, Redis, or Memcached for caching and rate-limiting storage. Given a deeper integration with Redis, and the low overall usage/adoption of Memcached across Directus installations, we've decided to sunset Memcached in favor of focussing on Redis as the primary solution for pub/sub and hot-storage across load-balanced Directus installations.
+
+### Updated Errors Structure for Extensions
+
+As part of standardizing how extensions are built and shipped, you must replace any system exceptions you extracted from `exceptions` with new errors created within the extension itself. We recommend prefixing the error code with your extension name for improved debugging, but you can keep using the system codes if you relied on that in the past.
+
+:::details Migration/Mitigation
+
+_Before_
+
+```js
+export default (router, { exceptions }) => {
+	const { ForbiddenException } = exceptions;
+
+	router.get('/', (req, res) => {
+		throw new ForbiddenException();
+	});
+};
+```
+
+_After_
+
+```js
+import { createError } from '@directus/errors';
+
+const ForbiddenError = createError('MY_EXTENSION_FORBIDDEN', 'No script kiddies please...');
+
+export default (router) => {
+	router.get('/', (req, res) => {
+		throw new ForbiddenError();
+	});
+};
+```
+
+:::
+
+## Version 10.2
+
+### Removed Fields from Server Info Endpoint
+
+As a security precaution, we have removed the following information from the `/server/info` endpoint:
+
+- Directus Version
+- Node Version and Uptime
+- OS Type, Version, Uptime, and Memory

--- a/docs/self-hosted/breaking-changes.md
+++ b/docs/self-hosted/breaking-changes.md
@@ -4,7 +4,8 @@ description: A list of any actions you may need to take as you upgrade Directus 
 
 # Breaking Changes
 
-As we continue to build Directus, we occasionally make changes that change how certain features works. We try and keep these to a minimum, but rest assured we only make them with good reason. 
+As we continue to build Directus, we occasionally make changes that change how certain features works. We try and keep
+these to a minimum, but rest assured we only make them with good reason.
 
 Starting with Directus 10.0, here is a list of potential breaking changes with remedial action you may need to take.
 
@@ -12,8 +13,9 @@ Starting with Directus 10.0, here is a list of potential breaking changes with r
 
 ### Consolidated Environment Variables for Redis Use
 
-
-Directus had various different functionalities that required you to use Redis when running Directus in a horizontally scaled environment such as caching, rate-limiting, realtime, and flows. The configuration for these different parts have been combined into a single set of `REDIS` environment variables that are reused across the system.
+Directus had various different functionalities that required you to use Redis when running Directus in a horizontally
+scaled environment such as caching, rate-limiting, realtime, and flows. The configuration for these different parts have
+been combined into a single set of `REDIS` environment variables that are reused across the system.
 
 :::details Migration/Mitigation
 
@@ -55,11 +57,16 @@ MESSENGER_STORE="redis"
 
 ### Dropped Support for Memcached
 
-Directus used to support either memory, Redis, or Memcached for caching and rate-limiting storage. Given a deeper integration with Redis, and the low overall usage/adoption of Memcached across Directus installations, we've decided to sunset Memcached in favor of focussing on Redis as the primary solution for pub/sub and hot-storage across load-balanced Directus installations.
+Directus used to support either memory, Redis, or Memcached for caching and rate-limiting storage. Given a deeper
+integration with Redis, and the low overall usage/adoption of Memcached across Directus installations, we've decided to
+sunset Memcached in favor of focusing on Redis as the primary solution for pub/sub and hot-storage across load-balanced
+Directus installations.
 
 ### Updated Errors Structure for Extensions
 
-As part of standardizing how extensions are built and shipped, you must replace any system exceptions you extracted from `exceptions` with new errors created within the extension itself. We recommend prefixing the error code with your extension name for improved debugging, but you can keep using the system codes if you relied on that in the past.
+As part of standardizing how extensions are built and shipped, you must replace any system exceptions you extracted from
+`exceptions` with new errors created within the extension itself. We recommend prefixing the error code with your
+extension name for improved debugging, but you can keep using the system codes if you relied on that in the past.
 
 :::details Migration/Mitigation
 


### PR DESCRIPTION
An addition of a new page to highlight breaking changes in a consolidated place. Release notes with breaking changes can now skip mitigation/migration in favor of linking to docs. Existing content sourced from GitHub release notes.

This will be needed as we look to a Directus without VM2, and an updated security model for extensions 🖖🏻 