### PR TITLE
Default sort by sort field in tabular layout

### DIFF
--- a/.changeset/metal-spiders-boil.md
+++ b/.changeset/metal-spiders-boil.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Ensured collections in tabular layout are sorted by the sort field by default, if available

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -156,7 +156,12 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		function useItemOptions() {
 			const page = syncRefProperty(layoutQuery, 'page', 1);
 			const limit = syncRefProperty(layoutQuery, 'limit', 25);
-			const defaultSort = computed(() => (primaryKeyField.value ? [primaryKeyField.value?.field] : []));
+
+			const defaultSort = computed(() => {
+				const field = sortField.value ?? primaryKeyField.value?.field;
+				return field ? [field] : [];
+			});
+
 			const sort = syncRefProperty(layoutQuery, 'sort', defaultSort);
 
 			const fieldsDefaultValue = computed(() => {

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -90,18 +90,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			return formatCollectionItemsCount(itemCount.value || 0, page.value, limit.value, filtering);
 		});
 
-		watch(
-			sortField,
-			(value) => {
-				if (!value) {
-					return;
-				}
-
-				onSortChange({ by: value, desc: false });
-			},
-			{ immediate: true },
-		);
-
 		return {
 			tableHeaders,
 			items,


### PR DESCRIPTION
## Scope

What's changed:

Adjust the logic for the default sort in tabular layout to pick `sortField` before `primaryKeyField` if available.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Should also be tested by updating the sort field to another one then reloading the collection, which doesn't work in #20612.

---

Fixes #20574
Closes #20612 (as replacement)
