### PR TITLE
Fix disabled input's border color

### DIFF
--- a/.changeset/gold-items-beam.md
+++ b/.changeset/gold-items-beam.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed disabled input's border color

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -285,7 +285,7 @@ function stepDown() {
 
 	--v-input-font-family         [--theme--font-family-sans-serif]
 	--v-input-placeholder-color   [--theme--foreground-subdued]
-	--v-input-color               [--theme--foreground]
+	--v-input-color               [--theme--form--field--input--foreground]
 	--v-input-background-color    [--theme--form--field--input--background]
 	--v-input-border-color        [--theme--form--field--input--border-color]
 	--v-input-border-color-hover  [--theme--form--field--input--border-color-hover]

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -381,7 +381,7 @@ function stepDown() {
 
 			color: var(--theme--foreground-subdued);
 			background-color: var(--background-subdued);
-			border-color: var(--v-input-border-color);
+			border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
 		}
 
 		.prefix,


### PR DESCRIPTION
Follow up to #20326.

## Scope

What's changed:

- Added default value `var(--theme--form--field--input--border-color)` to disabled input
- Updated the comment for `--v-input-color`

### Before

![](https://github.com/directus/directus/assets/42867097/04885bfe-ae0f-418d-aec2-2572f76a0223)

### After

![](https://github.com/directus/directus/assets/42867097/8adbf61e-a4d1-4b9c-b916-b2ae18081c8e)

## Potential Risks / Drawbacks

- None, unless it's an intentional design choice

## Review Notes / Questions

- Although slightly unrelated, the comment update for `--v-input-color` to `--theme--form--field--input--foreground` is due to it being the technically correct value when referring to the change from the same PR:

  https://github.com/directus/directus/blob/c560f6b64b33067322a5712a6de6225ecab4cdc3/app/src/components/v-input.vue#L318

  so hopefully this was the correct assumption.
