### PR TITLE
Fix unique constraint / alter statement issues in marketplace migration

### DIFF
--- a/.changeset/healthy-masks-hang.md
+++ b/.changeset/healthy-masks-hang.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Fixed issues with the marketplace migration script for MySQL/MariaDB, as well as for multiple bundle extensions having
+same sub-extension names


### PR DESCRIPTION
## Scope

What's changed:

- Fix unique constraint / alter statement issues in marketplace migration by storing `folder` in new column directly, instead of renaming the `name` column
- Fixed down script

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Reproduced issue first
- Tested & confirmed fix with:
  - SQLite
  - MariaDB
  - PostgreSQL

### Extensions Before Migration (with all DB vendors)

![Extensions · Directus](https://github.com/directus/directus/assets/5363448/fc9c654a-67f9-4743-9dd8-c125dd73586d)

### Extensions After Migration (with all DB vendors)

_Note: I didn't migrate/re-add the deprecated "test:interface" extension_

![Extensions · Directus](https://github.com/directus/directus/assets/5363448/856eb861-90aa-405a-ba4f-7db0b51e75ab)

---

Fixes #21710 
Fixes #21714
