### PR TITLE
Adding area toggle to top of docs nav

### DIFF
--- a/docs/.vitepress/components/Tabs.vue
+++ b/docs/.vitepress/components/Tabs.vue
@@ -41,7 +41,7 @@ const activeTab = ref(props.tabs[0]);
 	margin-inline: auto;
 	padding: 12px;
 	box-shadow: 0 5px 10px 0 rgba(23, 41, 64, 0.1);
-	border-radius: 8px;
+	border-radius: 2em;
 	width: 100%;
 }
 
@@ -56,8 +56,9 @@ const activeTab = ref(props.tabs[0]);
 }
 
 .tab-buttons button.active {
-	background: var(--vp-c-purple-dimm-3);
-	border-radius: 6px;
+	background: var(--vp-c-brand-darkest);
+	color: white;
+	border-radius: 10em;
 	width: 100%;
 }
 

--- a/docs/.vitepress/components/Tabs.vue
+++ b/docs/.vitepress/components/Tabs.vue
@@ -33,7 +33,7 @@ const activeTab = ref(props.tabs[0]);
 	</div>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 .tab-buttons {
 	display: flex;
 	justify-content: center;
@@ -43,23 +43,27 @@ const activeTab = ref(props.tabs[0]);
 	box-shadow: 0 5px 10px 0 rgba(23, 41, 64, 0.1);
 	border-radius: 2em;
 	width: 100%;
-}
 
-.tab-buttons button {
-	color: var(--vp-c-text-1);
-	cursor: pointer;
-	border: none;
-	font-size: 18px;
-	font-weight: bold;
-	width: 100%;
-	padding: 12px;
-}
+	button {
+		color: var(--vp-c-text-2);
+		cursor: pointer;
+		border: none;
+		font-size: 18px;
+		font-weight: bold;
+		width: 100%;
+		padding: 12px;
 
-.tab-buttons button.active {
-	background: var(--vp-c-brand-darkest);
-	color: white;
-	border-radius: 10em;
-	width: 100%;
+		&:hover {
+			color: var(--vp-c-text-1);
+		}
+
+		&.active {
+			background: var(--vp-c-brand-darkest);
+			color: white;
+			border-radius: 10em;
+			width: 100%;
+		}
+	}
 }
 
 .tab-content {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -135,17 +135,6 @@ gtag('config', 'UA-24637628-7');
 		},
 		socialLinks: [{ icon: 'github', link: 'https://github.com/directus/directus' }],
 		nav: [
-			{
-				text: 'Developer Reference',
-				link: '/getting-started/quickstart',
-				// Active on every path except for '/', '/user-guide', '/packages'
-				activeMatch: '^\\/(?!$|user-guide|packages).*',
-			},
-			{
-				text: 'User Guide',
-				link: '/user-guide/overview/data-studio-app',
-				activeMatch: '/user-guide',
-			},
 			{ text: 'Website', link: 'https://directus.io/' },
 			{ text: 'Cloud', link: 'https://directus.cloud/' },
 		],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -140,7 +140,7 @@ gtag('config', 'UA-24637628-7');
 		],
 		nav: [
 			{ text: 'Website', link: 'https://directus.io/' },
-			{ text: 'Cloud', link: 'https://directus.cloud/' },
+			{ text: 'Cloud Dashboard', link: 'https://directus.cloud/' },
 			{ text: 'Directus TV', link: 'https://directus.io/tv' },
 		],
 		algolia: {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -133,10 +133,15 @@ gtag('config', 'UA-24637628-7');
 			light: '/logo-light.svg',
 			dark: '/logo-dark.svg',
 		},
-		socialLinks: [{ icon: 'github', link: 'https://github.com/directus/directus' }],
+		socialLinks: [
+			{ icon: 'github', link: 'https://github.com/directus/directus' },
+			{ icon: 'twitter', link: 'https://twitter.com/directus' },
+			{ icon: 'discord', link: 'https://directus.chat' },
+		],
 		nav: [
 			{ text: 'Website', link: 'https://directus.io/' },
 			{ text: 'Cloud', link: 'https://directus.cloud/' },
+			{ text: 'Directus TV', link: 'https://directus.io/tv' },
 		],
 		algolia: {
 			appId: 'T5BDNEU205',

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useData, useRoute } from 'vitepress';
 import DefaultTheme from 'vitepress/theme';
-import { computed, ref, watchEffect } from 'vue';
+import { computed } from 'vue';
 import Feedback from '../components/Feedback.vue';
 import Newsletter from '../components/Newsletter.vue';
 
@@ -12,18 +12,9 @@ const title = computed(() => page.value.title);
 const contributors = computed(() => page.value.frontmatter['contributors']);
 const path = computed(() => route.path);
 
-const isPackagePage = ref(false);
-const isDevPage = ref(false);
-const isUserPage = ref(false);
-
-function determinePageAttributes() {
-	isPackagePage.value = RegExp('^/packages/.+$').test(path.value);
-	isDevPage.value = RegExp('^\\/(?!$|user-guide).*').test(path.value) || path.value == '/';
-	isUserPage.value = RegExp('^.*/user-guide/.*$').test(path.value);
-}
-
-determinePageAttributes();
-watchEffect(determinePageAttributes);
+const isUserPage = computed(() => RegExp('^/user-guide/.*$').test(path.value));
+const isDevPage = computed(() => !isUserPage.value);
+const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 </script>
 
 <template>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -55,27 +55,31 @@ const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 .sidebar-nav-before {
 	padding: 1em 0;
 	border-bottom: 1px solid var(--vp-c-divider);
-}
-.toggle {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 0.5rem;
-	a {
-		display: block;
-		text-align: center;
-		font-size: 12px;
-		padding: 0.25rem;
-		font-weight: bold;
-		border-radius: 10rem;
-		border: 1px solid var(--vp-input-border-color);
-		color: var(--vp-input-border-color);
-		&.active {
-			background: var(--vp-c-brand-darkest);
-			color: white;
-			border-color: transparent;
+
+	.toggle {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.5rem;
+
+		a {
+			display: block;
+			text-align: center;
+			font-size: 12px;
+			padding: 0.25rem;
+			font-weight: bold;
+			border-radius: 10rem;
+			border: 1px solid var(--vp-input-border-color);
+			color: var(--vp-input-border-color);
+
+			&.active {
+				background: var(--vp-c-brand-darkest);
+				color: white;
+				border-color: transparent;
+			}
 		}
 	}
 }
+
 .newsletter {
 	margin-top: 2em;
 }

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -22,7 +22,7 @@ const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 		<template #sidebar-nav-before>
 			<div class="sidebar-nav-before">
 				<div class="toggle">
-					<a href="/getting-started/introduction" :class="{ active: isDevPage }">Developers</a>
+					<a href="/" :class="{ active: isDevPage }">Developers</a>
 					<a href="/user-guide/overview/data-studio-app" :class="{ active: isUserPage }">User Guide</a>
 				</div>
 			</div>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -31,7 +31,7 @@ watchEffect(determinePageAttributes);
 		<template #sidebar-nav-before>
 			<div class="sidebar-nav-before">
 				<div class="toggle">
-					<a href="/" :class="{ active: isDevPage }">Developers</a>
+					<a href="/getting-started/introduction" :class="{ active: isDevPage }">Developers</a>
 					<a href="/user-guide/overview/data-studio-app" :class="{ active: isUserPage }">User Guide</a>
 				</div>
 			</div>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -74,7 +74,7 @@ watchEffect(determinePageAttributes);
 		text-align: center;
 		font-size: 12px;
 		padding: 0.25rem;
-		background: white;
+		background: var(--vp-c-bg-alt);
 		font-weight: bold;
 		border-radius: 0.25rem;
 		&.active {

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -68,8 +68,13 @@ const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 			padding: 0.25rem;
 			font-weight: bold;
 			border-radius: 10rem;
-			border: 1px solid var(--vp-input-border-color);
-			color: var(--vp-input-border-color);
+			border: 1px solid var(--vp-c-text-3);
+			color: var(--vp-c-text-2);
+
+			&:hover {
+				color: var(--vp-c-text-1);
+				border-color: var(--vp-c-text-2);
+			}
 
 			&.active {
 				background: var(--vp-c-brand-darkest);

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -12,10 +12,20 @@ const title = computed(() => page.value.title);
 const contributors = computed(() => page.value.frontmatter['contributors']);
 const path = computed(() => route.path);
 const isPackagePage = RegExp('^/packages/.+$').test(path.value);
+const isDevPage = RegExp('^\\/(?!$|user-guide|packages).*').test(path.value) || path.value == '/';
+const isUserPage = RegExp('^.*/user-guide/.*$').test(path.value);
 </script>
 
 <template>
 	<Layout>
+		<template #sidebar-nav-before>
+			<div class="sidebar-nav-before">
+				<div class="toggle">
+					<a href="/" :class="{ active: isDevPage }">Developers</a>
+					<a href="/user-guide/overview/data-studio-app" :class="{ active: isUserPage }">User Guide</a>
+				</div>
+			</div>
+		</template>
 		<template #doc-before>
 			<div v-if="isPackagePage" class="warning custom-block" style="padding-bottom: 16px; margin-bottom: 16px">
 				<p>
@@ -40,7 +50,28 @@ const isPackagePage = RegExp('^/packages/.+$').test(path.value);
 	</Layout>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
+.sidebar-nav-before {
+	padding: 1em 0;
+	border-bottom: 1px solid var(--vp-c-divider)
+}
+.toggle {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.5rem;
+	a {
+		display: block;
+		text-align: center;
+		font-size: 12px;
+		padding: 0.25rem;
+		background: white;
+		font-weight: bold;
+		border-radius: 0.25rem;
+		&.active {
+			background: var(--vp-c-purple-dimm-3);
+		}
+	}
+}
 .newsletter {
 	margin-top: 2em;
 }

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useData, useRoute } from 'vitepress';
 import DefaultTheme from 'vitepress/theme';
-import { computed } from 'vue';
+import { computed, ref, watchEffect } from 'vue';
 import Feedback from '../components/Feedback.vue';
 import Newsletter from '../components/Newsletter.vue';
 
@@ -11,9 +11,19 @@ const route = useRoute();
 const title = computed(() => page.value.title);
 const contributors = computed(() => page.value.frontmatter['contributors']);
 const path = computed(() => route.path);
-const isPackagePage = RegExp('^/packages/.+$').test(path.value);
-const isDevPage = RegExp('^\\/(?!$|user-guide|packages).*').test(path.value) || path.value == '/';
-const isUserPage = RegExp('^.*/user-guide/.*$').test(path.value);
+
+const isPackagePage = ref(false);
+const isDevPage = ref(false);
+const isUserPage = ref(false);
+
+function determinePageAttributes() {
+	isPackagePage.value = RegExp('^/packages/.+$').test(path.value);
+	isDevPage.value = RegExp('^\\/(?!$|user-guide).*').test(path.value) || path.value == '/';
+	isUserPage.value = RegExp('^.*/user-guide/.*$').test(path.value);
+}
+
+determinePageAttributes();
+watchEffect(determinePageAttributes);
 </script>
 
 <template>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -63,7 +63,7 @@ watchEffect(determinePageAttributes);
 <style lang="scss" scoped>
 .sidebar-nav-before {
 	padding: 1em 0;
-	border-bottom: 1px solid var(--vp-c-divider)
+	border-bottom: 1px solid var(--vp-c-divider);
 }
 .toggle {
 	display: grid;

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -65,11 +65,14 @@ const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 		text-align: center;
 		font-size: 12px;
 		padding: 0.25rem;
-		background: var(--vp-c-bg-alt);
 		font-weight: bold;
-		border-radius: 0.25rem;
+		border-radius: 10rem;
+		border: 1px solid var(--vp-input-border-color);
+		color: var(--vp-input-border-color);
 		&.active {
-			background: var(--vp-c-purple-dimm-3);
+			background: var(--vp-c-brand-darkest);
+			color: white;
+			border-color: transparent;
 		}
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ for await (const item of subscription) {
 			/>
 			<Card
 				title="Data Model"
-				text="Structure and organize items in your collection, while also establishing relationships between them."
+				text="Structure and organize items, fields, and relationships in your collections."
 				url="/app/data-model"
 				icon="database"
 			/>


### PR DESCRIPTION
There are two main areas of our docs - the developer reference and the user guide. @benhaynes has commented that it's hard to understand that the current header navigation links take you between these areas (sidebars). 

This PR adds tabs to the top of the sidebar, removes them from the top nav, and also adds Twitter/Discord/Directus TV to the top nav. 

![2024-01-24T0947 23](https://github.com/directus/directus/assets/1461554/66395e4c-36eb-4a84-9146-d6db122101b8)

