### PR TITLE
Add ability to ignore specific paths from the HTTP logger

### DIFF
--- a/.changeset/sixty-toys-nail.md
+++ b/.changeset/sixty-toys-nail.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Added the ability to ignore specific paths from HTTP logger

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -366,6 +366,8 @@ const typeMap: Record<string, string> = {
 	MAX_BATCH_MUTATION: 'number',
 
 	SERVER_SHUTDOWN_TIMEOUT: 'number',
+
+	LOGGER_HTTP_IGNORE_PATHS: 'array',
 };
 
 let env: Record<string, any> = {

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -26,6 +26,7 @@ const allowedEnvironmentVars = [
 	'PUBLIC_URL',
 	'LOG_LEVEL',
 	'LOG_STYLE',
+	'LOG_HTTP_IGNORE_PATHS',
 	'MAX_PAYLOAD_SIZE',
 	'ROOT_REDIRECT',
 	'SERVE_APP',
@@ -367,7 +368,7 @@ const typeMap: Record<string, string> = {
 
 	SERVER_SHUTDOWN_TIMEOUT: 'number',
 
-	LOGGER_HTTP_IGNORE_PATHS: 'array',
+	LOG_HTTP_IGNORE_PATHS: 'array',
 };
 
 let env: Record<string, any> = {

--- a/api/src/logger.test.ts
+++ b/api/src/logger.test.ts
@@ -1,6 +1,9 @@
 import { REDACTED_TEXT } from '@directus/utils';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { Writable } from 'node:stream';
 import { pino } from 'pino';
+import { pinoHttp, type HttpLogger } from 'pino-http';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { doMockEnv } from './__utils__/mock-env.js';
 
@@ -15,7 +18,7 @@ const MOCK_ENV = {
 	LOG_STYLE: 'raw',
 };
 
-doMockEnv({ env: MOCK_ENV });
+const { setEnv } = doMockEnv({ env: MOCK_ENV });
 
 const { httpLoggerOptions } = await import('./logger.js');
 
@@ -143,5 +146,60 @@ describe('res.headers', () => {
 				},
 			},
 		});
+	});
+});
+
+describe('ignored paths', () => {
+	afterEach(() => {
+		vi.resetModules();
+	});
+
+	const doRequest = (logger: HttpLogger) =>
+		new Promise((resolve) => {
+			const server = http.createServer((req, res) => {
+				logger(req, res);
+				res.end();
+			});
+
+			server.listen(0, '127.0.0.1', () => {
+				const address = server.address() as AddressInfo;
+				const path = '/server/ping';
+
+				http.get('http://' + address.address + ':' + address.port + path, () => {
+					server.close(resolve);
+				});
+			});
+		});
+
+	test('should log request with no ignored paths specified', async () => {
+		const { httpLoggerEnvConfig } = await import('./logger.js');
+
+		const logger = pinoHttp({
+			logger: pino(httpLoggerOptions, stream),
+			...httpLoggerEnvConfig,
+		});
+
+		await doRequest(logger);
+
+		expect(logOutput.mock.calls[0][0]).toMatchObject({
+			req: {
+				url: '/server/ping',
+			},
+		});
+	});
+
+	test('should not log request when it matches ignored path', async () => {
+		setEnv({ LOGGER_HTTP_IGNORE_PATHS: '/server/ping' });
+
+		const { httpLoggerEnvConfig } = await import('./logger.js');
+
+		const logger = pinoHttp({
+			logger: pino(httpLoggerOptions, stream),
+			...httpLoggerEnvConfig,
+		});
+
+		await doRequest(logger);
+
+		expect(logOutput).not.toHaveBeenCalled();
 	});
 });

--- a/api/src/logger.test.ts
+++ b/api/src/logger.test.ts
@@ -189,7 +189,7 @@ describe('ignored paths', () => {
 	});
 
 	test('should not log request when it matches ignored path', async () => {
-		setEnv({ LOGGER_HTTP_IGNORE_PATHS: '/server/ping' });
+		setEnv({ LOG_HTTP_IGNORE_PATHS: '/server/ping' });
 
 		const { httpLoggerEnvConfig } = await import('./logger.js');
 

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -1,6 +1,5 @@
 import { REDACTED_TEXT, toArray } from '@directus/utils';
 import type { Request, RequestHandler } from 'express';
-import type { IncomingMessage } from 'http';
 import { merge } from 'lodash-es';
 import { URL } from 'node:url';
 import { pino, type LoggerOptions } from 'pino';

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -102,8 +102,8 @@ const logger = pino(merge(pinoOptions, loggerEnvConfig));
 
 export const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', ['LOGGER_HTTP_LOGGER']);
 
-if (httpLoggerEnvConfig['ignorePaths']) {
-	const ignorePathsSet = new Set(httpLoggerEnvConfig['ignorePaths']);
+if (env['LOG_HTTP_IGNORE_PATHS']) {
+	const ignorePathsSet = new Set(env['LOG_HTTP_IGNORE_PATHS']);
 
 	httpLoggerEnvConfig['autoLogging'] = {
 		ignore: (req) => {
@@ -112,25 +112,6 @@ if (httpLoggerEnvConfig['ignorePaths']) {
 			return ignorePathsSet.has(pathname);
 		},
 	} as AutoLoggingOptions;
-
-	delete httpLoggerEnvConfig['ignorePaths'];
-}
-
-if (httpLoggerEnvConfig['ignorePaths']) {
-	const ignorePathsSet = new Set(httpLoggerEnvConfig['ignorePaths']);
-
-	httpLoggerEnvConfig['autoLogging'] = {
-		ignore: function (req: IncomingMessage) {
-			if (!req.url) {
-				return false;
-			}
-
-			const { pathname } = new URL(req.url, 'http://example.com/');
-			return ignorePathsSet.has(pathname);
-		},
-	};
-
-	delete httpLoggerEnvConfig['ignorePaths'];
 }
 
 export const expressLogger = pinoHttp({

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -2,10 +2,9 @@ import { REDACTED_TEXT, toArray } from '@directus/utils';
 import type { Request, RequestHandler } from 'express';
 import type { IncomingMessage } from 'http';
 import { merge } from 'lodash-es';
-import type { LoggerOptions } from 'pino';
-import { pino } from 'pino';
-import { pinoHttp, stdSerializers } from 'pino-http';
-import { URL } from 'url';
+import { URL } from 'node:url';
+import { pino, type LoggerOptions } from 'pino';
+import { pinoHttp, stdSerializers, type AutoLoggingOptions } from 'pino-http';
 import env from './env.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
 
@@ -101,7 +100,21 @@ if (loggerEnvConfig['levels']) {
 
 const logger = pino(merge(pinoOptions, loggerEnvConfig));
 
-const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', ['LOGGER_HTTP_LOGGER']);
+export const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', ['LOGGER_HTTP_LOGGER']);
+
+if (httpLoggerEnvConfig['ignorePaths']) {
+	const ignorePathsSet = new Set(httpLoggerEnvConfig['ignorePaths']);
+
+	httpLoggerEnvConfig['autoLogging'] = {
+		ignore: (req) => {
+			if (!req.url) return false;
+			const { pathname } = new URL(req.url, 'http://example.com/');
+			return ignorePathsSet.has(pathname);
+		},
+	} as AutoLoggingOptions;
+
+	delete httpLoggerEnvConfig['ignorePaths'];
+}
 
 if (httpLoggerEnvConfig['ignorePaths']) {
 	const ignorePathsSet = new Set(httpLoggerEnvConfig['ignorePaths']);

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -105,6 +105,7 @@ const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', ['LOGGER_HTTP_LOGGER
 
 if (httpLoggerEnvConfig['ignorePaths']) {
 	const ignorePathsSet = new Set(httpLoggerEnvConfig['ignorePaths']);
+
 	httpLoggerEnvConfig['autoLogging'] = {
 		ignore: function (req: IncomingMessage) {
 			if (!req.url) {

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -235,6 +235,7 @@ prefixing the value with `{type}:`. The following types are available:
 | `PUBLIC_URL`<sup>[1]</sup> | URL where your API can be reached on the web.                                                                               | `/`                          |
 | `LOG_LEVEL`                | What level of detail to log. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`.                         | `info`                       |
 | `LOG_STYLE`                | Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.                                                 | `pretty`                     |
+| `LOG_HTTP_IGNORE_PATHS`    | List of HTTP request paths which should not appear in the log, for example `/server/ping`.                                  | --                           |
 | `MAX_PAYLOAD_SIZE`         | Controls the maximum request body size. Accepts number of bytes, or human readable string.                                  | `1mb`                        |
 | `ROOT_REDIRECT`            | Redirect the root of the application `/` to a specific route. Accepts a relative path, absolute URL, or `false` to disable. | `./admin`                    |
 | `SERVE_APP`                | Whether or not to serve the Admin application                                                                               | `true`                       |


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added the ability to ignore specific paths from the HTTP logger.

## Potential Risks / Drawbacks

- Slower logging. The log sped reduction (if any) should be very marginal as Set is O(1) lookup.

## Review Notes / Questions

- The paths are controlled via a `LOGGER_HTTP_IGNORE_PATHS` key in the `.env`.
- I was not sure if a one liner (`ignorePathsSet.has(new URL(req.url, 'http://example.com/').pathname)`) is preferred here. The current implementation seems to be more readable but can update to whatever is preferred.
- Should we auto prepend a `/` to all defined paths or leave that up to the user? Another way is to auto remove the `/` from all incoming paths (probably less efficient than prepend).
- Should I be adding test coverage for this? This feature is not utilizing any new functionality.

---

Fixes #19464
