### PR TITLE
Fix select all logic in v-field-list-item component

### DIFF
--- a/.changeset/seven-hornets-destroy.md
+++ b/.changeset/seven-hornets-destroy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed select all logic in v-field-list-item component

--- a/app/src/components/v-field-list/v-field-list-item.vue
+++ b/app/src/components/v-field-list/v-field-list-item.vue
@@ -49,15 +49,7 @@ const selectAllDisabled = computed(() => props.field.children?.every((field: Fie
 const addAll = () => {
 	if (!props.field.children) return;
 
-	const selectedFields = props.field.children.map((selectableField) => {
-		let res = `${props.field.field}.${selectableField.field}`;
-
-		if (props.parent) {
-			res = `${props.parent}.${res}`;
-		}
-
-		return res;
-	});
+	const selectedFields = props.field.children.map((selectableField) => selectableField.key);
 
 	emit('add', selectedFields);
 };


### PR DESCRIPTION
## Scope

What's changed:

- When we are adding fields one by one, we are emitting `field.key` as seen here:

    https://github.com/directus/directus/blob/4a363552236584d056f4ff81dacc8bde6eb6d96a/app/src/components/v-field-list/v-field-list-item.vue#L132
   
   which is accurate and doesn't include groups in it (but still includes related collection if it's a related collection field).
   
   Hence this PR replaces the original select all logic to re-use `field.key` of the children rather than re-constructing it manually.

### Before

Currently when we add a field one by one, the fields are added as intended. However when we use the `Select All` button, fields within groups are being added as if it's a related collection field:

https://github.com/directus/directus/assets/42867097/9ccce85a-25e8-4bfd-99e3-cd81e20cab82

### After

https://github.com/directus/directus/assets/42867097/364f78bd-05e0-49bd-b5e9-1292178f0fe9

## Potential Risks / Drawbacks

- It should only affect the original bugged select all button, so there shouldn't be any risk of affecting the existing adding-one-by-one workflow.

---

Fixes #19567
