### PR TITLE
Don't load CLI extensions if database is missing or out of date

### DIFF
--- a/.changeset/metal-shrimps-enjoy.md
+++ b/.changeset/metal-shrimps-enjoy.md
@@ -2,5 +2,5 @@
 '@directus/api': patch
 ---
 
-Fixed an issue that could cause the CLI to log traces on caught errors
+Don't load extensions in the CLI if the database hasn't been installed yet or is out of date
 

--- a/.changeset/metal-shrimps-enjoy.md
+++ b/.changeset/metal-shrimps-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that could cause the CLI to log traces on caught errors
+

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { isInstalled } from '../database/index.js';
 import emitter from '../emitter.js';
 import { getExtensionManager } from '../extensions/index.js';
+import logger from '../logger.js';
 import { startServer } from '../server.js';
 import * as pkg from '../utils/package.js';
 import bootstrap from './commands/bootstrap/index.js';
@@ -21,8 +22,13 @@ export async function createCli(): Promise<Command> {
 	const program = new Command();
 
 	if ((await isInstalled()) === true) {
-		const extensionManager = getExtensionManager();
-		await extensionManager.initialize({ schedule: false, watch: false });
+		try {
+			const extensionManager = getExtensionManager();
+			await extensionManager.initialize({ schedule: false, watch: false });
+		} catch (err) {
+			logger.warn(`Couldn't load CLI extensions.`);
+			logger.trace(err);
+		}
 	}
 
 	await emitter.emitInit('cli.before', { program });

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -2,7 +2,6 @@ import { Command, Option } from 'commander';
 import { isInstalled } from '../database/index.js';
 import emitter from '../emitter.js';
 import { getExtensionManager } from '../extensions/index.js';
-import logger from '../logger.js';
 import { startServer } from '../server.js';
 import * as pkg from '../utils/package.js';
 import bootstrap from './commands/bootstrap/index.js';
@@ -22,13 +21,8 @@ export async function createCli(): Promise<Command> {
 	const program = new Command();
 
 	if ((await isInstalled()) === true) {
-		try {
-			const extensionManager = getExtensionManager();
-			await extensionManager.initialize({ schedule: false, watch: false });
-		} catch (err) {
-			logger.warn(`Couldn't load CLI extensions.`);
-			logger.trace(err);
-		}
+		const extensionManager = getExtensionManager();
+		await extensionManager.initialize({ schedule: false, watch: false });
 	}
 
 	await emitter.emitInit('cli.before', { program });

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -1,7 +1,5 @@
 import { Command, Option } from 'commander';
-import { isInstalled } from '../database/index.js';
 import emitter from '../emitter.js';
-import { getExtensionManager } from '../extensions/index.js';
 import { startServer } from '../server.js';
 import * as pkg from '../utils/package.js';
 import bootstrap from './commands/bootstrap/index.js';
@@ -16,14 +14,12 @@ import keyGenerate from './commands/security/key.js';
 import secretGenerate from './commands/security/secret.js';
 import usersCreate from './commands/users/create.js';
 import usersPasswd from './commands/users/passwd.js';
+import { loadExtensions } from './load-extensions.js';
 
 export async function createCli(): Promise<Command> {
 	const program = new Command();
 
-	if ((await isInstalled()) === true) {
-		const extensionManager = getExtensionManager();
-		await extensionManager.initialize({ schedule: false, watch: false });
-	}
+	await loadExtensions();
 
 	await emitter.emitInit('cli.before', { program });
 

--- a/api/src/cli/load-extensions.ts
+++ b/api/src/cli/load-extensions.ts
@@ -1,0 +1,22 @@
+import { isInstalled, validateMigrations } from '../database/index.js';
+import { getEnv } from '../env.js';
+import { getExtensionManager } from '../extensions/index.js';
+
+export const loadExtensions = async () => {
+	const env = getEnv();
+
+	if (!('DB_CLIENT' in env)) return;
+
+	const installed = await isInstalled();
+
+	if (!installed) return;
+
+	try {
+		await validateMigrations();
+	} catch {
+		return;
+	}
+
+	const extensionManager = getExtensionManager();
+	await extensionManager.initialize({ schedule: false, watch: false });
+};

--- a/api/src/cli/load-extensions.ts
+++ b/api/src/cli/load-extensions.ts
@@ -12,10 +12,10 @@ export const loadExtensions = async () => {
 
 	if (!installed) return;
 
-	try {
-		await validateMigrations();
-	} catch {
-		logger.info('Database is out of date. Skipping CLI extensions initialization.');
+	const migrationsValid = await validateMigrations();
+
+	if (!migrationsValid) {
+		logger.info('Migrations required. Skipping CLI extensions initialization.');
 		return;
 	}
 

--- a/api/src/cli/load-extensions.ts
+++ b/api/src/cli/load-extensions.ts
@@ -1,6 +1,7 @@
 import { isInstalled, validateMigrations } from '../database/index.js';
 import { getEnv } from '../env.js';
 import { getExtensionManager } from '../extensions/index.js';
+import logger from '../logger.js';
 
 export const loadExtensions = async () => {
 	const env = getEnv();
@@ -14,6 +15,7 @@ export const loadExtensions = async () => {
 	try {
 		await validateMigrations();
 	} catch {
+		logger.info('Database is out of date. Skipping CLI extensions initialization.');
 		return;
 	}
 

--- a/api/src/cli/load-extensions.ts
+++ b/api/src/cli/load-extensions.ts
@@ -15,7 +15,7 @@ export const loadExtensions = async () => {
 	const migrationsValid = await validateMigrations();
 
 	if (!migrationsValid) {
-		logger.info('Migrations required. Skipping CLI extensions initialization.');
+		logger.info('Skipping CLI extensions initialization due to outstanding migrations.');
 		return;
 	}
 

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -180,7 +180,7 @@ export class ExtensionManager {
 			this.extensionsSettings = await getExtensionsSettings(this.extensions);
 		} catch (err: any) {
 			logger.warn(`Couldn't load extensions`);
-			logger.trace(err);
+			logger.warn(err);
 		}
 
 		await this.registerHooks();
@@ -391,7 +391,7 @@ export class ExtensionManager {
 			return output[0].code;
 		} catch (error: any) {
 			logger.warn(`Couldn't bundle App extensions`);
-			logger.trace(error);
+			logger.warn(error);
 		}
 
 		return null;
@@ -488,7 +488,7 @@ export class ExtensionManager {
 				}
 			} catch (error: any) {
 				logger.warn(`Couldn't register hook "${hook.name}"`);
-				logger.trace(error);
+				logger.warn(error);
 			}
 		}
 	}
@@ -531,7 +531,7 @@ export class ExtensionManager {
 				}
 			} catch (error: any) {
 				logger.warn(`Couldn't register endpoint "${endpoint.name}"`);
-				logger.trace(error);
+				logger.warn(error);
 			}
 		}
 	}
@@ -588,7 +588,7 @@ export class ExtensionManager {
 				}
 			} catch (error: any) {
 				logger.warn(`Couldn't register operation "${operation.name}"`);
-				logger.trace(error);
+				logger.warn(error);
 			}
 		}
 	}
@@ -641,7 +641,7 @@ export class ExtensionManager {
 				});
 			} catch (error: any) {
 				logger.warn(`Couldn't register bundle "${bundle.name}"`);
-				logger.trace(error);
+				logger.warn(error);
 			}
 		}
 	}

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -180,7 +180,7 @@ export class ExtensionManager {
 			this.extensionsSettings = await getExtensionsSettings(this.extensions);
 		} catch (err: any) {
 			logger.warn(`Couldn't load extensions`);
-			logger.warn(err);
+			logger.trace(err);
 		}
 
 		await this.registerHooks();
@@ -391,7 +391,7 @@ export class ExtensionManager {
 			return output[0].code;
 		} catch (error: any) {
 			logger.warn(`Couldn't bundle App extensions`);
-			logger.warn(error);
+			logger.trace(error);
 		}
 
 		return null;
@@ -488,7 +488,7 @@ export class ExtensionManager {
 				}
 			} catch (error: any) {
 				logger.warn(`Couldn't register hook "${hook.name}"`);
-				logger.warn(error);
+				logger.trace(error);
 			}
 		}
 	}
@@ -531,7 +531,7 @@ export class ExtensionManager {
 				}
 			} catch (error: any) {
 				logger.warn(`Couldn't register endpoint "${endpoint.name}"`);
-				logger.warn(error);
+				logger.trace(error);
 			}
 		}
 	}
@@ -588,7 +588,7 @@ export class ExtensionManager {
 				}
 			} catch (error: any) {
 				logger.warn(`Couldn't register operation "${operation.name}"`);
-				logger.warn(error);
+				logger.trace(error);
 			}
 		}
 	}
@@ -641,7 +641,7 @@ export class ExtensionManager {
 				});
 			} catch (error: any) {
 				logger.warn(`Couldn't register bundle "${bundle.name}"`);
-				logger.warn(error);
+				logger.trace(error);
 			}
 		}
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Warn instead of crash if extensions couldn't be loaded

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #20166, fixes #20131