### PR TITLE
add meta object to createCollection SDK example.

### DIFF
--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -343,23 +343,7 @@ import { createDirectus, rest, createCollection } from '@directus/sdk';
 const client = createDirectus('directus_project_url').with(rest());
 
 const result = await client.request(
-	createCollection({
-		collection: 'collection_name',
-		meta: {},
-		fields: [
-			{
-				field: 'title',
-				type: 'string',
-				meta: {
-					icon: 'title'
-				},
-				schema: {
-					is_primary_key: true,
-					is_nullable: false
-				}
-			}
-		],
-	})
+	createCollection(collection_object)
 );
 ```
 

--- a/docs/reference/system/collections.md
+++ b/docs/reference/system/collections.md
@@ -345,6 +345,7 @@ const client = createDirectus('directus_project_url').with(rest());
 const result = await client.request(
 	createCollection({
 		collection: 'collection_name',
+		meta: {},
 		fields: [
 			{
 				field: 'title',


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- small bug in createCollection docs. The API requires a ```meta``` object in the createCollection payload otherwise it fails.

## Potential Risks / Drawbacks

- none

## Review Notes / Questions


---

Fixes #\<num\>
