### PR TITLE
Support for HEIF / HEIC image transformations

### DIFF
--- a/.changeset/two-drinks-own.md
+++ b/.changeset/two-drinks-own.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Added support for HEIF / HEIC image transformations

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -70,7 +70,14 @@ export const COOKIE_OPTIONS: CookieOptions = {
 export const OAS_REQUIRED_SCHEMAS = ['Diff', 'Schema', 'Query', 'x-metadata'];
 
 /** Formats from which transformation is supported */
-export const SUPPORTED_IMAGE_TRANSFORM_FORMATS = ['image/jpeg', 'image/png', 'image/webp', 'image/tiff', 'image/avif'];
+export const SUPPORTED_IMAGE_TRANSFORM_FORMATS = [
+	'image/jpeg',
+	'image/png',
+	'image/webp',
+	'image/tiff',
+	'image/avif',
+	'image/heic',
+];
 
 /** Formats where metadata extraction is supported */
 export const SUPPORTED_IMAGE_METADATA_FORMATS = [
@@ -80,4 +87,5 @@ export const SUPPORTED_IMAGE_METADATA_FORMATS = [
 	'image/gif',
 	'image/tiff',
 	'image/avif',
+	'image/heic',
 ];


### PR DESCRIPTION
## Scope
Add support to HEIC / HEIF images

What's changed:
- Just add this mimetype to supported images transforms and supported images metadata constants list.
Sharp already supports this image type

## Potential Risks / Drawbacks

- Image not being converted properly, but is out of Directus control

## Review Notes / Questions

- N/A
