### PR TITLE
Workaround for worker pool on ARM machines

### DIFF
--- a/.changeset/modern-moose-kiss.md
+++ b/.changeset/modern-moose-kiss.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Applied a workaround for failing CSV imports on ARM machines

--- a/api/src/worker-pool.ts
+++ b/api/src/worker-pool.ts
@@ -1,3 +1,4 @@
+import os from 'node:os';
 import Tinypool from 'tinypool';
 
 let workerPool: Tinypool | undefined;
@@ -8,6 +9,15 @@ export function getWorkerPool() {
 			minThreads: 0,
 			maxQueue: 'auto',
 		});
+
+		// TODO Workaround currently required for failing CPU count on ARM in Tinypool,
+		//      remove again once fixed upstream
+		if (workerPool.options.maxThreads === 0) {
+			const availableParallelism = os.availableParallelism();
+
+			workerPool.options.maxThreads = availableParallelism;
+			workerPool.options.maxQueue = availableParallelism ** 2;
+		}
 	}
 
 	return workerPool;


### PR DESCRIPTION
## Scope

What's changed:

The CPU count built into Tinypool doesn't work on ARM architectures, which means no pool for CSV import is available on such machines.
This introduces a workaround until the issue has been fixed upstream (I plan to submit a PR over there).

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

Linked issue can be simulated by setting `workerPool.options.maxQueue = 0`.

---

Fixes #20149
