### PR TITLE
[SDK] Added "_icontains" string operator

### DIFF
--- a/.changeset/rude-cougars-suffer.md
+++ b/.changeset/rude-cougars-suffer.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Added "_icontains" string operator to the SDK

--- a/sdk/src/types/filters.ts
+++ b/sdk/src/types/filters.ts
@@ -58,6 +58,7 @@ export type FilterOperators<
 	_nbetween: IsDateTime<FieldType, [T, T], IsNumber<T, [T, T], never>>;
 	_contains: IsDateTime<FieldType, never, IsString<T, string, never>>;
 	_ncontains: IsDateTime<FieldType, never, IsString<T, string, never>>;
+	_icontains: IsDateTime<FieldType, never, IsString<T, string, never>>;
 	_starts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
 	_istarts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;
 	_nstarts_with: IsDateTime<FieldType, never, IsString<T, string, never>>;


### PR DESCRIPTION
Fixes #22249 

## Scope

What's changed:

- Added the `_icontains` string operator

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I would like to lorem ipsum
