### PR TITLE
Fix format of stored field conditions value

### DIFF
--- a/.changeset/fast-ways-approve.md
+++ b/.changeset/fast-ways-approve.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed the format of the stored field conditions value

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -22,7 +22,7 @@ const interfaceId = computed(() => field.value.meta?.interface ?? null);
 
 const conditionsSync = computed({
 	get() {
-		return conditions.value;
+		return { conditions: conditions.value };
 	},
 	set(value) {
 		if (!value.conditions || value.conditions.length === 0) {
@@ -37,7 +37,7 @@ const conditionsSync = computed({
 			return condition;
 		});
 
-		conditions.value = { conditions: conditionsWithDefaults };
+		conditions.value = conditionsWithDefaults;
 	},
 });
 


### PR DESCRIPTION
Fixes #19757

Regression introduced with #19639:

`v-form` requires the conditions value to be passed in form of `{ conditions }`.
But instead of retrieving it that way in the getter, it was incorrectly stored in this form. 
The form of the stored value shouldn't be changed as otherwise the conditions have no effect.

## Review Guide

1. Verify the interface in the "Conditions" tab of Field configuration works as expected, i.e. values can be saved and displayed again
2. Verify the conditions take effect when editing a corresponding item