### PR TITLE
[SDK] Update Readonly Properties on Query Type

### DIFF
--- a/.changeset/slimy-garlics-fetch.md
+++ b/.changeset/slimy-garlics-fetch.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Updated SDK query type and added type documentation

--- a/docs/.vitepress/data/guides.ts
+++ b/docs/.vitepress/data/guides.ts
@@ -14,6 +14,7 @@ export const sections = {
 				items: [
 					{ display: 'SDK Quickstart', path: '/guides/sdk/getting-started' },
 					{ display: 'SDK Authentication', path: '/guides/sdk/authentication' },
+					{ display: 'SDK Types', path: '/guides/sdk/types' },
 				],
 			},
 			{

--- a/docs/guides/sdk/types.md
+++ b/docs/guides/sdk/types.md
@@ -140,7 +140,7 @@ interface CollectionB { // [!code ++]
 } // [!code ++]
 ```
 
-**Many to One**
+#### Many to One
 
 ```ts
 interface CollectionB {
@@ -149,7 +149,7 @@ interface CollectionB {
 }
 ```
 
-**One to Many**
+#### One to Many
 
 ```ts
 interface CollectionB {
@@ -164,7 +164,7 @@ interface CollectionB {
 For relations that rely on a junction collection, define the junction collection on the root schema and refer to this
 new type similar to the one to many relation above.
 
-**Many to Many**
+#### Many to Many
 
 ```ts
 interface MySchema {
@@ -194,7 +194,7 @@ interface CollectionB {
 }
 ```
 
-**Many to Any**
+#### Many to Any
 
 ```ts
 interface MySchema {

--- a/docs/guides/sdk/types.md
+++ b/docs/guides/sdk/types.md
@@ -5,26 +5,32 @@ description: Learn about all of the ways to manage types with the Directus SDK
 
 # Directus SDK Types
 
-The Directus SDK provides TypeScript types used for auto-completion and generating output item types, these can be quite complex and can be hard to work with. This guide will go over some approaches that can be taken for workine with these types and assumes you're working with the SDK in TypeScript 5+.
+The Directus SDK provides TypeScript types used for auto-completion and generating output item types, these can be quite
+complex and can be hard to work with. This guide will go over some approaches that can be taken for workine with these
+types and assumes you're working with the SDK in TypeScript 5+.
 
 ## Setting up the a Schema
 
 The schema entails a couple of things:
+
 - A root schema type (the type that is provided to the SDK client)
 - Adding custom fields on core collections
 - A defined type for each available collection and field
 
 ### The root Schema type
 
-This type should contain **all collections available** including junction collections for many-to-many and many-to-any relations because this type is used as lookup table to determine what the relations are.
+This type should contain **all collections available** including junction collections for many-to-many and many-to-any
+relations because this type is used as lookup table to determine what the relations are.
 
-By defining a collection as an array this is considered a regular collection with multiple records, if left away a singular type is considered to be a singleton.
+By defining a collection as an array this is considered a regular collection with multiple records, if left away a
+singular type is considered to be a singleton.
 
 For example:
+
 ```ts
 interface MySchema {
 	// regular collections are array types
-	collection_a: CollectionA[]; 
+	collection_a: CollectionA[];
 	// singleton collections are singular types
 	collection_c: CollectionC;
 }
@@ -32,21 +38,25 @@ interface MySchema {
 
 ::: tip
 
-For the most reliable results the root schema types should be kept as pure as possible, meaning no unions (`CollectionA | null`), no optional types (`optional_collection?: CollectionA[]`) and preferrably no inline relational types (types nested directly on the root schema) however an exception can be made here for extending core collections.
+For the most reliable results the root schema types should be kept as pure as possible, meaning no unions
+(`CollectionA | null`), no optional types (`optional_collection?: CollectionA[]`) and preferrably no inline relational
+types (types nested directly on the root schema) however an exception can be made here for extending core collections.
 
 :::
 
 #### Custom fields on Core Collections
 
-To define custom fields on the core collections that are shipped with the SDK you can add a type containing only these custom fields to be applied.
+To define custom fields on the core collections that are shipped with the SDK you can add a type containing only these
+custom fields to be applied.
 
 Extending core collections should always be a singular type.
 
 For example:
+
 ```ts
 interface MySchema {
 	// regular collections are array types
-	collection_a: CollectionA[]; 
+	collection_a: CollectionA[];
 	// singleton collections are singular types
 	collection_c: CollectionC;
 	// extend the provided DirectusUser type // [!code ++]
@@ -60,7 +70,8 @@ interface CustomUser {
 
 ::: tip Typing bug
 
-there is currently an unsolved bug where when using directus core collections. To work around this you'll need to add a `directus_` prefixed item to the root type.
+there is currently an unsolved bug where when using directus core collections. To work around this you'll need to add a
+`directus_` prefixed item to the root type.
 
 Reference: https://github.com/directus/directus/issues/19815
 
@@ -68,7 +79,9 @@ Reference: https://github.com/directus/directus/issues/19815
 
 ### Field types
 
-Most Directus field types will map to one of the TypeScript primitive types (`string`, `number`, `boolean`). There are some exceptions to this where literal types are used to distinguish between primitives in order to add extra functionality to the auto-completion types.
+Most Directus field types will map to one of the TypeScript primitive types (`string`, `number`, `boolean`). There are
+some exceptions to this where literal types are used to distinguish between primitives in order to add extra
+functionality to the auto-completion types.
 
 ```ts
 interface CollectionA {
@@ -78,7 +91,10 @@ interface CollectionA {
 }
 ```
 
-There are currently 3 literal types that can be applied. The first 2 are both used to apply the `count(field)` [array function](/reference/query.html#array-functions) in the `filter`/`field` auto-complete suggestions, these are the `'json'` and `'csv'` string literal type. There is also the `'datetime'` string literal type which is used to apply all [datetime  functions](/reference/query.html#datetime-functions) in the `filter`/`field` auto-complete suggestions.
+There are currently 3 literal types that can be applied. The first 2 are both used to apply the `count(field)`
+[array function](/reference/query.html#array-functions) in the `filter`/`field` auto-complete suggestions, these are the
+`'json'` and `'csv'` string literal type. There is also the `'datetime'` string literal type which is used to apply all
+[datetime functions](/reference/query.html#datetime-functions) in the `filter`/`field` auto-complete suggestions.
 
 ```ts
 interface CollectionA {
@@ -93,19 +109,22 @@ interface CollectionA {
 ```
 
 In the output types these string literals will get resolved to their appropriate types:
+
 - `'csv'` resolves to `string[]`
 - `'datetime'` resolves to `string`
 - `'json'` resolves to [`JsonValue`](https://github.com/directus/directus/blob/main/sdk/src/types/output.ts#L105)
 
 ::: tip Types to avoid
 
-Some types should be avoided in the Schema as they may not play well with the type logic: `any` or `any[]`, empty type `{}`, `never` or `void`.
+Some types should be avoided in the Schema as they may not play well with the type logic: `any` or `any[]`, empty type
+`{}`, `never` or `void`.
 
 :::
 
 ### Adding relational fields
 
-For regular relations without junction collections you define a relation using a union of the primary key type and the related object.
+For regular relations without junction collections you define a relation using a union of the primary key type and the
+related object.
 
 ```ts
 interface MySchema {
@@ -144,7 +163,8 @@ interface CollectionB {
 
 ### Adding relations with junction collections
 
-For relations that rely on a junction collection you will need to define the junction collection on the root schema and refer to this new type similar to the one to many relation above.
+For relations that rely on a junction collection you will need to define the junction collection on the root schema and
+refer to this new type similar to the one to many relation above.
 
 #### Many to Many
 
@@ -228,7 +248,9 @@ type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
 
 ### Debugging generated output types
 
-The SDK provides some utility generic types to help debug issues. The `Identity<>` generic type can be used to try and resolve generics to their results. This is however not a silver bullit and you may need to reduce the type for this to work.
+The SDK provides some utility generic types to help debug issues. The `Identity<>` generic type can be used to try and
+resolve generics to their results. This is however not a silver bullit and you may need to reduce the type for this to
+work.
 
 ```ts
 // the output type from the previous example
@@ -243,7 +265,8 @@ type ResolvedType = Identity< GeneratedType[0] >;
 
 ## Working with input Query types
 
-For the output types to work properly the `fields` list needs to be static so the types can read the fields that were selected in the query. 
+For the output types to work properly the `fields` list needs to be static so the types can read the fields that were
+selected in the query.
 
 ```ts
 const fields = ["id", "status"];
@@ -254,6 +277,7 @@ const fields = ["id", "status"] as const;
 ```
 
 Complete example:
+
 ```ts
 const query: Query<MySchema, CollectionA> = {
 	limit: 20,

--- a/docs/guides/sdk/types.md
+++ b/docs/guides/sdk/types.md
@@ -1,0 +1,216 @@
+---
+contributors: Tim de Heiden
+description: Learn about all of the ways to manage types with the Directus SDK
+---
+
+# Directus SDK Types
+
+The Directus SDK provides TypeScript types used for auto-completion and generating output item types, these can be quite complex and can be hard to work with. This guide will go over some approaches that can be taken for workine with these types and assumes you're working with the SDK in TypeScript 5+.
+
+## Setting up the a Schema
+
+The schema entails a couple of things:
+- A root schema type (the type that is provided to the SDK client)
+- Adding custom fields on core collections
+- A defined type for each available collection and field
+
+### The root Schema type
+
+This type should contain **all collections available** including junction collections for many-to-many and many-to-any relations because this type is used as lookup table to determine what the relations are.
+
+By defining a collection as an array this is considered a regular collection with multiple records, if left away a singular type is considered to be a singleton.
+
+For example:
+```ts
+interface MySchema {
+	// regular collections are array types
+	collection_a: CollectionA[]; 
+	// singleton collections are singular types
+	collection_c: CollectionC;
+}
+```
+
+::: tip
+
+For the most reliable results the root schema types should be kept as pure as possible, meaning no unions (`CollectionA | null`), no optional types (`optional_collection?: CollectionA[]`) and preferrably no inline relational types (types nested directly on the root schema) however an exception can be made here for extending core collections.
+
+:::
+
+#### Custom fields on Core Collections
+
+To define custom fields on the core collections that are shipped with the SDK you can add a type containing only these custom fields to be applied.
+
+Extending core collections should always be a singular type.
+
+For example:
+```ts
+interface MySchema {
+	// regular collections are array types
+	collection_a: CollectionA[]; 
+	// singleton collections are singular types
+	collection_c: CollectionC;
+	// extend the provided DirectusUser type // [!code ++]
+	directus_users: CustomUser; // [!code ++]
+}
+
+interface CustomUser {
+	custom_field: string;
+}
+```
+
+### Field types
+
+Most Directus field types will map to one of the TypeScript primitive types (`string`, `number`, `boolean`). There are some exceptions to this where literal types are used to distinguish between primitives in order to add extra functionality to the auto-completion types.
+
+```ts
+
+
+```
+
+::: tip Types to avoid
+
+Some types should be avoided in the Schema as they may not play well with the type logic: `any` or `any[]`, empty type `{}`, `never` or `void`.
+
+:::
+
+### Adding relational fields
+
+
+
+### Adding relations with junction collections
+
+### The root Schema type
+- schema rules and things to avoid
+- literal types for functions 'json' etc
+
+```ts
+// The main schema type containing all collections available
+interface MySchema {
+	collection_a: CollectionA[]; // regular collections are array types
+	collection_b: CollectionB[];
+	collection_c: CollectionC; // this is a singleton
+	// junction collections are collections too
+	collection_a_b_m2m: CollectionAB_Many[];
+	collection_a_b_m2a: CollectionAB_Any[];
+}
+// these should be pure types, meaning not-optional, no unions and no inline types with the exception of core collection extensions.
+
+// collection A
+interface CollectionA {
+	id: number;
+	status: string;
+	// relations
+	m2o: number | CollectionB;
+	o2m: number[] | CollectionB[];
+	m2m: number[] | CollectionAB_Many[];
+	m2a: number[] | CollectionAB_Any[];
+}
+
+// Many-to-Many junction table
+interface CollectionAB_Many {
+	id: number;
+	collection_a_id: CollectionA;
+	collection_b_id: CollectionB;
+}
+
+// Many-to-Any junction table
+interface CollectionAB_Any {
+	id: number;
+	collection_a_id: CollectionA;
+	collection: 'collection_b' | 'collection_c';
+	item: string | CollectionB | CollectionC;
+}
+
+// collection B
+interface CollectionB {
+	id: number;
+	value: string;
+}
+
+// singleton collection
+interface CollectionC {
+	id: number;
+	app_settings: string;
+	something: string;
+}
+```
+
+## Working with Directus Collections
+
+```ts
+import { DirectusUser } from '@directus/sdk';
+
+interface MySchema {
+	// ... types
+	collection_d: CollectionD[];
+	directus_files: {
+		custom_field: string;
+	};
+}
+
+interface CollectionD {
+	id: number;
+	user_created: string | DirectusUser<MySchema>;
+}
+```
+
+::: tip Typing bug
+
+there is currently an unsolved bug where when using directus core collections. To work around this you'll need to add a `directus_` prefixed item to the root type.
+
+:::
+
+## Working with the generated output types
+
+```ts
+async function getCustomers() {
+  return await client.request(
+    readItems('customer', {
+      fields: ['id']
+    })
+  )
+}
+
+type ApiCustomer = Awaited<ReturnType<typeof getCustomers>>
+// ^ this is your generated type that can be used in the component
+```
+
+## Working with Query types
+
+```ts
+const query: Query<MySchema, CollectionA> = {
+	limit: 20,
+	offset: 0,
+};
+
+let search = '5'
+
+if (search) {
+	query.search = search;
+}
+
+const query2 =  {
+  ...query,
+	fields: [
+    "id", "status"
+	],
+} satisfies Query<MySchema, CollectionA>;
+
+search = 'a';
+
+const results = await directusClient.request(readItems("collection_a", query2));
+
+const results2 = await directusClient.request(readItems("collection_a", {
+  ...query,
+    search,
+	fields: [
+    "id", "status"
+	],
+}));
+```
+
+::: tip Alias unsuported
+
+At this time `alias` has not been typed yet for use in other query parameters like `deep`.
+
+:::

--- a/docs/guides/sdk/types.md
+++ b/docs/guides/sdk/types.md
@@ -5,27 +5,24 @@ description: Learn about all of the ways to manage types with the Directus SDK
 
 # Directus SDK Types
 
-The Directus SDK provides TypeScript types used for auto-completion and generating output item types, these can be quite
-complex and can be hard to work with. This guide will go over some approaches that can be taken for working with these
-types and assumes you're working with the SDK in TypeScript 5+.
+The Directus SDK provides TypeScript types used for auto-completion and generating output item types, but these can be
+complex to work with. This guide will cover some approaches to more easily work with these types.
 
-## Setting up the a Schema
+This guide assumes you're working with the Directus SDK and using TypeScript 5 or later.
 
-The schema entails a couple of things:
+## Setting Up a Schema
 
-- A root schema type (the type that is provided to the SDK client)
-- Adding custom fields on core collections
-- A defined type for each available collection and field
+A schema contains a root schema type, custom fields on core collections, and a defined type for each available
+collection and field.
 
 ### The root Schema type
 
-This type should contain **all collections available** including junction collections for many-to-many and many-to-any
-relations because this type is used as lookup table to determine what the relations are.
+The root schema type is the type provided to the SDK client. It should contain **all available collections**, including
+junction collections for many-to-many and many-to-any relations. This type is used by the SDK as a lookup table to
+determine what relations exist.
 
-By defining a collection as an array this is considered a regular collection with multiple records, if left away a
-singular type is considered to be a singleton.
-
-For example:
+If a collection if defined as an array, it is considered a regular collection with multiple items. If not defined as an
+array, but instead as a single type, the collection is considered to be a singleton.
 
 ```ts
 interface MySchema {
@@ -36,22 +33,21 @@ interface MySchema {
 }
 ```
 
-::: tip
+::: tip Improving Results
 
-For the most reliable results the root schema types should be kept as pure as possible, meaning no unions
-(`CollectionA | null`), no optional types (`optional_collection?: CollectionA[]`) and preferably no inline relational
-types (types nested directly on the root schema) however an exception can be made here for extending core collections.
+For the most reliable results, the root schema types should be kept as pure as possible. This means avoiding unions
+(`CollectionA | null`), optional types (`optional_collection?: CollectionA[]`), and preferably inline relational types
+(types nested directly on the root schema) except when adding custom fields to core collections.
 
 :::
 
-#### Custom fields on Core Collections
+## Custom Fields on Core Collections
 
-To define custom fields on the core collections that are shipped with the SDK you can add a type containing only these
-custom fields to be applied.
+Core collections are provided and required in every Directus project, and are prefixed with `directus_`. Directus
+projects can add additional fields to these collections, but should also be included in the schema when initializing the
+Directus SDK.
 
-Extending core collections should always be a singular type.
-
-For example:
+To define custom fields on the core collections, add a type containing only your custom fields as a singular type.
 
 ```ts
 interface MySchema {
@@ -62,26 +58,28 @@ interface MySchema {
 	// extend the provided DirectusUser type // [!code ++]
 	directus_users: CustomUser; // [!code ++]
 }
-
-interface CustomUser {
-	custom_field: string;
-}
+// [!code ++]
+interface CustomUser { // [!code ++]
+	custom_field: string; // [!code ++]
+} // [!code ++]
 ```
 
-::: tip Typing bug
+::: tip 🪲 Core Collections Typing Bug
 
-there is currently an unsolved bug where when using directus core collections. To work around this you'll need to add a
-`directus_` prefixed item to the root type.
+There is currently an [unsolved bug](https://github.com/directus/directus/issues/19815) when using Directus core
+collections. If you need to include types for core collections, you will need to add an item to the root type starting
+with `directus_` for any other core collections to be correctly typed.
 
-Reference: https://github.com/directus/directus/issues/19815
+When [this bug](https://github.com/directus/directus/issues/19815) is resolved, you may need to remove this temporary
+fix.
 
 :::
 
-### Field types
+### Collection Field Types
 
 Most Directus field types will map to one of the TypeScript primitive types (`string`, `number`, `boolean`). There are
 some exceptions to this where literal types are used to distinguish between primitives in order to add extra
-functionality to the auto-completion types.
+functionality.
 
 ```ts
 interface CollectionA {
@@ -93,7 +91,7 @@ interface CollectionA {
 
 There are currently 3 literal types that can be applied. The first 2 are both used to apply the `count(field)`
 [array function](/reference/query.html#array-functions) in the `filter`/`field` auto-complete suggestions, these are the
-`'json'` and `'csv'` string literal type. There is also the `'datetime'` string literal type which is used to apply all
+`'json'` and `'csv'` string literal types. The `'datetime'` string literal type which is used to apply all
 [datetime functions](/reference/query.html#datetime-functions) in the `filter`/`field` auto-complete suggestions.
 
 ```ts
@@ -114,16 +112,16 @@ In the output types these string literals will get resolved to their appropriate
 - `'datetime'` resolves to `string`
 - `'json'` resolves to [`JsonValue`](https://github.com/directus/directus/blob/main/sdk/src/types/output.ts#L105)
 
-::: tip Types to avoid
+::: tip Types to Avoid
 
 Some types should be avoided in the Schema as they may not play well with the type logic: `any` or `any[]`, empty type
 `{}`, `never` or `void`.
 
 :::
 
-### Adding relational fields
+### Adding Relational Fields
 
-For regular relations without junction collections you define a relation using a union of the primary key type and the
+For regular relations without junction collections, define a relation using a union of the primary key type and the
 related object.
 
 ```ts
@@ -142,7 +140,7 @@ interface CollectionB { // [!code ++]
 } // [!code ++]
 ```
 
-#### Many to One
+**Many to One**
 
 ```ts
 interface CollectionB {
@@ -151,7 +149,7 @@ interface CollectionB {
 }
 ```
 
-#### One to Many
+**One to Many**
 
 ```ts
 interface CollectionB {
@@ -161,12 +159,12 @@ interface CollectionB {
 }
 ```
 
-### Adding relations with junction collections
+### Working with Junction Collections
 
-For relations that rely on a junction collection you will need to define the junction collection on the root schema and
-refer to this new type similar to the one to many relation above.
+For relations that rely on a junction collection, define the junction collection on the root schema and refer to this
+new type similar to the one to many relation above.
 
-#### Many to Many
+**Many to Many**
 
 ```ts
 interface MySchema {
@@ -181,7 +179,7 @@ interface MySchema {
 	directus_users: CustomUser;
 }
 
-// Many-to-Many junction table // [!code ++]
+// many-to-many junction table // [!code ++]
 interface CollectionBA_Many { // [!code ++]
 	id: number; // [!code ++]
 	collection_b_id: string | CollectionB; // [!code ++]
@@ -196,7 +194,7 @@ interface CollectionB {
 }
 ```
 
-#### Many to Any
+**Many to Any**
 
 ```ts
 interface MySchema {
@@ -207,13 +205,13 @@ interface MySchema {
 	collection_c: CollectionC;
 	// many-to-many junction collection
 	collection_b_a_m2m: CollectionBA_Many[];
-	// many-to-many junction collection // [!code ++]
+	// many-to-any junction collection // [!code ++]
 	collection_b_a_m2a: CollectionBA_Any[]; // [!code ++]
 	// extend the provided DirectusUser type
 	directus_users: CustomUser;
 }
 
-// Many-to-Any junction table // [!code ++]
+// many-to-any junction table // [!code ++]
 interface CollectionBA_Any { // [!code ++]
 	id: number; // [!code ++]
 	collection_b_id: string | CollectionB; // [!code ++]
@@ -230,7 +228,7 @@ interface CollectionB {
 }
 ```
 
-## Working with the generated output types
+## Working with Generated Output
 
 ```ts
 async function getCollectionA() {
@@ -241,16 +239,15 @@ async function getCollectionA() {
   )
 }
 
-type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
-// ^ this is your generated type that can be used in the component
+// generated type that can be used in the component
 // resolves to { "id": number } in this example
+type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
 ```
 
-### Debugging generated output types
+### Debugging
 
 The SDK provides some utility generic types to help debug issues. The `Identity<>` generic type can be used to try and
-resolve generics to their results. This is however not a silver bullet and you may need to reduce the type for this to
-work.
+resolve generics to their results. This may not always work, and you may need to reduce the type.
 
 ```ts
 // the output type from the previous example
@@ -259,21 +256,21 @@ type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
 // when hovering over this type it may look unreadable like:
 //  Merge<MapFlatFields<object & CollectionA, "id", MappedFunctionFields<MySchema, object & CollectionA>>, {}, MapFlatFields<...>, {}>[]
 
+// should resolve to { id: number; }
 type ResolvedType = Identity< GeneratedType[0] >;
-// ^ should resolve to { id: number; }
 ```
 
-## Working with input Query types
+## Working with input Query Types
 
-For the output types to work properly the `fields` list needs to be static so the types can read the fields that were
+For the output types to work properly, the `fields` list needs to be static so the types can read the fields that were
 selected in the query.
 
 ```ts
+// this does not work and resolves to string[], losing all information about the fields themselves
 const fields = ["id", "status"];
-// ^ does not work! this resolves to string[] losing all information about the fields themselves
 
+// correctly resolves to readonly ["id", "status"]
 const fields = ["id", "status"] as const;
-// This correctly resolves to readonly ["id", "status"]
 ```
 
 Complete example:
@@ -309,8 +306,8 @@ const results2 = await directusClient.request(readItems("collection_a", {
 }));
 ```
 
-::: tip Alias unsupported
+::: tip Alias Unsupported
 
-At this time `alias` has not been typed yet for use in other query parameters like `deep`.
+At this time, `alias` has not been typed yet for use in other query parameters like `deep`.
 
 :::

--- a/docs/guides/sdk/types.md
+++ b/docs/guides/sdk/types.md
@@ -6,7 +6,7 @@ description: Learn about all of the ways to manage types with the Directus SDK
 # Directus SDK Types
 
 The Directus SDK provides TypeScript types used for auto-completion and generating output item types, these can be quite
-complex and can be hard to work with. This guide will go over some approaches that can be taken for workine with these
+complex and can be hard to work with. This guide will go over some approaches that can be taken for working with these
 types and assumes you're working with the SDK in TypeScript 5+.
 
 ## Setting up the a Schema
@@ -39,7 +39,7 @@ interface MySchema {
 ::: tip
 
 For the most reliable results the root schema types should be kept as pure as possible, meaning no unions
-(`CollectionA | null`), no optional types (`optional_collection?: CollectionA[]`) and preferrably no inline relational
+(`CollectionA | null`), no optional types (`optional_collection?: CollectionA[]`) and preferably no inline relational
 types (types nested directly on the root schema) however an exception can be made here for extending core collections.
 
 :::
@@ -249,7 +249,7 @@ type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
 ### Debugging generated output types
 
 The SDK provides some utility generic types to help debug issues. The `Identity<>` generic type can be used to try and
-resolve generics to their results. This is however not a silver bullit and you may need to reduce the type for this to
+resolve generics to their results. This is however not a silver bullet and you may need to reduce the type for this to
 work.
 
 ```ts
@@ -309,7 +309,7 @@ const results2 = await directusClient.request(readItems("collection_a", {
 }));
 ```
 
-::: tip Alias unsuported
+::: tip Alias unsupported
 
 At this time `alias` has not been typed yet for use in other query parameters like `deep`.
 

--- a/docs/guides/sdk/types.md
+++ b/docs/guides/sdk/types.md
@@ -58,14 +58,44 @@ interface CustomUser {
 }
 ```
 
+::: tip Typing bug
+
+there is currently an unsolved bug where when using directus core collections. To work around this you'll need to add a `directus_` prefixed item to the root type.
+
+Reference: https://github.com/directus/directus/issues/19815
+
+:::
+
 ### Field types
 
 Most Directus field types will map to one of the TypeScript primitive types (`string`, `number`, `boolean`). There are some exceptions to this where literal types are used to distinguish between primitives in order to add extra functionality to the auto-completion types.
 
 ```ts
-
-
+interface CollectionA {
+	id: number;
+	status: string;
+	toggle: boolean;
+}
 ```
+
+There are currently 3 literal types that can be applied. The first 2 are both used to apply the `count(field)` [array function](/reference/query.html#array-functions) in the `filter`/`field` auto-complete suggestions, these are the `'json'` and `'csv'` string literal type. There is also the `'datetime'` string literal type which is used to apply all [datetime  functions](/reference/query.html#datetime-functions) in the `filter`/`field` auto-complete suggestions.
+
+```ts
+interface CollectionA {
+	id: number;
+	status: string;
+	toggle: boolean;
+
+	tags: 'csv'; // [!code ++]
+	json_field: 'json'; // [!code ++]
+	date_created: 'datetime'; // [!code ++]
+}
+```
+
+In the output types these string literals will get resolved to their appropriate types:
+- `'csv'` resolves to `string[]`
+- `'datetime'` resolves to `string`
+- `'json'` resolves to [`JsonValue`](https://github.com/directus/directus/blob/main/sdk/src/types/output.ts#L105)
 
 ::: tip Types to avoid
 
@@ -75,136 +105,182 @@ Some types should be avoided in the Schema as they may not play well with the ty
 
 ### Adding relational fields
 
+For regular relations without junction collections you define a relation using a union of the primary key type and the related object.
 
+```ts
+interface MySchema {
+	// regular collections are array types
+	collection_a: CollectionA[];
+	collection_b: CollectionB[]; // [!code ++]
+	// singleton collections are singular types
+	collection_c: CollectionC;
+	// extend the provided DirectusUser type
+	directus_users: CustomUser;
+}
+
+interface CollectionB { // [!code ++]
+	id: string; // [!code ++]
+} // [!code ++]
+```
+
+#### Many to One
+
+```ts
+interface CollectionB {
+	id: string;
+	m2o: number | CollectionA; // [!code ++]
+}
+```
+
+#### One to Many
+
+```ts
+interface CollectionB {
+	id: string;
+	m2o: number | CollectionA;
+	o2m: number[] | CollectionA[]; // [!code ++]
+}
+```
 
 ### Adding relations with junction collections
 
-### The root Schema type
-- schema rules and things to avoid
-- literal types for functions 'json' etc
+For relations that rely on a junction collection you will need to define the junction collection on the root schema and refer to this new type similar to the one to many relation above.
+
+#### Many to Many
 
 ```ts
-// The main schema type containing all collections available
 interface MySchema {
-	collection_a: CollectionA[]; // regular collections are array types
+	// regular collections are array types
+	collection_a: CollectionA[];
 	collection_b: CollectionB[];
-	collection_c: CollectionC; // this is a singleton
-	// junction collections are collections too
-	collection_a_b_m2m: CollectionAB_Many[];
-	collection_a_b_m2a: CollectionAB_Any[];
-}
-// these should be pure types, meaning not-optional, no unions and no inline types with the exception of core collection extensions.
-
-// collection A
-interface CollectionA {
-	id: number;
-	status: string;
-	// relations
-	m2o: number | CollectionB;
-	o2m: number[] | CollectionB[];
-	m2m: number[] | CollectionAB_Many[];
-	m2a: number[] | CollectionAB_Any[];
+	// singleton collections are singular types
+	collection_c: CollectionC;
+	// many-to-many junction collection // [!code ++]
+	collection_b_a_m2m: CollectionBA_Many[]; // [!code ++]
+	// extend the provided DirectusUser type
+	directus_users: CustomUser;
 }
 
-// Many-to-Many junction table
-interface CollectionAB_Many {
-	id: number;
-	collection_a_id: CollectionA;
-	collection_b_id: CollectionB;
-}
+// Many-to-Many junction table // [!code ++]
+interface CollectionBA_Many { // [!code ++]
+	id: number; // [!code ++]
+	collection_b_id: string | CollectionB; // [!code ++]
+	collection_a_id: number | CollectionA; // [!code ++]
+} // [!code ++]
 
-// Many-to-Any junction table
-interface CollectionAB_Any {
-	id: number;
-	collection_a_id: CollectionA;
-	collection: 'collection_b' | 'collection_c';
-	item: string | CollectionB | CollectionC;
-}
-
-// collection B
 interface CollectionB {
-	id: number;
-	value: string;
-}
-
-// singleton collection
-interface CollectionC {
-	id: number;
-	app_settings: string;
-	something: string;
+	id: string;
+	m2o: number | CollectionA;
+	o2m: number[] | CollectionA[];
+	m2m: number[] | CollectionBA_Many[]; // [!code ++]
 }
 ```
 
-## Working with Directus Collections
+#### Many to Any
 
 ```ts
-import { DirectusUser } from '@directus/sdk';
-
 interface MySchema {
-	// ... types
-	collection_d: CollectionD[];
-	directus_files: {
-		custom_field: string;
-	};
+	// regular collections are array types
+	collection_a: CollectionA[];
+	collection_b: CollectionB[];
+	// singleton collections are singular types
+	collection_c: CollectionC;
+	// many-to-many junction collection
+	collection_b_a_m2m: CollectionBA_Many[];
+	// many-to-many junction collection // [!code ++]
+	collection_b_a_m2a: CollectionBA_Any[]; // [!code ++]
+	// extend the provided DirectusUser type
+	directus_users: CustomUser;
 }
 
-interface CollectionD {
-	id: number;
-	user_created: string | DirectusUser<MySchema>;
+// Many-to-Any junction table // [!code ++]
+interface CollectionBA_Any { // [!code ++]
+	id: number; // [!code ++]
+	collection_b_id: string | CollectionB; // [!code ++]
+	collection: 'collection_a' | 'collection_c'; // [!code ++]
+	item: string | CollectionA | CollectionC; // [!code ++]
+} // [!code ++]
+
+interface CollectionB {
+	id: string;
+	m2o: number | CollectionA;
+	o2m: number[] | CollectionA[];
+	m2m: number[] | CollectionBA_Many[];
+	m2m: number[] | CollectionBA_Any[]; // [!code ++]
 }
 ```
-
-::: tip Typing bug
-
-there is currently an unsolved bug where when using directus core collections. To work around this you'll need to add a `directus_` prefixed item to the root type.
-
-:::
 
 ## Working with the generated output types
 
 ```ts
-async function getCustomers() {
+async function getCollectionA() {
   return await client.request(
-    readItems('customer', {
+    readItems('collection_a', {
       fields: ['id']
     })
   )
 }
 
-type ApiCustomer = Awaited<ReturnType<typeof getCustomers>>
+type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
 // ^ this is your generated type that can be used in the component
+// resolves to { "id": number } in this example
 ```
 
-## Working with Query types
+### Debugging generated output types
 
+The SDK provides some utility generic types to help debug issues. The `Identity<>` generic type can be used to try and resolve generics to their results. This is however not a silver bullit and you may need to reduce the type for this to work.
+
+```ts
+// the output type from the previous example
+type GeneratedType = Awaited<ReturnType<typeof getCollectionA>>;
+
+// when hovering over this type it may look unreadable like:
+//  Merge<MapFlatFields<object & CollectionA, "id", MappedFunctionFields<MySchema, object & CollectionA>>, {}, MapFlatFields<...>, {}>[]
+
+type ResolvedType = Identity< GeneratedType[0] >;
+// ^ should resolve to { id: number; }
+```
+
+## Working with input Query types
+
+For the output types to work properly the `fields` list needs to be static so the types can read the fields that were selected in the query. 
+
+```ts
+const fields = ["id", "status"];
+// ^ does not work! this resolves to string[] losing all information about the fields themselves
+
+const fields = ["id", "status"] as const;
+// This correctly resolves to readonly ["id", "status"]
+```
+
+Complete example:
 ```ts
 const query: Query<MySchema, CollectionA> = {
 	limit: 20,
 	offset: 0,
 };
 
-let search = '5'
-
+let search = 'test';
 if (search) {
 	query.search = search;
 }
 
+// create a second query for literal/readonly type inference
 const query2 =  {
-  ...query,
+    ...query,
 	fields: [
-    "id", "status"
+        "id", "status"
 	],
 } satisfies Query<MySchema, CollectionA>;
 
-search = 'a';
-
 const results = await directusClient.request(readItems("collection_a", query2));
 
+// or build the query directly inline
 const results2 = await directusClient.request(readItems("collection_a", {
-  ...query,
+    ...query,
     search,
 	fields: [
-    "id", "status"
+        "id", "status"
 	],
 }));
 ```

--- a/sdk/src/types/query.ts
+++ b/sdk/src/types/query.ts
@@ -9,13 +9,13 @@ import type { IfAny, UnpackList } from './utils.js';
  */
 export interface Query<Schema extends object, Item> {
 	readonly fields?: IfAny<Schema, (string | Record<string, any>)[], QueryFields<Schema, Item>> | undefined;
-	readonly filter?: IfAny<Schema, Record<string, any>, QueryFilter<Schema, Item>> | undefined;
-	readonly search?: string | undefined;
-	readonly sort?: IfAny<Schema, string | string[], QuerySort<Schema, Item> | QuerySort<Schema, Item>[]> | undefined;
-	readonly limit?: number | undefined;
-	readonly offset?: number | undefined;
-	readonly page?: number | undefined;
-	readonly deep?: IfAny<Schema, Record<string, any>, QueryDeep<Schema, Item>> | undefined;
+	filter?: IfAny<Schema, Record<string, any>, QueryFilter<Schema, Item>> | undefined;
+	search?: string | undefined;
+	sort?: IfAny<Schema, string | string[], QuerySort<Schema, Item> | QuerySort<Schema, Item>[]> | undefined;
+	limit?: number | undefined;
+	offset?: number | undefined;
+	page?: number | undefined;
+	deep?: IfAny<Schema, Record<string, any>, QueryDeep<Schema, Item>> | undefined;
 	readonly alias?: IfAny<Schema, Record<string, string>, QueryAlias<Schema, Item>> | undefined;
 }
 


### PR DESCRIPTION
Fixes #21254 

## Scope

What's changed:

- Removed `readonly` for properties on the `Query<Schema, Item>` that do not technically require it.
- Added a documentation page for common type issues and approaches

## Potential Risks / Drawbacks

- None i can think of

## Review Notes / Questions

- I would like to lorem ipsum

