### PR TITLE
Added extensions volume of self-hosted quickstart

### DIFF
--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -45,6 +45,7 @@ services:
     volumes:
       - ./database:/directus/database
       - ./uploads:/directus/uploads
+			- ./extensions:/directus/extensions
     environment:
       KEY: "replace-with-random-value"
       SECRET: "replace-with-random-value"


### PR DESCRIPTION
There's no reason this shouldn't be in the default `docker-compose.yml` file