### PR TITLE
[DOCS] Default to json SDK authentication in the example

### DIFF
--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -77,7 +77,7 @@ mutation {
 ```js
 import { createDirectus, authentication, rest, login } from '@directus/sdk';
 
-const client = createDirectus('directus_project_url').with(authentication()).with(rest());
+const client = createDirectus('directus_project_url').with(authentication('json')).with(rest());
 
 // login using the authentication composable
 const result = await client.login(email, password);


### PR DESCRIPTION
A tiny tweak to the SDK authentication example in the api reference.
To prevent confusion about the differing default mode between the API and SDK.

Refs #21188