### PR TITLE
Fix one-to-many table design

### DIFF
--- a/.changeset/forty-impalas-poke.md
+++ b/.changeset/forty-impalas-poke.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed action column background and search input height for table mode of one-to-many interface

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -588,6 +588,7 @@ function getLinkForItem(item: DisplayItem) {
 			.append {
 				position: sticky;
 				right: 0;
+				background: var(--theme--background);
 				border-left: var(--theme--border-width) solid var(--theme--border-color-subdued);
 			}
 		}
@@ -616,6 +617,11 @@ function getLinkForItem(item: DisplayItem) {
 			color: var(--danger-75);
 		}
 	}
+}
+
+
+.one-to-many .bordered tr.table-row .append {
+    background: var(--theme--background);
 }
 
 .v-skeleton-loader,

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -619,11 +619,6 @@ function getLinkForItem(item: DisplayItem) {
 	}
 }
 
-
-.one-to-many .bordered tr.table-row .append {
-    background: var(--theme--background);
-}
-
 .v-skeleton-loader,
 .v-notice {
 	margin-top: 8px;
@@ -651,6 +646,16 @@ function getLinkForItem(item: DisplayItem) {
 	.search {
 		position: relative;
 		z-index: 1;
+		align-self: stretch;
+
+		:deep(.search-input) {
+			height: 100%;
+			box-sizing: border-box;
+		}
+
+		:deep(.search-badge) {
+			height: 100%;
+		}
 	}
 
 	.item-count {


### PR DESCRIPTION
This small PR just fixes two design issues after the latest design updates.

1. is the the actions column not having a solid background color, thus showing stuff underneath if the table is scrollable.
2. is the search input which doesn't have a fixed height, and therefore is of horizontal center and very squished.

Before:
![Screenshot 2023-12-17 at 15 29 29](https://github.com/directus/directus/assets/6641242/dbf6a92a-e1c8-46d0-8a36-d2d2d21611b6)

After:
![Screenshot 2023-12-17 at 15 30 25](https://github.com/directus/directus/assets/6641242/29e75e69-df3f-49ef-ba1a-f26f745aaf02)
