### PR TITLE
Add unknown to select-dropdown types

### DIFF
--- a/app/src/interfaces/select-dropdown/index.ts
+++ b/app/src/interfaces/select-dropdown/index.ts
@@ -8,7 +8,7 @@ export default defineInterface({
 	description: '$t:interfaces.select-dropdown.description',
 	icon: 'arrow_drop_down_circle',
 	component: InterfaceSelectDropdown,
-	types: ['string', 'integer', 'float', 'bigInteger'],
+	types: ['string', 'integer', 'float', 'bigInteger', 'unknown'],
 	group: 'selection',
 	preview: PreviewSVG,
 	options: ({ field }) => [

--- a/contributors.yml
+++ b/contributors.yml
@@ -75,3 +75,4 @@
 - '0x2aff'
 - Zehir
 - programmarchy
+- ihadabs


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Add unknown to types of `select-dropdown` interface; this will allow the use of the interface for enum fields in Postgres

## Potential Risks / Drawbacks

- This solution will not cover all "unknown" scenarios, so if the underlying db type does not match the value set to it write to db will fail.

## Review Questions

-

---

Fixes https://github.com/directus/directus/discussions/4887#discussioncomment-4103787
