### PR TITLE
GQL directus_permissions ID nullable

### DIFF
--- a/.changeset/silent-pumpkins-relax.md
+++ b/.changeset/silent-pumpkins-relax.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Made directus_permissions ID nullable in GQL schema

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -444,10 +444,16 @@ export class GraphQLService {
 							}
 
 							if (collection.primary === field.field) {
-								if (!field.defaultValue && !field.special.includes('uuid') && action === 'create') {
+								// permissions IDs need to be nullable https://github.com/directus/directus/issues/20509
+								if (collection.collection === 'directus_permissions') {
+									type = GraphQLID;
+								} else if (!field.defaultValue && !field.special.includes('uuid') && action === 'create') {
 									type = new GraphQLNonNull(GraphQLID);
-								} else if (['create', 'update'].includes(action)) type = GraphQLID;
-								else type = new GraphQLNonNull(GraphQLID);
+								} else if (['create', 'update'].includes(action)) {
+									type = GraphQLID;
+								} else {
+									type = new GraphQLNonNull(GraphQLID);
+								}
 							}
 
 							acc[field.field] = {


### PR DESCRIPTION
Fixes #20509 

## Scope

What's changed:

- Updated the `directus_permissions.id` to be nullable so it doesnt error on the injected default permissions

## Potential Risks / Drawbacks

- Not sure

## Review Notes / Questions

- I would like to lorem ipsum
