### PR TITLE
Restrict v-menu content height to viewport

### DIFF
--- a/.changeset/pretty-flies-shave.md
+++ b/.changeset/pretty-flies-shave.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevented datetime picker to go off-screen and become unreachable


### PR DESCRIPTION
## Scope

### Before

https://github.com/directus/directus/assets/5363448/3b6a51c1-fde2-4bd7-9739-838fa35c907a

### After

https://github.com/directus/directus/assets/5363448/84aa31a6-2734-4295-8813-382ade4a7aa2

## Potential Risks / Drawbacks

This is a temporary solution, and while improving the situation a proper solution will only be feasible when we upgrade from Popper to Floating UI via its new [size](https://floating-ui.com/docs/size) middleware.

## Review Notes / Questions

None

---

Fixes #20850
