### PR TITLE
Fix issue where background color of the search input did not match the navigation bar

### DIFF
--- a/.changeset/dull-ants-relate.md
+++ b/.changeset/dull-ants-relate.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that the search input in the navigation bar matches the background color of the navigation bar

--- a/app/src/modules/content/components/navigation.vue
+++ b/app/src/modules/content/components/navigation.vue
@@ -140,6 +140,6 @@ const hasHiddenCollections = computed(
 	z-index: 2;
 	padding: 12px;
 	padding-bottom: 0;
-	background-color: var(--theme--background-normal);
+	background-color: var(--theme--navigation--background);
 }
 </style>


### PR DESCRIPTION
## Scope

What's changed:

- a CSS var

## Potential Risks / Drawbacks

- nope

## Review Notes / Questions

- tiny fix

---

Fixes #21461
