### PR TITLE
Support Numeric Fields for the Labels Display

### DIFF
--- a/.changeset/popular-cherries-count.md
+++ b/.changeset/popular-cherries-count.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added Support for Numeric Fields for the Labels Display

--- a/app/src/displays/labels/index.ts
+++ b/app/src/displays/labels/index.ts
@@ -5,7 +5,7 @@ export default defineDisplay({
 	id: 'labels',
 	name: '$t:displays.labels.labels',
 	description: '$t:displays.labels.description',
-	types: ['string', 'json', 'csv'],
+	types: ['string', 'json', 'csv', 'integer', 'float', 'decimal', 'bigInteger'],
 	icon: 'flag',
 	component: DisplayLabels,
 	handler: (value, options, { interfaceOptions }) => {
@@ -15,10 +15,10 @@ export default defineDisplay({
 			return getConfiguredChoice(value);
 		}
 
-		function getConfiguredChoice(val: string) {
+		function getConfiguredChoice(val: string | number) {
 			const configuredChoice =
-				options?.choices?.find((choice: { value: string }) => choice.value === val) ??
-				interfaceOptions?.choices?.find((choice: { value: string }) => choice.value === val);
+				options?.choices?.find((choice: { value: string | number }) => choice.value === val) ??
+				interfaceOptions?.choices?.find((choice: { value: string | number }) => choice.value === val);
 
 			return configuredChoice?.text ? configuredChoice.text : val;
 		}

--- a/app/src/displays/labels/labels.vue
+++ b/app/src/displays/labels/labels.vue
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash';
 import { computed } from 'vue';
 
 type Choice = {
-	value: string;
+	value: string | number;
 	text: string;
 	foreground: string | null;
 	background: string | null;
@@ -12,8 +12,8 @@ type Choice = {
 
 const props = withDefaults(
 	defineProps<{
-		value: string | string[];
-		type: 'text' | 'string' | 'json' | 'csv';
+		value: string | number | string[] | number[];
+		type: 'text' | 'string' | 'json' | 'csv' | 'integer' | 'bigInteger' | 'float' | 'decimal';
 		format?: boolean;
 		showAsDot?: boolean;
 		choices?: Choice[];
@@ -25,10 +25,11 @@ const props = withDefaults(
 );
 
 const items = computed(() => {
-	let items: string[];
+	let items: string[] | number[];
 
-	if (isEmpty(props.value)) items = [];
+	if (isEmpty(props.value) && isNaN(props.value as number)) items = [];
 	else if (props.type === 'string') items = [props.value as string];
+	else if (['integer', 'bigInteger', 'float', 'decimal'].includes(props.type)) items = [props.value as number];
 	else items = props.value as string[];
 
 	return items.map((item) => {
@@ -39,10 +40,10 @@ const items = computed(() => {
 		if (typeof item === 'object') {
 			itemStringValue = JSON.stringify(item);
 		} else {
-			if (props.format) {
-				itemStringValue = formatTitle(item);
+			if (props.format && isNaN(item as any)) {
+				itemStringValue = formatTitle(item as string);
 			} else {
-				itemStringValue = item;
+				itemStringValue = item as string;
 			}
 		}
 

--- a/app/src/interfaces/select-dropdown/index.ts
+++ b/app/src/interfaces/select-dropdown/index.ts
@@ -8,7 +8,7 @@ export default defineInterface({
 	description: '$t:interfaces.select-dropdown.description',
 	icon: 'arrow_drop_down_circle',
 	component: InterfaceSelectDropdown,
-	types: ['string', 'integer', 'float', 'bigInteger'],
+	types: ['string', 'integer', 'float', 'decimal', 'bigInteger'],
 	group: 'selection',
 	preview: PreviewSVG,
 	options: ({ field }) => [


### PR DESCRIPTION
## Scope

What's changed:

- Dropdown Interface now supports `decimal` type
- Label Display now supports `integer`, `bigInteger`, `float`, and `decimal`

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Had to change typing support in the display's vue file, please double check it :)

---

Fixes #20264 and Fixes #20267
