### PR TITLE
Do not show object instead of text for `v-select` preview

### DIFF
--- a/.changeset/polite-peas-thank.md
+++ b/.changeset/polite-peas-thank.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed object displayed instead of text for v-select preview

--- a/.changeset/polite-peas-thank.md
+++ b/.changeset/polite-peas-thank.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed object displayed instead of text for v-select preview
+Fixed `v-select` preview showing an object instead of text

--- a/.changeset/polite-peas-thank.md
+++ b/.changeset/polite-peas-thank.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed `v-select` preview showing an object instead of text

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -250,10 +250,10 @@ function useDisplayValue() {
 			<div
 				v-if="inline"
 				class="inline-display"
-				:class="{ placeholder: !displayValue, label, active, disabled }"
+				:class="{ placeholder: !displayValue.text, label, active, disabled }"
 				@click="toggle"
 			>
-				<slot name="preview">{{ displayValue || placeholder }}</slot>
+				<slot name="preview">{{ displayValue.text || placeholder }}</slot>
 				<v-icon name="expand_more" :class="{ active }" />
 			</div>
 			<slot v-else name="preview">


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- v-select preview should be showing display text not an object.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions
- This is a regression introduced in #20782
![image](https://github.com/directus/directus/assets/44623501/476807e9-8231-4e48-ba79-34ca449f6f81)


---

Fixes - N/A, this version is yet to be released
