### PR TITLE
Fix deselection of item in Collection Item Dropdown

### DIFF
--- a/.changeset/twelve-sloths-beg.md
+++ b/.changeset/twelve-sloths-beg.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the deselection of a saved item in the Collection Item Dropdown

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -118,7 +118,7 @@ function onSelection(selectedIds: (number | string)[] | null) {
 
 			<template #append>
 				<template v-if="displayItem">
-					<v-icon v-tooltip="t('deselect')" name="close" class="deselect" @click.stop="$emit('input', undefined)" />
+					<v-icon v-tooltip="t('deselect')" name="close" class="deselect" @click.stop="value = null" />
 				</template>
 				<template v-else>
 					<v-icon class="expand" name="expand_more" />


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

At some point it seems like emitting an `input` event with `undefined` does not unset a value, so I changed the emit to `null`.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #18358 
