### PR TITLE
SDK Fix all filters required

### DIFF
--- a/.changeset/giant-mayflies-destroy.md
+++ b/.changeset/giant-mayflies-destroy.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed all filters being required regression in the SDK

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -24,7 +24,7 @@ export type NestedQueryFilter<Schema extends object, Item> = UnpackList<Item> ex
 							: never;
 				  }
 				: never
-		>
+	  >
 	: never;
 
 /**
@@ -32,9 +32,9 @@ export type NestedQueryFilter<Schema extends object, Item> = UnpackList<Item> ex
  */
 export type NestedRelationalFilter<Schema extends object, Item, Field extends keyof Item> =
 	| (Field extends RelationalFields<Schema, Item>
-		? WrapRelationalFilters<NestedQueryFilter<Schema, Item[Field]>>
-		: never)
-	| FilterOperators<Item[Field]>
+			? WrapRelationalFilters<NestedQueryFilter<Schema, Item[Field]>>
+			: never)
+	| FilterOperators<Item[Field]>;
 
 /**
  * All regular filter operators

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -5,7 +5,7 @@ import type { MergeOptional, UnpackList } from './utils.js';
 /**
  * Filters
  */
-export type QueryFilter<_Schema extends object, _Item> = WrapLogicalFilters<{test: number}/*NestedQueryFilter<Schema, Item>*/>;
+export type QueryFilter<Schema extends object, Item> = WrapLogicalFilters<NestedQueryFilter<Schema, Item>>;
 
 /**
  * Query filters without logical filters
@@ -27,6 +27,9 @@ export type NestedQueryFilter<Schema extends object, Item> = UnpackList<Item> ex
 		>
 	: never;
 
+/**
+ * Allow for relational filters
+ */
 export type NestedRelationalFilter<Schema extends object, Item, Field extends keyof Item> =
 	| (Field extends RelationalFields<Schema, Item>
 		? WrapRelationalFilters<NestedQueryFilter<Schema, Item[Field]>>

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -20,6 +20,7 @@ export type Merge<A, B, TypeA = NeverToUnknown<A>, TypeB = NeverToUnknown<B>> = 
 		? TypeA[K]
 		: never;
 };
+export type MergeOptional<A, B, TypeA = NeverToUnknown<A>, TypeB = NeverToUnknown<B>> = Partial<Merge<A, B, TypeA, TypeB>>;
 
 /**
  * Fallback never to unknown

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -20,7 +20,9 @@ export type Merge<A, B, TypeA = NeverToUnknown<A>, TypeB = NeverToUnknown<B>> = 
 		? TypeA[K]
 		: never;
 };
-export type MergeOptional<A, B, TypeA = NeverToUnknown<A>, TypeB = NeverToUnknown<B>> = Partial<Merge<A, B, TypeA, TypeB>>;
+export type MergeOptional<A, B, TypeA = NeverToUnknown<A>, TypeB = NeverToUnknown<B>> = Partial<
+	Merge<A, B, TypeA, TypeB>
+>;
 
 /**
  * Fallback never to unknown


### PR DESCRIPTION
Fixes #20147 

## Scope

What's changed:

In https://github.com/directus/directus/pull/19792 functions were introduced in filters which made use of the `Merge<>` utility type to merge objects however this generic merges the objects and makes each property required.

This fix introduces the `MergeOptional<>` utility type and implements this in the filter types.


## Potential Risks / Drawbacks

- Potential other regressions in types that i missed in my testing

## Review Notes / Questions

- I would like to lorem ipsum
