### PR TITLE
Update requirements check to match LTS requirement

### DIFF
--- a/.changeset/pink-points-run.md
+++ b/.changeset/pink-points-run.md
@@ -1,0 +1,5 @@
+---
+'create-directus-project': patch
+---
+
+Update requirements check to match node 18+ requirement

--- a/packages/create-directus-project/lib/check-requirements.js
+++ b/packages/create-directus-project/lib/check-requirements.js
@@ -6,9 +6,9 @@ export default function checkRequirements() {
 	const nodeVersion = process.versions.node;
 	const major = +nodeVersion.split('.')[0];
 
-	if (major < 12) {
+	if (major < 18) {
 		console.error(`You are running ${chalk.red(`Node ${nodeVersion}`)}.`);
-		console.error(`Directus requires ${chalk.green(`Node 12`)} and up.`);
+		console.error(`Directus requires ${chalk.green(`Node 18`)} and up.`);
 		console.error('Please update your Node version and try again.');
 		process.exit(1);
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Check for node 18+ instead of 12+

## Potential Risks / Drawbacks

- This would be a every-2-year update I suppose. It'd be neater to have it read what the LTS should be and use that, but.. 🤷🏻  (Although.. that'd be 20+ since 2 days ago, whereas Directus runs fine on 18)

## Review Notes / Questions

- None

---

Fixes #20165
