### PR TITLE
Enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     needs: check-version
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
       - name: Publish packages to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
           pnpm --recursive publish \
             --access=public \


### PR DESCRIPTION
## Scope

What's changed:

Enable generation of provenance statements for npm packages [^1] in release workflow.

## Potential Risks / Drawbacks

In the worst case the "Publish to NPM" job might fail for whatever reason, but in this case we are able to publish the packages manually and fix/revert this PR.

## Review Notes / Questions

Using the env variable `NPM_CONFIG_PROVENANCE` instead of `--provenance` flag to ensure it works with pnpm [^2].

[^1]: https://docs.npmjs.com/generating-provenance-statements
[^2]: https://github.com/pnpm/pnpm/issues/6435#issuecomment-1518397267