### PR TITLE
fix: extension auto-load crashes directus if local extension is removed

### DIFF
--- a/.changeset/lucky-tables-leave.md
+++ b/.changeset/lucky-tables-leave.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where removing a local extension with autoload true resulted in a crash.

--- a/api/src/utils/delete-from-require-cache.ts
+++ b/api/src/utils/delete-from-require-cache.ts
@@ -1,7 +1,13 @@
 import { createRequire } from 'node:module';
+import logger from '../logger.js';
 
 const require = createRequire(import.meta.url);
 
 export function deleteFromRequireCache(modulePath: string): void {
-	delete require.cache[require.resolve(modulePath)];
+	try {
+		const moduleCachePath = require.resolve(modulePath);
+		delete require.cache[moduleCachePath];
+	} catch (error) {
+		logger.warn(`Module cache not found for ${modulePath}, skipped cache delete.`);
+	}
 }

--- a/api/src/utils/delete-from-require-cache.ts
+++ b/api/src/utils/delete-from-require-cache.ts
@@ -8,6 +8,6 @@ export function deleteFromRequireCache(modulePath: string): void {
 		const moduleCachePath = require.resolve(modulePath);
 		delete require.cache[moduleCachePath];
 	} catch (error) {
-		logger.warn(`Module cache not found for ${modulePath}, skipped cache delete.`);
+		logger.trace(`Module cache not found for ${modulePath}, skipped cache delete.`);
 	}
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:
- Updated the `deleteFromRequireCache` function to use a `try/catch` for the module resolve and cache removal. If it throws an error it will now notify the user that the modules cache was not deleted instead of crashing directus.

## Potential Risks / Drawbacks
- None

## Review Notes / Questions
- I tested adding an extension (as suggested in the issue) as well. No error or issue was observed for this functionality.
- I did notice that adding and removing more than once seems to work sometimes but not others, the same behaviour is on main without my changes.


---

Fixes #19755 