### PR TITLE
Fix tooltip arrow

### DIFF
--- a/.changeset/warm-months-enjoy.md
+++ b/.changeset/warm-months-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Improved tooltip arrow rendering for high resultion displays

--- a/app/src/styles/_tooltip.scss
+++ b/app/src/styles/_tooltip.scss
@@ -44,7 +44,7 @@
 	&::after {
 		position: absolute;
 		top: -5px;
-		left: calc(50% - 5px);
+		left: calc(50% - 6px);
 		width: 0;
 		height: 0;
 		border-right: 6px solid transparent;
@@ -65,7 +65,7 @@
 	&.top::after {
 		top: unset;
 		bottom: -5px;
-		left: calc(50% - 5px);
+		left: calc(50% - 6px);
 		border-top: 6px solid var(--tooltip-background-color);
 		border-right: 6px solid transparent;
 		border-bottom: unset;
@@ -82,7 +82,7 @@
 	}
 
 	&.left::after {
-		top: calc(50% - 5px);
+		top: calc(50% - 6px);
 		right: -5px;
 		left: unset;
 		border-top: 6px solid transparent;
@@ -101,7 +101,7 @@
 	}
 
 	&.right::after {
-		top: calc(50% - 5px);
+		top: calc(50% - 6px);
 		left: -5px;
 		border-top: 6px solid transparent;
 		border-right: 6px solid var(--tooltip-background-color);

--- a/app/src/styles/_tooltip.scss
+++ b/app/src/styles/_tooltip.scss
@@ -47,9 +47,9 @@
 		left: calc(50% - 5px);
 		width: 0;
 		height: 0;
-		border-right: 5px solid transparent;
-		border-bottom: 5px solid var(--tooltip-background-color);
-		border-left: 5px solid transparent;
+		border-right: 6px solid transparent;
+		border-bottom: 6px solid var(--tooltip-background-color);
+		border-left: 6px solid transparent;
 		content: '';
 	}
 
@@ -66,10 +66,10 @@
 		top: unset;
 		bottom: -5px;
 		left: calc(50% - 5px);
-		border-top: 5px solid var(--tooltip-background-color);
-		border-right: 5px solid transparent;
+		border-top: 6px solid var(--tooltip-background-color);
+		border-right: 6px solid transparent;
 		border-bottom: unset;
-		border-left: 5px solid transparent;
+		border-left: 6px solid transparent;
 	}
 
 	&.top.start::after {
@@ -85,10 +85,10 @@
 		top: calc(50% - 5px);
 		right: -5px;
 		left: unset;
-		border-top: 5px solid transparent;
+		border-top: 6px solid transparent;
 		border-right: unset;
-		border-bottom: 5px solid transparent;
-		border-left: 5px solid var(--tooltip-background-color);
+		border-bottom: 6px solid transparent;
+		border-left: 6px solid var(--tooltip-background-color);
 	}
 
 	&.left.start::after {
@@ -103,9 +103,9 @@
 	&.right::after {
 		top: calc(50% - 5px);
 		left: -5px;
-		border-top: 5px solid transparent;
-		border-right: 5px solid var(--tooltip-background-color);
-		border-bottom: 5px solid transparent;
+		border-top: 6px solid transparent;
+		border-right: 6px solid var(--tooltip-background-color);
+		border-bottom: 6px solid transparent;
 		border-left: unset;
 	}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

On high resolution displays or high zoom levels there is something going on with rounding of pixel borders which leads to a visible border between tooltip body and arrow.

<img width="413" alt="Screenshot 2024-06-27 at 08 38 52" src="https://github.com/directus/directus/assets/4376726/1aaf5bb0-29ed-49e9-8cbf-0f195b0324db">

Instead of having the arrow stop at the tooltip body exactly I extended the arrow into the body of the tooltip:


<img width="413" alt="Screenshot 2024-06-27 at 08 41 26" src="https://github.com/directus/directus/assets/4376726/8276d08f-0038-4f7a-bdd7-40d51925f8cb">

The result looks like this:

<img width="413" alt="Screenshot 2024-06-27 at 08 38 30" src="https://github.com/directus/directus/assets/4376726/8d55022a-f01c-4cbe-967f-442381f1b9f0">


## Potential Risks / Drawbacks

- People who have a custom style with a border around their tooltip might see the arrow overlap with it now, but it wasn't much better before 🤷 

## Review Notes / Questions


---

Fixes a personal thing.
