### PR TITLE
Publicly load custom translations

### DIFF
--- a/.changeset/happy-timers-think.md
+++ b/.changeset/happy-timers-think.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Adds possibility to load custom translations on the login page

--- a/app/src/lang/set-language.ts
+++ b/app/src/lang/set-language.ts
@@ -1,7 +1,6 @@
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useTranslationsStore } from '@/stores/translations';
-import { useUserStore } from '@/stores/user';
 import { loadDateFNSLocale } from '@/utils/get-date-fns-locale';
 import availableLanguages from './available-languages.yaml';
 import { i18n, Language, loadedLanguages } from './index';
@@ -9,7 +8,6 @@ import { i18n, Language, loadedLanguages } from './index';
 export async function setLanguage(lang: Language): Promise<boolean> {
 	const collectionsStore = useCollectionsStore();
 	const fieldsStore = useFieldsStore();
-	const { currentUser } = useUserStore();
 	const translationsStore = useTranslationsStore();
 
 	if (Object.keys(availableLanguages).includes(lang) === false) {
@@ -33,9 +31,7 @@ export async function setLanguage(lang: Language): Promise<boolean> {
 	}
 
 	try {
-		if (currentUser) {
-			await translationsStore.loadTranslations(lang);
-		}
+		await translationsStore.loadTranslations(lang);
 
 		collectionsStore.translateCollections();
 		fieldsStore.translateFields();

--- a/app/src/stores/translations.ts
+++ b/app/src/stores/translations.ts
@@ -32,7 +32,7 @@ export const useTranslationsStore = defineStore('translations', () => {
 
 			lang.value = newLang;
 		} catch (error) {
-			unexpectedError(error);
+			// No public permissions for translations
 		} finally {
 			loading.value = false;
 		}


### PR DESCRIPTION
Fixes #20758 

## Scope

What's changed:

Translations are attempted to be loaded without user authentication. This will only work if translations are readable with public permissions.

## Potential Risks / Drawbacks

- A risk of unexpected translation errors being hidden

## Review Notes / Questions

- I would like to lorem ipsum

