### PR TITLE
Re-hydrate server store after login to get authenticated data

### DIFF
--- a/.changeset/short-panthers-roll.md
+++ b/.changeset/short-panthers-roll.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed an issue where the Directus version in the Settings area was displayed as "undefined"


### PR DESCRIPTION
## Scope

What's changed:

The server store needs to be re-hydrated after authentication because the `/server/info` endpoint returns different data based on auth state.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #20857 
