### PR TITLE
Fix junction relation lookup in the relations store

### DIFF
--- a/.changeset/happy-parrots-repair.md
+++ b/.changeset/happy-parrots-repair.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the lookup of the M2M junction relation in case of multiple relations using the same junction table

--- a/app/src/stores/relations.ts
+++ b/app/src/stores/relations.ts
@@ -79,7 +79,9 @@ export const useRelationsStore = defineStore({
 				if (isM2M) {
 					const secondaryRelation = this.relations.find((relation) => {
 						return (
-							relation.collection === firstRelation.collection && relation.field === firstRelation.meta?.junction_field
+							relation.collection === firstRelation.collection &&
+							relation.field === firstRelation.meta?.junction_field &&
+							relation.meta?.junction_field === firstRelation.field
 						);
 					});
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

See #22651 for reproduction and explanation

What's changed:

- Check that the reverse junction relation also holds true when looking up relation info in the relations store

## Potential Risks / Drawbacks

- Under the assumption that M2M are setup up correctly this is just an additional check.
 - The assumption is that both sides of the relation have a `meta.junction_field` matching the other sides `field`, but afaik that's always true?

## Review Notes / Questions

N/A

---

Fixes #22651 
