### PR TITLE
[SDK] Expected response type of item query unequals SDK response type

### DIFF
--- a/sdk/src/types/output.ts
+++ b/sdk/src/types/output.ts
@@ -1,6 +1,6 @@
 import type { FieldsWildcard, HasManyToAnyRelation, PickRelationalFields } from './fields.js';
 import type { MappedFunctionFields } from './functions.js';
-import type { ItemType } from './schema.js';
+import type { ItemType, RemoveRelationships } from './schema.js';
 import type { IfAny, IsNullable, Merge, Mutable, UnpackList } from './utils.js';
 
 /**
@@ -22,7 +22,7 @@ export type ApplyQueryFields<
 	Record<string, any>,
 	Merge<
 		MappedFunctionFields<Schema, CollectionItem> extends infer FF
-			? MapFlatFields<CollectionItem, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>
+			? RemoveRelationships<Schema, MapFlatFields<CollectionItem, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>>
 			: never,
 		RelationalFields extends never
 			? never

--- a/sdk/src/types/output.ts
+++ b/sdk/src/types/output.ts
@@ -22,7 +22,10 @@ export type ApplyQueryFields<
 	Record<string, any>,
 	Merge<
 		MappedFunctionFields<Schema, CollectionItem> extends infer FF
-			? RemoveRelationships<Schema, MapFlatFields<CollectionItem, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>>
+			? RemoveRelationships<
+					Schema,
+					MapFlatFields<CollectionItem, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>
+			  >
 			: never,
 		RelationalFields extends never
 			? never


### PR DESCRIPTION
Fixes #20652 

## Scope

What's changed:

- [Work In Progress] More precise output types.

## TODO

- Add test covering this case
- Check relational fields combo's with this change

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

