### PR TITLE
added save options and hide archive button for Content Versioning

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -551,6 +551,7 @@ generated_uuid: Generated UUID
 manual_string: Manually entered string
 save_and_create_new: Save and Create New
 save_and_stay: Save and Stay
+save_and_quit: Save and Quit
 save_as_copy: Save as Copy
 add_existing: Add Existing
 creating_items: Creating Items

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -564,7 +564,7 @@ function revert(values: Record<string, any>) {
 			</v-dialog>
 
 			<v-dialog
-				v-if="collectionInfo.meta && collectionInfo.meta.archive_field && !isNew"
+				v-if="collectionInfo.meta && collectionInfo.meta.archive_field && !isNew && currentVersion === null"
 				v-model="confirmArchive"
 				:disabled="archiveAllowed === false"
 				@esc="confirmArchive = false"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -11,6 +11,7 @@ import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { renderStringTemplate } from '@/utils/render-string-template';
+import { translateShortcut } from '@/utils/translate-shortcut';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
 import FlowSidebarDetail from '@/views/private/components/flow-sidebar-detail.vue';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
@@ -137,8 +138,29 @@ const archiveTooltip = computed(() => {
 	return t('archive');
 });
 
-useShortcut('meta+s', saveAndStay, form);
-useShortcut('meta+shift+s', saveAndAddNew, form);
+useShortcut(
+	'meta+s',
+	() => {
+		if (unref(currentVersion) === null) {
+			saveAndStay();
+		} else {
+			saveVersionAction('stay');
+		}
+	},
+	form
+);
+
+useShortcut(
+	'meta+shift+s',
+	() => {
+		if (unref(currentVersion) === null) {
+			saveAndAddNew();
+		} else {
+			saveVersionAction('quit');
+		}
+	},
+	form
+);
 
 const {
 	createAllowed,
@@ -287,25 +309,24 @@ function useBreadcrumb() {
 	return { breadcrumb };
 }
 
-async function saveVersionAndQuit() {
+async function saveVersionAction(action: 'main' | 'stay' | 'quit') {
 	if (isSavable.value === false) return;
 
 	try {
 		await saveVersion(edits);
 		edits.value = {};
-		if (props.singleton === false) router.push(`/content/${props.collection}`);
-	} catch {
-		// Save version shows unexpected error dialog
-	}
-}
 
-async function saveVersionAndStay() {
-	if (isSavable.value === false) return;
-
-	try {
-		await saveVersion(edits);
-		edits.value = {};
-		refresh();
+		switch (action) {
+			case 'main':
+				currentVersion.value = null;
+				break;
+			case 'stay':
+				refresh();
+				break;
+			case 'quit':
+				if (!props.singleton) router.push(`/content/${props.collection}`);
+				break;
+		}
 	} catch {
 		// Save version shows unexpected error dialog
 	}
@@ -324,11 +345,6 @@ async function saveAndQuit() {
 
 async function saveAndStay() {
 	if (isSavable.value === false) return;
-
-	if (unref(currentVersion) !== null) {
-		saveVersionAndStay();
-		return;
-	}
 
 	try {
 		const savedItem: Record<string, any> = await save();
@@ -610,7 +626,7 @@ function revert(values: Record<string, any>) {
 				:tooltip="t('save_version')"
 				:loading="saveVersionLoading"
 				:disabled="!isSavable"
-				@click="saveVersionAndQuit"
+				@click="saveVersionAction('main')"
 			>
 				<v-icon name="beenhere" />
 
@@ -621,6 +637,16 @@ function revert(values: Record<string, any>) {
 						</template>
 
 						<v-list>
+							<v-list-item clickable @click="saveVersionAction('stay')">
+								<v-list-item-icon><v-icon name="beenhere" /></v-list-item-icon>
+								<v-list-item-content>{{ t('save_and_stay') }}</v-list-item-content>
+								<v-list-item-hint>{{ translateShortcut(['meta', 's']) }}</v-list-item-hint>
+							</v-list-item>
+							<v-list-item clickable @click="saveVersionAction('quit')">
+								<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
+								<v-list-item-content>{{ t('save_and_quit') }}</v-list-item-content>
+								<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
+							</v-list-item>
 							<v-list-item clickable @click="discardAndStay">
 								<v-list-item-icon><v-icon name="undo" /></v-list-item-icon>
 								<v-list-item-content>{{ t('discard_all_changes') }}</v-list-item-content>


### PR DESCRIPTION
## Scope

What's changed:

- Added save options for versions
  - Defaults to "Save and go to Main" for the Save Version button
  - Save and Stay (bound to `CTRL+S`)
  - Save and Quit (bound to `CTRL+ALT+S`)

- Hide Archive button when saving versions, similar to comments and shares being hidden in versions via commit https://github.com/directus/directus/pull/20095/commits/f799696be84c3018cdad728401fa2f18c3ed9b4b.

## Potential Risks / Drawbacks

- The default Save Version behavior may be unfamiliar to some users

## Review Notes / Questions

- Thoughts on whether the default behavior for Save Version and shortcut keys make sense?

---

Closes #20086, fixes #20085
