### PR TITLE
Calendar view one day added (end date) when an event is moved

### DIFF
--- a/.changeset/nine-bikes-wonder.md
+++ b/.changeset/nine-bikes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed date type fields adding an extra day in the calendar layout

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -24,6 +24,7 @@ import CalendarActions from './actions.vue';
 import CalendarLayout from './calendar.vue';
 import CalendarOptions from './options.vue';
 import { LayoutOptions } from './types';
+import { EventImpl } from '@fullcalendar/core/internal';
 
 export default defineLayout<LayoutOptions>({
 	id: 'calendar',
@@ -185,13 +186,12 @@ export default defineLayout<LayoutOptions>({
 					if (!collection.value || !startDateField.value || !startDateFieldInfo.value) return;
 
 					const itemChanges: Partial<Item> = {
-						[startDateField.value]: adjustForType(info.event.startStr, startDateFieldInfo.value.type),
+						[startDateField.value]: adjustDateTimeType(info.event.startStr, startDateFieldInfo.value.type),
 					};
 
 					if (endDateField.value && endDateFieldInfo.value && info.event.endStr) {
-						const endDateStr = info.event.allDay ? adjustDateType(info.event.end) : info.event.endStr;
-						itemChanges[endDateField.value] = adjustForType(endDateStr, endDateFieldInfo.value.type);
-						console.log(itemChanges, info);
+						const endDateStr = info.event.allDay ? adjustDateType(info.event) : info.event.endStr;
+						itemChanges[endDateField.value] = adjustDateTimeType(endDateStr, endDateFieldInfo.value.type);
 					}
 
 					const endpoint = getEndpoint(collection.value);
@@ -334,7 +334,7 @@ export default defineLayout<LayoutOptions>({
 			};
 		}
 
-		function adjustForType(dateString: string, type: string) {
+		function adjustDateTimeType(dateString: string, type: string) {
 			if (type === 'dateTime') {
 				return dateString.substring(0, 19);
 			}
@@ -342,9 +342,11 @@ export default defineLayout<LayoutOptions>({
 			return dateString;
 		}
 
-		function adjustDateType(date: Date) {
+		function adjustDateType(event: EventImpl) {
+			if (!event.end) return event.endStr;
 			// because we add a day for the "Date" type rendering we need to
 			// remove that extra day here before saving the updated value
+			const date = event.end;
 			date.setDate(date.getDate() - 1);
 			return format(date, 'yyyy-MM-dd');
 		}

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -189,7 +189,9 @@ export default defineLayout<LayoutOptions>({
 					};
 
 					if (endDateField.value && endDateFieldInfo.value && info.event.endStr) {
-						itemChanges[endDateField.value] = adjustForType(info.event.endStr, endDateFieldInfo.value.type);
+						const endDateStr = info.event.allDay ? adjustDateType(info.event.end) : info.event.endStr;
+						itemChanges[endDateField.value] = adjustForType(endDateStr, endDateFieldInfo.value.type);
+						console.log(itemChanges, info);
 					}
 
 					const endpoint = getEndpoint(collection.value);
@@ -338,6 +340,13 @@ export default defineLayout<LayoutOptions>({
 			}
 
 			return dateString;
+		}
+
+		function adjustDateType(date: Date) {
+			// because we add a day for the "Date" type rendering we need to
+			// remove that extra day here before saving the updated value
+			date.setDate(date.getDate() - 1);
+			return format(date, 'yyyy-MM-dd');
 		}
 	},
 });


### PR DESCRIPTION
Fixes #19995

For rendering purposes we add an extra day to the endDate specifically for the `Date` type
https://github.com/directus/directus/blob/1dd61a0b82a4054bc1d4704aace148991ca1700a/app/src/layouts/calendar/index.ts#L308-L314
However this was not accounted for when updating the data resulting in each change in the calendar adding an extra day to the end.

## Scope

What's changed:

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit
- Sed do eiusmod tempor incididunt

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
