### PR TITLE
Added session next_token to system-data

### DIFF
--- a/.changeset/calm-boats-tie.md
+++ b/.changeset/calm-boats-tie.md
@@ -1,0 +1,5 @@
+---
+"@directus/system-data": patch
+---
+
+Added session next_token to the system-data definitions

--- a/packages/system-data/src/fields/sessions.yaml
+++ b/packages/system-data/src/fields/sessions.yaml
@@ -14,3 +14,6 @@ fields:
   - field: origin
     width: half
   - field: share
+    width: half
+  - field: next_token
+    width: half


### PR DESCRIPTION
## Scope

What's changed:

Added `directus_session.next_token` to the `@directus/system-data` package so it gets ignored when applying snapshots.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I would like to lorem ipsum

---

Fixes #22584 
