### PR TITLE
Remove `v-image` deprecation notice

### DIFF
--- a/docs/releases/breaking-changes.md
+++ b/docs/releases/breaking-changes.md
@@ -102,9 +102,6 @@ applications, you can set `AUTH_<PROVIDER>_MODE=cookie`. This will however not w
 This affects App extensions that are currently extracting the token from `axios`. This will no longer be either possible
 or necessary, as the App now uses a session cookie, which will be sent with each request from the browser.
 
-This also means that the `<v-image>` component being deprecated as it does not add any value over using the native
-`<img>` tag anymore.
-
 ::: details Migration/Mitigation
 
 ::: code-group


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Removed `v-image` deprecation notice

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None