### PR TITLE
Pass file-id down so that FilesService can replace asset upon URL import

### DIFF
--- a/.changeset/rare-tools-clap.md
+++ b/.changeset/rare-tools-clap.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+---
+
+Fixed replacing an asset by importing via URL

--- a/.changeset/rare-tools-clap.md
+++ b/.changeset/rare-tools-clap.md
@@ -3,4 +3,4 @@
 "@directus/api": patch
 ---
 
-Fixed replacing an asset by importing via URL
+Fixed replacing an asset when importing a file via URL

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -298,7 +298,7 @@ export class FilesService extends ItemsService {
 			...(body || {}),
 		};
 
-		return await this.uploadOne(decompressResponse(fileResponse.data, fileResponse.headers), payload);
+		return await this.uploadOne(decompressResponse(fileResponse.data, fileResponse.headers), payload, payload.id);
 	}
 
 	/**

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -302,6 +302,7 @@ function useURLImport() {
 				url: url.value,
 				data: {
 					folder: props.folder,
+					id: props.fileId,
 				},
 			});
 


### PR DESCRIPTION
fix #19785

## Before

[Screencast from 25.09.2023 11:03:59.webm](https://github.com/directus/directus/assets/14810858/5f6144c2-ca66-4da0-81d1-5ea5b8365caa)

## After

[Screencast from 25.09.2023 12:29:01.webm](https://github.com/directus/directus/assets/14810858/b53b5469-add9-4623-b051-96634dce1352)
