### PR TITLE
`public_favicon` should be a system relation

### DIFF
--- a/.changeset/stale-jobs-shop.md
+++ b/.changeset/stale-jobs-shop.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed public_favicon to be correctly set as a system relation

--- a/api/src/database/system-data/relations/relations.yaml
+++ b/api/src/database/system-data/relations/relations.yaml
@@ -97,6 +97,10 @@ data:
     one_collection: directus_files
 
   - many_collection: directus_settings
+    many_field: public_favicon
+    one_collection: directus_files
+
+  - many_collection: directus_settings
     many_field: storage_default_folder
     one_collection: directus_folders
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- `public_favicon` has been marked as a system relation.

### Before
Requesting the `relations` endpoint for `directus_settings` returns null meta for `public_favicon`  and a snapshot incorrectly includes it as something to apply/track.
#### Relations API response
http://localhost:8055/relations/directus_settings
##### Response
<img width="347" alt="Screenshot 2023-12-12 at 11 56 59 AM" src="https://github.com/directus/directus/assets/44623501/a7aaf23c-15fb-4ad2-8243-75588142587f">

#### Snapshot on clean project
<img width="474" alt="Screenshot 2023-12-12 at 12 04 20 PM" src="https://github.com/directus/directus/assets/44623501/a429cf92-2a26-4d1e-9a9b-bdb711c474bd">

### After
Requesting the `relations` endpoint for `directus_settings` returns the correct meta for `public_favicon`  and a snapshot no longer includes it as something to apply/track.
#### Relations API response
http://localhost:8055/relations/directus_settings
<img width="483" alt="image" src="https://github.com/directus/directus/assets/44623501/d6448b6f-77a2-4382-a942-3c99e5a8e938">

#### Snapshot on clean project
<img width="147" alt="Screenshot 2023-12-12 at 12 06 20 PM" src="https://github.com/directus/directus/assets/44623501/e8865dad-951e-498b-9f55-6189dd9876b2">

## Potential Risks / Drawbacks

- version controlled snapshots will register this change on next snapshot generation. This can lead to some confusion as nothing has changed on clients side.

## Review Notes / Questions

- Generated/Applied snapshots with local copy of cli so changes would be registered. 

---

Fixes #20475
