### PR TITLE
Api / Assets: Prevent backpressure on sending big files

### DIFF
--- a/.changeset/dirty-buttons-judge.md
+++ b/.changeset/dirty-buttons-judge.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Ensured streaming of files to client is properly backpressured, preventing out of memory issues with large files

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -238,37 +238,28 @@ router.get(
 			return res.end();
 		}
 
-		let isDataSent = false;
+		stream
+			.on('error', (e) => {
+				logger.error(e, `Couldn't stream file ${file.id} to the client`);
 
-		stream.on('data', (chunk) => {
-			isDataSent = true;
-			res.write(chunk);
-		});
+				if (!res.headersSent) {
+					res.removeHeader('Content-Type');
+					res.removeHeader('Content-Disposition');
+					res.removeHeader('Cache-Control');
 
-		stream.on('end', () => {
-			res.end();
-		});
-
-		stream.on('error', (e) => {
-			logger.error(e, `Couldn't stream file ${file.id} to the client`);
-
-			if (!isDataSent) {
-				res.removeHeader('Content-Type');
-				res.removeHeader('Content-Disposition');
-				res.removeHeader('Cache-Control');
-
-				res.status(500).json({
-					errors: [
-						{
-							message: 'An unexpected error occurred.',
-							extensions: {
-								code: 'INTERNAL_SERVER_ERROR',
+					res.status(500).json({
+						errors: [
+							{
+								message: 'An unexpected error occurred.',
+								extensions: {
+									code: 'INTERNAL_SERVER_ERROR',
+								},
 							},
-						},
-					],
-				});
-			}
-		});
+						],
+					});
+				}
+			})
+			.pipe(res);
 
 		return undefined;
 	}),

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -239,10 +239,8 @@ router.get(
 		}
 
 		stream
-			.on('error', (e) => {
-				logger.error(e, `Couldn't stream file ${file.id} to the client`);
-
-				stream.unpipe(res);
+			.on('error', (error) => {
+				logger.error(error, `Couldn't stream file ${file.id} to the client`);
 
 				if (!res.headersSent) {
 					res.removeHeader('Content-Type');
@@ -259,6 +257,8 @@ router.get(
 							},
 						],
 					});
+				} else {
+					res.end();
 				}
 			})
 			.pipe(res);

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -242,6 +242,8 @@ router.get(
 			.on('error', (e) => {
 				logger.error(e, `Couldn't stream file ${file.id} to the client`);
 
+				stream.unpipe(res);
+
 				if (!res.headersSent) {
 					res.removeHeader('Content-Type');
 					res.removeHeader('Content-Disposition');


### PR DESCRIPTION
## Scope
For the majority of projects this is not an issue but when Directus have huge files and if the machine does not have enough memory to keep almost entire file, Directus will shut down due to out of memory.

This happens when the output write is slower than reading from storage. Data keeps being added to `res` buffer until there's no more space on memory:
https://github.com/directus/directus/blob/46381475917b32b32d656b1b8526d79fcb36e0a0/api/src/controllers/assets.ts#L243-L246

The solution for this is basically to `pipe` the data from the storage to the response output.
By doing so, we tell the storage stream to match the output stream "speed", i.e. we tell storage stream to hold a bit while we still write to the output. When output finishes write the chunk, it will tell the storage stream that new data can come in.
This is opposed of what happens currently where the entire file is written as soon as possible to `res`, but if the output has a slow connection, `res` will start filling up until there's no more memory available.

This only happens if the download rate is slower than reading from storage rate and the machine does not have much memory to keep the offset.

What's changed:

- Pipe the storage stream to the output stream

## Potential Risks / Drawbacks

- We were relying on `isDataSent` variable which was set when first data came in. Although, Response already has a property [`headersSent`](https://nodejs.org/api/http.html#responseheaderssent) which is the substitute of the former variable. They are not exactly the same thing so not sure if we may have any issue regarding that.

## Review Notes / Questions

- N/A

## Reproduction

- Replicating this is a bit tricky but you can see how I have done it in the following steps:
1. Edit docker-compose.yml on root of this repo and add this new service:
```yml
  directus:
    build:
      context: .
      dockerfile: Dockerfile
    volumes:
      - /tmp/uploads:/directus/uploads
    ports:
      - 8055:8055
    environment:
      NODE_OPTIONS: --max-old-space-size=256
    deploy:
      resources:
        limits:
          cpus: '0.5'
          memory: 256M
        reservations:
          cpus: '0.5'
          memory: 256M
    cap_add:
      - NET_ADMIN
```
1. From the root of this repo run `DOCKER_BUILDKIT=1 docker compose up --build directus`
1. Go to http://localhost:8055, login and upload a a big file (>5GB)
1. Now let's slow down the connection of container. To do so run `docker compose exec -it -u root directus sh`
1. From within the container run `apk add iproute2`. This will install the `tc` tool that adds the ability to manage network bandwidth
1. Still inside the container run `tc qdisc add dev eth0 root netem delay 500ms`. This will add a delay of 500ms to your network interface
1. Now try to download the file with "?download" query string. This is required otherwise if you are in a browser it will request the file in chunks using the `Range` header

If you run these steps on `main` branch, you will see the download of the file being canceled while some megabytes were already downloaded.
But you if you these steps on this PR, you will see that downloading the file is very slow (because of tc) but, in the end, the  file is downloaded as expected.
