### PR TITLE
Fixed SDK docblock for docs build

### DIFF
--- a/.changeset/nervous-months-exercise.md
+++ b/.changeset/nervous-months-exercise.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed SDK docblock for the docs build process

--- a/.changeset/nervous-months-exercise.md
+++ b/.changeset/nervous-months-exercise.md
@@ -1,5 +1,0 @@
----
-"@directus/sdk": patch
----
-
-Fixed SDK docblock for the docs build process

--- a/sdk/src/rest/commands/read/assets.ts
+++ b/sdk/src/rest/commands/read/assets.ts
@@ -4,7 +4,11 @@ import { throwIfEmpty } from '../../utils/index.js';
 import type { RestCommand } from '../../types.js';
 
 /**
- * @returns ReadableStream<Uint8Array>
+ * Read the contents of a file as a ReadableStream<Uint8Array>
+ *
+ * @param {string} key
+ * @param {AssetsQuery} query
+ * @returns {ReadableStream<Uint8Array>}
  */
 export const readAssetRaw =
 	<Schema extends object>(
@@ -23,7 +27,11 @@ export const readAssetRaw =
 	};
 
 /**
- * @returns Blob
+ * Read the contents of a file as a Blob
+ *
+ * @param {string} key
+ * @param {AssetsQuery} query
+ * @returns {Blob}
  */
 export const readAssetBlob =
 	<Schema extends object>(key: DirectusFile<Schema>['id'], query?: AssetsQuery): RestCommand<Blob, Schema> =>
@@ -39,7 +47,11 @@ export const readAssetBlob =
 	};
 
 /**
- * @returns ArrayBuffer
+ * Read the contents of a file as a ArrayBuffer
+ *
+ * @param {string} key
+ * @param {AssetsQuery} query
+ * @returns {ArrayBuffer}
  */
 export const readAssetArrayBuffer =
 	<Schema extends object>(key: DirectusFile<Schema>['id'], query?: AssetsQuery): RestCommand<ArrayBuffer, Schema> =>


### PR DESCRIPTION
The docblocks added in https://github.com/directus/directus/pull/20041 is breaking the docs TypeDoc build.

![image](https://github.com/directus/directus/assets/9389634/4042feaf-694d-47ac-b707-1079df8451c7)


## Scope

What's changed:

- Updated and improved docblocks

## Potential Risks / Drawbacks

- None
