### PR TITLE
Check for non-success status in LDAP

### DIFF
--- a/.changeset/happy-horses-bow.md
+++ b/.changeset/happy-horses-bow.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fix status check on LDAP end event

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -110,7 +110,8 @@ export class LDAPAuthDriver extends AuthDriver {
 
 				res.on('end', (result: LDAPResult | null) => {
 					// Handle edge case where authenticated bind user cannot read their own DN
-					if (result?.status === 0) {
+					// Status `0` is success
+					if (result?.status !== 0) {
 						logger.warn('[LDAP] Failed to find bind user record');
 						reject(new UnexpectedResponseError());
 					}


### PR DESCRIPTION
## Scope

What's changed:

- The LDAP driver erroneously checked for status = success to throw an error on the `end` event. The equality check was flipped to resolve the issue.

## Potential Risks / Drawbacks

- Status `0` is as per the documented LDAP spec. Unless the LDAP driver was not following the spec, this shouldn't cause any new issues or drawbacks for existing users.

## Review Questions

—

---

Fixes #19878