### PR TITLE
docs: update sdk  imports

### DIFF
--- a/docs/guides/sdk/getting-started.md
+++ b/docs/guides/sdk/getting-started.md
@@ -59,9 +59,7 @@ For example, to create a client with REST or GraphQL support, use the following:
 ::: code-group
 
 ```js [JavaScript]
-import { createDirectus } from '@directus/sdk';
-import { rest } from '@directus/sdk/rest';
-import { graphql } from '@directus/sdk/graphql';
+import { createDirectus, rest, graphql } from '@directus/sdk';
 
 // Client with REST support
 const client = createDirectus('http://directus.example.com').with(rest());
@@ -71,9 +69,7 @@ const client = createDirectus('http://directus.example.com').with(graphql());
 ```
 
 ```ts [TypeScript]
-import { createDirectus } from '@directus/sdk';
-import { rest } from '@directus/sdk/rest';
-import { graphql } from '@directus/sdk/graphql';
+import { createDirectus, rest, graphql } from '@directus/sdk';
 
 interface Article {
 	id: number;
@@ -105,8 +101,7 @@ Use the `authentication()` composable to add user login and tokens auto-refresh 
 For example, to login to your directus instance, invoke the `login` method
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { authentication } from '@directus/sdk/auth';
+import { createDirectus, authentication } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(authentication());
 
@@ -148,8 +143,7 @@ For example, to make a request to an `articles` collection.
 #### Read a single item
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItem } from '@directus/sdk/rest';
+import { createDirectus, rest, readItem } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(rest());
 
@@ -160,8 +154,7 @@ const result = await client.request(readItem('articles', article_id));
 #### Read all items
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(rest());
 
@@ -171,8 +164,7 @@ const result = await client.request(readItems('articles'));
 #### Read specific fields
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(rest());
 
@@ -186,8 +178,7 @@ const result = await client.request(
 #### Read all fields
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(rest());
 
@@ -201,8 +192,7 @@ const result = await client.request(
 #### Read nested fields
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(rest());
 
@@ -220,8 +210,7 @@ Add the `graphql()` composable to the client, this enables the `.query(...)` met
 For example, to make a request to an `articles` collection with TypeScript:
 
 ```ts
-import { createDirectus } from '@directus/sdk';
-import { graphql } from '@directus/sdk/graphql';
+import { createDirectus, graphql } from '@directus/sdk';
 
 interface Article {
 	id: number;
@@ -245,12 +234,6 @@ const result = await client.query<Article[]>(`
     }
 `);
 ```
-
-:::tip Importing SDK Composables
-
-All SDK composables can also be conveniently imported from the root package `@directus/sdk`.
-
-:::
 
 ## Global APIs
 


### PR DESCRIPTION
This PR updates the SDK Quickstart guide to have all functions imported from the root. Closes MARK-1584 https://linear.app/directus/issue/MARK-1584/sweep-docs-pages-for-non-root-exported-functions