### PR TITLE
Add prefix option to list-m2a

### DIFF
--- a/.changeset/eighty-ants-attack.md
+++ b/.changeset/eighty-ants-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added a option to the M2A interface allowing to set custom prefix instead of the collection name

--- a/app/src/interfaces/list-m2a/index.ts
+++ b/app/src/interfaces/list-m2a/index.ts
@@ -11,7 +11,7 @@ export default defineInterface({
 	types: ['alias'],
 	localTypes: ['m2a'],
 	group: 'relational',
-	options: [
+	options: ({ editing, relations, field: { meta } }) => [
 		{
 			field: 'enableSelect',
 			name: '$t:selecting_items',
@@ -62,6 +62,24 @@ export default defineInterface({
 				interface: 'boolean',
 				width: 'half',
 			},
+		},
+		{
+			field: 'prefix',
+			name: '$t:prefix',
+			meta:
+				editing === '+'
+					? {
+						interface: 'presentation-notice',
+						options: {
+							text: '$t:interfaces.list-m2m.display_template_configure_notice',
+						},
+					}
+					: {
+						interface: 'system-display-template',
+						options: {
+							collectionName: relations.o2m?.collection
+						},
+					},
 		},
 	],
 	preview: PreviewSVG,

--- a/app/src/interfaces/list-m2a/index.ts
+++ b/app/src/interfaces/list-m2a/index.ts
@@ -76,6 +76,7 @@ export default defineInterface({
 					}
 					: {
 						interface: 'system-display-template',
+						note: '$t:interfaces.list-m2a.prefix_note',
 						options: {
 							collectionName: relations.o2m?.collection
 						},

--- a/app/src/interfaces/list-m2a/index.ts
+++ b/app/src/interfaces/list-m2a/index.ts
@@ -11,7 +11,7 @@ export default defineInterface({
 	types: ['alias'],
 	localTypes: ['m2a'],
 	group: 'relational',
-	options: ({ editing, relations, field: { meta } }) => [
+	options: ({ editing, relations }) => [
 		{
 			field: 'enableSelect',
 			name: '$t:selecting_items',
@@ -69,18 +69,18 @@ export default defineInterface({
 			meta:
 				editing === '+'
 					? {
-						interface: 'presentation-notice',
-						options: {
-							text: '$t:interfaces.list-m2m.display_template_configure_notice',
-						},
-					}
+							interface: 'presentation-notice',
+							options: {
+								text: '$t:interfaces.list-m2m.display_template_configure_notice',
+							},
+					  }
 					: {
-						interface: 'system-display-template',
-						note: '$t:interfaces.list-m2a.prefix_note',
-						options: {
-							collectionName: relations.o2m?.collection
-						},
-					},
+							interface: 'system-display-template',
+							note: '$t:interfaces.list-m2a.prefix_note',
+							options: {
+								collectionName: relations.o2m?.collection,
+							},
+					  },
 		},
 	],
 	preview: PreviewSVG,

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -31,7 +31,7 @@
 						@click="editItem(element)"
 					>
 						<v-icon v-if="allowDrag" class="drag-handle" left name="drag_handle" @click.stop />
-						<span class="collection">{{ getCollectionName(element) }}:</span>
+						<span class="collection">{{ getPrefix(element) }}:</span>
 						<render-template
 							:collection="element[relationInfo.collectionField.field]"
 							:template="templates[element[relationInfo.collectionField.field]]"
@@ -144,6 +144,7 @@ import { useRelationPermissionsM2A } from '@/composables/use-relation-permission
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { hideDragImage } from '@/utils/hide-drag-image';
+import { renderStringTemplate } from '@/utils/render-string-template';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import { Filter } from '@directus/types';
@@ -163,6 +164,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		limit?: number;
+		prefix?: string;
 		allowDuplicates?: boolean;
 	}>(),
 	{
@@ -215,6 +217,10 @@ const fields = computed(() => {
 		).map((field) => `${relationInfo.value?.junctionField.field}:${collection.collection}.${field}`);
 
 		fields.push(...addRelatedPrimaryKeyToFields(collection.collection, displayFields));
+	}
+
+	if (props.prefix) {
+		fields.push(...getFieldsFromTemplate(props.prefix));
 	}
 
 	return fields;
@@ -375,7 +381,10 @@ function hasAllowedCollection(item: DisplayItem) {
 	);
 }
 
-function getCollectionName(item: DisplayItem) {
+function getPrefix(item: DisplayItem) {
+	if (relationInfo.value?.junctionField.field && props.prefix)
+		return renderStringTemplate(props.prefix, item).displayValue.value;
+
 	const info = relationInfo.value;
 	if (!info) return false;
 

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -382,8 +382,7 @@ function hasAllowedCollection(item: DisplayItem) {
 }
 
 function getPrefix(item: DisplayItem) {
-	if (relationInfo.value?.junctionField.field && props.prefix)
-		return renderStringTemplate(props.prefix, item).displayValue.value;
+	if (props.prefix) return renderStringTemplate(props.prefix, item).displayValue.value;
 
 	const info = relationInfo.value;
 	if (!info) return false;

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1506,6 +1506,8 @@ undo_removed_item: Undo Removed Item
 remove_item: Remove Item
 delete_item: Delete Item
 interfaces:
+  list-m2a:
+    prefix_note: Uses the related item's collection by default.
   filter:
     name: Filter
     description: Configure a filter object.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1507,7 +1507,7 @@ remove_item: Remove Item
 delete_item: Delete Item
 interfaces:
   list-m2a:
-    prefix_note: Uses the related item's collection by default.
+    prefix_note: Uses the related item's collection name by default.
   filter:
     name: Filter
     description: Configure a filter object.


### PR DESCRIPTION
fixes #19415

When the prefix on the m2a is set, instead of showing the collection name, we will now show the rendered prefix template.