### PR TITLE
Disable non-editable permissions on Access Control page

### DIFF
--- a/.changeset/new-badgers-look.md
+++ b/.changeset/new-badgers-look.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Disabled non-editable permission actions
+Disabled non-editable permission actions for editing on Access Control page

--- a/.changeset/new-badgers-look.md
+++ b/.changeset/new-badgers-look.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Disabled non-editable permission actions

--- a/app/src/modules/settings/routes/roles/app-permissions.ts
+++ b/app/src/modules/settings/routes/roles/app-permissions.ts
@@ -356,3 +356,10 @@ export const appMinimalPermissions: Partial<Permission>[] = [
 		],
 	},
 ];
+
+export const editablePermissionActions = ['create', 'read', 'update', 'delete', 'share'] as const;
+export type EditablePermissionsAction = (typeof editablePermissionActions)[number];
+
+export const disabledActions: Record<string, EditablePermissionsAction[]> = {
+	directus_extensions: ['create', 'delete'],
+};

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import { Collection } from '@/types/collections';
+import ValueNull from '@/views/private/components/value-null.vue';
 import { Permission } from '@directus/types';
 import { toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { editablePermissionActions, EditablePermissionsAction } from '../../app-permissions';
 import useUpdatePermissions from '../composables/use-update-permissions';
 import PermissionsOverviewToggle from './permissions-overview-toggle.vue';
-import { Collection } from '@/types/collections';
 
 const props = defineProps<{
 	collection: Collection;
+	disabledActions?: EditablePermissionsAction[];
 	permissions: Permission[];
 	refreshing: number[];
 	role?: string;
@@ -21,7 +24,7 @@ const { setFullAccessAll, setNoAccessAll, getPermission } = useUpdatePermissions
 
 function isLoading(action: string) {
 	const permission = getPermission(action);
-	if (!permission) return false;
+	if (!permission?.id) return false;
 	return props.refreshing.includes(permission.id);
 }
 </script>
@@ -37,46 +40,18 @@ function isLoading(action: string) {
 			</span>
 		</span>
 
-		<permissions-overview-toggle
-			action="create"
-			:collection="collection"
-			:role="role"
-			:permissions="permissions"
-			:loading="isLoading('create')"
-			:app-minimal="appMinimal && appMinimal.find((p) => p.action === 'create')"
-		/>
-		<permissions-overview-toggle
-			action="read"
-			:collection="collection"
-			:role="role"
-			:permissions="permissions"
-			:loading="isLoading('read')"
-			:app-minimal="appMinimal && appMinimal.find((p) => p.action === 'read')"
-		/>
-		<permissions-overview-toggle
-			action="update"
-			:collection="collection"
-			:role="role"
-			:permissions="permissions"
-			:loading="isLoading('update')"
-			:app-minimal="appMinimal && appMinimal.find((p) => p.action === 'update')"
-		/>
-		<permissions-overview-toggle
-			action="delete"
-			:collection="collection"
-			:role="role"
-			:permissions="permissions"
-			:loading="isLoading('delete')"
-			:app-minimal="appMinimal && appMinimal.find((p) => p.action === 'delete')"
-		/>
-		<permissions-overview-toggle
-			action="share"
-			:collection="collection"
-			:role="role"
-			:permissions="permissions"
-			:loading="isLoading('share')"
-			:app-minimal="appMinimal && appMinimal.find((p) => p.action === 'share')"
-		/>
+		<template v-for="action in editablePermissionActions" :key="action">
+			<permissions-overview-toggle
+				v-if="!disabledActions?.includes(action)"
+				:action="action"
+				:collection="collection"
+				:role="role"
+				:permissions="permissions"
+				:loading="isLoading(action)"
+				:app-minimal="appMinimal && appMinimal.find((p) => p.action === action)"
+			/>
+			<value-null v-else />
+		</template>
 	</div>
 </template>
 
@@ -123,7 +98,14 @@ function isLoading(action: string) {
 		opacity: 1;
 	}
 
-	.permissions-overview-toggle + .permissions-overview-toggle {
+	.null {
+		display: flex;
+		justify-content: center;
+		width: 24px;
+		color: var(--theme--foreground);
+	}
+
+	:is(.permissions-overview-toggle, .null) + :is(.permissions-overview-toggle, .null) {
 		margin-left: 20px;
 	}
 

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
@@ -6,7 +6,7 @@ import { Permission } from '@directus/types';
 import { orderBy } from 'lodash';
 import { computed, provide, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { appMinimalPermissions, appRecommendedPermissions } from '../../app-permissions';
+import { appMinimalPermissions, appRecommendedPermissions, disabledActions } from '../../app-permissions';
 import PermissionsOverviewHeader from './permissions-overview-header.vue';
 import PermissionsOverviewRow from './permissions-overview-row.vue';
 
@@ -160,6 +160,7 @@ function useReset() {
 						:key="collection.collection"
 						:collection="collection"
 						:role="role"
+						:disabled-actions="disabledActions[collection.collection]"
 						:permissions="permissions.filter((p) => p.collection === collection.collection)"
 						:refreshing="refreshing"
 						:app-minimal="


### PR DESCRIPTION
## Scope

What's changed:

Disable non-editable permissions, namely `create` and `delete` actions for `directus_extensions` collection.

<img width="700" src="https://github.com/directus/directus/assets/5363448/dd429478-fbdf-414b-a3ab-e70ff95121a3">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

We might disable it on API-level too, but this seems to be a good first step in making it clearer for App users.