### PR TITLE
Upgrade create-directus-project dependencies

### DIFF
--- a/.changeset/old-eggs-bathe.md
+++ b/.changeset/old-eggs-bathe.md
@@ -1,0 +1,5 @@
+---
+'create-directus-project': major
+---
+
+Moved from CJS to ESM

--- a/packages/create-directus-project/lib/check-requirements.js
+++ b/packages/create-directus-project/lib/check-requirements.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
-const chalk = require('chalk');
+import chalk from 'chalk';
 
-module.exports = function checkRequirements() {
+export default function checkRequirements() {
 	const nodeVersion = process.versions.node;
 	const major = +nodeVersion.split('.')[0];
 
@@ -12,4 +12,4 @@ module.exports = function checkRequirements() {
 		console.error('Please update your Node version and try again.');
 		process.exit(1);
 	}
-};
+}

--- a/packages/create-directus-project/package.json
+++ b/packages/create-directus-project/package.json
@@ -4,6 +4,7 @@
 	"description": "A small installer util that will create a directory, add boilerplate folders, and install Directus through npm.",
 	"main": "lib/index.js",
 	"repository": "directus/create-directus-project",
+	"type": "module",
 	"exports": {
 		".": "./lib/index.js",
 		"./package.json": "./package.json"
@@ -19,12 +20,12 @@
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"license": "MIT",
 	"dependencies": {
-		"chalk": "^4.1.1",
-		"commander": "^8.0.0",
-		"execa": "^5.1.1",
-		"fs-extra": "^10.0.0",
-		"log-symbols": "4.1.0",
-		"ora": "^5.4.0",
-		"update-check": "^1.5.4"
+		"chalk": "5.3.0",
+		"commander": "11.1.0",
+		"execa": "8.0.1",
+		"fs-extra": "11.1.1",
+		"log-symbols": "6.0.0",
+		"ora": "7.0.1",
+		"update-check": "1.5.4"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1113,25 +1113,25 @@ importers:
   packages/create-directus-project:
     dependencies:
       chalk:
-        specifier: ^4.1.1
-        version: 4.1.2
+        specifier: 5.3.0
+        version: 5.3.0
       commander:
-        specifier: ^8.0.0
-        version: 8.3.0
+        specifier: 11.1.0
+        version: 11.1.0
       execa:
-        specifier: ^5.1.1
-        version: 5.1.1
+        specifier: 8.0.1
+        version: 8.0.1
       fs-extra:
-        specifier: ^10.0.0
-        version: 10.1.0
+        specifier: 11.1.1
+        version: 11.1.1
       log-symbols:
-        specifier: 4.1.0
-        version: 4.1.0
+        specifier: 6.0.0
+        version: 6.0.0
       ora:
-        specifier: ^5.4.0
-        version: 5.4.1
+        specifier: 7.0.1
+        version: 7.0.1
       update-check:
-        specifier: ^1.5.4
+        specifier: 1.5.4
         version: 1.5.4
 
   packages/data:
@@ -11388,6 +11388,11 @@ packages:
     engines: {node: '>=16'}
     dev: true
 
+  /commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+    dev: false
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -11408,11 +11413,6 @@ packages:
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-    dev: false
-
-  /commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
     dev: false
 
   /commander@9.5.0:
@@ -12529,7 +12529,6 @@ packages:
 
   /emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
-    dev: true
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -13103,6 +13102,21 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: false
 
   /exif-reader@1.2.0:
     resolution: {integrity: sha512-C9jsLWxaUh9/gNwo9Ouf9jxP0vGn/2vkhu89wbPFyFfpfl8WPbwLrvrb7h9Q6oVvkyvA+e4lXgOllW+/bAk0RQ==}
@@ -13835,6 +13849,11 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+    dev: false
+
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -14500,6 +14519,11 @@ packages:
   /human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
+
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: false
 
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -15971,6 +15995,14 @@ packages:
   /log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
+    dependencies:
+      chalk: 5.3.0
+      is-unicode-supported: 1.3.0
+    dev: false
+
+  /log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
     dependencies:
       chalk: 5.3.0
       is-unicode-supported: 1.3.0
@@ -17767,6 +17799,21 @@ packages:
       stdin-discarder: 0.1.0
       strip-ansi: 7.1.0
       wcwidth: 1.0.1
+    dev: false
+
+  /ora@7.0.1:
+    resolution: {integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==}
+    engines: {node: '>=16'}
+    dependencies:
+      chalk: 5.3.0
+      cli-cursor: 4.0.0
+      cli-spinners: 2.9.1
+      is-interactive: 2.0.0
+      is-unicode-supported: 1.3.0
+      log-symbols: 5.1.0
+      stdin-discarder: 0.1.0
+      string-width: 6.1.0
+      strip-ansi: 7.1.0
     dev: false
 
   /os-tmpdir@1.0.2:
@@ -20916,6 +20963,15 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  /string-width@6.1.0:
+    resolution: {integrity: sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 10.3.0
+      strip-ansi: 7.1.0
+    dev: false
 
   /string.prototype.matchall@4.0.10:
     resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}


### PR DESCRIPTION
## Scope

What's changed:

- Moved the create-directus-project from CJS to ESM
- Upgraded all the dependencies
- Updated the npm flag to `--omit=dev` instead of `--production`

## Potential Risks / Drawbacks

- Low risk, just the create-directus-project

## Review Notes / Questions

- None

---

Fixes #20158