### PR TITLE
Make sure IP extraction in server `response` hook is consistent

### DIFF
--- a/.changeset/chilly-buckets-design.md
+++ b/.changeset/chilly-buckets-design.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that would cause the response hook to extract a different IP address from the rest of the API

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -14,6 +14,7 @@ import getDatabase from './database/index.js';
 import emitter from './emitter.js';
 import { useLogger } from './logger.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
+import { getIPFromReq } from './utils/get-ip-from-req.js';
 import {
 	createSubscriptionController,
 	createWebSocketController,
@@ -79,7 +80,7 @@ export async function createServer(): Promise<http.Server> {
 					size: metrics.out,
 					headers: res.getHeaders(),
 				},
-				ip: req.headers['x-forwarded-for'] || req.socket?.remoteAddress,
+				ip: getIPFromReq(req),
 				duration: elapsedMilliseconds.toFixed(),
 			};
 


### PR DESCRIPTION
## Scope

What's changed:

- Updated the server response hook to use the same `getIPFromReq` util that's used elsewhere

## Potential Risks / Drawbacks

- —

## Review Notes / Questions

- Simple bug fix, nothing special

---

Fixes #21272
