### PR TITLE
Include image extension in image URL when uploading image through WYSIWYG

### DIFF
--- a/.changeset/seven-ties-rhyme.md
+++ b/.changeset/seven-ties-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Include image file extensions inside WYSIWYG

--- a/app/src/interfaces/input-rich-text-html/useImage.test.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.test.ts
@@ -1,0 +1,46 @@
+import { test, expect } from 'vitest';
+import { ref } from 'vue';
+import { SettingsStorageAssetPreset, File } from '@directus/types';
+import useImage from './useImage';
+
+test('Returns the filename_disk as the imageUrl', () => {
+	const editorRef = ref<any | null>(null);
+	const imageToken = ref<string>('')
+	const storageAssetTransform = ref('all');
+	const storageAssetPresets = ref<SettingsStorageAssetPreset[]>([]);
+
+	const imageFile: File = {
+    id: "test_image",
+    storage: "local",
+    filename_disk: "test_image.svg",
+    filename_download: "600x400",
+    title: "Test Image",
+    type: "image/svg+xml; charset=utf-8",
+    folder: null,
+    uploaded_by: "user",
+    uploaded_on: "2024-06-12T22:22:54.065Z",
+    modified_by: null,
+    modified_on: "2024-06-12T22:22:54.100Z",
+    charset: null,
+    filesize: 100,
+    width: null,
+    height: null,
+    duration: null,
+    embed: null,
+    description: null,
+    location: null,
+    tags: null,
+    metadata: null,
+    focal_point_x: null,
+    focal_point_y: null
+	};
+
+	const { imageSelection, onImageSelect } = useImage(editorRef, imageToken, {
+		storageAssetTransform,
+		storageAssetPresets
+	});
+
+	onImageSelect(imageFile)
+
+	expect(imageSelection.value?.imageUrl).toEqual('http://localhost:3000/assets/test_image.svg')
+})

--- a/app/src/interfaces/input-rich-text-html/useImage.test.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.test.ts
@@ -3,44 +3,86 @@ import { ref } from 'vue';
 import { SettingsStorageAssetPreset, File } from '@directus/types';
 import useImage from './useImage';
 
-test('Returns the filename_disk as the imageUrl', () => {
+test('Returns the file id and file extension from the file type as the imageUrl', () => {
 	const editorRef = ref<any | null>(null);
-	const imageToken = ref<string>('')
+	const imageToken = ref<string>('');
 	const storageAssetTransform = ref('all');
 	const storageAssetPresets = ref<SettingsStorageAssetPreset[]>([]);
 
 	const imageFile: File = {
-    id: "test_image",
-    storage: "local",
-    filename_disk: "test_image.svg",
-    filename_download: "600x400",
-    title: "Test Image",
-    type: "image/svg+xml; charset=utf-8",
-    folder: null,
-    uploaded_by: "user",
-    uploaded_on: "2024-06-12T22:22:54.065Z",
-    modified_by: null,
-    modified_on: "2024-06-12T22:22:54.100Z",
-    charset: null,
-    filesize: 100,
-    width: null,
-    height: null,
-    duration: null,
-    embed: null,
-    description: null,
-    location: null,
-    tags: null,
-    metadata: null,
-    focal_point_x: null,
-    focal_point_y: null
+		id: 'unique_id',
+		storage: 'local',
+		filename_disk: 'unique_id.svg',
+		filename_download: '600x400.svg',
+		title: 'Test Image',
+		type: 'image/svg+xml',
+		folder: null,
+		uploaded_by: 'user',
+		uploaded_on: '2024-06-14T23:59:59.000Z',
+		modified_by: null,
+		modified_on: '2024-06-14T23:59:59.001Z',
+		charset: null,
+		filesize: 100,
+		width: null,
+		height: null,
+		duration: null,
+		embed: null,
+		description: null,
+		location: null,
+		tags: null,
+		metadata: null,
+		focal_point_x: null,
+		focal_point_y: null,
 	};
 
 	const { imageSelection, onImageSelect } = useImage(editorRef, imageToken, {
 		storageAssetTransform,
-		storageAssetPresets
+		storageAssetPresets,
 	});
 
-	onImageSelect(imageFile)
+	onImageSelect(imageFile);
 
-	expect(imageSelection.value?.imageUrl).toEqual('http://localhost:3000/assets/test_image.svg')
-})
+	expect(imageSelection.value?.imageUrl).toEqual('http://localhost:3000/assets/unique_id.svg');
+});
+
+test('Returns the file id and file extension from the filename_download as the imageUrl', () => {
+	const editorRef = ref<any | null>(null);
+	const imageToken = ref<string>('');
+	const storageAssetTransform = ref('all');
+	const storageAssetPresets = ref<SettingsStorageAssetPreset[]>([]);
+
+	const imageFile: File = {
+		id: 'unique_id',
+		storage: 'local',
+		filename_disk: 'unique_id.svg',
+		filename_download: '600x400.svg',
+		title: 'Test Image',
+		type: null,
+		folder: null,
+		uploaded_by: 'user',
+		uploaded_on: '2024-06-14T23:59:59.000Z',
+		modified_by: null,
+		modified_on: '2024-06-14T23:59:59.001Z',
+		charset: null,
+		filesize: 100,
+		width: null,
+		height: null,
+		duration: null,
+		embed: null,
+		description: null,
+		location: null,
+		tags: null,
+		metadata: null,
+		focal_point_x: null,
+		focal_point_y: null,
+	};
+
+	const { imageSelection, onImageSelect } = useImage(editorRef, imageToken, {
+		storageAssetTransform,
+		storageAssetPresets,
+	});
+
+	onImageSelect(imageFile);
+
+	expect(imageSelection.value?.imageUrl).toEqual('http://localhost:3000/assets/unique_id.svg');
+});

--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -1,6 +1,8 @@
 import { i18n } from '@/lang';
 import { addQueryToPath } from '@/utils/add-query-to-path';
 import { getPublicURL } from '@/utils/get-root-path';
+import { readableMimeType } from '@/utils/readable-mime-type';
+import mime from 'mime/lite';
 import { Ref, ref, watch } from 'vue';
 import { SettingsStorageAssetPreset, File } from '@directus/types';
 
@@ -116,7 +118,11 @@ export default function useImage(
 	}
 
 	function onImageSelect(image: File) {
-		const assetUrl = getPublicURL() + 'assets/' + image.filename_disk;
+		const fileExtension = image.type
+			? readableMimeType(image.type, true)
+			: readableMimeType(mime.getType(image.filename_download) as string, true);
+
+		const assetUrl = getPublicURL() + 'assets/' + image.id + '.' + fileExtension;
 
 		imageSelection.value = {
 			imageUrl: replaceUrlAccessToken(assetUrl, imageToken.value),

--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -2,14 +2,14 @@ import { i18n } from '@/lang';
 import { addQueryToPath } from '@/utils/add-query-to-path';
 import { getPublicURL } from '@/utils/get-root-path';
 import { Ref, ref, watch } from 'vue';
-import { SettingsStorageAssetPreset } from '@directus/types';
+import { SettingsStorageAssetPreset, File } from '@directus/types';
 
 type ImageSelection = {
 	imageUrl: string;
 	alt: string;
 	lazy?: boolean;
-	width?: number;
-	height?: number;
+	width?: number | null;
+	height?: number | null;
 	transformationKey?: string | null;
 	previewUrl?: string;
 };
@@ -25,7 +25,7 @@ type UsableImage = {
 	imageDrawerOpen: Ref<boolean>;
 	imageSelection: Ref<ImageSelection | null>;
 	closeImageDrawer: () => void;
-	onImageSelect: (image: Record<string, any>) => void;
+	onImageSelect: (image: File) => void;
 	saveImage: () => void;
 	imageButton: ImageButton;
 };
@@ -115,12 +115,12 @@ export default function useImage(
 		imageDrawerOpen.value = false;
 	}
 
-	function onImageSelect(image: Record<string, any>) {
-		const assetUrl = getPublicURL() + 'assets/' + image.id;
+	function onImageSelect(image: File) {
+		const assetUrl = getPublicURL() + 'assets/' + image.filename_disk;
 
 		imageSelection.value = {
 			imageUrl: replaceUrlAccessToken(assetUrl, imageToken.value),
-			alt: image.title,
+			alt: image.title!,
 			lazy: false,
 			width: image.width,
 			height: image.height,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- WYSIWYG images now include the file extension.

## Potential Risks / Drawbacks

- Adding the file extension could break processes down the line if not expecting file extension.
- Potential to be areas where double file extensions are added

## Review Notes / Questions

- I added a test case around this, but I am not familiar with the whole test suite, so I was unaware of any mocks/fixtures for images to import.
- Is there a cleaner solution?

---

Fixes #22739 
