### PR TITLE
Add target blank to form field notes

### DIFF
--- a/.changeset/old-steaks-notice.md
+++ b/.changeset/old-steaks-notice.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added target \_blank to links in form-field notes

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -206,7 +206,7 @@ function useComputedValues() {
 			@set-raw-value="onRawValueSubmit"
 		/>
 
-		<small v-if="field.meta && field.meta.note" v-md="field.meta.note" class="type-note" />
+		<small v-if="field.meta && field.meta.note" v-md="{ value: field.meta.note, target: '_blank' }" class="type-note" />
 
 		<small v-if="validationError" class="validation-error selectable">
 			<template v-if="field.meta?.validation_message">


### PR DESCRIPTION
## Scope

What's changed:

- Added target _blank to form-field notes

## Potential Risks / Drawbacks

- None as far as I know

## Review Notes / Questions

- None

---

We mentioned it in https://github.com/directus/directus/pull/20921#issue-2060082391
