### PR TITLE
Catch invalid HEIC images in the App

### DIFF
--- a/.changeset/brave-chairs-switch.md
+++ b/.changeset/brave-chairs-switch.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added error in the App for images without dimensions

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -149,6 +149,14 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				</span>
 			</div>
 
+			<div v-else-if="!image.height && !image.width" class="image-error">
+				<v-icon large name="error" />
+
+				<span class="message">
+					{{ t('errors.UNSUPPORTED_MEDIA_TYPE') }}
+				</span>
+			</div>
+
 			<v-image
 				v-else-if="image.type?.startsWith('image')"
 				:src="src"


### PR DESCRIPTION
Fixes #22301 

## Scope

What's changed:

- Show an unsupported image error when no `width` and `height` are present for the image.

**Before**
![image](https://github.com/directus/directus/assets/9389634/142e7459-ca88-4eb6-a823-c05304c39e84)

**After**
![image](https://github.com/directus/directus/assets/9389634/3362588f-3e1b-4b9c-83a1-0d518d344b81)

## Potential Risks / Drawbacks

- may not cover all the cases perhaps

## Review Notes / Questions

- I would like to lorem ipsum
