### PR TITLE
Fix `system-filter` wrap behavior

### DIFF
--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -271,6 +271,11 @@ function addKeyAsNode() {
 	.buttons {
 		padding: 0 10px;
 		font-weight: 600;
+
+		button {
+			display: inline-flex;
+			align-items: center;
+		}
 	}
 
 	&.empty {
@@ -346,8 +351,6 @@ function addKeyAsNode() {
 .field .buttons {
 	button {
 		color: var(--theme--primary);
-		display: inline-flex;
-		align-items: center;
 		cursor: pointer;
 	}
 

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -346,7 +346,8 @@ function addKeyAsNode() {
 .field .buttons {
 	button {
 		color: var(--theme--primary);
-		display: inline-block;
+		display: inline-flex;
+		align-items: center;
 		cursor: pointer;
 	}
 

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -193,7 +193,7 @@ function addKeyAsNode() {
 				<template #activator="{ toggle, active }">
 					<button class="add-filter" :class="{ active }" @click="toggle">
 						<v-icon v-if="inline" name="add" class="add" small />
-						<v-text-overflow :text="t('interfaces.filter.add_filter')" />
+						<span>{{ t('interfaces.filter.add_filter') }}</span>
 						<v-icon name="expand_more" class="expand_more" />
 					</button>
 				</template>
@@ -272,9 +272,8 @@ function addKeyAsNode() {
 		padding: 0 10px;
 		font-weight: 600;
 
-		button {
-			display: inline-flex;
-			align-items: center;
+		span {
+			white-space: nowrap;
 		}
 	}
 
@@ -351,6 +350,7 @@ function addKeyAsNode() {
 .field .buttons {
 	button {
 		color: var(--theme--primary);
+		display: inline-block;
 		cursor: pointer;
 	}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

In b7bc25d5a83cc294ef11142a95ebf525a93a21ee the `v-text-overflow` was introduced to the system filter "Add Filter" label to prevent line wrapping in the expand animation of the search component, causing unwanted wrapping of the down arrow in other places. Use a simple `span` with `white-space: nowrap` instead of `div` element brought along by `v-text-overflow`

|Before|After|
|-|-|
| <img width="608" alt="Screenshot 2024-05-03 at 09 04 13" src="https://github.com/directus/directus/assets/4376726/054c55bf-b487-42f7-b6a1-ba1c67b66704"> | <img width="608" alt="Screenshot 2024-05-03 at 09 02 32" src="https://github.com/directus/directus/assets/4376726/4539334a-04e1-467a-b486-a6d57bc5e32b"> |

In the search bar the text does still not wrap now (correct)

<img width="253" alt="Screenshot 2024-05-03 at 09 42 23" src="https://github.com/directus/directus/assets/4376726/f0cd11e0-1cbb-4f1a-a09b-87358d58c36e">

