### PR TITLE
Adjust translations test to not use vue-i18n legacy API

### DIFF
--- a/app/src/lang/translations.test.ts
+++ b/app/src/lang/translations.test.ts
@@ -33,12 +33,12 @@ async function importLanguageFile(locale: string): Promise<{ isImported: boolean
 }
 
 describe.each(locales)('Locale %s', async (locale) => {
-	const i18n = createI18n({ locale: locale });
+	const i18n = createI18n({ legacy: false, locale: locale });
 	const datefnsLocale = (await importDateLocale(locale))?.default;
 
 	const { isImported, translations } = await importLanguageFile(locale);
 	i18n.global.mergeLocaleMessage(locale, translations);
-	const messages = flatten((i18n.global.messages as Record<string, any>)[locale]);
+	const messages = flatten((i18n.global.messages.value as Record<string, any>)[locale]);
 	const translationKeys = Object.keys(messages);
 
 	test(`import ${locale} language file successfully`, () => {


### PR DESCRIPTION
## Scope

What's changed:

- The test incorrectly made use of the legacy API, thus failing now after dropping it in #21649
- The legacy API is disabled in app, as well as all other tests

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- The issue wasn't detected in #21649, because there currently seems to be a bug in Vitest's `changed` functionality not running on changes of the `vite.config.js` file - will be reported
