### PR TITLE
Account for share when updating stateful sessions

### DIFF
--- a/.changeset/shaggy-bees-search.md
+++ b/.changeset/shaggy-bees-search.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added missing share ID when refreshing/updating share sessions

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -417,7 +417,10 @@ export class AuthenticationService {
 		// Clear expired sessions for the current user
 		await this.knex('directus_sessions')
 			.delete()
-			.where('user', '=', record.user_id)
+			.where({
+				user: record.user_id,
+				share: record.share_id,
+			})
 			.andWhere('expires', '<', new Date());
 
 		return {
@@ -476,6 +479,7 @@ export class AuthenticationService {
 		await this.knex('directus_sessions').insert({
 			token: newSessionToken,
 			user: sessionRecord['user_id'],
+			share: sessionRecord['share_id'],
 			expires: sessionExpiration,
 			ip: this.accountability?.ip,
 			user_agent: this.accountability?.userAgent,


### PR DESCRIPTION
## Scope

- Adding the share ID when refreshing a share session - previously, would have been missing in the new session entry
- Similarly, the expired check is now checking for share sessions as well

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Fix from #22865 is required as well for review

---

Fixes #22693 (together with #22865)
