### PR TITLE
Pasting list into 'Is One Of' filter not working

### DIFF
--- a/.changeset/rich-yaks-taste.md
+++ b/.changeset/rich-yaks-taste.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed support for pasting comma-separated values into 'Is One Of' filter

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -102,18 +102,6 @@ function setValueAt(index: number, newVal: any) {
 	newArray[index] = newVal;
 	value.value = newArray;
 }
-
-function setListValue(index: number, newVal: any) {
-	if (typeof newVal === 'string' && newVal.includes(',')) {
-		const parts = newVal.split(',');
-
-		for (let i = 0; i < parts.length; i++) {
-			setValueAt(index + i, parts[i]);
-		}
-	} else {
-		setValueAt(index, newVal);
-	}
-}
 </script>
 
 <template>
@@ -165,7 +153,7 @@ function setListValue(index: number, newVal: any) {
 				:value="val"
 				:focus="false"
 				:choices="choices"
-				@input="setListValue(index, $event)"
+				@input="setValueAt(index, $event)"
 			/>
 		</div>
 	</div>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Removal of the `setListValue` function that gave special treatment to cases where the filter was '_in' or '_nin', but this is not really necessary because the computed value setter already deals with the possibility of receiving a string with values ​​separated by a comma.


## Potential Risks / Drawbacks

- There's still one detail that could make `setListValue` useful again. If you paste a sequence separated by commas into an already filled input, the first or last value (depends on the cursor position) will be included in the value of the current input, I'm not sure if this is the desired behavior, a possible solution is get the complete event and not just the input value coming from the `input-component` emit.
This way it will be possible to identify what was added to the input (`event.data`), separate and add the values ​​correctly and constantly (always add to the right, for example).
https://www.loom.com/share/323bec19e47b42caacb70967b1e672ba?sid=5a7cad3c-efde-4858-bfaf-c21eab998af2

## Demo
https://www.loom.com/share/3b11196ff3c349199f9bd8b9be2b7c1b?sid=d4316f2e-c47d-4c97-98b5-6e4722a861d6

---

Fixes #19871
