### PR TITLE
Recommend installation of pnpm via Corepack

### DIFF
--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -13,10 +13,11 @@ readTime: 4 min read
 
 ::: tip Minimum Requirements
 
-You will need to have [the latest LTS version of Node](https://nodejs.org/en/download) to _build_ a Development version
-of Directus.
+You will need to have the [latest LTS version of Node.js](https://nodejs.org/en/download) for the Development
+environment of Directus.
 
-You will also need to have the package manager [pnpm](https://pnpm.io) installed.
+You will also need to have the package manager [pnpm](https://pnpm.io) installed. It's recommended to install
+[pnpm via Corepack](https://pnpm.io/installation#using-corepack) for automatic use of the correct version.
 
 :::
 
@@ -37,14 +38,14 @@ git clone git@github.com:YOUR-USERNAME/directus.git
 git checkout -b YOUR-BRANCH-NAME
 ```
 
-## 4. Install the dependencies and build the project
+## 4. Install dependencies and build the project
 
 ```bash
 pnpm install
 pnpm build
 ```
 
-## 5. Setup Local Configuration
+## 5. Setup local configuration
 
 ### Create a `.env` file in `/api`
 


### PR DESCRIPTION
Recommend the installation of pnpm via Corepack, to ensure the correct version of pnpm is automatically used (the one currently defined in `packageManager` field in the `package.json` file).

Especially helpful since we have a strict engine rule for pnpm which is updated regularly and might also differ between branches.

Ref. https://github.com/directus/directus/pull/19975#issuecomment-1754811131
