### PR TITLE
Add the ability to submit plain code challenge method

### DIFF
--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -122,17 +122,15 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		let userInfo;
 
 		try {
+			const codeChallenge = plainCodeChallenge
+				? payload['codeVerifier']
+				: generators.codeChallenge(payload['codeVerifier']);
+			
 			tokenSet = await this.client.oauthCallback(
 				this.redirectUrl,
 				{ code: payload['code'], state: payload['state'] },
-				{
-					code_verifier: payload['codeVerifier'],
-					state: plainCodeChallenge
-						? payload['codeVerifier']
-						: generators.codeChallenge(payload['codeVerifier'])
-				}
+				{ code_verifier: payload['codeVerifier'], state: codeChallenge }
 			);
-
 			userInfo = await this.client.userinfo(tokenSet.access_token!);
 		} catch (e) {
 			throw handleError(e);

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -79,8 +79,10 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 	}
 
 	generateAuthUrl(codeVerifier: string, prompt = false): string {
+		const { plainCodeChallenge } = this.config;
+		
 		try {
-			const codeChallenge = generators.codeChallenge(codeVerifier);
+			const codeChallenge = plainCodeChallenge ? codeVerifier : generators.codeChallenge(codeVerifier);
 			const paramsConfig = typeof this.config['params'] === 'object' ? this.config['params'] : {};
 
 			return this.client.authorizationUrl({
@@ -89,7 +91,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 				prompt: prompt ? 'consent' : undefined,
 				...paramsConfig,
 				code_challenge: codeChallenge,
-				code_challenge_method: 'S256',
+				code_challenge_method: plainCodeChallenge ? 'plain' : 'S256',
 				// Some providers require state even with PKCE
 				state: codeChallenge,
 			});
@@ -114,6 +116,8 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsError();
 		}
 
+		const { plainCodeChallenge } = this.config;
+
 		let tokenSet;
 		let userInfo;
 
@@ -121,7 +125,12 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			tokenSet = await this.client.oauthCallback(
 				this.redirectUrl,
 				{ code: payload['code'], state: payload['state'] },
-				{ code_verifier: payload['codeVerifier'], state: generators.codeChallenge(payload['codeVerifier']) }
+				{
+					code_verifier: payload['codeVerifier'],
+					state: plainCodeChallenge
+						? payload['codeVerifier']
+						: generators.codeChallenge(payload['codeVerifier'])
+				}
 			);
 
 			userInfo = await this.client.userinfo(tokenSet.access_token!);

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -125,11 +125,11 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			const codeChallenge = plainCodeChallenge
 				? payload['codeVerifier']
 				: generators.codeChallenge(payload['codeVerifier']);
-			
+
 			tokenSet = await this.client.oauthCallback(
 				this.redirectUrl,
 				{ code: payload['code'], state: payload['state'] },
-				{ code_verifier: payload['codeVerifier'], state: codeChallenge }
+				{ code_verifier: payload['codeVerifier'], state: codeChallenge },
 			);
 
 			userInfo = await this.client.userinfo(tokenSet.access_token!);

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -131,6 +131,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 				{ code: payload['code'], state: payload['state'] },
 				{ code_verifier: payload['codeVerifier'], state: codeChallenge }
 			);
+
 			userInfo = await this.client.userinfo(tokenSet.access_token!);
 		} catch (e) {
 			throw handleError(e);

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -129,7 +129,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			tokenSet = await this.client.oauthCallback(
 				this.redirectUrl,
 				{ code: payload['code'], state: payload['state'] },
-				{ code_verifier: payload['codeVerifier'], state: codeChallenge },
+				{ code_verifier: payload['codeVerifier'], state: codeChallenge }
 			);
 
 			userInfo = await this.client.userinfo(tokenSet.access_token!);

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -80,7 +80,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 
 	generateAuthUrl(codeVerifier: string, prompt = false): string {
 		const { plainCodeChallenge } = this.config;
-		
+
 		try {
 			const codeChallenge = plainCodeChallenge ? codeVerifier : generators.codeChallenge(codeVerifier);
 			const paramsConfig = typeof this.config['params'] === 'object' ? this.config['params'] : {};

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -141,7 +141,8 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 
 		try {
 			const client = await this.client;
-			const codeChallenge = plainCodeChallenge 
+
+			const codeChallenge = plainCodeChallenge
 				? payload['codeVerifier']
 				: generators.codeChallenge(payload['codeVerifier']);
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -95,9 +95,11 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 	}
 
 	async generateAuthUrl(codeVerifier: string, prompt = false): Promise<string> {
+		const { plainCodeChallenge } = this.config;
+
 		try {
 			const client = await this.client;
-			const codeChallenge = generators.codeChallenge(codeVerifier);
+			const codeChallenge = plainCodeChallenge ? codeVerifier : generators.codeChallenge(codeVerifier);
 			const paramsConfig = typeof this.config['params'] === 'object' ? this.config['params'] : {};
 
 			return client.authorizationUrl({
@@ -106,7 +108,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				prompt: prompt ? 'consent' : undefined,
 				...paramsConfig,
 				code_challenge: codeChallenge,
-				code_challenge_method: 'S256',
+				code_challenge_method: plainCodeChallenge ? 'plain' : 'S256',
 				// Some providers require state even with PKCE
 				state: codeChallenge,
 				nonce: codeChallenge,
@@ -132,12 +134,16 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsError();
 		}
 
+		const { plainCodeChallenge } = this.config;
+
 		let tokenSet;
 		let userInfo;
 
 		try {
 			const client = await this.client;
-			const codeChallenge = generators.codeChallenge(payload['codeVerifier']);
+			const codeChallenge = plainCodeChallenge 
+				? payload['codeVerifier']
+				: generators.codeChallenge(payload['codeVerifier']);
 
 			tokenSet = await client.callback(
 				this.redirectUrl,


### PR DESCRIPTION
Adds the  `AUTH_<provider>_PLAIN_CODE_CHALLENGE=true` flag to allow using the "plain" OAuth challenge method. This is not documented due to being highly discouraged due to significantly weaker security.

Tested the changes with via Twitter login.

Closes #20189