### PR TITLE
Add theming fields to app required permissions

### DIFF
--- a/.changeset/many-beds-beam.md
+++ b/.changeset/many-beds-beam.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added theming fields to app minimal permissions

--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -99,7 +99,11 @@
     - preferences_divider
     - avatar
     - language
-    - theme
+    - appearance
+    - theme_light
+    - theme_dark
+    - theme_light_overrides
+    - theme_dark_overrides
     - tfa_secret
     - status
     - role


### PR DESCRIPTION
## Scope

What's changed:

- Adds the theming fields to the app required minimal permissions

## Potential Risks / Drawbacks

- None. There's no security implications around theming rules

## Review Notes / Questions

—

---

Fixes #20135
