### PR TITLE
Fixes secure extension register function types

### DIFF
--- a/.changeset/beige-weeks-occur.md
+++ b/.changeset/beige-weeks-occur.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"@directus/extensions": patch
+---
+
+Fixed secure extension register function return types

--- a/packages/extensions/api.d.ts
+++ b/packages/extensions/api.d.ts
@@ -17,7 +17,9 @@ declare module 'directus:api' {
 		body: string | Record<string, unknown>;
 	}
 
-	export type SandboxEndpointRouteHandlerFn = (request: SandboxEndpointRequest) => Promise<SandboxEndpointResponse> | SandboxEndpointResponse;
+	export type SandboxEndpointRouteHandlerFn = (
+		request: SandboxEndpointRequest
+	) => Promise<SandboxEndpointResponse> | SandboxEndpointResponse;
 
 	export type SandboxEndpointRegisterFn = (path: string, handler: SandboxEndpointRouteHandlerFn) => void;
 

--- a/packages/extensions/api.d.ts
+++ b/packages/extensions/api.d.ts
@@ -17,7 +17,7 @@ declare module 'directus:api' {
 		body: string | Record<string, unknown>;
 	}
 
-	export type SandboxEndpointRouteHandlerFn = (request: SandboxEndpointRequest) => Promise<SandboxEndpointResponse>;
+	export type SandboxEndpointRouteHandlerFn = (request: SandboxEndpointRequest) => Promise<SandboxEndpointResponse> | SandboxEndpointResponse;
 
 	export type SandboxEndpointRegisterFn = (path: string, handler: SandboxEndpointRouteHandlerFn) => void;
 
@@ -32,7 +32,7 @@ declare module 'directus:api' {
 	///////////////////////////////////////////////////////////////////////////////////////////
 	// Hooks
 
-	export type SandboxHookHandlerFn = (payload: unknown) => Promise<any>;
+	export type SandboxHookHandlerFn = (payload: unknown) => any;
 
 	export type SandboxHookRegisterFn = (event: string, handler: SandboxHookHandlerFn) => void;
 
@@ -44,7 +44,7 @@ declare module 'directus:api' {
 	///////////////////////////////////////////////////////////////////////////////////////////
 	// Operations
 
-	export type SandboxOperationHandlerFn = (data: Record<string, any>) => Promise<any>;
+	export type SandboxOperationHandlerFn = (data: Record<string, any>) => any;
 
 	export interface SandboxOperationConfig {
 		id: string;


### PR DESCRIPTION

The current types require all secure extension register functions to be `async` because they're explicitly expecting return types of `Promise<T>`.

This is resulting in the hooks example in the docs throwing errors when copy-pasted:
![image](https://github.com/directus/directus/assets/9389634/075b82a5-200c-4c5e-9087-2eba5f0c99b5)


## Scope

What's changed:

- Removed the hard `Promise` type requiring all register functions to be async
- Updated the `hook`, `operation` and `endpoint` handler return type.

## Potential Risks / Drawbacks

- This choice may have been intentional for an unknown reason to me. If so we'll need to update the Docs to always use `async` instead.

## Review Notes / Questions

- I would like to lorem ipsum
