### PR TITLE
Pause "Auto Refresh" when page is idle

### DIFF
--- a/.changeset/tasty-squids-hope.md
+++ b/.changeset/tasty-squids-hope.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured "Auto Refresh" is paused when the app is not in use

--- a/app/src/views/private/components/refresh-sidebar-detail.vue
+++ b/app/src/views/private/components/refresh-sidebar-detail.vue
@@ -47,7 +47,7 @@ watch(
 		}
 
 		if (newInterval !== null && newInterval > 0) {
-			setRefreshInterval(newInterval * 1000);
+			setRefreshInterval(newInterval);
 		}
 	},
 	{ immediate: true },


### PR DESCRIPTION
## Scope

Pause the "Auto Refresh" functionality if the page is idle (not focused / no interaction for 5min), to avoid unnecessary requests as well a requests with expired token.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Relevant commits by @br41nslug extracted from #17341
- Thanks to @jay-p-b-7span for initial work in #17341

---

Fixes #17083