### PR TITLE
Override default label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    labels: []
     directory: '/'
     schedule:
       interval: daily


### PR DESCRIPTION
## Scope

Follow-up on #22064, as it now seems to use (and even create) the default `dependencies` label.
Well... thanks for that @dependabot 👀😏 

<img width="558" src="https://github.com/directus/directus/assets/5363448/2b60dc74-3dc3-4833-96c2-e04416afa6e9">

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None
