### PR TITLE
Fix nested queries with unlimited default limit

### DIFF
--- a/.changeset/orange-crabs-work.md
+++ b/.changeset/orange-crabs-work.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where nested items would not be returned with default query limit of unlimited

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -476,21 +476,18 @@ function mergeWithParentItems(
 
 			parentItem[nestedNode.fieldKey].push(...itemChildren);
 
+			const limit = nestedNode.query.limit ?? Number(env['QUERY_LIMIT_DEFAULT']);
+
 			if (nestedNode.query.page && nestedNode.query.page > 1) {
-				parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(
-					(nestedNode.query.limit ?? Number(env['QUERY_LIMIT_DEFAULT'])) * (nestedNode.query.page - 1),
-				);
+				parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(limit * (nestedNode.query.page - 1));
 			}
 
 			if (nestedNode.query.offset && nestedNode.query.offset >= 0) {
 				parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(nestedNode.query.offset);
 			}
 
-			if (nestedNode.query.limit !== -1) {
-				parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(
-					0,
-					nestedNode.query.limit ?? Number(env['QUERY_LIMIT_DEFAULT']),
-				);
+			if (limit !== -1) {
+				parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].slice(0, limit);
 			}
 
 			parentItem[nestedNode.fieldKey] = parentItem[nestedNode.fieldKey].sort((a: Item, b: Item) => {


### PR DESCRIPTION
## Scope

Fix an issue where nested items would not be returned with default query limit of unlimited (`QUERY_LIMIT_DEFAULT=-1`).

## Potential Risks / Drawbacks

None

## Review Notes / Questions

`if` statement for slicing wasn't accounting for the value of `QUERY_LIMIT_DEFAULT` of `-1`

---

Fixes #22038
