### PR TITLE
Api / Graphql : Allow `version` as singleton argument on singleton

### DIFF
--- a/.changeset/khaki-pillows-collect.md
+++ b/.changeset/khaki-pillows-collect.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added missing `version` argument to singleton GraphQL queries

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1160,6 +1160,10 @@ export class GraphQLService {
 							type: GraphQLString,
 						},
 					};
+				} else {
+					resolver.args = {
+						version: GraphQLString,
+					};
 				}
 
 				ReadCollectionTypes[collection.collection]!.addResolver(resolver);

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -277,6 +277,8 @@ List a singleton item in Directus.
 
 ```graphql
 type Query {
+	<collection>(version: String): [<collection>]
+
 	<collection>_by_version(version: String): <collection>
 }
 ```

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -154,8 +154,9 @@ Get an item that exists in Directus.
 type Query {
 	<collection>_by_id(id: ID!, version: String): <collection>
 }
+
 type Query {
-	<collection>_by_version(id: ID!, version: String!): <collection_version>
+	<collection>_by_version(id: ID!, version: String!): <collection_version_raw>
 }
 ```
 
@@ -277,9 +278,11 @@ List a singleton item in Directus.
 
 ```graphql
 type Query {
-	<collection>(version: String): [<collection>]
+	<collection>(version: String): <collection>
+}
 
-	<collection>_by_version(version: String): <collection>
+type Query {
+	<collection>_by_version(version: String!): <collection_version_raw>
 }
 ```
 

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -152,10 +152,10 @@ Get an item that exists in Directus.
 
 ```graphql
 type Query {
-	<collection>_by_id(id: ID!): <collection>
+	<collection>_by_id(id: ID!, version: String): <collection>
 }
 type Query {
-	<collection>_by_version(id: ID!, version String!): <collection_version>
+	<collection>_by_version(id: ID!, version: String!): <collection_version>
 }
 ```
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope
On https://github.com/directus/directus/pull/21386 we have included support to fetch relational data when requestong a version of an item.

Although, this support were included only for existing resolvers, but we didn't have support to request a version of a singleton in Graphql.
The support for it is only included on `<collection>_by_id(id: ID!, version: String)`, but singletons so not have this resolver.

Since a singleton is retrieved using `<collection>` resolver, in this PR we just add `version` argument to this resolver.
In the end, the resolver for singleton will be `<collection>(version: String)`

What's changed:

- Add support to request a version for a singleton on Graphql

## Potential Risks / Drawbacks

- Since these are only additions, I don't foresee any issue

## Review Notes / Questions

- N/A
