### PR TITLE
Preserve translation strings when duplicating a field immediately after field update

### DIFF
--- a/.changeset/wet-masks-rest.md
+++ b/.changeset/wet-masks-rest.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Ensured that translation strings are preserved when duplicating a field immediately after creating the translation

--- a/.changeset/wet-masks-rest.md
+++ b/.changeset/wet-masks-rest.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that translation strings are preserved when duplicating a field immediately after creating the translation

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -251,7 +251,7 @@ export const useFieldDetailStore = defineStore({
 					await api.post(getEndpoint(collection), this.items[collection]);
 				}
 
-				await fieldsStore.hydrate();
+				await fieldsStore.hydrate({ skipTranslation: true });
 			} catch (error) {
 				unexpectedError(error);
 			} finally {

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -3,7 +3,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { Field, LocalType } from '@directus/types';
 import { isNil, orderBy } from 'lodash';
-import { computed, toRefs } from 'vue';
+import { computed, toRefs, onBeforeMount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Draggable from 'vuedraggable';
 import FieldSelect from './field-select.vue';
@@ -16,7 +16,7 @@ const { t } = useI18n();
 
 const { collection } = toRefs(props);
 const fieldsStore = useFieldsStore();
-fieldsStore.hydrate({ skipTranslation: true });
+onBeforeMount(async () => await fieldsStore.hydrate({ skipTranslation: true }));
 
 const fields = computed(() => fieldsStore.getFieldsForCollectionSorted(collection.value));
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- added `{ skipTranslation: true }` to `await fieldsStore.hydrate()` in the `useFieldDetailStore`
- is not directly related to this issue, but added `await` to the `fieldsStore.hydrate()` in the `fields-management` component


https://github.com/directus/directus/assets/78852214/4f35b964-f2d3-462f-9ab1-cdcfbcfb81d9



## Potential Risks / Drawbacks

- Adding `{ skipTranslation: true }` fixes this bug, but I am really not sure, how it will affect on other parts of the app

## Review Notes / Questions

- Feel free to revert f253d9eead5f573366a4512c8c118ff3b6f2024a, if you think it is an "over-commit" ;)

---

Fixes #21651
