### PR TITLE
Use official abbreviation of Exif

### DIFF
--- a/.changeset/thin-bottles-visit.md
+++ b/.changeset/thin-bottles-visit.md
@@ -1,0 +1,7 @@
+---
+"@directus/api": patch
+"docs": patch
+"@directus/specs": patch
+---
+
+Use official abbreviation "Exif" instead of "EXIF"

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -277,7 +277,7 @@ export class FilesService extends ItemsService {
 
 							Object.assign(fullMetadata, rest);
 						} catch (err) {
-							logger.warn(`Couldn't extract EXIF metadata from file`);
+							logger.warn(`Couldn't extract Exif metadata from file`);
 							logger.warn(err);
 						}
 					}

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -196,7 +196,7 @@ Entrypoint
 env
 ENV
 ESM
-EXIF
+Exif
 fallbacks
 falsy
 FavIcon

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -295,7 +295,7 @@ Location of the file.
 Tags for the file.
 
 `metadata` **object**\
-Any additional metadata Directus was able to scrape from the file. For images, this includes EXIF, IPTC, and ICC information.
+Any additional metadata Directus was able to scrape from the file. For images, this includes Exif, IPTC, and ICC information.
 
 ```json
 {

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -651,7 +651,7 @@ STORAGE_AWS_BUCKET="my-files"
 
 ### Metadata
 
-When uploading an image, Directus persists the _description, title, and tags_ from available EXIF metadata. For security
+When uploading an image, Directus persists the _description, title, and tags_ from available Exif metadata. For security
 purposes, collection of additional metadata must be configured:
 
 | Variable                   | Description                                                                                           | Default Value                                                                 |

--- a/docs/user-guide/file-library/files.md
+++ b/docs/user-guide/file-library/files.md
@@ -110,7 +110,7 @@ The file sidebar also includes the following details, which are not editable and
 - **Modified** – The timestamp of when the file was last modified.
 - **Edited By** – The User that modified the File.
 - **Folder** – The current parent folder that contains the File.
-- **Metadata** – Metadata JSON dump of the File's EXIF, IPTC, and ICC information.
+- **Metadata** – Metadata JSON dump of the File's Exif, IPTC, and ICC information.
 
 ## Edit an Image
 

--- a/packages/specs/src/components/file.yaml
+++ b/packages/specs/src/components/file.yaml
@@ -78,16 +78,16 @@ properties:
     type: string
     nullable: true
   location:
-    description: Where the file was created. Is automatically populated based on EXIF data for images.
+    description: Where the file was created. Is automatically populated based on Exif data for images.
     type: string
     nullable: true
   tags:
-    description: Tags for the file. Is automatically populated based on EXIF data for images.
+    description: Tags for the file. Is automatically populated based on Exif data for images.
     type: array
     nullable: true
     items:
       type: string
   metadata:
-    description: IPTC, EXIF, and ICC metadata extracted from file
+    description: IPTC, Exif, and ICC metadata extracted from file
     type: object
     nullable: true

--- a/packages/specs/src/paths/files/file.yaml
+++ b/packages/specs/src/paths/files/file.yaml
@@ -56,7 +56,7 @@ patch:
                 - $ref: '../../openapi.yaml#/components/schemas/Folders'
               nullable: true
             tags:
-              description: Tags for the file. Is automatically populated based on EXIF data for images.
+              description: Tags for the file. Is automatically populated based on Exif data for images.
               type: array
               nullable: true
               items:
@@ -87,7 +87,7 @@ patch:
                 - $ref: '../../openapi.yaml#/components/schemas/Folders'
               nullable: true
             tags:
-              description: Tags for the file. Is automatically populated based on EXIF data for images.
+              description: Tags for the file. Is automatically populated based on Exif data for images.
               type: array
               nullable: true
               items:


### PR DESCRIPTION
## Scope

What's changed:

TIL: The official abbreviation for "Exchangeable image file format" is Exif not EXIF [^1]

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A

[^1]: https://en.wikipedia.org/wiki/Exif, https://www.loc.gov/preservation/digital/formats/fdd/fdd000146.shtml