### PR TITLE
Fix boolean error in docker-compose quickstart template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -108,3 +108,4 @@
 - FloMaetschke
 - Marktawa
 - Humb3l
+- waldi

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -54,7 +54,7 @@ services:
       ADMIN_PASSWORD: "d1r3ctu5"
       DB_CLIENT: "sqlite3"
       DB_FILENAME: "/directus/database/data.db"
-      WEBSOCKETS_ENABLED: true
+      WEBSOCKETS_ENABLED: "true"
 ```
 
 Save the file. Let's step through it:


### PR DESCRIPTION
The current example in the quickstart guide give the following error:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.directus.environment.WEBSOCKETS_ENABLED contains true, which is an invalid type, it should be a string, number, or a null
```

## Scope

What's changed:

- changing `true` to `"true"` in the docs/self-hosted/quickstart.md

