### PR TITLE
Update placeholder text in file-image interface

### DIFF
--- a/.changeset/tidy-pants-clean.md
+++ b/.changeset/tidy-pants-clean.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Updated placeholder for file-image interface when it is disabled with no value

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -135,7 +135,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 	<div class="image" :class="[width, { crop }]">
 		<v-skeleton-loader v-if="loading" type="input-tall" />
 
-		<v-notice v-else-if="disabled && !image" class="disabled-placeholder" center icon="block">
+		<v-notice v-else-if="disabled && !image" class="disabled-placeholder" center icon="hide_image">
 			{{ t('no_image_selected') }}
 		</v-notice>
 

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -136,7 +136,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 		<v-skeleton-loader v-if="loading" type="input-tall" />
 
 		<v-notice v-else-if="disabled && !image" class="disabled-placeholder" center icon="block">
-			{{ t('disabled') }}
+			{{ t('no_image_selected') }}
 		</v-notice>
 
 		<div v-else-if="image" class="image-preview" :class="{ 'is-svg': image.type && image.type.includes('svg') }">

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -472,6 +472,7 @@ import_from_url: Import File from URL
 replace_from_device: Replace File from Device
 replace_from_library: Replace File from Library
 replace_from_url: Replace File from URL
+no_image_selected: No Image Selected
 no_file_selected: No File Selected
 download_file: Download File
 open_file_in_tab: Open file in new tab


### PR DESCRIPTION
## Description

Context: This was initially noticed by Pascal when looking at the "Preview" when promoting a version, however this is also the same behavior in the existing Revisions Preview since it's related to the file-image interface itself.

As seen in "Before", when the file-image interface is disabled AND has no value, it will display the text `Disabled`. However this may a bit odd in terms of when it's displayed in Promote Preview or Revisions Preview drawer for example.

### Before

![](https://github.com/directus/directus/assets/42867097/a0f4bf3c-cfbc-4ec2-8093-a8784fee9dff)

### After

![](https://github.com/directus/directus/assets/42867097/86ff5fab-8b75-40c0-90c9-5f759dac9a29)

## Scope

What's changed:

- placeholder text when file-image is disabled and there's no image

## Potential Risks / Drawbacks

- May be a change in terms of UX

## Review Notes / Questions

- Alternatively, we might be able to add `cursor: not-allowed;` styling to make it clearer like so:

    ![](https://github.com/directus/directus/assets/42867097/30afc8e1-0170-4dda-a6b7-0fa271734029)

    Thoughts on this? (we may potentially have to do this for other interfaces, but that definitely would be a separate discussion/PR)
