### PR TITLE
Fix live preview target URL with search parameters

### DIFF
--- a/.changeset/long-toes-pull.md
+++ b/.changeset/long-toes-pull.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed live preview accessed through bookmarked collections
+Fixed an endless refresh loop in the live preview of an item accessed through a bookmarked view

--- a/.changeset/long-toes-pull.md
+++ b/.changeset/long-toes-pull.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed live preview accessed through bookmarked collections

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -257,7 +257,8 @@ watch(
 			return;
 		}
 
-		const targetUrl = window.location.href + (window.location.href.endsWith('/') ? 'preview' : '/preview');
+		const targetUrl = new URL(window.location.href);
+		targetUrl.pathname += '/preview';
 
 		popupWindow = window.open(
 			targetUrl,

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -258,7 +258,7 @@ watch(
 		}
 
 		const targetUrl = new URL(window.location.href);
-		targetUrl.pathname += '/preview';
+		targetUrl.pathname += targetUrl.pathname.endsWith('/') ? 'preview' : '/preview';
 
 		popupWindow = window.open(
 			targetUrl,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Instead of appending the `/preview` directly to the current `href` (which fails if the `href` contains search parameters or a hash) we build a new URL and append it to the `pathname` only.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Create a collection with Preview URL and a Bookmark for that collection, observe that the `bookmark` search parameter is appended and then try to open the preview of an item in a separate tab. Before the change we entered and endless refresh loop, because instead of the preview the item itself was accessed, immediately trying to open the preview window in a new tab target (which was the open tab) and appending another `/preview` to the URL after the search parameters.

---

Fixes #21822 
