### PR TITLE
Fix multiple constraints to users system table from versions system table for MSSQL

### DIFF
--- a/api/src/database/migrations/20230823A-add-content-versioning.ts
+++ b/api/src/database/migrations/20230823A-add-content-versioning.ts
@@ -18,7 +18,7 @@ export async function up(knex: Knex): Promise<void> {
 		table.timestamp('date_created').defaultTo(knex.fn.now());
 		table.timestamp('date_updated').defaultTo(knex.fn.now());
 		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-		table.uuid('user_updated').references('id').inTable('directus_users').onDelete('SET NULL');
+		table.uuid('user_updated').references('id').inTable('directus_users');
 	});
 
 	await knex.schema.alterTable('directus_collections', (table) => {

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -65,6 +65,9 @@ describe('Integration Tests', () => {
 
 		// mock notifications update query in deleteOne/deleteMany/deleteByQuery methods
 		tracker.on.update('directus_notifications').response({});
+
+		// mock versions update query in deleteOne/deleteMany/deleteByQuery methods
+		tracker.on.update('directus_versions').response({});
 	});
 
 	afterEach(() => {

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -331,6 +331,7 @@ export class UsersService extends ItemsService {
 		}
 
 		await this.knex('directus_notifications').update({ sender: null }).whereIn('sender', keys);
+		await this.knex('directus_versions').update({ user_updated: null }).whereIn('user_updated', keys);
 
 		await super.deleteMany(keys, opts);
 		return keys;


### PR DESCRIPTION
## Reasoning

The blackbox tests caught an issue with `directus_versions` multiple constraints to `directus_users` as seen in: https://github.com/directus/directus/actions/runs/6411018799/job/17405562932#step:8:266

This is because as mentioned in (line 9):

https://github.com/directus/directus/blob/d43ecb20a26ccce64b3e08cbc4f0ea779da026ac/api/src/database/migrations/20210519A-add-system-fk-triggers.ts#L5-L13

We can't have two constraints form/to the same table (although other DBs don't explicitly throw error right away), especially MSSQL which would throw error stating that it may cause cycles or multiple cascade paths.

I believe this is also why when `directus_notifications` was added, although `recipient` and `sender` are both referencing `directus_users`, `sender` intentionally doesn't have `.onDelete()`:

https://github.com/directus/directus/blob/d43ecb20a26ccce64b3e08cbc4f0ea779da026ac/api/src/database/migrations/20211118A-add-notifications.ts#L8-L9

This is because it was later on (presumably) fixed in https://github.com/directus/directus/commit/a7126f7021a9d166d29ceacb9d33046e4d422480, which opts to update the `sender` field within the users service:

https://github.com/directus/directus/blob/d43ecb20a26ccce64b3e08cbc4f0ea779da026ac/api/src/services/users.ts#L333

to prevent this exact issue.

This PR opts to use the same approach and update `directus_versioning`'s `user_updated` using the same solution.



## Scope

What's changed:

- `directus_versions` system table's `user_updated` field now no longer have `ON DELETE SET NULL` constraint
- Opted to update said field within Users service instead

## Potential Risks / Drawbacks

- Unfortunately we have to handle this in the API (Users service)

## Review Questions

N/A

