### PR TITLE
Fix logic to update parent bundles enabled status

### DIFF
--- a/.changeset/two-walls-deliver.md
+++ b/.changeset/two-walls-deliver.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed logic to update parent bundles enabled status

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -245,18 +245,19 @@ export class ExtensionsService {
 	 *    - Entry status change resulted in all children being disabled then the parent bundle is disabled
 	 *    - Entry status change resulted in at least one child being enabled then the parent bundle is enabled
 	 */
-	private async checkBundleAndSyncStatus(trx: Knex, bundleId: string, extension: ApiOutput) {
+	private async checkBundleAndSyncStatus(trx: Knex, extensionId: string, extension: ApiOutput) {
 		if (extension.bundle === null && extension.schema?.type === 'bundle') {
 			// If extension is the parent bundle, set it and all nested extensions to enabled
 			await trx('directus_extensions')
 				.update({ enabled: extension.meta.enabled })
-				.where({ bundle: bundleId })
-				.orWhere({ id: bundleId });
+				.where({ bundle: extensionId })
+				.orWhere({ id: extensionId });
 
 			return;
 		}
 
-		const parent = await this.readOne(bundleId);
+		const parentId = extension.bundle ?? extensionId;
+		const parent = await this.readOne(parentId);
 
 		if (parent.schema?.type !== 'bundle') {
 			return;
@@ -269,14 +270,14 @@ export class ExtensionsService {
 		}
 
 		const hasEnabledChildren = !!(await trx('directus_extensions')
-			.where({ bundle: bundleId })
+			.where({ bundle: parentId })
 			.where({ enabled: true })
 			.first());
 
 		if (hasEnabledChildren) {
-			await trx('directus_extensions').update({ enabled: true }).where({ id: bundleId });
+			await trx('directus_extensions').update({ enabled: true }).where({ id: parentId });
 		} else {
-			await trx('directus_extensions').update({ enabled: false }).where({ id: bundleId });
+			await trx('directus_extensions').update({ enabled: false }).where({ id: parentId });
 		}
 	}
 }

--- a/api/src/services/extensions.ts
+++ b/api/src/services/extensions.ts
@@ -256,7 +256,10 @@ export class ExtensionsService {
 			return;
 		}
 
-		const parentId = extension.bundle ?? extensionId;
+		const parentId = extension.bundle ?? extension.meta.bundle;
+
+		if (!parentId) return;
+
 		const parent = await this.readOne(parentId);
 
 		if (parent.schema?.type !== 'bundle') {


### PR DESCRIPTION
## Scope

What's changed:

- Renamed `bundleId` to `extensionId` for increased clarity between extension IDs.
- Fixed logic to update parent bundles enabled status

https://github.com/directus/directus/assets/26413686/43fa3dac-59c4-4ebe-b2cd-877dfe243d33

## Potential Risks / Drawbacks

- None that I am aware of

## Review Notes / Questions

- Nil

---

Fixes #22569
