### PR TITLE
Extensions fixed hook filter generic type

### DIFF
--- a/.changeset/angry-crabs-cover.md
+++ b/.changeset/angry-crabs-cover.md
@@ -1,0 +1,5 @@
+---
+"@directus/extensions": patch
+---
+
+Fixed the hook filter type exposed in extensions

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -79,7 +79,7 @@ export class Emitter {
 		}
 	}
 
-	public onFilter(event: string, handler: FilterHandler): void {
+	public onFilter<T = unknown>(event: string, handler: FilterHandler<T>): void {
 		this.filterEmitter.on(event, handler);
 	}
 
@@ -91,7 +91,7 @@ export class Emitter {
 		this.initEmitter.on(event, handler);
 	}
 
-	public offFilter(event: string, handler: FilterHandler): void {
+	public offFilter<T = unknown>(event: string, handler: FilterHandler<T>): void {
 		this.filterEmitter.off(event, handler);
 	}
 

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -654,7 +654,7 @@ export class ExtensionManager {
 		const unregisterFunctions: PromiseCallback[] = [];
 
 		const hookRegistrationContext = {
-			filter: (event: string, handler: FilterHandler) => {
+			filter: <T = unknown>(event: string, handler: FilterHandler<T>) => {
 				emitter.onFilter(event, handler);
 
 				unregisterFunctions.push(() => {

--- a/packages/extensions/src/shared/types/hooks.ts
+++ b/packages/extensions/src/shared/types/hooks.ts
@@ -6,7 +6,7 @@ export type HookExtensionContext = ApiExtensionContext & {
 };
 
 type RegisterFunctions = {
-	filter: (event: string, handler: FilterHandler) => void;
+	filter: <T = unknown>(event: string, handler: FilterHandler<T>) => void;
 	action: (event: string, handler: ActionHandler) => void;
 	init: (event: string, handler: InitHandler) => void;
 	schedule: (cron: string, handler: ScheduleHandler) => void;


### PR DESCRIPTION
Fixes #20217 

## Scope

What's changed:

- Made the `RegisterFunctions['filter']` type generic so it accepts any payload.
- Applied this same generic fix to the api loading extensions

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I would like to lorem ipsum