### PR TITLE
add templates directory as volume in docker compose file

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,3 +128,4 @@
 - magiudev
 - burka
 - SharmaPawan11
+- sharkfin009

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -61,9 +61,10 @@ be removed [unless you persist them](https://docs.docker.com/storage) when creat
 Directus image by default will use the following locations for data persistence (note that these can be changed through
 environment variables):
 
-- `/directus/uploads` for uploads
 - `/directus/database` (only when using SQLite and not configured to a different folder)
+- `/directus/uploads` for uploads
 - `/directus/extensions` for loading extensions
+- `/directus/templates` for overriding and extending email templates
 
 The `services.directus.volumes` section in your docker-compose.yml is optional. To persist data to your local machine,
 include a list of persisted directories:
@@ -75,7 +76,7 @@ services:
       - ./database:/directus/database
       - ./uploads:/directus/uploads
       - ./extensions:/directus/extensions
-			- ./templates:/directus/templates
+      - ./templates:/directus/templates
 ```
 
 ## Example Docker Compose

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -75,6 +75,7 @@ services:
       - ./database:/directus/database
       - ./uploads:/directus/uploads
       - ./extensions:/directus/extensions
+			- ./templates:/directus/templates
 ```
 
 ## Example Docker Compose


### PR DESCRIPTION
## Scope

What's changed:

just one line in the docs: added templates as a volume in the docker compose in the self-hosting guide

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A
