### PR TITLE
Fix Histoire config

### DIFF
--- a/app/histoire.config.ts
+++ b/app/histoire.config.ts
@@ -32,5 +32,8 @@ export default defineConfig({
 	viteNodeInlineDeps: [/@joeattardi\/emoji-button/],
 	vite: {
 		base: '/',
+		server: {
+			proxy: undefined,
+		},
 	},
 });

--- a/app/histoire.config.ts
+++ b/app/histoire.config.ts
@@ -30,4 +30,7 @@ export default defineConfig({
 	backgroundPresets: [],
 	viteIgnorePlugins: ['directus-extensions-serve', 'directus-extensions-build'],
 	viteNodeInlineDeps: [/@joeattardi\/emoji-button/],
+	vite: {
+		base: '/',
+	},
 });


### PR DESCRIPTION
## Scope

Histoire by default uses the same Vite config as the app. That's great, except for the server proxying and base configuration. This would've required Histoire to also be served on `/admin/` and would've made it proxy requests to other paths to localhost:8055, which doesn't exist.

What's changed:

- Reset base to `''`
- Disable proxy 

## Potential Risks / Drawbacks

- Might break some components that secretly rely on the API

## Review Notes / Questions

—