### PR TITLE
docs: fixed a typo in the docs

### DIFF
--- a/.changeset/nine-dogs-see.md
+++ b/.changeset/nine-dogs-see.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+"@directus/sdk": patch
+---
+
+Fixed typo related to hook changes.

--- a/.changeset/nine-dogs-see.md
+++ b/.changeset/nine-dogs-see.md
@@ -1,6 +1,0 @@
----
-"docs": patch
-"@directus/sdk": patch
----
-
-Fixed typo related to hook changes.

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -67,7 +67,7 @@ sources and custom workflows.
 ### Hooks
 
 [Hooks](/extensions/hooks) are similar to Flows, but do not have a UI in the Directus Data Studio. Hooks can be
-triggered during Directus' startup, when data is changes, or on schedules.
+triggered during Directus' startup, when data is changed, or on schedules.
 
 ## Hybrid Extensions
 


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a typo in the docs

## Review Notes / Questions

- None
