### PR TITLE
Fix 20143 show feedback on empty login

### DIFF
--- a/.changeset/pretty-mangos-build.md
+++ b/.changeset/pretty-mangos-build.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Improved error handling on login-screen when trying to log in without credentials

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -56,7 +56,10 @@ const errorFormatted = computed(() => {
 });
 
 async function onSubmit() {
-	if (email.value === null || password.value === null) return;
+	if (email.value === null || password.value === null) {
+		error.value = 'INVALID_PAYLOAD';
+		return;
+	}
 
 	try {
 		loggingIn.value = true;


### PR DESCRIPTION
## Scope

What's changed:

- Instead of just returning, we now set the error variable to provide the user with feedback when they try to login without credentials

## Potential Risks / Drawbacks

- None. Previously we simply did nothing. Now we display an error.

## Review Notes / Questions

None.

## Demo

[Screencast from 24.10.2023 12:55:52.webm](https://github.com/directus/directus/assets/14810858/adf03529-22e8-4796-ad30-7357bf610a92)

---

Fixes #20143 
