### PR TITLE
Use getAssetUrl() utility function for asset url resolving

### DIFF
--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useSystem } from '@/composables/use-system';
 import { useServerStore } from '@/stores/server';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { generateFavicon } from '@/utils/generate-favicon';
 import { useAppStore } from '@directus/stores';
 import { ThemeProvider } from '@directus/themes';
@@ -48,7 +49,7 @@ useHead({
 		let href: string;
 
 		if (serverStore.info?.project?.public_favicon) {
-			href = `/assets/${serverStore.info.project.public_favicon}`;
+			href = getAssetUrl(serverStore.info.project.public_favicon);
 		} else if (serverStore.info?.project?.project_color) {
 			href = generateFavicon(serverStore.info.project.project_color, !!serverStore.info.project.project_logo === false);
 		} else {

--- a/app/src/displays/file/file.vue
+++ b/app/src/displays/file/file.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { readableMimeType } from '@/utils/readable-mime-type';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { computed, ref } from 'vue';
 
 type File = {
@@ -27,9 +28,9 @@ const fileExtension = computed(() => {
 
 const imageThumbnail = computed(() => {
 	if (!props.value) return null;
-	if (props.value.type?.includes('svg')) return '/assets/' + props.value.id;
+	if (props.value.type?.includes('svg')) return getAssetUrl(props.value.id);
 	if (props.value.type?.includes('image') === false) return null;
-	return `/assets/${props.value.id}?key=system-small-cover`;
+	return getAssetUrl(`${props.value.id}?key=system-small-cover`);
 });
 </script>
 

--- a/app/src/displays/image/image.vue
+++ b/app/src/displays/image/image.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { computed, ref } from 'vue';
 
 type Image = {
@@ -16,7 +17,7 @@ const imageError = ref(false);
 
 const src = computed(() => {
 	if (props.value?.id === null || props.value?.id === undefined) return null;
-	return `/assets/${props.value.id}?key=system-small-cover`;
+	return getAssetUrl(`${props.value.id}?key=system-small-cover`);
 });
 </script>
 

--- a/app/src/displays/user/user.vue
+++ b/app/src/displays/user/user.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { userName } from '@/utils/user-name';
 import { User } from '@directus/types';
 import { computed } from 'vue';
@@ -18,7 +19,7 @@ const src = computed(() => {
 	if (props.value === null) return null;
 
 	if (props.value.avatar?.id) {
-		return `/assets/${props.value.avatar.id}?key=system-small-cover`;
+		return getAssetUrl(`${props.value.avatar.id}?key=system-small-cover`);
 	}
 
 	return null;

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -66,12 +66,12 @@ const src = computed(() => {
 	if (!image.value?.type) return null;
 
 	if (image.value.type.includes('svg')) {
-		return '/assets/' + image.value.id;
+		return getAssetUrl(image.value.id);
 	}
 
 	if (image.value.type.includes('image')) {
 		const fit = props.crop ? 'cover' : 'contain';
-		const url = `/assets/${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}`;
+		const url = getAssetUrl(`${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}&test=1`);
 		return url;
 	}
 

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -71,7 +71,7 @@ const src = computed(() => {
 
 	if (image.value.type.includes('image')) {
 		const fit = props.crop ? 'cover' : 'contain';
-		const url = getAssetUrl(`${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}&test=1`);
+		const url = getAssetUrl(`${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}`);
 		return url;
 	}
 

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -57,7 +57,7 @@ const fileExtension = computed(() => {
 
 const assetURL = computed(() => {
 	const id = typeof props.value === 'string' ? props.value : props.value?.id;
-	return '/assets/' + id;
+	return getAssetUrl(id);
 });
 
 const imageThumbnail = computed(() => {

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -8,7 +8,7 @@ import 'codemirror/mode/markdown/markdown';
 
 import { useShortcut } from '@/composables/use-shortcut';
 import { useWindowSize } from '@/composables/use-window-size';
-import { getPublicURL } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { percentage } from '@/utils/percentage';
 import { translateShortcut } from '@/utils/translate-shortcut';
 import { Alteration, CustomSyntax, applyEdit } from './edits';
@@ -183,7 +183,7 @@ useShortcut('meta+alt+6', () => edit('heading', { level: 6 }), markdownInterface
 function onImageUpload(image: any) {
 	if (!codemirror) return;
 
-	let url = getPublicURL() + `assets/` + image.id;
+	let url = getAssetUrl(image.id);
 
 	if (props.imageToken) {
 		url += '?access_token=' + props.imageToken;

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
@@ -57,7 +58,7 @@ const imageInfo = computed(() => {
 		key = 'system-medium-contain';
 	}
 
-	const source = `/assets/${props.file.id}?key=${key}&modified=${props.file.modified_on}`;
+	const source = getAssetUrl(`${props.file.id}?key=${key}&modified=${props.file.modified_on}`);
 
 	return { source, fileType };
 });

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -6,7 +6,7 @@ export default {
 
 <script setup lang="ts">
 import { getItemRoute } from '@/utils/get-route';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import type { Field } from '@directus/types';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -64,7 +64,7 @@ function parseAvatar(file: Record<string, any>) {
 	if (!file || !file.type) return;
 	if (file.type.startsWith('image') === false) return;
 
-	const url = getRootPath() + `assets/${file.id}?modified=${file.modified_on}&key=system-small-cover`;
+	const url = getAssetUrl(`${file.id}?modified=${file.modified_on}&key=system-small-cover`);
 	return url;
 }
 

--- a/app/src/modules/files/components/file-info-sidebar-detail.vue
+++ b/app/src/modules/files/components/file-info-sidebar-detail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import api from '@/api';
 import { formatFilesize } from '@/utils/format-filesize';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { localizedFormat } from '@/utils/localized-format';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { userName } from '@/utils/user-name';
@@ -28,7 +28,7 @@ const size = computed(() => {
 const fileLink = computed(() => {
 	if (!props.file?.id) return;
 
-	return `${getRootPath()}assets/${props.file.id}`;
+	return getAssetUrl(props.file.id);
 });
 
 const creationDate = computed(() => {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -7,6 +7,7 @@ import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { userName } from '@/utils/user-name';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
@@ -89,7 +90,7 @@ const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 const confirmDelete = ref(false);
 const confirmArchive = ref(false);
 
-const avatarSrc = computed(() => (item.value?.avatar ? `/assets/${item.value.avatar}?key=system-medium-cover` : null));
+const avatarSrc = computed(() => (item.value?.avatar ? getAssetUrl(`${item.value.avatar}?key=system-medium-cover`) : null));
 
 const avatarError = ref(null);
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -90,7 +90,9 @@ const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 const confirmDelete = ref(false);
 const confirmArchive = ref(false);
 
-const avatarSrc = computed(() => (item.value?.avatar ? getAssetUrl(`${item.value.avatar}?key=system-medium-cover`) : null));
+const avatarSrc = computed(() =>
+	item.value?.avatar ? getAssetUrl(`${item.value.avatar}?key=system-medium-cover`) : null,
+);
 
 const avatarError = ref(null);
 

--- a/app/src/views/private/components/comment-input.vue
+++ b/app/src/views/private/components/comment-input.vue
@@ -2,6 +2,7 @@
 import api from '@/api';
 import { useShortcut } from '@/composables/use-shortcut';
 import { Activity } from '@/types/activity';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { md } from '@/utils/md';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -218,7 +219,7 @@ function triggerSearch({ searchQuery, caretPosition }: { searchQuery: string; ca
 
 function avatarSource(url: string) {
 	if (url === null) return '';
-	return `/assets/${url}?key=system-small-cover`;
+	return getAssetUrl(`${url}?key=system-small-cover`);
 }
 
 async function postComment() {

--- a/app/src/views/private/components/comment-item-header.vue
+++ b/app/src/views/private/components/comment-item-header.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import api from '@/api';
 import { Activity } from '@/types/activity';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { userName } from '@/utils/user-name';
 import type { User } from '@directus/types';
@@ -32,7 +33,7 @@ const formattedTime = computed(() => {
 const avatarSource = computed(() => {
 	if (!props.activity.user?.avatar) return null;
 
-	return `/assets/${props.activity.user.avatar.id}?key=system-small-cover`;
+	return getAssetUrl(`${props.activity.user.avatar.id}?key=system-small-cover`);
 });
 
 const { confirmDelete, deleting, remove } = useDelete();

--- a/app/src/views/private/components/file-preview.vue
+++ b/app/src/views/private/components/file-preview.vue
@@ -18,9 +18,8 @@ defineEmits<{
 
 const file = toRef(props, 'file');
 
-const src = computed(
-	() =>
-		getAssetUrl(`${file.value.id}?cache-buster=${file.value.modified_on}${props.preset ? `&key=${props.preset}` : ''}`),
+const src = computed(() =>
+	getAssetUrl(`${file.value.id}?cache-buster=${file.value.modified_on}${props.preset ? `&key=${props.preset}` : ''}`),
 );
 
 const type = computed<'image' | 'video' | 'audio' | string>(() => {

--- a/app/src/views/private/components/file-preview.vue
+++ b/app/src/views/private/components/file-preview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import type { File } from '@directus/types';
 import { computed, toRef } from 'vue';
@@ -20,8 +20,7 @@ const file = toRef(props, 'file');
 
 const src = computed(
 	() =>
-		getRootPath() +
-		`assets/${file.value.id}?cache-buster=${file.value.modified_on}${props.preset ? `&key=${props.preset}` : ''}`,
+		getAssetUrl(`${file.value.id}?cache-buster=${file.value.modified_on}${props.preset ? `&key=${props.preset}` : ''}`),
 );
 
 const type = computed<'image' | 'video' | 'audio' | string>(() => {

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import api from '@/api';
 import { useSettingsStore } from '@/stores/settings';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { unexpectedError } from '@/utils/unexpected-error';
 import type { File } from '@directus/types';
 import Cropper from 'cropperjs';
@@ -81,7 +81,7 @@ watch(internalActive, (isActive) => {
 const randomId = ref<string>(nanoid());
 
 const imageURL = computed(() => {
-	return `${getRootPath()}assets/${props.id}?${randomId.value}`;
+	return getAssetUrl(`${props.id}?${randomId.value}`);
 });
 
 const dimensionsString = computed(() => {

--- a/app/src/views/private/components/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { useAppStore } from '@directus/stores';
 import { User } from '@directus/types';
 import { storeToRefs } from 'pinia';
@@ -22,7 +22,7 @@ const signOutActive = ref(false);
 
 const avatarURL = computed<string | null>(() => {
 	if (!userStore.currentUser || !('avatar' in userStore.currentUser) || !userStore.currentUser?.avatar) return null;
-	return `${getRootPath()}assets/${userStore.currentUser.avatar.id}?key=system-medium-cover`;
+	return getAssetUrl(`${userStore.currentUser.avatar.id}?key=system-medium-cover`);
 });
 
 const avatarError = ref<null | Event>(null);

--- a/app/src/views/private/components/module-bar-logo.vue
+++ b/app/src/views/private/components/module-bar-logo.vue
@@ -3,7 +3,7 @@ import { useRequestsStore } from '@/stores/requests';
 import { useSettingsStore } from '@/stores/settings';
 import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 
 const { t } = useI18n();
 
@@ -13,7 +13,7 @@ const settingsStore = useSettingsStore();
 const customLogoPath = computed<string | null>(() => {
 	if (settingsStore.settings === null) return null;
 	if (!settingsStore.settings?.project_logo) return null;
-	return `${getRootPath()}assets/${settingsStore.settings.project_logo}`;
+	return getAssetUrl(`${settingsStore.settings.project_logo}`);
 });
 
 const showLoader = ref(false);

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import api from '@/api';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { userName } from '@/utils/user-name';
 import { User } from '@directus/types';
 import { computed, onUnmounted, ref, watch } from 'vue';
@@ -22,7 +23,7 @@ const avatarSrc = computed(() => {
 	if (data.value === null) return null;
 
 	if (data.value.avatar?.id) {
-		return `/assets/${data.value.avatar.id}?key=system-medium-cover`;
+		return getAssetUrl(`${data.value.avatar.id}?key=system-medium-cover`);
 	}
 
 	return null;

--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useServerStore } from '@/stores/server';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -23,7 +23,7 @@ const hasCustomBackground = computed(() => {
 });
 
 const customBackgroundIsVideo = computed(() => info.value?.project?.public_background?.type?.startsWith('video/'));
-const customBackgroundUrl = computed(() => getRootPath() + `assets/${info.value!.project?.public_background?.id}`);
+const customBackgroundUrl = computed(() => getAssetUrl(info.value?.project?.public_background?.id ?? ''));
 
 const artStyles = computed(() => {
 	if (!hasCustomBackground.value) return {};
@@ -37,12 +37,12 @@ const artStyles = computed(() => {
 
 const foregroundURL = computed(() => {
 	if (!info.value?.project?.public_foreground) return null;
-	return '/assets/' + info.value.project?.public_foreground;
+	return getAssetUrl(info.value.project?.public_foreground);
 });
 
 const logoURL = computed<string | null>(() => {
 	if (!info.value?.project?.project_logo) return null;
-	return '/assets/' + info.value.project?.project_logo;
+	return getAssetUrl(info.value.project?.project_logo);
 });
 </script>
 

--- a/app/src/views/shared/shared-view.vue
+++ b/app/src/views/shared/shared-view.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useServerStore } from '@/stores/server';
-import { getRootPath } from '@/utils/get-root-path';
+import { getAssetUrl } from '@/utils/get-asset-url';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -18,7 +18,7 @@ const { t } = useI18n();
 
 const logoURL = computed<string | null>(() => {
 	if (!serverStore.info?.project?.project_logo) return null;
-	return getRootPath() + `assets/${serverStore.info.project?.project_logo}`;
+	return getAssetUrl(serverStore.info.project?.project_logo);
 });
 </script>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -117,3 +117,4 @@
 - appy-one
 - fanmingfei
 - Joehoel
+- girtskokars


### PR DESCRIPTION
## Scope

What's changed:

- Use `getAssetUrl()` utility function instead of hardcoded path to assets.

## Potential Risks / Drawbacks

- None that I can think of

## Review Notes / Questions

- The original idea was to centralize asset resolution logic within the `v-image` component, but considering its (potential) use in other areas, I believe utilizing a utility function is a better approach as it also makes the code more explicit.

---

Fixes #21815
