### PR TITLE
Fix Supabase storage driver `list` operation

### DIFF
--- a/.changeset/seven-brooms-applaud.md
+++ b/.changeset/seven-brooms-applaud.md
@@ -1,0 +1,5 @@
+---
+'@directus/storage-driver-supabase': patch
+---
+
+Fixed `list` method to recursively list all files under a prefix

--- a/packages/storage-driver-supabase/src/index.test.ts
+++ b/packages/storage-driver-supabase/src/index.test.ts
@@ -105,7 +105,8 @@ describe('#constructor', () => {
 
 	test('Saves passed config to local property', () => {
 		const driver = new DriverSupabase(sample.config);
-		expect(driver['config']).toBe(sample.config);
+
+		expect(driver['config']).toStrictEqual(sample.config);
 	});
 
 	test('Creates shared client', () => {
@@ -115,7 +116,7 @@ describe('#constructor', () => {
 	});
 
 	test('Defaults root to empty string', () => {
-		expect(driver['config'].root).toBe(undefined);
+		expect(driver['config'].root).toBe('');
 	});
 });
 
@@ -497,26 +498,31 @@ describe('#delete', () => {
 
 describe('#list', () => {
 	test('Constructs list objects params based on input prefix', async () => {
+		const sampleFile = randFileName();
+		const sampleDirectory = randDirectoryPath();
+		const fullSample = `${sampleDirectory}/${sampleFile}`;
+
 		// TODO: Probably a better way to do this?
 		driver['bucket'] = {
 			list: vi.fn().mockReturnValue({ data: [], error: null }),
 		} as any;
 
-		await driver.list(sample.path.input)[Symbol.asyncIterator]().next();
+		await driver.list(fullSample)[Symbol.asyncIterator]().next();
 
-		expect(driver['bucket'].list).toHaveBeenCalledWith(sample.path.input, {
+		expect(driver['bucket'].list).toHaveBeenCalledWith(sampleDirectory, {
+			search: sampleFile,
 			limit: 1000,
 			offset: 0,
 		});
 	});
 
-	test('Yields file name omitting root', async () => {
+	test('Yields file name omitting root if prefix is the full file path', async () => {
 		const sampleRoot = randDirectoryPath();
 		const sampleFile = randFileName();
 		const sampleFull = `${sample.path.input}/${sampleFile}`;
 
 		driver['bucket'] = {
-			list: vi.fn().mockReturnValue({
+			list: vi.fn().mockResolvedValueOnce({
 				data: [
 					{
 						name: sampleFile,
@@ -529,7 +535,7 @@ describe('#list', () => {
 
 		driver['config'].root = sampleRoot;
 
-		const iterator = driver.list(sample.path.input);
+		const iterator = driver.list(sampleFull);
 		const output: string[] = [];
 
 		for await (const filepath of iterator) {
@@ -539,28 +545,12 @@ describe('#list', () => {
 		expect(output).toStrictEqual([sampleFull]);
 	});
 
-	test('Recursively fetches all nested directories and yields only the files', async () => {
+	test('Yields file name omitting root if prefix is the parent directory', async () => {
 		const sampleRoot = randDirectoryPath();
-		const samplePrefix = randUnique() + randDirectoryPath();
-
-		/*
-		sampleFile
-		sampleDirectory/
-		├─ sampleFileNested
-		├─ sampleDirectoryNested/
-		│  ├─ sampleFileDeeplyNested
-		 */
-		const sampleDirectory = randUnique();
-		const sampleDirectoryNested = randUnique();
 		const sampleFile = randFileName();
-		const sampleFileNested = randFileName();
-		const sampleFileDeeplyNested = randFileName();
-
-		const fullSampleDirectory = `${samplePrefix}/${sampleDirectory}`;
-		const fullSampleFile = `${samplePrefix}/${sampleFile}`;
-		const fullSampleDirectoryNested = `${fullSampleDirectory}/${sampleDirectoryNested}`;
-		const fullSampleFileNested = `${fullSampleDirectory}/${sampleFileNested}`;
-		const fullSampleFileDeeplyNested = `${fullSampleDirectoryNested}/${sampleFileDeeplyNested}`;
+		const sampleParentDir = randUnique();
+		const sampleInput = `${sample.path.input}/${sampleParentDir}`;
+		const sampleFull = `${sampleInput}/${sampleFile}`;
 
 		driver['bucket'] = {
 			list: vi
@@ -568,37 +558,106 @@ describe('#list', () => {
 				.mockResolvedValueOnce({
 					data: [
 						{
+							name: sampleParentDir,
+							id: null,
+						},
+					],
+					error: null,
+				})
+				.mockResolvedValueOnce({
+					data: [
+						{
 							name: sampleFile,
 							id: randUnique(),
 						},
-						{
-							name: sampleDirectory,
-							id: null,
-						},
 					],
 					error: null,
-				})
-				.mockResolvedValueOnce({
-					data: [
-						{
-							name: sampleFileNested,
-							id: randUnique(),
-						},
-						{
-							name: sampleDirectoryNested,
-							id: null,
-						},
-					],
-					error: null,
-				})
-				.mockResolvedValueOnce({
-					data: [
-						{
-							name: sampleFileDeeplyNested,
-							id: randUnique(),
-						},
-					],
 				}),
+		} as any;
+
+		driver['config'].root = sampleRoot;
+
+		const iterator = driver.list(sampleInput);
+		const output: string[] = [];
+
+		for await (const filepath of iterator) {
+			output.push(filepath);
+		}
+
+		expect(driver['bucket'].list).toHaveBeenCalledTimes(2);
+		expect(output).toStrictEqual([sampleFull]);
+	});
+
+	test('Yields file name omitting root if prefix is part of the file name', async () => {
+		const sampleRoot = randDirectoryPath();
+		const sampleFilePrefix = randFileName();
+		const sampleFiles = [1, 2, 3].map((i) => `${sampleFilePrefix}_postfix${i}`);
+		const sampleInput = `${sample.path.input}/${sampleFilePrefix}`;
+		const sampleFilesFull = sampleFiles.map((name) => `${sample.path.input}/${name}`);
+
+		driver['bucket'] = {
+			list: vi.fn().mockResolvedValueOnce({
+				data: sampleFiles.map((name) => ({
+					name,
+					id: randUnique(),
+				})),
+				error: null,
+			}),
+		} as any;
+
+		driver['config'].root = sampleRoot;
+
+		const iterator = driver.list(sampleInput);
+		const output: string[] = [];
+
+		for await (const filepath of iterator) {
+			output.push(filepath);
+		}
+
+		expect(output).toStrictEqual(sampleFilesFull);
+	});
+
+	test('Recursively fetches all nested directories and yields only the files', async () => {
+		const sampleRoot = randUnique() + randDirectoryPath();
+		const samplePrefixBase = randUnique() + randDirectoryPath();
+		const samplePrefixLastDir = randUnique();
+		const samplePrefix = `${samplePrefixBase}/${samplePrefixLastDir}`;
+
+		/*
+		sampleFile
+		sampleDirectory/
+		├─ sampleFileNested
+		 */
+		const sampleDirectory = randUnique();
+		const sampleFile = randFileName();
+		const sampleFileNested = randFileName();
+
+		const fullSampleDirectory = `${samplePrefix}/${sampleDirectory}`;
+		const fullSampleFile = `${samplePrefix}/${sampleFile}`;
+		const fullSampleFileNested = `${fullSampleDirectory}/${sampleFileNested}`;
+
+		driver['bucket'] = {
+			list: vi.fn(async (path, options): Promise<any> => {
+				// query for parent dir, return the contained dir
+				if (path === `${sampleRoot}/${samplePrefixBase}` && options?.search === samplePrefixLastDir)
+					return { data: [{ name: samplePrefixLastDir, id: null }], error: null };
+				// query for the contents of the samplePrefix, return file and directory
+				if (path === `${sampleRoot}/${samplePrefix}/` && options?.search === '')
+					return {
+						data: [
+							{ name: sampleDirectory, id: null },
+							{ name: sampleFile, id: randUnique() },
+						],
+						error: null,
+					};
+				// query for the contents of the sampleDirectory, return the nested file
+				if (path === `${sampleRoot}/${fullSampleDirectory}/` && options?.search === '')
+					return {
+						data: [{ name: sampleFileNested, id: randUnique() }],
+						error: null,
+					};
+				throw Error();
+			}),
 		} as any;
 
 		driver['config'].root = sampleRoot;
@@ -611,7 +670,7 @@ describe('#list', () => {
 		}
 
 		expect(driver['bucket'].list).toHaveBeenCalledTimes(3);
-		expect(output).toStrictEqual([fullSampleFile, fullSampleFileNested, fullSampleFileDeeplyNested]);
+		expect(output).toStrictEqual([fullSampleFileNested, fullSampleFile]);
 	});
 
 	test('Continuously fetches until all pages are returned', async () => {

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -155,27 +155,27 @@ export class DriverSupabase implements Driver {
 		let itemCount = 0;
 
 		/*
-     The Supabase API only returns the directories and files directly within the queried location
-     (called prefix in their API), matching the search query. Directories can be identified by the id being null.
+			The Supabase API only returns the directories and files directly within the queried location
+			(called prefix in their API), matching the search query. Directories can be identified by the id being null.
 
-     Since we are unsure if the last part of the prefix param is a directory, a file or part of a directory or file name
-     we first need to query with the largest common denominator (the parent directory part of the prefix)
-     and filter the results with the remaining part of the query.
+			Since we are unsure if the last part of the prefix param is a directory, a file or part of a directory or file name
+			we first need to query with the largest common denominator (the parent directory part of the prefix)
+			and filter the results with the remaining part of the query.
 
-     This can lead to these outcomes:
-     1. The full prefix is a file and is split up into parentdir/filename, the API is queried with
-        { prefix: parentdir, search: filename } and returns one result { name: filename, id: "..." }.
-        We then yield the filename.
-     2. The full prefix is a directory and is split up into parentdir/dir, the API is queried with
-        { prefix: parentdir, search: dir } and returns one result { name: dir, id: null } and importantly, not the
-        contents of the directory. We then need to recursively list the contents of the directory by calling this
-        function with the prefix and a trailing "/" as an indicator that we are interested in the directory contents.
-        2.1. The prefix ends with a "/", the API is queried with { prefix: prefix, search: "" }
-        		 and returns all files and directories within the prefix, which are yielded and recursively listed.
-     3. Special case of 1. and 2.: The prefix is part of a filename/directory name and could result in more than one result
-        that all match the search query. The API is queried with { prefix: parentdir, search: part of filename }
-        and returns all files and directories in parentdir that match the search query. Filenames are yielded and
-        directories are recursively listed.
+			This can lead to these outcomes:
+			1. The full prefix is a file and is split up into parentdir/filename, the API is queried with
+			   { prefix: parentdir, search: filename } and returns one result { name: filename, id: "..." }.
+			   We then yield the filename.
+			2. The full prefix is a directory and is split up into parentdir/dir, the API is queried with
+			   { prefix: parentdir, search: dir } and returns one result { name: dir, id: null } and importantly, not the
+			   contents of the directory. We then need to recursively list the contents of the directory by calling this
+			   function with the prefix and a trailing "/" as an indicator that we are interested in the directory contents.
+			   2.1. The prefix ends with a "/", the API is queried with { prefix: prefix, search: "" }
+			   		 and returns all files and directories within the prefix, which are yielded and recursively listed.
+			3. Special case of 1. and 2.: The prefix is part of a filename/directory name and could result in more than one result
+			   that all match the search query. The API is queried with { prefix: parentdir, search: part of filename }
+			   and returns all files and directories in parentdir that match the search query. Filenames are yielded and
+			   directories are recursively listed.
 		 */
 		const isDirectory = prefix.endsWith('/');
 		const prefixDirectory = isDirectory ? prefix : dirname(prefix);

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -10,7 +10,7 @@ export type DriverSupabaseConfig = {
 	bucket: string;
 	serviceRole: string;
 	projectId?: string;
-	// Allows a custom Supabase endpoint incase self-hosting
+	/** Allows a custom Supabase endpoint for self-hosting */
 	endpoint?: string;
 	root?: string;
 };
@@ -150,27 +150,27 @@ export class DriverSupabase implements Driver {
 		let itemCount = 0;
 
 		/*
-			The Supabase API only returns the directories and files directly within the queried location
-			(called prefix in their API), matching the search query. Directories can be identified by the id being null.
-
-			Since we are unsure if the last part of the prefix param is a directory, a file or part of a directory or file name
-			we first need to query with the largest common denominator (the parent directory part of the prefix)
-			and filter the results with the remaining part of the query.
-
-			This can lead to these outcomes:
-			1. The full prefix is a file and is split up into parentdir/filename, the API is queried with
-			   { prefix: parentdir, search: filename } and returns one result { name: filename, id: "..." }.
-			   We then yield the filename.
-			2. The full prefix is a directory and is split up into parentdir/dir, the API is queried with
-			   { prefix: parentdir, search: dir } and returns one result { name: dir, id: null } and importantly, not the
-			   contents of the directory. We then need to recursively list the contents of the directory by calling this
-			   function with the prefix and a trailing "/" as an indicator that we are interested in the directory contents.
-			   2.1. The prefix ends with a "/", the API is queried with { prefix: prefix, search: "" }
-			   		 and returns all files and directories within the prefix, which are yielded and recursively listed.
-			3. Special case of 1. and 2.: The prefix is part of a filename/directory name and could result in more than one result
-			   that all match the search query. The API is queried with { prefix: parentdir, search: part of filename }
-			   and returns all files and directories in parentdir that match the search query. Filenames are yielded and
-			   directories are recursively listed.
+		 *	The Supabase API only returns the directories and files directly within the queried location
+		 *	(called prefix in their API) matching the search query. Directories can be identified by the id being null.
+		 *
+		 *	Since it's unknown whether the last part of the prefix param is a directory, a file or part of a directory or file name,
+		 *	the first query will be the largest common denominator (the parent directory part of the prefix)
+		 *	and the results then filtered with the remaining part of the query.
+		 *
+		 *	This can lead to the following outcomes:
+		 *	1. The full prefix is a file and is split up into parentdir/filename, the API is queried with
+		 *	   { prefix: parentdir, search: filename } and returns one result { name: filename, id: "..." }.
+		 *	   The filename is yielded in that case.
+		 *	2. The full prefix is a directory and is split up into parentdir/dir, the API is queried with
+		 *	   { prefix: parentdir, search: dir } and returns one result { name: dir, id: null } and importantly, not the
+		 *	   contents of the directory. Then  the contents of the directory must be listed recursively by calling this
+		 *	   function with the prefix and a trailing "/".
+		 *	   2.1. The prefix ends with a "/", the API is queried with { prefix: prefix, search: "" }
+		 *	        and returns all files and directories within the prefix, which are yielded and recursively listed.
+		 *	3. Special case of 1. and 2.: The prefix is part of a filename/directory name and could result in more than one result
+		 *	   that all match the search query. The API is queried with { prefix: parentdir, search: part of filename }
+		 *	   and returns all files and directories in parentdir that match the search query. Filenames are yielded and
+		 *	   directories are recursively listed.
 		 */
 		const isDirectory = prefix.endsWith('/');
 		const prefixDirectory = isDirectory ? prefix : dirname(prefix);
@@ -191,15 +191,15 @@ export class DriverSupabase implements Driver {
 			offset += itemCount;
 
 			for (const item of data) {
-				// Since the API only returns the filename the file path is constructed by joining the prefix with the item name.
+				// Since the API only returns the filename, the file path is constructed by joining the prefix with the item name
 				const filePath = normalizePath(join(prefixDirectory, item.name));
 
 				if (item.id !== null) {
-					// remove the root from the path and yield the filename
+					// Remove the root from the path and yield the filename
 					yield filePath.substring(this.config.root ? this.config.root.length + 1 : 0);
 				} else {
-					// this is a directory, recursively list it
-					yield* this.listGenerator(filePath + '/');
+					// This is a directory, recursively list it
+					yield* this.listGenerator(`${filePath}/`);
 				}
 			}
 		} while (itemCount === limit);

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -58,7 +58,10 @@ export class DriverSupabase implements Driver {
 	}
 
 	private fullPath(filepath: string) {
-		return normalizePath(join(this.config.root, filepath));
+		const path = join(this.config.root, filepath);
+		// Supabase expects an empty string for current directory
+		if (path === '.') return '';
+		return normalizePath(path);
 	}
 
 	private getAuthenticatedUrl(filepath: string) {

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -6,11 +6,6 @@ import { Readable } from 'node:stream';
 import type { RequestInit } from 'undici';
 import { fetch } from 'undici';
 
-// dirname implementation that always uses '/' to split and returns '' in case of no separator present
-function dirname(path: string) {
-	return path.split('/').slice(0, -1).join('/');
-}
-
 export type DriverSupabaseConfig = {
 	bucket: string;
 	serviceRole: string;
@@ -212,3 +207,10 @@ export class DriverSupabase implements Driver {
 }
 
 export default DriverSupabase;
+
+/**
+ * dirname implementation that always uses '/' to split and returns '' in case of no separator present.
+ */
+function dirname(path: string) {
+	return path.split('/').slice(0, -1).join('/');
+}

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -6,6 +6,11 @@ import { Readable } from 'node:stream';
 import type { RequestInit } from 'undici';
 import { fetch } from 'undici';
 
+// dirname implementation that always uses '/' to split and returns '' in case of no separator present
+function dirname(path: string) {
+	return path.split('/').slice(0, -1).join('/');
+}
+
 export type DriverSupabaseConfig = {
 	bucket: string;
 	serviceRole: string;
@@ -139,13 +144,49 @@ export class DriverSupabase implements Driver {
 		await this.bucket.remove([this.fullPath(filepath)]);
 	}
 
-	async *list(prefix = ''): AsyncIterable<string> {
+	list(prefix = ''): AsyncIterable<string> {
+		const fullPrefix = this.fullPath(prefix);
+		return this.listGenerator(fullPrefix);
+	}
+
+	async *listGenerator(prefix: string): AsyncIterable<string> {
 		const limit = 1000;
 		let offset = 0;
 		let itemCount = 0;
 
+		/*
+     The Supabase API only returns the directories and files directly within the queried location
+     (called prefix in their API), matching the search query. Directories can be identified by the id being null.
+
+     Since we are unsure if the last part of the prefix param is a directory, a file or part of a directory or file name
+     we first need to query with the largest common denominator (the parent directory part of the prefix)
+     and filter the results with the remaining part of the query.
+
+     This can lead to these outcomes:
+     1. The full prefix is a file and is split up into parentdir/filename, the API is queried with
+        { prefix: parentdir, search: filename } and returns one result { name: filename, id: "..." }.
+        We then yield the filename.
+     2. The full prefix is a directory and is split up into parentdir/dir, the API is queried with
+        { prefix: parentdir, search: dir } and returns one result { name: dir, id: null } and importantly, not the
+        contents of the directory. We then need to recursively list the contents of the directory by calling this
+        function with the prefix and a trailing "/" as an indicator that we are interested in the directory contents.
+        2.1. The prefix ends with a "/", the API is queried with { prefix: prefix, search: "" }
+        		 and returns all files and directories within the prefix, which are yielded and recursively listed.
+     3. Special case of 1. and 2.: The prefix is part of a filename/directory name and could result in more than one result
+        that all match the search query. The API is queried with { prefix: parentdir, search: part of filename }
+        and returns all files and directories in parentdir that match the search query. Filenames are yielded and
+        directories are recursively listed.
+		 */
+		const isDirectory = prefix.endsWith('/');
+		const prefixDirectory = isDirectory ? prefix : dirname(prefix);
+		const search = isDirectory ? '' : prefix.split('/').pop() ?? '';
+
 		do {
-			const { data, error } = await this.bucket.list(this.fullPath(prefix), { limit, offset });
+			const { data, error } = await this.bucket.list(prefixDirectory, {
+				limit,
+				offset,
+				search,
+			});
 
 			if (!data || error) {
 				break;
@@ -155,12 +196,15 @@ export class DriverSupabase implements Driver {
 			offset += itemCount;
 
 			for (const item of data) {
+				// Since the API only returns the filename the file path is constructed by joining the prefix with the item name.
+				const filePath = normalizePath(join(prefixDirectory, item.name));
+
 				if (item.id !== null) {
-					// the API only return the pure filename, join it with the prefix for a relative path without root
-					yield normalizePath(join(prefix, item.name), { removeLeading: true });
+					// remove the root from the path and yield the filename
+					yield filePath.substring(this.config.root ? this.config.root.length + 1 : 0);
 				} else {
 					// this is a directory, recursively list it
-					yield* this.list(normalizePath(join(prefix, item.name)));
+					yield* this.listGenerator(filePath + '/');
 				}
 			}
 		} while (itemCount === limit);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The `Driver.list` method is expected to yield all files and nested files in the storage device matching the `prefix` parameter. Up until this point the Supabase storage driver only returned the folder level files and directories that matched with `prefix`, effectively breaking as soon as `prefix` contained a path and not just a single filename prefix (and also returning directories, which is not expected in the first place). This worked fine until the need for synching extensions 

So instead of querying the API once we need to recursively query the API multiple times to yield all files. This is what Supabase does in their CLI as well to recursively list a directory.[^1]

What's changed:

- Recursively query the Supabase
- Added more test cases based on the cases outlined in the large comment in the driver itself

## Potential Risks / Drawbacks

None, hopefully. The increased number of API queries are sadly necessary.

## Review Notes / Questions

- I tested it with their hosted service and created a free account, hit me up if you need my credentials for testing.
- To force a re-sync of your (marketplace) extensions remove the `node_modules/.directus/` directory and restart directus.

---

Fixes #21098

[^1]: https://github.com/supabase/cli/blob/b5e0e172e1a3a40d4d6f518490c68609941c4f41/internal/storage/ls/ls.go#L44
