### PR TITLE
Add max length to `key` & `name` for Content Versioning

### DIFF
--- a/api/src/database/migrations/20230823A-add-content-versioning.ts
+++ b/api/src/database/migrations/20230823A-add-content-versioning.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
 	await knex.schema.createTable('directus_versions', (table) => {
 		table.uuid('id').primary().notNullable();
-		table.string('key').notNullable();
+		table.string('key', 64).notNullable();
 		table.string('name');
 
 		table

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -325,6 +325,7 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 								class="full"
 								:placeholder="t('version_name')"
 								trim
+								:max-length="255"
 								@keyup.enter="createVersion"
 							/>
 						</div>
@@ -362,8 +363,9 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 							<v-input
 								v-model="newVersionName"
 								class="full"
-								trim
 								:placeholder="t('version_name')"
+								trim
+								:max-length="255"
 								@keyup.enter="renameVersion"
 							/>
 						</div>

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -315,6 +315,7 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 								autofocus
 								slug
 								trim
+								:max-length="64"
 								@keyup.enter="createVersion"
 							/>
 						</div>
@@ -353,6 +354,7 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 								autofocus
 								slug
 								trim
+								:max-length="64"
 								@keyup.enter="renameVersion"
 							/>
 						</div>


### PR DESCRIPTION
## Scope

What's changed:

- added limit of 64 to the Data Studio side and database side for version `key`.
- added limit of 255 (same as the default on db side) to the Data Studio side for version `name`. 

## Potential Risks / Drawbacks

- User may not be able to create key longer than 64 now. But since key is used as the value of the `version` query parameter, I do agree a limit is required, and 64 should be generally enough while less likely to hit URL length limit.

## Review Notes / Questions

- I've opted to not add db limit to `name` for now (so it defaults to 255) since technically we're also using the default 255 for name of folders, dashboards, flows etc. That being said, should we also at least add `:max-length="255"` on the Data Studio side for name of those? likely in a separate PR if we want to go forward with that.

---

Fixes #20081