### PR TITLE
Fix "Copy To" action for Flow operations

### DIFF
--- a/.changeset/bright-eagles-fix.md
+++ b/.changeset/bright-eagles-fix.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue where "Copy To" action on Flow operations failed when connected to subsequent operations

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -390,32 +390,32 @@ function editPanel(panel: AppTile) {
 	else router.push(`/settings/flows/${props.primaryKey}/${panel.id}`);
 }
 
-// ------------- Move Panel To ------------- //
+// ------------- Copy Panel To ------------- //
 
-const movePanelID = ref<string | undefined>();
-const movePanelTo = ref<string | undefined>();
-const movePanelLoading = ref(false);
+const copyPanelId = ref<string | undefined>();
+const copyPanelTo = ref<string | undefined>();
+const copyPanelLoading = ref(false);
 
-const movePanelChoices = computed(() => flowsStore.flows.filter((flow) => flow.id !== props.primaryKey));
+const copyPanelChoices = computed(() => flowsStore.flows.filter((flow) => flow.id !== props.primaryKey));
 
-async function movePanel() {
-	movePanelLoading.value = true;
+async function copyPanel() {
+	copyPanelLoading.value = true;
 
-	const currentPanel = panels.value.find((panel) => panel.id === movePanelID.value);
+	const currentPanel = panels.value.find((panel) => panel.id === copyPanelId.value);
 
 	try {
 		await api.post(`/operations`, {
-			...omit(currentPanel, ['id']),
-			flow: movePanelTo.value,
+			...omit(currentPanel, ['id', 'date_created', 'user_created', 'resolve', 'reject']),
+			flow: copyPanelTo.value,
 		});
 
 		await flowsStore.hydrate();
 
-		movePanelID.value = undefined;
+		copyPanelId.value = undefined;
 	} catch (error) {
 		unexpectedError(error);
 	} finally {
-		movePanelLoading.value = false;
+		copyPanelLoading.value = false;
 	}
 }
 
@@ -623,7 +623,7 @@ function discardAndLeave() {
 						:subdued="flow.status === 'inactive'"
 						@create="createPanel"
 						@edit="editPanel"
-						@move="movePanelID = $event"
+						@move="copyPanelId = $event"
 						@update="stageOperationEdits"
 						@delete="deletePanel"
 						@duplicate="duplicatePanel"
@@ -679,22 +679,22 @@ function discardAndLeave() {
 			</v-card>
 		</v-dialog>
 
-		<v-dialog :model-value="!!movePanelID" @update:model-value="movePanelID = undefined" @esc="movePanelID = undefined">
+		<v-dialog :model-value="!!copyPanelId" @update:model-value="copyPanelId = undefined" @esc="copyPanelId = undefined">
 			<v-card>
 				<v-card-title>{{ t('copy_to') }}</v-card-title>
 
 				<v-card-text>
-					<v-notice v-if="movePanelChoices.length === 0">
+					<v-notice v-if="copyPanelChoices.length === 0">
 						{{ t('no_other_flows_copy') }}
 					</v-notice>
-					<v-select v-else v-model="movePanelTo" :items="movePanelChoices" item-text="name" item-value="id" />
+					<v-select v-else v-model="copyPanelTo" :items="copyPanelChoices" item-text="name" item-value="id" />
 				</v-card-text>
 
 				<v-card-actions>
-					<v-button secondary @click="movePanelID = undefined">
+					<v-button secondary @click="copyPanelId = undefined">
 						{{ t('cancel') }}
 					</v-button>
-					<v-button :loading="movePanelLoading" :disabled="movePanelChoices.length === 0" @click="movePanel">
+					<v-button :loading="copyPanelLoading" :disabled="copyPanelChoices.length === 0" @click="copyPanel">
 						{{ t('copy') }}
 					</v-button>
 				</v-card-actions>


### PR DESCRIPTION
## Scope

What's changed:

- Fixes "Copy To" action for Flow operations by omitting unique/tied fields when copying

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #20215
