### PR TITLE
Optimize MSSQL test setup

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -61,9 +61,8 @@ jobs:
           sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/20.04/mssql-server-2019.list)"
           sudo apt-get update
           sudo apt-get install -y mssql-server
-          sudo MSSQL_PID='express' MSSQL_SA_PASSWORD='Test@123' /opt/mssql/bin/mssql-conf -n setup accept-eula
           sudo /opt/mssql/bin/mssql-conf set network.tcpport 6105
-          sudo systemctl restart mssql-server
+          sudo MSSQL_PID='express' MSSQL_SA_PASSWORD='Test@123' /opt/mssql/bin/mssql-conf -n setup accept-eula
 
       - name: Start database
         if: matrix.vendor != 'sqlite3' && matrix.vendor != 'mssql'


### PR DESCRIPTION
## Scope

What's changed:

Change MSSQL port before calling setup so the additional restart becomes superfluous. Hopefully preventing the setup from blocking for a longer time as seen in https://github.com/directus/directus/actions/runs/6467392658/job/17557338695.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
