### PR TITLE
Fix rendering of closed field groups once openend

### DIFF
--- a/.changeset/tall-lobsters-punch.md
+++ b/.changeset/tall-lobsters-punch.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed an issue where forms with detail/accordion fields starting closed would freeze the browser once opened

--- a/app/src/utils/push-group-options-down.test.ts
+++ b/app/src/utils/push-group-options-down.test.ts
@@ -3,7 +3,7 @@ import { expect, it, test } from 'vitest';
 import { Field } from '@directus/types';
 import { pushGroupOptionsDown } from './push-group-options-down.js';
 
-test('pushGroupOptionsDown', () => {
+test('basic', () => {
 	const fields: Field[] = [
 		{
 			field: 'group1',
@@ -64,7 +64,26 @@ test('pushGroupOptionsDown', () => {
 	});
 });
 
-test('pushGroupOptionsDown with nested groups', () => {
+test('with < 2 fields', () => {
+	const fields: Field[] = [
+		{
+			field: 'group1',
+			type: 'alias',
+			collection: 'test',
+			meta: {
+				required: true,
+				readonly: true,
+				special: ['group'],
+			} as any,
+			schema: null,
+			name: 'Group 1',
+		},
+	];
+
+	expect(pushGroupOptionsDown(fields)).toBe(fields);
+});
+
+test('with nested groups', () => {
 	const fields: Field[] = [
 		{
 			field: 'group1',
@@ -170,22 +189,33 @@ test('pushGroupOptionsDown with nested groups', () => {
 	]);
 });
 
-// This happens e.g. when fields are nested in a accordion
-test('pushGroupOptionsDown with single field', () => {
+// Happens when accordion / detail fields are starting closed & are then opened
+// (only sub fields are passed to pushGroupOptionsDown)
+test('with missing referenced groups', () => {
 	const fields: Field[] = [
 		{
+			field: 'field_in_group1',
+			type: 'boolean',
 			collection: 'test',
-			field: 'detail',
-			type: 'alias',
-			schema: null,
 			meta: {
-				special: ['alias', 'no-data', 'group'],
-				interface: 'group-detail',
+				required: true,
 				readonly: false,
-				required: false,
-				group: 'accordion-3ml8h4',
+				group: 'group1',
 			} as any,
-			name: 'Detail',
+			schema: null,
+			name: 'Field in group 1',
+		},
+		{
+			field: 'field_in_group1_1',
+			type: 'boolean',
+			collection: 'test',
+			meta: {
+				required: true,
+				readonly: true,
+				group: 'group1_1',
+			} as any,
+			schema: null,
+			name: 'Field in group 1 1',
 		},
 	];
 

--- a/app/src/utils/push-group-options-down.ts
+++ b/app/src/utils/push-group-options-down.ts
@@ -2,41 +2,98 @@ import { Field, FieldMeta } from '@directus/types';
 import { cloneDeep } from 'lodash';
 
 export function pushGroupOptionsDown(fields: Field[]) {
+	if (fields.length < 2) return fields;
+
 	fields = cloneDeep(fields);
 
-	const updatedGroups: string[] = [];
-	const fieldsQueue: Field[] = [...fields];
+	const tree = getFieldsTree(fields);
 
-	while (fieldsQueue.length > 1) {
-		const field = fieldsQueue.shift();
-
-		if (!field) break;
-
-		const parent = field?.meta?.group;
-		const isGroup = field.meta?.special?.includes('group');
-
-		if (!isGroup) continue;
-
-		if (parent && !updatedGroups.includes(parent)) {
-			fieldsQueue.push(field);
-			continue;
-		}
-
-		for (const childField of fields) {
-			if (childField.meta?.group !== field.field) continue;
-
-			childField.meta.required = field.meta?.required || childField.meta.required;
-			childField.meta.readonly = field.meta?.readonly || childField.meta.readonly;
-		}
-
-		if (!field.meta) {
-			field.meta = {} as FieldMeta;
-		}
-
-		field.meta.required = false;
-		field.meta.readonly = false;
-		updatedGroups.push(field.field);
-	}
+	processFieldsTree(tree);
 
 	return fields;
+}
+
+type Item = {
+	field: Field;
+};
+
+type GroupItem = {
+	field?: Field;
+	children: (Item | GroupItem)[];
+};
+
+type FinalGroupItem = {
+	field: Field;
+	children: (Item | FinalGroupItem)[];
+};
+
+type TreeItem = Item | FinalGroupItem;
+
+function processFieldsTree(tree: TreeItem[]) {
+	for (const item of tree) {
+		if ('children' in item) {
+			const readonly = item.field.meta?.readonly;
+			const required = item.field.meta?.required;
+
+			item.field.meta ??= {} as FieldMeta;
+
+			item.field.meta.readonly = false;
+			item.field.meta.required = false;
+
+			for (const child of item.children) {
+				child.field.meta ??= {} as FieldMeta;
+
+				if (readonly) {
+					child.field.meta.readonly = true;
+				}
+
+				if (required) {
+					child.field.meta.required = true;
+				}
+			}
+
+			processFieldsTree(item.children);
+		}
+	}
+}
+
+function getFieldsTree(fields: Field[]): TreeItem[] {
+	const rootFields: TreeItem[] = [];
+	const lookup = new Map<Field['field'], GroupItem>();
+
+	for (const field of fields) {
+		const id = field.field;
+		const groupId = field.meta?.group;
+		const isGroup = field.meta?.special?.includes('group');
+
+		let treeItem;
+
+		if (isGroup) {
+			treeItem = lookup.get(id);
+
+			if (!treeItem) {
+				treeItem = { field, children: [] };
+				lookup.set(id, treeItem);
+			} else {
+				treeItem.field = field;
+			}
+
+			if (!groupId) {
+				rootFields.push(treeItem as FinalGroupItem);
+			}
+		}
+
+		if (groupId) {
+			let group = lookup.get(groupId);
+
+			if (!group) {
+				group = { children: [] };
+				lookup.set(groupId, group);
+			}
+
+			group.children.push(treeItem ?? { field });
+		}
+	}
+
+	return rootFields;
 }


### PR DESCRIPTION
## Scope

What's changed:

In #19962 we didn't take into account that with closed field groups, once opened the `pushGroupOptionsDown` only receives a subset of fields (the nested ones), which means the referenced groups are missing in the set. This resulted into an infinite loop in the function.

To correctly handle such cases, we're now building a proper tree from the fields, which means the function does nothing if groups aren't part of the received array.

Corresponding test cases have been added.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

Did a quick benchmark to ensure the new implementation is at least as fast as the previous one. In fact, it is slightly faster compared to a "patched version" of the previous implementation.

---

Fixes #20145