### PR TITLE
API / CORS: Use coalesce operator because of falsy values

### DIFF
--- a/.changeset/witty-papayas-promise.md
+++ b/.changeset/witty-papayas-promise.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed the interpretation of CORS config options, allowing to use "falsy" values like `CORS_ORIGIN: false` and `CORS_MAX_AGE: 0`

--- a/api/src/middleware/cors.ts
+++ b/api/src/middleware/cors.ts
@@ -8,12 +8,12 @@ const env = useEnv();
 
 if (env['CORS_ENABLED'] === true) {
 	corsMiddleware = cors({
-		origin: (env['CORS_ORIGIN'] as string) || true,
-		methods: (env['CORS_METHODS'] as string) || 'GET,POST,PATCH,DELETE',
+		origin: (env['CORS_ORIGIN'] as string) ?? true,
+		methods: (env['CORS_METHODS'] as string) ?? 'GET,POST,PATCH,DELETE',
 		allowedHeaders: env['CORS_ALLOWED_HEADERS'] as string,
 		exposedHeaders: env['CORS_EXPOSED_HEADERS'] as string,
-		credentials: (env['CORS_CREDENTIALS'] as boolean) || undefined,
-		maxAge: (env['CORS_MAX_AGE'] as number) || undefined,
+		credentials: (env['CORS_CREDENTIALS'] as boolean) ?? undefined,
+		maxAge: (env['CORS_MAX_AGE'] as number) ?? undefined,
 	});
 }
 

--- a/api/src/middleware/cors.ts
+++ b/api/src/middleware/cors.ts
@@ -8,12 +8,12 @@ const env = useEnv();
 
 if (env['CORS_ENABLED'] === true) {
 	corsMiddleware = cors({
-		origin: (env['CORS_ORIGIN'] as string) ?? true,
-		methods: (env['CORS_METHODS'] as string) ?? 'GET,POST,PATCH,DELETE',
+		origin: env['CORS_ORIGIN'] as boolean | string,
+		methods: env['CORS_METHODS'] as string,
 		allowedHeaders: env['CORS_ALLOWED_HEADERS'] as string,
 		exposedHeaders: env['CORS_EXPOSED_HEADERS'] as string,
-		credentials: (env['CORS_CREDENTIALS'] as boolean) ?? undefined,
-		maxAge: (env['CORS_MAX_AGE'] as number) ?? undefined,
+		credentials: env['CORS_CREDENTIALS'] as boolean,
+		maxAge: env['CORS_MAX_AGE'] as number,
 	});
 }
 


### PR DESCRIPTION
## Scope
While trying to setup `CORS_MAX_AGE: 0` (don't cache) we figured out that this configuration was not being properly applied and the value `undefined` were set instead.
This seems to happen because `0` is a falsy value and the OR `||` operator is being used here:
https://github.com/directus/directus/blob/main/api/src/middleware/cors.ts#L16 

In order to fix this we should use the coalesce operator instead so falsy values can be accepted.

What's changed:

- Accept falsy values for CORS configuration

## Potential Risks / Drawbacks

- CORS is disabled by default (`CORS_ENABLED: false`) but if `CORS_ENABLED: true`, then when `CORS_ORIGIN: false` it will not work as expected, as `false` was not being set and `true` was being used instead: 
 https://github.com/directus/directus/blob/main/api/src/middleware/cors.ts#L11

## Review Notes / Questions

- N/A
