### PR TITLE
Ensure that v-list-items are displayed correctly throughout the app

### DIFF
--- a/.changeset/pretty-sheep-hammer.md
+++ b/.changeset/pretty-sheep-hammer.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensured that v-list-items are displayed correctly throughout the app
+Fixed the height of list items which do have thumbnails

--- a/.changeset/pretty-sheep-hammer.md
+++ b/.changeset/pretty-sheep-hammer.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that v-list-items are displayed correctly throughout the app

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -6,6 +6,8 @@ import { isEqual } from 'lodash';
 
 interface Props {
 	block?: boolean;
+	/** Makes the item height grow (if !!block) */
+	grow?: boolean;
 	/** Makes the item smaller */
 	dense?: boolean;
 	/** Where the item should link to */
@@ -36,6 +38,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
 	block: false,
+	grow: false,
 	dense: false,
 	to: '',
 	href: undefined,
@@ -116,6 +119,7 @@ function onClick(event: PointerEvent) {
 		class="v-list-item"
 		:class="{
 			active: isActiveRoute,
+			grow,
 			dense,
 			link: isLink,
 			disabled,
@@ -257,7 +261,7 @@ function onClick(event: PointerEvent) {
 		padding: var(--v-list-item-padding, var(--theme--form--field--input--padding));
 		position: relative;
 		display: flex;
-		min-height: var(--theme--form--field--input--height);
+		height: var(--theme--form--field--input--height);
 		margin: 0;
 		background-color: var(
 			--v-list-item-background-color,
@@ -304,6 +308,11 @@ function onClick(event: PointerEvent) {
 
 		& + & {
 			margin-top: var(--v-list-item-margin, 8px);
+		}
+
+		&.grow {
+			height: auto;
+			min-height: var(--theme--form--field--input--height);
 		}
 
 		&.dense {

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -6,7 +6,7 @@ import { isEqual } from 'lodash';
 
 interface Props {
 	block?: boolean;
-	/** Makes the item height grow (if !!block) */
+	/** Makes the item height grow, if 'block' is enabled */
 	grow?: boolean;
 	/** Makes the item smaller */
 	dense?: boolean;

--- a/app/src/modules/settings/routes/marketplace/components/extension-list-item.vue
+++ b/app/src/modules/settings/routes/marketplace/components/extension-list-item.vue
@@ -22,7 +22,7 @@ const chip = computed(() => t(`extension_${props.extension.type}`));
 </script>
 
 <template>
-	<v-list-item class="extension-list-item" block clickable :to="`/settings/marketplace/extension/${extension.id}`">
+	<v-list-item class="extension-list-item" block grow clickable :to="`/settings/marketplace/extension/${extension.id}`">
 		<div class="icon"><v-icon :name="icon" /></div>
 		<v-list-item-content>
 			<div class="name">


### PR DESCRIPTION
## Scope

What's changed:

- Set fixed height as default (`v-list-item`)
- Add a prop that allows to make the height grow (`v-list-item`)
- Applied the `grow` prop to the marketplace extension listing

Before

![issue](https://github.com/directus/directus/assets/78852214/1078955f-76c4-4f82-8c53-4ecac760b265)

After

![fix](https://github.com/directus/directus/assets/78852214/89e4a35a-cbde-462c-b1a3-d2868ec898f1)


## Potential Risks / Drawbacks

- At least it shouldn't make it worse

## Review Notes / Questions

- I guess you made that change because of the new extension listing in the marketplace, so this is the only place where I have added the `grow` prop
- Feel free to rename everything like you wish

---

Fixes #21755
