### PR TITLE
V11 docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -127,6 +127,7 @@ gtag('config', 'UA-24637628-7');
 				href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap',
 			},
 		],
+		['meta', { name: 'robots', content: 'noindex, nofollow' }],
 	],
 	lastUpdated: true,
 	themeConfig: {

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -20,6 +20,9 @@ const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 <template>
 	<Layout>
 		<template #sidebar-nav-before>
+			<a href="https://docs.directus.io" class="version-notice">
+				These docs are for the Directus 11 Release Candidate. Click here to return to our main docs.
+			</a>
 			<div class="sidebar-nav-before">
 				<div class="toggle">
 					<a href="/" :class="{ active: isDevPage }">Developers</a>
@@ -52,6 +55,18 @@ const isPackagePage = computed(() => RegExp('^/packages/.+$').test(path.value));
 </template>
 
 <style lang="scss" scoped>
+.version-notice {
+	background-color: var(--vp-c-purple-dimm-3);
+	border-radius: var(--rounded-lg);
+	padding: 1rem;
+	border: 1px solid var(--vp-c-purple-dimm-1);
+	margin-top: 1rem;
+	display: block;
+	font-size: 0.7rem;
+	line-height: 1.125rem;
+	margin-top: 0.75rems;
+}
+
 .sidebar-nav-before {
 	padding: 1em 0;
 	border-bottom: 1px solid var(--vp-c-divider);

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This is the deployment branch for the docs. As 11 goes GA, this will need to be merged in to head back to the main `release` branch.

- [ ] Remove RC notice in sidebar
- [ ] Remove robots nofollow in both the `<head>` and `robots.txt`