### PR TITLE
Fix position of empty form message with translations interface

### DIFF
--- a/.changeset/slow-knives-clean.md
+++ b/.changeset/slow-knives-clean.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the position of the empty fields info in translations interface

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -330,7 +330,7 @@ function useRawEditor() {
 </script>
 
 <template>
-	<div ref="el" class="v-form" :class="gridClass">
+	<div ref="el" :class="['v-form', gridClass, { inline }]">
 		<validation-errors
 			v-if="showValidationErrors && validationErrors.length > 0"
 			:validation-errors="validationErrors"
@@ -339,9 +339,10 @@ function useRawEditor() {
 		/>
 		<v-info
 			v-if="noVisibleFields && showNoVisibleFields && !loading"
+			class="no-fields-info"
 			:title="t('no_visible_fields')"
 			:icon="inline ? false : 'search'"
-			center
+			:center="!inline"
 		>
 			{{ t('no_visible_fields_copy') }}
 		</v-info>
@@ -423,10 +424,14 @@ function useRawEditor() {
 
 .v-form {
 	@include form-grid;
-}
 
-.v-form .first-visible-field :deep(.v-divider) {
-	margin-top: 0;
+	.first-visible-field :deep(.v-divider) {
+		margin-top: 0;
+	}
+
+	&.inline > .no-fields-info {
+		grid-column: 1 / -1;
+	}
 }
 
 .v-divider {


### PR DESCRIPTION
## Scope

What's changed:

- Fix position of empty form message with translations interface

![Creating Item in Demo · Directus](https://github.com/directus/directus/assets/5363448/a61c4228-987f-4be8-9869-f93a6832c028)
![Creating Item in Demo · Directus](https://github.com/directus/directus/assets/5363448/69746fa0-68f4-40ef-bc31-2a7590e63597)

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #21146
