### PR TITLE
add folder prop to v-upload so that import can use it

### DIFF
--- a/.changeset/clever-bobcats-collect.md
+++ b/.changeset/clever-bobcats-collect.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Fixed importing an image via URL into your current folder
+Fixed an issue where importing an image via URL wouldn't place it in the current folder

--- a/.changeset/clever-bobcats-collect.md
+++ b/.changeset/clever-bobcats-collect.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed importing an image via URL into your current folder

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -57,11 +57,10 @@ function useUpload() {
 		uploading.value = true;
 		progress.value = 0;
 
-		const folderPreset: { folder?: string } = {};
-
-		if (props.folder) {
-			folderPreset.folder = props.folder;
-		}
+		const preset = {
+			...props.preset,
+			...(props.folder && { folder: props.folder }),
+		};
 
 		try {
 			if (!validFiles(files)) {
@@ -76,10 +75,7 @@ function useUpload() {
 						progress.value = Math.round(percentage.reduce((acc, cur) => (acc += cur)) / files.length);
 						done.value = percentage.filter((p) => p === 100).length;
 					},
-					preset: {
-						...props.preset,
-						...folderPreset,
-					},
+					preset,
 				});
 
 				uploadedFiles && emit('input', uploadedFiles);
@@ -90,10 +86,7 @@ function useUpload() {
 						done.value = percentage === 100 ? 1 : 0;
 					},
 					fileId: props.fileId,
-					preset: {
-						...props.preset,
-						...folderPreset,
-					},
+					preset,
 				});
 
 				uploadedFile && emit('input', uploadedFile);
@@ -200,13 +193,16 @@ function useURLImport() {
 	async function importFromURL() {
 		loading.value = true;
 
+		const data = {
+			...props.preset,
+			...(props.folder && { folder: props.folder }),
+			id: props.fileId,
+		};
+
 		try {
 			const response = await api.post(`/files/import`, {
 				url: url.value,
-				data: {
-					folder: props.folder,
-					id: props.fileId,
-				},
+				data,
 			});
 
 			emitter.emit(Events.upload);

--- a/app/src/modules/files/routes/add-new.vue
+++ b/app/src/modules/files/routes/add-new.vue
@@ -23,7 +23,13 @@ function close() {
 		<v-card>
 			<v-card-title>{{ t('add_file') }}</v-card-title>
 			<v-card-text>
-				<v-upload :preset="props.folder ? { folder: props.folder } : undefined" multiple from-url @input="close" />
+				<v-upload
+					:preset="props.folder ? { folder: props.folder } : undefined"
+					:folder="props.folder"
+					multiple
+					from-url
+					@input="close"
+				/>
 			</v-card-text>
 			<v-card-actions>
 				<v-button secondary @click="close">{{ t('done') }}</v-button>

--- a/app/src/modules/files/routes/add-new.vue
+++ b/app/src/modules/files/routes/add-new.vue
@@ -23,13 +23,7 @@ function close() {
 		<v-card>
 			<v-card-title>{{ t('add_file') }}</v-card-title>
 			<v-card-text>
-				<v-upload
-					:preset="props.folder ? { folder: props.folder } : undefined"
-					:folder="props.folder"
-					multiple
-					from-url
-					@input="close"
-				/>
+				<v-upload :folder="props.folder" multiple from-url @input="close" />
 			</v-card-text>
 			<v-card-actions>
 				<v-button secondary @click="close">{{ t('done') }}</v-button>


### PR DESCRIPTION
## Scope

What's changed:

- Passed `folder` prop to `v-upload` so upload functions can use it for placing images into the correct folder

## Potential Risks / Drawbacks

- The `preset` prop was used in the `useUpload()` function and `folder` overwrites it like so:

```ts
if (props.folder) {
	folderPreset.folder = props.folder;
}
```

which then affects the `upload` function but that should be _fine_

## Review Questions

- I don't see further implications that this could have, do you?

---

Fixes #19891 
