### PR TITLE
Fix clipboard copy notification for blocked environments

### DIFF
--- a/.changeset/selfish-countries-check.md
+++ b/.changeset/selfish-countries-check.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where copying-to-clipboard displayed a success-notification eventhough it failed

--- a/.changeset/selfish-countries-check.md
+++ b/.changeset/selfish-countries-check.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed an issue where copying-to-clipboard displayed a success-notification eventhough it failed
+Fixed an issue where copying-to-clipboard displayed a success notification even though it failed

--- a/app/src/composables/use-clipboard.ts
+++ b/app/src/composables/use-clipboard.ts
@@ -1,6 +1,6 @@
+import { notify } from '@/utils/notify';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { notify } from '@/utils/notify';
 
 type Message = {
 	success?: string;
@@ -23,7 +23,7 @@ export function useClipboard() {
 	async function copyToClipboard(value: any, message?: Message): Promise<boolean> {
 		try {
 			const valueString = typeof value === 'string' ? value : JSON.stringify(value);
-			await navigator?.clipboard?.writeText(valueString);
+			await navigator.clipboard.writeText(valueString);
 
 			notify({
 				title: message?.success ?? t('copy_raw_value_success'),


### PR DESCRIPTION
## Scope

Some Browsers block the clipboard completely, for example see:

![image](https://github.com/directus/directus/assets/14810858/768f0253-57cb-4323-927a-b8cd11b17f43)

And that should technically lead to throwing inside our `useClipboard` utility when calling `copyToClipboard` so that we can notify users with: 

```ts
// ...
	} catch (err: any) {
		notify({
			type: 'error',
			title: message?.fail ?? t('copy_raw_value_fail'),
		});
		return false;
	}
```

But turns out because we use the `?.` operator we dont actually throw anything when it fails, resulting in displaying an erroneous success notification. 

| Before | After |
|--------|--------|
| ![image](https://github.com/directus/directus/assets/14810858/70019b88-5eda-4cdc-89be-227a6af4827e) | ![Screenshot from 2024-06-19 13-02-32](https://github.com/directus/directus/assets/14810858/6d5371d9-ddd7-4dc0-8ff5-4954c7587e0b) | 

What's changed:

- Actually let the call to `navigator.clipboard.writeText` throw for blocked environments

## Potential Risks / Drawbacks

- We do catch and handle errors already, we just dont throw - so: Should be none

## Review Notes / Questions

- Tested with Brave-Browser which seems to hard-block clipboard on the `0.0.0.0` host specifically. Localhost has clipboard support.
- Firefox also seems to block clipboard support on `0.0.0.0`, its reproducible there see:
    - ![image](https://github.com/directus/directus/assets/14810858/e10cc1eb-0ce3-4496-8379-212820a6859c)


---

Fixes no open issue, just a tiny one-liner tweak