### PR TITLE
Fix image select dialog showing above file drawer for markdown interface

### DIFF
--- a/.changeset/new-humans-worry.md
+++ b/.changeset/new-humans-worry.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed image select dialog showing above file drawer for markdown interface

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -398,7 +398,7 @@ function edit(type: Alteration, options?: Record<string, any>) {
 			@esc="imageDialogOpen = false"
 			@update:model-value="imageDialogOpen = false"
 		>
-			<v-card>
+			<v-card class="allow-drawer">
 				<v-card-title>{{ t('upload_from_device') }}</v-card-title>
 				<v-card-text>
 					<v-upload from-url from-library :folder="folder" @input="onImageUpload" />


### PR DESCRIPTION
## Scope

What's changed:

- Render the drawer for file library above the image selection dialog when inserting image in markdown interface

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Checked other interfaces too 👍 

---

Fixes #21519
