### PR TITLE
Continue termination when WebSocket is disabled

### DIFF
--- a/.changeset/lucky-gorillas-cross.md
+++ b/.changeset/lucky-gorillas-cross.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Improved WebSockets initialization handling, fixing termination during server shutdown

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -121,7 +121,14 @@ export async function createServer(): Promise<http.Server> {
 
 	async function onSignal() {
 		getSubscriptionController()?.terminate();
-		getWebSocketController()?.terminate();
+
+		try {
+			const websocketController = getWebSocketController();
+			websocketController.terminate();
+		} catch {
+			// WebSocket is disabled, its termination can be skipped
+		}
+
 		const database = getDatabase();
 		await database.destroy();
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -121,13 +121,7 @@ export async function createServer(): Promise<http.Server> {
 
 	async function onSignal() {
 		getSubscriptionController()?.terminate();
-
-		try {
-			const websocketController = getWebSocketController();
-			websocketController.terminate();
-		} catch {
-			// WebSocket is disabled, its termination can be skipped
-		}
+		getWebSocketController()?.terminate();
 
 		const database = getDatabase();
 		await database.destroy();

--- a/api/src/services/websocket.test.ts
+++ b/api/src/services/websocket.test.ts
@@ -7,6 +7,20 @@ import { WebSocketService } from './websocket.js';
 vi.mock('../emitter');
 vi.mock('../websocket/controllers/index');
 
+vi.mock('../env', async () => {
+	const actual = (await vi.importActual('../env')) as { default: Record<string, any> };
+
+	const MOCK_ENV = {
+		...actual.default,
+		WEBSOCKETS_ENABLED: true,
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: () => MOCK_ENV,
+	};
+});
+
 function mockClient(accountability: Accountability | null = null) {
 	return {
 		on: vi.fn(),

--- a/api/src/services/websocket.ts
+++ b/api/src/services/websocket.ts
@@ -3,13 +3,26 @@ import { getWebSocketController } from '../websocket/controllers/index.js';
 import type { WebSocketController } from '../websocket/controllers/rest.js';
 import type { WebSocketClient } from '../websocket/types.js';
 import type { WebSocketMessage } from '../websocket/messages.js';
+import { ServiceUnavailableError } from '../errors/index.js';
+import { toBoolean } from '../utils/to-boolean.js';
 import emitter from '../emitter.js';
+import env from '../env.js';
 
 export class WebSocketService {
 	private controller: WebSocketController;
 
 	constructor() {
-		this.controller = getWebSocketController();
+		if (!toBoolean(env['WEBSOCKETS_ENABLED']) || !toBoolean(env['WEBSOCKETS_REST_ENABLED'])) {
+			throw new ServiceUnavailableError({ service: 'ws', reason: 'WebSocket server is disabled' });
+		}
+
+		const controller = getWebSocketController();
+
+		if (!controller) {
+			throw new ServiceUnavailableError({ service: 'ws', reason: 'WebSocket server is not initialized' });
+		}
+
+		this.controller = controller;
 	}
 
 	on(event: 'connect' | 'message' | 'error' | 'close', callback: ActionHandler) {

--- a/api/src/websocket/controllers/index.ts
+++ b/api/src/websocket/controllers/index.ts
@@ -1,6 +1,5 @@
 import type { Server as httpServer } from 'http';
 import env from '../../env.js';
-import { ServiceUnavailableError } from '../../errors/index.js';
 import { toBoolean } from '../../utils/to-boolean.js';
 import { GraphQLSubscriptionController } from './graphql.js';
 import { WebSocketController } from './rest.js';
@@ -15,14 +14,6 @@ export function createWebSocketController(server: httpServer) {
 }
 
 export function getWebSocketController() {
-	if (!toBoolean(env['WEBSOCKETS_ENABLED']) || !toBoolean(env['WEBSOCKETS_REST_ENABLED'])) {
-		throw new ServiceUnavailableError({ service: 'ws', reason: 'WebSocket server is disabled' });
-	}
-
-	if (!websocketController) {
-		throw new ServiceUnavailableError({ service: 'ws', reason: 'WebSocket server is not initialized' });
-	}
-
 	return websocketController;
 }
 

--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -6,6 +6,7 @@ import { WebSocketController, getWebSocketController } from '../controllers/inde
 import { WebSocketMessage } from '../messages.js';
 import type { WebSocketClient } from '../types.js';
 import { fmtMessage, getMessageType } from '../utils/message.js';
+import { ServiceUnavailableError } from '../../errors/service-unavailable.js';
 
 const HEARTBEAT_FREQUENCY = Number(env['WEBSOCKETS_HEARTBEAT_PERIOD']) * 1000;
 
@@ -14,7 +15,13 @@ export class HeartbeatHandler {
 	private controller: WebSocketController;
 
 	constructor(controller?: WebSocketController) {
-		this.controller = controller ?? getWebSocketController();
+		controller = controller ?? getWebSocketController();
+
+		if (!controller) {
+			throw new ServiceUnavailableError({ service: 'ws', reason: 'WebSocket server is not initialized' });
+		}
+
+		this.controller = controller;
 
 		emitter.onAction('websocket.message', ({ client, message }) => {
 			try {


### PR DESCRIPTION
Fixes #19822

Moves the throwing errors out of the `getWebSocketController()` function into the `WebSocketService` where they were intended to be thrown. Bringing `getWebSocketController()` back in sync with the comparable `getSubscriptionController()` function.