### PR TITLE
Prevent error when reloading sandboxed extensions

### DIFF
--- a/.changeset/chatty-yaks-shake.md
+++ b/.changeset/chatty-yaks-shake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Prevented an error which could occur when sandboxed extensions are reloaded (for example via extensions auto reload)

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -547,7 +547,7 @@ export class ExtensionManager {
 		this.unregisterFunctionMap.set(extension.name, async () => {
 			await unregisterFunction();
 
-			isolate.dispose();
+			if (!isolate.isDisposed) isolate.dispose();
 		});
 	}
 


### PR DESCRIPTION
## Scope

What's changed:

- Prevent the following error which can occur when sandboxed extensions are reloaded (e.g. via extensions auto reload):
  ```
  [22:18:25.857] INFO: Extensions reloaded
  [22:18:25.857] INFO: Removed extensions: sandbox-hook
  /directus/api/src/extensions/manager.ts:559
  			isolate.dispose();
  			       ^
  Error: Isolate is already disposed
      at <anonymous> (/directus/api/src/extensions/manager.ts:559:12)
      at async Promise.all (index 0)
      at ExtensionManager.unregisterApiExtensions (/directus/api/src/extensions/manager.ts:912:3)
      at ExtensionManager.unload (/directus/api/src/extensions/manager.ts:278:3)
      at <anonymous> (/directus/api/src/extensions/manager.ts:310:5)
      at JobQueue.run (/directus/api/src/utils/job-queue.ts:26:4)
  Node.js v18.19.1
  ```

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- The isolate might already be garbage-collected at that point, so we need to check for that before calling `dispose`
