### PR TITLE
Fix snippet toggler active state, sync selected value across page

### DIFF
--- a/docs/.vitepress/components/SnippetToggler.vue
+++ b/docs/.vitepress/components/SnippetToggler.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeMount, ref, watch } from 'vue';
+import { useLocalStorage } from '@vueuse/core';
 
 const props = defineProps<{
 	choices: string[];
@@ -7,33 +7,11 @@ const props = defineProps<{
 	alwaysDark?: boolean;
 }>();
 
-const selected = ref();
+const selected = useLocalStorage('toggler-value', props.choices[0]);
 
-const useStorage = (key: string) => {
-	const getStorageValue = () => {
-		return localStorage.getItem(key);
-	};
-
-	const setStorageValue = (value: string) => localStorage.setItem(key, value);
-
-	return { getStorageValue, setStorageValue };
+const changeSelected = (choice: (typeof props.choices)[number]) => {
+	selected.value = choice;
 };
-
-const { getStorageValue, setStorageValue } = useStorage('toggler-value');
-
-onBeforeMount(() => {
-	const value = getStorageValue();
-
-	if (value && props.choices.includes(value)) {
-		selected.value = value;
-	} else {
-		selected.value = props.choices[0];
-	}
-
-	watch(selected, (value) => {
-		setStorageValue(value);
-	});
-});
 </script>
 
 <template>
@@ -45,7 +23,7 @@ onBeforeMount(() => {
 					:key="choice"
 					class="button"
 					:class="{ active: selected == choice }"
-					@click="selected = choice"
+					@click="changeSelected(choice)"
 				>
 					{{ choice }}
 				</button>

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,13 @@ import Badge from './.vitepress/components/Badge.vue'
 
 ```js
 GET /items/products/4?
-	fields[]=id,status,title,category,image.id,image.name
+	fields[]=
+	  id,
+	  status,
+	  title,
+	  category,
+	  image.id,
+	  image.name
 ```
 
 </template>

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,14 +30,13 @@ import Badge from './.vitepress/components/Badge.vue'
 <template #rest>
 
 ```js
-GET /items/products/4?
-	fields[]=
-	  id,
-	  status,
-	  title,
-	  category,
-	  image.id,
-	  image.name
+GET /items/products/4
+	?fields[]=id
+	&fields[]=status
+	&fields[]=title
+	&fields[]=category
+	&fields[]=image.id
+	&fields[]=image.name
 ```
 
 </template>

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
 		"@directus/sdk": "workspace:*",
 		"@directus/tsconfig": "workspace:*",
 		"@types/marked": "5.0.1",
+		"@vueuse/core": "10.1.2",
 		"eslint-parser-plain": "0.1.0",
 		"eslint-plugin-markdown": "3.0.1",
 		"eslint-plugin-prettier": "npm:@paescuj/eslint-plugin-prettier@4.3.0-1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,6 +920,9 @@ importers:
       '@types/marked':
         specifier: 5.0.1
         version: 5.0.1
+      '@vueuse/core':
+        specifier: 10.1.2
+        version: 10.1.2(vue@3.3.4)
       eslint-parser-plain:
         specifier: 0.1.0
         version: 0.1.0


### PR DESCRIPTION
Fixes #19879

## Scope

What's changed:

- Replace custom implementation of local storage sync with vueuse/core to live sync selected value across page
- Use `mounted` lifecycle instead of `beforeMount` to fix initial active state
- Use the height of the largest snippet as persistent height for the snippet toggler to prevent page jumps when selecting different value (when multiple snippet togglers on same page)

## Potential Risks / Drawbacks

- This does change the behavior of the snippet togglers now all being in sync and leaving some visible white space for smaller snippets:

_Before_

https://github.com/directus/directus/assets/9141017/be228bf5-d188-4af2-833d-333d811a69a1

_After_

https://github.com/directus/directus/assets/5363448/a032af22-2e19-4d5f-bbf1-7c22579f3946

However, the white space in smaller snippets is probably preferable over page jumps.

## Review Questions

- Agreed with the drawback opinion? 
