### PR TITLE
Require scope for log / sleep

### DIFF
--- a/api/src/extensions/lib/sandbox/sdk/generators/log.ts
+++ b/api/src/extensions/lib/sandbox/sdk/generators/log.ts
@@ -2,7 +2,9 @@ import type { ExtensionSandboxRequestedScopes } from '@directus/extensions';
 import type { Reference } from 'isolated-vm';
 import logger from '../../../../../logger.js';
 
-export function logGenerator(_requestedScopes: ExtensionSandboxRequestedScopes): (message: Reference<string>) => void {
+export function logGenerator(requestedScopes: ExtensionSandboxRequestedScopes): (message: Reference<string>) => void {
+	if (requestedScopes.log === undefined) throw new Error('No permission to access "log"');
+
 	return (message) => {
 		if (message.typeof !== 'string') throw new TypeError('Log message has to be of type string');
 

--- a/api/src/extensions/lib/sandbox/sdk/generators/sleep.ts
+++ b/api/src/extensions/lib/sandbox/sdk/generators/sleep.ts
@@ -3,8 +3,10 @@ import type { Reference } from 'isolated-vm';
 import { setTimeout } from 'node:timers/promises';
 
 export function sleepGenerator(
-	_requestedScopes: ExtensionSandboxRequestedScopes
+	requestedScopes: ExtensionSandboxRequestedScopes
 ): (milliseconds: Reference<number>) => Promise<void> {
+	if (requestedScopes.sleep === undefined) throw new Error('No permission to access "sleep"');
+
 	return async (milliseconds) => {
 		if (milliseconds.typeof !== 'number') throw new TypeError('Sleep milliseconds has to be of type number');
 

--- a/packages/extensions/src/shared/schemas/options.ts
+++ b/packages/extensions/src/shared/schemas/options.ts
@@ -17,6 +17,8 @@ export const ExtensionSandboxRequestedScopes = z.object({
 			),
 		})
 	),
+	log: z.optional(z.object({})),
+	sleep: z.optional(z.object({})),
 });
 
 export const ExtensionSandboxOptions = z.optional(


### PR DESCRIPTION
## Scope

What's changed:

- Require `log` / `sleep` to be requested in requestedScopes

## Potential Risks / Drawbacks

- Makes things a tad more annoying for the "basics", but safety first

## Review Notes / Questions

- n/a
