### PR TITLE
Fix deep sanitizeQuery

### DIFF
--- a/.changeset/eleven-timers-cross.md
+++ b/.changeset/eleven-timers-cross.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed an issue where deep query parameters could get lost in combination with a query limit

--- a/api/src/utils/sanitize-query.test.ts
+++ b/api/src/utils/sanitize-query.test.ts
@@ -341,6 +341,16 @@ describe('deep', () => {
 
 		expect(sanitizedQuery.deep).toEqual({ deep: { relational_field_a: { _sort: ['name'] } } });
 	});
+
+	test('should work in combination with query limit', () => {
+		factoryEnv = { QUERY_LIMIT_MAX: 100 };
+
+		const deep = { deep: { relational_field_a: { _sort: ['name'] } } };
+
+		const sanitizedQuery = sanitizeQuery({ deep });
+
+		expect(sanitizedQuery.deep).toEqual({ deep: { relational_field_a: { _limit: 100, _sort: ['name'] } } });
+	});
 });
 
 describe('alias', () => {

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -182,15 +182,14 @@ function sanitizeDeep(deep: Record<string, any>, accountability?: Accountability
 	return result;
 
 	function parse(level: Record<string, any>, path: string[] = []) {
-		const parsedLevel: Record<string, any> = {};
 		const subQuery: Record<string, any> = {};
+		const parsedLevel: Record<string, any> = {};
 
 		for (const [key, value] of Object.entries(level)) {
 			if (!key) break;
 
 			if (key.startsWith('_')) {
-				// Sanitize query only accepts non-underscore-prefixed query options
-				// sanitize the entire subquery together
+				// Collect all sub query parameters without the leading underscore
 				subQuery[key.substring(1)] = value;
 			} else if (isPlainObject(value)) {
 				parse(value, [...path, key]);
@@ -198,11 +197,12 @@ function sanitizeDeep(deep: Record<string, any>, accountability?: Accountability
 		}
 
 		if (Object.keys(subQuery).length > 0) {
+			// Sanitize the entire sub query
 			const parsedSubQuery = sanitizeQuery(subQuery, accountability);
 
-			Object.entries(parsedSubQuery).forEach(([parsedKey, parsedValue]) => {
+			for (const [parsedKey, parsedValue] of Object.entries(parsedSubQuery)) {
 				parsedLevel[`_${parsedKey}`] = parsedValue;
-			});
+			}
 		}
 
 		if (Object.keys(parsedLevel).length > 0) {


### PR DESCRIPTION
Fixes #19435

So instead of sanitising each part of a subquery by itself, this refactor groups the fields starting with `_ ` into a query to be sanitised together and then afterwards all of it is added back to the parsedQuery without the randomness of just taking the first element in the entries array.