### PR TITLE
Update tsx to 4.6.1

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -160,7 +160,7 @@
 		"snappy": "7.2.2",
 		"stream-json": "1.7.5",
 		"tinypool": "0.8.1",
-		"tsx": "4.6.0",
+		"tsx": "4.6.1",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
 		"wellknown": "0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,8 +324,8 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       tsx:
-        specifier: 4.6.0
-        version: 4.6.0
+        specifier: 4.6.1
+        version: 4.6.1
       uuid:
         specifier: 9.0.0
         version: 9.0.0
@@ -22029,8 +22029,8 @@ packages:
       - ts-node
     dev: true
 
-  /tsx@4.6.0:
-    resolution: {integrity: sha512-HLHaDQ78mly4Pd5co6tWQOiNVYoYYAPUcwSSZK4bcs3zSEsg+/67LS/ReHook0E7DKPfe1J5jc0ocIhUrnaR4w==}
+  /tsx@4.6.1:
+    resolution: {integrity: sha512-OQ4TAPHXAPUo/NZAmmIybl0o8LFOTlycQxFepLBAp6EV87U88fOKYGCQI2viGAEOVU9UW/cgQcxcOMnfEKVY3Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
To fix an issue with latest Node.js v18 version, see https://github.com/privatenumber/tsx/releases/tag/v4.6.1