### PR TITLE
[docs] Updated sdk storage example

### DIFF
--- a/.changeset/silly-poems-brush.md
+++ b/.changeset/silly-poems-brush.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Enriched the SDK storage example

--- a/docs/guides/sdk/authentication.md
+++ b/docs/guides/sdk/authentication.md
@@ -156,7 +156,7 @@ const storage = new LocalStorage();
 const client = createDirectus('http://directus.example.com')
   .with(authentication('json', { storage }));
 
-// set a long term token without refreshing logic
+// set a long term or static token without expiry information
 client.setToken('TOKEN');
 
 // set custom credentials to the storage

--- a/docs/guides/sdk/authentication.md
+++ b/docs/guides/sdk/authentication.md
@@ -152,10 +152,19 @@ class LocalStorage {
   }
 }
 
+const storage = new LocalStorage();
 const client = createDirectus('http://directus.example.com')
-  .with(authentication('json', { storage: new LocalStorage() }));
+  .with(authentication('json', { storage }));
 
+// set a long term token without refreshing logic
 client.setToken('TOKEN');
+
+// set custom credentials
+storage.set({
+	access_token: 'token',
+	refresh_token: 'token',
+	expires_at: 123456789
+});
 ```
 
 Note that the `LocalStorage` class is for demonstration purposes only, in production it is not recommended to store

--- a/docs/guides/sdk/authentication.md
+++ b/docs/guides/sdk/authentication.md
@@ -159,7 +159,7 @@ const client = createDirectus('http://directus.example.com')
 // set a long term token without refreshing logic
 client.setToken('TOKEN');
 
-// set custom credentials
+// set custom credentials to the storage
 storage.set({
 	access_token: 'token',
 	refresh_token: 'token',


### PR DESCRIPTION
Refs #21219 

Expanded the SDK authentication custom storage example to prevent confusion about the usage of the `setToken` and `storage.set` functions.
