### PR TITLE
fix(graphql):handle nested originalError inside the GraphQLError.originalError in processError method

### DIFF
--- a/.changeset/sixty-plums-wash.md
+++ b/.changeset/sixty-plums-wash.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed graphQL errors not reporting correct extension code
+Fixed GraphQL errors not containing correct extension code for basic errors

--- a/.changeset/sixty-plums-wash.md
+++ b/.changeset/sixty-plums-wash.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed graphQL errors not reporting correct extension code

--- a/api/src/services/graphql/utils/process-error.test.ts
+++ b/api/src/services/graphql/utils/process-error.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import processError from './process-error.js';
 import { createError } from '@directus/errors';
 
-describe.only('GraphQL processError util', () => {
+describe('GraphQL processError util', () => {
 	const sampleError = new GraphQLError('An error message', { path: ['test_collection'] });
 
 	const redactedError = {

--- a/api/src/services/graphql/utils/process-error.test.ts
+++ b/api/src/services/graphql/utils/process-error.test.ts
@@ -1,8 +1,9 @@
 import { GraphQLError } from 'graphql';
 import { describe, expect, test } from 'vitest';
 import processError from './process-error.js';
+import { createError } from '@directus/errors';
 
-describe('GraphQL processError util', () => {
+describe.only('GraphQL processError util', () => {
 	const sampleError = new GraphQLError('An error message', { path: ['test_collection'] });
 
 	const redactedError = {
@@ -28,6 +29,23 @@ describe('GraphQL processError util', () => {
 			extensions: {
 				code: 'INTERNAL_SERVER_ERROR',
 			},
+		});
+	});
+
+	test('returns original error when createError is used to create the error', () => {
+		const InvalidPayloadError = createError('INVALID_PAYLOAD_ERROR', 'Something went wrong...', 400);
+
+		const sampleError = new GraphQLError('An error message', {
+			path: ['test_collection'],
+			originalError: new InvalidPayloadError(),
+		});
+
+		expect(processError(null, sampleError)).toEqual({
+			message: 'Something went wrong...',
+			extensions: {
+				code: 'INVALID_PAYLOAD_ERROR',
+			},
+			path: ['test_collection'],
 		});
 	});
 });

--- a/api/src/services/graphql/utils/process-error.ts
+++ b/api/src/services/graphql/utils/process-error.ts
@@ -1,12 +1,19 @@
-import { isDirectusError } from '@directus/errors';
+import { isDirectusError, type DirectusError } from '@directus/errors';
 import type { Accountability } from '@directus/types';
 import type { GraphQLError, GraphQLFormattedError } from 'graphql';
 import logger from '../../../logger.js';
 
-const processError = (accountability: Accountability | null, error: Readonly<GraphQLError>): GraphQLFormattedError => {
+const processError = (
+	accountability: Accountability | null,
+	error: Readonly<GraphQLError & { originalError: GraphQLError | DirectusError | Error | undefined }>,
+): GraphQLFormattedError => {
 	logger.error(error);
 
-	const { originalError } = error;
+	let originalError = error.originalError;
+
+	if (originalError && 'originalError' in originalError) {
+		originalError = originalError.originalError;
+	}
 
 	if (isDirectusError(originalError)) {
 		return {
@@ -15,6 +22,8 @@ const processError = (accountability: Accountability | null, error: Readonly<Gra
 				code: originalError.code,
 				...(originalError.extensions ?? {}),
 			},
+			...(error.locations && { locations: error.locations }),
+			...(error.path && { path: error.path }),
 		};
 	} else {
 		if (accountability?.admin === true) {

--- a/api/src/services/graphql/utils/process-error.ts
+++ b/api/src/services/graphql/utils/process-error.ts
@@ -34,15 +34,9 @@ const processError = (
 				extensions: {
 					code: 'INTERNAL_SERVER_ERROR',
 				},
+				...(error.locations && { locations: error.locations }),
+				...(error.path && { path: error.path }),
 			};
-
-			if (error.locations) {
-				graphqlFormattedError.locations = error.locations;
-			}
-
-			if (error.path) {
-				graphqlFormattedError.path = error.path;
-			}
 
 			return graphqlFormattedError;
 		} else {


### PR DESCRIPTION
## Scope

What's changed:

- `processError` method to process the graphQL error was having wrong type for originalError
- GraphQLError.originalError was in fact of type GraphQLError, so "original error" is accessed by error.originalError.originalError`
<img width="853" alt="Screenshot 2023-12-25 at 2 18 09 PM" src="https://github.com/directus/directus/assets/22556323/1102ff5e-5b50-4f9e-bfb9-3bc022d69691">


## Potential Risks / Drawbacks

NA

## Review Notes / Questions

#### Error Response after fix

```
{
    "data": {
        "update_table_a_item": null
    },
    "errors": [
        {
            "message": "Something went wrong...",
            "extensions": {
                "code": "INVALID_PAYLOAD_ERROR"
            },
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "path": [
                "update_table_a_item"
            ]
        }
    ]
}
```

#### Sample Validation error response after fix
```
{
    "data": {
        "update_table_a_item": null
    },
    "errors": [
        {
            "message": "Validation failed for field \"status\". Value can't be null.",
            "extensions": {
                "code": "FAILED_VALIDATION",
                "field": "status",
                "type": "nnull"
            },
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "path": [
                "update_table_a_item"
            ]
        }
    ]
}
```
---

Fixes #20442
