### PR TITLE
Use shared extensions store state for managing extensions in settings

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -86,6 +86,7 @@ n_files: '{n} Files'
 verified: Verified
 homepage: Homepage
 repository: Repository
+reload_required: Reload Required
 report_an_issue: Report an Issue
 website: Website
 github: GitHub

--- a/app/src/modules/settings/routes/extensions/components/extension-item.vue
+++ b/app/src/modules/settings/routes/extensions/components/extension-item.vue
@@ -115,7 +115,7 @@ const toggleState = async () => {
 	</v-list-item>
 
 	<v-list v-if="children.length > 0" class="nested" :class="{ partial: isPartialEnabled }">
-		<extension-item v-for="item in children" :key="item.id" :extension="item" @refresh="$emit('refresh', $event)" />
+		<extension-item v-for="item in children" :key="item.id" :extension="item" />
 	</v-list>
 </template>
 

--- a/app/src/modules/settings/routes/extensions/extensions.vue
+++ b/app/src/modules/settings/routes/extensions/extensions.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import VNotice from '@/components/v-notice.vue';
-import { useReloadGuard } from '@/composables/use-reload-guard';
 import { useExtensionsStore } from '@/stores/extensions';
-import { APP_OR_HYBRID_EXTENSION_TYPES, ApiOutput, ExtensionType } from '@directus/extensions';
+import { ExtensionType } from '@directus/extensions';
 import { groupBy } from 'lodash';
 import { storeToRefs } from 'pinia';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import SettingsNavigation from '../../components/navigation.vue';
 import ExtensionGroupDivider from './components/extension-group-divider.vue';
@@ -17,65 +15,9 @@ const { t } = useI18n();
 const extensionsStore = useExtensionsStore();
 const { extensions, loading } = storeToRefs(extensionsStore);
 
-const needsReload = ref(false);
-
 const bundled = computed(() => extensionsStore.extensions.filter(({ bundle }) => bundle !== null));
 const regular = computed(() => extensionsStore.extensions.filter(({ bundle }) => bundle === null));
 const extensionsByType = computed(() => groupBy(regular.value, 'schema.type'));
-
-const { confirmLeave, leaveTo } = useReloadGuard(needsReload);
-
-const currentPageLink = () => document.location.href;
-
-const leavePage = () => {
-	needsReload.value = false;
-	// navigate to new page using a full page reload
-	document.location.href = leaveTo.value ?? currentPageLink();
-};
-
-const isBrowserExtension = (type: string) => {
-	return (APP_OR_HYBRID_EXTENSION_TYPES as readonly string[]).includes(type);
-};
-
-const refreshExtensions = async ({
-	enabled,
-	extension,
-	children,
-}: {
-	enabled: boolean;
-	extension: ApiOutput;
-	children: ApiOutput[];
-}) => {
-	await extensionsStore.refresh();
-
-	if (!extension.schema?.type) {
-		return;
-	}
-
-	if (isBrowserExtension(extension.schema.type)) {
-		needsReload.value = true;
-	}
-
-	if (extension.schema.type !== 'bundle') {
-		return;
-	}
-
-	if (extension.schema.partial === false) {
-		// A non partial bundles entries can only be toggled all at once.
-		// Only type needs to be checked as status will be in sync
-		if (children.some((e) => e.schema?.type && isBrowserExtension(e.schema?.type))) {
-			needsReload.value = true;
-		}
-
-		return;
-	}
-
-	if (children.some((e) => e.meta.enabled !== enabled && e.schema?.type && isBrowserExtension(e.schema.type))) {
-		// A partial bundle can have entries already be in the desired state so we need to check the status and type
-		needsReload.value = true;
-		return;
-	}
-};
 </script>
 
 <template>
@@ -96,24 +38,16 @@ const refreshExtensions = async ({
 			<extensions-info-sidebar-detail />
 		</template>
 
-		<div v-if="needsReload" class="page-container">
-			<v-notice type="warning">
-				{{ t('extension_reload_required_copy') }}&nbsp;
-				<a :href="currentPageLink()">{{ t('extension_reload_now') }}</a>
-			</v-notice>
-		</div>
-
 		<div v-if="extensions.length > 0 || loading === false" class="page-container">
 			<template v-if="extensions.length > 0">
 				<div v-for="(list, type) in extensionsByType" :key="`${type}-list`" class="extension-group">
-					<extension-group-divider class="group-divider" :type="(type as ExtensionType)" />
+					<extension-group-divider class="group-divider" :type="type as ExtensionType" />
 
 					<v-list>
 						<template v-for="ext in list" :key="ext.name">
 							<extension-item
 								:extension="ext"
 								:children="ext.schema?.type === 'bundle' ? bundled.filter(({ bundle }) => bundle === ext.id) : []"
-								@refresh="refreshExtensions"
 							/>
 						</template>
 					</v-list>
@@ -124,17 +58,6 @@ const refreshExtensions = async ({
 				{{ t('no_extensions_copy') }}
 			</v-info>
 		</div>
-
-		<v-dialog v-model="confirmLeave" @esc="confirmLeave = false">
-			<v-card>
-				<v-card-title>{{ t('extension_reload_required') }}</v-card-title>
-				<v-card-text>{{ t('extension_reload_required_copy') }}</v-card-text>
-				<v-card-actions>
-					<v-button secondary @click="confirmLeave = false">{{ t('back') }}</v-button>
-					<v-button @click="leavePage">{{ t('extension_reload_now') }}</v-button>
-				</v-card-actions>
-			</v-card>
-		</v-dialog>
 	</private-view>
 </template>
 

--- a/app/src/stores/extensions.ts
+++ b/app/src/stores/extensions.ts
@@ -1,0 +1,27 @@
+import api from '@/api';
+import type { ApiOutput } from '@directus/extensions';
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useExtensionsStore = defineStore('extensions', () => {
+	const loading = ref(false);
+	const error = ref<unknown>(null);
+	const extensions = ref<ApiOutput[]>([]);
+
+	const refresh = async () => {
+		loading.value = true;
+
+		try {
+			const response = await api.get('/extensions');
+			extensions.value = response.data.data;
+		} catch (err) {
+			error.value = err;
+		} finally {
+			loading.value = false;
+		}
+	};
+
+	refresh();
+
+	return { extensions, loading, error, refresh };
+});

--- a/app/src/stores/extensions.ts
+++ b/app/src/stores/extensions.ts
@@ -1,19 +1,70 @@
 import api from '@/api';
 import type { ApiOutput } from '@directus/extensions';
+import { APP_OR_HYBRID_EXTENSION_TYPES } from '@directus/extensions';
+import { isIn } from '@directus/utils';
+import { isEqual } from 'lodash';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useNotificationsStore } from './notifications';
+
+const getEnabledBrowserExtensions = (extensions: ApiOutput[]) => {
+	const enabledIds: string[] = [];
+
+	for (const extension of extensions) {
+		if (!extension.schema || !extension.schema.type) continue;
+
+		if (isIn(extension.schema.type, APP_OR_HYBRID_EXTENSION_TYPES) && extension.meta.enabled) {
+			enabledIds.push(extension.id);
+		}
+
+		if (extension.schema.type === 'bundle') {
+			const nested = extensions.filter((child) => child.bundle === extension.id);
+			const enabled = getEnabledBrowserExtensions(nested);
+
+			enabledIds.push(...enabled);
+
+			if (extension.schema.partial === false && enabled.length > 0) {
+				enabledIds.push(extension.id);
+			}
+		}
+	}
+
+	return enabledIds;
+};
 
 export const useExtensionsStore = defineStore('extensions', () => {
+	const notificationsStore = useNotificationsStore();
+	const { t } = useI18n();
+
 	const loading = ref(false);
 	const error = ref<unknown>(null);
 	const extensions = ref<ApiOutput[]>([]);
 
-	const refresh = async () => {
+	const refresh = async (forceRefresh = true) => {
 		loading.value = true;
+
+		const currentlyEnabledBrowserExtensions = getEnabledBrowserExtensions(extensions.value);
 
 		try {
 			const response = await api.get('/extensions');
 			extensions.value = response.data.data;
+
+			const newEnabledBrowserExtensions = getEnabledBrowserExtensions(extensions.value);
+
+			if (forceRefresh && isEqual(currentlyEnabledBrowserExtensions, newEnabledBrowserExtensions) === false) {
+				notificationsStore.add({
+					title: t('reload_required'),
+					text: t('extension_reload_required_copy'),
+					type: 'warning',
+					dialog: true,
+					persist: true,
+					dismissText: t('extension_reload_now'),
+					dismissAction: () => {
+						window.location.reload();
+					},
+				});
+			}
 		} catch (err) {
 			error.value = err;
 		} finally {
@@ -21,7 +72,19 @@ export const useExtensionsStore = defineStore('extensions', () => {
 		}
 	};
 
-	refresh();
+	const toggleState = async (id: string) => {
+		const extension = extensions.value.find((ext) => ext.id === id);
 
-	return { extensions, loading, error, refresh };
+		if (!extension) throw new Error(`Extension with ID ${id} does not exist`);
+
+		const current = extension.meta.enabled;
+		const endpoint = `/extensions/${id}`;
+
+		await api.patch(endpoint, { meta: { enabled: !current } });
+		await refresh();
+	};
+
+	refresh(false);
+
+	return { extensions, loading, error, refresh, toggleState };
 });

--- a/app/src/types/notifications.ts
+++ b/app/src/types/notifications.ts
@@ -11,6 +11,8 @@ export interface SnackbarRaw {
 	loading?: boolean;
 	dialog?: boolean;
 	error?: Error;
+	dismissText?: string;
+	dismissAction?: () => void | Promise<void>;
 }
 
 export interface Snackbar extends SnackbarRaw {

--- a/app/src/views/private/components/notification-dialogs.vue
+++ b/app/src/views/private/components/notification-dialogs.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
+import { Snackbar } from '@/types/notifications';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -11,9 +12,13 @@ const { isAdmin } = useUserStore();
 
 const notifications = computed(() => notificationsStore.dialogs);
 
-function done(id: string) {
-	notificationsStore.remove(id);
-}
+const done = async (notification: Snackbar) => {
+	if (notification.dismissAction) {
+		await notification.dismissAction();
+	}
+
+	notificationsStore.remove(notification.id);
+};
 </script>
 
 <template>
@@ -32,7 +37,7 @@ function done(id: string) {
 							{{ t('report_error') }}
 						</a>
 					</v-button>
-					<v-button @click="done(notification.id)">{{ t('dismiss') }}</v-button>
+					<v-button @click="done(notification)">{{ notification.dismissText ?? t('dismiss') }}</v-button>
 				</v-card-actions>
 			</v-card>
 		</v-dialog>


### PR DESCRIPTION
## Scope

What's changed:

- Adds a new `extensionsStore`
- Moves "reload requires" logic to extensions store
- Uses a new drawer to force a reload

## Potential Risks / Drawbacks

- Might interfere with current extensions disabling logic

## Review Notes / Questions

n/a