### PR TITLE
Docs update nodejs version 18

### DIFF
--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -13,7 +13,7 @@ readTime: 4 min read
 
 ::: tip Minimum Requirements
 
-You will need to have the [latest LTS version of Node.js](https://nodejs.org/en/download) for the Development
+You will need to have [version 18 of Node.js](https://nodejs.org/en/download) for the Development
 environment of Directus.
 
 You will also need to have the package manager [pnpm](https://pnpm.io) installed. It's recommended to install

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -13,8 +13,8 @@ readTime: 4 min read
 
 ::: tip Minimum Requirements
 
-You will need to have [version 18 of Node.js](https://nodejs.org/en/download) for the Development
-environment of Directus.
+You will need to have [version 18 of Node.js](https://nodejs.org/en/download) for the Development environment of
+Directus.
 
 You will also need to have the package manager [pnpm](https://pnpm.io) installed. It's recommended to install
 [pnpm via Corepack](https://pnpm.io/installation#using-corepack) for automatic use of the correct version.

--- a/docs/self-hosted/cli.md
+++ b/docs/self-hosted/cli.md
@@ -13,7 +13,7 @@ readTime: 7 min read
 
 ## Requirements
 
-- Node.js [Active LTS](https://github.com/nodejs/release#release-schedule)
+- Node.js [v18](https://github.com/nodejs/release#release-schedule)
 
 ## Server
 


### PR DESCRIPTION
## What's changed:

Updated the requirements of NodeJS LTS to V18 instead as we currently cannot confidently recommend running Directus on the current LTS nodejs version 20.

## References
- https://github.com/directus/directus/issues/20317
- https://github.com/directus/directus/issues/20584

![image](https://github.com/directus/directus/assets/9389634/49735b75-d152-497c-9966-420baeaa555f)

Closes #20585
