### PR TITLE
SDK map filter literal types

### DIFF
--- a/.changeset/tricky-walls-type.md
+++ b/.changeset/tricky-walls-type.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed mapping literal filter types in the SDK

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -44,7 +44,7 @@ export type NestedRelationalFilter<Schema extends object, Item, Field extends ke
  */
 export type FilterOperators<
 	FieldType,
-	T = FieldType extends keyof FieldOutputMap ? FieldOutputMap[FieldType] : FieldType
+	T = FieldType extends keyof FieldOutputMap ? FieldOutputMap[FieldType] : FieldType,
 > = {
 	_eq?: T;
 	_neq?: T;

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -1,4 +1,5 @@
 import type { MappedFieldNames } from './functions.js';
+import type { FieldOutputMap } from './output.js';
 import type { RelationalFields } from './schema.js';
 import type { MergeOptional, UnpackList } from './utils.js';
 
@@ -41,7 +42,10 @@ export type NestedRelationalFilter<Schema extends object, Item, Field extends ke
  *
  * TODO would love to filter this based on field type but thats not accurate enough in the schema atm
  */
-export type FilterOperators<T> = {
+export type FilterOperators<
+	FieldType,
+	T = FieldType extends keyof FieldOutputMap ? FieldOutputMap[FieldType] : FieldType
+> = {
 	_eq?: T;
 	_neq?: T;
 	_gt?: T;


### PR DESCRIPTION
Fixes #20596 

## Scope

What's changed:

Literal schema types (`json`,`csv`,`datetime`) were not being translated to their actual data types before being used in filters.

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
