### PR TITLE
Docs: 'hidden' blog posts

### DIFF
--- a/docs/.vitepress/data/blog.data.js
+++ b/docs/.vitepress/data/blog.data.js
@@ -4,7 +4,7 @@ export default {
 	async load() {
 		const { data: articles } = await (
 			await fetch(
-				'https://marketing.directus.app/items/developer_articles?fields=*,author.first_name,author.last_name,author.avatar,author.title,tags.directus_tags_id.title,tags.directus_tags_id.slug,tags.directus_tags_id.type,status&sort=-date_published'
+				'https://marketing.directus.app/items/developer_articles?fields=*,author.first_name,author.last_name,author.avatar,author.title,tags.directus_tags_id.title,tags.directus_tags_id.slug,tags.directus_tags_id.type&filter[status][_eq]=published&sort=-date_published'
 			)
 		).json();
 
@@ -12,18 +12,14 @@ export default {
 			await fetch('https://marketing.directus.app/items/docs_tags?fields=*&sort=-count(developer_articles)')
 		).json();
 
-		let posts = articles.map((article) => ({
+		const posts = articles.map((article) => ({
 			id: article.slug,
 			title: article.title,
 			date_published: article.date_published,
 			summary: article.summary,
 			image: article.image,
 			author: article.author,
-			status: article.status,
 		}));
-
-		const published = posts.filter((a) => a.status == 'published');
-		const hidden = posts.filter((a) => a.status == 'hidden');
 
 		// Create tags for the sidebar
 		let tagsForSidebar = [];
@@ -40,8 +36,7 @@ export default {
 
 		return {
 			blog: {
-				articles: published,
-				hidden: hidden,
+				articles: posts,
 				tags,
 				tagsForSidebar,
 			},

--- a/docs/.vitepress/data/blog.data.js
+++ b/docs/.vitepress/data/blog.data.js
@@ -4,7 +4,7 @@ export default {
 	async load() {
 		const { data: articles } = await (
 			await fetch(
-				'https://marketing.directus.app/items/developer_articles?fields=*,author.first_name,author.last_name,author.avatar,author.title,tags.directus_tags_id.title,tags.directus_tags_id.slug,tags.directus_tags_id.type&sort=-date_published'
+				'https://marketing.directus.app/items/developer_articles?fields=*,author.first_name,author.last_name,author.avatar,author.title,tags.directus_tags_id.title,tags.directus_tags_id.slug,tags.directus_tags_id.type,status&sort=-date_published'
 			)
 		).json();
 
@@ -19,7 +19,11 @@ export default {
 			summary: article.summary,
 			image: article.image,
 			author: article.author,
+			status: article.status,
 		}));
+
+		const published = posts.filter((a) => a.status == 'published');
+		const hidden = posts.filter((a) => a.status == 'hidden');
 
 		// Create tags for the sidebar
 		let tagsForSidebar = [];
@@ -36,7 +40,8 @@ export default {
 
 		return {
 			blog: {
-				articles: posts,
+				articles: published,
+				hidden: hidden,
 				tags,
 				tagsForSidebar,
 			},

--- a/docs/blog/tags/[slug].paths.js
+++ b/docs/blog/tags/[slug].paths.js
@@ -14,7 +14,7 @@ export default {
 				articles: tag.developer_articles
 					.map((article) => {
 						if (!article.developer_articles_id) return;
-						if (article.developer_articles_id.status != 'published') return;
+						if (article.developer_articles_id.status !== 'published') return;
 
 						return {
 							title: article.developer_articles_id.title,

--- a/docs/blog/tags/[slug].paths.js
+++ b/docs/blog/tags/[slug].paths.js
@@ -2,7 +2,7 @@ export default {
 	async paths() {
 		const response = await (
 			await fetch(
-				'https://marketing.directus.app/items/docs_tags?fields=*,developer_articles.developer_articles_id.title,developer_articles.developer_articles_id.date_published,developer_articles.developer_articles_id.slug,developer_articles.developer_articles_id.image,developer_articles.developer_articles_id.author.first_name,developer_articles.developer_articles_id.author.last_name,developer_articles.developer_articles_id.author.avatar,author.title'
+				'https://marketing.directus.app/items/docs_tags?fields=*,developer_articles.developer_articles_id.title,developer_articles.developer_articles_id.date_published,developer_articles.developer_articles_id.slug,developer_articles.developer_articles_id.image,developer_articles.developer_articles_id.author.first_name,developer_articles.developer_articles_id.author.last_name,developer_articles.developer_articles_id.author.avatar,author.title,developer_articles.developer_articles_id.status'
 			)
 		).json();
 
@@ -14,6 +14,7 @@ export default {
 				articles: tag.developer_articles
 					.map((article) => {
 						if (!article.developer_articles_id) return;
+						if (article.developer_articles_id.status != 'published') return;
 
 						return {
 							title: article.developer_articles_id.title,


### PR DESCRIPTION
This PR, along with updated permissions in Directus, introduces a new developer article status - 'hidden'. 

Hidden posts are still generated, but they are not shown in listings at /blog, /blog/tags/:tag, and on the docs landing page. 