### PR TITLE
Fix cloudinary resource type guessing to consider case insensitive extension

### DIFF
--- a/.changeset/new-squids-argue.md
+++ b/.changeset/new-squids-argue.md
@@ -1,0 +1,5 @@
+---
+'@directus/storage-driver-cloudinary': patch
+---
+
+Fixed upload resource type guessing to consider the file extension in a case insensitive manner

--- a/packages/storage-driver-cloudinary/src/constants.ts
+++ b/packages/storage-driver-cloudinary/src/constants.ts
@@ -1,3 +1,4 @@
+// https://cloudinary.com/documentation/image_transformations#supported_image_formats
 export const IMAGE_EXTENSIONS = [
 	'.ai',
 	'.avif',
@@ -6,6 +7,7 @@ export const IMAGE_EXTENSIONS = [
 	'.bmp',
 	'.bw',
 	'.dfvu',
+	'.dng',
 	'.ps',
 	'.ept',
 	'.eps',
@@ -42,6 +44,7 @@ export const IMAGE_EXTENSIONS = [
 	'.webp',
 ];
 
+// https://cloudinary.com/documentation/video_manipulation_and_delivery#supported_video_formats
 export const VIDEO_EXTENSIONS = [
 	'.3g2',
 	'.3gp',

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -84,7 +84,7 @@ export class DriverCloudinary implements Driver {
 	 * @see https://cloudinary.com/documentation/image_transformations#image_upload_note
 	 */
 	private getResourceType(filepath: string) {
-		const fileExtension = extname(filepath);
+		const fileExtension = extname(filepath).toLowerCase();
 		if (IMAGE_EXTENSIONS.includes(fileExtension)) return 'image';
 		if (VIDEO_EXTENSIONS.includes(fileExtension)) return 'video';
 		return 'raw';

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -84,7 +84,7 @@ export class DriverCloudinary implements Driver {
 	 * @see https://cloudinary.com/documentation/image_transformations#image_upload_note
 	 */
 	private getResourceType(filepath: string) {
-		const fileExtension = extname(filepath).toLowerCase();
+		const fileExtension = extname(filepath)?.toLowerCase();
 		if (IMAGE_EXTENSIONS.includes(fileExtension)) return 'image';
 		if (VIDEO_EXTENSIONS.includes(fileExtension)) return 'video';
 		return 'raw';


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

As pointed out in https://github.com/directus/directus/issues/22687#issuecomment-2164343835 the cloudinary driver guesses the type `raw` for images that have a non-lowercase extension, because we consider the extension in it's original case

What's changed:

- Transform extension to lowercase before comparing it to the list of known extensions
- Added `.dng` to list of extensions[^1] as it seemed to have been forgotten the time it was initially created

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

- I haven't actually tested this, since I don't have a Cloudinary account, but this change seems trivial enough?
- Apparently whatever version of `extname` we import returns `undefined` for strings that don't have extensions, even though the node docs clearly state that it should return an empty string[^2]

---

Fixes #22687

[^1]: https://cloudinary.com/documentation/image_transformations#supported_image_formats
[^2]: https://nodejs.org/api/path.html#pathextnamepath