### PR TITLE
Fix content module warnings

### DIFF
--- a/app/src/components/use-datetime.vue
+++ b/app/src/components/use-datetime.vue
@@ -16,6 +16,8 @@ export interface Props {
 	suffix?: boolean;
 }
 
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(defineProps<Props>(), {
 	format: 'long',
 	relative: false,

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -8,7 +8,7 @@ import { useI18n } from 'vue-i18n';
 const props = withDefaults(
 	defineProps<{
 		modelValue: string | null;
-		showFilter: boolean;
+		showFilter?: boolean;
 		collection?: string;
 		filter?: Filter | null;
 	}>(),


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Fixes the following warnings in the content module

```html
main.ts:53 
[Vue warn]: Missing required prop: "showFilter" 
  at <SearchInput modelValue=null onUpdate:modelValue=fn filter=null  ... > 
  at <HeaderBarActions show-sidebar-toggle=true onToggle:sidebar=fn > 

use-datetime.vue?t=1710341448641:118 
[Vue warn]: Extraneous non-props attributes (interface, interface-options, collection, field) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. 
  at <UseDatetime value="2024-03-27T12:00:00" type="dateTime" format="long"  ... > 
  at <Datetime interface="datetime" interface-options=null value="2024-03-27T12:00:00"  ... > 
```

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I would like to lorem ipsum
