### PR TITLE
Maintain snapshot order

### DIFF
--- a/api/src/utils/get-snapshot-diff.ts
+++ b/api/src/utils/get-snapshot-diff.ts
@@ -1,109 +1,98 @@
 import deepDiff from 'deep-diff';
-import { orderBy } from 'lodash-es';
 import type { Snapshot, SnapshotDiff } from '../types/index.js';
 import { DiffKind } from '../types/index.js';
 import { sanitizeCollection, sanitizeField, sanitizeRelation } from './sanitize-schema.js';
 
 export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDiff {
 	const diffedSnapshot: SnapshotDiff = {
-		collections: orderBy(
-			[
-				...current.collections.map((currentCollection) => {
-					const afterCollection = after.collections.find(
-						(afterCollection) => afterCollection.collection === currentCollection.collection,
+		collections: [
+			...current.collections.map((currentCollection) => {
+				const afterCollection = after.collections.find(
+					(afterCollection) => afterCollection.collection === currentCollection.collection,
+				);
+
+				return {
+					collection: currentCollection.collection,
+					diff: deepDiff.diff(sanitizeCollection(currentCollection), sanitizeCollection(afterCollection)),
+				};
+			}),
+			...after.collections
+				.filter((afterCollection) => {
+					const currentCollection = current.collections.find(
+						(currentCollection) => currentCollection.collection === afterCollection.collection,
 					);
 
-					return {
-						collection: currentCollection.collection,
-						diff: deepDiff.diff(sanitizeCollection(currentCollection), sanitizeCollection(afterCollection)),
-					};
-				}),
-				...after.collections
-					.filter((afterCollection) => {
-						const currentCollection = current.collections.find(
-							(currentCollection) => currentCollection.collection === afterCollection.collection,
-						);
+					return !!currentCollection === false;
+				})
+				.map((afterCollection) => ({
+					collection: afterCollection.collection,
+					diff: deepDiff.diff(undefined, sanitizeCollection(afterCollection)),
+				})),
+		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['collections'],
+		fields: [
+			...current.fields.map((currentField) => {
+				const afterField = after.fields.find(
+					(afterField) => afterField.collection === currentField.collection && afterField.field === currentField.field,
+				);
 
-						return !!currentCollection === false;
-					})
-					.map((afterCollection) => ({
-						collection: afterCollection.collection,
-						diff: deepDiff.diff(undefined, sanitizeCollection(afterCollection)),
-					})),
-			].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['collections'],
-			'collection',
-		),
-		fields: orderBy(
-			[
-				...current.fields.map((currentField) => {
-					const afterField = after.fields.find(
-						(afterField) =>
-							afterField.collection === currentField.collection && afterField.field === currentField.field,
+				const isAutoIncrementPrimaryKey =
+					!!currentField.schema?.is_primary_key && !!currentField.schema?.has_auto_increment;
+
+				return {
+					collection: currentField.collection,
+					field: currentField.field,
+					diff: deepDiff.diff(
+						sanitizeField(currentField, isAutoIncrementPrimaryKey),
+						sanitizeField(afterField, isAutoIncrementPrimaryKey),
+					),
+				};
+			}),
+			...after.fields
+				.filter((afterField) => {
+					const currentField = current.fields.find(
+						(currentField) =>
+							currentField.collection === afterField.collection && afterField.field === currentField.field,
 					);
 
-					const isAutoIncrementPrimaryKey =
-						!!currentField.schema?.is_primary_key && !!currentField.schema?.has_auto_increment;
+					return !!currentField === false;
+				})
+				.map((afterField) => ({
+					collection: afterField.collection,
+					field: afterField.field,
+					diff: deepDiff.diff(undefined, sanitizeField(afterField)),
+				})),
+		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['fields'],
 
-					return {
-						collection: currentField.collection,
-						field: currentField.field,
-						diff: deepDiff.diff(
-							sanitizeField(currentField, isAutoIncrementPrimaryKey),
-							sanitizeField(afterField, isAutoIncrementPrimaryKey),
-						),
-					};
-				}),
-				...after.fields
-					.filter((afterField) => {
-						const currentField = current.fields.find(
-							(currentField) =>
-								currentField.collection === afterField.collection && afterField.field === currentField.field,
-						);
+		relations: [
+			...current.relations.map((currentRelation) => {
+				const afterRelation = after.relations.find(
+					(afterRelation) =>
+						afterRelation.collection === currentRelation.collection && afterRelation.field === currentRelation.field,
+				);
 
-						return !!currentField === false;
-					})
-					.map((afterField) => ({
-						collection: afterField.collection,
-						field: afterField.field,
-						diff: deepDiff.diff(undefined, sanitizeField(afterField)),
-					})),
-			].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['fields'],
-			['collection'],
-		),
-		relations: orderBy(
-			[
-				...current.relations.map((currentRelation) => {
-					const afterRelation = after.relations.find(
-						(afterRelation) =>
-							afterRelation.collection === currentRelation.collection && afterRelation.field === currentRelation.field,
+				return {
+					collection: currentRelation.collection,
+					field: currentRelation.field,
+					related_collection: currentRelation.related_collection,
+					diff: deepDiff.diff(sanitizeRelation(currentRelation), sanitizeRelation(afterRelation)),
+				};
+			}),
+			...after.relations
+				.filter((afterRelation) => {
+					const currentRelation = current.relations.find(
+						(currentRelation) =>
+							currentRelation.collection === afterRelation.collection && afterRelation.field === currentRelation.field,
 					);
 
-					return {
-						collection: currentRelation.collection,
-						field: currentRelation.field,
-						related_collection: currentRelation.related_collection,
-						diff: deepDiff.diff(sanitizeRelation(currentRelation), sanitizeRelation(afterRelation)),
-					};
-				}),
-				...after.relations
-					.filter((afterRelation) => {
-						const currentRelation = current.relations.find(
-							(currentRelation) =>
-								currentRelation.collection === afterRelation.collection &&
-								afterRelation.field === currentRelation.field,
-						);
-
-						return !!currentRelation === false;
-					})
-					.map((afterRelation) => ({
-						collection: afterRelation.collection,
-						field: afterRelation.field,
-						related_collection: afterRelation.related_collection,
-						diff: deepDiff.diff(undefined, sanitizeRelation(afterRelation)),
-					})),
-			].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['relations'],
-			['collection'],
-		),
+					return !!currentRelation === false;
+				})
+				.map((afterRelation) => ({
+					collection: afterRelation.collection,
+					field: afterRelation.field,
+					related_collection: afterRelation.related_collection,
+					diff: deepDiff.diff(undefined, sanitizeRelation(afterRelation)),
+				})),
+		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['relations'],
 	};
 
 	/**

--- a/api/src/utils/get-snapshot.ts
+++ b/api/src/utils/get-snapshot.ts
@@ -30,8 +30,14 @@ export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOv
 	const relationsFiltered = relationsRaw.filter((item: any) => excludeSystem(item));
 
 	const collectionsSorted = sortBy(mapValues(collectionsFiltered, sortDeep), ['collection']);
-	const fieldsSorted = sortBy(mapValues(fieldsFiltered, sortDeep), ['meta.id']).map(omitID) as SnapshotField[];
-	const relationsSorted = sortBy(mapValues(relationsFiltered, sortDeep), ['meta.id']).map(omitID) as SnapshotRelation[];
+
+	const fieldsSorted = sortBy(mapValues(fieldsFiltered, sortDeep), ['collection', 'meta.id']).map(
+		omitID,
+	) as SnapshotField[];
+
+	const relationsSorted = sortBy(mapValues(relationsFiltered, sortDeep), ['collection', 'meta.id']).map(
+		omitID,
+	) as SnapshotRelation[];
 
 	return {
 		version: 1,


### PR DESCRIPTION
## Scope

What's changed:

Follow-up on #20704

- Order fields and relations by `collection` first
  - This makes snapshots deterministic again
  - Still respects the original concern from #19756, as ordering of fields only matters on collection level
- Don't re-sort in diff
  - Should increase the chance that original field order is maintained when applying the diff
  - Unnecessary step, as the input is already sorted

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Should help to get blackbox tests back on track 🎉 
