### PR TITLE
fix(sdk): changed keys to keysOrQuery to accept both keys and query in updateItems

### DIFF
--- a/.changeset/heavy-meals-poke.md
+++ b/.changeset/heavy-meals-poke.md
@@ -2,4 +2,4 @@
 '@directus/sdk': patch
 ---
 
-changed keys to keysOrQuery to accept both keys and query in updateItems
+Changed `keys` argument in `updateItems` method to `keysOrQuery` to accept both formats

--- a/.changeset/heavy-meals-poke.md
+++ b/.changeset/heavy-meals-poke.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+changed keys to keysOrQuery to accept both keys and query in updateItems

--- a/contributors.yml
+++ b/contributors.yml
@@ -98,3 +98,4 @@
 - wasimTQ
 - omahs
 - codeit-ninja
+- mahendraHegde

--- a/sdk/src/rest/commands/update/items.ts
+++ b/sdk/src/rest/commands/update/items.ts
@@ -12,7 +12,7 @@ export type UpdateItemOutput<
  * Update multiple items at the same time.
  *
  * @param collection The collection of the items
- * @param keysOrQuery The primary key of the items
+ * @param keysOrQuery The primary keys or a query
  * @param item The item data to update
  * @param query Optional return data query
  *

--- a/sdk/src/rest/commands/update/items.ts
+++ b/sdk/src/rest/commands/update/items.ts
@@ -17,7 +17,7 @@ export type UpdateItemOutput<
  * @param query Optional return data query
  *
  * @returns Returns the item objects for the updated items.
- * @throws Will throw if keysorQuery is empty
+ * @throws Will throw if keysOrQuery is empty
  * @throws Will throw if collection is empty
  * @throws Will throw if collection is a core collection
  */


### PR DESCRIPTION
## Scope

What's changed:

- SDK
    - added a `throwIfAllEmpty` utils method, which throws error if all given inputs are empty/undefined.
    - modified `updateItems` rest command to throw error if both `keys` and `query` are missing, buy utilising `throwIfAllEmpty` method

## Potential Risks / Drawbacks

- None, change is backward compatible

Fixes  #20749
