### PR TITLE
Remove root property from AbstractQuery and minor cleanup

### DIFF
--- a/packages/data-driver-postgres/src/index.test.ts
+++ b/packages/data-driver-postgres/src/index.test.ts
@@ -111,7 +111,6 @@ describe('querying the driver', () => {
 		});
 
 		const query: AbstractQuery = {
-			root: true,
 			collection: randomCollection,
 			store: 'randomDataStore1',
 			fields: [

--- a/packages/data-sql/src/query-converter/converter.test.ts
+++ b/packages/data-sql/src/query-converter/converter.test.ts
@@ -8,7 +8,6 @@ let sample: AbstractQuery;
 
 beforeEach(() => {
 	sample = {
-		root: true,
 		store: randomIdentifier(),
 		collection: randomIdentifier(),
 		fields: [

--- a/packages/data/readme.md
+++ b/packages/data/readme.md
@@ -35,7 +35,6 @@ await engine.registerStore('postgres', pgDriver);
 ```js
 // query data
 await engine.query({
-	root: true,
 	store: 'postgres',
 	collection: 'articles',
 	fields: [

--- a/packages/data/src/engine.test.ts
+++ b/packages/data/src/engine.test.ts
@@ -43,7 +43,6 @@ describe('#query', () => {
 	test('Passes AbstractQuery to store query method', async () => {
 		const query: AbstractQuery = {
 			store: sample.mockStoreIdentifier,
-			root: true,
 			collection: randomIdentifier(),
 			fields: [],
 		};

--- a/packages/data/src/types/abstract-query.ts
+++ b/packages/data/src/types/abstract-query.ts
@@ -4,7 +4,7 @@
  *
  * @module abstract-query
  */
-import type { AbstractQueryFieldNode } from './abstract-query/fields/fields.js';
+import type { AbstractQueryFieldNode } from './abstract-query/fields.js';
 import type { AbstractQueryModifiers } from './abstract-query/modifiers.js';
 
 /**

--- a/packages/data/src/types/abstract-query.ts
+++ b/packages/data/src/types/abstract-query.ts
@@ -11,9 +11,6 @@ import type { AbstractQueryModifiers } from './abstract-query/modifiers.js';
  * The abstract root query
  */
 export interface AbstractQuery {
-	/** Marked as entrypoint of the query */
-	root: boolean;
-
 	/** Location where the data is stored */
 	store: string;
 

--- a/packages/data/src/types/abstract-query/fields.ts
+++ b/packages/data/src/types/abstract-query/fields.ts
@@ -1,0 +1,9 @@
+import type { AbstractQueryFieldNodeFn } from './fields/function.js';
+import type { AbstractQueryFieldNodeNestedMany, AbstractQueryFieldNodeNestedOne } from './fields/nested.js';
+import type { AbstractQueryFieldNodePrimitive } from './fields/primitive.js';
+
+export type AbstractQueryFieldNode =
+	| AbstractQueryFieldNodePrimitive
+	| AbstractQueryFieldNodeFn
+	| AbstractQueryFieldNodeNestedMany
+	| AbstractQueryFieldNodeNestedOne;

--- a/packages/data/src/types/abstract-query/fields/fields.ts
+++ b/packages/data/src/types/abstract-query/fields/fields.ts
@@ -1,9 +1,0 @@
-import type { AbstractQueryFieldNodeFn } from './function.js';
-import type { AbstractQueryFieldNodeNestedMany, AbstractQueryFieldNodeNestedOne } from './nested.js';
-import type { AbstractQueryFieldNodePrimitive } from './primitive.js';
-
-export type AbstractQueryFieldNode =
-	| AbstractQueryFieldNodePrimitive
-	| AbstractQueryFieldNodeFn
-	| AbstractQueryFieldNodeNestedMany
-	| AbstractQueryFieldNodeNestedOne;

--- a/packages/data/src/types/abstract-query/fields/index.ts
+++ b/packages/data/src/types/abstract-query/fields/index.ts
@@ -1,4 +1,3 @@
-export * from './fields.js';
 export * from './function.js';
 export * from './nested.js';
 export * from './nested/index.js';

--- a/packages/data/src/types/abstract-query/fields/nested.ts
+++ b/packages/data/src/types/abstract-query/fields/nested.ts
@@ -1,5 +1,5 @@
 import type { AbstractQueryModifiers } from '../modifiers.js';
-import type { AbstractQueryFieldNode } from './fields.js';
+import type { AbstractQueryFieldNode } from '../fields.js';
 import type {
 	AbstractQueryFieldNodeNestedRelationalMany,
 	AbstractQueryFieldNodeNestedRelationalOne,

--- a/packages/data/src/types/abstract-query/index.ts
+++ b/packages/data/src/types/abstract-query/index.ts
@@ -1,3 +1,4 @@
+export * from './fields.js';
 export * from './fields/index.js';
 export * from './modifiers.js';
 export * from './modifiers/index.js';


### PR DESCRIPTION
## Scope

What's changed:

- Since nested queries are defined by using `nested-one` and `nested-many` and those will be split up at the `AbstractSql`-level, we don't need this `root` property anymore
- Moved `fields.ts` out of the `fields/` folder for consistency

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None