### PR TITLE
Enforce type-safe equality operators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,8 @@ const basicRules = {
 	'no-nested-ternary': 'error',
 	// Require brace style for multi-line control statements
 	curly: ['error', 'multi-line'],
+	// Require the use of type-safe equality operators
+	eqeqeq: 'error',
 };
 
 const tsRules = {

--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -32,7 +32,7 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 
 		const schema = await getSchema();
 
-		if (skipAdminInit == null) {
+		if (!skipAdminInit) {
 			await createDefaultAdmin(schema);
 		} else {
 			logger.info('Skipping creation of default Admin user and role...');

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -446,7 +446,7 @@ function mergeWithParentItems(
 		for (const parentItem of parentItems) {
 			const itemChild = nestedItems.find((nestedItem) => {
 				return (
-					nestedItem[schema.collections[nestedNode.relation.related_collection!]!.primary] ==
+					nestedItem[schema.collections[nestedNode.relation.related_collection!]!.primary] ===
 					parentItem[nestedNode.relation.field]
 				);
 			});
@@ -462,11 +462,11 @@ function mergeWithParentItems(
 				if (Array.isArray(nestedItem[nestedNode.relation.field])) return true;
 
 				return (
-					nestedItem[nestedNode.relation.field] ==
+					nestedItem[nestedNode.relation.field] ===
 						parentItem[schema.collections[nestedNode.relation.related_collection!]!.primary] ||
 					nestedItem[nestedNode.relation.field]?.[
 						schema.collections[nestedNode.relation.related_collection!]!.primary
-					] == parentItem[schema.collections[nestedNode.relation.related_collection!]!.primary]
+					] === parentItem[schema.collections[nestedNode.relation.related_collection!]!.primary]
 				);
 			});
 
@@ -526,7 +526,7 @@ function mergeWithParentItems(
 			}
 
 			const itemChild = (nestedItem as Record<string, any[]>)[relatedCollection]!.find((nestedItem) => {
-				return nestedItem[nestedNode.relatedKey[relatedCollection]!] == parentItem[nestedNode.fieldKey];
+				return nestedItem[nestedNode.relatedKey[relatedCollection]!] === parentItem[nestedNode.fieldKey];
 			});
 
 			parentItem[nestedNode.fieldKey] = itemChild || null;

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -623,13 +623,16 @@ export class PayloadService {
 						// If the related item is already associated to the current item, and there's no
 						// other updates (which is indicated by the fact that this is just the PK, we can
 						// ignore updating this item. This makes sure we don't trigger any update logic
-						// for items that aren't actually being updated. NOTE: We use == here, as the
-						// primary key might be reported as a string instead of number, coming from the
-						// http route, and or a bigInteger in the DB
+						// for items that aren't actually being updated.
 						if (
 							isNil(existingRecord[relation.field]) === false &&
-							(existingRecord[relation.field] === parent ||
-								existingRecord[relation.field] === payload[currentPrimaryKeyField])
+							// NOTE: We use == here, as the
+							// primary key might be reported as a string instead of number, coming from the
+							// http route, and or a bigInteger in the DB
+							/* eslint-disable eqeqeq  */
+							(existingRecord[relation.field] == parent ||
+								existingRecord[relation.field] == payload[currentPrimaryKeyField])
+							/* eslint-enable eqeqeq */
 						) {
 							savedPrimaryKeys.push(existingRecord[relatedPrimaryKeyField]);
 							continue;

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -251,9 +251,9 @@ export class PayloadService {
 	 */
 	processGeometries<T extends Partial<Record<string, any>>[]>(payloads: T, action: Action): T {
 		const process =
-			action == 'read'
+			action === 'read'
 				? (value: any) => (typeof value === 'string' ? wktToGeoJSON(value) : value)
-				: (value: any) => this.helpers.st.fromGeoJSON(typeof value == 'string' ? parseJSON(value) : value);
+				: (value: any) => this.helpers.st.fromGeoJSON(typeof value === 'string' ? parseJSON(value) : value);
 
 		const fieldsInCollection = Object.entries(this.schema.collections[this.collection]!.fields);
 		const geometryColumns = fieldsInCollection.filter(([_, field]) => field.type.startsWith('geometry'));
@@ -628,8 +628,8 @@ export class PayloadService {
 						// http route, and or a bigInteger in the DB
 						if (
 							isNil(existingRecord[relation.field]) === false &&
-							(existingRecord[relation.field] == parent ||
-								existingRecord[relation.field] == payload[currentPrimaryKeyField])
+							(existingRecord[relation.field] === parent ||
+								existingRecord[relation.field] === payload[currentPrimaryKeyField])
 						) {
 							savedPrimaryKeys.push(existingRecord[relatedPrimaryKeyField]);
 							continue;

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -785,19 +785,19 @@ export function applyFilter(
 				dbQuery[logical].whereNotBetween(selectionRaw, value);
 			}
 
-			if (operator == '_intersects') {
+			if (operator === '_intersects') {
 				dbQuery[logical].whereRaw(helpers.st.intersects(key, compareValue));
 			}
 
-			if (operator == '_nintersects') {
+			if (operator === '_nintersects') {
 				dbQuery[logical].whereRaw(helpers.st.nintersects(key, compareValue));
 			}
 
-			if (operator == '_intersects_bbox') {
+			if (operator === '_intersects_bbox') {
 				dbQuery[logical].whereRaw(helpers.st.intersects_bbox(key, compareValue));
 			}
 
-			if (operator == '_nintersects_bbox') {
+			if (operator === '_nintersects_bbox') {
 				dbQuery[logical].whereRaw(helpers.st.nintersects_bbox(key, compareValue));
 			}
 		}

--- a/api/src/utils/get-accountability-for-token.ts
+++ b/api/src/utils/get-accountability-for-token.ts
@@ -23,8 +23,8 @@ export async function getAccountabilityForToken(
 			const payload = verifyAccessJWT(token, env['SECRET'] as string);
 
 			accountability.role = payload.role;
-			accountability.admin = payload.admin_access === true || payload.admin_access == 1;
-			accountability.app = payload.app_access === true || payload.app_access == 1;
+			accountability.admin = payload.admin_access === true || payload.admin_access === 1;
+			accountability.app = payload.app_access === true || payload.app_access === 1;
 
 			if (payload.share) accountability.share = payload.share;
 			if (payload.share_scope) accountability.share_scope = payload.share_scope;
@@ -49,8 +49,8 @@ export async function getAccountabilityForToken(
 
 			accountability.user = user.id;
 			accountability.role = user.role;
-			accountability.admin = user.admin_access === true || user.admin_access == 1;
-			accountability.app = user.app_access === true || user.app_access == 1;
+			accountability.admin = user.admin_access === true || user.admin_access === 1;
+			accountability.app = user.app_access === true || user.app_access === 1;
 		}
 	}
 

--- a/api/src/utils/parse-image-metadata.ts
+++ b/api/src/utils/parse-image-metadata.ts
@@ -37,7 +37,7 @@ export function parseIptc(buffer: Buffer): Record<string, unknown> {
 		const iptcData = buffer.subarray(iptcBlockDataPos, iptcBlockDataPos + iptcBlockSize).toString();
 
 		if (iptcBlockTypeId) {
-			if (iptc[iptcBlockTypeId] == null) {
+			if (!iptc[iptcBlockTypeId]) {
 				iptc[iptcBlockTypeId] = iptcData;
 			} else if (Array.isArray(iptc[iptcBlockTypeId])) {
 				iptc[iptcBlockTypeId].push(iptcData);

--- a/app/src/components/transition/expand-methods.ts
+++ b/app/src/components/transition/expand-methods.ts
@@ -140,7 +140,7 @@ export default function (
 		if (!el._initialStyle) return;
 		const size = el._initialStyle[sizeProperty];
 		el.style.overflow = el._initialStyle.overflow;
-		if (size != null) el.style[sizeProperty] = size;
+		if (typeof size === 'string') el.style[sizeProperty] = size;
 		delete el._initialStyle;
 	}
 }

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -141,7 +141,7 @@ function addField(field: FieldTree) {
 	button.setAttribute('contenteditable', 'false');
 	button.innerText = String(field.name);
 
-	if (window.getSelection()?.rangeCount == 0) {
+	if (window.getSelection()?.rangeCount === 0) {
 		const range = document.createRange();
 		range.selectNodeContents(contentEl.value.children[0] as Node);
 		window.getSelection()?.addRange(range);

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -202,9 +202,7 @@ function stepUp() {
 
 	input.value.stepUp();
 
-	if (input.value.value != null) {
-		return emit('update:modelValue', Number(input.value.value));
-	}
+	return emit('update:modelValue', Number(input.value.value));
 }
 
 function stepDown() {

--- a/app/src/components/v-notice.vue
+++ b/app/src/components/v-notice.vue
@@ -21,13 +21,13 @@ const iconName = computed(() => {
 		return props.icon;
 	}
 
-	if (props.type == 'info') {
+	if (props.type === 'info') {
 		return 'info';
-	} else if (props.type == 'success') {
+	} else if (props.type === 'success') {
 		return 'check_circle';
-	} else if (props.type == 'warning') {
+	} else if (props.type === 'warning') {
 		return 'warning';
-	} else if (props.type == 'danger') {
+	} else if (props.type === 'danger') {
 		return 'error';
 	} else {
 		return 'info';

--- a/app/src/composables/use-local-storage.ts
+++ b/app/src/composables/use-local-storage.ts
@@ -37,7 +37,7 @@ export function useLocalStorage<T extends LocalStorageObjectType>(
 	data.value = getValue();
 
 	watch(data, () => {
-		if (data.value == null) {
+		if (data.value === null) {
 			localStorage.removeItem(internalKey);
 		} else {
 			setValue(data.value);

--- a/app/src/interfaces/input-code/index.ts
+++ b/app/src/interfaces/input-code/index.ts
@@ -11,7 +11,7 @@ const choicesMap = CodeMirror.modeInfo.reduce((acc: Record<string, string>, choi
 		return acc;
 	}
 
-	if (choice.mode == null || choice.mode == 'null') {
+	if (choice.mode === null || choice.mode === 'null') {
 		choice.mode = 'plaintext';
 	}
 

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -286,10 +286,10 @@ function setup(editor: any) {
 }
 
 function setFocus(val: boolean) {
-	if (editorElement.value == null) return;
+	if (editorElement.value === null) return;
 	const body = editorElement.value.$el.parentElement?.querySelector('.tox-tinymce');
 
-	if (body == null) return;
+	if (body === null) return;
 
 	if (val) {
 		body.classList.add('focus');

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -173,7 +173,7 @@ function addNew() {
 	if (Array.isArray(internalValue.value)) {
 		emitValue([...internalValue.value, newDefaults]);
 	} else {
-		if (internalValue.value != null) {
+		if (internalValue.value !== null) {
 			// eslint-disable-next-line no-console
 			console.warn(
 				'The repeater interface expects an array as value, but the given value is no array. Overriding given value.'

--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -79,7 +79,7 @@ const appStore = useAppStore();
 const { basemap } = toRefs(appStore);
 
 const style = computed(() => {
-	const source = basemaps.find((source) => source.name == basemap.value) ?? basemaps[0];
+	const source = basemaps.find((source) => source.name === basemap.value) ?? basemaps[0];
 	return basemap.value, getStyleFromBasemapSource(source);
 });
 
@@ -301,10 +301,10 @@ function isTypeCompatible(a?: GeometryType, b?: GeometryType): boolean {
 	}
 
 	if (a.startsWith('Multi')) {
-		return a.replace('Multi', '') == b.replace('Multi', '');
+		return a.replace('Multi', '') === b.replace('Multi', '');
 	}
 
-	return a == b;
+	return a === b;
 }
 
 function loadValueFromProps() {
@@ -348,7 +348,7 @@ function getCurrentGeometry(): Geometry | null {
 	const geometries = features.map((f) => f.geometry) as (SimpleGeometry | MultiGeometry)[];
 	let result: Geometry;
 
-	if (geometries.length == 0) {
+	if (geometries.length === 0) {
 		return null;
 	} else if (!geometryType) {
 		if (geometries.length > 1) {
@@ -358,7 +358,7 @@ function getCurrentGeometry(): Geometry | null {
 		}
 	} else if (geometryType.startsWith('Multi')) {
 		const coordinates = geometries
-			.filter(({ type }) => `Multi${type}` == geometryType)
+			.filter(({ type }) => `Multi${type}` === geometryType)
 			.map(({ coordinates }) => coordinates);
 
 		result = { type: geometryType, coordinates } as Geometry;

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -55,7 +55,7 @@ const appStore = useAppStore();
 const { basemap } = toRefs(appStore);
 
 const style = computed(() => {
-	const source = basemaps.find((source) => source.name == basemap.value) ?? basemaps[0];
+	const source = basemaps.find((source) => source.name === basemap.value) ?? basemaps[0];
 	return getStyleFromBasemapSource(source);
 });
 

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -163,7 +163,7 @@ export default defineLayout<LayoutOptions>({
 					if (!collection.value) return;
 
 					if (props.selectMode || selection.value?.length > 0) {
-						const item = items.value.find((item) => item[primaryKeyField.value!.field] == info.event.id);
+						const item = items.value.find((item) => item[primaryKeyField.value!.field] === info.event.id);
 
 						if (item) {
 							const primaryKey = item[primaryKeyField.value!.field];

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -520,7 +520,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				if (!item || !to) return;
 
 				if (isRelational.value) {
-					if (groupsSortField.value == null) return;
+					if (groupsSortField.value === null) return;
 					await groupsChangeManualSort({ item, to });
 				} else {
 					if (!selectedGroup.value) return;

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -328,7 +328,7 @@ function expandCluster(event: MapLayerMouseEvent) {
 }
 
 function hoverCluster(event: MapLayerMouseEvent) {
-	if (event.type == 'mousemove') {
+	if (event.type === 'mousemove') {
 		hoveredCluster.value = true;
 	} else {
 		hoveredCluster.value = false;

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -50,12 +50,12 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		const geometryField = syncRefProperty(layoutOptions, 'geometryField', undefined);
 
 		const geometryFieldData = computed(() => {
-			return fieldsInCollection.value.find((f: Field) => f.field == geometryField.value);
+			return fieldsInCollection.value.find((f: Field) => f.field === geometryField.value);
 		});
 
 		const geometryFields = computed(() => {
 			return (fieldsInCollection.value as Field[]).filter(
-				({ type, meta }) => type.startsWith('geometry') || meta?.interface == 'map'
+				({ type, meta }) => type.startsWith('geometry') || meta?.interface === 'map'
 			);
 		});
 

--- a/app/src/modules/settings/routes/flows/components/arrows.vue
+++ b/app/src/modules/settings/routes/flows/components/arrows.vue
@@ -208,7 +208,7 @@ const arrows = computed(() => {
 		let pointer = Math.floor(possiblePlaces.length / 2);
 
 		for (let i = 0; i < possiblePlaces.length; i++) {
-			pointer += i * (i % 2 == 0 ? -1 : 1);
+			pointer += i * (i % 2 === 0 ? -1 : 1);
 			if (possiblePlaces[pointer]) return min[axis] + pointer * 20;
 		}
 

--- a/app/src/panels/label/index.ts
+++ b/app/src/panels/label/index.ts
@@ -17,7 +17,7 @@ export default definePanel({
 				type: 'string',
 				required: true,
 				meta: {
-					interface: options?.whiteSpace == 'nowrap' ? 'input' : 'input-multiline',
+					interface: options?.whiteSpace === 'nowrap' ? 'input' : 'input-multiline',
 				},
 			},
 			{

--- a/app/src/panels/label/panel-label.vue
+++ b/app/src/panels/label/panel-label.vue
@@ -43,7 +43,7 @@ function adjustPadding() {
 
 	const padding = Math.round(Math.max(12, Math.min(paddingWidth, paddingHeight)));
 
-	if (props.showHeader == true) {
+	if (props.showHeader) {
 		container.style.padding = '0px 12px 12px 12px';
 	} else {
 		container.style.padding = `${padding}px`;

--- a/app/src/panels/line-chart/panel-line-chart.vue
+++ b/app/src/panels/line-chart/panel-line-chart.vue
@@ -110,7 +110,7 @@ function setUpChart() {
 		const seriesDifferentiators = [...new Set(props.data.map((d) => d['group'][props.grouping!]))]; // get the unique category differentiators
 
 		series = seriesDifferentiators.map((differentiator: string) => {
-			const seriesData = props.data.filter((item) => item['group'][props.grouping!] == differentiator);
+			const seriesData = props.data.filter((item) => item['group'][props.grouping!] === differentiator);
 
 			return {
 				name: differentiator,

--- a/app/src/panels/meter/panel-meter.vue
+++ b/app/src/panels/meter/panel-meter.vue
@@ -59,7 +59,7 @@ const radius = computed(() => {
 	// Determine the shorter dimension
 	const minDimension = Math.min(widthPx, heightPx);
 
-	if (props.size == 'half' && heightPx < widthPx) {
+	if (props.size === 'half' && heightPx < widthPx) {
 		// Added so half circles that have a shorter height than width can maximize the space up to the padding of the height
 		return Math.min(widthPx / 2 - strokeOffset, (props.height * 30) / 2 - 12);
 	}

--- a/app/src/panels/metric-list/index.ts
+++ b/app/src/panels/metric-list/index.ts
@@ -23,7 +23,7 @@ export default definePanel({
 
 		// sort by the aggregate field
 		const sort =
-			options.sortDirection == 'asc'
+			options.sortDirection === 'asc'
 				? [`${options.aggregateFunction}.${options.aggregateField}`]
 				: ['-' + `${options.aggregateFunction}.${options.aggregateField}`];
 

--- a/app/src/panels/metric/panel-metric.vue
+++ b/app/src/panels/metric/panel-metric.vue
@@ -68,7 +68,7 @@ function adjustPadding() {
 
 	const padding = Math.round(Math.max(8, Math.min(paddingWidth, paddingHeight)));
 
-	if (props.showHeader == true) {
+	if (props.showHeader) {
 		container.style.padding = '0px 12px 12px 12px';
 	} else {
 		container.style.padding = `${padding}px`;

--- a/app/src/stores/insights.ts
+++ b/app/src/stores/insights.ts
@@ -187,7 +187,7 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 	function emptyRelations() {
 		return unref(panels)
 			.filter(({ type }) => type === 'relational-variable')
-			.filter(({ options }) => get(unref(variables), options.field) == undefined)
+			.filter(({ options }) => get(unref(variables), options.field) === undefined)
 			.map(({ options }) => options.field)
 			.filter((fieldName) => typeof fieldName === 'string' && fieldName.length > 0);
 	}

--- a/app/src/utils/geometry/basemap.ts
+++ b/app/src/utils/geometry/basemap.ts
@@ -34,19 +34,19 @@ export function getBasemapSources(): BasemapSource[] {
 }
 
 export function getStyleFromBasemapSource(basemap: BasemapSource): Style | string {
-	if (basemap.type == 'style') {
+	if (basemap.type === 'style') {
 		return basemap.url;
 	} else {
 		const style: Style = { ...baseStyle };
 		const source: RasterSource = { type: 'raster' };
 		if (basemap.attribution) source.attribution = basemap.attribution;
 
-		if (basemap.type == 'raster') {
+		if (basemap.type === 'raster') {
 			source.tiles = expandUrl(basemap.url);
 			source.tileSize = basemap.tileSize || 512;
 		}
 
-		if (basemap.type == 'tile') {
+		if (basemap.type === 'tile') {
 			source.url = basemap.url;
 		}
 

--- a/app/src/utils/geometry/controls.ts
+++ b/app/src/utils/geometry/controls.ts
@@ -115,11 +115,11 @@ export class BoxSelectControl {
 	}
 
 	onKeyDown(event: KeyboardEvent): void {
-		if (event.key == 'Shift') {
+		if (event.key === 'Shift') {
 			this.activate(true);
 		}
 
-		if (event.key == 'Escape') {
+		if (event.key === 'Escape') {
 			this.reset();
 			this.activate(false);
 			this.map!.fire('select.end', { features: [] });
@@ -133,7 +133,7 @@ export class BoxSelectControl {
 	}
 
 	onKeyUp(event: KeyboardEvent): void {
-		if (event.key == 'Shift') {
+		if (event.key === 'Shift') {
 			this.activate(false);
 		}
 	}

--- a/app/src/utils/geometry/index.ts
+++ b/app/src/utils/geometry/index.ts
@@ -111,7 +111,7 @@ export function toGeoJSON(entries: any[], options: GeometryOptions): FeatureColl
 		geojson.features.push(feature as Feature);
 	}
 
-	if (geojson.features.length == 0) {
+	if (geojson.features.length === 0) {
 		delete geojson.bbox;
 	}
 
@@ -121,7 +121,7 @@ export function toGeoJSON(entries: any[], options: GeometryOptions): FeatureColl
 export function flatten(geometry?: AnyGeometry): SimpleGeometry[] {
 	if (!geometry) return [];
 
-	if (geometry.type == 'GeometryCollection') {
+	if (geometry.type === 'GeometryCollection') {
 		return geometry.geometries.flatMap(flatten);
 	}
 

--- a/app/src/utils/get-related-collection.ts
+++ b/app/src/utils/get-related-collection.ts
@@ -28,7 +28,7 @@ export function getRelatedCollection(collection: string, field: string): Related
 	const o2mTypes = ['o2m', 'm2m', 'm2a', 'translations', 'files'];
 
 	if (localType && o2mTypes.includes(localType)) {
-		if (localType == 'm2m' && relations.length > 1) {
+		if (localType === 'm2m' && relations.length > 1) {
 			return {
 				relatedCollection: relations[1].related_collection!,
 				junctionCollection: relations[0].collection,

--- a/app/src/utils/get-vue-component-name.ts
+++ b/app/src/utils/get-vue-component-name.ts
@@ -8,6 +8,7 @@ import { ComponentPublicInstance } from 'vue';
 export function getVueComponentName(vm: ComponentPublicInstance | null): string {
 	if (!vm) return `unknown`;
 	if (vm.$root === vm) return 'root';
+	// eslint-disable-next-line eqeqeq
 	const options = typeof vm === 'function' && (vm as any).cid != null ? (vm as any)?.options : vm?.$options;
 	let name = options.name || options.__name || options._componentTag;
 	const file = options.__file;

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -212,7 +212,7 @@ function useCropper() {
 		if (!imageData.value) return 'crop_original';
 
 		if (customAspectRatios) {
-			const customAspectRatio = customAspectRatios.find((customAR) => customAR.value == aspectRatio.value);
+			const customAspectRatio = customAspectRatios.find((customAR) => customAR.value === aspectRatio.value);
 			if (customAspectRatio) return 'crop_square';
 		}
 

--- a/docs/.vitepress/components/guides/GuidesListExtensions.vue
+++ b/docs/.vitepress/components/guides/GuidesListExtensions.vue
@@ -5,8 +5,8 @@ const props = defineProps<{
 	type: string;
 }>();
 
-const extensionsGuides = data.guides.sections.find((s) => s.indexPath == 'extensions');
-const section = extensionsGuides.blocks.find((b) => b.title == props.type);
+const extensionsGuides = data.guides.sections.find((s) => s.indexPath === 'extensions');
+const section = extensionsGuides.blocks.find((b) => b.title === props.type);
 const guides = section.items;
 </script>
 

--- a/packages/release-notes-generator/src/utils/generate-markdown.ts
+++ b/packages/release-notes-generator/src/utils/generate-markdown.ts
@@ -100,7 +100,7 @@ function formatUntypedPackages(untypedPackages: UntypedPackage[]): string {
 	const output = [];
 
 	for (const { name, changes } of untypedPackages) {
-		if (changes.length == 0) {
+		if (changes.length === 0) {
 			continue;
 		}
 

--- a/packages/schema/src/dialects/cockroachdb.ts
+++ b/packages/schema/src/dialects/cockroachdb.ts
@@ -488,7 +488,7 @@ export default class CockroachDB implements SchemaInspector {
 
 		for (const column of parsedColumns) {
 			const geometry = geometries.find((geometry) => {
-				return column.name == geometry.name && column.table == geometry.table;
+				return column.name === geometry.name && column.table === geometry.table;
 			});
 
 			if (geometry) {

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -509,7 +509,7 @@ export default class Postgres implements SchemaInspector {
 
 		for (const column of parsedColumns) {
 			const geometry = geometries.find((geometry) => {
-				return column.name == geometry.name && column.table == geometry.table;
+				return column.name === geometry.name && column.table === geometry.table;
 			});
 
 			if (geometry) {

--- a/packages/schema/src/dialects/sqlite.ts
+++ b/packages/schema/src/dialects/sqlite.ts
@@ -63,7 +63,7 @@ export default class SQLite implements SchemaInspector {
 						column.pk === 1 && tablesWithAutoIncrementPrimaryKeys.includes(table)
 							? 'AUTO_INCREMENT'
 							: parseDefaultValue(column.dflt_value),
-					is_nullable: column.notnull == 0,
+					is_nullable: column.notnull === 0,
 					is_generated: column.hidden !== 0,
 					data_type: extractType(column.type),
 					max_length: extractMaxLength(column.type),

--- a/tests/blackbox/routes/items/no-relation.test.ts
+++ b/tests/blackbox/routes/items/no-relation.test.ts
@@ -1143,7 +1143,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items', (pkType) => {
 
 					// Assert
 					expect(response.statusCode).toBe(200);
-					expect(response.body.data[0].count.id == count).toBeTruthy();
+					expect(response.body.data[0].count.id === count).toBeTruthy();
 
 					expect(gqlResponse.statusCode).toBe(200);
 					expect(gqlResponse.body.data[queryKey][0].count.id).toEqual(count);

--- a/tests/blackbox/routes/items/o2m.test.ts
+++ b/tests/blackbox/routes/items/o2m.test.ts
@@ -1678,7 +1678,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items', (pkType) => {
 
 					// Assert
 					expect(response.statusCode).toBe(200);
-					expect(response.body.data[0].states_count == count).toBeTruthy();
+					expect(response.body.data[0].states_count === count).toBeTruthy();
 
 					expect(gqlResponse.statusCode).toBe(200);
 					expect(gqlResponse.body.data[localCollectionCountries][0].states_func.count).toEqual(count);


### PR DESCRIPTION
## Scope

What's changed:

Enforce the usage of [type-safe equality operators via ESLint](https://eslint.org/docs/latest/rules/eqeqeq), for the following reasons:
- Safety
- Consistency
- Clearer intention what the check is supposed to do
  - e.g. when intentionally using `==` we can add a clear comment like
    ```js
    // eslint-disable-next-line eqeqeq --- Intentionally disabled because ...
    ```

## Potential Risks / Drawbacks

Went through all cases to ensure the checks still make sense, but obviously this needs to be treated with caution & double-checked 👀 👀 

## Review Notes / Questions

Some cases need to be discussed / updated.
