### PR TITLE
Add scope in gql schema cache key

### DIFF
--- a/.changeset/tame-grapes-mix.md
+++ b/.changeset/tame-grapes-mix.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that could cause the graphql system endpoint to use the wrong schema

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -178,7 +178,7 @@ export class GraphQLService {
 	getSchema(type: 'schema'): GraphQLSchema;
 	getSchema(type: 'sdl'): GraphQLSchema | string;
 	getSchema(type: 'schema' | 'sdl' = 'schema'): GraphQLSchema | string {
-		const key = `${type}_${this.accountability?.role}_${this.accountability?.user}`;
+		const key = `${this.scope}_${type}_${this.accountability?.role}_${this.accountability?.user}`;
 
 		const cachedSchema = cache.get(key);
 


### PR DESCRIPTION
## Scope

What's changed:

- Include the system v user scope in schema cache key

## Potential Risks / Drawbacks

- Can't think of any

## Review Notes / Questions

- —

---

Fixes #21820
