### PR TITLE
Handle empty translations in translations test

### DIFF
--- a/app/src/lang/translations.test.ts
+++ b/app/src/lang/translations.test.ts
@@ -13,15 +13,31 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
-/**
- * Flatten nested objects to dot notations
- * Example input: { a: { b: 'b', c: 'c' }, d: 'd' }
- * Example output: { 'a.b': 'b', 'a.c': 'c', d: 'd' }
- */
-function flatten(item: Record<string, any> | string, path: string[] = []): Record<string, any> {
-	if (typeof item === 'string') return { [path.join('.')]: item };
-	return Object.entries(item).reduce((acc, [key, value]) => merge(acc, flatten(value, [...path, key])), {});
-}
+describe.each(locales)('Locale %s', async (locale) => {
+	const i18n = createI18n({ legacy: false, locale: locale });
+	const datefnsLocale = (await importDateLocale(locale))?.default;
+
+	const { isImported, translations } = await importLanguageFile(locale);
+	i18n.global.mergeLocaleMessage(locale, translations);
+	const messages = flatten((i18n.global.messages.value as Record<string, any>)[locale]);
+	const translationSet = Object.entries(messages);
+
+	test(`import ${locale} language file successfully`, () => {
+		expect(isImported).toBe(true);
+	});
+
+	test.each(translationSet)('%s', (key, value) => {
+		expect(value).toBeDefined();
+
+		const translation = i18n.global.t(key);
+		expect(consoleErrorSpy).not.toBeCalled();
+
+		if (key.startsWith('date-fns_')) {
+			const date = new Date();
+			expect(() => format(date, translation, datefnsLocale ? { locale: datefnsLocale } : {})).not.toThrow();
+		}
+	});
+});
 
 async function importLanguageFile(locale: string): Promise<{ isImported: boolean; translations: Record<string, any> }> {
 	try {
@@ -32,26 +48,14 @@ async function importLanguageFile(locale: string): Promise<{ isImported: boolean
 	}
 }
 
-describe.each(locales)('Locale %s', async (locale) => {
-	const i18n = createI18n({ legacy: false, locale: locale });
-	const datefnsLocale = (await importDateLocale(locale))?.default;
+/**
+ * Flatten nested objects to dot notations
+ * Example input: { a: { b: 'b', c: 'c' }, d: 'd' }
+ * Example output: { 'a.b': 'b', 'a.c': 'c', d: 'd' }
+ */
+function flatten(item: Record<string, any> | string | null, path: string[] = []): Record<string, any> {
+	if (!item) return { [path.join('.')]: undefined };
 
-	const { isImported, translations } = await importLanguageFile(locale);
-	i18n.global.mergeLocaleMessage(locale, translations);
-	const messages = flatten((i18n.global.messages.value as Record<string, any>)[locale]);
-	const translationKeys = Object.keys(messages);
-
-	test(`import ${locale} language file successfully`, () => {
-		expect(isImported).toBe(true);
-	});
-
-	test.each(translationKeys)('%s', (key) => {
-		i18n.global.t(key);
-		expect(consoleErrorSpy).not.toBeCalled();
-
-		if (key.startsWith('date-fns_')) {
-			const date = new Date();
-			expect(() => format(date, i18n.global.t(key), datefnsLocale ? { locale: datefnsLocale } : {})).not.toThrow();
-		}
-	});
-});
+	if (typeof item === 'string') return { [path.join('.')]: item };
+	return Object.entries(item).reduce((acc, [key, value]) => merge(acc, flatten(value, [...path, key])), {});
+}


### PR DESCRIPTION
## Scope

What's changed:

As seen in #21787, translations coming from Crowdin can be empty. Currently, the translations test throws an error with no further indication. This PR updates the test to handle such empty translations and allows the problem as well as the causing locale and key to be identified quickly.

### Before

<img width="499" alt="Screenshot 2024-03-10 at 14 56 04" src="https://github.com/directus/directus/assets/5363448/3e7e7bd8-f392-445d-8c21-8706865829c4">


### After
<img width="632" alt="Screenshot 2024-03-10 at 14 55 40" src="https://github.com/directus/directus/assets/5363448/ff604942-664e-45a2-99dd-5b23284dc54b">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Note: The empty translations in #21787 have been cleaned-up in the meantime.