### PR TITLE
Fix links & typo in docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_problem.yml
+++ b/.github/ISSUE_TEMPLATE/docs_problem.yml
@@ -1,6 +1,6 @@
 name: Report a docs inaccuracy
 description: When something is wrong or incorrect in the docs
-labels: [":file_folder: Documentation"]
+labels: [':file_folder: Documentation']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_problem.yml
+++ b/.github/ISSUE_TEMPLATE/docs_problem.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Hi, thank you for taking the time to create an issue! If you're asking for _new_ docs, or have a suggestion on how to enhance existing docs, please open [a docs suggestion](https://github.com/directus/directus/discussions/new?category=docs-suggestions) instead!
+        Hi, thank you for taking the time to create an issue! If you're asking for _new_ docs, or have a suggestion on how to enhance existing docs, please open [a docs suggestion](https://github.com/directus/directus/discussions/new?category=docs_suggestions) instead!
   - type: input
     attributes:
       label: Page

--- a/.github/ISSUE_TEMPLATE/docs_problem.yml
+++ b/.github/ISSUE_TEMPLATE/docs_problem.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Hi, thank you for taking the time to create an issue! If you're asking for _new_ docs, or have a suggestion on how to enhance existing docs, please open [a docs suggestion](https://github.com/directus/directus/discussions/new?category=docs_suggestions) instead!
+        Hi, thank you for taking the time to create an issue! If you're asking for _new_ docs, or have a suggestion on how to enhance existing docs, please open [a docs suggestion](https://github.com/directus/directus/issues/new?labels=:file_folder:%20Documentation&template=docs_suggestions.yml) instead!
   - type: input
     attributes:
       label: Page

--- a/.github/ISSUE_TEMPLATE/docs_problem.yml
+++ b/.github/ISSUE_TEMPLATE/docs_problem.yml
@@ -1,6 +1,6 @@
 name: Report a docs inaccuracy
 description: When something is wrong or incorrect in the docs
-labels: Documentation
+labels: [":file_folder: Documentation"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_suggestions.yml
+++ b/.github/ISSUE_TEMPLATE/docs_suggestions.yml
@@ -1,6 +1,6 @@
 name: Suggest new docs or enhancements
 description: Suggest new docs that don't currently exist, or enhancements to existing docs.
-labels: Documentation
+labels: [":file_folder: Documentation"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_suggestions.yml
+++ b/.github/ISSUE_TEMPLATE/docs_suggestions.yml
@@ -1,11 +1,11 @@
 name: Suggest new docs or enhancements
 description: Suggest new docs that don't currently exist, or enhancements to existing docs.
-labels: [":file_folder: Documentation"]
+labels: [':file_folder: Documentation']
 body:
   - type: markdown
     attributes:
       value: |
-        Hi, thank you for taking the time to create an issue! If you're reporting a documentation inaccuracy or bug, please open [a docs inaccuracy](https://github.com/directus/directus/discussions/new?category=docs-problem) instead!
+        Hi, thank you for taking the time to create an issue! If you're reporting a documentation inaccuracy or bug, please open [a docs inaccuracy](https://github.com/directus/directus/issues/new?assignees=&labels=:file_folder:%20Documentation&projects=&template=docs_problem.yml) instead!
   - type: textarea
     attributes:
       label: Describe the Request

--- a/.github/ISSUE_TEMPLATE/docs_suggestions.yml
+++ b/.github/ISSUE_TEMPLATE/docs_suggestions.yml
@@ -14,7 +14,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Maintainence Strategy
+      label: Maintenance Strategy
       description: Docs need to be kept up to date. How often would this the resulting change require maintenance?
     validations:
       required: true


### PR DESCRIPTION
## Scope

Fix issues with "docs" issue template:

- Fix typo: Maintainence → Maintenance
- Rename file for consistency: `docs-suggestions.yml` → `docs_suggestions.yml`
- Fix links to docs problem/suggestion issues

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A
