### PR TITLE
Update node version in docs

### DIFF
--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -13,7 +13,7 @@ readTime: 4 min read
 
 ::: tip Minimum Requirements
 
-You will need to have [the latest version of Node](https://nodejs.org/en/download/current) to _build_ a Development
+You will need to have [the latest LTS version of Node](https://nodejs.org/en/download) to _build_ a Development
 version of Directus.
 
 You will also need to have the package manager [pnpm](https://pnpm.io) installed.

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -13,8 +13,8 @@ readTime: 4 min read
 
 ::: tip Minimum Requirements
 
-You will need to have [the latest LTS version of Node](https://nodejs.org/en/download) to _build_ a Development
-version of Directus.
+You will need to have [the latest LTS version of Node](https://nodejs.org/en/download) to _build_ a Development version
+of Directus.
 
 You will also need to have the package manager [pnpm](https://pnpm.io) installed.
 


### PR DESCRIPTION
Our codebase currently does not support node v20 (thanks to dependencies).

![image](https://github.com/directus/directus/assets/9389634/2859c8c8-f917-4612-b13d-a75467429059)

So this statement is factually incorrect at the moment
> You will need to have the latest version of Node

I suggest we stick to the LTS version as we suggest for running Directus.