### PR TITLE
Add workflow to lock threads after cooling time

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,20 @@
+name: Lock Threads
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+    # Reduce to daily execution once initial backlog has been processed
+    # - cron: '30 2 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: 60


### PR DESCRIPTION
## Scope

What's changed:

Add a new workflow which locks closed issues, pull request and discussions after two months of inactivity, based on https://github.com/dessant/lock-threads

**The goal is not to block communication, but to direct it to the right place:**
It is better to create a new issue/discussion as that way it will get the attention it needs while a comment on an old thread can easily be overlooked.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

Two months seemed reasonable to me, as a thread could still be relevant enough during this time span. Maybe there are other thoughts on this?