### PR TITLE
Prevent overflow with long collection names on Access Control page

### DIFF
--- a/.changeset/little-poems-cross.md
+++ b/.changeset/little-poems-cross.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured long collection names are not overflowing permission table on Access Control page

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
@@ -31,14 +31,15 @@ function isLoading(action: string) {
 
 <template>
 	<div class="permissions-overview-row">
-		<span class="name">
-			<span v-tooltip.left="collection.name">{{ collection.collection }}</span>
-			<span class="actions">
-				<span class="all" @click="setFullAccessAll">{{ t('all') }}</span>
-				<span class="divider">/</span>
-				<span class="none" @click="setNoAccessAll">{{ t('none') }}</span>
-			</span>
+		<span v-tooltip.left="collection.name" class="name">{{ collection.collection }}</span>
+
+		<span class="actions">
+			<span class="all" @click="setFullAccessAll">{{ t('all') }}</span>
+			<span class="divider">/</span>
+			<span class="none" @click="setNoAccessAll">{{ t('none') }}</span>
 		</span>
+
+		<span class="spacer" />
 
 		<template v-for="action in editablePermissionActions" :key="action">
 			<permissions-overview-toggle
@@ -63,39 +64,46 @@ function isLoading(action: string) {
 	padding: 0 12px;
 
 	.name {
-		flex-grow: 1;
 		font-family: var(--theme--fonts--monospace--font-family);
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 
-		.actions {
-			margin-left: 8px;
-			color: var(--theme--foreground-subdued);
-			font-size: 12px;
-			opacity: 0;
-			transition: opacity var(--fast) var(--transition);
+	.actions {
+		font-family: var(--theme--fonts--monospace--font-family);
+		margin-left: 8px;
+		color: var(--theme--foreground-subdued);
+		font-size: 12px;
+		opacity: 0;
+		transition: opacity var(--fast) var(--transition);
 
-			span {
-				cursor: pointer;
+		span {
+			cursor: pointer;
 
-				&:hover {
-					&.all {
-						color: var(--theme--success);
-					}
+			&:hover {
+				&.all {
+					color: var(--theme--success);
+				}
 
-					&.none {
-						color: var(--theme--danger);
-					}
+				&.none {
+					color: var(--theme--danger);
 				}
 			}
+		}
 
-			.divider {
-				margin: 0 6px;
-				cursor: default;
-			}
+		.divider {
+			margin: 0 6px;
+			cursor: default;
 		}
 	}
 
-	&:hover .name .actions {
+	&:hover .actions {
 		opacity: 1;
+	}
+
+	.spacer {
+		flex-grow: 1;
+		width: 20px;
 	}
 
 	.null {
@@ -103,6 +111,7 @@ function isLoading(action: string) {
 		justify-content: center;
 		width: 24px;
 		color: var(--theme--foreground);
+		cursor: not-allowed;
 	}
 
 	:is(.permissions-overview-toggle, .null) + :is(.permissions-overview-toggle, .null) {


### PR DESCRIPTION
## Scope
What's changed:

### Before

<img width="941" src="https://github.com/directus/directus/assets/5363448/448e7c97-390e-474f-a723-bfd49a0ca394">

### After

<img width="833" src="https://github.com/directus/directus/assets/5363448/88a04e64-f428-45f2-b8bd-3c25d2bdfb58">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Thanks @bryantgillespie for catching this 🐛 !
