### PR TITLE
Fix __dirname being undefined

### DIFF
--- a/api/src/extensions/get-shared-deps-mapping.ts
+++ b/api/src/extensions/get-shared-deps-mapping.ts
@@ -5,6 +5,10 @@ import path from 'path';
 import env from '../env.js';
 import logger from '../logger.js';
 import { Url } from '../utils/url.js';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export const getSharedDepsMapping = async (deps: string[]): Promise<Record<string, string>> => {
 	const appDir = await readdir(path.join(resolvePackage('@directus/app', __dirname), 'dist', 'assets'));


### PR DESCRIPTION
Regression from #19922

`__dirname` was not moved with the `getSharedDepsMapping` into a separate folder causing the api to not start up.

## Scope

What's changed:

Redefine `__dirname`

## Potential Risks / Drawbacks
- none

## Review Hints

- You have to enable `SERVE_APP=true` otherwhise `getSharedDepsMapping` gets never called and the api works normally.

---

Fixes #19922
