### PR TITLE
App: Add option to open image on block editor

### DIFF
--- a/.changeset/curvy-fishes-work.md
+++ b/.changeset/curvy-fishes-work.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Add option to open image directly from Block Editor

--- a/app/src/interfaces/input-block-editor/bus.ts
+++ b/app/src/interfaces/input-block-editor/bus.ts
@@ -1,0 +1,12 @@
+import { useEventBus } from '@vueuse/core';
+
+type Event = {
+	type: 'open-url';
+	payload: string;
+};
+
+export function useBus() {
+	const bus = useEventBus<Event>('editorjs');
+
+	return bus;
+}

--- a/app/src/interfaces/input-block-editor/editorjs-overrides.css
+++ b/app/src/interfaces/input-block-editor/editorjs-overrides.css
@@ -104,6 +104,14 @@
 	color: var(--theme--primary);
 }
 
+.codex-editor .ce-popover-item__icon i {
+	font-family: 'Material Symbols', sans-serif;
+	font-style: normal;
+	font-variant: normal;
+	text-rendering: auto;
+	-webkit-font-smoothing: antialiased;
+}
+
 .codex-editor .ce-inline-toolbar__toggler-and-button-wrapper {
 	padding: 0;
 }

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -8,6 +8,8 @@ import { onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import getTools from './tools';
 import { useFileHandler } from './use-file-handler';
+import { useBus } from './bus';
+import { useRouter } from 'vue-router';
 
 const props = withDefaults(
 	defineProps<{
@@ -28,6 +30,8 @@ const props = withDefaults(
 	},
 );
 
+const bus = useBus();
+
 const emit = defineEmits<{ input: [value: EditorJS.OutputData | null] }>();
 
 const { t } = useI18n();
@@ -43,6 +47,7 @@ const uploaderComponentElement = ref<HTMLElement>();
 const editorElement = ref<HTMLElement>();
 const haveFilesAccess = Boolean(collectionStore.getCollection('directus_files'));
 const haveValuesChanged = ref(false);
+const router = useRouter();
 
 const tools = getTools(
 	{
@@ -54,6 +59,12 @@ const tools = getTools(
 	props.tools,
 	haveFilesAccess,
 );
+
+bus.on(async (event) => {
+	if (event.type === 'open-url') {
+		router.push(event.payload);
+	}
+});
 
 onMounted(async () => {
 	editorjsRef.value = new EditorJS({
@@ -82,6 +93,8 @@ onMounted(async () => {
 
 onUnmounted(() => {
 	editorjsRef.value?.destroy();
+
+	bus.reset();
 });
 
 watch(

--- a/app/src/interfaces/input-block-editor/plugins.ts
+++ b/app/src/interfaces/input-block-editor/plugins.ts
@@ -1,6 +1,7 @@
 import BaseAttachesTool from '@editorjs/attaches';
 import BaseImageTool from '@editorjs/image';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { useBus } from './bus';
 
 /**
  * This file is a modified version of the attaches and image tool from editorjs to work with the Directus file manager.
@@ -157,5 +158,44 @@ export class ImageTool extends BaseImageTool {
 			const imageUrl = `${file.url}${separator}key=system-large-contain`;
 			this.ui.fillImage(imageUrl);
 		}
+	}
+
+	renderSettings() {
+		const items = [
+			{
+				icon: 'open_in_new',
+				label: 'Open Image',
+				onClick: () => {
+					const bus = useBus();
+					bus.emit({ type: 'open-url', payload: this.data.file.fileURL });
+				},
+			},
+		];
+
+		const wrapperElement = document.createElement('div');
+		wrapperElement.classList.add('ce-popover__items');
+
+		for (const item of items) {
+			const itemElement = document.createElement('div');
+			itemElement.classList.add('ce-popover-item');
+
+			const iconElement = document.createElement('div');
+			iconElement.classList.add('ce-popover-item__icon');
+			const iElement = document.createElement('i');
+			iElement.innerHTML = item.icon;
+			iconElement.appendChild(iElement);
+			itemElement.appendChild(iconElement);
+
+			const titleElement = document.createElement('div');
+			titleElement.classList.add('ce-popover-item__title');
+			titleElement.innerHTML = item.label;
+			itemElement.appendChild(titleElement);
+
+			itemElement.addEventListener('click', item.onClick);
+
+			wrapperElement.appendChild(itemElement);
+		}
+
+		return wrapperElement;
 	}
 }

--- a/app/src/interfaces/input-block-editor/plugins.ts
+++ b/app/src/interfaces/input-block-editor/plugins.ts
@@ -9,6 +9,14 @@ import { useBus } from './bus';
  * We include an uploader to directly use Directus file manager, along with a modified version of the attaches and image tools.
  */
 
+type Tune = {
+	name?: string;
+	title: string;
+	icon: string;
+	onActivate?: () => void;
+	toggle: boolean;
+};
+
 class Uploader {
 	getCurrentFile: any;
 	config: any;
@@ -161,39 +169,46 @@ export class ImageTool extends BaseImageTool {
 	}
 
 	renderSettings() {
-		const items = [
+		const tunes: Tune[] = [
 			{
 				icon: 'open_in_new',
-				label: 'Open Image',
-				onClick: () => {
+				title: 'Open Image',
+				toggle: false,
+				onActivate: () => {
 					const bus = useBus();
 					bus.emit({ type: 'open-url', payload: this.data.file.fileURL });
 				},
 			},
+			...ImageTool.tunes,
 		];
 
 		const wrapperElement = document.createElement('div');
 		wrapperElement.classList.add('ce-popover__items');
 
-		for (const item of items) {
-			const itemElement = document.createElement('div');
-			itemElement.classList.add('ce-popover-item');
+		for (const tune of tunes) {
+			const tuneElement = document.createElement('div');
+			tuneElement.classList.add('ce-popover-item');
 
 			const iconElement = document.createElement('div');
 			iconElement.classList.add('ce-popover-item__icon');
 			const iElement = document.createElement('i');
-			iElement.innerHTML = item.icon;
+			iElement.innerHTML = tune.icon;
 			iconElement.appendChild(iElement);
-			itemElement.appendChild(iconElement);
+			tuneElement.appendChild(iconElement);
 
 			const titleElement = document.createElement('div');
 			titleElement.classList.add('ce-popover-item__title');
-			titleElement.innerHTML = item.label;
-			itemElement.appendChild(titleElement);
+			titleElement.innerHTML = tune.title;
+			tuneElement.appendChild(titleElement);
 
-			itemElement.addEventListener('click', item.onClick);
+			if (tune.onActivate) tuneElement.addEventListener('click', tune.onActivate);
+			else if (tune.toggle)
+				tuneElement.addEventListener('click', () => {
+					this.tuneToggled(tune.name);
+					tuneElement.classList.toggle('ce-popover-item--active');
+				});
 
-			wrapperElement.appendChild(itemElement);
+			wrapperElement.appendChild(tuneElement);
 		}
 
 		return wrapperElement;


### PR DESCRIPTION
## Scope
In this PR we include a small improvement for user to be able to open image directly from block interface.
This is useful because, it's kinda difficult to see what is the image attached on block editor and may be needed if someone wants to edit the image.

## What's changed:

- Add a "Open Image" menu entry for images on block interface

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- Because we need to navigate to another page, we need `useRouter()`. 
Although, `useRouter()` uses `inject`, which means that this utility can only be used within a Vue component.
To circumvent that, I have used `useBus()` which is a wrapper around `useEventBus` from `@vueuse`. It basically sends events to the block interface component so `useRouter()` or other utils can be used.
Not sure if there's a simpler way to achieve this though 🤔

- This is a little small improvement to the block interface to make life a bit easier.
But the ultimate goal would be to use `file-image` interface in the block interface.
Since EditorJS renders plain

|Before|After|
|-|-|
|<img width="767" alt="image" src="https://github.com/directus/directus/assets/14039341/b5bb6038-aa11-4066-a4a5-28561b4e0478">|<img width="767" alt="Screenshot 2024-04-24 at 14 17 52" src="https://github.com/directus/directus/assets/14039341/6fd98bee-7ad9-41c3-8ae8-e41a000b596f">|
---

Fixes #21567
