### PR TITLE
Switch to pnpm 8.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
 		"eslint-plugin-vue": "9.19.2",
 		"prettier": "3.1.0"
 	},
-	"packageManager": "pnpm@8.12.0",
+	"packageManager": "pnpm@8.12.1",
 	"engines": {
 		"node": ">=18.0.0",
-		"pnpm": "~8.12.0"
+		"pnpm": "~8.12"
 	}
 }


### PR DESCRIPTION
## Scope

What's changed:

Switch to pnpm [v8.12.1](https://github.com/pnpm/pnpm/releases/tag/v8.12.1), of particular interest is
> - Don't report dependencies with optional dependencies as being added on repeat install. This was a bug in reporting https://github.com/pnpm/pnpm/issues/7384.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A
