### PR TITLE
Align extensions update endpoint

### DIFF
--- a/.changeset/eighty-numbers-eat.md
+++ b/.changeset/eighty-numbers-eat.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Adjusted extensions update endpoint to use permission rules for access check

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -1,10 +1,10 @@
-import { ForbiddenError, RouteNotFoundError } from '@directus/errors';
+import { ErrorCode, ForbiddenError, RouteNotFoundError, isDirectusError } from '@directus/errors';
 import express from 'express';
 import { useEnv } from '../env.js';
 import { getExtensionManager } from '../extensions/index.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
-import { ExtensionsService } from '../services/extensions.js';
+import { ExtensionReadError, ExtensionsService } from '../services/extensions.js';
 import asyncHandler from '../utils/async-handler.js';
 import { getCacheControlHeader } from '../utils/get-cache-headers.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
@@ -44,11 +44,22 @@ router.patch(
 			throw new ForbiddenError();
 		}
 
-		await service.updateOne(bundle, name, req.body);
+		try {
+			const result = await service.updateOne(bundle, name, req.body);
+			res.locals['payload'] = { data: result || null };
+		} catch (error) {
+			let finalError = error;
 
-		const updated = await service.readOne(bundle, name);
+			if (error instanceof ExtensionReadError) {
+				finalError = error.originalError;
 
-		res.locals['payload'] = { data: updated || null };
+				if (isDirectusError(finalError, ErrorCode.Forbidden)) {
+					return next();
+				}
+			}
+
+			throw finalError;
+		}
 
 		return next();
 	}),

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -1,6 +1,7 @@
 import { ForbiddenError, InvalidPayloadError, UnprocessableContentError } from '@directus/errors';
 import type { ApiOutput, Extension, ExtensionSettings } from '@directus/extensions';
 import type { Accountability, DeepPartial, SchemaOverview } from '@directus/types';
+import { isObject } from '@directus/utils';
 import type { Knex } from 'knex';
 import { omit, pick } from 'lodash-es';
 import getDatabase from '../database/index.js';
@@ -59,7 +60,7 @@ export class ExtensionsService {
 
 	async updateOne(bundle: string | null, name: string, data: DeepPartial<ApiOutput>) {
 		const result = await this.knex.transaction(async (trx) => {
-			if (!data.meta) {
+			if (!isObject(data.meta)) {
 				throw new InvalidPayloadError({ reason: `"meta" is required` });
 			}
 


### PR DESCRIPTION
## Scope

What's changed:

- Use permissions rules for access check in `extensions` update endpoint, enabling to configure rules which allow non-admin roles to manage extensions too
- Behave the same as other endpoints (specifically `items`)
  - 204 when patching non-existing extension
  - Ignore non-existing fields
  - Cast custom fields
- Enables activity tracking for extension updates
- Use transaction to ensure atomic updates
- Clean-up unused props in extensions service

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
