### PR TITLE
Add additional system fields to Content Versioning & include preview in promote drawer

### DIFF
--- a/api/src/controllers/versions.ts
+++ b/api/src/controllers/versions.ts
@@ -216,13 +216,7 @@ router.get(
 
 		const current = assign({}, ...saves);
 
-		const fields = Object.keys(current);
-
-		const main = await service.getMainItem(
-			version['collection'],
-			version['item'],
-			fields.length > 0 ? { fields } : undefined
-		);
+		const main = await service.getMainItem(version['collection'], version['item']);
 
 		res.locals['payload'] = { data: { outdated, mainHash, current, main } };
 

--- a/api/src/database/migrations/20230823A-add-content-versioning.ts
+++ b/api/src/database/migrations/20230823A-add-content-versioning.ts
@@ -3,12 +3,15 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
 	await knex.schema.createTable('directus_versions', (table) => {
 		table.uuid('id').primary().notNullable();
+		table.string('key').notNullable();
 		table.string('name').notNullable();
 		table.string('collection', 64).references('collection').inTable('directus_collections').onDelete('CASCADE');
 		table.string('item');
 		table.string('hash').notNullable();
 		table.timestamp('date_created').defaultTo(knex.fn.now());
+		table.timestamp('date_updated').defaultTo(knex.fn.now());
 		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+		table.uuid('user_updated').references('id').inTable('directus_users').onDelete('SET NULL');
 	});
 
 	await knex.schema.alterTable('directus_collections', (table) => {

--- a/api/src/database/system-data/fields/versions.yaml
+++ b/api/src/database/system-data/fields/versions.yaml
@@ -6,6 +6,7 @@ fields:
       - uuid
     readonly: true
     hidden: true
+  - field: key
   - field: name
   - field: collection
   - field: item
@@ -14,6 +15,13 @@ fields:
     special:
       - date-created
       - cast-timestamp
+  - field: date_updated
+    special:
+      - date-updated
+      - cast-timestamp
   - field: user_created
     special:
       - user-created
+  - field: user_updated
+    special:
+      - user-updated

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -128,6 +128,7 @@ export class VersionsService extends ItemsService {
 
 		const mainItem = await this.getMainItem(data['collection'], data['item']);
 
+		data['key'] = data['name'];
 		data['hash'] = objectHash(mainItem);
 
 		return super.createOne(data, opts);

--- a/app/src/composables/use-versions.ts
+++ b/app/src/composables/use-versions.ts
@@ -1,9 +1,14 @@
 import api from '@/api';
+import { usePermissionsStore } from '@/stores/permissions';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { Filter, Query, Version } from '@directus/types';
-import { computed, ref, Ref, unref, watch } from 'vue';
+import { Ref, computed, ref, unref, watch } from 'vue';
 
 export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, primaryKey: Ref<string | null>) {
+	const { hasPermission } = usePermissionsStore();
+
+	const readVersionsAllowed = computed<boolean>(() => hasPermission('directus_versions', 'read'));
+
 	const currentVersion = ref<Version | null>(null);
 	const versions = ref<Version[] | null>(null);
 	const loading = ref(false);
@@ -27,6 +32,7 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 	);
 
 	return {
+		readVersionsAllowed,
 		currentVersion,
 		versions,
 		loading,
@@ -40,6 +46,8 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 	};
 
 	async function getVersions() {
+		if (!readVersionsAllowed.value) return;
+
 		if ((!isSingleton && !primaryKey.value) || primaryKey.value === '+') return;
 
 		loading.value = true;

--- a/app/src/composables/use-versions.ts
+++ b/app/src/composables/use-versions.ts
@@ -80,12 +80,10 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 		}
 	}
 
-	async function addVersion(version: Version, switchToVersion: boolean) {
+	async function addVersion(version: Version) {
 		versions.value = [...(versions.value ? versions.value : []), version];
 
-		if (switchToVersion) {
-			currentVersion.value = version;
-		}
+		currentVersion.value = version;
 	}
 
 	async function renameVersion(name: string) {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -112,6 +112,8 @@ save_version: Save Version
 promote_version: Promote Version
 promote_version_disabled: No changes selected
 promote_version_drawer_title: Promote {version} into Main
+promote_version_changes: Changes
+promote_version_preview: Preview
 outdated_notice: >-
   The main item has been updated since this version was created. Please review all the field values below, and confirm
   which version should be used when promoting this version into the main item.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -110,6 +110,7 @@ rename_version: Rename Version
 compare_version: Compare Version
 save_version: Save Version
 promote_version: Promote Version
+promote_version_disabled: No changes selected
 promote_version_drawer_title: Promote {version} into Main
 outdated_notice: >-
   The main item has been updated since this version was created. Please review all the field values below, and confirm

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -104,8 +104,9 @@ suffix: Suffix
 version: Version
 version_name: Version Name
 main_version: Main
+switch_version: Switch Version
+switch_version_copy: Are you sure you want to switch to the "{version}" version?
 create_version: Create Version
-switch_to_version_after_creation: Switch to Version After Creation
 rename_version: Rename Version
 compare_version: Compare Version
 save_version: Save Version

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -74,9 +74,6 @@
 								@keyup.enter="createVersion"
 							/>
 						</div>
-						<div class="field">
-							<v-checkbox v-model="switchToVersion" :label="t('switch_to_version_after_creation')" />
-						</div>
 					</div>
 				</v-card-text>
 
@@ -149,7 +146,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-	add: [version: Version, switchToVersion: boolean];
+	add: [version: Version];
 	rename: [name: string];
 	delete: [];
 	switch: [version: Version | null];
@@ -162,7 +159,6 @@ const { hasPermission } = usePermissionsStore();
 const { collection, primaryKey, currentVersion } = toRefs(props);
 
 const newVersionName = ref<string | null>(null);
-const switchToVersion = ref(true);
 const isVersionPromoteDrawerOpen = ref(false);
 
 const createVersionsAllowed = computed<boolean>(() => hasPermission('directus_versions', 'create'));
@@ -199,7 +195,7 @@ function useCreateDialog() {
 				item: unref(primaryKey),
 			});
 
-			emit('add', version, unref(switchToVersion));
+			emit('add', version);
 
 			closeCreateDialog();
 		} catch (err: any) {
@@ -212,7 +208,6 @@ function useCreateDialog() {
 	function closeCreateDialog() {
 		createDialogActive.value = false;
 		newVersionName.value = null;
-		switchToVersion.value = true;
 	}
 }
 

--- a/app/src/modules/content/components/version-promote-drawer.vue
+++ b/app/src/modules/content/components/version-promote-drawer.vue
@@ -26,10 +26,8 @@
 					>
 						<v-icon name="looks_one" />
 						<version-promote-field class="field-content" :value="comparedData?.main[field.field]" />
-						<template v-if="!selectedFields.includes(field.field)">
-							<v-chip class="version" x-small>{{ t('main_version') }}</v-chip>
-							<v-icon name="check" />
-						</template>
+						<v-chip class="version" x-small>{{ t('main_version') }}</v-chip>
+						<v-icon :name="!selectedFields.includes(field.field) ? 'check' : 'close'" />
 					</div>
 					<div
 						class="compare current"
@@ -38,10 +36,8 @@
 					>
 						<v-icon name="looks_two" />
 						<version-promote-field class="field-content" :value="comparedData?.current[field.field]" />
-						<template v-if="selectedFields.includes(field.field)">
-							<v-chip class="version" x-small>{{ currentVersion.name }}</v-chip>
-							<v-icon name="check" />
-						</template>
+						<v-chip class="version" x-small>{{ currentVersion.name }}</v-chip>
+						<v-icon :name="selectedFields.includes(field.field) ? 'check' : 'close'" />
 					</div>
 				</div>
 			</div>

--- a/app/src/modules/content/components/version-promote-drawer.vue
+++ b/app/src/modules/content/components/version-promote-drawer.vue
@@ -48,7 +48,14 @@
 		</div>
 
 		<template #actions>
-			<v-button v-tooltip.bottom="t('promote_version')" :loading="promoting" icon rounded @click="promote">
+			<v-button
+				v-tooltip.bottom="selectedFields.length === 0 ? t('promote_version_disabled') : t('promote_version')"
+				:loading="promoting"
+				:disabled="selectedFields.length === 0"
+				icon
+				rounded
+				@click="promote"
+			>
 				<v-icon name="check" />
 			</v-button>
 		</template>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -68,6 +68,7 @@
 				"
 				:collection="collection"
 				:primary-key="internalPrimaryKey"
+				:has-edits="hasEdits"
 				:current-version="currentVersion"
 				:versions="versions"
 				@add="addVersion"
@@ -446,6 +447,10 @@ const disabledOptions = computed(() => {
 	if (!createAllowed.value) return ['save-and-add-new', 'save-as-copy'];
 	if (isNew.value) return ['save-as-copy'];
 	return [];
+});
+
+watch(currentVersion, () => {
+	edits.value = {};
 });
 
 const previewTemplate = computed(() => collectionInfo.value?.meta?.preview_url ?? '');

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -291,7 +291,6 @@ import { usePermissions } from '@/composables/use-permissions';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
-import { usePermissionsStore } from '@/stores/permissions';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
@@ -321,7 +320,6 @@ const props = withDefaults(defineProps<Props>(), {
 const { t, te } = useI18n();
 
 const router = useRouter();
-const { hasPermission } = usePermissionsStore();
 
 const form = ref<HTMLElement>();
 
@@ -332,9 +330,8 @@ const revisionsDrawerDetailRef = ref<InstanceType<typeof RevisionsDrawerDetail> 
 
 const { info: collectionInfo, defaults, primaryKeyField, isSingleton, accountabilityScope } = useCollection(collection);
 
-const readVersionsAllowed = computed<boolean>(() => hasPermission('directus_versions', 'read'));
-
 const {
+	readVersionsAllowed,
 	currentVersion,
 	versions,
 	loading: versionsLoading,


### PR DESCRIPTION
- Add additional fields to `directus_versions` (`key` will replace `name` in terms of being used as the query parameter value in a follow up PR)
- Add tabs to promote-version-drawer to show the changes and also preview the changes
- Remove "Switch to Version" checkbox in favor of auto redirect
- Check `directus_versions` read permission before fetching versions
- Check for edits before discarding the edits and switch to the target version