### PR TITLE
Preserve minimal app permissions/validations when merging

### DIFF
--- a/.changeset/twenty-maps-cough.md
+++ b/.changeset/twenty-maps-cough.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Preserved minimal app permissions/validations when merging

--- a/api/src/utils/merge-permissions.test.ts
+++ b/api/src/utils/merge-permissions.test.ts
@@ -76,24 +76,34 @@ describe('merging permissions', () => {
 		});
 	});
 
-	test('{} supersedes conditional permissions in _or', () => {
+	test('{} is removed from conditional permissions in _or', () => {
 		const mergedPermission = mergePermission(
 			'or',
 			{ ...permissionTemplate, permissions: fullFilter },
 			{ ...permissionTemplate, permissions: conditionalFilter }
 		);
 
-		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, permissions: fullFilter });
+		expect(mergedPermission).toStrictEqual({
+			...permissionTemplate,
+			permissions: {
+				_or: [conditionalFilter],
+			},
+		});
 	});
 
-	test('{} supersedes conditional validations in _or', () => {
+	test('{} is removed from conditional validations in _or', () => {
 		const mergedPermission = mergePermission(
 			'or',
 			{ ...permissionTemplate, validation: fullFilter },
 			{ ...permissionTemplate, validation: conditionalFilter }
 		);
 
-		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, validation: fullFilter });
+		expect(mergedPermission).toStrictEqual({
+			...permissionTemplate,
+			validation: {
+				_or: [conditionalFilter],
+			},
+		});
 	});
 
 	test('{} does not supersede conditional permissions in _and', () => {

--- a/api/src/utils/merge-permissions.ts
+++ b/api/src/utils/merge-permissions.ts
@@ -1,5 +1,5 @@
 import type { LogicalFilterAND, LogicalFilterOR, Permission } from '@directus/types';
-import { flatten, intersection, isEqual, merge, omit } from 'lodash-es';
+import { flatten, intersection, isEmpty, merge, omit } from 'lodash-es';
 
 export function mergePermissions(strategy: 'and' | 'or', ...permissions: Permission[][]): Permission[] {
 	const allPermissions = flatten(permissions);
@@ -37,14 +37,12 @@ export function mergePermission(
 				],
 			} as LogicalFilterAND | LogicalFilterOR;
 		} else if (currentPerm.permissions) {
-			// Empty {} supersedes other permissions in _OR merge
-			if (strategy === 'or' && (isEqual(currentPerm.permissions, {}) || isEqual(newPerm.permissions, {}))) {
-				permissions = {};
-			} else {
-				permissions = {
-					[logicalKey]: [currentPerm.permissions, newPerm.permissions],
-				} as LogicalFilterAND | LogicalFilterOR;
-			}
+			permissions = {
+				[logicalKey]:
+					strategy === 'or'
+						? [currentPerm.permissions, newPerm.permissions].filter((p) => !isEmpty(p))
+						: [currentPerm.permissions, newPerm.permissions],
+			} as LogicalFilterAND | LogicalFilterOR;
 		} else {
 			permissions = {
 				[logicalKey]: [newPerm.permissions],
@@ -61,14 +59,12 @@ export function mergePermission(
 				],
 			} as LogicalFilterAND | LogicalFilterOR;
 		} else if (currentPerm.validation) {
-			// Empty {} supersedes other validations in _OR merge
-			if (strategy === 'or' && (isEqual(currentPerm.validation, {}) || isEqual(newPerm.validation, {}))) {
-				validation = {};
-			} else {
-				validation = {
-					[logicalKey]: [currentPerm.validation, newPerm.validation],
-				} as LogicalFilterAND | LogicalFilterOR;
-			}
+			validation = {
+				[logicalKey]:
+					strategy === 'or'
+						? [currentPerm.validation, newPerm.validation].filter((p) => !isEmpty(p))
+						: [currentPerm.validation, newPerm.validation],
+			} as LogicalFilterAND | LogicalFilterOR;
 		} else {
 			validation = {
 				[logicalKey]: [newPerm.validation],


### PR DESCRIPTION
## To-do

- [x] Confirm this does not cause regression for #11439
- When looking into this, noticed another bug with how `mergePermissions` isn't used in permissions service (but just pushed to the array), causing multiple instances of the same role-collection-action permission like #19369 to appear when hydrating permissions on App side.
  - [x] Verify whether it needs to be a new ticket or tied to this or existing issue(s)
- [x] Check out whether this is relevant to other open permissions-related issues
- [x] Check out whether this is relevant to other open validations-related issues

## Scope

What's changed:

- Made sure `mergePermissions` now keeps any minimal app access permissions + validations when being merged with custom permissions/validations

## Description

When permissions are retrieved in the API side, they are `mergePermissions`'d with `appAccessMinimalPermissions` with a `or` strategy:

https://github.com/directus/directus/blob/5ee0ec886782fb67f14469cca412845f17ddcf7c/api/src/utils/get-permissions.ts#L86-L92

#11554 added check to make empty {} to supersede other permissions/validations in _OR merge, but this turns out to inadvertently remove the permissions/validations that needs to be set via minimal app access permissions.

### Original combined `_or` permission

As an example based on the linked issue, this is how it used to looked like before #11554:

```js
{
  _or: [
    {},
    { id: { _eq: '$CURRENT_USER' } }
  ]
}
```

### Before this PR

The original `_or` permission merges into an empty object, so the `id equal $CURRENT_USER` minimal read permissions on `directus_users` no longer takes effect:

```js
{}
```


### After this PR

The original `_or` permission merges but still keeps the minimal read permission of `id equal $CURRENT_USER`:

```js
{
  _or: [
    { id: { _eq: '$CURRENT_USER' } }
  ]
}
```

## Potential Risks / Drawbacks

- Permissions & validations cases that might be unaccounted for, but likely isolated to scenarios where it's `_or` containing empty objects (but confirmed #11439 is still resolved after this PR)

## Review Notes / Questions

- Is there a scenario where an empty `{}` perms/validations within `_or` _needs_ to exist/work?

---

Fixes #19536
