### PR TITLE
Use double quotes for docker-compose.yml snippets in docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -84,3 +84,4 @@
 - Boegie19
 - domsen123
 - mscbpi
+- eyecatchup

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -36,7 +36,7 @@ Open a text editor such as Visual Studio Code, nano, Vim, TextEdit, or Notepad.
 Copy and paste the following and save the file as `docker-compose.yml`:
 
 ```yaml-vue
-version: '3'
+version: "3"
 services:
   directus:
     image: directus/directus:{{ directus.version.full }}
@@ -46,12 +46,12 @@ services:
       - ./database:/directus/database
       - ./uploads:/directus/uploads
     environment:
-      KEY: 'replace-with-random-value'
-      SECRET: 'replace-with-random-value'
-      ADMIN_EMAIL: 'admin@example.com'
-      ADMIN_PASSWORD: 'd1r3ctu5'
-      DB_CLIENT: 'sqlite3'
-      DB_FILENAME: '/directus/database/data.db'
+      KEY: "replace-with-random-value"
+      SECRET: "replace-with-random-value"
+      ADMIN_EMAIL: "admin@example.com"
+      ADMIN_PASSWORD: "d1r3ctu5"
+      DB_CLIENT: "sqlite3"
+      DB_FILENAME: "/directus/database/data.db"
       WEBSOCKETS_ENABLED: true
 ```
 


### PR DESCRIPTION
Depending on the Docker version, the use of single quotes in the `docker-compose.yml` file results in an `Top-level object must be a mapping`-error on `docker compose up`. The use of double quotes should be safe for all version.

## Scope

What's changed:

- Replace single quotes with double quotes in `docker-compose.yml` example

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

-  None

---

Fixes #\<num\>
