### PR TITLE
Change csv db type to text

### DIFF
--- a/.changeset/gold-colts-trade.md
+++ b/.changeset/gold-colts-trade.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where CSV fields defaulted to a maximum length of 255 characters

--- a/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
+++ b/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
@@ -4,8 +4,10 @@ import { getHelpers } from '../helpers/index.js';
 export async function up(knex: Knex): Promise<void> {
 	const helper = getHelpers(knex).schema;
 	const csvFields = await knex.select('collection', 'field').from('directus_fields').where('special', '=', 'cast-csv');
+
 	for (const entry of csvFields) {
 		const { defaultValue, nullable } = await knex(entry.collection).columnInfo(entry.field);
+
 		await helper.changeToType(entry.collection, entry.field, 'text', {
 			default: defaultValue,
 			nullable,
@@ -16,8 +18,10 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
 	const helper = getHelpers(knex).schema;
 	const csvFields = await knex.select('collection', 'field').from('directus_fields').where('special', '=', 'cast-csv');
+
 	for (const entry of csvFields) {
 		const { defaultValue, nullable } = await knex(entry.collection).columnInfo(entry.field);
+
 		await helper.changeToType(entry.collection, entry.field, 'string', {
 			default: defaultValue,
 			nullable,

--- a/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
+++ b/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
@@ -1,0 +1,26 @@
+import type { Knex } from 'knex';
+import { getHelpers } from '../helpers/index.js';
+
+export async function up(knex: Knex): Promise<void> {
+	const helper = getHelpers(knex).schema;
+	const csvFields = await knex.select('collection', 'field').from('directus_fields').where('special', '=', 'cast-csv');
+	for (const entry of csvFields) {
+		const { defaultValue, nullable } = await knex(entry.collection).columnInfo(entry.field);
+		await helper.changeToType(entry.collection, entry.field, 'text', {
+			default: defaultValue,
+			nullable,
+		});
+	}
+}
+
+export async function down(knex: Knex): Promise<void> {
+	const helper = getHelpers(knex).schema;
+	const csvFields = await knex.select('collection', 'field').from('directus_fields').where('special', '=', 'cast-csv');
+	for (const entry of csvFields) {
+		const { defaultValue, nullable } = await knex(entry.collection).columnInfo(entry.field);
+		await helper.changeToType(entry.collection, entry.field, 'string', {
+			default: defaultValue,
+			nullable,
+		});
+	}
+}

--- a/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
+++ b/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
@@ -22,7 +22,7 @@ export async function up(knex: Knex) {
 		);
 	}
 
-	return Promise.all(updates);
+	return checkPromises(updates);
 }
 
 export async function down(knex: Knex) {
@@ -43,5 +43,19 @@ export async function down(knex: Knex) {
 		);
 	}
 
-	return Promise.all(updates);
+	return checkPromises(updates);
+}
+
+async function checkPromises<T>(promises: Promise<T>[]) {
+	const result = await Promise.allSettled(promises);
+
+	const errors = result.filter(isRejectedPromise).map((promise) => promise.reason);
+
+	if (errors.length > 0) {
+		throw new Error(errors.toString());
+	}
+}
+
+function isRejectedPromise<T>(promise: PromiseSettledResult<T>): promise is PromiseRejectedResult {
+	return promise.status === 'rejected';
 }

--- a/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
+++ b/api/src/database/migrations/20231009A-update-csv-fields-to-text.ts
@@ -12,6 +12,8 @@ export async function up(knex: Knex) {
 	for (const { collection, field } of csvFields) {
 		updates.push(
 			inspector.columnInfo(collection, field).then((column) => {
+				if (column.data_type === 'text') return;
+
 				return helper.changeToType(collection, field, 'text', {
 					default: column.default_value,
 					nullable: column.is_nullable,

--- a/api/src/database/seeds/run.ts
+++ b/api/src/database/seeds/run.ts
@@ -58,7 +58,7 @@ export default async function runSeed(database: Knex): Promise<void> {
 				} else if (columnInfo.increments) {
 					column = tableBuilder.increments();
 				} else if (columnInfo.type === 'csv') {
-					column = tableBuilder.string(columnName);
+					column = tableBuilder.text(columnName);
 				} else if (columnInfo.type === 'hash') {
 					column = tableBuilder.string(columnName, 255);
 				} else if (columnInfo.type?.startsWith('geometry')) {

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -680,7 +680,7 @@ export class FieldsService {
 			const type = field.type as 'float' | 'decimal';
 			column = table[type](field.field, field.schema?.numeric_precision ?? 10, field.schema?.numeric_scale ?? 5);
 		} else if (field.type === 'csv') {
-			column = table.string(field.field);
+			column = table.text(field.field);
 		} else if (field.type === 'hash') {
 			column = table.string(field.field, 255);
 		} else if (field.type === 'dateTime') {


### PR DESCRIPTION
## Scope

What's changed:

- Changed the database type of our CSV field from string to text so that its not capped to 255 characters

## Potential Risks / Drawbacks

- This'll only affect created columns in the future so we should be good there.
- Should in general fine as its still a string but just persisted differently I think. There are differences as to how database vendors store text but since we use knex it should just work out. We just see a string, so all other operations we do on said string dont change.

## Review Questions

- I included the change for the db seed and did do some global searches to find every mention of CSV to not miss further checks. Seems there are only these two.

## Example

Now you can have huge CSVs, see:

![image](https://github.com/directus/directus/assets/14810858/7669cd52-48a7-4962-8b00-6bd98e8a453b)

And it gets persisted properly in raw:

```json
[
    "asdaadssad",
    "asdaadssadasdaadssadasdaadssad",
    "asdaadssadasdaadssad",
    "asdaadssadasdaadssadasdaadssadasdaadssad",
...
```

And displays work too:

![image](https://github.com/directus/directus/assets/14810858/64d945f5-6e1c-49f8-bee9-1ba9e40817ad)


---

Fixes #19903 
