### PR TITLE
Fix Files interface with custom junction field

### DIFF
--- a/.changeset/six-bags-play.md
+++ b/.changeset/six-bags-play.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed Files interface when used with custom junction field

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -219,8 +219,9 @@ const downloadName = computed(() => {
 	const junctionField = relationInfo.value.junctionField.field;
 	const relationPkField = relationInfo.value.relatedPrimaryKeyField.field;
 
-	return displayItems.value.find((item) => get(item, [junctionField, relationPkField]))?.directus_files_id
-		?.filename_download;
+	return displayItems.value.find((item) => get(item, [junctionField, relationPkField]) === relatedPrimaryKey.value)?.[
+		junctionField
+	]?.filename_download;
 });
 
 const downloadUrl = computed(() => {
@@ -236,6 +237,13 @@ function getFilename(junctionRow: Record<string, any>) {
 	if (!key) return null;
 
 	return key;
+}
+
+function getDownloadName(junctionRow: Record<string, any>) {
+	const junctionField = relationInfo.value?.junctionField.field;
+	if (!junctionField) return;
+
+	return junctionRow[junctionField]?.filename_download;
 }
 
 const customFilter = computed(() => {
@@ -335,7 +343,7 @@ const allowDrag = computed(
 								</v-list-item>
 								<v-list-item
 									clickable
-									:download="element.directus_files_id.filename_download"
+									:download="getDownloadName(element)"
 									:href="getAssetUrl(getFilename(element), true)"
 								>
 									<v-list-item-icon><v-icon name="download" /></v-list-item-icon>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The Files interface was relying on the default junction field name `directus_files_id` and therefore broke with custom field names. 

What's changed:
- Use proper junction field in place of directus_files_id
- While I was at it, I noticed that the `download` property in the item drawer was incorrectly being set as well

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #22226 
