### PR TITLE
Enabled capitzalized table names for sequence reset

### DIFF
--- a/.changeset/silver-cars-hear.md
+++ b/.changeset/silver-cars-hear.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Fixed automatic sequence reset for capitalized table names in PostgresQL

--- a/.changeset/silver-cars-hear.md
+++ b/.changeset/silver-cars-hear.md
@@ -2,4 +2,4 @@
 '@directus/api': minor
 ---
 
-Fixed automatic sequence reset for capitalized table names in PostgresQL
+Fixed automatic sequence reset for capitalized table names in PostgreSQL

--- a/api/src/database/helpers/sequence/dialects/postgres.ts
+++ b/api/src/database/helpers/sequence/dialects/postgres.ts
@@ -5,10 +5,14 @@ export class AutoIncrementHelperPostgres extends AutoSequenceHelper {
 	/**
 	 * Resets the auto increment sequence based on the max value of the PK column.
 	 * The sequence name is determined using a sub query.
+	 *
+	 * The table name value for getting the sequence name needed to be escaped explicitly,
+	 * otherwise PostgreSQL would throw an error for capitalized table names saying "relation x does not exist".
 	 */
 	override async resetAutoIncrementSequence(table: string, column: string): Promise<Knex.Raw | void> {
 		return await this.knex.raw(
-			`WITH sequence_infos AS (SELECT pg_get_serial_sequence('"${table}"', '${column}') AS seq_name, MAX("${column}") as max_val FROM "${table}") SELECT SETVAL(seq_name, max_val) FROM sequence_infos;`
+			`WITH sequence_infos AS (SELECT pg_get_serial_sequence(?, ?) AS seq_name, MAX(??) as max_val FROM ??) SELECT SETVAL(seq_name, max_val) FROM sequence_infos;`,
+			[`"${table}"`, column, column, table]
 		);
 	}
 }

--- a/api/src/database/helpers/sequence/dialects/postgres.ts
+++ b/api/src/database/helpers/sequence/dialects/postgres.ts
@@ -6,7 +6,7 @@ export class AutoIncrementHelperPostgres extends AutoSequenceHelper {
 	 * Resets the auto increment sequence based on the max value of the PK column.
 	 * The sequence name is determined using a sub query.
 	 *
-	 * The table name value for getting the sequence name needed to be escaped explicitly,
+	 * The table name value for getting the sequence name needs to be escaped explicitly,
 	 * otherwise PostgreSQL would throw an error for capitalized table names saying "relation x does not exist".
 	 */
 	override async resetAutoIncrementSequence(table: string, column: string): Promise<Knex.Raw | void> {

--- a/api/src/database/helpers/sequence/dialects/postgres.ts
+++ b/api/src/database/helpers/sequence/dialects/postgres.ts
@@ -8,7 +8,7 @@ export class AutoIncrementHelperPostgres extends AutoSequenceHelper {
 	 */
 	override async resetAutoIncrementSequence(table: string, column: string): Promise<Knex.Raw | void> {
 		return await this.knex.raw(
-			`WITH sequence_infos AS (SELECT pg_get_serial_sequence('"${table}"', '${column}') AS seq_name, MAX("${column}") as max_val FROM "${table})" SELECT SETVAL(seq_name, max_val) FROM sequence_infos;`
+			`WITH sequence_infos AS (SELECT pg_get_serial_sequence('"${table}"', '${column}') AS seq_name, MAX("${column}") as max_val FROM "${table}") SELECT SETVAL(seq_name, max_val) FROM sequence_infos;`
 		);
 	}
 }

--- a/api/src/database/helpers/sequence/dialects/postgres.ts
+++ b/api/src/database/helpers/sequence/dialects/postgres.ts
@@ -3,12 +3,12 @@ import { AutoSequenceHelper } from '../types.js';
 
 export class AutoIncrementHelperPostgres extends AutoSequenceHelper {
 	/**
-	 * Resets the auto increment sequence for a table based on the max value of the PK column.
-	 * The sequence name of determined using a sub query.
+	 * Resets the auto increment sequence based on the max value of the PK column.
+	 * The sequence name is determined using a sub query.
 	 */
 	override async resetAutoIncrementSequence(table: string, column: string): Promise<Knex.Raw | void> {
 		return await this.knex.raw(
-			`WITH sequence_infos AS (SELECT pg_get_serial_sequence('${table}', '${column}') AS seq_name, MAX(${column}) as max_val FROM ${table}) SELECT SETVAL(seq_name, max_val) FROM sequence_infos;`
+			`WITH sequence_infos AS (SELECT pg_get_serial_sequence('"${table}"', '${column}') AS seq_name, MAX("${column}") as max_val FROM "${table})" SELECT SETVAL(seq_name, max_val) FROM sequence_infos;`
 		);
 	}
 }


### PR DESCRIPTION
Closes https://github.com/directus/directus/issues/19817 

When looking up the auto increment sequence name for a table which is capitalized, PostgreSQL throwed an error saying `relation xy does not exist`. The table name needed explicit quotes, otherwise PostgreSQL used a lowercase variant of the table name automatically and couldn't resolve some (internal) relationship (I guess).

So the table name for the `pg_get_serial_sequence` function call, which need to be passed as string, needed to be escaped.
 
In addition of just escaping the value to the `pg_get_serial_sequence`, now all the values get passed as parameters to the database (using Knex's `?`) and all  identifiers now get escaped via Knex using `??`.

This is an example of how the statement now looks:
```sql
WITH sequence_infos AS (SELECT pg_get_serial_sequence($1, $2) AS seq_name, MAX("id") as max_val FROM "articles") SELECT SETVAL(seq_name, max_val) FROM sequence_infos; ["articles", id]
```
I also tested with a capitalized column name, but this worked fine without the explicit double quotes like it was needed for the table name.