### PR TITLE
do not re-order package entries on bundle add

### DIFF
--- a/.changeset/stale-adults-swim.md
+++ b/.changeset/stale-adults-swim.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+Fixed an issue for bundle extensions where entries in the root package.json are re-ordered when a new extension is added to a bundle

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -42,7 +42,8 @@ export default async function add(): Promise<void> {
 
 	try {
 		const extensionManifestFile = await fse.readFile(packagePath, 'utf8');
-		extensionManifest = ExtensionManifest.passthrough().parse(JSON.parse(extensionManifestFile));
+		extensionManifest = JSON.parse(extensionManifestFile);
+		ExtensionManifest.passthrough().parse(extensionManifest);
 		indent = detectJsonIndent(extensionManifestFile);
 	} catch (e) {
 		log(`Current directory is not a valid Directus extension.`, 'error');

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -43,7 +43,7 @@ export default async function add(): Promise<void> {
 	try {
 		const extensionManifestFile = await fse.readFile(packagePath, 'utf8');
 		extensionManifest = JSON.parse(extensionManifestFile);
-		ExtensionManifest.passthrough().parse(extensionManifest);
+		ExtensionManifest.parse(extensionManifest);
 		indent = detectJsonIndent(extensionManifestFile);
 	} catch (e) {
 		log(`Current directory is not a valid Directus extension.`, 'error');

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -33,22 +33,33 @@ export default async function add(): Promise<void> {
 	const packagePath = path.resolve('package.json');
 
 	if (!(await fse.pathExists(packagePath))) {
-		log(`Current directory is not a valid package.`, 'error');
+		log(`Current directory is not a valid Directus extension:`, 'error');
+		log(`Missing "package.json" file.`, 'error');
+		process.exit(1);
+	}
+
+	let extensionManifestFile: string;
+
+	try {
+		extensionManifestFile = await fse.readFile(packagePath, 'utf8');
+	} catch {
+		log(`Failed to read "package.json" file from current directory.`, 'error');
 		process.exit(1);
 	}
 
 	let extensionManifest: TExtensionManifest;
-	let indent: string | null = null;
 
 	try {
-		const extensionManifestFile = await fse.readFile(packagePath, 'utf8');
 		extensionManifest = JSON.parse(extensionManifestFile);
 		ExtensionManifest.parse(extensionManifest);
-		indent = detectJsonIndent(extensionManifestFile);
-	} catch (e) {
-		log(`Current directory is not a valid Directus extension.`, 'error');
+	} catch {
+		log(`Current directory is not a valid Directus extension:`, 'error');
+		log(`Invalid "package.json" file.`, 'error');
+
 		process.exit(1);
 	}
+
+	const indent = detectJsonIndent(extensionManifestFile);
 
 	const extensionOptions = extensionManifest[EXTENSION_PKG_KEY];
 

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -65,16 +65,29 @@ export default async function build(options: BuildOptions): Promise<void> {
 		const packagePath = path.resolve('package.json');
 
 		if (!(await fse.pathExists(packagePath))) {
-			log(`Current directory is not a valid package.`, 'error');
+			log(`Current directory is not a valid Directus extension:`, 'error');
+			log(`Missing "package.json" file.`, 'error');
+			process.exit(1);
+		}
+
+		let extensionManifestFile: string;
+
+		try {
+			extensionManifestFile = await fse.readFile(packagePath, 'utf8');
+		} catch {
+			log(`Failed to read "package.json" file from current directory.`, 'error');
 			process.exit(1);
 		}
 
 		let extensionManifest: TExtensionManifest;
 
 		try {
-			extensionManifest = ExtensionManifest.parse(await fse.readJSON(packagePath));
-		} catch (err) {
-			log(`Current directory is not a valid Directus extension.`, 'error');
+			extensionManifest = JSON.parse(extensionManifestFile);
+			ExtensionManifest.parse(extensionManifest);
+		} catch {
+			log(`Current directory is not a valid Directus extension:`, 'error');
+			log(`Invalid "package.json" file.`, 'error');
+
 			process.exit(1);
 		}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- package.json entries will no longer be re-ordered when new extensions are added to a bundle type extension

#### Bundle package.json
```js
// bundle package.json
{
	"description": "Please enter a description for your extension",
	"icon": "extension",
	"version": "1.0.0",
	"name": "directus-extension-issue-20401",
        // ...
}
```
#### Before
Adding a new extension to the bundle via add will result in re-ordered entries:
```js
{
	"name": "directus-extension-issue-20401",
	"version": "1.0.0",
	"type": "module",
	"description": "Please enter a description for your extension",
	"icon": "extension",
        // ..
}
```
#### After
Adding a new extension to the bundle via add will not result in re-ordered entries:
```js
// bundle package.json
{
	"description": "Please enter a description for your extension",
	"icon": "extension",
	"version": "1.0.0",
	"name": "directus-extension-issue-20401",
        // ...
}
```

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- I noticed we do not display any errors that potentially occur during validation and instead assume if an error occurred we are not in a directus extensions directory, is this intentional?

---

Fixes #20401
