### PR TITLE
Only add `tus_id` filter if `TUS_ENABLED` is `true`

### DIFF
--- a/.changeset/eight-clocks-attack.md
+++ b/.changeset/eight-clocks-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed reliance on `tus_id` field when reading files, even if TUS is not enabled


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Since partial file upload are filtered out on a service level they are matched by checking for their `tus_id`, however for users with partial permissions on the `directus_files` collection this fails, even if `TUS_ENABLED` is `false` (which it is by default). 

What's changed:

- Don't add the `tus_id` filter if TUS is actually disabled.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- The same problem (users needed access to `tus_id`) will still be an issue if TUS is enabled, but then the admins should be better equipped to handle this

---
