### PR TITLE
Enable extensions auto reloading in dev mode

### DIFF
--- a/.changeset/dirty-pears-dream.md
+++ b/.changeset/dirty-pears-dream.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Enabled usage of extensions auto reloading in dev mode (`NODE_ENV` set to `development`)

--- a/api/package.json
+++ b/api/package.json
@@ -60,7 +60,7 @@
 	"scripts": {
 		"build": "tsc --project tsconfig.prod.json && copyfiles \"src/**/*.{yaml,liquid}\" -u 1 dist",
 		"cli": "NODE_ENV=development SERVE_APP=false tsx src/cli/run.ts",
-		"dev": "NODE_ENV=development SERVE_APP=true tsx watch --clear-screen=false src/start.ts",
+		"dev": "NODE_ENV=development SERVE_APP=true tsx watch --ignore extensions --clear-screen=false src/start.ts",
 		"test": "vitest --watch=false"
 	},
 	"dependencies": {

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -20,7 +20,7 @@ import type {
 	ScheduleHandler,
 } from '@directus/types';
 import { isTypeIn, toBoolean } from '@directus/utils';
-import { getNodeEnv, pathToRelativeUrl, processId } from '@directus/utils/node';
+import { pathToRelativeUrl, processId } from '@directus/utils/node';
 import aliasDefault from '@rollup/plugin-alias';
 import nodeResolveDefault from '@rollup/plugin-node-resolve';
 import virtualDefault from '@rollup/plugin-virtual';
@@ -69,7 +69,7 @@ const env = useEnv();
 
 const defaultOptions: ExtensionManagerOptions = {
 	schedule: true,
-	watch: (env['EXTENSIONS_AUTO_RELOAD'] as boolean) && getNodeEnv() !== 'development',
+	watch: env['EXTENSIONS_AUTO_RELOAD'] as boolean,
 };
 
 export class ExtensionManager {


### PR DESCRIPTION
## Scope

What's changed:

- Allow extensions auto reloading in dev mode (`NODE_ENV=development`)

## Potential Risks / Drawbacks

None

## Review Notes / Questions

If for some reason a different extensions folder (than `/api/extensions`) has been configured locally in dev mode, a server restart is performed by `tsx` when an extension is updated, since only the known default can be ignored.
That's no big deal, just a bit heavier than an extensions reload only.

---

Fixes #21414
Fixes #17102
