### PR TITLE
Add hook filter events in flow interface

### DIFF
--- a/.changeset/gentle-carrots-shop.md
+++ b/.changeset/gentle-carrots-shop.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Exposed `auth.create` and `auth.update` filter events to Flows

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -126,6 +126,8 @@ export function getTriggers() {
 									'database.error',
 									'auth.login',
 									'auth.jwt',
+									'auth.create',
+									'auth.update',
 									'authenticate',
 								],
 								font: 'monospace',


### PR DESCRIPTION
When we are going to create a new flow in the interface, and we select the trigger to be an `Event Hook` of type `Filter`, the options `auth.create` and `auth.update` that are in the [documentation](https://docs.directus.io/extensions/hooks.html#filter-events) do not appear in the scope.


![image](https://github.com/directus/directus/assets/374857/73fcfd30-33df-4767-a8d9-6dc7a6eb80d3)
