### PR TITLE
Reduce schedule for lock threads workflow to a daily basis

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -2,9 +2,7 @@ name: Lock Threads
 
 on:
   schedule:
-    - cron: '0 * * * *'
-    # Reduce to daily execution once initial backlog has been processed
-    # - cron: '30 2 * * *'
+    - cron: '30 2 * * *'
 
 permissions:
   issues: write


### PR DESCRIPTION
## Scope

What's changed:

- Reduce schedule for lock threads workflow to a daily basis, as older threads have been caught up in the meantime

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- 1h after stale issues workflow
