### PR TITLE
Fix randomUUID import in Webhooks deprecation migration

### DIFF
--- a/api/src/database/migrations/20240311A-deprecate-webhooks.ts
+++ b/api/src/database/migrations/20240311A-deprecate-webhooks.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from '@directus/random';
 import { parseJSON, toArray } from '@directus/utils';
 import type { Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
 import type { Webhook } from '../../types/webhooks.js';
 
 // To avoid typos


### PR DESCRIPTION
## Scope

Use `randomUUID()` from `node:crypto` instead of `@directus/random` (in line with other migrations), otherwise the migration would fail in production because `@directus/random` isn't a dependency of `@directus/api`.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
