### PR TITLE
Enable JIT compiler for vue-i18n & disable legacy API

### DIFF
--- a/.changeset/brown-masks-roll.md
+++ b/.changeset/brown-masks-roll.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Enabled JIT compiler for vue-i18n to drop need for 'unsafe-eval' CSP and excluded legacy API

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -136,7 +136,7 @@ export default async function createApp(): Promise<express.Application> {
 				{
 					useDefaults: true,
 					directives: {
-						// Unsafe-eval is required for vue3 / vue-i18n / app extensions
+						// Unsafe-eval is required for app extensions
 						scriptSrc: ["'self'", "'unsafe-eval'"],
 
 						// Even though this is recommended to have enabled, it breaks most local

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -43,6 +43,10 @@ export default defineConfig({
 			},
 		},
 	],
+	define: {
+		__INTLIFY_JIT_COMPILATION__: true,
+		__VUE_I18N_LEGACY_API__: false,
+	},
 	resolve: {
 		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
 	},


### PR DESCRIPTION
## Scope

What's changed:

- Enable JIT compiler for vue-i18n to drop need for 'unsafe-eval' CSP
- Disable legacy style API to reduce bundle size

## Potential Risks / Drawbacks

https://vue-i18n.intlify.dev/guide/advanced/optimization.html#performance

> If you are using the JIT compilation, all locale messages will not necessarily be compiled with the Message function.
> Also, since the message compiler is also bundled, the bundle size cannot be reduced. This is a trade-off.

## Review Notes / Questions

- See https://vue-i18n.intlify.dev/guide/advanced/optimization#jit-compilation & https://vue-i18n.intlify.dev/guide/advanced/optimization#reduce-bundle-size-with-tree-shaking

- Can we drop the default setting of 'unsafe-eval' altogether? The comment states that it might be used for app extensions, but I think these are rather edge cases, so better to make it opt-in. Would be a breaking change of course.

---

Fixes #21589
