### PR TITLE
Update GraphQL validation's error key in translations

### DIFF
--- a/.changeset/many-taxis-sing.md
+++ b/.changeset/many-taxis-sing.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Updated outdated errors.GRAPHQL_VALIDATION_EXCEPTION translation key to errors.GRAPHQL_VALIDATION

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -693,7 +693,7 @@ errors:
   VALUE_OUT_OF_RANGE: Value is out of range
   INVALID_FOREIGN_KEY: Invalid foreign key
   UNKNOWN: Unexpected Error
-  GRAPHQL_VALIDATION_EXCEPTION: GraphQL Validation Exception
+  GRAPHQL_VALIDATION: GraphQL Validation
   SERVICE_UNAVAILABLE: Service Unavailable
   UNSUPPORTED_MEDIA_TYPE: Unsupported media type
   UNEXPECTED_RESPONSE: Unexpected response


### PR DESCRIPTION
## Scope

What's changed:

- Update outdated `GRAPHQL_VALIDATION_EXCEPTION` translation key to `GRAPHQL_VALIDATION`, which was changed in #18797.

  - Older :
    https://github.com/directus/directus/blob/14283e2da27f0271fee45d0f11b8a9d08edcd540/api/src/exceptions/graphql-validation.ts#L5

  - Newer:
    https://github.com/directus/directus/blob/a706292c55836f9cdd6bbe9954b518c78cfe2a46/api/src/services/graphql/errors/validation.ts#L8-L12
