### PR TITLE
Updated SDK examples from "@directus/sdk/rest" to "@directus/sdk"

### DIFF
--- a/docs/guides/headless-cms/build-static-website/next-13.md
+++ b/docs/guides/headless-cms/build-static-website/next-13.md
@@ -56,8 +56,7 @@ To share a single instance of the Directus JavaScript SDK between multiple pages
 file that can be imported later. Create a new directory called `lib` and a new file called `directus.js` inside of it.
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest } from '@directus/sdk/rest';
+import { createDirectus, rest } from '@directus/sdk';
 
 const directus = createDirectus('https://directus.example.com').with(rest());
 
@@ -87,7 +86,7 @@ Inside of the `app` directory, create a new file called `page.tsx`.
 
 ```jsx
 import directus from 'lib/directus';
-import { readItems } from '@directus/sdk/rest';
+import { readItems } from '@directus/sdk';
 
 async function getGlobals() {
 	return directus.request(readItems('global'));
@@ -123,7 +122,7 @@ single file can be used for all of the top-level pages.
 ```jsx
 import directus from 'lib/directus';
 import { notFound } from 'next/navigation';
-import { readItem } from '@directus/sdk/rest';
+import { readItem } from '@directus/sdk';
 
 async function getPage(slug) {
 	try {
@@ -179,7 +178,7 @@ Inside of the `app` directory, create a new subdirectory called `blog` and a new
 
 ```jsx
 import directus from '@/lib/directus';
-import { readItems } from '@directus/sdk/rest';
+import { readItems } from '@directus/sdk';
 
 async function getPosts() {
 	return directus.request(
@@ -238,7 +237,7 @@ Each blog post links to a page that does not yet exist. In the `app/blog` direct
 ```jsx
 import directus from '@/lib/directus';
 import { notFound } from 'next/navigation';
-import { readItem } from '@directus/sdk/rest';
+import { readItem } from '@directus/sdk';
 
 async function getPost(slug) {
 	try {

--- a/docs/guides/headless-cms/build-static-website/nuxt-3.md
+++ b/docs/guides/headless-cms/build-static-website/nuxt-3.md
@@ -40,8 +40,7 @@ To expose an Node.js package available globally in your Nuxt project you must cr
 called `plugins` and a new file called `directus.js` inside of it.
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItem, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItem, readItems } from '@directus/sdk';
 
 const directus = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/guides/headless-cms/content-translations.md
+++ b/docs/guides/headless-cms/content-translations.md
@@ -161,8 +161,7 @@ relational data . It's incredible powerful.
 **Sample Request**
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 // Initialize the SDK.
 const directus = createDirectus('https://directus.example.com').with(rest());

--- a/docs/guides/headless-cms/live-preview/nextjs.md
+++ b/docs/guides/headless-cms/live-preview/nextjs.md
@@ -50,7 +50,7 @@ following content:
 
 ```tsx
 import directus from '@/lib/directus';
-import { readItem, readItems } from '@directus/sdk/rest';
+import { readItem, readItems } from '@directus/sdk';
 
 export default async function Post({ params: { id } }: { params: { id: string } }) {
 	const post = await directus.request(readItem('Posts', id));
@@ -93,7 +93,7 @@ In your Next.js application, create a route handler file at `app/api/draft/route
 ```ts
 import { draftMode } from 'next/headers';
 import directus from '@/lib/directus';
-import { readItem } from '@directus/sdk/rest';
+import { readItem } from '@directus/sdk';
 
 export async function GET(request: Request) {
 	const { searchParams } = new URL(request.url);
@@ -142,7 +142,7 @@ with the following code:
 
 ```tsx
 import directus from '@/lib/directus';
-import { readItem, readItems } from '@directus/sdk/rest';
+import { readItem, readItems } from '@directus/sdk';
 import { draftMode } from 'next/headers'; // [!code ++]
 
 export default async function Post({ params: { id } }: { params: { id: string } }) {

--- a/docs/guides/headless-cms/reusable-components.md
+++ b/docs/guides/headless-cms/reusable-components.md
@@ -210,8 +210,7 @@ how to properly fetch nested relational M2A data without over-fetching data that
 **Sample Request**
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 // Initialize the SDK.
 const directus = createDirectus('https://directus.example.com').with(rest());

--- a/docs/guides/headless-cms/schedule-content/dynamic-sites.md
+++ b/docs/guides/headless-cms/schedule-content/dynamic-sites.md
@@ -80,8 +80,7 @@ Using the [Directus JavaScript SDK](/guides/sdk/getting-started) (preferred)
 
 ```js
 // Initialize the SDK.
-import { createDirectus } from '@directus/sdk';
-import { rest, readItems } from '@directus/sdk/rest';
+import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const directus = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/activity.md
+++ b/docs/reference/system/activity.md
@@ -425,8 +425,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, updateComment } from '@directus/sdk/rest';
+import { createDirectus, rest, updateComment } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -498,8 +497,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteComment } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteComment } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/dashboards.md
+++ b/docs/reference/system/dashboards.md
@@ -789,8 +789,7 @@ mutation {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, deleteDashboards } from '@directus/sdk/rest';
+import { createDirectus, rest, deleteDashboards } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -90,8 +90,7 @@ type Query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, readFlows } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
@@ -140,8 +139,7 @@ query {
 <template #sdk>
 
 ```js
-import { createDirectus } from '@directus/sdk';
-import { rest, readFlows } from '@directus/sdk/rest';
+import { createDirectus, rest, readFlows } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 


### PR DESCRIPTION
## Scope

What's changed:

Replaces the old `import from '@directus/sdk/rest'` which only works for specific TSconfigs with the basic `import from '@directus/sdk'` which works everywhere.
