### PR TITLE
Correct error message if unsupported file has been selected for image field

### DIFF
--- a/.changeset/tame-pears-look.md
+++ b/.changeset/tame-pears-look.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed error message if unsupported file has been selected for image field

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -11,7 +11,7 @@
 				<v-icon large :name="imageError === 'UNKNOWN' ? 'error' : 'info'" />
 
 				<span class="message">
-					{{ t(`errors.${imageError}`) }}
+					{{ src ? t(`errors.${imageError}`) : t('errors.UNSUPPORTED_MEDIA_TYPE') }}
 				</span>
 			</div>
 
@@ -111,7 +111,7 @@ const props = withDefaults(
 		crop?: boolean;
 	}>(),
 	{
-		value: () => null,
+		value: null,
 		disabled: false,
 		crop: true,
 		folder: undefined,


### PR DESCRIPTION
Partially addresses #17123

<img width="600"  src="https://github.com/directus/directus/assets/5363448/1a79138b-89a2-4e74-b04a-1c92222a5929">
