### PR TITLE
SDK fixed permissions schema

### DIFF
--- a/.changeset/dull-camels-fix.md
+++ b/.changeset/dull-camels-fix.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed the permissions schema for the SDK

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -12,6 +12,6 @@ export type DirectusPermission<Schema extends object> = MergeCoreCollection<
 		permissions: Record<string, any> | null;
 		validation: Record<string, any> | null;
 		presets: Record<string, any> | null;
-		fields: string | null;
+		fields: string[] | null;
 	}
 >;


### PR DESCRIPTION
Fixes #20432 

## Scope

What's changed:

- Updated the `permissions.fields` type to be `string[] | null` instead of the incorrect `string | null`

## Review Notes / Questions

- I would like to lorem ipsum
