### PR TITLE
Durus sorting on an m2o field

### DIFF
--- a/packages/data-driver-postgres/src/query/index.test.ts
+++ b/packages/data-driver-postgres/src/query/index.test.ts
@@ -54,21 +54,23 @@ test('statement with limit and offset', () => {
 });
 
 test('statement with order', () => {
+	const orderField = randomIdentifier();
+	const table = randomIdentifier();
+
 	sample.clauses.order = [
 		{
 			type: 'order',
 			orderBy: {
 				type: 'primitive',
-				field: randomIdentifier(),
+				column: orderField,
+				table: table,
 			},
 			direction: 'ASC',
 		},
 	];
 
 	expect(convertToActualStatement(sample.clauses)).toEqual(
-		`SELECT "${firstSelectTable}"."${firstSelectColumn}", "${secondSelectTable}"."${secondSelectColumn}" FROM "${
-			sample.clauses.from
-		}" ORDER BY "${(sample.clauses.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field}" ASC;`
+		`SELECT "${firstSelectTable}"."${firstSelectColumn}", "${secondSelectTable}"."${secondSelectColumn}" FROM "${sample.clauses.from}" ORDER BY "${table}"."${orderField}" ASC;`
 	);
 });
 
@@ -126,12 +128,15 @@ test('statement with all possible local modifiers', () => {
 		],
 	};
 
+	const sortTable = randomIdentifier();
+
 	sample.clauses.order = [
 		{
 			type: 'order',
 			orderBy: {
 				type: 'primitive',
-				field: orderField,
+				column: orderField,
+				table: sortTable,
 			},
 			direction: 'ASC',
 		},
@@ -144,7 +149,7 @@ test('statement with all possible local modifiers', () => {
 			firstConditionParameterIndex + 1
 		} AND "${secondConditionTable}"."${secondConditionColumn}" < $${
 			secondConditionParameterIndex + 1
-		} ORDER BY "${orderField}" ASC LIMIT $1 OFFSET $2;`
+		} ORDER BY "${sortTable}"."${orderField}" ASC LIMIT $1 OFFSET $2;`
 	);
 });
 

--- a/packages/data-driver-postgres/src/query/index.test.ts
+++ b/packages/data-driver-postgres/src/query/index.test.ts
@@ -1,4 +1,3 @@
-import type { AbstractQueryFieldNodePrimitive } from '@directus/data';
 import type { AbstractSqlClauses } from '@directus/data-sql';
 import { randomIdentifier } from '@directus/random';
 import { beforeEach, expect, test } from 'vitest';

--- a/packages/data-driver-postgres/src/query/orderBy.test.ts
+++ b/packages/data-driver-postgres/src/query/orderBy.test.ts
@@ -1,4 +1,3 @@
-import type { AbstractQueryFieldNodePrimitive } from '@directus/data';
 import type { AbstractSqlClauses } from '@directus/data-sql';
 import { randomIdentifier } from '@directus/random';
 import { beforeEach, expect, test } from 'vitest';
@@ -6,10 +5,12 @@ import { orderBy } from './orderBy.js';
 
 let sample: AbstractSqlClauses;
 
+const randomTable = randomIdentifier();
+
 beforeEach(() => {
 	sample = {
 		select: [],
-		from: randomIdentifier(),
+		from: randomTable,
 	};
 });
 
@@ -18,28 +19,35 @@ test('Empty parametrized statement when order is not defined', () => {
 });
 
 test('Returns order part for one primitive field', () => {
+	const field = randomIdentifier();
+
 	sample.order = [
 		{
 			orderBy: {
 				type: 'primitive',
-				field: randomIdentifier(),
+				column: field,
+				table: randomTable,
 			},
 			type: 'order',
 			direction: 'ASC',
 		},
 	];
 
-	const expected = `ORDER BY "${(sample.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field}" ASC`;
+	const expected = `ORDER BY "${randomTable}"."${field}" ASC`;
 
 	expect(orderBy(sample)).toStrictEqual(expected);
 });
 
 test('Returns order part for multiple primitive fields', () => {
+	const field1 = randomIdentifier();
+	const field2 = randomIdentifier();
+
 	sample.order = [
 		{
 			orderBy: {
 				type: 'primitive',
-				field: randomIdentifier(),
+				column: field1,
+				table: randomTable,
 			},
 			type: 'order',
 			direction: 'ASC',
@@ -47,16 +55,15 @@ test('Returns order part for multiple primitive fields', () => {
 		{
 			orderBy: {
 				type: 'primitive',
-				field: randomIdentifier(),
+				column: field2,
+				table: randomTable,
 			},
 			type: 'order',
 			direction: 'DESC',
 		},
 	];
 
-	const expected = `ORDER BY "${(sample.order[0]!.orderBy as AbstractQueryFieldNodePrimitive).field}" ASC, "${
-		(sample.order[1]!.orderBy as AbstractQueryFieldNodePrimitive).field
-	}" DESC`;
+	const expected = `ORDER BY "${randomTable}"."${field1}" ASC, "${randomTable}"."${field2}" DESC`;
 
 	expect(orderBy(sample)).toStrictEqual(expected);
 });

--- a/packages/data-driver-postgres/src/query/orderBy.ts
+++ b/packages/data-driver-postgres/src/query/orderBy.ts
@@ -16,10 +16,8 @@ export function orderBy({ order }: AbstractSqlClauses): string | null {
 	const sortExpressions = order.map((o) => {
 		switch (o.orderBy.type) {
 			case 'primitive':
-				return `${escapeIdentifier(o.orderBy.field)} ${o.direction}`;
-			case 'fn':
-			case 'm2o':
-			case 'a2o':
+				return `${escapeIdentifier(o.orderBy.table)}.${escapeIdentifier(o.orderBy.column)} ${o.direction}`;
+			// @TODO: support functions˝
 			default:
 				throw new Error(`Type ${o.orderBy.type} hasn't been implemented yet`);
 		}

--- a/packages/data-driver-postgres/src/query/orderBy.ts
+++ b/packages/data-driver-postgres/src/query/orderBy.ts
@@ -1,5 +1,6 @@
 import type { AbstractSqlClauses } from '@directus/data-sql';
 import { escapeIdentifier } from '../utils/escape-identifier.js';
+import { applyFunction } from '../utils/functions.js';
 
 /**
  * Generates the `ORDER BY x` part of a SQL statement.
@@ -14,12 +15,10 @@ export function orderBy({ order }: AbstractSqlClauses): string | null {
 	}
 
 	const sortExpressions = order.map((o) => {
-		switch (o.orderBy.type) {
-			case 'primitive':
-				return `${escapeIdentifier(o.orderBy.table)}.${escapeIdentifier(o.orderBy.column)} ${o.direction}`;
-			// @TODO: support functions˝
-			default:
-				throw new Error(`Type ${o.orderBy.type} hasn't been implemented yet`);
+		if (o.orderBy.type === 'primitive') {
+			return `${escapeIdentifier(o.orderBy.table)}.${escapeIdentifier(o.orderBy.column)} ${o.direction}`;
+		} else {
+			return `${applyFunction(o.orderBy)} ${o.direction}`;
 		}
 	});
 

--- a/packages/data-driver-postgres/src/utils/functions.ts
+++ b/packages/data-driver-postgres/src/utils/functions.ts
@@ -8,7 +8,7 @@ import type { ExtractFn } from '@directus/data';
  * @param fnNode - The function node which holds the function name and the column
  * @returns	Basically FN("table"."column")
  */
-export function applyFunction(fnNode: AbstractSqlQueryFnNode) {
+export function applyFunction(fnNode: AbstractSqlQueryFnNode): string {
 	const wrappedColumn = wrapColumn(fnNode.table, fnNode.column);
 
 	if (fnNode.fn.type === 'arrayFn') {

--- a/packages/data-sql/src/query-converter/converter-integration.test.ts
+++ b/packages/data-sql/src/query-converter/converter-integration.test.ts
@@ -189,6 +189,8 @@ test('Convert query with limit and offset', () => {
 });
 
 test('Convert query with a sort', () => {
+	const sortField = randomIdentifier();
+
 	sample.modifiers = {
 		sort: [
 			{
@@ -196,7 +198,7 @@ test('Convert query with a sort', () => {
 				direction: 'ascending',
 				target: {
 					type: 'primitive',
-					field: randomIdentifier(),
+					field: sortField,
 				},
 			},
 		],
@@ -222,7 +224,11 @@ test('Convert query with a sort', () => {
 			order: [
 				{
 					type: 'order',
-					orderBy: sample.modifiers.sort![0]!.target,
+					orderBy: {
+						type: 'primitive',
+						table: rootCollection,
+						column: sortField,
+					},
 					direction: 'ASC',
 				},
 			],
@@ -281,6 +287,8 @@ test('Convert a query with a function as field select', () => {
 });
 
 test('Convert a query with all possible modifiers', () => {
+	const sortField = randomIdentifier();
+
 	sample.modifiers = {
 		limit: {
 			type: 'limit',
@@ -296,7 +304,7 @@ test('Convert a query with all possible modifiers', () => {
 				direction: 'ascending',
 				target: {
 					type: 'primitive',
-					field: randomIdentifier(),
+					field: sortField,
 				},
 			},
 		],
@@ -322,7 +330,11 @@ test('Convert a query with all possible modifiers', () => {
 			order: [
 				{
 					type: 'order',
-					orderBy: sample.modifiers.sort![0]!.target,
+					orderBy: {
+						type: 'primitive',
+						table: rootCollection,
+						column: sortField,
+					},
 					direction: 'ASC',
 				},
 			],

--- a/packages/data-sql/src/query-converter/modifiers/filter/conditions/utils.ts
+++ b/packages/data-sql/src/query-converter/modifiers/filter/conditions/utils.ts
@@ -55,13 +55,15 @@ export function convertTarget(
 			value: convertedFn.fn,
 			joins: [],
 		};
-	} else {
+	} else if (target.type === 'nested-one-target') {
 		const { value, joins } = convertNestedOneTarget(collection, target, idxGenerator);
 
 		return {
 			value,
 			joins,
 		};
+	} else {
+		throw new Error('Unknown target type');
 	}
 }
 

--- a/packages/data-sql/src/query-converter/modifiers/filter/conditions/utils.ts
+++ b/packages/data-sql/src/query-converter/modifiers/filter/conditions/utils.ts
@@ -55,15 +55,13 @@ export function convertTarget(
 			value: convertedFn.fn,
 			joins: [],
 		};
-	} else if (target.type === 'nested-one-target') {
+	} else {
 		const { value, joins } = convertNestedOneTarget(collection, target, idxGenerator);
 
 		return {
 			value,
 			joins,
 		};
-	} else {
-		throw new Error('Unknown target type');
 	}
 }
 

--- a/packages/data-sql/src/query-converter/modifiers/modifiers.ts
+++ b/packages/data-sql/src/query-converter/modifiers/modifiers.ts
@@ -14,14 +14,14 @@ export const convertModifiers = (
 	idxGenerator: Generator<number, number, number>
 ): ModifierConversionResult => {
 	const result: ModifierConversionResult = {
-		clauses: { joins: [] },
+		clauses: {},
 		parameters: [],
 	};
 
 	if (modifiers?.filter) {
 		const convertedFilter = convertFilter(modifiers.filter, collection, idxGenerator);
 		result.clauses.where = convertedFilter.clauses.where;
-		result.clauses.joins!.push(...convertedFilter.clauses.joins);
+		result.clauses.joins = convertedFilter.clauses.joins;
 		result.parameters.push(...convertedFilter.parameters);
 	}
 
@@ -36,7 +36,16 @@ export const convertModifiers = (
 	}
 
 	if (modifiers?.sort) {
-		result.clauses.order = convertSort(modifiers.sort, collection, idxGenerator);
+		const sortConversionResult = convertSort(modifiers.sort, collection, idxGenerator);
+		result.clauses.order = sortConversionResult.clauses.order;
+
+		if (sortConversionResult.clauses.joins.length > 0) {
+			if (result.clauses.joins) {
+				result.clauses.joins!.push(...sortConversionResult.clauses.joins);
+			} else {
+				result.clauses.joins = sortConversionResult.clauses.joins;
+			}
+		}
 	}
 
 	return result;

--- a/packages/data-sql/src/query-converter/modifiers/modifiers.ts
+++ b/packages/data-sql/src/query-converter/modifiers/modifiers.ts
@@ -36,8 +36,7 @@ export const convertModifiers = (
 	}
 
 	if (modifiers?.sort) {
-		result.clauses.order = convertSort(modifiers.sort);
-		// TODO: add support for nested sorts
+		result.clauses.order = convertSort(modifiers.sort, collection, idxGenerator);
 	}
 
 	return result;

--- a/packages/data-sql/src/query-converter/modifiers/sort.test.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.test.ts
@@ -4,6 +4,7 @@ import { randomIdentifier } from '@directus/random';
 import { convertSort, type SortConversionResult } from './sort.js';
 import { parameterIndexGenerator } from '../param-index-generator.js';
 import { convertTarget, type TargetConversionResult } from './filter/conditions/utils.js';
+import type { AbstractSqlQuerySelectNode } from '../../index.js';
 
 vi.mock('./filter/conditions/utils.js', (importOriginal) => {
 	const original = importOriginal();
@@ -50,7 +51,7 @@ test('convert ascending sort with a single field', () => {
 			order: [
 				{
 					type: 'order',
-					orderBy: mock.value,
+					orderBy: mock.value as AbstractSqlQuerySelectNode,
 					direction: 'ASC',
 				},
 			],
@@ -82,7 +83,7 @@ test('convert descending sort with a single field', () => {
 			order: [
 				{
 					type: 'order',
-					orderBy: mock.value,
+					orderBy: mock.value as AbstractSqlQuerySelectNode,
 					direction: 'DESC',
 				},
 			],
@@ -132,12 +133,12 @@ test('convert ascending sort with multiple fields', () => {
 			order: [
 				{
 					type: 'order',
-					orderBy: mock1.value,
+					orderBy: mock1.value as AbstractSqlQuerySelectNode,
 					direction: 'ASC',
 				},
 				{
 					type: 'order',
-					orderBy: mock2.value,
+					orderBy: mock2.value as AbstractSqlQuerySelectNode,
 					direction: 'ASC',
 				},
 			],
@@ -215,7 +216,7 @@ test('convert sort on nested item', () => {
 			order: [
 				{
 					type: 'order',
-					orderBy: mock.value,
+					orderBy: mock.value as AbstractSqlQuerySelectNode,
 					direction: 'ASC',
 				},
 			],

--- a/packages/data-sql/src/query-converter/modifiers/sort.test.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.test.ts
@@ -28,34 +28,33 @@ beforeEach(() => {
 			},
 		},
 	];
-
 });
 
 test('convert ascending sort with a single field', () => {
 
-	vi.mocked(convertTarget).mockReturnValueOnce({
+	const mock: TargetConversionResult = {
 		value: {
 			type: 'primitive',
 			table: localCollection,
 			column: targetField,
 		},
 		joins: [],
-	});
+	};
+
+	vi.mocked(convertTarget).mockReturnValueOnce(mock);
 
 	const res = convertSort(sample, localCollection, parameterIndexGenerator());
 
 	const expected: SortConversionResult = {
 		clauses: {
 			joins: [],
-			order: [{
-				type: 'order',
-				orderBy: {
-					type: 'primitive',
-					table: localCollection,
-					column: targetField,
+			order: [
+				{
+					type: 'order',
+					orderBy: mock.value,
+					direction: 'ASC',
 				},
-				direction: 'ASC',
-			}],
+			],
 		},
 	};
 
@@ -65,54 +64,50 @@ test('convert ascending sort with a single field', () => {
 test('convert descending sort with a single field', () => {
 	sample[0]!.direction = 'descending';
 
-	vi.mocked(convertTarget).mockReturnValueOnce({
+	const mock: TargetConversionResult = {
 		value: {
 			type: 'primitive',
-			table: localCollection,
-			column: targetField,
+			table: randomIdentifier(),
+			column: randomIdentifier(),
 		},
 		joins: [],
-	});
+	};
+
+	vi.mocked(convertTarget).mockReturnValueOnce(mock);
 
 	const res = convertSort(sample, localCollection, parameterIndexGenerator());
 
 	const expected: SortConversionResult = {
 		clauses: {
 			joins: [],
-			order: [{
-				type: 'order',
-				orderBy: {
-					type: 'primitive',
-					table: localCollection,
-					column: targetField,
+			order: [
+				{
+					type: 'order',
+					orderBy: mock.value,
+					direction: 'DESC',
 				},
-				direction: 'DESC',
-			}],
+			],
 		},
 	};
 
 	expect(res).toStrictEqual(expected);
-
-
 });
 
 test('convert ascending sort with multiple fields', () => {
-	const secondSortField = randomIdentifier();
-
 	sample.push({
 		type: 'sort',
 		direction: 'ascending',
 		target: {
 			type: 'primitive',
-			field: secondSortField,
+			field: randomIdentifier(),
 		},
 	});
 
 	const mock1: TargetConversionResult = {
 		value: {
 			type: 'primitive',
-			table: localCollection,
-			column: targetField,
+			table: randomIdentifier(),
+			column: randomIdentifier(),
 		},
 		joins: [],
 	};
@@ -122,8 +117,8 @@ test('convert ascending sort with multiple fields', () => {
 	const mock2: TargetConversionResult = {
 		value: {
 			type: 'primitive',
-			table: localCollection,
-			column: secondSortField,
+			table: randomIdentifier(),
+			column: randomIdentifier(),
 		},
 		joins: [],
 	};
@@ -145,7 +140,7 @@ test('convert ascending sort with multiple fields', () => {
 					type: 'order',
 					orderBy: mock2.value,
 					direction: 'ASC',
-				}
+				},
 			],
 		},
 	};
@@ -154,71 +149,65 @@ test('convert ascending sort with multiple fields', () => {
 });
 
 test('convert sort on nested item', () => {
-	const leftIdField = randomIdentifier();
-	const rightIdField = randomIdentifier();
-	const rightCollection = randomIdentifier();
-	const rightStore = randomIdentifier();
-	const foreignSortField = randomIdentifier();
-
-	const nestedSortSample: AbstractQueryNodeSort =
-	{
+	const nestedSortSample: AbstractQueryNodeSort = {
 		type: 'sort',
 		direction: 'ascending',
 		target: {
 			type: 'nested-one-target',
 			field: {
 				type: 'primitive',
-				field: foreignSortField,
+				field: randomIdentifier(),
 			},
 			meta: {
 				type: 'm2o',
 				join: {
 					local: {
-						fields: [leftIdField],
+						fields: [randomIdentifier()],
 					},
 					foreign: {
-						store: rightStore,
-						collection: rightCollection,
-						fields: [rightIdField],
-					}
-				}
-			}
-		}
+						store: randomIdentifier(),
+						collection: randomIdentifier(),
+						fields: [randomIdentifier()],
+					},
+				},
+			},
+		},
 	};
 
 	const mock: TargetConversionResult = {
 		value: {
 			type: 'primitive',
-			table: rightCollection,
-			column: foreignSortField,
+			table: randomIdentifier(),
+			column: randomIdentifier(),
 		},
-		joins: [{
-			type: 'join',
-			table: rightCollection,
-			as: rightStore + 'RANDOM',
-			on: {
-				type: 'condition',
-				negate: false,
-				condition: {
-					type: 'condition-field',
-					target: {
-						type: 'primitive',
-						table: rightCollection,
-						column: rightIdField,
-					},
-					operation: 'eq',
-					compareTo: {
-						type: 'primitive',
-						table: rightStore,
-						column: rightIdField,
+		joins: [
+			{
+				type: 'join',
+				table: randomIdentifier(),
+				as: randomIdentifier(),
+				on: {
+					type: 'condition',
+					negate: false,
+					condition: {
+						type: 'condition-field',
+						target: {
+							type: 'primitive',
+							table: randomIdentifier(),
+							column: randomIdentifier(),
+						},
+						operation: 'eq',
+						compareTo: {
+							type: 'primitive',
+							table: randomIdentifier(),
+							column: randomIdentifier(),
+						},
 					},
 				},
-			}
-		}],
+			},
+		],
 	};
 
 	vi.mocked(convertTarget).mockReturnValueOnce(mock);
-
 	const res = convertSort([nestedSortSample], localCollection, parameterIndexGenerator());
 
 	const expected: SortConversionResult = {

--- a/packages/data-sql/src/query-converter/modifiers/sort.test.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.test.ts
@@ -31,7 +31,6 @@ beforeEach(() => {
 });
 
 test('convert ascending sort with a single field', () => {
-
 	const mock: TargetConversionResult = {
 		value: {
 			type: 'primitive',

--- a/packages/data-sql/src/query-converter/modifiers/sort.test.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.test.ts
@@ -1,9 +1,21 @@
 import type { AbstractQueryNodeSort } from '@directus/data';
-import { beforeEach, expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { randomIdentifier } from '@directus/random';
-import { convertSort } from './sort.js';
+import { convertSort, type SortConversionResult } from './sort.js';
+import { parameterIndexGenerator } from '../param-index-generator.js';
+import { convertTarget, type TargetConversionResult } from './filter/conditions/utils.js';
+
+vi.mock('./filter/conditions/utils.js', (importOriginal) => {
+	const original = importOriginal();
+	return {
+		...original,
+		convertTarget: vi.fn(),
+	};
+});
 
 let sample: AbstractQueryNodeSort[];
+const localCollection = randomIdentifier();
+const targetField = randomIdentifier();
 
 beforeEach(() => {
 	sample = [
@@ -12,59 +24,215 @@ beforeEach(() => {
 			direction: 'ascending',
 			target: {
 				type: 'primitive',
-				field: randomIdentifier(),
+				field: targetField,
 			},
 		},
 	];
+
 });
 
 test('convert ascending sort with a single field', () => {
-	const res = convertSort(sample);
 
-	expect(res).toStrictEqual([
-		{
-			type: 'order',
-			orderBy: sample[0]!.target,
-			direction: 'ASC',
+	vi.mocked(convertTarget).mockReturnValueOnce({
+		value: {
+			type: 'primitive',
+			table: localCollection,
+			column: targetField,
 		},
-	]);
+		joins: [],
+	});
+
+	const res = convertSort(sample, localCollection, parameterIndexGenerator());
+
+	const expected: SortConversionResult = {
+		clauses: {
+			joins: [],
+			order: [{
+				type: 'order',
+				orderBy: {
+					type: 'primitive',
+					table: localCollection,
+					column: targetField,
+				},
+				direction: 'ASC',
+			}],
+		},
+	};
+
+	expect(res).toStrictEqual(expected);
 });
 
 test('convert descending sort with a single field', () => {
 	sample[0]!.direction = 'descending';
-	const res = convertSort(sample);
 
-	expect(res).toStrictEqual([
-		{
-			type: 'order',
-			orderBy: sample[0]!.target,
-			direction: 'DESC',
+	vi.mocked(convertTarget).mockReturnValueOnce({
+		value: {
+			type: 'primitive',
+			table: localCollection,
+			column: targetField,
 		},
-	]);
+		joins: [],
+	});
+
+	const res = convertSort(sample, localCollection, parameterIndexGenerator());
+
+	const expected: SortConversionResult = {
+		clauses: {
+			joins: [],
+			order: [{
+				type: 'order',
+				orderBy: {
+					type: 'primitive',
+					table: localCollection,
+					column: targetField,
+				},
+				direction: 'DESC',
+			}],
+		},
+	};
+
+	expect(res).toStrictEqual(expected);
+
+
 });
 
 test('convert ascending sort with multiple fields', () => {
+	const secondSortField = randomIdentifier();
+
 	sample.push({
 		type: 'sort',
 		direction: 'ascending',
 		target: {
 			type: 'primitive',
-			field: randomIdentifier(),
+			field: secondSortField,
 		},
 	});
 
-	const res = convertSort(sample);
+	const mock1: TargetConversionResult = {
+		value: {
+			type: 'primitive',
+			table: localCollection,
+			column: targetField,
+		},
+		joins: [],
+	};
 
-	expect(res).toStrictEqual([
-		{
-			type: 'order',
-			orderBy: sample[0]!.target,
-			direction: 'ASC',
+	vi.mocked(convertTarget).mockReturnValueOnce(mock1);
+
+	const mock2: TargetConversionResult = {
+		value: {
+			type: 'primitive',
+			table: localCollection,
+			column: secondSortField,
 		},
-		{
-			type: 'order',
-			orderBy: sample[1]!.target,
-			direction: 'ASC',
+		joins: [],
+	};
+
+	vi.mocked(convertTarget).mockReturnValueOnce(mock2);
+
+	const res = convertSort(sample, localCollection, parameterIndexGenerator());
+
+	const expected: SortConversionResult = {
+		clauses: {
+			joins: [],
+			order: [
+				{
+					type: 'order',
+					orderBy: mock1.value,
+					direction: 'ASC',
+				},
+				{
+					type: 'order',
+					orderBy: mock2.value,
+					direction: 'ASC',
+				}
+			],
 		},
-	]);
+	};
+
+	expect(res).toStrictEqual(expected);
+});
+
+test('convert sort on nested item', () => {
+	const leftIdField = randomIdentifier();
+	const rightIdField = randomIdentifier();
+	const rightCollection = randomIdentifier();
+	const rightStore = randomIdentifier();
+	const foreignSortField = randomIdentifier();
+
+	const nestedSortSample: AbstractQueryNodeSort =
+	{
+		type: 'sort',
+		direction: 'ascending',
+		target: {
+			type: 'nested-one-target',
+			field: {
+				type: 'primitive',
+				field: foreignSortField,
+			},
+			meta: {
+				type: 'm2o',
+				join: {
+					local: {
+						fields: [leftIdField],
+					},
+					foreign: {
+						store: rightStore,
+						collection: rightCollection,
+						fields: [rightIdField],
+					}
+				}
+			}
+		}
+	};
+
+	const mock: TargetConversionResult = {
+		value: {
+			type: 'primitive',
+			table: rightCollection,
+			column: foreignSortField,
+		},
+		joins: [{
+			type: 'join',
+			table: rightCollection,
+			as: rightStore + 'RANDOM',
+			on: {
+				type: 'condition',
+				negate: false,
+				condition: {
+					type: 'condition-field',
+					target: {
+						type: 'primitive',
+						table: rightCollection,
+						column: rightIdField,
+					},
+					operation: 'eq',
+					compareTo: {
+						type: 'primitive',
+						table: rightStore,
+						column: rightIdField,
+					},
+				},
+			}
+		}],
+	};
+
+	vi.mocked(convertTarget).mockReturnValueOnce(mock);
+
+	const res = convertSort([nestedSortSample], localCollection, parameterIndexGenerator());
+
+	const expected: SortConversionResult = {
+		clauses: {
+			joins: mock.joins,
+			order: [
+				{
+					type: 'order',
+					orderBy: mock.value,
+					direction: 'ASC',
+				},
+			],
+		},
+	};
+
+	expect(res).toStrictEqual(expected);
 });

--- a/packages/data-sql/src/query-converter/modifiers/sort.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.ts
@@ -6,17 +6,19 @@ export type SortConversionResult = {
 	clauses: Required<Pick<AbstractSqlClauses, 'order' | 'joins'>>;
 };
 
-
 /**
  * @param abstractSorts
  * @returns the converted sort nodes
  */
-export const convertSort = (abstractSorts: AbstractQueryNodeSort[], collection: string, idxGenerator: Generator<number, number, number>): SortConversionResult => {
-
+export const convertSort = (
+	abstractSorts: AbstractQueryNodeSort[],
+	collection: string,
+	idxGenerator: Generator<number, number, number>
+): SortConversionResult => {
 	const result: SortConversionResult = {
 		clauses: {
 			joins: [],
-			order: []
+			order: [],
 		},
 	};
 
@@ -37,4 +39,3 @@ export const convertSort = (abstractSorts: AbstractQueryNodeSort[], collection: 
 
 	return result;
 };
-

--- a/packages/data-sql/src/query-converter/modifiers/sort.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.ts
@@ -1,5 +1,5 @@
 import type { AbstractQueryNodeSort } from '@directus/data';
-import type { AbstractSqlClauses, AbstractSqlQueryOrderNode, AbstractSqlQuerySelectNode } from '../../types/index.js';
+import type { AbstractSqlClauses, AbstractSqlQueryOrderNode } from '../../types/index.js';
 import { convertTarget } from './filter/conditions/utils.js';
 
 export type SortConversionResult = {
@@ -23,15 +23,11 @@ export const convertSort = (
 	};
 
 	abstractSorts.forEach((abstractSort) => {
-		if (abstractSort.target.type === 'fn') {
-			throw new Error('Sorting by function is not supported');
-		}
-
 		const targetConversionResult = convertTarget(abstractSort.target, collection, idxGenerator);
 
 		const orderBy: AbstractSqlQueryOrderNode = {
 			type: 'order',
-			orderBy: targetConversionResult.value as AbstractSqlQuerySelectNode,
+			orderBy: targetConversionResult.value,
 			direction: abstractSort.direction === 'descending' ? 'DESC' : 'ASC',
 		};
 

--- a/packages/data-sql/src/query-converter/modifiers/sort.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.ts
@@ -1,20 +1,40 @@
 import type { AbstractQueryNodeSort } from '@directus/data';
-import type { AbstractSqlQueryOrderNode } from '../../types/index.js';
+import type { AbstractSqlClauses, AbstractSqlQueryOrderNode } from '../../types/index.js';
+import { convertTarget } from './filter/conditions/utils.js';
+
+export type SortConversionResult = {
+	clauses: Required<Pick<AbstractSqlClauses, 'order' | 'joins'>>;
+};
+
 
 /**
  * @param abstractSorts
  * @returns the converted sort nodes
  */
-export const convertSort = (abstractSorts: AbstractQueryNodeSort[]): AbstractSqlQueryOrderNode[] => {
-	return abstractSorts.map((abstractSort) => {
-		if (abstractSort.target.type !== 'primitive') {
-			throw new Error('Sorting on fields other than primitive fields not yet implemented!');
-		}
+export const convertSort = (abstractSorts: AbstractQueryNodeSort[], collection: string, idxGenerator: Generator<number, number, number>): SortConversionResult => {
 
-		return {
+	const result: SortConversionResult = {
+		clauses: {
+			joins: [],
+			order: []
+		},
+	};
+
+	abstractSorts.forEach((abstractSort) => {
+		const targetConversionResult = convertTarget(abstractSort.target, collection, idxGenerator);
+
+		const orderBy: AbstractSqlQueryOrderNode = {
 			type: 'order',
-			orderBy: abstractSort.target,
+			orderBy: targetConversionResult.value,
 			direction: abstractSort.direction === 'descending' ? 'DESC' : 'ASC',
 		};
+
+		result.clauses.order.push(orderBy);
+		result.clauses.joins.push(...targetConversionResult.joins);
+
+		return result;
 	});
+
+	return result;
 };
+

--- a/packages/data-sql/src/query-converter/modifiers/sort.ts
+++ b/packages/data-sql/src/query-converter/modifiers/sort.ts
@@ -1,5 +1,5 @@
 import type { AbstractQueryNodeSort } from '@directus/data';
-import type { AbstractSqlClauses, AbstractSqlQueryOrderNode } from '../../types/index.js';
+import type { AbstractSqlClauses, AbstractSqlQueryOrderNode, AbstractSqlQuerySelectNode } from '../../types/index.js';
 import { convertTarget } from './filter/conditions/utils.js';
 
 export type SortConversionResult = {
@@ -23,11 +23,15 @@ export const convertSort = (
 	};
 
 	abstractSorts.forEach((abstractSort) => {
+		if (abstractSort.target.type === 'fn') {
+			throw new Error('Sorting by function is not supported');
+		}
+
 		const targetConversionResult = convertTarget(abstractSort.target, collection, idxGenerator);
 
 		const orderBy: AbstractSqlQueryOrderNode = {
 			type: 'order',
-			orderBy: targetConversionResult.value,
+			orderBy: targetConversionResult.value as AbstractSqlQuerySelectNode,
 			direction: abstractSort.direction === 'descending' ? 'DESC' : 'ASC',
 		};
 

--- a/packages/data-sql/src/types/clauses/order.ts
+++ b/packages/data-sql/src/types/clauses/order.ts
@@ -1,9 +1,7 @@
+import type { AbstractSqlQuerySelectNode } from "./index.js";
+
 export interface AbstractSqlQueryOrderNode {
 	type: 'order';
-	orderBy: {
-		type: 'primitive';
-		column: string;
-		table: string;
-	};
+	orderBy: AbstractSqlQuerySelectNode;
 	direction: 'ASC' | 'DESC';
 }

--- a/packages/data-sql/src/types/clauses/order.ts
+++ b/packages/data-sql/src/types/clauses/order.ts
@@ -1,10 +1,9 @@
-interface AbstractSqlOrderPrimitive {
-	type: 'primitive';
-	field: string;
-}
-
 export interface AbstractSqlQueryOrderNode {
 	type: 'order';
-	orderBy: AbstractSqlOrderPrimitive;
+	orderBy: {
+		type: 'primitive';
+		column: string;
+		table: string;
+	};
 	direction: 'ASC' | 'DESC';
 }

--- a/packages/data-sql/src/types/clauses/order.ts
+++ b/packages/data-sql/src/types/clauses/order.ts
@@ -1,7 +1,7 @@
-import type { AbstractSqlQuerySelectNode } from "./index.js";
+import type { AbstractSqlQueryFnNode, AbstractSqlQuerySelectNode } from './index.js';
 
 export interface AbstractSqlQueryOrderNode {
 	type: 'order';
-	orderBy: AbstractSqlQuerySelectNode;
+	orderBy: AbstractSqlQuerySelectNode | AbstractSqlQueryFnNode;
 	direction: 'ASC' | 'DESC';
 }


### PR DESCRIPTION
## Scope
This PR introduces the ability to sort on a (m2o) related field.

The abstract sort node was already enhanced in  https://github.com/directus/directus/pull/20222. In this PR I took care of the conversion from abstract sort node to abstract SQL. Similar to nested filtering, the abstract query _sort_ node now also has the required meta data attached to it to make the join happen. Which means that the abstract SQL sort node now not only creates the `ORDER BY` statement, but now also the `JOIN` statement. the nested filter PR takes care of removing duplcated join statements, to in the abstract SQL they don't appear multiple times.   

## Potential Risks / Drawbacks
none

## Review Notes / Questions
none

---

Fixes https://github.com/directus/durus/issues/4
