### PR TITLE
Override Vite config for Histoire

### DIFF
--- a/app/histoire.config.ts
+++ b/app/histoire.config.ts
@@ -30,4 +30,7 @@ export default defineConfig({
 	backgroundPresets: [],
 	viteIgnorePlugins: ['directus-extensions-serve', 'directus-extensions-build'],
 	viteNodeInlineDeps: [/@joeattardi\/emoji-button/],
+	vite: {
+		base: '/',
+	},
 });

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -54,18 +54,20 @@ export default defineConfig({
 		],
 	},
 	base: process.env.NODE_ENV === 'production' ? '' : '/admin/',
-	server: {
-		port: 8080,
-		proxy: {
-			'^/(?!admin)': {
-				target: process.env.API_URL ? process.env.API_URL : 'http://127.0.0.1:8055/',
-				changeOrigin: true,
+	...(!process.env.HISTOIRE && {
+		server: {
+			port: 8080,
+			proxy: {
+				'^/(?!admin)': {
+					target: process.env.API_URL ? process.env.API_URL : 'http://127.0.0.1:8055/',
+					changeOrigin: true,
+				},
+			},
+			fs: {
+				allow: [searchForWorkspaceRoot(process.cwd()), ...getExtensionsRealPaths()],
 			},
 		},
-		fs: {
-			allow: [searchForWorkspaceRoot(process.cwd()), ...getExtensionsRealPaths()],
-		},
-	},
+	}),
 	test: {
 		environment: 'happy-dom',
 		setupFiles: ['src/__setup__/mock-globals.ts'],


### PR DESCRIPTION
This ensures the base is correct for Histoire and the server config doesn't apply
