### PR TITLE
Remove feedback widget from package pages

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -11,13 +11,14 @@ const route = useRoute();
 const title = computed(() => page.value.title);
 const contributors = computed(() => page.value.frontmatter['contributors']);
 const path = computed(() => route.path);
+const isPackagePage = RegExp('^/packages/.+$').test(path.value)
 </script>
 
 <template>
 	<Layout>
 		<template #doc-before>
 			<div
-				v-if="RegExp('^/packages/.+$').test(path)"
+				v-if="isPackagePage"
 				class="warning custom-block"
 				style="padding-bottom: 16px; margin-bottom: 16px"
 			>
@@ -33,7 +34,7 @@ const path = computed(() => route.path);
 			<Newsletter class="newsletter" />
 		</template>
 		<template #doc-footer-before>
-			<Feedback :url="path" :title="title" />
+			<Feedback v-if="!isPackagePage" :url="path" :title="title" />
 			<Meta v-if="contributors" id="contributors" title-left="Contributors">
 				<template #left>
 					<div class="contributors">{{ contributors }}</div>


### PR DESCRIPTION
Feedback on these pages doesn't tend to be actionable. Content in them, as they are are autogenerated, are not owned by our docs team and I find feedback on these pages is high volume. 

Following this PR, package pages now have a disclaimer at the top, and no feedback mechanism. They are a convenience to those who want the package definitions and should not be impacting our docs feedback scores. 

FYI @bryantgillespie 