### PR TITLE
Remove label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    labels:
-      - Dependencies
     directory: '/'
     schedule:
       interval: daily


### PR DESCRIPTION
## Scope

<img width="920" src="https://github.com/directus/directus/assets/5363448/6d28e2e7-3fb8-4600-948e-65f16c0394a3">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Alternatively, we could reintroduce an appropriate label