### PR TITLE
Remove padding in `v-highlight` to fix display issues

### DIFF
--- a/.changeset/clean-eagles-shop.md
+++ b/.changeset/clean-eagles-shop.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Removed padding in `v-highlight` to fix various display issues

--- a/app/src/components/__snapshots__/v-highlight.test.ts.snap
+++ b/app/src/components/__snapshots__/v-highlight.test.ts.snap
@@ -1,3 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Mount component 1`] = `"<span data-v-0a28d51c=\\"\\" class=\\"v-highlight\\"><span data-v-0a28d51c=\\"\\">Th</span><mark data-v-0a28d51c=\\"\\" class=\\"highlight\\">is</mark><span data-v-0a28d51c=\\"\\"> </span><mark data-v-0a28d51c=\\"\\" class=\\"highlight\\">is</mark><span data-v-0a28d51c=\\"\\"> a nice </span><mark data-v-0a28d51c=\\"\\" class=\\"highlight\\">text</mark></span>"`;
+exports[`Mount component 1`] = `
+"Th
+<mark data-v-0a28d51c=\\"\\" class=\\"highlight\\">is</mark>
+
+<mark data-v-0a28d51c=\\"\\" class=\\"highlight\\">is</mark>
+ a nice
+<mark data-v-0a28d51c=\\"\\" class=\\"highlight\\">text</mark>"
+`;

--- a/app/src/components/v-highlight.vue
+++ b/app/src/components/v-highlight.vue
@@ -1,10 +1,8 @@
 <template>
-	<span class="v-highlight">
-		<template v-for="(part, index) in parts" :key="index">
-			<mark v-if="part.highlighted" class="highlight">{{ part.text }}</mark>
-			<span v-else>{{ part.text }}</span>
-		</template>
-	</span>
+	<template v-for="(part, index) in parts" :key="index">
+		<mark v-if="part.highlighted" class="highlight">{{ part.text }}</mark>
+		<template v-else>{{ part.text }}</template>
+	</template>
 </template>
 
 <script setup lang="ts">
@@ -132,14 +130,8 @@ const parts = computed<HighlightPart[]>(() => {
 </script>
 
 <style scoped>
-.v-highlight {
-	padding: 1px 2px;
-}
-
 mark {
-	margin: -1px -2px;
-	padding: 1px 2px;
 	background-color: var(--primary-25);
-	border-radius: var(--border-radius);
+	border-radius: 2px;
 }
 </style>


### PR DESCRIPTION
### Before

#### Before #19451

In #19451 an attempt was made to prevent the highlight background from being cut off (see left side):

<img width="300" src="https://github.com/directus/directus/assets/5363448/26848a45-9508-467c-9b5e-66428734fab3">

#### After #19451

However, this led to an even stronger jump effect:

<img width="300" src="https://github.com/directus/directus/assets/5363448/742285e4-4290-4fce-a166-d02cee96d737">

Although this jump effect could be prevented by always rendering text with `v-highlight` even if no search is applied (which feels like an unsafe requirement), there was still the problem that narrow letters are overlapped and the letters themselves are jumpy.

### After

I've tried various approaches (absolute background behind the letter, ...), but the only one that works reliably is to leave out the padding of the background completely:

<img width="300" src="https://github.com/directus/directus/assets/5363448/6cafffcc-37d2-40b1-9980-9aa0aab43bc2">

A small disadvantage is that the highlighting is a bit less visible now. On the other hand, it makes it clearer which part is actually highlighted - before that fix it was sometimes not obvious (for example here one could think that the "l" is also marked):

<img width="108" src="https://github.com/directus/directus/assets/5363448/dcc6df6c-965c-42b2-8940-b17ed6455faf">


