### PR TITLE
Don't influence Cache-Control through `CACHE_AUTO_PURGE`

### DIFF
--- a/.changeset/giant-laws-rhyme.md
+++ b/.changeset/giant-laws-rhyme.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Don't influence Cache-Control header trough `CACHE_AUTO_PURGE` environment variable
+Ensured the `CACHE_AUTO_PURGE` config doesn't influence the Cache-Control header

--- a/.changeset/giant-laws-rhyme.md
+++ b/.changeset/giant-laws-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Don't influence Cache-Control header trough `CACHE_AUTO_PURGE` environment variable

--- a/api/src/utils/get-cache-headers.test.ts
+++ b/api/src/utils/get-cache-headers.test.ts
@@ -69,50 +69,6 @@ const scenarios = [
 		output: 'max-age=0',
 	},
 
-	// Test CACHE_AUTO_PURGE env for no-cache
-	{
-		name: 'when CACHE_AUTO_PURGE is true and globalCacheSettings is true',
-		input: {
-			env: {
-				CACHE_AUTO_PURGE: true,
-			},
-			headers: {},
-			accountability: null,
-			ttl: 5678910,
-			globalCacheSettings: true,
-			personalized: false,
-		},
-		output: 'no-cache',
-	},
-	{
-		name: 'when CACHE_AUTO_PURGE is true and globalCacheSettings is false',
-		input: {
-			env: {
-				CACHE_AUTO_PURGE: true,
-			},
-			headers: {},
-			accountability: null,
-			ttl: 5678910,
-			globalCacheSettings: false,
-			personalized: false,
-		},
-		output: 'max-age=5679',
-	},
-	{
-		name: 'when CACHE_AUTO_PURGE is false and globalCacheSettings is true',
-		input: {
-			env: {
-				CACHE_AUTO_PURGE: false,
-			},
-			headers: {},
-			accountability: null,
-			ttl: 5678910,
-			globalCacheSettings: true,
-			personalized: false,
-		},
-		output: 'max-age=5679',
-	},
-
 	// Test personalized
 	{
 		name: 'when personalized is true and accountability is null',

--- a/api/src/utils/get-cache-headers.ts
+++ b/api/src/utils/get-cache-headers.ts
@@ -24,9 +24,6 @@ export function getCacheControlHeader(
 	// When the resource / current request shouldn't be cached
 	if (ttl === undefined || ttl < 0) return 'no-cache';
 
-	// When the API cache can invalidate at any moment
-	if (globalCacheSettings && env['CACHE_AUTO_PURGE'] === true) return 'no-cache';
-
 	const headerValues = [];
 
 	// When caching depends on the authentication status of the users


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Removed the influence of the `CACHE_AUTO_PURGE` flag on Cache-Control header and dropped the associated tests.

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- Does anything else need to be done or was is really as easy as just removing this line (and the tests)?
- Does this need any mentioning in the docs, since it effectively changes the way the header behaves for the same environment configuration?

---

Fixes #21907 
