### PR TITLE
Add support for MIGRATIONS_PATH

### DIFF
--- a/.changeset/twenty-socks-brush.md
+++ b/.changeset/twenty-socks-brush.md
@@ -1,0 +1,7 @@
+---
+'@directus/api': major
+'docs': patch
+---
+
+Added new MIGRATIONS_PATH environment variable to control where custom migrations are read from
+

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -6,7 +6,7 @@ import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { flushCaches } from '../../cache.js';
-import { getExtensionsPath } from '../../extensions/lib/get-extensions-path.js';
+import env from '../../env.js';
 import logger from '../../logger.js';
 import type { Migration } from '../../types/index.js';
 import getModuleDefault from '../../utils/get-module-default.js';
@@ -16,7 +16,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default async function run(database: Knex, direction: 'up' | 'down' | 'latest', log = true): Promise<void> {
 	let migrationFiles = await fse.readdir(__dirname);
 
-	const customMigrationsPath = path.resolve(getExtensionsPath(), 'migrations');
+	const customMigrationsPath = path.resolve(env['MIGRATIONS_PATH']);
 
 	let customMigrationFiles =
 		((await fse.pathExists(customMigrationsPath)) && (await fse.readdir(customMigrationsPath))) || [];

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -37,10 +37,13 @@ const allowedEnvironmentVars = [
 	'QUERY_LIMIT_DEFAULT',
 	'ROBOTS_TXT',
 	'TEMP_PATH',
+
 	// server
 	'SERVER_.+',
+
 	// database
 	'DB_.+',
+
 	// security
 	'KEY',
 	'SECRET',
@@ -67,8 +70,10 @@ const allowedEnvironmentVars = [
 	'IMPORT_IP_DENY_LIST',
 	'CONTENT_SECURITY_POLICY_.+',
 	'HSTS_.+',
+
 	// hashing
 	'HASH_.+',
+
 	// cors
 	'CORS_ENABLED',
 	'CORS_ORIGIN',
@@ -77,9 +82,11 @@ const allowedEnvironmentVars = [
 	'CORS_EXPOSED_HEADERS',
 	'CORS_CREDENTIALS',
 	'CORS_MAX_AGE',
+
 	// rate limiting
 	'RATE_LIMITER_GLOBAL_.+',
 	'RATE_LIMITER_.+',
+
 	// cache
 	'CACHE_ENABLED',
 	'CACHE_TTL',
@@ -95,6 +102,7 @@ const allowedEnvironmentVars = [
 	'CACHE_VALUE_MAX_SIZE',
 	'CACHE_SKIP_ALLOWED',
 	'CACHE_HEALTHCHECK_THRESHOLD',
+
 	// storage
 	'STORAGE_LOCATIONS',
 	'STORAGE_.+_DRIVER',
@@ -128,6 +136,7 @@ const allowedEnvironmentVars = [
 	'ASSETS_TRANSFORM_TIMEOUT',
 	'ASSETS_CONTENT_SECURITY_POLICY',
 	'ASSETS_INVALID_IMAGE_SENSITIVITY_LEVEL',
+
 	// auth
 	'AUTH_PROVIDERS',
 	'AUTH_DISABLE_DEFAULT',
@@ -163,6 +172,7 @@ const allowedEnvironmentVars = [
 	'AUTH_.+_GROUP_SCOPE',
 	'AUTH_.+_IDP.+',
 	'AUTH_.+_SP.+',
+
 	// extensions
 	'PACKAGE_FILE_LOCATION',
 	'EXTENSIONS_LOCATION',
@@ -172,12 +182,18 @@ const allowedEnvironmentVars = [
 	'EXTENSIONS_CACHE_TTL',
 	'EXTENSIONS_SANDBOX_MEMORY',
 	'EXTENSIONS_SANDBOX_TIMEOUT',
+
+	// migrations
+	'MIGRATIONS_PATH',
+
 	// messenger
 	'MESSENGER_STORE',
 	'MESSENGER_NAMESPACE',
+
 	// synchronization
 	'SYNCHRONIZATION_STORE',
 	'SYNCHRONIZATION_NAMESPACE',
+
 	// emails
 	'EMAIL_FROM',
 	'EMAIL_TRANSPORT',
@@ -199,18 +215,23 @@ const allowedEnvironmentVars = [
 	'EMAIL_SES_CREDENTIALS__ACCESS_KEY_ID',
 	'EMAIL_SES_CREDENTIALS__SECRET_ACCESS_KEY',
 	'EMAIL_SES_REGION',
+
 	// admin account
 	'ADMIN_EMAIL',
 	'ADMIN_PASSWORD',
+
 	// telemetry
 	'TELEMETRY',
+
 	// limits & optimization
 	'RELATIONAL_BATCH_SIZE',
 	'EXPORT_BATCH_SIZE',
+
 	// flows
 	'FLOWS_ENV_ALLOW_LIST',
 	'FLOWS_RUN_SCRIPT_MAX_MEMORY',
 	'FLOWS_RUN_SCRIPT_TIMEOUT',
+
 	// websockets
 	'WEBSOCKETS_.+',
 ].map((name) => new RegExp(`^${name}$`));
@@ -287,6 +308,8 @@ export const defaults: Record<string, any> = {
 	EXTENSIONS_AUTO_RELOAD: false,
 	EXTENSIONS_SANDBOX_MEMORY: 100,
 	EXTENSIONS_SANDBOX_TIMEOUT: 1000,
+
+	MIGRATIONS_PATH: './migrations',
 
 	EMAIL_FROM: 'no-reply@example.com',
 	EMAIL_VERIFY_SETUP: true,

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -246,6 +246,7 @@ prefixing the value with `{type}:`. The following types are available:
 | `QUERY_LIMIT_MAX`          | The maximum query limit accepted on API requests.                                                                           | `-1`                         |
 | `ROBOTS_TXT`               | What the `/robots.txt` endpoint should return                                                                               | `User-agent: *\nDisallow: /` |
 | `TEMP_PATH`                | Where Directus' temporary files should be managed                                                                           | `./node_modules/.directus`   |
+| `MIGRATIONS_PATH`          | Where custom migrations are located                                                                                         | `./migrations`               |
 
 <sup>[1]</sup> The PUBLIC_URL value is used for things like OAuth redirects, forgot-password emails, and logos that
 needs to be publicly available on the internet.


### PR DESCRIPTION
## Scope

What's changed:

- Read custom migrations from `$MIGRATIONS_PATH` rather than `$EXTENSIONS_PATH/migrations`

## Potential Risks / Drawbacks

- It's a breaking change for those relying on custom migrations, as the new default path is `./migrations` rather than `$EXTENSIONS_PATH/migrations`.

## Review Notes / Questions

- Feels like a relatively straightforwards change. Works as expected on my end.

---

Fixes #20625
