### PR TITLE
Fixed handling of multiple WebSocket subscriptions on same target 

### DIFF
--- a/.changeset/olive-sheep-beam.md
+++ b/.changeset/olive-sheep-beam.md
@@ -2,5 +2,4 @@
 '@directus/api': patch
 ---
 
-changed loop behavior from prematurely exiting to evaluating all subscriptions on ws; fixed issue where Directus might
-skip valid subscriptions if a filter didn't match records.
+Fixed an issue where multiple WebSocket subscriptions on same target might result in skipped events

--- a/.changeset/olive-sheep-beam.md
+++ b/.changeset/olive-sheep-beam.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed an issue where multiple WebSocket subscriptions on same target might result in skipped events
+Fixed an issue where multiple WebSocket subscriptions on same target could result in skipped events

--- a/.changeset/olive-sheep-beam.md
+++ b/.changeset/olive-sheep-beam.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+changed loop behavior from prematurely exiting to evaluating all subscriptions on ws; fixed issue where Directus might
+skip valid subscriptions if a filter didn't match records.

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -128,7 +128,7 @@ export class SubscribeHandler {
 
 				const result = await getPayload(subscription, client.accountability, schema, event);
 
-				if (Array.isArray(result?.['data']) && result?.['data']?.length === 0) return;
+				if (Array.isArray(result?.['data']) && result?.['data']?.length === 0) continue;
 
 				client.send(fmtMessage('subscription', result, subscription.uid));
 			} catch (err) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -78,3 +78,4 @@
 - programmarchy
 - koredeycode
 - sajjadalis
+- nihcep

--- a/contributors.yml
+++ b/contributors.yml
@@ -78,4 +78,4 @@
 - programmarchy
 - koredeycode
 - sajjadalis
-- nihcep
+- Nihcep


### PR DESCRIPTION
## Scope

What's changed:

In the api/src/websocket/handlers/subscribe.ts file, the behavior of the loop handling event dispatching to subscriptions was modified. Previously, if a subscription's filter didn't match any records, Directus would exit the entire loop, potentially skipping valid subsequent subscriptions. This behavior was rectified by changing the premature return statement to a continue statement, ensuring that Directus evaluates all relevant subscriptions regardless of the order they were registered in.

## Potential Risks / Drawbacks

None.

---

Fixes #20003 
