### PR TITLE
Add env variables to configure PM2 log paths + documentation

### DIFF
--- a/.changeset/lazy-bears-tan.md
+++ b/.changeset/lazy-bears-tan.md
@@ -1,0 +1,5 @@
+---
+'docs': patch
+---
+
+Added support to for configuring PM2_LOG_ERROR_FILE and PM2_LOG_OUT_FILE

--- a/contributors.yml
+++ b/contributors.yml
@@ -123,3 +123,4 @@
 - useEffects
 - jonaskohl
 - kimiaabt
+- the-other-dev

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -1100,5 +1100,7 @@ For more information on what these options do, please refer to
 | `PM2_MAX_RESTARTS`            | Number of failed restarts before the process is killed             | —           |
 | `PM2_RESTART_DELAY`           | Time to wait before restarting a crashed app                       | `0`         |
 | `PM2_AUTO_RESTART`            | Automatically restart Directus if it crashes unexpectedly          | `false`     |
+| `PM2_LOG_ERROR_FILE`          | Error file path                                                    | `$HOME/.pm2/logs/<app name>-error-<pid>.log` |
+| `PM2_LOG_OUT_FILE`            | Output file path                                                   | `$HOME/.pm2/logs/<app name>-out-<pid>.log`   |
 
 <sup>[1]</sup> [Redis](#redis) is required in case of multiple instances.

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -1089,17 +1089,17 @@ These environment variables only exist when you're using the official Docker Con
 For more information on what these options do, please refer to
 [the `pm2` documentation](https://pm2.keymetrics.io/docs/usage/application-declaration/).
 
-| Variable                      | Description                                                        | Default     |
-| ----------------------------- | ------------------------------------------------------------------ | ----------- |
-| `PM2_INSTANCES`<sup>[1]</sup> | Number of app instance to be launched                              | `1`         |
-| `PM2_EXEC_MODE`               | One of `fork`, `cluster`                                           | `'cluster'` |
-| `PM2_MAX_MEMORY_RESTART`      | App will be restarted if it exceeds the amount of memory specified | —           |
-| `PM2_MIN_UPTIME`              | Min uptime of the app to be considered started                     | —           |
-| `PM2_LISTEN_TIMEOUT`          | Time in ms before forcing a reload if app not listening            | —           |
-| `PM2_KILL_TIMEOUT`            | Time in milliseconds before sending a final SIGKILL                | —           |
-| `PM2_MAX_RESTARTS`            | Number of failed restarts before the process is killed             | —           |
-| `PM2_RESTART_DELAY`           | Time to wait before restarting a crashed app                       | `0`         |
-| `PM2_AUTO_RESTART`            | Automatically restart Directus if it crashes unexpectedly          | `false`     |
+| Variable                      | Description                                                        | Default                                      |
+| ----------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| `PM2_INSTANCES`<sup>[1]</sup> | Number of app instance to be launched                              | `1`                                          |
+| `PM2_EXEC_MODE`               | One of `fork`, `cluster`                                           | `'cluster'`                                  |
+| `PM2_MAX_MEMORY_RESTART`      | App will be restarted if it exceeds the amount of memory specified | —                                            |
+| `PM2_MIN_UPTIME`              | Min uptime of the app to be considered started                     | —                                            |
+| `PM2_LISTEN_TIMEOUT`          | Time in ms before forcing a reload if app not listening            | —                                            |
+| `PM2_KILL_TIMEOUT`            | Time in milliseconds before sending a final SIGKILL                | —                                            |
+| `PM2_MAX_RESTARTS`            | Number of failed restarts before the process is killed             | —                                            |
+| `PM2_RESTART_DELAY`           | Time to wait before restarting a crashed app                       | `0`                                          |
+| `PM2_AUTO_RESTART`            | Automatically restart Directus if it crashes unexpectedly          | `false`                                      |
 | `PM2_LOG_ERROR_FILE`          | Error file path                                                    | `$HOME/.pm2/logs/<app name>-error-<pid>.log` |
 | `PM2_LOG_OUT_FILE`            | Output file path                                                   | `$HOME/.pm2/logs/<app name>-out-<pid>.log`   |
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -24,5 +24,9 @@ module.exports = [
 		max_restarts: process.env.PM2_MAX_RESTARTS,
 		restart_delay: process.env.PM2_RESTART_DELAY ?? 0,
 		autorestart: process.env.PM2_AUTO_RESTART === 'true',
+
+		// Logs
+		error_file: process.env.PM2_LOG_ERROR_FILE,
+		out_file: process.env.PM2_LOG_OUT_FILE
 	},
 ];

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -27,6 +27,6 @@ module.exports = [
 
 		// Logs
 		error_file: process.env.PM2_LOG_ERROR_FILE,
-		out_file: process.env.PM2_LOG_OUT_FILE
+		out_file: process.env.PM2_LOG_OUT_FILE,
 	},
 ];


### PR DESCRIPTION
## Scope

What's changed:

- Added two additional PM2 properties in the `ecosystem.config.cjs` to be able to configure PM2 log paths via environment variables
- The env variable `PM2_LOG_ERROR_FILE` sets the PM2 property `error_file`
- The env variable `PM2_LOG_OUT_FILE` sets the PM2 property `out_file`

## Potential Risks / Drawbacks

- No risks or drawbacks as the PM2 default is used if the env variables are not set (same behaviour as before)

## Review Notes / Questions

- None

---

Fixes #22131
