### PR TITLE
Fix ambiguous column SQL error for M2A relations

### DIFF
--- a/.changeset/blue-lies-double.md
+++ b/.changeset/blue-lies-double.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed SQL error when filtering collections with two or more M2A relations pointing to the same collection(s)

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -184,7 +184,7 @@ function addJoin({ path, collection, aliasMap, rootQuery, schema, relations, kne
 
 				rootQuery.leftJoin({ [alias]: pathScope }, (joinClause) => {
 					joinClause
-						.onVal(relation.meta!.one_collection_field!, '=', pathScope)
+						.onVal(`${aliasedParentCollection}.${relation.meta!.one_collection_field!}`, '=', pathScope)
 						.andOn(
 							`${aliasedParentCollection}.${relation.field}`,
 							'=',
@@ -201,7 +201,7 @@ function addJoin({ path, collection, aliasMap, rootQuery, schema, relations, kne
 			} else if (relationType === 'o2a') {
 				rootQuery.leftJoin({ [alias]: relation.collection }, (joinClause) => {
 					joinClause
-						.onVal(relation.meta!.one_collection_field!, '=', parentCollection)
+						.onVal(`${alias}.${relation.meta!.one_collection_field!}`, '=', parentCollection)
 						.andOn(
 							`${alias}.${relation.field}`,
 							'=',


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

As pointed out in #21663 the joining in collections which have two or more M2A relations pointing to the same collection results in an ambiguous column name SQL error since the `collection` column is used without aliasing.

What's changed:

- Add alias to the column name in `addJoin` for `a2o` and `o2a` relations

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- I verified that I can filter on fields of two separate M2A fields in a collection pointing to the same related collection
- I also verified that the reverse relation (`o2a`), which can be encountered in the wild when adding new items to a builder interface that does not allow duplicates, continues to work.
- But please tell me if I missing something in the `o2a` case.

---

Fixes #21663 
