### PR TITLE
Always place arrow for field details menu on left side

### DIFF
--- a/.changeset/tough-carpets-help.md
+++ b/.changeset/tough-carpets-help.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Changed the arrow for field details menu to always be placed on the left side

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -147,7 +147,7 @@ function useComputedValues() {
 
 <template>
 	<div class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
-		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow>
+		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -25,6 +25,8 @@ interface Props {
 	attached?: boolean;
 	/** Show an arrow pointer */
 	showArrow?: boolean;
+	/** Fixed arrow placement */
+	arrowPlacement?: 'start';
 	/** Menu does not appear */
 	disabled?: boolean;
 	/** Activate the menu on a trigger */
@@ -289,6 +291,7 @@ function usePopper(
 
 	function getModifiers(callback: (value?: unknown) => void = () => undefined) {
 		const padding = 8;
+		const arrowPadding = 6;
 
 		const modifiers: Modifier<string, any>[] = [
 			popperOffsets,
@@ -311,7 +314,7 @@ function usePopper(
 				...arrow,
 				enabled: options.value.arrow === true,
 				options: {
-					padding: 6,
+					padding: arrowPadding,
 				},
 			},
 			{
@@ -350,7 +353,27 @@ function usePopper(
 				fn({ state }) {
 					if (state.styles.popper) styles.value = state.styles.popper;
 
-					if (state.styles.arrow) arrowStyles.value = state.styles.arrow;
+					if (state.styles.arrow) {
+						if (props.arrowPlacement === 'start') {
+							let x = 0;
+							let y = 0;
+
+							switch (state.placement) {
+								case 'top-start':
+								case 'bottom-start':
+									x = arrowPadding;
+									break;
+								case 'left-start':
+								case 'right-start':
+									y = arrowPadding;
+									break;
+							}
+
+							state.styles.arrow.transform = `translate3d(${x}px, ${y}px, 0)`;
+						}
+
+						arrowStyles.value = state.styles.arrow;
+					}
 
 					callback();
 				},


### PR DESCRIPTION
## Scope

What's changed:

- Add `arrow-placement` option to `v-menu` (currently only implement `start`)
- Set to `start` for form field label so the arrow of the details menu is always placed on left side

Previously, the arrow would be on the right side because it references the whole form field label which is full width, but with that it wasn't clear where the arrow was pointing at (at least for shorter field names).

### Before

![before](https://github.com/directus/directus/assets/5363448/3ece11f0-8a93-44de-8faf-554e7d0038ec)

### After

![after](https://github.com/directus/directus/assets/5363448/e1ba5abf-cf46-4a88-84c4-6ddf30a9f28e)

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
