### PR TITLE
Align response when updating inexistent role

### DIFF
--- a/.changeset/angry-bobcats-join.md
+++ b/.changeset/angry-bobcats-join.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Aligned response when trying to update inexistent role

--- a/api/src/services/roles.ts
+++ b/api/src/services/roles.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, InvalidPayloadError, UnprocessableContentError } from '@directus/errors';
+import { InvalidPayloadError, UnprocessableContentError } from '@directus/errors';
 import type { Alterations, Item, PrimaryKey, Query, User } from '@directus/types';
 import { getMatch } from 'ip-matching';
 import type { AbstractServiceOptions, MutationOptions } from '../types/index.js';
@@ -35,7 +35,8 @@ export class RolesService extends ItemsService {
 	): Promise<void> {
 		const role = await this.knex.select('admin_access').from('directus_roles').where('id', '=', key).first();
 
-		if (!role) throw new ForbiddenError();
+		// No-op if role doesn't exist
+		if (!role) return;
 
 		const usersBefore = (await this.knex.select('id').from('directus_users').where('role', '=', key)).map(
 			(user) => user.id,


### PR DESCRIPTION
## Scope

Align response when updating inexistent role, to return `204 No Content` for users with corresponding update permission.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None