### PR TITLE
Add forum uninstall endpoint

### DIFF
--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -180,35 +180,20 @@ router.patch(
 );
 
 router.delete(
-	'/:bundleOrName/:name?',
-	asyncHandler(async (req, res, next) => {
+	`/:pk(${UUID_REGEX})`,
+	asyncHandler(async (req, _res, next) => {
 		const service = new ExtensionsService({
 			accountability: req.accountability,
 			schema: req.schema,
 		});
 
-		const bundle = req.params['name'] ? req.params['bundleOrName'] : null;
-		const name = req.params['name'] ? req.params['name'] : req.params['bundleOrName'];
+		const pk = req.params['pk'];
 
-		if (bundle === undefined || !name) {
+		if (!pk || typeof pk !== 'string') {
 			throw new ForbiddenError();
 		}
 
-		try {
-			await service.deleteOne(bundle, name);
-		} catch (error) {
-			let finalError = error;
-
-			if (error instanceof ExtensionReadError) {
-				finalError = error.originalError;
-
-				if (isDirectusError(finalError, ErrorCode.Forbidden)) {
-					return next();
-				}
-			}
-
-			throw finalError;
-		}
+		await service.deleteOne(pk);
 
 		return next();
 	}),

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -182,6 +182,42 @@ router.patch(
 	respond,
 );
 
+router.delete(
+	'/:bundleOrName/:name?',
+	asyncHandler(async (req, res, next) => {
+		const service = new ExtensionsService({
+			accountability: req.accountability,
+			schema: req.schema,
+		});
+
+		const bundle = req.params['name'] ? req.params['bundleOrName'] : null;
+		const name = req.params['name'] ? req.params['name'] : req.params['bundleOrName'];
+
+		if (bundle === undefined || !name) {
+			throw new ForbiddenError();
+		}
+
+		try {
+			await service.deleteOne(bundle, name);
+		} catch (error) {
+			let finalError = error;
+
+			if (error instanceof ExtensionReadError) {
+				finalError = error.originalError;
+
+				if (isDirectusError(finalError, ErrorCode.Forbidden)) {
+					return next();
+				}
+			}
+
+			throw finalError;
+		}
+
+		return next();
+	}),
+	respond,
+);
+
 router.get(
 	'/sources/:chunk',
 	asyncHandler(async (req, res) => {

--- a/api/src/extensions/lib/installation/manager.ts
+++ b/api/src/extensions/lib/installation/manager.ts
@@ -3,7 +3,7 @@ import { ServiceUnavailableError } from '@directus/errors';
 import { EXTENSION_PKG_KEY, ExtensionManifest } from '@directus/extensions';
 import { download, type DownloadOptions } from '@directus/extensions-registry';
 import DriverLocal from '@directus/storage-driver-local';
-import { move, rmdir } from 'fs-extra';
+import { move, remove } from 'fs-extra';
 import { mkdir, readFile, rm } from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import Queue from 'p-queue';
@@ -75,6 +75,7 @@ export class InstallationManager {
 
 					const remotePath = join(
 						env['EXTENSIONS_PATH'] as string,
+						'.registry',
 						versionId,
 						filepath.substring(extractedPath.length),
 					);
@@ -85,7 +86,7 @@ export class InstallationManager {
 				await queue.onIdle();
 			} else {
 				// No custom location, so save to regular local extensions folder
-				const dest = join(this.extensionPath, versionId);
+				const dest = join(this.extensionPath, '.registry', versionId);
 				await move(join(tempDir, extractedPath), dest, { overwrite: true });
 			}
 		} catch (err) {
@@ -107,14 +108,16 @@ export class InstallationManager {
 
 			const queue = new Queue({ concurrency: 1000 });
 
-			for await (const filepath of remoteDisk.list(folder)) {
+			const prefix = join(env['EXTENSIONS_PATH'] as string, '.registry', folder);
+
+			for await (const filepath of remoteDisk.list(prefix)) {
 				queue.add(() => remoteDisk.delete(filepath));
 			}
 
 			await queue.onIdle();
 		} else {
-			const path = join(this.extensionPath, folder);
-			await rmdir(path);
+			const path = join(this.extensionPath, '.registry', folder);
+			await remove(path);
 		}
 	}
 }

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -226,8 +226,8 @@ export class ExtensionManager {
 		await this.messenger.publish(this.reloadChannel, {});
 	}
 
-	public async uninstall(versionId: string) {
-		await this.installationManager.uninstall(versionId);
+	public async uninstall(folder: string) {
+		await this.installationManager.uninstall(folder);
 		// Publish a message so all instances will reload extensions. Note: this will also reload the
 		// current instance, as it's subscribed to the same channel
 		await this.messenger.publish(this.reloadChannel, {});

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -107,7 +107,7 @@ export class ExtensionsService {
 		}
 
 		await this.extensionsItemService.deleteOne(id);
-		await this.extensionsManager.uninstall(id);
+		await this.extensionsManager.uninstall(settings.folder);
 	}
 
 	/**

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -94,6 +94,12 @@ export class ExtensionsService {
 		return result;
 	}
 
+	async deleteOne(bundle: string | null, name: string) {
+		const key = this.getKey(bundle, name);
+		await this.extensionsItemService.deleteOne(key);
+		await this.extensionsManager.uninstall(key);
+	}
+
 	private getKey(bundle: string | null, name: string) {
 		return bundle ? `${bundle}/${name}` : name;
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Adds a `DELETE` handler for `/extensions/:pk`
- Will prevent uninstalling extensions that weren't registry installed

## Potential Risks / Drawbacks

- New endpoint shouldn't affect anything

## Review Notes / Questions

- Almost there!