### PR TITLE
Fix unique name check for extension locations and extensions within bundles

### DIFF
--- a/.changeset/red-ravens-breathe.md
+++ b/.changeset/red-ravens-breathe.md
@@ -1,0 +1,7 @@
+---
+'@directus/extensions-sdk': patch
+'@directus/extensions': patch
+'@directus/api': patch
+---
+
+Fixed unique name check for extension locations, bundle extensions, and adding an extension to a bundle via the cli

--- a/.changeset/red-ravens-breathe.md
+++ b/.changeset/red-ravens-breathe.md
@@ -4,4 +4,4 @@
 '@directus/api': patch
 ---
 
-Fixed unique name check for extension locations, bundle extensions, and adding an extension to a bundle via the cli
+Fixed the unique name check for extension locations and extensions within bundles

--- a/api/src/extensions/lib/get-extensions.ts
+++ b/api/src/extensions/lib/get-extensions.ts
@@ -40,7 +40,11 @@ export const getExtensions = async () => {
 	(await getPackageExtensions(env['PACKAGE_FILE_LOCATION'])).forEach(filterDuplicates);
 
 	if (duplicateExtensions.length > 0) {
-		logger.info(`Skipped loading duplicates of extensions: ${duplicateExtensions.join(', ')}`);
+		logger.warn(
+			`Failed to load the following extensions because they have/contain duplicate names: ${duplicateExtensions.join(
+				', ',
+			)}`,
+		);
 	}
 
 	return Array.from(loadedExtensions.values());

--- a/api/src/extensions/lib/get-extensions.ts
+++ b/api/src/extensions/lib/get-extensions.ts
@@ -8,7 +8,15 @@ export const getExtensions = async () => {
 
 	const loadedNames = localExtensions.map(({ name }) => name);
 
-	const filterDuplicates = ({ name }: Extension) => loadedNames.includes(name) === false;
+	const filterDuplicates = ({ name }: Extension) => {
+		const isUnique = loadedNames.includes(name) === false;
+
+		if (isUnique) {
+			loadedNames.push(name);
+		}
+
+		return isUnique;
+	};
 
 	const localPackageExtensions = (await resolvePackageExtensions(getExtensionsPath())).filter((extension) =>
 		filterDuplicates(extension),

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -101,7 +101,9 @@ export default async function add(options: AddOptions): Promise<void> {
 			},
 		]);
 
-		if (extensionOptions.entries.map((entry) => entry.name).includes(name)) {
+		const bundleEntryNames = new Set(extensionOptions.entries.map((entry) => entry.name));
+
+		if (bundleEntryNames.has(name)) {
 			log(`Extension ${chalk.bold(name)} already exists for this bundle.`, 'error');
 			process.exit(1);
 		}

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -101,6 +101,11 @@ export default async function add(options: AddOptions): Promise<void> {
 			},
 		]);
 
+		if (extensionOptions.entries.map((entry) => entry.name).includes(name)) {
+			log(`Extension ${chalk.bold(name)} already exists for this bundle.`, 'error');
+			process.exit(1);
+		}
+
 		const spinner = ora(chalk.bold('Modifying Directus extension...')).start();
 
 		const source = alternativeSource ?? 'src';

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -389,6 +389,17 @@ async function buildBundleExtension({
 		process.exit(1);
 	}
 
+	const bundleEntryNames = new Set();
+
+	for (const { name } of entries) {
+		if (bundleEntryNames.has(name)) {
+			log(`Duplicate extension found in bundle for ${chalk.bold(name)}.`, 'error');
+			process.exit(1);
+		}
+
+		bundleEntryNames.add(name);
+	}
+
 	const config = await loadConfig();
 	const plugins = config.plugins ?? [];
 

--- a/packages/extensions/src/node/utils/get-extensions.ts
+++ b/packages/extensions/src/node/utils/get-extensions.ts
@@ -42,6 +42,8 @@ export async function resolvePackageExtensions(root: string, extensionNames?: st
 		const extensionOptions = parsedManifest[EXTENSION_PKG_KEY];
 
 		if (extensionOptions.type === 'bundle') {
+			const loadedEntryNames: string[] = [];
+
 			extensions.push({
 				path: extensionPath,
 				name: parsedManifest.name,
@@ -51,7 +53,17 @@ export async function resolvePackageExtensions(root: string, extensionNames?: st
 					app: extensionOptions.path.app,
 					api: extensionOptions.path.api,
 				},
-				entries: extensionOptions.entries.map((entry) => pick(entry, 'name', 'type')),
+				entries: extensionOptions.entries
+					.filter((entry) => {
+						const isUnique = loadedEntryNames.includes(entry.name) === false;
+
+						if (isUnique) {
+							loadedEntryNames.push(entry.name);
+						}
+
+						return isUnique;
+					})
+					.map((entry) => pick(entry, 'name', 'type')),
 				host: extensionOptions.host,
 				local,
 			});

--- a/packages/extensions/src/node/utils/get-extensions.ts
+++ b/packages/extensions/src/node/utils/get-extensions.ts
@@ -42,8 +42,6 @@ export async function resolvePackageExtensions(root: string, extensionNames?: st
 		const extensionOptions = parsedManifest[EXTENSION_PKG_KEY];
 
 		if (extensionOptions.type === 'bundle') {
-			const loadedEntryNames: string[] = [];
-
 			extensions.push({
 				path: extensionPath,
 				name: parsedManifest.name,
@@ -53,17 +51,7 @@ export async function resolvePackageExtensions(root: string, extensionNames?: st
 					app: extensionOptions.path.app,
 					api: extensionOptions.path.api,
 				},
-				entries: extensionOptions.entries
-					.filter((entry) => {
-						const isUnique = loadedEntryNames.includes(entry.name) === false;
-
-						if (isUnique) {
-							loadedEntryNames.push(entry.name);
-						}
-
-						return isUnique;
-					})
-					.map((entry) => pick(entry, 'name', 'type')),
+				entries: extensionOptions.entries.map((entry) => pick(entry, 'name', 'type')),
 				host: extensionOptions.host,
 				local,
 			});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Duplicate extension names within a bundle are now properly filtered out.
   -  `./extensions/directus-extension-my-bundle`
       - `my-interface`
       - `my-display`
       - `my-interface`
- Attempting to add an extension with a duplicate name to a bundle via the cli will now error.
- Duplicate extension names within an extension location (local, npm etc) will now properly filter out.
  - `./extensions/directus-extension-my-bundle`
     - `name: "my-bundle"`
  - `./extensions/directus-extension-my-bundle1`
     - `name: "my-bundle"`

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Added a log message for when an extension (whether in a bundle or not) is filtered out.
- The entire bundle is disabled if there are duplicate entries. Reasoning here is usually bundle entries are dependant upon one another.
- Should we start using the folder names as the extension names? These are guaranteed to be unique.

---

Fixes #20412
