### PR TITLE
Fix marketplace pagination

### DIFF
--- a/.changeset/dirty-hornets-yawn.md
+++ b/.changeset/dirty-hornets-yawn.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed issue that would cause the marketplace registry pagination to fail on certain pages

--- a/app/src/components/v-pagination.test.ts
+++ b/app/src/components/v-pagination.test.ts
@@ -25,6 +25,7 @@ test('Mount component', () => {
 test('length prop', async () => {
 	const wrapper = mount(VPagination, {
 		props: {
+			modelValue: 1,
 			length: 5,
 		},
 		global,
@@ -40,6 +41,7 @@ test('length prop', async () => {
 test('totalVisible prop', async () => {
 	const wrapper = mount(VPagination, {
 		props: {
+			modelValue: 1,
 			length: 5,
 			totalVisible: 3,
 		},

--- a/app/src/components/v-pagination.vue
+++ b/app/src/components/v-pagination.vue
@@ -1,35 +1,18 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-const props = defineProps({
-	/** Disables the pagination */
-	disabled: {
-		type: Boolean,
-		default: false,
-	},
-	/** The amount of pages to render */
-	length: {
-		type: Number,
-		required: true,
-		validator: Number.isInteger,
-	},
-	/** Specify the max total visible pagination numbers */
-	totalVisible: {
-		type: Number,
-		default: undefined,
-		validator: (val: number) => val >= 0,
-	},
+const props = defineProps<{
 	/** Currently selected page */
-	modelValue: {
-		type: Number,
-		default: null,
-	},
+	modelValue: number;
+	/** The amount of pages to render */
+	length: number;
+	/** Disables the pagination */
+	disabled?: boolean;
+	/** Specify the max total visible pagination numbers */
+	totalVisible?: number;
 	/** Show first/last buttons */
-	showFirstLast: {
-		type: Boolean,
-		default: false,
-	},
-});
+	showFirstLast?: boolean;
+}>();
 
 const emit = defineEmits(['update:modelValue']);
 

--- a/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
@@ -15,8 +15,11 @@ const { t } = useI18n();
 
 const perPage = 10;
 
+const page = useRouteQuery('page', 1, {
+	transform: (value) => Number(Array.isArray(value) ? value[0] : value) || 1,
+});
+
 const search = useRouteQuery('search');
-const page = useRouteQuery('page', 1);
 const type = useRouteQuery('type');
 const sort = useRouteQuery<'popular' | 'recent' | 'downloads'>('sort', 'popular');
 


### PR DESCRIPTION
Cherry-picked the pagination fix from https://github.com/directus/directus/pull/21691

## Scope

What's changed:

- Fixes pagination by casting the page query param to a number

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- This was Pascal's original work already reviewed by me.
