### PR TITLE
SDK translation schema update

### DIFF
--- a/.changeset/four-pans-work.md
+++ b/.changeset/four-pans-work.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Updated custom translation schema in the SDK

--- a/sdk/src/schema/translation.ts
+++ b/sdk/src/schema/translation.ts
@@ -4,7 +4,7 @@ export type DirectusTranslation<Schema extends object> = MergeCoreCollection<
 	Schema,
 	'directus_translations',
 	{
-		id: number;
+		id: string; // uuid
 		language: string;
 		key: string;
 		value: string;


### PR DESCRIPTION
Fixes #20343 

## Scope

What's changed:

Seems the `directus_translations` schema wasnt updated after the move from auto-increment integer IDs to UUIDs. This PR updates that schema.

## Review Notes / Questions

- I would like to lorem ipsum
