### PR TITLE
Fix manual flow dialog showing above select item drawer

### DIFF
--- a/.changeset/breezy-moose-think.md
+++ b/.changeset/breezy-moose-think.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed manual flow dialog showing above select item drawer

--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -105,6 +105,10 @@ function nudge() {
 	z-index: 600;
 }
 
+.container.center:has(.manual-flow-card) {
+	z-index: 500;
+}
+
 .container.center.nudge > :slotted(*:not(:first-child)) {
 	animation: nudge 200ms;
 }

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -181,7 +181,7 @@ const runManualFlow = async (flowId: string) => {
 		</div>
 
 		<v-dialog :model-value="!!confirmRunFlow" @esc="resetConfirm">
-			<v-card>
+			<v-card class="manual-flow-card">
 				<template v-if="confirmDetails">
 					<v-card-title>{{ confirmDetails.description ?? t('run_flow_confirm') }}</v-card-title>
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now ensure that the manual flow dialog is overlayed by the item drawer for item selection fields

## Potential Risks / Drawbacks

- None, changes should be scoped to this component only

## Review Notes / Questions

- This seems to be the optimal solution for the current state of things, open to suggestions. 
- I believe we should review #20952 as the underlying issue should be addressed. The issue is that teleports seem to have pre-designated locations based on mount order. This can result in the outlined problem if not mounted in the expected order.
- Regression introduced by #20952

---

Fixes #21344
