### PR TITLE
Update Knex to v3

### DIFF
--- a/.changeset/wicked-plants-peel.md
+++ b/.changeset/wicked-plants-peel.md
@@ -1,0 +1,8 @@
+---
+"@directus/api": patch
+"@directus/extensions": patch
+"@directus/schema": patch
+"@directus/types": patch
+---
+
+Updated Knex to v3.1.0

--- a/api/package.json
+++ b/api/package.json
@@ -127,7 +127,7 @@
 		"json2csv": "5.0.7",
 		"jsonwebtoken": "9.0.2",
 		"keyv": "4.5.4",
-		"knex": "2.5.1",
+		"knex": "3.1.0",
 		"ldapjs": "2.3.3",
 		"liquidjs": "10.9.4",
 		"lodash-es": "4.17.21",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -53,7 +53,7 @@
 		"vitest": "1.0.4"
 	},
 	"peerDependencies": {
-		"knex": "2.5.1",
+		"knex": "3.1.0",
 		"pino": "8.16.2",
 		"vue": "3.3.11",
 		"vue-router": "4.2.5"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -35,7 +35,7 @@
 		"dev": "tsup src/index.ts --format=esm --dts --watch"
 	},
 	"dependencies": {
-		"knex": "2.5.1"
+		"knex": "3.1.0"
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -34,7 +34,7 @@
 		"typescript": "5.3.3"
 	},
 	"peerDependencies": {
-		"knex": "2.5.1",
+		"knex": "3.1.0",
 		"vue": "3.3.11"
 	},
 	"peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,8 @@ importers:
         specifier: 4.5.4
         version: 4.5.4
       knex:
-        specifier: 2.5.1
-        version: 2.5.1(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
+        specifier: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
       ldapjs:
         specifier: 2.3.3
         version: 2.3.3
@@ -498,7 +498,7 @@ importers:
         version: 4.0.0
       knex-mock-client:
         specifier: 2.0.1
-        version: 2.0.1(knex@2.5.1)
+        version: 2.0.1(knex@3.1.0)
       supertest:
         specifier: 6.3.3
         version: 6.3.3
@@ -953,7 +953,7 @@ importers:
         version: 1.0.4(vitest@1.0.4)
       histoire:
         specifier: 0.17.6
-        version: 0.17.6(sass@1.69.5)(vite@5.0.10)
+        version: 0.17.6(vite@5.0.10)
       rollup-plugin-node-externals:
         specifier: 6.1.2
         version: 6.1.2(rollup@3.29.4)
@@ -962,13 +962,13 @@ importers:
         version: 5.3.3
       vite:
         specifier: 5.0.10
-        version: 5.0.10(sass@1.69.5)
+        version: 5.0.10(@types/node@18.19.3)
       vite-plugin-dts:
         specifier: 3.6.4
         version: 3.6.4(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/composables:
     dependencies:
@@ -1017,7 +1017,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/constants:
     devDependencies:
@@ -1215,7 +1215,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/extensions:
     dependencies:
@@ -1238,8 +1238,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       knex:
-        specifier: 2.5.1
-        version: 2.5.1(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
+        specifier: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -1382,7 +1382,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/memory:
     dependencies:
@@ -1447,7 +1447,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/random:
     devDependencies:
@@ -1510,8 +1510,8 @@ importers:
   packages/schema:
     dependencies:
       knex:
-        specifier: 2.5.1
-        version: 2.5.1(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
+        specifier: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -1589,7 +1589,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/storage-driver-cloudinary:
     dependencies:
@@ -1623,7 +1623,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/storage-driver-gcs:
     dependencies:
@@ -1654,7 +1654,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/storage-driver-local:
     dependencies:
@@ -1719,7 +1719,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/storage-driver-supabase:
     dependencies:
@@ -1753,7 +1753,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   packages/stores:
     dependencies:
@@ -1827,7 +1827,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: 5.0.10
-        version: 5.0.10(sass@1.69.5)
+        version: 5.0.10(@types/node@18.19.3)
       vite-plugin-dts:
         specifier: 3.6.4
         version: 3.6.4(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
@@ -1846,8 +1846,8 @@ importers:
         specifier: 7946.0.13
         version: 7946.0.13
       knex:
-        specifier: 2.5.1
-        version: 2.5.1(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
+        specifier: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
       vue:
         specifier: 3.3.11
         version: 3.3.11(typescript@5.3.3)
@@ -1995,7 +1995,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   sdk:
     devDependencies:
@@ -2013,7 +2013,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
 
   tests/blackbox:
     devDependencies:
@@ -2067,7 +2067,7 @@ importers:
         version: 2.2.5
       knex:
         specifier: 3.1.0
-        version: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
       listr2:
         specifier: 8.0.0
         version: 8.0.0
@@ -2091,7 +2091,7 @@ importers:
         version: 4.2.2(typescript@5.3.3)
       vitest:
         specifier: 1.0.4
-        version: 1.0.4(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.0.4
       ws:
         specifier: 8.15.1
         version: 8.15.1
@@ -11704,6 +11704,58 @@ packages:
       - utf-8-validate
     dev: true
 
+  /histoire@0.17.6(vite@5.0.10):
+    resolution: {integrity: sha512-L9xLR0BFk+KIcpfDOPw5i0o4eq1ANj+f0i3xWS6F5yToV0jSu9Dh8eaagSrR1QbUpLoc7Kjhjq408Ecoop3JcA==}
+    hasBin: true
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      '@akryum/tinypool': 0.3.1
+      '@histoire/app': 0.17.6(vite@5.0.10)
+      '@histoire/controls': 0.17.6(vite@5.0.10)
+      '@histoire/shared': 0.17.6(vite@5.0.10)
+      '@histoire/vendors': 0.17.6
+      '@types/flexsearch': 0.7.6
+      '@types/markdown-it': 12.2.3
+      birpc: 0.1.1
+      change-case: 4.1.2
+      chokidar: 3.5.3
+      connect: 3.7.0
+      defu: 6.1.3
+      diacritics: 1.3.0
+      flexsearch: 0.7.21
+      fs-extra: 10.1.0
+      globby: 13.2.2
+      gray-matter: 4.0.3
+      jiti: 1.21.0
+      jsdom: 20.0.3
+      markdown-it: 12.3.2
+      markdown-it-anchor: 8.6.7(@types/markdown-it@12.2.3)(markdown-it@12.3.2)
+      markdown-it-attrs: 4.1.6(markdown-it@12.3.2)
+      markdown-it-emoji: 2.0.2
+      micromatch: 4.0.5
+      mrmime: 1.0.1
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      sade: 1.8.1
+      shiki-es: 0.2.0
+      sirv: 2.0.3
+      vite: 5.0.10(@types/node@18.19.3)
+      vite-node: 0.34.7
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - canvas
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - utf-8-validate
+    dev: true
+
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -12757,66 +12809,17 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /knex-mock-client@2.0.1(knex@2.5.1):
+  /knex-mock-client@2.0.1(knex@3.1.0):
     resolution: {integrity: sha512-tSNaht+aquo6SgEhwPYidfYWVS2IUbF2ZNu4Ye0mScGTmyS+ZTJzpAkogpUIDwiZbkjIg/bvsopRDM/Lbdt+Mw==}
     engines: {node: '>=12'}
     peerDependencies:
       knex: '>=2.0.0'
     dependencies:
-      knex: 2.5.1(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
+      knex: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1)
       lodash.clonedeep: 4.5.0
     dev: true
 
-  /knex@2.5.1(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1):
-    resolution: {integrity: sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    peerDependencies:
-      better-sqlite3: '*'
-      mysql: '*'
-      mysql2: '*'
-      pg: '*'
-      pg-native: '*'
-      sqlite3: '*'
-      tedious: '*'
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      mysql:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      sqlite3:
-        optional: true
-      tedious:
-        optional: true
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.1.1
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      mysql: 2.18.1
-      pg: 8.11.3
-      pg-connection-string: 2.6.1
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      sqlite3: 5.1.6
-      tarn: 3.0.2
-      tedious: 16.6.1
-      tildify: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /knex@3.1.0:
+  /knex@3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.6)(tedious@16.6.1):
     resolution: {integrity: sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==}
     engines: {node: '>=16'}
     hasBin: true
@@ -12853,14 +12856,17 @@ packages:
       getopts: 2.3.0
       interpret: 2.2.0
       lodash: 4.17.21
+      mysql: 2.18.1
+      pg: 8.11.3
       pg-connection-string: 2.6.2
       rechoir: 0.8.0
       resolve-from: 5.0.0
+      sqlite3: 5.1.6
       tarn: 3.0.2
+      tedious: 16.6.1
       tildify: 2.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -14996,9 +15002,6 @@ packages:
     resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
     requiresBuild: true
     optional: true
-
-  /pg-connection-string@2.6.1:
-    resolution: {integrity: sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg==}
 
   /pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
@@ -18797,6 +18800,28 @@ packages:
       - terser
     dev: true
 
+  /vite-node@0.34.7:
+    resolution: {integrity: sha512-0Yzb96QzHmqIKIs/x2q/sqG750V/EF6yDkS2p1WjJc1W2bgRSuQjf5vB9HY8h2nVb5j4pO5paS5Npcv3s69YUg==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.10(@types/node@18.19.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@0.34.7(sass@1.69.5):
     resolution: {integrity: sha512-0Yzb96QzHmqIKIs/x2q/sqG750V/EF6yDkS2p1WjJc1W2bgRSuQjf5vB9HY8h2nVb5j4pO5paS5Npcv3s69YUg==}
     engines: {node: '>=v14.18.0'}
@@ -18808,6 +18833,27 @@ packages:
       pathe: 1.1.1
       picocolors: 1.0.0
       vite: 5.0.10(sass@1.69.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-node@1.0.4:
+    resolution: {integrity: sha512-9xQQtHdsz5Qn8hqbV7UKqkm8YkJhzT/zr41Dmt5N7AlD8hJXw/Z7y0QiD5I8lnTthV9Rvcvi0QW7PI0Fq83ZPg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.10(@types/node@18.19.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18877,7 +18923,7 @@ packages:
       debug: 4.3.4
       kolorist: 1.8.0
       typescript: 5.3.3
-      vite: 5.0.10(sass@1.69.5)
+      vite: 5.0.10(@types/node@18.19.3)
       vue-tsc: 1.8.25(typescript@5.3.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -19116,6 +19162,62 @@ packages:
       tinypool: 0.7.0
       vite: 5.0.10(@types/node@18.19.3)
       vite-node: 0.34.6(@types/node@18.19.3)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.0.4:
+    resolution: {integrity: sha512-s1GQHp/UOeWEo4+aXDOeFBJwFzL6mjycbQwwKWX2QcYfh/7tIerS59hWQ20mxzupTJluA2SdwiBuWwQHH67ckg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 1.0.4
+      '@vitest/runner': 1.0.4
+      '@vitest/snapshot': 1.0.4
+      '@vitest/spy': 1.0.4
+      '@vitest/utils': 1.0.4
+      acorn-walk: 8.3.1
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.6.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.1
+      vite: 5.0.10(@types/node@18.19.3)
+      vite-node: 1.0.4
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## Scope

What's changed:

Update Knex to [v3.1.0](https://github.com/knex/knex/releases/tag/3.1.0).

## Potential Risks / Drawbacks

- No breaking changes besides dropping Node.js < 16
- Tested locally with Blackbox Tests

## Review Notes / Questions

N/A
