### PR TITLE
Fix create-directus-extension utility

### DIFF
--- a/.changeset/olive-icons-obey.md
+++ b/.changeset/olive-icons-obey.md
@@ -1,0 +1,6 @@
+---
+"directus": patch
+"create-directus-extension": patch
+---
+
+Fixed import error in create-directus-extension utility

--- a/packages/create-directus-extension/lib/index.js
+++ b/packages/create-directus-extension/lib/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import inquirer from 'inquirer';
-import { EXTENSION_LANGUAGES, EXTENSION_TYPES, BUNDLE_EXTENSION_TYPES } from '@directus/constants';
+import { EXTENSION_LANGUAGES, EXTENSION_TYPES, BUNDLE_EXTENSION_TYPES } from '@directus/extensions';
 import { create } from '@directus/extensions-sdk/cli';
 
 run();

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -33,7 +33,7 @@
 		"lib/index.js"
 	],
 	"dependencies": {
-		"@directus/constants": "workspace:*",
+		"@directus/extensions": "workspace:*",
 		"@directus/extensions-sdk": "workspace:*",
 		"inquirer": "9.2.4"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1103,9 +1103,9 @@ importers:
 
   packages/create-directus-extension:
     dependencies:
-      '@directus/constants':
+      '@directus/extensions':
         specifier: workspace:*
-        version: link:../constants
+        version: link:../extensions
       '@directus/extensions-sdk':
         specifier: workspace:*
         version: link:../extensions-sdk


### PR DESCRIPTION
Fix #20118 

## Scope

The create-directus-extensions utility was incorrectly importing from the `@directus/constants` package while the actual constants imported are in `@directus/extensions`.

What's changed:
- Fixed import

## Potential Risks / Drawbacks

- Thing will work again


