### PR TITLE
Fix visual inconsistency in filter interface

### DIFF
--- a/.changeset/silent-buckets-care.md
+++ b/.changeset/silent-buckets-care.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed visual inconsistency in filter interface for list of values

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -141,11 +141,7 @@ function setValueAt(index: number, newVal: any) {
 		/>
 	</template>
 
-	<div
-		v-else-if="['_in', '_nin'].includes(comparator)"
-		class="list"
-		:class="{ moveComma: interfaceType === 'interface-input' }"
-	>
+	<div v-else-if="['_in', '_nin'].includes(comparator)" class="list">
 		<div v-for="(val, index) in value" :key="index" class="value">
 			<input-component
 				:is="interfaceType"
@@ -201,13 +197,9 @@ function setValueAt(index: number, newVal: any) {
 		margin-right: 6px;
 		content: ',';
 	}
-
-	&.moveComma .value:not(:last-child)::after {
-		margin: 0 8px 0 -6px;
-	}
 }
 
 .and {
-	margin: 0px 8px;
+	margin: 0 8px;
 }
 </style>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- A list of values in the filter interface now has the correct margin applied to the comma separating individual commas

|Before|After|
|-|-|
| ![Screenshot 2024-04-16 at 13 25 33](https://github.com/directus/directus/assets/4376726/835282b4-9747-479f-90ba-04a1a21134d2) | ![Screenshot 2024-04-16 at 13 25 24](https://github.com/directus/directus/assets/4376726/1be87d85-2f7f-42ef-bd5f-7d1fd95e4c1d) |


## Potential Risks / Drawbacks

None

## Review Notes / Questions

- This previously was a specifically introduced change for `interface-input` type inputs (in 2021). Maybe some other CSS changed in the meantime hence the misalignment?

---
