### PR TITLE
Fix `reduceSchema` to strip out collections without access

### DIFF
--- a/.changeset/eighty-toys-clap.md
+++ b/.changeset/eighty-toys-clap.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `reduceSchema` to strip out collection the user does not have access to

--- a/api/src/utils/reduce-schema.ts
+++ b/api/src/utils/reduce-schema.ts
@@ -12,6 +12,11 @@ export function reduceSchema(schema: SchemaOverview, fieldMap: FieldMap): Schema
 	};
 
 	for (const [collectionName, collection] of Object.entries(schema.collections)) {
+		if (!fieldMap[collectionName]) {
+			// Collection is not allowed at all
+			continue;
+		}
+
 		const fields: SchemaOverview['collections'][string]['fields'] = {};
 
 		for (const [fieldName, field] of Object.entries(schema.collections[collectionName]!.fields)) {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When implementing permissions the check for collection permissions was removed in reduce schema (Previously at https://github.com/directus/directus/blob/c38d7d489742d1019547bb551d807d3e2bb3f1a2/api/src/utils/reduce-schema.ts#L40-L46)

![Screenshot 2024-07-03 at 19 27 50](https://github.com/directus/directus/assets/4376726/11aab753-b539-43ef-a894-bcbc900f4814)

And not replaced by something equivalent. As such the reduced schema still included all collections, without any fields, leading to problems in the GraphQL resolver generation down the line.

What's changed:
- Strip out collections the user does not have access to from the reduced schema (as indicated by their absence from the `fieldMap`

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- When giving no permissions to a public user the GraphQL response is now aligned with what it looks like in v10, instead of crashing during schema generation

---

Fixes #22897 
