### PR TITLE
Update Services for Extensions examples

### DIFF
--- a/docs/extensions/services/accessing-files.md
+++ b/docs/extensions/services/accessing-files.md
@@ -8,13 +8,16 @@ contributors: Esther Agbaje
 The `FilesService` provides access to upload, import, and perform CRUD operations on files.
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { FilesService } = services;
-  const schema = await getSchema();
-  const filesService = new FilesService({ schema });
 
   router.get('/', async (req, res) => {
+    const filesService = new FilesService({
+      schema: await getSchema(),
+      accountability: req.accountability
+    });
+
     // Your route handler logic
   });
 });
@@ -24,13 +27,19 @@ export default defineEndpoint(async (router, context) => {
 
 ```js
 router.post('/', async (req, res) => {
+  const filesService = new FilesService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const assetKey = await filesService.importOne({
     url: file_url,
     data: file_object,
   });
 
   const data = await filesService.readOne(assetKey);
-  res.locals['payload'] = { data: data || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -39,8 +48,14 @@ router.post('/', async (req, res) => {
 
 ```js
 router.get('/', async (req, res) => {
+  const filesService = new FilesService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await filesService.readOne('file_id');
-  res.locals['payload'] = { data: data || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -49,8 +64,14 @@ router.get('/', async (req, res) => {
 
 ```js
 router.patch('/', async (req, res) => {
+  const filesService = new FilesService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await filesService.updateOne('file_id', { title: 'Random' });
-  res.locals['payload'] = { data: data || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -59,8 +80,14 @@ router.patch('/', async (req, res) => {
 
 ```js
  router.delete('/', async (req, res) => {
+  const filesService = new FilesService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await filesService.deleteOne('file_id');
-  res.locals['payload'] = { data: data || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```

--- a/docs/extensions/services/accessing-files.md
+++ b/docs/extensions/services/accessing-files.md
@@ -39,7 +39,6 @@ router.post('/', async (req, res) => {
 
   const data = await filesService.readOne(assetKey);
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -55,7 +54,6 @@ router.get('/', async (req, res) => {
 
   const data = await filesService.readOne('file_id');
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -71,7 +69,6 @@ router.patch('/', async (req, res) => {
 
   const data = await filesService.updateOne('file_id', { title: 'Random' });
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -87,7 +84,6 @@ router.patch('/', async (req, res) => {
 
   const data = await filesService.deleteOne('file_id');
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```

--- a/docs/extensions/services/accessing-items.md
+++ b/docs/extensions/services/accessing-items.md
@@ -9,13 +9,16 @@ The `ItemsService` provides access to perform operations on items in a collectio
 to operate.
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { ItemsService } = services;
-  const schema = await getSchema();
-  const itemsService = new ItemsService('collection_name', { schema });
 
   router.get('/', async (req, res) => {
+    const itemsService = new ItemsService('collection_name', {
+      schema: await getSchema(),
+      accountability: req.accountability
+    });
+
     // Your route handler logic
   });
 });
@@ -25,6 +28,11 @@ export default defineEndpoint(async (router, context) => {
 
 ```js
 router.post('/', async (req, res) => {
+  const itemsService = new ItemsService('collection_name', {
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await itemsService.createOne({
     title: 'Hello world!',
     body: 'This is our first article',
@@ -38,6 +46,11 @@ router.post('/', async (req, res) => {
 
 ```js
 router.get('/', async (req, res) => {
+  const itemsService = new ItemsService('collection_name', {
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await itemsService.readOne('item_id');
 
   res.json(data);
@@ -48,6 +61,11 @@ router.get('/', async (req, res) => {
 
 ```js
 router.patch('/', async (req, res) => {
+  const itemsService = new ItemsService('collection_name', {
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await itemsService.updateOne('item_id', {
     title: "An updated title"
   });
@@ -60,9 +78,14 @@ router.patch('/', async (req, res) => {
 
 ```js
 router.delete('/', async (req, res) => {
-  await itemsService.deleteOne('item_id');
+  const itemsService = new ItemsService('collection_name', {
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
 
-  res.json();
+  const data = await itemsService.deleteOne('item_id');
+
+	res.json(data);
 });
 ```
 

--- a/docs/extensions/services/configuring-collections.md
+++ b/docs/extensions/services/configuring-collections.md
@@ -46,7 +46,6 @@ router.post('/', async (req, res) => {
 
   const data = await collectionsService.readOne(collectionKey);
 
-  res.locals['payload'] = { data };
   res.json(record);
 });
 ```
@@ -62,7 +61,6 @@ router.get('/', async (req, res) => {
 
   const data = await collectionsService.readOne('collection_name');
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -82,7 +80,6 @@ router.patch('/', async (req, res) => {
     },
   });
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -149,7 +146,6 @@ router.post('/', async (req, res) => {
     field.field,
   );
 
-  res.locals['payload'] = { data };
   res.json(createdField);
 });
 ```
@@ -165,7 +161,6 @@ router.get('/', async (req, res) => {
 
   const data = await fieldsService.readAll('collection_name');
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -194,7 +189,6 @@ router.patch('/', async (req, res) => {
     'field_name',
   );
 
-  res.locals['payload'] = { data };
   res.json(updatedField);
 });
 ```
@@ -257,7 +251,6 @@ router.post('/', async (req, res) => {
 
   const data = await relationsService.readOne(data);
 
-  res.locals['payload'] = { data };
   res.json(record);
 });
 ```

--- a/docs/extensions/services/configuring-collections.md
+++ b/docs/extensions/services/configuring-collections.md
@@ -136,7 +136,7 @@ router.post('/', async (req, res) => {
       default_value: 'Hello World',
     },
   };
-	
+
   const fieldsService = new FieldsService({
     schema: await getSchema(),
     accountability: req.accountability
@@ -303,7 +303,7 @@ router.patch('/', async (req, res) => {
 ### Delete a Relation
 
 ```js
-router.delete('/', async (req, res) => { 
+router.delete('/', async (req, res) => {
   const relationsService = new RelationsService({
     schema: await getSchema(),
     accountability: req.accountability

--- a/docs/extensions/services/configuring-collections.md
+++ b/docs/extensions/services/configuring-collections.md
@@ -13,13 +13,16 @@ collection.
 The `CollectionsService` is used for manipulating data and performing CRUD operations on a collection.
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { CollectionsService } = services;
-  const schema = await getSchema();
-  const collectionsService = new CollectionsService({ schema });
 
   router.get('/', async (req, res) => {
+    const collectionsService = new CollectionsService({
+      schema: await getSchema(),
+      accountability: req.accountability
+    });
+
     // Your route handler logic
   });
 });
@@ -29,6 +32,11 @@ export default defineEndpoint(async (router, context) => {
 
 ```js
 router.post('/', async (req, res) => {
+  const collectionsService = new CollectionsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const collectionKey = await collectionsService.createOne({
     collection:'articles',
     meta: {
@@ -36,8 +44,9 @@ router.post('/', async (req, res) => {
     },
   });
 
-  const record = await collectionsService.readOne(collectionKey);
-  res.locals['payload'] = { data: record || null };
+  const data = await collectionsService.readOne(collectionKey);
+
+  res.locals['payload'] = { data };
   res.json(record);
 });
 ```
@@ -46,9 +55,14 @@ router.post('/', async (req, res) => {
 
 ```js
 router.get('/', async (req, res) => {
+  const collectionsService = new CollectionsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await collectionsService.readOne('collection_name');
 
-  res.locals['payload'] = { data: collection || null };
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -57,12 +71,18 @@ router.get('/', async (req, res) => {
 
 ```js
 router.patch('/', async (req, res) => {
+  const collectionsService = new CollectionsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await collectionsService.updateOne('collection_name', {
     meta: {
       note: 'Updated blog posts',
     },
   });
-  res.locals['payload'] = { data: collection || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -71,10 +91,15 @@ router.patch('/', async (req, res) => {
 
 ```js
 router.delete('/', async (req, res) => {
-  await collectionsService.deleteOne('collection_name');
-
-  res.json();
+  const collectionsService = new CollectionsService({
+    schema: await getSchema(),
+    accountability: req.accountability
   });
+
+  const data = await collectionsService.deleteOne('collection_name');
+
+  res.json(data);
+});
 ```
 
 ## FieldsService
@@ -82,13 +107,16 @@ router.delete('/', async (req, res) => {
 The `FieldsService` provides access to perform CRUD operations on fields used in collections.
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { FieldsService } = services;
-  const schema = await getSchema();
-  const fieldsService = new FieldsService({ schema });
 
   router.get('/', async (req, res) => {
+    const fieldsService = new FieldsService({
+      schema: await getSchema(),
+      accountability: req.accountability
+    });
+
     // Your route handler logic
   });
 });
@@ -108,13 +136,20 @@ router.post('/', async (req, res) => {
       default_value: 'Hello World',
     },
   };
+	
+  const fieldsService = new FieldsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   await fieldsService.createField('collection_name', field);
 
-  const createdField = await fieldsService.readOne(
+  const data = await fieldsService.readOne(
     'collection_name',
     field.field,
   );
-  res.locals['payload'] = { data: createdField || null };
+
+  res.locals['payload'] = { data };
   res.json(createdField);
 });
 ```
@@ -123,8 +158,14 @@ router.post('/', async (req, res) => {
 
 ```js
 router.get('/', async (req, res) => {
+  const fieldsService = new FieldsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await fieldsService.readAll('collection_name');
-  res.locals['payload'] = { data: data || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -133,6 +174,11 @@ router.get('/', async (req, res) => {
 
 ```js
 router.patch('/', async (req, res) => {
+  const fieldsService = new FieldsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   await fieldsService.updateField('collection_name', {
     meta: {
       note: 'Put the title here',
@@ -142,12 +188,13 @@ router.patch('/', async (req, res) => {
     },
     field: 'field_name',
   });
-  const updatedField = await fieldsService.readOne(
+
+  const data = await fieldsService.readOne(
     'collection_name',
     'field_name',
   );
 
-  res.locals['payload'] = { data: updatedField || null };
+  res.locals['payload'] = { data };
   res.json(updatedField);
 });
 ```
@@ -162,8 +209,14 @@ Updating the field name is not supported at this time.
 
 ```js
 router.delete('/', async (req, res) => {
-  await fieldsService.deleteField('collection_name', 'field_name');
-  res.json();
+  const fieldsService = new FieldsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
+  const data = await fieldsService.deleteField('collection_name', 'field_name');
+
+  res.json(data);
 });
 ```
 
@@ -172,13 +225,16 @@ router.delete('/', async (req, res) => {
 The `RelationsService` allows you to perform CRUD operations on relations between items.
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { RelationsService } = services;
-  const schema = await getSchema();
-  const relationsService = new RelationsService({ schema });
 
   router.get('/', async (req, res) => {
+    const relationsService = new RelationsService({
+      schema: await getSchema(),
+      accountability: req.accountability
+    });
+
     // Your route handler logic
   });
 });
@@ -188,14 +244,20 @@ export default defineEndpoint(async (router, context) => {
 
 ```js
 router.post('/', async (req, res) => {
+  const relationsService = new RelationsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await relationsService.createOne({
     collection: 'articles',
     field: 'featured_image',
     related_collection: 'directus_files',
   });
 
-  const record = await relationsService.readOne(data);
-  res.locals['payload'] = { data: record || null };
+  const data = await relationsService.readOne(data);
+
+  res.locals['payload'] = { data };
   res.json(record);
 });
 ```
@@ -204,6 +266,11 @@ router.post('/', async (req, res) => {
 
 ```js
 router.get('/', async (req, res) => {
+  const relationsService = new RelationsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await relationsService.readOne('collection_name', 'field_name');
 
   res.json(data);
@@ -214,6 +281,11 @@ router.get('/', async (req, res) => {
 
 ```js
 router.patch('/', async (req, res) => {
+  const relationsService = new RelationsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await relationsService.updateOne(
     'collection_name',
     'field_name',
@@ -231,7 +303,13 @@ router.patch('/', async (req, res) => {
 ### Delete a Relation
 
 ```js
-router.delete('/', async (req, res) => {  const data = await relationsService.deleteOne(
+router.delete('/', async (req, res) => { 
+  const relationsService = new RelationsService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
+	const data = await relationsService.deleteOne(
     'collection_name',
     'field_name',
   );

--- a/docs/extensions/services/introduction.md
+++ b/docs/extensions/services/introduction.md
@@ -12,22 +12,33 @@ password hashing.
 When using REST or GraphQL endpoints, Directus uses services to perform operations. When building extensions, you should
 use the services directly.
 
-## Available Services
+## Initializing Services
 
-Various services are available within Directus including `ItemsService`, `CollectionsService`, `FilesService`.
+Various services are available within Directus including `ItemsService`, `CollectionsService`, `FilesService`. These services are available as part of an extension's `context`. 
 
-Services are available as part of an extension's `context`. It is common to destructure the specific service you need as
-shown below in an example of an [endpoint extension](/extensions/endpoints).
+To initialize a service, it is common to destructure the specific service as
+shown below, which is an an example of an [endpoint extension](/extensions/endpoints).
+
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { ItemsService } = services;
 
-  const schema = await getSchema();
-  const itemsService = new ItemsService({ schema });
-})
+  router.get('/', async (req, res) => {
+    const itemsService = new ItemsService('collection_name', {
+      schema: await getSchema(),
+      accountability: req.accountability
+    });
+
+    // Your route handler logic
+  });
+});
 ```
+
+- **Schema**: Schema refers to the underlying knex database schema used within Directus. The `getSchema` function is provided in the context and is required for each service to work. 
+
+- **Accountability:** Accountability is used for authorization and auditing logs. When initializing a service, pass the desired accountability. If no accountability is provided, the service will default to using administrator permissions - you should be careful about this since endpoints are always publicly accessible.  Setting accountability to `null` will use public permissions. Permissions are checked against the permissions in the accountability object (which gets populated by Directus on successful authentication).
 
 With each endpoint implementation, you can create an instance of a service and use its methods to perform operations.
 

--- a/docs/extensions/services/introduction.md
+++ b/docs/extensions/services/introduction.md
@@ -5,15 +5,20 @@ contributors: Esther Agbaje
 
 # Using Services in API Extensions
 
-Directus has a number of internal services that perform operations on system or user-created collections. These services can be used when building collections and automatically provide additional functionality like permission checks and password hashing.
+Directus has a number of internal services that perform operations on system or user-created collections. These services
+can be used when building collections and automatically provide additional functionality like permission checks and
+password hashing.
 
-When using REST or GraphQL endpoints, Directus uses services to perform operations. When building extensions, you should use the services directly.
+When using REST or GraphQL endpoints, Directus uses services to perform operations. When building extensions, you should
+use the services directly.
 
 ## Initializing Services
 
-Various services are available within Directus including `ItemsService`, `CollectionsService`, `FilesService`. These services are available as part of an extension's `context`. 
+Various services are available within Directus including `ItemsService`, `CollectionsService`, `FilesService`. These
+services are available as part of an extension's `context`.
 
-To initialize a service, it is common to destructure the specific service as shown below, which is an example of an [endpoint extension](/extensions/endpoints).
+To initialize a service, it is common to destructure the specific service as shown below, which is an example of an
+[endpoint extension](/extensions/endpoints).
 
 ```js
 export default defineEndpoint((router, context) => {
@@ -31,9 +36,14 @@ export default defineEndpoint((router, context) => {
 });
 ```
 
-- **Schema*:** Schema refers to the underlying Knex database schema used within Directus. The `getSchema` function is provided in the context and is required for each service to work. 
+- **Schema\*:** Schema refers to the underlying Knex database schema used within Directus. The `getSchema` function is
+  provided in the context and is required for each service to work.
 
-- **Accountability:** Accountability is used for authorization and auditing logs. When initializing a service, pass the desired accountability. If no accountability is provided, the service will default to using administrator permissions - you should be careful about this since endpoints are always publicly accessible.  Setting accountability to `null` will use public permissions. Permissions are checked against the permissions in the accountability object (which gets populated by Directus on successful authentication).
+- **Accountability:** Accountability is used for authorization and auditing logs. When initializing a service, pass the
+  desired accountability. If no accountability is provided, the service will default to using administrator
+  permissions - you should be careful about this since endpoints are always publicly accessible. Setting accountability
+  to `null` will use public permissions. Permissions are checked against the permissions in the accountability object
+  (which gets populated by Directus on successful authentication).
 
 With each endpoint implementation, you can create an instance of a service and use its methods to perform operations.
 
@@ -45,7 +55,9 @@ With each endpoint implementation, you can create an instance of a service and u
 - **UsersService:** Provides access to manage user accounts and perform operations on user profiles.
 - **FieldsService:** Provides access to perform operations on fields used in collections and items.
 
-All system collections have a dedicated service which often extend the `ItemsService`. If you are working with system collections, use the dedicated service as they may implement additional functionality. For example, user passwords are hashed when used with the `UsersService`, but not with the `ItemsService`.
+All system collections have a dedicated service which often extend the `ItemsService`. If you are working with system
+collections, use the dedicated service as they may implement additional functionality. For example, user passwords are
+hashed when used with the `UsersService`, but not with the `ItemsService`.
 
 ::: tip List of Available Services
 

--- a/docs/extensions/services/introduction.md
+++ b/docs/extensions/services/introduction.md
@@ -5,20 +5,15 @@ contributors: Esther Agbaje
 
 # Using Services in API Extensions
 
-Directus has a number of internal services that perform operations on system or user-created collections. These services
-can be used when building collections and automatically provide additional functionality like permission checks and
-password hashing.
+Directus has a number of internal services that perform operations on system or user-created collections. These services can be used when building collections and automatically provide additional functionality like permission checks and password hashing.
 
-When using REST or GraphQL endpoints, Directus uses services to perform operations. When building extensions, you should
-use the services directly.
+When using REST or GraphQL endpoints, Directus uses services to perform operations. When building extensions, you should use the services directly.
 
 ## Initializing Services
 
 Various services are available within Directus including `ItemsService`, `CollectionsService`, `FilesService`. These services are available as part of an extension's `context`. 
 
-To initialize a service, it is common to destructure the specific service as
-shown below, which is an an example of an [endpoint extension](/extensions/endpoints).
-
+To initialize a service, it is common to destructure the specific service as shown below, which is an example of an [endpoint extension](/extensions/endpoints).
 
 ```js
 export default defineEndpoint((router, context) => {
@@ -36,7 +31,7 @@ export default defineEndpoint((router, context) => {
 });
 ```
 
-- **Schema**: Schema refers to the underlying knex database schema used within Directus. The `getSchema` function is provided in the context and is required for each service to work. 
+- **Schema*:** Schema refers to the underlying Knex database schema used within Directus. The `getSchema` function is provided in the context and is required for each service to work. 
 
 - **Accountability:** Accountability is used for authorization and auditing logs. When initializing a service, pass the desired accountability. If no accountability is provided, the service will default to using administrator permissions - you should be careful about this since endpoints are always publicly accessible.  Setting accountability to `null` will use public permissions. Permissions are checked against the permissions in the accountability object (which gets populated by Directus on successful authentication).
 
@@ -50,9 +45,7 @@ With each endpoint implementation, you can create an instance of a service and u
 - **UsersService:** Provides access to manage user accounts and perform operations on user profiles.
 - **FieldsService:** Provides access to perform operations on fields used in collections and items.
 
-All system collections have a dedicated service which often extend the `ItemsService`. If you are working with system
-collections, use the dedicated service as they may implement additional functionality. For example, user passwords are
-hashed when used with the `UsersService`, but not with the `ItemsService`.
+All system collections have a dedicated service which often extend the `ItemsService`. If you are working with system collections, use the dedicated service as they may implement additional functionality. For example, user passwords are hashed when used with the `UsersService`, but not with the `ItemsService`.
 
 ::: tip List of Available Services
 

--- a/docs/extensions/services/introduction.md
+++ b/docs/extensions/services/introduction.md
@@ -22,9 +22,9 @@ shown below in an example of an [endpoint extension](/extensions/endpoints).
 ```js
 export default defineEndpoint(async (router, context) => {
   const { services, getSchema } = context;
-  const schema = await getSchema();
   const { ItemsService } = services;
-
+	
+  const schema = await getSchema();
   const itemsService = new ItemsService({ schema });
 })
 ```

--- a/docs/extensions/services/introduction.md
+++ b/docs/extensions/services/introduction.md
@@ -23,7 +23,7 @@ shown below in an example of an [endpoint extension](/extensions/endpoints).
 export default defineEndpoint(async (router, context) => {
   const { services, getSchema } = context;
   const { ItemsService } = services;
-	
+
   const schema = await getSchema();
   const itemsService = new ItemsService({ schema });
 })

--- a/docs/extensions/services/working-with-users.md
+++ b/docs/extensions/services/working-with-users.md
@@ -15,15 +15,16 @@ All three of these services extend the [ItemsService](/docs/extensions/services/
 very similar way.
 
 ```js
-export default defineEndpoint(async (router, context) => {
+export default defineEndpoint((router, context) => {
   const { services, getSchema } = context;
   const { UsersService, RolesService, PermissionsService } = services;
-  const schema = await getSchema();
-  const usersService = new UsersService({ schema });
-  const rolesService = new RolesService({ schema });
-  const permissionsService = new PermissionsService({ schema });
 
   router.get('/', async (req, res) => {
+    const schema = await getSchema();
+    const usersService = new UsersService({ schema, accountability: req.accountability });
+    const rolesService = new RolesService({ schema, accountability: req.accountability });
+    const permissionsService = new PermissionsService({ schema, accountability: req.accountability });
+
     // Your route handler logic
   });
 });
@@ -33,9 +34,14 @@ export default defineEndpoint(async (router, context) => {
 
 ```js
 router.get('/', async (req, res) => {
+  const usersService = new UsersService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await usersService.getUserByEmail('email');
 
-  res.locals['payload'] = { data: data || null };
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -44,6 +50,11 @@ router.get('/', async (req, res) => {
 
 ```js
 router.post('/', async (req, res) => {
+  const rolesService = new RolesService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await rolesService.createOne({
     name: 'Interns',
     icon: 'verified_user',
@@ -52,7 +63,7 @@ router.post('/', async (req, res) => {
     app_access: true,
   });
 
-  res.locals['payload'] = { data: data || null };
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -61,6 +72,11 @@ router.post('/', async (req, res) => {
 
 ```js
 router.post('/', async (req, res) => {
+  const rolesService = new RolesService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const roles = await rolesService.readByQuery({
     fields: ['*'],
   });
@@ -72,7 +88,7 @@ router.post('/', async (req, res) => {
     role: foundRole.id,
   });
 
-  res.locals['payload'] = { data: data || null };
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -87,10 +103,16 @@ A role is required when creating a user.
 
 ```js
 router.patch('/', async (req, res) => {
+  const usersService = new UsersService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await usersService.updateOne('user_id', {
     title: 'CTO'
   });
-  res.locals['payload'] = { data: data || null };
+
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -99,9 +121,14 @@ router.patch('/', async (req, res) => {
 
 ```js
 router.delete('/', async (req, res) => {
+  const usersService = new UsersService({
+    schema: await getSchema(),
+    accountability: req.accountability
+  });
+
   const data = await usersService.deleteOne('user_id');
 
-  res.locals['payload'] = { data: data || null };
+  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -110,22 +137,31 @@ router.delete('/', async (req, res) => {
 
 ```js
 router.post('/', async (req, res) => {
-	const roles = await rolesService.readByQuery({
-		fields: ['*'],
-	});
+  const schema = await getSchema();
+  const rolesService = new RolesService({ schema,	accountability: req.accountability });
+  const permissionsService = new PermissionsService({ schema, accountability: req.accountability });
 
-	const foundRole = roles.find((item) => item.name == 'role');
+  const roles = await rolesService.readByQuery({
+	  fields: ['*'],
+	  filter: {
+		  name: {
+			  _eq: 'role'
+		  }
+	  }
+  });
 
-	const data = await permissionsService.createOne({
-		collection: 'pages',
-		action: 'read',
-		role: 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7',
-		fields: ['id', 'title'],
-		role: foundRole.id,
-	});
+  const foundRole = roles[0];
 
-	res.locals['payload'] = { data: data || null };
-	res.json(data);
+  const data = await permissionsService.createOne({
+	  collection: 'pages',
+	  action: 'read',
+	  role: 'c86c2761-65d3-43c3-897f-6f74ad6a5bd7',
+	  fields: ['id', 'title'],
+	  role: foundRole.id,
+  });
+
+  res.locals['payload'] = { data };
+  res.json(data);
 });
 ```
 

--- a/docs/extensions/services/working-with-users.md
+++ b/docs/extensions/services/working-with-users.md
@@ -41,7 +41,6 @@ router.get('/', async (req, res) => {
 
   const data = await usersService.getUserByEmail('email');
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -63,7 +62,6 @@ router.post('/', async (req, res) => {
     app_access: true,
   });
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -88,7 +86,6 @@ router.post('/', async (req, res) => {
     role: foundRole.id,
   });
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -112,7 +109,6 @@ router.patch('/', async (req, res) => {
     title: 'CTO'
   });
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -128,7 +124,6 @@ router.delete('/', async (req, res) => {
 
   const data = await usersService.deleteOne('user_id');
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```
@@ -160,7 +155,6 @@ router.post('/', async (req, res) => {
 	  role: foundRole.id,
   });
 
-  res.locals['payload'] = { data };
   res.json(data);
 });
 ```


### PR DESCRIPTION
Follow up to https://github.com/directus/directus/pull/20376

## Scope

What's changed:

- In most cases the Services should be instantiated inside the endpoint so it has access to `accountability` for that specific request. We should be recommending people to use accountability instead of pushing the insecure way of working with `admin` permission services in publicly accessible endpoints.
- Same goes for the `const schema = await getSchema()` considering the schema may change between requests
- Cleaned up and fixed output payloads
- Removed obsolete `res.locals['payload']`

## Extra ideas

- A part describing what `accountability` is for, what happens if you dont pass it and the risks
- A part about `schema` and `knex` usage


