### PR TITLE
Fix slow introspection query for MS SQL

### DIFF
--- a/packages/schema/src/dialects/mssql.ts
+++ b/packages/schema/src/dialects/mssql.ts
@@ -341,8 +341,8 @@ export default class MSSQL implements SchemaInspector {
         ) AS [i]
         ON [i].[object_id] = [c].[object_id]
         AND [i].[column_id] = [c].[column_id]
-        AND ISNULL([i].[index_column_count], 1) = 1
-        AND ISNULL([i].[index_priority], 1) = 1`,
+        AND [i].[index_column_count] IS NOT NULL,
+        AND [i].[index_priority] IS NOT NULL`,
 			)
 			.where({ 's.schema_id': schemaId });
 

--- a/packages/schema/src/dialects/mssql.ts
+++ b/packages/schema/src/dialects/mssql.ts
@@ -333,12 +333,11 @@ export default class MSSQL implements SchemaInspector {
             [sys].[index_columns] [ic]
           JOIN [sys].[indexes] AS [ix] ON [ix].[object_id] = [ic].[object_id]
             AND [ix].[index_id] = [ic].[index_id]
-			WHERE (SELECT MAX([ic].[index_column_id]) OVER (partition by [ic].[index_id], [ic].[object_id])) IS NOT NULL
-                AND (SELECT ROW_NUMBER() OVER (
+			WHERE ISNULL((SELECT MAX([ic].[index_column_id])
+                                             OVER (PARTITION BY [ic].[index_id], [ic].[object_id])), 1) = 1
+                      AND ISNULL((SELECT ROW_NUMBER() OVER (
                         PARTITION BY [ic].[object_id], [ic].[column_id]
-                        ORDER BY [ix].[is_primary_key] DESC, [ix].[is_unique] DESC)
-					) IS NOT NULL
-        ) AS [i]
+                        ORDER BY [ix].[is_primary_key] DESC, [ix].[is_unique] DESC)), 1) = 1) AS [i]
         ON [i].[object_id] = [c].[object_id]
         AND [i].[column_id] = [c].[column_id]`,
 			)


### PR DESCRIPTION
## The problem

The field introspection query for ms sql is currently very slow. The query get's so slow due to a reference to a column of an sub select which is being joined.

```sql
select [i].[index_column_count] -- such reference slows down the query
from [master].[sys].[columns] [c]
         JOIN [sys].[types] [t] ON [c].[user_type_id] = [t].[user_type_id]
         JOIN [sys].[tables] [o] ON [o].[object_id] = [c].[object_id]
         JOIN [sys].[schemas] [s] ON [s].[schema_id] = [o].[schema_id]
         LEFT JOIN [sys].[computed_columns] AS [cc]
                   ON [cc].[object_id] = [c].[object_id] AND [cc].[column_id] = [c].[column_id]
         LEFT JOIN [sys].[foreign_key_columns] AS [fk]
                   ON [fk].[parent_object_id] = [c].[object_id] AND [fk].[parent_column_id] = [c].[column_id]
         LEFT JOIN (SELECT [ic].[object_id],
                           [ic].[column_id],
                           [ix].[is_unique],
                           [ix].[is_primary_key],
                           MAX([ic].[index_column_id])
                               OVER (partition by [ic].[index_id], [ic].[object_id])  AS index_column_count, -- this value needs to be null checked
                           ROW_NUMBER() OVER (
                               PARTITION BY [ic].[object_id], [ic].[column_id]
                               ORDER BY [ix].[is_primary_key] DESC, [ix].[is_unique] DESC) AS index_priority -- and this value
                    FROM [sys].[index_columns] [ic]
                             JOIN [sys].[indexes] AS [ix] ON [ix].[object_id] = [ic].[object_id]
                        AND [ix].[index_id] = [ic].[index_id]) AS [i] ON [i].[object_id] = [c].[object_id]
    AND [i].[column_id] = [c].[column_id]
    AND ISNULL([i].[index_column_count], 1) = 1 -- here 
    AND ISNULL([i].[index_priority], 1) = 1, -- and here are such problematic references
where [s].[name] = 'dbo';
```

## The solution
Instead of filter out values via the join condition, I moved the condition within the where clause of the inner select. that way I could eliminate the references which causes the problem. The result should be the same. 

I first tried it like this: 
```sql
SELECT
       MAX(...)  AS index_column_count,
       ROW_NUMBER() ... AS index_priority 
FROM ...
WHERE ISNULL(index_column_count, 1) = 1 
       AND ISNULL(index_priority, 1) = 1
```

But unfortunately **we cannot reference columns by their aliases within the where clause**.   ms sql processes the where clause before the select and hence doesn't know about the alias when processing the where clause.  This was probably the reason why the condition has been in the JOIN condition in the first place instead of within the where clause of the inner select. 

However with a small trick of wrapping the function call within another sub select in the where clause, I could do the not null check in  the where clause of the inner select. so like this:
```sql
 WHERE ISNULL((SELECT MAX(...), 1) = 1
```

I queried the database with the current query and the updated query and compared the result with `diff` and they are identical. 

I got a schema from @alexvdvalk for testing. Before the fix it tool around 4 seconds to complete. now it 150 ms 🎉 

---

Fixes https://github.com/directus/directus/issues/19486
