### PR TITLE
Optimize error messages in docs newsletter form

### DIFF
--- a/docs/.vitepress/components/Newsletter.vue
+++ b/docs/.vitepress/components/Newsletter.vue
@@ -110,4 +110,9 @@ p {
 	font-size: 0.75rem;
 	margin-top: 0.5rem;
 }
+
+/* Hide main error message if mail field already has one */
+:deep(form:has(.hs-form-field .hs-error-msgs) .hs_error_rollup) {
+	display: none;
+}
 </style>


### PR DESCRIPTION
## Scope

What's changed:

Already noticed a few times now, so submitting a small & easy fix for this:
In the newsletter sign-up form in the docs, sometimes there are two error messages displayed at the same time about the field being empty. The main form error message makes little sense in this case, as the form only has one field.
Therefore, simply hiding the main form error message now, when the field itself already has one.

I think there are a few ways to trigger this state, while the simplest one being to press the subscribe button twice.

<img width="240" src="https://github.com/directus/directus/assets/5363448/e5fafb11-99c1-4291-bbd3-191fe2123fb4">

## Potential Risks / Drawbacks

Ensured the main form error message is only hidden if the field error message is present, so it would still be shown, if there should be an error with the sign-up request.

## Review Notes / Questions

None