### PR TITLE
Fix issues with the form state when navigating between collection settings pages

### DIFF
--- a/.changeset/wild-needles-beg.md
+++ b/.changeset/wild-needles-beg.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Small code optimization in collection fields component

--- a/.changeset/wild-needles-beg.md
+++ b/.changeset/wild-needles-beg.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Small code optimization in collection fields component
+Fixed issues with the form state when navigating between collection settings pages

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -42,6 +42,7 @@ export function useItem<T extends Record<string, any>>(
 	collection: Ref<string>,
 	primaryKey: Ref<string | number | null>,
 	query: Ref<Query> | Query = {},
+	initialFetch = true,
 ): UsableItem<T> {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 	const item: Ref<T | null> = ref(null);
@@ -78,7 +79,7 @@ export function useItem<T extends Record<string, any>>(
 
 	const defaultValues = getDefaultValuesFromFields(fieldsWithPermissions);
 
-	watch([collection, primaryKey, ...(isRef(query) ? [query] : [])], refresh, { immediate: true });
+	watch([collection, primaryKey, ...(isRef(query) ? [query] : [])], refresh, { immediate: initialFetch });
 
 	return {
 		edits,

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -78,7 +78,7 @@ export function useItem<T extends Record<string, any>>(
 
 	const defaultValues = getDefaultValuesFromFields(fieldsWithPermissions);
 
-	watch([collection, primaryKey, ...(isRef(query) ? [query] : [])], refresh, { immediate: true });
+	watch([collection, primaryKey, ...(isRef(query) ? [query] : [])], refresh);
 
 	refreshItem();
 

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -446,7 +446,6 @@ export function useItem<T extends Record<string, any>>(
 		archiving.value = false;
 
 		item.value = null;
-		edits.value = {};
 
 		refreshItem();
 	}

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -42,7 +42,6 @@ export function useItem<T extends Record<string, any>>(
 	collection: Ref<string>,
 	primaryKey: Ref<string | number | null>,
 	query: Ref<Query> | Query = {},
-	initialFetch = true,
 ): UsableItem<T> {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 	const item: Ref<T | null> = ref(null);
@@ -79,7 +78,7 @@ export function useItem<T extends Record<string, any>>(
 
 	const defaultValues = getDefaultValuesFromFields(fieldsWithPermissions);
 
-	watch([collection, primaryKey, ...(isRef(query) ? [query] : [])], refresh, { immediate: initialFetch });
+	watch([collection, primaryKey, ...(isRef(query) ? [query] : [])], refresh, { immediate: true });
 
 	return {
 		edits,

--- a/app/src/interfaces/_system/system-field/system-field.vue
+++ b/app/src/interfaces/_system/system-field/system-field.vue
@@ -41,7 +41,7 @@ const fields = computed(() => {
 
 // Reset value whenever the chosen collection changes
 watch(collection, (newCol, oldCol) => {
-	if (oldCol !== null && newCol !== oldCol) {
+	if (oldCol && newCol !== oldCol) {
 		emit('input', null);
 	}
 });

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -28,7 +28,7 @@ const { info: collectionInfo } = useCollection(collection);
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
 
-const { edits, item, saving, loading, save, remove, deleting } = useItem(ref('directus_collections'), collection);
+const { edits, saving, save, remove, deleting } = useItem(ref('directus_collections'), collection, {}, false);
 
 const hasEdits = computed<boolean>(() => {
 	if (!edits.value.meta) return false;
@@ -84,13 +84,13 @@ function discardAndLeave() {
 			<v-dialog v-model="confirmDelete" @esc="confirmDelete = false">
 				<template #activator="{ on }">
 					<v-button
-						v-if="item && item.collection.startsWith('directus_') === false"
+						v-if="collectionInfo?.collection.startsWith('directus_') === false"
 						v-tooltip.bottom="t('delete_collection')"
 						rounded
 						icon
 						class="action-delete"
 						secondary
-						:disabled="item === null"
+						:disabled="collectionInfo === null"
 						@click="on"
 					>
 						<v-icon name="delete" />
@@ -141,10 +141,9 @@ function discardAndLeave() {
 			<v-form
 				v-model="edits.meta"
 				collection="directus_collections"
-				:loading="loading"
 				:initial-values="collectionInfo?.meta"
 				:primary-key="collection"
-				:disabled="item && item.collection.startsWith('directus_')"
+				:disabled="collectionInfo?.collection.startsWith('directus_')"
 			/>
 		</div>
 

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -499,7 +499,7 @@ function getNearAttachment(pos: Vector2) {
 const hasEdits = computed(() => stagedPanels.value.length > 0 || panelsToBeDeleted.value.length > 0);
 
 const { confirmLeave, leaveTo } = useEditsGuard(hasEdits, {
-	ignorePrefix: computed(() => `/settings/flows/${props.primaryKey}/`),
+	ignorePrefix: computed(() => `/settings/flows/${props.primaryKey}`),
 });
 
 const confirmCancel = ref(false);


### PR DESCRIPTION
## Scope

What's changed:

- **Switch back to `useItem` but re-initialize it on page changes**
  
  This page/component is a bit of a special case, because it is re-used with different props (collection) without being re-mounted (and thus not re-initialized) when navigating via provided links on relational fields or history.
  
  This reverts #20912 as we still want to rely on `useItem` to fetch the latest state of a collection incl. translation (was missing after #20912) as well as having the usual vars & methods available like `loading`, `save`, ... which we can pass to `v-form`.
  
  However, we need to completely re-initialize `useItem` per collection, not just fetching the new collection on page change.

- **Account for undefined collection prop in `system-field` interface**

  As outlined in https://github.com/directus/directus/pull/20912#issuecomment-1872203138

- **Improve subpath check in edit route guard**

  Previously, it would also match paths at the same level and thus wrongly allowing to exit page with unsaved changes. This happened, for example, when navigating between two collections that have the same base name (`example` and `example2`), which means the edits would be taken over from one to the other collection.

## Potential Risks / Drawbacks

Successfully tested all scenarios:
- #19417
- #20871
- https://github.com/directus/directus/pull/20949#pullrequestreview-1801865595
- "Note" for system collections is translated again
- Edit guard works for data-model, dashboards and flows pages

## Review Notes / Questions

None