### PR TITLE
Admin App: Alignment of half-width fields in detail group

### DIFF
--- a/app/src/composables/use-form-fields.ts
+++ b/app/src/composables/use-form-fields.ts
@@ -42,10 +42,14 @@ export function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<F
 			if (index !== 0 && field.meta!.width === 'half' && field.meta!.hidden !== true) {
 				const previousFields = [...formFields].slice(0, index).reverse();
 				const prevNonHiddenFields = previousFields.filter((field) => field.meta?.hidden !== true);
-				const prevNonHiddenField = prevNonHiddenFields[0]
-				const secondNonHiddenField = prevNonHiddenFields[1]
+				const prevNonHiddenField = prevNonHiddenFields[0];
+				const secondNonHiddenField = prevNonHiddenFields[1];
 
-				if (prevNonHiddenField && prevNonHiddenField.meta?.width === 'half'  && (secondNonHiddenField?.meta?.width === 'half-right' || !secondNonHiddenField)) {
+				if (
+					prevNonHiddenField &&
+					prevNonHiddenField.meta?.width === 'half' &&
+					(secondNonHiddenField?.meta?.width === 'half-right' || !secondNonHiddenField)
+				) {
 					field.meta.width = 'half-right';
 				}
 			}

--- a/app/src/composables/use-form-fields.ts
+++ b/app/src/composables/use-form-fields.ts
@@ -41,9 +41,11 @@ export function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<F
 
 			if (index !== 0 && field.meta!.width === 'half' && field.meta!.hidden !== true) {
 				const previousFields = [...formFields].slice(0, index).reverse();
-				const prevNonHiddenField = previousFields.find((field) => field.meta?.hidden !== true);
+				const prevNonHiddenFields = previousFields.filter((field) => field.meta?.hidden !== true);
+				const prevNonHiddenField = prevNonHiddenFields[0]
+				const secondNonHiddenField = prevNonHiddenFields[1]
 
-				if (prevNonHiddenField && prevNonHiddenField.meta?.width === 'half') {
+				if (prevNonHiddenField && prevNonHiddenField.meta?.width === 'half'  && (secondNonHiddenField?.meta?.width === 'half-right' || !secondNonHiddenField)) {
 					field.meta.width = 'half-right';
 				}
 			}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The logic related to adding the `half-right` class to the components in the composable `useFormFields`


## Review Notes / Questions

- The problem is not related to CSS but to the logic of adding classes, in the first rendering, the parent `v-form` uses the same hook, and the list of fields is changed before reaching the detail groups which also have `v-forms`. Here I am checking one more previous component to make sure that the class will only be added under the correct conditions
- the order of the components matters and in this case, on the first rendering, the other items present in the parent v-form were affecting the logic because the condition check was not complete

---

Fixes #20445