### PR TITLE
Include admin users under the app access limit

### DIFF
--- a/.changeset/polite-elephants-juggle.md
+++ b/.changeset/polite-elephants-juggle.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': patch
+'@directus/api': major
 ---
 
 Included admin users under the app access limit

--- a/.changeset/polite-elephants-juggle.md
+++ b/.changeset/polite-elephants-juggle.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Included admin users under the app access limit

--- a/api/src/telemetry/utils/check-increased-user-limits.test.ts
+++ b/api/src/telemetry/utils/check-increased-user-limits.test.ts
@@ -17,17 +17,33 @@ vi.mock('@directus/env', () => ({
 const mockDb: Knex = {} as unknown as Knex;
 
 test('Errors if limits are exceeded with an increase', () => {
-	vi.mocked(getUserCount).mockResolvedValue({ admin: 3, app: 3, api: 3 });
+	vi.mocked(getUserCount).mockResolvedValue({ admin: 1, app: 1, api: 1 });
 
-	expect(checkIncreasedUserLimits(mockDb, { admin: 1, app: 0, api: 0 })).rejects.toThrowError(
+	expect(checkIncreasedUserLimits(mockDb, { admin: 3, app: 0, api: 0 })).rejects.toThrowError(
 		'Active Admin users limit exceeded.',
 	);
 
-	expect(checkIncreasedUserLimits(mockDb, { admin: 0, app: 1, api: 0 })).rejects.toThrowError(
+	expect(checkIncreasedUserLimits(mockDb, { admin: 3, app: 2, api: 0 })).rejects.toThrowError(
+		'Active Admin users limit exceeded.',
+	);
+
+	expect(checkIncreasedUserLimits(mockDb, { admin: 0, app: 2, api: 0 })).rejects.toThrowError(
 		'Active App users limit exceeded.',
 	);
 
-	expect(checkIncreasedUserLimits(mockDb, { admin: 0, app: 0, api: 1 })).rejects.toThrowError(
+	expect(checkIncreasedUserLimits(mockDb, { admin: 2, app: 0, api: 0 })).rejects.toThrowError(
+		'Active App users limit exceeded.',
+	);
+
+	expect(checkIncreasedUserLimits(mockDb, { admin: 1, app: 1, api: 0 })).rejects.toThrowError(
+		'Active App users limit exceeded.',
+	);
+
+	expect(checkIncreasedUserLimits(mockDb, { admin: 2, app: 2, api: 0 })).rejects.toThrowError(
+		'Active App users limit exceeded.',
+	);
+
+	expect(checkIncreasedUserLimits(mockDb, { admin: 0, app: 0, api: 3 })).rejects.toThrowError(
 		'Active API users limit exceeded.',
 	);
 });
@@ -44,6 +60,6 @@ test('Does not errors if limits are not exceeded with an increase', () => {
 	expect(() => checkIncreasedUserLimits(mockDb, { admin: 1, app: 0, api: 0 })).not.toThrowError();
 	expect(() => checkIncreasedUserLimits(mockDb, { admin: 0, app: 1, api: 0 })).not.toThrowError();
 	expect(() => checkIncreasedUserLimits(mockDb, { admin: 0, app: 0, api: 1 })).not.toThrowError();
-	expect(() => checkIncreasedUserLimits(mockDb, { admin: 1, app: 1, api: 1 })).not.toThrowError();
-	expect(() => checkIncreasedUserLimits(mockDb, { admin: 2, app: 2, api: 2 })).not.toThrowError();
+	expect(() => checkIncreasedUserLimits(mockDb, { admin: 0, app: 1, api: 2 })).not.toThrowError();
+	expect(() => checkIncreasedUserLimits(mockDb, { admin: 1, app: 0, api: 2 })).not.toThrowError();
 });

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -1052,7 +1052,7 @@ Allows you to configure hard technical limits, to prevent abuse and optimize for
 | `RELATIONAL_BATCH_SIZE`     | How many rows are read into memory at a time when constructing nested relational datasets                                       | 25000         |
 | `EXPORT_BATCH_SIZE`         | How many rows are read into memory at a time when constructing exports                                                          | 5000          |
 | `USERS_ADMIN_ACCESS_LIMIT`  | How many active users with admin privilege are allowed                                                                          | `Infinity`    |
-| `USERS_APP_ACCESS_LIMIT`    | How many active users with app access are allowed                                                                               | `Infinity`    |
+| `USERS_APP_ACCESS_LIMIT`    | How many active users with access to the Data Studio are allowed                                                                | `Infinity`    |
 | `USERS_API_ACCESS_LIMIT`    | How many active API access users are allowed                                                                                    | `Infinity`    |
 | `GRAPHQL_QUERY_TOKEN_LIMIT` | How many GraphQL query tokens will be parsed. [More details here](https://graphql-js.org/api/interface/parseoptions/#maxTokens) | 5000          |
 


### PR DESCRIPTION
## Scope

What's changed:

- Include admins in the app access limit as admins have full permissions

## Potential Risks / Drawbacks

- Limits may have to be tweaked if already in use

## Review Notes / Questions

- The admin and app telemetry are kept separate for clarity and backward compatibility

---

Follow-up to the user limits implementation in #22479
