### PR TITLE
Align versions in dev / test docker compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,15 +63,24 @@
 #     User:          admin
 #     Password:      --
 
-version: '3.1'
+version: '3.8'
+
 services:
   postgres:
-    image: postgis/postgis:13-3.1-alpine
+    image: postgis/postgis:13-alpine
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: directus
     ports:
       - 5100:5432
+
+  postgres10:
+    image: postgis/postgis:10-alpine
+    environment:
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: directus
+    ports:
+      - 5111:5432
 
   mysql:
     image: mysql:8
@@ -84,8 +93,16 @@ services:
     cap_add:
       - SYS_NICE
 
+  mysql5:
+    image: mysql:5
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: directus
+    ports:
+      - 5108:3306
+
   maria:
-    image: mariadb:10.7
+    image: mariadb:10
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: directus
@@ -109,13 +126,19 @@ services:
       - ORACLE_ALLOW_REMOTE=true
     shm_size: '1gb' # more like smh-size amirite 🥁
 
+  cockroachdb:
+    image: cockroachdb/cockroach:latest-v21.1
+    command: start-single-node --cluster-name=example-single-node --insecure
+    ports:
+      - 5113:26257
+
   redis:
     image: redis:6-alpine
     ports:
       - 5105:6379
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio
     command: server /data/minio/ --console-address :9001
     ports:
       - 5106:9000
@@ -126,16 +149,8 @@ services:
     ports:
       - 5107:10000
 
-  mysql5:
-    image: mysql:5
-    environment:
-      MYSQL_ROOT_PASSWORD: secret
-      MYSQL_DATABASE: directus
-    ports:
-      - 5108:3306
-
   keycloak:
-    image: jboss/keycloak:latest
+    image: jboss/keycloak
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: secret
@@ -143,17 +158,3 @@ services:
       DB_VENDOR: h2
     ports:
       - 5110:8080
-
-  postgres10:
-    image: postgis/postgis:10-3.1-alpine
-    environment:
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: directus
-    ports:
-      - 5111:5432
-
-  cockroachdb:
-    image: cockroachdb/cockroach:latest-v21.1
-    command: start-single-node --cluster-name=example-single-node --insecure
-    ports:
-      - 5113:26257

--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -28,10 +28,11 @@
 #   CockroachDB:
 #     User:          root
 
-version: '3.1'
+version: '3.8'
+
 services:
   postgres:
-    image: postgis/postgis:13-3.1-alpine
+    image: postgis/postgis:13-alpine
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: directus
@@ -39,7 +40,7 @@ services:
       - 6100:5432
 
   postgres10:
-    image: postgis/postgis:10-3.1-alpine
+    image: postgis/postgis:10-alpine
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: directus
@@ -66,7 +67,7 @@ services:
       - 6103:3306
 
   maria:
-    image: mariadb:10.7
+    image: mariadb:10
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: directus
@@ -91,6 +92,7 @@ services:
     shm_size: '1gb' # more like smh-size ammirite 🥁
 
   cockroachdb:
+    # change in the YY.R component denotes a major release
     image: cockroachdb/cockroach:latest-v21.1
     command: start-single-node --cluster-name=example-single-node --insecure
     ports:
@@ -101,17 +103,8 @@ services:
     ports:
       - 6108:6379
 
-  auth-saml:
-    image: kristophjunge/test-saml-idp
-    ports:
-      - 8880:8080
-    environment:
-      - SIMPLESAMLPHP_SP_ENTITY_ID=saml-test
-      - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=http://127.0.0.1:8080/auth/login/saml/acs
-    extra_hosts:
-      - 'host.docker.internal:host-gateway'
-
   minio:
+    # should stay compatible via S3 driver
     image: minio/minio
     command: server /data/minio/ --console-address :9001
     ports:
@@ -130,3 +123,13 @@ services:
       directusminio/directus-blackbox-test; while true; do
           sleep 3600;
       done "
+
+  auth-saml:
+    image: kristophjunge/test-saml-idp
+    ports:
+      - 8880:8080
+    environment:
+      - SIMPLESAMLPHP_SP_ENTITY_ID=saml-test
+      - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=http://127.0.0.1:8080/auth/login/saml/acs
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
## Scope

What's changed:

- For DB providers which follow SemVer, we should stick to major instead of patch (e.g. `postgis:13-alpine` instead of `postgis:13-3.1-alpine`) to test against the latest version of that release channel.
- Reordered, first DBs then additional service images
- Update compose spec version to 3.8
- Added a few comments

## Potential Risks / Drawbacks

Unexpected, but might fail with newer minor versions. That would actually help us to catch the issue, though, which is kinda the goal of this PR.

## Review Notes / Questions

None