### PR TITLE
Fix messageBufferHandler in Bus

### DIFF
--- a/.changeset/great-guests-allow.md
+++ b/.changeset/great-guests-allow.md
@@ -1,0 +1,5 @@
+---
+"@directus/memory": patch
+---
+
+Fixed handling of Bus messages with Redis

--- a/packages/memory/src/utils/index.ts
+++ b/packages/memory/src/utils/index.ts
@@ -2,5 +2,7 @@ export * from './buffer-to-uint8array.js';
 export * from './compress.js';
 export * from './is-compressed.js';
 export * from './serialize.js';
+export * from './string-to-uint8array.js';
 export * from './uint8array-to-buffer.js';
+export * from './uint8array-to-string.js';
 export * from './with-namespace.js';

--- a/packages/memory/src/utils/serialize.ts
+++ b/packages/memory/src/utils/serialize.ts
@@ -1,7 +1,6 @@
 import { parseJSON } from '@directus/utils';
-
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
+import { stringToUint8Array } from './string-to-uint8array.js';
+import { uint8ArrayToString } from './uint8array-to-string.js';
 
 /**
  * Serialize a given JavaScript value to it's Uint8Array equivalent
@@ -11,7 +10,7 @@ const decoder = new TextDecoder();
  */
 export const serialize = (val: unknown) => {
 	const valueString = JSON.stringify(val);
-	return encoder.encode(valueString);
+	return stringToUint8Array(valueString);
 };
 
 /**
@@ -21,6 +20,6 @@ export const serialize = (val: unknown) => {
  * @returns JavaScript value
  */
 export const deserialize = <T = unknown>(val: Uint8Array) => {
-	const valueString = decoder.decode(val);
+	const valueString = uint8ArrayToString(val);
 	return <T>parseJSON(valueString);
 };

--- a/packages/memory/src/utils/string-to-uint8array.test.ts
+++ b/packages/memory/src/utils/string-to-uint8array.test.ts
@@ -1,0 +1,9 @@
+import { stringToUint8Array } from './string-to-uint8array.js';
+import { test, expect } from 'vitest';
+
+test('Converts string to uint8array', () => {
+	const string = 'hello';
+	const uint8Array = new Uint8Array([104, 101, 108, 108, 111]);
+
+	expect(stringToUint8Array(string)).toEqual(uint8Array);
+});

--- a/packages/memory/src/utils/string-to-uint8array.ts
+++ b/packages/memory/src/utils/string-to-uint8array.ts
@@ -1,0 +1,6 @@
+const encoder = new TextEncoder();
+
+/**
+ * Convert a String to a JS Uint8Array
+ */
+export const stringToUint8Array = (val: string) => encoder.encode(val);

--- a/packages/memory/src/utils/uint8array-to-string.test.ts
+++ b/packages/memory/src/utils/uint8array-to-string.test.ts
@@ -1,0 +1,9 @@
+import { uint8ArrayToString } from './uint8array-to-string.js';
+import { test, expect } from 'vitest';
+
+test('Converts uint8array to string', () => {
+	const uint8Array = new Uint8Array([104, 101, 108, 108, 111]);
+	const string = 'hello';
+
+	expect(uint8ArrayToString(uint8Array)).toEqual(string);
+});

--- a/packages/memory/src/utils/uint8array-to-string.ts
+++ b/packages/memory/src/utils/uint8array-to-string.ts
@@ -1,0 +1,6 @@
+const decoder = new TextDecoder();
+
+/**
+ * Convert a JS Uint8Array to a String
+ */
+export const uint8ArrayToString = (val: Uint8Array) => decoder.decode(val);


### PR DESCRIPTION
## Scope

What's changed:

`messageBufferHandler`:
1. was expecting the wrong format, both `channel` and `message` are buffers[^1]
2. wasn't receiving the right context (`this`), therefore no handlers were called

the new syntax solves 2) and also addresses 1) in the sense that it is now type-checked: 
```diff
- this.sub.on('messageBuffer', this.messageBufferHandler);
+ this.sub.on('messageBuffer', (channel, message) => this.messageBufferHandler(channel, message));
```

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Does the introduction of the new utils and its structure make sense?

[^1]: https://github.com/redis/ioredis#pubsub