### PR TITLE
fix default values for system-theme-overrides

### DIFF
--- a/.changeset/moody-pants-smile.md
+++ b/.changeset/moody-pants-smile.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed default values for system-theme-overrides interface

--- a/api/src/database/system-data/fields/settings.yaml
+++ b/api/src/database/system-data/fields/settings.yaml
@@ -120,6 +120,8 @@ fields:
   - field: theme_light_overrides
     width: full
     interface: system-theme-overrides
+    options:
+      appearance: light
     group: theming_group
     special:
       - cast-json
@@ -134,6 +136,8 @@ fields:
   - field: theme_dark_overrides
     width: full
     interface: system-theme-overrides
+    options:
+      appearance: dark
     group: theming_group
     special:
       - cast-json

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -124,6 +124,8 @@ fields:
   - field: theme_light_overrides
     width: full
     interface: system-theme-overrides
+    options:
+      appearance: light
     special:
       - cast-json
 
@@ -137,6 +139,8 @@ fields:
   - field: theme_dark_overrides
     width: full
     interface: system-theme-overrides
+    options:
+      appearance: dark
     special:
       - cast-json
 

--- a/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides.vue
+++ b/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides.vue
@@ -2,6 +2,7 @@
 import { useThemeConfiguration } from '@/composables/use-theme-configuration';
 import { Theme, useTheme } from '@directus/themes';
 import { clone, get, isEmpty, setWith, unset } from 'lodash';
+import { computed } from 'vue';
 import SystemThemeOverridesGroup from './system-theme-overrides-group.vue';
 import type { SetValueFn } from './types.js';
 
@@ -11,6 +12,7 @@ defineOptions({
 
 const props = defineProps<{
 	value: Record<string, unknown> | null;
+	appearance: 'dark' | 'light';
 }>();
 
 const emit = defineEmits<{
@@ -37,7 +39,9 @@ const set: SetValueFn = (path: string[], value: string) => {
 	}
 };
 
-const { darkMode, themeDark, themeLight } = useThemeConfiguration();
+const { themeDark, themeLight } = useThemeConfiguration();
+
+const darkMode = computed(() => props.appearance === 'dark');
 
 const { theme } = useTheme(darkMode, themeLight, themeDark, {}, {});
 </script>


### PR DESCRIPTION
## Context

Currently when a user with light theme looks at Dark Theme Customizations field, the default values are actually light theme's rather than dark theme's:

(the foreground for dark theme should be light/white, while the background should be black/dark)

![](https://github.com/directus/directus/assets/42867097/310e73d1-afb7-46b8-9c29-a1712f22beaa)

This is because `darkMode` here depends on the current user's configured appearance, rather than "light" for Light Theme Customization, and "dark" for Dark Theme Customization:

https://github.com/directus/directus/blob/be4410f948ee6522bb3e1cebcb665a2d80886465/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides.vue#L40

This PR adds a new prop to `system-theme-overrides` so it will use the forced/correct appearance instead of depending on the current user's appearance to show the correct default values.

### Result

![](https://github.com/directus/directus/assets/42867097/8773cfee-394d-43b8-b4e3-5fe5ed76954d)

## Scope

What's changed:

- Use fixed dark/light appearance to set the correct default values for Light Theme Customizations and Dark Theme Customizations fields

## Potential Risks / Drawbacks

- None if I'm not mistaken, unless `system-theme-overrides` component will be used elsewhere where it needs to depend on the user's appearance

## Review Notes / Questions

- Check whether this logic is correct


