### PR TITLE
Add no-results indicator

### DIFF
--- a/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
@@ -130,6 +130,8 @@ watchEffect(async () => {
 				{{ t('no_results_copy') }}
 			</v-info>
 
+			<v-error v-if="error && !loading" :error="error" />
+
 			<v-pagination v-if="pageCount > 1" v-model="page" class="pagination" :length="pageCount" :total-visible="5" />
 
 			<router-view />


### PR DESCRIPTION
## Scope

![CleanShot 2024-02-09 at 13 51 57@2x](https://github.com/directus/directus/assets/9141017/55c47c33-af5b-43ef-ad3c-6b846cff4cba)


What's changed:

- Adds a v-info box in case there's no results

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None needed