### PR TITLE
Fix item fetching in calendar layout when switching view

### DIFF
--- a/.changeset/strong-garlics-visit.md
+++ b/.changeset/strong-garlics-visit.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Ensured items are correctly loaded when switching the view in the calendar layout 

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -62,6 +62,9 @@ export default defineLayout<LayoutOptions>({
 				return null;
 			}
 
+			// Subscribe to 'view' updates to get latest start/end dates
+			void viewInfo.value;
+
 			const start = formatISO(calendar.value.view.activeStart);
 			const end = formatISO(calendar.value.view.activeEnd);
 			const startsHere = { [startDateField.value]: { _between: [start, end] } };


### PR DESCRIPTION
## Scope

When switching the view in the calendar layout (e.g. from month to week, navigating between months, ...), the items are currently not re-fetched and thus not displayed. This is fixed now, by ensuring the applied calendar filter is based on the latest view data.

https://github.com/directus/directus/assets/5363448/2396071b-471d-4dab-bb9a-d7b2440b2f41

https://github.com/directus/directus/assets/5363448/163d89fb-2290-4dbe-8836-c1936975fbfc

## Potential Risks / Drawbacks

None

## Review Notes / Questions

`calendar.value.view` is not reactive, therefore subscribing to `viewInfo` which is updated whenever the view changes. Values are still taken from `calendar.value.view` since it also contains the initial values (`viewInfo` does not).

---

Related to #21539
