### PR TITLE
Fix logout SDK auth composable to include auth mode

### DIFF
--- a/.changeset/nine-coins-pull.md
+++ b/.changeset/nine-coins-pull.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed logout SDK auth composable to include auth mode in request

--- a/sdk/src/auth/composable.ts
+++ b/sdk/src/auth/composable.ts
@@ -154,7 +154,7 @@ export const authentication = (mode: AuthenticationMode = 'cookie', config: Part
 					fetchOptions.credentials = authConfig.credentials;
 				}
 
-				const body: Record<string, any> = { mode };
+				const body: Record<string, string> = { mode };
 
 				if (mode === 'json' && authData?.refresh_token) {
 					body['refresh_token'] = authData.refresh_token;

--- a/sdk/src/auth/composable.ts
+++ b/sdk/src/auth/composable.ts
@@ -88,7 +88,7 @@ export const authentication = (mode: AuthenticationMode = 'cookie', config: Part
 					fetchOptions.credentials = authConfig.credentials;
 				}
 
-				const body: Record<string, any> = { mode };
+				const body: Record<string, string> = { mode };
 
 				if (mode === 'json' && authData?.refresh_token) {
 					body['refresh_token'] = authData.refresh_token;

--- a/sdk/src/auth/composable.ts
+++ b/sdk/src/auth/composable.ts
@@ -154,11 +154,13 @@ export const authentication = (mode: AuthenticationMode = 'cookie', config: Part
 					fetchOptions.credentials = authConfig.credentials;
 				}
 
+				const body: Record<string, any> = { mode };
+
 				if (mode === 'json' && authData?.refresh_token) {
-					fetchOptions.body = JSON.stringify({
-						refresh_token: authData.refresh_token,
-					});
+					body['refresh_token'] = authData.refresh_token;
 				}
+
+				fetchOptions.body = JSON.stringify(body);
 
 				const requestUrl = getRequestUrl(client.url, '/auth/logout');
 				await request(requestUrl.toString(), fetchOptions, client.globals.fetch);


### PR DESCRIPTION
## Scope

What's changed:

Fixes the logout SDK auth composable to include the auth mode in the request, required for the new `session` auth mode.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Applied same logic as in `refresh` composable:
https://github.com/directus/directus/blob/b3d04d695526644058f0d6fad5297f6c172de7d1/sdk/src/auth/composable.ts#L91-L97

---

Thanks to @tspvivek for spotting and reporting the issue!
