### PR TITLE
Tweak default email in `init` cli command email_from config

### DIFF
--- a/.changeset/yellow-baboons-walk.md
+++ b/.changeset/yellow-baboons-walk.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Changed init default EMAIL_FROM to no-reply@example.com

--- a/api/src/cli/utils/create-env/env-stub.liquid
+++ b/api/src/cli/utils/create-env/env-stub.liquid
@@ -312,8 +312,8 @@ EXTENSIONS_AUTO_RELOAD=false
 ####################################################################################################
 ### Email
 
-# Email address from which emails are sent ["no-reply@directus.io"]
-EMAIL_FROM="no-reply@directus.io"
+# Email address from which emails are sent ["no-reply@example.com"]
+EMAIL_FROM="no-reply@example.com"
 
 # What to use to send emails. One of
 # sendmail, smtp, mailgun, sendgrid, ses.


### PR DESCRIPTION
Directus's domain has a strict dmarc quarantine, so this will never work. Changing it to example should make it super obvious it's just an example.