### PR TITLE
Add homepage to root package.json for quick ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "directus-monorepo",
 	"private": true,
+	"homepage": "https://directus.io",
 	"scripts": {
 		"build": "pnpm --recursive --filter '!docs' run build",
 		"format": "prettier --cache --check .",


### PR DESCRIPTION
## Scope

What's changed:

Added the "homepage" prop to the root `package.json` file.
Although this is a private package, it's still a good ref and handy, for example if you run `pnpm docs` from within the root it automatically opens a browser and navigates you to https://directus.io 🐰 🚀 

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A