### PR TITLE
Ignore extra envs for mysql

### DIFF
--- a/.changeset/six-insects-begin.md
+++ b/.changeset/six-insects-begin.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fix validation when socket path is used with mysql

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -1,5 +1,5 @@
-import { createInspector } from '@directus/schema';
 import type { SchemaInspector } from '@directus/schema';
+import { createInspector } from '@directus/schema';
 import fse from 'fs-extra';
 import type { Knex } from 'knex';
 import knex from 'knex';
@@ -68,7 +68,7 @@ export default function getDatabase(): Knex {
 				requiredEnvVars.push('DB_DATABASE', 'DB_USER', 'DB_PASSWORD', 'DB_SOCKET_PATH');
 			}
 
-			break;	
+			break;
 		case 'mssql':
 			if (!env['DB_TYPE'] || env['DB_TYPE'] === 'default') {
 				requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -61,6 +61,14 @@ export default function getDatabase(): Knex {
 			}
 
 			break;
+		case 'mysql':
+			if (!env['DB_SOCKET_PATH']) {
+				requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');
+			} else {
+				requiredEnvVars.push('DB_DATABASE', 'DB_USER', 'DB_PASSWORD', 'DB_SOCKET_PATH');
+			}
+
+			break;	
 		case 'mssql':
 			if (!env['DB_TYPE'] || env['DB_TYPE'] === 'default') {
 				requiredEnvVars.push('DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_USER', 'DB_PASSWORD');

--- a/contributors.yml
+++ b/contributors.yml
@@ -67,3 +67,4 @@
 - JoMingyu
 - Dominic-Marcelino
 - AndreGKruger
+- AxeemHaider


### PR DESCRIPTION
Don't require `DB_HOST` and `DB_PORT` when setting `DB_SOCKET_PATH` in MySQL. These envs are ignored when set `socketPath` as mention in [mysql connection options](https://www.npmjs.com/package/mysql#connection-options) and therefore shouldn't be required to be set when socket-path is used.