### PR TITLE
Fix headers type check in Sandbox SDK request function

### DIFF
--- a/.changeset/modern-keys-confess.md
+++ b/.changeset/modern-keys-confess.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed the type check for `headers` in the Sandbox SDK request function

--- a/api/src/extensions/lib/sandbox/sdk/generators/request.ts
+++ b/api/src/extensions/lib/sandbox/sdk/generators/request.ts
@@ -51,8 +51,8 @@ export function requestGenerator(requestedScopes: ExtensionSandboxRequestedScope
 			throw new TypeError('Request body has to be of type string or object');
 		}
 
-		if (headers !== undefined && headers.typeof !== 'undefined' && headers.typeof !== 'array') {
-			throw new TypeError('Request headers has to be of type array');
+		if (headers !== undefined && headers.typeof !== 'undefined' && headers.typeof !== 'object') {
+			throw new TypeError('Request headers has to be of type object');
 		}
 
 		const methodCopied = await method?.copy();


### PR DESCRIPTION
## Scope

What's changed:

- Fixes the type check for `headers` in the Sandbox SDK [Request](https://docs.directus.io/extensions/sandbox/sandbox-sdk.html#request) function, which should be an object instead of an array

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- The headers are passed down to `axios`, which expects an object - see for example https://github.com/axios/axios?tab=readme-ov-file#axioscreateconfig

<details><summary>Reproduction</summary>

`package.json`
```
{
  "name": "my-operation",
  "icon": "extension",
  "version": "1.0.0",
  "keywords": [
    "directus",
    "directus-extension",
    "directus-extension-operation"
  ],
  "type": "module",
  "files": [
    "dist"
  ],
  "directus:extension": {
    "type": "operation",
    "path": {
      "app": "dist/app.js",
      "api": "dist/api.js"
    },
    "source": {
      "app": "src/app.js",
      "api": "src/api.js"
    },
    "host": "^10.10.0",
    "sandbox": {
      "enabled": true,
      "requestedScopes": {
        "log": {},
        "request": {
          "methods": [
            "POST"
          ],
          "urls": [
            "https://example.com"
          ]
        }
      }
    }
  },
  "scripts": {
    "build": "directus-extension build",
    "dev": "directus-extension build -w --no-minify",
    "link": "directus-extension link"
  },
  "devDependencies": {
    "@directus/extensions-sdk": "11.0.1",
    "vue": "^3.4.21"
  }
}
```

`api.js`
```js
import { request } from "directus:api";

// before #21751
export default () => ({
  id: "custom",
  handler: async () => {
    const url = 'https://example.com';

    await request(url, {
      method: "POST",
      headers: {
        Authorization: 'Bearer example',
        "Content-Type": "application/json",
      },
      body: JSON.stringify({ test: 'test' }),
    });
  },
});

// after #21751
export default {
  id: "custom",
  handler: async () => {
    const url = 'https://example.com';

    await request(url, {
      method: "POST",
      headers: {
        Authorization: 'Bearer example',
        "Content-Type": "application/json",
      },
      body: JSON.stringify({ test: 'test' }),
    });
  },
};
```

</details>

---

Thanks to @phazonoverload for reporting!