### PR TITLE
Update TypeScript to 5.3.2

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -216,7 +216,7 @@
 		"form-data": "4.0.0",
 		"knex-mock-client": "2.0.0",
 		"supertest": "6.3.3",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"optionalDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -161,7 +161,7 @@
 		"stream-json": "1.7.5",
 		"strip-bom-stream": "5.0.0",
 		"tinypool": "0.8.1",
-		"tsx": "4.1.4",
+		"tsx": "4.6.0",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
 		"wellknown": "0.5.0",

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -103,6 +103,7 @@ function validateFilter(filter: Query['filter']) {
 		} else if (Array.isArray(nested) === false) {
 			validateFilterPrimitive(nested, '_eq');
 		} else {
+			// @ts-ignore TODO Check which case this is supposed to cover
 			validateFilter(nested);
 		}
 	}

--- a/app/package.json
+++ b/app/package.json
@@ -150,7 +150,7 @@
 		"sass": "1.62.1",
 		"storybook": "7.0.12",
 		"tinymce": "6.6.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vite": "4.3.7",
 		"vitest": "0.34.6",
 		"vue": "3.3.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
 		"typedoc-plugin-markdown": "4.0.0-next.30",
 		"typedoc-plugin-zod": "1.1.0",
 		"typedoc-vitepress-theme": "1.0.0-next.3",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitepress": "1.0.0-rc.4",
 		"vitepress-plugin-tabs": "0.3.0",
 		"vue": "3.3.8"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@changesets/cli": "2.26.2",
 		"@directus/release-notes-generator": "workspace:*",
-		"@typescript-eslint/eslint-plugin": "6.11.0",
-		"@typescript-eslint/parser": "6.11.0",
+		"@typescript-eslint/eslint-plugin": "6.13.1",
+		"@typescript-eslint/parser": "6.13.1",
 		"eslint": "8.54.0",
 		"eslint-config-prettier": "9.0.0",
 		"eslint-plugin-vue": "9.18.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"histoire": "0.16.1",
 		"rollup-plugin-node-externals": "6.1.1",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vite": "4.3.7",
 		"vite-plugin-dts": "2.3.0",
 		"vitest": "0.34.6"

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -40,7 +40,7 @@
 		"@types/lodash-es": "4.17.7",
 		"@vitest/coverage-v8": "0.34.6",
 		"@vue/test-utils": "2.3.2",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -41,7 +41,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"@vue/test-utils": "2.3.2",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"peerDependencies": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -30,7 +30,7 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2"
 	}
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -31,6 +31,6 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2"
+		"typescript": "5.3.2"
 	}
 }

--- a/packages/data-driver-postgres/package.json
+++ b/packages/data-driver-postgres/package.json
@@ -36,7 +36,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"dependency-cruiser": "13.1.4",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"dependencies": {

--- a/packages/data-driver-postgres/package.json
+++ b/packages/data-driver-postgres/package.json
@@ -35,7 +35,7 @@
 		"@types/wellknown": "0.5.4",
 		"@vitest/coverage-v8": "0.34.6",
 		"dependency-cruiser": "13.1.4",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},

--- a/packages/data-sql/package.json
+++ b/packages/data-sql/package.json
@@ -36,7 +36,7 @@
 		"@types/wellknown": "0.5.4",
 		"@vitest/coverage-v8": "0.34.6",
 		"dependency-cruiser": "13.1.4",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},

--- a/packages/data-sql/package.json
+++ b/packages/data-sql/package.json
@@ -37,7 +37,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"dependency-cruiser": "13.1.4",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"dependencies": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -33,7 +33,7 @@
 		"@types/wellknown": "0.5.4",
 		"@vitest/coverage-v8": "0.34.6",
 		"dependency-cruiser": "13.1.4",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -34,7 +34,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"dependency-cruiser": "13.1.4",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -35,7 +35,7 @@
 		"@types/ms": "0.7.31",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -61,7 +61,7 @@
 		"@types/fs-extra": "11.0.1",
 		"@types/inquirer": "9.0.3",
 		"@vitest/coverage-v8": "0.34.6",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"engines": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -51,7 +51,7 @@
 		"knex": "2.4.2",
 		"pino": "8.14.1",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6",
 		"vue": "3.3.4",
 		"vue-router": "4.2.0"

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -50,7 +50,7 @@
 		"concurrently": "8.2.1",
 		"knex": "2.4.2",
 		"pino": "8.14.1",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6",
 		"vue": "3.3.4",

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -33,7 +33,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@types/express": "4.17.17",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -34,7 +34,7 @@
 		"@types/express": "4.17.17",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -30,7 +30,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -31,7 +31,7 @@
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/release-notes-generator/package.json
+++ b/packages/release-notes-generator/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "18.16.12",
 		"@types/semver": "7.5.0",
 		"@vitest/coverage-v8": "0.34.6",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -40,6 +40,6 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2"
+		"typescript": "5.3.2"
 	}
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2"
 	}
 }

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -34,7 +34,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -35,7 +35,7 @@
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -36,7 +36,7 @@
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -35,7 +35,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -34,7 +34,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -35,7 +35,7 @@
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -34,7 +34,7 @@
 		"@ngneat/falso": "6.4.0",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -35,7 +35,7 @@
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -38,7 +38,7 @@
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -37,7 +37,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -36,7 +36,7 @@
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -35,7 +35,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@ngneat/falso": "6.4.0",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,7 +30,7 @@
 		"@types/node": "18.16.12",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -30,7 +30,7 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"@vueuse/shared": "10.1.2",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2"
 	},
 	"peerDependencies": {

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -31,7 +31,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@vueuse/shared": "10.1.2",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2"
+		"typescript": "5.3.2"
 	},
 	"peerDependencies": {
 		"pinia": "2.1.7",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -39,7 +39,7 @@
 		"@types/lodash-es": "4.17.9",
 		"@vitejs/plugin-vue": "4.4.0",
 		"rollup-plugin-node-externals": "6.1.2",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vite": "4.4.11",
 		"vite-plugin-dts": "3.6.0"
 	},

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
-		"typescript": "5.2.2"
+		"typescript": "5.3.2"
 	}
 }

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -41,7 +41,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"keyv": "4.5.2",
 		"strip-ansi": "7.1.0",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -42,7 +42,7 @@
 		"keyv": "4.5.2",
 		"strip-ansi": "7.1.0",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	}
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,7 @@
 		"@vitest/coverage-v8": "0.34.6",
 		"concurrently": "8.2.1",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"peerDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -49,7 +49,7 @@
 		"@types/tmp": "0.2.3",
 		"@vitest/coverage-v8": "0.34.6",
 		"concurrently": "8.2.1",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -31,7 +31,7 @@
 		"@directus/types": "workspace:*",
 		"@vitest/coverage-v8": "0.34.6",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"dependencies": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -30,7 +30,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@vitest/coverage-v8": "0.34.6",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: workspace:*
         version: link:packages/release-notes-generator
       '@typescript-eslint/eslint-plugin':
-        specifier: 6.11.0
-        version: 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.2.2)
+        specifier: 6.13.1
+        version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.54.0)(typescript@5.3.2)
       '@typescript-eslint/parser':
-        specifier: 6.11.0
-        version: 6.11.0(eslint@8.54.0)(typescript@5.2.2)
+        specifier: 6.13.1
+        version: 6.13.1(eslint@8.54.0)(typescript@5.3.2)
       eslint:
         specifier: 8.54.0
         version: 8.54.0
@@ -509,8 +509,8 @@ importers:
         specifier: 6.3.3
         version: 6.3.3
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -684,7 +684,7 @@ importers:
         version: 7.0.12(vue@3.3.4)
       '@storybook/vue3-vite':
         specifier: 7.0.12
-        version: 7.0.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.3.7)(vue@3.3.4)
+        version: 7.0.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2)(vite@4.3.7)(vue@3.3.4)
       '@tinymce/tinymce-vue':
         specifier: 5.1.0
         version: 5.1.0(vue@3.3.4)
@@ -858,7 +858,7 @@ importers:
         version: 7.3.4
       pinia:
         specifier: 2.1.7
-        version: 2.1.7(typescript@5.2.2)(vue@3.3.4)
+        version: 2.1.7(typescript@5.3.2)(vue@3.3.4)
       pretty-ms:
         specifier: 8.0.0
         version: 8.0.0
@@ -881,8 +881,8 @@ importers:
         specifier: 6.6.0
         version: 6.6.0
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vite:
         specifier: 4.3.7
         version: 4.3.7(sass@1.62.1)
@@ -900,7 +900,7 @@ importers:
         version: 4.2.0(vue@3.3.4)
       vue-tsc:
         specifier: 1.6.5
-        version: 1.6.5(typescript@5.2.2)
+        version: 1.6.5(typescript@5.3.2)
       vuedraggable:
         specifier: 4.1.0
         version: 4.1.0(vue@3.3.4)
@@ -961,7 +961,7 @@ importers:
         version: 6.1.1
       typedoc:
         specifier: 0.25.4
-        version: 0.25.4(typescript@5.2.2)
+        version: 0.25.4(typescript@5.3.2)
       typedoc-plugin-frontmatter:
         specifier: 0.0.2
         version: 0.0.2
@@ -975,23 +975,23 @@ importers:
         specifier: 1.0.0-next.3
         version: 1.0.0-next.3(typedoc-plugin-markdown@4.0.0-next.30)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitepress:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@algolia/client-search@4.20.0)(search-insights@2.11.0)(typescript@5.2.2)
+        version: 1.0.0-rc.4(@algolia/client-search@4.20.0)(search-insights@2.11.0)(typescript@5.3.2)
       vitepress-plugin-tabs:
         specifier: 0.3.0
         version: 0.3.0(vitepress@1.0.0-rc.4)(vue@3.3.8)
       vue:
         specifier: 3.3.8
-        version: 3.3.8(typescript@5.2.2)
+        version: 3.3.8(typescript@5.3.2)
 
   packages/components:
     dependencies:
       pinia:
         specifier: 2.1.1
-        version: 2.1.1(typescript@5.2.2)(vue@3.3.4)
+        version: 2.1.1(typescript@5.3.2)(vue@3.3.4)
       vue:
         specifier: 3.3.4
         version: 3.3.4
@@ -1024,8 +1024,8 @@ importers:
         specifier: 6.1.1
         version: 6.1.1(rollup@3.22.0)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vite:
         specifier: 4.3.7
         version: 4.3.7(sass@1.62.1)
@@ -1077,10 +1077,10 @@ importers:
         version: 2.3.2(vue@3.3.4)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1096,10 +1096,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
 
   packages/create-directus-extension:
     dependencies:
@@ -1159,10 +1159,10 @@ importers:
         version: 13.1.4
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1208,10 +1208,10 @@ importers:
         version: 13.1.4
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1251,10 +1251,10 @@ importers:
         version: 13.1.4
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1285,10 +1285,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1349,10 +1349,10 @@ importers:
         version: 8.14.1
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1451,8 +1451,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1477,10 +1477,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1498,10 +1498,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1540,8 +1540,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1557,10 +1557,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
 
   packages/specs:
     dependencies:
@@ -1594,10 +1594,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1625,10 +1625,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1659,10 +1659,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1690,10 +1690,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1721,10 +1721,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1761,10 +1761,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1795,10 +1795,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -1810,7 +1810,7 @@ importers:
         version: 10.1.2(vue@3.3.4)
       pinia:
         specifier: 2.1.7
-        version: 2.1.7(typescript@5.2.2)(vue@3.3.4)
+        version: 2.1.7(typescript@5.3.2)(vue@3.3.4)
       vue:
         specifier: 3.3.4
         version: 3.3.4
@@ -1823,10 +1823,10 @@ importers:
         version: 10.1.2(vue@3.3.4)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
 
   packages/themes:
     dependencies:
@@ -1850,7 +1850,7 @@ importers:
         version: 4.17.21
       pinia:
         specifier: 2.1.7
-        version: 2.1.7(typescript@5.2.2)(vue@3.3.4)
+        version: 2.1.7(typescript@5.3.2)(vue@3.3.4)
       vue:
         specifier: 3.3.4
         version: 3.3.4
@@ -1871,14 +1871,14 @@ importers:
         specifier: 6.1.2
         version: 6.1.2(rollup@3.22.0)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vite:
         specifier: 4.4.11
         version: 4.4.11(@types/node@18.16.12)(sass@1.62.1)
       vite-plugin-dts:
         specifier: 3.6.0
-        version: 3.6.0(rollup@3.22.0)(typescript@5.2.2)(vite@4.4.11)
+        version: 3.6.0(rollup@3.22.0)(typescript@5.3.2)(vite@4.4.11)
 
   packages/tsconfig: {}
 
@@ -1922,8 +1922,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
 
   packages/update-check:
     dependencies:
@@ -1969,10 +1969,10 @@ importers:
         version: 7.1.0
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -2030,10 +2030,10 @@ importers:
         version: 8.2.1
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -2064,10 +2064,10 @@ importers:
         version: 0.34.6(vitest@0.34.6)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -2082,10 +2082,10 @@ importers:
         version: 2.6.4
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.3.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -2156,14 +2156,14 @@ importers:
         specifier: 6.3.3
         version: 6.3.3
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.3.2
+        version: 5.3.2
       uuid:
         specifier: 9.0.1
         version: 9.0.1
       vite-tsconfig-paths:
         specifier: 4.2.1
-        version: 4.2.1(typescript@5.2.2)
+        version: 4.2.1(typescript@5.3.2)
       vitest:
         specifier: 0.34.6
         version: 0.34.6(happy-dom@12.10.3)(sass@1.62.1)
@@ -6767,7 +6767,7 @@ packages:
     peerDependencies:
       pinia: '>=2.1.0'
     dependencies:
-      pinia: 2.1.7(typescript@5.2.2)(vue@3.3.4)
+      pinia: 2.1.7(typescript@5.3.2)(vue@3.3.4)
       vue-demi: 0.14.6(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -8104,7 +8104,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.0.12(typescript@5.2.2)(vite@4.3.7):
+  /@storybook/builder-vite@7.0.12(typescript@5.3.2)(vite@4.3.7):
     resolution: {integrity: sha512-6FJNXis+dYs/KrhfRQgz8HcRw/Oq4FaEghCwsjngQDy4PcpQuxkDbvGJKlBaSr92vUL36FWSPq8u5+VGCHjh5Q==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -8139,7 +8139,7 @@ packages:
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       rollup: 3.22.0
-      typescript: 5.2.2
+      typescript: 5.3.2
       vite: 4.3.7(sass@1.62.1)
     transitivePeerDependencies:
       - supports-color
@@ -8544,7 +8544,7 @@ packages:
       file-system-cache: 2.4.4
     dev: true
 
-  /@storybook/vue3-vite@7.0.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.3.7)(vue@3.3.4):
+  /@storybook/vue3-vite@7.0.12(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2)(vite@4.3.7)(vue@3.3.4):
     resolution: {integrity: sha512-SdAGfBRfm4cR9VNLRcBCLo3rTzeUTvZfyh5ll0cgInCo9gTxwfs1Y4zEmmVqDDOWQ7qlpJanITNGFGiSsdvRmg==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
@@ -8552,7 +8552,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@storybook/builder-vite': 7.0.12(typescript@5.2.2)(vite@4.3.7)
+      '@storybook/builder-vite': 7.0.12(typescript@5.3.2)(vite@4.3.7)
       '@storybook/core-server': 7.0.12
       '@storybook/vue3': 7.0.12(vue@3.3.4)
       '@vitejs/plugin-vue': 4.4.0(vite@4.3.7)(vue@3.3.4)
@@ -9381,8 +9381,8 @@ packages:
       '@types/yargs-parser': 21.0.2
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==}
+  /@typescript-eslint/eslint-plugin@6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
@@ -9393,25 +9393,25 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/scope-manager': 6.11.0
-      '@typescript-eslint/type-utils': 6.11.0(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 6.11.0
+      '@typescript-eslint/parser': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/scope-manager': 6.13.1
+      '@typescript-eslint/type-utils': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4
       eslint: 8.54.0
       graphemer: 1.4.0
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==}
+  /@typescript-eslint/parser@6.13.1(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -9420,27 +9420,27 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.11.0
-      '@typescript-eslint/types': 6.11.0
-      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 6.11.0
+      '@typescript-eslint/scope-manager': 6.13.1
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
+      '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4
       eslint: 8.54.0
-      typescript: 5.2.2
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@6.11.0:
-    resolution: {integrity: sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==}
+  /@typescript-eslint/scope-manager@6.13.1:
+    resolution: {integrity: sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.11.0
-      '@typescript-eslint/visitor-keys': 6.11.0
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/visitor-keys': 6.13.1
     dev: true
 
-  /@typescript-eslint/type-utils@6.11.0(eslint@8.54.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==}
+  /@typescript-eslint/type-utils@6.13.1(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -9449,23 +9449,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
       debug: 4.3.4
       eslint: 8.54.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@6.11.0:
-    resolution: {integrity: sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==}
+  /@typescript-eslint/types@6.13.1:
+    resolution: {integrity: sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.11.0(typescript@5.2.2):
-    resolution: {integrity: sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==}
+  /@typescript-eslint/typescript-estree@6.13.1(typescript@5.3.2):
+    resolution: {integrity: sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -9473,30 +9473,30 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.11.0
-      '@typescript-eslint/visitor-keys': 6.11.0
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.11.0(eslint@8.54.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==}
+  /@typescript-eslint/utils@6.13.1(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.5
-      '@typescript-eslint/scope-manager': 6.11.0
-      '@typescript-eslint/types': 6.11.0
-      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.2.2)
+      '@types/semver': 7.5.1
+      '@typescript-eslint/scope-manager': 6.13.1
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
       eslint: 8.54.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -9504,11 +9504,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.11.0:
-    resolution: {integrity: sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==}
+  /@typescript-eslint/visitor-keys@6.13.1:
+    resolution: {integrity: sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.11.0
+      '@typescript-eslint/types': 6.13.1
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -9600,7 +9600,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 4.4.11(@types/node@18.16.12)(sass@1.62.1)
-      vue: 3.3.8(typescript@5.2.2)
+      vue: 3.3.8(typescript@5.3.2)
     dev: true
 
   /@vitest/coverage-v8@0.34.6(vitest@0.34.6):
@@ -9692,13 +9692,13 @@ packages:
       '@volar/language-core': 1.10.4
     dev: true
 
-  /@volar/typescript@1.4.1-patch.2(typescript@5.2.2):
+  /@volar/typescript@1.4.1-patch.2(typescript@5.3.2):
     resolution: {integrity: sha512-lPFYaGt8OdMEzNGJJChF40uYqMO4Z/7Q9fHPQC/NRVtht43KotSXLrkPandVVMf9aPbiJ059eAT+fwHGX16k4w==}
     peerDependencies:
       typescript: '*'
     dependencies:
       '@volar/language-core': 1.4.1
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /@volar/vue-language-core@1.6.5:
@@ -9715,14 +9715,14 @@ packages:
       vue-template-compiler: 2.7.14
     dev: true
 
-  /@volar/vue-typescript@1.6.5(typescript@5.2.2):
+  /@volar/vue-typescript@1.6.5(typescript@5.3.2):
     resolution: {integrity: sha512-er9rVClS4PHztMUmtPMDTl+7c7JyrxweKSAEe/o/Noeq2bQx6v3/jZHVHBe8ZNUti5ubJL/+Tg8L3bzmlalV8A==}
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/typescript': 1.4.1-patch.2(typescript@5.2.2)
+      '@volar/typescript': 1.4.1-patch.2(typescript@5.3.2)
       '@volar/vue-language-core': 1.6.5
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /@vue/compiler-core@3.3.4:
@@ -9840,7 +9840,7 @@ packages:
   /@vue/devtools-api@6.5.1:
     resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
 
-  /@vue/language-core@1.8.19(typescript@5.2.2):
+  /@vue/language-core@1.8.19(typescript@5.3.2):
     resolution: {integrity: sha512-nt3dodGs97UM6fnxeQBazO50yYCKBK53waFWB3qMbLmR6eL3aUryZgQtZoBe1pye17Wl8fs9HysV3si6xMgndQ==}
     peerDependencies:
       typescript: '*'
@@ -9855,7 +9855,7 @@ packages:
       '@vue/shared': 3.3.9
       minimatch: 9.0.3
       muggle-string: 0.3.1
-      typescript: 5.2.2
+      typescript: 5.3.2
       vue-template-compiler: 2.7.14
     dev: true
 
@@ -9949,7 +9949,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.3.8
       '@vue/shared': 3.3.8
-      vue: 3.3.8(typescript@5.2.2)
+      vue: 3.3.8(typescript@5.3.2)
     dev: true
 
   /@vue/server-renderer@3.3.9(vue@3.3.4):
@@ -10005,11 +10005,11 @@ packages:
       vue-component-type-helpers: 1.8.22
     dev: true
 
-  /@vue/typescript@1.8.19(typescript@5.2.2):
+  /@vue/typescript@1.8.19(typescript@5.3.2):
     resolution: {integrity: sha512-k/SHeeQROUgqsxyHQ8Cs3Zz5TnX57p7BcBDVYR2E0c61QL2DJ2G8CsaBremmNGuGE6o1R5D50IHIxFmroMz8iw==}
     dependencies:
       '@volar/typescript': 1.10.4
-      '@vue/language-core': 1.8.19(typescript@5.2.2)
+      '@vue/language-core': 1.8.19(typescript@5.3.2)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -18675,7 +18675,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /pinia@2.1.1(typescript@5.2.2)(vue@3.3.4):
+  /pinia@2.1.1(typescript@5.3.2)(vue@3.3.4):
     resolution: {integrity: sha512-Y2CgpcUtD8Ogdvo5LW5g20ykSZgnVDMgTSZFr40EvO6HB8axQk+0lHa1UrRah9wworFaxjovwRlY/wRICWj/KQ==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -18688,12 +18688,12 @@ packages:
         optional: true
     dependencies:
       '@vue/devtools-api': 6.5.1
-      typescript: 5.2.2
+      typescript: 5.3.2
       vue: 3.3.4
       vue-demi: 0.14.6(vue@3.3.4)
     dev: false
 
-  /pinia@2.1.7(typescript@5.2.2)(vue@3.3.4):
+  /pinia@2.1.7(typescript@5.3.2)(vue@3.3.4):
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -18706,7 +18706,7 @@ packages:
         optional: true
     dependencies:
       '@vue/devtools-api': 6.5.1
-      typescript: 5.2.2
+      typescript: 5.3.2
       vue: 3.3.4
       vue-demi: 0.14.6(vue@3.3.4)
 
@@ -22094,13 +22094,13 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.2.2):
+  /ts-api-utils@1.0.3(typescript@5.3.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /ts-dedent@2.2.0:
@@ -22127,7 +22127,7 @@ packages:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
     dev: true
 
-  /tsconfck@2.1.2(typescript@5.2.2):
+  /tsconfck@2.1.2(typescript@5.3.2):
     resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
     engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
@@ -22137,7 +22137,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /tsconfig-paths-webpack-plugin@4.1.0:
@@ -22165,7 +22165,7 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.2.0(typescript@5.2.2):
+  /tsup@7.2.0(typescript@5.3.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -22195,7 +22195,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.2.2
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -22380,7 +22380,7 @@ packages:
     peerDependencies:
       typedoc: 0.25.x
     dependencies:
-      typedoc: 0.25.4(typescript@5.2.2)
+      typedoc: 0.25.4(typescript@5.3.2)
     dev: true
 
   /typedoc-plugin-zod@1.1.0(typedoc@0.25.4):
@@ -22388,7 +22388,7 @@ packages:
     peerDependencies:
       typedoc: 0.23.x || 0.24.x || 0.25.x
     dependencies:
-      typedoc: 0.25.4(typescript@5.2.2)
+      typedoc: 0.25.4(typescript@5.3.2)
     dev: true
 
   /typedoc-vitepress-theme@1.0.0-next.3(typedoc-plugin-markdown@4.0.0-next.30):
@@ -22399,7 +22399,7 @@ packages:
       typedoc-plugin-markdown: 4.0.0-next.30(typedoc@0.25.4)
     dev: true
 
-  /typedoc@0.25.4(typescript@5.2.2):
+  /typedoc@0.25.4(typescript@5.3.2):
     resolution: {integrity: sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==}
     engines: {node: '>= 16'}
     hasBin: true
@@ -22410,7 +22410,7 @@ packages:
       marked: 4.3.0
       minimatch: 9.0.3
       shiki: 0.14.5
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /types-ramda@0.29.5:
@@ -22425,8 +22425,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.3.2:
+    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -22669,7 +22669,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.6
       '@babel/generator': 7.23.0
-      '@babel/parser': 7.23.0
+      '@babel/parser': 7.23.3
       '@rollup/pluginutils': 5.0.5(rollup@3.22.0)
       ast-kit: 0.6.9
       magic-string-ast: 0.1.3
@@ -23013,7 +23013,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-dts@3.6.0(rollup@3.22.0)(typescript@5.2.2)(vite@4.4.11):
+  /vite-plugin-dts@3.6.0(rollup@3.22.0)(typescript@5.3.2)(vite@4.4.11):
     resolution: {integrity: sha512-doxhDRFJCZD2sGjIp4V800nm8Y19GvmwckjG5vYPuiqJ7OBjc9NlW1Vp9Gkyh2aXlUs1jTDRH/lxWfcsPLOQHg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -23025,19 +23025,19 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.38.0
       '@rollup/pluginutils': 5.0.5(rollup@3.22.0)
-      '@vue/language-core': 1.8.19(typescript@5.2.2)
+      '@vue/language-core': 1.8.19(typescript@5.3.2)
       debug: 4.3.4
       kolorist: 1.8.0
-      typescript: 5.2.2
+      typescript: 5.3.2
       vite: 4.4.11(@types/node@18.16.12)(sass@1.62.1)
-      vue-tsc: 1.8.19(typescript@5.2.2)
+      vue-tsc: 1.8.19(typescript@5.3.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
     dev: true
 
-  /vite-tsconfig-paths@4.2.1(typescript@5.2.2):
+  /vite-tsconfig-paths@4.2.1(typescript@5.3.2):
     resolution: {integrity: sha512-GNUI6ZgPqT3oervkvzU+qtys83+75N/OuDaQl7HmOqFTb0pjZsuARrRipsyJhJ3enqV8beI1xhGbToR4o78nSQ==}
     peerDependencies:
       vite: '*'
@@ -23047,7 +23047,7 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 2.1.2(typescript@5.2.2)
+      tsconfck: 2.1.2(typescript@5.3.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -23128,11 +23128,11 @@ packages:
       vitepress: ^1.0.0-beta.2
       vue: ^3.3.4
     dependencies:
-      vitepress: 1.0.0-rc.4(@algolia/client-search@4.20.0)(search-insights@2.11.0)(typescript@5.2.2)
-      vue: 3.3.8(typescript@5.2.2)
+      vitepress: 1.0.0-rc.4(@algolia/client-search@4.20.0)(search-insights@2.11.0)(typescript@5.3.2)
+      vue: 3.3.8(typescript@5.3.2)
     dev: true
 
-  /vitepress@1.0.0-rc.4(@algolia/client-search@4.20.0)(search-insights@2.11.0)(typescript@5.2.2):
+  /vitepress@1.0.0-rc.4(@algolia/client-search@4.20.0)(search-insights@2.11.0)(typescript@5.3.2):
     resolution: {integrity: sha512-JCQ89Bm6ECUTnyzyas3JENo00UDJeK8q1SUQyJYou+4Yz5BKEc/F3O21cu++DnUT2zXc0kvQ2Aj4BZCc/nioXQ==}
     hasBin: true
     dependencies:
@@ -23148,7 +23148,7 @@ packages:
       minisearch: 6.1.0
       shiki: 0.14.5
       vite: 4.4.11(@types/node@18.16.12)(sass@1.62.1)
-      vue: 3.3.8(typescript@5.2.2)
+      vue: 3.3.8(typescript@5.3.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -23294,7 +23294,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.3.8(typescript@5.2.2)
+      vue: 3.3.8(typescript@5.3.2)
     dev: true
 
   /vue-docgen-api@4.74.2(vue@3.3.4):
@@ -23382,28 +23382,28 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc@1.6.5(typescript@5.2.2):
+  /vue-tsc@1.6.5(typescript@5.3.2):
     resolution: {integrity: sha512-Wtw3J7CC+JM2OR56huRd5iKlvFWpvDiU+fO1+rqyu4V2nMTotShz4zbOZpW5g9fUOcjnyZYfBo5q5q+D/q27JA==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
       '@volar/vue-language-core': 1.6.5
-      '@volar/vue-typescript': 1.6.5(typescript@5.2.2)
+      '@volar/vue-typescript': 1.6.5(typescript@5.3.2)
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
-  /vue-tsc@1.8.19(typescript@5.2.2):
+  /vue-tsc@1.8.19(typescript@5.3.2):
     resolution: {integrity: sha512-tacMQLQ0CXAfbhRycCL5sWIy1qujXaIEtP1hIQpzHWOUuICbtTj9gJyFf91PvzG5KCNIkA5Eg7k2Fmgt28l5DQ==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@vue/language-core': 1.8.19(typescript@5.2.2)
-      '@vue/typescript': 1.8.19(typescript@5.2.2)
+      '@vue/language-core': 1.8.19(typescript@5.3.2)
+      '@vue/typescript': 1.8.19(typescript@5.3.2)
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /vue@3.3.4:
@@ -23415,7 +23415,7 @@ packages:
       '@vue/server-renderer': 3.3.4(vue@3.3.4)
       '@vue/shared': 3.3.4
 
-  /vue@3.3.8(typescript@5.2.2):
+  /vue@3.3.8(typescript@5.3.2):
     resolution: {integrity: sha512-5VSX/3DabBikOXMsxzlW8JyfeLKlG9mzqnWgLQLty88vdZL7ZJgrdgBOmrArwxiLtmS+lNNpPcBYqrhE6TQW5w==}
     peerDependencies:
       typescript: '*'
@@ -23428,7 +23428,7 @@ packages:
       '@vue/runtime-dom': 3.3.8
       '@vue/server-renderer': 3.3.8(vue@3.3.8)
       '@vue/shared': 3.3.8
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /vuedraggable@4.1.0(vue@3.3.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,8 +327,8 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       tsx:
-        specifier: 4.1.4
-        version: 4.1.4
+        specifier: 4.6.0
+        version: 4.6.0
       uuid:
         specifier: 9.0.0
         version: 9.0.0
@@ -1076,8 +1076,8 @@ importers:
         specifier: 2.3.2
         version: 2.3.2(vue@3.3.4)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1095,8 +1095,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1158,8 +1158,8 @@ importers:
         specifier: 13.1.4
         version: 13.1.4
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1207,8 +1207,8 @@ importers:
         specifier: 13.1.4
         version: 13.1.4
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1250,8 +1250,8 @@ importers:
         specifier: 13.1.4
         version: 13.1.4
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1284,8 +1284,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1348,8 +1348,8 @@ importers:
         specifier: 8.14.1
         version: 8.14.1
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1476,8 +1476,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1497,8 +1497,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1556,8 +1556,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1593,8 +1593,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1624,8 +1624,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1658,8 +1658,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1689,8 +1689,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1720,8 +1720,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1760,8 +1760,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1794,8 +1794,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1822,8 +1822,8 @@ importers:
         specifier: 10.1.2
         version: 10.1.2(vue@3.3.4)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -1968,8 +1968,8 @@ importers:
         specifier: 7.1.0
         version: 7.1.0
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -2029,8 +2029,8 @@ importers:
         specifier: 8.2.1
         version: 8.2.1
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -2063,8 +2063,8 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -2081,8 +2081,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4
       tsup:
-        specifier: 7.2.0
-        version: 7.2.0(typescript@5.3.2)
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.3.2)
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -5424,6 +5424,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-arm64@0.19.8:
+    resolution: {integrity: sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm@0.17.19:
     resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
     engines: {node: '>=12'}
@@ -5438,6 +5447,15 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/android-arm@0.19.8:
+    resolution: {integrity: sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.17.19:
@@ -5456,6 +5474,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-x64@0.19.8:
+    resolution: {integrity: sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.17.19:
     resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
     engines: {node: '>=12'}
@@ -5470,6 +5497,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.19.8:
+    resolution: {integrity: sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.17.19:
@@ -5488,6 +5524,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/darwin-x64@0.19.8:
+    resolution: {integrity: sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.17.19:
     resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
     engines: {node: '>=12'}
@@ -5502,6 +5547,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.19.8:
+    resolution: {integrity: sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.17.19:
@@ -5520,6 +5574,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/freebsd-x64@0.19.8:
+    resolution: {integrity: sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm64@0.17.19:
     resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
     engines: {node: '>=12'}
@@ -5534,6 +5597,15 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.19.8:
+    resolution: {integrity: sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.17.19:
@@ -5552,6 +5624,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-arm@0.19.8:
+    resolution: {integrity: sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32@0.17.19:
     resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
     engines: {node: '>=12'}
@@ -5566,6 +5647,15 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.19.8:
+    resolution: {integrity: sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.19:
@@ -5584,6 +5674,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-loong64@0.19.8:
+    resolution: {integrity: sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.17.19:
     resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
     engines: {node: '>=12'}
@@ -5598,6 +5697,15 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.19.8:
+    resolution: {integrity: sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.17.19:
@@ -5616,6 +5724,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-ppc64@0.19.8:
+    resolution: {integrity: sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.17.19:
     resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
     engines: {node: '>=12'}
@@ -5630,6 +5747,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.19.8:
+    resolution: {integrity: sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.17.19:
@@ -5648,6 +5774,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-s390x@0.19.8:
+    resolution: {integrity: sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64@0.17.19:
     resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
     engines: {node: '>=12'}
@@ -5662,6 +5797,15 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-x64@0.19.8:
+    resolution: {integrity: sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.17.19:
@@ -5680,6 +5824,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.19.8:
+    resolution: {integrity: sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.17.19:
     resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
     engines: {node: '>=12'}
@@ -5694,6 +5847,15 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.19.8:
+    resolution: {integrity: sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.17.19:
@@ -5712,6 +5874,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/sunos-x64@0.19.8:
+    resolution: {integrity: sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.17.19:
     resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
     engines: {node: '>=12'}
@@ -5726,6 +5897,15 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.19.8:
+    resolution: {integrity: sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.17.19:
@@ -5744,6 +5924,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-ia32@0.19.8:
+    resolution: {integrity: sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.19:
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -5758,6 +5947,15 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.8:
+    resolution: {integrity: sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.54.0):
@@ -7657,6 +7855,102 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.22.0
+
+  /@rollup/rollup-android-arm-eabi@4.6.0:
+    resolution: {integrity: sha512-keHkkWAe7OtdALGoutLY3utvthkGF+Y17ws9LYT8pxMBYXaCoH/8dXS2uzo6e8+sEhY7y/zi5RFo22Dy2lFpDw==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.6.0:
+    resolution: {integrity: sha512-y3Kt+34smKQNWilicPbBz/MXEY7QwDzMFNgwEWeYiOhUt9MTWKjHqe3EVkXwT2fR7izOvHpDWZ0o2IyD9SWX7A==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.6.0:
+    resolution: {integrity: sha512-oLzzxcUIHltHxOCmaXl+pkIlU+uhSxef5HfntW7RsLh1eHm+vJzjD9Oo4oUKso4YuP4PpbFJNlZjJuOrxo8dPg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.6.0:
+    resolution: {integrity: sha512-+ANnmjkcOBaV25n0+M0Bere3roeVAnwlKW65qagtuAfIxXF9YxUneRyAn/RDcIdRa7QrjRNJL3jR7T43ObGe8Q==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.6.0:
+    resolution: {integrity: sha512-tBTSIkjSVUyrekddpkAqKOosnj1Fc0ZY0rJL2bIEWPKqlEQk0paORL9pUIlt7lcGJi3LzMIlUGXvtNi1Z6MOCQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.6.0:
+    resolution: {integrity: sha512-Ed8uJI3kM11de9S0j67wAV07JUNhbAqIrDYhQBrQW42jGopgheyk/cdcshgGO4fW5Wjq97COCY/BHogdGvKVNQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.6.0:
+    resolution: {integrity: sha512-mZoNQ/qK4D7SSY8v6kEsAAyDgznzLLuSFCA3aBHZTmf3HP/dW4tNLTtWh9+LfyO0Z1aUn+ecpT7IQ3WtIg3ViQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.6.0:
+    resolution: {integrity: sha512-rouezFHpwCqdEXsqAfNsTgSWO0FoZ5hKv5p+TGO5KFhyN/dvYXNMqMolOb8BkyKcPqjYRBeT+Z6V3aM26rPaYg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.6.0:
+    resolution: {integrity: sha512-Bbm+fyn3S6u51urfj3YnqBXg5vI2jQPncRRELaucmhBVyZkbWClQ1fEsRmdnCPpQOQfkpg9gZArvtMVkOMsh1w==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.6.0:
+    resolution: {integrity: sha512-+MRMcyx9L2kTrTUzYmR61+XVsliMG4odFb5UmqtiT8xOfEicfYAGEuF/D1Pww1+uZkYhBqAHpvju7VN+GnC3ng==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.6.0:
+    resolution: {integrity: sha512-rxfeE6K6s/Xl2HGeK6cO8SiQq3k/3BYpw7cfhW5Bk2euXNEpuzi2cc7llxx1si1QgwfjNtdRNTGqdBzGlFZGFw==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.6.0:
+    resolution: {integrity: sha512-QqmCsydHS172Y0Kc13bkMXvipbJSvzeglBncJG3LsYJSiPlxYACz7MmJBs4A8l1oU+jfhYEIC/+AUSlvjmiX/g==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@rushstack/node-core-library@3.61.0:
     resolution: {integrity: sha512-tdOjdErme+/YOu4gPed3sFS72GhtWCgNV9oDsHDnoLY5oDfwjKUc9Z+JOZZ37uAxcm/OCahDHfuu2ugqrfWAVQ==}
@@ -11238,13 +11532,13 @@ packages:
       run-applescript: 5.0.0
     dev: true
 
-  /bundle-require@4.0.2(esbuild@0.18.20):
+  /bundle-require@4.0.2(esbuild@0.19.8):
     resolution: {integrity: sha512-jwzPOChofl67PSTW2SGubV9HBQAhhR2i6nskiOThauo9dzwDUgOWQScFVaJkjEfYX+UXiD+LEx8EblQMc2wIag==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.17'
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.19.8
       load-tsconfig: 0.2.5
     dev: true
 
@@ -13199,6 +13493,36 @@ packages:
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
 
+  /esbuild@0.19.8:
+    resolution: {integrity: sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.19.8
+      '@esbuild/android-arm64': 0.19.8
+      '@esbuild/android-x64': 0.19.8
+      '@esbuild/darwin-arm64': 0.19.8
+      '@esbuild/darwin-x64': 0.19.8
+      '@esbuild/freebsd-arm64': 0.19.8
+      '@esbuild/freebsd-x64': 0.19.8
+      '@esbuild/linux-arm': 0.19.8
+      '@esbuild/linux-arm64': 0.19.8
+      '@esbuild/linux-ia32': 0.19.8
+      '@esbuild/linux-loong64': 0.19.8
+      '@esbuild/linux-mips64el': 0.19.8
+      '@esbuild/linux-ppc64': 0.19.8
+      '@esbuild/linux-riscv64': 0.19.8
+      '@esbuild/linux-s390x': 0.19.8
+      '@esbuild/linux-x64': 0.19.8
+      '@esbuild/netbsd-x64': 0.19.8
+      '@esbuild/openbsd-x64': 0.19.8
+      '@esbuild/sunos-x64': 0.19.8
+      '@esbuild/win32-arm64': 0.19.8
+      '@esbuild/win32-ia32': 0.19.8
+      '@esbuild/win32-x64': 0.19.8
+    dev: true
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -14375,7 +14699,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.1
-      ignore: 5.2.4
+      ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -20437,6 +20761,26 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rollup@4.6.0:
+    resolution: {integrity: sha512-R8i5Her4oO1LiMQ3jKf7MUglYV/mhQ5g5OKeld5CnkmPdIGo79FDDQYqPhq/PCVuTQVuxsWgIbDy9F+zdHn80w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.6.0
+      '@rollup/rollup-android-arm64': 4.6.0
+      '@rollup/rollup-darwin-arm64': 4.6.0
+      '@rollup/rollup-darwin-x64': 4.6.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.6.0
+      '@rollup/rollup-linux-arm64-gnu': 4.6.0
+      '@rollup/rollup-linux-arm64-musl': 4.6.0
+      '@rollup/rollup-linux-x64-gnu': 4.6.0
+      '@rollup/rollup-linux-x64-musl': 4.6.0
+      '@rollup/rollup-win32-arm64-msvc': 4.6.0
+      '@rollup/rollup-win32-ia32-msvc': 4.6.0
+      '@rollup/rollup-win32-x64-msvc': 4.6.0
+      fsevents: 2.3.3
+    dev: true
+
   /run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
     engines: {node: '>=12'}
@@ -22165,15 +22509,18 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.2.0(typescript@5.3.2):
-    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
-    engines: {node: '>=16.14'}
+  /tsup@8.0.1(typescript@5.3.2):
+    resolution: {integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==}
+    engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
       postcss: ^8.4.12
-      typescript: '>=4.1.0'
+      typescript: '>=4.5.0'
     peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
       '@swc/core':
         optional: true
       postcss:
@@ -22181,17 +22528,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 4.0.2(esbuild@0.18.20)
+      bundle-require: 4.0.2(esbuild@0.19.8)
       cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4
-      esbuild: 0.18.20
+      esbuild: 0.19.8
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 4.0.1
       resolve-from: 5.0.0
-      rollup: 3.22.0
+      rollup: 4.6.0
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
@@ -22201,14 +22548,13 @@ packages:
       - ts-node
     dev: true
 
-  /tsx@4.1.4:
-    resolution: {integrity: sha512-9X7uBCIyUsvMzIH+o8m+5o/5eL461cChCF+XUtOZsPr1a4pZx2lTQx0Muu5G5VwJWZwAGKBe3sJHLk82BENAVw==}
+  /tsx@4.6.0:
+    resolution: {integrity: sha512-HLHaDQ78mly4Pd5co6tWQOiNVYoYYAPUcwSSZK4bcs3zSEsg+/67LS/ReHook0E7DKPfe1J5jc0ocIhUrnaR4w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
       esbuild: 0.18.20
       get-tsconfig: 4.7.2
-      source-map-support: 0.5.21
     optionalDependencies:
       fsevents: 2.3.3
     dev: false

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -50,7 +50,7 @@
 		"@directus/tsconfig": "workspace:*",
 		"@types/node-fetch": "2.6.4",
 		"tsup": "7.2.0",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},
 	"engines": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -49,7 +49,7 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"@types/node-fetch": "2.6.4",
-		"tsup": "7.2.0",
+		"tsup": "8.0.1",
 		"typescript": "5.3.2",
 		"vitest": "0.34.6"
 	},

--- a/tests/blackbox/package.json
+++ b/tests/blackbox/package.json
@@ -29,7 +29,7 @@
 		"lodash-es": "4.17.21",
 		"seedrandom": "3.0.5",
 		"supertest": "6.3.3",
-		"typescript": "5.2.2",
+		"typescript": "5.3.2",
 		"uuid": "9.0.1",
 		"vite-tsconfig-paths": "4.2.1",
 		"vitest": "0.34.6",


### PR DESCRIPTION
## Scope

What's changed:

- Update TypeScript to 5.3.2
- Update TypeScript ESLint plugin and related tools, tsup and tsx

## Potential Risks / Drawbacks

No breaking changes which affects us

## Review Notes / Questions

TypeScript 5.3 comes with some cool stuff: https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/
