### PR TITLE
Rerender forms in translations interface when switching languages

### DIFF
--- a/.changeset/smooth-falcons-dream.md
+++ b/.changeset/smooth-falcons-dream.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added rerendering of forms in translations interface when switching languages

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -14,6 +14,7 @@
 			</language-select>
 			<v-form
 				v-if="languageOptions.find((lang) => lang.value === firstLang)"
+				:key="languageOptions.find((lang) => lang.value === firstLang)?.value"
 				:primary-key="
 					relationInfo?.junctionPrimaryKeyField.field
 						? firstItemInitial?.[relationInfo?.junctionPrimaryKeyField.field]
@@ -45,6 +46,7 @@
 			</language-select>
 			<v-form
 				v-if="languageOptions.find((lang) => lang.value === secondLang)"
+				:key="languageOptions.find((lang) => lang.value === secondLang)?.value"
 				:primary-key="
 					relationInfo?.junctionPrimaryKeyField.field
 						? secondItemInitial?.[relationInfo?.junctionPrimaryKeyField.field]


### PR DESCRIPTION
Fixes #19041

As described by https://github.com/directus/directus/issues/19041#issuecomment-1683588652, currently the block editor doesn't re-render when there have been changes, which is intended to avoid it from re-rendering unnecessarily. 

However in the context of block editor being used _within_ translations interface, _not_ rerendering on switching of languages causes it to retain the previous content.

This PR attempts to resolve this on the translations interface level instead of the block editor itself, with the usage of vue `key` to ensure the form is rerendered whenever there's switching of languages.

## Before

https://github.com/directus/directus/assets/42867097/a32e81dd-f888-4143-96df-255a48b1c974

## After

https://github.com/directus/directus/assets/42867097/cc0d4b68-828c-4cee-8c54-c98265d8177d

