### PR TITLE
Fix the system theme overrides interface color rules to refresh on external changes

### DIFF
--- a/.changeset/breezy-candles-wonder.md
+++ b/.changeset/breezy-candles-wonder.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed colors in system theme overrides interface not refreshing on external changes
+Fixed the system theme overrides interface color rules to refresh on external changes

--- a/.changeset/breezy-candles-wonder.md
+++ b/.changeset/breezy-candles-wonder.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed colors in system theme overrides interface not refreshing on external changes

--- a/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides-rule.vue
+++ b/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides-rule.vue
@@ -18,12 +18,17 @@ const onInput = (event: Event) => {
 };
 
 const swatchValue = computed(() => {
-	let value = props.value ?? props.defaultValue;
+	const value = props.value ?? props.defaultValue;
 
 	if (typeof value !== 'string') return null;
 
 	if (value.startsWith('var(--')) {
-		value = cssVar(value.slice(4, -1));
+		// A var function that resolves to a color should be rendered directly.
+		const result = cssVar(value.slice(4, -1));
+
+		if (!result.startsWith('#')) {
+			return null;
+		}
 	}
 
 	return value;
@@ -33,6 +38,15 @@ const showSwatch = computed(() => {
 	if (!swatchValue.value) return false;
 
 	try {
+		if (swatchValue.value.startsWith('var(--') || swatchValue.value.startsWith('color-mix(')) {
+			/**
+			 * var and color-mix are not support by the color lib.
+			 * We assume var has been validated by this point and can be directly rendered.
+			 * By rendering the function directly we ensure reactivity for realtime changes.
+			 */
+			return true;
+		}
+
 		Color(swatchValue.value);
 		return true;
 	} catch {

--- a/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides-rule.vue
+++ b/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides-rule.vue
@@ -39,7 +39,7 @@ const showSwatch = computed(() => {
 
 	try {
 		if (swatchValue.value.startsWith('var(--') || swatchValue.value.startsWith('color-mix(')) {
-			/**
+			/*
 			 * var and color-mix are not supported by the color lib.
 			 * We assume var has been validated by this point and can be directly rendered.
 			 * By rendering the function directly we ensure reactivity for realtime changes.

--- a/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides-rule.vue
+++ b/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides-rule.vue
@@ -40,7 +40,7 @@ const showSwatch = computed(() => {
 	try {
 		if (swatchValue.value.startsWith('var(--') || swatchValue.value.startsWith('color-mix(')) {
 			/**
-			 * var and color-mix are not support by the color lib.
+			 * var and color-mix are not supported by the color lib.
 			 * We assume var has been validated by this point and can be directly rendered.
 			 * By rendering the function directly we ensure reactivity for realtime changes.
 			 */


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Fixed colors in the system theme overrides interface not refreshing on external changes.
  - We now directly render var (that has a color rule) and color-mix instead of just the result.
- Rules that have color-mix now render a swatch properly.

https://github.com/directus/directus/assets/44623501/f2d3f61f-bfb1-4701-91e0-a64fb3c10a3e

## Potential Risks / Drawbacks

- None, this is the only location where this interface is used.

## Review Notes / Questions

- This seemed the optimal solution here, open to any suggestions. 
   - The issue here is that the value for the var function never changed although the result does. The cssVar function is not reactive from a vue perspective and therefor does not trigger a re-compute.
   - Rendering the functions directly seem to be an easy and ideal solution.

---

Fixes #20126
