### PR TITLE
Hiding non session SSO providers from the app

### DIFF
--- a/.changeset/polite-islands-collect.md
+++ b/.changeset/polite-islands-collect.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Hidden non session SSO providers from the app

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -262,7 +262,8 @@ router.post(
 router.get(
 	'/',
 	asyncHandler(async (req, res, next) => {
-		const sessionOnly = 'sessionOnly' in req.query && (req.query['sessionOnly'] === '' || Boolean(req.query['sessionOnly']));
+		const sessionOnly =
+			'sessionOnly' in req.query && (req.query['sessionOnly'] === '' || Boolean(req.query['sessionOnly']));
 
 		res.locals['payload'] = {
 			data: getAuthProviders({ sessionOnly }),

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -16,7 +16,7 @@ import { respond } from '../middleware/respond.js';
 import { AuthenticationService } from '../services/authentication.js';
 import { UsersService } from '../services/users.js';
 import asyncHandler from '../utils/async-handler.js';
-import { getAuthProviders } from '../utils/get-auth-providers.js';
+import { getAuthProviders, getSessionAuthProviders } from '../utils/get-auth-providers.js';
 import { getIPFromReq } from '../utils/get-ip-from-req.js';
 import isDirectusJWT from '../utils/is-directus-jwt.js';
 import { verifyAccessJWT } from '../utils/jwt.js';
@@ -263,7 +263,7 @@ router.get(
 	'/',
 	asyncHandler(async (_req, res, next) => {
 		res.locals['payload'] = {
-			data: getAuthProviders(),
+			data: getSessionAuthProviders(),
 			disableDefault: env['AUTH_DISABLE_DEFAULT'],
 		};
 

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -16,7 +16,7 @@ import { respond } from '../middleware/respond.js';
 import { AuthenticationService } from '../services/authentication.js';
 import { UsersService } from '../services/users.js';
 import asyncHandler from '../utils/async-handler.js';
-import { getAuthProviders, getSessionAuthProviders } from '../utils/get-auth-providers.js';
+import { getAuthProviders } from '../utils/get-auth-providers.js';
 import { getIPFromReq } from '../utils/get-ip-from-req.js';
 import isDirectusJWT from '../utils/is-directus-jwt.js';
 import { verifyAccessJWT } from '../utils/jwt.js';
@@ -263,7 +263,7 @@ router.get(
 	'/',
 	asyncHandler(async (_req, res, next) => {
 		res.locals['payload'] = {
-			data: getSessionAuthProviders(),
+			data: getAuthProviders({ sessionOnly: true }),
 			disableDefault: env['AUTH_DISABLE_DEFAULT'],
 		};
 

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -261,9 +261,11 @@ router.post(
 
 router.get(
 	'/',
-	asyncHandler(async (_req, res, next) => {
+	asyncHandler(async (req, res, next) => {
+		const sessionOnly = 'sessionOnly' in req.query && (req.query['sessionOnly'] === '' || Boolean(req.query['sessionOnly']));
+
 		res.locals['payload'] = {
-			data: getAuthProviders({ sessionOnly: true }),
+			data: getAuthProviders({ sessionOnly }),
 			disableDefault: env['AUTH_DISABLE_DEFAULT'],
 		};
 

--- a/api/src/utils/get-auth-providers.ts
+++ b/api/src/utils/get-auth-providers.ts
@@ -8,39 +8,31 @@ interface AuthProvider {
 	label?: string;
 }
 
-export function getAuthProviders(): AuthProvider[] {
+export function getAuthProviders({ sessionOnly } = { sessionOnly: false }): AuthProvider[] {
 	const env = useEnv();
 
-	return toArray(env['AUTH_PROVIDERS'] as string)
-		.filter((provider) => provider && env[`AUTH_${provider.toUpperCase()}_DRIVER`])
-		.map((provider) => ({
-			name: provider,
-			label: env[`AUTH_${provider.toUpperCase()}_LABEL`] as string,
-			driver: env[`AUTH_${provider.toUpperCase()}_DRIVER`] as string,
-			icon: env[`AUTH_${provider.toUpperCase()}_ICON`] as string,
-		}));
-}
+	let providers = toArray(env['AUTH_PROVIDERS'] as string)
+		.filter((provider) => provider && env[`AUTH_${provider.toUpperCase()}_DRIVER`]);
 
-export function getSessionAuthProviders(): AuthProvider[] {
-	const env = useEnv();
-
-	return toArray(env['AUTH_PROVIDERS'] as string)
-		.filter((provider) => {
-			if (!provider) return false;
+	if (sessionOnly) {
+		providers = providers.filter((provider) => {
 			const driver = env[`AUTH_${provider.toUpperCase()}_DRIVER`] as string;
-			if (!driver) return false;
 
+			// only the following 3 drivers require a mode selection
 			if (['oauth2', 'openid', 'saml'].includes(driver)) {
-				const mode = env[`AUTH_${provider.toUpperCase()}_MODE`] as string;
+				const mode = env[`AUTH_${provider.toUpperCase()}_MODE`] as string | undefined;
+				// if mode is not defined it defaults to session
 				return !mode || mode === 'session';
 			}
 
 			return true;
-		})
-		.map((provider) => ({
-			name: provider,
-			label: env[`AUTH_${provider.toUpperCase()}_LABEL`] as string,
-			driver: env[`AUTH_${provider.toUpperCase()}_DRIVER`] as string,
-			icon: env[`AUTH_${provider.toUpperCase()}_ICON`] as string,
-		}));
+		});
+	}
+
+	return providers.map((provider) => ({
+		name: provider,
+		label: env[`AUTH_${provider.toUpperCase()}_LABEL`] as string,
+		driver: env[`AUTH_${provider.toUpperCase()}_DRIVER`] as string,
+		icon: env[`AUTH_${provider.toUpperCase()}_ICON`] as string,
+	}));
 }

--- a/api/src/utils/get-auth-providers.ts
+++ b/api/src/utils/get-auth-providers.ts
@@ -11,8 +11,9 @@ interface AuthProvider {
 export function getAuthProviders({ sessionOnly } = { sessionOnly: false }): AuthProvider[] {
 	const env = useEnv();
 
-	let providers = toArray(env['AUTH_PROVIDERS'] as string)
-		.filter((provider) => provider && env[`AUTH_${provider.toUpperCase()}_DRIVER`]);
+	let providers = toArray(env['AUTH_PROVIDERS'] as string).filter(
+		(provider) => provider && env[`AUTH_${provider.toUpperCase()}_DRIVER`],
+	);
 
 	if (sessionOnly) {
 		providers = providers.filter((provider) => {

--- a/api/src/utils/get-auth-providers.ts
+++ b/api/src/utils/get-auth-providers.ts
@@ -20,3 +20,27 @@ export function getAuthProviders(): AuthProvider[] {
 			icon: env[`AUTH_${provider.toUpperCase()}_ICON`] as string,
 		}));
 }
+
+export function getSessionAuthProviders(): AuthProvider[] {
+	const env = useEnv();
+
+	return toArray(env['AUTH_PROVIDERS'] as string)
+		.filter((provider) => {
+			if (!provider) return false;
+			const driver = env[`AUTH_${provider.toUpperCase()}_DRIVER`] as string;
+			if (!driver) return false;
+
+			if (['oauth2', 'openid', 'saml'].includes(driver)) {
+				const mode = env[`AUTH_${provider.toUpperCase()}_MODE`] as string;
+				return !mode || mode === 'session';
+			}
+
+			return true;
+		})
+		.map((provider) => ({
+			name: provider,
+			label: env[`AUTH_${provider.toUpperCase()}_LABEL`] as string,
+			driver: env[`AUTH_${provider.toUpperCase()}_DRIVER`] as string,
+			icon: env[`AUTH_${provider.toUpperCase()}_ICON`] as string,
+		}));
+}

--- a/app/src/stores/server.test.ts
+++ b/app/src/stores/server.test.ts
@@ -76,7 +76,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -97,7 +97,7 @@ describe('hydrate action', async () => {
 				return Promise.resolve({ data: {} });
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				return Promise.resolve({
 					data: {
 						data: mockAuthProviders,
@@ -128,7 +128,7 @@ describe('hydrate action', async () => {
 				return Promise.resolve({ data: {} });
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -152,7 +152,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -176,7 +176,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -203,7 +203,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -230,7 +230,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -257,7 +257,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -281,7 +281,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -312,7 +312,7 @@ describe('hydrate action', async () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				// stub as auth is not tested here
 				return Promise.resolve({ data: {} });
 			}
@@ -342,7 +342,7 @@ describe('dehydrate action', () => {
 				});
 			}
 
-			if (path === '/auth') {
+			if (path.startsWith('/auth')) {
 				return Promise.resolve({
 					data: {
 						data: mockAuthProviders,

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -84,7 +84,10 @@ export const useServerStore = defineStore('serverStore', () => {
 	});
 
 	const hydrate = async (options?: HydrateOptions) => {
-		const [serverInfoResponse, authResponse] = await Promise.all([api.get(`/server/info`), api.get('/auth?sessionOnly')]);
+		const [serverInfoResponse, authResponse] = await Promise.all([
+			api.get(`/server/info`),
+			api.get('/auth?sessionOnly'),
+		]);
 
 		info.project = serverInfoResponse.data.data?.project;
 		info.queryLimit = serverInfoResponse.data.data?.queryLimit;

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -84,7 +84,7 @@ export const useServerStore = defineStore('serverStore', () => {
 	});
 
 	const hydrate = async (options?: HydrateOptions) => {
-		const [serverInfoResponse, authResponse] = await Promise.all([api.get(`/server/info`), api.get('/auth')]);
+		const [serverInfoResponse, authResponse] = await Promise.all([api.get(`/server/info`), api.get('/auth?sessionOnly')]);
 
 		info.project = serverInfoResponse.data.data?.project;
 		info.queryLimit = serverInfoResponse.data.data?.queryLimit;

--- a/sdk/src/rest/commands/auth/providers.ts
+++ b/sdk/src/rest/commands/auth/providers.ts
@@ -12,8 +12,8 @@ export interface ReadProviderOutput {
  * @returns Array of configured auth providers.
  */
 export const readProviders =
-	<Schema extends object>(): RestCommand<ReadProviderOutput[], Schema> =>
+	<Schema extends object>(sessionOnly = false): RestCommand<ReadProviderOutput[], Schema> =>
 	() => ({
-		path: `/auth`,
+		path: sessionOnly ? '/auth?sessionOnly' : '/auth',
 		method: 'GET',
 	});


### PR DESCRIPTION
Fixes #21836

## Scope

What's changed:

- The `/auth` list endpoint now filters out SSO providers not compatible with the App while keeping the `/auth/login/[provider]` flow working

## Potential Risks / Drawbacks

- Potential breaking change if someone is depending on the `/auth` endpoint

## Review Notes / Questions

- I would like to lorem ipsum


