### PR TITLE
More accurate OAS based on authenticated user

### DIFF
--- a/.changeset/late-shrimps-destroy.md
+++ b/.changeset/late-shrimps-destroy.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"@directus/specs": patch
+---
+
+Ensured the paths and schemas in the generated OAS are based on current user

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -67,7 +67,7 @@ export const COOKIE_OPTIONS: CookieOptions = {
 	sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
 };
 
-export const OAS_REQUIRED_SCHEMAS = ['Diff', 'Schema', 'Query', 'x-metadata'];
+export const OAS_REQUIRED_SCHEMAS = ['Query', 'x-metadata'];
 
 /** Formats from which transformation is supported */
 export const SUPPORTED_IMAGE_TRANSFORM_FORMATS = ['image/jpeg', 'image/png', 'image/webp', 'image/tiff', 'image/avif'];

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -320,7 +320,7 @@ class OASSpecsService implements SpecificationSubService {
 
 				components.schemas[name] = {
 					...cloneDeep(schema),
-					'x-collection': collection,
+					...(collection && { 'x-collection': collection }),
 				};
 			}
 		}

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -52,8 +52,8 @@ class OASSpecsService implements SpecificationSubService {
 		this.accountability = accountability || null;
 		this.knex = knex || getDatabase();
 
-		this.schema = this.accountability?.admin === true
-			? schema : reduceSchema(schema, accountability?.permissions || null)
+		this.schema =
+			this.accountability?.admin === true ? schema : reduceSchema(schema, accountability?.permissions || null);
 	}
 
 	async generate() {
@@ -91,8 +91,12 @@ class OASSpecsService implements SpecificationSubService {
 		const collections = Object.values(this.schema.collections);
 		const tags: OpenAPIObject['tags'] = [];
 
-		// System tags that don't have an associated collection are always readable to the user
 		for (const systemTag of systemTags) {
+			// Check if necessary authentication level is given
+			if (systemTag['x-authentication'] === 'admin' && !this.accountability?.admin) continue;
+			if (systemTag['x-authentication'] === 'user' && !this.accountability?.user) continue;
+
+			// Remaining system tags that don't have an associated collection are publicly available
 			if (!systemTag['x-collection']) {
 				tags.push(systemTag);
 			}
@@ -295,23 +299,33 @@ class OASSpecsService implements SpecificationSubService {
 	}
 
 	private async generateComponents(tags: OpenAPIObject['tags']): Promise<OpenAPIObject['components']> {
+		if (!tags) return;
+
 		let components: OpenAPIObject['components'] = cloneDeep(spec.components);
 
 		if (!components) components = {};
 
 		components.schemas = {};
-		const collections = Object.values(this.schema.collections);
 
-		// Always includes the schemas with these names
-		if (spec.components?.schemas !== null) {
-			for (const schemaName of OAS_REQUIRED_SCHEMAS) {
-				if (spec.components!.schemas![schemaName] !== null) {
-					components.schemas[schemaName] = cloneDeep(spec.components!.schemas![schemaName])!;
-				}
+		const tagSchemas = tags.reduce(
+			(schemas, tag) => [...schemas, ...(tag['x-schemas'] ? tag['x-schemas'] : [])],
+			[] as string[]
+		);
+
+		const requiredSchemas = [...OAS_REQUIRED_SCHEMAS, ...tagSchemas];
+
+		for (const [name, schema] of Object.entries(spec.components?.schemas ?? {})) {
+			if (requiredSchemas.includes(name)) {
+				const collection = spec.tags?.find((tag) => tag.name === name)?.['x-collection'];
+
+				components.schemas[name] = {
+					...cloneDeep(schema),
+					'x-collection': collection,
+				};
 			}
 		}
 
-		if (!tags) return;
+		const collections = Object.values(this.schema.collections);
 
 		for (const collection of collections) {
 			const tag = tags.find((tag) => tag['x-collection'] === collection.collection);
@@ -326,6 +340,7 @@ class OASSpecsService implements SpecificationSubService {
 				const schemaComponent = cloneDeep(spec.components!.schemas![tag.name]) as SchemaObject;
 
 				schemaComponent.properties = {};
+				schemaComponent['x-collection'] = collection.collection;
 
 				for (const field of fieldsInCollection) {
 					schemaComponent.properties[field.field] =
@@ -403,7 +418,11 @@ class OASSpecsService implements SpecificationSubService {
 			if (relationType === 'm2o') {
 				const relatedTag = tags.find((tag) => tag['x-collection'] === relation.related_collection);
 
-				if (!relatedTag || !relation.related_collection || relation.related_collection in this.schema.collections === false) {
+				if (
+					!relatedTag ||
+					!relation.related_collection ||
+					relation.related_collection in this.schema.collections === false
+				) {
 					return propertyObject;
 				}
 

--- a/packages/specs/src/components/activity.yaml
+++ b/packages/specs/src/components/activity.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_activity
 properties:
   id:
     description: Unique identifier for the object.

--- a/packages/specs/src/components/collection.yaml
+++ b/packages/specs/src/components/collection.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_collections
 properties:
   collection:
     description: The collection key.

--- a/packages/specs/src/components/extension.yaml
+++ b/packages/specs/src/components/extension.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_extensions
 properties:
   bundle:
     description: Name of the bundle the extension is in.

--- a/packages/specs/src/components/field.yaml
+++ b/packages/specs/src/components/field.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_fields
 properties:
   collection:
     description: Unique name of the collection this field is in.

--- a/packages/specs/src/components/file.yaml
+++ b/packages/specs/src/components/file.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_files
 properties:
   id:
     description: Unique identifier for the file.

--- a/packages/specs/src/components/flow.yaml
+++ b/packages/specs/src/components/flow.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_flows
 properties:
   id:
     description: Unique identifier for the flow.

--- a/packages/specs/src/components/folder.yaml
+++ b/packages/specs/src/components/folder.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_files
 properties:
   id:
     description: Unique identifier for the folder.

--- a/packages/specs/src/components/operation.yaml
+++ b/packages/specs/src/components/operation.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_operations
 properties:
   id:
     description: Unique identifier for the operation.

--- a/packages/specs/src/components/permissions.yaml
+++ b/packages/specs/src/components/permissions.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_permissions
 properties:
   id:
     description: Unique identifier for the permission.

--- a/packages/specs/src/components/preset.yaml
+++ b/packages/specs/src/components/preset.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_presets
 properties:
   id:
     description: Unique identifier for this single collection preset.

--- a/packages/specs/src/components/relation.yaml
+++ b/packages/specs/src/components/relation.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_relations
 properties:
   id:
     description: Unique identifier for the relation.

--- a/packages/specs/src/components/revision.yaml
+++ b/packages/specs/src/components/revision.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_revisions
 properties:
   id:
     description: Unique identifier for the revision.

--- a/packages/specs/src/components/role.yaml
+++ b/packages/specs/src/components/role.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_roles
 properties:
   id:
     description: Unique identifier for the role.

--- a/packages/specs/src/components/setting.yaml
+++ b/packages/specs/src/components/setting.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_settings
 properties:
   id:
     description: Unique identifier for the setting.

--- a/packages/specs/src/components/user.yaml
+++ b/packages/specs/src/components/user.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_users
 properties:
   id:
     description: Unique identifier for the user.

--- a/packages/specs/src/components/version.yaml
+++ b/packages/specs/src/components/version.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_versions
 properties:
   id:
     description: Primary key of the Content Version.

--- a/packages/specs/src/components/webhook.yaml
+++ b/packages/specs/src/components/webhook.yaml
@@ -1,5 +1,4 @@
 type: object
-x-collection: directus_webhooks
 properties:
   id:
     description: The index of the webhook.

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -21,8 +21,8 @@ tags:
     description: Image typed files can be dynamically resized and transformed to fit any need.
   - name: Authentication
     description:
-      All events that happen within Directus are tracked and stored in the activities collection. This gives you full
-      accountability over everything that happens.
+      All data within the platform is private by default. The public role can be configured to expose data without
+      authentication, or you can pass an access token to the API to access private data.
   - name: Presets
     description:
       Presets hold the preferences of individual users of the platform. This allows Directus to show and maintain custom
@@ -76,6 +76,10 @@ tags:
     x-collection: directus_roles
   - name: Schema
     description: Retrieve and update the schema of an instance.
+    x-authentication: admin
+    x-schemas:
+      - Schema
+      - Diff
   - name: Server
     description:
       Access to where Directus runs. Allows you to make sure your server has everything needed to run the platform, and
@@ -88,6 +92,12 @@ tags:
     x-collection: directus_users
   - name: Utilities
     description: Directus comes with various utility endpoints you can use to simplify your development flow.
+    x-authentication: user
+    x-schemas:
+      - Files
+      - Folders
+      - Users
+      - Roles
   - name: Versions
     description:
       Enables users to create unpublished copies of an item, modify them independently from the main version, and


### PR DESCRIPTION
## Scope

What's changed:

- Return only paths / schemas that are actually available for current user (differentiating between public / normal user / admin)
- Ensure all included schemas are available
- Bit of clean-up

## Potential Risks / Drawbacks

- Currently, required schemas are manually defined via `x-schemas` in `openapi.yaml`, meaning that it if the specs are updated it must be ensured that those are still correct. In the future, this could be made more dynamic by pulling in the schemas based on used `$refs`.

## Review Notes / Questions

[oas-user.json](https://github.com/directus/directus/files/13394181/oas-user.json)
[oas-public.json](https://github.com/directus/directus/files/13394182/oas-public.json)
[oas-user.json](https://github.com/directus/directus/files/13394183/oas-user.json)
