### PR TITLE
fix duplicate extensions clash

### DIFF
--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -25,7 +25,7 @@ export const getExtensionsSettings = async (extensions: Extension[]) => {
 				return [extension.name, ...extension.entries.map((entry) => `${extension.name}/${entry.name}`)];
 			}
 
-			return extension.name;
+			return `${extension.type}:${extension.name}`;
 		})
 		.flat();
 

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -158,7 +158,7 @@ export class ExtensionsService {
 					schema = null;
 				}
 			} else {
-				schema = installed.find((extension) => extension.name === name) ?? null;
+				schema = installed.find((extension) => `${extension.type}:${extension.name}` === name) ?? null;
 			}
 
 			return {


### PR DESCRIPTION
This will insert new rows, so existing ones without prefix could be removed.

Also benefit is that the type and structure of name looks same as those of bundled extensions.

Frontend would need to be updated to format out the `type:` part of the name

Fixes #20213
