### PR TITLE
Docs update content version description

### DIFF
--- a/docs/guides/headless-cms/content-versioning.md
+++ b/docs/guides/headless-cms/content-versioning.md
@@ -14,8 +14,7 @@ use Content Versioning, including drafting content without publishing it, and mo
 
 ## Concepts
 
-1. **Version:** A version is a snapshot of a piece of content at a particular point in time. Each version represents the
-   state of the content at a specific moment, and it can be used to track changes and maintain a history of the content.
+1. **Version:** A version is a snapshot of the differences between the original item and the created version. Each version represents a set of future changes to be applied to the item.
 2. **Main:** The main version is the original version of a piece of content that has been created and published. It is
    the default version that is displayed to users. The main version is the "source of truth" for all other versions.
 3. **Promote:** Promoting a version means to make it the new main version. When a new version is promoted, it becomes

--- a/docs/guides/headless-cms/content-versioning.md
+++ b/docs/guides/headless-cms/content-versioning.md
@@ -14,7 +14,8 @@ use Content Versioning, including drafting content without publishing it, and mo
 
 ## Concepts
 
-1. **Version:** A version is a snapshot of the differences between the original item and the created version. Each version represents a set of future changes to be applied to the item.
+1. **Version:** A version is a snapshot of the differences between the original item and the created version. Each
+   version represents a set of future changes to be applied to the item.
 2. **Main:** The main version is the original version of a piece of content that has been created and published. It is
    the default version that is displayed to users. The main version is the "source of truth" for all other versions.
 3. **Promote:** Promoting a version means to make it the new main version. When a new version is promoted, it becomes


### PR DESCRIPTION
Fixes #21748 

As discussed in the issue the current description of the "content version" concept in the docs can be incorrectly interpreted and construed as misleading.

## Scope

What's changed:

- Updated wording in the docs

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I would like to lorem ipsum
