### PR TITLE
Resolve npm extensions by package manifest

### DIFF
--- a/packages/extensions/src/node/utils/get-extensions.ts
+++ b/packages/extensions/src/node/utils/get-extensions.ts
@@ -93,7 +93,7 @@ export async function resolveFsExtensions(root: string): Promise<Map<string, Ext
 		try {
 			parsedManifest = ExtensionManifest.parse(manifest);
 		} catch (error) {
-			throw new Error(`The manifest of the extension "${name} (${path}) is invalid.\n${error}`);
+			throw new Error(`The manifest of the extension "${name}" (${path}) is invalid.\n${error}`);
 		}
 
 		const extensionDefinition = getExtensionDefinition(parsedManifest, { path, local: true });


### PR DESCRIPTION
## Scope

What's changed:

- Resolve npm extensions by package manifests instead of package names
  - Allows to install extensions locally without the `directus-extension-` prefix
- Better error messages
- Clean-up `get-extensions.ts` utils
  - Concurrent loading of package manifests
  - Simplify (dropping `ExtensionList`)
  - Reduce fs calls
  - resolve all paths

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A

