### PR TITLE
Specific error type mapping in `isDirectusError` function

### DIFF
--- a/.changeset/smooth-games-hug.md
+++ b/.changeset/smooth-games-hug.md
@@ -1,0 +1,5 @@
+---
+'@directus/errors': minor
+---
+
+Extended `isDirectusError` guard to return specific error type when code for built-in error is provided

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"build": "tsup src/index.ts --format=esm --dts",
 		"dev": "tsup src/index.ts --format=esm --dts --watch",
-		"test": "vitest --watch=false"
+		"test": "vitest --typecheck --watch=false"
 	},
 	"dependencies": {
 		"@directus/storage": "workspace:*",

--- a/packages/errors/src/errors/contains-null-values.ts
+++ b/packages/errors/src/errors/contains-null-values.ts
@@ -1,6 +1,6 @@
 import { createError, ErrorCode } from '../index.js';
 
-interface ContainsNullValuesErrorExtensions {
+export interface ContainsNullValuesErrorExtensions {
 	collection: string;
 	field: string;
 }

--- a/packages/errors/src/errors/range-not-satisfiable.ts
+++ b/packages/errors/src/errors/range-not-satisfiable.ts
@@ -1,7 +1,7 @@
 import type { Range } from '@directus/storage';
 import { createError, ErrorCode } from '../index.js';
 
-interface RangeNotSatisfiableErrorExtensions {
+export interface RangeNotSatisfiableErrorExtensions {
 	range: Range;
 }
 

--- a/packages/errors/src/errors/service-unavailable.ts
+++ b/packages/errors/src/errors/service-unavailable.ts
@@ -1,6 +1,6 @@
 import { createError, ErrorCode } from '../index.js';
 
-interface ServiceUnavailableErrorExtensions {
+export interface ServiceUnavailableErrorExtensions {
 	service: string;
 	reason: string;
 }

--- a/packages/errors/src/errors/unprocessable-content.ts
+++ b/packages/errors/src/errors/unprocessable-content.ts
@@ -1,6 +1,6 @@
 import { createError, ErrorCode } from '../index.js';
 
-interface UnprocessableContentErrorExtensions {
+export interface UnprocessableContentErrorExtensions {
 	reason: string;
 }
 

--- a/packages/errors/src/is-directus-error.test-d.ts
+++ b/packages/errors/src/is-directus-error.test-d.ts
@@ -1,0 +1,31 @@
+import { expect, expectTypeOf, test } from 'vitest';
+import { ErrorCode } from './codes.js';
+import { type DirectusError } from './create-error.js';
+import type { ContainsNullValuesErrorExtensions } from './errors/contains-null-values.js';
+import { isDirectusError } from './is-directus-error.js';
+
+test('Guards input as DirectusError', () => {
+	expectTypeOf(isDirectusError).guards.toEqualTypeOf<DirectusError<unknown>>();
+});
+
+test('Returns specific type when provided code for built-in error', () => {
+	const error = { name: 'DirectusError', code: ErrorCode.ContainsNullValues };
+
+	expect.assertions(1);
+
+	if (isDirectusError(error, ErrorCode.ContainsNullValues)) {
+		expectTypeOf(error).toMatchTypeOf<DirectusError<ContainsNullValuesErrorExtensions>>();
+	}
+});
+
+test('Allows to pass custom extensions type', () => {
+	const error = { name: 'DirectusError' };
+
+	expect.assertions(1);
+
+	type CustomDirectusErrorExtensions = { custom: string };
+
+	if (isDirectusError<CustomDirectusErrorExtensions>(error)) {
+		expectTypeOf(error).toMatchTypeOf<DirectusError<CustomDirectusErrorExtensions>>();
+	}
+});

--- a/packages/errors/src/is-directus-error.ts
+++ b/packages/errors/src/is-directus-error.ts
@@ -1,20 +1,26 @@
 import type { DirectusError } from './create-error.js';
+import type { ExtensionsMap } from './types.js';
 
 /**
- * Check whether or not a passed thing is a valid Directus error
+ * Check whether or not a passed value is a valid Directus error.
  *
- * @param err - Any input
+ * @param value - Any value
+ * @param code - Error code to check for
  */
-export const isDirectusError = <T = unknown>(err: unknown, code?: string): err is DirectusError<T> => {
+
+export const isDirectusError = <T = never, C extends string = string>(
+	value: unknown,
+	code?: C,
+): value is DirectusError<[T] extends [never] ? (C extends keyof ExtensionsMap ? ExtensionsMap[C] : unknown) : T> => {
 	const isDirectusError =
-		typeof err === 'object' &&
-		err !== null &&
-		Array.isArray(err) === false &&
-		'name' in err &&
-		err.name === 'DirectusError';
+		typeof value === 'object' &&
+		value !== null &&
+		Array.isArray(value) === false &&
+		'name' in value &&
+		value.name === 'DirectusError';
 
 	if (code) {
-		return isDirectusError && 'code' in err && err.code === code.toUpperCase();
+		return isDirectusError && 'code' in value && value.code === code.toUpperCase();
 	}
 
 	return isDirectusError;

--- a/packages/errors/src/is-directus-error.ts
+++ b/packages/errors/src/is-directus-error.ts
@@ -7,7 +7,6 @@ import type { ExtensionsMap } from './types.js';
  * @param value - Any value
  * @param code - Error code to check for
  */
-
 export const isDirectusError = <T = never, C extends string = string>(
 	value: unknown,
 	code?: C,

--- a/packages/errors/src/types.ts
+++ b/packages/errors/src/types.ts
@@ -1,0 +1,56 @@
+import { ErrorCode } from './codes.js';
+import type { ContainsNullValuesErrorExtensions } from './errors/contains-null-values.js';
+import type { HitRateLimitErrorExtensions } from './errors/hit-rate-limit.js';
+import type { IllegalAssetTransformationErrorExtensions } from './errors/illegal-asset-transformation.js';
+import type { InvalidForeignKeyErrorExtensions } from './errors/invalid-foreign-key.js';
+import type { InvalidPayloadErrorExtensions } from './errors/invalid-payload.js';
+import type { InvalidProviderConfigErrorExtensions } from './errors/invalid-provider-config.js';
+import type { InvalidQueryErrorExtensions } from './errors/invalid-query.js';
+import type { MethodNotAllowedErrorExtensions } from './errors/method-not-allowed.js';
+import type { NotNullViolationErrorExtensions } from './errors/not-null-violation.js';
+import type { RangeNotSatisfiableErrorExtensions } from './errors/range-not-satisfiable.js';
+import type { RecordNotUniqueErrorExtensions } from './errors/record-not-unique.js';
+import type { RouteNotFoundErrorExtensions } from './errors/route-not-found.js';
+import type { ServiceUnavailableErrorExtensions } from './errors/service-unavailable.js';
+import type { UnprocessableContentErrorExtensions } from './errors/unprocessable-content.js';
+import type { UnsupportedMediaTypeErrorExtensions } from './errors/unsupported-media-type.js';
+import type { ValueOutOfRangeErrorExtensions } from './errors/value-out-of-range.js';
+import type { ValueTooLongErrorExtensions } from './errors/value-too-long.js';
+
+type Map = {
+	[ErrorCode.ContainsNullValues]: ContainsNullValuesErrorExtensions;
+	[ErrorCode.ContentTooLarge]: never;
+	[ErrorCode.Forbidden]: never;
+	[ErrorCode.IllegalAssetTransformation]: IllegalAssetTransformationErrorExtensions;
+	[ErrorCode.InvalidCredentials]: never;
+	[ErrorCode.InvalidForeignKey]: InvalidForeignKeyErrorExtensions;
+	[ErrorCode.InvalidIp]: never;
+	[ErrorCode.InvalidOtp]: never;
+	[ErrorCode.InvalidPayload]: InvalidPayloadErrorExtensions;
+	[ErrorCode.InvalidProvider]: never;
+	[ErrorCode.InvalidProviderConfig]: InvalidProviderConfigErrorExtensions;
+	[ErrorCode.InvalidQuery]: InvalidQueryErrorExtensions;
+	[ErrorCode.InvalidToken]: never;
+	[ErrorCode.LimitExceeded]: never;
+	[ErrorCode.MethodNotAllowed]: MethodNotAllowedErrorExtensions;
+	[ErrorCode.NotNullViolation]: NotNullViolationErrorExtensions;
+	[ErrorCode.OutOfDate]: never;
+	[ErrorCode.RangeNotSatisfiable]: RangeNotSatisfiableErrorExtensions;
+	[ErrorCode.RecordNotUnique]: RecordNotUniqueErrorExtensions;
+	[ErrorCode.RequestsExceeded]: HitRateLimitErrorExtensions;
+	[ErrorCode.RouteNotFound]: RouteNotFoundErrorExtensions;
+	[ErrorCode.ServiceUnavailable]: ServiceUnavailableErrorExtensions;
+	[ErrorCode.TokenExpired]: never;
+	[ErrorCode.UnexpectedResponse]: never;
+	[ErrorCode.UnprocessableContent]: UnprocessableContentErrorExtensions;
+	[ErrorCode.UnsupportedMediaType]: UnsupportedMediaTypeErrorExtensions;
+	[ErrorCode.UserSuspended]: never;
+	[ErrorCode.ValueOutOfRange]: ValueOutOfRangeErrorExtensions;
+	[ErrorCode.ValueTooLong]: ValueTooLongErrorExtensions;
+};
+
+/** Verify all error codes are covered in the map. */
+type Extends<T, U extends T> = U;
+
+/** Map error codes to error extensions. */
+export type ExtensionsMap = Extends<Record<(typeof ErrorCode)[keyof typeof ErrorCode], any>, Map>;

--- a/packages/errors/src/types.ts
+++ b/packages/errors/src/types.ts
@@ -19,38 +19,25 @@ import type { ValueTooLongErrorExtensions } from './errors/value-too-long.js';
 
 type Map = {
 	[ErrorCode.ContainsNullValues]: ContainsNullValuesErrorExtensions;
-	[ErrorCode.ContentTooLarge]: never;
-	[ErrorCode.Forbidden]: never;
 	[ErrorCode.IllegalAssetTransformation]: IllegalAssetTransformationErrorExtensions;
-	[ErrorCode.InvalidCredentials]: never;
 	[ErrorCode.InvalidForeignKey]: InvalidForeignKeyErrorExtensions;
-	[ErrorCode.InvalidIp]: never;
-	[ErrorCode.InvalidOtp]: never;
 	[ErrorCode.InvalidPayload]: InvalidPayloadErrorExtensions;
-	[ErrorCode.InvalidProvider]: never;
 	[ErrorCode.InvalidProviderConfig]: InvalidProviderConfigErrorExtensions;
 	[ErrorCode.InvalidQuery]: InvalidQueryErrorExtensions;
-	[ErrorCode.InvalidToken]: never;
-	[ErrorCode.LimitExceeded]: never;
 	[ErrorCode.MethodNotAllowed]: MethodNotAllowedErrorExtensions;
 	[ErrorCode.NotNullViolation]: NotNullViolationErrorExtensions;
-	[ErrorCode.OutOfDate]: never;
 	[ErrorCode.RangeNotSatisfiable]: RangeNotSatisfiableErrorExtensions;
 	[ErrorCode.RecordNotUnique]: RecordNotUniqueErrorExtensions;
 	[ErrorCode.RequestsExceeded]: HitRateLimitErrorExtensions;
 	[ErrorCode.RouteNotFound]: RouteNotFoundErrorExtensions;
 	[ErrorCode.ServiceUnavailable]: ServiceUnavailableErrorExtensions;
-	[ErrorCode.TokenExpired]: never;
-	[ErrorCode.UnexpectedResponse]: never;
 	[ErrorCode.UnprocessableContent]: UnprocessableContentErrorExtensions;
 	[ErrorCode.UnsupportedMediaType]: UnsupportedMediaTypeErrorExtensions;
-	[ErrorCode.UserSuspended]: never;
 	[ErrorCode.ValueOutOfRange]: ValueOutOfRangeErrorExtensions;
 	[ErrorCode.ValueTooLong]: ValueTooLongErrorExtensions;
 };
 
-/** Verify all error codes are covered in the map. */
-type Extends<T, U extends T> = U;
-
 /** Map error codes to error extensions. */
-export type ExtensionsMap = Extends<Record<(typeof ErrorCode)[keyof typeof ErrorCode], any>, Map>;
+export type ExtensionsMap = {
+	[code in ErrorCode]: code extends keyof Map ? Map[code] : never;
+};


### PR DESCRIPTION
## Scope

Extend `isDirectusError` guard function to return specific error type when `code` for built-in error is provided

### Before

<img width="800" src="https://github.com/directus/directus/assets/5363448/1468eff8-5bd5-4426-bbb7-c21b96193d88">

### After

<img width="800" src="https://github.com/directus/directus/assets/5363448/bf0692fd-941e-4263-8d4f-abea95b1dee8">

## Potential Risks / Drawbacks

If a custom error would use same error code as a built-in error, the type could vary. However, this is a) not recommended and b) a matching custom type could still be passed in as generic param.

## Review Notes / Questions

None