### PR TITLE
Add "Project Default" option to user appearance setting

### DIFF
--- a/.changeset/quick-parrots-study.md
+++ b/.changeset/quick-parrots-study.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Added explicit "Project Default" option to user appearance setting

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -104,6 +104,8 @@ fields:
     interface: select-dropdown
     options:
       choices:
+        - value: null
+          text: $t:appearance_global
         - value: auto
           text: $t:appearance_auto
         - value: light

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1029,9 +1029,10 @@ deselect: Deselect
 deselect_all: Deselect All
 theme: Theme
 select_a_theme: Select a Theme
-appearance_auto: Automatic (Based on System)
-appearance_light: Light Mode
-appearance_dark: Dark Mode
+appearance_global: Project Default
+appearance_auto: Automatic (Sync with System)
+appearance_light: Light
+appearance_dark: Dark
 other: Other...
 adding_user: Adding User
 unknown_user: Unknown User


### PR DESCRIPTION
## Scope

To use the project settings default for `appearance`, the user would have to use the field-label options to "Clear Value" back to `null`.

What's changed:

- Added an explicit `null` option to the user settings `appearance` option

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—

---

Fixes #20192