### PR TITLE
insert new translation key to system-input-translated-string

### DIFF
--- a/.changeset/khaki-phones-perform.md
+++ b/.changeset/khaki-phones-perform.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Enabled insertion of the translated string newly created via the system-input-translated-string interface

--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -83,6 +83,7 @@ const localValue = computed<string | null>({
 const create = async (item: Translation) => {
 	await translationsStore.create(item);
 	await fetchTranslationsKeys();
+	setValue(`${translationPrefix}${item.key}`);
 };
 
 watch(


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- set value after creating a new custom translation 


https://github.com/directus/directus/assets/78852214/5acb693c-a1ed-4a2d-84a9-bb4c1ff69f24



## Potential Risks / Drawbacks

- It will replace the existing value of the field, but since this is the same behavior as selecting an existing translation, I don't think it will be a problem (in terms of UX).

## Review Notes / Questions

- A small but important UX improvement

---

Fixes #21631
