### PR TITLE
Improve sorting UX in M2A

### DIFF
--- a/.changeset/stupid-laws-jog.md
+++ b/.changeset/stupid-laws-jog.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Improved M2A builder sorting UX for large number of items

--- a/app/src/composables/use-page-size.ts
+++ b/app/src/composables/use-page-size.ts
@@ -1,5 +1,5 @@
 import { useServerStore } from '@/stores/server';
-import { ComputedRef, computed, MaybeRef, toValue } from 'vue';
+import { computed, ComputedRef, MaybeRef, unref } from 'vue';
 
 export function usePageSize<T = any>(
 	availableSizes: MaybeRef<number[]>,
@@ -12,10 +12,10 @@ export function usePageSize<T = any>(
 
 	const pageSizes = computed<T[]>(() => {
 		if (queryLimit === undefined || queryLimit.max === -1) {
-			return toValue(availableSizes).map(mapCallback);
+			return unref(availableSizes).map(mapCallback);
 		}
 
-		const sizes = toValue(availableSizes).filter((size) => size <= queryLimit.max);
+		const sizes = unref(availableSizes).filter((size) => size <= queryLimit.max);
 
 		if (sizes.length === 0) {
 			sizes.push(queryLimit.max);

--- a/app/src/composables/use-page-size.ts
+++ b/app/src/composables/use-page-size.ts
@@ -1,8 +1,8 @@
 import { useServerStore } from '@/stores/server';
-import { ComputedRef, computed } from 'vue';
+import { ComputedRef, computed, MaybeRef, toValue } from 'vue';
 
 export function usePageSize<T = any>(
-	availableSizes: number[],
+	availableSizes: MaybeRef<number[]>,
 	mapCallback: (value: number, index: number, array: number[]) => T,
 	defaultSize = 25,
 ): { sizes: ComputedRef<T[]>; selected: number } {
@@ -12,10 +12,10 @@ export function usePageSize<T = any>(
 
 	const pageSizes = computed<T[]>(() => {
 		if (queryLimit === undefined || queryLimit.max === -1) {
-			return availableSizes.map(mapCallback);
+			return toValue(availableSizes).map(mapCallback);
 		}
 
-		const sizes = availableSizes.filter((size) => size <= queryLimit.max);
+		const sizes = toValue(availableSizes).filter((size) => size <= queryLimit.max);
 
 		if (sizes.length === 0) {
 			sizes.push(queryLimit.max);

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -99,9 +99,8 @@ const pageCount = computed(() => Math.ceil(totalItemCount.value / limitWritable.
 const page = ref(1);
 
 watch(limitWritable, (newLimit, oldLimit) => {
-	const low = Math.min(newLimit, oldLimit);
-	const high = Math.max(newLimit, oldLimit);
-	page.value = Math.ceil((page.value * low) / high);
+	const offset = (page.value - 1) * oldLimit;
+	page.value = Math.floor(offset / newLimit + 1);
 });
 
 const query = computed<RelationQueryMultiple>(() => ({
@@ -232,8 +231,8 @@ function stageEdits(item: Record<string, any>) {
 
 function deleteItem(item: DisplayItem) {
 	if (
-		page.value === Math.ceil(totalItemCount.value / limit.value) &&
-		page.value !== Math.ceil((totalItemCount.value - 1) / limit.value)
+		page.value === Math.ceil(totalItemCount.value / limitWritable.value) &&
+		page.value !== Math.ceil((totalItemCount.value - 1) / limitWritable.value)
 	) {
 		page.value = Math.max(1, page.value - 1);
 	}
@@ -346,7 +345,7 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 		<v-notice v-if="canDrag && !allowDrag">{{ t('interfaces.list-m2a.sorting_disabled') }}</v-notice>
 		<template v-if="loading">
 			<v-skeleton-loader
-				v-for="n in clamp(totalItemCount - (page - 1) * limit, 1, limit)"
+				v-for="n in clamp(totalItemCount - (page - 1) * limitWritable, 1, limitWritable)"
 				:key="n"
 				:type="totalItemCount > 4 ? 'block-list-item-dense' : 'block-list-item'"
 			/>

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { usePageSize } from '@/composables/use-page-size';
 import { useRelationM2A } from '@/composables/use-relation-m2a';
 import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
 import { useRelationPermissionsM2A } from '@/composables/use-relation-permissions';
@@ -87,15 +88,25 @@ const fields = computed(() => {
 	return fields;
 });
 
+const { sizes: pageSizes, selected: selectedPageSize } = usePageSize<string>(
+	computed(() => [10, 25, 50, 100, limit.value].filter((v) => v >= limit.value).sort((a, b) => a - b)),
+	(value) => String(value),
+	limit.value,
+);
+
+const limitWritable = ref(selectedPageSize);
+const pageCount = computed(() => Math.ceil(totalItemCount.value / limitWritable.value));
 const page = ref(1);
 
-watch([limit], () => {
-	page.value = 1;
+watch(limitWritable, (newLimit, oldLimit) => {
+	const low = Math.min(newLimit, oldLimit);
+	const high = Math.max(newLimit, oldLimit);
+	page.value = Math.ceil((page.value * low) / high);
 });
 
 const query = computed<RelationQueryMultiple>(() => ({
 	fields: fields.value,
-	limit: limit.value,
+	limit: limitWritable.value,
 	page: page.value,
 }));
 
@@ -112,8 +123,6 @@ const {
 	isLocalItem,
 	getItemEdits,
 } = useRelationMultiple(value, query, relationInfo, primaryKey);
-
-const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
 function getDeselectIcon(item: DisplayItem) {
 	if (item.$type === 'deleted') return 'settings_backup_restore';
@@ -326,19 +335,15 @@ const createCollections = computed(() => {
 	});
 });
 
-const allowDrag = computed(
-	() =>
-		totalItemCount.value <= limit.value &&
-		relationInfo.value?.sortField !== undefined &&
-		!props.disabled &&
-		updateAllowed.value,
-);
+const canDrag = computed(() => relationInfo.value?.sortField !== undefined && !props.disabled && updateAllowed.value);
+const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitWritable.value);
 </script>
 
 <template>
 	<v-notice v-if="!relationInfo" type="warning">{{ t('relationship_not_setup') }}</v-notice>
 	<v-notice v-else-if="allowedCollections.length === 0" type="warning">{{ t('no_singleton_relations') }}</v-notice>
 	<div v-else class="m2a-builder">
+		<v-notice v-if="canDrag && !allowDrag">{{ t('interfaces.list-m2a.sorting_disabled') }}</v-notice>
 		<template v-if="loading">
 			<v-skeleton-loader
 				v-for="n in clamp(totalItemCount - (page - 1) * limit, 1, limit)"
@@ -445,7 +450,19 @@ const allowDrag = computed(
 				</v-list>
 			</v-menu>
 
-			<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="5" />
+			<div v-if="pageCount > 1 || limitWritable !== limit" class="pagination">
+				<div v-if="pageSizes.length > 1" class="per-page">
+					<span>{{ t('per_page') }}</span>
+					<v-select
+						:model-value="`${limitWritable}`"
+						:items="pageSizes"
+						inline
+						@update:model-value="limitWritable = +$event"
+					/>
+				</div>
+
+				<v-pagination v-model="page" :length="pageCount" :total-visible="5" />
+			</div>
 		</div>
 
 		<drawer-collection
@@ -475,6 +492,11 @@ const allowDrag = computed(
 </template>
 
 <style lang="scss" scoped>
+.m2a-builder {
+	.v-notice {
+		margin-bottom: 8px;
+	}
+}
 .v-list {
 	--v-list-padding: 0 0 4px;
 }
@@ -506,13 +528,34 @@ const allowDrag = computed(
 	margin-top: 8px;
 	display: flex;
 	align-items: end;
+	flex-wrap: wrap;
 	gap: 8px;
 
-	.v-pagination {
+	.pagination {
 		margin-left: auto;
+		display: flex;
+		gap: 8px 16px;
 
-		::v-deep(.v-button) {
-			display: inline-flex;
+		.v-pagination {
+			::v-deep(.v-button) {
+				display: inline-flex;
+			}
+		}
+
+		.per-page {
+			display: flex;
+			align-items: center;
+			justify-content: flex-end;
+			color: var(--theme--foreground-subdued);
+
+			span {
+				width: auto;
+				margin-right: 4px;
+			}
+
+			.v-select {
+				color: var(--theme--foreground);
+			}
 		}
 	}
 }

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1661,6 +1661,7 @@ delete_item: Delete Item
 interfaces:
   list-m2a:
     prefix_note: Uses the related item's collection name by default.
+    sorting_disabled: Sorting is disabled because there are more items than can fit on one page.
   filter:
     name: Filter
     description: Configure a filter object.


### PR DESCRIPTION

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added a notice that is shown if sorting in a M2A Builder is disabled due to having too many items for one page
- Added page size selector that is always shown if there are more than one page for the default page size, with the sizes `10, 25, 50, 100` and the configured page size as possible options
  - Page sizes smaller than the configured page size are not shown
  - Page sizes larger than the query limit are not shown
  - When selecting different sizes the 

Notice and disabled sorting
![Screenshot 2024-04-17 at 14 26 04](https://github.com/directus/directus/assets/4376726/95c5219b-e485-4558-b7df-86a8ad5199a6)

Enabled sorting if page size > # of items
![Screenshot 2024-04-17 at 14 26 19](https://github.com/directus/directus/assets/4376726/6089bf96-2953-4675-9c7a-54045e6860d3)


## Potential Risks / Drawbacks

None

## Review Notes / Questions

- I would like feedback on the placement of the page size selector and its behavior as well as the wording of the notice.

---

Fixes #21532 
