### PR TITLE
Fix typo for user `last_access` field in OAS

### DIFF
--- a/.changeset/empty-parents-burn.md
+++ b/.changeset/empty-parents-burn.md
@@ -1,0 +1,5 @@
+---
+'@directus/specs': patch
+---
+
+Fixed typo for user last_access field in OAS

--- a/packages/specs/src/components/user.yaml
+++ b/packages/specs/src/components/user.yaml
@@ -78,7 +78,7 @@ properties:
     description: Static token for the user.
     type: string
     nullable: true
-  last_acces:
+  last_access:
     description: When this user used the API last.
     example: '2020-05-31T14:32:37Z'
     type: string


### PR DESCRIPTION
## Scope

What's changed:

- Tiny uncaught typo of `last_acces` (missing a trailing `s`) from quite a long time ago
