### PR TITLE
Swap edit and Select actions on M2O

### DIFF
--- a/.changeset/moody-windows-matter.md
+++ b/.changeset/moody-windows-matter.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Swapped out the actions on the Many to One interface to match the behaviour of the other relational interfaces

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -268,7 +268,7 @@ function onSelection(selection: (number | string)[] | null) {
 	}
 }
 
-.edit {
+.select {
 	margin-right: 4px;
 
 	&:hover {

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -32,7 +32,13 @@
 
 			<template #append>
 				<template v-if="displayItem">
-					<v-icon v-tooltip="t('edit')" name="open_in_new" class="edit" @click="editModalActive = true" />
+					<v-icon
+						v-if="enableSelect && !disabled"
+						v-tooltip="t('select_an_item')"
+						name="swap_horiz"
+						class="select"
+						@click="selectModalActive = true"
+					/>
 					<v-icon
 						v-if="!disabled"
 						v-tooltip="t('deselect')"
@@ -193,13 +199,15 @@ function onPreviewClick() {
 	if (props.disabled) return;
 
 	// Prevent double dialog in case the edit dialog is already open
-	if (editModalActive.value === true) return;
+	if (selectModalActive.value === true) return;
 
-	if (props.enableSelect) {
+	// if select is enabled, and there's no value, open the select dialog
+	if (props.enableSelect && !displayItem.value) {
 		selectModalActive.value = true;
 		return;
 	}
 
+	// else open the edit dialog
 	editModalActive.value = true;
 }
 

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -34,7 +34,7 @@
 				<template v-if="displayItem">
 					<v-icon
 						v-if="enableSelect && !disabled"
-						v-tooltip="t('select_an_item')"
+						v-tooltip="t('change_item')"
 						name="swap_horiz"
 						class="select"
 						@click="selectModalActive = true"

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -198,10 +198,10 @@ const edits = computed(() => {
 function onPreviewClick() {
 	if (props.disabled) return;
 
-	// Prevent double dialog in case the edit dialog is already open
-	if (selectModalActive.value === true) return;
+	// Prevent double dialog in case it has already been opened by click on nested icon
+	if (selectModalActive.value || editModalActive.value) return;
 
-	// if select is enabled, and there's no value, open the select dialog
+	// If select is enabled, and there's no value, open the select dialog
 	if (props.enableSelect && !displayItem.value) {
 		selectModalActive.value = true;
 		return;

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -589,6 +589,7 @@ bookmark_doesnt_exist: Bookmark Doesn't Exist
 bookmark_doesnt_exist_copy: The bookmark you're trying to open couldn't be found.
 bookmark_doesnt_exist_cta: Return to collection
 select_an_item: Select an item...
+change_item: Change Item
 edit: Edit
 enabled: Enabled
 disable_tfa: Disable 2FA

--- a/contributors.yml
+++ b/contributors.yml
@@ -71,3 +71,4 @@
 - alexvdvalk
 - thame
 - christianrr
+- D3VL-Jack


### PR DESCRIPTION
Closes #19708 

![chrome_Cxxt1F9rra](https://github.com/directus/directus/assets/21148384/c14b227c-b278-49fc-b838-4bed52d932dd)

The edit and swap behaviour have been swapped such that clicking the larger box opens the edit menu, and the swap moved to a smaller icon at the end.
