### PR TITLE
Properly handle circular structures in redaction

### DIFF
--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -1,4 +1,5 @@
 import { Action } from '@directus/constants';
+import { ForbiddenError } from '@directus/errors';
 import type { OperationHandler } from '@directus/extensions';
 import type { Accountability, ActionHandler, FilterHandler, Flow, Operation, SchemaOverview } from '@directus/types';
 import { applyOptionsData, getRedactedString, isValidJSON, parseJSON, toArray } from '@directus/utils';
@@ -8,7 +9,6 @@ import { get } from 'micromustache';
 import getDatabase from './database/index.js';
 import emitter from './emitter.js';
 import env from './env.js';
-import { ForbiddenError } from '@directus/errors';
 import logger from './logger.js';
 import { getMessenger } from './messenger.js';
 import { ActivityService } from './services/activity.js';
@@ -358,7 +358,7 @@ class FlowManager {
 					data: {
 						steps: steps.map((step) => redactObject(step, { values: this.envs }, getRedactedString)),
 						data: redactObject(
-							omit(keyedData, '$accountability.permissions'), // Permissions is a ton of data, and is just a copy of what's in the directus_permissions table
+							omit(keyedData, '$accountability.permissions', '$last'), // Permissions is a ton of data, and is just a copy of what's in the directus_permissions table
 							{
 								keys: [
 									['**', 'headers', 'authorization'],

--- a/api/src/utils/redact-object.test.ts
+++ b/api/src/utils/redact-object.test.ts
@@ -179,7 +179,7 @@ describe('getReplacer tests', () => {
 		const replacer = getReplacer(getRedactedString);
 
 		for (const value of values) {
-			expect(replacer('', value)).toBe(value);
+			expect(replacer('', value)).toEqual(value);
 		}
 	});
 
@@ -193,7 +193,26 @@ describe('getReplacer tests', () => {
 
 		const expectedResult = {
 			a: 'foo',
-			c: {},
+			b: '[Circular]',
+			c: { obj: '[Circular]' },
+		};
+
+		const result = JSON.parse(JSON.stringify(obj, getReplacer(getRedactedString)));
+
+		expect(result).toStrictEqual(expectedResult);
+	});
+
+	test('Correctly parses object with repeatedly occurring same refs', () => {
+		const ref = {};
+
+		const obj: Record<string, any> = {
+			a: ref,
+			b: ref,
+		};
+
+		const expectedResult = {
+			a: ref,
+			b: ref,
 		};
 
 		const result = JSON.parse(JSON.stringify(obj, getReplacer(getRedactedString)));


### PR DESCRIPTION
## Scope

What's changed:

- Organize imports (auto format)
- Added omission of `$last` because that resulted through [WeakSet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet) _magic_ in us deleting our actually needed data.

## Potential Risks / Drawbacks

- Redacting is important and a priority thing so we gotta double check 

## Review Notes / Questions

- I'm adding this PR with the quick fix but we might need to look deeper into how we redact to make sure this cant happen again. Let's discuss.

---

Fixes #20155 
