### PR TITLE
Clean-up obsolete tags in extensions docs pages

### DIFF
--- a/docs/extensions/displays.md
+++ b/docs/extensions/displays.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom Display Extensions in Directus.
 readTime: 4 min read
 ---
 
-# Custom Displays <small></small>
+# Custom Displays
 
 > Displays are small inline components that allow you to create new ways of viewing field values throughout the App.
 > They are developed using Vue.js. [Learn more about Displays](/user-guide/overview/glossary#displays).

--- a/docs/extensions/email-templates.md
+++ b/docs/extensions/email-templates.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom Email Templates in Directus.
 readTime: 1 min read
 ---
 
-# Email Templates <small></small>
+# Email Templates
 
 > Templates can be used to add custom templates for your emails, or to override the system emails used for things like
 > resetting a password or inviting a user.

--- a/docs/extensions/endpoints.md
+++ b/docs/extensions/endpoints.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom API endpoints in Directus.
 readTime: 3 min read
 ---
 
-# Custom API Endpoints <small></small>
+# Custom API Endpoints
 
 > Custom API Endpoints register new API routes which can be used to infinitely extend the core functionality of the
 > platform. They are developed using JavaScript / Node.js.

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom hooks in Directus.
 readTime: 7 min read
 ---
 
-# Custom API Hooks <small></small>
+# Custom API Hooks
 
 > Custom API Hooks allow running custom logic when a specified event occurs within your project. There are different
 > types of events to choose from. They are developed using JavaScript / Node.js.

--- a/docs/extensions/interfaces.md
+++ b/docs/extensions/interfaces.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom Interfaces in Directus.
 readTime: 4 min read
 ---
 
-# Custom Interfaces <small></small>
+# Custom Interfaces
 
 > Custom Interfaces allow you to create new ways of viewing or interacting with field data on the Item Detail page. They
 > are developed using Vue.js. [Learn more about Interfaces](/user-guide/overview/glossary#interfaces).

--- a/docs/extensions/layouts.md
+++ b/docs/extensions/layouts.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom Layouts in Directus.
 readTime: 4 min read
 ---
 
-# Custom Layouts <small></small>
+# Custom Layouts
 
 > Custom Layouts allow for building new ways to view or interact with Items via the Collection Detail pages. They are
 > developed using Vue.js. [Learn more about Layouts](/user-guide/overview/glossary#layouts).

--- a/docs/extensions/modules.md
+++ b/docs/extensions/modules.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom Modules in Directus.
 readTime: 5 min read
 ---
 
-# Custom Modules <small></small>
+# Custom Modules
 
 > Custom Modules are completely open-ended components that allow you to create new experiences within the Directus
 > platform. They are developed using Vue.js. [Learn more about Modules](/user-guide/overview/glossary#modules).

--- a/docs/extensions/operations.md
+++ b/docs/extensions/operations.md
@@ -1,4 +1,4 @@
-# Custom Operations <small></small>
+# Custom Operations
 
 > Custom Operations allow you to create new types of steps for flows. They are developed using JavaScript / Node.js.
 > [Learn more about Operations](/app/flows/operations).

--- a/docs/extensions/panels.md
+++ b/docs/extensions/panels.md
@@ -3,7 +3,7 @@ description: A guide on how to build custom Panels in Directus.
 readTime: 3 min read
 ---
 
-# Custom Panels <small></small>
+# Custom Panels
 
 > Panels are modular units of data visualization that exist within the
 > [Insights module](/user-guide/insights/dashboards). Each panel exists within a Dashboard and can be positioned and


### PR DESCRIPTION
Clean-up some relics of the distant past... These tags were used when documentation was in-app.

😄⌛📃 
<img width="300" src="https://github.com/directus/directus/assets/5363448/92ee8b2a-aa92-47f3-96d0-443e7feb3e76">

cc @phazonoverload 😇 