### PR TITLE
Fix alignment of Marketplace extension metadata buttons

### DIFF
--- a/.changeset/short-oranges-sniff.md
+++ b/.changeset/short-oranges-sniff.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured the Marketplace extension metadata buttons are perfectly aligned

--- a/app/src/modules/settings/routes/marketplace/routes/extension/components/extension-metadata.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/extension/components/extension-metadata.vue
@@ -35,15 +35,14 @@ const maintainers = computed(() => {
 <template>
 	<div class="metadata">
 		<v-list class="list">
-			<div class="grid">
-				<ExtensionInstall class="install" :extension-id="extension.id" :version-id="latestVersion.id" />
+			<div class="grid buttons">
+				<ExtensionInstall :extension-id="extension.id" :version-id="latestVersion.id" />
 				<ExtensionMetadataAuthor
 					:id="latestVersion.publisher.id"
 					:verified="latestVersion.publisher.verified"
 					:username="latestVersion.publisher.username"
 					:github-name="latestVersion.publisher.github_name"
 					:github-avatar-url="latestVersion.publisher.github_avatar_url"
-					class="author"
 				/>
 
 				<ExtensionMetadataAuthor
@@ -54,7 +53,6 @@ const maintainers = computed(() => {
 					:username="maintainer.username"
 					:github-name="maintainer.github_name"
 					:github-avatar-url="maintainer.github_avatar_url"
-					class="author"
 				/>
 			</div>
 		</v-list>
@@ -92,10 +90,6 @@ const maintainers = computed(() => {
 }
 
 .grid {
-	.install {
-		margin-bottom: 8px !important;
-	}
-
 	@container metadata (width > 580px) {
 		--v-list-item-margin: 0;
 
@@ -107,19 +101,22 @@ const maintainers = computed(() => {
 			grid-column: 1 / span 2;
 			margin-block-start: 16px;
 		}
+	}
 
-		.install {
-			margin-bottom: 0 !important;
+	&.buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		@container metadata (width > 580px) {
+			display: grid;
+			gap: 8px 16px;
 		}
 	}
 }
 
 .divider {
 	margin: 16px 0;
-}
-
-.author {
-	margin-block-start: 8px;
 }
 
 .sparkline {


### PR DESCRIPTION
## Scope

What's changed:

- Ensured the Marketplace extension metadata buttons are perfectly aligned
- Changed some CSS


Before:
![issue](https://github.com/directus/directus/assets/78852214/0d5a1391-dd2f-47dd-865f-b055e9e69f75)


After:
![fix](https://github.com/directus/directus/assets/78852214/dfe80794-34d6-41a3-9c66-6d29b0c393ae)


## Potential Risks / Drawbacks

- nope

## Review Notes / Questions

- Just a small one

---

Fixes #21699
