### PR TITLE
Enable more checks for `next` branch

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
     paths:
       - api/**
       - tests/blackbox/**
@@ -13,7 +14,7 @@ on:
       - .github/workflows/blackbox-main.yml
 
 concurrency:
-  group: blackbox-main
+  group: blackbox-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
 
 concurrency:
   group: check-${{ github.ref }}


### PR DESCRIPTION
Follow-up on #19511 to enable checks in PRs targeting `next` and also run blackbox tests when merged into `next`.