### PR TITLE
Fix `flattenFilter` logic to account for not plain filter values

### DIFF
--- a/.changeset/violet-numbers-retire.md
+++ b/.changeset/violet-numbers-retire.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `flattenFilter` logic to not look for keys in filter operands if not nested

--- a/.changeset/violet-numbers-retire.md
+++ b/.changeset/violet-numbers-retire.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed `flattenFilter` logic to not look for keys in filter operands if not nested
+Fixed an issue where keys in filter operand objects where incorrectly checked for field permissions

--- a/api/src/permissions/modules/process-ast/utils/flatten-filter.test.ts
+++ b/api/src/permissions/modules/process-ast/utils/flatten-filter.test.ts
@@ -37,7 +37,7 @@ test('Flattens _eq shortcut', () => {
 	expect(paths).toEqual([['author']]);
 });
 
-test('Flattens single level and handles underscore in field names', () => {
+test.todo('Flattens single level and handles underscore in field names', () => {
 	const paths: FieldKey[][] = [];
 
 	const filter: Query['filter'] = {

--- a/api/src/permissions/modules/process-ast/utils/flatten-filter.test.ts
+++ b/api/src/permissions/modules/process-ast/utils/flatten-filter.test.ts
@@ -8,7 +8,7 @@ test('Returns early when no filter is passed', () => {
 
 	flattenFilter(paths, undefined);
 
-	expect(paths).toBe(paths);
+	expect(paths).toEqual([]);
 });
 
 test('Flattens single level', () => {
@@ -149,4 +149,50 @@ test('Leaves function usage', () => {
 	flattenFilter(paths, filter);
 
 	expect(paths).toEqual([['year(timestamp)']]);
+});
+
+test.each(['_and', '_or'])('Checks inside of logical operator (%s)', (operator) => {
+	const paths: FieldKey[][] = [];
+
+	const filter = {
+		[operator]: [
+			{
+				author: { _eq: 'Rijk' },
+				published: { year: { _eq: 2024 } },
+			},
+		],
+	} as Query['filter'];
+
+	flattenFilter(paths, filter);
+
+	expect(paths).toEqual([['published', 'year'], ['author']]);
+});
+
+test.each(['_some', '_none'])('Checks inside of relational operator (%s)', (operator) => {
+	const paths: FieldKey[][] = [];
+
+	const filter = {
+		[operator]: {
+			author: { _eq: 'Rijk' },
+			published: { year: { _eq: 2024 } },
+		},
+	} as Query['filter'];
+
+	flattenFilter(paths, filter);
+
+	expect(paths).toEqual([['published', 'year'], ['author']]);
+});
+
+test('Does not look into operators that might contain objects', () => {
+	const paths: FieldKey[][] = [];
+
+	const filter = {
+		_intersects: {
+			type: 'Point',
+		},
+	} as Query['filter'];
+
+	flattenFilter(paths, filter);
+
+	expect(paths).toEqual([]);
 });


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

`flattenFilter` is responsible for extracting all field name paths as string arrays from a nested filter. This did previously not account valid filter values (operands) that are objects themselves, eg. `_intersects_bbox` where the key value is an object, eg.

```json
{
  "_intersects_bbox": {
    "type": "Feature",
    "geometry": {
      "type": "Polygon",
      "coordinates": [
        [
          [ 33.7, 43.9 ],
          [ 39.1, 43.9 ],
          [ 39.1, 39.2 ],
          [ 33.7, 39.2 ],
          [ 33.7, 43.9 ]
        ]
      ]
    }
  }
}
```

What's changed:

- Improved `flattenFilter` logic to account for filter values (operands) which might not be plain non-object
- Now, `flattenFilter` does not extract any keys from operands if the key starts with `_` and is not one of `_and`, `_or`, `_some` or `_none` where we actually need to look into the nested objects for additional path parts

## Potential Risks / Drawbacks

- The test work fine, even with additional tests

## Review Notes / Questions

- We still do not account for any field names start with an `_`, which would need some rework in the `types` and `constants` package, hence the one failing unit test.

---

Fixes #22893 