### PR TITLE
Allow updating custom fields for `directus_extensions`

### DIFF
--- a/.changeset/lazy-tables-lie.md
+++ b/.changeset/lazy-tables-lie.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Allowed updating custom fields for `directus_extensions`

--- a/.changeset/lazy-tables-lie.md
+++ b/.changeset/lazy-tables-lie.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Allowed updating custom fields for `directus_extensions`
+Allow updating custom fields for `directus_extensions` collection


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now allow updating custom fields for `directus_extensions`.
- Refactored bundle/bundle entry extension status toggle logic into a `checkBundleAndSyncStatus` function.
- Utilized `getKey` extension service util for generating `LIKE` query value. 

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #20948
