### PR TITLE
Sdk credentials

### DIFF
--- a/.changeset/twelve-boxes-teach.md
+++ b/.changeset/twelve-boxes-teach.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Removed default values for fetch credentials in the SDK

--- a/sdk/src/auth/composable.ts
+++ b/sdk/src/auth/composable.ts
@@ -8,7 +8,6 @@ import { memoryStorage } from './utils/memory-storage.js';
 const defaultConfigValues: AuthenticationConfig = {
 	msRefreshBeforeExpires: 30000, // 30 seconds
 	autoRefresh: true,
-	credentials: 'same-origin',
 };
 
 /**
@@ -78,23 +77,26 @@ export const authentication = (mode: AuthenticationMode = 'cookie', config: Part
 				const authData = await storage.get();
 				resetStorage();
 
-				const options = {
+				const fetchOptions: RequestInit = {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
 					},
-					credentials: authConfig.credentials,
-				} as RequestInit;
+				};
+
+				if ('credentials' in authConfig) {
+					fetchOptions.credentials = authConfig.credentials;
+				}
 
 				if (mode === 'json' && authData?.refresh_token) {
-					options.body = JSON.stringify({
+					fetchOptions.body = JSON.stringify({
 						refresh_token: authData.refresh_token,
 					});
 				}
 
 				const requestUrl = getRequestUrl(client.url, '/auth/refresh');
 
-				const data = await request<AuthenticationData>(requestUrl.toString(), options, client.globals.fetch);
+				const data = await request<AuthenticationData>(requestUrl.toString(), fetchOptions, client.globals.fetch);
 
 				setCredentials(data);
 				return data;
@@ -120,18 +122,19 @@ export const authentication = (mode: AuthenticationMode = 'cookie', config: Part
 				if ('otp' in options) authData['otp'] = options.otp;
 				if ('mode' in options) authData['mode'] = options.mode;
 
-				const data = await request<AuthenticationData>(
-					requestUrl.toString(),
-					{
-						method: 'POST',
-						headers: {
-							'Content-Type': 'application/json',
-						},
-						body: JSON.stringify(authData),
-						credentials: authConfig.credentials,
+				const fetchOptions: RequestInit = {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
 					},
-					client.globals.fetch
-				);
+					body: JSON.stringify(authData),
+				};
+
+				if ('credentials' in authConfig) {
+					fetchOptions.credentials = authConfig.credentials;
+				}
+
+				const data = await request<AuthenticationData>(requestUrl.toString(), fetchOptions, client.globals.fetch);
 
 				setCredentials(data);
 				return data;
@@ -139,22 +142,25 @@ export const authentication = (mode: AuthenticationMode = 'cookie', config: Part
 			async logout() {
 				const authData = await storage.get();
 
-				const options: RequestInit = {
+				const fetchOptions: RequestInit = {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
 					},
-					credentials: authConfig.credentials,
 				};
 
+				if ('credentials' in authConfig) {
+					fetchOptions.credentials = authConfig.credentials;
+				}
+
 				if (mode === 'json' && authData?.refresh_token) {
-					options.body = JSON.stringify({
+					fetchOptions.body = JSON.stringify({
 						refresh_token: authData.refresh_token,
 					});
 				}
 
 				const requestUrl = getRequestUrl(client.url, '/auth/logout');
-				await request(requestUrl.toString(), options, client.globals.fetch);
+				await request(requestUrl.toString(), fetchOptions, client.globals.fetch);
 
 				if (refreshTimeout) clearTimeout(refreshTimeout);
 				resetStorage();

--- a/sdk/src/auth/types.ts
+++ b/sdk/src/auth/types.ts
@@ -17,7 +17,7 @@ export interface AuthenticationStorage {
 export interface AuthenticationConfig {
 	autoRefresh: boolean;
 	msRefreshBeforeExpires: number;
-	credentials: RequestCredentials;
+	credentials?: RequestCredentials;
 	storage?: AuthenticationStorage;
 }
 

--- a/sdk/src/graphql/composable.ts
+++ b/sdk/src/graphql/composable.ts
@@ -4,9 +4,7 @@ import { request } from '../utils/request.js';
 import { getRequestUrl } from '../utils/get-request-url.js';
 import type { AuthenticationClient } from '../auth/types.js';
 
-const defaultConfigValues: GraphqlConfig = {
-	credentials: 'same-origin',
-};
+const defaultConfigValues: GraphqlConfig = {};
 
 /**
  * Creates a client to communicate with Directus GraphQL.
@@ -22,11 +20,14 @@ export const graphql = (config: Partial<GraphqlConfig> = {}) => {
 				variables?: Record<string, unknown>,
 				scope: 'items' | 'system' = 'items'
 			): Promise<Output> {
-				const options: RequestInit = {
+				const fetchOptions: RequestInit = {
 					method: 'POST',
 					body: JSON.stringify({ query, variables }),
-					credentials: gqlConfig.credentials,
 				};
+
+				if ('credentials' in gqlConfig) {
+					fetchOptions.credentials = gqlConfig.credentials;
+				}
 
 				const headers: Record<string, string> = {};
 
@@ -42,11 +43,11 @@ export const graphql = (config: Partial<GraphqlConfig> = {}) => {
 					headers['Content-Type'] = 'application/json';
 				}
 
-				options.headers = headers;
+				fetchOptions.headers = headers;
 				const requestPath = scope === 'items' ? '/graphql' : '/graphql/system';
 				const requestUrl = getRequestUrl(client.url, requestPath);
 
-				return await request<Output>(requestUrl.toString(), options, client.globals.fetch);
+				return await request<Output>(requestUrl.toString(), fetchOptions, client.globals.fetch);
 			},
 		};
 	};

--- a/sdk/src/graphql/types.ts
+++ b/sdk/src/graphql/types.ts
@@ -7,7 +7,7 @@ export interface GraphqlClient<_Schema extends object> {
 }
 
 export interface GraphqlConfig {
-	credentials: RequestCredentials;
+	credentials?: RequestCredentials;
 }
 
 export type GqlResult<Schema extends object, Collection extends keyof Schema> = {

--- a/sdk/src/rest/composable.ts
+++ b/sdk/src/rest/composable.ts
@@ -4,9 +4,7 @@ import { getRequestUrl } from '../utils/get-request-url.js';
 import { request } from '../utils/request.js';
 import type { RestClient, RestCommand, RestConfig } from './types.js';
 
-const defaultConfigValues: RestConfig = {
-	credentials: 'same-origin',
-};
+const defaultConfigValues: RestConfig = {};
 
 /**
  * Creates a client to communicate with the Directus REST API.
@@ -21,7 +19,9 @@ export const rest = (config: Partial<RestConfig> = {}) => {
 				const options = getOptions();
 
 				// all api requests require this content type
-				if (!options.headers) options.headers = {};
+				if (!options.headers) {
+					options.headers = {};
+				}
 
 				if ('Content-Type' in options.headers === false) {
 					options.headers['Content-Type'] = 'application/json';
@@ -45,8 +45,11 @@ export const rest = (config: Partial<RestConfig> = {}) => {
 				let fetchOptions: RequestInit = {
 					method: options.method ?? 'GET',
 					headers: options.headers ?? {},
-					credentials: restConfig.credentials,
 				};
+
+				if ('credentials' in restConfig) {
+					fetchOptions.credentials = restConfig.credentials;
+				}
 
 				if (options.body) {
 					fetchOptions['body'] = options.body;

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -9,7 +9,7 @@ export interface RestClient<Schema extends object> {
 }
 
 export interface RestConfig {
-	credentials: RequestCredentials;
+	credentials?: RequestCredentials;
 	// onError?: (error: any) => any;
 	onRequest?: RequestTransformer;
 	onResponse?: ResponseTransformer;


### PR DESCRIPTION
A recent fix added a default value for fetch `credentials` but some edge fetch implementations do not support the `credentials` option resulting in errors.
https://github.com/directus/directus/pull/19354

This improvement removes all the defaulted values for `credentials` and instead only adds it to the fetch options if explicitly defined in the config.

A partial workaround for those running into this:
```js
const client = createDirectus(...)
  .with(rest({
    onRequest: (opts) => {
      delete opts.credentials;
    }
  })
```