### PR TITLE
Fix not opening group with conditions

### DIFF
--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -30,11 +30,22 @@ const props = withDefaults(
 	}
 );
 
-defineEmits(['apply']);
+const emit = defineEmits(['apply']);
 
 const { t } = useI18n();
 
 const detailOpen = ref(props.start === 'open');
+
+// In case that conditions change the start prop after the group already got rendered
+// caused by the async loading of data to run the conditions against
+let interacted = false;
+
+watch(
+	() => props.start,
+	(newVal) => {
+		if (!interacted) detailOpen.value = newVal === 'open';
+	}
+);
 
 const edited = computed(() => {
 	if (!props.values) return false;
@@ -75,6 +86,11 @@ watch(validationMessages, (newVal, oldVal) => {
 	if (isEqual(newVal, oldVal)) return;
 	detailOpen.value = validationMessages.value.length > 0;
 });
+
+function onUpdateModelValue(data: any) {
+	interacted = true;
+	emit('apply', data);
+}
 </script>
 
 <template>
@@ -119,7 +135,7 @@ watch(validationMessages, (newVal, oldVal) => {
 			:direction="direction"
 			:show-no-visible-fields="false"
 			:show-validation-errors="false"
-			@update:model-value="$emit('apply', $event)"
+			@update:model-value="onUpdateModelValue"
 		/>
 	</v-detail>
 </template>

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -30,7 +30,7 @@ const props = withDefaults(
 	}
 );
 
-const emit = defineEmits(['apply']);
+defineEmits(['apply']);
 
 const { t } = useI18n();
 
@@ -38,12 +38,10 @@ const detailOpen = ref(props.start === 'open');
 
 // In case that conditions change the start prop after the group already got rendered
 // caused by the async loading of data to run the conditions against
-let interacted = false;
-
 watch(
-	() => props.start,
+	() => props.loading,
 	(newVal) => {
-		if (!interacted) detailOpen.value = newVal === 'open';
+		if (!newVal) detailOpen.value = props.start === 'open';
 	}
 );
 
@@ -86,11 +84,6 @@ watch(validationMessages, (newVal, oldVal) => {
 	if (isEqual(newVal, oldVal)) return;
 	detailOpen.value = validationMessages.value.length > 0;
 });
-
-function onUpdateModelValue(data: any) {
-	interacted = true;
-	emit('apply', data);
-}
 </script>
 
 <template>
@@ -135,7 +128,7 @@ function onUpdateModelValue(data: any) {
 			:direction="direction"
 			:show-no-visible-fields="false"
 			:show-validation-errors="false"
-			@update:model-value="onUpdateModelValue"
+			@update:model-value="$emit('apply', $event)"
 		/>
 	</v-detail>
 </template>


### PR DESCRIPTION
Problem was that, as Rijk already mentioned in the issue, conditions set the `start` prop to `open` after the interface already got rendered causing it to ignore that state. Now `detailOpen` will be set after the values have been loaded in order to account for this.

## Potential Risks / Drawbacks

- very low risk as it just updates the open state on load

Fixes #19571 
