### PR TITLE
Support replacing files in the SDK

### DIFF
--- a/.changeset/tasty-foxes-peel.md
+++ b/.changeset/tasty-foxes-peel.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Adds support for replacing files in the SDK

--- a/.changeset/tasty-foxes-peel.md
+++ b/.changeset/tasty-foxes-peel.md
@@ -2,4 +2,4 @@
 "@directus/sdk": patch
 ---
 
-Adds support for replacing files in the SDK
+Added support for replacing files in the SDK

--- a/sdk/src/rest/commands/update/files.ts
+++ b/sdk/src/rest/commands/update/files.ts
@@ -45,16 +45,18 @@ export const updateFiles =
 export const updateFile =
 	<Schema extends object, const TQuery extends Query<Schema, DirectusFile<Schema>>>(
 		key: DirectusFile<Schema>['id'],
-		item: Partial<DirectusFile<Schema>>,
+		item: Partial<DirectusFile<Schema>> | FormData,
 		query?: TQuery
 	): RestCommand<UpdateFileOutput<Schema, TQuery>, Schema> =>
 	() => {
 		throwIfEmpty(key, 'Key cannot be empty');
 
+		const data = item instanceof FormData ? item : JSON.stringify(item);
+
 		return {
 			path: `/files/${key}`,
 			params: query ?? {},
-			body: JSON.stringify(item),
+			body: data,
 			method: 'PATCH',
 		};
 	};

--- a/sdk/src/rest/commands/update/files.ts
+++ b/sdk/src/rest/commands/update/files.ts
@@ -51,12 +51,20 @@ export const updateFile =
 	() => {
 		throwIfEmpty(key, 'Key cannot be empty');
 
-		const data = item instanceof FormData ? item : JSON.stringify(item);
+		if (item instanceof FormData) {
+			return {
+				path: `/files/${key}`,
+				params: query ?? {},
+				body: item,
+				method: 'PATCH',
+				headers: { 'Content-Type': 'multipart/form-data' },
+			};
+		}
 
 		return {
 			path: `/files/${key}`,
 			params: query ?? {},
-			body: data,
+			body: JSON.stringify(item),
 			method: 'PATCH',
 		};
 	};


### PR DESCRIPTION
Fixes #19821

Adds support for updating file contents using a FormData object.

## Snippet for testing

```ts
import { authentication, createDirectus, rest, updateFile } from '@directus/sdk';

// for node 18
import { createReadStream } from 'node:fs';
import { blob } from 'node:stream/consumers';

const client = createDirectus('http://localhost:8055/')
    .with(authentication('json', {autoRefresh:false})) //staticToken('admin'))
    .with(rest());

await client.login('admin@example.com', 'd1r3ctu5');

const file = await blob(createReadStream("/path/to/test.txt"));

const formData = new FormData();
formData.append('title', 'example-2');
formData.append('file', file, 'test.txt');

console.log(await client.request(updateFile('<file-uuid>', formData)))
```