### PR TITLE
Bump pnpm to 9.4.0 & relax engine check to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
 		"eslint-plugin-vue": "9.26.0",
 		"prettier": "3.1.0"
 	},
-	"packageManager": "pnpm@9.0.6",
+	"packageManager": "pnpm@9.4.0",
 	"engines": {
 		"node": ">=18.18.0",
-		"pnpm": "~9.0"
+		"pnpm": "9"
 	}
 }


### PR DESCRIPTION
## Scope

- Bump pnpm to current latest ([v9.4.0](https://github.com/pnpm/pnpm/releases/tag/v9.4.0))
- Relax the engine check and allow all versions within v9
  - The strict check was added as a result of breaking changes being introduced under minor releases several times in the past, which led to unwanted lockfile changes. This has not been the case in more recent releases and together with the fact that the risk of causing actual harm is rather low, we relax the check again for a more comfortable DX.

## Potential Risks / Drawbacks

As described above.

## Review Notes / Questions

N/A