### PR TITLE
Tab-based snippet toggler

### DIFF
--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -5,9 +5,9 @@
 				<button
 					v-for="choice in choices"
 					:key="choice"
-					@click="selected = choice"
 					class="button"
 					:class="{ active: selected == choice }"
+					@click="selected = choice"
 				>
 					{{ choice }}
 				</button>

--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -64,15 +64,24 @@ onBeforeMount(() => {
 
 <style scoped>
 .snippet-toggler {
+	--snippet-toggler-border-color: var(--vp-c-gray-light-4);
+}
+
+html.dark .snippet-toggler,
+.snippet-toggler.dark {
+	--snippet-toggler-border-color: transparent;
+}
+
+.snippet-toggler {
 	overflow: hidden;
 	background: linear-gradient(172.36deg, rgba(228, 234, 241, 0.1) -5.49%, rgba(228, 234, 241, 0) 123.05%);
-	border: 1px solid var(--vp-snippet-toggler-border);
+	border: 1px solid var(--snippet-toggler-border-color);
 }
 
 .snippet-toggler-header {
 	background: linear-gradient(172.36deg, rgba(228, 234, 241, 0.1) -5.49%, rgba(228, 234, 241, 0) 123.05%);
 	color: var(--vp-c-gray-light-2);
-	border-bottom: 1px solid var(--vp-snippet-toggler-border);
+	border-bottom: 1px solid var(--snippet-toggler-border-color);
 	height: 40px;
 	display: flex;
 	align-items: center;

--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -95,11 +95,13 @@ onBeforeMount(() => {
 	border-radius: var(--rounded-lg);
 }
 
-html.dark .snippet-toggler .button {
+html.dark .snippet-toggler .button,
+.snippet-toggler.dark .button {
 	color: var(--vp-c-gray-light-2);
 }
 
-html.dark .snippet-toggler .button.active {
+html.dark .snippet-toggler .button.active,
+.snippet-toggler.dark .button.active {
 	color: var(--vp-c-gray-light-4);
 }
 

--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -107,6 +107,10 @@ html.dark .snippet-toggler .button.active {
 	display: none;
 }
 
+.snippet-toggler.dark .content-area :deep(.vp-code-dark) {
+	display: block;
+}
+
 @media (min-width: 640px) {
 	.snippet-toggler {
 		border-radius: 12px;

--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -1,25 +1,16 @@
 <template>
 	<div class="snippet-toggler" :class="{ dark: alwaysDark }">
 		<div class="snippet-toggler-header">
-			<span class="snippet-toggler-header-label">{{ label }}</span>
-
-			<span class="spacer" />
-
-			<div class="snippet-toggler-header-lang-container">
-				<select v-model="selected" class="snippet-toggler-header-lang">
-					<option v-for="choice in choices" :key="choice" :value="choice">
-						{{ choice }}
-					</option>
-				</select>
-				<svg
-					class="snippet-toggler-header-lang-arrow"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 48 48"
-					height="18"
-					width="18"
+			<div class="buttons">
+				<button
+					v-for="choice in choices"
+					:key="choice"
+					@click="selected = choice"
+					class="button"
+					:class="{ active: selected == choice }"
 				>
-					<path d="m24 30.75-12-12 2.15-2.15L24 26.5l9.85-9.85L36 18.8Z" />
-				</svg>
+					{{ choice }}
+				</button>
 			</div>
 		</div>
 
@@ -85,64 +76,35 @@ onBeforeMount(() => {
 	height: 40px;
 	display: flex;
 	align-items: center;
-	padding: 0 24px;
+	padding: 24px;
 }
 
-.spacer {
-	flex-grow: 1;
-}
-
-.snippet-toggler-header-label {
-	text-transform: uppercase;
-	font-size: 12px;
-	font-weight: 600;
-}
-
-.snippet-toggler-header-lang-container {
+.buttons {
 	display: flex;
-	align-items: center;
+	gap: 0.5em;
 }
 
-.snippet-toggler-header-lang-container:hover {
-	color: var(--vp-snippet-toggler-lang-hover);
+.button {
+	padding: 0.25em 0.75em;
+	color: var(--vp-c-gray);
 }
 
-.snippet-toggler-header-lang {
-	background-color: transparent;
-	text-align: right;
-	border: 0;
-	border-color: transparent;
-	padding: 0;
-	font-family: inherit;
-	color: inherit;
-	appearance: none;
-	line-height: inherit;
-	position: relative;
-	font-size: 12px;
-	padding-inline-end: 20px;
-}
-.snippet-toggler-header-lang option {
+.button.active {
 	color: var(--vp-c-black);
+	background: var(--vp-c-mute);
+	border-radius: var(--rounded-lg);
 }
 
-.snippet-toggler-header-lang:focus {
-	outline: none;
+html.dark .snippet-toggler .button {
+	color: var(--vp-c-gray-light-2);
 }
 
-.snippet-toggler-header-lang-arrow {
-	position: absolute;
-	right: 24px;
-	fill: currentColor;
-	user-select: none;
-	pointer-events: none;
+html.dark .snippet-toggler .button.active {
+	color: var(--vp-c-gray-light-4);
 }
 
 .snippet-toggler .content-area :deep(.lang) {
 	display: none;
-}
-
-.snippet-toggler.dark .content-area :deep(.vp-code-dark) {
-	display: block;
 }
 
 @media (min-width: 640px) {

--- a/docs/.vitepress/theme/vars.css
+++ b/docs/.vitepress/theme/vars.css
@@ -134,15 +134,3 @@
 .dark {
 	--vp-docs-section-bg: #000;
 }
-
-/**
- * Component: Snippet Toggler
- * -------------------------------------------------------------------------- */
-
-:root {
-	--vp-snippet-toggler-border: var(--vp-c-gray-light-4);
-}
-
-.dark {
-	--vp-snippet-toggler-border: transparent;
-}

--- a/docs/.vitepress/theme/vars.css
+++ b/docs/.vitepress/theme/vars.css
@@ -50,6 +50,16 @@
 	--vp-c-red-dimm-3: rgba(244, 63, 94, 0.05);
 
 	--vp-c-pink: #fe97dc;
+
+	--rounded-none: 0;
+	--rounded-sm: 0.125rem;
+	--rounded: 0.25rem;
+	--rounded-md: 0.375rem;
+	--rounded-lg: 0.5rem;
+	--rounded-xl: 0.75rem;
+	--rounded-2xl: 1rem;
+	--rounded-3xl: 1.5rem;
+	--rounded-full: 9999px;
 }
 
 /**

--- a/docs/.vitepress/theme/vars.css
+++ b/docs/.vitepress/theme/vars.css
@@ -135,10 +135,8 @@
 
 :root {
 	--vp-snippet-toggler-border: var(--vp-c-gray-light-4);
-	--vp-snippet-toggler-lang-hover: var(--vp-c-gray);
 }
 
 .dark {
 	--vp-snippet-toggler-border: transparent;
-	--vp-snippet-toggler-lang-hover: var(--vp-c-gray-light-5);
 }

--- a/docs/.vitepress/theme/vars.css
+++ b/docs/.vitepress/theme/vars.css
@@ -50,16 +50,6 @@
 	--vp-c-red-dimm-3: rgba(244, 63, 94, 0.05);
 
 	--vp-c-pink: #fe97dc;
-
-	--rounded-none: 0;
-	--rounded-sm: 0.125rem;
-	--rounded: 0.25rem;
-	--rounded-md: 0.375rem;
-	--rounded-lg: 0.5rem;
-	--rounded-xl: 0.75rem;
-	--rounded-2xl: 1rem;
-	--rounded-3xl: 1.5rem;
-	--rounded-full: 9999px;
 }
 
 /**
@@ -83,6 +73,22 @@
 	--vp-c-purple-dimm-3: rgba(159, 132, 255, 0.1);
 
 	--vp-c-divider: rgba(82, 82, 89, 0.32);
+}
+
+/**
+ * Globals
+ * -------------------------------------------------------------------------- */
+
+:root {
+	--rounded-none: 0;
+	--rounded-sm: 0.125rem;
+	--rounded: 0.25rem;
+	--rounded-md: 0.375rem;
+	--rounded-lg: 0.5rem;
+	--rounded-xl: 0.75rem;
+	--rounded-2xl: 1rem;
+	--rounded-3xl: 1.5rem;
+	--rounded-full: 9999px;
 }
 
 /**


### PR DESCRIPTION
This PR updates the docs `<SnippetToggler>` component to use a tab-based layout instead of the top-right dropdown. 

Before: 
<img width="632" alt="2023-09-12T0956 59@2x" src="https://github.com/directus/directus/assets/1461554/b0e29719-2c3f-4440-b18e-6f36217cffd6">

After:
![2023-09-12T1000 24](https://github.com/directus/directus/assets/1461554/4c57625d-933d-41b8-9a73-d08d2c096e23)
![2023-09-12T1001 03](https://github.com/directus/directus/assets/1461554/b7088bcf-f394-4180-b31c-8c980515a661)

All other functionality remains the same. 