### PR TITLE
SDK FieldMetaConditionType does not allow partial entry

### DIFF
--- a/.changeset/eight-terms-fetch.md
+++ b/.changeset/eight-terms-fetch.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Improved SDK recursive partial entry handling

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -39,7 +39,13 @@ export type IsAny<T> = IfAny<T, true, never>;
 export type IsNullable<T, Y = true, N = never> = T | null extends T ? Y : N;
 
 export type NestedPartial<Item extends object> = {
-	[Key in keyof Item]?: Item[Key] extends object ? NestedPartial<Item[Key]> : Item[Key];
+	[Key in keyof Item]?: NonNullable<Item[Key]> extends infer NestedItem
+		? NestedItem extends object[]
+			? NestedPartial<UnpackList<NestedItem>>[] | Exclude<Item[Key], NestedItem>
+			: NestedItem extends object
+				? NestedPartial<NestedItem> | Exclude<Item[Key], NestedItem>
+				: Item[Key]
+		: Item[Key];
 };
 
 /**


### PR DESCRIPTION
Fixes #20444 

## Scope

What's changed:

Improved the recursive `NestedPartial` so it recurses through nullable properties by excluding them first and adding them back after the recursion and added the capability of handling arrays of objects recursively too

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum

