### PR TITLE
Delete files based on "filename_disk"

### DIFF
--- a/.changeset/unlucky-grapes-love.md
+++ b/.changeset/unlucky-grapes-love.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed removing files based on "filename_disk"

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -49,7 +49,7 @@ export class FilesService extends ItemsService {
 		if (primaryKey !== undefined) {
 			existingFile =
 				(await this.knex
-					.select('folder', 'filename_download')
+					.select('folder', 'filename_download', 'filename_disk')
 					.from('directus_files')
 					.where({ id: primaryKey })
 					.first()) ?? null;
@@ -71,8 +71,9 @@ export class FilesService extends ItemsService {
 			// If the file you're uploading already exists, we'll consider this upload a replace. In that case, we'll
 			// delete the previously saved file and thumbnails to ensure they're generated fresh
 			const disk = storage.location(payload.storage);
+			const filePrefix = path.basename(existingFile['filename_disk'], path.extname(existingFile['filename_disk']));
 
-			for await (const filepath of disk.list(String(primaryKey))) {
+			for await (const filepath of disk.list(filePrefix)) {
 				await disk.delete(filepath);
 			}
 		} else {
@@ -330,7 +331,7 @@ export class FilesService extends ItemsService {
 	 */
 	override async deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]> {
 		const storage = await getStorage();
-		const files = await super.readMany(keys, { fields: ['id', 'storage'], limit: -1 });
+		const files = await super.readMany(keys, { fields: ['id', 'storage', 'filename_disk'], limit: -1 });
 
 		if (!files) {
 			throw new ForbiddenError();
@@ -340,9 +341,10 @@ export class FilesService extends ItemsService {
 
 		for (const file of files) {
 			const disk = storage.location(file['storage']);
+			const filePrefix = path.basename(file['filename_disk'], path.extname(file['filename_disk']));
 
 			// Delete file + thumbnails
-			for await (const filepath of disk.list(file['id'])) {
+			for await (const filepath of disk.list(filePrefix)) {
 				await disk.delete(filepath);
 			}
 		}

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -71,7 +71,7 @@ export class FilesService extends ItemsService {
 			// If the file you're uploading already exists, we'll consider this upload a replace. In that case, we'll
 			// delete the previously saved file and thumbnails to ensure they're generated fresh
 			const disk = storage.location(payload.storage);
-			const filePrefix = path.basename(existingFile['filename_disk'], path.extname(existingFile['filename_disk']));
+			const filePrefix = path.parse(existingFile['filename_disk']).name;
 
 			for await (const filepath of disk.list(filePrefix)) {
 				await disk.delete(filepath);

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -341,7 +341,7 @@ export class FilesService extends ItemsService {
 
 		for (const file of files) {
 			const disk = storage.location(file['storage']);
-			const filePrefix = path.basename(file['filename_disk'], path.extname(file['filename_disk']));
+			const filePrefix = path.parse(file['filename_disk']).name;
 
 			// Delete file + thumbnails
 			for await (const filepath of disk.list(filePrefix)) {


### PR DESCRIPTION
Fixes #16241 

## Scope

What's changed:

- Deletes files based on the `filename_disk` instead of the `primaryKey`

## Potential Risks / Drawbacks

- Possibly unforeseen accidental deleting

## Review Notes / Questions

- I would like to lorem ipsum
