### PR TITLE
Show package version if available

### DIFF
--- a/.changeset/nice-bottles-flow.md
+++ b/.changeset/nice-bottles-flow.md
@@ -1,0 +1,7 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+"@directus/extensions": patch
+---
+
+Made extension versions visible in new extension panel

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -164,7 +164,7 @@ export class ExtensionsService {
 			return {
 				name,
 				bundle: bundleName,
-				schema: schema ? pick(schema, 'type', 'local') : null,
+				schema: schema ? pick(schema, 'type', 'local', 'version') : null,
 				meta: omit(meta, 'name'),
 			};
 		});

--- a/app/src/modules/settings/routes/extensions/components/extension-item.vue
+++ b/app/src/modules/settings/routes/extensions/components/extension-item.vue
@@ -49,6 +49,7 @@ const toggleEnabled = async () => {
 	<v-list-item block :class="{ disabled: !extension.meta.enabled }">
 		<v-list-item-icon v-tooltip="t(`extension_${type}`)"><v-icon :name="icon" small /></v-list-item-icon>
 		<v-list-item-content class="monospace">{{ extension.name }}</v-list-item-content>
+		<v-chip v-if="extension.schema?.version" class="label" small>{{ extension.schema.version }}</v-chip>
 
 		<template v-if="extension.schema?.type !== 'bundle'">
 			<v-progress-circular v-if="changingEnabledState" indeterminate />
@@ -88,5 +89,9 @@ const toggleEnabled = async () => {
 
 .options {
 	margin-left: 12px;
+}
+
+.label {
+	margin-right: 8px;
 }
 </style>

--- a/app/src/modules/settings/routes/extensions/components/extension-item.vue
+++ b/app/src/modules/settings/routes/extensions/components/extension-item.vue
@@ -49,11 +49,13 @@ const toggleEnabled = async () => {
 	<v-list-item block :class="{ disabled: !extension.meta.enabled }">
 		<v-list-item-icon v-tooltip="t(`extension_${type}`)"><v-icon :name="icon" small /></v-list-item-icon>
 		<v-list-item-content class="monospace">{{ extension.name }}</v-list-item-content>
-		<v-chip v-if="extension.schema?.version" class="label" small>{{ extension.schema.version }}</v-chip>
+		<v-chip v-if="extension.schema?.version" class="version" small>{{ extension.schema.version }}</v-chip>
 
 		<template v-if="extension.schema?.type !== 'bundle'">
 			<v-progress-circular v-if="changingEnabledState" indeterminate />
-			<v-chip v-else small>{{ extension.meta.enabled ? t('enabled') : t('disabled') }}</v-chip>
+			<v-chip v-else class="state" :class="{ enabled: extension.meta.enabled }" small>
+				{{ extension.meta.enabled ? t('enabled') : t('disabled') }}
+			</v-chip>
 			<extension-item-options
 				class="options"
 				:name="extension.name"
@@ -91,7 +93,17 @@ const toggleEnabled = async () => {
 	margin-left: 12px;
 }
 
-.label {
+.version {
 	margin-right: 8px;
+}
+
+.state {
+	--v-chip-color: var(--theme--danger);
+	--v-chip-background-color: var(--theme--danger-background);
+
+	&.enabled {
+		--v-chip-color: var(--theme--success);
+		--v-chip-background-color: var(--theme--success-background);
+	}
 }
 </style>

--- a/packages/extensions/src/shared/types/api.ts
+++ b/packages/extensions/src/shared/types/api.ts
@@ -1,14 +1,12 @@
 import type { Extension } from './extension-types.js';
 import type { ExtensionSettings } from './settings.js';
 
-type SchemaFields = 'type' | 'local';
-
 /**
  * The API output structure used when engaging with the /extensions endpoints
  */
 export interface ApiOutput {
 	name: string;
 	bundle: string | null;
-	schema: Pick<Extension, SchemaFields> | null;
+	schema: Partial<Extension> | null;
 	meta: Omit<ExtensionSettings, 'name'>;
 }


### PR DESCRIPTION
Fixes #20282

## Scope

What's changed:

- Added the package version string for extension types that use a `package.json`

![image](https://github.com/directus/directus/assets/9389634/010d3448-eefc-4074-ad44-574ff394d104)
![image](https://github.com/directus/directus/assets/9389634/3c54faed-ea2b-4c4f-91de-5489bf2cdfe2)


## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet

## Review Notes / Questions

- Based on these screenshots i think it would be good for consistency to have a "enabled"/"disabled" function for a complete bundle too https://github.com/directus/directus/issues/20304

