### PR TITLE
do not remove custom devDependencies on bundle add

### DIFF
--- a/.changeset/old-mails-explain.md
+++ b/.changeset/old-mails-explain.md
@@ -1,0 +1,6 @@
+---
+'@directus/extensions-sdk': patch
+'@directus/extensions': patch
+---
+
+Fixed an issue for bundle extensions where custom devDependencies in the package.json were overriden when a new extension was added to the bundle

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -133,6 +133,7 @@ export default async function add(): Promise<void> {
 			devDependencies: await getExtensionDevDeps(
 				newEntries.map((entry) => entry.type),
 				getLanguageFromEntries(newEntries),
+				{ base: extensionManifest.devDependencies },
 			),
 		};
 
@@ -273,6 +274,7 @@ export default async function add(): Promise<void> {
 			devDependencies: await getExtensionDevDeps(
 				entries.map((entry) => entry.type),
 				getLanguageFromEntries(entries),
+				{ base: extensionManifest.devDependencies },
 			),
 		};
 

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -130,11 +130,13 @@ export default async function add(): Promise<void> {
 		const newExtensionManifest = {
 			...extensionManifest,
 			[EXTENSION_PKG_KEY]: newExtensionOptions,
-			devDependencies: await getExtensionDevDeps(
-				newEntries.map((entry) => entry.type),
-				getLanguageFromEntries(newEntries),
-				{ base: extensionManifest.devDependencies },
-			),
+			devDependencies: {
+				...extensionManifest.devDependencies,
+				...(await getExtensionDevDeps(
+					newEntries.map((entry) => entry.type),
+					getLanguageFromEntries(newEntries),
+				)),
+			},
 		};
 
 		await fse.writeJSON(packagePath, newExtensionManifest, { spaces: indent ?? '\t' });
@@ -271,11 +273,13 @@ export default async function add(): Promise<void> {
 			name: EXTENSION_NAME_REGEX.test(extensionName) ? extensionName : `directus-extension-${extensionName}`,
 			keywords: ['directus', 'directus-extension', `directus-custom-bundle`],
 			[EXTENSION_PKG_KEY]: newExtensionOptions,
-			devDependencies: await getExtensionDevDeps(
-				entries.map((entry) => entry.type),
-				getLanguageFromEntries(entries),
-				{ base: extensionManifest.devDependencies },
-			),
+			devDependencies: {
+				...extensionManifest.devDependencies,
+				...(await getExtensionDevDeps(
+					entries.map((entry) => entry.type),
+					getLanguageFromEntries(entries),
+				)),
+			},
 		};
 
 		await fse.writeJSON(packagePath, newExtensionManifest, { spaces: indent ?? '\t' });

--- a/packages/extensions-sdk/src/cli/commands/helpers/get-extension-dev-deps.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/get-extension-dev-deps.ts
@@ -5,16 +5,20 @@ import type { Language } from '../../types.js';
 import getPackageVersion from '../../utils/get-package-version.js';
 import getSdkVersion from '../../utils/get-sdk-version.js';
 
+type GetExtensionDevDepsOptions = {
+	base?: Record<string, string> | undefined;
+};
+
 export default async function getExtensionDevDeps(
 	type: ExtensionType | ExtensionType[],
 	language: Language | Language[] = [],
+	options?: GetExtensionDevDepsOptions,
 ): Promise<Record<string, string>> {
 	const types = Array.isArray(type) ? type : [type];
 	const languages = Array.isArray(language) ? language : [language];
+	const deps = options?.base ?? {};
 
-	const deps: Record<string, string> = {
-		'@directus/extensions-sdk': getSdkVersion(),
-	};
+	deps['@directus/extensions-sdk'] = getSdkVersion();
 
 	if (languages.includes('typescript')) {
 		if (types.some((type) => isIn(type, [...API_EXTENSION_TYPES, ...HYBRID_EXTENSION_TYPES]))) {

--- a/packages/extensions-sdk/src/cli/commands/helpers/get-extension-dev-deps.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/get-extension-dev-deps.ts
@@ -5,20 +5,16 @@ import type { Language } from '../../types.js';
 import getPackageVersion from '../../utils/get-package-version.js';
 import getSdkVersion from '../../utils/get-sdk-version.js';
 
-type GetExtensionDevDepsOptions = {
-	base?: Record<string, string> | undefined;
-};
-
 export default async function getExtensionDevDeps(
 	type: ExtensionType | ExtensionType[],
 	language: Language | Language[] = [],
-	options?: GetExtensionDevDepsOptions,
 ): Promise<Record<string, string>> {
 	const types = Array.isArray(type) ? type : [type];
 	const languages = Array.isArray(language) ? language : [language];
-	const deps = options?.base ?? {};
 
-	deps['@directus/extensions-sdk'] = getSdkVersion();
+	const deps: Record<string, string> = {
+		'@directus/extensions-sdk': getSdkVersion(),
+	};
 
 	if (languages.includes('typescript')) {
 		if (types.some((type) => isIn(type, [...API_EXTENSION_TYPES, ...HYBRID_EXTENSION_TYPES]))) {

--- a/packages/extensions/src/shared/schemas/manifest.ts
+++ b/packages/extensions/src/shared/schemas/manifest.ts
@@ -9,6 +9,7 @@ export const ExtensionManifest = z.object({
 	description: z.string().optional(),
 	icon: z.string().optional(),
 	dependencies: z.record(z.string()).optional(),
+	devDependencies: z.record(z.string()).optional(),
 	[EXTENSION_PKG_KEY]: ExtensionOptions,
 });
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- we no longer remove custom devDependencies from the package.json when a new extension is added to the bundle.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- ~Special attention should be paid to the naming of the option `base` as the current defined devDeps, base seemed to be somewhat appropriate.~ This is no longer relevant.

---

Fixes #20394
