### PR TITLE
Unable to import files with predefined ids

### DIFF
--- a/.changeset/five-balloons-drum.md
+++ b/.changeset/five-balloons-drum.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed importing files with predefined ids

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -44,7 +44,7 @@ export class FilesService extends ItemsService {
 	): Promise<PrimaryKey> {
 		const storage = await getStorage();
 
-		let existingFile = {};
+		let existingFile: Record<string, any> | null = null;
 
 		if (primaryKey !== undefined) {
 			existingFile =
@@ -52,10 +52,10 @@ export class FilesService extends ItemsService {
 					.select('folder', 'filename_download')
 					.from('directus_files')
 					.where({ id: primaryKey })
-					.first()) ?? {};
+					.first()) ?? null;
 		}
 
-		const payload = { ...existingFile, ...clone(data) };
+		const payload = { ...(existingFile ?? {}), ...clone(data) };
 
 		if ('folder' in payload === false) {
 			const settings = await this.knex.select('storage_default_folder').from('directus_settings').first();
@@ -65,7 +65,7 @@ export class FilesService extends ItemsService {
 			}
 		}
 
-		if (primaryKey !== undefined) {
+		if (existingFile !== null && primaryKey !== undefined) {
 			await this.updateOne(primaryKey, payload, { emitEvents: false });
 
 			// If the file you're uploading already exists, we'll consider this upload a replace. In that case, we'll


### PR DESCRIPTION
Fixes #20294 

## Scope

What's changed:

A small fix for the regression introduced in https://github.com/directus/directus/pull/19788 . Checks for the existence of the file in the database instead of updating solely based on the the presence of a primaryKey.

## Review Notes / Questions

- I would like to lorem ipsum
