### PR TITLE
Add display options for repeater

### DIFF
--- a/.changeset/blue-meals-admire.md
+++ b/.changeset/blue-meals-admire.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": minor
+---
+
+Introduced option to configure the display of repeater fields

--- a/app/src/interfaces/_system/system-display-options/index.ts
+++ b/app/src/interfaces/_system/system-display-options/index.ts
@@ -1,0 +1,13 @@
+import { defineInterface } from '@directus/utils';
+import InterfaceSystemDisplayOptions from './system-display-options.vue';
+
+export default defineInterface({
+	id: 'system-display-options',
+	name: '$t:interfaces.system-display-options.display-options',
+	description: '$t:interfaces.system-display-options.description',
+	icon: 'box',
+	component: InterfaceSystemDisplayOptions,
+	types: ['string'],
+	options: [],
+	system: true,
+});

--- a/app/src/interfaces/_system/system-display-options/system-display-options.vue
+++ b/app/src/interfaces/_system/system-display-options/system-display-options.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-notice v-if="!selectedDisplay">
-		{{ t('select_interface') }}
+		{{ t('select_display') }}
 	</v-notice>
 
 	<v-notice v-else-if="usesCustomComponent === false && optionsFields.length === 0">

--- a/app/src/interfaces/_system/system-display-options/system-display-options.vue
+++ b/app/src/interfaces/_system/system-display-options/system-display-options.vue
@@ -44,7 +44,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(e: 'input', value: Record<string, unknown> | null): void;
+	input: [value: Record<string, unknown> | null];
 }>();
 
 const { t } = useI18n();

--- a/app/src/interfaces/_system/system-display-options/system-display-options.vue
+++ b/app/src/interfaces/_system/system-display-options/system-display-options.vue
@@ -1,0 +1,129 @@
+<template>
+	<v-notice v-if="!selectedDisplay">
+		{{ t('select_interface') }}
+	</v-notice>
+
+	<v-notice v-else-if="usesCustomComponent === false && optionsFields.length === 0">
+		{{ t('no_options_available') }}
+	</v-notice>
+
+	<div v-else class="inset">
+		<v-form
+			v-if="usesCustomComponent === false"
+			v-model="options"
+			class="extension-options"
+			:fields="optionsFields"
+			:disabled="disabled"
+			primary-key="+"
+		/>
+
+		<component
+			:is="`display-options-${selectedDisplay.id}`"
+			v-else
+			:value="value"
+			:collection="collection"
+			@input="$emit('input', $event)"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { useExtension } from '@/composables/use-extension';
+import { ExtensionOptionsContext } from '@directus/types';
+import { isVueComponent } from '@directus/utils';
+import { computed, inject, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{
+	value: Record<string, unknown> | null;
+	displayField?: string;
+	display?: string;
+	collection?: string;
+	disabled?: boolean;
+	context?: () => ExtensionOptionsContext;
+}>();
+
+const emit = defineEmits<{
+	(e: 'input', value: Record<string, unknown> | null): void;
+}>();
+
+const { t } = useI18n();
+
+const options = computed({
+	get() {
+		return props.value;
+	},
+	set(newVal: any) {
+		emit('input', newVal);
+	},
+});
+
+const values = inject('values', ref<Record<string, any>>({}));
+
+const selectedDisplayId = computed(() => props.display ?? values.value[props.displayField!] ?? null);
+const selectedDisplay = useExtension('display', selectedDisplayId);
+
+const usesCustomComponent = computed(() => {
+	if (!selectedDisplay.value) return false;
+
+	return isVueComponent(selectedDisplay.value.options);
+});
+
+const optionsFields = computed(() => {
+	if (!selectedDisplay.value?.options || usesCustomComponent.value) return [];
+
+	let optionsObjectOrArray;
+
+	if (typeof selectedDisplay.value.options === 'function') {
+		optionsObjectOrArray = selectedDisplay.value.options(
+			props.context?.() ?? {
+				field: {
+					type: 'unknown',
+				},
+				editing: '+',
+				collection: props.collection,
+				relations: {
+					o2m: undefined,
+					m2o: undefined,
+					m2a: undefined,
+				},
+				collections: {
+					related: undefined,
+					junction: undefined,
+				},
+				fields: {
+					corresponding: undefined,
+					junctionCurrent: undefined,
+					junctionRelated: undefined,
+					sort: undefined,
+				},
+				items: {},
+				localType: 'standard',
+				autoGenerateJunctionRelation: false,
+				saving: false,
+			}
+		);
+	} else {
+		optionsObjectOrArray = selectedDisplay.value.options;
+	}
+
+	if (Array.isArray(optionsObjectOrArray)) return optionsObjectOrArray;
+
+	return [...optionsObjectOrArray.standard, ...optionsObjectOrArray.advanced];
+});
+</script>
+
+<style lang="scss" scoped>
+.inset {
+	--form-horizontal-gap: 24px;
+	--form-vertical-gap: 24px;
+
+	padding: 12px;
+	border: var(--border-width) solid var(--border-normal);
+	border-radius: var(--border-radius);
+
+	:deep(.type-label) {
+		font-size: 1rem;
+	}
+}
+</style>

--- a/app/src/interfaces/_system/system-display/index.ts
+++ b/app/src/interfaces/_system/system-display/index.ts
@@ -1,0 +1,13 @@
+import { defineInterface } from '@directus/utils';
+import InterfaceSystemDisplay from './system-display.vue';
+
+export default defineInterface({
+	id: 'system-display',
+	name: '$t:interfaces.system-display.display',
+	description: '$t:interfaces.system-display.description',
+	icon: 'box',
+	component: InterfaceSystemDisplay,
+	types: ['string'],
+	system: true,
+	options: [],
+});

--- a/app/src/interfaces/_system/system-display/system-display.vue
+++ b/app/src/interfaces/_system/system-display/system-display.vue
@@ -1,0 +1,60 @@
+<template>
+	<v-notice v-if="selectedType === undefined">
+		{{ t('select_field_type') }}
+	</v-notice>
+	<v-select
+		v-else
+		:items="items"
+		:model-value="value"
+		:placeholder="t('interfaces.system-display.placeholder')"
+		show-deselect
+		@update:model-value="$emit('input', $event)"
+	/>
+</template>
+
+<script setup lang="ts">
+import { useExtensions } from '@/extensions';
+import { DisplayConfig } from '@directus/types';
+import { computed, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{
+	value: string | null;
+	typeField?: string;
+}>();
+
+const emit = defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
+
+const { t } = useI18n();
+
+const { displays } = useExtensions();
+
+const values = inject('values', ref<Record<string, any>>({}));
+
+const selectedType = computed(() => {
+	if (!props.typeField || !values.value[props.typeField]) return;
+	return values.value[props.typeField];
+});
+
+watch(
+	() => values.value[props.typeField!],
+	() => {
+		emit('input', null);
+	}
+);
+
+const items = computed(() => {
+	console.log(displays.value.map((display) => display.localTypes));
+	return displays.value
+		.filter((display: DisplayConfig) => (display.localTypes?.length ?? 0) === 0)
+		.filter((display: DisplayConfig) => selectedType.value === undefined || display.types.includes(selectedType.value))
+		.map((display: DisplayConfig) => {
+			return {
+				text: display.name,
+				value: display.id,
+			};
+		});
+});
+</script>

--- a/app/src/interfaces/_system/system-display/system-display.vue
+++ b/app/src/interfaces/_system/system-display/system-display.vue
@@ -24,7 +24,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(e: 'input', value: string | null): void;
+	input: [value: string | null];
 }>();
 
 const { t } = useI18n();

--- a/app/src/interfaces/_system/system-display/system-display.vue
+++ b/app/src/interfaces/_system/system-display/system-display.vue
@@ -46,7 +46,6 @@ watch(
 );
 
 const items = computed(() => {
-	console.log(displays.value.map((display) => display.localTypes));
 	return displays.value
 		.filter((display: DisplayConfig) => (display.localTypes?.length ?? 0) === 0)
 		.filter((display: DisplayConfig) => selectedType.value === undefined || display.types.includes(selectedType.value))

--- a/app/src/interfaces/list/options.vue
+++ b/app/src/interfaces/list/options.vue
@@ -47,6 +47,7 @@ import Repeater from './list.vue';
 
 const props = defineProps<{
 	value: Record<string, any> | null;
+	collection: string;
 }>();
 
 const emit = defineEmits<{
@@ -127,16 +128,16 @@ const repeaterFields: DeepPartial<Field>[] = [
 		},
 	},
 	{
-		name: t('interface_label'),
-		field: 'interface',
-		type: 'string',
+		name: t('required'),
+		field: 'required',
+		type: 'boolean',
 		meta: {
-			interface: 'system-interface',
-			width: 'half',
+			interface: 'boolean',
 			sort: 5,
 			options: {
-				typeField: 'type',
+				label: t('requires_value'),
 			},
+			width: 'half',
 		},
 	},
 	{
@@ -153,29 +154,63 @@ const repeaterFields: DeepPartial<Field>[] = [
 		},
 	},
 	{
-		name: t('required'),
-		field: 'required',
-		type: 'boolean',
+		name: t('interfaces.list.interface_group'),
+		field: 'group-interface',
+		type: 'alias',
 		meta: {
-			interface: 'boolean',
+			interface: 'group-detail',
+			field: 'group-interface',
+			width: 'full',
 			sort: 7,
 			options: {
-				label: t('requires_value'),
+				start: 'open',
 			},
-			width: 'half',
+			collection: props.collection,
+			special: ['group', 'no-data', 'alias'],
 		},
 	},
 	{
-		name: t('options'),
+		name: t('interface_label'),
+		field: 'interface',
+		type: 'string',
+		meta: {
+			interface: 'system-interface',
+			width: 'half',
+			sort: 8,
+			group: 'group-interface',
+			options: {
+				typeField: 'type',
+			},
+		},
+	},
+	{
+		name: t('interface_options'),
 		field: 'options',
 		type: 'string',
 		meta: {
 			interface: 'system-interface-options',
 			width: 'full',
-			sort: 8,
+			sort: 9,
+			group: 'group-interface',
 			options: {
 				interfaceField: 'interface',
 			},
+		},
+	},
+	{
+		name: t('interfaces.list.display_group'),
+		field: 'group-display',
+		type: 'alias',
+		meta: {
+			interface: 'group-detail',
+			field: 'group-display',
+			width: 'full',
+			sort: 10,
+			options: {
+				start: 'closed',
+			},
+			collection: props.collection,
+			special: ['group', 'no-data', 'alias'],
 		},
 	},
 	{
@@ -185,7 +220,8 @@ const repeaterFields: DeepPartial<Field>[] = [
 		meta: {
 			interface: 'system-display',
 			width: 'half',
-			sort: 9,
+			group: 'group-display',
+			sort: 11,
 			options: {
 				typeField: 'type',
 			},
@@ -198,7 +234,8 @@ const repeaterFields: DeepPartial<Field>[] = [
 		meta: {
 			interface: 'system-display-options',
 			width: 'full',
-			sort: 10,
+			group: 'group-display',
+			sort: 12,
 			options: {
 				displayField: 'display',
 			},

--- a/app/src/interfaces/list/options.vue
+++ b/app/src/interfaces/list/options.vue
@@ -178,6 +178,32 @@ const repeaterFields: DeepPartial<Field>[] = [
 			},
 		},
 	},
+	{
+		name: t('display_label'),
+		field: 'display',
+		type: 'string',
+		meta: {
+			interface: 'system-display',
+			width: 'half',
+			sort: 9,
+			options: {
+				typeField: 'type',
+			},
+		},
+	},
+	{
+		name: t('display_options'),
+		field: 'display_options',
+		type: 'string',
+		meta: {
+			interface: 'system-display-options',
+			width: 'full',
+			sort: 10,
+			options: {
+				displayField: 'display',
+			},
+		},
+	},
 ];
 
 const template = computed({

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -402,6 +402,7 @@ move: Move
 system: System
 add_field_related: Add Field to Related Collection
 interface_label: Interface
+display_label: Display
 today: Today
 yesterday: Yesterday
 delete_comment: Delete Comment
@@ -760,6 +761,7 @@ upload_pending: Upload Pending
 drag_file_here: Drag & Drop a File Here
 click_to_browse: Click to Browse
 interface_options: Interface Options
+display_options: Display Options
 layout_options: Layout Options
 rows: Rows
 columns: Columns
@@ -1475,6 +1477,7 @@ search: Search
 select_existing: Select Existing
 select_field_type: Select a field type
 select_interface: Select an interface
+select_display: Select a display
 settings: Settings
 sign_in: Sign In
 sign_out: Sign Out
@@ -1722,6 +1725,9 @@ interfaces:
     incompatible_data:
       The current data is not compatible with the repeater interface and will be overridden when adding items to the
       repeater
+    interface_group: Interface Options
+    display_group: Display Options
+
   slider:
     slider: Slider
     description: Select a number using a slider

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1644,6 +1644,13 @@ interfaces:
   system-interface-options:
     interface-options: Interface Options
     description: A modal for selecting options of an interface
+  system-display:
+    display: Display
+    description: Select an existing display
+    placeholder: Select an display...
+  system-display-options:
+    display-options: Display Options
+    description: A modal for selecting options of a display
   list-m2m:
     many-to-many: Many to Many
     description: Select multiple related junction items

--- a/docs/app/data-model/fields/selection.md
+++ b/docs/app/data-model/fields/selection.md
@@ -51,8 +51,8 @@ Value is stored as a JSON array of objects.
   - **Note**: A helpful note for the user.
   - **Interface**: The interface to use for the fields.
   - **Interface Options**: Option configuration for the selected Interface.
-	- **Display**: The display to use for the preview template.
-	- **Display Options**: Option configuration for the selected Display.
+  - **Display**: The display to use for the preview template.
+  - **Display Options**: Option configuration for the selected Display.
 
 ## Map
 

--- a/docs/app/data-model/fields/selection.md
+++ b/docs/app/data-model/fields/selection.md
@@ -48,9 +48,11 @@ Value is stored as a JSON array of objects.
   - **Field**: Name of the field.
   - **Field Width**: Width of field on the Item Detail page.
   - **Type**: Type of value.
-  - **Interface**: The interface to use for the fields.
   - **Note**: A helpful note for the user.
-  - **Options**: Option configuration for the selected Interface.
+  - **Interface**: The interface to use for the fields.
+  - **Interface Options**: Option configuration for the selected Interface.
+	- **Display**: The display to use for the preview template.
+	- **Display Options**: Option configuration for the selected Display.
 
 ## Map
 


### PR DESCRIPTION
closes #19692

Adds options for specifying a display on the repeater interface.

![grafik](https://github.com/directus/directus/assets/22577866/8042d5f5-f655-4416-bfbc-7ddca5cb11cb)
