### PR TITLE
[Docs] Prevent icon translation in components and markdown sources

### DIFF
--- a/docs/.vitepress/components/Card.vue
+++ b/docs/.vitepress/components/Card.vue
@@ -25,7 +25,7 @@ const iconIsImage = computed(() => props.icon.startsWith('/'));
 	<component :is="tagType" :href="url" class="card" :class="{ margin: addMargin }">
 		<div v-if="icon" class="icon">
 			<img v-if="iconIsImage" :src="icon" alt="" />
-			<span v-else mi>{{ icon }}</span>
+			<span v-else mi translate="no">{{ icon }}</span>
 		</div>
 
 		<div class="text">

--- a/docs/.vitepress/components/Feedback.vue
+++ b/docs/.vitepress/components/Feedback.vue
@@ -98,7 +98,7 @@ async function handleSubmission(rating?: number) {
 					<div>
 						<span>{{ getRatingOption(feedback.rating)?.label }}</span>
 						<button style="margin-left: 0.5rem" class="btn" @click="feedback.rating = undefined">
-							<span mi icon>close</span>
+							<span mi icon translate="no">close</span>
 						</button>
 					</div>
 				</div>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vitepress';
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs';
 import sidebar from './data/sidebar.js';
+import { useMaterialIconsNoTranslate } from './lib/markdown-plugins/material-icons-no-translate.js';
 
 export default defineConfig({
 	base: '/',
@@ -19,6 +20,7 @@ export default defineConfig({
 		},
 		config(md) {
 			md.use(tabsMarkdownPlugin);
+			useMaterialIconsNoTranslate(md);
 		},
 	},
 	head: [

--- a/docs/.vitepress/lib/markdown-plugins/material-icons-no-translate.ts
+++ b/docs/.vitepress/lib/markdown-plugins/material-icons-no-translate.ts
@@ -1,0 +1,14 @@
+// @ts-ignore
+import iterator from 'markdown-it-for-inline';
+
+const MATERIAL_ICON_RE = /<span(.*\bmi\b.*)>/;
+
+export function useMaterialIconsNoTranslate(md: any) {
+	md.use(iterator, 'mi_no_translate', 'html_inline', function (tokens: any, idx: number) {
+		const m = tokens[idx].content.match(MATERIAL_ICON_RE);
+
+		if (m) {
+			tokens[idx].content = `<span${m[1]} translate="no">`;
+		}
+	});
+}

--- a/docs/.vitepress/lib/markdown-plugins/material-icons-no-translate.ts
+++ b/docs/.vitepress/lib/markdown-plugins/material-icons-no-translate.ts
@@ -4,11 +4,9 @@ import iterator from 'markdown-it-for-inline';
 const MATERIAL_ICON_RE = /<span(.*\bmi\b.*)>/;
 
 export function useMaterialIconsNoTranslate(md: any) {
-	md.use(iterator, 'mi_no_translate', 'html_inline', function (tokens: any, idx: number) {
-		const m = tokens[idx].content.match(MATERIAL_ICON_RE);
+	md.use(iterator, 'mi_no_translate', 'html_inline', (tokens: any, idx: number) => {
+		const match = tokens[idx].content.match(MATERIAL_ICON_RE);
 
-		if (m) {
-			tokens[idx].content = `<span${m[1]} translate="no">`;
-		}
+		if (match) tokens[idx].content = `<span translate="no"${match[1]}>`;
 	});
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
 		"eslint-plugin-markdown": "3.0.1",
 		"eslint-plugin-prettier": "npm:@paescuj/eslint-plugin-prettier@5.0.1-1",
 		"eslint-plugin-react": "7.34.1",
+		"markdown-it-for-inline": "2.0.1",
 		"marked": "12.0.1",
 		"spellchecker-cli": "6.2.0",
 		"typedoc": "0.25.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,6 +920,9 @@ importers:
       eslint-plugin-react:
         specifier: 7.34.1
         version: 7.34.1(eslint@8.57.0)
+      markdown-it-for-inline:
+        specifier: 2.0.1
+        version: 2.0.1
       marked:
         specifier: 12.0.1
         version: 12.0.1
@@ -8245,6 +8248,9 @@ packages:
 
   markdown-it-emoji@2.0.2:
     resolution: {integrity: sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==}
+
+  markdown-it-for-inline@2.0.1:
+    resolution: {integrity: sha512-JGOi3/Ohhzehs+1qSA4CkDydmVBtiYi2q2BD//YtTbSK+75InrGJX2MtPq1AdMeC4BV7rwEhq1+3pLnwGbsgzA==}
 
   markdown-it@12.3.2:
     resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
@@ -19084,6 +19090,8 @@ snapshots:
       markdown-it: 12.3.2
 
   markdown-it-emoji@2.0.2: {}
+
+  markdown-it-for-inline@2.0.1: {}
 
   markdown-it@12.3.2:
     dependencies:


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Since we're using Material Icons with the icon font we have a bunch of `<span mi>icon_name</span>` in our docs. This leads to problems with the automatic Google Translate feature of some browsers. 

What's changed:

- Changed the two uses in components
- Added a `markdown-it` plugin that transforms all occurrences of `<span.*mi.*>` when `mi` is standing on its own. So it's not transforming e.g. `<span min-width="10px">`

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Rebuilt the docs on my end, looked fine to me, translation no longer broken

---

Fixes #21463
