### PR TITLE
Fix boolean attributes for draggable component

### DIFF
--- a/.changeset/hot-clouds-protect.md
+++ b/.changeset/hot-clouds-protect.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed boolean attributes for draggable component
+Fixed drag and drop issues with sortable components in Safari

--- a/.changeset/hot-clouds-protect.md
+++ b/.changeset/hot-clouds-protect.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed boolean attributes for draggable component

--- a/app/src/components/v-table/table-header.vue
+++ b/app/src/components/v-table/table-header.vue
@@ -176,7 +176,6 @@ function toggleManualSort() {
 	<thead class="table-header" :class="{ resizing, reordering }">
 		<draggable
 			v-model="headersWritable"
-			force-fallback
 			:class="{ fixed }"
 			item-key="value"
 			tag="tr"
@@ -186,6 +185,7 @@ function toggleManualSort() {
 			animation="150"
 			ghost-class="header-order-ghost"
 			swap-threshold="0.5"
+			v-bind="{ 'force-fallback': true }"
 			@start="$emit('update:reordering', true)"
 			@end="$emit('update:reordering', false)"
 		>

--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -302,12 +302,12 @@ function updateSort(newSort: Sort) {
 			<draggable
 				v-else
 				v-model="internalItems"
-				force-fallback
 				:item-key="itemKey"
 				tag="tbody"
 				handle=".drag-handle"
 				:disabled="disabled || internalSort.by !== manualSortKey"
 				:set-data="hideDragImage"
+				v-bind="{ 'force-fallback': true }"
 				@end="onSortChange"
 			>
 				<template #item="{ element }">

--- a/app/src/interfaces/_system/system-fields/system-fields.vue
+++ b/app/src/interfaces/_system/system-fields/system-fields.vue
@@ -96,7 +96,7 @@ const removeField = (field: string) => {
 			<v-notice class="no-fields">{{ t('interfaces.system-fields.no_fields') }}</v-notice>
 		</v-list>
 		<v-list v-else>
-			<draggable v-model="fields" force-fallback item-key="key" handle=".drag-handle">
+			<draggable v-model="fields" item-key="key" handle=".drag-handle" v-bind="{ 'force-fallback': true }">
 				<template #item="{ element: field }">
 					<v-list-item block>
 						<v-icon name="drag_handle" class="drag-handle" left />

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -279,7 +279,7 @@ function isExistingField(node: Record<string, any>): boolean {
 		:group="{ name: 'g1' }"
 		:item-key="getIndex"
 		:swap-threshold="0.3"
-		force-fallback
+		v-bind="{ 'force-fallback': true }"
 		@change="$emit('change')"
 	>
 		<template #item="{ element, index }">

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -213,11 +213,11 @@ function remove(id: string) {
 		<v-list class="list">
 			<draggable
 				v-model="valuesWithData"
-				force-fallback
 				:set-data="hideDragImage"
 				item-key="id"
 				handle=".drag-handle"
 				:animation="150"
+				v-bind="{ 'force-fallback': true }"
 			>
 				<template #item="{ element }">
 					<v-list-item

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -294,11 +294,11 @@ const allowDrag = computed(
 
 		<v-list v-else>
 			<draggable
-				force-fallback
 				:model-value="displayItems"
 				item-key="id"
 				handle=".drag-handle"
 				:disabled="!allowDrag"
+				v-bind="{ 'force-fallback': true }"
 				@update:model-value="sortItems($event)"
 			>
 				<template #item="{ element }">

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -351,11 +351,11 @@ const allowDrag = computed(
 			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
 
 			<draggable
-				force-fallback
 				:model-value="displayItems"
 				item-key="$index"
 				:set-data="hideDragImage"
 				:disabled="!allowDrag"
+				v-bind="{ 'force-fallback': true }"
 				@update:model-value="sortItems"
 			>
 				<template #item="{ element }">

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -516,11 +516,11 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 
 			<v-list v-else>
 				<draggable
-					force-fallback
 					:model-value="displayItems"
 					item-key="id"
 					handle=".drag-handle"
 					:disabled="!allowDrag"
+					v-bind="{ 'force-fallback': true }"
 					@update:model-value="sortItems($event)"
 				>
 					<template #item="{ element }">

--- a/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
@@ -110,6 +110,7 @@ const dragOptions = {
 	group: 'description',
 	disabled: false,
 	ghostClass: 'ghost',
+	forceFallback: true,
 };
 
 const filteredDisplayItems = computed(() => {
@@ -201,7 +202,6 @@ function stageEdits(item: Record<string, any>) {
 		draggable=".draggable"
 		:set-data="hideDragImage"
 		:disabled="disabled"
-		force-fallback
 		@start="drag = true"
 		@end="drag = false"
 		@change="change($event as ChangeEvent)"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -477,11 +477,11 @@ function getLinkForItem(item: DisplayItem) {
 
 			<v-list v-else>
 				<draggable
-					force-fallback
 					:model-value="displayItems"
 					item-key="id"
 					handle=".drag-handle"
 					:disabled="!allowDrag"
+					v-bind="{ 'force-fallback': true }"
 					@update:model-value="sortItems($event)"
 				>
 					<template #item="{ element }">

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -218,10 +218,10 @@ function closeDrawer() {
 		<v-list v-if="Array.isArray(internalValue) && internalValue.length > 0">
 			<draggable
 				:disabled="disabled"
-				force-fallback
 				:model-value="internalValue"
 				item-key="id"
 				handle=".drag-handle"
+				v-bind="{ 'force-fallback': true }"
 				@update:model-value="$emit('input', $event)"
 			>
 				<template #item="{ element, index }">

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -199,13 +199,13 @@ async function onSort(updates: Collection[], removeGroup = false) {
 
 			<v-list v-else class="draggable-list">
 				<draggable
-					force-fallback
 					:model-value="rootCollections"
 					:group="{ name: 'collections' }"
 					:swap-threshold="0.3"
 					class="root-drag-container"
 					item-key="collection"
 					handle=".drag-handle"
+					v-bind="{ 'force-fallback': true }"
 					@update:model-value="onSort($event, true)"
 				>
 					<template #item="{ element }">

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -86,13 +86,13 @@ function onGroupSortChange(collections: Collection[]) {
 		<transition-expand class="collection-items">
 			<draggable
 				v-if="isCollectionExpanded"
-				force-fallback
 				:model-value="nestedCollections"
 				:group="{ name: 'collections' }"
 				:swap-threshold="0.3"
 				class="drag-container"
 				item-key="collection"
 				handle=".drag-handle"
+				v-bind="{ 'force-fallback': true }"
 				@update:model-value="onGroupSortChange"
 			>
 				<template #item="{ element }">

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -186,14 +186,12 @@ async function onGroupSortChange(fields: Field[]) {
 				v-if="localType === 'group'"
 				class="field-grid group full nested"
 				:model-value="nestedFields"
-				force-fallback
 				handle=".drag-handle"
 				:group="{ name: 'fields' }"
 				:set-data="hideDragImage"
 				:animation="150"
 				item-key="field"
-				fallback-on-body
-				invert-swap
+				v-bind="{ 'force-fallback': true, 'fallback-on-body': true, 'invert-swap': true }"
 				@update:model-value="onGroupSortChange"
 			>
 				<template #header>

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -125,14 +125,12 @@ async function setNestedSort(updates?: Field[]) {
 		<draggable
 			class="field-grid"
 			:model-value="usableFields.filter((field) => isNil(field?.meta?.group))"
-			force-fallback
 			handle=".drag-handle"
 			:group="{ name: 'fields' }"
 			:set-data="hideDragImage"
 			item-key="field"
 			:animation="150"
-			fallback-on-body
-			invert-swap
+			v-bind="{ 'force-fallback': true, 'fallback-on-body': true, 'invert-swap': true }"
 			@update:model-value="setSort"
 		>
 			<template #item="{ element }">


### PR DESCRIPTION
## Context

This turned out to be a side effect of #20079, particularly this seemingly benign change: https://github.com/directus/directus/pull/20079/files#diff-a087097bb3450fb01f9d7c2e83fc40bc1a0dc51000a35c718ede8c5f9b61239fR128

Which updated `:force-fallback="true"` to `force-fallback`. Technically they should be equivalent in Vue, but the `<draggable>` component specifically isn't interpreting `force-fallback` as a boolean value. However other changes such as this: https://github.com/directus/directus/pull/20079/files#diff-b015f593611961044fb04a0ca3f20d6c82cb19cd8f4f4ca6dc7169d0e46f1396R246, to update `:icon="true"` to `icon` still passes the boolean properly.

Reverting `force-fallback` syntax to `:force-fallback="true"` does make it work again as seen in this screen capture:

(Technically I am using Playwright's webkit browser on Windows here to replicate it)

https://github.com/directus/directus/assets/42867097/90f6fe2c-6d50-48e9-9b79-128918f94023

We can also see `force-fallback` is passed as an empty string rather than `true`, but `:force-fallback="true"` ensures it's a boolean attribute, thus falling back properly for Safari:

| `force-fallback` (Not working as intended) | `:force-fallback="true"` or v-bind |
|---|---|
|![](https://github.com/directus/directus/assets/42867097/6942539a-8d78-4523-9d54-528e9f008cf3)|![](https://github.com/directus/directus/assets/42867097/f4e4044c-ce86-459d-83d0-a7847f292994)|

I believe this is due to `force-fallback` not being an actual declared _prop_ in vuedraggable: [link to code](https://github.com/SortableJS/vue.draggable.next/blob/8687d34f3182a1a0bfb138e995609f32ffe3ce6b/src/vuedraggable.js#L35-L69), but it's passed as `$attrs` instead in [this line](https://github.com/SortableJS/vue.draggable.next/blob/8687d34f3182a1a0bfb138e995609f32ffe3ce6b/src/vuedraggable.js#L128). So it is not casted as a boolean as originally expected, as it is passed as an empty string _attr_ instead, rather than a `true` boolean _prop_.

Here's an [additional example via Vue SFC playground](https://play.vuejs.org/#eNp9U8Fq4zAQ/ZVBLNgGN4btLesE0qUL20Nb2t6qHkwySdTKkpDkNMX43zuSajeHkhDwzJv35KeZcc9WxswOHbI5q93aCuPBoe/MkivRGm099LAvoXO48t46GGBrdQsZSbI/XHG11sp5sKg2aP8pWEDPFYBQe7TCR80cto10WAbcWG0IiBxiudU9AVMO4D8MzuFKa4kNHR6gITyGqI7O8nhGMWrS+5tobjH5zItUtaSwCvICFkvY5+Nrso04ZPHI8HseAyBKZixmJdw83t3OnLdC7cT2I++Tc/IBqpOyhN9FMenPyZKxU9moeklBzOmO9K+rNAHqPSUeWyMbj5QB1FODhbtoLoKZECntv7JlXY0UEtTVpGYl846atBW72avTigYdO8fZWrdGSLR3xgtqImfTHDhrpNTvNxHztkuzi5o9rt9+wF/dMWCc3Vt0aA/I2VTzjd2hT+Xrx1s8UjwVW73pJLHPFB/QadkFj4l21akN2T7hRbf/47pS45/c9dGjcuOlgtHvHeKMVvfvmat/272cXY7DoS4GzY9fyrmx0Z7FgEJakGXfw6+vjRjqKiCRVSXaydS4YsMnyA0qKg==), where we can see `is-a-prop` is casted to a boolean as expected since it's declared, but `is-not-a-prop` remains as an empty string.

Note that although the passed attrs are still kebab-case, the draggable component does have an internal camelize function as seen here: https://github.com/SortableJS/vue.draggable.next/blob/8687d34f3182a1a0bfb138e995609f32ffe3ce6b/src/core/componentBuilderHelper.js#L39, thus `force-fallback` will turn into `forceFallback` when passed as an option to the underlying SortableJS.

## Scope

What's changed:

- Ensure boolean attributes are passed as `true` to draggable component
  - Uses `v-bind`, because doing `:force-fallback="true"` will get flagged by `vue/prefer-true-attribute-shorthand`

## Potential Risks / Drawbacks

- May seem slightly odd at first glance as to why these booleans are passed via v-bind, without knowing that they are intended as attrs rather than declared props within the draggable component (not sure is there a way for us to document/comment this?)

## Review Notes / Questions

- Would be helpful if reviewer can verify this on Safari on their end as well
- Technically we can also do `v-bind="{ forceFallback: true }"` instead of the current suggested change of `v-bind="{ 'force-fallback': true }"`, so if reviewers feel like the former is better, let's go with camelCase instead.
- Wished the `vue/prefer-true-attribute-shorthand` would ignore ones ending with the [`.attr` modifier](https://vuejs.org/api/built-in-directives.html#v-bind)!

---

Fixes #20349