### PR TITLE
Fix initial values for boolean filter operators in search interface

### DIFF
--- a/.changeset/tough-lobsters-poke.md
+++ b/.changeset/tough-lobsters-poke.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensured the search interface applies the correct initial value for boolean filter types (like "Is null")
+Ensured the search interface applies the correct initial value for boolean filter operators (like "Is null")

--- a/.changeset/tough-lobsters-poke.md
+++ b/.changeset/tough-lobsters-poke.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured the search interface applies the correct initial value for boolean filter types (like "Is null")

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -120,7 +120,11 @@ function addNode(key: string) {
 
 		const filterOperators = getFilterOperatorsForType(type, { includeValidation: props.includeValidation });
 		const operator = field?.meta?.options?.choices && filterOperators.includes('eq') ? 'eq' : filterOperators[0];
-		const node = set({}, key, { ['_' + operator]: null });
+
+		const booleanOptionTypes: Type[] = ['json', 'hash'];
+		const initialValue = booleanOptionTypes.includes(type) ? true : null;
+
+		const node = set({}, key, { ['_' + operator]: initialValue });
 		innerValue.value = innerValue.value.concat(node);
 	}
 }

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
-import { FieldFunction, Filter, Type } from '@directus/types';
+import { ClientFilterOperator, FieldFunction, Filter, Type } from '@directus/types';
 import {
 	getFilterOperatorsForType,
 	getOutputTypeForFunction,
@@ -121,8 +121,8 @@ function addNode(key: string) {
 		const filterOperators = getFilterOperatorsForType(type, { includeValidation: props.includeValidation });
 		const operator = field?.meta?.options?.choices && filterOperators.includes('eq') ? 'eq' : filterOperators[0];
 
-		const booleanOptionTypes: Type[] = ['json', 'hash'];
-		const initialValue = booleanOptionTypes.includes(type) ? true : null;
+		const booleanOperators: ClientFilterOperator[] = ['empty', 'nempty', 'null', 'nnull'];
+		const initialValue = operator && booleanOperators.includes(operator) ? true : null;
 
 		const node = set({}, key, { ['_' + operator]: initialValue });
 		innerValue.value = innerValue.value.concat(node);

--- a/packages/utils/shared/get-filter-operators-for-type.ts
+++ b/packages/utils/shared/get-filter-operators-for-type.ts
@@ -38,17 +38,16 @@ export function getFilterOperatorsForType(
 				'nin',
 				...validationOnlyStringFilterOperators,
 			];
-		// Hash
+
 		case 'hash':
 			return ['empty', 'nempty', 'null', 'nnull'];
-		// JSON
-		// UUID
+
 		case 'uuid':
 			return ['eq', 'neq', 'null', 'nnull', 'in', 'nin'];
+
 		case 'json':
 			return ['null', 'nnull'];
 
-		// Boolean
 		case 'boolean':
 			return ['eq', 'neq', 'null', 'nnull'];
 


### PR DESCRIPTION
## Scope

Ensure the search interface applies the correct initial value for boolean filter operators (like "Is null")

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #22012
