### PR TITLE
Properly handle circular structures in redaction

### DIFF
--- a/.changeset/eighty-teachers-crash.md
+++ b/.changeset/eighty-teachers-crash.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed an issue where in values in the logs of Flows were erroneously redacted

--- a/api/src/utils/redact-object.test.ts
+++ b/api/src/utils/redact-object.test.ts
@@ -190,11 +190,13 @@ describe('getReplacer tests', () => {
 
 		obj['b'] = obj;
 		obj['c'] = { obj };
+		obj['d'] = [obj];
 
 		const expectedResult = {
 			a: 'foo',
 			b: '[Circular]',
 			c: { obj: '[Circular]' },
+			d: ['[Circular]'],
 		};
 
 		const result = JSON.parse(JSON.stringify(obj, getReplacer(getRedactedString)));

--- a/api/src/utils/redact-object.test.ts
+++ b/api/src/utils/redact-object.test.ts
@@ -179,7 +179,7 @@ describe('getReplacer tests', () => {
 		const replacer = getReplacer(getRedactedString);
 
 		for (const value of values) {
-			expect(replacer('', value)).toBe(value);
+			expect(replacer('', value)).toEqual(value);
 		}
 	});
 
@@ -193,7 +193,26 @@ describe('getReplacer tests', () => {
 
 		const expectedResult = {
 			a: 'foo',
-			c: {},
+			b: '[Circular]',
+			c: { obj: '[Circular]' },
+		};
+
+		const result = JSON.parse(JSON.stringify(obj, getReplacer(getRedactedString)));
+
+		expect(result).toStrictEqual(expectedResult);
+	});
+
+	test('Correctly parses object with repeatedly occurring same refs', () => {
+		const ref = {};
+
+		const obj: Record<string, any> = {
+			a: ref,
+			b: ref,
+		};
+
+		const expectedResult = {
+			a: ref,
+			b: ref,
 		};
 
 		const result = JSON.parse(JSON.stringify(obj, getReplacer(getRedactedString)));


### PR DESCRIPTION
## Scope

What's changed:

Previous check for circular structures in redaction was a "cheap" check, globally checking if a value with same ref already appeared. This didn't take into account that the same value can actually appear again like with the `$last` object in Flows.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

Instead of deleting circular props, those are now getting replaced with `[Circular]` for easier debugging.

---

Fixes #20155
