### PR TITLE
Truncate User-Agent to 1024 Chars and Migrate DB Column

### DIFF
--- a/.changeset/poor-garlics-behave.md
+++ b/.changeset/poor-garlics-behave.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed an issue where requests with long User-Agent headers could fail

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -422,7 +422,7 @@ export function createLDAPAuthRouter(provider: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent');
+			const userAgent = req.get('user-agent')?.substring(0, 1024);;
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -422,7 +422,7 @@ export function createLDAPAuthRouter(provider: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent')?.substring(0, 1024);;
+			const userAgent = req.get('user-agent')?.substring(0, 1024);
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/local.ts
+++ b/api/src/auth/drivers/local.ts
@@ -67,7 +67,7 @@ export function createLocalAuthRouter(provider: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent');
+			const userAgent = req.get('user-agent')?.substring(0, 1024);;
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/local.ts
+++ b/api/src/auth/drivers/local.ts
@@ -67,7 +67,7 @@ export function createLocalAuthRouter(provider: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent')?.substring(0, 1024);;
+			const userAgent = req.get('user-agent')?.substring(0, 1024);
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -357,7 +357,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent');
+			const userAgent = req.get('user-agent')?.substring(0, 1024);;
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -357,7 +357,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent')?.substring(0, 1024);;
+			const userAgent = req.get('user-agent')?.substring(0, 1024);
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -387,7 +387,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent')?.substring(0, 1024);;
+			const userAgent = req.get('user-agent')?.substring(0, 1024);
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -387,7 +387,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 				role: null,
 			};
 
-			const userAgent = req.get('user-agent');
+			const userAgent = req.get('user-agent')?.substring(0, 1024);;
 			if (userAgent) accountability.userAgent = userAgent;
 
 			const origin = req.get('origin');

--- a/api/src/controllers/activity.ts
+++ b/api/src/controllers/activity.ts
@@ -93,7 +93,7 @@ router.post(
 			action: Action.COMMENT,
 			user: req.accountability?.user,
 			ip: getIPFromReq(req),
-			user_agent: req.get('user-agent'),
+			user_agent: req.accountability?.userAgent,
 			origin: req.get('origin'),
 		});
 

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -106,7 +106,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent');
+		const userAgent = req.get('user-agent')?.substring(0, 1024);;
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');
@@ -160,7 +160,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent');
+		const userAgent = req.get('user-agent')?.substring(0, 1024);;
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');
@@ -207,7 +207,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent');
+		const userAgent = req.get('user-agent')?.substring(0, 1024);;
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');
@@ -246,7 +246,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent');
+		const userAgent = req.get('user-agent')?.substring(0, 1024);;
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -106,7 +106,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent')?.substring(0, 1024);;
+		const userAgent = req.get('user-agent')?.substring(0, 1024);
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');
@@ -160,7 +160,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent')?.substring(0, 1024);;
+		const userAgent = req.get('user-agent')?.substring(0, 1024);
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');
@@ -207,7 +207,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent')?.substring(0, 1024);;
+		const userAgent = req.get('user-agent')?.substring(0, 1024);
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');
@@ -246,7 +246,7 @@ router.post(
 			role: null,
 		};
 
-		const userAgent = req.get('user-agent')?.substring(0, 1024);;
+		const userAgent = req.get('user-agent')?.substring(0, 1024);
 		if (userAgent) accountability.userAgent = userAgent;
 
 		const origin = req.get('origin');

--- a/api/src/database/migrations/20240305A-change-useragent-type.ts
+++ b/api/src/database/migrations/20240305A-change-useragent-type.ts
@@ -1,8 +1,6 @@
 import type { Knex } from 'knex';
 import { getHelpers } from '../helpers/index.js';
 
-// sessions, activity
-
 export async function up(knex: Knex): Promise<void> {
 	const helper = getHelpers(knex).schema;
 

--- a/api/src/database/migrations/20240305A-change-useragent-type.ts
+++ b/api/src/database/migrations/20240305A-change-useragent-type.ts
@@ -11,12 +11,12 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-	const helper = await getHelpers(knex).schema
+	const helper = await getHelpers(knex).schema;
 
 	const opts = {
 		nullable: false,
 		length: 255,
-	}
+	};
 
 	await Promise.all([
 		helper.changeToType('directus_activity', 'user_agent', 'string', opts),

--- a/api/src/database/migrations/20240305A-change-useragent-type.ts
+++ b/api/src/database/migrations/20240305A-change-useragent-type.ts
@@ -1,0 +1,27 @@
+import type { Knex } from 'knex';
+import { getHelpers } from '../helpers/index.js';
+
+// sessions, activity
+
+export async function up(knex: Knex): Promise<void> {
+	const helper = getHelpers(knex).schema;
+
+	await Promise.all([
+		helper.changeToType('directus_activity', 'user_agent', 'text'),
+		helper.changeToType('directus_sessions', 'user_agent', 'text'),
+	]);
+}
+
+export async function down(knex: Knex): Promise<void> {
+	const helper = await getHelpers(knex).schema
+
+	const opts = {
+		nullable: false,
+		length: 255,
+	}
+
+	await Promise.all([
+		helper.changeToType('directus_activity', 'user_agent', 'string', opts),
+		helper.changeToType('directus_sessions', 'user_agent', 'string', opts),
+	]);
+}

--- a/api/src/middleware/authenticate.ts
+++ b/api/src/middleware/authenticate.ts
@@ -19,7 +19,7 @@ export const handler = async (req: Request, _res: Response, next: NextFunction) 
 		ip: getIPFromReq(req),
 	};
 
-	const userAgent = req.get('user-agent');
+	const userAgent = req.get('user-agent')?.substring(0, 1024);
 	if (userAgent) defaultAccountability.userAgent = userAgent;
 
 	const origin = req.get('origin');


### PR DESCRIPTION
## Scope

What's changed:

- Fixed Activity Controller using Request User-Agent instead of Accountabilities User-Agent
- Migrated the User-Agent column to a `TEXT` column instead of `VARCHAR`
- Added character limits to any place where the user-agent is extracted from request and put into accountability.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- This PR is different from the first PR where it added a 255 char limit on every place where the user-agent was _used_, and now puts a 1024 char limit on the root where User-Agent is extracted and put into accountability.

---

Fixes #19642
