### PR TITLE
Fix arrow misalignment in M2A relation settings

### DIFF
--- a/.changeset/unlucky-bugs-refuse.md
+++ b/.changeset/unlucky-bugs-refuse.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed arrow alignment when selecting 5 or more collections in the "Relationship" tab of M2A interface settings

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -251,7 +251,7 @@ const unsortableJunctionFields = computed(() => {
 
 			top: 50%;
 			transform: translateY(-50%);
-			right: -26px;
+			right: -26px; // moves it to the center of the column-gap ( icon-width + (gap - icon-width) / 2 )
 		}
 	}
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -92,7 +92,12 @@ const unsortableJunctionFields = computed(() => {
 				/>
 			</div>
 
-			<v-input disabled :model-value="currentPrimaryKey" />
+			<div class="primary-key">
+				<div class="field-wrapper">
+					<v-input disabled :model-value="currentPrimaryKey" />
+					<v-icon class="arrow" name="arrow_forward" />
+				</div>
+			</div>
 
 			<related-field-select
 				v-model="junctionFieldCurrent"
@@ -104,24 +109,29 @@ const unsortableJunctionFields = computed(() => {
 
 			<div class="spacer" />
 
-			<related-field-select
-				v-model="oneCollectionField"
-				:collection="junctionCollection"
-				:placeholder="t('collection_key') + '...'"
-				:disabled="autoGenerateJunctionRelation || isExisting"
-			/>
+			<div class="junction-field-related">
+				<div class="field-wrapper">
+					<related-field-select
+						v-model="oneCollectionField"
+						:collection="junctionCollection"
+						:placeholder="t('collection_key') + '...'"
+						:disabled="autoGenerateJunctionRelation || isExisting"
+					/>
+					<v-icon class="arrow" name="arrow_back" />
+				</div>
+			</div>
 
 			<div class="spacer" />
 
-			<related-field-select v-model="junctionFieldRelated" :disabled="autoGenerateJunctionRelation || isExisting" />
+			<div class="field-wrapper">
+				<related-field-select v-model="junctionFieldRelated" :disabled="autoGenerateJunctionRelation || isExisting" />
+				<v-icon class="arrow" name="arrow_back" />
+			</div>
 
 			<v-input disabled :model-value="t('primary_key')" />
 
 			<div class="spacer" />
 			<v-checkbox v-if="!isExisting" v-model="autoGenerateJunctionRelation" block :label="t('auto_fill')" />
-			<v-icon class="arrow" name="arrow_forward" />
-			<v-icon class="arrow" name="arrow_back" />
-			<v-icon class="arrow" name="arrow_back" />
 		</div>
 
 		<div class="sort-field">
@@ -229,27 +239,30 @@ const unsortableJunctionFields = computed(() => {
 	gap: 12px 28px;
 	margin-top: 48px;
 
-	.v-icon.arrow {
-		--v-icon-color: var(--theme--primary);
+	.field-wrapper {
+		display: flex;
+		flex: 1;
+		position: relative;
 
-		position: absolute;
-		transform: translateX(-50%);
-		pointer-events: none;
+		.v-icon.arrow {
+			--v-icon-color: var(--theme--primary);
+			position: absolute;
+			pointer-events: none;
 
-		&:first-of-type {
-			top: 117px;
-			left: 32.5%;
+			top: 50%;
+			transform: translateY(-50%);
+			right: -26px;
 		}
+	}
 
-		&:nth-of-type(2) {
-			top: 190px;
-			left: 67.4%;
-		}
+	.junction-field-related {
+		display: flex;
+		align-items: flex-end;
+	}
 
-		&:last-of-type {
-			top: 261px;
-			left: 67.4%;
-		}
+	.primary-key {
+		display: flex;
+		align-items: flex-start;
 	}
 }
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Use a few wrappers to push the fields up or down
- Actually position the arrows with the fields they are pointing to / from to not rely on fixed positions

|Before|After few|After many|
|-|-|-|
| ![Screenshot 2024-04-30 at 19 48 05](https://github.com/directus/directus/assets/4376726/7ba5d959-6e7e-4bcf-bfcd-b4ca5bf642d1) | ![Screenshot 2024-04-30 at 19 40 43](https://github.com/directus/directus/assets/4376726/1a274a5e-664f-42d3-972b-cb30ed33aa81) | ![Screenshot 2024-04-30 at 19 40 54](https://github.com/directus/directus/assets/4376726/fb17b008-d8d5-4c5f-99ed-4f57be21f2db) |

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #22348
