### PR TITLE
Remove flaky api storage test

### DIFF
--- a/api/src/storage/register-locations.test.ts
+++ b/api/src/storage/register-locations.test.ts
@@ -1,5 +1,4 @@
 import type { StorageManager } from '@directus/storage';
-import { toArray } from '@directus/utils';
 import { randNumber, randWord } from '@ngneat/falso';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { setEnv } from '../__utils__/mock-env.js';
@@ -11,7 +10,6 @@ vi.mock('../env.js', async () => {
 	return mockEnv();
 });
 
-vi.mock('@directus/utils');
 vi.mock('../utils/get-config-from-env.js');
 
 let sample: {
@@ -49,19 +47,12 @@ beforeEach(() => {
 	vi.mocked(getConfigFromEnv).mockImplementation((name) => sample.options[name]!);
 
 	setEnv({
-		STORAGE_LOCATIONS: sample.locations.join(', '),
+		STORAGE_LOCATIONS: sample.locations.join(','),
 	});
-
-	vi.mocked(toArray).mockReturnValue(sample.locations);
 });
 
 afterEach(() => {
 	vi.resetAllMocks();
-});
-
-test('Converts storage locations env var to array', async () => {
-	await registerLocations(mockStorage);
-	expect(toArray).toHaveBeenCalledWith(sample.locations.join(', '));
 });
 
 test('Gets config for each location', async () => {


### PR DESCRIPTION
## Scope

What's changed:

- The test fails from time to time, most recently in https://github.com/directus/directus/actions/runs/7161458982/job/19497092203?pr=20698
  <img width="700" src="https://github.com/directus/directus/assets/5363448/92cdb8e5-c996-47f8-bab9-41548bf24b7c">
- The actual issue seems to originate from a bug in Vitest: Although we're importing the actual `env.js` in https://github.com/directus/directus/blob/30d53c5df622aae42b2b5edd24a4bcee9cba54f0/api/src/__utils__/mock-env.ts#L20 it is affected by the mock of `@directus/utils` https://github.com/directus/directus/blob/30d53c5df622aae42b2b5edd24a4bcee9cba54f0/api/src/storage/register-locations.test.ts#L14 which means `toArray` is not available in the mocked env implementation.
- I'll report the issue in the evening. However, in this case here, we can simply remove the affected test since the other two tests covers that logic as well.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A
