### PR TITLE
Align menu for toggling invisible collections

### DIFF
--- a/.changeset/three-crabs-end.md
+++ b/.changeset/three-crabs-end.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Aligned the menu for toggling invisible collections

--- a/app/src/modules/content/components/navigation.vue
+++ b/app/src/modules/content/components/navigation.vue
@@ -73,14 +73,16 @@ const hasHiddenCollections = computed(
 			/>
 
 			<v-menu v-if="hasHiddenCollections" ref="contextMenu" show-arrow placement="bottom-start">
-				<v-list-item clickable @click="showHidden = !showHidden">
-					<v-list-item-icon>
-						<v-icon :name="showHidden ? 'visibility_off' : 'visibility'" />
-					</v-list-item-icon>
-					<v-list-item-content>
-						<v-text-overflow :text="showHidden ? t('hide_hidden_collections') : t('show_hidden_collections')" />
-					</v-list-item-content>
-				</v-list-item>
+				<v-list>
+					<v-list-item clickable @click="showHidden = !showHidden">
+						<v-list-item-icon>
+							<v-icon :name="showHidden ? 'visibility_off' : 'visibility'" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							<v-text-overflow :text="showHidden ? t('hide_hidden_collections') : t('show_hidden_collections')" />
+						</v-list-item-content>
+					</v-list-item>
+				</v-list>
 			</v-menu>
 		</v-list>
 	</div>


### PR DESCRIPTION
## Scope

What's changed:

- Align menu for toggling invisible collections, by nesting the item in `v-list`
  - to give more spacing and prevent the arrow from overlapping
    <table><tr><th>Before</th><td><img width="600" src="https://github.com/directus/directus/assets/5363448/02f49643-17f6-46ae-bf4e-bd36ec018260"></td><tr/><tr><th>After</th><td><img width="600" alt="Screenshot 2024-02-27 at 09 32 43" src="https://github.com/directus/directus/assets/5363448/1cf7d011-0a6c-47a0-8689-adca32fc38d0"></td></tr></table>
  - to match other context menus, e.g.
    <img width="400" src="https://github.com/directus/directus/assets/5363448/c03bd4d1-5a4a-496a-ad42-be71d417a257">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None