### PR TITLE
Docs update query limit=-1

### DIFF
--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -369,15 +369,16 @@ Set the maximum number of items that will be returned. The default limit is set 
 Get the first 200 items\
 `200`
 
-Get the maximum allowed items\
+Get the maximum allowed number of items\
 `-1`
 
 ::: warning Maximum Items
 
-Depending on the size of your collection, fetching the maximum amount of data may result in degraded performance or
+Depending on the size of your collection, fetching the maximum amount of items may result in degraded performance or
 timeouts, use with caution.
 
-The maximum amount of items that can be requested on the API can be configured using the `QUERY_LIMIT_MAX` variable.
+The maximum amount of items that can be requested on the API can be configured using the
+[`QUERY_LIMIT_MAX` variable](/self-hosted/config-options.html#general).
 
 :::
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -369,13 +369,13 @@ Set the maximum number of items that will be returned. The default limit is set 
 Get the first 200 items\
 `200`
 
-Get all items\
+Get the maximum allowed items\
 `-1`
 
 ::: warning All Items
 
-Depending on the size of your collection, fetching unlimited data may result in degraded performance or timeouts, use
-with caution.
+Depending on the size of your collection and configuration of your instance, fetching the maximum amount of data may
+result in degraded performance or timeouts, use with caution.
 
 :::
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -372,10 +372,12 @@ Get the first 200 items\
 Get the maximum allowed items\
 `-1`
 
-::: warning All Items
+::: warning Maximum Items
 
-Depending on the size of your collection and configuration of your instance, fetching the maximum amount of data may
-result in degraded performance or timeouts, use with caution.
+Depending on the size of your collection, fetching the maximum amount of data may result in degraded performance or
+timeouts, use with caution.
+
+The maximum amount of items that can be requested on the API can be configured using the `QUERY_LIMIT_MAX` variable.
 
 :::
 


### PR DESCRIPTION
Refs #20229 

## Scope

What's changed:

- Updated "limit=-1" wording from "get all items" to "get the maximum allowed amount of items"

