### PR TITLE
Add field note & template for wysiwyg-html interface

### DIFF
--- a/.changeset/old-pears-pull.md
+++ b/.changeset/old-pears-pull.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added field note & template for wysiwyg-html interface

--- a/app/src/interfaces/input-rich-text-html/index.ts
+++ b/app/src/interfaces/input-rich-text-html/index.ts
@@ -284,6 +284,7 @@ export default defineInterface({
 				type: 'json',
 				meta: {
 					interface: 'code',
+					note: '$t:interfaces.input-rich-text-html.custom_formats_note',
 					options: {
 						language: 'json',
 						template: JSON.stringify(
@@ -308,8 +309,17 @@ export default defineInterface({
 				type: 'json',
 				meta: {
 					interface: 'code',
+					note: '$t:interfaces.input-rich-text-html.options_override_note',
 					options: {
 						language: 'json',
+						template: JSON.stringify(
+							{
+								font_size_formats: '8pt 10pt 12pt 14pt 16pt 18pt 24pt 36pt 48pt',
+								font_family_formats: 'Arial=arial,helvetica,sans-serif; Courier New=courier new,courier,monospace;',
+							},
+							null,
+							4,
+						),
 					},
 				},
 			},

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1889,7 +1889,13 @@ interfaces:
     description: A rich-text editor writing HTML content
     toolbar: Toolbar
     custom_formats: Custom Formats
+    custom_formats_note:
+      List of TinyMCE Content Formats. See the TinyMCE documentation about [Content
+      Formatting](https://www.tiny.cloud/docs/tinymce/latest/content-formatting/) for more information.
     options_override: Options Override
+    options_override_note:
+      The TinyMCE User Formatting keys and their values. See the TinyMCE documentation about [User
+      Formatting](https://www.tiny.cloud/docs/tinymce/latest/user-formatting-options/) for more information.
     folder_note: Folder for uploaded files. Does not affect existing files.
     imageToken: Static Access Token
     imageToken_label: Static access token is appended to the assets' URL


### PR DESCRIPTION
## Scope

Similar to how we link to Sharps documentation in the custom image transformations, I thought it'd be nice to point users to TinyMCEs Docs to improve their UX when they want to customize it.

What's changed:

- Added field note & template for wysiwyg-html interface

![image](https://github.com/directus/directus/assets/14810858/36808d0d-3097-4f4d-9501-ea2211304be7)

## Potential Risks / Drawbacks

- Implementation wise nothing, the ol' trusty `v-form` renders this. Only risk is that at some point the URLs might be out of date or 404, etc.

## Review Notes / Questions

- The link to Sharp and these ones open in the same tab which feels not right. Theyre external links and it'd be better if the link would open in a new tab. For that we would need to change `form-field.vue` to the following:

```diff
- <small v-if="field.meta && field.meta.note" v-md="field.meta.note" class="type-note" />
+ <small v-if="field.meta && field.meta.note" v-md="{ value: field.meta.note, target: '_blank' }" class="type-note" />
```

But that would then apply to every link in form-fields. Do we want this? :thinking: 

---

Fixes #20882 
