### PR TITLE
SDK websocket handshake messages not emitted

### DIFF
--- a/.changeset/fair-horses-deliver.md
+++ b/.changeset/fair-horses-deliver.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed SDK websocket handshake messages not being emitted

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -235,6 +235,11 @@ export function realtime(config: WebSocketConfig = {}) {
 					ws.addEventListener('open', async (evt: Event) => {
 						debug('info', `Connection open.`);
 
+						state = { code: 'open', connection: ws, firstMessage: true };
+						reconnectState.attempts = 0;
+						reconnectState.active = false;
+						handleMessages(self);
+
 						if (config.authMode === 'handshake' && hasAuth(self)) {
 							const access_token = await self.getToken();
 
@@ -262,12 +267,7 @@ export function realtime(config: WebSocketConfig = {}) {
 							}
 						}
 
-						state = { code: 'open', connection: ws, firstMessage: true };
-						reconnectState.attempts = 0;
-						reconnectState.active = false;
-
 						eventHandlers['open'].forEach((handler) => handler.call(ws, evt));
-						handleMessages(self);
 
 						resolved = true;
 						resolve(ws);


### PR DESCRIPTION
Fixes #21955 

## Scope

What's changed:

- Fixed order of operations for registering message events

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
