### PR TITLE
Consolidate content versioning

### DIFF
--- a/.changeset/loud-avocados-serve.md
+++ b/.changeset/loud-avocados-serve.md
@@ -1,0 +1,7 @@
+---
+'@directus/system-data': patch
+'@directus/types': patch
+'@directus/api': patch
+---
+
+Consolidated content versioning with a new `delta` field in `directus_versions`

--- a/api/src/controllers/versions.ts
+++ b/api/src/controllers/versions.ts
@@ -211,9 +211,15 @@ router.get(
 
 		const { outdated, mainHash } = await service.verifyHash(version['collection'], version['item'], version['hash']);
 
-		const saves = await service.getVersionSavesById(version['id']);
+		let current;
 
-		const current = assign({}, ...saves);
+		if (version['delta']) {
+			current = version['delta'];
+		} else {
+			const saves = await service.getVersionSavesById(version['id']);
+
+			current = assign({}, ...saves);
+		}
 
 		const main = await service.getMainItem(version['collection'], version['item']);
 
@@ -238,9 +244,9 @@ router.post(
 
 		await service.save(req.params['pk']!, req.body);
 
-		const saves = await service.getVersionSavesById(req.params['pk']!);
+		const updatedVersion = await service.readOne(req.params['pk']!);
 
-		const result = assign(mainItem, ...saves);
+		const result = assign(mainItem, updatedVersion['delta']);
 
 		res.locals['payload'] = { data: result || null };
 

--- a/api/src/database/migrations/20240415A-consolidate-content-versioning.ts
+++ b/api/src/database/migrations/20240415A-consolidate-content-versioning.ts
@@ -1,0 +1,29 @@
+import type { Knex } from 'knex';
+import { assign, sortBy } from 'lodash-es';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_versions', (table) => {
+		table.json('delta');
+	});
+
+	const versions = await knex.select('id').from('directus_versions');
+
+	for (const version of versions) {
+		const deltas = sortBy(
+			await knex.select('id', 'delta').from('directus_revisions').where('version', '=', version.id),
+			'id',
+		).map((revision) => (typeof revision.delta === 'string' ? JSON.parse(revision.delta) : revision.delta));
+
+		const finalVersionDelta = assign({}, ...deltas);
+
+		await knex('directus_versions')
+			.update({ delta: JSON.stringify(finalVersionDelta) })
+			.where('id', '=', version.id);
+	}
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_versions', (table) => {
+		table.dropColumn('delta');
+	});
+}

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -123,6 +123,10 @@ export class VersionsService extends ItemsService {
 
 		if (!versions?.[0]) return null;
 
+		if (versions[0]['delta']) {
+			return [versions[0]['delta']];
+		}
+
 		const saves = await this.getVersionSavesById(versions[0]['id']);
 
 		return saves;
@@ -167,10 +171,11 @@ export class VersionsService extends ItemsService {
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		// Only allow updates on "key" and "name" fields
+		// Only allow updates on "key", "name" and "delta" fields
 		const versionUpdateSchema = Joi.object({
 			key: Joi.string(),
 			name: Joi.string().allow(null).optional(),
+			delta: Joi.object().optional(),
 		});
 
 		const { error } = versionUpdateSchema.validate(data);
@@ -253,6 +258,10 @@ export class VersionsService extends ItemsService {
 			delta: revisionDelta,
 		});
 
+		const finalVersionDelta = assign({}, version['delta'], revisionDelta ? JSON.parse(revisionDelta) : null);
+
+		await this.updateOne(key, { delta: finalVersionDelta });
+
 		const { cache } = getCache();
 
 		if (shouldClearCache(cache, undefined, collection)) {
@@ -263,7 +272,7 @@ export class VersionsService extends ItemsService {
 	}
 
 	async promote(version: PrimaryKey, mainHash: string, fields?: string[]) {
-		const { id, collection, item } = (await this.readOne(version)) as ContentVersion;
+		const { id, collection, item, delta } = (await this.readOne(version)) as ContentVersion;
 
 		// will throw an error if the accountability does not have permission to update the item
 		await this.authorizationService.checkAccess('update', collection, item);
@@ -276,9 +285,15 @@ export class VersionsService extends ItemsService {
 			});
 		}
 
-		const saves = await this.getVersionSavesById(id);
+		let versionResult;
 
-		const versionResult = assign({}, ...saves);
+		if (delta) {
+			versionResult = delta;
+		} else {
+			const saves = await this.getVersionSavesById(id);
+
+			versionResult = assign({}, ...saves);
+		}
 
 		const payloadToUpdate = fields ? pick(versionResult, fields) : versionResult;
 

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -258,7 +258,15 @@ export class VersionsService extends ItemsService {
 			delta: revisionDelta,
 		});
 
-		const finalVersionDelta = assign({}, version['delta'], revisionDelta ? JSON.parse(revisionDelta) : null);
+		let existingDelta = version['delta'];
+
+		if (!existingDelta) {
+			const saves = await this.getVersionSavesById(key);
+
+			existingDelta = assign({}, ...saves);
+		}
+
+		const finalVersionDelta = assign({}, existingDelta, revisionDelta ? JSON.parse(revisionDelta) : null);
 
 		await this.updateOne(key, { delta: finalVersionDelta });
 

--- a/packages/system-data/src/fields/versions.yaml
+++ b/packages/system-data/src/fields/versions.yaml
@@ -36,3 +36,7 @@ fields:
   - field: user_updated
     special:
       - user-updated
+
+  - field: delta
+    special:
+      - cast-json

--- a/packages/types/src/versions.ts
+++ b/packages/types/src/versions.ts
@@ -9,4 +9,5 @@ export type ContentVersion = {
 	date_updated: string | null;
 	user_created: string | null;
 	user_updated: string | null;
+	delta: Record<string, any> | null;
 };

--- a/sdk/src/schema/version.ts
+++ b/sdk/src/schema/version.ts
@@ -16,5 +16,6 @@ export type DirectusVersion<Schema extends object> = MergeCoreCollection<
 		date_updated: 'datetime' | null;
 		user_created: DirectusUser<Schema> | string | null;
 		user_updated: DirectusUser<Schema> | string | null;
+		delta: Record<string, any> | null;
 	}
 >;


### PR DESCRIPTION
## Scope

What's changed:

- Added a new `delta` field to the `directus_versions` table
  - Contains the final delta which is the combination of all revisions

## Potential Risks / Drawbacks

- Updates to existing revisions during the migration may result in an incorrect final delta stored
  - This happens when an existing instance of Directus is performing the patch
  - The final delta could be fully repopulated in a subsequent release

## Review Notes / Questions

- The existing `versions` field in the `directus_revisions` table will be removed in a subsequent release
- If the `delta` field in `directus_versions` is empty, the existing behaviour of fetching from `directus_revisions` remains
- Needs further testing to ensure content versioning remains fully operational

---

Related to #17894
