### PR TITLE
Fix sdk api endpoint for registration verification

### DIFF
--- a/.changeset/rancher-booker-minnie.md
+++ b/.changeset/rancher-booker-minnie.md
@@ -2,4 +2,4 @@
 '@directus/sdk': patch
 ---
 
-Fixed sdk endpoint for user registration verify email method
+Fixed SDK endpoint path for user registration verify email method

--- a/.changeset/rancher-booker-minnie.md
+++ b/.changeset/rancher-booker-minnie.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed sdk endpoint for user registration verify email method

--- a/contributors.yml
+++ b/contributors.yml
@@ -129,3 +129,4 @@
 - burka
 - SharmaPawan11
 - sharkfin009
+- npostulart

--- a/sdk/src/rest/commands/utils/users.ts
+++ b/sdk/src/rest/commands/utils/users.ts
@@ -75,7 +75,7 @@ export const registerUser =
 export const registerUserVerify =
 	<Schema>(token: string): RestCommand<void, Schema> =>
 	() => ({
-		path: `/register/verify-email`,
+		path: `/users/register/verify-email`,
 		params: { token },
 		method: 'GET',
 	});


### PR DESCRIPTION
## Scope

What's changed:

- Endpoint in directus/sdk changed from `/register/verify-email` to `/users/register/verify-email`.

## Potential Risks / Drawbacks

- Couldn't find any definition for route `/register/verify-email` so risk should be low to none.

---

Fixes #22598
