### PR TITLE
SDK Extra JSON Mime-Type

### DIFF
--- a/.changeset/cold-terms-march.md
+++ b/.changeset/cold-terms-march.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Added an extra JSON Mime-Type check to the SDK response parsing

--- a/sdk/src/utils/extract-data.ts
+++ b/sdk/src/utils/extract-data.ts
@@ -6,7 +6,7 @@
 export async function extractData(response: Response) {
 	const type = response.headers.get('Content-Type')?.toLowerCase();
 
-	if (type?.startsWith('application/json')) {
+	if (type?.startsWith('application/json') || type?.startsWith('application/health+json')) {
 		const result = await response.json();
 		if (!response.ok) throw result;
 		if ('data' in result) return result.data;


### PR DESCRIPTION
Fixes https://github.com/directus/directus/issues/19776

the `/server/health` endpoint was returning a different mime-type `application/health+json; charset=utf-8` resulting in its response not getting parsed. I've added a check for this variation.
