### PR TITLE
Default to current user language in field translation language selector

### DIFF
--- a/.changeset/chilly-meals-ring.md
+++ b/.changeset/chilly-meals-ring.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Changed the hard-coded default to current user language in field translation language selector

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
+import { getCurrentLanguage } from '@/lang/get-current-language';
 
 const { t } = useI18n();
 const fieldDetailStore = useFieldDetailStore();
@@ -65,7 +66,7 @@ const isGenerated = computed(() => field.value.schema?.is_generated);
 							},
 						},
 						schema: {
-							default_value: 'en-US',
+							default_value: getCurrentLanguage(),
 						},
 					},
 					{

--- a/contributors.yml
+++ b/contributors.yml
@@ -105,3 +105,4 @@
 - emahuni
 - khako
 - Voldemorten
+- FloMaetschke


### PR DESCRIPTION
## Scope

What's changed:

- Default to the current user language in field translation language selector

Taken over from #20258 due to read-only branch, all props to @FloMaetschke! (I'll make sure credits are given to you in release notes)

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #20257
Closes #20258