### PR TITLE
Fix collection meta fields not showing and saving properly

### DIFF
--- a/.changeset/angry-pugs-bow.md
+++ b/.changeset/angry-pugs-bow.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed collection meta fields sometimes not showing and saving properly

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -5,12 +5,12 @@ import { useShortcut } from '@/composables/use-shortcut';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useCollection } from '@directus/composables';
+import formatTitle from '@directus/format-title';
 import { computed, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import SettingsNavigation from '../../../components/navigation.vue';
 import FieldsManagement from './components/fields-management.vue';
-import formatTitle from '@directus/format-title';
 
 const props = defineProps<{
 	collection: string;
@@ -142,7 +142,7 @@ function discardAndLeave() {
 				v-model="edits.meta"
 				collection="directus_collections"
 				:loading="loading"
-				:initial-values="item && item.meta"
+				:initial-values="collectionInfo?.meta"
 				:primary-key="collection"
 				:disabled="item && item.collection.startsWith('directus_')"
 			/>


### PR DESCRIPTION
## Scope

Please see the Review Notes

| Before | After |
|--------|--------|
| <video src="https://github.com/directus/directus/assets/14810858/69d76490-3974-4fdb-8261-4756491659c5"></video> | <video src="https://github.com/directus/directus/assets/14810858/17ede4e6-46a3-4e7a-9d32-387f89172374"></video> | 
| Going into the m2a junction collection reproduces the talked about issues of the broken sort field, etc. | When replacing the initial values to the other object `edits` and all other meta fields work correctly |




What's changed:

- Changed initial values from `item` to `collectionInfo`

## Potential Risks / Drawbacks

- Not being able to persist your changes like described in the issues

## Review Notes / Questions

- I have to admit as of right now I dont know why this fixes it... I investigated the values that we provide but they are the same?

When passing `item?.meta` the v-form receives:

```json
{"collection":"page_blocks","icon":"import_export","note":"as","display_template":null,"hidden":true,"singleton":false,"translations":null,"archive_field":null,"archive_app_filter":true,"archive_value":null,"unarchive_value":null,"sort_field":"sort","accountability":"all","color":null,"item_duplication_fields":null,"sort":null,"group":null,"collapse":"open","preview_url":"dasd","versioning":false}
```

Then I switched it to `collectionInfo?.meta` and v-form gets the same initial values:

```json
{"collection":"page_blocks","icon":"import_export","note":"as","display_template":null,"hidden":true,"singleton":false,"translations":null,"archive_field":null,"archive_app_filter":true,"archive_value":null,"unarchive_value":null,"sort_field":"sort","accountability":"all","color":null,"item_duplication_fields":null,"sort":null,"group":null,"collapse":"open","preview_url":"dasd","versioning":false}
```

But now when switching to this collection I dont have the error anymore and my saves actually persist now? Can you guys please confirm that its the same for you? :pray: 

Will look into with fresh eyes in the morning, it's late now.

---

Fixes #19417 
Fixes #20871 
Closes #20562