### PR TITLE
Rename legacy role's `ip_whitelist` to `ip_access`

### DIFF
--- a/.changeset/many-camels-impress.md
+++ b/.changeset/many-camels-impress.md
@@ -1,0 +1,6 @@
+---
+'@directus/specs': patch
+'@directus/types': patch
+---
+
+Renamed legacy role's `ip_whitelist` to `ip_access`

--- a/packages/specs/src/paths/roles/role.yaml
+++ b/packages/specs/src/paths/roles/role.yaml
@@ -43,7 +43,7 @@ patch:
             external_id:
               description: ID used with external services in SCIM.
               type: string
-            ip_whitelist:
+            ip_access:
               description: Array of IP addresses that are allowed to connect to the API as a user of this role.
               type: array
               items:

--- a/packages/specs/src/paths/roles/roles.yaml
+++ b/packages/specs/src/paths/roles/roles.yaml
@@ -54,7 +54,7 @@ post:
             external_id:
               description: ID used with external services in SCIM.
               type: string
-            ip_whitelist:
+            ip_access:
               description: Array of IP addresses that are allowed to connect to the API as a user of this role.
               type: array
               items:
@@ -120,7 +120,7 @@ patch:
                 external_id:
                   description: ID used with external services in SCIM.
                   type: string
-                ip_whitelist:
+                ip_access:
                   description: Array of IP addresses that are allowed to connect to the API as a user of this role.
                   type: array
                   items:

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -5,7 +5,7 @@ export type Role = {
 	icon: string;
 	enforce_tfa: null | boolean;
 	external_id: null | string;
-	ip_whitelist: string[];
+	ip_access: string[];
 	app_access: boolean;
 	admin_access: boolean;
 };


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Rename legacy role's `ip_whitelist` to `ip_access`

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---
