### PR TITLE
Fixed incorrect extension path

### DIFF
--- a/.changeset/polite-chefs-run.md
+++ b/.changeset/polite-chefs-run.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed incorrect extension loading path

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -384,7 +384,7 @@ export class ExtensionManager {
 				const operationPath = path.resolve(operation.path, operation.entrypoint.api!);
 
 				const operationInstance: OperationApiConfig | { default: OperationApiConfig } = await import(
-					`../${pathToRelativeUrl(operationPath, __dirname)}?t=${Date.now()}`
+					`./${pathToRelativeUrl(operationPath, __dirname)}?t=${Date.now()}`
 				);
 
 				const config = getModuleDefault(operationInstance);
@@ -407,7 +407,7 @@ export class ExtensionManager {
 				const bundlePath = path.resolve(bundle.path, bundle.entrypoint.api);
 
 				const bundleInstances: BundleConfig | { default: BundleConfig } = await import(
-					`../${pathToRelativeUrl(bundlePath, __dirname)}?t=${Date.now()}`
+					`./${pathToRelativeUrl(bundlePath, __dirname)}?t=${Date.now()}`
 				);
 
 				const configs = getModuleDefault(bundleInstances);


### PR DESCRIPTION
Fixes #20036

## Scope

What's changed:

In https://github.com/directus/directus/pull/19922 the loading path for Custom Bundles and Operations was updated to go up an extra directory which results in an incorrect import path in the compiled production platform. 

This PR reverts the updated paths
- https://github.com/directus/directus/commit/1383e85fe93e0a58bcc249b2988ca34ec4aaa750#diff-09fef1df59269b49b62b7e749e695089e0e51baa3f666521c50a48a58a7820f6L490
- https://github.com/directus/directus/commit/1383e85fe93e0a58bcc249b2988ca34ec4aaa750#diff-09fef1df59269b49b62b7e749e695089e0e51baa3f666521c50a48a58a7820f6L513

## Potential Risks / Drawbacks

- Missed edge cases with this fix

## Review Notes / Questions

- I would like to lorem ipsum
