### PR TITLE
Display missing extensions

### DIFF
--- a/app/src/constants/extension-type-icon-map.ts
+++ b/app/src/constants/extension-type-icon-map.ts
@@ -1,6 +1,6 @@
 import type { ExtensionType } from '@directus/extensions';
 
-export const extensionTypeIconMap: Record<ExtensionType, string> = {
+export const extensionTypeIconMap: Record<ExtensionType | 'missing', string> = {
 	interface: 'design_services',
 	display: 'label',
 	layout: 'dataset',
@@ -11,4 +11,5 @@ export const extensionTypeIconMap: Record<ExtensionType, string> = {
 	endpoint: 'api',
 	operation: 'flowsheet',
 	bundle: 'hub',
+	missing: 'warning',
 };

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -80,6 +80,7 @@ extension_hooks: Hooks
 extension_endpoints: Endpoints
 extension_operations: Operations
 extension_bundles: Bundles
+extension_missing: Missing
 extension_reload_required: Page Reload Required
 extension_reload_required_copy: A page reload is required to see the changes after enabling or disabling app extensions.
 extension_reload_now: Reload now

--- a/app/src/modules/settings/routes/extensions/components/extension-group-divider.vue
+++ b/app/src/modules/settings/routes/extensions/components/extension-group-divider.vue
@@ -6,12 +6,12 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-	type: ExtensionType;
+	type: ExtensionType | 'missing';
 }>();
 
 const { t } = useI18n();
 
-const label = computed(() => t(`extension_${pluralize(props.type)}`));
+const label = computed(() => t(`extension_${props.type !== 'missing' ? pluralize(props.type) : props.type}`));
 
 const icon = computed(() => extensionTypeIconMap[props.type]);
 </script>

--- a/app/src/modules/settings/routes/extensions/extensions.vue
+++ b/app/src/modules/settings/routes/extensions/extensions.vue
@@ -16,8 +16,19 @@ const extensionsStore = useExtensionsStore();
 const { extensions, loading } = storeToRefs(extensionsStore);
 
 const bundled = computed(() => extensionsStore.extensions.filter(({ bundle }) => bundle !== null));
+
 const regular = computed(() => extensionsStore.extensions.filter(({ bundle }) => bundle === null));
-const extensionsByType = computed(() => groupBy(regular.value, 'schema.type'));
+
+const extensionsByType = computed(() => {
+	const groups = groupBy(regular.value, 'schema.type');
+
+	if ('undefined' in groups) {
+		groups['missing'] = groups['undefined'];
+		delete groups['undefined'];
+	}
+
+	return groups;
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Scope

What's changed:

- Correctly display missing (uninstalled) extensions
  <table><tr><td>
  <img width="1170" src="https://github.com/directus/directus/assets/5363448/72239aa9-4e44-4b65-8a37-de4c32549aed"></td></tr></table>

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Does it look good styling-wise?
