### PR TITLE
Increased blackbox tests timeouts

### DIFF
--- a/tests/blackbox/routes/assets/format.test.ts
+++ b/tests/blackbox/routes/assets/format.test.ts
@@ -45,35 +45,39 @@ describe('/assets', () => {
 				{ requestHeaderAccept: '*/*', responseHeaderContentType: 'image/png' }, // Expect to return png as original image is png
 			])('with "$requestHeaderAccept" Accept request header', ({ requestHeaderAccept, responseHeaderContentType }) => {
 				describe.each(storages)('Storage: %s', (storage) => {
-					it.each(vendors)('%s', async (vendor) => {
-						// Setup
-						const insertResponse = await request(getUrl(vendor))
-							.post('/files')
-							.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
-							.field('storage', storage)
-							.attach('file', createReadStream(imageFilePng));
-
-						// Action
-						let retrieveResponse: Response | undefined;
-
-						// Retry if server is too busy
-						while (!retrieveResponse) {
-							const response = await request(getUrl(vendor))
-								.get(`/assets/${insertResponse.body.data.id}?format=auto`)
+					it.each(vendors)(
+						'%s',
+						async (vendor) => {
+							// Setup
+							const insertResponse = await request(getUrl(vendor))
+								.post('/files')
 								.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
-								.set('Accept', requestHeaderAccept);
+								.field('storage', storage)
+								.attach('file', createReadStream(imageFilePng));
 
-							if (response.statusCode !== 503) {
-								retrieveResponse = response;
-							} else {
-								await sleep(2_500);
+							// Action
+							let retrieveResponse: Response | undefined;
+
+							// Retry if server is too busy
+							while (!retrieveResponse) {
+								const response = await request(getUrl(vendor))
+									.get(`/assets/${insertResponse.body.data.id}?format=auto`)
+									.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+									.set('Accept', requestHeaderAccept);
+
+								if (response.statusCode !== 503) {
+									retrieveResponse = response;
+								} else {
+									await sleep(2_000);
+								}
 							}
-						}
 
-						// Assert
-						expect(retrieveResponse.statusCode).toBe(200);
-						expect(retrieveResponse.headers['content-type']).toBe(responseHeaderContentType);
-					});
+							// Assert
+							expect(retrieveResponse.statusCode).toBe(200);
+							expect(retrieveResponse.headers['content-type']).toBe(responseHeaderContentType);
+						},
+						30_000,
+					);
 				});
 			});
 		});

--- a/tests/blackbox/routes/auth/login.test.ts
+++ b/tests/blackbox/routes/auth/login.test.ts
@@ -11,73 +11,77 @@ describe('/auth', () => {
 			describe('returns an access_token, expires and a refresh_token', () => {
 				TEST_USERS.forEach((userKey) => {
 					describe(USER[userKey].NAME, () => {
-						it.each(vendors)('%s', async (vendor) => {
-							// Action
-							const response = await request(getUrl(vendor))
-								.post(`/auth/login`)
-								.send({ email: USER[userKey].EMAIL, password: USER[userKey].PASSWORD })
-								.expect('Content-Type', /application\/json/);
+						it.each(vendors)(
+							'%s',
+							async (vendor) => {
+								// Action
+								const response = await request(getUrl(vendor))
+									.post(`/auth/login`)
+									.send({ email: USER[userKey].EMAIL, password: USER[userKey].PASSWORD })
+									.expect('Content-Type', /application\/json/);
 
-							const mutationKey = 'auth_login';
+								const mutationKey = 'auth_login';
 
-							const gqlResponse = await requestGraphQL(getUrl(vendor), true, null, {
-								mutation: {
-									[mutationKey]: {
-										__args: {
-											email: USER[userKey].EMAIL,
-											password: USER[userKey].PASSWORD,
+								const gqlResponse = await requestGraphQL(getUrl(vendor), true, null, {
+									mutation: {
+										[mutationKey]: {
+											__args: {
+												email: USER[userKey].EMAIL,
+												password: USER[userKey].PASSWORD,
+											},
+											access_token: true,
+											expires: true,
+											refresh_token: true,
 										},
-										access_token: true,
-										expires: true,
-										refresh_token: true,
 									},
-								},
-							});
+								});
 
-							const ws = createWebSocketConn(getUrl(vendor));
+								const ws = createWebSocketConn(getUrl(vendor));
 
-							await ws.sendMessage({
-								type: 'auth',
-								email: USER[userKey].EMAIL,
-								password: USER[userKey].PASSWORD,
-							});
+								await ws.sendMessage({
+									type: 'auth',
+									email: USER[userKey].EMAIL,
+									password: USER[userKey].PASSWORD,
+								});
 
-							const wsMessages = await ws.getMessages(1);
-							ws.conn.close();
+								const wsMessages = await ws.getMessages(1);
+								ws.conn.close();
 
-							// Assert
-							expect(response.statusCode).toBe(200);
+								// Assert
+								expect(response.statusCode).toBe(200);
 
-							expect(response.body).toMatchObject({
-								data: {
-									access_token: expect.any(String),
-									expires: expect.any(Number),
-									refresh_token: expect.any(String),
-								},
-							});
-
-							expect(gqlResponse.statusCode).toBe(200);
-
-							expect(gqlResponse.body).toMatchObject({
-								data: {
-									[mutationKey]: {
+								expect(response.body).toMatchObject({
+									data: {
 										access_token: expect.any(String),
-										expires: expect.any(String),
+										expires: expect.any(Number),
 										refresh_token: expect.any(String),
 									},
-								},
-							});
+								});
 
-							expect(wsMessages?.length).toBe(1);
+								expect(gqlResponse.statusCode).toBe(200);
 
-							expect(wsMessages![0]).toEqual(
-								expect.objectContaining({
-									type: 'auth',
-									status: 'ok',
-									refresh_token: expect.any(String),
-								}),
-							);
-						});
+								expect(gqlResponse.body).toMatchObject({
+									data: {
+										[mutationKey]: {
+											access_token: expect.any(String),
+											expires: expect.any(String),
+											refresh_token: expect.any(String),
+										},
+									},
+								});
+
+								expect(wsMessages?.length).toBe(1);
+
+								expect(wsMessages![0]).toEqual(
+									expect.objectContaining({
+										type: 'auth',
+										status: 'ok',
+										refresh_token: expect.any(String),
+									}),
+								);
+							},
+							30_000,
+						);
 					});
 				});
 			});


### PR DESCRIPTION
- Increase login test timeout to 30s

  This test includes multiple steps, so an increased timeout seems fair

- Increase assets test timeout to 30s

  Since we're retrying the request multiple times a slightly increased
timeout makes sense

  Hopefully that will be enough 🤞

Related to #20502