### PR TITLE
Enable `no-constant-binary-expression` eslint rule

### DIFF
--- a/.changeset/famous-apes-know.md
+++ b/.changeset/famous-apes-know.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Added no-constant-binary-expression ESLint rule

--- a/.changeset/famous-apes-know.md
+++ b/.changeset/famous-apes-know.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Added no-constant-binary-expression ESLint rule
+Fixed small logical issues detected by newely introduced `no-constant-binary-expression` ESLint rule

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,8 @@ const basicRules = {
 	'no-nested-ternary': 'error',
 	// Require brace style for multi-line control statements
 	curly: ['error', 'multi-line'],
+	// Disallow expressions where the operation doesn't affect the value
+	'no-constant-binary-expression': 'error',
 };
 
 const tsRules = {

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -64,7 +64,7 @@ export class ExtensionsService {
 
 		const key = this.getKey(bundle, name);
 
-		const schema = this.extensionsManager.getExtensions().find((extension) => extension.name === bundle ?? name);
+		const schema = this.extensionsManager.getExtensions().find((extension) => extension.name === (bundle ?? name));
 		const meta = await this.extensionsItemService.readOne(key);
 
 		const stitched = this.stitch(schema ? [schema] : [], [meta])[0];

--- a/app/src/lang/index.ts
+++ b/app/src/lang/index.ts
@@ -30,11 +30,12 @@ export function translateAPIError(error: RequestError | string): string {
 		code = error?.response?.data?.errors?.[0]?.extensions?.code;
 	}
 
-	if (!error) return defaultMsg;
-	if (!code) return defaultMsg;
-	const key = `errors.${code}`;
+	if (!error || !code) return defaultMsg;
 
+	const key = `errors.${code}`;
 	const exists = i18n.global.te(key);
+
 	if (exists === false) return defaultMsg;
+
 	return i18n.global.t(key);
 }

--- a/app/src/lang/index.ts
+++ b/app/src/lang/index.ts
@@ -31,7 +31,7 @@ export function translateAPIError(error: RequestError | string): string {
 	}
 
 	if (!error) return defaultMsg;
-	if (!code === undefined) return defaultMsg;
+	if (!code) return defaultMsg;
 	const key = `errors.${code}`;
 
 	const exists = i18n.global.te(key);

--- a/app/src/panels/line-chart/panel-line-chart.vue
+++ b/app/src/panels/line-chart/panel-line-chart.vue
@@ -205,12 +205,19 @@ function setUpChart() {
 		},
 		grid: {
 			borderColor: 'var(--theme--border-color-subdued)',
-			padding: {
-				top: isSparkline ? (props.showHeader && 0) || 5 : (props.showHeader && -20) || -2,
-				bottom: isSparkline ? 5 : 0,
-				left: isSparkline ? 0 : 12,
-				right: isSparkline ? 0 : 12,
-			},
+			padding: isSparkline
+				? {
+						top: props.showHeader ? 0 : 5,
+						bottom: 5,
+						left: 0,
+						right: 0,
+				  }
+				: {
+						top: props.showHeader ? -20 : -2,
+						bottom: 0,
+						left: 12,
+						right: 12,
+				  },
 		},
 		markers: {
 			colors: colors,


### PR DESCRIPTION
## Context

Attempted to enable the [`no-constant-binary-expression` rule](https://eslint.org/docs/latest/rules/no-constant-binary-expression) and ended up finding the following 3 subtle logic issues:

![](https://github.com/directus/directus/assets/42867097/94fde318-1b4c-44fa-ab64-39a936e3db13)

Credit to https://x.com/boshen_c/status/1736029429896548821 for bringing up this particular rule.

ESLint blog post by Jordan Eldredge, the author of this particular rule: https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/ 

## Scope

What's changed:

- Enabled ESLint rule `no-constant-binary-expression`
- Updated 3 pieces of code flagged by this rule

## Potential Risks / Drawbacks

- Likely none, unless there's ever false-positives flagged in the future

## Review Notes / Questions

- Marked this with `chore` label without changeset similar to other eslint rule PRs like #20079 and #18376, but since there is technically somewhat of a behavior/logical change in this PR, do we want to add a changeset for this?
