### PR TITLE
Require less items to show search in `v-select` & `v-field-list`

### DIFF
--- a/.changeset/shiny-years-crash.md
+++ b/.changeset/shiny-years-crash.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Adjusted the `v-select` and `v-field-list` component to show search already if there are more than 10 items (used to be 20)

--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-list :mandatory="false" @toggle="loadFieldRelations($event.value)">
 		<slot name="prepend" />
-		<v-list-item v-if="fieldsCount > 20">
+		<v-list-item v-if="fieldsCount > 10">
 			<v-list-item-content>
 				<v-input v-model="search" autofocus small :placeholder="t('search')" @click.stop>
 					<template #append>

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -54,7 +54,7 @@
 				<v-divider />
 			</template>
 
-			<v-list-item v-if="internalItemsCount > 20 || search">
+			<v-list-item v-if="internalItemsCount > 10 || search">
 				<v-list-item-content>
 					<v-input v-model="search" autofocus small :placeholder="t('search')" @click.stop.prevent>
 						<template #append>


### PR DESCRIPTION
The `v-select` and `v-field-list` components both come with search functionality. Though, the search is currently only displayed if there are more than 20 items.
In my opinion it would be helpful if it was available from +10, especially for lists with child items. 
This would also match the value in the `select-multiple-checkbox-tree` interface:

https://github.com/directus/directus/blob/c413788c672567e5b7bfda69bbd68d0af7008e77/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue#L3