### PR TITLE
Set `uploaded_on` through Directus flag

### DIFF
--- a/.changeset/neat-grapes-kick.md
+++ b/.changeset/neat-grapes-kick.md
@@ -2,4 +2,4 @@
 '@directus/system-data': patch
 ---
 
-Fixed an issue that caused the uploaded_on time to beset in a different format than modified_on in SQlite
+Fixed an issue that caused the uploaded_on time to be set in a different format than modified_on in SQlite

--- a/.changeset/neat-grapes-kick.md
+++ b/.changeset/neat-grapes-kick.md
@@ -2,4 +2,4 @@
 '@directus/system-data': patch
 ---
 
-Fixed an issue that caused the uploaded_on time to be set in a different format than modified_on in SQlite
+Fixed an issue that caused the `uploaded_on` time to be set in a different format than `modified_on` in SQLite

--- a/.changeset/neat-grapes-kick.md
+++ b/.changeset/neat-grapes-kick.md
@@ -1,0 +1,5 @@
+---
+'@directus/system-data': patch
+---
+
+Fixed an issue that caused the uploaded_on time to beset in a different format than modified_on in SQlite

--- a/packages/system-data/src/fields/files.yaml
+++ b/packages/system-data/src/fields/files.yaml
@@ -108,7 +108,7 @@ fields:
     display: user
     readonly: true
     options:
-      template: "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+      template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}'
 
   - field: modified_on
     interface: datetime
@@ -143,7 +143,7 @@ fields:
       - m2o
     display: related-values
     display_options:
-      template: "{{ name }}"
+      template: '{{ name }}'
 
   - field: width
     width: half

--- a/packages/system-data/src/fields/files.yaml
+++ b/packages/system-data/src/fields/files.yaml
@@ -108,7 +108,7 @@ fields:
     display: user
     readonly: true
     options:
-      template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}'
+      template: "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
 
   - field: modified_on
     interface: datetime
@@ -133,6 +133,8 @@ fields:
     display: datetime
     width: half
     hidden: true
+    special:
+      - date-created
 
   - field: folder
     width: half
@@ -141,7 +143,7 @@ fields:
       - m2o
     display: related-values
     display_options:
-      template: '{{ name }}'
+      template: "{{ name }}"
 
   - field: width
     width: half


### PR DESCRIPTION
## Scope

What's changed:

- Use the Directus special flag to set the create date rather than the database default value
- This fixes a difference in SQLite between the value for modified_on versus created_on

## Potential Risks / Drawbacks

- It no longer relies on the database default value, so could cause differences in other databases. That being said, this uses the same system as the system recommended 'created_on' field which has no known issues

## Review Notes / Questions

n/a

---

Fixes #22884
