### PR TITLE
Add missing null-check for user-role in user-popover-component.

### DIFF
--- a/.changeset/sharp-lemons-admire.md
+++ b/.changeset/sharp-lemons-admire.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Resolve issue rendering the user-popover for users without a role.

--- a/.changeset/sharp-lemons-admire.md
+++ b/.changeset/sharp-lemons-admire.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Resolve issue rendering the user-popover for users without a role.
+Fixed rendering the user-popover for users without a role

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -22,7 +22,7 @@
 			</v-avatar>
 			<div class="data">
 				<div class="name type-title">{{ userName(data) }}</div>
-				<div class="status-role" :class="data!.status">{{ t(data.status) }} {{ data.role?.name }}</div>
+				<div class="status-role" :class="data.status">{{ t(data.status) }} {{ data.role?.name }}</div>
 				<div class="email">{{ data.email }}</div>
 			</div>
 		</div>

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -22,7 +22,7 @@
 			</v-avatar>
 			<div class="data">
 				<div class="name type-title">{{ userName(data) }}</div>
-				<div class="status-role" :class="data!.status">{{ t(data.status) }} {{ data.role.name }}</div>
+				<div class="status-role" :class="data!.status">{{ t(data.status) }} {{ data.role?.name }}</div>
 				<div class="email">{{ data.email }}</div>
 			</div>
 		</div>

--- a/contributors.yml
+++ b/contributors.yml
@@ -72,3 +72,4 @@
 - thame
 - christianrr
 - jeremyzilar
+- '0x2aff'


### PR DESCRIPTION
Should fix #19773 

The user-popover component is missing a null-check for the Directus user role. Hovering over the display of a user without a role will lead to the rendering problem described in the issue.

Just added the null-check. If the user has no active role this means that the popover will only show the active status without role. 

Maybe it would be better to add the information that the user has no active role?

With role:
![image](https://github.com/directus/directus/assets/9035310/d1513f28-0e7b-4fc1-88b4-95db125d5d9a)

Without role:
![image](https://github.com/directus/directus/assets/9035310/5e4b11b6-221a-46cb-89af-d0c1d822ed10)

