### PR TITLE
fix(api): bigInt auto increment not being reset in postgres

### DIFF
--- a/.changeset/silver-cameras-end.md
+++ b/.changeset/silver-cameras-end.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed bigInt auto increment not being reset in postgres

--- a/.changeset/silver-cameras-end.md
+++ b/.changeset/silver-cameras-end.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed bigInt auto increment not being reset in postgres
+Fixed big integer auto-incremented primary key not being reset in PostgreSQL

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -177,7 +177,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 			// The primary key can already exist in the payload.
 			// In case of manual string / UUID primary keys it's always provided at this point.
-			// In case of an integer primary key, it might be provided as the user can specify the value manually.
+			// In case of an (big) integer primary key, it might be provided as the user can specify the value manually.
 			let primaryKey: undefined | PrimaryKey = payloadWithTypeCasting[primaryKeyField];
 
 			if (primaryKey) {
@@ -192,9 +192,10 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 			if (
 				primaryKey &&
+				pkField &&
 				!opts.bypassAutoIncrementSequenceReset &&
-				['integer', 'bigInteger'].includes(pkField!.type) &&
-				pkField!.defaultValue === 'AUTO_INCREMENT'
+				['integer', 'bigInteger'].includes(pkField.type) &&
+				pkField.defaultValue === 'AUTO_INCREMENT'
 			) {
 				autoIncrementSequenceNeedsToBeReset = true;
 			}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -193,7 +193,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			if (
 				primaryKey &&
 				!opts.bypassAutoIncrementSequenceReset &&
-				pkField!.type === 'integer' &&
+				['integer', 'bigInteger'].includes(pkField!.type) &&
 				pkField!.defaultValue === 'AUTO_INCREMENT'
 			) {
 				autoIncrementSequenceNeedsToBeReset = true;

--- a/tests/blackbox/common/types.ts
+++ b/tests/blackbox/common/types.ts
@@ -2,7 +2,9 @@ import type { Query } from '@directus/types';
 import type { ClientOptions } from 'ws';
 import type { ClientOptions as ClientOptionsGql } from 'graphql-ws';
 
+/** @TODO Could also be big integer */
 export type PrimaryKeyType = 'integer' | 'uuid' | 'string';
+
 export type WebSocketAuthMethod = 'public' | 'handshake' | 'strict';
 export type WebSocketUID = string | number;
 export type WebSocketResponse = {


### PR DESCRIPTION
## Scope

What's changed:
- Reset auto increment for fields for both bigint and integer
## Potential Risks / Drawbacks

NA

## Review Notes / Questions

NA

---

Fixes #20550

### Screenshots

#### Big int auto inc ID
<img width="627" alt="Screenshot 2023-12-24 at 7 10 58 PM" src="https://github.com/directus/directus/assets/22556323/419101c3-b3b7-4a85-b2dc-0a12d134c852">

#### uploaded file with id 100, subsequent auto generations generated 101,102
<img width="1065" alt="Screenshot 2023-12-24 at 7 11 29 PM" src="https://github.com/directus/directus/assets/22556323/f7dd1cdf-f574-4f2d-a6b5-9d2baf248b1c">

