### PR TITLE
Added docs suggestions issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-suggestions.yml
+++ b/.github/ISSUE_TEMPLATE/docs-suggestions.yml
@@ -1,0 +1,20 @@
+name: Suggest new docs or enhancements
+description: Suggest new docs that don't currently exist, or enhancements to existing docs.
+labels: Documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi, thank you for taking the time to create an issue! If you're reporting a documentation inaccuracy or bug, please open [a docs inaccuracy](https://github.com/directus/directus/discussions/new?category=docs-problem) instead!
+  - type: textarea
+    attributes:
+      label: Describe the Request
+      description: A clear and concise description of what you are asking for
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Maintainence Strategy
+      description: Docs need to be kept up to date. How often would this the resulting change require maintenance?
+    validations:
+      required: true


### PR DESCRIPTION
This is referenced in the docs problems template, but doesn't exist. As we move more docs project management to GitHub, a more general docs issue type is needed. 