### PR TITLE
Fixed document title

### DIFF
--- a/.changeset/real-panthers-heal.md
+++ b/.changeset/real-panthers-heal.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed document title formatting

--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -25,10 +25,11 @@ const brandStyleCss = computed(() => {
 
 useHead({
 	style: [{ textContent: brandStyleCss }],
-	titleTemplate: computed((title?: string) => {
-		const projectName = serverStore.info?.project?.project_name ?? 'Directus';
-		return !title ? projectName : `${title} · ${projectName}`;
-	}),
+	title: 'Directus',
+	titleTemplate: '%s · %projectName',
+	templateParams: {
+		projectName: computed(() => serverStore.info?.project?.project_name ?? 'Directus')
+	},
 	meta: computed(() => {
 		const content = serverStore.info?.project?.project_color ?? '#6644ff';
 

--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -28,7 +28,7 @@ useHead({
 	title: 'Directus',
 	titleTemplate: '%s · %projectName',
 	templateParams: {
-		projectName: computed(() => serverStore.info?.project?.project_name ?? 'Directus')
+		projectName: computed(() => serverStore.info?.project?.project_name ?? 'Directus'),
 	},
 	meta: computed(() => {
 		const content = serverStore.info?.project?.project_color ?? '#6644ff';


### PR DESCRIPTION
Fixes #21394 

## Scope

In https://github.com/directus/directus/pull/19141 we introduced `useHead` from `@unhead/vue` to manage the document title.

The implementation here was causing a recursive formatting issue, applying the title template on an already formatted title (as seen in the screenshot below).
![image](https://github.com/directus/directus/assets/9389634/dba42c07-e6c1-4afc-82ad-f7afd1d46bb6)


What's changed:

- Moved from a singular `computed` to the suggested template plus params

## Review Notes / Questions

- I would like to lorem ipsum

