### PR TITLE
Updates sdk documentaton for realtime()

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -80,4 +80,4 @@
 - sajjadalis
 - Nihcep
 - nodeworks
-- hpaulson
+- HPaulson

--- a/contributors.yml
+++ b/contributors.yml
@@ -80,3 +80,4 @@
 - sajjadalis
 - Nihcep
 - nodeworks
+- hpaulson

--- a/docs/guides/sdk/authentication.md
+++ b/docs/guides/sdk/authentication.md
@@ -53,7 +53,7 @@ import { createDirectus, realtime } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(realtime());
 
-client.sendMessage(JSON.stringify({ type: 'auth', email: email, password: password }));
+client.sendMessage({ type: 'auth', email: email, password: password });
 ```
 
 When using Directus Realtime's [default 'handshake' authentication strategy](/guides/real-time/authentication), the
@@ -103,9 +103,9 @@ import { createDirectus, realtime } from '@directus/sdk';
 const client = createDirectus('http://directus.example.com').with(realtime());
 
 // with access token or static token
-client.sendMessage(JSON.stringify({ type: 'auth', access_token: 'TOKEN' }));
+client.sendMessage({ type: 'auth', access_token: 'TOKEN' });
 // with refresh token
-client.sendMessage(JSON.stringify({ type: 'auth', refresh_token: 'TOKEN' }));
+client.sendMessage({ type: 'auth', refresh_token: 'TOKEN' });
 ```
 
 ## Get a Token

--- a/docs/guides/sdk/authentication.md
+++ b/docs/guides/sdk/authentication.md
@@ -53,7 +53,7 @@ import { createDirectus, realtime } from '@directus/sdk';
 
 const client = createDirectus('http://directus.example.com').with(realtime());
 
-client.send(JSON.stringify({ type: 'auth', email: email, password: password }));
+client.sendMessage(JSON.stringify({ type: 'auth', email: email, password: password }));
 ```
 
 When using Directus Realtime's [default 'handshake' authentication strategy](/guides/real-time/authentication), the
@@ -103,9 +103,9 @@ import { createDirectus, realtime } from '@directus/sdk';
 const client = createDirectus('http://directus.example.com').with(realtime());
 
 // with access token or static token
-client.send(JSON.stringify({ type: 'auth', access_token: 'TOKEN' }));
+client.sendMessage(JSON.stringify({ type: 'auth', access_token: 'TOKEN' }));
 // with refresh token
-client.send(JSON.stringify({ type: 'auth', refresh_token: 'TOKEN' }));
+client.sendMessage(JSON.stringify({ type: 'auth', refresh_token: 'TOKEN' }));
 ```
 
 ## Get a Token


### PR DESCRIPTION
## Scope

What's changed:

SDK Docs
- `client.send()` is not a method of [`WebSocketClient`](https://github.com/directus/directus/blob/bf05c8fd8efac0b20047d2bccc8ba1705b540c16/sdk/src/realtime/types.ts#L28)
     - `Property 'send' does not exist on type 'DirectusClient<any> & WebSocketClient<any>'.`
- Replaced with the correct method, `client.sendMessage()`