### PR TITLE
Fix the failing auto-creation of default languages in translation field setup

### DIFF
--- a/.changeset/curvy-houses-grin.md
+++ b/.changeset/curvy-houses-grin.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the failing auto-creating of default languages for custom languages collections in the translation field setup

--- a/.changeset/curvy-houses-grin.md
+++ b/.changeset/curvy-houses-grin.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed the failing auto-creating of default languages for custom languages collections in the translation field setup
+Fixed the failing auto-creating of default languages for translation fields when using an existing, custom language collection.

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -38,7 +38,7 @@ export const useFieldDetailStore = defineStore({
 		/** What field we're currently editing ("+"" for new)  */
 		editing: '+' as string,
 
-		/** Full field data with edits  */
+		/** Full field data with edits */
 		field: {
 			field: undefined,
 			type: undefined,
@@ -167,12 +167,7 @@ export const useFieldDetailStore = defineStore({
 
 				const { field: fieldUpdates, items: itemUpdates, ...restUpdates } = updates;
 
-				mergeWith(state, restUpdates, (_, srcValue, key, object) => {
-					if (Array.isArray(srcValue)) return srcValue;
-					if (srcValue === undefined) object[key] = undefined;
-					return;
-				});
-
+				// Handle `field` updates, shallow merge and mirror to `fieldUpdates`
 				if (fieldUpdates) {
 					const { schema: schemaUpdates, meta: metaUpdates, ...restFieldUpdates } = fieldUpdates;
 
@@ -190,9 +185,19 @@ export const useFieldDetailStore = defineStore({
 					}
 				}
 
+				// Handle `item` updates, allowing full replacements
 				if (itemUpdates) {
 					state.items = itemUpdates as (typeof this.$state)['items'];
 				}
+
+				// Handle remaining updates, deep merge
+				mergeWith(state, restUpdates, (_, srcValue, key, object) => {
+					// Override arrays instead of merging
+					if (Array.isArray(srcValue)) return srcValue;
+					// Allow properties to be resettable
+					if (srcValue === undefined) object[key] = undefined;
+					return;
+				});
 			});
 		},
 		async save() {

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -165,7 +165,7 @@ export const useFieldDetailStore = defineStore({
 					alterations[localType].applyChanges(updates, state, { hasChanged, getCurrent });
 				}
 
-				const { field: fieldUpdates, ...restUpdates } = updates;
+				const { field: fieldUpdates, items: itemUpdates, ...restUpdates } = updates;
 
 				mergeWith(state, restUpdates, (_, srcValue, key, object) => {
 					if (Array.isArray(srcValue)) return srcValue;
@@ -188,6 +188,10 @@ export const useFieldDetailStore = defineStore({
 						Object.assign((state.field.meta ??= {}), metaUpdates);
 						Object.assign((state.fieldUpdates.meta ??= {}), metaUpdates);
 					}
+				}
+
+				if (itemUpdates) {
+					state.items = itemUpdates as (typeof this.$state)['items'];
 				}
 			});
 		},


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When creating a new translation field and the selected languages collection does not exist the app will create that collection and populate it with some default languages. There is however the edge case that surfaced where the app will try to create items in the non existing collection default collection (`languages`) if the user selects a custom languages collection and does not have the default collection in the data base. This is caused by `items` not properly resetting in the `fieldDetailsStore`.

To reproduce:

- Make sure you start without the `languages` collection in your DB
- Create a custom languages collection that is not called `languages`
- Add a Translation field to an example collection (through the advanced creation flow)
- Select your custom languages collection
- Create the field and observe an error (also see that the app tries to call `/items/languages` in the network panel)

What's changed:

- If item updates are provided do not merge them with the existing state but rather overwrite them. As far as I can tell the `state.items` is only utilized in the `translations.ts` alterations of the field detail store. 

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #20510 
