### PR TITLE
Fix SDK fields formatting in withSearch

### DIFF
--- a/.changeset/wicked-brooms-pull.md
+++ b/.changeset/wicked-brooms-pull.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed SDK fields formatting in withSearch

--- a/sdk/src/rest/helpers/with-search.ts
+++ b/sdk/src/rest/helpers/with-search.ts
@@ -1,3 +1,4 @@
+import { formatFields } from '../index.js';
 import type { RestCommand } from '../types.js';
 
 export function withSearch<Schema extends object, Output>(
@@ -6,9 +7,16 @@ export function withSearch<Schema extends object, Output>(
 	return () => {
 		const options = getOptions();
 
-		if (options.method === 'GET') {
+		if (options.method === 'GET' && options.params) {
 			options.method = 'SEARCH';
-			options.body = JSON.stringify({ query: options.params });
+
+			options.body = JSON.stringify({
+				query: {
+					...options.params,
+					fields: formatFields(options.params['fields'] ?? []),
+				},
+			});
+
 			delete options.params;
 		}
 

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -5,6 +5,42 @@ type ExtendedQuery<Schema extends object, Item> = Query<Schema, Item> & {
 	groupBy?: (string | GroupByFields<Schema, Item>)[];
 };
 
+export const formatFields = (fields: (string | Record<string, any>)[]) => {
+	type FieldItem = (typeof fields)[number];
+
+	const walkFields = (value: FieldItem, chain: string[] = []): string | string[] => {
+		if (typeof value === 'object') {
+			const result = [];
+
+			for (const key in value) {
+				const nestedField = value[key as keyof typeof value] ?? [];
+
+				if (Array.isArray(nestedField)) {
+					// regular nested fields
+					for (const item of nestedField) {
+						result.push(walkFields(item as FieldItem, [...chain, key]));
+					}
+				} else if (typeof nestedField === 'object') {
+					// many to any nested
+					for (const scope of Object.keys(nestedField)) {
+						const fields = (nestedField as Record<string, FieldItem[]>)[scope]!;
+
+						for (const item of fields) {
+							result.push(walkFields(item as FieldItem, [...chain, `${key}:${scope}`]));
+						}
+					}
+				}
+			}
+
+			return result.flatMap((items) => items);
+		}
+
+		return [...chain, String(value)].join('.');
+	};
+
+	return fields.flatMap((value) => walkFields(value));
+}
+
 /**
  * Transform nested query object to an url compatible format
  *
@@ -18,39 +54,7 @@ export const queryToParams = <Schema extends object, Item>(
 	const params: Record<string, string> = {};
 
 	if (Array.isArray(query.fields) && query.fields.length > 0) {
-		type FieldItem = (typeof query.fields)[number];
-
-		const walkFields = (value: FieldItem, chain: string[] = []): string | string[] => {
-			if (typeof value === 'object') {
-				const result = [];
-
-				for (const key in value) {
-					const nestedField = value[key as keyof typeof value] ?? [];
-
-					if (Array.isArray(nestedField)) {
-						// regular nested fields
-						for (const item of nestedField) {
-							result.push(walkFields(item as FieldItem, [...chain, key]));
-						}
-					} else if (typeof nestedField === 'object') {
-						// many to any nested
-						for (const scope of Object.keys(nestedField)) {
-							const fields = (nestedField as Record<string, FieldItem[]>)[scope]!;
-
-							for (const item of fields) {
-								result.push(walkFields(item as FieldItem, [...chain, `${key}:${scope}`]));
-							}
-						}
-					}
-				}
-
-				return result.flatMap((items) => items);
-			}
-
-			return [...chain, String(value)].join('.');
-		};
-
-		params['fields'] = query.fields.flatMap((value) => walkFields(value)).join(',');
+		params['fields'] = formatFields(query.fields).join(',');
 	}
 
 	if (query.filter && Object.keys(query.filter).length > 0) {

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -39,7 +39,7 @@ export const formatFields = (fields: (string | Record<string, any>)[]) => {
 	};
 
 	return fields.flatMap((value) => walkFields(value));
-}
+};
 
 /**
  * Transform nested query object to an url compatible format


### PR DESCRIPTION
Fixes #20851

## Scope

What's changed:

- correctly format the fields when moving from url query to request body
- extracted fields formatting to be reused for the `withSearch` helper
