### PR TITLE
Fix caching for marketplace account / type extension listing

### DIFF
--- a/.changeset/smooth-ears-buy.md
+++ b/.changeset/smooth-ears-buy.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Fixed caching of marketplace user extension listing

--- a/.changeset/smooth-ears-buy.md
+++ b/.changeset/smooth-ears-buy.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Fixed a caching issue which could lead to wrong extensions being listed under an account inside Marketplace
+Fixed a caching issue which could lead to wrong extensions being listed under Marketplace when filtering by type / account

--- a/.changeset/smooth-ears-buy.md
+++ b/.changeset/smooth-ears-buy.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Fixed caching of marketplace user extension listing
+Fixed a caching issue which could lead to wrong extensions being listed under an account inside Marketplace

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -49,7 +49,7 @@ router.get(
 			throw new ForbiddenError();
 		}
 
-		const { search, limit, offset, type, by, sort } = req.query;
+		const { search, limit, offset, type, sort } = req.query;
 		const { filter } = req.sanitizedQuery as { filter?: { by?: FieldFilterOperator } };
 
 		const query: ListQuery = {};

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -49,8 +49,7 @@ router.get(
 			throw new ForbiddenError();
 		}
 
-		const { search, limit, offset, type, sort } = req.query;
-		const { filter } = req.sanitizedQuery as { filter?: { by?: FieldFilterOperator } };
+		const { search, limit, offset, sort, filter } = req.sanitizedQuery;
 
 		const query: ListQuery = {};
 

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -1,15 +1,16 @@
 import { useEnv } from '@directus/env';
-import { ErrorCode, ForbiddenError, RouteNotFoundError, isDirectusError } from '@directus/errors';
+import { ErrorCode, ForbiddenError, isDirectusError, RouteNotFoundError } from '@directus/errors';
 import { EXTENSION_TYPES } from '@directus/extensions';
 import {
 	account,
-	describe,
-	list,
 	type AccountOptions,
+	describe,
 	type DescribeOptions,
+	list,
 	type ListOptions,
 	type ListQuery,
 } from '@directus/extensions-registry';
+import type { FieldFilterOperator } from '@directus/types';
 import { isIn } from '@directus/utils';
 import express from 'express';
 import { UUID_REGEX } from '../constants.js';
@@ -49,6 +50,7 @@ router.get(
 		}
 
 		const { search, limit, offset, type, by, sort } = req.query;
+		const { filter } = req.sanitizedQuery as { filter?: { by?: FieldFilterOperator } };
 
 		const query: ListQuery = {};
 
@@ -64,8 +66,8 @@ router.get(
 			query.offset = Number(offset);
 		}
 
-		if (typeof by === 'string') {
-			query.by = by;
+		if (filter?.by) {
+			query.by = filter.by._eq as string;
 		}
 
 		if (typeof sort === 'string' && isIn(sort, ['popular', 'recent', 'downloads'] as const)) {

--- a/app/src/modules/settings/routes/marketplace/routes/account/account.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/account/account.vue
@@ -48,7 +48,7 @@ watchEffect(async () => {
 		params: {
 			limit: perPage,
 			offset: (page.value - 1) * perPage,
-			by: props.accountId,
+			filter: { by: { _eq: props.accountId } },
 		},
 	});
 

--- a/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/registry.vue
@@ -53,7 +53,11 @@ watchEffect(async () => {
 				search: search.value,
 				limit: perPage,
 				offset: (page.value - 1) * perPage,
-				type: type.value,
+				filter: {
+					type: {
+						_eq: type.value,
+					},
+				},
 				sort: sort.value,
 			},
 		});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The account page of marketplace users listed the extensions of the first visited account page for all users. This was due to using a custom query parameter for filtering (`by`) that is stripped in the `sanitizedQuery` from which the cache key is derived. As such all requests even with different `by` parameters have the same cache key and get the same (wrong) cached response. 

What's changed:

- Use the filter parameter together with a fixed filter to convey the `by` "field" filter to the endpoint.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Use `CACHE_ENABLED="true"` and `CACHE_AUTO_PURGE="true"` to verify this change, otherwise the data studio will always skip the cache all-together.

---

Fixes #21886 
