### PR TITLE
Account for empty response in update check

### DIFF
--- a/.changeset/clean-flies-tickle.md
+++ b/.changeset/clean-flies-tickle.md
@@ -1,0 +1,5 @@
+---
+"@directus/update-check": patch
+---
+
+Fixed the update check to account for empty response

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -26,8 +26,8 @@
 		"test": "vitest --watch=false"
 	},
 	"dependencies": {
-		"axios": "1.6.5",
-		"axios-cache-interceptor": "1.4.1",
+		"axios": "1.6.6",
+		"axios-cache-interceptor": "1.5.1",
 		"boxen": "7.1.1",
 		"chalk": "5.3.0",
 		"find-cache-dir": "5.0.0",

--- a/packages/update-check/src/index.test.ts
+++ b/packages/update-check/src/index.test.ts
@@ -1,7 +1,6 @@
 import stripAnsi from 'strip-ansi';
-import { expect, test, vi, type MockInstance } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi, type MockInstance } from 'vitest';
 import { updateCheck } from './index.js';
-import { afterEach, beforeEach } from 'node:test';
 
 vi.mock('./cache.js');
 

--- a/packages/update-check/src/index.test.ts
+++ b/packages/update-check/src/index.test.ts
@@ -74,7 +74,7 @@ test('Print banner if update is available', async () => {
 
 test('Do not fail on empty response', async () => {
 	axiosMock.get.mockResolvedValue({
-		data: {},
+		data: null,
 	});
 
 	const currentVersion = '10.5.0';

--- a/packages/update-check/src/index.ts
+++ b/packages/update-check/src/index.ts
@@ -11,7 +11,7 @@ const instance = Axios.create();
 const axios = cache ? setupCache(instance, { storage: cache }) : instance;
 
 export async function updateCheck(currentVersion: string) {
-	let packageManifest: Partial<Manifest>;
+	let packageManifest: Partial<Manifest> | null;
 
 	try {
 		const response = await axios.get('https://registry.npmjs.org/directus', {
@@ -25,8 +25,8 @@ export async function updateCheck(currentVersion: string) {
 		return;
 	}
 
-	const latestVersion = packageManifest['dist-tags']?.['latest'];
-	const versions = packageManifest.versions;
+	const latestVersion = packageManifest?.['dist-tags']?.['latest'];
+	const versions = packageManifest?.versions;
 
 	if (!latestVersion || !versions || gte(currentVersion, latestVersion)) return;
 

--- a/packages/update-check/src/index.ts
+++ b/packages/update-check/src/index.ts
@@ -8,31 +8,29 @@ import { getCache } from './cache.js';
 
 const cache = await getCache();
 const instance = Axios.create();
-// @ts-ignore TODO Remove once type is fixed in axios-cache-interceptor
-const axios = setupCache(instance, { storage: cache });
+const axios = cache ? setupCache(instance, { storage: cache }) : instance;
 
 export async function updateCheck(currentVersion: string) {
-	let response;
+	let packageManifest: Partial<Manifest>;
 
 	try {
-		response = await axios.get<Manifest>('https://registry.npmjs.org/directus', {
+		const response = await axios.get('https://registry.npmjs.org/directus', {
 			headers: { accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*' },
 			timeout: 8_000,
 		});
+
+		packageManifest = response.data;
 	} catch {
 		// Errors are intentionally ignored and update check is skipped
 		return;
 	}
 
-	const packageManifest = response.data;
+	const latestVersion = packageManifest['dist-tags']?.['latest'];
+	const versions = packageManifest.versions;
 
-	const latestVersion = packageManifest['dist-tags']['latest'];
+	if (!latestVersion || !versions || gte(currentVersion, latestVersion)) return;
 
-	if (!latestVersion || gte(currentVersion, latestVersion)) {
-		return;
-	}
-
-	const allVersions = Object.keys(packageManifest.versions).filter((version) => !prerelease(version));
+	const allVersions = Object.keys(versions).filter((version) => !prerelease(version));
 	const indexOfCurrent = allVersions.indexOf(currentVersion);
 	const indexOfLatest = allVersions.indexOf(latestVersion);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1902,11 +1902,11 @@ importers:
   packages/update-check:
     dependencies:
       axios:
-        specifier: 1.6.5
-        version: 1.6.5
+        specifier: 1.6.6
+        version: 1.6.6
       axios-cache-interceptor:
-        specifier: 1.4.1
-        version: 1.4.1(axios@1.6.5)
+        specifier: 1.5.1
+        version: 1.5.1(axios@1.6.6)
       boxen:
         specifier: 7.1.1
         version: 7.1.1
@@ -8698,13 +8698,13 @@ packages:
     dev: false
     optional: true
 
-  /axios-cache-interceptor@1.4.1(axios@1.6.5):
-    resolution: {integrity: sha512-Ax4+PiGfNxpQvyF00t55nFzWoVnqW7slKCg9va6dbqiuAGIxRE8r1uMzunw8TKJ5iwLivFqAb0EeiLeUCxuZIw==}
+  /axios-cache-interceptor@1.5.1(axios@1.6.6):
+    resolution: {integrity: sha512-1p/rTi7DSqUghJ5Ck8GKNt47X6f3IB8XnJ+TM4PwIdhimmCgh0jEQiwI8mBvf2kIMIl4Kz5idwbf/ouK75nEHA==}
     engines: {node: '>=12'}
     peerDependencies:
       axios: ^1
     dependencies:
-      axios: 1.6.5
+      axios: 1.6.6
       cache-parser: 1.2.4
       fast-defer: 1.1.8
       object-code: 1.3.2
@@ -8718,6 +8718,16 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  /axios@1.6.6:
+    resolution: {integrity: sha512-XZLZDFfXKM9U/Y/B4nNynfCRUqNyVZ4sBC/n9GDRCkq9vd2mIvKjKKsbIh1WPmHmNbg6ND7cTBY3Y2+u1G3/2Q==}
+    dependencies:
+      follow-redirects: 1.15.4
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /backoff@2.5.0:
     resolution: {integrity: sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==}


### PR DESCRIPTION
## Scope

What's changed:

- Apparently the response in the update check can be empty / missing properties, which is now accounted for
- Updating the deps to enhance types

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #21192