### PR TITLE
Fix alignment of half-width fields inside groups

### DIFF
--- a/.changeset/swift-crabs-notice.md
+++ b/.changeset/swift-crabs-notice.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed an issue where the alignment of half-width fields within groups could be incorrect

--- a/app/src/composables/use-form-fields.test.ts
+++ b/app/src/composables/use-form-fields.test.ts
@@ -1,0 +1,132 @@
+import type { DeepPartial, Field } from '@directus/types';
+import { describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useFormFields } from './use-form-fields';
+
+vi.mock('@/utils/get-default-interface-for-type', () => ({
+	getDefaultInterfaceForType: () => 'input',
+}));
+
+vi.mock('@/utils/translate-object-values', () => ({ translate: (obj: Record<string, unknown>) => obj }));
+
+vi.mock('./use-extension', () => ({
+	useExtension: () => ({
+		value: null,
+	}),
+}));
+
+describe('field width calculation', () => {
+	it('should detect and update right aligned fields', () => {
+		const fields: DeepPartial<Field>[] = [
+			{
+				field: 'field1',
+				meta: {
+					id: 1,
+					interface: 'input',
+					hidden: false,
+					sort: 1,
+					width: 'half',
+					group: null,
+				},
+			},
+			{
+				field: 'field2',
+				meta: {
+					id: 2,
+					interface: 'input',
+					hidden: false,
+					sort: 2,
+					width: 'half',
+					group: null,
+				},
+			},
+		];
+
+		const { formFields } = useFormFields(ref(fields as Field[]));
+
+		expect(formFields.value).toMatchInlineSnapshot(`
+			[
+			  {
+			    "field": "field1",
+			    "meta": {
+			      "group": null,
+			      "hidden": false,
+			      "id": 1,
+			      "interface": "input",
+			      "sort": 1,
+			      "width": "half",
+			    },
+			  },
+			  {
+			    "field": "field2",
+			    "meta": {
+			      "group": null,
+			      "hidden": false,
+			      "id": 2,
+			      "interface": "input",
+			      "sort": 2,
+			      "width": "half-right",
+			    },
+			  },
+			]
+		`);
+	});
+
+	it('should only consider previous fields from same group', () => {
+		const fields: DeepPartial<Field>[] = [
+			{
+				// field2 appears before field1 because it's deeper nested
+				field: 'field2',
+				meta: {
+					id: 2,
+					interface: 'input',
+					hidden: false,
+					sort: 1,
+					width: 'half',
+					// raw1 is inside detail1
+					group: 'raw1',
+				},
+			},
+			{
+				field: 'field1',
+				meta: {
+					id: 1,
+					interface: 'input',
+					hidden: false,
+					sort: 1,
+					width: 'half',
+					group: 'detail1',
+				},
+			},
+		];
+
+		const { formFields } = useFormFields(ref(fields as Field[]));
+
+		expect(formFields.value).toMatchInlineSnapshot(`
+			[
+			  {
+			    "field": "field2",
+			    "meta": {
+			      "group": "raw1",
+			      "hidden": false,
+			      "id": 2,
+			      "interface": "input",
+			      "sort": 1,
+			      "width": "half",
+			    },
+			  },
+			  {
+			    "field": "field1",
+			    "meta": {
+			      "group": "detail1",
+			      "hidden": false,
+			      "id": 1,
+			      "interface": "input",
+			      "sort": 1,
+			      "width": "half",
+			    },
+			  },
+			]
+		`);
+	});
+});

--- a/app/src/composables/use-form-fields.ts
+++ b/app/src/composables/use-form-fields.ts
@@ -39,11 +39,16 @@ export function useFormFields(fields: Ref<Field[]>): { formFields: ComputedRef<F
 				(field as FormField).hideLoader = true;
 			}
 
-			if (index !== 0 && field.meta!.width === 'half' && field.meta!.hidden !== true) {
-				const previousFields = [...formFields].slice(0, index).reverse();
-				const prevNonHiddenField = previousFields.find((field) => field.meta?.hidden !== true);
+			if (index !== 0 && field.meta.width === 'half' && field.meta.hidden !== true) {
+				let prevNonHiddenField;
 
-				if (prevNonHiddenField && prevNonHiddenField.meta?.width === 'half') {
+				for (const formField of formFields) {
+					if (formField.meta?.group !== field.meta?.group || formField.meta?.hidden) continue;
+					if (formField === field) break;
+					prevNonHiddenField = formField;
+				}
+
+				if (prevNonHiddenField?.meta?.width === 'half') {
 					field.meta.width = 'half-right';
 				}
 			}


### PR DESCRIPTION
## Scope

What's changed:

The logic responsible for the alignment of half-width fields wasn't accounting for groups, which means fields outside of a group could affect the alignment of fields inside a group.
This PR fixes that logic while also reducing its complexity, using a single loop instead of a combination of (unnecessary) array copy, `slice`, `reverse` and `find`. 

## Potential Risks / Drawbacks

- Minimal, tested with various setups of fields & groups
- Verified by added tests which also lower the risk for future changes

## Review Notes / Questions

None

---

Fixes #20445
Closes #20547 (as replacement)