### PR TITLE
`system-filter`: Prevent text wrap, and keep field list dropdown for functions

### DIFF
--- a/.changeset/yellow-frogs-warn.md
+++ b/.changeset/yellow-frogs-warn.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed missing field selection dropdown for functions in filter interface

--- a/app/src/interfaces/_system/system-filter/utils.ts
+++ b/app/src/interfaces/_system/system-filter/utils.ts
@@ -15,6 +15,10 @@ export function getField(node: Record<string, any>): string {
 	return subFields !== '' ? `${name}.${subFields}` : name;
 }
 
+export function fieldHasFunction(field: string) {
+	return field.includes('(') && field.includes(')');
+}
+
 export function getComparator(node: Record<string, any>): string {
 	return getNodeName(get(node, getField(node)));
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Two minor improvements for the `system-filter` interface:

* Make sure that long plain names don't wrap:

|Before|After|
|-|-|
| <img width="520" alt="Screenshot 2024-05-07 at 11 34 42" src="https://github.com/directus/directus/assets/4376726/3b40b0ba-dcd1-4430-bfe4-4ced89a392bf"> | <img width="550" alt="Screenshot 2024-05-07 at 11 36 16" src="https://github.com/directus/directus/assets/4376726/a31ce0fd-ea35-4b10-a5bb-82e5b8fd5f96"> |

* Handle fields with function names the same as field names when it comes to dropdown behavior. Previously, fields with function names were not identified as existing fields and only displayed as `plain-name` and one had to manually remove the filter and re-add it with a different field if a function was selected. Now, it behaves just like a normal field name and shows the dropdown on click.

![Screenshot 2024-05-08 at 10 45 39](https://github.com/directus/directus/assets/4376726/39b30458-ebbf-46ec-9f7a-28e52d015749)


What's changed:

- Minor CSS change
- Extend `isExistingField` to account for function names in the last key part (which is AFAIK the only part that can have a function?)

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Does this warrant a changeset?
