### PR TITLE
Allow editing content versions without edit permission on the main version item

### DIFF
--- a/.changeset/big-walls-knock.md
+++ b/.changeset/big-walls-knock.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Allowed editing of versions without edit permission on main version item

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -279,6 +279,7 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 			v-if="currentVersion !== null"
 			:active="isVersionPromoteDrawerOpen"
 			:current-version="currentVersion"
+			:delete-versions-allowed="deleteVersionsAllowed"
 			@cancel="isVersionPromoteDrawerOpen = false"
 			@promote="onPromoteComplete($event)"
 		/>

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -11,6 +11,7 @@ import VersionPromoteDrawer from './version-promote-drawer.vue';
 interface Props {
 	collection: string;
 	primaryKey: string | number;
+	updateAllowed: boolean;
 	hasEdits: boolean;
 	currentVersion: ContentVersion | null;
 	versions: ContentVersion[] | null;
@@ -259,7 +260,7 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 				<template v-if="currentVersion !== null">
 					<v-divider />
 
-					<v-list-item clickable @click="isVersionPromoteDrawerOpen = true">
+					<v-list-item v-if="updateAllowed" clickable @click="isVersionPromoteDrawerOpen = true">
 						{{ t('promote_version') }}
 					</v-list-item>
 

--- a/app/src/modules/content/components/version-promote-drawer.vue
+++ b/app/src/modules/content/components/version-promote-drawer.vue
@@ -18,6 +18,7 @@ type Comparison = {
 interface Props {
 	active: boolean;
 	currentVersion: ContentVersion;
+	deleteVersionsAllowed: boolean;
 }
 
 const { t } = useI18n();
@@ -26,7 +27,7 @@ const fieldsStore = useFieldsStore();
 
 const props = defineProps<Props>();
 
-const { active, currentVersion } = toRefs(props);
+const { active, currentVersion, deleteVersionsAllowed } = toRefs(props);
 
 const selectedFields = ref<string[]>([]);
 
@@ -36,7 +37,7 @@ const loading = ref(false);
 
 const { tabs, currentTab } = useTab();
 
-const { confirmDeleteOnPromoteDialogActive, promoting, promote } = usePromoteDialog();
+const { confirmDeleteOnPromoteDialogActive, onPromoteClick, promoting, promote } = usePromoteDialog();
 
 const emit = defineEmits<{
 	cancel: [];
@@ -120,7 +121,15 @@ function usePromoteDialog() {
 	const confirmDeleteOnPromoteDialogActive = ref(false);
 	const promoting = ref(false);
 
-	return { confirmDeleteOnPromoteDialogActive, promoting, promote };
+	return { confirmDeleteOnPromoteDialogActive, onPromoteClick, promoting, promote };
+
+	function onPromoteClick() {
+		if (deleteVersionsAllowed.value) {
+			confirmDeleteOnPromoteDialogActive.value = true;
+		} else {
+			promote(false);
+		}
+	}
 
 	async function promote(deleteOnPromote: boolean) {
 		promoting.value = true;
@@ -243,7 +252,8 @@ function useTab() {
 				:disabled="selectedFields.length === 0"
 				icon
 				rounded
-				@click="confirmDeleteOnPromoteDialogActive = true"
+				:loading="promoting"
+				@click="onPromoteClick"
 			>
 				<v-icon name="check" />
 			</v-button>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -9,6 +9,7 @@ import { usePermissions } from '@/composables/use-permissions';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
+import { usePermissionsStore } from '@/stores/permissions';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import { translateShortcut } from '@/utils/translate-shortcut';
@@ -41,6 +42,8 @@ const { t, te } = useI18n();
 const router = useRouter();
 
 const form = ref<HTMLElement>();
+
+const { hasPermission } = usePermissionsStore();
 
 const { collection, primaryKey } = toRefs(props);
 const { breadcrumb } = useBreadcrumb();
@@ -84,7 +87,7 @@ const {
 const { templateData } = useTemplateData(collectionInfo, primaryKey);
 
 const isSavable = computed(() => {
-	if (saveAllowed.value === false) return false;
+	if (saveAllowed.value === false && currentVersion.value === null) return false;
 	if (hasEdits.value === true) return true;
 
 	if (!primaryKeyField.value?.schema?.has_auto_increment && !primaryKeyField.value?.meta?.special?.includes('uuid')) {
@@ -172,6 +175,15 @@ const {
 	fields,
 	revisionsAllowed,
 } = usePermissions(collection, item, isNew);
+
+const updateVersionsAllowed = computed<boolean>(() => hasPermission('directus_versions', 'update'));
+
+const isFormDisabled = computed(() => {
+	if (isNew.value) return false;
+	if (updateAllowed.value) return false;
+	if (updateVersionsAllowed.value && currentVersion.value !== null) return false;
+	return true;
+});
 
 const internalPrimaryKey = computed(() => {
 	if (unref(loading)) return '+';
@@ -665,7 +677,7 @@ function revert(values: Record<string, any>) {
 			ref="form"
 			v-model="edits"
 			:autofocus="isNew"
-			:disabled="isNew ? false : updateAllowed === false"
+			:disabled="isFormDisabled"
 			:loading="loading"
 			:initial-values="item"
 			:fields="fields"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -176,12 +176,11 @@ const {
 	revisionsAllowed,
 } = usePermissions(collection, item, isNew);
 
-const updateVersionsAllowed = computed<boolean>(() => hasPermission('directus_versions', 'update'));
-
 const isFormDisabled = computed(() => {
 	if (isNew.value) return false;
 	if (updateAllowed.value) return false;
-	if (updateVersionsAllowed.value && currentVersion.value !== null) return false;
+	const updateVersionsAllowed = hasPermission('directus_versions', 'update');
+	if (currentVersion.value !== null && updateVersionsAllowed) return false;
 	return true;
 });
 

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -516,6 +516,7 @@ function revert(values: Record<string, any>) {
 				"
 				:collection="collection"
 				:primary-key="internalPrimaryKey"
+				:update-allowed="updateAllowed"
 				:has-edits="hasEdits"
 				:current-version="currentVersion"
 				:versions="versions"


### PR DESCRIPTION
## Scope

What's changed:

- The form is no longer disabled for users with update permissions to versions but _no_ update permission on the main version item
- Hide promote button when user has no update permissions on the main version item
- Hide delete dialog when user has no delete permission on versions in the promote drawer

## Potential Risks / Drawbacks

- Not that I am aware of at the moment

## Review Notes / Questions

- You may come across #20337 during testing with relational fields (and see that the save button is still disabled), but after looking at it, I think the solution for that PR likely requires fixing it via API (such as "transform" or turn create/update/delete object to a typical relational array, only when querying a version of an item), so let's keep that as a separate PR.

