### PR TITLE
API / Graphql: Handle `time` type as `Date` scalar

### DIFF
--- a/.changeset/strong-otters-bake.md
+++ b/.changeset/strong-otters-bake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that could cause time type fields to be treated as a string in GraphQL

--- a/api/src/utils/get-graphql-type.ts
+++ b/api/src/utils/get-graphql-type.ts
@@ -31,6 +31,7 @@ export function getGraphQLType(
 			return GraphQLJSON;
 		case 'geometry':
 			return GraphQLGeoJSON;
+		case 'time':
 		case 'timestamp':
 		case 'dateTime':
 		case 'date':


### PR DESCRIPTION
## Scope
Currently, `time` data types are being handled as `string` because they are falling back to default value here:
https://github.com/directus/directus/blob/main/api/src/utils/get-graphql-type.ts#L41

This means that it is currently not possible to do comparisons with `time` types.
Although, SQL databases support them as they do for `date` and `timestamp` types.

Since all `date` operators are supported by `time` type, we should handle `time` as a `date` type.

What's changed:

- Support `date` operations for `time` types

## Potential Risks / Drawbacks

- ~~Users relying on `string` operators to handle `time` may have issues as operations like `_ends_with` will not be supported anymore by `time` type.
⚠️ Maybe a breaking change~~
Actually, operators like `_ends_with` are using `like` in database so it's already not possible to use those operators with `time` type.

## Review Notes / Questions

- Should we create a new scalar type just for `time` type instead of reusing `date` type?