### PR TITLE
Fix storage initialization

### DIFF
--- a/.changeset/tidy-bulldogs-argue.md
+++ b/.changeset/tidy-bulldogs-argue.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where storage could be unavailable at the first use after the start of Directus

--- a/api/src/storage/index.ts
+++ b/api/src/storage/index.ts
@@ -14,10 +14,12 @@ export const getStorage = async (): Promise<StorageManager> => {
 
 	validateEnv(['STORAGE_LOCATIONS']);
 
-	_cache.storage = new StorageManager();
+	const storage = new StorageManager();
 
-	await registerDrivers(_cache.storage);
-	await registerLocations(_cache.storage);
+	await registerDrivers(storage);
+	await registerLocations(storage);
 
-	return _cache.storage;
+	_cache.storage = storage;
+
+	return storage;
 };


### PR DESCRIPTION
## Scope

What's changed:

- Fix order in initialization of storage, to prevent race condition on first usage of storage after start of Directus which would result in the storage not being available that time

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Props to @VincentKempers for investigation in https://github.com/directus/directus/issues/20769#issuecomment-1919670748 🕵️❤️ 

---

Fixes #20769
