### PR TITLE
Re-add description for relational table headers

### DIFF
--- a/.changeset/quick-toes-remember.md
+++ b/.changeset/quick-toes-remember.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the dot tooltip within table headers of relational fields to be shown again

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -230,7 +230,19 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			const tableHeaders = computed<HeaderRaw[]>({
 				get() {
 					return activeFields.value.map((field) => {
-						const description: string | null = null;
+						let description: string | null = null;
+
+						const fieldParts = field.key.split('.');
+
+						if (fieldParts.length > 1) {
+							const fieldNames = fieldParts.map((fieldKey, index) => {
+								const pathPrefix = fieldParts.slice(0, index);
+								const field = fieldsStore.getField(collection.value!, [...pathPrefix, fieldKey].join('.'));
+								return field?.name ?? fieldKey;
+							});
+
+							description = fieldNames.join(' -> ');
+						}
 
 						return {
 							text: field.name,


### PR DESCRIPTION
## Overview

As described by #19849, relational fields' table header used to show a dot with a tooltip such as `collection_a -> id`, however it is no longer visible now.

The dot displays the value of the header's `description`:

https://github.com/directus/directus/blob/7048f0710616a8f99fea033124ce6752e459a176/app/src/components/v-table/table-header.vue#L238

However currently `description` is always initialized as `null` before being returned, hence it never appears anymore for relational fields:

https://github.com/directus/directus/blob/7048f0710616a8f99fea033124ce6752e459a176/app/src/layouts/tabular/index.ts#L233-L238

Looking back at https://github.com/directus/directus/pull/18186#issuecomment-1514639289, I believe the code related to `description` was removed in this commit https://github.com/directus/directus/pull/18186/commits/ca8f8d5fb5398006c6a7abe8973c6f5a84a6890a#diff-e14f33e4cb8983288068d36c875f2699625d6883475c1c22a30030217769d51cL224-L233 when it was originally meant to only remove the workaround for translations.

This PR is technically a minor/partial revert of said commit to ensure `description` once again gets updated for relational fields.

### Before

The dot is missing for `id` in the O2M collection `B`:

![](https://github.com/directus/directus/assets/42867097/7fe9ce46-c8a0-40c0-947b-afa03ce97a3d)

### After

![](https://github.com/directus/directus/assets/42867097/980b5986-852a-4bc3-b5d6-ccad7be06d67)

## Scope

What's changed:

- updates `description` if it is a relational field

## Potential Risks / Drawbacks

- Presumably not risky as this is technically a partial revert

## Review Questions

No questions at the moment

---

Fixes #19849
