### PR TITLE
add a `--no-install` option to the extensions-sdk cli to skip dep install

### DIFF
--- a/.changeset/young-items-brush.md
+++ b/.changeset/young-items-brush.md
@@ -2,4 +2,4 @@
 '@directus/extensions-sdk': patch
 ---
 
-added an option to the extensions-sdk cli to skip dep install
+Added a --no-install option to the extensions-sdk cli to skip dep install

--- a/.changeset/young-items-brush.md
+++ b/.changeset/young-items-brush.md
@@ -3,4 +3,4 @@
 'create-directus-extension': minor
 ---
 
-Added a --no-install option to the extensions-sdk cli to skip dep install
+Added a `--no-install` option to the extensions CLI to skip dependency installation

--- a/.changeset/young-items-brush.md
+++ b/.changeset/young-items-brush.md
@@ -3,4 +3,4 @@
 'create-directus-extension': minor
 ---
 
-Added a `--no-install` option to the extensions CLI to skip dependency installation
+Added a `--no-install` option to the extensions CLI allowing to skip dependency installation

--- a/.changeset/young-items-brush.md
+++ b/.changeset/young-items-brush.md
@@ -1,5 +1,6 @@
 ---
-'@directus/extensions-sdk': patch
+'@directus/extensions-sdk': minor
+'create-directus-extension': minor
 ---
 
 Added a --no-install option to the extensions-sdk cli to skip dep install

--- a/.changeset/young-items-brush.md
+++ b/.changeset/young-items-brush.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+added an option to the extensions-sdk cli to skip dep install

--- a/packages/create-directus-extension/lib/index.js
+++ b/packages/create-directus-extension/lib/index.js
@@ -11,7 +11,7 @@ async function run() {
 	// eslint-disable-next-line no-console
 	console.log('This utility will walk you through creating a Directus extension.\n');
 
-	const { type, name, language } = await inquirer.prompt([
+	const { type, name, language, install } = await inquirer.prompt([
 		{
 			type: 'list',
 			name: 'type',
@@ -30,7 +30,13 @@ async function run() {
 			choices: EXTENSION_LANGUAGES,
 			when: ({ type }) => BUNDLE_EXTENSION_TYPES.includes(type) === false,
 		},
+		{
+			type: 'confirm',
+			name: 'install',
+			message: 'Auto install dependencies?',
+			default: true,
+		},
 	]);
 
-	await create(type, name, { language });
+	await create(type, name, { language, install });
 }

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -141,13 +141,16 @@ export default async function add(options: AddOptions): Promise<void> {
 
 		await fse.writeJSON(packagePath, newExtensionManifest, { spaces: indent ?? '\t' });
 
-		if (install) {
-			const packageManager = getPackageManager();
+		const packageManager = getPackageManager();
 
+		if (install) {
 			await execa(packageManager, ['install'], { cwd: extensionPath });
+		} else {
+			spinner.info(`Dependancy install skipped, to install run: ${chalk.blue(`${packageManager}`)} install`);
 		}
 
 		spinner.succeed(chalk.bold('Done'));
+		log(`Your ${type} extension has been added.`);
 	} else {
 		const { proceed } = await inquirer.prompt<{ proceed: boolean }>([
 			{
@@ -283,13 +286,16 @@ export default async function add(options: AddOptions): Promise<void> {
 
 		await fse.writeJSON(packagePath, newExtensionManifest, { spaces: indent ?? '\t' });
 
-		if (install) {
-			const packageManager = getPackageManager();
+		const packageManager = getPackageManager();
 
+		if (install) {
 			await execa(packageManager, ['install'], { cwd: extensionPath });
+		} else {
+			spinner.info(`Dependancy install skipped, to install run: ${chalk.blue(`${packageManager}`)} install`);
 		}
 
 		spinner.succeed(chalk.bold('Done'));
+		log(`Your ${type} extension has been added.`);
 	}
 }
 

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -28,7 +28,10 @@ import { log } from '../utils/logger.js';
 import copyTemplate from './helpers/copy-template.js';
 import getExtensionDevDeps from './helpers/get-extension-dev-deps.js';
 
-export default async function add(): Promise<void> {
+type AddOptions = { install?: boolean };
+
+export default async function add(options: AddOptions): Promise<void> {
+	const install = options.install ?? true;
 	const extensionPath = process.cwd();
 	const packagePath = path.resolve('package.json');
 
@@ -138,9 +141,11 @@ export default async function add(): Promise<void> {
 
 		await fse.writeJSON(packagePath, newExtensionManifest, { spaces: indent ?? '\t' });
 
-		const packageManager = getPackageManager();
+		if (install) {
+			const packageManager = getPackageManager();
 
-		await execa(packageManager, ['install'], { cwd: extensionPath });
+			await execa(packageManager, ['install'], { cwd: extensionPath });
+		}
 
 		spinner.succeed(chalk.bold('Done'));
 	} else {
@@ -278,9 +283,11 @@ export default async function add(): Promise<void> {
 
 		await fse.writeJSON(packagePath, newExtensionManifest, { spaces: indent ?? '\t' });
 
-		const packageManager = getPackageManager();
+		if (install) {
+			const packageManager = getPackageManager();
 
-		await execa(packageManager, ['install'], { cwd: extensionPath });
+			await execa(packageManager, ['install'], { cwd: extensionPath });
+		}
 
 		spinner.succeed(chalk.bold('Done'));
 	}

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -146,7 +146,7 @@ export default async function add(options: AddOptions): Promise<void> {
 		if (install) {
 			await execa(packageManager, ['install'], { cwd: extensionPath });
 		} else {
-			spinner.info(`Dependancy install skipped, to install run: ${chalk.blue(`${packageManager}`)} install`);
+			spinner.info(`Dependency installation skipped, to install run: ${chalk.blue(`${packageManager}`)} install`);
 		}
 
 		spinner.succeed(chalk.bold('Done'));
@@ -291,7 +291,7 @@ export default async function add(options: AddOptions): Promise<void> {
 		if (install) {
 			await execa(packageManager, ['install'], { cwd: extensionPath });
 		} else {
-			spinner.info(`Dependancy install skipped, to install run: ${chalk.blue(`${packageManager}`)} install`);
+			spinner.info(`Dependency installation skipped, to install run: ${chalk.blue(`${packageManager}`)} install`);
 		}
 
 		spinner.succeed(chalk.bold('Done'));

--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -27,9 +27,13 @@ import { log } from '../utils/logger.js';
 import copyTemplate from './helpers/copy-template.js';
 import getExtensionDevDeps from './helpers/get-extension-dev-deps.js';
 
-type CreateOptions = { language?: string };
+type CreateOptions = {
+	language?: string;
+	install?: boolean;
+};
 
 export default async function create(type: string, name: string, options: CreateOptions): Promise<void> {
+	const install = options.install ?? true;
 	const targetDir = name.substring(name.lastIndexOf('/') + 1);
 	const targetPath = path.resolve(targetDir);
 
@@ -66,11 +70,11 @@ export default async function create(type: string, name: string, options: Create
 	}
 
 	if (isIn(type, BUNDLE_EXTENSION_TYPES)) {
-		await createPackageExtension({ type, name, targetDir, targetPath });
+		await createPackageExtension({ type, name, targetDir, targetPath, install });
 	} else {
 		const language = options.language ?? 'javascript';
 
-		await createLocalExtension({ type, name, targetDir, targetPath, language });
+		await createLocalExtension({ type, name, targetDir, targetPath, language, install });
 	}
 }
 
@@ -79,11 +83,13 @@ async function createPackageExtension({
 	name,
 	targetDir,
 	targetPath,
+	install,
 }: {
 	type: BundleExtensionType;
 	name: string;
 	targetDir: string;
 	targetPath: string;
+	install: boolean;
 }) {
 	const spinner = ora(chalk.bold('Scaffolding Directus extension...')).start();
 
@@ -98,7 +104,9 @@ async function createPackageExtension({
 
 	const packageManager = getPackageManager();
 
-	await execa(packageManager, ['install'], { cwd: targetPath });
+	if (install) {
+		await execa(packageManager, ['install'], { cwd: targetPath });
+	}
 
 	spinner.succeed(chalk.bold('Done'));
 
@@ -111,12 +119,14 @@ async function createLocalExtension({
 	targetDir,
 	targetPath,
 	language,
+	install,
 }: {
 	type: AppExtensionType | ApiExtensionType | HybridExtensionType;
 	name: string;
 	targetDir: string;
 	targetPath: string;
 	language: string;
+	install: boolean;
 }) {
 	if (!isLanguage(language)) {
 		log(
@@ -156,7 +166,9 @@ async function createLocalExtension({
 
 	const packageManager = getPackageManager();
 
-	await execa(packageManager, ['install'], { cwd: targetPath });
+	if (install) {
+		await execa(packageManager, ['install'], { cwd: targetPath });
+	}
 
 	spinner.succeed(chalk.bold('Done'));
 

--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -110,7 +110,7 @@ async function createPackageExtension({
 
 	spinner.succeed(chalk.bold('Done'));
 
-	log(getDoneMessage(type, targetDir, targetPath, packageManager));
+	log(getDoneMessage(type, targetDir, targetPath, packageManager, install));
 }
 
 async function createLocalExtension({
@@ -172,7 +172,7 @@ async function createLocalExtension({
 
 	spinner.succeed(chalk.bold('Done'));
 
-	log(getDoneMessage(type, targetDir, targetPath, packageManager));
+	log(getDoneMessage(type, targetDir, targetPath, packageManager, install));
 }
 
 function getPackageManifest(name: string, options: ExtensionOptions, deps: Record<string, string>) {
@@ -199,15 +199,30 @@ function getPackageManifest(name: string, options: ExtensionOptions, deps: Recor
 	return packageManifest;
 }
 
-function getDoneMessage(type: ExtensionType, targetDir: string, targetPath: string, packageManager: string) {
-	return `
+function getDoneMessage(
+	type: ExtensionType,
+	targetDir: string,
+	targetPath: string,
+	packageManager: string,
+	install: boolean,
+) {
+	let message = `
 Your ${type} extension has been created at ${chalk.green(targetPath)}
 
 To start developing, run:
-	${chalk.blue('cd')} ${targetDir}
+	${chalk.blue('cd')} ${targetDir}`;
+
+	if (!install) {
+		message += `
+	${chalk.blue(`${packageManager}`)} install`;
+	}
+
+	message += `
 	${chalk.blue(`${packageManager} run`)} dev
 
-and then to build for production, run:
+To build for production, run:
 	${chalk.blue(`${packageManager} run`)} build
-`;
+	`;
+
+	return message;
 }

--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -222,7 +222,7 @@ To start developing, run:
 
 To build for production, run:
 	${chalk.blue(`${packageManager} run`)} build
-	`;
+`;
 
 	return message;
 }

--- a/packages/extensions-sdk/src/cli/run.ts
+++ b/packages/extensions-sdk/src/cli/run.ts
@@ -14,14 +14,14 @@ program
 	.command('create')
 	.arguments('<type> <name>')
 	.description('Scaffold a new Directus extension')
-	.option('--no-install', 'disable install after updating package.json file')
+	.option('--no-install', 'skip dependency installation after creating extension')
 	.option('-l, --language <language>', 'specify the language to use')
 	.action(create);
 
 program
 	.command('add')
 	.description('Add entries to an existing Directus extension')
-	.option('--no-install', 'disable install after updating package.json file')
+	.option('--no-install', 'skip dependency (re)installation after adding extension')
 	.action(add);
 
 program

--- a/packages/extensions-sdk/src/cli/run.ts
+++ b/packages/extensions-sdk/src/cli/run.ts
@@ -14,10 +14,15 @@ program
 	.command('create')
 	.arguments('<type> <name>')
 	.description('Scaffold a new Directus extension')
+	.option('--no-install', 'disable install after updating package.json file')
 	.option('-l, --language <language>', 'specify the language to use')
 	.action(create);
 
-program.command('add').description('Add entries to an existing Directus extension').action(add);
+program
+	.command('add')
+	.description('Add entries to an existing Directus extension')
+	.option('--no-install', 'disable install after updating package.json file')
+	.action(add);
 
 program
 	.command('build')


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- added an option (`--no-install`) to the extensions-sdk cli to skip dep install.

## Potential Risks / Drawbacks

- None, it is an opt in feature.

## Review Notes / Questions

- should we allow this for create-directus-extension as well? It uses its own prompter (inquirer) and passes the options directly.
- should we log a message when dep install is skipped?

---

Fixes #20402
