### PR TITLE
Add "Create Collection" button to nav bar if there are no collections

### DIFF
--- a/.changeset/wild-pandas-peel.md
+++ b/.changeset/wild-pandas-peel.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added "Create Collection" button to nav bar for admins if there are no collections

--- a/app/src/modules/content/components/navigation.vue
+++ b/app/src/modules/content/components/navigation.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
+import { useUserStore } from '@/stores/user';
 import { isNil, orderBy } from 'lodash';
 import { computed, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -17,6 +18,7 @@ const { activeGroups, showHidden } = useNavigation(currentCollection);
 const search = ref('');
 
 const collectionsStore = useCollectionsStore();
+const userStore = useUserStore();
 
 const rootItems = computed(() => {
 	const shownCollections = showHidden.value ? collectionsStore.allCollections : collectionsStore.visibleCollections;
@@ -52,6 +54,16 @@ const hasHiddenCollections = computed(
 			:mandatory="false"
 			:dense="dense"
 		>
+			<v-button
+				v-if="userStore.isAdmin && collectionsStore.allCollections.length === 0"
+				full-width
+				outlined
+				dashed
+				to="/settings/data-model/+"
+			>
+				{{ t('create_collection') }}
+			</v-button>
+
 			<navigation-item
 				v-for="collection in rootItems"
 				:key="collection.collection"

--- a/app/src/modules/content/routes/no-collections.vue
+++ b/app/src/modules/content/routes/no-collections.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
 import { useUserStore } from '@/stores/user';
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import ContentNavigation from '../components/navigation.vue';
 
 const { t } = useI18n();
 
 const userStore = useUserStore();
-
-const isAdmin = computed(() => userStore.currentUser?.role.admin_access === true);
 </script>
 
 <template>
@@ -24,7 +21,7 @@ const isAdmin = computed(() => userStore.currentUser?.role.admin_access === true
 		</template>
 
 		<v-info icon="box" :title="t('no_collections')" center>
-			<template v-if="isAdmin">
+			<template v-if="userStore.isAdmin">
 				{{ t('no_collections_copy_admin') }}
 			</template>
 
@@ -32,7 +29,7 @@ const isAdmin = computed(() => userStore.currentUser?.role.admin_access === true
 				{{ t('no_collections_copy') }}
 			</template>
 
-			<template v-if="isAdmin" #append>
+			<template v-if="userStore.isAdmin" #append>
 				<v-button to="/settings/data-model/+">{{ t('create_collection') }}</v-button>
 			</template>
 		</v-info>


### PR DESCRIPTION
## Scope

What's changed:

- If there are no collections, the nav bar is oddly empty. For admins there will now be a "Create Collection" button like on the Insights page:
![Content · Directus old](https://github.com/directus/directus/assets/5363448/565832fa-006b-4099-b324-63e6b33aed81)
![Content · Directus new](https://github.com/directus/directus/assets/5363448/a7e65778-758a-4cb3-bdf8-699abcf8a4cb)
![Insights · Directus](https://github.com/directus/directus/assets/5363448/d59a727e-ecc1-4be5-856c-2166516ff49d)


## Potential Risks / Drawbacks

- This is for admins only, for users we should probably show a message instead of the empty nav bar. Same if there are only hidden collections.

## Review Notes / Questions

None
