### PR TITLE
Loosen peer dependencies

### DIFF
--- a/.changeset/small-poems-relate.md
+++ b/.changeset/small-poems-relate.md
@@ -1,0 +1,11 @@
+---
+"@directus/components": patch
+"@directus/composables": patch
+"@directus/extensions": patch
+"@directus/stores": patch
+"@directus/themes": patch
+"@directus/types": patch
+"@directus/utils": patch
+---
+
+Loosened the peer dependencies constraints

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,16 +34,20 @@
 		"@vitejs/plugin-vue": "5.0.3",
 		"@vitest/coverage-v8": "1.2.2",
 		"histoire": "0.17.9",
+		"pinia": "2.1.7",
 		"rollup-plugin-node-externals": "7.0.0",
 		"typescript": "5.3.3",
 		"vite": "5.0.12",
 		"vite-plugin-dts": "3.7.2",
-		"vitest": "1.2.2"
+		"vitest": "1.2.2",
+		"vue": "3.4.15",
+		"vue-i18n": "9.9.0",
+		"vue-router": "4.2.5"
 	},
 	"peerDependencies": {
-		"pinia": "2.1.7",
-		"vue": "3.4.15",
-		"vue-i18n": "9.2.2",
-		"vue-router": "4.2.5"
+		"pinia": "2",
+		"vue": "^3.4",
+		"vue-i18n": "9",
+		"vue-router": "4"
 	}
 }

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -43,9 +43,10 @@
 		"@vue/test-utils": "2.4.4",
 		"tsup": "8.0.1",
 		"typescript": "5.3.3",
-		"vitest": "1.2.2"
+		"vitest": "1.2.2",
+		"vue": "3.4.15"
 	},
 	"peerDependencies": {
-		"vue": "3.4.15"
+		"vue": "^3.4"
 	}
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -47,16 +47,20 @@
 		"@types/node": "18.19.10",
 		"@types/tmp": "0.2.6",
 		"@vitest/coverage-v8": "1.2.2",
+		"knex": "3.1.0",
+		"pino": "8.17.2",
 		"tmp": "0.2.1",
 		"tsup": "8.0.1",
 		"typescript": "5.3.3",
-		"vitest": "1.2.2"
-	},
-	"peerDependencies": {
-		"knex": "3.1.0",
-		"pino": "8.17.1",
+		"vitest": "1.2.2",
 		"vue": "3.4.15",
 		"vue-router": "4.2.5"
+	},
+	"peerDependencies": {
+		"knex": "3",
+		"pino": "8",
+		"vue": "^3.4",
+		"vue-router": "4"
 	},
 	"peerDependenciesMeta": {
 		"knex": {

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -30,11 +30,13 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"@vueuse/shared": "10.7.2",
+		"pinia": "2.1.7",
 		"tsup": "8.0.1",
-		"typescript": "5.3.3"
+		"typescript": "5.3.3",
+		"vue": "3.4.15"
 	},
 	"peerDependencies": {
-		"pinia": "2.1.7",
-		"vue": "3.4.15"
+		"pinia": "2",
+		"vue": "^3.4"
 	}
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -36,15 +36,18 @@
 		"@directus/tsconfig": "workspace:*",
 		"@directus/types": "workspace:*",
 		"@types/lodash-es": "4.17.12",
+		"@unhead/vue": "1.8.10",
 		"@vitejs/plugin-vue": "5.0.3",
+		"pinia": "2.1.7",
 		"rollup-plugin-node-externals": "7.0.0",
 		"typescript": "5.3.3",
 		"vite": "5.0.12",
-		"vite-plugin-dts": "3.7.2"
+		"vite-plugin-dts": "3.7.2",
+		"vue": "3.4.15"
 	},
 	"peerDependencies": {
-		"@unhead/vue": "1.8.9",
-		"pinia": "2.1.7",
-		"vue": "3.4.15"
+		"@unhead/vue": "1",
+		"pinia": "2",
+		"vue": "^3.4"
 	}
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,11 +31,13 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
-		"typescript": "5.3.3"
+		"knex": "3.1.0",
+		"typescript": "5.3.3",
+		"vue": "3.4.15"
 	},
 	"peerDependencies": {
-		"knex": "3.1.0",
-		"vue": "3.4.15"
+		"knex": "3",
+		"vue": "^3.4"
 	},
 	"peerDependenciesMeta": {
 		"knex": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,10 +52,11 @@
 		"tmp": "0.2.1",
 		"tsup": "8.0.1",
 		"typescript": "5.3.3",
-		"vitest": "1.2.2"
+		"vitest": "1.2.2",
+		"vue": "3.4.15"
 	},
 	"peerDependencies": {
-		"vue": "3.4.15"
+		"vue": "^3.4"
 	},
 	"peerDependenciesMeta": {
 		"vue": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,7 +886,7 @@ importers:
         version: 3.0.1(eslint@8.56.0)
       eslint-plugin-prettier:
         specifier: npm:@paescuj/eslint-plugin-prettier@5.0.1-1
-        version: /@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.2.4)
+        version: /@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.1.0)
       eslint-plugin-react:
         specifier: 7.33.2
         version: 7.33.2(eslint@8.56.0)
@@ -925,19 +925,6 @@ importers:
         version: 3.3.8(typescript@5.3.3)
 
   packages/components:
-    dependencies:
-      pinia:
-        specifier: 2.1.7
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
-      vue-i18n:
-        specifier: 9.2.2
-        version: 9.2.2(vue@3.4.15)
-      vue-router:
-        specifier: 4.2.5
-        version: 4.2.5(vue@3.4.15)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -954,6 +941,9 @@ importers:
       histoire:
         specifier: 0.17.9
         version: 0.17.9(vite@5.0.12)
+      pinia:
+        specifier: 2.1.7
+        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
       rollup-plugin-node-externals:
         specifier: 7.0.0
         version: 7.0.0(rollup@4.9.6)
@@ -969,6 +959,15 @@ importers:
       vitest:
         specifier: 1.2.2
         version: 1.2.2(happy-dom@13.3.1)(sass@1.70.0)
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
+      vue-i18n:
+        specifier: 9.9.0
+        version: 9.9.0(vue@3.4.15)
+      vue-router:
+        specifier: 4.2.5
+        version: 4.2.5(vue@3.4.15)
 
   packages/composables:
     dependencies:
@@ -987,9 +986,6 @@ importers:
       nanoid:
         specifier: 5.0.4
         version: 5.0.4
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
     devDependencies:
       '@directus/extensions':
         specifier: workspace:*
@@ -1021,6 +1017,9 @@ importers:
       vitest:
         specifier: 1.2.2
         version: 1.2.2(happy-dom@13.3.1)(sass@1.70.0)
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
 
   packages/constants:
     devDependencies:
@@ -1277,21 +1276,9 @@ importers:
       fs-extra:
         specifier: 11.2.0
         version: 11.2.0
-      knex:
-        specifier: 3.1.0
-        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.7)(tedious@16.6.1)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
-      pino:
-        specifier: 8.17.1
-        version: 8.17.1
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
-      vue-router:
-        specifier: 4.2.5
-        version: 4.2.5(vue@3.4.15)
       zod:
         specifier: 3.22.4
         version: 3.22.4
@@ -1314,6 +1301,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: 1.2.2
         version: 1.2.2(vitest@1.2.2)
+      knex:
+        specifier: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.7)(tedious@16.6.1)
+      pino:
+        specifier: 8.17.2
+        version: 8.17.2
       tmp:
         specifier: 0.2.1
         version: 0.2.1
@@ -1326,6 +1319,12 @@ importers:
       vitest:
         specifier: 1.2.2
         version: 1.2.2(@types/node@18.19.10)
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
+      vue-router:
+        specifier: 4.2.5
+        version: 4.2.5(vue@3.4.15)
 
   packages/extensions-sdk:
     dependencies:
@@ -1800,12 +1799,6 @@ importers:
       '@vueuse/core':
         specifier: 10.7.2
         version: 10.7.2(vue@3.4.15)
-      pinia:
-        specifier: 2.1.7
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -1813,12 +1806,18 @@ importers:
       '@vueuse/shared':
         specifier: 10.7.2
         version: 10.7.2(vue@3.4.15)
+      pinia:
+        specifier: 2.1.7
+        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
       tsup:
         specifier: 8.0.1
         version: 8.0.1(typescript@5.3.3)
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
 
   packages/themes:
     dependencies:
@@ -1828,9 +1827,6 @@ importers:
       '@sinclair/typebox':
         specifier: 0.32.13
         version: 0.32.13
-      '@unhead/vue':
-        specifier: 1.8.9
-        version: 1.8.9(vue@3.4.15)
       decamelize:
         specifier: 6.0.0
         version: 6.0.0
@@ -1840,12 +1836,6 @@ importers:
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
-      pinia:
-        specifier: 2.1.7
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -1856,9 +1846,15 @@ importers:
       '@types/lodash-es':
         specifier: 4.17.12
         version: 4.17.12
+      '@unhead/vue':
+        specifier: 1.8.10
+        version: 1.8.10(vue@3.4.15)
       '@vitejs/plugin-vue':
         specifier: 5.0.3
         version: 5.0.3(vite@5.0.12)(vue@3.4.15)
+      pinia:
+        specifier: 2.1.7
+        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
       rollup-plugin-node-externals:
         specifier: 7.0.0
         version: 7.0.0(rollup@4.9.6)
@@ -1871,6 +1867,9 @@ importers:
       vite-plugin-dts:
         specifier: 3.7.2
         version: 3.7.2(rollup@4.9.6)(typescript@5.3.3)(vite@5.0.12)
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
 
   packages/tsconfig: {}
 
@@ -1885,19 +1884,19 @@ importers:
       '@types/geojson':
         specifier: 7946.0.13
         version: 7946.0.13
-      knex:
-        specifier: 3.1.0
-        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.7)(tedious@16.6.1)
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      knex:
+        specifier: 3.1.0
+        version: 3.1.0(mysql@2.18.1)(pg@8.11.3)(sqlite3@5.1.7)(tedious@16.6.1)
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
 
   packages/update-check:
     dependencies:
@@ -1971,9 +1970,6 @@ importers:
       micromustache:
         specifier: 8.0.3
         version: 8.0.3
-      vue:
-        specifier: 3.4.15
-        version: 3.4.15(typescript@5.3.3)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -2011,6 +2007,9 @@ importers:
       vitest:
         specifier: 1.2.2
         version: 1.2.2(@types/node@18.19.10)
+      vue:
+        specifier: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
 
   packages/validation:
     dependencies:
@@ -3308,6 +3307,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.23.6
+    dev: true
 
   /@babel/parser@7.23.9:
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
@@ -3315,7 +3315,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.23.9
-    dev: true
 
   /@babel/runtime@7.23.6:
     resolution: {integrity: sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==}
@@ -3331,6 +3330,7 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.23.9:
     resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
@@ -3339,7 +3339,6 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -5025,16 +5024,6 @@ packages:
     dev: false
     optional: true
 
-  /@intlify/core-base@9.2.2:
-    resolution: {integrity: sha512-JjUpQtNfn+joMbrXvpR4hTF8iJQ2sEFzzK3KIESOx+f+uwIjgw20igOyaIdhfsVVBCds8ZM64MoeNSx+PHQMkA==}
-    engines: {node: '>= 14'}
-    dependencies:
-      '@intlify/devtools-if': 9.2.2
-      '@intlify/message-compiler': 9.2.2
-      '@intlify/shared': 9.2.2
-      '@intlify/vue-devtools': 9.2.2
-    dev: false
-
   /@intlify/core-base@9.9.0:
     resolution: {integrity: sha512-C7UXPymDIOlMGSNjAhNLtKgzITc/8BjINK5gNKXg8GiWCTwL6n3MWr55czksxn8RM5wTMz0qcLOFT+adtaVQaA==}
     engines: {node: '>= 16'}
@@ -5042,21 +5031,6 @@ packages:
       '@intlify/message-compiler': 9.9.0
       '@intlify/shared': 9.9.0
     dev: true
-
-  /@intlify/devtools-if@9.2.2:
-    resolution: {integrity: sha512-4ttr/FNO29w+kBbU7HZ/U0Lzuh2cRDhP8UlWOtV9ERcjHzuyXVZmjyleESK6eVP60tGC9QtQW9yZE+JeRhDHkg==}
-    engines: {node: '>= 14'}
-    dependencies:
-      '@intlify/shared': 9.2.2
-    dev: false
-
-  /@intlify/message-compiler@9.2.2:
-    resolution: {integrity: sha512-IUrQW7byAKN2fMBe8z6sK6riG1pue95e5jfokn8hA5Q3Bqy4MBJ5lJAofUsawQJYHeoPJ7svMDyBaVJ4d0GTtA==}
-    engines: {node: '>= 14'}
-    dependencies:
-      '@intlify/shared': 9.2.2
-      source-map: 0.6.1
-    dev: false
 
   /@intlify/message-compiler@9.9.0:
     resolution: {integrity: sha512-yDU/jdUm9KuhEzYfS+wuyja209yXgdl1XFhMlKtXEgSFTxz4COZQCRXXbbH8JrAjMsaJ7bdoPSLsKlY6mXG2iA==}
@@ -5066,23 +5040,10 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /@intlify/shared@9.2.2:
-    resolution: {integrity: sha512-wRwTpsslgZS5HNyM7uDQYZtxnbI12aGiBZURX3BTR9RFIKKRWpllTsgzHWvj3HKm3Y2Sh5LPC1r0PDCKEhVn9Q==}
-    engines: {node: '>= 14'}
-    dev: false
-
   /@intlify/shared@9.9.0:
     resolution: {integrity: sha512-1ECUyAHRrzOJbOizyGufYP2yukqGrWXtkmTu4PcswVnWbkcjzk3YQGmJ0bLkM7JZ0ZYAaohLGdYvBYnTOGYJ9g==}
     engines: {node: '>= 16'}
     dev: true
-
-  /@intlify/vue-devtools@9.2.2:
-    resolution: {integrity: sha512-+dUyqyCHWHb/UcvY1MlIpO87munedm3Gn6E9WWYdWrMuYLcoIoOEVDWSS8xSwtlPU+kA+MEQTP6Q1iI/ocusJg==}
-    engines: {node: '>= 14'}
-    dependencies:
-      '@intlify/core-base': 9.2.2
-      '@intlify/shared': 9.2.2
-    dev: false
 
   /@ioredis/commands@1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -5656,7 +5617,7 @@ packages:
       '@otplib/plugin-thirty-two': 12.0.1
     dev: false
 
-  /@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.2.4):
+  /@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.1.0):
     resolution: {integrity: sha512-gc+FaHyaGEnlcjN9n/bjXxa8CRxmkZRZTHkclaePXNgHSMIqgucFukE+4N1PYnSza2CnRijLjpRo8Z6UiGmNUA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -5672,7 +5633,7 @@ packages:
     dependencies:
       eslint: 8.56.0
       eslint-config-prettier: 9.1.0(eslint@8.56.0)
-      prettier: 3.2.4
+      prettier: 3.1.0
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.6
     dev: true
@@ -7749,13 +7710,6 @@ packages:
       '@unhead/shared': 1.8.10
     dev: true
 
-  /@unhead/dom@1.8.9:
-    resolution: {integrity: sha512-qY4CUVNKEM7lEAcTz5t71QYca+NXgUY5RwhSzB6sBBzZxQTiFOeTVKC6uWXU0N+3jBUdP/zdD3iN1JIjziDlng==}
-    dependencies:
-      '@unhead/schema': 1.8.9
-      '@unhead/shared': 1.8.9
-    dev: false
-
   /@unhead/schema@1.8.10:
     resolution: {integrity: sha512-cy8RGOPkwOVY5EmRoCgGV8AqLjy/226xBVTY54kBct02Om3hBdpB9FZa9frM910pPUXMI8PNmFgABO23O7IdJA==}
     dependencies:
@@ -7763,24 +7717,11 @@ packages:
       zhead: 2.2.4
     dev: true
 
-  /@unhead/schema@1.8.9:
-    resolution: {integrity: sha512-Cumjt2uLfBMEXflvq7Nk8KNqa/JS4MlRGWkjXx/uUXJ1vUeQqeMV8o3hrnRvDDoTXr9LwPapTMUbtClN3TSBgw==}
-    dependencies:
-      hookable: 5.5.3
-      zhead: 2.2.4
-    dev: false
-
   /@unhead/shared@1.8.10:
     resolution: {integrity: sha512-pEFryAs3EmV+ShDQx2ZBwUnt5l3RrMrXSMZ50oFf+MImKZNARVvD4+3I8fEI9wZh+Zq0JYG3UAfzo51MUP+Juw==}
     dependencies:
       '@unhead/schema': 1.8.10
     dev: true
-
-  /@unhead/shared@1.8.9:
-    resolution: {integrity: sha512-0o4+CBCi9EnTKPF6cEuLacnUHUkF0u/FfiKrWnKWUiB8wTD1v3UCf5ZCrNCjuJmKHTqj6ZtZ2hIfXsqWfc+3tA==}
-    dependencies:
-      '@unhead/schema': 1.8.9
-    dev: false
 
   /@unhead/vue@1.8.10(vue@3.4.15):
     resolution: {integrity: sha512-KF8pftHnxnlBlgNpKXWLTg3ZUtkuDCxRPUFSDBy9CtqRSX/qvAhLZ26mbqRVmHj8KigiRHP/wnPWNyGnUx20Bg==}
@@ -7793,18 +7734,6 @@ packages:
       unhead: 1.8.10
       vue: 3.4.15(typescript@5.3.3)
     dev: true
-
-  /@unhead/vue@1.8.9(vue@3.4.15):
-    resolution: {integrity: sha512-sL1d2IRBZd5rjzhgTYni2DiociSpt+Cfz3iVWKb0EZwQHgg0GzV8Hkoj5TjZYZow6EjDSPRfVPXDwOwxkVOgug==}
-    peerDependencies:
-      vue: '>=2.7 || >=3'
-    dependencies:
-      '@unhead/schema': 1.8.9
-      '@unhead/shared': 1.8.9
-      hookable: 5.5.3
-      unhead: 1.8.9
-      vue: 3.4.15(typescript@5.3.3)
-    dev: false
 
   /@vitejs/plugin-vue@4.6.2(vite@4.5.2)(vue@3.4.15):
     resolution: {integrity: sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==}
@@ -7911,7 +7840,7 @@ packages:
   /@vue/compiler-core@3.3.8:
     resolution: {integrity: sha512-hN/NNBUECw8SusQvDSqqcVv6gWq8L6iAktUR0UF3vGu2OhzRqcOiAno0FmBJWwxhYEXRlQJT5XnoKsVq1WZx4g==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/shared': 3.3.8
       estree-walker: 2.0.2
       source-map-js: 1.0.2
@@ -7920,7 +7849,7 @@ packages:
   /@vue/compiler-core@3.4.15:
     resolution: {integrity: sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/shared': 3.4.15
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -7957,7 +7886,7 @@ packages:
   /@vue/compiler-sfc@3.4.15:
     resolution: {integrity: sha512-LCn5M6QpkpFsh3GQvs2mJUOAlBQcCco8D60Bcqmf3O3w5a+KWS5GvYbrrJBkgvL1BDnTp+e8q0lXCLgHhKguBA==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/compiler-core': 3.4.15
       '@vue/compiler-dom': 3.4.15
       '@vue/compiler-ssr': 3.4.15
@@ -7982,6 +7911,7 @@ packages:
 
   /@vue/devtools-api@6.5.1:
     resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
+    dev: true
 
   /@vue/language-core@1.8.27(typescript@5.3.3):
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
@@ -8006,7 +7936,7 @@ packages:
   /@vue/reactivity-transform@3.3.8:
     resolution: {integrity: sha512-49CvBzmZNtcHua0XJ7GdGifM8GOXoUMOX4dD40Y5DxI3R8OUhMlvf2nvgUAcPxaXiV5MQQ1Nwy09ADpnLQUqRw==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/compiler-core': 3.3.8
       '@vue/shared': 3.3.8
       estree-walker: 2.0.2
@@ -8683,7 +8613,6 @@ packages:
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-    dev: false
 
   /autocannon@7.14.0:
     resolution: {integrity: sha512-lusP43BAwrTwQhihLjKwy7LceyX01eKSvFJUsBktASGqcR1g1ySYSPxCoCGDX08uLEs9oaqEKBBUFMenK3B3lQ==}
@@ -11223,7 +11152,6 @@ packages:
   /fast-redact@3.3.0:
     resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -12215,6 +12143,7 @@ packages:
 
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+    dev: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -14611,6 +14540,7 @@ packages:
 
   /node-addon-api@7.0.0:
     resolution: {integrity: sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==}
+    requiresBuild: true
 
   /node-addon-api@7.1.0:
     resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}
@@ -15014,7 +14944,6 @@ packages:
   /on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
-    dev: false
 
   /on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -15630,6 +15559,7 @@ packages:
       typescript: 5.3.3
       vue: 3.4.15(typescript@5.3.3)
       vue-demi: 0.14.6(vue@3.4.15)
+    dev: true
 
   /pino-abstract-transport@0.4.0:
     resolution: {integrity: sha512-Znl3f1ntZnDG+NpCyJyJDS+lkrlRSbgQBkV3eqNAvet/QHql6rhKLc4DuYRlwfc3fvV611O9NXPm5pbT9AJ50g==}
@@ -15650,7 +15580,6 @@ packages:
     dependencies:
       readable-stream: 4.5.1
       split2: 4.2.0
-    dev: false
 
   /pino-http-print@3.1.0:
     resolution: {integrity: sha512-rIcBdxJYcknGDC1LJjbkEBPHqGRCE9Rjs00b8KGhwT5AQ0yIXp6xa68SG57bAwQqydyK/SUJzXYBvyv1jrheHA==}
@@ -15715,24 +15644,6 @@ packages:
 
   /pino-std-serializers@6.2.2:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
-    dev: false
-
-  /pino@8.17.1:
-    resolution: {integrity: sha512-YoN7/NJgnsJ+fkADZqjhRt96iepWBndQHeClmSBH0sQWCb8zGD74t00SK4eOtKFi/f8TUmQnfmgglEhd2kI1RQ==}
-    hasBin: true
-    dependencies:
-      atomic-sleep: 1.0.0
-      fast-redact: 3.3.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 1.1.0
-      pino-std-serializers: 6.2.2
-      process-warning: 2.3.2
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.4.3
-      sonic-boom: 3.7.0
-      thread-stream: 2.4.1
-    dev: false
 
   /pino@8.17.2:
     resolution: {integrity: sha512-LA6qKgeDMLr2ux2y/YiUt47EfgQ+S9LznBWOJdN3q1dx2sv0ziDLUBeVpyVv17TEcGCBuWf0zNtg3M5m1NhhWQ==}
@@ -15749,7 +15660,6 @@ packages:
       safe-stable-stringify: 2.4.3
       sonic-boom: 3.7.0
       thread-stream: 2.4.1
-    dev: false
 
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
@@ -16273,12 +16183,6 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.2.4:
-    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -16314,13 +16218,8 @@ packages:
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  /process-warning@2.3.2:
-    resolution: {integrity: sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==}
-    dev: false
-
   /process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
-    dev: false
 
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -16455,7 +16354,6 @@ packages:
 
   /quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-    dev: false
 
   /quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -16627,7 +16525,6 @@ packages:
   /real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
-    dev: false
 
   /realpath-missing@1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
@@ -17197,7 +17094,6 @@ packages:
   /safe-stable-stringify@2.4.3:
     resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
-    dev: false
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -17637,7 +17533,6 @@ packages:
     resolution: {integrity: sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==}
     dependencies:
       atomic-sleep: 1.0.0
-    dev: false
 
   /sort-keys@4.2.0:
     resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
@@ -18449,7 +18344,6 @@ packages:
     resolution: {integrity: sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==}
     dependencies:
       real-require: 0.2.0
-    dev: false
 
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -18948,15 +18842,6 @@ packages:
       '@unhead/shared': 1.8.10
       hookable: 5.5.3
     dev: true
-
-  /unhead@1.8.9:
-    resolution: {integrity: sha512-qqCNmA4KOEDjcl+OtRZTllGehXewcQ31zbHjvhl/jqCs2MfRcZoxFW1y7A4Y4BgR/O7PI89K+GoWGcxK3gn64Q==}
-    dependencies:
-      '@unhead/dom': 1.8.9
-      '@unhead/schema': 1.8.9
-      '@unhead/shared': 1.8.9
-      hookable: 5.5.3
-    dev: false
 
   /unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}
@@ -19771,19 +19656,6 @@ packages:
       - supports-color
     dev: true
 
-  /vue-i18n@9.2.2(vue@3.4.15):
-    resolution: {integrity: sha512-yswpwtj89rTBhegUAv9Mu37LNznyu3NpyLQmozF3i1hYOhwpG8RjcjIFIIfnu+2MDZJGSZPXaKWvnQA71Yv9TQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      vue: ^3.0.0
-    dependencies:
-      '@intlify/core-base': 9.2.2
-      '@intlify/shared': 9.2.2
-      '@intlify/vue-devtools': 9.2.2
-      '@vue/devtools-api': 6.5.1
-      vue: 3.4.15(typescript@5.3.3)
-    dev: false
-
   /vue-i18n@9.9.0(vue@3.4.15):
     resolution: {integrity: sha512-xQ5SxszUAqK5n84N+uUyHH/PiQl9xZ24FOxyAaNonmOQgXeN+rD9z/6DStOpOxNFQn4Cgcquot05gZc+CdOujA==}
     engines: {node: '>= 16'}
@@ -19803,6 +19675,7 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.5.1
       vue: 3.4.15(typescript@5.3.3)
+    dev: true
 
   /vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
@@ -20308,6 +20181,7 @@ packages:
 
   /zhead@2.2.4:
     resolution: {integrity: sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==}
+    dev: true
 
   /zod-validation-error@3.0.0(zod@3.22.4):
     resolution: {integrity: sha512-x+agsJJG9rvC7axF0xqTEdZhJkLHyIZkdOAWDJSmwGPzxNHMHwtU6w2yDOAAP6yuSfTAUhAMJRBfhVGY64ySEQ==}


### PR DESCRIPTION
## Scope

What's changed:

- Loosen the peer dependencies to major releases
  - Exception is `vue` where we require `^3.4` to ensure max overall compatibility (e.g. due to various new features introduced in 3.4)
- This makes dependency management easier for extension developers, for example, a newer patch version can be used before we release a new version of `@directus/extensions`
- This makes dependency management easier for us, as all versions can be kept the same (via dev deps) and the peer deps do not have to be adjusted manually each time

## Potential Risks / Drawbacks

- Since we have the same versions in the monorepo, we still test against the correct versions
- If one of the packages has incompatibilities by mistake, it could lead to unexpected issues
  - the probability is very low, the advantages outweigh the disadvantages
  - we could adjust the constraint accordingly in a small patch release

## Review Notes / Questions

None
