### PR TITLE
Add Warning to TypeDoc Pages

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -2,7 +2,7 @@
 	<Layout>
 		<template #doc-before>
 			<div
-				v-if="path.startsWith('/packages')"
+				v-if="RegExp('^/packages/.+$').test(path)"
 				class="warning custom-block"
 				style="padding-bottom: 16px; margin-bottom: 16px"
 			>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,5 +1,19 @@
 <template>
 	<Layout>
+		<template #doc-before>
+			<div
+				v-if="path.startsWith('/packages')"
+				class="warning custom-block"
+				style="padding-bottom: 16px; margin-bottom: 16px"
+			>
+				<p>
+					This is an auto-generated document to support extension builders understand the internal packages they can
+					utilize. To find our written guides, tutorials, and API/SDK reference, check out our
+					<a href="/">main docs</a>
+					.
+				</p>
+			</div>
+		</template>
 		<template #doc-footer-before>
 			<Feedback :url="path" :title="title" />
 			<Meta v-if="contributors" id="contributors" title-left="Contributors">


### PR DESCRIPTION
This PR adds a warning at the top of TypeDoc pages to notify users that these pages are auto-generated.

> This is an auto-generated document to support extension builders understand the internal packages they can utilize. To find our written guides, tutorials, and API/SDK reference, check out our [main docs](http://localhost:5173/) .

![CleanShot 2023-08-30 at 11 18 14@2x](https://github.com/directus/directus/assets/12714889/5bae8807-fe5e-4ddd-83a4-e63e8ce893bd)
