### PR TITLE
Fix "Download Page as CSV" for related value display with empty template

### DIFF
--- a/.changeset/selfish-sloths-double.md
+++ b/.changeset/selfish-sloths-double.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed "Download Page as CSV" for Related Values display with not display template

--- a/.changeset/selfish-sloths-double.md
+++ b/.changeset/selfish-sloths-double.md
@@ -1,5 +1,6 @@
 ---
 '@directus/app': patch
+'@directus/utils': patch
 ---
 
-Fixed "Download Page as CSV" for Related Values display with not display template
+Fixed "Download Page as CSV" for Related Values display with no display template

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -56,7 +56,7 @@ export default defineDisplay({
 
 		const fieldsStore = useFieldsStore();
 
-		const fieldKeys = getFieldsFromTemplate(options.template);
+		const fieldKeys = getFieldsFromTemplate(options.template ?? null);
 
 		const fields = fieldKeys.map((fieldKey) => {
 			return {
@@ -93,7 +93,7 @@ export default defineDisplay({
 			set(stringValues, key, stringValue);
 		}
 
-		return renderPlainStringTemplate(options.template, stringValues);
+		return renderPlainStringTemplate(options.template ?? null, stringValues);
 	},
 	types: ['alias', 'string', 'uuid', 'integer', 'bigInteger', 'json'],
 	localTypes: ['m2m', 'm2o', 'o2m', 'translations', 'm2a', 'file', 'files'],

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -56,7 +56,7 @@ export default defineDisplay({
 
 		const fieldsStore = useFieldsStore();
 
-		const fieldKeys = getFieldsFromTemplate(options.template ?? null);
+		const fieldKeys = getFieldsFromTemplate(options.template);
 
 		const fields = fieldKeys.map((fieldKey) => {
 			return {
@@ -93,7 +93,7 @@ export default defineDisplay({
 			set(stringValues, key, stringValue);
 		}
 
-		return renderPlainStringTemplate(options.template ?? null, stringValues);
+		return renderPlainStringTemplate(options.template, stringValues);
 	},
 	types: ['alias', 'string', 'uuid', 'integer', 'bigInteger', 'json'],
 	localTypes: ['m2m', 'm2o', 'o2m', 'translations', 'm2a', 'file', 'files'],

--- a/packages/utils/shared/get-fields-from-template.test.ts
+++ b/packages/utils/shared/get-fields-from-template.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { getFieldsFromTemplate } from './get-fields-from-template.js';
 
 describe('getFieldsFromTemplate', () => {
-	it('returns an empty array when passed null', () => {
+	it('returns an empty array when no value passed', () => {
+		expect(getFieldsFromTemplate('')).toStrictEqual([]);
+		expect(getFieldsFromTemplate(undefined)).toStrictEqual([]);
 		expect(getFieldsFromTemplate(null)).toStrictEqual([]);
 	});
 

--- a/packages/utils/shared/get-fields-from-template.ts
+++ b/packages/utils/shared/get-fields-from-template.ts
@@ -1,5 +1,7 @@
-export function getFieldsFromTemplate(template: string | null): string[] {
-	if (template === null) return [];
+import { isNil } from 'lodash-es';
+
+export function getFieldsFromTemplate(template?: string | null): string[] {
+	if (isNil(template)) return [];
 
 	const regex = /{{(.*?)}}/g;
 	const fields = template.match(regex);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

If the display template of a related value display is never touched we end up with empty display options, and an `undefined` template. `getFieldsFromTemplate` only explicitly checks for `null` and then tries to proceed.

What's changed:

- Explicitly pass `null` instead of `undefined` template

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- I wonder if the healthier option is to also check for `undefined` templates and broaden the parameter type in `getFieldsFromTemplate` in order to avoid problems like this in the future. The reason Typescript didn't complain was that the `Options` type requires the `template` property to be string, but apparently we force it to taking an empty object at some point. 

---

Fixes #21941 
