### PR TITLE
Mock debounce in v-select test instead of manual timeout

### DIFF
--- a/app/src/components/v-menu.test.ts
+++ b/app/src/components/v-menu.test.ts
@@ -5,9 +5,9 @@ import TransitionBounce from './transition/bounce.vue';
 import VMenu from './v-menu.vue';
 
 vi.mock('lodash', async () => {
-	const mod = await vi.importActual<typeof import('lodash')>('lodash');
+	const mod = await vi.importActual<{ default: typeof import('lodash') }>('lodash');
 	return {
-		...mod,
+		...mod.default,
 		debounce: (fn: any) => fn,
 	};
 });

--- a/app/src/components/v-select/v-select.test.ts
+++ b/app/src/components/v-select/v-select.test.ts
@@ -1,10 +1,19 @@
 import { Focus } from '@/__utils__/focus';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { mount } from '@vue/test-utils';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 import VList from '../v-list.vue';
 import VSelect from './v-select.vue';
+
+vi.mock('lodash', async () => {
+	const mod = await vi.importActual<{ default: typeof import('lodash') }>('lodash');
+	return {
+		...mod.default,
+		debounce: (fn: any) => fn,
+	};
+});
 
 const i18n = createI18n({
 	legacy: false,
@@ -125,8 +134,7 @@ describe('should hide items not matching search value', () => {
 			global: { ...global, stubs: { ...global.stubs, 'v-input': VInput } },
 		});
 
-		// Wait for search debounce
-		await new Promise((r) => setTimeout(r, 300));
+		await nextTick();
 
 		expect(wrapper.html()).toMatchSnapshot();
 	});


### PR DESCRIPTION
Following updated v-menu test, also fix actual lodash import (cjs)