### PR TITLE
Fix search filter input & border state

### DIFF
--- a/.changeset/real-spiders-destroy.md
+++ b/.changeset/real-spiders-destroy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the search filter to show the input in collapsed state and use the correct border color in expanded state

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -142,7 +142,7 @@ function emitValue() {
 				/>
 
 				<transition-expand @before-enter="filterBorder = true" @after-leave="filterBorder = false">
-					<div v-show="filterActive" ref="filterElement" class="filter">
+					<div v-show="filterActive" ref="filterElement" class="filter" :class="{ active }">
 						<interface-system-filter
 							class="filter-input"
 							inline
@@ -222,6 +222,10 @@ function emitValue() {
 
 		.icon-filter {
 			margin-left: 0;
+		}
+
+		input {
+			opacity: 1;
 		}
 	}
 
@@ -318,6 +322,10 @@ function emitValue() {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 22px;
 	border-bottom-left-radius: 22px;
+
+	&.active {
+		border-color: var(--theme--form--field--input--border-color-focus);
+	}
 }
 
 .filter-input {


### PR DESCRIPTION
## Scope

- Show the input if the search filter is not active but has content (collapsed state)
- Use the same border color for filter box if the search filter is in active state

https://github.com/directus/directus/assets/5363448/907719c4-ae0c-4974-abe7-f1e099cb1703

https://github.com/directus/directus/assets/5363448/54889360-65ab-41ff-b9ac-5ca16b0d28cb

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #21838