### PR TITLE
Adjust subscription async order to prevent handlers from being overwritten

### DIFF
--- a/.changeset/rotten-meals-hear.md
+++ b/.changeset/rotten-meals-hear.md
@@ -1,0 +1,5 @@
+---
+'@directus/memory': patch
+---
+
+Adjusted bus subscription method for redis to ensure handlers are not being overwritten on consecutive calls

--- a/api/src/websocket/controllers/hooks.ts
+++ b/api/src/websocket/controllers/hooks.ts
@@ -149,7 +149,7 @@ function registerSortHooks() {
 function registerAction(event: string, transform: (args: Record<string, any>) => WebSocketEvent) {
 	const messenger = useBus();
 
-	emitter.onAction(event, async (data: Record<string, any>) => {
+	emitter.onAction(event, (data: Record<string, any>) => {
 		// push the event through the Redis pub/sub
 		messenger.publish('websocket.event', transform(data) as Record<string, any>);
 	});

--- a/packages/memory/src/bus/lib/redis.ts
+++ b/packages/memory/src/bus/lib/redis.ts
@@ -47,11 +47,11 @@ export class BusRedis implements Bus {
 		const existingSet = this.handlers[namespaced];
 
 		if (existingSet === undefined) {
-			await this.sub.subscribe(namespaced);
-
 			const set = new Set<MessageHandler<T>>();
 			set.add(callback);
 			this.handlers[namespaced] = set;
+
+			await this.sub.subscribe(namespaced);
 		} else {
 			existingSet.add(callback);
 		}
@@ -70,7 +70,8 @@ export class BusRedis implements Bus {
 
 		if (set.size === 0) {
 			delete this.handlers[namespaced];
-			this.sub.unsubscribe(namespaced);
+
+			await this.sub.unsubscribe(namespaced);
 		}
 	}
 


### PR DESCRIPTION
## Scope

What's changed:

- While the `subscription` method itself doesn't necessarily need to be awaited (usually does not matter whether the subscription has been completed or not), when doing so (no await) it can lead to an overwriting of handlers on consecutive calls, due to the async nature of `this.sub.subscribe`, which is currently called before the handler registration.
- This can be easily be fixed by calling `this.sub.subscribe` after adding the handler to the list, making sure consecutive calls will add the handler to the existing list instead of overwriting it.

## Potential Risks / Drawbacks

- Another solution could be to `await` the `subscription` call in every case, but that would require a larger refactoring and as mentioned above, it does not necessarily make sense (having) to await these calls.

## Review Notes / Questions

N/A

---

Addresses these failing blackbox tests:
<img width="750" src="https://github.com/directus/directus/assets/5363448/76ed43e8-6878-4253-835b-02037994ca8e">

