### PR TITLE
Preserve translation strings when duplicating a field

### DIFF
--- a/.changeset/tough-hotels-reflect.md
+++ b/.changeset/tough-hotels-reflect.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that translation strings are preserved when duplicating a field

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -18,7 +18,7 @@ const { collection } = toRefs(props);
 const fieldsStore = useFieldsStore();
 fieldsStore.hydrate({ skipTranslation: true });
 
-const fields = computed(() => fieldsStore.getFieldsForCollectionSorted(collection.value) as Field[]);
+const fields = computed(() => fieldsStore.getFieldsForCollectionSorted(collection.value));
 
 const parsedFields = computed(() => {
 	return orderBy(fields.value, [(o) => (o.meta?.sort ? Number(o.meta?.sort) : null), (o) => o.meta?.id]).filter(

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
 import { hideDragImage } from '@/utils/hide-drag-image';
-import { useCollection } from '@directus/composables';
 import { Field, LocalType } from '@directus/types';
 import { isNil, orderBy } from 'lodash';
 import { computed, toRefs } from 'vue';
@@ -16,8 +15,10 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const { collection } = toRefs(props);
-const { fields } = useCollection(collection);
 const fieldsStore = useFieldsStore();
+fieldsStore.hydrate({ skipTranslation: true });
+
+const fields = computed(() => fieldsStore.getFieldsForCollectionSorted(collection.value) as Field[]);
 
 const parsedFields = computed(() => {
 	return orderBy(fields.value, [(o) => (o.meta?.sort ? Number(o.meta?.sort) : null), (o) => o.meta?.id]).filter(


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- To get the collection fields, I’ve removed `useCollection` and used the `useFieldsStore.getFieldsForCollectionSorted` directly instead, as this does the same
- Set `fieldsStore.hydrate({ skipTranslation: true })` so that the values won’t be translated

https://github.com/directus/directus/assets/78852214/229b63a4-f9e9-452c-b78a-c60846ee5dd8

## Potential Risks / Drawbacks

- Since the `fieldStore` was already used to call `updateFields` before in this component, I am not quite sure if `{ skipTranslation: true }` has any effect on it.

https://github.com/directus/directus/blob/0237fc8b18a585962311a2af4655fc1da075d962/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue#L107
https://github.com/directus/directus/blob/0237fc8b18a585962311a2af4655fc1da075d962/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue#L114

## Review Notes / Questions

- Small but useful UX improvement

---

Fixes #21647
