### PR TITLE
Docs: Fix broken link

### DIFF
--- a/.changeset/clever-guests-stare.md
+++ b/.changeset/clever-guests-stare.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Fixed broken link under the "Themes & Styling" page

--- a/.changeset/clever-guests-stare.md
+++ b/.changeset/clever-guests-stare.md
@@ -2,4 +2,4 @@
 "docs": patch
 ---
 
-Fixed broken link under the "Themes & Styling" page
+Fixed broken link under the "Themes & Styling" extension page

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -25,7 +25,7 @@ no limit to customization. Below are several code resources for key SCSS files.
 
 ## Project Styling
 
-See [Adjusting Project Settings](/user-guide/cloud/project-settings)
+See [Adjusting Project Settings](/user-guide/settings/project-settings#branding-style)
 
 ## Custom CSS
 

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -25,7 +25,7 @@ no limit to customization. Below are several code resources for key SCSS files.
 
 ## Project Styling
 
-See [Adjusting Project Settings](/user-guide/settings/project-settings#branding-style)
+See [Project Settings - Branding & Style](/user-guide/settings/project-settings#branding-style).
 
 ## Custom CSS
 


### PR DESCRIPTION
Link was pointing to an older page (I assume). Updated to what I believe is the right page.