### PR TITLE
Add a small border to the description dot for easier mouse-over

### DIFF
--- a/.changeset/cyan-rockets-build.md
+++ b/.changeset/cyan-rockets-build.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added a small border to the description dot for easier mouse-over

--- a/app/src/components/v-table/table-header.vue
+++ b/app/src/components/v-table/table-header.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed, ref, useSlots } from 'vue';
-import { ShowSelect } from '@directus/types';
 import { useEventListener } from '@/composables/use-event-listener';
-import { Header, Sort } from './types';
-import { throttle, clone } from 'lodash';
-import Draggable from 'vuedraggable';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { useSync } from '@directus/composables';
+import { ShowSelect } from '@directus/types';
+import { clone, throttle } from 'lodash';
+import { computed, ref, useSlots } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
+import { Header, Sort } from './types';
 
 interface Props {
 	headers: Header[];
@@ -441,6 +441,8 @@ function toggleManualSort() {
 	background-color: var(--foreground-subdued);
 	display: inline-block;
 	border-radius: 50%;
+	border: var(--background-page) 6px solid;
+	box-sizing: content-box;
 	margin-right: 8px;
 	vertical-align: middle;
 }


### PR DESCRIPTION
## Scope

What's changed:

- Added a small border to the description dot for easier mouse-over
- Used variable for bg color and made it not too big, only 6px

## Potential Risks / Drawbacks

- None. Small css fix.

## Review Questions

- You like it? I like it, way easier to hover now.

| Light | Dark |
|--------|--------|
| ![image](https://github.com/directus/directus/assets/14810858/83a208dc-a373-4cae-9635-107bfe0fd1bc) | ![image](https://github.com/directus/directus/assets/14810858/f18b9ac7-66b2-4f40-80c4-3e7ff309be40) | 

---

Was mentioned in #19952 for a standalone PR.
