### PR TITLE
Revert/Pin MinIO version for blackbox tests

### DIFF
--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       - 'host.docker.internal:host-gateway'
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2023-10-25T06-33-25Z
     command: server /data/minio/ --console-address :9001
     ports:
       - 8881:9000


### PR DESCRIPTION
Despite being a bugfix release, it seems like https://github.com/minio/minio/releases/tag/RELEASE.2023-11-01T01-57-10Z introduced a bug / breaking change and the assets blackbox tests no longer worked:
```
 FAIL  routes/assets/format.test.ts > /assets > GET /assets/:id > format=auto Tests > without Accept request header > Storage: minio > sqlite3
 FAIL  routes/assets/format.test.ts > /assets > GET /assets/:id > format=auto Tests > with "'image/avif,image/webp,image/*,*/*;q=0.8'" Accept request header > Storage: minio > sqlite3
 FAIL  routes/assets/format.test.ts > /assets > GET /assets/:id > format=auto Tests > with "'image/avif'" Accept request header > Storage: minio > sqlite3
 FAIL  routes/assets/format.test.ts > /assets > GET /assets/:id > format=auto Tests > with "'image/webp'" Accept request header > Storage: minio > sqlite3
 FAIL  routes/assets/format.test.ts > /assets > GET /assets/:id > format=auto Tests > with "'*/*'" Accept request header > Storage: minio > sqlite3
Error: Test timed out in 15000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
```
