### PR TITLE
Fix policies migration for public role permissions

### DIFF
--- a/.changeset/thick-dingos-film.md
+++ b/.changeset/thick-dingos-film.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed the policies migration for the case were permissions had been configured for the public role
+Fixed the policies migration for the case where permissions had been configured for the public role

--- a/.changeset/thick-dingos-film.md
+++ b/.changeset/thick-dingos-film.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed the policies migration for the case were permissions had been configured for the public role

--- a/api/src/database/migrations/20240619A-permissions-policies.ts
+++ b/api/src/database/migrations/20240619A-permissions-policies.ts
@@ -69,7 +69,7 @@ export async function up(knex: Knex) {
 	// Link permissions to policies instead of roles
 
 	await knex.schema.alterTable('directus_permissions', (table) => {
-		table.uuid('policy').notNullable().references('directus_policies.id').onDelete('CASCADE');
+		table.uuid('policy').references('directus_policies.id').onDelete('CASCADE');
 		// Drop the foreign key constraint here in order to update `null` role to public policy ID
 		table.dropForeign('role');
 	});
@@ -86,6 +86,7 @@ export async function up(knex: Knex) {
 
 	await knex.schema.alterTable('directus_permissions', (table) => {
 		table.dropColumns('role');
+		table.dropNullable('policy');
 	});
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Scope

Fixes the policies migration if the public role previously had permissions configured.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Making the `policy` column not nullable only after applying the new public role UUID, as before that there would be no value in that column for permissions coming from the public role.

---

Fixes issue as reported on [Discord](https://discord.com/channels/725371605378924594/1253447768089956382/1253492896817086574):
```
error: alter table "directus_permissions" add column "policy" uuid not null - column "policy" of relation > "directus_permissions" contains null values
```