### PR TITLE
Remove admin only restriction for extension read operations

### DIFF
--- a/.changeset/healthy-eggs-help.md
+++ b/.changeset/healthy-eggs-help.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Removed admin only restriction for extension read operations

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -39,7 +39,7 @@ export class ExtensionsService {
 		this.extensionsItemService = new ItemsService('directus_extensions', {
 			knex: this.knex,
 			schema: this.schema,
-			// No accountability here, as every other method is hardcoded to be admin only
+			accountability: this.accountability,
 		});
 
 		this.systemCache = getCache().systemCache;
@@ -47,10 +47,6 @@ export class ExtensionsService {
 	}
 
 	async readAll() {
-		if (this.accountability?.admin !== true) {
-			throw new ForbiddenError();
-		}
-
 		const installedExtensions = this.extensionsManager.getExtensions();
 		const configuredExtensions = await this.extensionsItemService.readByQuery({ limit: -1 });
 
@@ -58,10 +54,6 @@ export class ExtensionsService {
 	}
 
 	async readOne(bundle: string | null, name: string) {
-		if (this.accountability?.admin !== true) {
-			throw new ForbiddenError();
-		}
-
 		const key = this.getKey(bundle, name);
 
 		const schema = this.extensionsManager.getExtensions().find((extension) => extension.name === (bundle ?? name));


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Removed the admin only restriction for extension read operations. It now follows whatever is set in the users permissions.

## Potential Risks / Drawbacks

- None, the default is off for all but admin

## Review Notes / Questions

- N/A

---

Fixes #20830 