### PR TITLE
Export: Fix empty file when limit is `-1`

### DIFF
--- a/.changeset/nasty-mirrors-kiss.md
+++ b/.changeset/nasty-mirrors-kiss.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed export empty file when limit is `-1`

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -239,7 +239,7 @@ export class ExportService {
 					})
 					.then((result) => Number(result?.[0]?.['count'] ?? 0));
 
-				const count = query.limit ? Math.min(totalCount, query.limit) : totalCount;
+				const count = query.limit && query.limit > -1 ? Math.min(totalCount, query.limit) : totalCount;
 
 				const requestedLimit = query.limit ?? -1;
 				const batchesRequired = Math.ceil(count / env['EXPORT_BATCH_SIZE']);


### PR DESCRIPTION
# Motivation
When trying to export data from a collection into File Library and if limit is `-1`, it would generate an empty file.
Although it is expected to return all data, since that's the behaviour on API:
https://docs.directus.io/reference/query.html#limit

# Solution
In order to fix this we check if the `limit` provided is greater or equal than 0 (zero):
  - If is, then return the amount of records mentioned on `limit` (if `limit` is 0, then an empty file will be generated)
  - If not, means it's a negative number, then will return all records
