### PR TITLE
Configure inactive days for PRs and Discussions in Lock Thread workflow

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -18,3 +18,5 @@ jobs:
       - uses: dessant/lock-threads@v5
         with:
           issue-inactive-days: 60
+          pr-inactive-days: 60
+          discussion-inactive-days: 60


### PR DESCRIPTION
Missed the fact in #21224 that PRs and Discussions need to be configured separately, https://github.com/dessant/lock-threads?tab=readme-ov-file#available-input-parameters