### PR TITLE
Improve rolling deployments from 10.6 to 10.7

### DIFF
--- a/.changeset/eighty-sloths-dream.md
+++ b/.changeset/eighty-sloths-dream.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Improve rolling deployment experience

--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -107,3 +107,8 @@
     - tfa_secret
     - status
     - role
+
+    # This is a temporary field to help people migrate from
+    # 10.6.4 to 10.7.0 and should be removed in 10.7.3
+    # @TODO remove
+    - theme

--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -108,7 +108,7 @@
     - status
     - role
 
-    # This is a temporary field to help people migrate from
-    # 10.6.4 to 10.7.0 and should be removed in 10.7.3
+    # This is a temporary allowed field to help people migrate from
+    # 10.6 to 10.7 and should be removed in 10.8
     # @TODO remove
     - theme

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -100,16 +100,6 @@ fields:
       - no-data
     width: full
 
-  # This is a temporary field to help people migrate from
-  # 10.6.4 to 10.7.0 and should be removed in 10.7.3
-  # @TODO remove
-  - field: theme
-    options:
-      hidden: true
-    special:
-      - alias
-      - no-data
-
   - field: appearance
     interface: select-dropdown
     options:

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -100,6 +100,13 @@ fields:
       - no-data
     width: full
 
+  # This is a temporary field to help people migrate from
+  # 10.6.4 to 10.7.0 and should be removed in 10.7.3
+  # @TODO remove
+  - field: theme
+    options:
+      hidden: true
+
   - field: appearance
     interface: select-dropdown
     options:

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -106,6 +106,9 @@ fields:
   - field: theme
     options:
       hidden: true
+    special:
+      - alias
+      - no-data
 
   - field: appearance
     interface: select-dropdown

--- a/app/src/stores/user.test.ts
+++ b/app/src/stores/user.test.ts
@@ -1,5 +1,4 @@
 import { createTestingPinia } from '@pinia/testing';
-import { AxiosRequestConfig } from 'axios';
 import { setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { RouteLocationNormalized } from 'vue-router';
@@ -14,7 +13,6 @@ beforeEach(() => {
 });
 
 import { User } from '@directus/types';
-import { pick } from 'lodash';
 import { useLatencyStore } from './latency';
 import { useUserStore } from './user';
 
@@ -43,13 +41,11 @@ const mockAdminUser = {
 vi.mock('@/api', () => {
 	return {
 		default: {
-			get: (path: string, config?: AxiosRequestConfig<any>) => {
-				if (path === '/users/me' && config?.params?.fields) {
-					const returnedData = pick(mockAdminUser, config.params.fields);
-
+			get: (path: string) => {
+				if (path === '/users/me') {
 					return Promise.resolve({
 						data: {
-							data: returnedData,
+							data: mockAdminUser,
 						},
 					});
 				}
@@ -110,16 +106,6 @@ describe('actions', () => {
 		test('should fetch user fields and set current user as the returned value', async () => {
 			const userStore = useUserStore();
 			await userStore.hydrate();
-			expect(userStore.currentUser).toEqual(mockAdminUser);
-		});
-	});
-
-	describe('hydrateAdditionalFields', () => {
-		test('should fetch additional fields and add them to the current user', async () => {
-			const userStore = useUserStore();
-			await userStore.hydrate();
-			await userStore.hydrateAdditionalFields(['custom_user_field', 'role.custom_role_field']);
-
 			expect(userStore.currentUser).toEqual(mockAdminUser);
 		});
 	});

--- a/app/src/stores/user.test.ts
+++ b/app/src/stores/user.test.ts
@@ -107,29 +107,10 @@ describe('getters', () => {
 
 describe('actions', () => {
 	describe('hydrate', () => {
-		test('should fetch required fields and set current user as the returned value', async () => {
+		test('should fetch user fields and set current user as the returned value', async () => {
 			const userStore = useUserStore();
 			await userStore.hydrate();
-
-			const requiredFields = [
-				'id',
-				'language',
-				'first_name',
-				'last_name',
-				'email',
-				'last_page',
-				'appearance',
-				'theme_light',
-				'theme_dark',
-				'tfa_secret',
-				'avatar.id',
-				'role.admin_access',
-				'role.app_access',
-				'role.id',
-				'role.enforce_tfa',
-			];
-
-			expect(userStore.currentUser).toEqual(pick(mockAdminUser, requiredFields));
+			expect(userStore.currentUser).toEqual(mockAdminUser);
 		});
 	});
 

--- a/app/src/stores/user.ts
+++ b/app/src/stores/user.ts
@@ -37,18 +37,7 @@ export const useUserStore = defineStore({
 
 			try {
 				const fields = [
-					'id',
-					'language',
-					'first_name',
-					'last_name',
-					'email',
-					'last_page',
-					'appearance',
-					'theme_light',
-					'theme_dark',
-					'theme_light_overrides',
-					'theme_dark_overrides',
-					'tfa_secret',
+					'*',
 					'avatar.id',
 					'role.admin_access',
 					'role.app_access',

--- a/app/src/stores/user.ts
+++ b/app/src/stores/user.ts
@@ -36,14 +36,7 @@ export const useUserStore = defineStore({
 			this.loading = true;
 
 			try {
-				const fields = [
-					'*',
-					'avatar.id',
-					'role.admin_access',
-					'role.app_access',
-					'role.id',
-					'role.enforce_tfa',
-				];
+				const fields = ['*', 'avatar.id', 'role.admin_access', 'role.app_access', 'role.id', 'role.enforce_tfa'];
 
 				const { data } = await api.get(`/users/me`, { params: { fields } });
 


### PR DESCRIPTION
## Scope

Resolves some issues people were having in seamlessly deploying from 10.6 to 10.7 in a rolling deployment strategy.

What's changed:

- Don't fetch user fields by name (instead fetch all available with `*`)
- Allow `theme` to be read during 10.7

## Potential Risks / Drawbacks

- It's a bit of tech debt to have fields floating around, but it's worth the benefit

## Review Notes / Questions

n/a