### PR TITLE
Add masked option to formatted value display

### DIFF
--- a/.changeset/thick-badgers-report.md
+++ b/.changeset/thick-badgers-report.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added masked option to formatted value display

--- a/app/src/displays/formatted-value/formatted-value.vue
+++ b/app/src/displays/formatted-value/formatted-value.vue
@@ -20,6 +20,7 @@ const props = withDefaults(
 		background?: string;
 		icon?: string;
 		border?: boolean;
+		masked?: boolean;
 		conditionalFormatting?: {
 			operator: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains' | 'starts_with' | 'ends_with';
 			value: string;
@@ -85,6 +86,8 @@ const computedStyle = computed(() => {
 });
 
 const displayValue = computed(() => {
+	if (props.masked) return '**********';
+
 	if (computedFormat.value.text) {
 		const { text } = computedFormat.value;
 		return text.startsWith('$t:') ? t(text.slice(3)) : text;

--- a/app/src/displays/formatted-value/index.ts
+++ b/app/src/displays/formatted-value/index.ts
@@ -165,6 +165,21 @@ export default defineDisplay({
 				},
 			},
 			{
+				field: 'masked',
+				name: '$t:displays.formatted-value.mask',
+				type: 'boolean',
+				meta: {
+					width: 'half',
+					interface: 'boolean',
+					options: {
+						label: '$t:displays.formatted-value.mask_label',
+					},
+				},
+				schema: {
+					default_value: false,
+				},
+			},
+			{
 				field: 'conditionalFormatting',
 				type: 'json',
 				name: '$t:conditional_styles',

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2008,6 +2008,8 @@ displays:
     icon: Icon
     border: Border
     border_label: Show border
+    mask: Masked
+    mask_label: Hide the real value
     text: Text
     text_placeholder: Optional value override...
   formatted-json-value:


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Add masked option to the formatted value display to be consistent with the input masked option.
Naming conventions are consistent with the masked option from the input interface.

| New masked option in formatted value display  | Existing masked option in input interface  |
|---|---|
| <img width="635" alt="image" src="https://github.com/directus/directus/assets/26413686/764cd115-2b14-4b42-9fc7-a130b53c2a74"> | <img width="635" alt="image" src="https://github.com/directus/directus/assets/26413686/6dffb1ad-ce0f-4edb-901c-951d50388572"> |

### Masked when viewing in Content
https://github.com/directus/directus/assets/26413686/d1c7d551-f992-4601-8a4f-58840765de22

### Masked when viewing in Insights
https://github.com/directus/directus/assets/26413686/13d1e653-6b2c-4181-a096-8dbce25fb193

## Scope

What's changed:

- Added a masked option to formatted value display

## Potential Risks / Drawbacks

- None, this simply masks the value within the admin app.

## Review Notes / Questions

- None.

---

Fixes #20671
