### PR TITLE
Fix display of thumbnail with tabular layout in File Library

### DIFF
--- a/.changeset/serious-pants-melt.md
+++ b/.changeset/serious-pants-melt.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed display of thumbnail using tabular layout in File Library

--- a/app/src/composables/use-alias-fields.ts
+++ b/app/src/composables/use-alias-fields.ts
@@ -112,10 +112,12 @@ export function useAliasFields(
 		const aliasInfo = Object.values(aliasedFields.value).find((field) => field.key === key);
 
 		// Skip any fields prefixed with $ as they dont exist. ($thumbnail as an example)
-		key = key
-			.split('.')
-			.filter((k) => !k.startsWith('$'))
-			.join('.');
+		key = key.includes('.')
+			? key
+					.split('.')
+					.filter((k) => !k.startsWith('$'))
+					.join('.')
+			: key;
 
 		if (!aliasInfo || !aliasInfo.aliased) return get(item, key);
 

--- a/app/src/composables/use-alias-fields.ts
+++ b/app/src/composables/use-alias-fields.ts
@@ -111,7 +111,7 @@ export function useAliasFields(
 	function getFromAliasedItem<K, T extends Record<string, K>>(item: T, key: string): K | undefined {
 		const aliasInfo = Object.values(aliasedFields.value).find((field) => field.key === key);
 
-		// Skip any fields prefixed with $ as they dont exist. ($thumbnail as an example)
+		// Skip any nested fields prefixed with $ as they dont exist. ($thumbnail as an example)
 		key = key.includes('.')
 			? key
 					.split('.')


### PR DESCRIPTION
Fixes #19472

If the thumbnail field was selected on the File Library itself, the key would be empty thus returning no data.
Not entirely sure whether the PR is the best solution (cc @Nitwel), but it works! Another solution, for example, would be to return the `item` directly instead of using `get(item, key)` when the key is empty.