### PR TITLE
Only run CI against files that changed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -31,7 +35,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Run Linter
-        run: pnpm exec eslint .
+        run: pnpm exec eslint steps.changed-files.outputs.all_changed_files
 
   format:
     name: Format

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,12 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-
-      - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,9 +33,11 @@ jobs:
 
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          build: false
 
       - name: Run Linter
-        run: pnpm exec eslint steps.changed-files.outputs.all_changed_files
+        run: pnpm exec eslint ${{ steps.changed-files.outputs.all_changed_files }}
 
   format:
     name: Format

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          # Vitest uses `git diff` under the hood to find the changed files in it's `--changed`
+          # option, which in turn means we need to fetch the full git history so git is able to diff
           fetch-depth: 0
 
       - name: Prepare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
           build: false
 
       - name: Run Formatter
-        run: pnpm exec prettier --check .
+        run: pnpm exec prettier --check ${{ steps.changed-files.outputs.all_changed_files }}
 
   unit:
     name: Unit Tests
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Run Tests
-        run: pnpm test
+        run: pnpm test -- --changed ${{ github.base_ref }} --passWithNoTests
 
   analyze:
     name: CodeQL Analysis

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,6 +60,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
         # with:
         #   fetch-depth: 0
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,7 +66,3 @@ jobs:
 
       - name: Run Tests
         run: pnpm test -- -- --changed ${{ github.base_ref }} --passWithNoTests
-
-  analyze:
-    name: CodeQL Analysis
-    uses: ./.github/workflows/codeql-analysis.yml

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: github.base_ref
+          ref: ${{ github.base_ref }}
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
         uses: tj-actions/changed-files@v40
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -58,6 +58,11 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: github.base_ref
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,8 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        # with:
+        #   fetch-depth: 0
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,4 +67,4 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Run Tests
-        run: pnpm test -- -- --changed ${{ github.base_ref }} --passWithNoTests
+        run: pnpm test -- -- --changed origin/${{ github.base_ref }} --passWithNoTests

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,12 +61,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.base_ref }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        # with:
-        #   fetch-depth: 0
+          fetch-depth: 0
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Run Tests
-        run: pnpm test -- --changed ${{ github.base_ref }} --passWithNoTests
+        run: pnpm test -- -- --changed ${{ github.base_ref }} --passWithNoTests
 
   analyze:
     name: CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@ name: CodeQL Analysis
 on:
   workflow_call:
   schedule:
-    - cron: '42 23 * * 5'
+    - cron: '0 0 * * *'
 
 env:
   NODE_OPTIONS: --max_old_space_size=6144


### PR DESCRIPTION
## Scope

What's changed:

- Allow the CI to run a bit quicker by only testing against the files that actually changes. This means we'll only check linting and formatting against the changed files.

## Potential Risks / Drawbacks

- Might miss formatting errors in other files, but if the base repo state is correct, this shouldn't happen as all changes have to come from a PR

## Review Notes / Questions

n/a

---

Fixes #20273
