### PR TITLE
Fail instance on error during extensions syncing

### DIFF
--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -176,12 +176,18 @@ export class ExtensionManager {
 	private async load(): Promise<void> {
 		try {
 			await syncExtensions();
+		} catch (error) {
+			logger.error(`Failed to sync extensions`);
+			logger.error(error);
+			process.exit(1);
+		}
 
+		try {
 			this.extensions = await getExtensions();
 			this.extensionsSettings = await getExtensionsSettings(this.extensions);
-		} catch (err: any) {
+		} catch (error) {
 			logger.warn(`Couldn't load extensions`);
-			logger.warn(err);
+			logger.warn(error);
 		}
 
 		await this.registerHooks();


### PR DESCRIPTION
Follow-up on #20207

If the extensions sync errors-out for some reason we need to fail the instance itself, so that it can be restarted externally (pm2) and the sync will be tried again.

It should be fine to wrap around the whole `syncExtensions` function because the `ensureExtensionDirs` function has its own error catcher.

### Example

<img width="709" src="https://github.com/directus/directus/assets/5363448/12f32b5c-a199-4d03-8c50-53f01db335a6">
