### PR TITLE
Calendar Layout: Fix #20576 by falling back to the calendar filter even if no user filter is provided

### DIFF
--- a/.changeset/plenty-seahorses-taste.md
+++ b/.changeset/plenty-seahorses-taste.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed the calendar layout to only load items for current range, when no user filter is provided

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -78,12 +78,13 @@ export default defineLayout<LayoutOptions>({
 		});
 
 		const filterWithCalendarView = computed(() => {
-			if (!calendarFilter.value) return filter.value;
-			if (!filter.value) return null;
+			// If both the user filter and calendar filter are set, combine them.
+			if (filter?.value && calendarFilter.value) {
+				return { _and: [filter.value, calendarFilter.value] };
+			}
 
-			return {
-				_and: [filter.value, calendarFilter.value],
-			};
+			// Otherwise, return whichever one is set, or null.
+			return filter?.value || calendarFilter.value || null;
 		});
 
 		const template = syncRefProperty(layoutOptions, 'template', undefined);

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -11,7 +11,7 @@ import { useCollection, useItems, useSync } from '@directus/composables';
 import { defineLayout } from '@directus/extensions';
 import { useAppStore } from '@directus/stores';
 import { Field, Item } from '@directus/types';
-import { getEndpoint, getFieldsFromTemplate } from '@directus/utils';
+import { getEndpoint, getFieldsFromTemplate, mergeFilters } from '@directus/utils';
 import { Calendar, CssDimValue, EventInput, CalendarOptions as FullCalendarOptions } from '@fullcalendar/core';
 import { EventImpl } from '@fullcalendar/core/internal';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -59,7 +59,7 @@ export default defineLayout<LayoutOptions>({
 
 		const calendarFilter = computed(() => {
 			if (!calendar.value || !startDateField.value) {
-				return;
+				return null;
 			}
 
 			const start = formatISO(calendar.value.view.activeStart);
@@ -77,15 +77,7 @@ export default defineLayout<LayoutOptions>({
 			return { _or: [startsHere, endsHere, overlapsHere] };
 		});
 
-		const filterWithCalendarView = computed(() => {
-			// If both the user filter and calendar filter are set, combine them.
-			if (filter?.value && calendarFilter.value) {
-				return { _and: [filter.value, calendarFilter.value] };
-			}
-
-			// Otherwise, return whichever one is set, or null.
-			return filter?.value || calendarFilter.value || null;
-		});
+		const filterWithCalendarView = computed(() => mergeFilters(filter.value, calendarFilter.value));
 
 		const template = syncRefProperty(layoutOptions, 'template', undefined);
 		const viewInfo = syncRefProperty(layoutOptions, 'viewInfo', undefined);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:
- The calendar layout will now use the computed date range filter even if the user doesn't provide a custom filter on top of it.

## Potential Risks / Drawbacks

- There shouldn't be any. 👀 
 
## Review Notes / Questions

To verify:
- Create a collection with a primary id field and a date field.
- Create 6 items in that collection spanning several years.
- Change the collection layout to Calendar and set it up properly to use your date field.
- Switch the calendar so that it should only show one item in the view.
- The top of the screen will show "1 item", and only one item will display in the calendar view. Before the change it would have displayed "6 items"

---

Fixes #20576
