### PR TITLE
Fix confirmation dialog not always showing top level

### DIFF
--- a/.changeset/shy-tomatoes-sing.md
+++ b/.changeset/shy-tomatoes-sing.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed confirmation dialog not always showing top level

--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -102,6 +102,7 @@ function nudge() {
 .container.center {
 	align-items: center;
 	justify-content: center;
+	z-index: 600;
 }
 
 .container.center.nudge > :slotted(*:not(:first-child)) {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Confirmation dialogue now shows top level at all times.

https://github.com/directus/directus/assets/44623501/c0e717be-04e7-4e8c-a051-3cbd4f9cd652

## Potential Risks / Drawbacks

- Cases where we want a confirmation dialogue not showing top level. I am not aware of any such case.

## Review Notes / Questions

- N/A

---

Fixes #19206
