### PR TITLE
Consider OS release for pnpm cache in GH workflows

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,5 +1,5 @@
 name: Prepare
-description: Install and build the app
+description: Install dependencies and build the platform
 inputs:
   build:
     description: Build the production bundle of the platform
@@ -10,7 +10,7 @@ inputs:
     required: false
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Install Node.js
       uses: actions/setup-node@v3
@@ -24,19 +24,21 @@ runs:
       with:
         run_install: false
 
-    - name: Get pnpm store directory
-      id: pnpm-cache
+    - name: Get cache info
+      id: cache-info
       shell: bash
       run: |
-        echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+        echo "os-release=$(node --eval 'console.log(os.release())')" >> $GITHUB_OUTPUT
+        echo "pnpm-cache-dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       name: Setup pnpm cache
       with:
-        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        path: ${{ steps.cache-info.outputs.pnpm-cache-dir }}
+        key:
+          ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Scope

What's changed:

The OS release version needs to be considered for the pnpm cache key to ensure the MSSQL test job using runner VM `ubuntu-20.04` maintains its own cache instead of using the one from `ubuntu-latest` (22.04).

Ensures the MSSQL test works again.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None