### PR TITLE
feat(openid): retrieve role id from claims

### DIFF
--- a/.changeset/mighty-months-shake.md
+++ b/.changeset/mighty-months-shake.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"docs": patch
+---
+
+feat(openid): retrieve role id from claims

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -140,7 +140,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		// Flatten response to support dot indexes
 		userInfo = flatten(userInfo) as Record<string, unknown>;
 
-		const { provider, emailKey, identifierKey, allowPublicRegistration } = this.config;
+		const { provider, emailKey, identifierKey, allowPublicRegistration, roleIdClaim } = this.config;
 
 		const email = userInfo[emailKey ?? 'email'] ? String(userInfo[emailKey ?? 'email']) : undefined;
 		// Fallback to email if explicit identifier not found
@@ -157,7 +157,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			last_name: userInfo[this.config['lastNameKey']],
 			email: email,
 			external_identifier: identifier,
-			role: this.config['defaultRoleId'],
+			role: userInfo[roleIdClaim] || this.config['defaultRoleId'],
 			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
 		};
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -167,7 +167,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		// Flatten response to support dot indexes
 		userInfo = flatten(userInfo) as Record<string, unknown>;
 
-		const { provider, identifierKey, allowPublicRegistration, requireVerifiedEmail } = this.config;
+		const { provider, identifierKey, allowPublicRegistration, requireVerifiedEmail, roleIdClaim } = this.config;
 
 		const email = userInfo['email'] ? String(userInfo['email']) : undefined;
 		// Fallback to email if explicit identifier not found
@@ -184,7 +184,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			last_name: userInfo['family_name'],
 			email: email,
 			external_identifier: identifier,
-			role: this.config['defaultRoleId'],
+			role: userInfo[roleIdClaim] || this.config['defaultRoleId'],
 			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
 		};
 

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -144,6 +144,7 @@ const allowedEnvironmentVars = [
 	'AUTH_.+_LAST_NAME_KEY',
 	'AUTH_.+_ALLOW_PUBLIC_REGISTRATION',
 	'AUTH_.+_DEFAULT_ROLE_ID',
+	'AUTH_.+_ROLE_ID_CLAIM',
 	'AUTH_.+_ICON',
 	'AUTH_.+_LABEL',
 	'AUTH_.+_PARAMS',

--- a/contributors.yml
+++ b/contributors.yml
@@ -95,3 +95,4 @@
 - u5r0
 - wasimTQ
 - omahs
+- ziouf

--- a/docs/self-hosted/sso.md
+++ b/docs/self-hosted/sso.md
@@ -71,7 +71,7 @@ AUTH_GOOGLE_ICON="google"
 AUTH_GOOGLE_LABEL="Google"
 AUTH_GOOGLE_ALLOW_PUBLIC_REGISTRATION="true" # This allows users to be automatically created on logins. Use "false" if you want to create users manually
 AUTH_GOOGLE_DEFAULT_ROLE_ID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" # Replace this with the Directus Role ID you would want for new users. If this is not properly configured, new users will not have access to Directus
-AUTH_GOOGLE_ROLE_ID_CLAIM="directus_role_id" # Retreive the role ID from OIDC provider, fallback to default role id if not present
+AUTH_GOOGLE_ROLE_ID_CLAIM="directus_role_id" # Claim name to retreive the role ID from, fallback to default role id if not present
 ```
 
 8. Now you can see a nice functional `Login with Google` button on Directus login page.

--- a/docs/self-hosted/sso.md
+++ b/docs/self-hosted/sso.md
@@ -71,6 +71,7 @@ AUTH_GOOGLE_ICON="google"
 AUTH_GOOGLE_LABEL="Google"
 AUTH_GOOGLE_ALLOW_PUBLIC_REGISTRATION="true" # This allows users to be automatically created on logins. Use "false" if you want to create users manually
 AUTH_GOOGLE_DEFAULT_ROLE_ID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" # Replace this with the Directus Role ID you would want for new users. If this is not properly configured, new users will not have access to Directus
+AUTH_GOOGLE_ROLE_ID_CLAIM="directus_role_id" # Retreive the role ID from OIDC provider, fallback to default role id if not present
 ```
 
 8. Now you can see a nice functional `Login with Google` button on Directus login page.


### PR DESCRIPTION
## Scope

What's changed:

- In openid sso driver, extract user role id from claim returned by oidc provider.
- if not found, fallback to default role id.

## Potential Risks / Drawbacks

none

## Review Notes / Questions

none

---

Fixes #20631
