### PR TITLE
Fix readonly and required on groups

### DIFF
--- a/.changeset/fuzzy-rice-refuse.md
+++ b/.changeset/fuzzy-rice-refuse.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix readonly and required on groups
+Ensured the "Readonly" and "Required" options work on groups

--- a/.changeset/fuzzy-rice-refuse.md
+++ b/.changeset/fuzzy-rice-refuse.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix readonly and required on groups

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -183,18 +183,6 @@ function useForm() {
 
 	const fieldsForGroup = computed(() => {
 		return fieldNames.value.map((name: string) => getFieldsForGroup(fieldsMap.value[name]?.meta?.field || null));
-
-		const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
-
-		return fieldNames.value.map((name: string) => {
-			const fields = getFieldsForGroup(fieldsMap.value[name]?.meta?.field || null);
-
-			return fields.reduce((result: Field[], field: Field) => {
-				const newField = applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field));
-				if (newField.field) result.push(newField);
-				return result;
-			}, [] as Field[]);
-		});
 	});
 
 	return { fieldNames, fieldsMap, isDisabled, getFieldsForGroup, fieldsForGroup };

--- a/app/src/composables/use-form-fields.ts
+++ b/app/src/composables/use-form-fields.ts
@@ -5,6 +5,7 @@ import { cloneDeep, orderBy } from 'lodash';
 import { computed, ComputedRef, Ref } from 'vue';
 import { translate } from '@/utils/translate-object-values';
 import { useExtension } from './use-extension';
+import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 
 export function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<Field[]> } {
 	const formFields = computed(() => {

--- a/app/src/composables/use-form-fields.ts
+++ b/app/src/composables/use-form-fields.ts
@@ -5,7 +5,6 @@ import { cloneDeep, orderBy } from 'lodash';
 import { computed, ComputedRef, Ref } from 'vue';
 import { translate } from '@/utils/translate-object-values';
 import { useExtension } from './use-extension';
-import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 
 export function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<Field[]> } {
 	const formFields = computed(() => {

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -13,7 +13,7 @@ import { useCollection } from '@directus/composables';
 import { Field, Query, Relation } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
 import { AxiosResponse } from 'axios';
-import { cloneDeep, mergeWith } from 'lodash';
+import { mergeWith } from 'lodash';
 import { ComputedRef, Ref, computed, isRef, ref, unref, watch } from 'vue';
 import { usePermissions } from './use-permissions';
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
@@ -130,7 +130,7 @@ export function useItem<T extends Record<string, any>>(
 			}
 		);
 
-		const fields = pushGroupOptionsDown(fieldsWithPermissions.value)
+		const fields = pushGroupOptionsDown(fieldsWithPermissions.value);
 
 		const errors = validateItem(payloadToValidate, fields, isNew.value);
 

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -13,9 +13,10 @@ import { useCollection } from '@directus/composables';
 import { Field, Query, Relation } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
 import { AxiosResponse } from 'axios';
-import { mergeWith } from 'lodash';
+import { cloneDeep, mergeWith } from 'lodash';
 import { ComputedRef, Ref, computed, isRef, ref, unref, watch } from 'vue';
 import { usePermissions } from './use-permissions';
+import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 
 type UsableItem<T extends Record<string, any>> = {
 	edits: Ref<Record<string, any>>;
@@ -129,7 +130,9 @@ export function useItem<T extends Record<string, any>>(
 			}
 		);
 
-		const errors = validateItem(payloadToValidate, fieldsWithPermissions.value, isNew.value);
+		const fields = pushGroupOptionsDown(fieldsWithPermissions.value)
+
+		const errors = validateItem(payloadToValidate, fields, isNew.value);
 
 		if (errors.length > 0) {
 			validationErrors.value = errors;

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -199,7 +199,10 @@ async function onGroupSortChange(fields: Field[]) {
 				<template #header>
 					<div class="header full">
 						<v-icon class="drag-handle" name="drag_indicator" @click.stop />
-						<span class="name">{{ field.field }}</span>
+						<span class="name">
+							{{ field.field }}
+							<v-icon v-if="field.meta?.required === true" name="star" class="required" sup filled />
+						</span>
 						<v-icon v-if="hidden" v-tooltip="t('hidden_field')" name="visibility_off" class="hidden-icon" small />
 						<field-select-menu
 							:field="field"

--- a/app/src/utils/push-group-options-down.test.ts
+++ b/app/src/utils/push-group-options-down.test.ts
@@ -61,3 +61,104 @@ test('Test pushGroupOptionsDown', () => {
 		}
 	]);
 })
+
+const fieldsNested: Field[] = [
+	{
+		field: 'group1',
+		type: 'alias',
+		collection: 'test',
+		meta: {
+			required: true,
+			readonly: false,
+			special: ['group']
+		} as any,
+		schema: null,
+		name: 'Group 1',
+	}, {
+		field: 'field_in_group1',
+		type: 'boolean',
+		collection: 'test',
+		meta: {
+			required: false,
+			readonly: false,
+			group: 'group1'
+		} as any,
+		schema: null,
+		name: 'Field in group 1',
+	}, {
+		field: 'group1_1',
+		type: 'alias',
+		collection: 'test',
+		meta: {
+			group: 'group1',
+			required: false,
+			readonly: true,
+			special: ['group']
+		} as any,
+		schema: null,
+		name: 'Group 1 1',
+	}, {
+		field: 'field_in_group1_1',
+		type: 'boolean',
+		collection: 'test',
+		meta: {
+			required: false,
+			readonly: false,
+			group: 'group1_1'
+		} as any,
+		schema: null,
+		name: 'Field in group 1 1',
+	}
+]
+
+test('Test pushGroupOptionsDown with nested groups', () => {
+
+	expect(pushGroupOptionsDown(fieldsNested)).toEqual([
+		{
+			field: 'group1',
+			type: 'alias',
+			collection: 'test',
+			meta: {
+				required: false,
+				readonly: false,
+				special: ['group']
+			} as any,
+			schema: null,
+			name: 'Group 1',
+		}, {
+			field: 'field_in_group1',
+			type: 'boolean',
+			collection: 'test',
+			meta: {
+				required: true,
+				readonly: false,
+				group: 'group1'
+			} as any,
+			schema: null,
+			name: 'Field in group 1',
+		}, {
+			field: 'group1_1',
+			type: 'alias',
+			collection: 'test',
+			meta: {
+				group: 'group1',
+				required: false,
+				readonly: false,
+				special: ['group']
+			} as any,
+			schema: null,
+			name: 'Group 1 1',
+		}, {
+			field: 'field_in_group1_1',
+			type: 'boolean',
+			collection: 'test',
+			meta: {
+				required: true,
+				readonly: true,
+				group: 'group1_1'
+			} as any,
+			schema: null,
+			name: 'Field in group 1 1',
+		}
+	]);
+})

--- a/app/src/utils/push-group-options-down.test.ts
+++ b/app/src/utils/push-group-options-down.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from 'vitest';
+
+import { pushGroupOptionsDown } from './push-group-options-down.js';
+import { Field } from '@directus/types';
+
+const fields: Field[] = [
+	{
+		field: 'group1',
+		type: 'alias',
+		collection: 'test',
+		meta: {
+			required: true,
+			readonly: true,
+			special: ['group']
+		} as any,
+		schema: null,
+		name: 'Group 1',
+	}, {
+		field: 'field_in_group1',
+		type: 'boolean',
+		collection: 'test',
+		meta: {
+			required: false,
+			group: 'group1'
+		} as any,
+		schema: null,
+		name: 'Field in group 1',
+	}
+]
+
+test('Test pushGroupOptionsDown not mutating', () => {
+
+	expect(pushGroupOptionsDown(fields)).not.toBe(fields);
+});
+
+test('Test pushGroupOptionsDown', () => {
+
+	expect(pushGroupOptionsDown(fields)).toEqual([
+		{
+			field: 'group1',
+			type: 'alias',
+			collection: 'test',
+			meta: {
+				required: false,
+				readonly: false,
+				special: ['group']
+			},
+			schema: null,
+			name: 'Group 1',
+		}, {
+			field: 'field_in_group1',
+			type: 'boolean',
+			collection: 'test',
+			meta: {
+				required: true,
+				readonly: true,
+				group: 'group1'
+			},
+			schema: null,
+			name: 'Field in group 1',
+		}
+	]);
+})

--- a/app/src/utils/push-group-options-down.test.ts
+++ b/app/src/utils/push-group-options-down.test.ts
@@ -11,30 +11,29 @@ const fields: Field[] = [
 		meta: {
 			required: true,
 			readonly: true,
-			special: ['group']
+			special: ['group'],
 		} as any,
 		schema: null,
 		name: 'Group 1',
-	}, {
+	},
+	{
 		field: 'field_in_group1',
 		type: 'boolean',
 		collection: 'test',
 		meta: {
 			required: false,
-			group: 'group1'
+			group: 'group1',
 		} as any,
 		schema: null,
 		name: 'Field in group 1',
-	}
-]
+	},
+];
 
 test('Test pushGroupOptionsDown not mutating', () => {
-
 	expect(pushGroupOptionsDown(fields)).not.toBe(fields);
 });
 
 test('Test pushGroupOptionsDown', () => {
-
 	expect(pushGroupOptionsDown(fields)).toEqual([
 		{
 			field: 'group1',
@@ -43,24 +42,25 @@ test('Test pushGroupOptionsDown', () => {
 			meta: {
 				required: false,
 				readonly: false,
-				special: ['group']
+				special: ['group'],
 			},
 			schema: null,
 			name: 'Group 1',
-		}, {
+		},
+		{
 			field: 'field_in_group1',
 			type: 'boolean',
 			collection: 'test',
 			meta: {
 				required: true,
 				readonly: true,
-				group: 'group1'
+				group: 'group1',
 			},
 			schema: null,
 			name: 'Field in group 1',
-		}
+		},
 	]);
-})
+});
 
 const fieldsNested: Field[] = [
 	{
@@ -70,22 +70,24 @@ const fieldsNested: Field[] = [
 		meta: {
 			required: true,
 			readonly: false,
-			special: ['group']
+			special: ['group'],
 		} as any,
 		schema: null,
 		name: 'Group 1',
-	}, {
+	},
+	{
 		field: 'field_in_group1',
 		type: 'boolean',
 		collection: 'test',
 		meta: {
 			required: false,
 			readonly: false,
-			group: 'group1'
+			group: 'group1',
 		} as any,
 		schema: null,
 		name: 'Field in group 1',
-	}, {
+	},
+	{
 		field: 'group1_1',
 		type: 'alias',
 		collection: 'test',
@@ -93,26 +95,26 @@ const fieldsNested: Field[] = [
 			group: 'group1',
 			required: false,
 			readonly: true,
-			special: ['group']
+			special: ['group'],
 		} as any,
 		schema: null,
 		name: 'Group 1 1',
-	}, {
+	},
+	{
 		field: 'field_in_group1_1',
 		type: 'boolean',
 		collection: 'test',
 		meta: {
 			required: false,
 			readonly: false,
-			group: 'group1_1'
+			group: 'group1_1',
 		} as any,
 		schema: null,
 		name: 'Field in group 1 1',
-	}
-]
+	},
+];
 
 test('Test pushGroupOptionsDown with nested groups', () => {
-
 	expect(pushGroupOptionsDown(fieldsNested)).toEqual([
 		{
 			field: 'group1',
@@ -121,22 +123,24 @@ test('Test pushGroupOptionsDown with nested groups', () => {
 			meta: {
 				required: false,
 				readonly: false,
-				special: ['group']
+				special: ['group'],
 			} as any,
 			schema: null,
 			name: 'Group 1',
-		}, {
+		},
+		{
 			field: 'field_in_group1',
 			type: 'boolean',
 			collection: 'test',
 			meta: {
 				required: true,
 				readonly: false,
-				group: 'group1'
+				group: 'group1',
 			} as any,
 			schema: null,
 			name: 'Field in group 1',
-		}, {
+		},
+		{
 			field: 'group1_1',
 			type: 'alias',
 			collection: 'test',
@@ -144,21 +148,22 @@ test('Test pushGroupOptionsDown with nested groups', () => {
 				group: 'group1',
 				required: false,
 				readonly: false,
-				special: ['group']
+				special: ['group'],
 			} as any,
 			schema: null,
 			name: 'Group 1 1',
-		}, {
+		},
+		{
 			field: 'field_in_group1_1',
 			type: 'boolean',
 			collection: 'test',
 			meta: {
 				required: true,
 				readonly: true,
-				group: 'group1_1'
+				group: 'group1_1',
 			} as any,
 			schema: null,
 			name: 'Field in group 1 1',
-		}
+		},
 	]);
-})
+});

--- a/app/src/utils/push-group-options-down.ts
+++ b/app/src/utils/push-group-options-down.ts
@@ -1,0 +1,44 @@
+import { Field, FieldMeta } from "@directus/types";
+import { cloneDeep } from "lodash";
+
+
+export function pushGroupOptionsDown(fields: Field[]) {
+	fields = cloneDeep(fields)
+
+	const updatedGroups: string[] = []
+	const fieldsQueue: Field[] = [...fields]
+
+	while (fieldsQueue.length > 0) {
+		const field = fieldsQueue.shift()
+
+		if (!field) break;
+
+		const parent = field?.meta?.group
+		const isGroup = field.meta?.special?.includes('group')
+
+		if (!isGroup) continue
+
+		if (parent && !updatedGroups.includes(parent)) {
+			fieldsQueue.push(field)
+			continue
+		}
+
+		for (const childField of fields) {
+			if (childField.meta?.group !== field.field) continue
+
+			childField.meta.required = field.meta?.required ?? false
+			childField.meta.readonly = field.meta?.readonly ?? false
+		}
+
+		if (!field.meta) {
+			field.meta = {} as FieldMeta
+		}
+
+		field.meta.required = false
+		field.meta.readonly = false
+		updatedGroups.push(field.field)
+
+	}
+
+	return fields
+}

--- a/app/src/utils/push-group-options-down.ts
+++ b/app/src/utils/push-group-options-down.ts
@@ -1,44 +1,42 @@
-import { Field, FieldMeta } from "@directus/types";
-import { cloneDeep } from "lodash";
-
+import { Field, FieldMeta } from '@directus/types';
+import { cloneDeep } from 'lodash';
 
 export function pushGroupOptionsDown(fields: Field[]) {
-	fields = cloneDeep(fields)
+	fields = cloneDeep(fields);
 
-	const updatedGroups: string[] = []
-	const fieldsQueue: Field[] = [...fields]
+	const updatedGroups: string[] = [];
+	const fieldsQueue: Field[] = [...fields];
 
 	while (fieldsQueue.length > 0) {
-		const field = fieldsQueue.shift()
+		const field = fieldsQueue.shift();
 
 		if (!field) break;
 
-		const parent = field?.meta?.group
-		const isGroup = field.meta?.special?.includes('group')
+		const parent = field?.meta?.group;
+		const isGroup = field.meta?.special?.includes('group');
 
-		if (!isGroup) continue
+		if (!isGroup) continue;
 
 		if (parent && !updatedGroups.includes(parent)) {
-			fieldsQueue.push(field)
-			continue
+			fieldsQueue.push(field);
+			continue;
 		}
 
 		for (const childField of fields) {
-			if (childField.meta?.group !== field.field) continue
+			if (childField.meta?.group !== field.field) continue;
 
-			childField.meta.required = field.meta?.required || childField.meta.required
-			childField.meta.readonly = field.meta?.readonly || childField.meta.readonly
+			childField.meta.required = field.meta?.required || childField.meta.required;
+			childField.meta.readonly = field.meta?.readonly || childField.meta.readonly;
 		}
 
 		if (!field.meta) {
-			field.meta = {} as FieldMeta
+			field.meta = {} as FieldMeta;
 		}
 
-		field.meta.required = false
-		field.meta.readonly = false
-		updatedGroups.push(field.field)
-
+		field.meta.required = false;
+		field.meta.readonly = false;
+		updatedGroups.push(field.field);
 	}
 
-	return fields
+	return fields;
 }

--- a/app/src/utils/push-group-options-down.ts
+++ b/app/src/utils/push-group-options-down.ts
@@ -26,8 +26,8 @@ export function pushGroupOptionsDown(fields: Field[]) {
 		for (const childField of fields) {
 			if (childField.meta?.group !== field.field) continue
 
-			childField.meta.required = field.meta?.required ?? false
-			childField.meta.readonly = field.meta?.readonly ?? false
+			childField.meta.required = field.meta?.required || childField.meta.required
+			childField.meta.readonly = field.meta?.readonly || childField.meta.readonly
 		}
 
 		if (!field.meta) {


### PR DESCRIPTION
While working on another issue I came accross this bug and though it was related. Turns out it wasn't but still is a bug so here the explanation:

When setting `required` or `readonly` on a group, nothing would happen as those options didn't get passed to the child fields of these groups. Only `hidden` worked at the moment as is hid the whole group.

A problem with this was that if you had a group set to be required, validation would always fail as it was checking against the group which never has a value.

To fix this we now go over each group in the form and pass `required` and `readonly` to it's children so everything should behave as to be expected.

## Potential Risks / Drawbacks

- Working with the v-form is always risky so there is a high chance something will break.

## Review Questions

- I also made sure this works properly with conditions but it would still be nice to check against that and validation too
