### PR TITLE
SDK Fixes serverPing output type

### DIFF
--- a/.changeset/smooth-games-hunt.md
+++ b/.changeset/smooth-games-hunt.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Removed invalid type constraint on the SDK client request function

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -5,7 +5,7 @@ export interface RestCommand<_Output extends object | unknown, _Schema extends o
 }
 
 export interface RestClient<Schema extends object> {
-	request<Output extends object>(options: RestCommand<Output, Schema>): Promise<Output>;
+	request<Output>(options: RestCommand<Output, Schema>): Promise<Output>;
 }
 
 export interface RestConfig {


### PR DESCRIPTION
Fixes #19775

An `extends object` sneaked in on the `Output` type of `client.request` resulting in `object` being the minimum fallback while the output may be anything from `void` to `string` to json payload.