### PR TITLE
Ignore json files for eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ dist/
 *.yml
 *.yaml
 *.md
+*.json


### PR DESCRIPTION
This is a follow-up to #20366 and #20388 where `yaml` and `md` files were ignored for eslint.

Error thrown when linting a `package.json`:
```
/home/runner/work/directus/directus/api/package.json
  2:8  error  Parsing error: Unexpected token :
```
