### PR TITLE
Fix emit value for system-raw-editor component

### DIFF
--- a/.changeset/spotty-items-shout.md
+++ b/.changeset/spotty-items-shout.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed emit value for system-raw-editor component

--- a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
+++ b/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import { useWindowSize } from '@/composables/use-window-size';
-import { parseJSON } from '@directus/utils';
+import { isValidJSON, parseJSON } from '@directus/utils';
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/mode/simple';
 import { computed, onMounted, ref, unref, watch } from 'vue';
@@ -99,14 +99,10 @@ onMounted(async () => {
 
 			if (origin === 'setValue') return;
 
-			if (unref(isObjectLike)) {
-				try {
-					emit('input', content !== '' ? parseJSON(content) : null);
-				} catch {
-					// Skip emitting invalid JSON
-				}
+			if (content === '') {
+				emit('input', null);
 			} else {
-				emit('input', content !== '' ? content : null);
+				emit('input', unref(isObjectLike) && isValidJSON(content) ? parseJSON(content) : content);
 			}
 		});
 	}


### PR DESCRIPTION
Previously #16139 added a safety check to skip emitting invalid JSONs in system-raw-editor:

https://github.com/directus/directus/blob/f770fefc962ef959a8490dff1f1ef799ac662108/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue#L102-L110

Although that was an intended guard rail, we would still need to emit values for technically invalid JSON values such as `{{my_payload_from_another_operation}}` in Flows or `{{my_global_variable_as_filter}}` in Insights.

Changes in this PR:

- Ensure technically invalid JSON to still be emitted
- added a `isValidJSON` check in place of the previous try/catch logic and "reversed" the `content !== ''` check to simplify the code a little bit