### PR TITLE
Fix file selection drawer failing when some files fail loading

### DIFF
--- a/.changeset/brave-students-tap.md
+++ b/.changeset/brave-students-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the cards layout if used with files that fail loading

--- a/.changeset/nice-pans-applaud.md
+++ b/.changeset/nice-pans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed an issue where the file selection drawer could not be opened when some files fail loading

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -106,7 +106,7 @@ function handleClick() {
 			<div class="selection-fade"></div>
 			<v-skeleton-loader v-if="loading" />
 			<template v-else>
-				<v-icon-file v-if="type || imgError" :ext="type" />
+				<v-icon-file v-if="type || imgError" :ext="type ?? ''" />
 				<template v-else>
 					<v-image
 						v-if="showThumbnail"


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Fall back to an empty `type` since the `file-icon` component is used for image errors as well, which might cause `type` to be `null`

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A

---

Fixes #22528
