### PR TITLE
Fix collection folder dialog showing above translation drawer

### DIFF
--- a/.changeset/many-boxes-lick.md
+++ b/.changeset/many-boxes-lick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed collection folder dialog showing above translation drawer

--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -105,7 +105,7 @@ function nudge() {
 	z-index: 600;
 }
 
-.container.center:has(.manual-flow-card) {
+.container.center:has(.allow-drawer) {
 	z-index: 500;
 }
 

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue
@@ -72,7 +72,7 @@ async function save() {
 			<slot name="activator" v-bind="slotBinding" />
 		</template>
 
-		<v-card>
+		<v-card class="allow-drawer">
 			<v-card-title v-if="!collection">{{ t('create_folder') }}</v-card-title>
 			<v-card-title v-else>{{ t('edit_folder') }}</v-card-title>
 

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -181,7 +181,7 @@ const runManualFlow = async (flowId: string) => {
 		</div>
 
 		<v-dialog :model-value="!!confirmRunFlow" @esc="resetConfirm">
-			<v-card class="manual-flow-card">
+			<v-card class="allow-drawer">
 				<template v-if="confirmDetails">
 					<v-card-title>{{ confirmDetails.description ?? t('run_flow_confirm') }}</v-card-title>
 


### PR DESCRIPTION
## Scope

What's changed:

- Render the drawer for translations above the collection folder dialog
  - Settings -> Data Model -> Create Folder -> Translations -> Create New
- Complementary to #21361, using generalized class

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Thanks @bryantgillespie for reporting!