### PR TITLE
Add a default preset for bookmarks

### DIFF
--- a/.changeset/dry-shrimps-reply.md
+++ b/.changeset/dry-shrimps-reply.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added a default preset for bookmarks to display the relevant fields by default

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -114,6 +114,25 @@ const systemDefaults: Record<string, Partial<Preset>> = {
 			},
 		},
 	},
+	directus_presets: {
+		collection: 'directus_presets',
+		layout: 'tabular',
+		layout_query: {
+			tabular: {
+				fields: ['bookmark', 'collection', 'user', 'role'],
+			},
+		},
+		layout_options: {
+			tabular: {
+				widths: {
+					bookmark: 200,
+					collection: 200,
+					user: 200,
+					role: 200,
+				},
+			},
+		},
+	},
 };
 
 const currentUpdate: Record<number, string> = {};

--- a/packages/system-data/src/fields/presets.yaml
+++ b/packages/system-data/src/fields/presets.yaml
@@ -40,9 +40,11 @@ fields:
 
   - field: icon
     width: half
+    display: icon
 
   - field: color
     width: half
+    display: color
 
   - field: search
     width: half


### PR DESCRIPTION
## Scope

- Add a default preset for bookmarks to ensure the relevant fields are displayed by default and the available space is better utilized
  <table><tr><th>Before</th><td><img width="800" src="https://github.com/directus/directus/assets/5363448/5c2544e1-c583-46e3-8225-0bef40383449"></td></tr><tr><th>After</th><td><img width="800" src="https://github.com/directus/directus/assets/5363448/e718ff88-364f-49cb-b9cb-85a715a2545b"></td></tr></table>
- Define displays for icon and color fields
  <table><tr><th>Before</th><td><img width="800" src="https://github.com/directus/directus/assets/5363448/f4a95d7a-34b9-4210-8891-5101e3c1433b"></td></tr><tr><th>After</th><td><img width="800" src="https://github.com/directus/directus/assets/5363448/9004b1c4-eb1a-471d-b854-dfe2a7b1de99"></td></tr></table>

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None





