### PR TITLE
Account for revisions data/delta to be null

### DIFF
--- a/app/src/types/revisions.ts
+++ b/app/src/types/revisions.ts
@@ -1,7 +1,7 @@
 export type Revision = {
 	id: number;
-	data: Record<string, any>;
-	delta: Record<string, any>;
+	data: Record<string, any> | null;
+	delta: Record<string, any> | null;
 	collection: string;
 	item: string | number;
 	activity: {

--- a/app/src/views/private/components/revision-item.vue
+++ b/app/src/views/private/components/revision-item.vue
@@ -16,9 +16,7 @@ defineEmits<{
 
 const { t } = useI18n();
 
-const revisionCount = computed(() => {
-	return Object.keys(props.revision.delta).length;
-});
+const revisionCount = computed(() => (props.revision.delta ? Object.keys(props.revision.delta).length : 0));
 
 const headerMessage = computed(() => {
 	switch (props.revision.activity.action.toLowerCase()) {


### PR DESCRIPTION
## Scope

What's changed:

- Account for revisions data/delta to be null, for revision count
  - fixes warning in console

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
