### PR TITLE
Allow Flow Update data operation to update item bulk (unique values per item)

### DIFF
--- a/.changeset/tricky-lies-suffer.md
+++ b/.changeset/tricky-lies-suffer.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Enabled usage of bulk update format in "Update Item" Flow operation

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -52,7 +52,9 @@ export default defineOperationApi<Options>({
 
 		let result: PrimaryKey | PrimaryKey[] | null;
 
-		if (!key || (Array.isArray(key) && key.length === 0)) {
+		if (Array.isArray(payloadObject)) {
+			result = await itemService.updateBatch(payloadObject, { emitEvents: !!emitEvents });
+		} else if (!key || (Array.isArray(key) && key.length === 0)) {
 			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
 		} else {
 			const keys = toArray(key);

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -53,7 +53,7 @@ export default defineOperationApi<Options>({
 		let result: PrimaryKey | PrimaryKey[] | null;
 
 		if (Array.isArray(payloadObject)) {
-			result = await itemService.updateBatch(payloadObject, { emitEvents: !!emitEvents });
+			result = await itemsService.updateBatch(payloadObject, { emitEvents: !!emitEvents });
 		} else if (!key || (Array.isArray(key) && key.length === 0)) {
 			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
 		} else {

--- a/contributors.yml
+++ b/contributors.yml
@@ -110,3 +110,4 @@
 - Humb3l
 - waldi
 - jstet
+- datnv9

--- a/docs/app/flows/operations.md
+++ b/docs/app/flows/operations.md
@@ -239,7 +239,11 @@ This operation updates item(s) in a collection. You may select item(s) to update
 - **Permissions** — Set the role that this operation will inherit permissions from.
 - **Emit Events** — Toggle whether the event is emitted.
 - **IDs** — Input the ID for Item(s) you wish to read and press enter. Click the ID to remove.
-- **Payload** — Update Items in a collection. To learn more, see [API > Items](/reference/items).
+- **Payload** — Update Items in a collection, using one of the following formats:
+  - Single object with data, to update items specified in **IDs** or **Query** to the same values.
+  - Single object with keys and data, to update multiple items to the same values.
+  - Array of objects with data including primary keys, to update multiple items to different values.
+  - To learn more, see [API > Items](/reference/items).
 - **Query** — Select items to update with a query. To learn more, see [Filter Rules](/reference/filter-rules).
 
 **Payload**


### PR DESCRIPTION


<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Api flow operation item-update allow update items bulk (unique values per item) 

## Potential Risks / Drawbacks

## Review Notes / Questions

---

Fixes #16258

> Flows
> 
> It does looks like Flows Update Data operation does not have this capability yet (as it was built to work "similarly" as other data operations), so that's definitely a potential enhancement to that specific operation 👍
> 