### PR TITLE
Prioritize access_token in searchparam over access_token in the cookies when using "strict" mode for websocket authentication

### DIFF
--- a/.changeset/moody-bees-pay.md
+++ b/.changeset/moody-bees-pay.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Prioritized access_token in query over cookies when using "strict" mode for websocket authentication
+Prioritized access_token in query over cookies for websocket authentication

--- a/.changeset/moody-bees-pay.md
+++ b/.changeset/moody-bees-pay.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Prioritized access_token in query over cookies when using "strict" mode for websocket authentication

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -137,7 +137,7 @@ export default abstract class SocketController {
 		const context: UpgradeContext = { request, socket, head };
 		const sessionCookieName = env['SESSION_COOKIE_NAME'] as string;
 
-		if (this.authentication.mode === 'strict') {
+		if (this.authentication.mode === 'strict' || 'access_token' in query) {
 			const token = query['access_token'] as string;
 			await this.handleTokenUpgrade(context, token);
 			return;

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -137,12 +137,6 @@ export default abstract class SocketController {
 		const context: UpgradeContext = { request, socket, head };
 		const sessionCookieName = env['SESSION_COOKIE_NAME'] as string;
 
-		if (cookies[sessionCookieName]) {
-			const token = cookies[sessionCookieName] as string;
-			await this.handleTokenUpgrade(context, token);
-			return;
-		}
-
 		if (this.authentication.mode === 'strict') {
 			const token = query['access_token'] as string;
 			await this.handleTokenUpgrade(context, token);
@@ -151,6 +145,12 @@ export default abstract class SocketController {
 
 		if (this.authentication.mode === 'handshake') {
 			await this.handleHandshakeUpgrade(context);
+			return;
+		}
+
+		if (cookies[sessionCookieName]) {
+			const token = cookies[sessionCookieName] as string;
+			await this.handleTokenUpgrade(context, token);
 			return;
 		}
 

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -143,14 +143,14 @@ export default abstract class SocketController {
 			return;
 		}
 
-		if (this.authentication.mode === 'handshake') {
-			await this.handleHandshakeUpgrade(context);
-			return;
-		}
-
 		if (cookies[sessionCookieName]) {
 			const token = cookies[sessionCookieName] as string;
 			await this.handleTokenUpgrade(context, token);
+			return;
+		}
+
+		if (this.authentication.mode === 'handshake') {
+			await this.handleHandshakeUpgrade(context);
 			return;
 		}
 

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -137,7 +137,7 @@ export default abstract class SocketController {
 		const context: UpgradeContext = { request, socket, head };
 		const sessionCookieName = env['SESSION_COOKIE_NAME'] as string;
 
-		if (this.authentication.mode === 'strict' || 'access_token' in query) {
+		if (this.authentication.mode === 'strict' || query['access_token']) {
 			const token = query['access_token'] as string;
 			await this.handleTokenUpgrade(context, token);
 			return;


### PR DESCRIPTION
fixes #22874