### PR TITLE
Fix dead links in documentation

### DIFF
--- a/.changeset/fresh-rocks-breathe.md
+++ b/.changeset/fresh-rocks-breathe.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Replaced dead links

--- a/docs/app/data-model/collections.md
+++ b/docs/app/data-model/collections.md
@@ -60,7 +60,7 @@ each system collection is responsible for, as well as where to find relevant App
 | Revisions         | Revisions are changes/edits made to Items. Directus keeps track of edits made, so you're able to revert to a previous state at will. | [Revert an Item](/user-guide/content-module/content/items#revert-an-item)                                                       | [Revisions](/reference/system/revisions)         |
 | Roles             | Stores information about each role created.                                                                                          | [Users, Roles, and Permissions](/user-guide/user-management/users-roles-permissions)                                            | [Roles](/reference/system/roles)                 |
 | Sessions          | Stores information about each user session, for system purposes.                                                                     | **N/A**                                                                                                                         | **N/A**                                          |
-| Settings          | Stores all configurations made within **Settings > Project Settings**.                                                               | [Project Settings](/user-guide/cloud/project-settings)                                                                          | [settings](/reference/system/settings)           |
+| Settings          | Stores all configurations made within **Settings > Project Settings**.                                                               | [Project Settings](/user-guide/settings/project-settings)                                                                       | [settings](/reference/system/settings)           |
 | Shares            | Stores all information regarding data shares.                                                                                        | [Data Sharing](/user-guide/content-module/content/shares)                                                                       |                                                  |
 | Users             | Stores information about each user within the platform.                                                                              | [User Directory](/user-guide/user-management/user-directory)                                                                    | [Users](/reference/system/relations)             |
 | Webhooks          | Stores all information about configured webhooks.                                                                                    | [Webhooks](/app/webhooks)                                                                                                       | [Webhooks](/reference/system/relations)          |
@@ -231,7 +231,7 @@ These controls allow you to modify how the collection is displayed within the Co
 - **Singleton** — Toggle to bypass the [Collection Page](/user-guide/content-module/content/collections) and take users
   to the [Item Details Page](/user-guide/content-module/content/items).
 - **Collection Naming Translations** — Translate the collection name across multiple languages. When the default
-  language is changed in [Project Settings](/user-guide/cloud/project-settings#general) or
+  language is changed in [Project Settings](/user-guide/settings/project-settings#general) or
   [User Details Page](/user-guide/user-management/user-directory#user-details-page), the relevant translation, if any
   exists, will be used throughout the app.
 

--- a/docs/extensions/services/working-with-users.md
+++ b/docs/extensions/services/working-with-users.md
@@ -11,8 +11,8 @@ There are various services related to users:
 - `RolesServices`: Used to assign roles to users.
 - `PermissionsServices`: Used to manage the permissions associated with each role.
 
-All three of these services extend the [ItemsService](/docs/extensions/services/accessing-items.md) and are used in a
-very similar way.
+All three of these services extend the [ItemsService](/extensions/services/accessing-items) and are used in a very
+similar way.
 
 ```js
 export default defineEndpoint((router, context) => {

--- a/docs/guides/extensions/modules-native-layout-features.md
+++ b/docs/guides/extensions/modules-native-layout-features.md
@@ -5,7 +5,7 @@ contributors: Tim Butterfield
 
 # Use Native Layout Features In Your Modules
 
-This guide follows on [Create a Custom Portal Module](/guides/extensions/modules-build-portal), where you created a
+This guide follows on [Create a Custom Portal Module](/guides/extensions/modules-build-landing-page), where you created a
 landing page module. You will learn how to add native sidebar dropdown element, action buttons and search, a split view
 window, and layout options using the built-in functions of Directus. These help provide a more coherent experience from
 other Directus modules and collections.

--- a/docs/guides/extensions/modules-native-layout-features.md
+++ b/docs/guides/extensions/modules-native-layout-features.md
@@ -5,10 +5,10 @@ contributors: Tim Butterfield
 
 # Use Native Layout Features In Your Modules
 
-This guide follows on [Create a Custom Portal Module](/guides/extensions/modules-build-landing-page), where you created a
-landing page module. You will learn how to add native sidebar dropdown element, action buttons and search, a split view
-window, and layout options using the built-in functions of Directus. These help provide a more coherent experience from
-other Directus modules and collections.
+This guide follows on [Create a Custom Portal Module](/guides/extensions/modules-build-landing-page), where you created
+a landing page module. You will learn how to add native sidebar dropdown element, action buttons and search, a split
+view window, and layout options using the built-in functions of Directus. These help provide a more coherent experience
+from other Directus modules and collections.
 
 ![A module showing title icon and append, action prepend, search box, and several UI buttons in the header](https://marketing.directus.app/assets/7ef23d67-366a-42a6-9fb4-15740e31458a.png)
 

--- a/docs/guides/headless-cms/build-static-website/next-13.md
+++ b/docs/guides/headless-cms/build-static-website/next-13.md
@@ -103,9 +103,9 @@ export default async function HomePage() {
 }
 ```
 
-Type `npm run dev` in your terminal to start the Next development server and open `http://localhost:3000` in your
-browser. You should see data from your Directus Global collection in your page. Some additional files will be created by
-Next that it expects, but do not yet exist - these can be safely ignored for now.
+Type `npm run dev` in your terminal to start the Next development server and open http://localhost:3000 in your browser.
+You should see data from your Directus Global collection in your page. Some additional files will be created by Next
+that it expects, but do not yet exist - these can be safely ignored for now.
 
 ## Creating Pages With Directus
 
@@ -144,8 +144,8 @@ export default async function DynamicPage({ params }) {
 }
 ```
 
-Go to `http://localhost:3000/about`, replacing `about` with any of your item slugs. Using the Directus JavaScript SDK,
-the single item with that slug is retrieved, and the page should show your data. `readItem()` allows you to specify the
+Go to http://localhost:3000/about, replacing `about` with any of your item slugs. Using the Directus JavaScript SDK, the
+single item with that slug is retrieved, and the page should show your data. `readItem()` allows you to specify the
 Primary ID Field.
 
 _Note that we check if a returned value exists, and return a 404 if not. Please also note that
@@ -225,7 +225,7 @@ Update the returned HTML:
 </div>;
 ```
 
-Visit `http://localhost:3000` and you should now see a blog post listing, with latest items first.
+Visit http://localhost:3000 and you should now see a blog post listing, with latest items first.
 
 ![A page with a title of "Blog". On it is a list of three items - each with a title, author, and date. The title is a link.](https://cdn.directus.io/docs/v9/headless-cms/how-to-packet-20220222A/next-blog-listing.webp)
 

--- a/docs/guides/headless-cms/build-static-website/nuxt-3.md
+++ b/docs/guides/headless-cms/build-static-website/nuxt-3.md
@@ -32,7 +32,7 @@ npm install @directus/sdk
 ```
 
 Open `my-website` in your code editor and type `npm run dev` in your terminal to start the Nuxt development server and
-open `http://localhost:3000` in your browser.
+open http://localhost:3000 in your browser.
 
 ## Create a Plugin for the SDK
 
@@ -138,12 +138,12 @@ if (!page.value) throw createError({
 </script>
 ```
 
-Go to `http://localhost:3000/about`, replacing `about` with any of your item slugs. Using the Directus JavaScript SDK,
-the single item with that slug is retrieved, and the page should show your data. `readOne()` only checks against your
-`slug` Primary ID Field.
+Go to http://localhost:3000/about, replacing `about` with any of your item slugs. Using the Directus JavaScript SDK, the
+single item with that slug is retrieved, and the page should show your data. `readOne()` only checks against your `slug`
+Primary ID Field.
 
 _Note that we check if a returned value exists, and return a 404 if not. Please also note that
-[`v-html` should only be used for trusted content.](https://vuejs.org/api/built-in-directives.html#v-html)_
+[`v-html` should only be used for trusted content](https://vuejs.org/api/built-in-directives.html#v-html)._
 
 ## Creating Blog Posts With Directus
 
@@ -209,7 +209,7 @@ Update the `<template>` section:
 </template>
 ```
 
-Visit `http://localhost:3000` and you should now see a blog post listing, with latest items first.
+Visit http://localhost:3000 and you should now see a blog post listing, with latest items first.
 
 ![A page with a title of "Blog". On it is a list of three items - each with a title, author, and date. The title is a link.](https://cdn.directus.io/docs/v9/headless-cms/how-to-packet-20220222A/nuxt-blog-listing.webp)
 

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -98,5 +98,4 @@ docker compose up
 
 :::
 
-Directus should now be available at <a href="http://localhost:8055" target="_blank">http://localhost:8055</a> or
-<a href="http://127.0.0.1:8055" target="_blank">http://127.0.0.1:8055</a>
+Directus should now be available at http://localhost:8055 or http://127.0.0.1:8055.

--- a/docs/use-cases/headless-cms/security.md
+++ b/docs/use-cases/headless-cms/security.md
@@ -114,7 +114,7 @@ But when it’s time to go to production and add all your different users, we re
    ![A sample user's detail page is shown. The Two-Factor Authentication form field is highlighted. ](https://cdn.directus.io/docs/v9/headless-cms/security-20230322/2fa-user.webp)
 
 2. **Enable the Strong option for Auth Password Policy under
-   [Project Settings > Security](/user-guide/cloud/project-settings#security).**
+   [Project Settings > Security](/user-guide/settings/project-settings#security).**
 
    ![The Project Settings page is shown. The Security section is highlighted. Within the Security, section there are two fields shown: Auth Password Policy and Auth Login Attempts.](https://cdn.directus.io/docs/v9/headless-cms/security-20230322/security-project-settings.webp)
 

--- a/docs/user-guide/content-module/translation-strings.md
+++ b/docs/user-guide/content-module/translation-strings.md
@@ -51,7 +51,7 @@ have the option assign a Translation String. To assign a Translation String, fol
 
 Your Translation String is set! Now the language-appropriate text will be shown based on the current language of the
 app. There are two ways to change the app language. First, administrators can set the Project's
-[default language](/user-guide/cloud/project-settings#general). Second, Users can choose their own personal
+[default language](/user-guide/settings/project-settings#general). Second, Users can choose their own personal
 [language preference](/user-guide/user-management/user-directory#user-preferences). Also note that if a language is
 chosen for which there is no Translation String, the translation key _(from step three)_ will be displayed instead.
 

--- a/docs/user-guide/overview/data-studio-app.md
+++ b/docs/user-guide/overview/data-studio-app.md
@@ -23,8 +23,8 @@ The leftmost section of the App is the module bar, which includes the:
   If configured, clicking this component will navigate to the Project URL. During platform activity, an indeterminate
   progress indicator will also be shown here.
 - **Module Navigation** — Allows navigating between the different modules your user has access to. Customizing the
-  Module Navigation is done within the [Project Settings](/user-guide/settings/settings), but the default module list
-  includes:
+  Module Navigation is done within the [Project Settings > Modules](/user-guide/settings/project-settings#modules), but
+  the default module list includes:
   - [Content](/user-guide/content-module/content/collections) — The primary way to view and interact with database
     content
   - [User Directory](/user-guide/user-management/user-directory) — A dedicated section for the platform's system Users
@@ -32,7 +32,8 @@ The leftmost section of the App is the module bar, which includes the:
   - [Insights](/user-guide/insights/dashboards) — Access to infinitely customizable data dashboards
   - [App Guide](/user-guide/overview/data-studio-app) — A tailored, in-app portal for the platform's concepts, guides,
     and reference
-  - [Settings](/user-guide/settings/settings) — An admin-only section for configuring the project and system settings
+  - [Settings](/user-guide/settings/project-settings) — An admin-only section for configuring the project and system
+    settings
 - **Notifications** - Opens a drawer of notifications, such as from
   [mentions](/user-guide/content-module/content/items#mentions).
 - **Current User Menu** — This component displays the authenticated user's name and avatar.
@@ -43,7 +44,7 @@ The leftmost section of the App is the module bar, which includes the:
 The navigation bar is based on the current module, and includes:
 
 - **Project Name** — Shows an icon and tooltip indicating the API's connection strength, and the name of your current
-  project, which can be configured under [Project Settings](/user-guide/settings/settings).
+  project, which can be configured under [Project Settings > General](/user-guide/settings/project-settings#general).
 - **Navigation** — This is a dynamic navigation based on your current module. Some modules also support
   [Bookmark Presets](/user-guide/overview/glossary#presets), which are a customizable links to specific data-sets.
 

--- a/docs/user-guide/overview/glossary.md
+++ b/docs/user-guide/overview/glossary.md
@@ -294,7 +294,7 @@ file, asset storage, and any custom extensions. Projects are the highest level o
 
 - [Creating a Project](/self-hosted/quickstart)
 - [Configuring a Project](/self-hosted/config-options)
-- [Adjusting Project Settings](/user-guide/cloud/project-settings)
+- [Adjusting Project Settings](/user-guide/settings/project-settings)
 - [Upgrading a Project](/self-hosted/upgrades-migrations)
 - [Backing-up a Project](/self-hosted/upgrades-migrations#backing-up-a-project)
 - [Migrating a Project](/self-hosted/upgrades-migrations#migrating-a-project)


### PR DESCRIPTION
## Scope

What's changed:

- Fixed dead links in documentation
- Convert localhost references in guides to actual links

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Thanks @Vincent-HD for noticing, https://github.com/directus/directus/pull/20630#issuecomment-1863053140!