### PR TITLE
 Show divider in related item drawer only if necessary

### DIFF
--- a/.changeset/fresh-plums-repeat.md
+++ b/.changeset/fresh-plums-repeat.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Ensured the divider in related item drawer is only shown if necessary

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -114,17 +114,17 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	active: undefined,
 	primaryKey: null,
-	edits: undefined,
 	junctionField: null,
-	disabled: false,
 	relatedPrimaryKey: '+',
 	circularField: null,
 	junctionFieldLocation: 'bottom',
 });
 
-const emit = defineEmits(['update:active', 'input']);
+const emit = defineEmits<{
+	'update:active': [value: boolean];
+	input: [value: Record<string, any>];
+}>();
 
 const { t, te } = useI18n();
 

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -44,7 +44,7 @@
 					:fields="relatedCollectionFields"
 					:validation-errors="junctionField ? validationErrors : undefined"
 					:autofocus="!swapFormOrder"
-					:show-divider="!swapFormOrder"
+					:show-divider="!swapFormOrder && hasVisibleFieldsJunction"
 					@update:model-value="setRelationEdits"
 				/>
 
@@ -55,7 +55,7 @@
 					:show-no-visible-fields="false"
 					:initial-values="initialValues"
 					:autofocus="swapFormOrder"
-					:show-divider="swapFormOrder"
+					:show-divider="swapFormOrder && hasVisibleFieldsRelated"
 					:primary-key="primaryKey"
 					:fields="fields"
 					:validation-errors="!junctionField ? validationErrors : undefined"
@@ -216,11 +216,13 @@ const fieldsWithoutCircular = computed(() => {
 	}
 });
 
-const emptyForm = computed(() => {
-	const visibleFieldsRelated = relatedCollectionFields.value.filter((field: Field) => !field.meta?.hidden);
-	const visibleFieldsJunction = fields.value.filter((field: Field) => !field.meta?.hidden);
-	return visibleFieldsRelated.length + visibleFieldsJunction.length === 0;
-});
+const hasVisibleFieldsRelated = computed(() =>
+	relatedCollectionFields.value.some((field: Field) => !field.meta?.hidden)
+);
+
+const hasVisibleFieldsJunction = computed(() => fields.value.some((field: Field) => !field.meta?.hidden));
+
+const emptyForm = computed(() => !hasVisibleFieldsRelated.value && !hasVisibleFieldsJunction.value);
 
 const templatePrimaryKey = computed(() =>
 	junctionFieldInfo.value ? String(props.relatedPrimaryKey) : String(props.primaryKey)


### PR DESCRIPTION
Ensures the divider is only shown if there are visible fields in both, the related and the junction collection.

### With Fields in Junction Collection

![Screenshot 2023-09-17 at 16-57-34 Directus](https://github.com/directus/directus/assets/5363448/adf7e41e-5d7b-49d0-bbee-9973849fcaf5)

### Without Fields in Junction Collection

The divider is now hidden:

![Screenshot 2023-09-17 at 16-59-40 Directus](https://github.com/directus/directus/assets/5363448/c3000ca7-2504-4475-87f7-bdb7b4a578b6)
