### PR TITLE
Drop extension folder creation

### DIFF
--- a/.changeset/warm-bees-glow.md
+++ b/.changeset/warm-bees-glow.md
@@ -1,0 +1,6 @@
+---
+"directus": patch
+"create-directus-project": patch
+---
+
+Drop extension folder creation

--- a/.changeset/warm-bees-glow.md
+++ b/.changeset/warm-bees-glow.md
@@ -3,4 +3,4 @@
 "create-directus-project": patch
 ---
 
-Drop extension folder creation
+Dropped creation of typed extension folders during project initialization 

--- a/packages/create-directus-project/lib/index.js
+++ b/packages/create-directus-project/lib/index.js
@@ -52,12 +52,6 @@ async function create(directory) {
 	await fse.mkdir(join(rootPath, 'uploads'));
 	await fse.mkdir(join(rootPath, 'extensions'));
 
-	const extensionFolders = ['interfaces', 'displays', 'layouts', 'modules'];
-
-	for (const folderName of extensionFolders) {
-		await fse.mkdir(join(rootPath, 'extensions', folderName));
-	}
-
 	// Let's get into the Directus mood while waiting
 	const bunnyFrames = [];
 	const numOfSpaces = 3;


### PR DESCRIPTION
## Scope

What's changed:

- Don't auto-create scoped deprecated extension folders in create-directus-project

## Potential Risks / Drawbacks

- Doesn't affect anything else in the platform.

## Review Notes / Questions

- Did this in the GitHub editor while in a meeting, so needs some eyeballs 😁 

---

Fixes #22314
