### PR TITLE
Fix marketplace pagination not allowing partial pages

### DIFF
--- a/.changeset/weak-needles-film.md
+++ b/.changeset/weak-needles-film.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed marketplace pagination not allowing partial pages and corrected TS type errors for search and type query parameters.

--- a/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
@@ -32,7 +32,7 @@ watch([search, sort, type], (newVal, oldVal) => {
 const filterCount = ref(0);
 
 const extensions = ref<RegistryListResponse['data'] | null>(null);
-const pageCount = computed(() => Math.round(filterCount.value / perPage));
+const pageCount = computed(() => Math.ceil(filterCount.value / perPage));
 const loading = ref(false);
 const error = ref<unknown>(null);
 

--- a/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
@@ -22,9 +22,11 @@ const page = useRouteQuery('page', 1, {
 const search = useRouteQuery<string | null>('search', null, {
 	transform: (value) => (Array.isArray(value) ? value[0] : value),
 });
+
 const type = useRouteQuery<string | null>('type', null, {
 	transform: (value) => (Array.isArray(value) ? value[0] : value),
 });
+
 const sort = useRouteQuery<'popular' | 'recent' | 'downloads'>('sort', 'popular');
 
 watch([search, sort, type], (newVal, oldVal) => {

--- a/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
@@ -19,8 +19,12 @@ const page = useRouteQuery('page', 1, {
 	transform: (value) => Number(Array.isArray(value) ? value[0] : value) || 1,
 });
 
-const search = useRouteQuery('search');
-const type = useRouteQuery('type');
+const search = useRouteQuery<string | null>('search', null, {
+	transform: (value) => (Array.isArray(value) ? value[0] : value),
+});
+const type = useRouteQuery<string | null>('type', null, {
+	transform: (value) => (Array.isArray(value) ? value[0] : value),
+});
 const sort = useRouteQuery<'popular' | 'recent' | 'downloads'>('sort', 'popular');
 
 watch([search, sort, type], (newVal, oldVal) => {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Corrected page count calculation to use `ceil` over `round`. This ensures an additional page is added when results overflow past a page multiple.
- Updated `search` and `type` query parameters to have correct TS type.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Any alternative for narrowing down the query param type to `string | null`? 
-  The action linter flagged a lint issue that the local lint command `pnpm format` did not. Possibly something worth looking into.

---

Fixes #22020