### PR TITLE
Fix styling issues with the related-values display

### DIFF
--- a/.changeset/hip-jeans-fix.md
+++ b/.changeset/hip-jeans-fix.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed styling issues with the related-values display

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -320,10 +320,7 @@ function onClick(event: PointerEvent) {
 
 		&.dense {
 			--theme--form--field--input--height: 44px;
-			padding: var(
-				--v-list-item-padding,
-				calc(var(--theme--form--field--input--padding) / 4) calc(var(--theme--form--field--input--padding) / 2)
-			);
+			padding: calc(var(--theme--form--field--input--padding) / 4) calc(var(--theme--form--field--input--padding) / 2);
 
 			& + & {
 				margin-top: var(--v-list-item-margin, 4px);

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -258,7 +258,7 @@ function onClick(event: PointerEvent) {
 	&.block {
 		--v-icon-color: var(--v-icon-color, var(--theme--foreground-subdued));
 
-		padding: var(--v-list-item-padding, var(--theme--form--field--input--padding));
+		padding: var(--v-list-item-padding, 8px var(--theme--form--field--input--padding));
 		position: relative;
 		display: flex;
 		height: var(--theme--form--field--input--height);

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -260,7 +260,7 @@ function onClick(event: PointerEvent) {
 
 		padding: var(
 			--v-list-item-padding,
-			calc(var(--theme--form--field--input--height) * 0.13333) var(--theme--form--field--input--padding)
+			calc(var(--theme--form--field--input--padding) / 2) var(--theme--form--field--input--padding)
 		);
 		position: relative;
 		display: flex;
@@ -320,7 +320,10 @@ function onClick(event: PointerEvent) {
 
 		&.dense {
 			--theme--form--field--input--height: 44px;
-			padding-inline: calc(var(--theme--form--field--input--padding) / 2);
+			padding: var(
+				--v-list-item-padding,
+				calc(var(--theme--form--field--input--padding) / 4) calc(var(--theme--form--field--input--padding) / 2)
+			);
 
 			& + & {
 				margin-top: var(--v-list-item-margin, 4px);

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -258,7 +258,10 @@ function onClick(event: PointerEvent) {
 	&.block {
 		--v-icon-color: var(--v-icon-color, var(--theme--foreground-subdued));
 
-		padding: var(--v-list-item-padding, calc(var(--theme--form--field--input--height) * 0.13333) var(--theme--form--field--input--padding));
+		padding: var(
+			--v-list-item-padding,
+			calc(var(--theme--form--field--input--height) * 0.13333) var(--theme--form--field--input--padding)
+		);
 		position: relative;
 		display: flex;
 		height: var(--theme--form--field--input--height);

--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -258,7 +258,7 @@ function onClick(event: PointerEvent) {
 	&.block {
 		--v-icon-color: var(--v-icon-color, var(--theme--foreground-subdued));
 
-		padding: var(--v-list-item-padding, 8px var(--theme--form--field--input--padding));
+		padding: var(--v-list-item-padding, calc(var(--theme--form--field--input--height) * 0.13333) var(--theme--form--field--input--padding));
 		position: relative;
 		display: flex;
 		height: var(--theme--form--field--input--height);
@@ -316,8 +316,8 @@ function onClick(event: PointerEvent) {
 		}
 
 		&.dense {
-			height: 44px;
-			padding: 4px 8px;
+			--theme--form--field--input--height: 44px;
+			padding-inline: calc(var(--theme--form--field--input--padding) / 2);
 
 			& + & {
 				margin-top: var(--v-list-item-margin, 4px);

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -108,16 +108,19 @@ function getLinkForItem(item: any) {
 </template>
 
 <style lang="scss" scoped>
+$toggle-px: 6px;
+$toggle-py: $toggle-px;
+
 .toggle {
 	position: relative;
 
 	&::before {
 		position: absolute;
-		top: -6px;
-		left: -6px;
+		top: #{$toggle-py * -1};
+		left: #{$toggle-px * -1};
 		z-index: 1;
-		width: calc(100% + 12px);
-		height: calc(100% + 12px);
+		width: calc(100% + #{$toggle-px * 2});
+		height: calc(100% + #{$toggle-py * 2});
 		background-color: var(--theme--background-normal);
 		border-radius: var(--theme--border-radius);
 		opacity: 0;
@@ -138,9 +141,14 @@ function getLinkForItem(item: any) {
 		background-color: var(--theme--background-accent);
 	}
 }
+
 .render-template {
 	> .v-menu {
 		display: inline;
+
+		.toggle {
+			margin: $toggle-py $toggle-px;
+		}
 	}
 }
 

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -109,7 +109,7 @@ function getLinkForItem(item: any) {
 
 <style lang="scss" scoped>
 $toggle-px: 6px;
-$toggle-py: $toggle-px;
+$toggle-py: 4px;
 
 .toggle {
 	position: relative;

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -80,7 +80,7 @@ function getLinkForItem(item: any) {
 		:disabled="value?.length === 0"
 	>
 		<template #activator="{ toggle }">
-			<span class="toggle" :class="{ subdued: value?.length === 0 }" @click.stop="toggle">
+			<span class="toggle" :class="{ disabled: value?.length === 0 }" @click.stop="toggle">
 				<span class="label">
 					{{ value?.length }}
 					<template v-if="value?.length >= 100">+</template>
@@ -130,17 +130,18 @@ function getLinkForItem(item: any) {
 		z-index: 2;
 	}
 
-	&:not(.subdued):hover::before {
+	&:not(.disabled):hover::before {
 		opacity: 1;
 	}
 
-	&:not(.subdued):active::before {
+	&:not(.disabled):active::before {
 		background-color: var(--theme--background-accent);
 	}
 }
 
-.subdued {
+.disabled {
 	color: var(--theme--foreground-subdued);
+	pointer-events: none;
 }
 
 .links {

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -138,6 +138,11 @@ function getLinkForItem(item: any) {
 		background-color: var(--theme--background-accent);
 	}
 }
+.render-template {
+	> .v-menu {
+		display: inline;
+	}
+}
 
 .disabled {
 	color: var(--theme--foreground-subdued);

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -108,19 +108,18 @@ function getLinkForItem(item: any) {
 </template>
 
 <style lang="scss" scoped>
-$toggle-px: 6px;
-$toggle-py: 4px;
-
 .toggle {
 	position: relative;
+	--toggle-px: 6px;
+	--toggle-py: 4px;
 
 	&::before {
 		position: absolute;
-		top: #{$toggle-py * -1};
-		left: #{$toggle-px * -1};
+		top: calc(-1 * var(--toggle-py));
+		left: calc(-1 * var(--toggle-px));
 		z-index: 1;
-		width: calc(100% + #{$toggle-px * 2});
-		height: calc(100% + #{$toggle-py * 2});
+		width: calc(100% + var(--toggle-px) * 2);
+		height: calc(100% + var(--toggle-py) * 2);
 		background-color: var(--theme--background-normal);
 		border-radius: var(--theme--border-radius);
 		opacity: 0;
@@ -140,16 +139,14 @@ $toggle-py: 4px;
 	&:not(.disabled):active::before {
 		background-color: var(--theme--background-accent);
 	}
+
+	.render-template > .v-menu & {
+		margin: var(--toggle-py) var(--toggle-px);
+	}
 }
 
-.render-template {
-	> .v-menu {
-		display: inline;
-
-		.toggle {
-			margin: $toggle-py $toggle-px;
-		}
-	}
+.render-template > .v-menu {
+	display: inline;
 }
 
 .disabled {


### PR DESCRIPTION
## Scope

What's changed:

- changed vertical padding of `v-list-items.block` (+ `.dense`) to provide more space for the render-template
  - this prevents the render-template from cutting off the mouseover-background of the `related-values` display
  - this also affects thumbnails as they get larger
- fix alignment and overlapping of `related-values` display within the `render-template`
- made `height` and `padding` of v-list-item.block (+ `.dense`) more dynamic

Before:
![issue](https://github.com/directus/directus/assets/78852214/88b87493-9c30-42d2-83d6-b817cdf603e9)


After:
![fix](https://github.com/directus/directus/assets/78852214/4f852eff-4b56-4e60-8262-50776e316dac)



## Potential Risks / Drawbacks

- Could cause visual bugs on other parts of the app, even though I've tested many use cases
  - default and dense listing
  - m2m, m2a listings
  - table layout
  - title in the drawer

## Review Notes / Questions

- Feel free to change things

---

Fixes #21853
Potentially fixes #22160
