### PR TITLE
Fix regression in `count` database helper when counting filtered related fields

### DIFF
--- a/.changeset/plenty-trees-draw.md
+++ b/.changeset/plenty-trees-draw.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed count function for related, filtered fields
+Fixed count function on relational, filtered fields

--- a/.changeset/plenty-trees-draw.md
+++ b/.changeset/plenty-trees-draw.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed count function for related, filtered fields

--- a/api/src/database/helpers/fn/types.ts
+++ b/api/src/database/helpers/fn/types.ts
@@ -1,6 +1,7 @@
 import type { Query, SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
 import { applyFilter, generateAlias } from '../../../utils/apply-query.js';
+import type { AliasMap } from '../../../utils/get-column-path.js';
 import { DatabaseHelper } from '../types.js';
 
 export type FnHelperOptions = {
@@ -51,7 +52,7 @@ export abstract class FnHelper extends DatabaseHelper {
 
 		if (options?.query?.filter) {
 			// set the newly aliased collection in the alias map as the default parent collection, indicated by '', for any nested filters
-			const aliasMap = {
+			const aliasMap: AliasMap = {
 				'': {
 					alias,
 					collection: relation.collection,

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -561,7 +561,9 @@ export function applyFilter(
 
 				validateFilterOperator(type, filterOperator, special);
 
-				applyFilterToQuery(`${collection}.${filterPath[0]}`, filterOperator, filterValue, logical);
+				const aliasedCollection = aliasMap['']?.alias || collection;
+
+				applyFilterToQuery(`${aliasedCollection}.${filterPath[0]}`, filterOperator, filterValue, logical, collection);
 			}
 		}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

A special case that slipped the cracks of #22297: When counting the items of a related field, that is filtered down using permissions, we incorrectly use the un-aliased collection name for the joins in `addJoin`.

You can reproduce this by setting up the following collections

- `videos` collection
- `battles` collection with at least a `status` field and a o2m relation to the `videos` collections, called `videos`, call the foreign key `battle`

Create a test role and set the permissions:
- `battles` collection to `All Access` for reading
- `videos` collection to `Custom`. Allow all fields and set the Item Permission filter to `{"_and":[{"battle_id":{"status":{"_eq":"published"}}}]}`

Without this PR you should see the error as described in #22443 for the GraphQL query

```
{
  battles {
    id
    videos_func {
      count
    }
}
```

**What's changed:**

Add the newly aliased related collection to the alias map as parent collection with an empty string as key for the nested`applyFilter`. This will cause `addJoin` to use this alias as `aliasedParentCollection` instead of the real name of the collection here, as `parentFields` is undefined for the first level of nested filter.  

https://github.com/directus/directus/blob/1d65b0d55c049170f426231bd16ba888910dfc3a/api/src/utils/apply-query.ts#L165

For additional levels of nested filters `parentFields` has the parent collections in there as thus the behavior is still the default behavior for nested filters.

## Potential Risks / Drawbacks

None, hopefully

## Review Notes / Questions

- Is the changeset understandable?

---

Fixes #22443 
