### PR TITLE
Fix typed env defaults

### DIFF
--- a/.changeset/giant-clocks-hang.md
+++ b/.changeset/giant-clocks-hang.md
@@ -1,0 +1,5 @@
+---
+'@directus/env': patch
+---
+
+Cast env defaults that are typed

--- a/packages/env/src/lib/create-env.test.ts
+++ b/packages/env/src/lib/create-env.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { getConfigPath } from '../utils/get-config-path.js';
+import { getTypeFromMap } from '../utils/get-type-from-map.js';
 import { isDirectusVariable } from '../utils/is-directus-variable.js';
 import { isFileKey } from '../utils/is-file-key.js';
 import { readConfigurationFromProcess } from '../utils/read-configuration-from-process.js';
@@ -16,11 +17,13 @@ vi.mock('../utils/read-configuration-from-process.js');
 vi.mock('../utils/remove-file-suffix.js');
 vi.mock('./cast.js');
 vi.mock('./read-configuration-from-file.js');
+vi.mock('../utils/get-type-from-map.js');
 vi.mock('node:fs');
 
 vi.mock('../constants/defaults.js', () => ({
 	DEFAULTS: {
 		DEFAULT: 'test-default',
+		DEFAULT_ARRAY: 'one,two,three',
 	},
 }));
 
@@ -41,6 +44,30 @@ afterEach(() => {
 	vi.resetAllMocks();
 });
 
+test('Defaults that have a type set is casted', () => {
+	vi.mocked(getTypeFromMap).mockImplementation((key) => {
+		if (key === 'DEFAULT_ARRAY') return 'array';
+		return null;
+	});
+
+	vi.mocked(cast).mockImplementation((value, key) => {
+		if (key === 'DEFAULT_ARRAY') return String(value).split(',');
+		return value;
+	});
+
+	const env = createEnv();
+
+	expect(env).toEqual({
+		PROCESS: 'test-process',
+		FILE: 'test-file',
+		DEFAULT: 'test-default',
+		DEFAULT_ARRAY: ['one', 'two', 'three'],
+	});
+
+	expect(getTypeFromMap).toHaveBeenCalledTimes(2);
+	expect(cast).toHaveBeenCalledTimes(3);
+});
+
 test('Combines process/file based config with defaults', () => {
 	const env = createEnv();
 
@@ -48,6 +75,7 @@ test('Combines process/file based config with defaults', () => {
 		PROCESS: 'test-process',
 		FILE: 'test-file',
 		DEFAULT: 'test-default',
+		DEFAULT_ARRAY: 'one,two,three',
 	});
 });
 
@@ -84,6 +112,7 @@ test('Reads value from file if key is a file key', () => {
 		PROCESS: 'test-process',
 		TEST: 'file-contents',
 		DEFAULT: 'test-default',
+		DEFAULT_ARRAY: 'one,two,three',
 	});
 });
 
@@ -103,6 +132,7 @@ test('Passthrough file variables that are not Directus configuration flags', () 
 	expect(env).toEqual({
 		PROCESS: 'test-process',
 		DEFAULT: 'test-default',
+		DEFAULT_ARRAY: 'one,two,three',
 		TEST_FILE: './test/path',
 	});
 });
@@ -140,5 +170,6 @@ test('Casts regular values', () => {
 		PROCESS: 'cast-test-process',
 		FILE: 'cast-test-file',
 		DEFAULT: 'test-default',
+		DEFAULT_ARRAY: 'one,two,three',
 	});
 });

--- a/packages/env/src/lib/create-env.ts
+++ b/packages/env/src/lib/create-env.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { DEFAULTS } from '../constants/defaults.js';
 import type { Env } from '../types/env.js';
 import { getConfigPath } from '../utils/get-config-path.js';
+import { getTypeFromMap } from '../utils/get-type-from-map.js';
 import { isDirectusVariable } from '../utils/is-directus-variable.js';
 import { isFileKey } from '../utils/is-file-key.js';
 import { readConfigurationFromProcess } from '../utils/read-configuration-from-process.js';
@@ -17,6 +18,10 @@ export const createEnv = (): Env => {
 
 	const output: Env = {};
 
+	for (const [key, value] of Object.entries(DEFAULTS)) {
+		output[key] = getTypeFromMap(key) ? cast(value, key) : value;
+	}
+
 	for (let [key, value] of Object.entries(rawConfiguration)) {
 		if (isFileKey(key) && isDirectusVariable(key) && typeof value === 'string') {
 			try {
@@ -30,5 +35,5 @@ export const createEnv = (): Env => {
 		output[key] = cast(value, key);
 	}
 
-	return { ...DEFAULTS, ...output };
+	return output;
 };


### PR DESCRIPTION
## Issue

`CACHE_AUTO_PURGE_IGNORE_LIST` has a default value but it remains as a string value instead of an array.

https://github.com/directus/directus/blob/0032a03d34b0647cd482f40f22f180b6d793bc0e/packages/env/src/constants/defaults.ts#L64

https://github.com/directus/directus/blob/0032a03d34b0647cd482f40f22f180b6d793bc0e/packages/env/src/constants/type-map.ts#L20

## Scope

What's changed:

- Cast default env values that are typed in
https://github.com/directus/directus/blob/0032a03d34b0647cd482f40f22f180b6d793bc0e/packages/env/src/constants/type-map.ts#L7-L33

## Potential Risks / Drawbacks

- Uncertain if there is any negative effect on other default envs that are typed

---