### PR TITLE
Handle extension names in npm org scopes

### DIFF
--- a/.changeset/thick-wolves-train.md
+++ b/.changeset/thick-wolves-train.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that would prevent npm-organization scoped packages from showing up in the extensions pane in the app

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -120,7 +120,24 @@ export class ExtensionsService {
 			let name = meta.name;
 
 			if (name.includes('/')) {
-				[bundleName, name] = name.split('/') as [string, string];
+				const parts = name.split('/');
+
+				// NPM packages can have an optional organization scope in the format
+				// `@<org>/<package>`. This is limited to a single `/`.
+				//
+				// `foo` -> extension
+				// `foo/bar` -> bundle
+				// `@rijk/foo` -> extension
+				// `@rijk/foo/bar -> bundle
+
+				const hasOrg = parts.at(0)!.startsWith('@');
+
+				if (hasOrg && parts.length > 2) {
+					name = parts.pop() as string;
+					bundleName = parts.join('/');
+				} else if (hasOrg === false) {
+					[bundleName, name] = parts as [string, string];
+				}
 			}
 
 			let schema;


### PR DESCRIPTION
## Scope

Extensions can have an optional npm scope at the start (`@<org>/<package>`). This introduces an extra `/`, breaking the bundle splitting.

What's changed:

- Add logic to handle extension names starting with an organization scope

## Potential Risks / Drawbacks

- We do expect package names to adhere to "npm rules". There shouldn't be any additional `/` characters beyond the organization scope

## Review Notes / Questions

—

---

Fixes #20142 
