### PR TITLE
Custom first name / last name key for OpenID

### DIFF
--- a/.changeset/healthy-planets-rescue.md
+++ b/.changeset/healthy-planets-rescue.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"docs": patch
+---
+
+Made first/last name keys customizable via environment variable for OpenID providers

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -173,8 +173,8 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 
 		const userPayload = {
 			provider,
-			first_name: userInfo['given_name'],
-			last_name: userInfo['family_name'],
+			first_name: userInfo[(this.config['firstNameKey']) ? this.config['firstNameKey'] : 'given_name'],
+			last_name: userInfo[(this.config['lastNameKey']) ? this.config['lastNameKey'] : 'family_name'],
 			email: email,
 			external_identifier: identifier,
 			role: this.config['defaultRoleId'],

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -173,8 +173,8 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 
 		const userPayload = {
 			provider,
-			first_name: userInfo[(this.config['firstNameKey']) ? this.config['firstNameKey'] : 'given_name'],
-			last_name: userInfo[(this.config['lastNameKey']) ? this.config['lastNameKey'] : 'family_name'],
+			first_name: userInfo[this.config['firstNameKey'] ?? 'given_name'],
+			last_name: userInfo[this.config['lastNameKey'] ?? 'family_name'],
 			email: email,
 			external_identifier: identifier,
 			role: this.config['defaultRoleId'],

--- a/contributors.yml
+++ b/contributors.yml
@@ -75,3 +75,4 @@
 - '0x2aff'
 - Zehir
 - programmarchy
+- xxsuperdreamxx

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -764,6 +764,8 @@ OpenID is an authentication protocol built on OAuth 2.0, and should be preferred
 | `AUTH_<PROVIDER>_SCOPE`                     | A white-space separated list of permissions to request.                                           | `openid profile email` |
 | `AUTH_<PROVIDER>_ISSUER_URL`                | OpenID `.well-known` discovery document URL of the external service.                              | --                     |
 | `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>.                                                       | `sub`<sup>[2]</sup>    |
+| `AUTH_<PROVIDER>_FIRST_NAME_KEY`            | User profile first name key.                                                                      | `given_name`      	   |
+| `AUTH_<PROVIDER>_LAST_NAME_KEY`             | User profile last name key.                                                                       | `family_name`          |
 | `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users.                                           | `false`                |
 | `AUTH_<PROVIDER>_REQUIRE_VERIFIED_EMAIL`    | Require created users to have a verified email address.                                           | `false`                |
 | `AUTH_<PROVIDER>_DEFAULT_ROLE_ID`           | A Directus role ID to assign created users.                                                       | --                     |

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -764,7 +764,7 @@ OpenID is an authentication protocol built on OAuth 2.0, and should be preferred
 | `AUTH_<PROVIDER>_SCOPE`                     | A white-space separated list of permissions to request.                                           | `openid profile email` |
 | `AUTH_<PROVIDER>_ISSUER_URL`                | OpenID `.well-known` discovery document URL of the external service.                              | --                     |
 | `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>.                                                       | `sub`<sup>[2]</sup>    |
-| `AUTH_<PROVIDER>_FIRST_NAME_KEY`            | User profile first name key.                                                                      | `given_name`      	   |
+| `AUTH_<PROVIDER>_FIRST_NAME_KEY`            | User profile first name key.                                                                      | `given_name`           |
 | `AUTH_<PROVIDER>_LAST_NAME_KEY`             | User profile last name key.                                                                       | `family_name`          |
 | `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users.                                           | `false`                |
 | `AUTH_<PROVIDER>_REQUIRE_VERIFIED_EMAIL`    | Require created users to have a verified email address.                                           | `false`                |


### PR DESCRIPTION
#19827

Adding the ability to use a dynamic First and Last name for OpenID providers