### PR TITLE
Fix running SDK in dev mode

### DIFF
--- a/.changeset/empty-baboons-wave.md
+++ b/.changeset/empty-baboons-wave.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed running SDK in dev mode

--- a/sdk/tsup.config.js
+++ b/sdk/tsup.config.js
@@ -20,8 +20,8 @@ export default defineConfig(() => ({
 	dts: true, // generate dts file for main module
 	format: ['cjs', 'esm'], // generate cjs and esm files
 	minify: env === 'production',
-	bundle: env === 'production',
 	watch: env === 'development',
+	bundle: true,
 	target: 'es2020',
 	entry: ['src/index.ts'],
 }));


### PR DESCRIPTION
A tiny tweak fixing the SDK when running in development mode.

When running `pnpm dev` in the SDK package it currently is not bundling the output resulting in an `index.js` that looks like this:
```js
export * from "./auth/index.js";
export * from "./client.js";
export * from "./graphql/index.js";
export * from "./realtime/index.js";
export * from "./rest/index.js";
export * from "./schema/index.js";
```

However none of these subfolders are actually created if you havent run a `pnpm build` beforehand.
This fix simply always enables `bundling` so even in dev mode the package gets properly build into a single file.