### PR TITLE
Fixed incorrect input pattern in the app

### DIFF
--- a/.changeset/strange-vans-watch.md
+++ b/.changeset/strange-vans-watch.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed incorrect input pattern in the app

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -47,10 +47,10 @@ const inputPattern = computed(() => {
 	switch (props.type) {
 		case 'integer':
 		case 'bigInteger':
-			return '[+-]?[0-9]+';
+			return '[+\\-]?[0-9]+';
 		case 'decimal':
 		case 'float':
-			return '[+-]?[0-9]+\\.?[0-9]*';
+			return '[+\\-]?[0-9]+\\.?[0-9]*';
 		case 'uuid':
 			return '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}';
 		default:


### PR DESCRIPTION
Fixes #20262 

## Scope

What's changed:

The old regex had `[+-]?` which is invalid as the minus inside the square brackets is a reserved character to do character ranges like `[a-z]` however it is missing its right hand range argument.
Solution is to escape the minus character.