### PR TITLE
Attempt to make "require shares fields" migration safer/more reliable

### DIFF
--- a/.changeset/soft-apples-rush.md
+++ b/.changeset/soft-apples-rush.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Attempt to make "require shares fields" migration more safer/reliable

--- a/.changeset/soft-apples-rush.md
+++ b/.changeset/soft-apples-rush.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Attempt to make "require shares fields" migration more safer/reliable
+Attempt to make "require shares fields" migration safer/more reliable for MySQL instances

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -1,48 +1,61 @@
 import { createInspector } from '@directus/schema';
 import type { Knex } from 'knex';
 import logger from '../../logger.js';
+import { getHelpers } from '../helpers/index.js';
 
 export async function up(knex: Knex): Promise<void> {
-	await dropConstraint(knex);
+	const helper = getHelpers(knex).schema;
+	const isMysql = helper.isOneOfClients(['mysql']);
+
+	if (isMysql) {
+		await dropConstraint(knex);
+	}
 
 	await knex.schema.alterTable('directus_shares', (table) => {
 		table.dropNullable('collection');
 		table.dropNullable('item');
 	});
 
-	await recreateConstraint(knex);
+	if (isMysql) {
+		await recreateConstraint(knex);
+	}
 }
 
 export async function down(knex: Knex): Promise<void> {
-	await dropConstraint(knex);
+	const helper = getHelpers(knex).schema;
+	const isMysql = helper.isOneOfClients(['mysql']);
+
+	if (isMysql) {
+		await dropConstraint(knex);
+	}
 
 	await knex.schema.alterTable('directus_shares', (table) => {
 		table.setNullable('collection');
 		table.setNullable('item');
 	});
 
-	await recreateConstraint(knex);
+	if (isMysql) {
+		await recreateConstraint(knex);
+	}
 }
 
 /**
  * Temporarily drop foreign key constraint for MySQL instances, see https://github.com/directus/directus/issues/19399
  */
 async function dropConstraint(knex: Knex) {
-	if (knex.client.constructor.name === 'Client_MySQL') {
-		const inspector = createInspector(knex);
+	const inspector = createInspector(knex);
 
-		const foreignKeys = await inspector.foreignKeys('directus_shares');
-		const collectionForeignKeys = foreignKeys.filter((fk) => fk.column === 'collection');
-		const constraintName = collectionForeignKeys[0]?.constraint_name;
+	const foreignKeys = await inspector.foreignKeys('directus_shares');
+	const collectionForeignKeys = foreignKeys.filter((fk) => fk.column === 'collection');
+	const constraintName = collectionForeignKeys[0]?.constraint_name;
 
-		if (constraintName && collectionForeignKeys.length === 1) {
-			await knex.schema.alterTable('directus_shares', (table) => {
-				table.dropForeign('collection', constraintName);
-			});
-		} else {
-			logger.warn(`Unexpected number of foreign key constraints on 'directus_shares.collection':`);
-			logger.warn(JSON.stringify(collectionForeignKeys, null, 4));
-		}
+	if (constraintName && collectionForeignKeys.length === 1) {
+		await knex.schema.alterTable('directus_shares', (table) => {
+			table.dropForeign('collection', constraintName);
+		});
+	} else {
+		logger.warn(`Unexpected number of foreign key constraints on 'directus_shares.collection':`);
+		logger.warn(JSON.stringify(collectionForeignKeys, null, 4));
 	}
 }
 
@@ -50,9 +63,7 @@ async function dropConstraint(knex: Knex) {
  * Recreate foreign key constraint for MySQL instances, from 20211211A-add-shares.ts
  */
 async function recreateConstraint(knex: Knex) {
-	if (knex.client.constructor.name === 'Client_MySQL') {
-		return knex.schema.alterTable('directus_shares', async (table) => {
-			table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
-		});
-	}
+	return knex.schema.alterTable('directus_shares', async (table) => {
+		table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
+	});
 }

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -40,10 +40,8 @@ async function dropConstraint(knex: Knex) {
 				table.dropForeign('collection', constraintName);
 			});
 		} else {
-			logger.warn(
-				`Unexpected number of foreign key constraints on 'directus_shares.collection':`,
-				collectionForeignKeys
-			);
+			logger.warn(`Unexpected number of foreign key constraints on 'directus_shares.collection':`);
+			logger.warn(JSON.stringify(collectionForeignKeys, null, 4));
 		}
 	}
 }

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -1,37 +1,62 @@
+import { createInspector } from '@directus/schema';
 import type { Knex } from 'knex';
+import logger from '../../logger.js';
 
 export async function up(knex: Knex): Promise<void> {
+	await dropConstraint(knex);
+
 	await knex.schema.alterTable('directus_shares', (table) => {
-		if (knex.client.constructor.name === 'Client_MySQL') {
-			// Temporary drop foreign key constraint, see https://github.com/directus/directus/issues/19399
-			table.dropForeign('collection', 'directus_shares_collection_foreign');
-		}
-
 		table.dropNullable('collection');
-
-		if (knex.client.constructor.name === 'Client_MySQL') {
-			// Recreate foreign key constraint, from 20211211A-add-shares.ts
-			table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
-		}
-
 		table.dropNullable('item');
 	});
+
+	await recreateConstraint(knex);
 }
 
 export async function down(knex: Knex): Promise<void> {
+	await dropConstraint(knex);
+
 	await knex.schema.alterTable('directus_shares', (table) => {
-		if (knex.client.constructor.name === 'Client_MySQL') {
-			// Temporary drop foreign key constraint, see https://github.com/directus/directus/issues/19399
-			table.dropForeign('collection', 'directus_shares_collection_foreign');
-		}
-
 		table.setNullable('collection');
-
-		if (knex.client.constructor.name === 'Client_MySQL') {
-			// Recreate foreign key constraint, from 20211211A-add-shares.ts
-			table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
-		}
-
 		table.setNullable('item');
 	});
+
+	await recreateConstraint(knex);
+}
+
+/**
+ * Temporary drop foreign key constraint for MySQL instances, see https://github.com/directus/directus/issues/19399
+ */
+async function dropConstraint(knex: Knex) {
+	if (knex.client.constructor.name === 'Client_MySQL') {
+		const inspector = createInspector(knex);
+
+		const foreignKeys = await inspector.foreignKeys('directus_shares');
+		const collectionForeignKeys = foreignKeys.filter((fk) => fk.column === 'collection');
+		const constraintName = collectionForeignKeys[0]?.constraint_name;
+
+		if (constraintName && collectionForeignKeys.length === 1) {
+			await knex.schema.alterTable('directus_shares', (table) => {
+				table.dropForeign('collection', constraintName);
+			});
+		} else {
+			logger.warn(
+				`Unexpected number of foreign key constraints on 'directus_shares.collection':`,
+				collectionForeignKeys
+			);
+		}
+	}
+}
+
+/**
+ * Recreate foreign key constraint for MySQL instances, from 20211211A-add-shares.ts
+ */
+async function recreateConstraint(knex: Knex) {
+	if (knex.client.constructor.name === 'Client_MySQL') {
+		return knex.schema.alterTable('directus_shares', async (table) => {
+			if (knex.client.constructor.name === 'Client_MySQL') {
+				table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
+			}
+		});
+	}
 }

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -52,9 +52,7 @@ async function dropConstraint(knex: Knex) {
 async function recreateConstraint(knex: Knex) {
 	if (knex.client.constructor.name === 'Client_MySQL') {
 		return knex.schema.alterTable('directus_shares', async (table) => {
-			if (knex.client.constructor.name === 'Client_MySQL') {
-				table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
-			}
+			table.foreign('collection').references('directus_collections.collection').onDelete('CASCADE');
 		});
 	}
 }

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -25,7 +25,7 @@ export async function down(knex: Knex): Promise<void> {
 }
 
 /**
- * Temporary drop foreign key constraint for MySQL instances, see https://github.com/directus/directus/issues/19399
+ * Temporarily drop foreign key constraint for MySQL instances, see https://github.com/directus/directus/issues/19399
  */
 async function dropConstraint(knex: Knex) {
 	if (knex.client.constructor.name === 'Client_MySQL') {


### PR DESCRIPTION
After the last correction of the  ["require shares fields" migration](https://github.com/directus/directus/blob/548819686cf49e2c2a714163e0fefbe44c6754e8/api/src/database/migrations/20230721A-require-shares-fields.ts) in #19407, it seems that there are still MySQL instances that struggle with this migration (see #19399).

Unfortunately this could not be reproduced so far, so here's an attempt to make the migration a bit safer/more reliable:
- Split into multiple `ALTER TABLE` statements, because depending on the engine it may not be supported to drop & recreate in the same statement.
- Fetch and use the actual foreign key constraint name instead of static one.
- Log foreign key constraints if it should come in an unexpected form.

Closes #19399 (we'll reopen if issue should still not be solved)