### PR TITLE
Add `replaced_on` column to `directus_files` that updates only when replacing an existing file

### DIFF
--- a/.changeset/swift-colts-drive.md
+++ b/.changeset/swift-colts-drive.md
@@ -1,0 +1,9 @@
+---
+'@directus/system-data': patch
+'@directus/types': patch
+'@directus/api': patch
+'@directus/app': patch
+'@directus/sdk': patch
+---
+
+Add `replaced_on` field to `directus_files` collection to track when an existing file is replaced.

--- a/api/src/database/migrations/20240716A-add-files-replaced-on-field.ts
+++ b/api/src/database/migrations/20240716A-add-files-replaced-on-field.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_files', (table) => {
+		table.datetime('replaced_on');
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_files', (table) => {
+		table.dropColumn('replaced_on');
+	});
+}

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream';
+import { StorageManager } from '@directus/storage';
 import { InvalidPayloadError } from '@directus/errors';
 import type { Knex } from 'knex';
 import knex from 'knex';
@@ -14,6 +16,32 @@ import {
 	type MockInstance,
 } from 'vitest';
 import { FilesService, ItemsService } from './index.js';
+import { _cache } from '../storage/index.js';
+
+vi.mock('@directus/storage');
+
+vi.mock('./files/lib/extract-metadata', () => ({
+	extractMetadata: vi.fn().mockResolvedValue({
+		height: 100,
+		width: 100,
+		description: null,
+		title: 'Test Image',
+		tags: null,
+		metadata: {},
+	}),
+}));
+
+vi.mock('../../src/database/index', () => ({
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../database/helpers/index', () => ({
+	getHelpers: vi.fn().mockImplementation(() => ({
+		date: {
+			writeTimestamp: vi.fn().mockReturnValue(new Date('2024-06-28T14:00:00.000Z')),
+		},
+	})),
+}));
 
 describe('Integration Tests', () => {
 	let db: MockedFunction<Knex>;
@@ -67,6 +95,204 @@ describe('Integration Tests', () => {
 				});
 
 				expect(superCreateOne).toHaveBeenCalled();
+			});
+		});
+
+		describe('uploadOne', () => {
+			let service: FilesService;
+			let superUploadOne: MockInstance;
+			let superUpdateOne: MockInstance;
+			let mockStorage: StorageManager;
+
+			const mockAsyncIterator = {
+				async *[Symbol.asyncIterator]() {
+					yield* await Promise.resolve([]);
+				},
+			};
+
+			const mockFileData = {
+				id: 'test_image_id',
+				storage: 'local',
+				filename_disk: 'test_image_id.png',
+				filename_download: 'test_image.png',
+				title: 'Test Image',
+				type: 'image/png',
+				folder: null,
+				replaced_on: null,
+			};
+
+			const mockMetadata = {
+				height: 100,
+				width: 100,
+				description: null,
+				title: 'Test Image',
+				tags: null,
+				metadata: {},
+			};
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: {
+						collections: {},
+						relations: [],
+					},
+				});
+
+				mockStorage = {
+					registerDriver: vi.fn(),
+					registerLocation: vi.fn(),
+					location: vi.fn(() => ({
+						write: vi.fn(),
+						stat: vi.fn().mockReturnValue({
+							size: 200,
+							modified: '2024-06-14T23:59:59.001Z',
+						}),
+						read: vi.fn((value) => Readable.from(value)),
+						list: vi.fn().mockReturnValue(mockAsyncIterator),
+						move: vi.fn(),
+					})),
+				} as unknown as StorageManager;
+
+				_cache.storage = mockStorage;
+
+				vi.mocked(StorageManager).mockReturnValue(mockStorage);
+
+				superUploadOne = vi.spyOn(FilesService.prototype, 'uploadOne');
+				superUpdateOne = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue(1);
+
+				tracker.on.select('select "storage_default_folder" from "directus_settings"').response([]);
+			});
+
+			it('should update the file `replaced_on`, `filename_download`, & `filename_disk` if primary key exists', async () => {
+				tracker.on
+					.select(
+						'select "folder", "filename_download", "filename_disk", "title", "description", "metadata", "replaced_on" from "directus_files" where "id" = ?',
+					)
+					.response(mockFileData);
+
+				const readableData = Readable.from('test_image.jpeg', { encoding: 'utf8' });
+
+				await service.uploadOne(
+					readableData,
+					{
+						storage: 'local',
+						type: 'image/jpeg',
+						filename_download: 'test_image',
+						filename_disk: 'test_image.jpeg',
+						title: 'Test Image',
+					},
+					'test_image_id',
+				);
+
+				expect(superUploadOne).toHaveBeenCalled();
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					'test_image_id',
+					expect.objectContaining({
+						...mockFileData,
+						...mockMetadata,
+						filesize: 200,
+						type: 'image/jpeg',
+						filename_download: 'test_image.jpeg',
+						filename_disk: 'test_image.jpeg',
+						replaced_on: '2024-06-28T14:00:00.000Z',
+					}),
+					expect.objectContaining({
+						emitEvents: false,
+					}),
+				);
+			});
+
+			it('should not update file `replaced_on` if primary key does not exist', async () => {
+				tracker.on
+					.select(
+						'select "folder", "filename_download", "filename_disk", "title", "description", "metadata", "replaced_on" from "directus_files" where "id" = ?',
+					)
+					.response(null);
+
+				const readableData = Readable.from('test_image.png', { encoding: 'utf8' });
+
+				await service.uploadOne(readableData, {
+					storage: 'local',
+					type: 'image/png',
+					filename_download: 'test_image',
+					title: 'Test Image',
+				});
+
+				expect(superUploadOne).toHaveBeenCalled();
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					1,
+					expect.objectContaining({
+						...mockMetadata,
+						storage: 'local',
+						filename_download: 'test_image.png',
+						type: 'image/png',
+						filename_disk: '1.png',
+						filesize: 200,
+					}),
+					expect.objectContaining({
+						emitEvents: false,
+					}),
+				);
+			});
+
+			it('should use default filename_disk if filename_disk is not supplied', async () => {
+				const readableData = Readable.from('test_image.png', { encoding: 'utf8' });
+
+				await service.uploadOne(readableData, {
+					storage: 'local',
+					type: 'image/png',
+					filename_download: 'test_image.png',
+					title: 'Test Image',
+				});
+
+				expect(superUploadOne).toHaveBeenCalled();
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					1,
+					expect.objectContaining({
+						...mockMetadata,
+						storage: 'local',
+						filename_download: 'test_image.png',
+						type: 'image/png',
+						filename_disk: '1.png',
+						filesize: 200,
+					}),
+					expect.objectContaining({
+						emitEvents: false,
+					}),
+				);
+			});
+
+			it('should use supplied filename_disk', async () => {
+				const readableData = Readable.from('test_image.png', { encoding: 'utf8' });
+
+				await service.uploadOne(readableData, {
+					storage: 'local',
+					type: 'image/png',
+					filename_download: 'test_image.png',
+					filename_disk: 'test_image.png',
+					title: 'Test Image',
+				});
+
+				expect(superUploadOne).toHaveBeenCalled();
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					1,
+					expect.objectContaining({
+						...mockMetadata,
+						storage: 'local',
+						filename_download: 'test_image.png',
+						type: 'image/png',
+						filename_disk: 'test_image.png',
+						filesize: 200,
+					}),
+					expect.objectContaining({
+						emitEvents: false,
+					}),
+				);
 			});
 		});
 	});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -40,7 +40,9 @@ export type MutationTracker = {
 	getCount: () => number;
 };
 
-export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string> implements AbstractService {
+export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string>
+	implements AbstractService
+{
 	collection: Collection;
 	knex: Knex;
 	accountability: Accountability | null;

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -25,6 +25,7 @@ const inputFile = {
 	metadata: null,
 	modified_by: null,
 	modified_on: '',
+	replaced_on: null,
 	focal_point_x: null,
 	focal_point_y: null,
 } satisfies File;

--- a/app/src/components/__snapshots__/v-upload.test.ts.snap
+++ b/app/src/components/__snapshots__/v-upload.test.ts.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`V-Upload > Mount component 1`] = `
+"<div data-v-88c1425a="" data-dropzone="" class="v-upload">
+  <div data-v-88c1425a="" class="actions">
+    <div data-v-28d526fe="" data-v-88c1425a="" class="v-button secondary rounded"><button data-v-28d526fe="" class="button align-center icon normal" type="button"><span data-v-28d526fe="" class="content"><input data-v-88c1425a="" class="browse" type="file"><v-icon-stub data-v-88c1425a="" name="file_upload"></v-icon-stub></span>
+        <div data-v-28d526fe="" class="spinner">
+          <!--v-if-->
+        </div>
+      </button></div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <p data-v-88c1425a="" class="type-label">Drag & Drop a File Here</p>
+  <!--v-if-->
+</div>"
+`;

--- a/app/src/components/v-upload.test.ts
+++ b/app/src/components/v-upload.test.ts
@@ -1,0 +1,125 @@
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { Focus } from '@/__utils__/focus';
+import { mount } from '@vue/test-utils';
+import { expect, test, beforeEach, vi, describe } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { Tooltip } from '../__utils__/tooltip';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import VButton from './v-button.vue';
+import VUpload from './v-upload.vue';
+
+vi.mock('vue-router', () => ({
+	useRoute: vi.fn(),
+	useLink: vi.fn().mockImplementation(() => ({
+		route: vi.fn().mockReturnValue(''),
+		isActive: vi.fn().mockReturnValue(false),
+		isExactActive: vi.fn().mockReturnValue(false),
+	})),
+}));
+
+const i18n = createI18n({
+	legacy: false,
+	messages: {
+		'en-US': {
+			click_to_browse: 'Click to Browse',
+			drag_file_here: 'Drag & Drop a File Here',
+			import_from_url: 'Import File from URL',
+			folders: 'Folders',
+		},
+	},
+});
+
+const global: GlobalMountOptions = {
+	stubs: [
+		'v-icon',
+		'v-progress-linear',
+		'v-card-title',
+		'v-input',
+		'v-card-text',
+		'v-card-actions',
+		'v-card',
+		'v-dialog',
+		'v-progress-circular',
+	],
+	plugins: [i18n],
+	directives: {
+		Tooltip,
+		Focus,
+	},
+	components: {
+		'v-button': VButton,
+	},
+};
+
+Object.defineProperty(window, 'FormData', {
+	writable: true,
+	value: FormData,
+});
+
+vi.mock('@/utils/notify', () => ({
+	notify: vi.fn(),
+}));
+
+vi.mock('@/api', () => {
+	return {
+		default: {
+			post: vi.fn(),
+			patch: vi.fn(),
+		},
+	};
+});
+
+describe('V-Upload', () => {
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+				stubActions: false,
+			}),
+		);
+	});
+
+	const props = {
+		multiple: false,
+		preset: undefined,
+		fileId: undefined,
+		fromUser: true,
+		fromUrl: false,
+		fromLibrary: false,
+	};
+
+	test('Mount component', () => {
+		expect(VUpload).toBeTruthy();
+
+		const wrapper = mount(VUpload, {
+			props,
+			global,
+		});
+
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	test('Should upload new file', async () => {
+		const wrapper = mount(VUpload, {
+			props,
+			global,
+		});
+
+		const file = new File(['image'], 'image.png', { type: 'image/png' });
+
+		const fileUpload = wrapper.get<HTMLInputElement>('input[type="file"]');
+
+		expect(fileUpload).toBeTruthy();
+
+		Object.defineProperty(fileUpload.element, 'files', {
+			value: [file],
+			writable: false,
+		});
+
+		await fileUpload.trigger('change');
+		await wrapper.vm.$nextTick();
+
+		expect(fileUpload.element.files).toEqual([file]);
+	});
+});

--- a/app/src/interfaces/input-rich-text-html/useImage.test.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.test.ts
@@ -33,6 +33,7 @@ test('Returns the file id and file extension from the file type as the imageUrl'
 		metadata: null,
 		focal_point_x: null,
 		focal_point_y: null,
+		hash: null,
 	};
 
 	const { imageSelection, onImageSelect } = useImage(editorRef, imageToken, {
@@ -63,6 +64,7 @@ test('Returns the file id and file extension from the filename_download as the i
 		uploaded_on: '2024-06-14T23:59:59.000Z',
 		modified_by: null,
 		modified_on: '2024-06-14T23:59:59.001Z',
+		replaced_on: null,
 		charset: null,
 		filesize: 100,
 		width: null,

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -276,6 +276,9 @@ When the file was uploaded.
 `modified_by` **many-to-one**\
 Who updated the file last. Many-to-one to [users](/reference/system/users).
 
+`replaced_on` **datetime**\
+When the file was last overwritten/replaced.
+
 `filesize` **number**\
 Size of the file in bytes.
 
@@ -322,6 +325,7 @@ Any additional metadata Directus was able to scrape from the file. For images, t
 	"uploaded_on": "2021-02-04T11:37:41-05:00",
 	"modified_by": null,
 	"modified_on": "2021-02-04T11:37:42-05:00",
+	"replaced_on": null,
 	"filesize": 3442252,
 	"width": 3456,
 	"height": 5184,

--- a/packages/system-data/src/fields/files.yaml
+++ b/packages/system-data/src/fields/files.yaml
@@ -170,3 +170,10 @@ fields:
     hidden: true
     special:
       - cast-json
+
+  - field: replaced_on
+    width: half
+    display: datetime
+    interface: datetime
+    readonly: true
+    hidden: true

--- a/packages/types/src/files.ts
+++ b/packages/types/src/files.ts
@@ -12,6 +12,7 @@ export type File = {
 	uploaded_on: string;
 	modified_by: string | null;
 	modified_on: string;
+	replaced_on: string | null;
 	charset: string | null;
 	filesize: number;
 	width: number | null;

--- a/sdk/src/schema/file.ts
+++ b/sdk/src/schema/file.ts
@@ -18,6 +18,7 @@ export type DirectusFile<Schema = any> = MergeCoreCollection<
 		uploaded_on: 'datetime';
 		modified_by: DirectusUser<Schema> | string | null;
 		modified_on: 'datetime';
+		replaced_on: 'datetime' | null;
 		charset: string | null;
 		filesize: string | null;
 		width: number | null;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- `directus_files` now includes a `hash` column that gets updated when using the `Replace File` toggle.

## Potential Risks / Drawbacks

- I am not sure if I am missing anything on the migration side.
- Adding a migration to add a column to a system collection. 
- I am not sure how to setup a test for `v-upload.vue` just yet.
- [x] add test for `v-upload.vue`
- [x] add test for `files.ts` service

## Review Notes / Questions


- Added some test coverage, but I am not 100% sure they are "good" tests. Would love to get some extra eyes on the tests to make sure they are valid and complete.
---

Related to #22606 
