### PR TITLE
Remove two unused imports, resolving lint warnings

### DIFF
--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -7,7 +7,7 @@ import { unexpectedError } from '@/utils/unexpected-error';
 import { Filter, Item } from '@directus/types';
 import { getEndpoint, toArray } from '@directus/utils';
 import { clamp, cloneDeep, get, isEqual, merge } from 'lodash';
-import { Ref, computed, ref, unref, watch } from 'vue';
+import { Ref, computed, ref, watch } from 'vue';
 
 export type RelationQueryMultiple = {
 	page: number;

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -7,7 +7,6 @@ import { getSpecialForType } from '@/utils/get-special-for-type';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
-import formatTitle from '@directus/format-title';
 import type { Field, Width } from '@directus/types';
 import { cloneDeep } from 'lodash';
 import { computed, ref, unref } from 'vue';


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Remove two unused imports, resolving lint warnings:
  ```
  app/src/composables/use-relation-multiple.ts
  10:30  warning  'unref' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

  app/src/modules/settings/routes/data-model/fields/components/field-select.vue
  10:8  warning  'formatTitle' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
  ```

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A


