### PR TITLE
Apply workaround for update permission check for rules with relational fields

### DIFF
--- a/.changeset/sour-flies-report.md
+++ b/.changeset/sour-flies-report.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/utils": patch
+---
+
+Applied a workaround for the update permission check for rules with relational fields to prevent items from incorrectly not being updatable

--- a/app/src/utils/is-allowed.test.ts
+++ b/app/src/utils/is-allowed.test.ts
@@ -1,0 +1,78 @@
+import { it, expect } from 'vitest';
+import { isAllowed } from './is-allowed.js';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeAll, vi, describe } from 'vitest';
+import { Filter, Permission } from '@directus/types';
+
+let permissions: Permission[] = [];
+const isAdmin = false;
+
+beforeAll(() => {
+	setActivePinia(
+		createTestingPinia({
+			createSpy: vi.fn,
+			initialState: {
+				permissionsStore: {
+					permissions,
+				},
+				userStore: {
+					isAdmin,
+				},
+			},
+		})
+	);
+});
+
+describe('update', () => {
+	const collection = 'example';
+	const action = 'update';
+
+	permissions = [
+		{
+			role: '33fb7ff0-3bb2-4bce-8ac4-49d34b6580ec',
+			collection,
+			action,
+			permissions: {
+				update_allowed: {
+					_eq: true,
+				},
+			},
+			validation: null,
+			presets: null,
+			fields: ['*'],
+		},
+	];
+
+	it('should be allowed if item value matches permission rule', () => {
+		const value = { update_allowed: true };
+
+		expect(isAllowed(collection, action, value)).toBe(true);
+	});
+
+	it('should be disallowed if item value does not match permission rule', () => {
+		const value = { update_allowed: false };
+
+		expect(isAllowed(collection, action, value)).toBe(false);
+	});
+
+	// TODO: Test for temporary workaround, needs to be revisited after clean-up of workaround
+	it('should be always allowed if rule contains relational fields', () => {
+		const rules: Filter = {
+			nested_collection: {
+				update_allowed: {
+					_eq: true,
+				},
+			},
+		};
+
+		permissions[0]!.permissions = rules;
+
+		const value = {
+			// Will be key of related item
+			nested_collection: 1,
+		};
+
+		expect(isAllowed(collection, action, value)).toBe(true);
+	});
+});

--- a/app/src/utils/is-allowed.ts
+++ b/app/src/utils/is-allowed.ts
@@ -32,6 +32,9 @@ export function isAllowed(
 
 	if (!permissionInfo.permissions || Object.keys(permissionInfo.permissions).length === 0) return true;
 
+	// Value is `null` while data is still loading, skip check in this case
+	if (value === null) return true;
+
 	return checkPermissions(permissionInfo.permissions);
 
 	function checkPermissions(permissions: Filter): boolean {
@@ -45,6 +48,13 @@ export function isAllowed(
 			const schema = generateJoi(permissions as FieldFilter);
 
 			const { error } = schema.validate(value);
+
+			// TODO: This is a temporary workaround, currently necessary for permission rules
+			//       containing relational fields because those values aren't received at this point
+			//		 and the check would always fail.
+			//       Therefore the check is instead always considered successful for now.
+			if (action === 'update' && error?.message.endsWith('must be of type object')) return true;
+
 			return error === undefined;
 		}
 	}


### PR DESCRIPTION
Addresses #19327

Temporary workaround, currently necessary for permission rules containing relational fields because those relational values aren't available in the `isAllowed` update check and it would therefore always fail.
For now, the check is instead always considered successful in such a case, ensuring items can be update again.
Though, this means items might be presented to the user as "updatable" even if they aren't, but the API will correctly refuse the update in that case and the `You don't have permission to access this` message will be shown.

A complete solution will be provided at a later date.