### PR TITLE
Fix caching for Content Versioning

### DIFF
--- a/.changeset/tiny-spoons-pay.md
+++ b/.changeset/tiny-spoons-pay.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed cache value for content versions and added auto cache purging to content version saves

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -4,9 +4,11 @@ import type { ContentVersion, Filter, Item, PrimaryKey, Query } from '@directus/
 import Joi from 'joi';
 import { assign, pick } from 'lodash-es';
 import objectHash from 'object-hash';
+import { getCache } from '../cache.js';
 import getDatabase from '../database/index.js';
 import emitter from '../emitter.js';
 import type { AbstractServiceOptions, MutationOptions } from '../types/index.js';
+import { shouldClearCache } from '../utils/should-clear-cache.js';
 import { ActivityService } from './activity.js';
 import { AuthorizationService } from './authorization.js';
 import { ItemsService } from './items.js';
@@ -248,6 +250,12 @@ export class VersionsService extends ItemsService {
 			data: revisionDelta,
 			delta: revisionDelta,
 		});
+
+		const { cache } = getCache();
+
+		if (shouldClearCache(cache, undefined, version['collection'])) {
+			cache.clear();
+		}
 
 		return data;
 	}

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -480,7 +480,7 @@ than you would cache database content. To learn more, see [Assets](#assets).
 | `CACHE_ENABLED`                              | Whether or not data caching is enabled.                                                                                 | `false`                              |
 | `CACHE_TTL`<sup>[1]</sup>                    | How long the data cache is persisted.                                                                                   | `5m`                                 |
 | `CACHE_CONTROL_S_MAXAGE`                     | Whether to not to add the `s-maxage` expiration flag. Set to a number for a custom value.                               | `0`                                  |
-| `CACHE_AUTO_PURGE`<sup>[2]</sup>             | Automatically purge the data cache on `create`, `update`, and `delete` actions.                                         | `false`                              |
+| `CACHE_AUTO_PURGE`<sup>[2]</sup>             | Automatically purge the data cache on `create`/`update`/`delete` actions, Content Version saves, and the sort utility.  | `false`                              |
 | `CACHE_AUTO_PURGE_IGNORE_LIST`<sup>[3]</sup> | List of collections that prevent cache purging when `CACHE_AUTO_PURGE` is enabled.                                      | `directus_activity,directus_presets` |
 | `CACHE_SYSTEM_TTL`<sup>[4]</sup>             | How long `CACHE_SCHEMA` and `CACHE_PERMISSIONS` are persisted.                                                          | --                                   |
 | `CACHE_SCHEMA`<sup>[4]</sup>                 | Whether or not the database schema is cached. One of `false`, `true`                                                    | `true`                               |

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -480,7 +480,7 @@ than you would cache database content. To learn more, see [Assets](#assets).
 | `CACHE_ENABLED`                              | Whether or not data caching is enabled.                                                                                 | `false`                              |
 | `CACHE_TTL`<sup>[1]</sup>                    | How long the data cache is persisted.                                                                                   | `5m`                                 |
 | `CACHE_CONTROL_S_MAXAGE`                     | Whether to not to add the `s-maxage` expiration flag. Set to a number for a custom value.                               | `0`                                  |
-| `CACHE_AUTO_PURGE`<sup>[2]</sup>             | Automatically purge the data cache on `create`/`update`/`delete` actions, Content Version saves, and the sort utility.  | `false`                              |
+| `CACHE_AUTO_PURGE`<sup>[2]</sup>             | Automatically purge the data cache on actions that manipulate the data.                                                 | `false`                              |
 | `CACHE_AUTO_PURGE_IGNORE_LIST`<sup>[3]</sup> | List of collections that prevent cache purging when `CACHE_AUTO_PURGE` is enabled.                                      | `directus_activity,directus_presets` |
 | `CACHE_SYSTEM_TTL`<sup>[4]</sup>             | How long `CACHE_SCHEMA` and `CACHE_PERMISSIONS` are persisted.                                                          | --                                   |
 | `CACHE_SCHEMA`<sup>[4]</sup>                 | Whether or not the database schema is cached. One of `false`, `true`                                                    | `true`                               |


### PR DESCRIPTION
## Scope

What's changed:

- Ensured cache value contains content version values when `version` query parameter is used
  Previously the `version` query param augments the payload _after_ `setCacheValue` is called, so the cached data is actually incorrect. This PR ensures the augmentation happens _before_ the cache is saved.
- Added auto cache purging for Content Version saves
  Uses the same code over here:
  https://github.com/directus/directus/blob/d9736d001c3b3cfede1e49e9549e6ee04a4decff/api/src/services/utils.ts#L129-L134
  
  which was added in #19115.

## Potential Risks / Drawbacks

- N/A at the moment

## Review Notes / Questions

- Partially unrelated, but should we mention both Content Version saves and also util sort (by #19115) in the description here:

    https://github.com/directus/directus/blob/b0c166ff46bee84f551864b3dc86796c06678b35/docs/self-hosted/config-options.md?plain=1#L483

---

Fixes #20133
