### PR TITLE
Fix check for bootstrap success in blackbox test

### DIFF
--- a/tests/blackbox/setup/setup.ts
+++ b/tests/blackbox/setup/setup.ts
@@ -43,7 +43,7 @@ export async function setup() {
 									env: config.envs[vendor],
 								});
 
-								if (bootstrap.status !== null) {
+								if (bootstrap.status !== null && bootstrap.status !== 0) {
 									throw new Error(
 										`Directus-${vendor} bootstrap failed (${bootstrap.status}): \n ${bootstrap.stderr.toString()}`,
 									);


### PR DESCRIPTION
## Scope

What's changed:

Wrong check logic added in #20694.
Status on success of bootstrap can be both `null` and `0`.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A