### PR TITLE
Add layout styling for detail page

### DIFF
--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -303,7 +303,7 @@ function onClick(event: PointerEvent) {
 		}
 
 		& + & {
-			margin-top: 8px;
+			margin-top: var(--v-list-item-margin, 8px);
 		}
 
 		&.dense {
@@ -311,7 +311,7 @@ function onClick(event: PointerEvent) {
 			padding: 4px 8px;
 
 			& + & {
-				margin-top: 4px;
+				margin-top: var(--v-list-item-margin, 4px);
 			}
 		}
 	}

--- a/app/src/modules/settings/routes/marketplace/extension/components/extension-metadata.vue
+++ b/app/src/modules/settings/routes/marketplace/extension/components/extension-metadata.vue
@@ -20,24 +20,45 @@ const latestVersion = computed(() => props.extension.versions.at(0)!);
 </script>
 
 <template>
-	<v-list>
-		<ExtensionMetadataAuthor
-			:verified="latestVersion.publisher.verified"
-			:username="latestVersion.publisher.username"
-		/>
-		<ExtensionMetadataCompatibility :host-version="latestVersion.host_version" />
-		<ExtensionMetadataVersion :version="latestVersion.version" />
-		<ExtensionMetadataDownloads :downloads="extension.downloads" />
-		<ExtensionMetadataDate :publish-date="latestVersion.publish_date" />
-		<ExtensionMetadataSize :unpacked-size="latestVersion.unpacked_size" :file-count="latestVersion.file_count" />
-		<ExtensionMetadataItem v-if="latestVersion.url_homepage" icon="link" :href="latestVersion.url_homepage">
-			{{ t('homepage') }}
-		</ExtensionMetadataItem>
-		<ExtensionMetadataItem v-if="latestVersion.url_repository" icon="commit" :href="latestVersion.url_repository">
-			{{ t('repository') }}
-		</ExtensionMetadataItem>
-		<ExtensionMetadataItem v-if="latestVersion.url_bugs" icon="bug_report" :href="latestVersion.url_bugs">
-			{{ t('report_an_issue') }}
-		</ExtensionMetadataItem>
-	</v-list>
+	<div class="metadata">
+		<v-list class="list">
+			<div class="grid">
+				<ExtensionMetadataCompatibility :host-version="latestVersion.host_version" />
+				<ExtensionMetadataAuthor
+					:verified="latestVersion.publisher.verified"
+					:username="latestVersion.publisher.username"
+				/>
+				<ExtensionMetadataVersion :version="latestVersion.version" />
+				<ExtensionMetadataDownloads :downloads="extension.downloads" />
+				<ExtensionMetadataDate :publish-date="latestVersion.publish_date" />
+				<ExtensionMetadataSize :unpacked-size="latestVersion.unpacked_size" :file-count="latestVersion.file_count" />
+				<ExtensionMetadataItem v-if="latestVersion.url_homepage" icon="link" :href="latestVersion.url_homepage">
+					{{ t('homepage') }}
+				</ExtensionMetadataItem>
+				<ExtensionMetadataItem v-if="latestVersion.url_repository" icon="commit" :href="latestVersion.url_repository">
+					{{ t('repository') }}
+				</ExtensionMetadataItem>
+				<ExtensionMetadataItem v-if="latestVersion.url_bugs" icon="bug_report" :href="latestVersion.url_bugs">
+					{{ t('report_an_issue') }}
+				</ExtensionMetadataItem>
+			</div>
+		</v-list>
+	</div>
 </template>
+
+<style scoped>
+.metadata {
+	container-type: inline-size;
+	container-name: metadata;
+}
+
+.grid {
+	@container metadata (width > 580px) {
+		--v-list-item-margin: 0;
+
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 10px;
+	}
+}
+</style>

--- a/app/src/modules/settings/routes/marketplace/extension/components/extension-readme.vue
+++ b/app/src/modules/settings/routes/marketplace/extension/components/extension-readme.vue
@@ -10,8 +10,6 @@ defineProps<{
 
 <style scoped lang="scss">
 .readme {
-	max-width: 600px;
-
 	:deep() {
 		@import '@/styles/markdown';
 	}

--- a/app/src/modules/settings/routes/marketplace/extension/extension.vue
+++ b/app/src/modules/settings/routes/marketplace/extension/extension.vue
@@ -52,9 +52,13 @@ const navigateBack = () => router.push('/settings/marketplace');
 
 		<div class="drawer-item-content">
 			<template v-if="extension">
-				<ExtensionBanner :extension="extension" />
-				<ExtensionMetadata :extension="extension" />
-				<ExtensionReadme v-if="extension.readme" :readme="extension.readme" />
+				<div class="container">
+					<div class="grid">
+						<ExtensionBanner class="banner" :extension="extension" />
+						<ExtensionMetadata class="metadata" :extension="extension" />
+						<ExtensionReadme v-if="extension.readme" class="readme" :readme="extension.readme" />
+					</div>
+				</div>
 			</template>
 
 			<v-progress-circular v-else-if="loading" indeterminate />
@@ -68,9 +72,38 @@ const navigateBack = () => router.push('/settings/marketplace');
 .drawer-item-content {
 	padding: var(--content-padding);
 	padding-bottom: var(--content-padding-bottom);
+	max-width: 1200px;
+	width: 100%;
 }
 
-.readme {
-	max-width: 600px;
+.container {
+	container-type: inline-size;
+	container-name: item;
+}
+
+.grid {
+	display: grid;
+	gap: 40px;
+	grid-template-areas: 'banner' 'metadata' 'readme';
+
+	.banner {
+		grid-area: banner;
+	}
+
+	.readme {
+		grid-area: readme;
+		min-width: 0;
+	}
+
+	.metadata {
+		grid-area: metadata;
+	}
+
+	@container item (width > 800px) {
+		grid-template-columns: 1fr 320px;
+		grid-template-areas:
+			'banner banner'
+			'readme metadata';
+	}
 }
 </style>


### PR DESCRIPTION
## Scope

What's changed:

- Added layout styling for forum detail page

## Potential Risks / Drawbacks

- Updated block margin style to be overridable with `v-item-margin`. Could cause unexpected visual glitches

## Review Notes / Questions

- —
