### PR TITLE
Return payload of sandboxed operation extensions

### DIFF
--- a/.changeset/perfect-stingrays-scream.md
+++ b/.changeset/perfect-stingrays-scream.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed sandboxed operation extensions to return the payload

--- a/api/src/extensions/lib/sandbox/register/operation.ts
+++ b/api/src/extensions/lib/sandbox/register/operation.ts
@@ -11,15 +11,15 @@ export function registerOperationGenerator() {
 
 	const registerOperation = (
 		id: Reference<string>,
-		cb: Reference<(data: Record<string, unknown>) => unknown | Promise<unknown> | void>,
+		cb: Reference<(options: Record<string, unknown>) => unknown | Promise<unknown> | void>,
 	) => {
 		if (id.typeof !== 'string') throw new TypeError('Operation config id has to be of type string');
 		if (cb.typeof !== 'function') throw new TypeError('Operation config handler has to be of type function');
 
 		const idCopied = id.copySync();
 
-		const handler: OperationHandler = async (payload) => {
-			const response = await callReference(cb, [payload]);
+		const handler: OperationHandler = async (options) => {
+			const response = await callReference(cb, [options]);
 
 			return response.copy();
 		};

--- a/api/src/extensions/lib/sandbox/register/operation.ts
+++ b/api/src/extensions/lib/sandbox/register/operation.ts
@@ -18,7 +18,11 @@ export function registerOperationGenerator() {
 
 		const idCopied = id.copySync();
 
-		const handler: OperationHandler = async (data) => callReference(cb, [data]);
+		const handler: OperationHandler = async (payload) => {
+			const response = await callReference(cb, [payload]);
+
+			return response.copy();
+		};
 
 		flowManager.addOperation(idCopied, handler);
 


### PR DESCRIPTION
## Scope

What's changed:

- The payload of sandboxed operation extensions wasn't handled, always resulting in an empty object
- This has been fixed by copying the result ref before returning

### Before

<img width="150" src="https://github.com/directus/directus/assets/5363448/4ded2adf-6200-430d-b003-0825216fb1c5">

### After

<img width="150" src="https://github.com/directus/directus/assets/5363448/297626f4-79db-4b82-8c99-f3418d7ed708">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Thanks @phazonoverload for reporting, thanks to @nickrum for helping out with the fix ❤️ 