### PR TITLE
SDK Fix realtime infinite auth loop

### DIFF
--- a/.changeset/tiny-penguins-roll.md
+++ b/.changeset/tiny-penguins-roll.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed infinite loop in the SDK realtime authentication

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -111,7 +111,7 @@ export function realtime(config: WebSocketConfig = {}) {
 				if (!message) continue;
 
 				if ('type' in message) {
-					if (message['type'] === 'auth' && hasAuth(currentClient)) {
+					if (message['type'] === 'auth' && 'status' in message && message['status'] === 'error' && hasAuth(currentClient)) {
 						const access_token = await currentClient.getToken();
 
 						if (access_token) {

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -128,7 +128,6 @@ export function realtime(config: WebSocketConfig = {}) {
 
 						if (message['error'] === 'AUTH_TIMEOUT') {
 							ws.close();
-							resetConnection();
 							continue;
 						}
 					}
@@ -170,8 +169,6 @@ export function realtime(config: WebSocketConfig = {}) {
 					ws.addEventListener('error', (evt: Event) => {
 						eventHandlers['error'].forEach((handler) => handler.call(ws, evt));
 						ws.close();
-						resetConnection();
-						reconnect.call(this);
 						if (!resolved) reject(evt);
 					});
 
@@ -242,15 +239,13 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				send({ ...options, collection, type: 'subscribe' });
 
-				// const initialMessage = await messageCallback(ws);
-
 				async function* subscriptionGenerator(): AsyncGenerator<
 					SubscriptionOutput<Schema, Collection, Options['query'], SubscriptionEvents>,
 					void,
 					unknown
 				> {
-					while (subscribed && socket && socket.readyState === WebSocket.OPEN) {
-						const message = await messageCallback(socket).catch(() => {
+					while (subscribed && ws && ws.readyState === WebSocket.OPEN) {
+						const message = await messageCallback(ws).catch(() => {
 							/* let the loop continue */
 						});
 

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -111,7 +111,12 @@ export function realtime(config: WebSocketConfig = {}) {
 				if (!message) continue;
 
 				if ('type' in message) {
-					if (message['type'] === 'auth' && 'status' in message && message['status'] === 'error' && hasAuth(currentClient)) {
+					if (
+						message['type'] === 'auth' &&
+						'status' in message &&
+						message['status'] === 'error' &&
+						hasAuth(currentClient)
+					) {
 						const access_token = await currentClient.getToken();
 
 						if (access_token) {

--- a/sdk/src/realtime/utils/message-callback.ts
+++ b/sdk/src/realtime/utils/message-callback.ts
@@ -10,7 +10,7 @@ interface WebSocketListener {
  *
  * @returns Incoming message object
  */
-export const messageCallback = (socket: globalThis.WebSocket, timeout=1000) =>
+export const messageCallback = (socket: globalThis.WebSocket, timeout = 1000) =>
 	new Promise<Record<string, any> | MessageEvent<string> | undefined>((resolve, reject) => {
 		const handler: WebSocketListener = (data: MessageEvent<string>) => {
 			try {
@@ -46,5 +46,5 @@ export const messageCallback = (socket: globalThis.WebSocket, timeout=1000) =>
 		const timer = setTimeout(() => {
 			unbind();
 			resolve(undefined);
-		}, timeout)
+		}, timeout);
 	});

--- a/sdk/src/realtime/utils/message-callback.ts
+++ b/sdk/src/realtime/utils/message-callback.ts
@@ -6,11 +6,12 @@ interface WebSocketListener {
  * Wait for a websocket response
  *
  * @param socket WebSocket
+ * @param number timeout
  *
  * @returns Incoming message object
  */
-export const messageCallback = (socket: globalThis.WebSocket) =>
-	new Promise<Record<string, any> | MessageEvent<string>>((resolve, reject) => {
+export const messageCallback = (socket: globalThis.WebSocket, timeout=1000) =>
+	new Promise<Record<string, any> | MessageEvent<string> | undefined>((resolve, reject) => {
 		const handler: WebSocketListener = (data: MessageEvent<string>) => {
 			try {
 				const message = JSON.parse(data.data) as Record<string, any>;
@@ -32,6 +33,7 @@ export const messageCallback = (socket: globalThis.WebSocket) =>
 		const abort = () => reject();
 
 		const unbind = () => {
+			clearTimeout(timer);
 			socket.removeEventListener('message', handler);
 			socket.removeEventListener('error', abort);
 			socket.removeEventListener('close', abort);
@@ -40,4 +42,9 @@ export const messageCallback = (socket: globalThis.WebSocket) =>
 		socket.addEventListener('message', handler);
 		socket.addEventListener('error', abort);
 		socket.addEventListener('close', abort);
+
+		const timer = setTimeout(() => {
+			unbind();
+			resolve(undefined);
+		}, timeout)
 	});


### PR DESCRIPTION
Fixes #19583

- Fixed the SDK responding to the authentication confirmation message with new authentication causing an infinite loop between client and server
- Fixed leaking memory on event listeners by making sure each event handler gets removed before re-adding a new one