### PR TITLE
Remove obsolete temporary theme field permission

### DIFF
--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -105,8 +105,3 @@
     - tfa_secret
     - status
     - role
-
-    # This is a temporary allowed field to help people migrate from
-    # 10.6 to 10.7 and should be removed in 10.8
-    # @TODO remove
-    - theme


### PR DESCRIPTION
Added in #20308, it's no longer required now.