### PR TITLE
SDK Fixes websocket subscription output typing

### DIFF
--- a/.changeset/polite-pears-exercise.md
+++ b/.changeset/polite-pears-exercise.md
@@ -2,4 +2,4 @@
 "@directus/sdk": patch
 ---
 
-Fixes websocket subscription output typing in the SDK
+Fixed WebSocket subscription output typing in the SDK

--- a/.changeset/polite-pears-exercise.md
+++ b/.changeset/polite-pears-exercise.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixes websocket subscription output typing in the SDK

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -226,7 +226,7 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				socket?.send(JSON.stringify(message));
 			},
-			async subscribe<Collection extends keyof Schema, Options extends SubscribeOptions<Schema, Collection>>(
+			async subscribe<Collection extends keyof Schema, const Options extends SubscribeOptions<Schema, Collection>>(
 				collection: Collection,
 				options = {} as Options
 			) {

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -34,7 +34,7 @@ export interface WebSocketClient<Schema extends object> {
 	onWebSocket(event: 'message', callback: (this: WebSocket, ev: any) => any): RemoveEventHandler;
 	onWebSocket(event: WebSocketEvents, callback: WebSocketEventHandler): RemoveEventHandler;
 	sendMessage(message: string | Record<string, any>): void;
-	subscribe<Collection extends keyof Schema, Options extends SubscribeOptions<Schema, Collection>>(
+	subscribe<Collection extends keyof Schema, const Options extends SubscribeOptions<Schema, Collection>>(
 		collection: Collection,
 		options?: Options
 	): Promise<{
@@ -64,9 +64,12 @@ export type SubscriptionOutput<
 	TItem = TQuery extends Query<Schema, Schema[Collection]>
 		? ApplyQueryFields<Schema, CollectionType<Schema, Collection>, TQuery['fields']>
 		: Partial<Schema[Collection]>
-> = { type: 'subscription' } & {
-	[Event in Events]: SubscriptionPayload<TItem>[Event];
-}[Events];
+> = { type: 'subscription'; uid?: string } & (
+	| {
+			[Event in Events]: { event: Event; data: SubscriptionPayload<TItem>[Event] };
+	  }[Events]
+	| { event: 'error'; error: { code: string; message: string } }
+);
 
 export type SubscriptionPayload<Item> = {
 	init: Item[];


### PR DESCRIPTION
Fixes #19538 

Fixes output types for websocket subscriptions in the SDK.
This adds both the missing `init` and `error` message payloads to the output typing.
