### PR TITLE
Fix `system-display-template` reactivity

### DIFF
--- a/.changeset/new-carrots-do.md
+++ b/.changeset/new-carrots-do.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed display template not showing newly added fields in collection field settings

--- a/.changeset/new-carrots-do.md
+++ b/.changeset/new-carrots-do.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed display template not showing newly added fields in collection field settings
+Fixed display template not showing newly added fields under collection field settings

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -35,7 +35,11 @@ export function useFieldTree(
 	const treeList = ref<FieldNode[]>([]);
 	const visitedPaths = ref<Set<string>>(new Set());
 
-	watch(() => collection.value, refresh, { immediate: true });
+	watch(
+		[() => collection.value, () => collection.value && fieldsStore.getFieldsForCollectionSorted(collection.value)],
+		refresh,
+		{ immediate: true },
+	);
 
 	return { treeList, loadFieldRelations, refresh };
 

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -35,11 +35,10 @@ export function useFieldTree(
 	const treeList = ref<FieldNode[]>([]);
 	const visitedPaths = ref<Set<string>>(new Set());
 
-	watch(
-		[() => collection.value, () => collection.value && fieldsStore.getFieldsForCollectionSorted(collection.value)],
-		refresh,
-		{ immediate: true },
-	);
+	// Refresh when collection or fields of the collection are updated
+	watch([collection, () => collection.value && fieldsStore.getFieldsForCollectionSorted(collection.value)], refresh, {
+		immediate: true,
+	});
 
 	return { treeList, loadFieldRelations, refresh };
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added shallow reactivity to `useFieldTree` used in `system-display-template` by adding a watcher target for the top level fields of a collection

## Potential Risks / Drawbacks

- None I could think of, should only matter if the fields of a collection change in the `fieldsStore` and the only obvious location that might influence that is the collection settings

## Review Notes / Questions

None

---

Fixes #22429 
