### PR TITLE
Fix "Auto Refresh" for Kanban and Calendar layouts

### DIFF
--- a/.changeset/twelve-owls-tickle.md
+++ b/.changeset/twelve-owls-tickle.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed "Auto Refresh" for Kanban and Calendar layouts

--- a/app/src/layouts/calendar/calendar.vue
+++ b/app/src/layouts/calendar/calendar.vue
@@ -10,6 +10,8 @@ interface Props {
 	createCalendar: (calendarElement: HTMLElement) => void;
 	destroyCalendar: () => void;
 	itemCount?: number;
+	resetPresetAndRefresh: () => Promise<void>;
+	error?: any;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -43,7 +45,8 @@ export default defineComponent({
 		<v-notice v-if="atLimit" type="warning">
 			{{ t('dataset_too_large_currently_showing_n_items', { n: n(10000) }) }}
 		</v-notice>
-		<div ref="calendarElement" />
+		<div v-if="!error" ref="calendarElement" />
+		<slot v-else name="error" :error="error" :reset="resetPresetAndRefresh" />
 	</div>
 </template>
 

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -254,8 +254,19 @@ export default defineLayout<LayoutOptions>({
 			showingCount,
 			createCalendar,
 			destroyCalendar,
+			resetPresetAndRefresh,
+			refresh,
 			download,
 		};
+
+		async function resetPresetAndRefresh() {
+			await props?.resetPreset?.();
+			refresh();
+		}
+
+		function refresh() {
+			getItems();
+		}
 
 		function download() {
 			if (!collection.value) return;

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -138,18 +138,7 @@ watch(innerWidth, (value) => {
 			</div>
 		</template>
 
-		<v-info v-else-if="error" type="danger" :title="t('unexpected_error')" icon="error" center>
-			{{ t('unexpected_error_copy') }}
-
-			<template #append>
-				<v-error :error="error" />
-
-				<v-button small class="reset-preset" @click="resetPresetAndRefresh">
-					{{ t('reset_page_preferences') }}
-				</v-button>
-			</template>
-		</v-info>
-
+		<slot v-else-if="error" name="error" :error="error" :reset="resetPresetAndRefresh" />
 		<slot v-else-if="itemCount === 0 && (filter || search)" name="no-results" />
 		<slot v-else-if="itemCount === 0" name="no-items" />
 	</div>
@@ -197,9 +186,5 @@ watch(innerWidth, (value) => {
 			color: var(--theme--foreground);
 		}
 	}
-}
-
-.reset-preset {
-	margin-top: 24px;
 }
 </style>

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -319,6 +319,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		function refresh() {
 			getItems();
+			// potentially reload the related group items, if the group field is relational
 			if (isRelational.value) getGroups();
 		}
 

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -127,20 +127,24 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			groupTitleFields,
 			groupsCollection,
 			changeGroupSort,
+			getGroups,
 			addGroup,
 			editGroup,
 			deleteGroup,
 			isRelational,
 		} = useGrouping();
 
-		const { items, loading, error, totalPages, itemCount, totalCount, changeManualSort } = useItems(collection, {
-			sort,
-			limit,
-			page,
-			fields,
-			filter,
-			search,
-		});
+		const { items, loading, error, totalPages, itemCount, totalCount, changeManualSort, getItems } = useItems(
+			collection,
+			{
+				sort,
+				limit,
+				page,
+				fields,
+				filter,
+				search,
+			},
+		);
 
 		const limitWarning = computed(() => items.value.length >= limit.value);
 
@@ -250,6 +254,8 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			showUngrouped,
 			limitWarning,
 			userFieldType,
+			resetPresetAndRefresh,
+			refresh,
 		};
 
 		async function change(group: Group, event: ChangeEvent<Item>) {
@@ -304,6 +310,16 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const url = getRootPath() + `assets/${file.id}?modified=${file.modified_on}` + fit;
 			return url;
+		}
+
+		async function resetPresetAndRefresh() {
+			await props?.resetPreset?.();
+			refresh();
+		}
+
+		function refresh() {
+			getItems();
+			if (isRelational.value) getGroups();
 		}
 
 		function useLayoutOptions() {
@@ -450,6 +466,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				groupsPrimaryKeyField,
 				groupsSortField,
 				groupsCollection,
+				getGroups,
 				addGroup,
 				editGroup,
 				deleteGroup,

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -32,6 +32,8 @@ const props = withDefaults(
 		userField?: string | null;
 		groupsSortField?: string | null;
 		layoutOptions: LayoutOptions;
+		resetPresetAndRefresh: () => Promise<void>;
+		error?: any;
 	}>(),
 	{
 		collection: null,
@@ -90,7 +92,7 @@ const textFieldConfiguration = computed<Field | undefined>(() => {
 </script>
 
 <template>
-	<div class="kanban">
+	<div v-if="!error" class="kanban">
 		<draggable
 			:model-value="groupedItems"
 			group="groups"
@@ -180,9 +182,6 @@ const textFieldConfiguration = computed<Field | undefined>(() => {
 				</div>
 			</template>
 		</draggable>
-		<!-- <div v-if="isRelational" class="add-group" @click="editDialogOpen = '+'">
-			<v-icon name="add_box" />
-		</div> -->
 
 		<v-dialog :model-value="editDialogOpen !== null" @esc="cancelChanges()">
 			<v-card>
@@ -199,13 +198,14 @@ const textFieldConfiguration = computed<Field | undefined>(() => {
 			</v-card>
 		</v-dialog>
 	</div>
+	<slot v-else name="error" :error="error" :reset="resetPresetAndRefresh" />
 </template>
 
 <style lang="scss" scoped>
 .kanban {
 	display: flex;
 	height: calc(100% - 65px - 2 * 24px);
-	padding: 0px 32px 24px 32px;
+	padding: 0 32px 24px 32px;
 	overflow-x: auto;
 	overflow-y: hidden;
 	--user-spacing: 16px;

--- a/app/src/layouts/map/map.vue
+++ b/app/src/layouts/map/map.vue
@@ -92,15 +92,7 @@ limitWritable.value = selectedSize;
 		</transition>
 
 		<transition name="fade">
-			<v-info v-if="error" type="danger" :title="t('unexpected_error')" icon="error" center>
-				{{ t('unexpected_error_copy') }}
-				<template #append>
-					<v-error :error="error" />
-					<v-button small class="reset-preset" @click="resetPresetAndRefresh">
-						{{ t('reset_page_preferences') }}
-					</v-button>
-				</template>
-			</v-info>
+			<slot v-if="error" name="error" :error="error" :reset="resetPresetAndRefresh" />
 			<v-info
 				v-else-if="geojsonError"
 				type="warning"
@@ -215,10 +207,6 @@ limitWritable.value = selectedSize;
 .v-progress-circular {
 	--v-progress-circular-background-color: var(--theme--primary-background);
 	--v-progress-circular-color: var(--theme--primary);
-}
-
-.reset-preset {
-	margin-top: 24px;
 }
 
 .footer {

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -266,18 +266,7 @@ function removeField(fieldKey: string) {
 			</template>
 		</v-table>
 
-		<v-info v-else-if="error" type="danger" :title="t('unexpected_error')" icon="error" center>
-			{{ t('unexpected_error_copy') }}
-
-			<template #append>
-				<v-error :error="error" />
-
-				<v-button small class="reset-preset" @click="resetPresetAndRefresh">
-					{{ t('reset_page_preferences') }}
-				</v-button>
-			</template>
-		</v-info>
-
+		<slot v-else-if="error" name="error" :error="error" :reset="resetPresetAndRefresh" />
 		<slot v-else-if="itemCount === 0 && (filterUser || search)" name="no-results" />
 		<slot v-else-if="itemCount === 0" name="no-items" />
 	</div>
@@ -334,10 +323,6 @@ function removeField(fieldKey: string) {
 			color: var(--theme--foreground);
 		}
 	}
-}
-
-.reset-preset {
-	margin-top: 24px;
 }
 
 .add-field {

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -502,6 +502,20 @@ function clearFilters() {
 						</template>
 					</v-info>
 				</template>
+
+				<template #error="{ error, reset }">
+					<v-info type="danger" :title="t('unexpected_error')" icon="error" center>
+						{{ t('unexpected_error_copy') }}
+
+						<template #append>
+							<v-error :error="error" />
+
+							<v-button small class="reset-preset" @click="reset">
+								{{ t('reset_page_preferences') }}
+							</v-button>
+						</template>
+					</v-info>
+				</template>
 			</component>
 
 			<drawer-batch
@@ -563,6 +577,10 @@ function clearFilters() {
 
 .header-icon {
 	--v-button-color-disabled: var(--theme--foreground);
+}
+
+.reset-preset {
+	margin-top: 24px;
 }
 
 .bookmark-controls {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The `refresh` handler were not implemented for the two layouts

What's changed:

- Added a simple `refresh` and `resetPresetAndRefresh` (that is used in case of a misconfiguration) to calendar layout
- Add `refresh` and `resetPresetAndRefresh` to kanban layout that reloads items and group items.

## Potential Risks / Drawbacks

- Performance implications of allowing the user to reload the calendar view every 10s with a default limit of 10k.

## Review Notes / Questions



---

Fixes #22274 
