### PR TITLE
Set minwidth for popper menu to input size

### DIFF
--- a/.changeset/mighty-avocados-draw.md
+++ b/.changeset/mighty-avocados-draw.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Set minimum width for collection picker to the inputs width.

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -382,6 +382,14 @@ function usePopper(
 					callback();
 				},
 			},
+			{
+				name: 'minWidth',
+				enabled: true,
+				phase: 'beforeWrite',
+				fn({ state }) {
+					state.styles.popper.minWidth = `${state.rects.reference.width}px`;
+				},
+			},
 		];
 
 		if (options.value.arrow === true) {


### PR DESCRIPTION
fixes #19516 

Copying my previous comment:

Managed to make it at least as wide as the `reference` which is an improvement but not perfect.

| Before | After |
|--------|--------|
| [Screencast from 24.08.2023 12:11:07.webm](https://github.com/directus/directus/assets/14810858/f92c2262-c9f6-483e-be4c-ffabb98f3e4a) | [Screencast from 24.08.2023 12:08:28.webm](https://github.com/directus/directus/assets/14810858/8255f282-a64b-4fb8-ab95-80f6dc73c483) | 

Do we want to get rid off the dynamic size completely? Reading longer system tables like the future `directus_extension_permissions` might be painful then :smile: 