### PR TITLE
Use fixed tag for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.version.outputs.prerelease && true || false }}
-      prerelease-id: ${{ steps.version.outputs.prerelease-0 }}
     steps:
       - name: Check version
         uses: madhead/semver-utils@v3
@@ -61,7 +60,7 @@ jobs:
           pnpm --recursive publish \
             --access=public \
             --no-git-checks \
-            --tag ${{ needs.check-version.outputs.prerelease == 'true' && needs.check-version.outputs.prerelease-id  || 'latest' }}
+            --tag ${{ needs.check-version.outputs.prerelease == 'true' && 'canary'  || 'latest' }}
 
   build-images:
     name: Build Images
@@ -96,7 +95,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=${{ needs.check-version.outputs.prerelease-id }},enable=${{ needs.check-version.outputs.prerelease }}
+            type=raw,value=canary,enable=${{ needs.check-version.outputs.prerelease }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
Based on earlier discussion, we should use the same tag (`canary`) for all prereleases so consumers can stay on that channel and receive all prereleases updates (without having to switch between `beta`, `alpha`, ...).
