### PR TITLE
Update docs for Theming

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -845,12 +845,12 @@ function sidebarUserGuide() {
 			collapsed: true,
 			items: [
 				{
-					text: 'Theming',
-					link: '/user-guide/settings/theming',
-				},
-				{
 					text: 'Project Settings',
 					link: '/user-guide/settings/project-settings',
+				},
+				{
+					text: 'Theming',
+					link: '/user-guide/settings/theming',
 				},
 				{
 					text: 'Preset and Bookmarks',

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -28,6 +28,7 @@
 (D|d)ropdowns
 (DN|dn)
 (E|e)ntrypoints?
+(F|f)avicon
 (F|f)ilesystem
 (F|f)ormatter
 (F|f)rontend

--- a/docs/reference/system/settings.md
+++ b/docs/reference/system/settings.md
@@ -35,8 +35,26 @@ Foreground image for the Admin App's public pages. Many-to-one to [files](/refer
 `public_background` **many-to-one**\
 Background image for the Admin App's public pages. Many-to-one to [files](/reference/files).
 
+`public_favicon` **many-to-one**\
+Favicon for the Data Studio. Many-to-one to [files](/reference/files).
+
 `public_note` **string**\
 Note shown on the Admin App's public pages. Supports Markdown.
+
+`default_appearance` **string**\
+One of `auto`, `light`, `dark`.
+
+`default_theme_light` **string**\
+Default theme to use in `light` mode.
+
+`default_theme_dark` **string**\
+Default theme to use in `dark` mode.
+
+`theme_light_overrides` **json**\
+Default customization for `light` theme in use.
+
+`theme_dark_overrides` **json**\
+Default customization for `dark` theme in use.
 
 `auth_login_attempts` **integer**\
 How often a user is allowed to try to login. After which times the user will be suspended.

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -45,8 +45,20 @@ Avatar file. Many-to-one to [files](/reference/files).
 Language the Admin App is rendered in. See [our Crowdin page](https://locales.directus.io) for all available languages and
 translations.
 
-`theme` **string**\
+`appearance` **string**\
 One of `auto`, `light`, `dark`.
+
+`theme_light` **string**\
+Theme to use in `light` mode.
+
+`theme_dark` **string**\
+Theme to use in `dark` mode.
+
+`theme_light_overrides` **json**\
+Customization for `light` theme in use.
+
+`theme_dark_overrides` **json**\
+Customization for `dark` theme in use.
 
 `tfa_secret` **string**\
 When TFA is enabled, this holds the secret key for it.
@@ -91,7 +103,7 @@ When this is enabled, the user will receive emails for notifications.
 	"tags": null,
 	"avatar": null,
 	"language": "en-US",
-	"theme": "auto",
+	"appearance": "auto",
 	"tfa_secret": null,
 	"status": "active",
 	"role": "653925a9-970e-487a-bfc0-ab6c96affcdc",

--- a/docs/user-guide/settings/project-settings.md
+++ b/docs/user-guide/settings/project-settings.md
@@ -46,32 +46,6 @@ To manage your project settings programmatically, see our API documentation on [
   [Module Bar](/user-guide/overview/data-studio-app#_1-module-bar).
 - **Default Language** — Sets the default language used within the app.
 
-## Branding & Style
-
-<video title="How to Configure Branding and Style in Project Settings" autoplay playsinline muted loop controls>
-<source src="https://cdn.directus.io/docs/v9/configuration/project-settings/project-settings-20220815/branding-and-style-20220811A.mp4" type="video/mp4" />
-</video>
-
-- **Project Color** — Sets color on the project logo, FavIcon and login/public pages.
-- **Project Logo** — Adds a 40x40px logo at the top of the
-  [Module Bar](/user-guide/overview/data-studio-app#_1-module-bar) and on the login/public pages. The image is inset
-  within a 64x64px square filled with the project color. We recommend using a PNG file for optimal compatibility.
-- **Public Foreground** — Adds image on the public page's right-pane _(max-width 400px)_.
-- **Public Background** — Adds image displayed behind the public foreground image, shown full-bleed within the public
-  page's right-pane. When a public background image is not set, the project color is used instead.
-- **Public Note** — A helpful note displayed at the bottom of the public page's right-pane, supports markdown for
-  rich-text formatting.
-- **Custom CSS** — Applies custom CSS rules to override the Data Studio's default styling. Be aware that the Data
-  Studio's core code, and therefore its DOM selectors, can change at any time. These updates are not considered a
-  breaking change.
-
-::: tip Browser FavIcon & Title
-
-The Project Color is also used to set a dynamic FavIcon and the Project Name is used in the browser's page title, making
-it easier to identify different Directus projects.
-
-:::
-
 ## Modules
 
 <video title="How to Configure the Module Bar in Project Settings" autoplay playsinline muted loop controls>

--- a/docs/user-guide/settings/theming.md
+++ b/docs/user-guide/settings/theming.md
@@ -10,7 +10,8 @@ readTime: 2 min read
 The Directus App has been developed with customization and extensibility in mind. Colors and styles referenced within
 the codebase are based around theme rules which makes it easy to make comprehensive changes to the App styling.
 
-There are two themes included by default: Light and Dark. Each of the rules of these themes can be overridden through the settings in either Theming or User Settings.
+There are two themes included by default: Light and Dark. Each of the rules of these themes can be overridden through
+the settings in either Theming or User Settings.
 
 ## Branding
 

--- a/docs/user-guide/settings/theming.md
+++ b/docs/user-guide/settings/theming.md
@@ -7,13 +7,43 @@ readTime: 2 min read
 
 > Theming allows you to customize and style the visual appearance of your Directus App.
 
-## App Themes
-
 The Directus App has been developed with customization and extensibility in mind. Colors and styles referenced within
 the codebase are based around theme rules which makes it easy to make comprehensive changes to the App styling.
 
-There are two themes included by default: Light and Dark. Each of the rules of these themes can be overridden through
-the settings in either Project Settings (Global) or User Settings.
+There are two themes included by default: Light and Dark. Each of the rules of these themes can be overridden through the settings in either Theming or User Settings.
+
+## Branding
+
+<!-- <video title="How to Configure Branding and Style in Project Settings" autoplay playsinline muted loop controls>
+<source src="https://cdn.directus.io/docs/v9/configuration/project-settings/project-settings-20220815/branding-and-style-20220811A.mp4" type="video/mp4" />
+</video> -->
+
+- **Project Color** — Sets color on the project logo, FavIcon and login/public pages.
+- **Project Logo** — Adds a 40x40px logo at the top of the
+  [Module Bar](/user-guide/overview/data-studio-app#_1-module-bar) and on the login/public pages. The image is inset
+  within a 64x64px square filled with the project color. We recommend using a PNG file for optimal compatibility.
+- **Public Foreground** — Adds image on the public page's right-pane _(max-width 400px)_.
+- **Public Background** — Adds image displayed behind the public foreground image, shown full-bleed within the public
+  page's right-pane. When a public background image is not set, the project color is used instead.
+- **Public Favicon** — Adds favicon for the app.
+- **Public Note** — A helpful note displayed at the bottom of the public page's right-pane, supports markdown for
+  rich-text formatting.
+- **Default Appearance** — Light or Dark theme (or based on system preference).
+
+## Theming Defaults
+
+- **Light Theme Customization** — Default customization for `light` theme in use.
+- **Dark Theme Customization** — Default customization for `dark` theme in use.
+- **Custom CSS** — Applies custom CSS rules to override the Data Studio's default styling. Be aware that the Data
+  Studio's core code, and therefore its DOM selectors, can change at any time. These updates are not considered a
+  breaking change.
+
+::: tip Browser FavIcon & Title
+
+The Project Color is also used to set a dynamic FavIcon and the Project Name is used in the browser's page title, making
+it easier to identify different Directus projects.
+
+:::
 
 ## Custom CSS
 

--- a/docs/user-guide/user-management/user-directory.md
+++ b/docs/user-guide/user-management/user-directory.md
@@ -92,9 +92,16 @@ under [Settings > Data Model > Directus Users](/app/data-model), but the followi
 ![User Preferences](https://cdn.directus.io/docs/v9/app-guide/user-directory/user-directory-20220222A/user-preferences-20220222A.webp)
 
 - **Language** — The preferred App language/locale.
-- **Theme** — Light or Dark mode (or based on system preferences).
 - **Multi-Factor Authentication** — Configuration for MFA.
 - **Email Notifications** — Receive emails for notifications.
+
+### Theme
+
+<!-- ![Theme]() -->
+
+- **Appearance** — Light or Dark theme (or based on system preference).
+- **Light Theme Customization** — Customization for `light` theme in use.
+- **Dark Theme Customization** — Customization for `dark` theme in use.
 
 ### Admin Options
 


### PR DESCRIPTION

## Scope

What's changed:

- Added docs for Theming update via #20026

## Potential Risks / Drawbacks

N/A for now

## Review Notes / Questions

- The description/wordings may have room for improvement.
- User Guide -> User Management -> User Directory's User Preferences screen capture is slightly outdated as it includes the "Theme" field that was moved to a different section.
- We're currently missing a screen capture for User Guide -> User Management -> User Directory's Theme section.
- The User Guide -> General Settings -> Theming's Branding screen capture is outdated (currently intentionally commented out in this PR).
