### PR TITLE
Fix collection selection in field duplication

### DIFF
--- a/.changeset/cyan-toys-fly.md
+++ b/.changeset/cyan-toys-fly.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed collection selection in field duplication dialog

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -154,7 +154,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import { ref, computed, unref } from 'vue';
-import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRouter } from 'vue-router';
 import { cloneDeep } from 'lodash';

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -118,7 +118,7 @@
 						<div class="form-grid">
 							<div class="field">
 								<span class="type-label">{{ t('collection', 0) }}</span>
-								<v-select v-model="duplicateTo" class="monospace" :items="collections" />
+								<interface-system-collection :value="duplicateTo" class="monospace" @input="duplicateTo = $event" />
 							</div>
 
 							<div class="field">
@@ -187,11 +187,10 @@ const { t } = useI18n();
 
 const router = useRouter();
 
-const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
 
 const { deleteActive, deleting, deleteField } = useDeleteField();
-const { duplicateActive, duplicateName, collections, duplicateTo, saveDuplicate, duplicating } = useDuplicate();
+const { duplicateActive, duplicateName, duplicateTo, saveDuplicate, duplicating } = useDuplicate();
 
 const inter = useExtension(
 	'interface',
@@ -247,18 +246,11 @@ function useDuplicate() {
 	const duplicateName = ref(props.field.field + '_copy');
 	const duplicating = ref(false);
 
-	const collections = computed(() =>
-		collectionsStore.collections
-			.map(({ collection }) => collection)
-			.filter((collection) => collection.startsWith('directus_') === false)
-	);
-
 	const duplicateTo = ref(props.field.collection);
 
 	return {
 		duplicateActive,
 		duplicateName,
-		collections,
 		duplicateTo,
 		saveDuplicate,
 		duplicating,


### PR DESCRIPTION
Fixes #19413

Replacing `v-select` with the `system-collection` interface to fix the search functionality but also to ensure that only collections are displayed and not folders.

### Before

<img width="500" src="https://github.com/directus/directus/assets/5363448/d7c81e0f-5c5d-4325-b4ba-a973f799e043">

### After

<img width="500" src="https://github.com/directus/directus/assets/5363448/30b9267a-94b2-4073-bb05-b43263049692">


