### PR TITLE
Drop TS Vue Plugin from VS Code recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,3 @@
 {
-	"recommendations": [
-		"dbaeumer.vscode-eslint",
-		"editorconfig.editorconfig",
-		"esbenp.prettier-vscode",
-		"vue.volar",
-		"vue.vscode-typescript-vue-plugin"
-	]
+	"recommendations": ["dbaeumer.vscode-eslint", "editorconfig.editorconfig", "esbenp.prettier-vscode", "vue.volar"]
 }


### PR DESCRIPTION
## Scope

What's changed:

- Drop TypeScript Vue Plugin from list of recommended extensions for VS Code
- No longer required, thanks to https://github.com/vuejs/language-tools/releases/tag/v2.0.0 🚀 

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
