### PR TITLE
Remove scoped entrypoints

### DIFF
--- a/.changeset/rare-spiders-fold.md
+++ b/.changeset/rare-spiders-fold.md
@@ -1,0 +1,17 @@
+---
+'@directus/sdk': major
+---
+
+Dropped the ability to import parts of the SDK through scoped entrypoints to prevent issues with TypeScript based
+libraries consuming the SDK.
+
+To migrate away, please update your scoped imports of @directus/sdk to use the root, for example:
+
+```js
+// Before
+import { createDirectus } from '@directus/sdk';
+import { rest } from '@directus/sdk/rest';
+
+// After
+import { createDirectus, rest } from '@directus/sdk';
+```

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -17,26 +17,6 @@
 			"require": "./dist/index.cjs",
 			"types": "./dist/index.d.ts"
 		},
-		"./auth": {
-			"import": "./dist/auth/index.js",
-			"require": "./dist/auth/index.cjs",
-			"types": "./dist/auth/index.d.ts"
-		},
-		"./graphql": {
-			"import": "./dist/graphql/index.js",
-			"require": "./dist/graphql/index.cjs",
-			"types": "./dist/graphql/index.d.ts"
-		},
-		"./realtime": {
-			"import": "./dist/realtime/index.js",
-			"require": "./dist/realtime/index.cjs",
-			"types": "./dist/realtime/index.d.ts"
-		},
-		"./rest": {
-			"import": "./dist/rest/index.js",
-			"require": "./dist/rest/index.cjs",
-			"types": "./dist/rest/index.d.ts"
-		},
 		"./package.json": "./package.json"
 	},
 	"main": "./dist/index.js",

--- a/sdk/tsup.config.js
+++ b/sdk/tsup.config.js
@@ -1,7 +1,7 @@
-import { defineConfig } from 'tsup';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'tsup';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -23,12 +23,5 @@ export default defineConfig(() => ({
 	bundle: env === 'production',
 	watch: env === 'development',
 	target: 'es2020',
-	entry: [
-		'src/index.ts',
-		// composables
-		'src/auth/index.ts',
-		'src/graphql/index.ts',
-		'src/realtime/index.ts',
-		'src/rest/index.ts',
-	],
+	entry: ['src/index.ts'],
 }));


### PR DESCRIPTION
## Scope

What's changed:

- Drops the scoped entrypoints of the SDK (eg `/rest` `/graphql` etc)

## Potential Risks / Drawbacks

- It's a breaking change for imports, but doesn't touch / change anything else so low risk

## Review Notes / Questions

- Nada

---

Fixes #21204 
