### PR TITLE
Add missing `mailService` in Stripe Hook extension guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -124,5 +124,6 @@
 - jonaskohl
 - kimiaabt
 - the-other-dev
+- Oleksii909
 - magiudev
 - burka

--- a/docs/guides/extensions/hooks-add-stripe-customer.md
+++ b/docs/guides/extensions/hooks-add-stripe-customer.md
@@ -77,14 +77,14 @@ Instantiate Stripe with the secret token:
 const stripe = new Stripe(env.STRIPE_TOKEN);
 ```
 
-Instantiate mailService with schema
+`env` looks inside the Directus environment variables for `STRIPE_TOKEN`. In order to start using this hook, this
+variable must be added to your `.env` file. This can be found in the developers area on your Stripe dashboard.
+
+Instantiate the `MailService`:
 
 ```js
 const mailService = new MailService({ schema });
 ```
-
-`env` looks inside the Directus environment variables for `STRIPE_TOKEN`. In order to start using this hook, this
-variable must be added to your `.env` file. This can be found in the developers area on your Stripe dashboard.
 
 Create a new customer with the customer's name and email as the input values.
 
@@ -107,7 +107,7 @@ Use the `ItemsService` to update the customer record. Initialize the service and
 stripe.customers
 	.create({})
 	.then((customer) => {
-		const customers = new ItemsService(collection, { schema: schema }); // [!code ++]
+		const customers = new ItemsService(collection, { schema }); // [!code ++]
 		customers.updateByQuery({ filter: { id: key } }, { stripe_id: customer.id }, { emitEvents: false }); // [!code ++]
 	})
 	.catch((error) => {});
@@ -185,7 +185,7 @@ export default ({ action }, { env, services }) => {
 				email: payload.email_address,
 			})
 			.then((customer) => {
-				const customers = new ItemsService(collection, { schema: schema });
+				const customers = new ItemsService(collection, { schema });
 				customers.updateByQuery({ filter: { id: key } }, { stripe_id: customer.id }, { emitEvents: false });
 			})
 			.catch((error) => {

--- a/docs/guides/extensions/hooks-add-stripe-customer.md
+++ b/docs/guides/extensions/hooks-add-stripe-customer.md
@@ -77,6 +77,12 @@ Instantiate Stripe with the secret token:
 const stripe = new Stripe(env.STRIPE_TOKEN);
 ```
 
+Instantiate mailService with schema
+
+```js
+const mailService = new MailService({ schema });
+```
+
 `env` looks inside the Directus environment variables for `STRIPE_TOKEN`. In order to start using this hook, this
 variable must be added to your `.env` file. This can be found in the developers area on your Stripe dashboard.
 
@@ -117,7 +123,7 @@ stripe.customers
 	.create({})
 	.then((customer) => {})
 	.catch((error) => {
-		MailService.send({ // [!code ++]
+		mailService.send({ // [!code ++]
 			to: 'sharedmailbox@directus.io', // [!code ++]
 			from: 'noreply@directus.io', // [!code ++]
 			subject: `An error has occurred with Stripe API`, // [!code ++]
@@ -171,6 +177,7 @@ export default ({ action }, { env, services }) => {
 	action('items.create', async ({ key, collection, payload }, { schema }) => {
 		if (collection !== 'customers') return;
 		const stripe = new Stripe(env.STRIPE_TOKEN);
+		const mailService = new MailService({ schema });
 
 		stripe.customers
 			.create({
@@ -182,7 +189,7 @@ export default ({ action }, { env, services }) => {
 				customers.updateByQuery({ filter: { id: key } }, { stripe_id: customer.id }, { emitEvents: false });
 			})
 			.catch((error) => {
-				MailService.send({
+				mailService.send({
 					to: 'sharedmailbox@directus.io',
 					from: 'noreply@directus.io',
 					subject: `An error has occurred with Stripe API`,

--- a/docs/guides/extensions/hooks-add-stripe-customer.md
+++ b/docs/guides/extensions/hooks-add-stripe-customer.md
@@ -117,7 +117,7 @@ stripe.customers
 	.create({})
 	.then((customer) => {})
 	.catch((error) => {
-		mailService.send({ // [!code ++]
+		MailService.send({ // [!code ++]
 			to: 'sharedmailbox@directus.io', // [!code ++]
 			from: 'noreply@directus.io', // [!code ++]
 			subject: `An error has occurred with Stripe API`, // [!code ++]
@@ -182,7 +182,7 @@ export default ({ action }, { env, services }) => {
 				customers.updateByQuery({ filter: { id: key } }, { stripe_id: customer.id }, { emitEvents: false });
 			})
 			.catch((error) => {
-				mailService.send({
+				MailService.send({
 					to: 'sharedmailbox@directus.io',
 					from: 'noreply@directus.io',
 					subject: `An error has occurred with Stripe API`,

--- a/docs/guides/extensions/hooks-add-stripe-customer.md
+++ b/docs/guides/extensions/hooks-add-stripe-customer.md
@@ -80,12 +80,6 @@ const stripe = new Stripe(env.STRIPE_TOKEN);
 `env` looks inside the Directus environment variables for `STRIPE_TOKEN`. In order to start using this hook, this
 variable must be added to your `.env` file. This can be found in the developers area on your Stripe dashboard.
 
-Instantiate the `MailService`:
-
-```js
-const mailService = new MailService({ schema });
-```
-
 Create a new customer with the customer's name and email as the input values.
 
 ```js
@@ -123,6 +117,7 @@ stripe.customers
 	.create({})
 	.then((customer) => {})
 	.catch((error) => {
+		const mailService = new MailService({ schema });
 		mailService.send({ // [!code ++]
 			to: 'sharedmailbox@directus.io', // [!code ++]
 			from: 'noreply@directus.io', // [!code ++]
@@ -177,7 +172,6 @@ export default ({ action }, { env, services }) => {
 	action('items.create', async ({ key, collection, payload }, { schema }) => {
 		if (collection !== 'customers') return;
 		const stripe = new Stripe(env.STRIPE_TOKEN);
-		const mailService = new MailService({ schema });
 
 		stripe.customers
 			.create({
@@ -189,6 +183,7 @@ export default ({ action }, { env, services }) => {
 				customers.updateByQuery({ filter: { id: key } }, { stripe_id: customer.id }, { emitEvents: false });
 			})
 			.catch((error) => {
+				const mailService = new MailService({ schema });
 				mailService.send({
 					to: 'sharedmailbox@directus.io',
 					from: 'noreply@directus.io',


### PR DESCRIPTION
## Scope

Add missing `mailService` in Stripe Hook extension guide [^1]

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A

[^1]: https://docs.directus.io/guides/extensions/hooks-add-stripe-customer.html