### PR TITLE
[OpenID/OAuth2] Only update user information if payload not empty

### DIFF
--- a/.changeset/light-toys-rule.md
+++ b/.changeset/light-toys-rule.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Ensured with OpenID and OAuth2 user info is only updated if payload is not empty

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -168,7 +168,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{ auth_data: userPayload.auth_data ?? null },
+				{ auth_data: userPayload.auth_data },
 				{
 					identifier,
 					provider: this.config['provider'],
@@ -178,7 +178,9 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			);
 
 			// Update user to update refresh_token and other properties that might have changed
-			await this.usersService.updateOne(userId, updatedUserPayload);
+			if (Object.values(updatedUserPayload).some((value) => value !== undefined)) {
+				await this.usersService.updateOne(userId, updatedUserPayload);
+			}
 
 			return userId;
 		}

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -195,7 +195,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{ auth_data: userPayload.auth_data ?? null },
+				{ auth_data: userPayload.auth_data },
 				{
 					identifier,
 					provider: this.config['provider'],
@@ -205,7 +205,9 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			);
 
 			// Update user to update refresh_token and other properties that might have changed
-			await this.usersService.updateOne(userId, updatedUserPayload);
+			if (Object.values(updatedUserPayload).some((value) => value !== undefined)) {
+				await this.usersService.updateOne(userId, updatedUserPayload);
+			}
 
 			return userId;
 		}


### PR DESCRIPTION
Better late than never! A PR to ensure that the `userPayload` isn't empty before triggering an user update on login. This allows the `userPayload.auth_data` to correctly pass through its previous value.

Related to the discussion here: https://github.com/directus/directus/issues/20362

Tagging: @dasantonym
