### PR TITLE
Fix using wrong type for default values

### DIFF
--- a/.changeset/silent-poets-cover.md
+++ b/.changeset/silent-poets-cover.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed issue where type of value coming from a default value might be wrong

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -83,7 +83,10 @@ export class FieldsService {
 
 		const columns = (await this.schemaInspector.columnInfo(collection)).map((column) => ({
 			...column,
-			default_value: getDefaultValue(column, fields.find((field) => field.collection === column.table && field.field === column.name)),
+			default_value: getDefaultValue(
+				column,
+				fields.find((field) => field.collection === column.table && field.field === column.name)
+			),
 		}));
 
 		const columnsWithSystem = columns.map((column) => {
@@ -227,9 +230,9 @@ export class FieldsService {
 
 		const columnWithCastDefaultValue = column
 			? {
-				...column,
-				default_value: getDefaultValue(column, fieldInfo),
-			}
+					...column,
+					default_value: getDefaultValue(column, fieldInfo),
+			  }
 			: null;
 
 		const data = {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -81,17 +81,9 @@ export class FieldsService {
 			fields.push(...systemFieldRows);
 		}
 
-		let fieldsInfo = await this.knex.select('*').from('directus_fields').where({ collection })
-
-		if (fieldsInfo) {
-			fieldsInfo = (await this.payloadService.processValues('read', fieldsInfo)) as FieldMeta[];
-		}
-
-		fieldsInfo = fieldsInfo || systemFieldRows.find((fieldMeta) => fieldMeta.collection === collection);
-
 		const columns = (await this.schemaInspector.columnInfo(collection)).map((column) => ({
 			...column,
-			default_value: getDefaultValue(column, fieldsInfo.find((field) => field.field === column.name)),
+			default_value: getDefaultValue(column, fields.find((field) => field.collection === column.table && field.field === column.name)),
 		}));
 
 		const columnsWithSystem = columns.map((column) => {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -81,9 +81,17 @@ export class FieldsService {
 			fields.push(...systemFieldRows);
 		}
 
+		let fieldsInfo = await this.knex.select('*').from('directus_fields').where({ collection })
+
+		if (fieldsInfo) {
+			fieldsInfo = (await this.payloadService.processValues('read', fieldsInfo)) as FieldMeta[];
+		}
+
+		fieldsInfo = fieldsInfo || systemFieldRows.find((fieldMeta) => fieldMeta.collection === collection);
+
 		const columns = (await this.schemaInspector.columnInfo(collection)).map((column) => ({
 			...column,
-			default_value: getDefaultValue(column),
+			default_value: getDefaultValue(column, fieldsInfo.find((field) => field.field === column.name)),
 		}));
 
 		const columnsWithSystem = columns.map((column) => {
@@ -227,9 +235,9 @@ export class FieldsService {
 
 		const columnWithCastDefaultValue = column
 			? {
-					...column,
-					default_value: getDefaultValue(column),
-			  }
+				...column,
+				default_value: getDefaultValue(column, fieldInfo),
+			}
 			: null;
 
 		const data = {

--- a/api/src/utils/get-default-value.ts
+++ b/api/src/utils/get-default-value.ts
@@ -4,11 +4,13 @@ import type { Column } from '@directus/schema';
 import env from '../env.js';
 import logger from '../logger.js';
 import getLocalType from './get-local-type.js';
+import type { FieldMeta } from '@directus/types';
 
 export default function getDefaultValue(
-	column: SchemaOverview[string]['columns'][string] | Column
+	column: SchemaOverview[string]['columns'][string] | Column,
+	field?: { special?: FieldMeta['special'] }
 ): string | boolean | number | Record<string, any> | any[] | null {
-	const type = getLocalType(column);
+	const type = getLocalType(column, field);
 
 	const defaultValue = column.default_value ?? null;
 	if (defaultValue === null) return null;


### PR DESCRIPTION
Problem was that `type` was string on MariaDB and possibly other vendors because we weren't passing in fieldMeta data with it meaning it didn't have access to the `cast-json` special flag resulting in not being able to know that it is a json field.

Fixes #19438, fixes #15351
