### PR TITLE
Fix filter parsing for _in/_nin operators with large arrays

### DIFF
--- a/.changeset/silly-balloons-fly.md
+++ b/.changeset/silly-balloons-fly.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed filter parsing for \_in/\_nin operators when the array indices are higher than qs' default limit of 20

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -5,6 +5,7 @@ import { adjustDate } from './adjust-date.js';
 import { deepMap } from './deep-map.js';
 import { get } from './get-with-arrays.js';
 import { isDynamicVariable } from './is-dynamic-variable.js';
+import { isObject } from './is-object.js';
 import { parseJSON } from './parse-json.js';
 import { toArray } from './to-array.js';
 
@@ -103,9 +104,9 @@ function parseFilterEntry(
 		return { [key]: value.map((filter: Filter) => parseFilterRecursive(filter, accountability, context)) };
 	} else if (['_in', '_nin', '_between', '_nbetween'].includes(String(key))) {
 		// When array indices are above 20 (default value),
-		// the query parser parses them as an key-value pair object instead of an array,
+		// the query parser (qs) parses them as a key-value pair object instead of an array,
 		// so we will need to convert them back to an array
-		const val = typeof value === 'object' && !Array.isArray(value) ? Object.values(value) : value;
+		const val = isObject(value) ? Object.values(value) : value;
 		return { [key]: toArray(val).flatMap((value) => parseFilterValue(value, accountability, context)) } as Filter;
 	} else if (['_intersects', '_nintersects', '_intersects_bbox', '_nintersects_bbox'].includes(String(key))) {
 		// Geometry filters always expect to operate against a GeoJSON object. Parse the

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -102,7 +102,11 @@ function parseFilterEntry(
 	if (['_or', '_and'].includes(String(key))) {
 		return { [key]: value.map((filter: Filter) => parseFilterRecursive(filter, accountability, context)) };
 	} else if (['_in', '_nin', '_between', '_nbetween'].includes(String(key))) {
-		return { [key]: toArray(value).flatMap((value) => parseFilterValue(value, accountability, context)) } as Filter;
+		// When array indices are above 20 (default value),
+		// the query parser parses them as an key-value pair object instead of an array,
+		// so we will need to convert them back to an array
+		const val = typeof value === 'object' && !Array.isArray(value) ? Object.values(value) : value;
+		return { [key]: toArray(val).flatMap((value) => parseFilterValue(value, accountability, context)) } as Filter;
 	} else if (['_intersects', '_nintersects', '_intersects_bbox', '_nintersects_bbox'].includes(String(key))) {
 		// Geometry filters always expect to operate against a GeoJSON object. Parse the
 		// value to JSON in case a stringified JSON blob is passed

--- a/tests/blackbox/routes/items/no-relation.test.ts
+++ b/tests/blackbox/routes/items/no-relation.test.ts
@@ -1095,6 +1095,39 @@ describe.each(PRIMARY_KEY_TYPES)('/items', (pkType) => {
 			});
 		});
 
+		describe('Query parameters with array indices larger than 20', () => {
+			describe('large _in query parameter should return result', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const artists = [];
+					const artistsCount = 30;
+
+					for (let i = 0; i < artistsCount; i++) {
+						artists.push(createArtist(pkType));
+					}
+
+					await CreateItem(vendor, { collection: localCollectionArtists, item: artists });
+
+					// Generates a filter that looks like this:
+					// filter[id][_in][0]=1&filter[id][_in][1]=2&filter[id][_in][2]=3...
+					const filter = Array.from(
+						{ length: artistsCount },
+						(_, index) => `filter[id][_in][${index}]=${index + 1}`
+					).join('&');
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArtists}`)
+						.query(filter)
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toEqual(200);
+					expect(response.body.data.length).toEqual(artistsCount);
+				});
+			});
+		});
+
 		describe('Aggregation Tests', () => {
 			describe('retrieves count correctly', () => {
 				it.each(vendors)('%s', async (vendor) => {


### PR DESCRIPTION
## Context

Currently when a query has an array index above 20, which is [`qs` default limit](https://github.com/ljharb/qs#parsing-arrays):

> qs will also limit specifying indices in an array to a maximum index of `20`. Any array members with an index of greater than `20` will instead be converted to an object with the index as the key. This is needed to handle cases when someone sent, for example, `a[999999999]` and it will take significant time to iterate over this huge array.

This causes query such as:

```
filter[id][_in][0]=1&filter[id][_in][1]=2&filter[id][_in][2]=3&filter[id][_in][3]=4&filter[id][_in][4]=5&filter[id][_in][5]=6&filter[id][_in][6]=7&filter[id][_in][7]=8&filter[id][_in][8]=9&filter[id][_in][9]=10&filter[id][_in][10]=11&filter[id][_in][11]=12&filter[id][_in][12]=13&filter[id][_in][13]=14&filter[id][_in][14]=15&filter[id][_in][15]=16&filter[id][_in][16]=17&filter[id][_in][17]=18&filter[id][_in][18]=19&filter[id][_in][19]=20&filter[id][_in][20]=21&filter[id][_in][21]=22&filter[id][_in][22]=23&filter[id][_in][23]=24&filter[id][_in][24]=25
```

to turn into an object:

```js
{
  '0': '1',
  '1': '2',
  '2': '3',
  '3': '4',
  '4': '5',
  '5': '6',
  '6': '7',
  '7': '8',
  '8': '9',
  '9': '10',
  '10': '11',
  '11': '12',
  '12': '13',
  '13': '14',
  '14': '15',
  '15': '16',
  '16': '17',
  '17': '18',
  '18': '19',
  '19': '20',
  '20': '21',
  '21': '22',
  '22': '23',
  '23': '24',
  '24': '25'
}
```

rather than the expected array:

```js
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
```

We can configure `qs` default limit or provide it as a configurable environment variable as proposed by #18646, however as seen in the discussion within said PR, it can be indeed difficult to determine the actual limit (eg. what if we set the limit as 50, but a user were to still hit 51?). Though I also understand at that point that would technically be an odd practice by said user, and they should opt to simply pass it as a string as suggested by https://github.com/directus/directus/issues/16745#issuecomment-1377828578.

#16813 implemented a POC fix of turning said object to an array in the `applyQuery` level, however I think we should implement it "earlier" at the `sanitizeQuery` level:

https://github.com/directus/directus/blob/6e351544f51a44de3402003d4486040779b2e0e7/api/src/utils/sanitize-query.ts#L45-L47

which in turn calls `sanitizeFilter` that then calls `parseFilter`, which is where this PR opts to resolve said issue.

Technically this "array index over 20" issue can still be hit somewhere else other than `_in`/`_nin`/`_between`/`_nbetween`, but as the reported issue & 3 other duplicate issues are all caused by `_in` only, I've opted to only tackle this for these operators under the (bold) assumption that "array index over 20" usage in other places are malformed in the first place.

## Scope

What's changed:

- Handles `_in` and `_nin` when it gets turned into an object by the query parser (technically this PR also includes `_between` and `_nbetween`, but they _can_ technically have the same issue if someone were to do something like `filter[amount][_between][21]=100&filter[amount][_between][22]=200`, so I believe it shouldn't affect typical/expected usage of `_between` and `_nbetween`)

## Potential Risks / Drawbacks

- Outside of usages such as `Axios` that also turns array query params into values such as `filter[id][_in][0]=1&filter[id][_in][1]=2` or if a user were to manually form such query, I'm not sure are there other unaccounted risks here.

## Review Notes / Questions

- Is this PR correct based on the justification within the Context section?
- Maybe this approach should be weighted against #18646 to determine which one we want to opt for? Understandably being able to customize the query parser's options can be handy, outside of just to alleviate this qs array limit issue. And that PR is technically "more complete", if this sort of usage is used outside of `filter` query parameter (which I am not able to think of what could that be yet).

---

Fixes #16745
