### PR TITLE
Correct count param in BlobClient.download()

### DIFF
--- a/.changeset/twelve-glasses-agree.md
+++ b/.changeset/twelve-glasses-agree.md
@@ -1,0 +1,6 @@
+---
+"@directus/storage-driver-azure": patch
+"@directus/storage": patch
+---
+
+Fixed range requests when using Azure storage driver

--- a/contributors.yml
+++ b/contributors.yml
@@ -82,3 +82,4 @@
 - nodeworks
 - HPaulson
 - Boegie19
+- mscbpi

--- a/packages/storage-driver-azure/src/index.test.ts
+++ b/packages/storage-driver-azure/src/index.test.ts
@@ -238,7 +238,7 @@ describe('#read', () => {
 	test('Calls download with count if end range is provided', async () => {
 		await driver.read(sample.path.input, { end: sample.range.end });
 
-		expect(mockDownload).toHaveBeenCalledWith(undefined, sample.range.end);
+		expect(mockDownload).toHaveBeenCalledWith(undefined, sample.range.end + 1);
 	});
 
 	test('Calls download with offset and count if start and end ranges are provided', async () => {

--- a/packages/storage-driver-azure/src/index.test.ts
+++ b/packages/storage-driver-azure/src/index.test.ts
@@ -244,7 +244,7 @@ describe('#read', () => {
 	test('Calls download with offset and count if start and end ranges are provided', async () => {
 		await driver.read(sample.path.input, sample.range);
 
-		expect(mockDownload).toHaveBeenCalledWith(sample.range.start, sample.range.end - sample.range.start);
+		expect(mockDownload).toHaveBeenCalledWith(sample.range.start, sample.range.end - sample.range.start + 1);
 	});
 
 	test('Throws error when no readable stream is returned', async () => {

--- a/packages/storage-driver-azure/src/index.ts
+++ b/packages/storage-driver-azure/src/index.ts
@@ -36,7 +36,7 @@ export class DriverAzure implements Driver {
 	async read(filepath: string, range?: Range) {
 		const { readableStreamBody } = await this.containerClient
 			.getBlobClient(this.fullPath(filepath))
-			.download(range?.start, range?.end ? range.end - (range.start || 0) : undefined);
+			.download(range?.start, range?.end ? range.end - (range.start || 0) + 1 : undefined);
 
 		if (!readableStreamBody) {
 			throw new Error(`No stream returned for file "${filepath}"`);


### PR DESCRIPTION
`(range.end - range.start)` for bytes `count` results in a missing byte for range requests on azure blob.

Mathematically expected (start: 0, end: 4, end-start=4, actual count of bytes: 5 not 4).

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

Added a +1 for `count` parameter when `range` is in use.

## Potential Risks / Drawbacks

Not much

## Review Notes / Questions

---

Fixes #20055 