### PR TITLE
Add new "Releases" section to place "Breaking Changes" page

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -681,8 +681,19 @@ function sidebar() {
 					link: '/self-hosted/upgrades-migrations',
 					text: 'Upgrades & Migrations',
 				},
+			],
+		},
+		{
+			text: 'Releases',
+			collapsible: true,
+			collapsed: true,
+			items: [
 				{
-					link: '/self-hosted/breaking-changes',
+					link: 'https://github.com/directus/directus/releases',
+					text: 'Release Notes',
+				},
+				{
+					link: '/releases/breaking-changes',
 					text: 'Breaking Changes',
 				},
 			],

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -13,7 +13,8 @@ readTime: 7 min read
 
 ## 1. Create a Project
 
-:::tabs \
+::: tabs
+
 == Directus Cloud
 
 Create and login to your [Directus Cloud account](https://directus.cloud).

--- a/docs/releases/breaking-changes.md
+++ b/docs/releases/breaking-changes.md
@@ -1,11 +1,13 @@
 ---
-description: A list of any actions you may need to take as you upgrade Directus versions.
+description: A list of any actions you may need to take on upgrades of Directus.
 ---
 
 # Breaking Changes
 
 As we continue to build Directus, we occasionally make changes that change how certain features works. We try and keep
 these to a minimum, but rest assured we only make them with good reason.
+
+[Learn more about Versioning ->](/getting-started/architecture#versioning)
 
 Starting with Directus 10.0, here is a list of potential breaking changes with remedial action you may need to take.
 
@@ -17,13 +19,13 @@ Directus had various different functionalities that required you to use Redis wh
 scaled environment such as caching, rate-limiting, realtime, and flows. The configuration for these different parts have
 been combined into a single set of `REDIS` environment variables that are reused across the system.
 
-:::details Migration/Mitigation
+::: details Migration/Mitigation
 
 Combine all the `*_REDIS` environment variables into a single shared one as followed:
 
-_Before_
+::: code-group
 
-```
+```ini [Before]
 CACHE_STORE="redis"
 CACHE_REDIS_HOST="127.0.0.1"
 CACHE_REDIS_PORT="6379"
@@ -41,9 +43,7 @@ MESSENGER_REDIS_HOST="127.0.0.1"
 MESSENGER_REDIS_PORT="6379"
 ```
 
-_After_
-
-```
+```ini [After]
 REDIS_HOST="127.0.0.1"
 REDIS_PORT="6379"
 
@@ -68,11 +68,11 @@ As part of standardizing how extensions are built and shipped, you must replace 
 `exceptions` with new errors created within the extension itself. We recommend prefixing the error code with your
 extension name for improved debugging, but you can keep using the system codes if you relied on that in the past.
 
-:::details Migration/Mitigation
+::: details Migration/Mitigation
 
-_Before_
+::: code-group
 
-```js
+```js [Before]
 export default (router, { exceptions }) => {
 	const { ForbiddenException } = exceptions;
 
@@ -82,9 +82,7 @@ export default (router, { exceptions }) => {
 };
 ```
 
-_After_
-
-```js
+```js [After]
 import { createError } from '@directus/errors';
 
 const ForbiddenError = createError('MY_EXTENSION_FORBIDDEN', 'No script kiddies please...');


### PR DESCRIPTION
@phazonoverload and I noticed that the new "Breaking Changes" page introduced in #19425 contains information which also applies to Cloud users and not only to Self-Hosted users.
Therefore it would make sense to move the page to another section. However, we weren't quite sure where it would be best placed.
This is now an attempt to solve it by introducing a new dedicated section called "Releases" where the page can be moved along with a link to the releases notes.

Additional minor changes:
- Link to [Versioning](https://docs.directus.io/getting-started/architecture.html#versioning) in intro of "Breaking Changes" page
- Organize "Before" / "After" migration instructions in code groups

<img width="500" src="https://github.com/directus/directus/assets/5363448/6afcbb20-eb06-4a15-8bde-e958994e91c6">
