### PR TITLE
API / Auth: Require OTP if Enforce TFA is enabled

### DIFF
--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -178,7 +178,10 @@ export class AuthenticationService {
 			throw e;
 		}
 
-		if (user.enforce_tfa && (!user.tfa_secret || !options?.otp)) {
+		const requiresTfa = user.enforce_tfa || user.tfa_secret;
+		const hasTfa = user.tfa_secret && options?.otp;
+
+		if (requiresTfa && !hasTfa) {
 			emitStatus('fail');
 			await stall(STALL_TIME, timeStart);
 			throw new InvalidOtpError();

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -72,7 +72,7 @@ export class AuthenticationService {
 		}
 
 		const user = await this.knex
-			.select<User & { tfa_secret: string | null }>(
+			.select<User & { tfa_secret: string | null; enforce_tfa: boolean | null }>(
 				'u.id',
 				'u.first_name',
 				'u.last_name',
@@ -82,6 +82,7 @@ export class AuthenticationService {
 				'u.role',
 				'r.admin_access',
 				'r.app_access',
+				'r.enforce_tfa',
 				'u.tfa_secret',
 				'u.provider',
 				'u.external_identifier',
@@ -177,7 +178,7 @@ export class AuthenticationService {
 			throw e;
 		}
 
-		if (user.tfa_secret && !options?.otp) {
+		if (user.enforce_tfa && (!user.tfa_secret || !options?.otp)) {
 			emitStatus('fail');
 			await stall(STALL_TIME, timeStart);
 			throw new InvalidOtpError();


### PR DESCRIPTION
While doing some tests I have enabled "Require 2FA" under the role page.
Then I have tried to login with a user via API under this role and it worked.

I was expecting that to not work, as I have enabled the Require 2FA.
Although the login worked expected.

In this PR we fix this behaviour so if Required 2FA is enabled on role, then an `otp` will be required on `login`.

## Scope

What's changed:

- Require OTP on login endpoint if role enforces 2FA

## Potential Risks / Drawbacks

- People thinking that MFA only applies to App and not API might have issues as `otp` field is now required per role conditions.

## Review Notes / Questions

- N/A

