### PR TITLE
Fix deselection of field permissions in access control settings

### DIFF
--- a/.changeset/tough-rocks-do.md
+++ b/.changeset/tough-rocks-do.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed the deselection of field permissions in the access control settings when changing the "All Access" preset
+Fixed the deselection of fields for permissions which previously had the "All Access" preset applied

--- a/.changeset/tough-rocks-do.md
+++ b/.changeset/tough-rocks-do.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the deselection of field permissions in the access control settings when changing the "All Access" preset

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
@@ -51,9 +51,11 @@ const fields = computed({
 
 		const appMinimal = new Set(props.appMinimal ?? []);
 		const previousFields = new Set(permissionSync.value.fields ?? []);
+		const allSelected = fieldsInCollection.value.every(({ value }) => newFields?.includes(value));
 
 		for (const field of newFields ?? []) {
 			if (appMinimal.has(field) && !previousFields.has(field)) continue;
+			if (field === '*' && !allSelected) continue;
 			fields.push(field);
 		}
 

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
@@ -39,6 +39,9 @@ const fields = computed({
 		const fields = new Set([...(props.appMinimal ?? []), ...(permissionSync.value.fields ?? [])]);
 
 		if (fields.has('*')) {
+			fields.delete('*');
+
+			// Show all available fields as selected
 			for (const field of fieldsInCollection.value) {
 				fields.add(field.value);
 			}
@@ -51,15 +54,14 @@ const fields = computed({
 
 		const appMinimal = new Set(props.appMinimal ?? []);
 		const previousFields = new Set(permissionSync.value.fields ?? []);
-		const allSelected = fieldsInCollection.value.every(({ value }) => newFields?.includes(value));
 
 		for (const field of newFields ?? []) {
+			// Ignore fields coming from app minimal permissions only
 			if (appMinimal.has(field) && !previousFields.has(field)) continue;
-			if (field === '*' && !allSelected) continue;
 			fields.push(field);
 		}
 
-		if (fields && fields.length > 0) {
+		if (fields.length > 0) {
 			permissionSync.value = {
 				...permissionSync.value,
 				fields,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The deselection of a field permission never properly took effect, since the `newFields` always included `'*'`, effectively overwriting any unselected values. 

What's changed:

- Check if actually all fields are selected and if they are not drop the `'*'` wildcard added by the "All Access" preset

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Should we add the wildcard back in case all fields are selected? I could see this potentially leading to a situation where a new field is added and without specifically selecting the field in a custom field permission, setting roles are granted access. One the other hand it might lead to confusion if all fields are selected but it still is different from the "All Access" preset.

---

Fixes #22132 
