### PR TITLE
Docs: Marked meta prameter as depecated in REST API

### DIFF
--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -803,6 +803,12 @@ const result = await client.request(
 Metadata allows you to retrieve some additional information about the items in the collection you're fetching. `*` can
 be used as a wildcard to retrieve all metadata.
 
+::: warning DEPRECATED
+
+This will be removed in the future in favor of [Aggregation & Grouping](#aggregation-grouping).
+
+:::
+
 ### Total Count
 
 Returns the total item count of the collection you're querying.

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -805,7 +805,8 @@ be used as a wildcard to retrieve all metadata.
 
 ::: warning DEPRECATED
 
-This will be removed in the future in favor of [Aggregation & Grouping](#aggregation-grouping).
+The `metadata` parameter will be removed in the future in favor of [Aggregation](#aggregation-grouping).
+To receive the previous `total_count` and `filter_count` values, please use the `aggregation[count]` parameter instead - either with or without an additional `filter` parameter respectively.
 
 :::
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -805,8 +805,9 @@ be used as a wildcard to retrieve all metadata.
 
 ::: warning DEPRECATED
 
-The `metadata` parameter will be removed in the future in favor of [Aggregation](#aggregation-grouping).
-To receive the previous `total_count` and `filter_count` values, please use the `aggregation[count]` parameter instead - either with or without an additional `filter` parameter respectively.
+The `metadata` parameter will be removed in the future in favor of [Aggregation](#aggregation-grouping). To receive the
+previous `total_count` and `filter_count` values, please use the `aggregation[count]` parameter instead - either with or
+without an additional `filter` parameter respectively.
 
 :::
 


### PR DESCRIPTION
Added a deprecation warning for the global parameter `meta` as preparation to remove it in https://github.com/directus/directus/issues/15665