### PR TITLE
Default to current user language in field translation language selector

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
+import { getCurrentLanguage } from '@/lang/get-current-language';
 
 const { t } = useI18n();
 const fieldDetailStore = useFieldDetailStore();
@@ -65,7 +66,7 @@ const isGenerated = computed(() => field.value.schema?.is_generated);
 							},
 						},
 						schema: {
-							default_value: 'en-US',
+							default_value: getCurrentLanguage(),
 						},
 					},
 					{

--- a/contributors.yml
+++ b/contributors.yml
@@ -89,3 +89,4 @@
 - cyrilf
 - ComfortablyCoding
 - pstuifzand
+- FloMaetschke


### PR DESCRIPTION
## Scope

What's changed:

- The language selector when creating translation defaults to the current user language.

## Potential Risks / Drawbacks

nope

## Review Notes / Questions

- I ran the tests, and they failed before my change the file and after. Because of this consitency i guess its not messing up the tests.

---

Fixes #20257
