### PR TITLE
Add support for nested root o2m filters (some / every)

### DIFF
--- a/packages/data/src/types/abstract-query/modifiers/filters.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters.ts
@@ -1,5 +1,11 @@
 import type { AbstractQueryConditionNode } from './filters/conditions.js';
 import type { AbstractQueryNodeLogical } from './filters/logical.js';
 import type { AbstractQueryNodeNegate } from './filters/negate.js';
+import type { AbstractQueryNodeQuantifier } from './filters/quantifier.js';
+import type { AbstractQueryTarget } from './target.js';
 
-export type AbstractQueryFilterNode = AbstractQueryConditionNode | AbstractQueryNodeLogical | AbstractQueryNodeNegate;
+export type AbstractQueryFilterNode<Target = AbstractQueryTarget> =
+	| AbstractQueryConditionNode<Target>
+	| AbstractQueryNodeLogical<Target>
+	| AbstractQueryNodeQuantifier<Target>
+	| AbstractQueryNodeNegate<Target>;

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions.ts
@@ -17,9 +17,9 @@ import type { ConditionStringNode } from './conditions/string-condition.js';
  * },
  * ```
  */
-export interface AbstractQueryConditionNode {
+export interface AbstractQueryConditionNode<Target> {
 	type: 'condition';
-	condition: ActualConditionNodes;
+	condition: ActualConditionNodes<Target>;
 }
 
 /**
@@ -28,10 +28,10 @@ export interface AbstractQueryConditionNode {
  * @todo The API should make sure, that the type of the targeting column has the correct type,
  * so that f.e. a condition-string will only be applied to a column of type string.
  */
-export type ActualConditionNodes =
-	| ConditionStringNode
-	| ConditionNumberNode
-	| ConditionGeoIntersectsNode
-	| ConditionGeoIntersectsBBoxNode
-	| ConditionSetNode
-	| ConditionFieldNode;
+export type ActualConditionNodes<Target> =
+	| ConditionStringNode<Target>
+	| ConditionNumberNode<Target>
+	| ConditionGeoIntersectsNode<Target>
+	| ConditionGeoIntersectsBBoxNode<Target>
+	| ConditionSetNode<Target>
+	| ConditionFieldNode<Target>;

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions/field-condition.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions/field-condition.ts
@@ -1,12 +1,10 @@
-import type { AbstractQueryTarget } from '../../target.js';
-
 /**
  * It's mainly used to compare two fields for relational queries.
  * That's why only the eq comparator is valid.
  */
-export interface ConditionFieldNode {
+export interface ConditionFieldNode<Target> {
 	type: 'condition-field';
-	target: AbstractQueryTarget;
+	target: Target;
 	operation: 'eq';
-	compareTo: AbstractQueryTarget;
+	compareTo: Target;
 }

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions/geo-condition-bbox.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions/geo-condition-bbox.ts
@@ -1,13 +1,11 @@
 import type { GeoJSONGeometryCollection, GeoJSONMultiPolygon, GeoJSONPolygon } from 'wellknown';
 
-import type { AbstractQueryTarget } from '../../target.js';
-
 /**
  * Used to check if geo box objects intersect
  */
-export interface ConditionGeoIntersectsBBoxNode {
+export interface ConditionGeoIntersectsBBoxNode<Target> {
 	type: 'condition-geo-intersects-bbox';
-	target: AbstractQueryTarget;
+	target: Target;
 	operation: 'intersects_bbox';
 	compareTo: GeoJSONPolygon | GeoJSONMultiPolygon | GeoJSONGeometryCollection;
 	/** @TODO confirm if MultiPolygon works as expected across drivers */

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions/geo-condition.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions/geo-condition.ts
@@ -6,8 +6,6 @@ import type {
 	GeoJSONPoint,
 } from 'wellknown';
 
-import type { AbstractQueryTarget } from '../../target.js';
-
 /**
  * Checks if a non box geo object intersects with another.
  * @example
@@ -31,9 +29,9 @@ import type { AbstractQueryTarget } from '../../target.js';
  * }
  * ```
  */
-export interface ConditionGeoIntersectsNode {
+export interface ConditionGeoIntersectsNode<Target> {
 	type: 'condition-geo-intersects';
-	target: AbstractQueryTarget /** the type of the field needs to be a 'geometry' object */;
+	target: Target /** the type of the field needs to be a 'geometry' object */;
 	operation: 'intersects';
 	compareTo: GeoJSONPoint | GeoJSONMultiPoint | GeoJSONLineString | GeoJSONMultiLineString | GeoJSONGeometryCollection;
 }

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions/number-condition.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions/number-condition.ts
@@ -1,5 +1,3 @@
-import type { AbstractQueryTarget } from '../../target.js';
-
 /**
  * Used to compare a number or date time field with a number value.
  * @example
@@ -14,9 +12,9 @@ import type { AbstractQueryTarget } from '../../target.js';
  * 	compareTo: 5
  * ```
  */
-export interface ConditionNumberNode {
+export interface ConditionNumberNode<Target> {
 	type: 'condition-number';
-	target: AbstractQueryTarget;
+	target: Target;
 	operation: 'eq' | 'lt' | 'lte' | 'gt' | 'gte';
 	compareTo: number;
 }

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions/set-condition.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions/set-condition.ts
@@ -1,5 +1,3 @@
-import type { AbstractQueryTarget } from '../../target.js';
-
 /**
  * Used to compare a number field with a number value.
  * @example
@@ -14,9 +12,9 @@ import type { AbstractQueryTarget } from '../../target.js';
  * 	compareTo: [1, 2, 3]
  * ```
  */
-export interface ConditionSetNode {
+export interface ConditionSetNode<Target> {
 	type: 'condition-set';
-	target: AbstractQueryTarget;
+	target: Target;
 	operation: 'in';
 	compareTo: (string | number)[]; // could also be an actual JS Set
 }

--- a/packages/data/src/types/abstract-query/modifiers/filters/conditions/string-condition.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/conditions/string-condition.ts
@@ -1,5 +1,3 @@
-import type { AbstractQueryTarget } from '../../target.js';
-
 /**
  * Used to compare a string field with a string value.
  *
@@ -15,10 +13,10 @@ import type { AbstractQueryTarget } from '../../target.js';
  * 	compareTo: 'someString'
  * ```
  */
-export interface ConditionStringNode {
+export interface ConditionStringNode<Target> {
 	type: 'condition-string';
 
-	target: AbstractQueryTarget;
+	target: Target;
 
 	/** @TODO maybe also regex? */
 	operation: 'contains' | 'starts_with' | 'ends_with' | 'eq';

--- a/packages/data/src/types/abstract-query/modifiers/filters/logical.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/logical.ts
@@ -1,6 +1,5 @@
 import type { AtLeastOneElement } from '../../../misc.js';
-import type { AbstractQueryConditionNode } from './conditions.js';
-import type { AbstractQueryNodeNegate } from './negate.js';
+import type { AbstractQueryFilterNode } from '../filters.js';
 
 /**
  * Used to create logical operations.
@@ -53,10 +52,10 @@ import type { AbstractQueryNodeNegate } from './negate.js';
  * }
  * ```
  */
-export interface AbstractQueryNodeLogical {
+export interface AbstractQueryNodeLogical<Target> {
 	type: 'logical';
 	operator: 'and' | 'or';
 
 	/** the values for the operation. */
-	childNodes: AtLeastOneElement<AbstractQueryConditionNode | AbstractQueryNodeLogical | AbstractQueryNodeNegate>;
+	childNodes: AtLeastOneElement<AbstractQueryFilterNode<Target>>;
 }

--- a/packages/data/src/types/abstract-query/modifiers/filters/negate.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/negate.ts
@@ -3,9 +3,9 @@ import type { AbstractQueryFilterNode } from '../filters.js';
 /**
  * Specifies that the wrapper filter should be negated.
  */
-export interface AbstractQueryNodeNegate {
+export interface AbstractQueryNodeNegate<Target> {
 	type: 'negate';
 
 	/** the values for the operation. */
-	childNode: AbstractQueryFilterNode;
+	childNode: AbstractQueryFilterNode<Target>;
 }

--- a/packages/data/src/types/abstract-query/modifiers/filters/quantifier.ts
+++ b/packages/data/src/types/abstract-query/modifiers/filters/quantifier.ts
@@ -1,13 +1,25 @@
-export interface AbstractQueryQuantifierNode {
+import type { AtLeastOneElement } from '../../../misc.js';
+import type { AbstractQueryFilterNode } from '../filters.js';
+import type { AbstractQueryTarget } from '../target.js';
+import type { AbstractQueryTargetNestedMany } from '../target/nested.js';
+
+interface AbstractQueryReference {
+	type: 'reference';
+
+	id: number;
+	target: AbstractQueryTarget;
+}
+
+export interface AbstractQueryNodeQuantifier<Target> {
 	type: 'quantifier';
 	operator: 'every' | 'some';
 
+	/** A reference to this o2m target */
+	reference: number;
+
 	/** The o2m field that the every/some should be applied on */
-	target: string;
+	target: AbstractQueryTargetNestedMany;
 
-	/** An alias to reference the o2m item */
-	alias: string;
-
-	/** the values for the the operation. */
-	// childNode: AbstractQueryConditionNode | AbstractQueryNodeLogical | AbstractQueryNodeNegate;
+	/** the values for the operation. */
+	childNodes: AtLeastOneElement<AbstractQueryFilterNode<Target | AbstractQueryReference>>;
 }

--- a/packages/data/src/types/abstract-query/modifiers/target/nested.ts
+++ b/packages/data/src/types/abstract-query/modifiers/target/nested.ts
@@ -1,4 +1,7 @@
-import type { AbstractQueryFieldNodeNestedRelationalOne } from '../../common/nested/relational.js';
+import type {
+	AbstractQueryFieldNodeNestedRelationalMany,
+	AbstractQueryFieldNodeNestedRelationalOne,
+} from '../../common/nested/relational.js';
 import type { AbstractQueryTarget } from '../target.js';
 
 export interface AbstractQueryTargetNestedOne {
@@ -8,4 +11,10 @@ export interface AbstractQueryTargetNestedOne {
 	field: AbstractQueryTarget;
 
 	meta: AbstractQueryFieldNodeNestedRelationalOne; // AbstractQueryFieldNodeNestedObjectOne | AbstractQueryFieldNodeNestedJsonOne
+}
+
+export interface AbstractQueryTargetNestedMany {
+	type: 'nested-many-target';
+
+	meta: AbstractQueryFieldNodeNestedRelationalMany; // AbstractQueryFieldNodeNestedObjectOne | AbstractQueryFieldNodeNestedJsonOne
 }


### PR DESCRIPTION
```js
// Articleš
// comments.some((comment) => comment.author.name === author.name);

const articlesQuery = {
	type: 'quantifier',
	operator: 'some',
	reference: 0,
	target: {
		type: 'nested-many-target',
		meta: {
			type: 'o2m',
			join: {
				local: {
					fields: ['id'],
				},
				foreign: {
					fields: ['article_id'],
					collection: 'comments',
					store: 'root',
				},
			},
		},
	},
	childNodes: [
		{
			type: 'condition',
			condition: {
				type: 'condition-field',
				target: {
					type: 'reference',
					id: 0,
					target: {
						type: 'nested-one-target',
						field: {
							type: 'primitive',
							field: 'name',
						},
						meta: {
							type: 'm2o',
							join: {
								local: {
									fields: ['author_id'],
								},
								foreign: {
									fields: ['id'],
									collection: 'authors',
									store: 'root',
								},
							},
						},
					},
				},
				operation: 'eq',
				compareTo: {
					type: 'nested-one-target',
					field: {
						type: 'primitive',
						field: 'name',
					},
					meta: {
						type: 'm2o',
						join: {
							local: {
								fields: ['author_id'],
							},
							foreign: {
								fields: ['id'],
								collection: 'authors',
								store: 'root',
							},
						},
					},
				},
			},
		},
	],
};

```

Closes directus/durus#10