### PR TITLE
Fix loading of Sandbox Operation Extensions

### DIFF
--- a/.changeset/chilly-pumpkins-sin.md
+++ b/.changeset/chilly-pumpkins-sin.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed loading of Sandbox Operation Extensions

--- a/api/src/extensions/lib/sandbox/generate-api-extensions-sandbox-entrypoint.ts
+++ b/api/src/extensions/lib/sandbox/generate-api-extensions-sandbox-entrypoint.ts
@@ -86,7 +86,7 @@ export function generateApiExtensionsSandboxEntrypoint(
 
 			const registerOperation = ${generateHostFunctionReference(index, ['id', 'handler'], { async: false })}
 
-			const operationConfig = extensionExport();
+			const operationConfig = extensionExport;
 
 			registerOperation(operationConfig.id, operationConfig.handler);
 		`;

--- a/docs/extensions/sandbox/register.md
+++ b/docs/extensions/sandbox/register.md
@@ -126,3 +126,23 @@ export default {
 ```
 
 The handler function receives the data payload of the current in-flight flow.
+
+### TypeScript
+
+You can import the `SandboxOperationConfig` type from `directus:api` to type the operation object:
+
+```ts
+/// <reference types="@directus/extensions/api.d.ts" />
+
+import { log } from "directus:api";
+import type { SandboxOperationConfig } from "directus:api";
+
+const operation: SandboxOperationConfig = {
+	id: 'custom',
+	handler: ({ text }) => {
+		log(text);
+	},
+};
+
+export default operation;
+```


### PR DESCRIPTION
## Scope

What's changed:

- The expected definition format for Sandbox Operation Extensions was a function while it should be an object instead
- See https://docs.directus.io/extensions/sandbox/register.html#operations and also aligns with https://docs.directus.io/extensions/operations.html#api-entrypoint

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Thanks to @phazonoverload for reporting!
