### PR TITLE
Fix extensions sync issue when `EXTENSIONS_LOCATION` is set

### DIFF
--- a/.changeset/dry-crews-scream.md
+++ b/.changeset/dry-crews-scream.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that would cause the extensions folder sync from third party sources to fail if the sync request came
+from a secondary process

--- a/.changeset/dry-crews-scream.md
+++ b/.changeset/dry-crews-scream.md
@@ -1,5 +1,6 @@
 ---
 '@directus/api': patch
+'@directus/memory': patch
 ---
 
 Fixed an issue that would cause the extensions folder sync from third party sources to fail if the sync request came

--- a/api/src/extensions/lib/sync-extensions.ts
+++ b/api/src/extensions/lib/sync-extensions.ts
@@ -12,7 +12,12 @@ import { getStorage } from '../../storage/index.js';
 import { getExtensionsPath } from './get-extensions-path.js';
 import { SyncStatus, getSyncStatus, setSyncStatus } from './sync-status.js';
 
-export const syncExtensions = async (): Promise<void> => {
+export const syncExtensions = async (options?: { force: boolean }): Promise<void> => {
+	if (!options?.force) {
+		const isDone = (await getSyncStatus()) === SyncStatus.DONE;
+		if (isDone) return;
+	}
+
 	const env = useEnv();
 	const logger = useLogger();
 
@@ -29,10 +34,6 @@ export const syncExtensions = async (): Promise<void> => {
 	const message = `extensions-sync/${id}`;
 
 	if (isPrimaryProcess === false) {
-		const isDone = (await getSyncStatus()) === SyncStatus.DONE;
-
-		if (isDone) return;
-
 		logger.trace('Extensions already being synced to this machine from another process.');
 
 		/**

--- a/api/src/extensions/lib/sync-extensions.ts
+++ b/api/src/extensions/lib/sync-extensions.ts
@@ -34,54 +34,55 @@ export const syncExtensions = async (options?: { force: boolean }): Promise<void
 	if (currentProcessShouldHandleSync === false) {
 		logger.trace('Extensions already being synced to this machine from another process.');
 
-		/**
-		 * Wait until the process that called the lock publishes a message that the syncing is complete
-		 */
+		// Wait until the process that called the lock publishes a message that the syncing is complete
 		return new Promise((resolve) => {
 			messenger.subscribe(machineKey, () => resolve());
 		});
 	}
 
-	const extensionsPath = getExtensionsPath();
-	const storageExtensionsPath = env['EXTENSIONS_PATH'] as string;
+	try {
+		const extensionsPath = getExtensionsPath();
+		const storageExtensionsPath = env['EXTENSIONS_PATH'] as string;
 
-	if (await exists(extensionsPath)) {
-		// In case the FS still contains the cached extensions from a previous invocation. We have to
-		// clear them out to ensure the remote extensions folder remains the source of truth for all
-		// extensions that are loaded.
-		await rm(extensionsPath, { recursive: true, force: true });
+		if (await exists(extensionsPath)) {
+			// In case the FS still contains the cached extensions from a previous invocation. We have to
+			// clear them out to ensure the remote extensions folder remains the source of truth for all
+			// extensions that are loaded.
+			await rm(extensionsPath, { recursive: true, force: true });
+		}
+
+		// Ensure that the local extensions cache path exists
+		await mkdir(extensionsPath, { recursive: true });
+		await setSyncStatus(SyncStatus.SYNCING);
+
+		logger.trace('Syncing extensions from configured storage location...');
+
+		const storage = await getStorage();
+
+		const disk = storage.location(env['EXTENSIONS_LOCATION'] as string);
+
+		// Make sure we don't overload the file handles
+		const queue = new Queue({ concurrency: 1000 });
+
+		for await (const filepath of disk.list(storageExtensionsPath)) {
+			const readStream = await disk.read(filepath);
+
+			// We want files to be stored in the root of `$TEMP_PATH/extensions`, so gotta remove the
+			// extensions path on disk from the start of the file path
+			const destPath = join(extensionsPath, relative(resolve(sep, storageExtensionsPath), resolve(sep, filepath)));
+
+			// Ensure that the directory path exists
+			await mkdir(dirname(destPath), { recursive: true });
+
+			const writeStream = createWriteStream(destPath);
+
+			queue.add(() => pipeline(readStream, writeStream));
+		}
+
+		await queue.onIdle();
+		await setSyncStatus(SyncStatus.DONE);
+		messenger.publish(machineKey, { ready: true });
+	} finally {
+		await lock.delete(machineKey);
 	}
-
-	// Ensure that the local extensions cache path exists
-	await mkdir(extensionsPath, { recursive: true });
-	await setSyncStatus(SyncStatus.SYNCING);
-
-	logger.trace('Syncing extensions from configured storage location...');
-
-	const storage = await getStorage();
-
-	const disk = storage.location(env['EXTENSIONS_LOCATION'] as string);
-
-	// Make sure we don't overload the file handles
-	const queue = new Queue({ concurrency: 1000 });
-
-	for await (const filepath of disk.list(storageExtensionsPath)) {
-		const readStream = await disk.read(filepath);
-
-		// We want files to be stored in the root of `$TEMP_PATH/extensions`, so gotta remove the
-		// extensions path on disk from the start of the file path
-		const destPath = join(extensionsPath, relative(resolve(sep, storageExtensionsPath), resolve(sep, filepath)));
-
-		// Ensure that the directory path exists
-		await mkdir(dirname(destPath), { recursive: true });
-
-		const writeStream = createWriteStream(destPath);
-
-		queue.add(() => pipeline(readStream, writeStream));
-	}
-
-	await queue.onIdle();
-	await setSyncStatus(SyncStatus.DONE);
-	await lock.delete(machineKey);
-	messenger.publish(machineKey, { ready: true });
 };

--- a/api/src/extensions/lib/sync-extensions.ts
+++ b/api/src/extensions/lib/sync-extensions.ts
@@ -7,42 +7,43 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import Queue from 'p-queue';
 import { useBus } from '../../bus/index.js';
+import { useLock } from '../../lock/index.js';
 import { useLogger } from '../../logger.js';
 import { getStorage } from '../../storage/index.js';
 import { getExtensionsPath } from './get-extensions-path.js';
 import { SyncStatus, getSyncStatus, setSyncStatus } from './sync-status.js';
 
 export const syncExtensions = async (options?: { force: boolean }): Promise<void> => {
+	const lock = useLock();
+	const messenger = useBus();
+	const env = useEnv();
+	const logger = useLogger();
+
 	if (!options?.force) {
 		const isDone = (await getSyncStatus()) === SyncStatus.DONE;
 		if (isDone) return;
 	}
 
-	const env = useEnv();
-	const logger = useLogger();
+	const machineId = await mid.machineId();
+	const machineKey = `extensions-sync/${machineId}`;
 
-	const extensionsPath = getExtensionsPath();
-	const storageExtensionsPath = env['EXTENSIONS_PATH'] as string;
+	const processId = await lock.increment(machineKey);
 
-	const messenger = useBus();
+	const currentProcessShouldHandleSync = processId === 1;
 
-	const isPrimaryProcess =
-		String(process.env['NODE_APP_INSTANCE']) === '0' || process.env['NODE_APP_INSTANCE'] === undefined;
-
-	const id = await mid.machineId();
-
-	const message = `extensions-sync/${id}`;
-
-	if (isPrimaryProcess === false) {
+	if (currentProcessShouldHandleSync === false) {
 		logger.trace('Extensions already being synced to this machine from another process.');
 
 		/**
 		 * Wait until the process that called the lock publishes a message that the syncing is complete
 		 */
 		return new Promise((resolve) => {
-			messenger.subscribe(message, () => resolve());
+			messenger.subscribe(machineKey, () => resolve());
 		});
 	}
+
+	const extensionsPath = getExtensionsPath();
+	const storageExtensionsPath = env['EXTENSIONS_PATH'] as string;
 
 	if (await exists(extensionsPath)) {
 		// In case the FS still contains the cached extensions from a previous invocation. We have to
@@ -80,7 +81,7 @@ export const syncExtensions = async (options?: { force: boolean }): Promise<void
 	}
 
 	await queue.onIdle();
-
 	await setSyncStatus(SyncStatus.DONE);
-	messenger.publish(message, { ready: true });
+	await lock.delete(machineKey);
+	messenger.publish(machineKey, { ready: true });
 };

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -230,7 +230,7 @@ export class ExtensionManager {
 
 	public async uninstall(folder: string) {
 		await this.installationManager.uninstall(folder);
-		await this.reload();
+		await this.reload({ forceSync: true });
 		await this.messenger.publish(this.reloadChannel, { origin: this.processId });
 	}
 

--- a/api/src/lock/index.ts
+++ b/api/src/lock/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/use-lock.js';

--- a/api/src/lock/lib/use-lock.test.ts
+++ b/api/src/lock/lib/use-lock.test.ts
@@ -1,0 +1,65 @@
+import { createKv, type KvLocal, type KvRedis } from '@directus/memory';
+import type { Redis } from 'ioredis';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { redisConfigAvailable, useRedis } from '../../redis/index.js';
+import { _cache, useLock } from './use-lock.js';
+
+vi.mock('../../redis/index.js');
+vi.mock('@directus/memory');
+
+let mockLock: KvLocal | KvRedis;
+
+beforeEach(() => {
+	mockLock = {} as unknown as KvLocal;
+	vi.mocked(createKv).mockReturnValue(mockLock);
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+	_cache.lock = undefined;
+});
+
+test('Returns existing lock if exists', () => {
+	_cache.lock = mockLock;
+
+	const lock = useLock();
+
+	expect(lock).toBe(mockLock);
+});
+
+test('Creates Redis based lock if Redis configuration is available', () => {
+	const mockRedis = {} as unknown as Redis;
+	vi.mocked(redisConfigAvailable).mockReturnValue(true);
+	vi.mocked(useRedis).mockReturnValue(mockRedis);
+
+	useLock();
+
+	expect(createKv).toHaveBeenCalledWith({
+		type: 'redis',
+		redis: mockRedis,
+		namespace: 'directus:lock',
+	});
+
+	expect(_cache.lock).toBe(mockLock);
+});
+
+test('Creates Local lock if Redis configuration is unavailable', () => {
+	vi.mocked(redisConfigAvailable).mockReturnValue(false);
+
+	useLock();
+
+	expect(createKv).toHaveBeenCalledWith({
+		type: 'local',
+	});
+
+	expect(_cache.lock).toBe(mockLock);
+});
+
+test('Returns created lock', () => {
+	vi.mocked(redisConfigAvailable).mockReturnValue(false);
+
+	const lock = useLock();
+
+	expect(lock).toBe(_cache.lock);
+	expect(lock).toBe(mockLock);
+});

--- a/api/src/lock/lib/use-lock.ts
+++ b/api/src/lock/lib/use-lock.ts
@@ -1,0 +1,23 @@
+import { createKv, type Kv } from '@directus/memory';
+import { redisConfigAvailable, useRedis } from '../../redis/index.js';
+
+export const _cache: { lock: Kv | undefined } = {
+	lock: undefined,
+};
+
+/**
+ * Returns globally shared lock kv instance.
+ */
+export const useLock = () => {
+	if (_cache.lock) {
+		return _cache.lock;
+	}
+
+	if (redisConfigAvailable()) {
+		_cache.lock = createKv({ type: 'redis', redis: useRedis(), namespace: 'directus:lock' });
+	} else {
+		_cache.lock = createKv({ type: 'local' });
+	}
+
+	return _cache.lock;
+};

--- a/packages/memory/src/kv/types/class.ts
+++ b/packages/memory/src/kv/types/class.ts
@@ -36,7 +36,7 @@ export interface Kv {
 	 * @param [amount=1] Amount to increment. Defaults to 1
 	 * @returns Updated value
 	 */
-	increment(key: string, amount: number): Promise<number>;
+	increment(key: string, amount?: number): Promise<number>;
 
 	/**
 	 * Save the given value to the store if the given value is larger than the existing value


### PR DESCRIPTION
## Scope

There's an obscure bug where occasionally extensions stored in a non-local location (like an S3 bucket) aren't synced into the local machine. This is the case when you're running your container with more than 1 node process through pm2. When the second process instigates a reload, the sync hits the "if done return" check and stops. 

To solve this, instead of checking for primary pm2 process, the sync check will now happen based on the first process on the container that starts the sync. Secondly, I've moved the "if done return" check to apply to any process that hits the refresh, and added a dedicated `force` option that will skip the done check (for explicit reloads). This should mean that extensions aren't re-downloaded on process start (like a scaling or error event), but still reload when extensions have changed (f.e. when installing through the marketplace).

## Potential Risks / Drawbacks

- It overhauls how the syncing lock works for extensions, which could fail
- This is the first time using an increments lock based on the previously created `/memory` package, so there's some unknowns there as well.

## Review Notes / Questions

- Unlike the previously used "if value does not exist, then set it" type of locking, the `increments()` approach is atomic. Because Redis is single threaded, it's guaranteed that the won't ever return the same value, even if they're called at the same time.
- This one is a little tricky to test locally, as you have to make sure to use `pm2` to run at least 2 instances of the API, and rely on a storage location for extensions, like `minio`. 