### PR TITLE
Add docs for themes extension type

### DIFF
--- a/.changeset/silly-eggs-tap.md
+++ b/.changeset/silly-eggs-tap.md
@@ -1,0 +1,5 @@
+---
+'docs': minor
+---
+
+Added docs for the new custom theme extension type

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,7 @@ jobs:
           build: false
 
       - name: Run Formatter
-        run: pnpm exec prettier --check ${{ steps.changed-files.outputs.all_changed_files }}
+        run: pnpm exec prettier --check --ignore-unknown ${{ steps.changed-files.outputs.all_changed_files }}
 
   unit:
     name: Unit Tests

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ pnpm-lock.yaml
 storybook-static/
 /api/uploads/
 /api/extensions/
+*.txt

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,3 @@ pnpm-lock.yaml
 storybook-static/
 /api/uploads/
 /api/extensions/
-*.txt

--- a/docs/.vitepress/data/sidebar.ts
+++ b/docs/.vitepress/data/sidebar.ts
@@ -335,6 +335,10 @@ function sidebarDeveloperReference() {
 							text: 'Panels',
 						},
 						{
+							link: '/extensions/themes',
+							text: 'Themes',
+						},
+						{
 							link: '/extensions/bundles',
 							text: 'Bundles',
 						},

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -402,7 +402,7 @@ SVGs?
 TablePlus
 tfa
 TFA
-Theming
+(T|t)heming
 TileJSON
 TinyMCE
 TLS

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -53,6 +53,8 @@ input.
 entirely new page your Directus app. For example, a page solely containing an integration with an external service. When
 new modules are added, they appear as new icons in the main module side bar.
 
+![Modules](https://marketing.directus.app/assets/f761a496-f49b-4fcc-a09e-d074b6cbf8a5.png)
+
 ### Themes
 
 [Themes](/extensions/themes) allow you to create a new app design that's tailored to your brand or aesthetic. They allow configuration of colors, typography, forms, and more.

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -57,7 +57,8 @@ new modules are added, they appear as new icons in the main module side bar.
 
 ### Themes
 
-[Themes](/extensions/themes) allow you to create a new app design that's tailored to your brand or aesthetic. They allow configuration of colors, typography, forms, and more.
+[Themes](/extensions/themes) allow you to create a new app design that's tailored to your brand or aesthetic. They allow
+configuration of colors, typography, forms, and more.
 
 ## API Extensions
 

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -53,7 +53,9 @@ input.
 entirely new page your Directus app. For example, a page solely containing an integration with an external service. When
 new modules are added, they appear as new icons in the main module side bar.
 
-![Modules](https://marketing.directus.app/assets/f761a496-f49b-4fcc-a09e-d074b6cbf8a5.png)
+### Themes
+
+[Themes](/extensions/themes) allow you to create a new app design that's tailored to your brand or aesthetic. They allow configuration of colors, typography, forms, and more.
 
 ## API Extensions
 

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -34,7 +34,9 @@ export default defineTheme({
 
 ### Available Rules
 
-Rules that are configured in the `rules` property have to adhere to the properties defined in the Rules section of the [theme schema](https://github.com/directus/directus/blob/main/packages/themes/src/schemas/theme.ts). This includes matching how properties are nested in the JavaScript object, for example:
+Rules that are configured in the `rules` property have to adhere to the properties defined in the Rules section of the
+[theme schema](https://github.com/directus/directus/blob/main/packages/themes/src/schemas/theme.ts). This includes
+matching how properties are nested in the JavaScript object, for example:
 
 ```js{3-5}
 rules: {
@@ -62,8 +64,8 @@ components. For example, the JSON path `navigation.modules.button.foregroundActi
 
 :::info Property Names
 
-Nested objects are separated by `--`, and
-camelCase values are transformed to hyphen-case (for example, `foregroundActive` becomes `foreground-active`).
+Nested objects are separated by `--`, and camelCase values are transformed to hyphen-case (for example,
+`foregroundActive` becomes `foreground-active`).
 
 :::
 
@@ -74,14 +76,15 @@ alternatives.
 
 ## Using User Theming Options as a Development Tool
 
-The Theming Options customization interface found in the global appearance settings and user detail page uses theming rules. For easier extension development, you can use this interface to configure your theme, and
-then save the output to your theme extension by using the "Copy Raw Value" option above the interface.
+The Theming Options customization interface found in the global appearance settings and user detail page uses theming
+rules. For easier extension development, you can use this interface to configure your theme, and then save the output to
+your theme extension by using the "Copy Raw Value" option above the interface.
 
 ## Google Fonts
 
-The `fontFamily` rules take any valid CSS `font-family` value. To load a Google Font, wrap the
-font name in a set of quotes `""`. This is still valid CSS, but if the font-name is wrapped in quotes, Directus will
-automatically try downloading it through Google Fonts. For example:
+The `fontFamily` rules take any valid CSS `font-family` value. To load a Google Font, wrap the font name in a set of
+quotes `""`. This is still valid CSS, but if the font-name is wrapped in quotes, Directus will automatically try
+downloading it through Google Fonts. For example:
 
 ```
 // Use the locally installed font called "Comic Sans MS"

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -51,7 +51,7 @@ Any rules that are not defined will fallback to the default theme for it's appea
 ([`default dark theme`](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts) and
 [`default light theme`](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts)).
 
-We recommend using TypeScript for this extension type. The `defineTheme` function is typed to properly auto-complete all
+We recommend using TypeScript for this extension type. The `defineTheme` function is typed to properly check and auto-complete all
 available rules.
 
 Custom Themes include only the allowed rules, and do not include custom CSS.

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -51,8 +51,8 @@ Any rules that are not defined will fallback to the default theme for it's appea
 ([`default dark theme`](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts) and
 [`default light theme`](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts)).
 
-We recommend using TypeScript for this extension type. The `defineTheme` function is typed to properly check and auto-complete all
-available rules.
+We recommend using TypeScript for this extension type. The `defineTheme` function is typed to properly check and
+auto-complete all available rules.
 
 Custom Themes include only the allowed rules, and do not include custom CSS.
 

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -3,14 +3,14 @@ description: A guide on how to build custom Themes in Directus.
 readTime: 2 min read
 ---
 
-# Custom Themes <small></small>
+# Custom Themes
 
 > Custom Themes allow you to create a new app design that's tailored to your brand or aesthetic.
 
 ## Extension Entrypoint
 
 The entrypoint of your theme is the `index` file inside the `src/` folder of your extension package. It exports the
-theme configuration and its' rules. When loading your theme, this rule set is imported by the Directus host app.
+theme configuration and rules. When loading your theme, this rule set is imported by the Directus host app.
 
 Example of a theme:
 
@@ -26,42 +26,62 @@ export default defineTheme({
 });
 ```
 
+### Available Options
+
+- `name` - The displayed name for this theme. This must be unique within your Directus project.
+- `appearance` - The section where this theme is displayed. Options are `'light'` or `'dark'`.
+- `rules` - A set of theming rules from the theme schema.
+
 ### Available Rules
 
-Rules that are configured in the `rules` property have to adhere to the rules defined in the theme schema:
+Rules that are configured in the `rules` property have to adhere to the properties defined in the Rules section of the [theme schema](https://github.com/directus/directus/blob/main/packages/themes/src/schemas/theme.ts). This includes matching how properties are nested in the JavaScript object, for example:
 
-https://github.com/directus/directus/blob/main/packages/themes/src/schemas/theme.ts
+```js{3-5}
+rules: {
+	borderRadius: '24px',
+	navigation: {
+		background: 'rebeccapurple'
+	}
+}
+```
+
+Any rules that are not defined will fallback to the default theme for it's appearance. See the
+([`default dark theme`](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts) and
+[`default light theme`](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts)).
 
 We recommend using TypeScript for this extension type. The `defineTheme` function is typed to properly auto-complete all
 available rules.
 
-Any rules that are not defined will fallback to the default theme for it's appearance.
-([dark](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts) |
-[light](https://github.com/directus/directus/blob/main/packages/themes/src/themes/dark/default.ts))
+Custom Themes include only the allowed rules, and do not include custom CSS.
+
+### Theme Usage in the Directus Data Studio
 
 Every rule is automatically inserted in the app's root element as a CSS variable which are used across the app's
 components. For example, the JSON path `navigation.modules.button.foregroundActive` will be available as
-`var(--theme--navigation--modules--button--foreground-active)`. Note that nested objects are separated by `--`, and
-camelCase values are transformed to hyphen-case (so `foregroundActive` -> `foreground-active`).
+`var(--theme--navigation--modules--button--foreground-active)`.
+
+:::info Property Names
+
+Nested objects are separated by `--`, and
+camelCase values are transformed to hyphen-case (for example, `foregroundActive` becomes `foreground-active`).
+
+:::
 
 Because each rule is used as a CSS variable, each rule value should be valid CSS. This also means you can use any CSS
 functions in the rules. For example, CSS'
 [`color-mix`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) is a great way to theme palette
 alternatives.
 
-## Using "Overrides" as a dev tool
+## Using User Theming Options as a Development Tool
 
-The Theme Overrides interface found in Settings > Appearance or on the user detail page uses the same rules available to
-the theme extensions. For easier extension development, you can use that interface to configure your ideal theme, and
-then save the output to your theme extension by using the "Copy Raw Value" option.
+The Theming Options customization interface found in the global appearance settings and user detail page uses theming rules. For easier extension development, you can use this interface to configure your theme, and
+then save the output to your theme extension by using the "Copy Raw Value" option above the interface.
 
 ## Google Fonts
 
-The `fontFamily` rules take any standard CSS `font-family` value. To load in a font from Google Fonts, simply wrap the
-font-name in a set of quotes `""`. This is still valid CSS, but if the font-name is wrapped in quotes, Directus will
-automatically try downloading it through Google Fonts.
-
-For example:
+The `fontFamily` rules take any valid CSS `font-family` value. To load a Google Font, wrap the
+font name in a set of quotes `""`. This is still valid CSS, but if the font-name is wrapped in quotes, Directus will
+automatically try downloading it through Google Fonts. For example:
 
 ```
 // Use the locally installed font called "Comic Sans MS"

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -93,3 +93,5 @@ fontFamily: 'Comic Sans MS, sans-serif'
 // Use the Google font "Yesteryear"
 fontFamily: '"Yesteryear", sans-serif'
 ```
+
+When using a Google Font, ensure the configured weight is available for the selected font.

--- a/docs/extensions/themes.md
+++ b/docs/extensions/themes.md
@@ -29,7 +29,7 @@ export default defineTheme({
 ### Available Options
 
 - `name` - The displayed name for this theme. This must be unique within your Directus project.
-- `appearance` - The section where this theme is displayed. Options are `'light'` or `'dark'`.
+- `appearance` - To which appearance mode the theme belongs to, `light` or `dark`.
 - `rules` - A set of theming rules from the theme schema.
 
 ### Available Rules


### PR DESCRIPTION
This PR does three things:
1. Adds a themes section to the extensions overview page. 
2. Adds themes to the sidebar under developing extensions.
3. Cleans up the existing custom themes page created by @rijkvanzanten to provide additional context.

Originally I expected to also create a guide, but this particular extension type doesn't demand one as it can effectively be 'developed' in the Data Studio. One may follow, but is a nice-to-have.

Closes #20555 