### PR TITLE
Fix default naming of related collection junction field for translations

### DIFF
--- a/.changeset/fluffy-walls-destroy.md
+++ b/.changeset/fluffy-walls-destroy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed default naming of the related field name for the first translations field created

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/translations.ts
@@ -122,7 +122,7 @@ export function updateJunctionRelated(updates: StateUpdates, _state: State, { ge
 	const relatedCollection = getCurrent('relations.m2o.related_collection');
 
 	const relatedCollectionPrimaryKeyField =
-		fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection)?.field ?? 'id';
+		fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection)?.field ?? 'code';
 
 	set(updates, 'relations.m2o.field', `${relatedCollection}_${relatedCollectionPrimaryKeyField}`);
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The default (auto-filled) related collection key field in the `..._translations` junctions table defaults to `..._id` if the `languages` (or whatever the user decides to call it) table does not exist when creating the first ever translations field. For all subsequent translation fields this get filled to `..._code`. It probably makes sense to default to `..._code` in case the collection does not exist, since we auto create the related collection if it is missing and have a hardcoded primary key of `code` in there. 

If the user selects a different (already existing) collection the behavior does not change since then `fieldsStore.getPrimaryKeyFieldForCollection` returns the actual primary key which is used.

What's changed:
- Default to `code` instead of `id` in case we can not get the primary key name for the related collection (which as far as I can tell only happens if the table does not exist?)

## Potential Risks / Drawbacks

- Are there any cases where the `fieldsStore` would not have the primary key field of a collection that does exist? This probably would have been broken before then as well, if it didn't happen to by `id`.

## Review Notes / Questions

None

---

Fixes #22377 
