### PR TITLE
Enable vendor chunking

### DIFF
--- a/.changeset/fuzzy-donuts-cover.md
+++ b/.changeset/fuzzy-donuts-cover.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Chunk vendor dependencies into separate JS file to reduce main bundle size

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -16,7 +16,7 @@ import UnheadVite from '@unhead/addons/vite';
 import vue from '@vitejs/plugin-vue';
 import fs from 'node:fs';
 import path from 'node:path';
-import { searchForWorkspaceRoot } from 'vite';
+import { searchForWorkspaceRoot, splitVendorChunkPlugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 const API_PATH = path.join('..', 'api');
@@ -33,6 +33,7 @@ export default defineConfig({
 				return data === null ? {} : undefined;
 			},
 		}),
+		splitVendorChunkPlugin(),
 		{
 			name: 'watch-directus-dependencies',
 			configureServer: (server) => {

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -44,6 +44,23 @@ export default defineConfig({
 			},
 		},
 	],
+	build: {
+		rollupOptions: {
+			output: {
+				manualChunks(id) {
+					/*
+					 * PNPM modules will be returned as a full resolved path, so doing an includes rather
+					 * than equality check allows this to work ish.
+					 */
+					if (id.includes('lodash')) return 'lodash';
+					if (id.includes('tinymce')) return 'tinymce';
+					if (id.includes('@fullcalendar')) return 'fullcalendar';
+					if (id.includes('@editorjs')) return 'editorjs';
+					if (id.includes('apexcharts')) return 'apexcharts';
+				},
+			},
+		},
+	},
 	resolve: {
 		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
 	},


### PR DESCRIPTION
## Scope

What's changed:

- Splits up the app's JS into a app and vendor chunk
- This won't reduce the overall bundle size, but does allow the bundle to be loaded a little faster as both files can be downloaded in parallel

## Potential Risks / Drawbacks

- It used to be Vite's default up until 2.6, so at one point in time we actually did it like this. Not entirely sure how this behaves in prod across various network conditions.

## Review Notes / Questions

- Some lightweight local testing makes me think this works just fine, but more testing is needed!

---

Ref https://github.com/directus/directus/issues/21416
