### PR TITLE
Disable field permissions for fields marked as minimally required

### DIFF
--- a/.changeset/famous-planes-run.md
+++ b/.changeset/famous-planes-run.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Disabled field permissions to be set for a collections minimal required fields

--- a/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
+++ b/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n';
 type Option = {
 	text: string;
 	value: string | number | boolean;
+	disabled?: boolean;
 };
 
 const props = withDefaults(
@@ -89,7 +90,7 @@ const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple
 			block
 			:value="item.value"
 			:label="item.text"
-			:disabled="disabled"
+			:disabled="item.disabled || disabled"
 			:icon-on="iconOn"
 			:icon-off="iconOff"
 			:model-value="value || []"

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
@@ -22,9 +22,12 @@ const internalPermission = useSync(props, 'permission', emit);
 const fieldsInCollection = computed(() => {
 	const fields = fieldsStore.getFieldsForCollectionSorted(props.permission.collection);
 
+	const appMinimalPermissionsFields = new Set(props.appMinimal ?? []);
+
 	return fields.map((field: Field) => {
 		return {
 			text: field.field,
+			disabled: appMinimalPermissionsFields.has(field.field),
 			value: field.field,
 		};
 	});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Fields that are marked as minimally required for a collection are now disabled from being changed in field permissions.

#### Before
<img width="622" alt="Screenshot 2023-12-27 at 1 57 57 PM" src="https://github.com/directus/directus/assets/44623501/dd5e5b14-5135-4d30-85b9-a6f9ba7aa90a">

#### After
<img width="622" alt="Screenshot 2023-12-27 at 1 57 40 PM" src="https://github.com/directus/directus/assets/44623501/55581905-0b4e-43d8-a072-506a4340c4d0">



## Potential Risks / Drawbacks

- Some confusion as to why these fields are disabled.

## Review Notes / Questions

- Disabling the field seemed to be the optimal solution, open to suggestions though.

---

Fixes #20900
