### PR TITLE
Fallback to hostname for OAS URL if no PUBLIC_URL specified

### DIFF
--- a/.changeset/good-apricots-shake.md
+++ b/.changeset/good-apricots-shake.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Use the hostname as the OAS URL if no PUBLIC_URL has been specified

--- a/api/src/controllers/server.ts
+++ b/api/src/controllers/server.ts
@@ -16,7 +16,7 @@ router.get(
 			schema: req.schema,
 		});
 
-		res.locals['payload'] = await service.oas.generate();
+		res.locals['payload'] = await service.oas.generate(req.headers.host);
 		return next();
 	}),
 	respond

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -63,8 +63,8 @@ class OASSpecsService implements SpecificationSubService {
 		const paths = await this.generatePaths(permissions, tags);
 		const components = await this.generateComponents(tags);
 
-		const isDefaultUrl = env['PUBLIC_URL'] === '/';
-		const url = isDefaultUrl && host ? host : env['PUBLIC_URL'];
+		const isDefaultPublicUrl = env['PUBLIC_URL'] === '/';
+		const url = isDefaultPublicUrl && host ? host : env['PUBLIC_URL'];
 
 		const spec: OpenAPIObject = {
 			openapi: '3.0.1',

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -56,12 +56,15 @@ class OASSpecsService implements SpecificationSubService {
 			? schema : reduceSchema(schema, accountability?.permissions || null)
 	}
 
-	async generate() {
+	async generate(host?: string) {
 		const permissions = this.accountability?.permissions ?? [];
 
 		const tags = await this.generateTags();
 		const paths = await this.generatePaths(permissions, tags);
 		const components = await this.generateComponents(tags);
+
+		const isDefaultUrl = env['PUBLIC_URL'] === '/';
+		const url = isDefaultUrl && host ? host : env['PUBLIC_URL'];
 
 		const spec: OpenAPIObject = {
 			openapi: '3.0.1',
@@ -73,7 +76,7 @@ class OASSpecsService implements SpecificationSubService {
 			},
 			servers: [
 				{
-					url: env['PUBLIC_URL'],
+					url,
 					description: 'Your current Directus instance.',
 				},
 			],


### PR DESCRIPTION
Allows the OAS to be usable in Swagger Editor ("Try it out" button) when no `PUBLIC_URL` has been specified which is usually the case in dev env.