### PR TITLE
Manage extensions by directus_extensions primary key instead of npm package name

### DIFF
--- a/.changeset/old-buttons-call.md
+++ b/.changeset/old-buttons-call.md
@@ -1,0 +1,14 @@
+---
+'@directus/extensions-sdk': major
+'@directus/api': major
+'@directus/extensions-registry': patch
+'@directus/extensions': patch
+'@directus/errors': patch
+'@directus/themes': patch
+'@directus/utils': patch
+'@directus/env': patch
+'docs': patch
+'@directus/app': patch
+---
+
+Updated the extensions management endpoints to rely on a unique primary key rather than npm package name

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -146,22 +146,19 @@ router.post(
 );
 
 router.patch(
-	'/:bundleOrName/:name?',
+	`/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, res, next) => {
 		const service = new ExtensionsService({
 			accountability: req.accountability,
 			schema: req.schema,
 		});
 
-		const bundle = req.params['name'] ? req.params['bundleOrName'] : null;
-		const name = req.params['name'] ? req.params['name'] : req.params['bundleOrName'];
-
-		if (bundle === undefined || !name) {
+		if (!req.params['pk']) {
 			throw new ForbiddenError();
 		}
 
 		try {
-			const result = await service.updateOne(bundle, name, req.body);
+			const result = await service.updateOne(req.params['pk'], req.body);
 			res.locals['payload'] = { data: result || null };
 		} catch (error) {
 			let finalError = error;

--- a/api/src/database/migrations/20240204A-marketplace.ts
+++ b/api/src/database/migrations/20240204A-marketplace.ts
@@ -39,12 +39,19 @@ export async function up(knex: Knex): Promise<void> {
 		table.string('source', 255).alter().notNullable().defaultTo('local');
 		table.renameColumn('name', 'folder');
 	});
+
+	await knex.schema.alterTable('directus_extensions', (table) => {
+		table.string('folder', 255).nullable().alter();
+	});
 }
 
 export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_extensions', (table) => {
 		table.dropColumns('id', 'source', 'bundle');
 		table.renameColumn('folder', 'name');
+	});
+
+	await knex.schema.alterTable('directus_extensions', (table) => {
 		table.string('name', 255).primary().alter();
 	});
 }

--- a/api/src/database/migrations/20240204A-marketplace.ts
+++ b/api/src/database/migrations/20240204A-marketplace.ts
@@ -37,12 +37,14 @@ export async function up(knex: Knex): Promise<void> {
 		table.dropPrimary();
 		table.uuid('id').alter().primary().notNullable();
 		table.string('source', 255).alter().notNullable().defaultTo('local');
+		table.renameColumn('name', 'folder');
 	});
 }
 
 export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_extensions', (table) => {
 		table.dropColumns('id', 'source', 'bundle');
+		table.renameColumn('folder', 'name');
 		table.string('name', 255).primary().alter();
 	});
 }

--- a/api/src/database/migrations/20240204A-marketplace.ts
+++ b/api/src/database/migrations/20240204A-marketplace.ts
@@ -29,7 +29,7 @@ export async function up(knex: Knex): Promise<void> {
 		if (!bundleParent) continue;
 
 		await knex('directus_extensions')
-			.update({ bundle: idMap.get(bundleParent) })
+			.update({ bundle: idMap.get(bundleParent), name: name.substring(bundleParent.length + 1) })
 			.where({ name });
 	}
 
@@ -38,10 +38,6 @@ export async function up(knex: Knex): Promise<void> {
 		table.uuid('id').alter().primary().notNullable();
 		table.string('source', 255).alter().notNullable().defaultTo('local');
 		table.renameColumn('name', 'folder');
-	});
-
-	await knex.schema.alterTable('directus_extensions', (table) => {
-		table.string('folder', 255).nullable().alter();
 	});
 }
 

--- a/api/src/database/migrations/20240204A-marketplace.ts
+++ b/api/src/database/migrations/20240204A-marketplace.ts
@@ -5,23 +5,44 @@ export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_extensions', (table) => {
 		table.uuid('id').nullable();
 		table.string('source', 255);
+		table.uuid('bundle');
 	});
 
 	const installedExtensions = await knex.select('name').from('directus_extensions');
 
+	// name: id
+	const idMap = new Map<string, string>();
+
 	for (const { name } of installedExtensions) {
-		await knex('directus_extensions').update({ id: uuid(), source: 'local' }).where({ name });
+		const id = uuid();
+		await knex('directus_extensions').update({ id, source: 'local' }).where({ name });
+		idMap.set(name, id);
+	}
+
+	// This will also include flat extensions with an NPM org scope, but there's no way to identify
+	// those
+	const bundleNames = Array.from(idMap.keys()).filter((name) => name.includes('/'));
+
+	for (const { name } of installedExtensions) {
+		const bundleParent = bundleNames.find((bundleName) => name.startsWith(bundleName + '/'));
+
+		if (!bundleParent) continue;
+
+		await knex('directus_extensions')
+			.update({ bundle: idMap.get(bundleParent) })
+			.where({ name });
 	}
 
 	await knex.schema.alterTable('directus_extensions', (table) => {
 		table.dropPrimary();
 		table.uuid('id').alter().primary().notNullable();
+		table.string('source', 255).alter().notNullable().defaultTo('local');
 	});
 }
 
 export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_extensions', (table) => {
-		table.dropColumns('id', 'source');
+		table.dropColumns('id', 'source', 'bundle');
 		table.string('name', 255).primary().alter();
 	});
 }

--- a/api/src/database/migrations/20240204A-marketplace.ts
+++ b/api/src/database/migrations/20240204A-marketplace.ts
@@ -1,0 +1,27 @@
+import type { Knex } from 'knex';
+import { v4 as uuid } from 'uuid';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_extensions', (table) => {
+		table.uuid('id').nullable();
+		table.string('source', 255);
+	});
+
+	const installedExtensions = await knex.select('name').from('directus_extensions');
+
+	for (const { name } of installedExtensions) {
+		await knex('directus_extensions').update({ id: uuid(), source: 'local' }).where({ name });
+	}
+
+	await knex.schema.alterTable('directus_extensions', (table) => {
+		table.dropPrimary();
+		table.uuid('id').alter().primary().notNullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_extensions', (table) => {
+		table.dropColumns('id', 'source');
+		table.string('name', 255).primary().alter();
+	});
+}

--- a/api/src/database/system-data/fields/extensions.yaml
+++ b/api/src/database/system-data/fields/extensions.yaml
@@ -2,7 +2,18 @@ table: directus_extensions
 
 fields:
   - collection: directus_extensions
-    field: name
+    field: id
+    special:
+      - uuid
+
+  - collection: directus_extensions
+    field: folder
+
+  - collection: directus_extensions
+    field: source
+
+  - collection: directus_extensions
+    field: bundle
 
   - collection: directus_extensions
     field: enabled

--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -1,5 +1,5 @@
-import type { Extension } from '@directus/extensions';
-import { difference } from 'lodash-es';
+import type { Extension, ExtensionSettings } from '@directus/extensions';
+import { v4 as uuid } from 'uuid';
 import getDatabase from '../../database/index.js';
 import { ExtensionsService } from '../../services/extensions.js';
 import { getSchema } from '../../utils/get-schema.js';
@@ -9,7 +9,15 @@ import { getSchema } from '../../utils/get-schema.js';
  * extensions that don't have settings yet, and remove any settings for extensions that are no
  * longer installed.
  */
-export const getExtensionsSettings = async (extensions: Extension[]) => {
+export const getExtensionsSettings = async ({
+	local,
+	module,
+	registry,
+}: {
+	local: Map<string, Extension>;
+	module: Map<string, Extension>;
+	registry: Map<string, Extension>;
+}) => {
 	const database = getDatabase();
 
 	const service = new ExtensionsService({
@@ -17,33 +25,83 @@ export const getExtensionsSettings = async (extensions: Extension[]) => {
 		schema: await getSchema(),
 	});
 
-	const settings = await service.extensionsItemService.readByQuery({ limit: -1 });
+	const existingSettings = await service.extensionsItemService.readByQuery({ limit: -1 });
 
-	const extensionNames = extensions
-		.map((extension) => {
-			if (extension.type === 'bundle') {
-				return [extension.name, ...extension.entries.map((entry) => `${extension.name}/${entry.name}`)];
+	const newSettings: ExtensionSettings[] = [];
+
+	const localSettings = existingSettings.filter(({ source }) => source === 'local');
+	const registrySettings = existingSettings.filter(({ source }) => source === 'registry');
+	const moduleSettings = existingSettings.filter(({ source }) => source === 'module');
+
+	const generateSettingsEntry = (folder: string, extension: Extension, source: 'local' | 'registry' | 'module') => {
+		if (extension.type === 'bundle') {
+			const bundleId = uuid();
+
+			newSettings.push({
+				id: bundleId,
+				enabled: true,
+				source: source,
+				bundle: null,
+				folder: folder,
+			});
+
+			for (const entry of extension.entries) {
+				newSettings.push({
+					id: uuid(),
+					enabled: true,
+					source: source,
+					bundle: bundleId,
+					folder: entry.name,
+				});
 			}
+		} else {
+			newSettings.push({
+				id: uuid(),
+				enabled: true,
+				source: source,
+				bundle: null,
+				folder: folder,
+			});
+		}
+	};
 
-			return extension.name;
-		})
-		.flat();
-
-	const extensionSettingNames = settings.map(({ name }) => name);
-
-	const missing = difference(extensionNames, extensionSettingNames);
-
-	if (missing.length > 0) {
-		const missingRows = missing.map((name) => ({ name, enabled: true }));
-		await database.insert(missingRows).into('directus_extensions');
-		settings.push(...missingRows);
+	for (const [folder, extension] of local.entries()) {
+		const settingsExist = localSettings.some((settings) => settings.folder === folder);
+		if (!settingsExist) generateSettingsEntry(folder, extension, 'local');
 	}
 
-	/**
-	 * Silently ignore settings for extensions that have been manually removed from the extensions
-	 * folder. Having them automatically synced feels dangerous, as it's a destructive action. In the
-	 * edge case you'd deploy / start with the extensions folder misconfigured, it would remove all
-	 * previous options on startup, without an option to undo.
-	 */
-	return settings.filter(({ name }) => extensionNames.includes(name));
+	for (const [folder, extension] of module.entries()) {
+		const settingsExist = moduleSettings.some((settings) => settings.folder === folder);
+		if (!settingsExist) generateSettingsEntry(folder, extension, 'module');
+	}
+
+	for (const [folder, extension] of registry.entries()) {
+		const settingsExist = registrySettings.some((settings) => settings.folder === folder);
+		if (!settingsExist) generateSettingsEntry(folder, extension, 'registry');
+	}
+
+	if (newSettings.length > 0) {
+		await database.insert(newSettings).into('directus_extensions');
+	}
+
+	const settings = [...existingSettings, ...newSettings];
+
+	// /**
+	//  * Silently ignore settings for extensions that have been manually removed from the extensions
+	//  * folder. Having them automatically synced feels dangerous, as it's a destructive action. In the
+	//  * edge case you'd deploy / start with the extensions folder misconfigured, it would remove all
+	//  * previous options on startup, without an option to undo.
+	//  */
+	return settings.filter(({ source, folder }) => {
+		switch (source) {
+			case 'module':
+				return Array.from(module.keys()).includes(folder);
+			case 'registry':
+				return Array.from(registry.keys()).includes(folder);
+			case 'local':
+				return Array.from(local.keys()).includes(folder);
+			default:
+				return false;
+		}
+	});
 };

--- a/api/src/extensions/lib/get-extensions.ts
+++ b/api/src/extensions/lib/get-extensions.ts
@@ -1,26 +1,16 @@
 import { useEnv } from '@directus/env';
-import { resolveLocalExtensions, resolvePackageExtensions } from '@directus/extensions/node';
-import { useLogger } from '../../logger.js';
+import { resolveFsExtensions, resolveModuleExtensions } from '@directus/extensions/node';
+import { join } from 'node:path';
 import { getExtensionsPath } from './get-extensions-path.js';
 
 export const getExtensions = async () => {
 	const env = useEnv();
-	const logger = useLogger();
 
-	const localExtensions = await resolveLocalExtensions(getExtensionsPath());
-	const localExtensionNames = localExtensions.map(({ name }) => name);
+	const localExtensions = await resolveFsExtensions(getExtensionsPath());
+	const registryExtensions = await resolveFsExtensions(join(getExtensionsPath(), '.registry'));
 
 	/** Extensions that are listed as dependencies in the root package.json */
-	const packageExtensions = await resolvePackageExtensions(env['PACKAGE_FILE_LOCATION'] as string);
+	const moduleExtensions = await resolveModuleExtensions(env['PACKAGE_FILE_LOCATION'] as string);
 
-	const dedupedPackageExtensions = packageExtensions.filter((ext) => {
-		if (localExtensionNames.includes(ext.name)) {
-			logger.warn(`Package extension "${ext.name}" skipped in favor of local extension with the same name.`);
-			return false;
-		}
-
-		return true;
-	});
-
-	return [...localExtensions, ...dedupedPackageExtensions];
+	return { local: localExtensions, registry: registryExtensions, module: moduleExtensions };
 };

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -438,7 +438,10 @@ export class ExtensionManager {
 			replacement: path,
 		}));
 
-		const entrypoint = generateExtensionsEntrypoint({ module: this.moduleExtensions, registry: this.registryExtensions, local: this.localExtensions }, this.extensionsSettings);
+		const entrypoint = generateExtensionsEntrypoint(
+			{ module: this.moduleExtensions, registry: this.registryExtensions, local: this.localExtensions },
+			this.extensionsSettings,
+		);
 
 		try {
 			const bundle = await rollup({

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -438,7 +438,7 @@ export class ExtensionManager {
 			replacement: path,
 		}));
 
-		const entrypoint = generateExtensionsEntrypoint(this.extensions, this.extensionsSettings);
+		const entrypoint = generateExtensionsEntrypoint({ module: this.moduleExtensions, registry: this.registryExtensions, local: this.localExtensions }, this.extensionsSettings);
 
 		try {
 			const bundle = await rollup({

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -80,9 +80,14 @@ export class ExtensionManager {
 	 */
 	private isLoaded = false;
 
-	private localExtensions: Extension[] = [];
-	private registryExtensions: Extension[] = [];
-	private moduleExtensions: Extension[] = [];
+	// folder:Extension
+	private localExtensions: Map<string, Extension> = new Map();
+
+	// versionId:Extension
+	private registryExtensions: Map<string, Extension> = new Map();
+
+	// name:Extension
+	private moduleExtensions: Map<string, Extension> = new Map();
 
 	/**
 	 * Settings for the extensions that are loaded within the current process
@@ -154,7 +159,20 @@ export class ExtensionManager {
 	private extensionInstalledChannel = `extension.registry.installed`;
 
 	public get extensions() {
-		return [...this.localExtensions, ...this.registryExtensions, ...this.moduleExtensions];
+		return [...this.localExtensions.values(), ...this.registryExtensions.values(), ...this.moduleExtensions.values()];
+	}
+
+	public getExtension(source: string, folder: string) {
+		switch (source) {
+			case 'module':
+				return this.moduleExtensions.get(folder);
+			case 'registry':
+				return this.registryExtensions.get(folder);
+			case 'local':
+				return this.localExtensions.get(folder);
+		}
+
+		return undefined;
 	}
 
 	/**
@@ -183,17 +201,13 @@ export class ExtensionManager {
 		if (!this.isLoaded) {
 			await this.load();
 
-			if (this.extensions.size > 0) {
-				logger.info(
-					`Loaded extensions: ${Array.from(this.extensions.values())
-						.map((ext) => ext.name)
-						.join(', ')}`,
-				);
+			if (this.extensions.length > 0) {
+				logger.info(`Loaded extensions: ${this.extensions.map((ext) => ext.name).join(', ')}`);
 			}
 		}
 
 		if (this.options.watch && !wasWatcherInitialized) {
-			this.updateWatchedExtensions(Array.from(this.extensions.values()));
+			this.updateWatchedExtensions(Array.from(this.localExtensions.values()));
 		}
 
 		this.messenger.subscribe(this.extensionInstalledChannel, () => {
@@ -234,15 +248,12 @@ export class ExtensionManager {
 			this.registryExtensions = registry;
 			this.moduleExtensions = module;
 
-			this.extensionsSettings = await getExtensionsSettings(this.extensions);
+			this.extensionsSettings = await getExtensionsSettings({ local, registry, module });
 		} catch (error) {
 			this.handleExtensionError({ error, reason: `Couldn't load extensions` });
 		}
 
-		await this.registerHooks();
-		await this.registerEndpoints();
-		await this.registerOperations();
-		await this.registerBundles();
+		await Promise.all([this.registerInternalOperations(), this.registerApiExtensions()]);
 
 		if (env['SERVE_APP']) {
 			this.appExtensionsBundle = await this.generateExtensionBundle();
@@ -339,13 +350,6 @@ export class ExtensionManager {
 			head: wrapEmbeds('Custom Embed Head', this.hookEmbedsHead),
 			body: wrapEmbeds('Custom Embed Body', this.hookEmbedsBody),
 		};
-	}
-
-	/**
-	 * Allow reading the installed extensions
-	 */
-	public getExtensions() {
-		return this.extensions;
 	}
 
 	/**
@@ -522,83 +526,191 @@ export class ExtensionManager {
 		});
 	}
 
-	/**
-	 * Import the hook module code for all hook extensions, and register them individually through
-	 * registerHook
-	 */
-	private async registerHooks(): Promise<void> {
-		const hooks = this.extensions.filter((extension): extension is ApiExtension => extension.type === 'hook');
+	private async registerApiExtensions(): Promise<void> {
+		const sources = {
+			module: this.moduleExtensions,
+			registry: this.registryExtensions,
+			local: this.localExtensions,
+		} as const;
 
-		for (const hook of hooks) {
-			const { enabled } = this.extensionsSettings.find(({ name }) => name === hook.name) ?? { enabled: false };
+		await Promise.all(
+			Object.entries(sources).map(async ([source, extensions]) => {
+				await Promise.all(
+					Array.from(extensions.entries()).map(async ([folder, extension]) => {
+						const { id, enabled } = this.extensionsSettings.find(
+							(settings) => settings.source === source && settings.folder === folder,
+						) ?? { enabled: false };
 
-			if (!enabled) continue;
+						if (!enabled) return;
 
-			try {
-				if (hook.sandbox?.enabled) {
-					await this.registerSandboxedApiExtension(hook);
-				} else {
-					const hookPath = path.resolve(hook.path, hook.entrypoint);
+						switch (extension.type) {
+							case 'hook':
+								await this.registerHookExtension(extension);
+								break;
+							case 'endpoint':
+								await this.registerEndpointExtension(extension);
+								break;
+							case 'operation':
+								await this.registerOperationExtension(extension);
+								break;
+							case 'bundle':
+								await this.registerBundleExtension(extension, source as 'module' | 'registry' | 'local', id);
+								break;
+							default:
+								return;
+						}
+					}),
+				);
+			}),
+		);
+	}
 
-					const hookInstance: HookConfig | { default: HookConfig } = await importFileUrl(hookPath, import.meta.url, {
-						fresh: true,
-					});
+	private async registerHookExtension(hook: ApiExtension) {
+		try {
+			if (hook.sandbox?.enabled) {
+				await this.registerSandboxedApiExtension(hook);
+			} else {
+				const hookPath = path.resolve(hook.path, hook.entrypoint);
 
-					const config = getModuleDefault(hookInstance);
+				const hookInstance: HookConfig | { default: HookConfig } = await importFileUrl(hookPath, import.meta.url, {
+					fresh: true,
+				});
 
-					const unregisterFunctions = this.registerHook(config, hook.name);
+				const config = getModuleDefault(hookInstance);
 
-					this.unregisterFunctionMap.set(hook.name, async () => {
-						await Promise.all(unregisterFunctions.map((fn) => fn()));
+				const unregisterFunctions = this.registerHook(config, hook.name);
 
-						deleteFromRequireCache(hookPath);
-					});
-				}
-			} catch (error) {
-				this.handleExtensionError({ error, reason: `Couldn't register hook "${hook.name}"` });
+				this.unregisterFunctionMap.set(hook.name, async () => {
+					await Promise.all(unregisterFunctions.map((fn) => fn()));
+
+					deleteFromRequireCache(hookPath);
+				});
 			}
+		} catch (error) {
+			this.handleExtensionError({ error, reason: `Couldn't register hook "${hook.name}"` });
 		}
 	}
 
-	/**
-	 * Import the endpoint module code for all endpoint extensions, and register them individually through
-	 * registerEndpoint
-	 */
-	private async registerEndpoints(): Promise<void> {
-		const endpoints = this.extensions.filter((extension): extension is ApiExtension => extension.type === 'endpoint');
+	private async registerEndpointExtension(endpoint: ApiExtension) {
+		try {
+			if (endpoint.sandbox?.enabled) {
+				await this.registerSandboxedApiExtension(endpoint);
+			} else {
+				const endpointPath = path.resolve(endpoint.path, endpoint.entrypoint);
 
-		for (const endpoint of endpoints) {
-			const { enabled } = this.extensionsSettings.find(({ name }) => name === endpoint.name) ?? { enabled: false };
+				const endpointInstance: EndpointConfig | { default: EndpointConfig } = await importFileUrl(
+					endpointPath,
+					import.meta.url,
+					{
+						fresh: true,
+					},
+				);
 
-			if (!enabled) continue;
+				const config = getModuleDefault(endpointInstance);
 
-			try {
-				if (endpoint.sandbox?.enabled) {
-					await this.registerSandboxedApiExtension(endpoint);
-				} else {
-					const endpointPath = path.resolve(endpoint.path, endpoint.entrypoint);
+				const unregister = this.registerEndpoint(config, endpoint.name);
 
-					const endpointInstance: EndpointConfig | { default: EndpointConfig } = await importFileUrl(
-						endpointPath,
-						import.meta.url,
-						{
-							fresh: true,
-						},
-					);
+				this.unregisterFunctionMap.set(endpoint.name, async () => {
+					await unregister();
 
-					const config = getModuleDefault(endpointInstance);
-
-					const unregister = this.registerEndpoint(config, endpoint.name);
-
-					this.unregisterFunctionMap.set(endpoint.name, async () => {
-						await unregister();
-
-						deleteFromRequireCache(endpointPath);
-					});
-				}
-			} catch (error) {
-				this.handleExtensionError({ error, reason: `Couldn't register endpoint "${endpoint.name}"` });
+					deleteFromRequireCache(endpointPath);
+				});
 			}
+		} catch (error) {
+			this.handleExtensionError({ error, reason: `Couldn't register endpoint "${endpoint.name}"` });
+		}
+	}
+
+	private async registerOperationExtension(operation: HybridExtension) {
+		try {
+			if (operation.sandbox?.enabled) {
+				await this.registerSandboxedApiExtension(operation);
+			} else {
+				const operationPath = path.resolve(operation.path, operation.entrypoint.api!);
+
+				const operationInstance: OperationApiConfig | { default: OperationApiConfig } = await importFileUrl(
+					operationPath,
+					import.meta.url,
+					{
+						fresh: true,
+					},
+				);
+
+				const config = getModuleDefault(operationInstance);
+
+				const unregister = this.registerOperation(config);
+
+				this.unregisterFunctionMap.set(operation.name, async () => {
+					await unregister();
+
+					deleteFromRequireCache(operationPath);
+				});
+			}
+		} catch (error) {
+			this.handleExtensionError({ error, reason: `Couldn't register operation "${operation.name}"` });
+		}
+	}
+
+	private async registerBundleExtension(
+		bundle: BundleExtension,
+		source: 'local' | 'registry' | 'module',
+		bundleId: string,
+	) {
+		const extensionEnabled = (extensionName: string) => {
+			const settings = this.extensionsSettings.find(
+				(settings) => settings.source === source && settings.folder === extensionName && settings.bundle === bundleId,
+			);
+
+			if (!settings) return false;
+			return settings.enabled;
+		};
+
+		try {
+			const bundlePath = path.resolve(bundle.path, bundle.entrypoint.api);
+
+			const bundleInstances: BundleConfig | { default: BundleConfig } = await importFileUrl(
+				bundlePath,
+				import.meta.url,
+				{
+					fresh: true,
+				},
+			);
+
+			const configs = getModuleDefault(bundleInstances);
+
+			const unregisterFunctions: PromiseCallback[] = [];
+
+			for (const { config, name } of configs.hooks) {
+				if (!extensionEnabled(name)) continue;
+
+				const unregisters = this.registerHook(config, name);
+
+				unregisterFunctions.push(...unregisters);
+			}
+
+			for (const { config, name } of configs.endpoints) {
+				if (!extensionEnabled(name)) continue;
+
+				const unregister = this.registerEndpoint(config, name);
+
+				unregisterFunctions.push(unregister);
+			}
+
+			for (const { config, name } of configs.operations) {
+				if (!extensionEnabled(name)) continue;
+
+				const unregister = this.registerOperation(config);
+
+				unregisterFunctions.push(unregister);
+			}
+
+			this.unregisterFunctionMap.set(bundle.name, async () => {
+				await Promise.all(unregisterFunctions.map((fn) => fn()));
+
+				deleteFromRequireCache(bundlePath);
+			});
+		} catch (error) {
+			this.handleExtensionError({ error, reason: `Couldn't register bundle "${bundle.name}"` });
 		}
 	}
 
@@ -606,7 +718,7 @@ export class ExtensionManager {
 	 * Import the operation module code for all operation extensions, and register them individually through
 	 * registerOperation
 	 */
-	private async registerOperations(): Promise<void> {
+	private async registerInternalOperations(): Promise<void> {
 		const internalOperations = await readdir(path.join(__dirname, '..', 'operations'));
 
 		for (const operation of internalOperations) {
@@ -617,108 +729,6 @@ export class ExtensionManager {
 			const config = getModuleDefault(operationInstance);
 
 			this.registerOperation(config);
-		}
-
-		const operations = this.extensions.filter(
-			(extension): extension is HybridExtension => extension.type === 'operation',
-		);
-
-		for (const operation of operations) {
-			const { enabled } = this.extensionsSettings.find(({ name }) => name === operation.name) ?? { enabled: false };
-
-			if (!enabled) continue;
-
-			try {
-				if (operation.sandbox?.enabled) {
-					await this.registerSandboxedApiExtension(operation);
-				} else {
-					const operationPath = path.resolve(operation.path, operation.entrypoint.api!);
-
-					const operationInstance: OperationApiConfig | { default: OperationApiConfig } = await importFileUrl(
-						operationPath,
-						import.meta.url,
-						{
-							fresh: true,
-						},
-					);
-
-					const config = getModuleDefault(operationInstance);
-
-					const unregister = this.registerOperation(config);
-
-					this.unregisterFunctionMap.set(operation.name, async () => {
-						await unregister();
-
-						deleteFromRequireCache(operationPath);
-					});
-				}
-			} catch (error) {
-				this.handleExtensionError({ error, reason: `Couldn't register operation "${operation.name}"` });
-			}
-		}
-	}
-
-	/**
-	 * Import the module code for all hook, endpoint, and operation extensions registered within a
-	 * bundle, and register them with their respective registration function
-	 */
-	private async registerBundles(): Promise<void> {
-		const bundles = this.extensions.filter((extension): extension is BundleExtension => extension.type === 'bundle');
-
-		const extensionEnabled = (extensionName: string) => {
-			const settings = this.extensionsSettings.find(({ name }) => name === extensionName);
-			if (!settings) return false;
-			return settings.enabled;
-		};
-
-		for (const bundle of bundles) {
-			try {
-				const bundlePath = path.resolve(bundle.path, bundle.entrypoint.api);
-
-				const bundleInstances: BundleConfig | { default: BundleConfig } = await importFileUrl(
-					bundlePath,
-					import.meta.url,
-					{
-						fresh: true,
-					},
-				);
-
-				const configs = getModuleDefault(bundleInstances);
-
-				const unregisterFunctions: PromiseCallback[] = [];
-
-				for (const { config, name } of configs.hooks) {
-					if (!extensionEnabled(`${bundle.name}/${name}`)) continue;
-
-					const unregisters = this.registerHook(config, name);
-
-					unregisterFunctions.push(...unregisters);
-				}
-
-				for (const { config, name } of configs.endpoints) {
-					if (!extensionEnabled(`${bundle.name}/${name}`)) continue;
-
-					const unregister = this.registerEndpoint(config, name);
-
-					unregisterFunctions.push(unregister);
-				}
-
-				for (const { config, name } of configs.operations) {
-					if (!extensionEnabled(`${bundle.name}/${name}`)) continue;
-
-					const unregister = this.registerOperation(config);
-
-					unregisterFunctions.push(unregister);
-				}
-
-				this.unregisterFunctionMap.set(bundle.name, async () => {
-					await Promise.all(unregisterFunctions.map((fn) => fn()));
-
-					deleteFromRequireCache(bundlePath);
-				});
-			} catch (error) {
-				this.handleExtensionError({ error, reason: `Couldn't register bundle "${bundle.name}"` });
-			}
 		}
 	}
 

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -2969,8 +2969,7 @@ export class GraphQLService {
 				update_extensions_item: {
 					type: Extension,
 					args: {
-						bundle: GraphQLString,
-						name: new GraphQLNonNull(GraphQLString),
+						id: GraphQLID,
 						data: toInputObjectType(
 							schemaComposer.createObjectTC({
 								name: 'update_directus_extensions_input',
@@ -2991,8 +2990,8 @@ export class GraphQLService {
 							schema: this.schema,
 						});
 
-						await extensionsService.updateOne(args['bundle'], args['name'], args['data']);
-						return await extensionsService.readOne(args['bundle'], args['name']);
+						await extensionsService.updateOne(args['id'], args['data']);
+						return await extensionsService.readOne(args['id']);
 					},
 				},
 			});

--- a/app/src/modules/settings/routes/extensions/components/extension-item.vue
+++ b/app/src/modules/settings/routes/extensions/components/extension-item.vue
@@ -80,10 +80,7 @@ async function toggleExtensionStatus(enabled: boolean) {
 	const status = !enabled;
 
 	try {
-		const endpoint = props.extension.bundle
-			? `/extensions/${props.extension.bundle}/${props.extension.name}`
-			: `/extensions/${props.extension.name}`;
-
+		const endpoint = `/extensions/${props.extension.id}`;
 		await api.patch(endpoint, { meta: { enabled: status } });
 	} finally {
 		changingEnabledState.value = false;
@@ -97,7 +94,7 @@ async function toggleExtensionStatus(enabled: boolean) {
 		<v-list-item-icon v-tooltip="t(`extension_${type}`)"><v-icon :name="icon" small /></v-list-item-icon>
 		<v-list-item-content>
 			<span class="monospace">
-				{{ extension.name }}
+				{{ extension.schema!.name }}
 				<v-chip v-if="extension.schema?.version" class="version" small>{{ extension.schema.version }}</v-chip>
 			</span>
 		</v-list-item-content>

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,9 +1,5 @@
 import { APP_SHARED_DEPS } from '@directus/extensions';
-import {
-	generateExtensionsEntrypoint,
-	resolveLocalExtensions,
-	resolvePackageExtensions,
-} from '@directus/extensions/node';
+import { generateExtensionsEntrypoint, resolveFsExtensions, resolveModuleExtensions } from '@directus/extensions/node';
 import yaml from '@rollup/plugin-yaml';
 import UnheadVite from '@unhead/addons/vite';
 import vue from '@vitejs/plugin-vue';
@@ -137,8 +133,12 @@ function directusExtensions() {
 	];
 
 	async function loadExtensions() {
-		const localExtensions = extensionsPathExists ? await resolveLocalExtensions(EXTENSIONS_PATH) : [];
-		const packageExtensions = await resolvePackageExtensions(API_PATH);
+		const localExtensions = extensionsPathExists ? await resolveFsExtensions(EXTENSIONS_PATH) : [];
+		const packageExtensions = await resolveModuleExtensions(API_PATH);
+
+		const registryExtensions = extensionsPathExists
+			? await resolveFsExtensions(path.join(EXTENSIONS_PATH, 'registry'))
+			: [];
 
 		/*
 		 * @TODO
@@ -146,7 +146,7 @@ function directusExtensions() {
 		 * always been the case. Is this a bug?
 		 * @see /api/src/extensions/lib/get-extensions.ts
 		 */
-		const extensions = [...localExtensions, ...packageExtensions];
+		const extensions = [...localExtensions, ...packageExtensions, ...registryExtensions];
 
 		// default to enabled for app extension in developer mode
 		const extensionSettings = extensions.flatMap((extension) =>

--- a/packages/extensions/src/node/utils/generate-extensions-entrypoint.test.ts
+++ b/packages/extensions/src/node/utils/generate-extensions-entrypoint.test.ts
@@ -4,20 +4,31 @@ import { generateExtensionsEntrypoint } from './generate-extensions-entrypoint.j
 
 describe('generateExtensionsEntrypoint', () => {
 	it('returns an empty extension entrypoint if there is no App, Hybrid or Bundle extension', () => {
-		const mockExtensions: Extension[] = [
-			{
-				path: './extensions/bundle',
-				name: 'mock-bundle0-extension',
-				version: '1.0.0',
-				type: 'bundle',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				entries: [],
-				host: '^10.0.0',
-				local: false,
-			},
-		];
+		const mockExtensions: {
+			module: Map<string, Extension>;
+			registry: Map<string, Extension>;
+			local: Map<string, Extension>;
+		} = {
+			module: new Map(),
+			registry: new Map(),
+			local: new Map(),
+		};
 
-		const mockSettings: ExtensionSettings[] = [{ name: 'mock-bundle0-extension', enabled: true }];
+		mockExtensions.local.set('mock-bundle0-extension', {
+			path: './extensions/bundle',
+			name: 'mock-bundle0-extension',
+			version: '1.0.0',
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [],
+			host: '^10.0.0',
+			local: false,
+			partial: false,
+		});
+
+		const mockSettings: ExtensionSettings[] = [
+			{ id: 'x', folder: 'mock-bundle0-extension', enabled: true, source: 'local', bundle: null },
+		];
 
 		expect(generateExtensionsEntrypoint(mockExtensions, mockSettings)).toMatchInlineSnapshot(
 			`"export const interfaces = [];export const displays = [];export const layouts = [];export const modules = [];export const panels = [];export const themes = [];export const operations = [];"`,
@@ -25,55 +36,68 @@ describe('generateExtensionsEntrypoint', () => {
 	});
 
 	it('returns an empty extension entrypoint if there are no enabled extensions', () => {
-		const mockExtensions: Extension[] = [
-			{
-				path: './extensions/display',
-				name: 'mock-display-extension',
-				type: 'display',
-				entrypoint: 'index.js',
-				local: true,
-			},
-			{
-				path: './extensions/operation',
-				name: 'mock-operation-extension',
-				type: 'operation',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				local: true,
-			},
-			{
-				path: './extensions/bundle',
-				name: 'mock-bundle0-extension',
-				version: '1.0.0',
-				type: 'bundle',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				entries: [
-					{ type: 'layout', name: 'mock-bundle-layout' },
-					{ type: 'operation', name: 'mock-bundle-operation' },
-					{ type: 'hook', name: 'mock-bundle-hook' },
-				],
-				host: '^10.0.0',
-				local: false,
-			},
-			{
-				path: './extensions/bundle-no-app',
-				name: 'mock-bundle-no-app-extension',
-				version: '1.0.0',
-				type: 'bundle',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				entries: [{ type: 'endpoint', name: 'mock-bundle-no-app-endpoint' }],
-				host: '^10.0.0',
-				local: false,
-			},
-		];
+		const mockExtensions: {
+			module: Map<string, Extension>;
+			registry: Map<string, Extension>;
+			local: Map<string, Extension>;
+		} = {
+			module: new Map(),
+			registry: new Map(),
+			local: new Map(),
+		};
 
-		const mockSettings: ExtensionSettings[] = [
-			{ name: 'mock-display-extension', enabled: false },
-			{ name: 'mock-operation-extension', enabled: false },
-			{ name: 'mock-bundle0-extension/mock-bundle-layout', enabled: false },
-			{ name: 'mock-bundle0-extension/mock-bundle-operation', enabled: false },
-			{ name: 'mock-bundle0-extension/mock-bundle-hook', enabled: false },
-			{ name: 'mock-bundle-no-app-extension/mock-bundle-no-app-endpoint', enabled: false },
-		];
+		mockExtensions.local.set('mock-display-extension', {
+			path: './extensions/display',
+			name: 'mock-display-extension',
+			type: 'display',
+			entrypoint: 'index.js',
+			local: true,
+		});
+
+		mockExtensions.local.set('mock-operation-extension', {
+			path: './extensions/operation',
+			name: 'mock-operation-extension',
+			type: 'operation',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			local: true,
+		});
+
+		mockExtensions.local.set('mock-bundle0-extension', {
+			path: './extensions/bundle',
+			name: 'mock-bundle0-extension',
+			version: '1.0.0',
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [
+				{ type: 'layout', name: 'mock-bundle-layout' },
+				{ type: 'operation', name: 'mock-bundle-operation' },
+				{ type: 'hook', name: 'mock-bundle-hook' },
+			],
+			host: '^10.0.0',
+			local: false,
+			partial: false,
+		});
+
+		mockExtensions.local.set('mock-bundle-no-app-extension', {
+			path: './extensions/bundle-no-app',
+			name: 'mock-bundle-no-app-extension',
+			version: '1.0.0',
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [{ type: 'endpoint', name: 'mock-bundle-no-app-endpoint' }],
+			host: '^10.0.0',
+			local: false,
+			partial: true,
+		});
+
+		const mockSettings = [
+			{ folder: 'mock-display-extension', enabled: false },
+			{ folder: 'mock-operation-extension', enabled: false },
+			{ folder: 'mock-bundle0-extension/mock-bundle-layout', enabled: false },
+			{ folder: 'mock-bundle0-extension/mock-bundle-operation', enabled: false },
+			{ folder: 'mock-bundle0-extension/mock-bundle-hook', enabled: false },
+			{ folder: 'mock-bundle-no-app-extension/mock-bundle-no-app-endpoint', enabled: false },
+		] as ExtensionSettings[];
 
 		expect(generateExtensionsEntrypoint(mockExtensions, mockSettings)).toMatchInlineSnapshot(
 			`"export const interfaces = [];export const displays = [];export const layouts = [];export const modules = [];export const panels = [];export const themes = [];export const operations = [];"`,
@@ -81,11 +105,25 @@ describe('generateExtensionsEntrypoint', () => {
 	});
 
 	it('returns an extension entrypoint exporting a single App extension', () => {
-		const mockExtensions: Extension[] = [
-			{ path: './extensions/panel', name: 'mock-panel-extension', type: 'panel', entrypoint: 'index.js', local: true },
-		];
+		const mockExtensions: {
+			module: Map<string, Extension>;
+			registry: Map<string, Extension>;
+			local: Map<string, Extension>;
+		} = {
+			module: new Map(),
+			registry: new Map(),
+			local: new Map(),
+		};
 
-		const mockSettings: ExtensionSettings[] = [{ name: 'mock-panel-extension', enabled: true }];
+		mockExtensions.local.set('mock-panel-extension', {
+			path: './extensions/panel',
+			name: 'mock-panel-extension',
+			type: 'panel',
+			entrypoint: 'index.js',
+			local: true,
+		});
+
+		const mockSettings = [{ source: 'local', folder: 'mock-panel-extension', enabled: true }] as ExtensionSettings[];
 
 		expect(generateExtensionsEntrypoint(mockExtensions, mockSettings)).toMatchInlineSnapshot(
 			`"import panel0 from './extensions/panel/index.js';export const interfaces = [];export const displays = [];export const layouts = [];export const modules = [];export const panels = [panel0];export const themes = [];export const operations = [];"`,
@@ -93,17 +131,27 @@ describe('generateExtensionsEntrypoint', () => {
 	});
 
 	it('returns an extension entrypoint exporting a single Hybrid extension', () => {
-		const mockExtensions: Extension[] = [
-			{
-				path: './extensions/operation',
-				name: 'mock-operation-extension',
-				type: 'operation',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				local: true,
-			},
-		];
+		const mockExtensions: {
+			module: Map<string, Extension>;
+			registry: Map<string, Extension>;
+			local: Map<string, Extension>;
+		} = {
+			module: new Map(),
+			registry: new Map(),
+			local: new Map(),
+		};
 
-		const mockSettings: ExtensionSettings[] = [{ name: 'mock-operation-extension', enabled: true }];
+		mockExtensions.local.set('mock-operation-extension', {
+			path: './extensions/operation',
+			name: 'mock-operation-extension',
+			type: 'operation',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			local: true,
+		});
+
+		const mockSettings = [
+			{ source: 'local', folder: 'mock-operation-extension', enabled: true },
+		] as ExtensionSettings[];
 
 		expect(generateExtensionsEntrypoint(mockExtensions, mockSettings)).toMatchInlineSnapshot(
 			`"import operation0 from './extensions/operation/app.js';export const interfaces = [];export const displays = [];export const layouts = [];export const modules = [];export const panels = [];export const themes = [];export const operations = [operation0];"`,
@@ -111,28 +159,56 @@ describe('generateExtensionsEntrypoint', () => {
 	});
 
 	it('returns an extension entrypoint exporting from a single Bundle extension', () => {
-		const mockExtensions: Extension[] = [
-			{
-				path: './extensions/bundle',
-				name: 'mock-bundle-extension',
-				version: '1.0.0',
-				type: 'bundle',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				entries: [
-					{ type: 'interface', name: 'mock-bundle-interface' },
-					{ type: 'operation', name: 'mock-bundle-operation' },
-					{ type: 'hook', name: 'mock-bundle-hook' },
-				],
-				host: '^10.0.0',
-				local: false,
-			},
-		];
+		const mockExtensions: {
+			module: Map<string, Extension>;
+			registry: Map<string, Extension>;
+			local: Map<string, Extension>;
+		} = {
+			module: new Map(),
+			registry: new Map(),
+			local: new Map(),
+		};
 
-		const mockSettings: ExtensionSettings[] = [
-			{ name: 'mock-bundle-extension/mock-bundle-interface', enabled: true },
-			{ name: 'mock-bundle-extension/mock-bundle-operation', enabled: true },
-			{ name: 'mock-bundle-extension/mock-bundle-hook', enabled: true },
-		];
+		mockExtensions.local.set('mock-bundle-extension', {
+			path: './extensions/bundle',
+			name: 'mock-bundle-extension',
+			version: '1.0.0',
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [
+				{ type: 'interface', name: 'mock-bundle-interface' },
+				{ type: 'operation', name: 'mock-bundle-operation' },
+				{ type: 'hook', name: 'mock-bundle-hook' },
+			],
+			host: '^10.0.0',
+			local: false,
+			partial: true,
+		});
+
+		const mockSettings = [
+			{ id: 'mock-bundle-id', source: 'local', folder: 'mock-bundle-extension', enabled: true },
+			{
+				id: 'mock-bundle-interface-id',
+				source: 'local',
+				folder: 'mock-bundle-interface',
+				enabled: true,
+				bundle: 'mock-bundle-id',
+			},
+			{
+				id: 'mock-bundle-operation-id',
+				source: 'local',
+				folder: 'mock-bundle-operation',
+				enabled: true,
+				bundle: 'mock-bundle-id',
+			},
+			{
+				id: 'mock-bundle-hook-id',
+				source: 'local',
+				folder: 'mock-bundle-hook',
+				enabled: true,
+				bundle: 'mock-bundle-id',
+			},
+		] as ExtensionSettings[];
 
 		expect(generateExtensionsEntrypoint(mockExtensions, mockSettings)).toMatchInlineSnapshot(
 			`"import {interfaces as interfaceBundle0,operations as operationBundle0} from './extensions/bundle/app.js';export const interfaces = [...interfaceBundle0];export const displays = [];export const layouts = [];export const modules = [];export const panels = [];export const themes = [];export const operations = [...operationBundle0];"`,
@@ -140,54 +216,104 @@ describe('generateExtensionsEntrypoint', () => {
 	});
 
 	it('returns an extension entrypoint exporting multiple extensions', () => {
-		const mockExtensions: Extension[] = [
-			{
-				path: './extensions/display',
-				name: 'mock-display-extension',
-				type: 'display',
-				entrypoint: 'index.js',
-				local: true,
-			},
-			{
-				path: './extensions/operation',
-				name: 'mock-operation-extension',
-				type: 'operation',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				local: true,
-			},
-			{
-				path: './extensions/bundle',
-				name: 'mock-bundle0-extension',
-				version: '1.0.0',
-				type: 'bundle',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				entries: [
-					{ type: 'layout', name: 'mock-bundle-layout' },
-					{ type: 'operation', name: 'mock-bundle-operation' },
-					{ type: 'hook', name: 'mock-bundle-hook' },
-				],
-				host: '^10.0.0',
-				local: false,
-			},
-			{
-				path: './extensions/bundle-no-app',
-				name: 'mock-bundle-no-app-extension',
-				version: '1.0.0',
-				type: 'bundle',
-				entrypoint: { app: 'app.js', api: 'api.js' },
-				entries: [{ type: 'endpoint', name: 'mock-bundle-no-app-endpoint' }],
-				host: '^10.0.0',
-				local: false,
-			},
-		];
+		const mockExtensions: {
+			module: Map<string, Extension>;
+			registry: Map<string, Extension>;
+			local: Map<string, Extension>;
+		} = {
+			module: new Map(),
+			registry: new Map(),
+			local: new Map(),
+		};
+
+		mockExtensions.local.set('mock-display-extension', {
+			path: './extensions/display',
+			name: 'mock-display-extension',
+			type: 'display',
+			entrypoint: 'index.js',
+			local: true,
+		});
+
+		mockExtensions.local.set('mock-operation-extension', {
+			path: './extensions/operation',
+			name: 'mock-operation-extension',
+			type: 'operation',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			local: true,
+		});
+
+		mockExtensions.local.set('mock-bundle0-extension', {
+			path: './extensions/bundle',
+			name: 'mock-bundle0-extension',
+			version: '1.0.0',
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [
+				{ type: 'layout', name: 'mock-bundle-layout' },
+				{ type: 'operation', name: 'mock-bundle-operation' },
+				{ type: 'hook', name: 'mock-bundle-hook' },
+			],
+			host: '^10.0.0',
+			local: false,
+			partial: true,
+		});
+
+		mockExtensions.local.set('mock-bundle-no-app-extension', {
+			path: './extensions/bundle-no-app',
+			name: 'mock-bundle-no-app-extension',
+			version: '1.0.0',
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [{ type: 'endpoint', name: 'mock-bundle-no-app-endpoint' }],
+			host: '^10.0.0',
+			local: false,
+			partial: true,
+		});
 
 		const mockSettings: ExtensionSettings[] = [
-			{ name: 'mock-display-extension', enabled: true },
-			{ name: 'mock-operation-extension', enabled: true },
-			{ name: 'mock-bundle0-extension/mock-bundle-layout', enabled: true },
-			{ name: 'mock-bundle0-extension/mock-bundle-operation', enabled: true },
-			{ name: 'mock-bundle0-extension/mock-bundle-hook', enabled: true },
-			{ name: 'mock-bundle-no-app-extension/mock-bundle-no-app-endpoint', enabled: true },
+			{
+				id: 'mock-display-extension-id',
+				folder: 'mock-display-extension',
+				enabled: true,
+				source: 'local',
+				bundle: null,
+			},
+			{
+				id: 'mock-operation-extension-id',
+				folder: 'mock-operation-extension',
+				enabled: true,
+				source: 'local',
+				bundle: null,
+			},
+			{ id: 'mock-bundle-id', folder: 'mock-bundle0-extension', enabled: true, source: 'local', bundle: null },
+			{
+				id: 'mock-bundle-layout-id',
+				folder: 'mock-bundle-layout',
+				enabled: true,
+				source: 'local',
+				bundle: 'mock-bundle-id',
+			},
+			{
+				id: 'mock-bundle-operation-id',
+				folder: 'mock-bundle-operation',
+				enabled: true,
+				source: 'local',
+				bundle: 'mock-bundle-id',
+			},
+			{
+				id: 'mock-bundle-hook-id',
+				folder: 'mock-bundle-hook',
+				enabled: true,
+				source: 'local',
+				bundle: 'mock-bundle-id',
+			},
+			{
+				id: 'mock-bundle-no-app-endpoint-id',
+				folder: 'mock-bundle-no-app-endpoint',
+				enabled: true,
+				source: 'local',
+				bundle: null,
+			},
 		];
 
 		expect(generateExtensionsEntrypoint(mockExtensions, mockSettings)).toMatchInlineSnapshot(

--- a/packages/extensions/src/node/utils/get-extensions.ts
+++ b/packages/extensions/src/node/utils/get-extensions.ts
@@ -89,8 +89,8 @@ export async function getExtensions(extensionList: ExtensionList, local: boolean
 	return extensions;
 }
 
-export async function resolveLocalExtensions(root: string): Promise<Extension[]> {
-	const extensionFolders = await listFolders(root);
+export async function resolveFsExtensions(root: string): Promise<Extension[]> {
+	const extensionFolders = await listFolders(root, { ignoreHidden: true });
 
 	const extensionList: ExtensionList = extensionFolders.map((folder) => [folder, join(root, folder)]);
 
@@ -102,7 +102,7 @@ const isExtension = (pkgName: string) => {
 	return regex.test(pkgName);
 };
 
-export async function resolvePackageExtensions(root: string): Promise<Extension[]> {
+export async function resolveModuleExtensions(root: string): Promise<Extension[]> {
 	let pkg: { dependencies?: Record<string, string> };
 
 	try {

--- a/packages/extensions/src/node/utils/get-extensions.ts
+++ b/packages/extensions/src/node/utils/get-extensions.ts
@@ -90,7 +90,7 @@ export async function getExtensions(extensionList: ExtensionList, local: boolean
 }
 
 export async function resolveFsExtensions(root: string): Promise<Map<string, Extension>> {
-	if (!await fse.exists(root)) return new Map();
+	if (!(await fse.exists(root))) return new Map();
 
 	const extensionFolders = await listFolders(root, { ignoreHidden: true });
 

--- a/packages/extensions/src/shared/types/api.ts
+++ b/packages/extensions/src/shared/types/api.ts
@@ -5,8 +5,8 @@ import type { ExtensionSettings } from './settings.js';
  * The API output structure used when engaging with the /extensions endpoints
  */
 export interface ApiOutput {
-	name: string;
+	id: string;
 	bundle: string | null;
 	schema: Partial<Extension> | null;
-	meta: Omit<ExtensionSettings, 'name'>;
+	meta: ExtensionSettings;
 }

--- a/packages/extensions/src/shared/types/settings.ts
+++ b/packages/extensions/src/shared/types/settings.ts
@@ -1,6 +1,9 @@
 export interface ExtensionSettings {
-	name: string;
+	id: string;
+	source: 'module' | 'registry' | 'local';
 	enabled: boolean;
+	bundle: string | null;
+	folder: string;
 	// options: Record<string, unknown> | null;
 	// permissions: Record<string, unknown> | null;
 }

--- a/packages/utils/node/list-folders.ts
+++ b/packages/utils/node/list-folders.ts
@@ -1,7 +1,14 @@
-import path from 'path';
 import fse from 'fs-extra';
+import path from 'path';
 
-export async function listFolders(location: string): Promise<string[]> {
+export interface ListFoldersOptions {
+	/**
+	 * Ignore folders starting with a period `.`
+	 */
+	ignoreHidden?: boolean;
+}
+
+export async function listFolders(location: string, options?: ListFoldersOptions): Promise<string[]> {
 	const fullPath = path.resolve(location);
 	const files = await fse.readdir(fullPath);
 
@@ -9,6 +16,11 @@ export async function listFolders(location: string): Promise<string[]> {
 
 	for (const file of files) {
 		const filePath = path.join(fullPath, file);
+
+		if (options?.ignoreHidden && file.startsWith('.')) {
+			continue;
+		}
+
 		const stats = await fse.stat(filePath);
 
 		if (stats.isDirectory()) {


### PR DESCRIPTION
## Scope

What's changed:

- Updates the extensions APIs to rely on the `directus_extensions` `id` column as the unique identifier for extensions rather than the package.json `name` field.
- Splits up the extensions in the manager by the three main sources

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

This is needed as there's no guarantee that the `package.json` name field is unique. Extensions can be loaded in from three sources (`node_modules`, the marketplace, and the local extensions), which in turn means there's no one way to accurately deduplicate them. By assigning a unique ID in a system table, we can find / manage the individual extension by source and folder location within that source.