### PR TITLE
Fix a 404 on the Self-Hosted CLI doc page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -86,3 +86,4 @@
 - mscbpi
 - eyecatchup
 - kevincam3
+- cyrilf

--- a/docs/self-hosted/cli.md
+++ b/docs/self-hosted/cli.md
@@ -13,7 +13,7 @@ readTime: 7 min read
 
 ## Requirements
 
-- Node.js [Active LTS](https://nodejs.dev/en/about/releases/)
+- Node.js [Active LTS](https://github.com/nodejs/release#release-schedule)
 
 ## Server
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Link to Node.js active LTS in the doc page

Fixes #20233 
