### PR TITLE
Docs update: Dynamic variables are not available in flows

### DIFF
--- a/docs/reference/filter-rules.md
+++ b/docs/reference/filter-rules.md
@@ -229,3 +229,9 @@ Note: This feature is available for permissions, validation, presets and conditi
 support the root ID.
 
 :::
+
+::: tip Dynamic Variables not available in Flows
+
+Although certain Operations in Flows use filter rules, dynamic variables are not available in Flows.
+
+:::


### PR DESCRIPTION
Adds a "tip" box to inform users dynamic variables are not available in flows.

# Scope

What's changed:

- Single documentation file (filter-rules.md)

# Review Questions

- Review text casing and wording to make sure it aligns with documentation standards
