### PR TITLE
fix(api): dont allow setting nullable for primary key while updating a field

### DIFF
--- a/.changeset/metal-walls-accept.md
+++ b/.changeset/metal-walls-accept.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Dont allow setting nullable for primary key
+Prevented changing primary keys to nullable

--- a/.changeset/metal-walls-accept.md
+++ b/.changeset/metal-walls-accept.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Dont allow setting nullable for primary key

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -412,15 +412,21 @@ export class FieldsService {
 			if (hookAdjustedField.schema) {
 				const existingColumn = await this.schemaInspector.columnInfo(collection, hookAdjustedField.field);
 
+				if (hookAdjustedField.schema?.is_nullable === true && existingColumn.is_primary_key) {
+					throw new InvalidPayloadError({ reason: 'Primary key cannot be null' });
+				}
+
 				// Sanitize column only when applying snapshot diff as opts is only passed from /utils/apply-diff.ts
 				const columnToCompare =
 					opts?.bypassLimits && opts.autoPurgeSystemCache === false ? sanitizeColumn(existingColumn) : existingColumn;
 
 				if (!isEqual(columnToCompare, hookAdjustedField.schema)) {
 					try {
-						await this.knex.schema.alterTable(collection, (table) => {
-							if (!hookAdjustedField.schema) return;
-							this.addColumnToTable(table, field, existingColumn);
+						await this.knex.transaction(async (trx) => {
+							await trx.schema.alterTable(collection, async (table) => {
+								if (!hookAdjustedField.schema) return;
+								this.addColumnToTable(table, field, existingColumn);
+							});
 						});
 					} catch (err: any) {
 						throw await translateDatabaseError(err);

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -439,7 +439,7 @@ function useOnUpdate() {
 
 			<div v-if="!isAlias" class="field half-left">
 				<div class="label type-label">{{ t('nullable') }}</div>
-				<v-checkbox v-model="nullable" :disabled="isGenerated" :label="t('allow_null_value')" block />
+				<v-checkbox v-model="nullable" :disabled="isGenerated || isPrimaryKey" :label="t('allow_null_value')" block />
 			</div>
 
 			<div v-if="!isAlias" class="field half-right">


### PR DESCRIPTION
## Scope

What's changed:

- Validate `is_nullable` and throw invalid payload error when the column is PK
- Use transaction to update a field
- Disable allow nullable in UI for PK

## Potential Risks / Drawbacks
NA

## Review Notes / Questions

- Using transaction for item update is optional, but i feel we should to avoid these kind of inconsistencies, in this specific case, knex was generating a series of queries and it was failing while setting nullable to PK, but before that default(auto increment) was removed, since it was not a transaction, statements(remove default in this case) was not rolled back.

---

Fixes #20361
