### PR TITLE
Fix issue when duplicating an item (Save as Copy) with many relational items

### DIFF
--- a/.changeset/small-socks-hug.md
+++ b/.changeset/small-socks-hug.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that resulted in a "414 URI Too Long" error when duplicating an item

--- a/.changeset/small-socks-hug.md
+++ b/.changeset/small-socks-hug.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed an issue where duplicating an item with many relational items could fail
+Fixed an issue where duplicating an item (Save as Copy) with many relational items could fail

--- a/.changeset/small-socks-hug.md
+++ b/.changeset/small-socks-hug.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed an issue that resulted in a "414 URI Too Long" error when duplicating an item
+Fixed an issue where duplicating an item with many relational items could fail

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -11,13 +11,13 @@ import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
 import { useCollection } from '@directus/composables';
+import { isSystemCollection } from '@directus/system-data';
 import { Field, Query, Relation } from '@directus/types';
+import { getEndpoint } from '@directus/utils';
 import { AxiosResponse } from 'axios';
 import { mergeWith } from 'lodash';
 import { ComputedRef, MaybeRef, Ref, computed, isRef, ref, unref, watch } from 'vue';
 import { UsablePermissions, usePermissions } from './use-permissions';
-import { getEndpoint } from '@directus/utils';
-import { isSystemCollection } from '@directus/system-data';
 
 type UsableItem<T extends Record<string, any>> = {
 	edits: Ref<Record<string, any>>;
@@ -304,7 +304,7 @@ export function useItem<T extends Record<string, any>>(
 				const response = await api.get(getEndpoint(relation.collection), {
 					params: {
 						fields: [relatedPrimaryKeyField!.field, ...fieldsToFetch],
-						[`filter[${relatedPrimaryKeyField!.field}][_in]`]: existingIds.join(','),
+						[`filter[${relation.meta?.many_field}][_eq]`]: itemData.data.data[primaryKeyField.value!.field],
 					},
 				});
 

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -304,7 +304,7 @@ export function useItem<T extends Record<string, any>>(
 				const response = await api.get(getEndpoint(relation.collection), {
 					params: {
 						fields: [relatedPrimaryKeyField!.field, ...fieldsToFetch],
-						[`filter[${relation.meta?.many_field}][_eq]`]: itemData.data.data[primaryKeyField.value!.field],
+						[`filter[${relation.field}][_eq]`]: itemData.data.data[primaryKeyField.value!.field],
 					},
 				});
 

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -304,7 +304,7 @@ export function useItem<T extends Record<string, any>>(
 				const response = await api.get(getEndpoint(relation.collection), {
 					params: {
 						fields: [relatedPrimaryKeyField!.field, ...fieldsToFetch],
-						[`filter[${relation.field}][_eq]`]: itemData.data.data[primaryKeyField.value!.field],
+						[`filter[${relation.field}][_eq]`]: primaryKey.value,
 					},
 				});
 


### PR DESCRIPTION
## Scope

What's changed:

- Changed the filter when retrieving existing related items

Previously we fetched all related items using the `_in` operator which concatenated their IDs. It looked like this:

```js
{
  fields: [ "id", "*" ],
  "filter[id][_in]": [ 123, 124, 125, 126, 127, ... ]
}
```

This lead to a potentially very large array of IDs, especially if they're UUIDs for example, which ultimately leads to an _URI too long_ error when GET requesting with that huge filter.

This PR flips the filter around and aims to retrieve the related items by fetching it via its foreign key. This means its just a simple lookup like so:

```js
{
  fields: [ "id", "*" ],
  "filter[foreign_key][_eq]": 42069
}
```

## Potential Risks / Drawbacks

- Changes to relational logic is always tricky pls we need to be careful :pray: 
- In my local testing I had a collection with M2M, M2A, M2O, O2M and for all them the duplication worked!

## Review Notes / Questions

1. For example create a collection with a many-to-any that holds a couple items
2. Press "save as copy" in the top action bar
3. That should work and in the network tab there should be a GET request showing you the previously mentioned filter with the `_eq` instead of `_in` operator.

---

Fixes #21229 
