### PR TITLE
Content Versioning: Allow removal of version name

### DIFF
--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -168,7 +168,7 @@ export class VersionsService extends ItemsService {
 		// Only allow updates on "key" and "name" fields
 		const versionUpdateSchema = Joi.object({
 			key: Joi.string(),
-			name: Joi.string(),
+			name: Joi.string().allow(null).optional(),
 		});
 
 		const { error } = versionUpdateSchema.validate(data);

--- a/app/src/composables/use-versions.ts
+++ b/app/src/composables/use-versions.ts
@@ -94,7 +94,7 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 		currentVersion.value = version;
 	}
 
-	async function updateVersion(updates: { key: string; name?: string }) {
+	async function updateVersion(updates: { key: string; name?: string | null }) {
 		if (!currentVersion.value || !versions.value) return;
 
 		const currentVersionId = currentVersion.value.id;
@@ -103,7 +103,7 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 
 		if (versionToUpdate) {
 			versionToUpdate.key = updates.key;
-			if (updates?.name) versionToUpdate.name = updates.name;
+			if ('name' in updates) versionToUpdate.name = updates.name ?? null;
 			currentVersion.value = versionToUpdate;
 		}
 	}

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -20,7 +20,7 @@ const props = defineProps<Props>();
 
 const emit = defineEmits<{
 	add: [version: ContentVersion];
-	update: [updates: { key: string; name?: string }];
+	update: [updates: { key: string; name?: string | null }];
 	delete: [];
 	switch: [version: ContentVersion | null];
 }>();
@@ -137,7 +137,7 @@ function useRenameDialog() {
 		try {
 			const updates = {
 				key: newVersionKey.value,
-				...(newVersionName.value ? { name: newVersionName.value } : {}),
+				...(newVersionName.value !== currentVersion.value?.name ? { name: newVersionName.value } : {}),
 			};
 
 			await api.patch(`/versions/${unref(currentVersion)!.id}`, updates);

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -137,7 +137,7 @@ function useRenameDialog() {
 		try {
 			const updates = {
 				key: newVersionKey.value,
-				...(newVersionName.value !== currentVersion.value?.name ? { name: newVersionName.value } : {}),
+				...(newVersionName.value !== currentVersion.value?.name && { name: newVersionName.value }),
 			};
 
 			await api.patch(`/versions/${unref(currentVersion)!.id}`, updates);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Version name can now be removed. The update request currently does not send a `null` across, and the removed name isn't updated.

## Potential Risks / Drawbacks

- None I believe.

## Review Notes / Questions

- The `name` field is not required. When the name is removed, it falls back to displaying the key.

---

Fixes #\<num\>
