### PR TITLE
Update date-fns to 3.0.1

### DIFF
--- a/.changeset/mighty-files-run.md
+++ b/.changeset/mighty-files-run.md
@@ -1,0 +1,7 @@
+---
+"@directus/app": patch
+"@directus/api": patch
+"@directus/utils": patch
+---
+
+Updated date-fns to 3.0.1

--- a/api/package.json
+++ b/api/package.json
@@ -101,7 +101,7 @@
 		"cookie-parser": "1.4.6",
 		"cors": "2.8.5",
 		"cron-parser": "4.9.0",
-		"date-fns": "2.30.0",
+		"date-fns": "3.0.1",
 		"deep-diff": "1.0.2",
 		"destroy": "1.2.0",
 		"dotenv": "16.3.1",

--- a/app/package.json
+++ b/app/package.json
@@ -102,7 +102,7 @@
 		"codemirror": "5.65.16",
 		"color": "4.2.3",
 		"cropperjs": "1.6.1",
-		"date-fns": "2.30.0",
+		"date-fns": "3.0.1",
 		"diacritics": "1.3.0",
 		"diff": "5.1.0",
 		"dompurify": "3.0.6",

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -30,7 +30,7 @@ const { displayValue, isValidValue } = useDisplayValue();
 function useDisplayValue() {
 	const displayValue = ref<string | null>(null);
 
-	const isValidValue = computed(() => isValid(parseValue(props.value!)));
+	const isValidValue = computed(() => (props.value ? isValid(parseValue(props.value)) : false));
 
 	watch(() => props.value, setDisplayValue, { immediate: true });
 

--- a/app/src/utils/get-date-fns-locale.ts
+++ b/app/src/utils/get-date-fns-locale.ts
@@ -1,5 +1,5 @@
 import { i18n } from '@/lang';
-import { Locale } from 'date-fns';
+import type { Locale } from 'date-fns';
 
 const locales: { lang: string; locale: Locale }[] = [];
 
@@ -30,165 +30,165 @@ export async function loadDateFNSLocale(lang: string) {
 export function importDateLocale(locale: string): Promise<any> {
 	switch (locale) {
 		case 'af':
-			return import('date-fns/locale/af/index.js');
+			return import('date-fns/locale/af');
 		case 'ar-DZ':
-			return import('date-fns/locale/ar-DZ/index.js');
+			return import('date-fns/locale/ar-DZ');
 		case 'ar-MA':
-			return import('date-fns/locale/ar-MA/index.js');
+			return import('date-fns/locale/ar-MA');
 		case 'ar-SA':
-			return import('date-fns/locale/ar-SA/index.js');
+			return import('date-fns/locale/ar-SA');
 		case 'az':
-			return import('date-fns/locale/az/index.js');
+			return import('date-fns/locale/az');
 		case 'be':
-			return import('date-fns/locale/be/index.js');
+			return import('date-fns/locale/be');
 		case 'bg':
-			return import('date-fns/locale/bg/index.js');
+			return import('date-fns/locale/bg');
 		case 'bn':
-			return import('date-fns/locale/bn/index.js');
+			return import('date-fns/locale/bn');
 		case 'ca':
-			return import('date-fns/locale/ca/index.js');
+			return import('date-fns/locale/ca');
 		case 'cs':
-			return import('date-fns/locale/cs/index.js');
+			return import('date-fns/locale/cs');
 		case 'cy':
-			return import('date-fns/locale/cy/index.js');
+			return import('date-fns/locale/cy');
 		case 'da':
-			return import('date-fns/locale/da/index.js');
+			return import('date-fns/locale/da');
 		case 'de':
-			return import('date-fns/locale/de/index.js');
+			return import('date-fns/locale/de');
 		case 'de-AT':
-			return import('date-fns/locale/de-AT/index.js');
+			return import('date-fns/locale/de-AT');
 		case 'el':
-			return import('date-fns/locale/el/index.js');
+			return import('date-fns/locale/el');
 		case 'en-AU':
-			return import('date-fns/locale/en-AU/index.js');
+			return import('date-fns/locale/en-AU');
 		case 'en-CA':
-			return import('date-fns/locale/en-CA/index.js');
+			return import('date-fns/locale/en-CA');
 		case 'en-GB':
-			return import('date-fns/locale/en-GB/index.js');
+			return import('date-fns/locale/en-GB');
 		case 'en-IN':
-			return import('date-fns/locale/en-IN/index.js');
+			return import('date-fns/locale/en-IN');
 		case 'en-NZ':
-			return import('date-fns/locale/en-NZ/index.js');
+			return import('date-fns/locale/en-NZ');
 		case 'en-US':
-			return import('date-fns/locale/en-US/index.js');
+			return import('date-fns/locale/en-US');
 		case 'en-ZA':
-			return import('date-fns/locale/en-ZA/index.js');
+			return import('date-fns/locale/en-ZA');
 		case 'eo':
-			return import('date-fns/locale/eo/index.js');
+			return import('date-fns/locale/eo');
 		case 'es':
-			return import('date-fns/locale/es/index.js');
+			return import('date-fns/locale/es');
 		case 'et':
-			return import('date-fns/locale/et/index.js');
+			return import('date-fns/locale/et');
 		case 'eu':
-			return import('date-fns/locale/eu/index.js');
+			return import('date-fns/locale/eu');
 		case 'fa-IR':
-			return import('date-fns/locale/fa-IR/index.js');
+			return import('date-fns/locale/fa-IR');
 		case 'fi':
-			return import('date-fns/locale/fi/index.js');
+			return import('date-fns/locale/fi');
 		case 'fr':
-			return import('date-fns/locale/fr/index.js');
+			return import('date-fns/locale/fr');
 		case 'fr-CA':
-			return import('date-fns/locale/fr-CA/index.js');
+			return import('date-fns/locale/fr-CA');
 		case 'fr-CH':
-			return import('date-fns/locale/fr-CH/index.js');
+			return import('date-fns/locale/fr-CH');
 		case 'gd':
-			return import('date-fns/locale/gd/index.js');
+			return import('date-fns/locale/gd');
 		case 'gl':
-			return import('date-fns/locale/gl/index.js');
+			return import('date-fns/locale/gl');
 		case 'gu':
-			return import('date-fns/locale/gu/index.js');
+			return import('date-fns/locale/gu');
 		case 'he':
-			return import('date-fns/locale/he/index.js');
+			return import('date-fns/locale/he');
 		case 'hi':
-			return import('date-fns/locale/hi/index.js');
+			return import('date-fns/locale/hi');
 		case 'hr':
-			return import('date-fns/locale/hr/index.js');
+			return import('date-fns/locale/hr');
 		case 'ht':
-			return import('date-fns/locale/ht/index.js');
+			return import('date-fns/locale/ht');
 		case 'hu':
-			return import('date-fns/locale/hu/index.js');
+			return import('date-fns/locale/hu');
 		case 'hy':
-			return import('date-fns/locale/hy/index.js');
+			return import('date-fns/locale/hy');
 		case 'id':
-			return import('date-fns/locale/id/index.js');
+			return import('date-fns/locale/id');
 		case 'is':
-			return import('date-fns/locale/is/index.js');
+			return import('date-fns/locale/is');
 		case 'it':
-			return import('date-fns/locale/it/index.js');
+			return import('date-fns/locale/it');
 		case 'ja':
-			return import('date-fns/locale/ja/index.js');
+			return import('date-fns/locale/ja');
 		case 'ka':
-			return import('date-fns/locale/ka/index.js');
+			return import('date-fns/locale/ka');
 		case 'kk':
-			return import('date-fns/locale/kk/index.js');
+			return import('date-fns/locale/kk');
 		case 'kn':
-			return import('date-fns/locale/kn/index.js');
+			return import('date-fns/locale/kn');
 		case 'ko':
-			return import('date-fns/locale/ko/index.js');
+			return import('date-fns/locale/ko');
 		case 'lb':
-			return import('date-fns/locale/lb/index.js');
+			return import('date-fns/locale/lb');
 		case 'lt':
-			return import('date-fns/locale/lt/index.js');
+			return import('date-fns/locale/lt');
 		case 'lv':
-			return import('date-fns/locale/lv/index.js');
+			return import('date-fns/locale/lv');
 		case 'mk':
-			return import('date-fns/locale/mk/index.js');
+			return import('date-fns/locale/mk');
 		case 'mn':
-			return import('date-fns/locale/mn/index.js');
+			return import('date-fns/locale/mn');
 		case 'ms':
-			return import('date-fns/locale/ms/index.js');
+			return import('date-fns/locale/ms');
 		case 'mt':
-			return import('date-fns/locale/mt/index.js');
+			return import('date-fns/locale/mt');
 		case 'nb':
-			return import('date-fns/locale/nb/index.js');
+			return import('date-fns/locale/nb');
 		case 'nl':
-			return import('date-fns/locale/nl/index.js');
+			return import('date-fns/locale/nl');
 		case 'nl-BE':
-			return import('date-fns/locale/nl-BE/index.js');
+			return import('date-fns/locale/nl-BE');
 		case 'nn':
-			return import('date-fns/locale/nn/index.js');
+			return import('date-fns/locale/nn');
 		case 'pl':
-			return import('date-fns/locale/pl/index.js');
+			return import('date-fns/locale/pl');
 		case 'pt':
-			return import('date-fns/locale/pt/index.js');
+			return import('date-fns/locale/pt');
 		case 'pt-BR':
-			return import('date-fns/locale/pt-BR/index.js');
+			return import('date-fns/locale/pt-BR');
 		case 'ro':
-			return import('date-fns/locale/ro/index.js');
+			return import('date-fns/locale/ro');
 		case 'ru':
-			return import('date-fns/locale/ru/index.js');
+			return import('date-fns/locale/ru');
 		case 'sk':
-			return import('date-fns/locale/sk/index.js');
+			return import('date-fns/locale/sk');
 		case 'sl':
-			return import('date-fns/locale/sl/index.js');
+			return import('date-fns/locale/sl');
 		case 'sq':
-			return import('date-fns/locale/sq/index.js');
+			return import('date-fns/locale/sq');
 		case 'sr':
-			return import('date-fns/locale/sr/index.js');
+			return import('date-fns/locale/sr');
 		case 'sr-Latn':
-			return import('date-fns/locale/sr-Latn/index.js');
+			return import('date-fns/locale/sr-Latn');
 		case 'sv':
-			return import('date-fns/locale/sv/index.js');
+			return import('date-fns/locale/sv');
 		case 'ta':
-			return import('date-fns/locale/ta/index.js');
+			return import('date-fns/locale/ta');
 		case 'te':
-			return import('date-fns/locale/te/index.js');
+			return import('date-fns/locale/te');
 		case 'th':
-			return import('date-fns/locale/th/index.js');
+			return import('date-fns/locale/th');
 		case 'tr':
-			return import('date-fns/locale/tr/index.js');
+			return import('date-fns/locale/tr');
 		case 'ug':
-			return import('date-fns/locale/ug/index.js');
+			return import('date-fns/locale/ug');
 		case 'uk':
-			return import('date-fns/locale/uk/index.js');
+			return import('date-fns/locale/uk');
 		case 'uz':
-			return import('date-fns/locale/uz/index.js');
+			return import('date-fns/locale/uz');
 		case 'vi':
-			return import('date-fns/locale/vi/index.js');
+			return import('date-fns/locale/vi');
 		case 'zh-CN':
-			return import('date-fns/locale/zh-CN/index.js');
+			return import('date-fns/locale/zh-CN');
 		case 'zh-TW':
-			return import('date-fns/locale/zh-TW/index.js');
+			return import('date-fns/locale/zh-TW');
 		default:
 			return Promise.resolve();
 	}

--- a/app/src/utils/localized-format-distance-strict.ts
+++ b/app/src/utils/localized-format-distance-strict.ts
@@ -1,5 +1,5 @@
 import { getDateFNSLocale } from '@/utils/get-date-fns-locale';
-import formatDistanceStrict from 'date-fns/formatDistanceStrict';
+import { formatDistanceStrict } from 'date-fns';
 
 type LocalizedFormatDistanceStrict = (...a: Parameters<typeof formatDistanceStrict>) => string;
 

--- a/app/src/utils/localized-format-distance.ts
+++ b/app/src/utils/localized-format-distance.ts
@@ -1,5 +1,5 @@
 import { getDateFNSLocale } from '@/utils/get-date-fns-locale';
-import formatDistanceOriginal from 'date-fns/formatDistance';
+import { formatDistance as formatDistanceOriginal } from 'date-fns';
 
 type LocalizedFormatDistance = (...a: Parameters<typeof formatDistanceOriginal>) => string;
 

--- a/app/src/utils/localized-format.ts
+++ b/app/src/utils/localized-format.ts
@@ -1,5 +1,5 @@
 import { getDateFNSLocale } from '@/utils/get-date-fns-locale';
-import formatOriginal from 'date-fns/format';
+import { format as formatOriginal } from 'date-fns';
 
 type LocalizedFormat = (...a: Parameters<typeof formatOriginal>) => string;
 

--- a/app/src/views/private/components/comment-item-header.vue
+++ b/app/src/views/private/components/comment-item-header.vue
@@ -4,7 +4,7 @@ import { Activity } from '@/types/activity';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { userName } from '@/utils/user-name';
 import type { User } from '@directus/types';
-import format from 'date-fns/format';
+import { format } from 'date-fns';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@directus/constants": "workspace:*",
-		"date-fns": "2.30.0",
+		"date-fns": "3.0.1",
 		"fs-extra": "11.2.0",
 		"joi": "17.11.0",
 		"lodash-es": "4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: 4.9.0
         version: 4.9.0
       date-fns:
-        specifier: 2.30.0
-        version: 2.30.0
+        specifier: 3.0.1
+        version: 3.0.1
       deep-diff:
         specifier: 1.0.2
         version: 1.0.2
@@ -725,8 +725,8 @@ importers:
         specifier: 1.6.1
         version: 1.6.1
       date-fns:
-        specifier: 2.30.0
-        version: 2.30.0
+        specifier: 3.0.1
+        version: 3.0.1
       diacritics:
         specifier: 1.3.0
         version: 1.3.0
@@ -944,7 +944,7 @@ importers:
         version: 1.1.0(vitest@1.1.0)
       histoire:
         specifier: 0.17.6
-        version: 0.17.6(sass@1.69.5)(vite@5.0.10)
+        version: 0.17.6(vite@5.0.10)
       rollup-plugin-node-externals:
         specifier: 6.1.2
         version: 6.1.2(rollup@4.9.1)
@@ -953,13 +953,13 @@ importers:
         version: 5.3.3
       vite:
         specifier: 5.0.10
-        version: 5.0.10(sass@1.69.5)
+        version: 5.0.10(@types/node@18.19.3)
       vite-plugin-dts:
         specifier: 3.6.4
         version: 3.6.4(rollup@4.9.1)(typescript@5.3.3)(vite@5.0.10)
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/composables:
     dependencies:
@@ -1008,7 +1008,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/constants:
     devDependencies:
@@ -1206,7 +1206,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/extensions:
     dependencies:
@@ -1373,7 +1373,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/memory:
     dependencies:
@@ -1438,7 +1438,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/random:
     devDependencies:
@@ -1580,7 +1580,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/storage-driver-cloudinary:
     dependencies:
@@ -1614,7 +1614,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/storage-driver-gcs:
     dependencies:
@@ -1645,7 +1645,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/storage-driver-local:
     dependencies:
@@ -1710,7 +1710,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/storage-driver-supabase:
     dependencies:
@@ -1744,7 +1744,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   packages/stores:
     dependencies:
@@ -1818,7 +1818,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: 5.0.10
-        version: 5.0.10(sass@1.69.5)
+        version: 5.0.10(@types/node@18.19.3)
       vite-plugin-dts:
         specifier: 3.6.4
         version: 3.6.4(rollup@4.9.1)(typescript@5.3.3)(vite@5.0.10)
@@ -1905,8 +1905,8 @@ importers:
         specifier: workspace:*
         version: link:../constants
       date-fns:
-        specifier: 2.30.0
-        version: 2.30.0
+        specifier: 3.0.1
+        version: 3.0.1
       fs-extra:
         specifier: 11.2.0
         version: 11.2.0
@@ -1986,7 +1986,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   sdk:
     devDependencies:
@@ -2004,7 +2004,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
 
   tests/blackbox:
     devDependencies:
@@ -2085,7 +2085,7 @@ importers:
         version: 4.2.2(typescript@5.3.3)
       vitest:
         specifier: 1.1.0
-        version: 1.1.0(happy-dom@12.10.3)(sass@1.69.5)
+        version: 1.1.0
       ws:
         specifier: 8.15.1
         version: 8.15.1
@@ -3248,6 +3248,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+    dev: true
 
   /@babel/types@7.23.6:
     resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
@@ -9945,11 +9946,8 @@ packages:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: false
 
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.23.6
+  /date-fns@3.0.1:
+    resolution: {integrity: sha512-cr9igCUa0QSqgAMj7JOrYTY6Nh1rmyGrFDko7ADqfmaQqP/I2N4rlfrLl7AWuzDaoIpz6MNjoEcTPzgZYIrhnA==}
 
   /date-format@4.0.3:
     resolution: {integrity: sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==}
@@ -12046,6 +12044,58 @@ packages:
       sirv: 2.0.3
       vite: 5.0.10(sass@1.69.5)
       vite-node: 0.34.7(sass@1.69.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - canvas
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - utf-8-validate
+    dev: true
+
+  /histoire@0.17.6(vite@5.0.10):
+    resolution: {integrity: sha512-L9xLR0BFk+KIcpfDOPw5i0o4eq1ANj+f0i3xWS6F5yToV0jSu9Dh8eaagSrR1QbUpLoc7Kjhjq408Ecoop3JcA==}
+    hasBin: true
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      '@akryum/tinypool': 0.3.1
+      '@histoire/app': 0.17.6(vite@5.0.10)
+      '@histoire/controls': 0.17.6(vite@5.0.10)
+      '@histoire/shared': 0.17.6(vite@5.0.10)
+      '@histoire/vendors': 0.17.6
+      '@types/flexsearch': 0.7.6
+      '@types/markdown-it': 12.2.3
+      birpc: 0.1.1
+      change-case: 4.1.2
+      chokidar: 3.5.3
+      connect: 3.7.0
+      defu: 6.1.3
+      diacritics: 1.3.0
+      flexsearch: 0.7.21
+      fs-extra: 10.1.0
+      globby: 13.2.2
+      gray-matter: 4.0.3
+      jiti: 1.21.0
+      jsdom: 20.0.3
+      markdown-it: 12.3.2
+      markdown-it-anchor: 8.6.7(@types/markdown-it@12.2.3)(markdown-it@12.3.2)
+      markdown-it-attrs: 4.1.6(markdown-it@12.3.2)
+      markdown-it-emoji: 2.0.2
+      micromatch: 4.0.5
+      mrmime: 1.0.1
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      sade: 1.8.1
+      shiki-es: 0.2.0
+      sirv: 2.0.3
+      vite: 5.0.10(@types/node@18.19.3)
+      vite-node: 0.34.7
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -16467,6 +16517,7 @@ packages:
 
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: true
 
   /regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -19143,6 +19194,28 @@ packages:
       vfile-message: 3.1.4
     dev: true
 
+  /vite-node@0.34.7:
+    resolution: {integrity: sha512-0Yzb96QzHmqIKIs/x2q/sqG750V/EF6yDkS2p1WjJc1W2bgRSuQjf5vB9HY8h2nVb5j4pO5paS5Npcv3s69YUg==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.10(@types/node@18.19.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@0.34.7(sass@1.69.5):
     resolution: {integrity: sha512-0Yzb96QzHmqIKIs/x2q/sqG750V/EF6yDkS2p1WjJc1W2bgRSuQjf5vB9HY8h2nVb5j4pO5paS5Npcv3s69YUg==}
     engines: {node: '>=v14.18.0'}
@@ -19154,6 +19227,27 @@ packages:
       pathe: 1.1.1
       picocolors: 1.0.0
       vite: 5.0.10(sass@1.69.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-node@1.1.0:
+    resolution: {integrity: sha512-jV48DDUxGLEBdHCQvxL1mEh7+naVy+nhUUUaPAZLd3FJgXuxQiewHcfeZebbJ6onDqNGkP4r3MhQ342PRlG81Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.10(@types/node@18.19.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -19223,7 +19317,7 @@ packages:
       debug: 4.3.4
       kolorist: 1.8.0
       typescript: 5.3.3
-      vite: 5.0.10(sass@1.69.5)
+      vite: 5.0.10(@types/node@18.19.3)
       vue-tsc: 1.8.25(typescript@5.3.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -19406,6 +19500,62 @@ packages:
       - terser
       - typescript
       - universal-cookie
+    dev: true
+
+  /vitest@1.1.0:
+    resolution: {integrity: sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 1.1.0
+      '@vitest/runner': 1.1.0
+      '@vitest/snapshot': 1.1.0
+      '@vitest/spy': 1.1.0
+      '@vitest/utils': 1.1.0
+      acorn-walk: 8.3.1
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.6.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.1
+      vite: 5.0.10(@types/node@18.19.3)
+      vite-node: 1.1.0
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@1.1.0(@types/node@18.19.3):


### PR DESCRIPTION
Update date-fns to [v3](https://blog.date-fns.org/v3-is-out/).

No breaking changes, except for new locale import paths.

