### PR TITLE
Add database info to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,3 +41,7 @@ body:
         - Directus Cloud
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Database
+      description: If applicable, the vendor and version of the database being used. For example, PostgreSQL 16.


### PR DESCRIPTION
## Scope

Following an internal discussion, we're adding back a field for database info to the bug report template, while making it optional so it only needs to be filled in if applicable (e.g. not for Directus Cloud).

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A
