### PR TITLE
 Ensure overlapping popovers from block editor are rendered above other interfaces' elements

### DIFF
--- a/.changeset/mean-plants-cross.md
+++ b/.changeset/mean-plants-cross.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured overlapping popovers from block editor are rendered above other interfaces' elements

--- a/app/src/interfaces/input-block-editor/editorjs-overrides.css
+++ b/app/src/interfaces/input-block-editor/editorjs-overrides.css
@@ -2,6 +2,9 @@
 	--bg-color: var(--theme--background-normal) !important;
 	--front-color: var(--theme--form--field--input--foreground) !important;
 	--border-color: var(--theme--form--field--input--border-color) !important;
+
+	/* To ensure overlapping popovers are rendered above other interfaces' elements (Map / WYSIWYG) */
+	z-index: 3;
 }
 
 .codex-editor ::selection {


### PR DESCRIPTION
## Scope

What's changed:

- Fixes the following conflicts
  <img width="200" src="https://github.com/directus/directus/assets/5363448/c0dcb6d5-0efe-4f03-8a0c-67a7f2e30186">
  <img width="200" src="https://github.com/directus/directus/assets/5363448/54d85def-cab2-4d63-93f5-60d278bfb801">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None