### PR TITLE
Add support for split rollup configuration for different modes

### DIFF
--- a/.changeset/brown-turtles-impress.md
+++ b/.changeset/brown-turtles-impress.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': minor
+---
+
+Introduced the possibility to split rollup configuration for node and browser environments

--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -61,6 +61,11 @@ export default {
 };
 ```
 
+If you are developing a bundle or hybrid extension, like a flow operation, your code will be bundled for two
+different environments: `node` for API extensions and `browser` for Data Studio extensions. You can specify different
+options for each environment by optionally including the `.node` or `.browser` suffixes to the configuration filename:
+`extension.config.node.js` and `extension.config.browser.js`.
+
 #### Supported Options
 
 - `plugins` — An array of Rollup plugins that will be used when building extensions in addition to the built-in ones.

--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -62,8 +62,8 @@ export default {
 ```
 
 If you are developing a bundle or hybrid extension, like a flow operation, your code will be bundled for two
-different environments: `node` for API extensions and `browser` for Data Studio extensions. You can specify different
-options for each environment by optionally including the `.node` or `.browser` suffixes to the configuration filename:
+different modes: `node` for API extensions and `browser` for Data Studio extensions. You can specify different
+options for each mode by optionally including the `.node` or `.browser` suffixes to the configuration filename:
 `extension.config.node.js` and `extension.config.browser.js`.
 
 #### Supported Options

--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -61,9 +61,9 @@ export default {
 };
 ```
 
-If you are developing a bundle or hybrid extension, like a flow operation, your code will be bundled for two
-different modes: `node` for API extensions and `browser` for Data Studio extensions. You can specify different
-options for each mode by optionally including the `.node` or `.browser` suffixes to the configuration filename:
+If you are developing a bundle or hybrid extension, like a flow operation, your code will be bundled for two different
+modes: `node` for API extensions and `browser` for Data Studio extensions. You can specify different options for each
+mode by optionally including the `.node` or `.browser` suffixes to the configuration filename:
 `extension.config.node.js` and `extension.config.browser.js`.
 
 #### Supported Options

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -274,10 +274,10 @@ async function buildAppOrApiExtension({
 		process.exit(1);
 	}
 
-	const config = await loadConfig();
-	const plugins = config.plugins ?? [];
-
 	const mode = isIn(type, APP_EXTENSION_TYPES) ? 'browser' : 'node';
+
+	const config = await loadConfig(mode);
+	const plugins = config.plugins ?? [];
 
 	const rollupOptions = getRollupOptions({ mode, input, sourcemap, minify, plugins });
 	const rollupOutputOptions = getRollupOutputOptions({ mode, output, format, sourcemap });
@@ -328,15 +328,12 @@ async function buildHybridExtension({
 		process.exit(1);
 	}
 
-	const config = await loadConfig();
-	const plugins = config.plugins ?? [];
-
 	const rollupOptionsApp = getRollupOptions({
 		mode: 'browser',
 		input: inputApp,
 		sourcemap,
 		minify,
-		plugins,
+		plugins: (await loadConfig('browser')).plugins ?? [],
 	});
 
 	const rollupOptionsApi = getRollupOptions({
@@ -344,7 +341,7 @@ async function buildHybridExtension({
 		input: inputApi,
 		sourcemap,
 		minify,
-		plugins,
+		plugins: (await loadConfig('node')).plugins ?? [],
 	});
 
 	const rollupOutputOptionsApp = getRollupOutputOptions({ mode: 'browser', output: outputApp, format, sourcemap });
@@ -400,9 +397,6 @@ async function buildBundleExtension({
 		bundleEntryNames.add(name);
 	}
 
-	const config = await loadConfig();
-	const plugins = config.plugins ?? [];
-
 	const entrypointApp = generateBundleEntrypoint('app', entries);
 	const entrypointApi = generateBundleEntrypoint('api', entries);
 
@@ -411,7 +405,7 @@ async function buildBundleExtension({
 		input: { entry: entrypointApp },
 		sourcemap,
 		minify,
-		plugins,
+		plugins: (await loadConfig('browser')).plugins ?? [],
 	});
 
 	const rollupOptionsApi = getRollupOptions({
@@ -419,7 +413,7 @@ async function buildBundleExtension({
 		input: { entry: entrypointApi },
 		sourcemap,
 		minify,
-		plugins,
+		plugins: (await loadConfig('node')).plugins ?? [],
 	});
 
 	const rollupOutputOptionsApp = getRollupOutputOptions({ mode: 'browser', output: outputApp, format, sourcemap });

--- a/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
@@ -7,14 +7,17 @@ import type { Config } from '../../types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default async function loadConfig(): Promise<Config> {
+export default async function loadConfig(mode: 'browser' | 'node'): Promise<Config> {
 	for (const ext of JAVASCRIPT_FILE_EXTS) {
-		const fileName = `extension.config.${ext}`;
+		// Try to find a config file for the given mode first, then default to the generic one
+		for (const modeSuffix of [`.${mode}`, '']) {
+			const fileName = `extension.config${modeSuffix}.${ext}`;
 
-		if (await fse.pathExists(fileName)) {
-			const configFile = await import(pathToRelativeUrl(path.resolve(fileName), __dirname));
+			if (await fse.pathExists(fileName)) {
+				const configFile = await import(pathToRelativeUrl(path.resolve(fileName), __dirname));
 
-			return configFile.default;
+				return configFile.default;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Add the option to split `extension.config.js` file for the two different rollup modes we use: `extension.config.node.js` and `extension.config.browser.js`.

I stumbled over this while developing a bundle extension that uses dependencies that have different [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) for different bundling environments and require the `node-resolve` plugin to be configured differently for API and app extensions.

For example I need to be able to use this configuration for node:

```js
import { nodeResolve } from "@rollup/plugin-node-resolve";

export default {
  plugins: [
    nodeResolve({exportConditions: ["node"]})
  ]
}
```

and this for the browser:

```js
import { nodeResolve } from "@rollup/plugin-node-resolve";

export default {
  plugins: [
    nodeResolve({exportConditions: ["browser"]})
  ]
}
```

which would import the correct dependencies for each environment that are exported with export conditions.

What's changed:

- Added the possibility for the extension developer to specify different `extension.config` files for the two different modes in which we currently use rollup `node` and `browser`. This is fully backwards compatible, as it defaults to no mode suffix, but prefers configuration files with the mode suffix.
- You can now have the configuration files `extension.config.node.js` and `extension.config.browser.js` and they will be considered for their applicable environment
- Improved the DX with this, yeah!

## Potential Risks / Drawbacks

- None, since fully backward compatible

## Review Notes / Questions

- N/A

---

Fixes a problem I currently have...
