### PR TITLE
Fix v-notice scope & render "No items" notice for relational list interfaces inside list

### DIFF
--- a/.changeset/rare-bananas-clean.md
+++ b/.changeset/rare-bananas-clean.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Aligned "No items" notice across relational list interfaces to prevent jumping on selection of items

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -290,9 +290,9 @@ const allowDrag = computed(
 			/>
 		</template>
 
-		<v-notice v-else-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
-
 		<v-list v-else>
+			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
+
 			<draggable
 				:model-value="displayItems"
 				item-key="id"

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -347,9 +347,9 @@ const allowDrag = computed(
 			/>
 		</template>
 
-		<v-notice v-else-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
-
 		<v-list v-else>
+			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
+
 			<draggable
 				:model-value="displayItems"
 				item-key="$index"

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -347,9 +347,9 @@ const allowDrag = computed(
 			/>
 		</template>
 
-		<v-list v-else>
-			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
+		<v-notice v-else-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
 
+		<v-list v-else>
 			<draggable
 				:model-value="displayItems"
 				item-key="$index"

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -510,11 +510,11 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 				/>
 			</template>
 
-			<v-notice v-else-if="displayItems.length === 0">
-				{{ t('no_items') }}
-			</v-notice>
-
 			<v-list v-else>
+				<v-notice v-if="displayItems.length === 0">
+					{{ t('no_items') }}
+				</v-notice>
+
 				<draggable
 					:model-value="displayItems"
 					item-key="id"
@@ -663,10 +663,6 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 	.deselect.deleted {
 		color: var(--danger-75);
 	}
-}
-
-.v-notice {
-	margin-top: 8px;
 }
 
 .actions {

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -471,11 +471,11 @@ function getLinkForItem(item: DisplayItem) {
 				/>
 			</template>
 
-			<v-notice v-else-if="displayItems.length === 0">
-				{{ t('no_items') }}
-			</v-notice>
-
 			<v-list v-else>
+				<v-notice v-if="displayItems.length === 0">
+					{{ t('no_items') }}
+				</v-notice>
+
 				<draggable
 					:model-value="displayItems"
 					item-key="id"
@@ -617,11 +617,6 @@ function getLinkForItem(item: DisplayItem) {
 			color: var(--danger-75);
 		}
 	}
-}
-
-.v-skeleton-loader,
-.v-notice {
-	margin-top: 8px;
 }
 
 .actions {

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/permissions.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/permissions.vue
@@ -64,7 +64,7 @@ const fields = computed<DeepPartial<Field>[]>(() => [
 	</div>
 </template>
 
-<style lang="scss">
+<style scoped>
 .v-notice {
 	margin-bottom: 36px;
 }


### PR DESCRIPTION
## Scope

What's changed:

- Fix v-notice scope, bug from #21543
- Render "No items" notice inside v-list in all relational list interfaces to prevent jumping when selecting item and to have same padding across those interfaces

  https://github.com/directus/directus/assets/5363448/60796ce7-4661-44e7-8bad-a7f55de5bcb6

  https://github.com/directus/directus/assets/5363448/67d7a2b4-4152-4f2d-b09e-43900ec1ad5e

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
