### PR TITLE
Drop EOL DB versions from blackbox tests

### DIFF
--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -30,9 +30,7 @@ jobs:
         vendor:
           - sqlite3
           - postgres
-          - postgres10
           - mysql
-          - mysql5
           - maria
           - mssql
           - oracle


### PR DESCRIPTION
## Scope

What's changed:

MySQL 5 and PostgreSQL 10 are end of life, we only support LTS versions: https://docs.directus.io/self-hosted/docker-guide.html#supported-databases
As for now, we're just dropping these versions from blackbox tests.

- https://endoflife.date/mysql
- https://endoflife.date/postgresql

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A
