### PR TITLE
Fix primary key unique constraint error extraction for MySQL

### DIFF
--- a/.changeset/slimy-jeans-shout.md
+++ b/.changeset/slimy-jeans-shout.md
@@ -1,0 +1,6 @@
+---
+'@directus/errors': patch
+'@directus/api': patch
+---
+
+Fixed error extraction for MySQL unique primary key constraints

--- a/.changeset/slimy-jeans-shout.md
+++ b/.changeset/slimy-jeans-shout.md
@@ -1,5 +1,4 @@
 ---
-'@directus/errors': patch
 '@directus/api': patch
 ---
 

--- a/.changeset/twenty-seahorses-drop.md
+++ b/.changeset/twenty-seahorses-drop.md
@@ -1,0 +1,5 @@
+---
+'@directus/errors': patch
+---
+
+Added `primaryKey` flag in `RecordNotUniqueError` extensions

--- a/api/src/database/errors/dialects/mysql.ts
+++ b/api/src/database/errors/dialects/mysql.ts
@@ -48,42 +48,38 @@ function uniqueViolation(error: MySQLError) {
 	/**
 	 * MySQL's error doesn't return the field name in the error. In case the field is created through
 	 * Directus (/ Knex), the key name will be `<collection>_<field>_unique` in which case we can pull
-	 * the field name from the key name
+	 * the field name from the key name.
+	 * If the field is the primary key it instead will be `<collection>_PRIMARY` for MySQL 8+ and `PRIMARY` for MySQL 5.7.
 	 */
 
-	/** MySQL 8+ style error message */
+	let collection: string | null;
+	let indexName: string;
+	let field = null;
+
 	if (matches[1]!.includes('.')) {
-		const collection = matches[1]!.slice(1, -1).split('.')[0]!;
+		// MySQL 8+ style error message
 
-		let field = null;
-
-		const indexName = matches[1]?.slice(1, -1).split('.')[1];
-
-		if (indexName?.startsWith(`${collection}_`) && indexName.endsWith('_unique')) {
-			field = indexName?.slice(collection.length + 1, -7);
-		}
-
-		return new RecordNotUniqueError({
-			collection,
-			field,
-		});
+		// In case of primary key matches[1] is `'<collection>.PRIMARY'`
+		// In case of other field matches[1] is `'<collection>.<collection>_<field>_unique'`
+		[collection, indexName] = matches[1]!.slice(1, -1).split('.') as [string, string];
 	} else {
-		/** MySQL 5.7 style error message */
-		const indexName = matches[1]!.slice(1, -1);
+		// MySQL 5.7 style error message
 
-		const collection = indexName.split('_')[0]!;
-
-		let field = null;
-
-		if (indexName?.startsWith(`${collection}_`) && indexName.endsWith('_unique')) {
-			field = indexName?.slice(collection.length + 1, -7);
-		}
-
-		return new RecordNotUniqueError({
-			collection,
-			field,
-		});
+		// In case of primary key matches[1] is `'PRIMARY'`
+		// In case of other field matches[1] is `'<collection>_<field>_unique'`
+		indexName = matches[1]!.slice(1, -1);
+		collection = indexName.includes('_') ? indexName.split('_')[0]! : null;
 	}
+
+	if (collection !== null && indexName.startsWith(`${collection}_`) && indexName.endsWith('_unique')) {
+		field = indexName?.slice(collection.length + 1, -7);
+	}
+
+	return new RecordNotUniqueError({
+		collection,
+		field,
+		primaryKey: indexName === 'PRIMARY', // propagate information about primary key violation
+	});
 }
 
 function numericValueOutOfRange(error: MySQLError) {

--- a/api/src/database/errors/dialects/mysql.ts
+++ b/api/src/database/errors/dialects/mysql.ts
@@ -49,7 +49,8 @@ function uniqueViolation(error: MySQLError) {
 	 * MySQL's error doesn't return the field name in the error. In case the field is created through
 	 * Directus (/ Knex), the key name will be `<collection>_<field>_unique` in which case we can pull
 	 * the field name from the key name.
-	 * If the field is the primary key it instead will be `<collection>_PRIMARY` for MySQL 8+ and `PRIMARY` for MySQL 5.7.
+	 * If the field is the primary key it instead will be `<collection>_PRIMARY` for MySQL 8+
+	 * and `PRIMARY` for MySQL 5.7 and MariaDB.
 	 */
 
 	let collection: string | null;
@@ -63,7 +64,7 @@ function uniqueViolation(error: MySQLError) {
 		// In case of other field matches[1] is `'<collection>.<collection>_<field>_unique'`
 		[collection, indexName] = matches[1]!.slice(1, -1).split('.') as [string, string];
 	} else {
-		// MySQL 5.7 style error message
+		// MySQL 5.7 and MariaDB style error message
 
 		// In case of primary key matches[1] is `'PRIMARY'`
 		// In case of other field matches[1] is `'<collection>_<field>_unique'`

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1,6 +1,6 @@
 import { Action } from '@directus/constants';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidPayloadError, ErrorCode, isDirectusError } from '@directus/errors';
+import { ErrorCode, ForbiddenError, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import { isSystemCollection } from '@directus/system-data';
 import type {
 	Accountability,
@@ -223,11 +223,6 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
 					// if the unique constraint is the primary key
 					dbError.extensions.field = pkField?.field ?? null;
-
-					if (dbError.extensions.collection === null) {
-						// This is a special case for MySQL 5.7, where the collection is not returned for the primary key constraint
-						dbError.extensions.collection = this.collection;
-					}
 
 					delete dbError.extensions.primaryKey;
 				}

--- a/packages/errors/src/errors/record-not-unique.ts
+++ b/packages/errors/src/errors/record-not-unique.ts
@@ -3,6 +3,7 @@ import { createError, ErrorCode } from '../index.js';
 export interface RecordNotUniqueErrorExtensions {
 	collection: string | null;
 	field: string | null;
+	primaryKey?: boolean;
 }
 
 export const messageConstructor = ({ collection, field }: RecordNotUniqueErrorExtensions) => {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

MySQL does some weird stuff for primary key unique constraints errors, where it doesn't actually tell us the primary key, but instead yells `PRIMARY` at us. Handle this case in the error extraction logic and propagate that info up the stack to where we actually have the info about the primary key field name. 

Additionally MySQL 5.7 won't even tell us the collection we're dealing with, so we have to add that in as well...

What's changed:

- Added `primaryKey` flag to the `RecordNotUniqueError` extensions to propagate error info
- Fixed handling for unique primary key constraints

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Should this sit this far up the stack, or should we pass more context to the `translateDatabaseError` function? I'm not sure 🤔 

---

Fixes #15033
