### PR TITLE
Durus refactoring: New directory for node conversions

### DIFF
--- a/packages/data-sql/src/query-converter/fields/fields.ts
+++ b/packages/data-sql/src/query-converter/fields/fields.ts
@@ -1,10 +1,10 @@
 import type { AbstractQueryFieldNode } from '@directus/data';
 import type { AbstractSqlClauses, AliasMapping, ParameterTypes, SubQuery } from '../../types/index.js';
 import type { IndexGenerators } from '../utils/create-index-generators.js';
-import { createJoin } from './create-join.js';
-import { getNestedMany } from './create-nested-manys.js';
-import { createPrimitiveSelect } from './create-primitive-select.js';
-import { convertFieldFn } from './function.js';
+import { createJoin } from './nodes/join.js';
+import { getNestedMany } from './nodes/nested-manys.js';
+import { createPrimitiveSelect } from './nodes/primitive-select.js';
+import { convertFieldFn } from './nodes/function.js';
 
 export type FieldConversionResult = {
 	clauses: Required<Pick<AbstractSqlClauses, 'select' | 'joins'>>;

--- a/packages/data-sql/src/query-converter/fields/nodes/function.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/function.ts
@@ -1,7 +1,7 @@
 import type { AbstractQueryFunction } from '@directus/data';
-import type { AbstractSqlQuerySelectFnNode, ParameterTypes } from '../../types/index.js';
-import type { IndexGenerators } from '../utils/create-index-generators.js';
-import { convertFn } from '../common/function.js';
+import type { AbstractSqlQuerySelectFnNode, ParameterTypes } from '../../../types/index.js';
+import type { IndexGenerators } from '../../utils/create-index-generators.js';
+import { convertFn } from '../../common/function.js';
 
 /**
  * @param tableIndex

--- a/packages/data-sql/src/query-converter/fields/nodes/join.test.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/join.test.ts
@@ -1,8 +1,8 @@
 import type { AbstractQueryFieldNodeNestedRelationalMany } from '@directus/data';
 import { randomIdentifier, randomInteger } from '@directus/random';
 import { expect, test } from 'vitest';
-import type { AbstractSqlQueryJoinNode } from '../../types/index.js';
-import { createJoin } from './create-join.js';
+import type { AbstractSqlQueryJoinNode } from '../../../types/index.js';
+import { createJoin } from './join.js';
 
 test('Convert m2o relation on single field ', () => {
 	const tableIndex = randomInteger(0, 100);

--- a/packages/data-sql/src/query-converter/fields/nodes/join.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/join.ts
@@ -3,7 +3,7 @@ import type {
 	AbstractSqlQueryConditionNode,
 	AbstractSqlQueryJoinNode,
 	AbstractSqlQueryLogicalNode,
-} from '../../types/index.js';
+} from '../../../types/index.js';
 
 export const createJoin = (
 	relationalField: AbstractQueryFieldNodeNestedRelationalMany,

--- a/packages/data-sql/src/query-converter/fields/nodes/nested-manys.test.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/nested-manys.test.ts
@@ -1,8 +1,8 @@
 import type { AbstractQueryFieldNodeNestedSingleMany } from '@directus/data';
 import { randomAlpha, randomIdentifier, randomInteger, randomUUID } from '@directus/random';
 import { expect, test } from 'vitest';
-import type { ConverterResult } from '../../index.js';
-import { getNestedMany, type NestedManyResult } from './create-nested-manys.js';
+import type { ConverterResult } from '../../../index.js';
+import { getNestedMany, type NestedManyResult } from './nested-manys.js';
 
 test('getNestedMany with a single identifier', () => {
 	const columnIndexToIdentifier = (columnIndex: number) => `c${columnIndex}`;

--- a/packages/data-sql/src/query-converter/fields/nodes/nested-manys.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/nested-manys.ts
@@ -5,11 +5,11 @@ import type {
 	AbstractSqlQuerySelectNode,
 	AbstractSqlQueryWhereNode,
 	SubQuery,
-} from '../../types/index.js';
-import { createIndexGenerators, type IndexGenerators } from '../utils/create-index-generators.js';
-import { convertModifiers } from '../modifiers/modifiers.js';
-import { createPrimitiveSelect } from './create-primitive-select.js';
-import { convertFieldNodes } from './fields.js';
+} from '../../../types/index.js';
+import { createIndexGenerators, type IndexGenerators } from '../../utils/create-index-generators.js';
+import { convertModifiers } from '../../modifiers/modifiers.js';
+import { createPrimitiveSelect } from './primitive-select.js';
+import { convertFieldNodes } from '../fields.js';
 
 export interface NestedManyResult {
 	/** Function to generate a sub query */

--- a/packages/data-sql/src/query-converter/fields/nodes/primitive-select.test.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/primitive-select.test.ts
@@ -1,8 +1,8 @@
 import type { AbstractQueryFieldNodePrimitive } from '@directus/data';
 import { randomIdentifier, randomInteger } from '@directus/random';
 import { expect, test } from 'vitest';
-import type { AbstractSqlQuerySelectPrimitiveNode } from '../../types/index.js';
-import { createPrimitiveSelect } from './create-primitive-select.js';
+import type { AbstractSqlQuerySelectPrimitiveNode } from '../../../types/index.js';
+import { createPrimitiveSelect } from './primitive-select.js';
 
 test('createPrimitiveSelect', () => {
 	const tableIndex = randomInteger(0, 100);

--- a/packages/data-sql/src/query-converter/fields/nodes/primitive-select.ts
+++ b/packages/data-sql/src/query-converter/fields/nodes/primitive-select.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqlQuerySelectPrimitiveNode } from '../../types/index.js';
+import type { AbstractSqlQuerySelectPrimitiveNode } from '../../../types/index.js';
 
 /**
  * @param tableIndex

--- a/packages/data-sql/src/query-converter/modifiers/target.ts
+++ b/packages/data-sql/src/query-converter/modifiers/target.ts
@@ -2,7 +2,7 @@ import type { AbstractQueryTarget, AbstractQueryTargetNestedOne } from '@directu
 import type { AbstractSqlQueryJoinNode, AbstractSqlQueryTargetNode } from '../../types/index.js';
 import type { IndexGenerators } from '../utils/create-index-generators.js';
 import { convertFn } from '../common/function.js';
-import { createJoin } from '../fields/create-join.js';
+import { createJoin } from '../fields/nodes/join.js';
 
 export interface TargetConversionResult {
 	value: AbstractSqlQueryTargetNode;

--- a/packages/data-sql/src/types/abstract-sql.ts
+++ b/packages/data-sql/src/types/abstract-sql.ts
@@ -42,13 +42,7 @@ export interface AbstractSqlQuery {
 export type SubQuery = (
 	rootRow: Record<string, unknown>,
 	columnIndexToIdentifier: (columnIndex: number) => string,
-) => {
-	rootQuery: AbstractSqlQuery;
-
-	subQueries: SubQuery[];
-
-	aliasMapping: AliasMapping;
-};
+) => ConverterResult;
 
 export type AliasMapping = (
 	| { type: 'nested'; alias: string; children: AliasMapping }


### PR DESCRIPTION
## Scope

What's changed:

- I created a new directory in `data-sql/src/converter/fields` called `nodes`in which I moved all the actual field nodes conversions. the `fields` folder gets bigger and bigger. now the node conversion is one level deeper as it is in the tree, so now it's also aligned with the depth of the abstract query. In this folder there will be soon added various other node types, like json and those for a2o/o2a 
- I also removed the "create-" prefix in the name of the files since I found those rather distracting
- There was a tiny redundancy in the type definitions I removed as well