### PR TITLE
App: Fix rate limit when having much relationships

### DIFF
--- a/.changeset/stupid-dingos-drop.md
+++ b/.changeset/stupid-dingos-drop.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Prevent rate limit hit when having multiple different relationships
+Ensured that the rate limit is adhered to when having multiple different relationships

--- a/.changeset/stupid-dingos-drop.md
+++ b/.changeset/stupid-dingos-drop.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Prevent rate limit hit when having multiple different relationships

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -73,20 +73,20 @@ export async function replaceQueue(options?: Options<any, QueueAddOptions>) {
 
 function onRequestEnd(response?: AxiosResponse | Response) {
 	// Note: Cancelled requests don't respond with the config
-	const { id, start } = response?.config as InternalRequestConfig;
+	const config = response?.config as InternalRequestConfig | undefined;
 
-	if (id) {
+	if (config?.id) {
 		const requestsStore = useRequestsStore();
-		requestsStore.endRequest(id);
+		requestsStore.endRequest(config.id);
 	}
 
-	if (start) {
+	if (config?.start) {
 		const end = performance.now();
 		const latencyStore = useLatencyStore();
 
 		latencyStore.save({
 			timestamp: new Date(),
-			latency: end - start,
+			latency: end - config.start,
 		});
 	}
 }

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -1,7 +1,8 @@
+import { useLatencyStore } from '@/stores/latency';
 import { useRequestsStore } from '@/stores/requests';
 import { getRootPath } from '@/utils/get-root-path';
 import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import PQueue, { type QueueAddOptions, type Options } from 'p-queue';
+import PQueue, { Options, QueueAddOptions } from 'p-queue';
 import sdk from './sdk';
 
 const api = axios.create({
@@ -16,7 +17,9 @@ export let requestQueue: PQueue = new PQueue({
 	carryoverConcurrencyCount: true,
 });
 
-type RequestConfig = InternalAxiosRequestConfig & { id: string };
+export type RequestConfig = InternalAxiosRequestConfig & { measureLatency?: boolean };
+
+type InternalRequestConfig = RequestConfig & { id: string; start?: number };
 type Response = AxiosResponse & { config: RequestConfig };
 export type RequestError = AxiosError & { response: Response };
 
@@ -24,9 +27,9 @@ export const onRequest = (config: InternalAxiosRequestConfig): Promise<InternalA
 	const requestsStore = useRequestsStore();
 	const id = requestsStore.startRequest();
 
-	const requestConfig: RequestConfig = {
-		id: id,
+	const requestConfig: InternalRequestConfig = {
 		...config,
+		id,
 	};
 
 	return new Promise((resolve) => {
@@ -36,26 +39,20 @@ export const onRequest = (config: InternalAxiosRequestConfig): Promise<InternalA
 				/* fail gracefully */
 			});
 
+			if (requestConfig.measureLatency) requestConfig.start = performance.now();
+
 			return resolve(requestConfig);
 		});
 	});
 };
 
 export const onResponse = (response: AxiosResponse | Response): AxiosResponse | Response => {
-	const requestsStore = useRequestsStore();
-	const id = (response.config as RequestConfig)?.id;
-	if (id) requestsStore.endRequest(id);
+	onRequestEnd(response);
 	return response;
 };
 
 export const onError = async (error: RequestError): Promise<RequestError> => {
-	const requestsStore = useRequestsStore();
-
-	// Note: Cancelled requests don't respond with the config
-	const id = (error.response?.config as RequestConfig)?.id;
-
-	if (id) requestsStore.endRequest(id);
-
+	onRequestEnd(error.response);
 	return Promise.reject(error);
 };
 
@@ -72,4 +69,24 @@ export function resumeQueue() {
 export async function replaceQueue(options?: Options<any, QueueAddOptions>) {
 	await requestQueue.onIdle();
 	requestQueue = new PQueue(options);
+}
+
+function onRequestEnd(response?: AxiosResponse | Response) {
+	// Note: Cancelled requests don't respond with the config
+	const { id, start } = response?.config as InternalRequestConfig;
+
+	if (id) {
+		const requestsStore = useRequestsStore();
+		requestsStore.endRequest(id);
+	}
+
+	if (start) {
+		const end = performance.now();
+		const latencyStore = useLatencyStore();
+
+		latencyStore.save({
+			timestamp: new Date(),
+			latency: end - start,
+		});
+	}
 }

--- a/app/src/stores/requests.ts
+++ b/app/src/stores/requests.ts
@@ -4,26 +4,26 @@ import { defineStore } from 'pinia';
 export const useRequestsStore = defineStore({
 	id: 'requestsStore',
 	state: () => ({
-		queue: [] as string[],
+		queue: new Set<string>(),
 	}),
 	getters: {
 		queueHasItems(): boolean {
-			return this.queue.length > 0;
+			return this.queue.size > 0;
 		},
 	},
 	actions: {
 		startRequest() {
 			const id = nanoid();
-			this.queue = [...this.queue, id];
+			this.queue.add(id);
 
-			// If requests take more than 3.5 seconds, we'll have to assume they'll either never
+			// If requests take more than 3.5 seconds, it's assumed they'll either never
 			// happen, or already crashed
 			setTimeout(() => this.endRequest(id), 3500);
 
 			return id;
 		},
 		endRequest(id: string) {
-			this.queue = this.queue.filter((queueID: string) => queueID !== id);
+			this.queue.delete(id);
 		},
 	},
 });

--- a/app/src/stores/server.test.ts
+++ b/app/src/stores/server.test.ts
@@ -324,9 +324,9 @@ describe('hydrate action', async () => {
 		await serverStore.hydrate();
 
 		expect(replaceQueueSpy).toHaveBeenCalledWith({
-			intervalCap: mockRateLimit.points - 10,
-			interval: mockRateLimit.duration * 1000,
-			carryoverConcurrencyCount: true,
+			intervalCap: 1,
+			// Interval for 1 point (duration * 1000(ms) / points)
+			interval: 500,
 		});
 	});
 });

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -115,8 +115,9 @@ export const useServerStore = defineStore('serverStore', () => {
 			} else {
 				const { duration, points } = serverInfoResponse.data.data.rateLimit;
 				const intervalCap = 1;
+				/** Interval for 1 point */
 				const interval = Math.ceil((duration * 1000) / points);
-				await replaceQueue({ intervalCap, interval, carryoverConcurrencyCount: true, concurrency: 1 });
+				await replaceQueue({ intervalCap, interval });
 			}
 		}
 	};

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -114,7 +114,9 @@ export const useServerStore = defineStore('serverStore', () => {
 				await replaceQueue();
 			} else {
 				const { duration, points } = serverInfoResponse.data.data.rateLimit;
-				await replaceQueue({ intervalCap: points - 10, interval: duration * 1000, carryoverConcurrencyCount: true });
+				const intervalCap = 1;
+				const interval = Math.ceil((duration * 1000) / points);
+				await replaceQueue({ intervalCap, interval, carryoverConcurrencyCount: true, concurrency: 1 });
 			}
 		}
 	};

--- a/app/src/stores/user.test.ts
+++ b/app/src/stores/user.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { RouteLocationNormalized } from 'vue-router';
 
 import { User } from '@directus/types';
-import { useLatencyStore } from './latency';
 import { useUserStore } from './user';
 
 beforeEach(() => {
@@ -132,9 +131,6 @@ describe('actions', () => {
 		const page = '/test';
 
 		test('should not set last_page if there is no current user', async () => {
-			const latencyStore = useLatencyStore();
-			vi.spyOn(latencyStore, 'save').mockReturnValue();
-
 			const userStore = useUserStore();
 			await userStore.trackPage({ path: page, fullPath: page } as RouteLocationNormalized);
 
@@ -142,9 +138,6 @@ describe('actions', () => {
 		});
 
 		test('should set last_page if there is current user', async () => {
-			const latencyStore = useLatencyStore();
-			vi.spyOn(latencyStore, 'save').mockReturnValue();
-
 			const userStore = useUserStore();
 			await userStore.hydrate();
 			await userStore.trackPage({ path: page, fullPath: page } as RouteLocationNormalized);

--- a/app/src/stores/user.ts
+++ b/app/src/stores/user.ts
@@ -1,5 +1,4 @@
-import api from '@/api';
-import { useLatencyStore } from '@/stores/latency';
+import api, { RequestConfig } from '@/api';
 import { userName } from '@/utils/user-name';
 import { User } from '@directus/types';
 import { merge } from 'lodash';
@@ -69,20 +68,13 @@ export const useUserStore = defineStore({
 				return;
 			}
 
-			const latencyStore = useLatencyStore();
-
-			const start = performance.now();
-
-			await api.patch(`/users/me/track/page`, {
-				last_page: to.fullPath,
-			});
-
-			const end = performance.now();
-
-			latencyStore.save({
-				timestamp: new Date(),
-				latency: end - start,
-			});
+			await api.patch(
+				`/users/me/track/page`,
+				{
+					last_page: to.fullPath,
+				},
+				{ measureLatency: true } as RequestConfig,
+			);
 
 			if (this.currentUser && !('share' in this.currentUser)) {
 				this.currentUser.last_page = to.fullPath;


### PR DESCRIPTION
## Scope
When there's much different relationships[^1] configured on the collection, we sometimes see the following error while navigating in the App:
```json
{
  "errors": [
    {
      "message": "Too many requests, retry after 56ms.",
      "extensions": {
        "code": "REQUESTS_EXCEEDED",
        "limit": 50,
        "reset": "2024-05-01T07:28:36.286Z",
        "stack": "DirectusError: Too many requests, retry after 56ms."
      }
    }
  ]
}
```

The requests come from server with status 429 Too Many Requests. This is because rate limiter is set to 50 points for 1 second and the requests from App are going beyond this.

After looking into this, we saw Directus App using `p-queue` in order to prevent this rate limit errors.
Although, the way it's configured does not seem right as we still see issues.
The current configuration sets the `intervalCap` to `RATE_LIMITER_POINTS - 10` and `interval` to `RATE_LIMITER_DURATION`.
This seems right, but since the duration is too long, some requests may start after hitting the rate limit on the server.

In this PR, we change the way this is configured.
To prevent the issue mentioned above, we do the math to get the smallest interval possible. In other words, we set `intervalCap` to 1 and the `interval` to `RATE_LIMITER_DURATION / RATE_LIMITER_POINTS` which will give the interval for 1 point.

What's changed:

- Prevent rate limit while using Directus App when having multiple relationships

## Potential Risks / Drawbacks

- None as I foresee

## Review Notes / Questions

- N/A

## Reproduction
|Before|After|
|-|-|
|<video src="https://github.com/directus/directus/assets/14039341/e5f2f7c2-9311-4c8f-b6f8-a9ce44f6ec6d"></video> | <video src="https://github.com/directus/directus/assets/14039341/dff5c408-35d5-4385-8200-500c2baacbfa"></video>|

Use the following database dump to reproduce the issue:
[app_fix-rate-limit.sql.zip](https://github.com/directus/directus/files/15174939/app_fix-rate-limit.sql.zip)
Then navigate between items in different collections and items in collection `e`

[^1]: I was not able to determine the amount but it is dependant on the values configured for the rate limiter