### PR TITLE
Add missing pong reply in docs

### DIFF
--- a/.changeset/yellow-bulldogs-impress.md
+++ b/.changeset/yellow-bulldogs-impress.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Added info about pong reply to WebSocket ping event

--- a/contributors.yml
+++ b/contributors.yml
@@ -96,3 +96,4 @@
 - u5r0
 - wasimTQ
 - omahs
+- codeit-ninja

--- a/docs/guides/real-time/getting-started/websockets.md
+++ b/docs/guides/real-time/getting-started/websockets.md
@@ -186,17 +186,17 @@ You may have noticed that, periodically, you will receive a message with a type 
 In order to prevent the connection from *closing*, you have to reply with a `pong` event.
 
 ```js
-connection.addEventListener( 'message', (message) => {
-    const data = JSON.parse(message.data);
+connection.addEventListener('message', (message) => {
+	const data = JSON.parse(message.data);
 
-    if( data.type === 'ping' ) {
-        this.connection.send(
-            JSON.stringify({
-                type: 'pong'
-            })
-        )
-    }
-} )
+	if (data.type === 'ping') {
+		this.connection.send(
+			JSON.stringify({
+				type: 'pong',
+			}),
+		);
+	}
+});
 ```
 
 On Directus Cloud, this feature is enabled. If you are self-hosting, you can alter this behavior with the

--- a/docs/guides/real-time/getting-started/websockets.md
+++ b/docs/guides/real-time/getting-started/websockets.md
@@ -183,6 +183,22 @@ You may have noticed that, periodically, you will receive a message with a type 
    application technology stack.
 2. To verify that the connection is still active.
 
+In order to prevent the connection from *closing*, you have to reply with a `pong` event.
+
+```js
+connection.addEventListener( 'message', (message) => {
+    const data = JSON.parse(message.data);
+
+    if( data.type === 'ping' ) {
+        this.connection.send(
+            JSON.stringify({
+                type: 'pong'
+            })
+        )
+    }
+} )
+```
+
 On Directus Cloud, this feature is enabled. If you are self-hosting, you can alter this behavior with the
 `WEBSOCKETS_HEARTBEAT_ENABLED` and `WEBSOCKETS_HEARTBEAT_PERIOD` environment variables.
 

--- a/docs/guides/real-time/getting-started/websockets.md
+++ b/docs/guides/real-time/getting-started/websockets.md
@@ -183,9 +183,10 @@ You may have noticed that, periodically, you will receive a message with a type 
    application technology stack.
 2. To verify that the connection is still active.
 
-In order to prevent the connection from *closing*, you have to reply with a `pong` event.
+In order to prevent the connection from _closing_, you may reply with a `pong` event:
 
 ```js
+// Exemplary code
 connection.addEventListener('message', (message) => {
 	const data = JSON.parse(message.data);
 


### PR DESCRIPTION
### Add missing `pong` reply in docs

If the server sends a `ping` event, and you don't reply with a `pong` event the connection will be closed as the server thinks the connection is idle.

This part is missing in the documentation but should be added to prevent confusing among developers, as they will wonder why the connection keeps closing itself 😅