### PR TITLE
Fix extensions auto reloading

### DIFF
--- a/.changeset/soft-eyes-scream.md
+++ b/.changeset/soft-eyes-scream.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Ensured extension auto reload functionality works with all local extensions
+Ensured extensions auto reloading works for all local extensions

--- a/.changeset/soft-eyes-scream.md
+++ b/.changeset/soft-eyes-scream.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Ensured extension auto reload functionality works with all local extensions


### PR DESCRIPTION
## Scope

What's changed:

- Fix extensions auto reloading by updating the logic to respect the new extension layout & folder structure

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Watch all local extensions (extensions under extensions dir), excluding extensions installed via marketplace (`.registry` subfolder) 

---

Fixes #21745
