### PR TITLE
Updates to Next and Nuxt Guides

### DIFF
--- a/.changeset/fast-cats-remember.md
+++ b/.changeset/fast-cats-remember.md
@@ -1,0 +1,5 @@
+---
+'docs': patch
+---
+
+Added a note to warn users about NextJS's default caching in fetch

--- a/docs/guides/headless-cms/build-static-website/next-13.md
+++ b/docs/guides/headless-cms/build-static-website/next-13.md
@@ -64,6 +64,21 @@ const directus = createDirectus('https://directus.example.com').with(rest());
 export default directus;
 ```
 
+::: tip Next.js Caching
+
+Next.js extends the native fetch API with a `force-cache` configuration by default. This means you may sometimes run
+into scenarios where Next.js returns stale data. To fix this, update the `rest()` composable as follows:
+
+```js
+const directus = createDirectus('https://directus.example.com').with(
+  rest({
+    onRequest: (options) => ({ ...options, cache: 'no-store' }),
+  })
+);
+```
+
+:::
+
 Ensure your Project URL is correct when initializing the Directus JavaScript SDK.
 
 ## Using Global Metadata and Settings

--- a/docs/guides/headless-cms/build-static-website/nuxt-3.md
+++ b/docs/guides/headless-cms/build-static-website/nuxt-3.md
@@ -140,8 +140,8 @@ if (!page.value) throw createError({
 ```
 
 Go to http://localhost:3000/about, replacing `about` with any of your item slugs. Using the Directus JavaScript SDK, the
-single item with that slug is retrieved, and the page should show your data. `readOne()` only checks against your `slug`
-Primary ID Field.
+single item with that slug is retrieved, and the page should show your data. `readItem()` only checks against your
+`slug` Primary ID Field.
 
 _Note that we check if a returned value exists, and return a 404 if not. Please also note that
 [`v-html` should only be used for trusted content](https://vuejs.org/api/built-in-directives.html#v-html)._


### PR DESCRIPTION
This PR makes updates to the next.js guide, calling out caching for users to be aware of.

Also replaces the `readOne` method in the Nuxt guide.

Closes #21230