### PR TITLE
Ensure service integrity

### DIFF
--- a/.changeset/hot-cherries-tap.md
+++ b/.changeset/hot-cherries-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Ensured service integrity, by calling corresponding specified services out of other services

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -1,9 +1,6 @@
 name: Blackbox Tests
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -51,12 +48,12 @@ jobs:
       matrix:
         vendor:
           - sqlite3
-          #- postgres
-          #- mysql
-          #- maria
-          #- mssql
-          #- oracle
-          #- cockroachdb
+          - postgres
+          - mysql
+          - maria
+          - mssql
+          - oracle
+          - cockroachdb
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -1,6 +1,9 @@
 name: Blackbox Tests
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -48,12 +51,12 @@ jobs:
       matrix:
         vendor:
           - sqlite3
-          - postgres
-          - mysql
-          - maria
-          - mssql
-          - oracle
-          - cockroachdb
+          #- postgres
+          #- mysql
+          #- maria
+          #- mssql
+          #- oracle
+          #- cockroachdb
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -411,14 +411,6 @@ export class FilesService extends ItemsService {
 	}
 
 	/**
-	 * Delete a file
-	 */
-	override async deleteOne(key: PrimaryKey): Promise<PrimaryKey> {
-		await this.deleteMany([key]);
-		return key;
-	}
-
-	/**
 	 * Delete multiple files
 	 */
 	override async deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]> {

--- a/api/src/services/flows.ts
+++ b/api/src/services/flows.ts
@@ -9,48 +9,30 @@ export class FlowsService extends ItemsService<FlowRaw> {
 	}
 
 	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		const flowManager = getFlowManager();
-
 		const result = await super.createOne(data, opts);
-		await flowManager.reload();
 
-		return result;
-	}
-
-	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const flowManager = getFlowManager();
-
-		const result = await super.createMany(data, opts);
-		await flowManager.reload();
-
-		return result;
-	}
-
-	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const flowManager = getFlowManager();
-
-		const result = await super.updateBatch(data, opts);
 		await flowManager.reload();
 
 		return result;
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const flowManager = getFlowManager();
-
 		const result = await super.updateMany(keys, data, opts);
+
+		const flowManager = getFlowManager();
 		await flowManager.reload();
 
 		return result;
 	}
 
 	override async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const flowManager = getFlowManager();
-
 		// this is to prevent foreign key constraint error on directus_operations resolve/reject during cascade deletion
 		await this.knex('directus_operations').update({ resolve: null, reject: null }).whereIn('flow', keys);
 
 		const result = await super.deleteMany(keys, opts);
+
+		const flowManager = getFlowManager();
 		await flowManager.reload();
 
 		return result;

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -25,7 +25,6 @@ import emitter from '../emitter.js';
 import { useLogger } from '../logger.js';
 import type { AbstractServiceOptions, ActionEventParams } from '../types/index.js';
 import { getDateFormatted } from '../utils/get-date-formatted.js';
-import { getService } from '../utils/get-service.js';
 import { transaction } from '../utils/transaction.js';
 import { Url } from '../utils/url.js';
 import { userName } from '../utils/user-name.js';
@@ -75,9 +74,11 @@ export class ImportService {
 		}
 	}
 
-	importJSON(collection: string, stream: Readable): Promise<void> {
+	async importJSON(collection: string, stream: Readable): Promise<void> {
 		const extractJSON = StreamArray.withParser();
 		const nestedActionEvents: ActionEventParams[] = [];
+
+		const { getService } = await import('../utils/get-service.js');
 
 		return transaction(this.knex, (trx) => {
 			const service = getService(collection, {
@@ -126,6 +127,8 @@ export class ImportService {
 		if (!tmpFile) throw new Error('Failed to create temporary file for import');
 
 		const nestedActionEvents: ActionEventParams[] = [];
+
+		const { getService } = await import('../utils/get-service.js');
 
 		return transaction(this.knex, (trx) => {
 			const service = getService(collection, {
@@ -274,6 +277,7 @@ export class ExportService {
 			};
 
 			const database = getDatabase();
+			const { getService } = await import('../utils/get-service.js');
 
 			await transaction(database, async (trx) => {
 				const service = getService(collection, {

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -25,11 +25,11 @@ import emitter from '../emitter.js';
 import { useLogger } from '../logger.js';
 import type { AbstractServiceOptions, ActionEventParams } from '../types/index.js';
 import { getDateFormatted } from '../utils/get-date-formatted.js';
+import { getService } from '../utils/get-service.js';
 import { transaction } from '../utils/transaction.js';
 import { Url } from '../utils/url.js';
 import { userName } from '../utils/user-name.js';
 import { FilesService } from './files.js';
-import { ItemsService } from './items.js';
 import { NotificationsService } from './notifications.js';
 import { UsersService } from './users.js';
 
@@ -80,7 +80,7 @@ export class ImportService {
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		return transaction(this.knex, (trx) => {
-			const service = new ItemsService(collection, {
+			const service = getService(collection, {
 				knex: trx,
 				schema: this.schema,
 				accountability: this.accountability,
@@ -128,7 +128,7 @@ export class ImportService {
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		return transaction(this.knex, (trx) => {
-			const service = new ItemsService(collection, {
+			const service = getService(collection, {
 				knex: trx,
 				schema: this.schema,
 				accountability: this.accountability,
@@ -276,7 +276,7 @@ export class ExportService {
 			const database = getDatabase();
 
 			await transaction(database, async (trx) => {
-				const service = new ItemsService(collection, {
+				const service = getService(collection, {
 					accountability: this.accountability,
 					schema: this.schema,
 					knex: trx,

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -25,6 +25,7 @@ import emitter from '../emitter.js';
 import { useLogger } from '../logger.js';
 import type { AbstractServiceOptions, ActionEventParams } from '../types/index.js';
 import { getDateFormatted } from '../utils/get-date-formatted.js';
+import { getService } from '../utils/get-service.js';
 import { transaction } from '../utils/transaction.js';
 import { Url } from '../utils/url.js';
 import { userName } from '../utils/user-name.js';
@@ -78,8 +79,6 @@ export class ImportService {
 		const extractJSON = StreamArray.withParser();
 		const nestedActionEvents: ActionEventParams[] = [];
 
-		const { getService } = await import('../utils/get-service.js');
-
 		return transaction(this.knex, (trx) => {
 			const service = getService(collection, {
 				knex: trx,
@@ -127,8 +126,6 @@ export class ImportService {
 		if (!tmpFile) throw new Error('Failed to create temporary file for import');
 
 		const nestedActionEvents: ActionEventParams[] = [];
-
-		const { getService } = await import('../utils/get-service.js');
 
 		return transaction(this.knex, (trx) => {
 			const service = getService(collection, {
@@ -277,7 +274,6 @@ export class ExportService {
 			};
 
 			const database = getDatabase();
-			const { getService } = await import('../utils/get-service.js');
 
 			await transaction(database, async (trx) => {
 				const service = getService(collection, {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -59,6 +59,25 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		return this;
 	}
 
+	/**
+	 * Create a fork of the current service, allowing instantiation with different options.
+	 */
+	private fork(options?: Partial<AbstractServiceOptions>): ItemsService<AnyItem> {
+		const Service = this.constructor;
+
+		// ItemsService expects `collection` and `options` as parameters,
+		// while the other services only expect `options`
+		const isItemsService = Service.length === 2;
+
+		const newOptions = { knex: this.knex, accountability: this.accountability, schema: this.schema, ...options };
+
+		if (isItemsService) {
+			return new ItemsService(this.collection, newOptions);
+		}
+
+		return new (Service as new (options: AbstractServiceOptions) => this)(newOptions);
+	}
+
 	createMutationTracker(initialCount = 0): MutationTracker {
 		const maxCount = Number(env['MAX_BATCH_MUTATION']);
 		let mutationCount = initialCount;
@@ -341,16 +360,14 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 
 	/**
 	 * Create multiple new items at once. Inserts all provided records sequentially wrapped in a transaction.
+	 *
+	 * Uses `this.createOne` under the hood.
 	 */
 	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
-			const service = new ItemsService(this.collection, {
-				accountability: this.accountability,
-				schema: this.schema,
-				knex: knex,
-			});
+			const service = this.fork({ knex });
 
 			const primaryKeys: PrimaryKey[] = [];
 			const nestedActionEvents: ActionEventParams[] = [];
@@ -398,7 +415,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Get items by query
+	 * Get items by query.
 	 */
 	async readByQuery(query: Query, opts?: QueryOptions): Promise<Item[]> {
 		const updatedQuery =
@@ -485,7 +502,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Get single item by primary key
+	 * Get single item by primary key.
+	 *
+	 * Uses `this.readByQuery` under the hood.
 	 */
 	async readOne(key: PrimaryKey, query: Query = {}, opts?: QueryOptions): Promise<Item> {
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
@@ -504,7 +523,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Get multiple items by primary keys
+	 * Get multiple items by primary keys.
+	 *
+	 * Uses `this.readByQuery` under the hood.
 	 */
 	async readMany(keys: PrimaryKey[], query: Query = {}, opts?: QueryOptions): Promise<Item[]> {
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
@@ -524,7 +545,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Update multiple items by query
+	 * Update multiple items by query.
+	 *
+	 * Uses `this.updateMany` under the hood.
 	 */
 	async updateByQuery(query: Query, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const keys = await this.getKeysByQuery(query);
@@ -536,7 +559,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Update a single item by primary key
+	 * Update a single item by primary key.
+	 *
+	 * Uses `this.updateMany` under the hood.
 	 */
 	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
@@ -547,7 +572,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Update multiple items in a single transaction
+	 * Update multiple items in a single transaction.
+	 *
+	 * Uses `this.updateOne` under the hood.
 	 */
 	async updateBatch(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!Array.isArray(data)) {
@@ -561,17 +588,15 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 		const keys: PrimaryKey[] = [];
 
 		try {
-			await transaction(this.knex, async (trx) => {
-				const service = new ItemsService(this.collection, {
-					accountability: this.accountability,
-					knex: trx,
-					schema: this.schema,
-				});
+			await transaction(this.knex, async (knex) => {
+				const service = this.fork({ knex });
 
 				for (const item of data) {
-					if (!item[primaryKeyField]) throw new InvalidPayloadError({ reason: `Item in update misses primary key` });
+					const primaryKey = item[primaryKeyField];
+					if (!primaryKey) throw new InvalidPayloadError({ reason: `Item in update misses primary key` });
+
 					const combinedOpts = Object.assign({ autoPurgeCache: false }, opts);
-					keys.push(await service.updateOne(item[primaryKeyField]!, omit(item, primaryKeyField), combinedOpts));
+					keys.push(await service.updateOne(primaryKey, omit(item, primaryKeyField), combinedOpts));
 				}
 			});
 		} finally {
@@ -584,7 +609,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Update many items by primary key, setting all items to the same change
+	 * Update many items by primary key, setting all items to the same change.
 	 */
 	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
@@ -806,7 +831,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Upsert a single item
+	 * Upsert a single item.
+	 *
+	 * Uses `this.createOne` / `this.updateOne` under the hood.
 	 */
 	async upsertOne(payload: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
@@ -832,17 +859,15 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Upsert many items
+	 * Upsert many items.
+	 *
+	 * Uses `this.upsertOne` under the hood.
 	 */
 	async upsertMany(payloads: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
-		const primaryKeys = await transaction(this.knex, async (trx) => {
-			const service = new ItemsService(this.collection, {
-				accountability: this.accountability,
-				schema: this.schema,
-				knex: trx,
-			});
+		const primaryKeys = await transaction(this.knex, async (knex) => {
+			const service = this.fork({ knex });
 
 			const primaryKeys: PrimaryKey[] = [];
 
@@ -862,7 +887,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Delete multiple items by query
+	 * Delete multiple items by query.
+	 *
+	 * Uses `this.deleteMany` under the hood.
 	 */
 	async deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const keys = await this.getKeysByQuery(query);
@@ -874,7 +901,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Delete a single item by primary key
+	 * Delete a single item by primary key.
+	 *
+	 * Uses `this.deleteMany` under the hood.
 	 */
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
@@ -885,7 +914,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Delete multiple items by primary key
+	 * Delete multiple items by primary key.
 	 */
 	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
@@ -985,7 +1014,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Read/treat collection as singleton
+	 * Read/treat collection as singleton.
 	 */
 	async readSingleton(query: Query, opts?: QueryOptions): Promise<Partial<Item>> {
 		query = clone(query);
@@ -1021,7 +1050,9 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 	}
 
 	/**
-	 * Upsert/treat collection as singleton
+	 * Upsert/treat collection as singleton.
+	 *
+	 * Uses `this.createOne` / `this.updateOne` under the hood.
 	 */
 	async upsertSingleton(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;

--- a/api/src/services/notifications.ts
+++ b/api/src/services/notifications.ts
@@ -29,16 +29,6 @@ export class NotificationsService extends ItemsService {
 		return response;
 	}
 
-	override async createMany(data: Partial<Notification>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const response = await super.createMany(data, opts);
-
-		for (const notification of data) {
-			await this.sendEmail(notification);
-		}
-
-		return response;
-	}
-
 	async sendEmail(data: Partial<Notification>) {
 		if (data.recipient) {
 			const user = await this.usersService.readOne(data.recipient, {

--- a/api/src/services/operations.ts
+++ b/api/src/services/operations.ts
@@ -9,45 +9,27 @@ export class OperationsService extends ItemsService<OperationRaw> {
 	}
 
 	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		const flowManager = getFlowManager();
-
 		const result = await super.createOne(data, opts);
-		await flowManager.reload();
 
-		return result;
-	}
-
-	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const flowManager = getFlowManager();
-
-		const result = await super.createMany(data, opts);
-		await flowManager.reload();
-
-		return result;
-	}
-
-	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const flowManager = getFlowManager();
-
-		const result = await super.updateBatch(data, opts);
 		await flowManager.reload();
 
 		return result;
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const flowManager = getFlowManager();
-
 		const result = await super.updateMany(keys, data, opts);
+
+		const flowManager = getFlowManager();
 		await flowManager.reload();
 
 		return result;
 	}
 
 	override async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const flowManager = getFlowManager();
-
 		const result = await super.deleteMany(keys, opts);
+
+		const flowManager = getFlowManager();
 		await flowManager.reload();
 
 		return result;

--- a/api/src/services/roles.ts
+++ b/api/src/services/roles.ts
@@ -479,11 +479,6 @@ export class RolesService extends ItemsService {
 		return super.updateByQuery(query, data, opts);
 	}
 
-	override async deleteOne(key: PrimaryKey): Promise<PrimaryKey> {
-		await this.deleteMany([key]);
-		return key;
-	}
-
 	override async deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]> {
 		const opts: MutationOptions = {};
 
@@ -549,9 +544,5 @@ export class RolesService extends ItemsService {
 		});
 
 		return keys;
-	}
-
-	override deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		return super.deleteByQuery(query, opts);
 	}
 }

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -765,7 +765,7 @@ describe('Integration Tests', () => {
 			});
 		});
 
-		describe('deleteByQuery', () => {
+		describe.only('deleteByQuery', () => {
 			it('should checkRemainingAdminExistence once', async () => {
 				const service = new UsersService({
 					knex: db,
@@ -774,7 +774,7 @@ describe('Integration Tests', () => {
 				});
 
 				// mock return value for the following empty query
-				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValueOnce([{ id: 1 }]);
+				vi.spyOn(ItemsService.prototype, 'getKeysByQuery').mockResolvedValueOnce([1]);
 
 				const promise = service.deleteByQuery({ filter: { id: { _eq: 1 } } });
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -765,7 +765,7 @@ describe('Integration Tests', () => {
 			});
 		});
 
-		describe.only('deleteByQuery', () => {
+		describe('deleteByQuery', () => {
 			it('should checkRemainingAdminExistence once', async () => {
 				const service = new UsersService({
 					knex: db,

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -115,7 +115,7 @@ describe('Integration Tests', () => {
 	describe('Services / Users', () => {
 		let service: UsersService;
 		let mailService: MailService;
-		let superCreateManySpy: MockInstance;
+		let superCreateOneSpy: MockInstance;
 		let superUpdateManySpy: MockInstance;
 		let checkUniqueEmailsSpy: MockInstance;
 		let checkPasswordPolicySpy: MockInstance;
@@ -156,7 +156,7 @@ describe('Integration Tests', () => {
 				},
 			});
 
-			superCreateManySpy = vi.spyOn(ItemsService.prototype as any, 'createMany');
+			superCreateOneSpy = vi.spyOn(ItemsService.prototype as any, 'createOne');
 			superUpdateManySpy = vi.spyOn(ItemsService.prototype as any, 'updateMany');
 
 			// "as any" are needed since these are private methods
@@ -217,7 +217,7 @@ describe('Integration Tests', () => {
 
 			it('should checkUniqueEmails once', async () => {
 				await service.createMany([{ email: 'test@example.com' }]);
-				expect(checkUniqueEmailsSpy).toBeCalledTimes(1);
+				expect(checkUniqueEmailsSpy).toBeCalledTimes(2);
 			});
 
 			it('should not checkPasswordPolicy', async () => {
@@ -227,7 +227,7 @@ describe('Integration Tests', () => {
 
 			it('should checkPasswordPolicy once', async () => {
 				await service.createMany([{ password: 'testpassword' }]);
-				expect(checkPasswordPolicySpy).toBeCalledTimes(1);
+				expect(checkPasswordPolicySpy).toBeCalledTimes(2);
 			});
 
 			it('should process user limits for new roles', async () => {
@@ -808,13 +808,13 @@ describe('Integration Tests', () => {
 
 				await expect(promise).resolves.not.toThrow();
 
-				expect(superCreateManySpy.mock.lastCall![0]).toEqual([
+				expect(superCreateOneSpy.mock.lastCall![0]).toEqual(
 					expect.objectContaining({
 						email: 'user@example.com',
 						status: 'invited',
 						role: 'invite-role',
 					}),
-				]);
+				);
 
 				expect(mailService.send).toBeCalledTimes(1);
 			});
@@ -835,7 +835,7 @@ describe('Integration Tests', () => {
 				const promise = service.inviteUser('user@example.com', 'invite-role', null);
 				await expect(promise).resolves.not.toThrow();
 
-				expect(superCreateManySpy).not.toBeCalled();
+				expect(superCreateOneSpy).not.toBeCalled();
 				expect(mailService.send).toBeCalledTimes(1);
 			});
 
@@ -855,7 +855,7 @@ describe('Integration Tests', () => {
 				const promise = service.inviteUser('user@example.com', 'invite-role', null);
 				await expect(promise).resolves.not.toThrow();
 
-				expect(superCreateManySpy).not.toBeCalled();
+				expect(superCreateOneSpy).not.toBeCalled();
 				expect(mailService.send).not.toBeCalled();
 			});
 

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -398,14 +398,6 @@ export class UsersService extends ItemsService {
 	}
 
 	/**
-	 * Delete a single user by primary key
-	 */
-	override async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
-		await this.deleteMany([key], opts);
-		return key;
-	}
-
-	/**
 	 * Delete multiple users by primary key
 	 */
 	override async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]> {
@@ -421,25 +413,6 @@ export class UsersService extends ItemsService {
 
 		await super.deleteMany(keys, opts);
 		return keys;
-	}
-
-	override async deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		const primaryKeyField = this.schema.collections[this.collection]!.primary;
-		const readQuery = cloneDeep(query);
-		readQuery.fields = [primaryKeyField];
-
-		// Not authenticated:
-		const itemsService = new ItemsService(this.collection, {
-			knex: this.knex,
-			schema: this.schema,
-		});
-
-		const itemsToDelete = await itemsService.readByQuery(readQuery);
-		const keys: PrimaryKey[] = itemsToDelete.map((item: Item) => item[primaryKeyField]);
-
-		if (keys.length === 0) return [];
-
-		return await this.deleteMany(keys, opts);
 	}
 
 	async inviteUser(email: string | string[], role: string, url: string | null, subject?: string | null): Promise<void> {

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,11 +1,11 @@
 import { useEnv } from '@directus/env';
 import { ForbiddenError, InvalidPayloadError, RecordNotUniqueError, UnprocessableContentError } from '@directus/errors';
-import type { Item, PrimaryKey, Query, RegisterUserInput, User } from '@directus/types';
+import type { Item, PrimaryKey, RegisterUserInput, User } from '@directus/types';
 import { getSimpleHash, toArray, toBoolean, validatePayload } from '@directus/utils';
 import { FailedValidationError, joiValidationErrorItemToErrorExtensions } from '@directus/validation';
 import Joi from 'joi';
 import jwt from 'jsonwebtoken';
-import { cloneDeep, isEmpty, mergeWith } from 'lodash-es';
+import { isEmpty, mergeWith } from 'lodash-es';
 import { performance } from 'perf_hooks';
 import getDatabase from '../database/index.js';
 import { useLogger } from '../logger.js';

--- a/api/src/utils/get-service.ts
+++ b/api/src/utils/get-service.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '@directus/errors';
 import {
 	ActivityService,
 	DashboardsService,
@@ -14,6 +15,7 @@ import {
 	RolesService,
 	SettingsService,
 	SharesService,
+	TranslationsService,
 	UsersService,
 	VersionsService,
 	WebhooksService,
@@ -22,18 +24,14 @@ import type { AbstractServiceOptions } from '../types/services.js';
 
 /**
  * Select the correct service for the given collection. This allows the individual services to run
- * their custom checks (f.e. it allows UsersService to prevent updating TFA secret from outside)
+ * their custom checks (f.e. it allows `UsersService` to prevent updating TFA secret from outside).
  */
 export function getService(collection: string, opts: AbstractServiceOptions): ItemsService {
 	switch (collection) {
 		case 'directus_activity':
 			return new ActivityService(opts);
-		// case 'directus_collections':
-		// 	return new CollectionsService(opts);
 		case 'directus_dashboards':
 			return new DashboardsService(opts);
-		// case 'directus_fields':
-		// 	return new FieldsService(opts);
 		case 'directus_files':
 			return new FilesService(opts);
 		case 'directus_flows':
@@ -50,8 +48,6 @@ export function getService(collection: string, opts: AbstractServiceOptions): It
 			return new PermissionsService(opts);
 		case 'directus_presets':
 			return new PresetsService(opts);
-		// case 'directus_relations':
-		// 	return new RelationsService(opts);
 		case 'directus_revisions':
 			return new RevisionsService(opts);
 		case 'directus_roles':
@@ -60,13 +56,18 @@ export function getService(collection: string, opts: AbstractServiceOptions): It
 			return new SettingsService(opts);
 		case 'directus_shares':
 			return new SharesService(opts);
+		case 'directus_translations':
+			return new TranslationsService(opts);
 		case 'directus_users':
 			return new UsersService(opts);
-		case 'directus_webhooks':
-			return new WebhooksService(opts);
 		case 'directus_versions':
 			return new VersionsService(opts);
+		case 'directus_webhooks':
+			return new WebhooksService(opts);
 		default:
+			// Deny usage of other system collections via ItemsService
+			if (collection.startsWith('directus_')) throw new ForbiddenError();
+
 			return new ItemsService(collection, opts);
 	}
 }

--- a/api/src/websocket/utils/items.ts
+++ b/api/src/websocket/utils/items.ts
@@ -1,6 +1,7 @@
+import { InvalidPayloadError } from '@directus/errors';
 import type { Accountability, SchemaOverview } from '@directus/types';
-import { getService } from '../../utils/get-service.js';
 import { CollectionsService, FieldsService, MetaService } from '../../services/index.js';
+import { getService } from '../../utils/get-service.js';
 import type { WebSocketEvent } from '../messages.js';
 import type { Subscription } from '../types.js';
 
@@ -37,6 +38,8 @@ export async function getPayload(
 		case 'directus_relations':
 			result['data'] = event?.payload;
 			break;
+		case 'directus_extensions':
+			throw new InvalidPayloadError({ reason: '"directus_extensions" is currently not supported.' });
 		default:
 			result['data'] = await getItemsPayload(subscription, accountability, schema, event);
 			break;


### PR DESCRIPTION
## Scope

Ensure service integrity, by calling corresponding specified services out of other services.

- Using `getService` in `PayloadService` to get the correct service for relational mutations
- Using `getService` in `ImportService` to get the correct service when importing data
- Forking the current service (either the specified one or ItemsService) in `ItemsService` for transactions, ensuring overridden methods in specified services are reached (without having to re-implement all methods)
- Removing (now / already) redundant methods/calls
- Deny usage of unlisted system collections via `getService` to prevent potential misuse

## Potential Risks / Drawbacks

- A few "preMutationChecks" can be called multiple times at the moment, while this isn't ideal, it shouldn't harm too much. The situation should already be better with #22737. Further clean-up can be done later on.
- Need to be a bit cautious to not introduce infinitive recursions, like calling `this.createMany` from `createOne` as it was the case in `UsersService`

## Review Notes / Questions

Tested with:
- Export / Import of Users while setting a user limit before starting the import
  <img width="600" src="https://github.com/directus/directus/assets/5363448/c163a4d2-59d8-4d28-b170-5425e05423a7">
- Relations to system collections
  <img width="600" src="https://github.com/directus/directus/assets/5363448/31d75c85-e22d-44f1-a75e-dacdec1bb8fd">

