### PR TITLE
Fix revert revision with no previous data

### DIFF
--- a/.changeset/swift-dryers-shake.md
+++ b/.changeset/swift-dryers-shake.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed revision revert for revisions with no previous field value

--- a/.changeset/swift-dryers-shake.md
+++ b/.changeset/swift-dryers-shake.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed revision revert for revisions with no previous field value
+Fixed revision revert for revisions with no previous data

--- a/app/src/views/private/components/revisions-drawer.vue
+++ b/app/src/views/private/components/revisions-drawer.vue
@@ -73,8 +73,8 @@ function revert() {
 
 	const revertToValues: Record<string, any> = {};
 
-	for (const [field, newValue] of Object.entries(currentRevision.value.delta)) {
-		const previousValue = previousRevision.value?.data[field] ?? null;
+	for (const [field, newValue] of Object.entries(currentRevision.value.delta ?? {})) {
+		const previousValue = previousRevision.value?.data?.[field] ?? null;
 		if (isEqual(newValue, previousValue)) continue;
 		revertToValues[field] = previousValue;
 	}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added optional chaining to catch missing data in previous revision when reverting

## Potential Risks / Drawbacks

None 

## Review Notes / Questions

- To reproduce the initial bug make sure that the created item has no data at all (all fields are null)

---

Fixes #22229 
