### PR TITLE
Updated SDK filter types

### DIFF
--- a/.changeset/hot-humans-battle.md
+++ b/.changeset/hot-humans-battle.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Updated SDK filter operator typing

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -74,7 +74,8 @@ export type FilterOperators<
 	_nintersects: T;
 	_intersects_bbox: T;
 	_nintersects_bbox: T;
-	_regex: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	// regex is not available over the API https://docs.directus.io/reference/filter-rules.html#filter-operators
+	// _regex: IsDateTime<FieldType, never, IsString<T, string, never>>;
 }>;
 
 // filter not applicable filters based on "never" types

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -1,7 +1,7 @@
 import type { MappedFieldNames } from './functions.js';
 import type { FieldOutputMap } from './output.js';
 import type { RelationalFields } from './schema.js';
-import type { MergeOptional, UnpackList } from './utils.js';
+import type { IfNever, IsDateTime, IsNumber, IsString, MergeOptional, UnpackList } from './utils.js';
 
 /**
  * Filters
@@ -45,36 +45,41 @@ export type NestedRelationalFilter<Schema extends object, Item, Field extends ke
 export type FilterOperators<
 	FieldType,
 	T = FieldType extends keyof FieldOutputMap ? FieldOutputMap[FieldType] : FieldType,
-> = {
-	_eq?: T;
-	_neq?: T;
-	_gt?: T;
-	_gte?: T;
-	_lt?: T;
-	_lte?: T;
-	_in?: T[];
-	_nin?: T[];
-	_between?: [T, T];
-	_nbetween?: [T, T];
-	_contains?: T;
-	_ncontains?: T;
-	_starts_with?: T;
-	_istarts_with?: T;
-	_nstarts_with?: T;
-	_nistarts_with?: T;
-	_ends_with?: T;
-	_iends_with?: T;
-	_nends_with?: T;
-	_niends_with?: T;
-	_empty?: boolean;
-	_nempty?: boolean;
-	_nnull?: boolean;
-	_null?: boolean;
-	_intersects?: T;
-	_nintersects?: T;
-	_intersects_bbox?: T;
-	_nintersects_bbox?: T;
-	_regex?: T;
+> = MapFilterOperators<{
+	_eq: T;
+	_neq: T;
+	_gt: IsDateTime<FieldType, string, IsNumber<T, number, never>>;
+	_gte: IsDateTime<FieldType, string, IsNumber<T, number, never>>;
+	_lt: IsDateTime<FieldType, string, IsNumber<T, number, never>>;
+	_lte: IsDateTime<FieldType, string, IsNumber<T, number, never>>;
+	_in: T[];
+	_nin: T[];
+	_between: IsDateTime<FieldType, [T, T], IsNumber<T, [T, T], never>>;
+	_nbetween: IsDateTime<FieldType, [T, T], IsNumber<T, [T, T], never>>;
+	_contains: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_ncontains: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_starts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_istarts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_nstarts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_nistarts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_ends_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_iends_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_nends_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_niends_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_empty: boolean;
+	_nempty: boolean;
+	_nnull: boolean;
+	_null: boolean;
+	_intersects: T;
+	_nintersects: T;
+	_intersects_bbox: T;
+	_nintersects_bbox: T;
+	_regex: IsDateTime<FieldType, never, IsString<T, string, never>>;
+}>;
+
+// filter not applicable filters based on "never" types
+type MapFilterOperators<Filters extends object> = {
+	[Key in keyof Filters as IfNever<Filters[Key], never, Key>]?: Filters[Key];
 };
 
 /**

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -28,7 +28,7 @@ export type MergeOptional<A, B, TypeA = NeverToUnknown<A>, TypeB = NeverToUnknow
  * Fallback never to unknown
  */
 export type NeverToUnknown<T> = IfNever<T, unknown>;
-export type IfNever<T, Y> = [T] extends [never] ? Y : T;
+export type IfNever<T, Y, N = T> = [T] extends [never] ? Y : N;
 
 /**
  * Test for any
@@ -37,6 +37,9 @@ export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 export type IsAny<T> = IfAny<T, true, never>;
 
 export type IsNullable<T, Y = true, N = never> = T | null extends T ? Y : N;
+export type IsDateTime<T, Y, N> = T extends 'datetime' ? Y : N;
+export type IsNumber<T, Y, N> = T extends number ? Y : N;
+export type IsString<T, Y, N> = T extends string ? Y : N;
 
 export type NestedPartial<Item extends object> = {
 	[Key in keyof Item]?: NonNullable<Item[Key]> extends infer NestedItem


### PR DESCRIPTION
Fixes #21072 

## Scope

What's changed:

Updated filter types to both allow for broader default types and restrict what filters are applicable to what field types.
- Limited the `_gt`,`_gte`,`_lt`,`_lte`,`_between`,`_nbetween` operators to only apply to `datetime` and `number` fields.
- Limited the `_contains`,`_ncontains`,`_starts_with`,`_istarts_with`,`_nstarts_with`,`_nistarts_with`,`_ends_with`,`_iends_with`,`_nends_with`,`_niends_with` operators to only apply to `string` fields (excluding `datetime` strings)
- Removed the `_regex` operator which is not available over the API.
- Broaden literal types to their primitives (`'string' -> string` and `42 -> number` as described in #21072 )

## Potential Risks / Drawbacks

- Type regressions as always

## Review Notes / Questions

- I would like to lorem ipsum

