### PR TITLE
Fix theme fallback for theme-preview in system-theme interface

### DIFF
--- a/app/src/interfaces/_system/system-theme/system-theme.vue
+++ b/app/src/interfaces/_system/system-theme/system-theme.vue
@@ -23,9 +23,12 @@ const serverStore = useServerStore();
 const themeStore = useThemeStore();
 
 const systemTheme = computed(() => {
-	return props.appearance === 'dark'
-		? serverStore.info.project!.default_theme_dark
-		: serverStore.info.project!.default_theme_light;
+	const theme =
+		props.appearance === 'dark'
+			? serverStore.info.project?.default_theme_dark
+			: serverStore.info.project?.default_theme_light;
+
+	return theme ?? null;
 });
 
 const items = computed(() => themeStore.themes[props.appearance].map((theme) => ({ id: theme.id, name: theme.name })));


### PR DESCRIPTION
## Scope

What's changed:

- Fix theme fallback for theme-preview in system-theme interface
  - fixes the following console warning
    <img width="600" src="https://github.com/directus/directus/assets/5363448/17fed0f5-30e4-494f-a0c8-d981ee7f70db">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
