### PR TITLE
Revert "Revert/Pin MinIO version for blackbox tests (#20400)"

### DIFF
--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       - 'host.docker.internal:host-gateway'
 
   minio:
-    image: minio/minio:RELEASE.2023-10-25T06-33-25Z
+    image: minio/minio
     command: server /data/minio/ --console-address :9001
     ports:
       - 8881:9000


### PR DESCRIPTION
This reverts commit 292400341ff64eeb988e3a9451257f8084adf313.

It seems like the sudden fail of asset tests hasn't really been caused by the updated MinIO version, although the revert of the version has shown a reproducible effect locally 🤷