### PR TITLE
Fix blackbox assets tests

### DIFF
--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -12,6 +12,9 @@ on:
       - package.json
       - pnpm-lock.yaml
       - .github/workflows/blackbox-main.yml
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: blackbox-${{ github.ref }}

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -32,14 +32,14 @@ jobs:
       matrix:
         vendor:
           - sqlite3
-          - postgres
-          - postgres10
-          - mysql
-          - mysql5
-          - maria
-          - mssql
-          - oracle
-          - cockroachdb
+          # - postgres
+          # - postgres10
+          # - mysql
+          # - mysql5
+          # - maria
+          # - mssql
+          # - oracle
+          # - cockroachdb
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -72,8 +72,10 @@ jobs:
         run: docker compose -f tests/blackbox/docker-compose.yml up ${{ matrix.vendor }} -d --quiet-pull --wait
 
       - name: Start services
-        run:
+        run: |
           docker compose -f tests/blackbox/docker-compose.yml up auth-saml redis minio minio-mc -d --quiet-pull --wait
+          docker compose ps
+          docker image ls
 
       - name: Run tests
         run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -29,14 +29,14 @@ jobs:
       matrix:
         vendor:
           - sqlite3
-          # - postgres
-          # - postgres10
-          # - mysql
-          # - mysql5
-          # - maria
-          # - mssql
-          # - oracle
-          # - cockroachdb
+          - postgres
+          - postgres10
+          - mysql
+          - mysql5
+          - maria
+          - mssql
+          - oracle
+          - cockroachdb
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -69,10 +69,8 @@ jobs:
         run: docker compose -f tests/blackbox/docker-compose.yml up ${{ matrix.vendor }} -d --quiet-pull --wait
 
       - name: Start services
-        run: |
+        run:
           docker compose -f tests/blackbox/docker-compose.yml up auth-saml redis minio minio-mc -d --quiet-pull --wait
-          docker compose ps
-          docker image ls
 
       - name: Run tests
         run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -12,9 +12,6 @@ on:
       - package.json
       - pnpm-lock.yaml
       - .github/workflows/blackbox-main.yml
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: blackbox-${{ github.ref }}

--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -147,7 +147,7 @@ const config: Config = {
 				database: 'directus',
 				user: 'root',
 				password: 'secret',
-				host: 'localhost',
+				host: '127.0.0.1',
 				port: 6104,
 			},
 			...knexConfig,
@@ -264,7 +264,7 @@ const config: Config = {
 		maria: {
 			...directusConfig,
 			DB_CLIENT: 'mysql',
-			DB_HOST: `localhost`,
+			DB_HOST: `127.0.0.1`,
 			DB_PORT: '6104',
 			DB_USER: 'root',
 			DB_PASSWORD: 'secret',

--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -66,7 +66,7 @@ const directusStorageConfig = {
 	STORAGE_MINIO_SECRET: 'miniosecret',
 	STORAGE_MINIO_BUCKET: 'directus-blackbox-test',
 	STORAGE_MINIO_REGION: 'us-east-1',
-	STORAGE_MINIO_ENDPOINT: 'http://localhost:8881',
+	STORAGE_MINIO_ENDPOINT: 'http://127.0.0.1:8881',
 	STORAGE_MINIO_FORCE_PATH_STYLE: 'true',
 };
 

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -56,6 +56,7 @@ describe('/assets', () => {
 						// Action
 						let retrieveResponse: Response | undefined;
 
+						// Retry if server is too busy
 						while (!retrieveResponse) {
 							const response = await request(getUrl(vendor))
 								.get(`/assets/${insertResponse.body.data.id}?format=auto`)
@@ -65,7 +66,7 @@ describe('/assets', () => {
 							if (response.statusCode !== 503) {
 								retrieveResponse = response;
 							} else {
-								await sleep(2_000);
+								await sleep(2_500);
 							}
 						}
 

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -1,9 +1,10 @@
 import { getUrl, paths } from '@common/config';
 import vendors from '@common/get-dbs-to-test';
 import { USER } from '@common/variables';
+import { sleep } from '@utils/sleep';
 import { createReadStream } from 'fs';
 import { join } from 'path';
-import request from 'supertest';
+import request, { type Response } from 'supertest';
 import { describe, expect, it } from 'vitest';
 
 const assetsDirectory = [paths.cwd, 'assets'];
@@ -52,21 +53,25 @@ describe('/assets', () => {
 							.field('storage', storage)
 							.attach('file', createReadStream(imageFilePng));
 
-						console.log(insertResponse.statusCode);
-						console.log(insertResponse.body);
-
 						// Action
-						const response = await request(getUrl(vendor))
-							.get(`/assets/${insertResponse.body.data.id}?format=auto`)
-							.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
-							.set('Accept', requestHeaderAccept);
+						let retrieveResponse: Response | undefined;
 
-						console.log(response.statusCode);
-						console.log(response.body);
+						while (!retrieveResponse) {
+							const response = await request(getUrl(vendor))
+								.get(`/assets/${insertResponse.body.data.id}?format=auto`)
+								.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+								.set('Accept', requestHeaderAccept);
+
+							if (response.statusCode !== 503) {
+								retrieveResponse = response;
+							} else {
+								await sleep(2_000);
+							}
+						}
 
 						// Assert
-						expect(response.statusCode).toBe(200);
-						expect(response.headers['content-type']).toBe(responseHeaderContentType);
+						expect(retrieveResponse.statusCode).toBe(200);
+						expect(retrieveResponse.headers['content-type']).toBe(responseHeaderContentType);
 					});
 				});
 			});

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -61,7 +61,8 @@ describe('/assets', () => {
 							.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
 							.set('Accept', requestHeaderAccept);
 
-						console.log(insertResponse.body);
+						console.log(response.statusCode);
+						console.log(response.body);
 
 						// Assert
 						expect(response.statusCode).toBe(200);

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -25,10 +25,15 @@ describe('/assets', () => {
 							.field('storage', storage)
 							.attach('file', createReadStream(imageFileAvif));
 
+						console.log(insertResponse.statusCode);
+						console.log(insertResponse.body);
+
 						// Action
 						const response = await request(getUrl(vendor))
 							.get(`/assets/${insertResponse.body.data.id}?format=auto`)
 							.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+						console.log(insertResponse.body);
 
 						// Assert
 						expect(response.statusCode).toBe(200);

--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -25,15 +25,10 @@ describe('/assets', () => {
 							.field('storage', storage)
 							.attach('file', createReadStream(imageFileAvif));
 
-						console.log(insertResponse.statusCode);
-						console.log(insertResponse.body);
-
 						// Action
 						const response = await request(getUrl(vendor))
 							.get(`/assets/${insertResponse.body.data.id}?format=auto`)
 							.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
-
-						console.log(insertResponse.body);
 
 						// Assert
 						expect(response.statusCode).toBe(200);
@@ -57,11 +52,16 @@ describe('/assets', () => {
 							.field('storage', storage)
 							.attach('file', createReadStream(imageFilePng));
 
+						console.log(insertResponse.statusCode);
+						console.log(insertResponse.body);
+
 						// Action
 						const response = await request(getUrl(vendor))
 							.get(`/assets/${insertResponse.body.data.id}?format=auto`)
 							.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
 							.set('Accept', requestHeaderAccept);
+
+						console.log(insertResponse.body);
 
 						// Assert
 						expect(response.statusCode).toBe(200);

--- a/tests/blackbox/routes/assets/read.test.ts
+++ b/tests/blackbox/routes/assets/read.test.ts
@@ -1,7 +1,8 @@
 import { getUrl, paths } from '@common/config';
 import vendors from '@common/get-dbs-to-test';
 import { USER } from '@common/variables';
-import { createReadStream, readFileSync } from 'fs';
+import { createReadStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'path';
 import request from 'supertest';
 import { describe, expect, it } from 'vitest';
@@ -37,7 +38,7 @@ describe('/assets', () => {
 				expect(response.statusCode).toBe(200);
 				expect(response.headers['content-type']).toBe(imageFile.type);
 				expect(response.headers['content-length']).toBe(imageFile.filesize);
-				expect(Buffer.compare(response.body, await readFileSync(imageFilePath))).toBe(0);
+				expect(Buffer.compare(response.body, await readFile(imageFilePath))).toBe(0);
 			});
 		});
 	});

--- a/tests/blackbox/routes/fields/crud.test.ts
+++ b/tests/blackbox/routes/fields/crud.test.ts
@@ -4,6 +4,7 @@ import vendors from '@common/get-dbs-to-test';
 import { requestGraphQL } from '@common/transport';
 import { DEFAULT_DB_TABLES, PRIMARY_KEY_TYPES, TEST_USERS, USER } from '@common/variables';
 import type { FieldRaw } from '@directus/types';
+import { sleep } from '@utils/sleep';
 import type { Knex } from 'knex';
 import knex from 'knex';
 import { sortedUniq } from 'lodash-es';
@@ -490,7 +491,10 @@ describe.each(PRIMARY_KEY_TYPES)('/fields', (pkType) => {
 			});
 		});
 
-		describe('Verify schema action hook run', () => {
+		describe('Verify schema action hook run', async () => {
+			// Wait for a short period to allow hook to be completed
+			await sleep(1_000);
+
 			it.each(vendors)('%s', async (vendor) => {
 				// Action
 				const response = await request(getUrl(vendor))


### PR DESCRIPTION
Fixes the assets tests which recently started to fail, I guess due to some external factor (GitHub runner version, new image version, updated dependencies, ...) - hard to tell though.
The assets endpoints returns 503 if server is too busy (see [`ASSETS_TRANSFORM_MAX_CONCURRENT`](https://docs.directus.io/self-hosted/config-options.html#assets)). In such a case the request will now be repeated.

Related to #20502