### PR TITLE
Improve stale github action

### DIFF
--- a/.changeset/sweet-socks-eat.md
+++ b/.changeset/sweet-socks-eat.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Improved stale github action

--- a/.changeset/sweet-socks-eat.md
+++ b/.changeset/sweet-socks-eat.md
@@ -1,5 +1,0 @@
----
-
----
-
-Improved stale github action

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           days-before-stale: -1
           days-before-close: 7
+          ignore-updates: true
           stale-issue-label: 'Needs More Info'
           close-issue-message:
             "Heya! There isn't enough information available to keep investigating this issue at present time, so it'll

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           days-before-stale: -1
           days-before-close: 7
-          ignore-updates: true
+          remove-stale-when-updated: false
           stale-issue-label: 'Needs More Info'
           close-issue-message:
             "Heya! There isn't enough information available to keep investigating this issue at present time, so it'll


### PR DESCRIPTION
Adds the `remove-stale-when-updated: false` [setting](https://github.com/actions/stale#remove-stale-when-updated) to the stale GH action in an attempt to prevent the bot from removing the "needs more info" tags from issues that still need more info.
