### PR TITLE
Fix multi relational sort in query generation

### DIFF
--- a/.changeset/three-teachers-destroy.md
+++ b/.changeset/three-teachers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fix query error on some DB vendors when using multi relation sort

--- a/api/src/database/run-ast/lib/get-db-query.ts
+++ b/api/src/database/run-ast/lib/get-db-query.ts
@@ -206,7 +206,15 @@ export function getDBQuery(
 		// based on the case/when of that field.
 		dbQuery.select(o2mNodes.map(innerPreprocess).filter((x) => x !== null));
 
-		dbQuery.groupByRaw(`${table}.${primaryKey}`);
+		const groupByFields = [knex.raw('??.??', [table, primaryKey])];
+
+		if (hasMultiRelationalSort) {
+			// Sort fields that are not directly in the table the primary key is from need to be included in the group
+			// by clause, otherwise this causes problems on some DBs
+			groupByFields.push(...innerQuerySortRecords.map(({ alias }) => knex.raw('??', alias)));
+		}
+
+		dbQuery.groupBy(groupByFields);
 	}
 
 	const wrapperQuery = knex


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

While working / testing on #22787 I noticed that all sort fields of a relational sort need to included in the `group by` clause, as they might not be ["functionally dependent on the grouped columns"](https://arc.net/l/quote/olazkmze) which can cause problems in some DB vendors (at least Postgres).

What's changed:

- If the sort is multi relational, ie. it might include o2m related fields, include the sort aliases in the group by clause.

## Potential Risks / Drawbacks

- This messes up the group/by, I could not think of a way how that might happen

## Review Notes / Questions

- Tested on Postgres so far, will test on other vendors as well, don't think it is too special tho.

---

Do we want an issue for that?
