### PR TITLE
Fix small visual inconsistency in Files interface

### DIFF
--- a/.changeset/six-tigers-pull.md
+++ b/.changeset/six-tigers-pull.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a small visual inconsistency with the item menu in Files interface

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -298,7 +298,7 @@ const allowDrag = computed(
 			/>
 		</template>
 
-		<v-list v-else>
+		<v-list v-else class="files">
 			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
 
 			<draggable
@@ -416,7 +416,7 @@ const allowDrag = computed(
 </template>
 
 <style lang="scss" scoped>
-.v-list {
+.v-list.files {
 	--v-list-padding: 0 0 4px;
 
 	.v-list-item.deleted {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -571,7 +571,7 @@ replace_from_url: Replace File from URL
 no_image_selected: No Image Selected
 no_file_selected: No File Selected
 download_file: Download File
-open_file_in_tab: Open file in new tab
+open_file_in_tab: Open File in New Tab
 start_export: Start Export
 not_available_for_local_downloads: Not available for local downloads
 exporting_all_items_in_collection: Exporting all items ({total}) within {collection}.


### PR DESCRIPTION
## Scope

Fix a small visual inconsistency with the item menu in Files interface:
- First option not capitalized (while second is)
- Missing padding, due to unscoped `v-list` styling (notice the arrow overlapping the first option)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img width="260" src="https://github.com/directus/directus/assets/5363448/ded4c22a-913b-4b1d-9ed1-b228447d49d4"></td><td><img width="260" src="https://github.com/directus/directus/assets/5363448/a7ee4c60-6ef1-495f-af4a-f670bf623f8c"></td></tr>
</table>




## Potential Risks / Drawbacks

None

## Review Notes / Questions

None