### PR TITLE
Add missing page titles

### DIFF
--- a/.changeset/chilly-needles-trade.md
+++ b/.changeset/chilly-needles-trade.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixes issue where public pages didn't have the correct tab titles

--- a/app/src/routes/accept-invite.vue
+++ b/app/src/routes/accept-invite.vue
@@ -50,7 +50,7 @@ async function onSubmit() {
 }
 
 useHead({
-	title: t('invite'),
+	title: t('create_account'),
 });
 </script>
 

--- a/app/src/routes/accept-invite.vue
+++ b/app/src/routes/accept-invite.vue
@@ -2,6 +2,7 @@
 import api, { RequestError } from '@/api';
 import { translateAPIError } from '@/lang';
 import { jwtPayload } from '@/utils/jwt-payload';
+import { useHead } from '@unhead/vue';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
@@ -47,6 +48,10 @@ async function onSubmit() {
 		creating.value = false;
 	}
 }
+
+useHead({
+	title: t('invite'),
+});
 </script>
 
 <template>

--- a/app/src/routes/login/login.vue
+++ b/app/src/routes/login/login.vue
@@ -8,6 +8,7 @@ import { useI18n } from 'vue-i18n';
 import ContinueAs from './components/continue-as.vue';
 import { LdapForm, LoginForm } from './components/login-form/';
 import SsoLinks from './components/sso-links.vue';
+import { useHead } from '@unhead/vue';
 
 withDefaults(
 	defineProps<{
@@ -38,6 +39,10 @@ const providerSelect = computed({
 });
 
 const authenticated = computed(() => appStore.authenticated);
+
+useHead({
+	title: t('sign_in'),
+});
 </script>
 
 <template>

--- a/app/src/routes/private-not-found.vue
+++ b/app/src/routes/private-not-found.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
+import { useHead } from '@unhead/vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
+
+useHead({
+	title: t('page_not_found'),
+});
 </script>
 
 <template>

--- a/app/src/routes/reset-password/request.vue
+++ b/app/src/routes/reset-password/request.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import api, { RequestError } from '@/api';
 import { translateAPIError } from '@/lang';
+import { useHead } from '@unhead/vue';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -38,6 +39,10 @@ async function onSubmit() {
 		sending.value = false;
 	}
 }
+
+useHead({
+	title: t('reset_password'),
+});
 </script>
 
 <template>

--- a/app/src/routes/reset-password/reset-password.vue
+++ b/app/src/routes/reset-password/reset-password.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useHead } from '@unhead/vue';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
@@ -10,6 +11,10 @@ const { t } = useI18n();
 const route = useRoute();
 
 const resetToken = computed(() => (Array.isArray(route.query.token) ? route.query.token[0] : route.query.token));
+
+useHead({
+	title: t('reset_password'),
+});
 </script>
 
 <template>

--- a/app/src/routes/reset-password/reset.vue
+++ b/app/src/routes/reset-password/reset.vue
@@ -2,6 +2,7 @@
 import api, { RequestError } from '@/api';
 import { translateAPIError } from '@/lang';
 import { jwtPayload } from '@/utils/jwt-payload';
+import { useHead } from '@unhead/vue';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -46,6 +47,10 @@ async function onSubmit() {
 		resetting.value = false;
 	}
 }
+
+useHead({
+	title: t('reset_password'),
+});
 </script>
 
 <template>

--- a/app/src/routes/shared/shared.vue
+++ b/app/src/routes/shared/shared.vue
@@ -134,9 +134,7 @@ async function authenticate() {
 	}
 }
 
-useHead({
-	title: title,
-});
+useHead({ title });
 </script>
 
 <template>

--- a/app/src/routes/shared/shared.vue
+++ b/app/src/routes/shared/shared.vue
@@ -6,6 +6,7 @@ import { getItemRoute } from '@/utils/get-route';
 import { useCollection } from '@directus/composables';
 import { useAppStore } from '@directus/stores';
 import { Share } from '@directus/types';
+import { useHead } from '@unhead/vue';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -132,6 +133,10 @@ async function authenticate() {
 		authenticating.value = false;
 	}
 }
+
+useHead({
+	title: title,
+});
 </script>
 
 <template>

--- a/app/src/routes/tfa-setup.vue
+++ b/app/src/routes/tfa-setup.vue
@@ -4,6 +4,7 @@ import { router } from '@/router';
 import { useUserStore } from '@/stores/user';
 import { useAppStore } from '@directus/stores';
 import { User } from '@directus/types';
+import { useHead } from '@unhead/vue';
 import { nextTick, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -42,6 +43,10 @@ async function enable() {
 		(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
 	}
 }
+
+useHead({
+	title: t('tfa_setup'),
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Scope

What's changed:

- Adds `title` through `useHead` on pages that didn't have it yet

## Potential Risks / Drawbacks

- Breaking / displaying a wrong tab title here and there. Low risk

## Review Notes / Questions

- 5 sec fix, 5 sec review hopefully 🙏🏻 

---

Fixes #21469
