### PR TITLE
Add SSE KMS Key ID to S3 storage provider

### DIFF
--- a/.changeset/bright-goats-double.md
+++ b/.changeset/bright-goats-double.md
@@ -1,0 +1,6 @@
+---
+'@directus/storage-driver-s3': minor
+'docs': patch
+---
+
+Adds ability to provide a KMS key ID when the server side encription of the S3 bucket is encrypted with aws:kms

--- a/contributors.yml
+++ b/contributors.yml
@@ -112,3 +112,4 @@
 - jstet
 - datnv9
 - kashike
+- Joey92

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -578,16 +578,17 @@ Based on your configured driver, you must also provide the following configurati
 
 ### S3 (`s3`)
 
-| Variable                                    | Description               | Default Value      |
-| ------------------------------------------- | ------------------------- | ------------------ |
-| `STORAGE_<LOCATION>_KEY`                    | User key                  | --                 |
-| `STORAGE_<LOCATION>_SECRET`                 | User secret               | --                 |
-| `STORAGE_<LOCATION>_BUCKET`                 | S3 Bucket                 | --                 |
-| `STORAGE_<LOCATION>_REGION`                 | S3 Region                 | --                 |
-| `STORAGE_<LOCATION>_ENDPOINT`               | S3 Endpoint               | `s3.amazonaws.com` |
-| `STORAGE_<LOCATION>_ACL`                    | S3 ACL                    | --                 |
-| `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION` | S3 Server Side Encryption | --                 |
-| `STORAGE_<LOCATION>_FORCE_PATH_STYLE`       | S3 Force Path Style       | false              |
+| Variable                                    | Description                | Default Value      |
+| ------------------------------------------- | -------------------------- | ------------------ |
+| `STORAGE_<LOCATION>_KEY`                    | User key                   | --                 |
+| `STORAGE_<LOCATION>_SECRET`                 | User secret                | --                 |
+| `STORAGE_<LOCATION>_BUCKET`                 | S3 Bucket                  | --                 |
+| `STORAGE_<LOCATION>_REGION`                 | S3 Region                  | --                 |
+| `STORAGE_<LOCATION>_ENDPOINT`               | S3 Endpoint                | `s3.amazonaws.com` |
+| `STORAGE_<LOCATION>_ACL`                    | S3 ACL                     | --                 |
+| `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION` | S3 Server Side Encryption  | --                 |
+| `STORAGE_<LOCATION>_FORCE_PATH_STYLE`       | S3 Force Path Style        | false              |
+| `STORAGE_<LOCATION>_SSE_KMS_KEY_ID`         | KMS Key ID (If applicable) | --                 |
 
 ### Azure (`azure`)
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Adds ability to provide a KMS key ID when the server side encription of the S3 bucket is encrypted with aws:kms

## Review Notes / Questions

- I still need to verify this on a KMS encrypted S3 bucket, will undraft the PR when done

---

Fixes #20541 
