### PR TITLE
Replace `process.env.NODE_ENV` when extensions manager is bundling

### DIFF
--- a/.changeset/thin-clouds-repair.md
+++ b/.changeset/thin-clouds-repair.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Replace `process.env.NODE_ENV` when the manager is bundling app extensions

--- a/api/package.json
+++ b/api/package.json
@@ -88,6 +88,7 @@
 		"@rollup/plugin-alias": "5.0.0",
 		"@rollup/plugin-node-resolve": "15.0.2",
 		"@rollup/plugin-virtual": "3.0.1",
+		"@rollup/plugin-replace": "5.0.2",
 		"argon2": "0.31.1",
 		"async": "3.2.4",
 		"axios": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: 15.0.2
         version: 15.0.2(rollup@3.22.0)
+      '@rollup/plugin-replace':
+        specifier: 5.0.2
+        version: 5.0.2(rollup@3.22.0)
       '@rollup/plugin-virtual':
         specifier: 3.0.1
         version: 3.0.1(rollup@3.22.0)


### PR DESCRIPTION
## Scope

What's changed:

- The extensions manager in @directus/api uses rollup plugin to replace `process.env.NODE_ENV` to `"production"` when bundling extensions.

## Potential Risks / Drawbacks

- Since the target of the bundle is browser, it should be harmless.

---

Fixes #20351
