### PR TITLE
Use forks for blackbox tests

### DIFF
--- a/tests/blackbox/vitest.config.ts
+++ b/tests/blackbox/vitest.config.ts
@@ -5,6 +5,7 @@ import Sequencer from './setup/sequencer';
 export default defineConfig({
 	plugins: [tsconfigPaths()],
 	test: {
+		pool: 'forks',
 		environment: './setup/environment.ts',
 		sequence: {
 			sequencer: Sequencer,


### PR DESCRIPTION
## Scope

What's changed:

- Use `forks` (child_process) [^1] as pooling method to run blackbox tests
- Vitest itself is about to make this the new default since the current default `threads` comes with some drawbacks/issues which we experience too in blackbox tests [^2], so this is just a premature measure before that happens 

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

[^1]: https://vitest.dev/config/#forks
[^2]: https://github.com/vitest-dev/vitest/pull/5047