### PR TITLE
Add RTL support to markdown interface

### DIFF
--- a/.changeset/gorgeous-eyes-sit.md
+++ b/.changeset/gorgeous-eyes-sit.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added RTL support to markdown interface

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -235,6 +235,7 @@ const props = withDefaults(
 		imageToken?: string;
 		softLength?: number;
 		folder?: string;
+		direction?: string;
 	}>(),
 	{
 		editorFont: 'sans-serif',
@@ -292,6 +293,7 @@ onMounted(async () => {
 			configureMouse: () => ({ addNew: false }),
 			lineWrapping: true,
 			readOnly: readOnly.value,
+			direction: props.direction === 'rtl' ? props.direction : 'ltr',
 			cursorBlinkRate: props.disabled ? -1 : 530,
 			placeholder: props.placeholder,
 			value: props.value || '',
@@ -348,6 +350,13 @@ watch(
 		codemirror?.setOption('cursorBlinkRate', disabled ? -1 : 530);
 	},
 	{ immediate: true }
+);
+
+watch(
+	() => props.direction,
+	(direction) => {
+		codemirror?.setOption('direction', direction === 'rtl' ? direction : 'ltr');
+	}
 );
 
 const editFamily = computed(() => {

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -187,7 +187,7 @@
 		<div
 			v-md="markdownString"
 			class="preview-box"
-			:style="view[0] === 'preview' ? 'display:block' : 'display:none'"
+			:style="{ display: view[0] === 'preview' ? 'block' : 'none', direction: direction === 'rtl' ? direction : 'ltr' }"
 		></div>
 
 		<v-dialog


### PR DESCRIPTION
Closes #19624

RTL support was added in #14665, but the original PR didn't include the `input-rich-text-md` Markdown interface. This PR adds the same support in the markdown interface.

### Changes Made

- Similar to how `input-rich-text-html` uses TinyMCE's built in `directionality` plugin, now the markdown interface uses CodeMirror's built in `direction` option.
- Added CSS direction styling to the preview div so that it also renders in RTL properly.

## Before

https://github.com/directus/directus/assets/42867097/c4fe0500-793c-46a7-a834-2709d2d8d265

## After

https://github.com/directus/directus/assets/42867097/34a3732e-de14-4f56-b1b2-a1859bc1664f

