### PR TITLE
Fix pattern check in filter component

### DIFF
--- a/.changeset/silly-emus-kick.md
+++ b/.changeset/silly-emus-kick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the input pattern check in the filter component

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -47,14 +47,14 @@ const inputPattern = computed(() => {
 	switch (props.type) {
 		case 'integer':
 		case 'bigInteger':
-			return '[+\\-]?[0-9]+';
+			return '^[+\\-]?[0-9]+$';
 		case 'decimal':
 		case 'float':
-			return '[+\\-]?[0-9]+\\.?[0-9]*';
+			return '^[+\\-]?[0-9]+\\.?[0-9]*$';
 		case 'uuid':
-			return '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}';
+			return '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$';
 		default:
-			return '';
+			return undefined;
 	}
 });
 
@@ -77,7 +77,7 @@ watch(
 );
 
 function isValueValid(value: any): boolean {
-	if (value === '' || typeof value !== 'string' || new RegExp(inputPattern.value).test(value)) {
+	if (value === '' || typeof value !== 'string' || !inputPattern.value || new RegExp(inputPattern.value).test(value)) {
 		return true;
 	}
 


### PR DESCRIPTION
## Scope

Fix the RegExp patterns used for checking inputs in the filter component:
- Adding start and end anchors, so the whole value is checked
  <table><tr><th>Before</th><td><img width="400" src="https://github.com/directus/directus/assets/5363448/821a1e86-2158-4fd6-b26e-2cbc083c955e"></td></tr><tr><th>After</th><td><img width="180" src="https://github.com/directus/directus/assets/5363448/167475fc-e384-484a-a854-f60043687c1a"></td></tr></table>
- Returning `undefined` for default case, so the input field (pattern browser API) doesn't complain on string types 
  <table><tr><td><img width="400" src="https://github.com/directus/directus/assets/5363448/577cf2b1-2f5c-464b-924c-2b4c1f6b72b2"></td></tr></table>


## Potential Risks / Drawbacks

None

## Review Notes / Questions

None