### PR TITLE
fix(#19386): fix cli schema apply display colors

### DIFF
--- a/.changeset/modern-llamas-act.md
+++ b/.changeset/modern-llamas-act.md
@@ -2,5 +2,4 @@
 '@directus/api': patch
 ---
 
-fixed issue #19386 by making the cli's 
-`schema apply command output more visible
+Ensured the CLI's `schema apply` command output is better visible across different terminals / color schemes

--- a/.changeset/modern-llamas-act.md
+++ b/.changeset/modern-llamas-act.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+fixed issue #19386 by making the cli's 
+`schema apply command output more visible

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -61,7 +61,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 
 				for (const { collection, diff } of snapshotDiff.collections) {
 					if (diff[0]?.kind === DiffKind.EDIT) {
-						message += `\n  - ${chalk.blue('Update')} ${collection}`;
+						message += `\n  - ${chalk.magenta('Update')} ${collection}`;
 
 						for (const change of diff) {
 							if (change.kind === DiffKind.EDIT) {
@@ -74,7 +74,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 					} else if (diff[0]?.kind === DiffKind.NEW) {
 						message += `\n  - ${chalk.green('Create')} ${collection}`;
 					} else if (diff[0]?.kind === DiffKind.ARRAY) {
-						message += `\n  - ${chalk.blue('Update')} ${collection}`;
+						message += `\n  - ${chalk.magenta('Update')} ${collection}`;
 					}
 				}
 			}
@@ -84,7 +84,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 
 				for (const { collection, field, diff } of snapshotDiff.fields) {
 					if (diff[0]?.kind === DiffKind.EDIT || isNestedMetaUpdate(diff[0]!)) {
-						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
+						message += `\n  - ${chalk.magenta('Update')} ${collection}.${field}`;
 
 						for (const change of diff) {
 							const path = change.path!.slice(1).join('.');
@@ -102,7 +102,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 					} else if (diff[0]?.kind === DiffKind.NEW) {
 						message += `\n  - ${chalk.green('Create')} ${collection}.${field}`;
 					} else if (diff[0]?.kind === DiffKind.ARRAY) {
-						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
+						message += `\n  - ${chalk.magenta('Update')} ${collection}.${field}`;
 					}
 				}
 			}
@@ -112,7 +112,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 
 				for (const { collection, field, related_collection, diff } of snapshotDiff.relations) {
 					if (diff[0]?.kind === DiffKind.EDIT) {
-						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
+						message += `\n  - ${chalk.magenta('Update')} ${collection}.${field}`;
 
 						for (const change of diff) {
 							if (change.kind === DiffKind.EDIT) {
@@ -125,7 +125,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 					} else if (diff[0]?.kind === DiffKind.NEW) {
 						message += `\n  - ${chalk.green('Create')} ${collection}.${field}`;
 					} else if (diff[0]?.kind === DiffKind.ARRAY) {
-						message += `\n  - ${chalk.blue('Update')} ${collection}.${field}`;
+						message += `\n  - ${chalk.magenta('Update')} ${collection}.${field}`;
 					} else {
 						continue;
 					}
@@ -137,7 +137,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 				}
 			}
 
-			message = 'The following changes will be applied:\n\n' + chalk.gray(message);
+			message = 'The following changes will be applied:\n\n' + message;
 
 			if (dryRun) {
 				logger.info(message);

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -57,7 +57,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 			let message = '';
 
 			if (snapshotDiff.collections.length > 0) {
-				message += chalk.black.underline.bold('Collections:');
+				message += chalk.underline.bold('Collections:');
 
 				for (const { collection, diff } of snapshotDiff.collections) {
 					if (diff[0]?.kind === DiffKind.EDIT) {
@@ -80,7 +80,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 			}
 
 			if (snapshotDiff.fields.length > 0) {
-				message += '\n\n' + chalk.black.underline.bold('Fields:');
+				message += '\n\n' + chalk.underline.bold('Fields:');
 
 				for (const { collection, field, diff } of snapshotDiff.fields) {
 					if (diff[0]?.kind === DiffKind.EDIT || isNestedMetaUpdate(diff[0]!)) {
@@ -108,7 +108,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 			}
 
 			if (snapshotDiff.relations.length > 0) {
-				message += '\n\n' + chalk.black.underline.bold('Relations:');
+				message += '\n\n' + chalk.underline.bold('Relations:');
 
 				for (const { collection, field, related_collection, diff } of snapshotDiff.relations) {
 					if (diff[0]?.kind === DiffKind.EDIT) {
@@ -137,7 +137,7 @@ export async function apply(snapshotPath: string, options?: { yes: boolean; dryR
 				}
 			}
 
-			message = 'The following changes will be applied:\n\n' + chalk.black(message);
+			message = 'The following changes will be applied:\n\n' + chalk.gray(message);
 
 			if (dryRun) {
 				logger.info(message);

--- a/contributors.yml
+++ b/contributors.yml
@@ -100,3 +100,4 @@
 - omahs
 - codeit-ninja
 - mahendraHegde
+- nassan


### PR DESCRIPTION
## Scope

What's changed:

black terminal output color in cli `schema apply` command was removed.

## Potential Risks / Drawbacks

Visibility could be worse in some edge-case colors of terminal backgrounds. (gray)

## Review Notes / Questions

Colors are a judgement call, could be reviewers will have different opinion of a nicer looking output

---

Fixes #19386 
