### PR TITLE
Display icon file in cards for when the image is too large for transformations

### DIFF
--- a/.changeset/slow-clouds-jump.md
+++ b/.changeset/slow-clouds-jump.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed displaying of icon fallbacks for card thumbnails

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -113,6 +113,7 @@ function handleClick() {
 						:src="imageInfo?.source"
 						:alt="item?.title"
 						role="presentation"
+						@error="imgError = true"
 					/>
 					<v-icon v-else large :name="icon" />
 				</template>


### PR DESCRIPTION
## Demo

| Before | After |
|--------|--------|
| ![image](https://github.com/directus/directus/assets/14810858/d8bb619d-b50b-4872-9878-4fa09823ff5b) | ![image](https://github.com/directus/directus/assets/14810858/7d93bc65-4090-43f0-9a18-d35b7712606f) | 


## Scope

What's changed:

- Display icon file in cards for when the image is too large for transformations

## Potential Risks / Drawbacks

- Should be none. We just didnt use the existing error behaviour.

## Review Notes / Questions

- That issue is a little older and back then there was no visual indicator in the item file and collection route. In the meanwhile a fallback for the item route got added but the same behaviour for the cards is missing. This PR fixes that.

---

Fixes #16440 
