### PR TITLE
App / Translations: Use `sort` field if is defined in language select

### DIFF
--- a/.changeset/tame-hornets-deliver.md
+++ b/.changeset/tame-hornets-deliver.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Updated the language selector of translation form to respect sort field of language collection if defined 

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -218,6 +218,7 @@ function useLanguages() {
 		}
 
 		const pkField = relationInfo.value.relatedPrimaryKeyField.field;
+		const sortField = relationInfo.value.relatedCollection.meta?.sort_field;
 
 		fields.add(pkField);
 
@@ -229,7 +230,7 @@ function useLanguages() {
 				{
 					params: {
 						fields: Array.from(fields),
-						sort: props.languageField ?? pkField,
+						sort: sortField ?? props.languageField ?? pkField,
 					},
 				},
 			);


### PR DESCRIPTION
## Scope

What's changed:

- The list of the languages will now be sorted by the sort field on languages collections, if it is defined, otherwise will fallback to the previous behaviour, which was showing sorted alphabetically.

## Potential Risks / Drawbacks

- The drawback I can see is if project is configured to use sort for another use case but users want it alphabetically. I am not sure if this is even a real case but just wanted to bring some attention to it.

## Review Notes / Questions

- Small improvement that may give some life quality
