### PR TITLE
App: Support relative links on images on WYSIWYG

### DIFF
--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -141,7 +141,7 @@ export default function useImage(
 		if (img === null) return;
 
 		const queries: Record<string, any> = {};
-		const newURL = new URL(img.imageUrl);
+		const newURL = new URL(img.imageUrl, 'file://');
 
 		newURL.searchParams.delete('width');
 		newURL.searchParams.delete('height');
@@ -160,7 +160,7 @@ export default function useImage(
 			}
 		}
 
-		const resizedImageUrl = addQueryToPath(newURL.toString(), queries);
+		const resizedImageUrl = addQueryToPath(newURL.toString().replace('file://', ''), queries);
 		const imageHtml = `<img src="${resizedImageUrl}" alt="${img.alt}" ${img.lazy ? 'loading="lazy" ' : ''}/>`;
 		editor.value.selection.setContent(imageHtml);
 		editor.value.undoManager.add();


### PR DESCRIPTION
## Scope
We have a WYSIWYG interface configured across our environments.
We usually migrate data from one environment to another one but we face an issue which are the absolute URLs in WYSIWYG interface for Images.
While Media tool accepts relative links ([because of try/catch block](https://github.com/directus/directus/blob/main/app/src/interfaces/input-rich-text-html/useMedia.ts#L207-L222)), Image tool do not (because there's no [guard against relative links](https://github.com/directus/directus/blob/main/app/src/interfaces/input-rich-text-html/useImage.ts#L144))

In this PR, we add support for relative links on Image tool and also handle query string if exists.

What's changed:

- Support for relative links on Image tool on WYSIWYG interface

## Potential Risks / Drawbacks

- None 🤔

## Review Notes / Questions

- This was done using `file://` protocol so relative links can be handled properly. Although, if an absolute link is passed, the `file://` protocol is ignored.

## Result
|Before|After|
|-|-|
|<video src="https://github.com/directus/directus/assets/14039341/a2cb5838-08e8-4607-a0db-1d2f232fb4ad"></video>|<video src="https://github.com/directus/directus/assets/14039341/277aa581-12de-4091-b4e9-c74cfaf91119"></video>|