### PR TITLE
Disable "Download Page as CSV" button if layout does not support it

### DIFF
--- a/.changeset/big-kiwis-happen.md
+++ b/.changeset/big-kiwis-happen.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Hide "Download Page as CSV" button if the selected layout does not support his action
+Ensured "Download Page as CSV" button is disabled if the selected layout does not support that action

--- a/.changeset/big-kiwis-happen.md
+++ b/.changeset/big-kiwis-happen.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Hide "Download Page as CSV" button if the selected layout does not support his action

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -460,6 +460,7 @@ revision_delta_other: Revision
 revision_delta_by: '{date} by {user}'
 presentation_text_values_cannot_be_reimported: 'Uses presentation text, values can not be re-imported.'
 download_page_as_csv: 'Download Page as CSV'
+download_page_as_csv_unsupported: This layout does not support downloading the current page.
 private_user: Private User
 creation_preview: Creation Preview
 revision_preview: Revision Preview

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -135,6 +135,8 @@ const archiveFilter = computed<Filter | null>(() => {
 	}
 });
 
+const isPageDownloadSupported = computed(() => !!layoutRef.value?.state.download);
+
 async function refresh() {
 	await layoutRef.value?.state?.refresh?.();
 }
@@ -529,6 +531,7 @@ function clearFilters() {
 					:filter="mergeFilters(filter, archiveFilter)"
 					:search="search"
 					:layout-query="layoutQuery"
+					:page-download-available="isPageDownloadSupported"
 					@download="download"
 					@refresh="refresh"
 				/>

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -135,15 +135,11 @@ const archiveFilter = computed<Filter | null>(() => {
 	}
 });
 
-const isPageDownloadSupported = computed(() => !!layoutRef.value?.state.download);
-
 async function refresh() {
 	await layoutRef.value?.state?.refresh?.();
 }
 
-async function download() {
-	await layoutRef.value?.state?.download?.();
-}
+const downloadHandler = computed(() => layoutRef.value?.state?.download);
 
 async function batchRefresh() {
 	selection.value = [];
@@ -531,8 +527,7 @@ function clearFilters() {
 					:filter="mergeFilters(filter, archiveFilter)"
 					:search="search"
 					:layout-query="layoutQuery"
-					:page-download-available="isPageDownloadSupported"
-					@download="download"
+					:on-download="downloadHandler"
 					@refresh="refresh"
 				/>
 				<flow-sidebar-detail

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -422,9 +422,11 @@ async function exportDataFiles() {
 				</v-button>
 
 				<button
-					v-if="onDownload"
-					v-tooltip.bottom="t('presentation_text_values_cannot_be_reimported')"
+					v-tooltip.bottom="
+						!!onDownload ? t('presentation_text_values_cannot_be_reimported') : t('download_page_as_csv_unsupported')
+					"
 					class="download-local"
+					:disabled="!onDownload"
 					@click="onDownload"
 				>
 					{{ t('download_page_as_csv') }}
@@ -636,8 +638,8 @@ async function exportDataFiles() {
 	justify-content: center;
 	height: var(--theme--form--field--input--height);
 	padding: var(--theme--form--field--input--padding);
-	padding-top: 0px;
-	padding-bottom: 0px;
+	padding-top: 0;
+	padding-bottom: 0;
 	color: var(--white);
 	background-color: var(--theme--primary);
 	border: var(--theme--border-width) solid var(--theme--primary);
@@ -718,6 +720,11 @@ async function exportDataFiles() {
 
 	&:hover {
 		color: var(--theme--primary);
+	}
+
+	&:disabled {
+		color: var(--theme--foreground-subdued);
+		cursor: not-allowed;
 	}
 }
 </style>

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 	layoutQuery?: LayoutQuery;
 	filter?: Filter;
 	search?: string;
+	pageDownloadAvailable?: boolean;
 }>();
 
 const emit = defineEmits(['refresh', 'download']);
@@ -421,6 +422,7 @@ async function exportDataFiles() {
 				</v-button>
 
 				<button
+					v-if="pageDownloadAvailable"
 					v-tooltip.bottom="t('presentation_text_values_cannot_be_reimported')"
 					class="download-local"
 					@click="$emit('download')"

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -26,10 +26,10 @@ const props = defineProps<{
 	layoutQuery?: LayoutQuery;
 	filter?: Filter;
 	search?: string;
-	pageDownloadAvailable?: boolean;
+	onDownload?: () => Promise<void>;
 }>();
 
-const emit = defineEmits(['refresh', 'download']);
+const emit = defineEmits(['refresh']);
 
 const { t, n, te } = useI18n();
 
@@ -422,10 +422,10 @@ async function exportDataFiles() {
 				</v-button>
 
 				<button
-					v-if="pageDownloadAvailable"
+					v-if="onDownload"
 					v-tooltip.bottom="t('presentation_text_values_cannot_be_reimported')"
 					class="download-local"
-					@click="$emit('download')"
+					@click="onDownload"
 				>
 					{{ t('download_page_as_csv') }}
 				</button>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added check for the presence of the `download` handler in the layout definition
- If the handler is missing hide the export page button

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- <s>This might confuse users why it is present for some layouts but not for others, maybe the better option is to instead disable the button and show a tooltip along the lines of `This layout does not allow exporting single pages`.</s> ✅ 

---

Fixes #22275 
