### PR TITLE
Make SDK realtime composable compatible with React Native

### DIFF
--- a/.changeset/lucky-rivers-taste.md
+++ b/.changeset/lucky-rivers-taste.md
@@ -1,5 +1,5 @@
 ---
-'@directus/sdk': patch
+'@directus/sdk': major
 ---
 
-Made the SDK realtime composable compatible with React Native
+Made the SDK realtime composable compatible with React Native, the WebSocket client will now be initialized with the URL as `string` instead of `URL`

--- a/.changeset/lucky-rivers-taste.md
+++ b/.changeset/lucky-rivers-taste.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Made the SDK realtime composable compatible with React Native

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -58,17 +58,19 @@ export function realtime(config: WebSocketConfig = {}) {
 		const debug = (level: keyof ConsoleInterface, ...data: any[]) =>
 			config.debug && client.globals.logger[level]('[Directus SDK]', ...data);
 
-		const withStrictAuth = async (url: URL, currentClient: AuthWSClient<Schema>) => {
+		const withStrictAuth = async (url: URL | string, currentClient: AuthWSClient<Schema>) => {
+			const newUrl = typeof url === "string" ? new client.globals.URL(url) : url;
+
 			if (config.authMode === 'strict' && hasAuth(currentClient)) {
 				const token = await currentClient.getToken();
-				if (token) url.searchParams.set('access_token', token);
+				if (token) newUrl.searchParams.set('access_token', token);
 			}
 
-			return url.toString();
+			return newUrl.toString();
 		};
 
 		const getSocketUrl = async (currentClient: AuthWSClient<Schema>) => {
-			if ('url' in config) return await withStrictAuth(new client.globals.URL(config.url), currentClient);
+			if ('url' in config) return await withStrictAuth(config.url, currentClient);
 
 			// if the main URL is a websocket URL use it directly!
 			if (['ws:', 'wss:'].includes(client.url.protocol)) {

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -59,7 +59,7 @@ export function realtime(config: WebSocketConfig = {}) {
 			config.debug && client.globals.logger[level]('[Directus SDK]', ...data);
 
 		const withStrictAuth = async (url: URL | string, currentClient: AuthWSClient<Schema>) => {
-			const newUrl = typeof url === 'string' ? new client.globals.URL(url) : url;
+			const newUrl = new client.globals.URL(url);
 
 			if (config.authMode === 'strict' && hasAuth(currentClient)) {
 				const token = await currentClient.getToken();

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -59,7 +59,7 @@ export function realtime(config: WebSocketConfig = {}) {
 			config.debug && client.globals.logger[level]('[Directus SDK]', ...data);
 
 		const withStrictAuth = async (url: URL | string, currentClient: AuthWSClient<Schema>) => {
-			const newUrl = typeof url === "string" ? new client.globals.URL(url) : url;
+			const newUrl = typeof url === 'string' ? new client.globals.URL(url) : url;
 
 			if (config.authMode === 'strict' && hasAuth(currentClient)) {
 				const token = await currentClient.getToken();

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -64,7 +64,7 @@ export function realtime(config: WebSocketConfig = {}) {
 				if (token) url.searchParams.set('access_token', token);
 			}
 
-			return url;
+			return url.toString();
 		};
 
 		const getSocketUrl = async (currentClient: AuthWSClient<Schema>) => {
@@ -76,7 +76,7 @@ export function realtime(config: WebSocketConfig = {}) {
 			}
 
 			// try filling in the defaults based on the main URL
-			const newUrl = new client.globals.URL(client.url.toString());
+			const newUrl = new client.globals.URL(client.url);
 			newUrl.protocol = client.url.protocol === 'https:' ? 'wss:' : 'ws:';
 			newUrl.pathname = '/websocket';
 

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -76,7 +76,7 @@ export function realtime(config: WebSocketConfig = {}) {
 			}
 
 			// try filling in the defaults based on the main URL
-			const newUrl = new client.globals.URL(client.url);
+			const newUrl = new client.globals.URL(client.url.toString());
 			newUrl.protocol = client.url.protocol === 'https:' ? 'wss:' : 'ws:';
 			newUrl.pathname = '/websocket';
 

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -3,7 +3,7 @@ export type FetchInterface = (input: string | any, init?: RequestInit | any) => 
 
 export type UrlInterface = typeof URL;
 
-/** While the standard envisages 'string | URL', some implementations (e.g. React Native) only accept 'string' */
+/** While the standard says 'string | URL' for the 'url' parameter, some implementations (e.g. React Native) only accept 'string' */
 export type WebSocketConstructor = {
 	new (url: string, protocols?: string | string[]): WebSocketInterface;
 };

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -3,8 +3,11 @@ export type FetchInterface = (input: string | any, init?: RequestInit | any) => 
 
 export type UrlInterface = typeof URL;
 
+/** While the standard envisages 'string | URL', some implementations (e.g. React Native) only accept 'string' */
+type WebSocketUrl = string;
+
 export type WebSocketConstructor = {
-	new (url: URL, protocols?: string | string[]): WebSocketInterface;
+	new (url: WebSocketUrl, protocols?: string | string[]): WebSocketInterface;
 };
 
 export type WebSocketInterface = {

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -4,10 +4,8 @@ export type FetchInterface = (input: string | any, init?: RequestInit | any) => 
 export type UrlInterface = typeof URL;
 
 /** While the standard envisages 'string | URL', some implementations (e.g. React Native) only accept 'string' */
-type WebSocketUrl = string;
-
 export type WebSocketConstructor = {
-	new (url: WebSocketUrl, protocols?: string | string[]): WebSocketInterface;
+	new (url: string, protocols?: string | string[]): WebSocketInterface;
 };
 
 export type WebSocketInterface = {


### PR DESCRIPTION
## Scope

Make the SDK `realtime` composable compatible with the WebSocket implementation of React Native, which only accepts `string` for the `url` parameter.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #22098
