### PR TITLE
Remove unused translation strings

### DIFF
--- a/.changeset/honest-scissors-end.md
+++ b/.changeset/honest-scissors-end.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Removed the unused `weeks` translation string

--- a/.changeset/honest-scissors-end.md
+++ b/.changeset/honest-scissors-end.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Removed unused translation strings
+Cleaned-up unused translation strings

--- a/.changeset/honest-scissors-end.md
+++ b/.changeset/honest-scissors-end.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Removed the unused `weeks` translation string
+Removed unused translation strings

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -696,7 +696,6 @@ security: Security
 value_hashed: Value Securely Hashed
 bookmark_name: Bookmark name...
 create_bookmark: Create Bookmark
-create_default: Create Default
 edit_bookmark: Edit Bookmark
 edit_personal_bookmark: Edit Personal Bookmark
 edit_role_bookmark: Edit Role Bookmark

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1571,7 +1571,6 @@ translation: Translation
 translation_placeholder: Enter a translation...
 value: Value
 view_project: View Project
-weeks: {}
 report_error: Report Error
 start: Start
 table: Table


### PR DESCRIPTION
The `weeks` string in particular keeps getting added/removed in other translations and confuses translators 🧹🗑️ 