### PR TITLE
Prevent re-installation of deps in Docker image

### DIFF
--- a/.changeset/few-bugs-sing.md
+++ b/.changeset/few-bugs-sing.md
@@ -1,0 +1,5 @@
+---
+directus: patch
+---
+
+Prevent re-installation of dependencies in Docker image when adding extensions from NPM

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/.editorconfig
 **/.dockerignore
+**/Dockerfile
 **/.git
 **/.DS_Store
 **/.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,7 @@ RUN : \
 	&& npm_config_workspace_concurrency=1 pnpm run build \
 	&& pnpm --filter directus deploy --prod dist \
 	&& cd dist \
-	&& pnpm pack \
-	&& tar -zxvf *.tgz package/package.json \
-	&& mv package/package.json package.json \
-	&& rm -r *.tgz package \
+	&& node -e 'const f = "./package.json", {name, version, type, exports, bin} = require(f); fs.writeFileSync(f, JSON.stringify({name, version, type, exports, bin}, null, 2))' \
 	&& mkdir -p database extensions uploads \
 	;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ COPY pnpm-lock.yaml .
 RUN pnpm fetch
 
 COPY . .
-
 RUN <<EOF
 	pnpm install --recursive --offline --frozen-lockfile
 	npm_config_workspace_concurrency=1 pnpm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN <<EOF
 	npm_config_workspace_concurrency=1 pnpm run build
 	pnpm --filter directus deploy --prod dist
 	cd dist
+	# Regenerate package.json file with essential fields only
+	# (see https://github.com/directus/directus/pull/20346)
 	node -e '
 		const f = "package.json", {name, version, type, exports, bin} = require(`./${f}`), {packageManager} = require(`../${f}`);
 		fs.writeFileSync(f, JSON.stringify({name, version, type, exports, bin, packageManager}, null, 2));

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN <<EOF
 	pnpm --filter directus deploy --prod dist
 	cd dist
 	# Regenerate package.json file with essential fields only
-	# (see https://github.com/directus/directus/pull/20346)
+	# (see https://github.com/directus/directus/issues/20338)
 	node -e '
 		const f = "package.json", {name, version, type, exports, bin} = require(`./${f}`), {packageManager} = require(`../${f}`);
 		fs.writeFileSync(f, JSON.stringify({name, version, type, exports, bin, packageManager}, null, 2));

--- a/docs/.vitepress/data/directus.data.ts
+++ b/docs/.vitepress/data/directus.data.ts
@@ -11,15 +11,12 @@ export default defineLoader({
 		const { version: fullVersion } = await readPackageJson(join(rootDir, 'directus'));
 		const splitVersion = fullVersion.split('.');
 
-		const { packageManager } = await readPackageJson(rootDir);
-
 		return {
 			version: {
 				full: fullVersion,
 				major: splitVersion[0],
 				minor: splitVersion.slice(0, 2).join('.'),
 			},
-			pnpmVersion: packageManager.slice(5),
 		};
 	},
 });

--- a/docs/extensions/installing-extensions.md
+++ b/docs/extensions/installing-extensions.md
@@ -40,10 +40,9 @@ At the root of your project, create a `Dockerfile` if one doesn't already exist 
 FROM directus/directus:{{ directus.version.major }}.x.y
 
 USER root
-RUN corepack enable \
- && corepack prepare pnpm@{{ directus.pnpmVersion }} --activate
-
+RUN corepack enable
 USER node
+
 RUN pnpm install directus-extension-package-name
 ```
 


### PR DESCRIPTION
## Scope

What's changed:

Ship Docker image with the root `package.json` containing only the essential fields.

Especially, by omitting the `dependencies` field a re-installation of the dependencies is prevented when installing additional packages, namely Directus Extensions.

A Docker image is to be considered ephemeral, which is why the existing dependencies in `node_modules` should not be touched anyway. When extending the Directus base image, only the additional dependencies are to be added.
This is what's happening now with the updated `package.json` file.

## Potential Risks / Drawbacks

- It works fine with the steps described in our [Extension Installation Guide](https://docs.directus.io/extensions/installing-extensions.html#installing-through-npm) but might lead to removal of the Directus deps from `node_modules` when using more advanced pnpm commands. However, I do not expect this to be a problem - if there really are such cases, the commands can certainly be adapted.
- When extending the Directus image and running `pnpm install` a few warnings are thrown about failing resolutions
  ```  
  node_modules/.pnpm                       |  WARN  Cannot find resolution of /fsevents/2.3.3 in lockfile
  ```
  Those can be ignored, but might be a bit confusing for users. Unfortunately, I don't think there's much we can do about it. Ideally, `pnpm deploy` would create a lockfile out of the box which would solve this whole issue.

## Review Notes / Questions

To test:

1. `docker build -t directus-test .`
2. https://docs.directus.io/extensions/installing-extensions.html#installing-through-npm with `directus-test` as base image

---

Fixes #20338

This should also reduce the final image size when installing additional packages.