### PR TITLE
Set payload filename on upload even if primaryKey exists.

### DIFF
--- a/.changeset/lemon-walls-sort.md
+++ b/.changeset/lemon-walls-sort.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Updated asset file name after replacing it

--- a/.changeset/lemon-walls-sort.md
+++ b/.changeset/lemon-walls-sort.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Updated asset file name after replacing it
+Fixed updating filename and file-extension after replacing asset

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -92,9 +92,9 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 			if (!payload.title) {
 				payload.title = formatTitle(path.parse(filename).name);
 			}
-
-			payload.filename_download = filename;
 		}
+
+		payload.filename_download = filename;
 
 		const payloadWithRequiredFields = {
 			...payload,

--- a/contributors.yml
+++ b/contributors.yml
@@ -72,3 +72,4 @@
 - thame
 - christianrr
 - jeremyzilar
+- 0x2aff

--- a/contributors.yml
+++ b/contributors.yml
@@ -72,4 +72,4 @@
 - thame
 - christianrr
 - jeremyzilar
-- 0x2aff
+- '0x2aff'


### PR DESCRIPTION
Should fix #19657 

The multipart handler on file upload only sets the payload filename if we upload new file.
If we always add the filename to the payload we always update the file extension on disk and download-filename.