### PR TITLE
Run fields CRUD blackbox test sequentially

### DIFF
--- a/tests/blackbox/setup/sequential-tests.ts
+++ b/tests/blackbox/setup/sequential-tests.ts
@@ -15,6 +15,7 @@ export const sequentialTestsList: Record<'db' | 'common', SequentialTestsList> =
 			'/tests/db/routes/schema/schema.test.ts',
 			'/tests/db/routes/collections/crud.test.ts',
 			'/tests/db/routes/fields/change-fields.test.ts',
+			'/tests/db/routes/fields/crud.test.ts',
 		],
 		after: [
 			'/tests/db/schema/timezone/timezone.test.ts',


### PR DESCRIPTION
## Scope

The "fields CRUD" blackbox test needs to run in sequence, as it involves schema changes.
Without this, the test occasionally fails:

<img width="800" src="https://github.com/directus/directus/assets/5363448/16363882-d33e-46c0-9234-954658308e6a">

## Potential Risks / Drawbacks

A teeny-tiny bit slower

## Review Notes / Questions

None

---

Related to #20502, e.g. seen in https://github.com/directus/directus/actions/runs/9483834696/job/26135389859?pr=22738 (#22738)