### PR TITLE
Add Copy button to `system-token` interface

### DIFF
--- a/.changeset/rude-brooms-cry.md
+++ b/.changeset/rude-brooms-cry.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added a copy to clipboard button to token interface

--- a/app/src/interfaces/_system/system-token/system-token.vue
+++ b/app/src/interfaces/_system/system-token/system-token.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useClipboard } from '@/composables/use-clipboard';
+import { HTMLInputElement } from 'happy-dom';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import api from '@/api';
@@ -17,6 +19,7 @@ const props = withDefaults(
 const emit = defineEmits(['input']);
 
 const { t } = useI18n();
+const { isCopySupported, copyToClipboard } = useClipboard();
 
 const placeholder = computed(() => {
 	if (props.disabled && !props.value) return null;
@@ -62,6 +65,14 @@ function emitValue(newValue: string | null) {
 	emit('input', newValue);
 	localValue.value = newValue;
 }
+
+function select(event: FocusEvent) {
+	if (localValue.value) (event.target as HTMLInputElement | null)?.select();
+}
+
+function deselect() {
+	window.getSelection()?.removeAllRanges();
+}
 </script>
 
 <template>
@@ -74,8 +85,18 @@ function emitValue(newValue: string | null) {
 			readonly
 			:class="{ saved: value && !localValue }"
 			@update:model-value="emitValue"
+			@focus="select"
+			@blur="deselect"
 		>
 			<template #append>
+				<v-icon
+					v-if="localValue && isCopySupported"
+					v-tooltip="t('copy')"
+					name="content_copy"
+					clickable
+					class="clipboard-icon"
+					@click="copyToClipboard(value)"
+				/>
 				<v-icon
 					v-if="!disabled"
 					v-tooltip="value ? t('interfaces.system-token.regenerate') : t('interfaces.system-token.generate')"
@@ -113,6 +134,10 @@ function emitValue(newValue: string | null) {
 
 .v-notice {
 	margin-top: 12px;
+}
+
+.clipboard-icon {
+	margin-right: 4px;
 }
 
 .regenerate-icon {

--- a/app/src/interfaces/_system/system-token/system-token.vue
+++ b/app/src/interfaces/_system/system-token/system-token.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useClipboard } from '@/composables/use-clipboard';
-import { HTMLInputElement } from 'happy-dom';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import api from '@/api';


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Just a tiny UX improvement for the `system-token` interface.

What's changed:

- Add a copy to clipboard button that is only shown when a new token is generated (`localValue !== null`)
- Auto-select all input text on focus and deselect again on blur
<img width="679" alt="Screenshot 2024-04-24 at 20 39 26" src="https://github.com/directus/directus/assets/4376726/72979406-0e63-469f-b1cd-23ccc998d9f8">


## Potential Risks / Drawbacks

## Review Notes / Questions

---