### PR TITLE
Only load extensions for users/roles command

### DIFF
--- a/.changeset/loud-starfishes-fly.md
+++ b/.changeset/loud-starfishes-fly.md
@@ -1,0 +1,7 @@
+---
+'@directus/api': major
+---
+
+Only load extensions in CLI commands that modify database records like users/roles.
+
+This change is made to avoid blocking errors that are thrown when extensions are attempted to be loaded against a database that isn't installed/updated yet. This can and will happen during any of the database schema commands (like migrate, bootstrap, snapshot).

--- a/api/src/cli/commands/roles/create.ts
+++ b/api/src/cli/commands/roles/create.ts
@@ -1,7 +1,8 @@
-import { getSchema } from '../../../utils/get-schema.js';
-import { RolesService } from '../../../services/roles.js';
 import getDatabase from '../../../database/index.js';
+import { getExtensionManager } from '../../../extensions/index.js';
 import logger from '../../../logger.js';
+import { RolesService } from '../../../services/roles.js';
+import { getSchema } from '../../../utils/get-schema.js';
 
 export default async function rolesCreate({ role: name, admin }: { role: string; admin: boolean }): Promise<void> {
 	const database = getDatabase();
@@ -14,6 +15,9 @@ export default async function rolesCreate({ role: name, admin }: { role: string;
 	try {
 		const schema = await getSchema();
 		const service = new RolesService({ schema: schema, knex: database });
+
+		const extensionManager = getExtensionManager();
+		await extensionManager.initialize({ schedule: false, watch: false });
 
 		const id = await service.createOne(admin ? { name, admin_access: admin } : { name });
 		process.stdout.write(`${String(id)}\n`);

--- a/api/src/cli/commands/users/create.ts
+++ b/api/src/cli/commands/users/create.ts
@@ -1,7 +1,8 @@
-import { getSchema } from '../../../utils/get-schema.js';
-import { UsersService } from '../../../services/users.js';
 import getDatabase from '../../../database/index.js';
+import { getExtensionManager } from '../../../extensions/index.js';
 import logger from '../../../logger.js';
+import { UsersService } from '../../../services/users.js';
+import { getSchema } from '../../../utils/get-schema.js';
 
 export default async function usersCreate({
 	email,
@@ -20,6 +21,9 @@ export default async function usersCreate({
 	}
 
 	try {
+		const extensionManager = getExtensionManager();
+		await extensionManager.initialize({ schedule: false, watch: false });
+
 		const schema = await getSchema();
 		const service = new UsersService({ schema, knex: database });
 

--- a/api/src/cli/commands/users/passwd.ts
+++ b/api/src/cli/commands/users/passwd.ts
@@ -1,8 +1,9 @@
-import { getSchema } from '../../../utils/get-schema.js';
-import { generateHash } from '../../../utils/generate-hash.js';
-import { UsersService } from '../../../services/users.js';
 import getDatabase from '../../../database/index.js';
+import { getExtensionManager } from '../../../extensions/index.js';
 import logger from '../../../logger.js';
+import { UsersService } from '../../../services/users.js';
+import { generateHash } from '../../../utils/generate-hash.js';
+import { getSchema } from '../../../utils/get-schema.js';
 
 export default async function usersPasswd({ email, password }: { email?: string; password?: string }): Promise<void> {
 	const database = getDatabase();
@@ -13,6 +14,9 @@ export default async function usersPasswd({ email, password }: { email?: string;
 	}
 
 	try {
+		const extensionManager = getExtensionManager();
+		await extensionManager.initialize({ schedule: false, watch: false });
+
 		const passwordHashed = await generateHash(password);
 		const schema = await getSchema();
 		const service = new UsersService({ schema, knex: database });

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -1,7 +1,5 @@
 import { Command, Option } from 'commander';
-import { isInstalled } from '../database/index.js';
 import emitter from '../emitter.js';
-import { getExtensionManager } from '../extensions/index.js';
 import { startServer } from '../server.js';
 import * as pkg from '../utils/package.js';
 import bootstrap from './commands/bootstrap/index.js';
@@ -19,11 +17,6 @@ import usersPasswd from './commands/users/passwd.js';
 
 export async function createCli(): Promise<Command> {
 	const program = new Command();
-
-	if ((await isInstalled()) === true) {
-		const extensionManager = getExtensionManager();
-		await extensionManager.initialize({ schedule: false, watch: false });
-	}
 
 	await emitter.emitInit('cli.before', { program });
 


### PR DESCRIPTION
## Scope

PR #7675 was intended to run hooks when using the users/roles command in the CLI. Using extensions everywhere can cause major issues, as the database may or may not exist, and may or may not be up to date.

What's changed:

- Remove the global loading of the extensions manager in the CLI
- Load the extensions in the CLI commands where extensions are intended to be loaded

## Potential Risks / Drawbacks

- I don't know if this is a use case people are exploiting, but it could be a breaking change for people who rely on `init` hooks during the bootstrapping phase.

## Review Notes / Questions

- None

---

Fixes #20166, fixes #20131