### PR TITLE
Fix wrong trigger type `hook` to correct `event` in flows.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -121,3 +121,4 @@
 - kaifulee
 - vamsii777
 - useEffects
+- kimiaabt

--- a/docs/reference/system/flows.md
+++ b/docs/reference/system/flows.md
@@ -29,7 +29,7 @@ Short description displayed in the Admin App.
 Current status of the flow. One of `active`, `inactive`. Defaults to `active` when not specified.
 
 `trigger` **string**\
-Type of trigger for the flow. One of `hook`, `webhook`, `operation`, `schedule`, `manual`.
+Type of trigger for the flow. One of `event`, `webhook`, `operation`, `schedule`, `manual`.
 
 `options` **json**\
 Options of the selected trigger for the flow.


### PR DESCRIPTION
Fixes the error in Flow documentation where it stated that one of the available trigger types is `hook` which does not work when used in flows. Corrects the documentation to the trigger type `event`.


Fixes #22140 
