### PR TITLE
Use comments for embed insertion

### DIFF
--- a/.changeset/shaggy-vans-fry.md
+++ b/.changeset/shaggy-vans-fry.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Use a comment as the replacement token for embeds

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -216,8 +216,8 @@ export default async function createApp(): Promise<express.Application> {
 
 		const htmlWithVars = html
 			.replace(/<base \/>/, `<base href="${adminUrl.toString({ rootRelative: true })}/" />`)
-			.replace(/<embed-head \/>/, embeds.head)
-			.replace(/<embed-body \/>/, embeds.body);
+			.replace('<!-- directus-embed-head -->', embeds.head)
+			.replace('<!-- directus-embed-body -->', embeds.body);
 
 		const sendHtml = (_req: Request, res: Response) => {
 			res.setHeader('Cache-Control', 'no-cache');

--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,7 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<title>Loading&hellip;</title>
 		<style id="custom-css"></style>
-		<embed-head />
+		<!-- directus-embed-head -->
 	</head>
 	<body class="auto">
 		<noscript>
@@ -32,6 +32,6 @@
 		<div id="menu-outlet"></div>
 
 		<script type="module" src="/src/main.ts"></script>
-		<embed-body />
+		<!-- directus-embed-body -->
 	</body>
 </html>


### PR DESCRIPTION
In dev-mode, the elements aren't replaced as SERVE_APP is false. That'd cause the whole app to be wrapped in a non-existing custom element:

![image](https://github.com/directus/directus/assets/9141017/abf5e9d5-4f45-47ea-934a-38ace7130c0f)

Which was due to the fact that we used `<embed-head />` as the token to replace. By switching to a comment, we can prevent that type of weirdness if the embedding fails or isn't available in dev mode. Also switched the replacement from a regex to a string, as it's a known unique comment we're replacing.