### PR TITLE
Fix WYSIWYG interface text color in dark mode

### DIFF
--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -27,7 +27,7 @@ export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospac
 	background: ${cssVar('--background-normal-alt')};
 }
 body {
-	color: ${cssVar('--foreground-normal')};
+	color: ${cssVar('--theme--form--field--input--foreground')};
 	background-color: ${cssVar('--theme--form--field--input--background')};
 	margin: 20px;
 	font-family: ${cssVar('--theme--font-family-sans-serif')};


### PR DESCRIPTION
## Scope

What's changed:

- update `--foreground-normal` to `--theme--form--field--input--foreground`, based on changes in #20026.

### Before

![](https://github.com/directus/directus/assets/42867097/06f00e2b-081c-43b3-ac0b-6e8bf302f280)

### After

![](https://github.com/directus/directus/assets/42867097/c326c74a-eb6a-48c5-b564-b705849de1de)

---

Fixes #20048
