### PR TITLE
Default to exact version when adding packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 shell-emulator=true
+save-prefix=''


### PR DESCRIPTION
Setting `save-prefix` to `''` will automatically save the package with exact version when adding a new one, that is `1.2.3` instead of `^1.2.3`. This is the intention in our repo.
Will also result in the correct workspace protocol `workspace:*`.

https://pnpm.io/npmrc#save-prefix
https://pnpm.io/npmrc#save-workspace-protocol
