### PR TITLE
Optimize shipped files in `@directus/sdk`

### DIFF
--- a/.changeset/strange-eggs-admire.md
+++ b/.changeset/strange-eggs-admire.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Configured sourcemaps to use source from GitHub instead of inlining, reducing the size of the package

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -39,8 +39,11 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "./dist/index.d.ts",
 	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build": "NODE_ENV=production tsup",
 		"dev": "NODE_ENV=development tsup",

--- a/sdk/readme.md
+++ b/sdk/readme.md
@@ -1,10 +1,12 @@
 # Directus JavaScript SDK
 
-The design goals for this rebuild:
+## Features
 
-- TypeScript first
-- Modular/Composable architecture
-- Lightweight and Dependency Free
+- **TypeScript first:** The SDK provides a robust and type-safe development experience.
+- **Modular architecture:** The SDK is split into separate modules, giving you granular control over which features to
+  include and which can be pruned at build-time.
+- **Lightweight and dependency-free:** It does not require external libraries, ensuring a lighter bundle and streamlined
+  experience.
 
 ## Composable Client
 

--- a/sdk/tsup.config.js
+++ b/sdk/tsup.config.js
@@ -1,9 +1,21 @@
 import { defineConfig } from 'tsup';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { version } = JSON.parse(await readFile(join(__dirname, '../directus/package.json'), 'utf8'));
 
 const env = process.env.NODE_ENV;
 
 export default defineConfig(() => ({
 	sourcemap: env === 'production', // source map is only available in prod
+	esbuildOptions(options) {
+		// fetch source from GitHub
+		options.sourceRoot = `https://raw.githubusercontent.com/directus/directus/v${version}/sdk/dist/`;
+		options.sourcesContent = false;
+	},
 	clean: true, // clean dist before build
 	dts: true, // generate dts file for main module
 	format: ['cjs', 'esm'], // generate cjs and esm files


### PR DESCRIPTION
## Scope

What's changed:

- Update intro in readme
- Only include `dist` in package
- Fetch source code for source map from GitHub, instead of shipping by default
  - Tested in Firefox

Reduces package size

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None