### PR TITLE
Fix awaiting of token refresh request before making any further API requests

### DIFF
--- a/.changeset/strange-days-drive.md
+++ b/.changeset/strange-days-drive.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed awaiting of token refresh request before making any further API requests

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -29,7 +29,6 @@ export const onRequest = (config: InternalAxiosRequestConfig): Promise<InternalA
 		if (config.url && config.url === '/auth/refresh') {
 			queue.pause();
 			resolve(requestConfig);
-			queue.start();
 		} else {
 			queue.add(() => resolve(requestConfig));
 		}
@@ -101,6 +100,11 @@ export function addTokenToURL(url: string, token?: string): string {
 	if (!accessToken) return url;
 
 	return addQueryToPath(url, { access_token: accessToken });
+}
+
+export function resumeQueue() {
+	if (!queue.isPaused) return;
+	queue.start();
 }
 
 export async function replaceQueue(options?: Options<any, DefaultAddOptions>) {

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -30,7 +30,10 @@ export const onRequest = (config: InternalAxiosRequestConfig): Promise<InternalA
 			queue.pause();
 			resolve(requestConfig);
 		} else {
-			queue.add(() => resolve(requestConfig));
+			queue.add(() => {
+				requestConfig.headers['Authorization'] = api.defaults.headers.common['Authorization'];
+				return resolve(requestConfig);
+			});
 		}
 	});
 };

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -28,13 +28,13 @@ export const onRequest = (config: InternalAxiosRequestConfig): Promise<InternalA
 	return new Promise((resolve) => {
 		if (config.url && config.url === '/auth/refresh') {
 			queue.pause();
-			resolve(requestConfig);
-		} else {
-			queue.add(() => {
-				requestConfig.headers['Authorization'] = api.defaults.headers.common['Authorization'];
-				return resolve(requestConfig);
-			});
+			return resolve(requestConfig);
 		}
+
+		queue.add(() => {
+			requestConfig.headers['Authorization'] = api.defaults.headers.common['Authorization'];
+			return resolve(requestConfig);
+		});
 	});
 };
 

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -1,4 +1,4 @@
-import api from '@/api';
+import api, { resumeQueue } from '@/api';
 import { DEFAULT_AUTH_PROVIDER } from '@/constants';
 import { dehydrate, hydrate } from '@/hydrate';
 import { router } from '@/router';
@@ -138,6 +138,7 @@ export async function refresh({ navigate }: LogoutOptions = { navigate: true }):
 		await logout({ navigate, reason: LogoutReason.SESSION_EXPIRED });
 	} finally {
 		isRefreshing = false;
+		resumeQueue();
 	}
 }
 


### PR DESCRIPTION
## Overview

### Reproduction

in all the recordings below, I have artificially added a 5 seconds delay for `/auth/refresh` API endpoint just to reproduce this issue easier & show the "queueing" clearer. Particularly adding the following code:

```js
await new Promise((resolve) => setTimeout(resolve, 5000));
```

right before this line:

https://github.com/directus/directus/blob/09edc033f863091b8e575be2b971253254ce0d20/api/src/controllers/auth.ts#L105

as well as setting `ACCESS_TOKEN_TTL="45s"` to make the access token expire faster.

Admittedly I also had to use [Edge's sleeping tab function](https://github.com/directus/directus/issues/18016#issuecomment-1803861669) to prevent the constant periodic token refresh in the background, I believe an alternative way to test this would be to disable said periodic token refresh by removing the setTimeout here:

https://github.com/directus/directus/blob/09edc033f863091b8e575be2b971253254ce0d20/app/src/auth.ts#L129-L131

### Context

Currently there is a logic added by #8827 to await token refresh request before any further requests are fired:

https://github.com/directus/directus/blob/09edc033f863091b8e575be2b971253254ce0d20/app/src/api.ts#L28-L36

However the `resolve(requestConfig)` isn't really a blocking code, so `queue.start()` gets calls within milliseconds after `queue.pause()`, as if it was never paused at all. Here's a look at all the requests firing even when the `/auth/refresh` request is still pending:

https://github.com/directus/directus/assets/42867097/30123051-bd14-4a16-867b-c0317b8b6b94

The first commit https://github.com/directus/directus/commit/c9f517c14e730d58344f50369cbd098cb867147c of this PR makes sure requests are queued _after_ the refresh request completes:

https://github.com/directus/directus/assets/42867097/9af960ab-e9fc-416d-b12c-e6b8bb7e065b

However as seen in the video, they are still failing. This is because when they were queued, they were still using the old token, so they will still fail. This is why the second commit https://github.com/directus/directus/commit/f436985a49397991a54e4fff86df5bd1fc6b3bf2 of this PR is meant to make it so they will use the new token:

https://github.com/directus/directus/blob/3f3db2c10ad592e3405dce1143c6a82a8e4c1fd5/app/src/auth.ts#L120-L121

and make sure it's updated in the queued requestConfig when `p-queue` does call the arrow function:

https://github.com/directus/directus/assets/42867097/9f8521aa-c695-4dcb-af5a-ab26e7a216e8

## Scope

What's changed:

- Ensure the previous "pause all requests while token is refreshing" to work properly now
- Made sure requests that are queued will use the new token rather than the token that they were using when they were _added_ to the queue

## Potential Risks / Drawbacks

- It should be fixing a logic that was intended by wasn't working, so I'm not sure are there _new_ risks added here
- Tiny drawback would be requests are technically ever so slightly slower than before since they need to wait for `/auth/refresh` to finish, even if the old access token has a long valid duration.

## Review Notes / Questions

None at the moment

---

Fixes #18016
