### PR TITLE
Fix loading of FullCalendar language

### DIFF
--- a/.changeset/pink-scissors-return.md
+++ b/.changeset/pink-scissors-return.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed loading of region-specific languages for calendar layout

--- a/app/src/utils/get-fullcalendar-locale.ts
+++ b/app/src/utils/get-fullcalendar-locale.ts
@@ -21,7 +21,7 @@ export async function getFullcalendarLocale(lang: string): Promise<LocaleInput> 
 }
 
 export function importCalendarLocale(locale: string): Promise<any> {
-	switch (locale) {
+	switch (locale.toLowerCase()) {
 		case 'af':
 			return import('@fullcalendar/core/locales/af');
 		case 'ar-dz':


### PR DESCRIPTION
browser's locales are such as en-US,zh-CN. It should change to lowercase
[The fullcalendar locale doesn't change with system's default language #19823](https://github.com/directus/directus/issues/19823)
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->
