### PR TITLE
App: Allow interpolation string as the only value on `input-code` interface

### DIFF
--- a/.changeset/wise-donuts-sit.md
+++ b/.changeset/wise-donuts-sit.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added support to define single interpolation value in code interface

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -76,6 +76,10 @@ onMounted(async () => {
 					return emit('input', null);
 				}
 
+				if (isInterpolation(content)) {
+					return emit('input', content);
+				}
+
 				try {
 					const parsedJson = JSON.parse(content);
 					if (typeof parsedJson !== 'string') return emit('input', parsedJson);
@@ -92,6 +96,8 @@ onMounted(async () => {
 
 const stringValue = computed(() => {
 	if (props.value === null || props.value === undefined) return '';
+
+	if (isInterpolation(props.value)) return props.value;
 
 	return getStringifiedValue(props.value, props.type === 'json');
 });
@@ -126,6 +132,9 @@ async function setLanguage() {
 
 			CodeMirror.registerHelper('lint', 'json', (text: string) => {
 				const found: Record<string, any>[] = [];
+
+				if (isInterpolation(text)) return found;
+
 				const parser = jsonlint.parser;
 
 				parser.parseError = (str: string, hash: any) => {
@@ -277,6 +286,10 @@ function fillTemplate() {
 	} else {
 		emit('input', props.template);
 	}
+}
+
+function isInterpolation(value: any) {
+	return typeof value === 'string' && value.startsWith('{{') && value.endsWith('}}');
 }
 </script>
 

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -19,6 +19,9 @@ import 'codemirror/addon/search/searchcursor.js';
 
 import 'codemirror/keymap/sublime.js';
 
+/** Regex to check for interpolation, e.g. `{{ $trigger }}` */
+const INTERPOLATION_REGEX = /^\{\{\s*[^}\s]+\s*\}\}$/;
+
 const props = withDefaults(
 	defineProps<{
 		value?: string | Record<string, unknown> | unknown[] | boolean | number | null;
@@ -97,7 +100,7 @@ onMounted(async () => {
 const stringValue = computed(() => {
 	if (props.value === null || props.value === undefined) return '';
 
-	if (isInterpolation(props.value)) return props.value;
+	if (props.type === 'json' && isInterpolation(props.value)) return props.value;
 
 	return getStringifiedValue(props.value, props.type === 'json');
 });
@@ -289,7 +292,7 @@ function fillTemplate() {
 }
 
 function isInterpolation(value: any) {
-	return typeof value === 'string' && value.startsWith('{{') && value.endsWith('}}');
+	return typeof value === 'string' && value.match(INTERPOLATION_REGEX);
 }
 </script>
 


### PR DESCRIPTION
## Scope
When using Flows, there's cases that we just want to pass the response from previous operation to the next one.
For example, we might want to pass the payload of a Read Date operation to another flow using Trigger Flow operation.
For such cases we should be able to pass the following into the Payload option of Trigger Flow operation:
```
{{ $last }}
```
Although, the Code interface will complain because the Payload option is defined as JSON and this value is not a valid JSON so the linter will show an error.
Since this is a valid action to do (to pass `{{ $last }}`), in this PR we ignore the lint if the value is an interpolation, i.e., if the value starts with `{{` and ends with `}}`. 

What's changed:

- Allow interpolation at root level of Code interface using JSON language

## Potential Risks / Drawbacks

- If the value used is not an interpolation but anything that starts with `{{` and ends with `}}`, there will be no errors

## Review Notes / Questions

- This seems to be a nice first approach to this. Although we should also be able to validate the payload on the API. I have not did it since I didn't found any example on how to validate requests according to the entity.
For example, we could try add some validation into [`OperationsService`](https://github.com/directus/directus/blob/main/api/src/services/operations.ts#L6) but the App send the operation data within a flow which will be handled by [`FlowService`](https://github.com/directus/directus/blob/main/api/src/services/flows.ts#L6) so no validation would be made


## Comparision
|Before|After|
|-|-|
|<video src="https://github.com/directus/directus/assets/14039341/f2af4a27-b0a0-4ea5-82f7-d293aadd105e" ></video>|<video src="https://github.com/directus/directus/assets/14039341/262999ed-c156-428c-a58e-61dd99eab600"></video>|
|In this case you can see that when using `{{$last}}` the Code interface shows an error. Although the Flow works as expected. When I type `"{{ $last }}"` the Flow throws an error.|In this case you can see that using `{{$last}}` **does not** show any error any more and Flow works as expected. Although when typing `"{{ $last }}"` it will still throw an error as  `"` are not removed and Flow will have double quotes conflicting.|
---

Fixes #21263
