### PR TITLE
Loosening the engine check of pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
 	"packageManager": "pnpm@8.9.0",
 	"engines": {
 		"node": ">=18.0.0",
-		"pnpm": "~8.9.0"
+		"pnpm": "^8.8.0"
 	}
 }


### PR DESCRIPTION
## Scope

What's changed:

While the strict engine check (~x.y.z) gave us a little more certainty that no unwanted lockfile changes slip through, it has become apparent that it is somewhat difficult to maintain this strictness, as with that different pnpm versions might be  required across branches / PRs.
We therefore try to relax the rule again a bit by allowing the last version that is known to work well up to <9.0.0.

## Potential Risks / Drawbacks

Unwanted lockfile changes could slip in in a PR when using a newer pnpm version.
Then again, in general pnpm follows SemVer too, so such unexpected changes should be a great exception.

## Review Notes / Questions

None
