### PR TITLE
Improve schema retrieval by caching the schema cache creation

### DIFF
--- a/.changeset/shaggy-pens-try.md
+++ b/.changeset/shaggy-pens-try.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved schema retrieval performance by locking the generation of the cached value

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -128,7 +128,7 @@ export async function getSystemCache(key: string): Promise<Record<string, any>> 
 
 export async function setSchemaCache(schema: SchemaOverview): Promise<void> {
 	const { localSchemaCache, sharedSchemaCache } = getCache();
-	const schemaHash = await getSimpleHash(JSON.stringify(schema));
+	const schemaHash = getSimpleHash(JSON.stringify(schema));
 
 	await sharedSchemaCache.set('hash', schemaHash);
 

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -68,8 +68,8 @@ export async function getSchema(options?: {
 		await setSchemaCache(schema);
 		return schema;
 	} finally {
-		bus.publish(messageKey, { ready: true });
 		await lock.delete(lockKey);
+		bus.publish(messageKey, { ready: true });
 	}
 }
 

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -66,9 +66,9 @@ export async function getSchema(options?: {
 	try {
 		const schema = await getDatabaseSchema(database, schemaInspector);
 		await setSchemaCache(schema);
-		bus.publish(messageKey, { ready: true });
 		return schema;
 	} finally {
+		bus.publish(messageKey, { ready: true });
 		await lock.delete(lockKey);
 	}
 }

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -31,7 +31,7 @@ export async function getSchema(
 	},
 	attempt = 0,
 ): Promise<SchemaOverview> {
-	const MAX_ATTEMPTS = 5;
+	const MAX_ATTEMPTS = 3;
 
 	const env = useEnv();
 

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -53,7 +53,7 @@ export async function getSchema(options?: {
 	const currentProcessShouldHandleOperation = processId === 1;
 
 	if (currentProcessShouldHandleOperation === false) {
-		logger.trace('Schema cache is prepared elsewhere, waiting for result.');
+		logger.trace('Schema cache is prepared in another process, waiting for result.');
 
 		return new Promise((resolve) => {
 			bus.subscribe(messageKey, async () => {

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -30,10 +30,10 @@ export async function getSchema(options?: {
 }): Promise<SchemaOverview> {
 	const env = useEnv();
 
-	const database = options?.database || getDatabase();
-	const schemaInspector = createInspector(database);
-
 	if (options?.bypassCache || env['CACHE_SCHEMA'] === false) {
+		const database = options?.database || getDatabase();
+		const schemaInspector = createInspector(database);
+
 		return await getDatabaseSchema(database, schemaInspector);
 	}
 
@@ -67,6 +67,9 @@ export async function getSchema(options?: {
 	}
 
 	try {
+		const database = options?.database || getDatabase();
+		const schemaInspector = createInspector(database);
+
 		const schema = await getDatabaseSchema(database, schemaInspector);
 		await setSchemaCache(schema);
 		return schema;

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -56,10 +56,13 @@ export async function getSchema(options?: {
 		logger.trace('Schema cache is prepared in another process, waiting for result.');
 
 		return new Promise((resolve) => {
-			bus.subscribe(messageKey, async () => {
+			const callback = async () => {
 				const schema = await getSchema(options);
 				resolve(schema);
-			});
+				bus.unsubscribe(messageKey, callback);
+			};
+
+			bus.subscribe(messageKey, callback);
 		});
 	}
 

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -67,7 +67,11 @@ export async function getSchema(
 		return new Promise((resolve) => {
 			const TIMEOUT = 10000;
 
+			let timeout: NodeJS.Timeout;
+
 			const callback = async () => {
+				if (timeout) clearTimeout(timeout);
+
 				const schema = await getSchema(options, attempt + 1);
 				resolve(schema);
 				bus.unsubscribe(messageKey, callback);
@@ -75,12 +79,9 @@ export async function getSchema(
 
 			bus.subscribe(messageKey, callback);
 
-			setTimeout(async () => {
+			timeout = setTimeout(async () => {
 				logger.trace('Did not receive schema callback message in time. Pulling schema...');
-				bus.unsubscribe(messageKey, callback);
-
-				const schema = await getSchema(options, attempt + 1);
-				resolve(schema);
+				callback();
 			}, TIMEOUT);
 		});
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Process lock the schema generation call

This will prevent multiple processes from trying to read / generate the schema object simultaneously, in turn drastically reducing the resources needed when making schema modifications under heavy load

## Potential Risks / Drawbacks

- There's currently no timeout on the message waiting. If for whatever reason the process doesn't receive the subscribed message, it can theoretically hang forever.
- The message handler recursively calls `getSchema` again with the assumption it will now grab the cached schema. If the schema was invalidated in the meantime, the intention is that it will then become the first new process to hit it. That being said.. It feels like a potential infinite loop in the making.

## Review Notes / Questions

- I'd love some additional ideas on 'problem-prevention' when it comes to the infinite loop possibility above and potentially some sort of timeout in case all else fails.

---

Fixes #21823
