### PR TITLE
Add missing translation strings, type & icon for theme extensions

### DIFF
--- a/.changeset/green-dolls-clean.md
+++ b/.changeset/green-dolls-clean.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+"@directus/extensions": patch
+---
+
+Added missing translation strings & types for theme extensions

--- a/.changeset/green-dolls-clean.md
+++ b/.changeset/green-dolls-clean.md
@@ -3,4 +3,4 @@
 "@directus/extensions": patch
 ---
 
-Added missing translation strings & types for theme extensions
+Added missing translation strings, type & icon for theme extensions

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -60,6 +60,7 @@ extension_display: Display
 extension_layout: Layout
 extension_module: Module
 extension_panel: Panel
+extension_theme: Theme
 extension_hook: Hook
 extension_endpoint: Endpoint
 extension_operation: Operation
@@ -69,6 +70,7 @@ extension_displays: Displays
 extension_layouts: Layouts
 extension_modules: Modules
 extension_panels: Panels
+extension_themes: Themes
 extension_hooks: Hooks
 extension_endpoints: Endpoints
 extension_operations: Operations

--- a/app/src/modules/settings/routes/extensions/constants/icons.ts
+++ b/app/src/modules/settings/routes/extensions/constants/icons.ts
@@ -1,11 +1,12 @@
-import { EXTENSION_TYPES } from '@directus/extensions';
+import type { ExtensionType } from '@directus/extensions';
 
-export const iconMap: Record<(typeof EXTENSION_TYPES)[number], string> = {
+export const iconMap: Record<ExtensionType, string> = {
 	interface: 'design_services',
 	display: 'label',
 	layout: 'dataset',
 	module: 'web',
 	panel: 'analytics',
+	theme: 'palette',
 	hook: 'webhook',
 	endpoint: 'api',
 	operation: 'flowsheet',

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@directus/constants": "workspace:*",
+		"@directus/themes": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@directus/utils": "workspace:*",
 		"@types/express": "4.17.17",

--- a/packages/extensions/src/shared/types/app-extension-config.ts
+++ b/packages/extensions/src/shared/types/app-extension-config.ts
@@ -1,9 +1,10 @@
+import type { Theme } from '@directus/themes';
 import type { DisplayConfig } from './displays.js';
 import type { InterfaceConfig } from './interfaces.js';
 import type { LayoutConfig } from './layouts.js';
 import type { ModuleConfig } from './modules.js';
-import type { PanelConfig } from './panels.js';
 import type { OperationAppConfig } from './operations.js';
+import type { PanelConfig } from './panels.js';
 
 export type AppExtensionConfigs = {
 	interfaces: InterfaceConfig[];
@@ -11,5 +12,6 @@ export type AppExtensionConfigs = {
 	layouts: LayoutConfig[];
 	modules: ModuleConfig[];
 	panels: PanelConfig[];
+	themes: Theme[];
 	operations: OperationAppConfig[];
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1261,6 +1261,9 @@ importers:
       '@directus/constants':
         specifier: workspace:*
         version: link:../constants
+      '@directus/themes':
+        specifier: workspace:*
+        version: link:../themes
       '@directus/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Scope

What's changed:

Add missing translation strings, type and icon for theme extensions.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

I went with the same icon as for the "Appearance" nav item for the purpose of recognition, but we might also want to choose a different one for the same reason (clear distinction between settings & extensions) 😅🤷

https://fonts.google.com/icons?icon.set=Material+Icons&icon.query=paint

<img width="500" src="https://github.com/directus/directus/assets/5363448/4ac5cb3e-7c10-44a2-a46a-c4c5fe1588f5">