### PR TITLE
Fix user register endpoint in documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -133,3 +133,4 @@
 - alejandrocortell
 - boring-joey
 - sharkfabri
+- quadrixm

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -77,7 +77,7 @@ project.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" group="api">
 <template #rest>
 
-`POST /register`
+`POST /users/register`
 
 ```json
 {
@@ -136,7 +136,7 @@ parameter.\
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" group="api">
 <template #rest>
 
-`POST /register`
+`POST /users/register`
 
 ```json
 {
@@ -180,7 +180,7 @@ URL) to allow the user to finish their registration.
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" group="api">
 <template #rest>
 
-`POST /register/verify-email`
+`POST /users/register/verify-email`
 
 ```json
 {
@@ -223,7 +223,7 @@ Verification token, as provided in the verification email sent by the registrati
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" group="api">
 <template #rest>
 
-`POST /register/verify-email`
+`POST /users/register/verify-email`
 
 ```json
 {


### PR DESCRIPTION
/register api doesn't work I need to prepend /users/ to it this

## Scope

What's changed:

- api end point for /regsiter is changed to /users/register and same with register verify=

## Potential Risks / Drawbacks

- Users will get confuse when trying to hit the /register api as this returns route not found error which will leads to a thinking that this doesn't work and documentation are not updated and lose trust in the authenticity of the documentaion

## Review Notes / Questions

- There should be dynamic updating of documentation or periodic check for the apis endpoints

---

Fixes #\<num\>
