### PR TITLE
Limit amount of characters you can enter

### DIFF
--- a/.changeset/grumpy-pigs-guess.md
+++ b/.changeset/grumpy-pigs-guess.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Limit amount of characters you can enter on input interface
+Ensured the hard limit for amount of characters is properly represented in input interface

--- a/.changeset/grumpy-pigs-guess.md
+++ b/.changeset/grumpy-pigs-guess.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Limit amount of characters you can enter on input interface

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -37,6 +37,8 @@ interface Props {
 	type?: string;
 	/** Hide the arrows that are used to increase or decrease a number */
 	hideArrows?: boolean;
+	/** The maximum amount of characters that can be entered */
+	maxLength?: number;
 	/** The maximum number that can be entered */
 	max?: number;
 	/** The minimum number that can be entered */
@@ -237,6 +239,7 @@ function stepDown() {
 					:placeholder="placeholder ? String(placeholder) : undefined"
 					:autocomplete="autocomplete"
 					:type="type"
+					:maxlength="maxLength"
 					:min="min"
 					:max="max"
 					:step="step"

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -75,6 +75,7 @@ const inputType = computed(() => {
 		:slug="slug"
 		:min="min"
 		:max="max"
+		:max-length="length"
 		:step="step"
 		:dir="direction"
 		:autocomplete="masked ? 'new-password' : 'off'"


### PR DESCRIPTION
Now we use the `maxlength` option on inputs for strings so you can't enter strings that are larger than the DB allows.

## Potential Risks / Drawbacks

- low, only the input interface could break

Fixes #18232 
