### PR TITLE
fix(api): use payload updated with filter event for O2M processing

### DIFF
--- a/.changeset/short-socks-sort.md
+++ b/.changeset/short-socks-sort.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed use O2M entities modified by filter event for subsequent opertions

--- a/.changeset/short-socks-sort.md
+++ b/.changeset/short-socks-sort.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed use O2M entities modified by filter event for subsequent opertions
+Enabled updates of O2M entities via filter hook on parent level, ensured the payload of update action event reflects the actual updated value

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -685,7 +685,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 			for (const key of keys) {
 				const { revisions, nestedActionEvents: nestedActionEventsO2M } = await payloadService.processO2M(
-					payload,
+					payloadWithA2O,
 					key,
 					opts,
 				);
@@ -774,7 +774,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 						? ['items.update', `${this.collection}.items.update`]
 						: `${this.eventScope}.update`,
 				meta: {
-					payload,
+					payload: payloadAfterHooks,
 					keys,
 					collection: this.collection,
 				},

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -774,7 +774,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 						? ['items.update', `${this.collection}.items.update`]
 						: `${this.eventScope}.update`,
 				meta: {
-					payload: payloadAfterHooks,
+					payload: payloadWithPresets,
 					keys,
 					collection: this.collection,
 				},


### PR DESCRIPTION

## Scope

What's changed:

- use filter event modified o2m entities in processO2M while updating entities
- use the eventModified payload in `action` event

## Potential Risks / Drawbacks

NA

## Review Notes / Questions

added below

---

Fixes #20746
