### PR TITLE
Api: Do not suspend user if rate limiter store is unreachable

### DIFF
--- a/.changeset/tender-windows-destroy.md
+++ b/.changeset/tender-windows-destroy.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed an issue where users would be suspended when authenticating while Redis is temporarily unavailable

--- a/api/src/rate-limiter.ts
+++ b/api/src/rate-limiter.ts
@@ -8,8 +8,6 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
-export { RateLimiterRes };
-
 type IRateLimiterOptionsOverrides = Partial<IRateLimiterOptions> | Partial<IRateLimiterStoreOptions>;
 
 export function createRateLimiter(
@@ -26,6 +24,8 @@ export function createRateLimiter(
 			return new RateLimiterMemory(getConfig('memory', configPrefix, configOverrides));
 	}
 }
+
+export { RateLimiterRes };
 
 function getConfig(
 	store: 'memory',

--- a/api/src/rate-limiter.ts
+++ b/api/src/rate-limiter.ts
@@ -1,12 +1,14 @@
 import { merge } from 'lodash-es';
 import type { IRateLimiterOptions, IRateLimiterStoreOptions, RateLimiterAbstract } from 'rate-limiter-flexible';
-import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible';
+import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 import { useEnv } from './env.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
 
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
+
+export { RateLimiterRes };
 
 type IRateLimiterOptionsOverrides = Partial<IRateLimiterOptions> | Partial<IRateLimiterStoreOptions>;
 

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -150,8 +150,8 @@ export class AuthenticationService {
 
 			try {
 				await loginAttemptsLimiter.consume(user.id);
-			} catch (err) {
-				if (err && err instanceof RateLimiterRes && err.remainingPoints === 0) {
+			} catch (error) {
+				if (error instanceof RateLimiterRes && error.remainingPoints === 0) {
 					await this.knex('directus_users').update({ status: 'suspended' }).where({ id: user.id });
 					user.status = 'suspended';
 

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -1,5 +1,11 @@
 import { Action } from '@directus/constants';
-import { InvalidCredentialsError, InvalidOtpError, InvalidProviderError, UserSuspendedError } from '@directus/errors';
+import {
+	InvalidCredentialsError,
+	InvalidOtpError,
+	InvalidProviderError,
+	UserSuspendedError,
+	ServiceUnavailableError,
+} from '@directus/errors';
 import type { Accountability, SchemaOverview } from '@directus/types';
 import jwt from 'jsonwebtoken';
 import type { Knex } from 'knex';
@@ -145,13 +151,17 @@ export class AuthenticationService {
 			try {
 				await loginAttemptsLimiter.consume(user.id);
 			} catch (err) {
-				// This can also be caused by a failed connection to Redis so let's only handle when is caused by brute force
 				if (err && err instanceof RateLimiterRes && err.remainingPoints === 0) {
 					await this.knex('directus_users').update({ status: 'suspended' }).where({ id: user.id });
 					user.status = 'suspended';
 
 					// This means that new attempts after the user has been re-activated will be accepted
 					await loginAttemptsLimiter.set(user.id, 0, 0);
+				} else {
+					throw new ServiceUnavailableError({
+						service: 'authentication',
+						reason: 'Rate limiter unreachable',
+					});
 				}
 			}
 		}


### PR DESCRIPTION
## Scope

What's changed:

- Do not suspend user if rate limiter store is unreachable

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- In addition, I would like to ask why do we have a specific rate limiter for authentication? Shouldn't the global rate limiter be enough? 🤔

This was originally set on the following PR:
https://github.com/directus/directus/pull/5225
which fixed the following issue:
https://github.com/directus/directus/issues/2969

---

Fixes #19928
