### PR TITLE
Add falsy fallback condition to search query

### DIFF
--- a/.changeset/thick-chicken-swim.md
+++ b/.changeset/thick-chicken-swim.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added falsy fallback condition to search query

--- a/.changeset/thick-chicken-swim.md
+++ b/.changeset/thick-chicken-swim.md
@@ -2,4 +2,8 @@
 '@directus/api': patch
 ---
 
-Added falsy fallback condition to search query
+Fixed API queries with the `search` parameter to return no results if the query is not applicable to any fields
+
+::: notice
+Previously, the API returned all items for collections where the `search` parameter was not applicable to any fields. Now the API returns no items in such a case.
+:::

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -105,6 +105,7 @@ describe('applySearch', () => {
 			expect(db['andWhere']).toBeCalledTimes(1);
 			expect(db['orWhere']).toBeCalledTimes(0);
 			expect(db['orWhereRaw']).toBeCalledTimes(1);
+			expect(db['orWhereRaw']).toBeCalledWith('LOWER(??) LIKE ?', ['test.text', `%${number.toLowerCase()}%`]);
 		},
 	);
 
@@ -122,6 +123,28 @@ describe('applySearch', () => {
 		expect(db['andWhere']).toBeCalledTimes(1);
 		expect(db['orWhere']).toBeCalledTimes(2);
 		expect(db['orWhereRaw']).toBeCalledTimes(1);
+		expect(db['orWhereRaw']).toBeCalledWith('LOWER(??) LIKE ?', ['test.text', `%${number.toLowerCase()}%`]);
+	});
+
+	test('Query is falsy if no other clause is added', async () => {
+		const db = mockDatabase();
+
+		const schemaWithStringFieldRemoved = JSON.parse(JSON.stringify(FAKE_SCHEMA));
+
+		delete schemaWithStringFieldRemoved.collections.test.fields.text;
+
+		db['andWhere'].mockImplementation((callback: () => void) => {
+			// detonate the andWhere function
+			callback.call(db);
+			return db;
+		});
+
+		await applySearch(schemaWithStringFieldRemoved, db as any, 'searchstring', 'test');
+
+		expect(db['andWhere']).toBeCalledTimes(1);
+		expect(db['orWhere']).toBeCalledTimes(0);
+		expect(db['orWhereRaw']).toBeCalledTimes(1);
+		expect(db['orWhereRaw']).toBeCalledWith('1 = 0');
 	});
 });
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -258,9 +258,9 @@ query {
 
 ## Search
 
-The search parameter allows you to perform a search on all textual and numeric type fields within a collection. It's an
-easy way to search for an item without creating complex field filters – though it is far less optimized. It only
-searches the root item's fields, related item fields are not included.
+The search parameter allows you to perform a search on textual and numeric type fields within a collection. It's an easy
+way to search for an item without creating complex field filters – though it is far less optimized. It only searches the
+root item's fields, related item fields are not included.
 
 ### Example
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -258,9 +258,9 @@ query {
 
 ## Search
 
-The search parameter allows you to perform a search on all string and text type fields within a collection. It's an easy
-way to search for an item without creating complex field filters – though it is far less optimized. It only searches the
-root item's fields, related item fields are not included.
+The search parameter allows you to perform a search on all textual and numeric type fields within a collection. It's an
+easy way to search for an item without creating complex field filters – though it is far less optimized. It only
+searches the root item's fields, related item fields are not included.
 
 ### Example
 


### PR DESCRIPTION
## Scope

What's changed:

- Added falsy fallback condition to search query

## Potential Risks / Drawbacks

- Unlikely as DBs should not error out on the falsy clause

## Review Notes / Questions

- The falsy fallback condition is only added when there are no other search clauses

---

Fixes #22336
