### PR TITLE
Validate the query for SEARCH requests

### DIFF
--- a/.changeset/ten-onions-shop.md
+++ b/.changeset/ten-onions-shop.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed query validation for SEARCH requests

--- a/api/src/middleware/validate-batch.ts
+++ b/api/src/middleware/validate-batch.ts
@@ -2,6 +2,7 @@ import Joi from 'joi';
 import { InvalidPayloadError } from '@directus/errors';
 import asyncHandler from '../utils/async-handler.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
+import { validateQuery } from '../utils/validate-query.js';
 
 export const validateBatch = (scope: 'read' | 'update' | 'delete') =>
 	asyncHandler(async (req, _res, next) => {
@@ -23,6 +24,8 @@ export const validateBatch = (scope: 'read' | 'update' | 'delete') =>
 		// In reads, the query in the body should override the query params for searching
 		if (scope === 'read' && req.body.query) {
 			req.sanitizedQuery = sanitizeQuery(req.body.query, req.accountability);
+
+			validateQuery(req.sanitizedQuery);
 		}
 
 		// Every cRUD action has either keys or query


### PR DESCRIPTION
Fixes #20228

## Scope

What's changed:

- Added the use of the `validateQuery` function so it follows the same logic as the `sanitize-query` middleware https://github.com/directus/directus/blob/main/api/src/middleware/sanitize-query.ts#L24

## Potential Risks / Drawbacks

- Unexpected errors on SEARCH endpoints that worked before due to lack of validation.

