### PR TITLE
API: Fix Env inline casting

### DIFF
--- a/.changeset/giant-glasses-ring.md
+++ b/.changeset/giant-glasses-ring.md
@@ -1,5 +1,0 @@
----
-"@directus/env": patch
----
-
-Fix inline casting values

--- a/.changeset/giant-glasses-ring.md
+++ b/.changeset/giant-glasses-ring.md
@@ -1,0 +1,5 @@
+---
+"@directus/env": patch
+---
+
+Fix inline casting values

--- a/packages/env/src/lib/cast.test.ts
+++ b/packages/env/src/lib/cast.test.ts
@@ -90,4 +90,46 @@ describe('Casting', () => {
 		vi.mocked(tryJson).mockReturnValue('cast-value');
 		expect(cast('key', 'value')).toBe('cast-value');
 	});
+
+	describe('Inline', () => {
+		test('Uses toString for string types', () => {
+			vi.mocked(getCastFlag).mockReturnValue('string');
+
+			vi.mocked(toString).mockReturnValue('cast-value');
+			expect(cast('key', 'string:value')).toBe('cast-value');
+		});
+
+		test('Uses toNumber for number types', () => {
+			vi.mocked(getCastFlag).mockReturnValue('number');
+
+			vi.mocked(toNumber).mockReturnValue(123);
+			expect(cast('key', 'number:value')).toBe(123);
+		});
+
+		test('Uses toBoolean for number types', () => {
+			vi.mocked(getCastFlag).mockReturnValue('boolean');
+
+			vi.mocked(toBoolean).mockReturnValue(false);
+			expect(cast('key', 'boolean:value')).toBe(false);
+		});
+
+		test('Uses RegExp for regex types', () => {
+			vi.mocked(getCastFlag).mockReturnValue('regex');
+			expect(cast('key', 'regex:value')).toBeInstanceOf(RegExp);
+		});
+
+		test('Uses toArray for array types', () => {
+			vi.mocked(getCastFlag).mockReturnValue('array');
+
+			vi.mocked(toArray).mockReturnValue([1, 2, 3]);
+			expect(cast('key', 'array:value')).toEqual([1, 2, 3]);
+		});
+
+		test('Uses tryJson for json types', () => {
+			vi.mocked(getCastFlag).mockReturnValue('json');
+
+			vi.mocked(tryJson).mockReturnValue('cast-value');
+			expect(cast('key', 'json:value')).toBe('cast-value');
+		});
+	});
 });

--- a/packages/env/src/lib/cast.ts
+++ b/packages/env/src/lib/cast.ts
@@ -10,7 +10,7 @@ export const cast = (key: string, value: unknown) => {
 	const prefix = `${type}:`;
 
 	if (typeof value === 'string' && value.startsWith(prefix)) {
-		value = value.split(prefix).at(1);
+		value = value.substring(prefix.length);
 	}
 
 	switch (type) {

--- a/packages/env/src/lib/cast.ts
+++ b/packages/env/src/lib/cast.ts
@@ -7,6 +7,11 @@ import { tryJson } from '../utils/try-json.js';
 
 export const cast = (key: string, value: unknown) => {
 	const type = getCastFlag(value) ?? getTypeFromMap(key) ?? guessType(value);
+	const prefix = `${type}:`;
+
+	if (typeof value === 'string' && value.startsWith(prefix)) {
+		value = value.split(prefix).at(1);
+	}
 
 	switch (type) {
 		case 'string':


### PR DESCRIPTION
## Scope

What's changed:

With the new package `@directus/env` (https://github.com/directus/directus/pull/20985) I see that inline casting like `SOMETHING=json:{"test":"hey"}` does not work anymore.

With this change we put it back working as before.

## Potential Risks / Drawbacks

None as I can think of.

## Review Notes / Questions

None as I can think of.

