### PR TITLE
Fix default query for table layout

### DIFF
--- a/.changeset/poor-ladybugs-help.md
+++ b/.changeset/poor-ladybugs-help.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed table layout default query, to not include presetational fields

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -11,7 +11,7 @@ import { syncRefProperty } from '@/utils/sync-ref-property';
 import { useCollection, useItems, useSync } from '@directus/composables';
 import { defineLayout } from '@directus/extensions';
 import { Field } from '@directus/types';
-import { debounce } from 'lodash';
+import { debounce, flatten } from 'lodash';
 import { computed, ref, toRefs, unref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import TabularActions from './actions.vue';
@@ -47,11 +47,9 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		const { aliasedFields, aliasQuery, aliasedKeys } = useAliasFields(fields, collection);
 
-		const fieldsWithRelationalAliased = computed(() => {
-			return Object.values(aliasedFields.value).reduce<string[]>((acc, value) => {
-				return [...acc, ...value.fields];
-			}, []);
-		});
+		const fieldsWithRelationalAliased = computed(() =>
+			flatten(Object.values(aliasedFields.value).map(({ fields }) => fields)),
+		);
 
 		const {
 			items,
@@ -166,7 +164,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const fieldsDefaultValue = computed(() => {
 				return fieldsInCollection.value
-					.filter((field: Field) => !field.meta?.hidden)
+					.filter((field: Field) => !field.meta?.hidden && !field.meta?.special?.includes('no-data'))
 					.slice(0, 4)
 					.map(({ field }: Field) => field)
 					.sort();

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -164,9 +164,9 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const fieldsDefaultValue = computed(() => {
 				return fieldsInCollection.value
-					.filter((field: Field) => !field.meta?.hidden && !field.meta?.special?.includes('no-data'))
+					.filter((field) => !field.meta?.hidden && !field.meta?.special?.includes('no-data'))
 					.slice(0, 4)
-					.map(({ field }: Field) => field)
+					.map(({ field }) => field)
 					.sort();
 			});
 

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -11,7 +11,7 @@ import SearchInput from '@/views/private/components/search-input.vue';
 import UsersInvite from '@/views/private/components/users-invite.vue';
 import { useLayout } from '@directus/composables';
 import { mergeFilters } from '@directus/utils';
-import { computed, ref } from 'vue';
+import { computed, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
@@ -23,9 +23,10 @@ type Item = {
 
 const props = defineProps<{ role?: string }>();
 
-const { t } = useI18n();
+const { role } = toRefs(props);
 
-const { roles } = useNavigation();
+const { t } = useI18n();
+const { roles } = useNavigation(role);
 const userInviteModalActive = ref(false);
 const serverStore = useServerStore();
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added additional check to only include fields that hold data in the table layout default query
- Unrelated fix to the call of `useNavigation` that sets the correct initial role in the user nav

## Potential Risks / Drawbacks


## Review Notes / Questions

- Does the `no-data` value in special capture all cases of presentational fields? Looking at the code it sure seems like it
- Do we want to include the unrelated change? Happy to open another PR for this.

---

Fixes #22839 
