### PR TITLE
Fix issue where data from CSV imports can be corrupted

### DIFF
--- a/.changeset/serious-zoos-relax.md
+++ b/.changeset/serious-zoos-relax.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where data from CSV imports can be corrupted

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -5,17 +5,19 @@ import {
 	ServiceUnavailableError,
 	UnsupportedMediaTypeError,
 } from '@directus/errors';
+import { isSystemCollection } from '@directus/system-data';
 import type { Accountability, File, Query, SchemaOverview } from '@directus/types';
 import { parseJSON, toArray } from '@directus/utils';
+import { createTmpFile } from '@directus/utils/node';
 import { queue } from 'async';
 import destroyStream from 'destroy';
 import { dump as toYAML } from 'js-yaml';
 import { parse as toXML } from 'js2xmlparser';
 import { Parser as CSVParser, transforms as CSVTransforms } from 'json2csv';
 import type { Knex } from 'knex';
-import { createReadStream } from 'node:fs';
+import { createReadStream, createWriteStream } from 'node:fs';
 import { appendFile } from 'node:fs/promises';
-import type { Readable } from 'node:stream';
+import type { Readable, Stream } from 'node:stream';
 import Papa from 'papaparse';
 import StreamArray from 'stream-json/streamers/StreamArray.js';
 import getDatabase from '../database/index.js';
@@ -29,7 +31,6 @@ import { FilesService } from './files.js';
 import { ItemsService } from './items.js';
 import { NotificationsService } from './notifications.js';
 import { UsersService } from './users.js';
-import { isSystemCollection } from '@directus/system-data';
 
 const env = useEnv();
 const logger = useLogger();
@@ -119,7 +120,10 @@ export class ImportService {
 		});
 	}
 
-	importCSV(collection: string, stream: Readable): Promise<void> {
+	async importCSV(collection: string, stream: Readable): Promise<void> {
+		const tmpFile = await createTmpFile().catch(() => null);
+		if (!tmpFile) throw new Error('Failed to create temporary file for import');
+
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		return this.knex.transaction((trx) => {
@@ -155,38 +159,75 @@ export class ImportService {
 			};
 
 			return new Promise<void>((resolve, reject) => {
-				stream
-					.pipe(Papa.parse(Papa.NODE_STREAM_INPUT, PapaOptions))
-					.on('data', (obj: Record<string, unknown>) => {
-						// Filter out all undefined fields
-						for (const field in obj) {
-							if (obj[field] === undefined) {
-								delete obj[field];
-							}
-						}
+				const streams: Stream[] = [stream];
 
-						saveQueue.push(obj);
-					})
-					.on('error', (err: any) => {
+				const cleanup = () => {
+					for (const stream of streams) {
 						destroyStream(stream);
-						reject(new InvalidPayloadError({ reason: err.message }));
+					}
+
+					tmpFile.cleanup().catch(() => {
+						logger.warn(`Failed to cleanup temporary import file (${tmpFile.path})`);
+					});
+				};
+
+				saveQueue.error((error) => {
+					reject(error);
+				});
+
+				const fileWriteStream = createWriteStream(tmpFile.path)
+					.on('error', (error) => {
+						cleanup();
+						reject(new Error('Error while writing import data to temporary file', { cause: error }));
 					})
-					.on('end', () => {
-						// In case of empty CSV file
-						if (!saveQueue.started) return resolve();
-
-						saveQueue.drain(() => {
-							for (const nestedActionEvent of nestedActionEvents) {
-								emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-							}
-
-							return resolve();
+					.on('finish', () => {
+						const fileReadStream = createReadStream(tmpFile.path).on('error', (error) => {
+							cleanup();
+							reject(new Error('Error while reading import data from temporary file', { cause: error }));
 						});
+
+						streams.push(fileReadStream);
+
+						fileReadStream
+							.pipe(Papa.parse(Papa.NODE_STREAM_INPUT, PapaOptions))
+							.on('data', (obj: Record<string, unknown>) => {
+								// Filter out all undefined fields
+								for (const field in obj) {
+									if (obj[field] === undefined) {
+										delete obj[field];
+									}
+								}
+
+								saveQueue.push(obj);
+							})
+							.on('error', (error) => {
+								cleanup();
+								reject(new InvalidPayloadError({ reason: error.message }));
+							})
+							.on('end', () => {
+								cleanup();
+
+								// In case of empty CSV file
+								if (!saveQueue.started) return resolve();
+
+								saveQueue.drain(() => {
+									for (const nestedActionEvent of nestedActionEvents) {
+										emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
+									}
+
+									return resolve();
+								});
+							});
 					});
 
-				saveQueue.error((err) => {
-					reject(err);
-				});
+				streams.push(fileWriteStream);
+
+				stream
+					.on('error', (error) => {
+						cleanup();
+						reject(new Error('Error while retrieving import data', { cause: error }));
+					})
+					.pipe(fileWriteStream);
 			});
 		});
 	}

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -161,9 +161,11 @@ export class ImportService {
 			return new Promise<void>((resolve, reject) => {
 				const streams: Stream[] = [stream];
 
-				const cleanup = () => {
-					for (const stream of streams) {
-						destroyStream(stream);
+				const cleanup = (destroy = true) => {
+					if (destroy) {
+						for (const stream of streams) {
+							destroyStream(stream);
+						}
 					}
 
 					tmpFile.cleanup().catch(() => {
@@ -205,7 +207,7 @@ export class ImportService {
 								reject(new InvalidPayloadError({ reason: error.message }));
 							})
 							.on('end', () => {
-								cleanup();
+								cleanup(false);
 
 								// In case of empty CSV file
 								if (!saveQueue.started) return resolve();


### PR DESCRIPTION
## Scope

What's changed:

- Data from CSV imports can be corrupted in same cases, due to a bug in PapaParse (CSV parser), see https://github.com/mholt/PapaParse/issues/998
- A workaround is to first write the data down to a file and then stream it to PapaParse from there, as we used to do it before #21406

## Potential Risks / Drawbacks

- A tad slower imports as we write the data to the file first and then read it again
- This additional step could also be another source of errors, however as mentioned above we've already relied on temporary files for quite some time before #21406. Also tested various scenarios (see below).

## Review Notes / Questions

- Issues can be provoked by manually destroying streams with `stream.destroy(new Error())` while import is still running
- Tested with invalid CSV / data
- Tested with bigger valid CSV
- Couldn't really notice a slowdown
- In case of an error, all streams are [`destroy`](https://www.npmjs.com/package/destroy)ed to be on the safe side - AFAICS this is a no-op if the stream has already finished, so that should not be a concern
- Error handlers are attached to all streams to ensure the tmp file is cleaned-up in case of any error

---

Fixes #21491
