### PR TITLE
Update hint about WebSocket timeout 

### DIFF
--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -978,8 +978,9 @@ Allows you to configure hard technical limits, to prevent abuse and optimize for
 | `WEBSOCKETS_HEARTBEAT_ENABLED`              | Whether or not to enable the heartbeat ping signal.                                                                              | `true`        |
 | `WEBSOCKETS_HEARTBEAT_PERIOD`<sup>[1]</sup> | The period in seconds at which to send the ping. This period doubles as the timeout used for closing an unresponsive connection. | 30            |
 
-sup>[1]</sup> It's recommended to keep this value between 30 and 120 seconds, otherwise the connections could be considered idle by other
-parties and therefore terminated. See https://websockets.readthedocs.io/en/stable/topics/timeouts.html.
+sup>[1]</sup> It's recommended to keep this value between 30 and 120 seconds, otherwise the connections could be
+considered idle by other parties and therefore terminated. See
+https://websockets.readthedocs.io/en/stable/topics/timeouts.html.
 
 ### REST
 

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -978,7 +978,7 @@ Allows you to configure hard technical limits, to prevent abuse and optimize for
 | `WEBSOCKETS_HEARTBEAT_ENABLED`              | Whether or not to enable the heartbeat ping signal.                                                                              | `true`        |
 | `WEBSOCKETS_HEARTBEAT_PERIOD`<sup>[1]</sup> | The period in seconds at which to send the ping. This period doubles as the timeout used for closing an unresponsive connection. | 30            |
 
-sup>[1]</sup> It's recommended to keep this value low, otherwise the connections could be considered idle by other
+sup>[1]</sup> It's recommended to keep this value between 30 and 120 seconds, otherwise the connections could be considered idle by other
 parties and therefore terminated. See https://websockets.readthedocs.io/en/stable/topics/timeouts.html.
 
 ### REST


### PR DESCRIPTION
Follow up to #19652

Let's be more specific in this advice because "it is recommended to keep this value low" may give the impression that a heartbeat of lower than 30secs is recommended while that could add up to a lot of unneeded overhead on server handling multiple connections.
