### PR TITLE
Consistent link to documentation of jsonwebtoken

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2184,7 +2184,7 @@ operations:
     token: Token
     token_placeholder: eyJhbGciOi......
     options: Options
-    options_placeholder: Refer to https://www.npmjs.com/package/jsonwebtoken for the available options
+    options_placeholder: Refer to https://www.npmjs.com/package/jsonwebtoken#usage for the available options
     sign: Sign Token
     verify: Verify Token
     decode: Decode Token

--- a/docs/app/flows/operations.md
+++ b/docs/app/flows/operations.md
@@ -276,7 +276,7 @@ This operation lets you sign and verify a JSON Web Token (JWT) using the
 - **Token** — The JSON Web Token to verify or decode.
 - **Secret** — The secret key used to sign or verify a token.
 - **Options** — The options object provided to the operation. For the list of available options, see the
-  [documentation of `jsonwebtoken`](https://github.com/auth0/node-jsonwebtoken#usage).
+  [documentation of `jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken#usage).
 
 **Payload**
 


### PR DESCRIPTION
GitHub repository may change, thus linking to npm in both places