### PR TITLE
Fix being able to save on no changes in drawer-item

### DIFF
--- a/.changeset/gentle-panthers-exist.md
+++ b/.changeset/gentle-panthers-exist.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed issue where drawer for editing item would allow to press save although no changes were made 

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -154,7 +154,12 @@ const validationPrefix = computed(() => {
 
 function emitValue(value: any) {
 	if (
-		(isEqual(value, props.initialValue) || (props.initialValue === undefined && isEqual(value, defaultValue.value))) &&
+		(isEqual(value, props.initialValue) ||
+			(props.initialValue === undefined && isEqual(value, defaultValue.value)) ||
+			(props.field.meta?.special?.some((s) =>
+				['m2m', 'm2o', 'o2m', 'translations', 'm2a', 'file', 'files'].includes(s)
+			) &&
+				value === undefined)) &&
 		props.batchMode === false
 	) {
 		emit('unset', props.field);

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -57,7 +57,7 @@ export function useRelationMultiple(
 		},
 		set(newValue) {
 			if (newValue.create.length === 0 && newValue.update.length === 0 && newValue.delete.length === 0) {
-				value.value = undefined;
+				value.value = [];
 				return;
 			}
 
@@ -171,7 +171,7 @@ export function useRelationMultiple(
 						return (
 							itemCollection === editCollection &&
 							edit[relation.value.junctionField.field][editPkField] ===
-								item[relation.value.junctionField.field][itemPkField]
+							item[relation.value.junctionField.field][itemPkField]
 						);
 					}
 				}

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -57,7 +57,7 @@ export function useRelationMultiple(
 		},
 		set(newValue) {
 			if (newValue.create.length === 0 && newValue.update.length === 0 && newValue.delete.length === 0) {
-				value.value = [];
+				value.value = undefined;
 				return;
 			}
 

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -171,7 +171,7 @@ export function useRelationMultiple(
 						return (
 							itemCollection === editCollection &&
 							edit[relation.value.junctionField.field][editPkField] ===
-							item[relation.value.junctionField.field][itemPkField]
+								item[relation.value.junctionField.field][itemPkField]
 						);
 					}
 				}

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -417,7 +417,7 @@ function useActions() {
 		const defaultValues = getDefaultValuesFromFields(fieldsToValidate);
 
 		if (isNew.value) {
-			return Object.keys(defaultValues.value).length > 0 || hasEdits.value;
+			return Object.keys(defaultValues.value).filter((key) => defaultValues.value[key]).length > 0;
 		}
 
 		return false;

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -399,9 +399,6 @@ function useRelation() {
 
 function useActions() {
 	const isSavable = computed(() => {
-		const fieldsToValidate = props.junctionField ? relatedCollectionFields.value : fieldsWithoutCircular.value;
-		const defaultValues = getDefaultValuesFromFields(fieldsToValidate);
-
 		if (hasEdits.value) return true;
 
 		if (
@@ -411,6 +408,9 @@ function useActions() {
 		) {
 			return Boolean(internalEdits.value?.[primaryKeyField.value.field]);
 		}
+
+		const fieldsToValidate = props.junctionField ? relatedCollectionFields.value : fieldsWithoutCircular.value;
+		const defaultValues = getDefaultValuesFromFields(fieldsToValidate);
 
 		if (isNew.value) {
 			return Object.keys(defaultValues.value).length > 0 || hasEdits.value;

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -154,7 +154,11 @@ const swapFormOrder = computed(() => {
 const hasEdits = computed(() => {
 	if (isEmpty(internalEdits.value)) return false;
 
-	if (props.junctionField && Object.keys.length === 1 && isEmpty(internalEdits.value[props.junctionField]))
+	if (
+		props.junctionField &&
+		Object.keys(internalEdits.value).length === 1 &&
+		isEmpty(internalEdits.value[props.junctionField])
+	)
 		return false;
 
 	return true;


### PR DESCRIPTION
~~attempted #19417~~

You were able to press save in the drawer item even though there where no changes to be saved.

An alternative fix would have been to validate the changes on the v-form side but that is overly complex especially because of the `{create, update, delete}` structure of relations.