### PR TITLE
endpoint for updating an operation is /operations not /operation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -109,3 +109,4 @@
 - Marktawa
 - Humb3l
 - waldi
+- jstet

--- a/docs/reference/system/operations.md
+++ b/docs/reference/system/operations.md
@@ -491,7 +491,7 @@ Update an existing operation.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" group="api">
 <template #rest>
 
-`PATCH /operation/:id`
+`PATCH /operations/:id`
 
 Provide a partial [operation object](#the-operation-object) as the body of your request.
 


### PR DESCRIPTION
The endpoint for updating an operation is /operations not /operation

Closes #21356

## Scope

What's changed:

Change PATCH /operation/:id to PATCH /operations/:id at https://docs.directus.io/reference/system/operations.html#update-an-operation

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

