### PR TITLE
fix(api): added support to update PK

### DIFF
--- a/.changeset/three-foxes-happen.md
+++ b/.changeset/three-foxes-happen.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added support to update non auto increment primary key upate

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -595,6 +595,10 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		const { RevisionsService } = await import('./revisions.js');
 
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+
+		const isAutoIncrementPK =
+			this.schema.collections[this.collection]!.fields[primaryKeyField]!.defaultValue === 'AUTO_INCREMENT';
+
 		validateKeys(this.schema, this.collection, primaryKeyField, keys);
 
 		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
@@ -667,7 +671,11 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 				nestedActionEvents: nestedActionEventsA2O,
 			} = await payloadService.processA2O(payloadWithM2O, opts);
 
-			const payloadWithoutAliasAndPK = pick(payloadWithA2O, without(fields, primaryKeyField, ...aliases));
+			const payloadWithoutAliasAndPK = pick(
+				payloadWithA2O,
+				without(fields, ...aliases.concat(isAutoIncrementPK ? [primaryKeyField] : [])),
+			);
+
 			const payloadWithTypeCasting = await payloadService.processValues('update', payloadWithoutAliasAndPK);
 
 			if (Object.keys(payloadWithTypeCasting).length > 0) {


### PR DESCRIPTION
## Scope

What's changed:

- check if primary key is auto increment, if not allow to update primary key.

## Potential Risks / Drawbacks

- NA

## Review Notes / Questions

- does it make sense to allow updating all PKs? and then reset the auto increment?
---

Fixes #21101
