### PR TITLE
Fix a few inaccuracies in auth provider docs

### DIFF
--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -772,7 +772,7 @@ OpenID is an authentication protocol built on OAuth 2.0, and should be preferred
 | `AUTH_<PROVIDER>_CLIENT_SECRET`             | Client secret for the external service.                                                           | --                     |
 | `AUTH_<PROVIDER>_SCOPE`                     | A white-space separated list of permissions to request.                                           | `openid profile email` |
 | `AUTH_<PROVIDER>_ISSUER_URL`                | OpenID `.well-known` discovery document URL of the external service.                              | --                     |
-| `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>.                                                       | `sub`<sup>[2]</sup>    |
+| `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>. Will default to `EMAIL_KEY`.                          | `sub`<sup>[2]</sup>    |
 | `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users.                                           | `false`                |
 | `AUTH_<PROVIDER>_REQUIRE_VERIFIED_EMAIL`    | Require created users to have a verified email address.                                           | `false`                |
 | `AUTH_<PROVIDER>_DEFAULT_ROLE_ID`           | A Directus role ID to assign created users.                                                       | --                     |
@@ -842,14 +842,16 @@ without a password.
 - Identity provider (IdP) authenticates users and provides to service providers an authentication assertion that
   indicates a user has been authenticated.
 
-| Variable                                    | Description                                                              | Default Value |
-| ------------------------------------------- | ------------------------------------------------------------------------ | ------------- |
-| `AUTH_<PROVIDER>_SP_metadata`               | String containing XML metadata for service provider                      | --            |
-| `AUTH_<PROVIDER>_IDP_metadata`              | String containing XML metadata for identity provider                     | --            |
-| `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users.                  | `false`       |
-| `AUTH_<PROVIDER>_DEFAULT_ROLE_ID`           | A Directus role ID to assign created users.                              | --            |
-| `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>. Will default to `EMAIL_KEY`. | --            |
-| `AUTH_<PROVIDER>_EMAIL_KEY`                 | User profile email key.                                                  | `email`       |
+| Variable                                    | Description                                             | Default Value                                                          |
+| ------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `AUTH_<PROVIDER>_SP_metadata`               | String containing XML metadata for service provider     | --                                                                     |
+| `AUTH_<PROVIDER>_IDP_metadata`              | String containing XML metadata for identity provider    | --                                                                     |
+| `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users. | `false`                                                                |
+| `AUTH_<PROVIDER>_DEFAULT_ROLE_ID`           | A Directus role ID to assign created users.             | --                                                                     |
+| `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>.             | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` |
+| `AUTH_<PROVIDER>_EMAIL_KEY`                 | User profile email key.                                 | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   |
+| `AUTH_<PROVIDER>_GIVEN_NAME_KEY`            | User first name attribute.                              | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`      |
+| `AUTH_<PROVIDER>_FAMILY_NAME_KEY`           | User last name attribute.                               | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`        |
 
 <sup>[1]</sup> When authenticating, Directus will match the identifier value from the external user profile to a
 Directus users "External Identifier".

--- a/docs/self-hosted/sso-examples.md
+++ b/docs/self-hosted/sso-examples.md
@@ -158,7 +158,7 @@ Twitter does not provide "email" so we define "username" as the identifier.
 
 ```
 AUTH_AWS_DRIVER="saml"
-AUTH_AWS_IDP_metadata="{Your IAM Identity Center SAML metadata file}""
+AUTH_AWS_IDP_metadata="{Your IAM Identity Center SAML metadata file}"
 AUTH_AWS_SP_metadata=""
 AUTH_AWS_ALLOW_PUBLIC_REGISTRATION="true"
 AUTH_AWS_DEFAULT_ROLE_ID="{Needs to be a valid role on the instance}"
@@ -189,14 +189,14 @@ Maps the email address into Directus as `external_identifier`:
 **Config:**
 
 - Relay state: `admin/login`
-- Application ACS URL: `https://your-directus-instance/auth/login/awssso/acs`
+- Application ACS URL: `https://your-directus-instance/auth/login/aws/acs`
 
 ### Google
 
 ```
 AUTH_GOOGLE_DRIVER="saml"
-AUTH_GOOGLE_IDP_metadata="{Your SAML metadata file from Google}""
-AUTH_GOOGLE_SP_metadata="{Create your own SAML metadata file, see example below}""
+AUTH_GOOGLE_IDP_metadata="{Your SAML metadata file from Google}"
+AUTH_GOOGLE_SP_metadata="{Create your own SAML metadata file, see example below}"
 AUTH_GOOGLE_ALLOW_PUBLIC_REGISTRATION="true"
 AUTH_GOOGLE_DEFAULT_ROLE_ID="{Needs to be a valid role on the instance}"
 AUTH_GOOGLE_IDENTIFIER_KEY="email"
@@ -207,7 +207,7 @@ AUTH_GOOGLE_EMAIL_KEY="email"
 
 - The `entityID` should be the same as the one configured in Google in the `EntityDescriptor` tag
 - The `Location` should be the ACS URL of your Directus instance in the format of
-  `https://your-directus-instance/auth/login/sso/acs`
+  `https://your-directus-instance/auth/login/google/acs`
 - Directus expects `<?xml version="1.0" encoding="UTF-8"?>` to be removed from the start of the XML.
 
 Example:
@@ -216,7 +216,7 @@ Example:
 <EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="SHOULD_MATCH_GOOGLE_CONFIG">
   <SPSSODescriptor WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
-    <AssertionConsumerService isDefault="true" index="0" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="YOUR_DOMAIN/auth/login/sso/acs"/>
+    <AssertionConsumerService isDefault="true" index="0" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="YOUR_DOMAIN/auth/login/google/acs"/>
   </SPSSODescriptor>
 </EntityDescriptor>
 ```


### PR DESCRIPTION
## Scope

What's changed:

- Fix a few inaccuracies in auth provider docs

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- The SAML defaults (and first/last name keys) feel strange, but changing them would be a breaking change, so for now just ensuring the docs are accurate