### PR TITLE
Only set default filename disk if none is provided

### DIFF
--- a/.changeset/stale-falcons-clean.md
+++ b/.changeset/stale-falcons-clean.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that would ignore the filename_disk value if it was provided during file uploads

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -86,7 +86,7 @@ export class FilesService extends ItemsService {
 			path.extname(payload.filename_download!) || (payload.type && '.' + extension(payload.type)) || '';
 
 		// The filename_disk is the FINAL filename on disk
-		payload.filename_disk = primaryKey + (fileExtension || '');
+		payload.filename_disk ||= primaryKey + (fileExtension || '');
 
 		// Temp filename is used for replacements
 		const tempFilenameDisk = 'temp_' + payload.filename_disk;


### PR DESCRIPTION
## Scope

What's changed:

- Only default to primary key + ext if no filename_disk is provided during the upload

## Potential Risks / Drawbacks

- I didn't see any other places where we assume the `filename_disk` is the primary key + ext, but it's something to look out for in testing and reviews

## Review Notes / Questions

- Simple bug, simple fix? 🤞🏻 

---

Fixes #22846
