### PR TITLE
Enforce Vue shorthand form for `true` attributes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,8 @@ const vueRules = {
 	'vue/multi-word-component-names': 'off',
 	// Don't require default value for props that are not marked as required
 	'vue/require-default-prop': 'off',
+	// Require shorthand form attribute when v-bind value is true
+	'vue/prefer-true-attribute-shorthand': 'error',
 };
 
 const getExtends = (configs = []) => [

--- a/app/src/components/v-table/table-header.vue
+++ b/app/src/components/v-table/table-header.vue
@@ -175,7 +175,7 @@ function toggleManualSort() {
 	<thead class="table-header" :class="{ resizing, reordering }">
 		<draggable
 			v-model="headersWritable"
-			:force-fallback="true"
+			force-fallback
 			:class="{ fixed }"
 			item-key="value"
 			tag="tr"

--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -301,7 +301,7 @@ function updateSort(newSort: Sort) {
 			<draggable
 				v-else
 				v-model="internalItems"
-				:force-fallback="true"
+				force-fallback
 				:item-key="itemKey"
 				tag="tbody"
 				handle=".drag-handle"

--- a/app/src/interfaces/_system/system-fields/system-fields.vue
+++ b/app/src/interfaces/_system/system-fields/system-fields.vue
@@ -96,7 +96,7 @@ const removeField = (field: string) => {
 			<v-notice class="no-fields">{{ t('interfaces.system-fields.no_fields') }}</v-notice>
 		</v-list>
 		<v-list v-else>
-			<draggable v-model="fields" :force-fallback="true" item-key="key" handle=".drag-handle">
+			<draggable v-model="fields" force-fallback item-key="key" handle=".drag-handle">
 				<template #item="{ element: field }">
 					<v-list-item block>
 						<v-icon name="drag_handle" class="drag-handle" left />

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -120,14 +120,7 @@ function emitValue(val: string) {
 			placeholder="--"
 			@input="emitValue(($event.target as HTMLInputElement).value)"
 		/>
-		<v-menu
-			ref="dateTimeMenu"
-			:close-on-content-click="false"
-			:show-arrow="true"
-			placement="bottom-start"
-			seamless
-			full-height
-		>
+		<v-menu ref="dateTimeMenu" :close-on-content-click="false" show-arrow placement="bottom-start" seamless full-height>
 			<template #activator="{ toggle }">
 				<v-icon class="preview" name="event" small @click="toggle" />
 			</template>
@@ -141,7 +134,7 @@ function emitValue(val: string) {
 			</div>
 		</v-menu>
 	</template>
-	<v-menu v-else :close-on-content-click="false" :show-arrow="true" placement="bottom-start">
+	<v-menu v-else :close-on-content-click="false" show-arrow placement="bottom-start">
 		<template #activator="{ toggle }">
 			<v-icon
 				v-if="type.startsWith('geometry') || type === 'json'"

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -279,7 +279,7 @@ function isExistingField(node: Record<string, any>): boolean {
 		:group="{ name: 'g1' }"
 		:item-key="getIndex"
 		:swap-threshold="0.3"
-		:force-fallback="true"
+		force-fallback
 		@change="$emit('change')"
 	>
 		<template #item="{ element, index }">

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -160,7 +160,7 @@ function addKeyAsNode() {
 	</v-notice>
 
 	<div v-else class="system-filter" :class="{ inline, empty: innerValue.length === 0, field: fieldName !== undefined }">
-		<v-list :mandatory="true">
+		<v-list mandatory>
 			<div v-if="innerValue.length === 0" class="no-rules">
 				{{ t('interfaces.filter.no_rules') }}
 			</div>

--- a/app/src/interfaces/_system/system-folder/folder.vue
+++ b/app/src/interfaces/_system/system-folder/folder.vue
@@ -48,14 +48,7 @@ function folderParentPath(folder: Folder, folders: Folder[]) {
 
 <template>
 	<v-skeleton-loader v-if="loading" />
-	<v-menu
-		v-else
-		class="v-select"
-		:attached="true"
-		:show-arrow="false"
-		:disabled="disabled"
-		:close-on-content-click="true"
-	>
+	<v-menu v-else class="v-select" attached :show-arrow="false" :disabled="disabled" close-on-content-click>
 		<template #activator="{ toggle, active }">
 			<v-input
 				readonly

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -213,7 +213,7 @@ function remove(id: string) {
 		<v-list class="list">
 			<draggable
 				v-model="valuesWithData"
-				:force-fallback="true"
+				force-fallback
 				:set-data="hideDragImage"
 				item-key="id"
 				handle=".drag-handle"

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -294,7 +294,7 @@ const allowDrag = computed(
 
 		<v-list v-else>
 			<draggable
-				:force-fallback="true"
+				force-fallback
 				:model-value="displayItems"
 				item-key="id"
 				handle=".drag-handle"

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -155,7 +155,7 @@ function sanitizeValue(value: any): EditorJS.OutputData | null {
 			:model-value="fileHandler !== null"
 			icon="image"
 			:title="t('upload_from_device')"
-			:cancelable="true"
+			cancelable
 			@update:model-value="unsetFileHandler"
 			@cancel="unsetFileHandler"
 		>

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -362,7 +362,7 @@ function setFocus(val: boolean) {
 				<interface-input-code
 					:value="code"
 					language="htmlmixed"
-					:line-wrapping="true"
+					line-wrapping
 					@input="code = $event"
 				></interface-input-code>
 			</div>
@@ -406,7 +406,7 @@ function setFocus(val: boolean) {
 							<v-select
 								v-model="imageSelection.transformationKey"
 								:items="storageAssetPresets.map((preset) => ({ text: preset.key, value: preset.key }))"
-								:show-deselect="true"
+								show-deselect
 							/>
 						</div>
 					</div>

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -348,7 +348,7 @@ const allowDrag = computed(
 			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
 
 			<draggable
-				:force-fallback="true"
+				force-fallback
 				:model-value="displayItems"
 				item-key="$index"
 				:set-data="hideDragImage"

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -516,7 +516,7 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 
 			<v-list v-else>
 				<draggable
-					:force-fallback="true"
+					force-fallback
 					:model-value="displayItems"
 					item-key="id"
 					handle=".drag-handle"

--- a/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
@@ -207,7 +207,7 @@ function stageEdits(item: Record<string, any>) {
 		draggable=".draggable"
 		:set-data="hideDragImage"
 		:disabled="disabled"
-		:force-fallback="true"
+		force-fallback
 		@start="drag = true"
 		@end="drag = false"
 		@change="change($event as ChangeEvent)"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -477,7 +477,7 @@ function getLinkForItem(item: DisplayItem) {
 
 			<v-list v-else>
 				<draggable
-					:force-fallback="true"
+					force-fallback
 					:model-value="displayItems"
 					item-key="id"
 					handle=".drag-handle"

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -217,7 +217,7 @@ function closeDrawer() {
 		<v-list v-if="Array.isArray(internalValue) && internalValue.length > 0">
 			<draggable
 				:disabled="disabled"
-				:force-fallback="true"
+				force-fallback
 				:model-value="internalValue"
 				item-key="id"
 				handle=".drag-handle"

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -89,7 +89,7 @@ onUnmounted(() => {
 			<v-select
 				v-model="geometryType"
 				:placeholder="t('any')"
-				:show-deselect="true"
+				show-deselect
 				:items="GEOMETRY_TYPES.map((value) => ({ value, text: value }))"
 			/>
 		</div>

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -243,7 +243,7 @@ function useColor() {
 					/>
 					<v-button
 						class="swatch"
-						:icon="true"
+						icon
 						:style="{
 							'--v-button-background-color': isValidColor ? hex : 'transparent',
 							border: lowContrast === false ? 'none' : 'var(--border-width) solid var(--border-normal)',

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -199,7 +199,7 @@ async function onSort(updates: Collection[], removeGroup = false) {
 
 			<v-list v-else class="draggable-list">
 				<draggable
-					:force-fallback="true"
+					force-fallback
 					:model-value="rootCollections"
 					:group="{ name: 'collections' }"
 					:swap-threshold="0.3"

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -84,7 +84,7 @@ function onGroupSortChange(collections: Collection[]) {
 		<transition-expand class="collection-items">
 			<draggable
 				v-if="isCollectionExpanded"
-				:force-fallback="true"
+				force-fallback
 				:model-value="nestedCollections"
 				:group="{ name: 'collections' }"
 				:swap-threshold="0.3"

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -130,7 +130,7 @@ const unsortableJunctionFields = computed(() => {
 				:disabled-fields="unsortableJunctionFields"
 				:collection="junctionCollection"
 				:placeholder="t('add_sort_field')"
-				:nullable="true"
+				nullable
 			/>
 		</div>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -153,7 +153,7 @@ const unsortableJunctionFields = computed(() => {
 				:type-allow-list="['integer', 'bigInteger', 'float', 'decimal']"
 				:disabled-fields="unsortableJunctionFields"
 				:placeholder="t('add_sort_field') + '...'"
-				:nullable="true"
+				nullable
 			/>
 		</div>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -66,7 +66,7 @@ const unsortableJunctionFields = computed(() => {
 				:type-allow-list="['integer', 'bigInteger', 'float', 'decimal']"
 				:disabled-fields="unsortableJunctionFields"
 				:placeholder="t('add_sort_field') + '...'"
-				:nullable="true"
+				nullable
 			/>
 		</div>
 

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -186,14 +186,14 @@ async function onGroupSortChange(fields: Field[]) {
 				v-if="localType === 'group'"
 				class="field-grid group full nested"
 				:model-value="nestedFields"
-				:force-fallback="true"
+				force-fallback
 				handle=".drag-handle"
 				:group="{ name: 'fields' }"
 				:set-data="hideDragImage"
 				:animation="150"
 				item-key="field"
-				:fallback-on-body="true"
-				:invert-swap="true"
+				fallback-on-body
+				invert-swap
 				@update:model-value="onGroupSortChange"
 			>
 				<template #header>

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -125,14 +125,14 @@ async function setNestedSort(updates?: Field[]) {
 		<draggable
 			class="field-grid"
 			:model-value="usableFields.filter((field) => isNil(field?.meta?.group))"
-			:force-fallback="true"
+			force-fallback
 			handle=".drag-handle"
 			:group="{ name: 'fields' }"
 			:set-data="hideDragImage"
 			item-key="field"
 			:animation="150"
-			:fallback-on-body="true"
-			:invert-swap="true"
+			fallback-on-body
+			invert-swap
 			@update:model-value="setSort"
 		>
 			<template #item="{ element }">

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -389,7 +389,7 @@ function useActions() {
 		</template>
 
 		<div class="drawer-item-content">
-			<file-preview-replace v-if="file" class="preview" :file="file" :in-modal="true" @replace="refresh" />
+			<file-preview-replace v-if="file" class="preview" :file="file" in-modal @replace="refresh" />
 
 			<v-info v-if="emptyForm" :title="t('no_visible_fields')" icon="search" center>
 				{{ t('no_visible_fields_copy') }}

--- a/app/src/views/private/components/notification-dialogs.vue
+++ b/app/src/views/private/components/notification-dialogs.vue
@@ -18,7 +18,7 @@ function done(id: string) {
 
 <template>
 	<div class="notification-dialogs">
-		<v-dialog v-for="notification in notifications" :key="notification.id" :model-value="true" persist>
+		<v-dialog v-for="notification in notifications" :key="notification.id" model-value persist>
 			<v-card :class="[notification.type]">
 				<v-card-title>{{ notification.title }}</v-card-title>
 				<v-card-text v-if="notification.text || notification.error">


### PR DESCRIPTION
## Scope

What's changed:

Enforce the usage of [Vue shorthand form for `true` attributes via ESLint](https://eslint.vuejs.org/rules/prefer-true-attribute-shorthand.html), for the following reasons:
- Consistency
- Easier to spot
- Shorter & takes up less space

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A