### PR TITLE
default language for the system-input-translated-string

### DIFF
--- a/.changeset/swift-buses-live.md
+++ b/.changeset/swift-buses-live.md
@@ -2,5 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensured that the system default language is used as the default language when creating a new custom translation via the
-system-input-translated-string interface
+Ensured the user / project language is used as default value when creating a new custom translation via translation dropdown interface

--- a/.changeset/swift-buses-live.md
+++ b/.changeset/swift-buses-live.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Ensured that the system default language is used as the default language when creating a new custom translation via the
+system-input-translated-string interface

--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
+import { getCurrentLanguage } from '@/lang/get-current-language';
 import type { Translation } from '@/stores/translations';
 import { useTranslationsStore } from '@/stores/translations';
-import { useSettingsStore } from '@/stores/settings';
 import { fetchAll } from '@/utils/fetch-all';
 import { unexpectedError } from '@/utils/unexpected-error';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
@@ -36,8 +36,6 @@ const searchValue = ref<string | null>(null);
 const loading = ref(false);
 const translationsKeys = ref<string[]>([]);
 const translationsStore = useTranslationsStore();
-
-const settingsStore = useSettingsStore();
 
 const isCustomTranslationDrawerOpen = ref<boolean>(false);
 
@@ -207,7 +205,7 @@ function openNewCustomTranslationDrawer() {
 			v-model:active="isCustomTranslationDrawerOpen"
 			collection="directus_translations"
 			primary-key="+"
-			:edits="{ language: settingsStore?.settings?.default_language }"
+			:edits="{ language: getCurrentLanguage() }"
 			@input="create"
 		/>
 	</div>

--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Translation } from '@/stores/translations';
 import { useTranslationsStore } from '@/stores/translations';
+import { useSettingsStore } from '@/stores/settings';
 import { fetchAll } from '@/utils/fetch-all';
 import { unexpectedError } from '@/utils/unexpected-error';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
@@ -35,6 +36,8 @@ const searchValue = ref<string | null>(null);
 const loading = ref(false);
 const translationsKeys = ref<string[]>([]);
 const translationsStore = useTranslationsStore();
+
+const settingsStore = useSettingsStore();
 
 const isCustomTranslationDrawerOpen = ref<boolean>(false);
 
@@ -204,6 +207,7 @@ function openNewCustomTranslationDrawer() {
 			v-model:active="isCustomTranslationDrawerOpen"
 			collection="directus_translations"
 			primary-key="+"
+			:edits="{ language: settingsStore?.settings?.default_language }"
 			@input="create"
 		/>
 	</div>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- use default language when adding new custom translation via the system-input-translated-string

https://github.com/directus/directus/assets/78852214/1ebc86a3-99cf-4bf5-b76e-e4b45d02b639

## Potential Risks / Drawbacks

- Even if you don’t want to use the system’s default language, you can choose a different one.

## Review Notes / Questions

- A small but useful UX improvement

---

Fixes #21633
