### PR TITLE
Fix database session duration

### DIFF
--- a/.changeset/dry-carrots-sin.md
+++ b/.changeset/dry-carrots-sin.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed database session duration

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -358,7 +358,7 @@ export class AuthenticationService {
 		}
 
 		const newRefreshToken = nanoid(64);
-		const refreshTokenExpiration = new Date(Date.now() + getMilliseconds(env['REFRESH_TOKEN_TTL'], 0));
+		const refreshTokenExpiration = new Date(Date.now() + getMilliseconds(env[options?.session ? 'SESSION_COOKIE_TTL' : 'REFRESH_TOKEN_TTL'], 0));
 
 		const tokenPayload: DirectusTokenPayload = {
 			id: record.user_id,

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -358,7 +358,8 @@ export class AuthenticationService {
 		}
 
 		const newRefreshToken = nanoid(64);
-		const refreshTokenExpiration = new Date(Date.now() + getMilliseconds(env[options?.session ? 'SESSION_COOKIE_TTL' : 'REFRESH_TOKEN_TTL'], 0));
+		const sessionDuration = env[options?.session ? 'SESSION_COOKIE_TTL' : 'REFRESH_TOKEN_TTL'];
+		const refreshTokenExpiration = new Date(Date.now() + getMilliseconds(sessionDuration, 0));
 
 		const tokenPayload: DirectusTokenPayload = {
 			id: record.user_id,


### PR DESCRIPTION
I stumbled on this mistake while working on the race condition. 

## Scope

What's changed:

- When creating a new database session (using `mode: session`) this will now use the `SESSION_TOKEN_TTL` duration instead of defaulting to the longer lived `REFRESH_TOKEN_TTL`.

## Potential Risks / Drawbacks

- None i can think of at the moment

## Review Notes / Questions

- I would like to lorem ipsum

