### PR TITLE
Add option in translation interface for opening the splitview by default

### DIFF
--- a/.changeset/chilled-adults-arrive.md
+++ b/.changeset/chilled-adults-arrive.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added option in the translation interface for opening the splitview by default

--- a/app/src/interfaces/translations/index.ts
+++ b/app/src/interfaces/translations/index.ts
@@ -80,6 +80,21 @@ export default defineInterface({
 					width: 'half',
 				},
 			},
+			{
+				field: 'defaultOpenSplitView',
+				name: '$t:interfaces.translations.default_split_view_state',
+				type: 'boolean',
+				schema: {
+					default_value: false,
+				},
+				meta: {
+					interface: 'toggle',
+					options: {
+						label: '$t:start_open',
+					},
+					width: 'half',
+				},
+			},
 		];
 	},
 	preview: PreviewSVG,

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -11,11 +11,11 @@ import { useFieldsStore } from '@/stores/fields';
 import { usePermissionsStore } from '@/stores/permissions';
 import { fetchAll } from '@/utils/fetch-all';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { getEndpoint } from '@directus/utils';
 import { cloneDeep, isNil } from 'lodash';
 import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import LanguageSelect from './language-select.vue';
-import { getEndpoint } from '@directus/utils';
 
 const props = withDefaults(
 	defineProps<{
@@ -25,6 +25,7 @@ const props = withDefaults(
 		languageField?: string | null;
 		languageDirectionField?: string | null;
 		defaultLanguage?: string | null;
+		defaultOpenSplitView?: boolean;
 		userLanguage?: boolean;
 		value: (number | string | Record<string, any>)[] | Record<string, any>;
 		autofocus?: boolean;
@@ -37,6 +38,7 @@ const props = withDefaults(
 		autofocus: false,
 		disabled: false,
 		defaultLanguage: null,
+		defaultOpenSplitView: false,
 		userLanguage: false,
 	},
 );
@@ -59,7 +61,7 @@ const permissionsStore = usePermissionsStore();
 
 const { width } = useWindowSize();
 
-const splitView = ref(false);
+const splitView = ref(props.defaultOpenSplitView);
 const firstLang = ref<string>();
 const secondLang = ref<string>();
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1872,6 +1872,7 @@ interfaces:
     no_collection: No Collection
     toggle_split_view: Toggle Split View
     enable: Enable
+    default_split_view_state: Default Split View State
     user_language: Use Current User Language
     default_language: Default Language
     language_field: Language Indicator Field


### PR DESCRIPTION
## Scope

What's changed:

- Add option in translation interface for opening the splitview by default
- Add new translation key

![image](https://github.com/directus/directus/assets/14810858/0b5d835f-35d5-4607-b63c-12afcc09144a)

## Potential Risks / Drawbacks

- Should be _just fineeeee :notes:_

## Review Notes / Questions

- Mhh could also rephrase the label to **Open Split View By Default: Enable** depending on what you like more(?)

---

Fixes #21145 

cc @bryantgillespie :heart: :wave: 
