### PR TITLE
Make version prop in revisions-drawer-detail component optional

### DIFF
--- a/app/src/composables/use-revisions.ts
+++ b/app/src/composables/use-revisions.ts
@@ -18,7 +18,7 @@ type UseRevisionsOptions = {
 export function useRevisions(
 	collection: Ref<string>,
 	primaryKey: Ref<number | string>,
-	version: Ref<ContentVersion | null>,
+	version: Ref<ContentVersion | null | undefined>,
 	options?: UseRevisionsOptions,
 ) {
 	const { t } = useI18n();
@@ -55,7 +55,7 @@ export function useRevisions(
 						},
 					},
 					{
-						version: version.value
+						version: version?.value
 							? {
 									_eq: version.value.id,
 							  }

--- a/app/src/views/private/components/revisions-drawer-detail.vue
+++ b/app/src/views/private/components/revisions-drawer-detail.vue
@@ -10,7 +10,7 @@ import RevisionsDrawer from './revisions-drawer.vue';
 const props = defineProps<{
 	collection: string;
 	primaryKey: string | number;
-	version: ContentVersion | null;
+	version?: ContentVersion | null;
 }>();
 
 defineEmits(['revert']);


### PR DESCRIPTION
This warning has been haunting me for a while...

<img width="600" src="https://github.com/directus/directus/assets/5363448/7cf9f056-f065-4559-91a7-6e230309f9ff">

The `version` prop (Content Versioning) is only relevant for custom collections, not for system collections. Therefore making it optional.

Reducing type errors from 461 to 456 😅