### PR TITLE
Reduce access token refreshing if it is still fresh

### DIFF
--- a/.changeset/bright-trains-greet.md
+++ b/.changeset/bright-trains-greet.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Reduced access token refreshing if it is still fresh

--- a/.changeset/bright-trains-greet.md
+++ b/.changeset/bright-trains-greet.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Reduced access token refreshing if it is still fresh
+Reduced the number of session token refreshes if the token is still fresh

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -1,5 +1,5 @@
 import { resumeQueue } from '@/api';
-import { DEFAULT_AUTH_PROVIDER } from '@/constants';
+import { DEFAULT_AUTH_PROVIDER, SDK_AUTH_REFRESH_BEFORE_EXPIRES } from '@/constants';
 import { dehydrate, hydrate } from '@/hydrate';
 import { router } from '@/router';
 import { sdk } from '@/sdk';
@@ -93,6 +93,9 @@ export async function refresh({ navigate }: LogoutOptions = { navigate: true }):
 
 	// Allow refresh during initial page load, skip if not logged in
 	if (!firstRefresh && !appStore.authenticated) return;
+
+	// Skip access token refreshing if it is still fresh
+	if (appStore.accessTokenExpiry && Date.now() < appStore.accessTokenExpiry - SDK_AUTH_REFRESH_BEFORE_EXPIRES) return;
 
 	try {
 		const response = await sdk.refresh();

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -156,3 +156,5 @@ export const AUTH_SSO_DRIVERS = ['oauth2', 'openid', 'saml'];
 export const DEFAULT_REPORT_BUG_URL = 'https://github.com/directus/directus/issues/new?template=bug_report.yml';
 export const DEFAULT_REPORT_FEATURE_URL =
 	'https://github.com/directus/directus/discussions/new?category=feature-requests';
+
+export const SDK_AUTH_REFRESH_BEFORE_EXPIRES = 10_000;

--- a/app/src/sdk.ts
+++ b/app/src/sdk.ts
@@ -1,9 +1,10 @@
-import type { AuthenticationClient, DirectusClient, RestClient } from '@directus/sdk';
-import { createDirectus, rest, authentication } from '@directus/sdk';
 import { getPublicURL } from '@/utils/get-root-path';
+import type { AuthenticationClient, DirectusClient, RestClient } from '@directus/sdk';
+import { authentication, createDirectus, rest } from '@directus/sdk';
 import { ofetch, type FetchContext } from 'ofetch';
-import { useRequestsStore } from './stores/requests';
 import { requestQueue } from './api';
+import { SDK_AUTH_REFRESH_BEFORE_EXPIRES } from './constants';
+import { useRequestsStore } from './stores/requests';
 
 export type SdkClient = DirectusClient<any> & AuthenticationClient<any> & RestClient<any>;
 
@@ -49,7 +50,7 @@ const baseClient = ofetch.create({
 });
 
 export const sdk: SdkClient = createDirectus(getPublicURL(), { globals: { fetch: baseClient.native } })
-	.with(authentication('session', { credentials: 'include', msRefreshBeforeExpires: 10_000 }))
+	.with(authentication('session', { credentials: 'include', msRefreshBeforeExpires: SDK_AUTH_REFRESH_BEFORE_EXPIRES }))
 	.with(rest({ credentials: 'include' }));
 
 export default sdk;


### PR DESCRIPTION
## Scope

What's changed:

- Reimplemented the skipping of access token refresh logic while it is still fresh

## Potential Risks / Drawbacks

- Should not have any as the access token generally should remain valid up till its expiry

## Review Notes / Questions

- This logic was removed in #21938

https://github.com/directus/directus/blob/77d73398f1be1501ee9196b9fd384666a0a9712b/app/src/auth.ts#L99-L105
