### PR TITLE
[quick fix] Broken import fixed for docs BlogHeader

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -5,7 +5,7 @@ description: Project tutorials, tips & tricks, and best practices from the Direc
 ---
 
 <script setup>
-import BlogHero from '.@/components/blog/BlogHero.vue';
+import BlogHero from '@/components/blog/BlogHero.vue';
 import BlogIndex from '@/components/blog/BlogIndex.vue';
 </script>
 


### PR DESCRIPTION
What it says on the tin. We broke this accidentally in a previous merged PR leading to broken builds