### PR TITLE
Fix untranslated field meta data

### DIFF
--- a/.changeset/stupid-singers-smash.md
+++ b/.changeset/stupid-singers-smash.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed untranslated translation placeholders in field metadata that appear after visiting a collection settings page

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -3,7 +3,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { Field, LocalType } from '@directus/types';
 import { isNil, orderBy } from 'lodash';
-import { computed, toRefs, onBeforeMount } from 'vue';
+import { computed, toRefs, onBeforeMount, onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Draggable from 'vuedraggable';
 import FieldSelect from './field-select.vue';
@@ -17,6 +17,7 @@ const { t } = useI18n();
 const { collection } = toRefs(props);
 const fieldsStore = useFieldsStore();
 onBeforeMount(async () => await fieldsStore.hydrate({ skipTranslation: true }));
+onBeforeUnmount(() => fieldsStore.translateFields());
 
 const fields = computed(() => fieldsStore.getFieldsForCollectionSorted(collection.value));
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Since we rehydrate the `fieldsStore` with explicitly disabling translation of field meta data when visiting the settings route of a collection they are left in an untranslated state. This PR retranslates the field meta data when leaving said route. 
This is only slightly more inefficient than before. And I could not find any edge cases in which the strings are left untranslated or are wrongly translated where not intended.

One other place where the store is rehydrated without translating is the `fieldDetailsStore` that is contained in the parent component of the `fields-management` component and as such will always be loaded (and closed) before the `fields-management` component is unmounted. 

What's changed:

- Retranslate the fields in `fieldsStore` when unmounting the `fields-management` component (which is where they are rehydrated in the first place).

## Potential Risks / Drawbacks

- We could show translated string where we intend on showing translation string templates, I however could not think of any edge case

## Review Notes / Questions


---

Fixes #22256 
