### PR TITLE
Fix custom field presentation in system collections

### DIFF
--- a/.changeset/old-llamas-check.md
+++ b/.changeset/old-llamas-check.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Fixed custom field presentation in system collections (namely Users)
+Fixed custom field presentation in system collections

--- a/.changeset/old-llamas-check.md
+++ b/.changeset/old-llamas-check.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed custom field presentation in system collections (namely Users)

--- a/app/src/components/v-form/utils/get-form-fields.test.ts
+++ b/app/src/components/v-form/utils/get-form-fields.test.ts
@@ -1,8 +1,9 @@
+import * as useExtension from '@/composables/use-extension';
+import type { InterfaceConfig } from '@directus/extensions';
 import type { DeepPartial, Field } from '@directus/types';
 import { expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import { getFormFields } from './get-form-fields';
-import * as useExtension from '@/composables/use-extension';
 
 vi.mock('@/utils/get-default-interface-for-type', () => ({
 	getDefaultInterfaceForType: () => 'input',
@@ -43,8 +44,32 @@ it('should set default interface', () => {
 	expect(formFields.value[0]).toEqual(expect.objectContaining({ meta: { interface: 'input' } }));
 });
 
+it('should sort fields', () => {
+	const fields: DeepPartial<Field>[] = [
+		{ field: 'field3', meta: { id: 1 } },
+		{ field: 'field4', meta: { id: 2 } },
+		{ field: 'field2', meta: { sort: 2 } },
+		{ field: 'field5', meta: { sort: 1, group: 'group1' } },
+		{ field: 'field6', meta: { group: 'group1' } },
+		{ field: 'field1', meta: { sort: 1 } },
+	];
+
+	const formFields = getFormFields(ref(fields as Field[]));
+
+	expect(formFields.value.map((field) => field.field)).toEqual([
+		'field1',
+		'field2',
+		'field3',
+		'field4',
+		'field5',
+		'field6',
+	]);
+});
+
 it('should inherit config from interface', () => {
-	vi.spyOn(useExtension, 'useExtension').mockImplementationOnce(() => ref({ hideLabel: true, hideLoader: true }));
+	vi.spyOn(useExtension, 'useExtension').mockImplementationOnce(() =>
+		ref({ hideLabel: true, hideLoader: true } as InterfaceConfig),
+	);
 
 	const fields: DeepPartial<Field>[] = [
 		{
@@ -58,4 +83,41 @@ it('should inherit config from interface', () => {
 	expect(formFields.value[0]).toEqual(
 		expect.objectContaining({ meta: { interface: 'example' }, hideLabel: true, hideLoader: true }),
 	);
+});
+
+it('should arrange system and user fields and inject system divider', () => {
+	const fields: DeepPartial<Field>[] = [
+		{ field: 'user_field', meta: {} },
+		{ field: 'system_field', meta: { system: true } },
+	];
+
+	const formFields = getFormFields(ref(fields as Field[]));
+
+	expect(formFields.value).toMatchInlineSnapshot(`
+		[
+		  {
+		    "field": "system_field",
+		    "meta": {
+		      "interface": "input",
+		      "system": true,
+		    },
+		  },
+		  {
+		    "field": "$system_divider",
+		    "hideLabel": true,
+		    "hideLoader": true,
+		    "meta": {
+		      "group": null,
+		      "interface": "presentation-divider",
+		    },
+		    "type": "alias",
+		  },
+		  {
+		    "field": "user_field",
+		    "meta": {
+		      "interface": "input",
+		    },
+		  },
+		]
+	`);
 });

--- a/app/src/components/v-form/utils/get-form-fields.ts
+++ b/app/src/components/v-form/utils/get-form-fields.ts
@@ -3,7 +3,7 @@ import { useExtension } from '@/composables/use-extension';
 import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
 import { translate } from '@/utils/translate-object-values';
 import { Field } from '@directus/types';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, orderBy } from 'lodash';
 import { ComputedRef, Ref, computed } from 'vue';
 
 export function getFormFields(fields: Ref<Field[]>): ComputedRef<Field[]> {
@@ -39,6 +39,12 @@ export function getFormFields(fields: Ref<Field[]>): ComputedRef<Field[]> {
 			formFields.push(field);
 		}
 
-		return formFields;
+		const sortedFields = orderBy(
+			formFields,
+			[(field) => !!field.meta?.system, 'meta.group', 'meta.sort', 'meta.id'],
+			['desc', 'desc', 'asc', 'asc'],
+		);
+
+		return sortedFields;
 	});
 }

--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -1,18 +1,11 @@
 import { Field } from '@directus/types';
-import { orderBy } from 'lodash';
 
 export function updateFieldWidths(fields: Field[]) {
-	const sortedFields = orderBy(
-		fields,
-		[(field) => !!field.meta?.system, 'meta.group', 'meta.sort', 'meta.id'],
-		['desc', 'desc', 'asc', 'asc'],
-	);
-
-	for (const [index, field] of sortedFields.entries()) {
+	for (const [index, field] of fields.entries()) {
 		if (index !== 0 && field.meta?.width === 'half' && field.meta.hidden !== true) {
 			let prevNonHiddenField;
 
-			for (const formField of sortedFields) {
+			for (const formField of fields) {
 				if (formField.meta?.group !== field.meta?.group || formField.meta?.hidden) continue;
 				if (formField === field) break;
 				prevNonHiddenField = formField;

--- a/app/src/components/v-form/utils/update-system-divider.test.ts
+++ b/app/src/components/v-form/utils/update-system-divider.test.ts
@@ -32,7 +32,7 @@ it('should hide system divider when no visible system fields', () => {
 	});
 });
 
-it('should hide system divider when no visible system fields', () => {
+it('should hide system divider when no visible user fields', () => {
 	const fields = cloneDeep(mockFields);
 	fields[2]!.meta!.hidden = true;
 

--- a/app/src/components/v-form/utils/update-system-divider.test.ts
+++ b/app/src/components/v-form/utils/update-system-divider.test.ts
@@ -1,0 +1,45 @@
+import type { DeepPartial, Field } from '@directus/types';
+import { expect, it } from 'vitest';
+import { updateSystemDivider } from './update-system-divider';
+import { cloneDeep } from 'lodash';
+
+const mockFields: DeepPartial<Field>[] = [
+	{ field: 'system_field', meta: { system: true } },
+	{ field: '$system_divider', meta: {} },
+	{ field: 'user_field', meta: {} },
+];
+
+it('should show/reveal system divider with visible system and user fields', () => {
+	const fields = cloneDeep(mockFields);
+
+	updateSystemDivider(fields as Field[]);
+
+	expect(fields).toContainEqual({
+		field: '$system_divider',
+		meta: { hidden: false },
+	});
+});
+
+it('should hide system divider when no visible system fields', () => {
+	const fields = cloneDeep(mockFields);
+	fields[0]!.meta!.hidden = true;
+
+	updateSystemDivider(fields as Field[]);
+
+	expect(fields).toContainEqual({
+		field: '$system_divider',
+		meta: { hidden: true },
+	});
+});
+
+it('should hide system divider when no visible system fields', () => {
+	const fields = cloneDeep(mockFields);
+	fields[2]!.meta!.hidden = true;
+
+	updateSystemDivider(fields as Field[]);
+
+	expect(fields).toContainEqual({
+		field: '$system_divider',
+		meta: { hidden: true },
+	});
+});

--- a/app/src/components/v-form/utils/update-system-divider.ts
+++ b/app/src/components/v-form/utils/update-system-divider.ts
@@ -1,0 +1,26 @@
+import type { Field } from '@directus/types';
+
+export function updateSystemDivider(fields: Field[]) {
+	let hasVisibleSystemFields = false;
+	let hasVisibleUserFields = false;
+	let systemDivider;
+
+	for (const field of fields) {
+		if (field.field === '$system_divider') {
+			systemDivider = field;
+			continue;
+		}
+
+		if (field.meta?.hidden) continue;
+
+		if (field.meta?.system) {
+			hasVisibleSystemFields = true;
+		} else {
+			hasVisibleUserFields = true;
+			// All system fields processed at this point, due to order
+			break;
+		}
+	}
+
+	if (systemDivider?.meta) systemDivider.meta.hidden = !hasVisibleSystemFields || !hasVisibleUserFields;
+}

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -120,6 +120,8 @@ const noVisibleFields = computed(() => {
 	});
 });
 
+defineExpose({ noVisibleFields });
+
 watch(
 	() => props.validationErrors,
 	(newVal, oldVal) => {

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -14,6 +14,7 @@ import FormField from './form-field.vue';
 import type { FormField as TFormField } from './types';
 import { getFormFields } from './utils/get-form-fields';
 import { updateFieldWidths } from './utils/update-field-widths';
+import { updateSystemDivider } from './utils/update-system-divider';
 import ValidationErrors from './validation-errors.vue';
 
 type FieldValues = {
@@ -120,8 +121,6 @@ const noVisibleFields = computed(() => {
 	});
 });
 
-defineExpose({ noVisibleFields });
-
 watch(
 	() => props.validationErrors,
 	(newVal, oldVal) => {
@@ -158,6 +157,7 @@ function useForm() {
 		let fields = formFields.value.map((field) => applyConditions(valuesWithDefaults, setPrimaryKeyReadonly(field)));
 
 		fields = pushGroupOptionsDown(fields);
+		updateSystemDivider(fields);
 		updateFieldWidths(fields);
 
 		return fields;

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -123,6 +123,10 @@ const customFields = computed(() => {
 	return fields.value.filter((field) => !field.meta?.system);
 });
 
+const showCustomForm = computed(() => {
+	return customFields.value.length > 0 && !customFields.value.every((field) => field.meta?.hidden === true);
+});
+
 const archiveTooltip = computed(() => {
 	if (archiveAllowed.value === false) return t('not_allowed');
 	if (isArchived.value === true) return t('unarchive');
@@ -411,11 +415,11 @@ function revert(values: Record<string, any>) {
 				:initial-values="user"
 				:primary-key="primaryKey"
 				:validation-errors="validationErrors"
-				:show-divider="customFields.length > 0"
+				:show-divider="showCustomForm"
 			/>
 
 			<v-form
-				v-if="customFields.length > 0"
+				v-if="showCustomForm"
 				ref="customForm"
 				v-model="edits"
 				:disabled="isNew ? false : updateAllowed === false"

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -19,6 +19,7 @@ import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
 import UserInfoSidebarDetail from '../components/user-info-sidebar-detail.vue';
+import VForm from '@/components/v-form/v-form.vue';
 
 const props = defineProps<{
 	primaryKey: string;
@@ -29,8 +30,8 @@ const { t, locale } = useI18n();
 
 const router = useRouter();
 
-const systemForm = ref<HTMLElement>();
-const customForm = ref<HTMLElement>();
+const systemForm = ref<HTMLElement | null>(null);
+const customForm = ref<InstanceType<typeof VForm> | null>(null);
 const fieldsStore = useFieldsStore();
 const collectionsStore = useCollectionsStore();
 const userStore = useUserStore();
@@ -415,11 +416,10 @@ function revert(values: Record<string, any>) {
 				:initial-values="user"
 				:primary-key="primaryKey"
 				:validation-errors="validationErrors"
-				:show-divider="showCustomForm"
+				:show-divider="!customForm?.noVisibleFields"
 			/>
 
 			<v-form
-				v-if="showCustomForm"
 				ref="customForm"
 				v-model="edits"
 				:disabled="isNew ? false : updateAllowed === false"
@@ -428,6 +428,7 @@ function revert(values: Record<string, any>) {
 				:initial-values="user"
 				:primary-key="primaryKey"
 				:validation-errors="validationErrors"
+				:show-no-visible-fields="false"
 			/>
 		</div>
 

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -335,7 +335,7 @@ export const useFieldsStore = defineStore('fieldsStore', () => {
 	function getFieldsForCollectionSorted(collection: string): Field[] {
 		const fieldsSorted = orderBy(
 			fields.value.filter((field) => field.collection === collection),
-			'meta.sort',
+			['meta.system', 'meta.sort'],
 		);
 
 		const nonGroupFields = fieldsSorted.filter((field: Field) => !field.meta?.group);

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -335,7 +335,7 @@ export const useFieldsStore = defineStore('fieldsStore', () => {
 	function getFieldsForCollectionSorted(collection: string): Field[] {
 		const fieldsSorted = orderBy(
 			fields.value.filter((field) => field.collection === collection),
-			['meta.sort'],
+			'meta.sort',
 		);
 
 		const nonGroupFields = fieldsSorted.filter((field: Field) => !field.meta?.group);

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -335,7 +335,7 @@ export const useFieldsStore = defineStore('fieldsStore', () => {
 	function getFieldsForCollectionSorted(collection: string): Field[] {
 		const fieldsSorted = orderBy(
 			fields.value.filter((field) => field.collection === collection),
-			['meta.system', 'meta.sort'],
+			['meta.sort'],
 		);
 
 		const nonGroupFields = fieldsSorted.filter((field: Field) => !field.meta?.group);


### PR DESCRIPTION
## Scope

| Before | After |
|--------|--------|
| ![image](https://github.com/directus/directus/assets/14810858/984c3d7c-397d-4a68-a45a-07c8aac076bd) | ![image](https://github.com/directus/directus/assets/14810858/e03b9367-9608-45eb-8bce-1760f16fb958) | 


This is because of the `meta.sort` property on the new field object.

`first_name` has `meta.sort == 1` and if you add new fields they get initialized to also start from `1` which leads to this "collision" 

Contrary on the data model view we check for the `meta.system` field to separate the non-editable fields from the user supplied ones. Thats why they appear at the bottom there. Theres different methods on how we could fix this.

What's changed:

- Add `meta.system` iteratee to field sorting so that system fields come before user created ones

## Potential Risks / Drawbacks

- Maybe we break existing layouts that people already rely on?

## Review Notes / Questions

- Careful: This change affects the `getTree` function in `use-field-tree.ts` which is used throughout said file so this change will touch a couple different places.

---

Fixes #20894 
