### PR TITLE
Fix full permissions & minimal app permissions

### DIFF
--- a/.changeset/wild-crabs-brush.md
+++ b/.changeset/wild-crabs-brush.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed full permissions & minimal app permissions

--- a/api/src/utils/get-permissions.ts
+++ b/api/src/utils/get-permissions.ts
@@ -126,20 +126,14 @@ function parsePermissions(permissions: any[]) {
 
 		if (permission.permissions && typeof permission.permissions === 'string') {
 			permission.permissions = parseJSON(permission.permissions);
-		} else if (permission.permissions === null) {
-			permission.permissions = {};
 		}
 
 		if (permission.validation && typeof permission.validation === 'string') {
 			permission.validation = parseJSON(permission.validation);
-		} else if (permission.validation === null) {
-			permission.validation = {};
 		}
 
 		if (permission.presets && typeof permission.presets === 'string') {
 			permission.presets = parseJSON(permission.presets);
-		} else if (permission.presets === null) {
-			permission.presets = {};
 		}
 
 		if (permission.fields && typeof permission.fields === 'string') {

--- a/api/src/utils/get-permissions.ts
+++ b/api/src/utils/get-permissions.ts
@@ -130,10 +130,14 @@ function parsePermissions(permissions: any[]) {
 
 		if (permission.validation && typeof permission.validation === 'string') {
 			permission.validation = parseJSON(permission.validation);
+		} else if (permission.validation === null) {
+			permission.validation = {};
 		}
 
 		if (permission.presets && typeof permission.presets === 'string') {
 			permission.presets = parseJSON(permission.presets);
+		} else if (permission.presets === null) {
+			permission.presets = {};
 		}
 
 		if (permission.fields && typeof permission.fields === 'string') {

--- a/api/src/utils/merge-permissions.test.ts
+++ b/api/src/utils/merge-permissions.test.ts
@@ -76,34 +76,24 @@ describe('merging permissions', () => {
 		});
 	});
 
-	test('{} is removed from conditional permissions in _or', () => {
+	test('{} supersedes conditional permissions in _or', () => {
 		const mergedPermission = mergePermission(
 			'or',
 			{ ...permissionTemplate, permissions: fullFilter },
 			{ ...permissionTemplate, permissions: conditionalFilter },
 		);
 
-		expect(mergedPermission).toStrictEqual({
-			...permissionTemplate,
-			permissions: {
-				_or: [conditionalFilter],
-			},
-		});
+		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, permissions: fullFilter });
 	});
 
-	test('{} is removed from conditional validations in _or', () => {
+	test('{} supersedes conditional validations in _or', () => {
 		const mergedPermission = mergePermission(
 			'or',
 			{ ...permissionTemplate, validation: fullFilter },
 			{ ...permissionTemplate, validation: conditionalFilter },
 		);
 
-		expect(mergedPermission).toStrictEqual({
-			...permissionTemplate,
-			validation: {
-				_or: [conditionalFilter],
-			},
-		});
+		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, validation: fullFilter });
 	});
 
 	test('{} does not supersede conditional permissions in _and', () => {

--- a/api/src/utils/merge-permissions.ts
+++ b/api/src/utils/merge-permissions.ts
@@ -1,5 +1,5 @@
 import type { LogicalFilterAND, LogicalFilterOR, Permission } from '@directus/types';
-import { flatten, intersection, isEmpty, merge, omit } from 'lodash-es';
+import { flatten, intersection, isEqual, merge, omit } from 'lodash-es';
 
 export function mergePermissions(strategy: 'and' | 'or', ...permissions: Permission[][]): Permission[] {
 	const allPermissions = flatten(permissions);
@@ -37,12 +37,14 @@ export function mergePermission(
 				],
 			} as LogicalFilterAND | LogicalFilterOR;
 		} else if (currentPerm.permissions) {
-			permissions = {
-				[logicalKey]:
-					strategy === 'or'
-						? [currentPerm.permissions, newPerm.permissions].filter((p) => !isEmpty(p))
-						: [currentPerm.permissions, newPerm.permissions],
-			} as LogicalFilterAND | LogicalFilterOR;
+			// Empty {} supersedes other permissions in _OR merge
+			if (strategy === 'or' && (isEqual(currentPerm.permissions, {}) || isEqual(newPerm.permissions, {}))) {
+				permissions = {};
+			} else {
+				permissions = {
+					[logicalKey]: [currentPerm.permissions, newPerm.permissions],
+				} as LogicalFilterAND | LogicalFilterOR;
+			}
 		} else {
 			permissions = {
 				[logicalKey]: [newPerm.permissions],
@@ -59,12 +61,14 @@ export function mergePermission(
 				],
 			} as LogicalFilterAND | LogicalFilterOR;
 		} else if (currentPerm.validation) {
-			validation = {
-				[logicalKey]:
-					strategy === 'or'
-						? [currentPerm.validation, newPerm.validation].filter((p) => !isEmpty(p))
-						: [currentPerm.validation, newPerm.validation],
-			} as LogicalFilterAND | LogicalFilterOR;
+			// Empty {} supersedes other validations in _OR merge
+			if (strategy === 'or' && (isEqual(currentPerm.validation, {}) || isEqual(newPerm.validation, {}))) {
+				validation = {};
+			} else {
+				validation = {
+					[logicalKey]: [currentPerm.validation, newPerm.validation],
+				} as LogicalFilterAND | LogicalFilterOR;
+			}
 		} else {
 			validation = {
 				[logicalKey]: [newPerm.validation],


### PR DESCRIPTION
## Scope

What's changed:

- technically reverts the following PRs:

  - #8391: We revert this PR _only_ for `permissions.permissions`. The reason why #8391 was implemented, turning `NULL` permission into `{}`, was because of null issue in `parseFilter()`. However, #10336 actually fixed the null problem within `parseFilter()`, so there's no longer a need for #8391. With #10336, all the following `parseFilter()` now continues to handle null properly:
  
    https://github.com/directus/directus/blob/f4917cf2690f6632bb63f7016f6e136de582dd54/api/src/utils/get-permissions.ts#L202-L204
  
  - #20347: Once we revert #8391 so that `NULL` permissions aren't "forced" into an empty object, the means we will no longer go through the ELSE IF logic here and go straight to the ELSE logic, which would mean minimal app access permissions will be added properly and not be overridden by any `{}` anymore:
  
    https://github.com/directus/directus/blob/539518e821947c42de5c43ac07c410e256a05913/api/src/utils/merge-permissions.ts#L39-L52

## Potential Risks / Drawbacks

- #8253 may crop up again, but #10305 seems to have resolved it (refer https://github.com/directus/directus/issues/10305#issuecomment-986810902)

## Review Notes / Questions



---

Fixes #20504
