### PR TITLE
Rename to `articles` to match other examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ import Badge from './.vitepress/components/Badge.vue'
 <template #rest>
 
 ```js
-GET /items/products/4
+GET /items/articles/4
 	?fields[]=id
 	&fields[]=status
 	&fields[]=title


### PR DESCRIPTION
## Scope

What's changed:

- Aligned naming with GraphQL and SDK example

  The GraphQL and SDK example both uses `articles`:
  
  https://github.com/directus/directus/blob/9a1ba0982ce0e8d0bf93b8367d82e69a1b458aeb/docs/index.md?plain=1#L43-L77
  
  so this updates the REST example to `articles` as well for consistency
