### PR TITLE
Allow for cookie authentication in websocket strict mode

### DIFF
--- a/.changeset/seven-suits-live.md
+++ b/.changeset/seven-suits-live.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed cookie authentication in websocket strict mode

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -140,9 +140,9 @@ export default abstract class SocketController {
 		if (this.authentication.mode === 'strict' || query['access_token'] || cookies[sessionCookieName]) {
 			let token: string | null = null;
 
-			if (typeof query['access_token'] === "string") {
+			if (typeof query['access_token'] === 'string') {
 				token = query['access_token'];
-			} else if (typeof cookies[sessionCookieName] === "string") {
+			} else if (typeof cookies[sessionCookieName] === 'string') {
 				token = cookies[sessionCookieName] ?? null;
 			}
 

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -137,14 +137,8 @@ export default abstract class SocketController {
 		const context: UpgradeContext = { request, socket, head };
 		const sessionCookieName = env['SESSION_COOKIE_NAME'] as string;
 
-		if (this.authentication.mode === 'strict' || query['access_token']) {
-			const token = query['access_token'] as string;
-			await this.handleTokenUpgrade(context, token);
-			return;
-		}
-
-		if (cookies[sessionCookieName]) {
-			const token = cookies[sessionCookieName] as string;
+		if (this.authentication.mode === 'strict' || query['access_token'] || cookies[sessionCookieName]) {
+			const token = (query['access_token'] ?? cookies[sessionCookieName]) as string;
 			await this.handleTokenUpgrade(context, token);
 			return;
 		}

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -138,7 +138,14 @@ export default abstract class SocketController {
 		const sessionCookieName = env['SESSION_COOKIE_NAME'] as string;
 
 		if (this.authentication.mode === 'strict' || query['access_token'] || cookies[sessionCookieName]) {
-			const token = (query['access_token'] ?? cookies[sessionCookieName]) as string;
+			let token: string | null = null;
+
+			if (typeof query['access_token'] === "string") {
+				token = query['access_token'];
+			} else if (typeof cookies[sessionCookieName] === "string") {
+				token = cookies[sessionCookieName] ?? null;
+			}
+
 			await this.handleTokenUpgrade(context, token);
 			return;
 		}
@@ -155,18 +162,21 @@ export default abstract class SocketController {
 		});
 	}
 
-	protected async handleTokenUpgrade({ request, socket, head }: UpgradeContext, token: string) {
-		let accountability: Accountability | null, expires_at: number | null;
+	protected async handleTokenUpgrade({ request, socket, head }: UpgradeContext, token: string | null) {
+		let accountability: Accountability | null = null;
+		let expires_at: number | null = null;
 
-		try {
-			accountability = await getAccountabilityForToken(token);
-			expires_at = getExpiresAtForToken(token);
-		} catch {
-			accountability = null;
-			expires_at = null;
+		if (token) {
+			try {
+				accountability = await getAccountabilityForToken(token);
+				expires_at = getExpiresAtForToken(token);
+			} catch {
+				accountability = null;
+				expires_at = null;
+			}
 		}
 
-		if (!accountability || !accountability.user) {
+		if (!token || !accountability || !accountability.user) {
 			logger.debug('WebSocket upgrade denied - ' + JSON.stringify(accountability || 'invalid'));
 			socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
 			socket.destroy();


### PR DESCRIPTION
In the changes done in #22888 i realized that cookies are no longer being considered for `strict` authentication while they should be.

## Scope

What's changed:

- Check for existing cookies in `strict` mode if no query token is present.

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet

## Review Notes / Questions

- I would like to lorem ipsum

Refs #22874 
