### PR TITLE
Support international emails in login

### DIFF
--- a/.changeset/poor-cameras-march.md
+++ b/.changeset/poor-cameras-march.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that prevented logging in when emails contained unicode characters

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -56,8 +56,10 @@ const errorFormatted = computed(() => {
 });
 
 async function onSubmit() {
-	// Very simple(!) Regex solely as a help for the user instead of validation
-	if (email.value === null || email.value.match(/^\S+@\S+$/) === null || password.value === null) {
+	// Simple RegEx, not for validation, but to prevent unnecessary login requests when the value is clearly invalid
+	const emailRegex = /^\S+@\S+$/;
+
+	if (email.value === null || !emailRegex.test(email.value) || password.value === null) {
 		error.value = 'INVALID_PAYLOAD';
 		return;
 	}

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -56,7 +56,8 @@ const errorFormatted = computed(() => {
 });
 
 async function onSubmit() {
-	if (email.value === null || password.value === null) {
+	// Very simple(!) Regex solely as a help for the user instead of validation
+	if (email.value === null || email.value.match(/^\S+@\S+$/) === null || password.value === null) {
 		error.value = 'INVALID_PAYLOAD';
 		return;
 	}
@@ -97,7 +98,7 @@ async function onSubmit() {
 </script>
 
 <template>
-	<form @submit.prevent="onSubmit">
+	<form novalidate @submit.prevent="onSubmit">
 		<v-input v-model="email" autofocus autocomplete="username" type="email" :placeholder="t('email')" />
 		<v-input v-model="password" type="password" autocomplete="current-password" :placeholder="t('password')" />
 

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -78,7 +78,7 @@ async function onSubmit() {
 
 		const redirectQuery = router.currentRoute.value.query.redirect as string;
 
-		let lastPage: string | undefined;
+		let lastPage: string | null = null;
 
 		if (userStore.currentUser && 'last_page' in userStore.currentUser) {
 			lastPage = userStore.currentUser.last_page;


### PR DESCRIPTION
## Scope

What's changed:

- Removed browser form-validation for email on login to support more emails
  - Now users can login with German names for example `jürgen@example.com`
- Fixed a type error

## Potential Risks / Drawbacks

- We didnt use form validation for `password`, nor for the one-time-pass as its simply `type="text"` with no other constraints - theres no more fields in this form so we should be good. 

## Review Notes / Questions

- Didnt remove `type="email"` so we preserve niceties like custom keyboards on mobile devices
- Tried adding `formnovalidate` to the email input but that didnt help, it only worked for me (chromium) with the `novalidate` on the form directly

---

Fixes #21309 
