### PR TITLE
Update docker guide docs to persist extensions volume

### DIFF
--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -106,8 +106,7 @@ services:
       - 8055:8055
     volumes:
       - ./uploads:/directus/uploads
-      # If you want to load extensions from the host
-      # - ./extensions:/directus/extensions
+      - ./extensions:/directus/extensions
     depends_on:
       - cache
       - database

--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -62,8 +62,8 @@ Save the file. Let's step through it:
 - This file defines a single Docker container that will use the specified version of the `directus/directus` image.
 - The `ports` list maps internal port `8055` is made available to our machine using the same port number, meaning we can
   access it from our computer's browser.
-- The`volumes` section maps internal `directus/database` and `directus/uploads` to our local file system alongside the
-  `docker-compose.yml` - meaning data is backed up outside of Docker containers.
+- The`volumes` section maps internal `database`, `uploads` and `extensions` data to our local file system alongside the
+  `docker-compose.yml` - meaning data is stored and persisted outside of Docker containers.
 - The `environment` section contains any [configuration variables](/self-hosted/config-options.html) we wish to set.
   - `KEY` and `SECRET` are required and should be long random values. `KEY` is used for telemetry and health tracking,
     and `SECRET` is used to sign access tokens.


### PR DESCRIPTION
## Scope

What's changed:

- Update the `docker-compose.yml` snippet in the Docker Guide to mount the `extensions` folder by default
- Since marketplace stores extensions in this folder, it should be persisted

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
