### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: pnpm
+    labels:
+      - Dependencies
+    directory: '/'
+    schedule:
+      interval: daily
+    target-branch: main
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: '@directus/*'
+      - update-types:
+          - version-update:semver-major
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Scope

We used to do a dependency upgrade day once a month, but that's turning out to be quite a lot of work. We did try Renovate bot back in the day, but it used to cause a lot of spam. Curious to see if dependabot has gotten any better since. Worth a shot!

## Potential Risks / Drawbacks

- The only worry I have is that there's a chance there's more than 3 dependency upgrades every day, which would cause our PRs to lag behind. We'll have to try!

## Review Notes / Questions

Lemme know any and all thoughts! We'll run this for a little experiment, but nothing is set in stone on this.