### PR TITLE
Fix race condition for concurrent `/auth/refresh` calls

### DIFF
--- a/.changeset/hot-apples-greet.md
+++ b/.changeset/hot-apples-greet.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed a race condition when multiple app windows refresh at the same time

--- a/.changeset/hot-apples-greet.md
+++ b/.changeset/hot-apples-greet.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed a race condition when multiple app windows refresh at the same time
+Fixed a race condition in `/auth/refresh` that occured when multiple app windows refresh at the same time

--- a/.changeset/hot-apples-greet.md
+++ b/.changeset/hot-apples-greet.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed a race condition in `/auth/refresh` that occured when multiple app windows refresh at the same time
+Fixed a race condition that occurred when multiple browser tabs refresh at the same time,  whereby a user could unintentionally lose the session

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -11,6 +11,7 @@ import type { Accountability, SchemaOverview } from '@directus/types';
 import jwt from 'jsonwebtoken';
 import type { Knex } from 'knex';
 import { clone, cloneDeep } from 'lodash-es';
+import { nanoid } from 'nanoid';
 import { performance } from 'perf_hooks';
 import { getAuthProvider } from '../auth.js';
 import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
@@ -56,8 +57,6 @@ export class AuthenticationService {
 			session: boolean;
 		}>,
 	): Promise<LoginResult> {
-		const { nanoid } = await import('nanoid');
-
 		const STALL_TIME = env['LOGIN_STALL_TIME'] as number;
 		const timeStart = performance.now();
 
@@ -274,7 +273,6 @@ export class AuthenticationService {
 	}
 
 	async refresh(refreshToken: string, options?: Partial<{ session: boolean }>): Promise<LoginResult> {
-		const { nanoid } = await import('nanoid');
 		const STALL_TIME = env['LOGIN_STALL_TIME'] as number;
 		const timeStart = performance.now();
 
@@ -357,7 +355,7 @@ export class AuthenticationService {
 			});
 		}
 
-		const newRefreshToken = nanoid(64);
+		const newRefreshToken = options?.session ? refreshToken : nanoid(64);
 		const refreshTokenExpiration = new Date(Date.now() + getMilliseconds(env['REFRESH_TOKEN_TTL'], 0));
 
 		const tokenPayload: DirectusTokenPayload = {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

In #22360 we uncovered that concurrent requests to the `/auth/refresh` endpoint end up causing a race condition where the user get's logged out if following happens:

**Scenario 1:**

- Window A requests `/auth/refresh` with a valid session cookie and session identifier (which is called `refreshToken` in the code) `token_1`
- Window B requests `/auth/refresh` with a the same session cookie and session identifier `token_1`
- Window A passes the valid session check since `token_1` is in the `directus_sessions` table
- Window A receives a new token `token_2`, updates that in the `directus_sessions` table, and receives a new session cookie with `session: token_2`
- Window B does not pass valid session check since `token_1` is not in the `directus_sessions` table anymore
- Window B gets logged out

**Scenario 2:**

Similar two Scenario 1, but the verification are more interleaved due to the async nature of the database / auth provider / hook calls we're making.

- Window A & B both pass the valid session check since `token_1` is in the `directus_sessions` table
- Window A updates the token to `token_2` and sets the session cookie
- Window B updates the token to `token_3` and sets the session cookie
- Window A does another request with while the session cookie from Window B is not yet received, and is being logged out because it still has the now invalid `token_2` set.

--- 

Since we're using the `refreshToken` as a session identifier, wrapped in the session cookie, in the `session` mode, it should safe to not update it in the DB. The signed session cookie with the expiry time coded in takes care of invalidating the session after `SESSION_COOKIE_TTL` and `REFRESH_TOKEN_TTL` takes care of invalidating the session stored in the DB. 
Not rotating the `refreshToken` (really the session identifier) should not impact the security as far as I 

What's changed:

- Don't refresh the session identifying token when using `session` mode

## Potential Risks / Drawbacks

Should be none

## Review Notes / Questions

- Is not rotating the session identifier a problem I can't think of?

---

Fixes #22360
