### PR TITLE
Fix filter creation in `fetchPolicies` for users without roles

### DIFF
--- a/.changeset/pink-wolves-beg.md
+++ b/.changeset/pink-wolves-beg.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed filter creation in `fetchPolicies` for users without roles

--- a/api/src/permissions/lib/fetch-policies.test.ts
+++ b/api/src/permissions/lib/fetch-policies.test.ts
@@ -27,12 +27,18 @@ test('Fetches policies for public role and user when user is given without role'
 			_or: [
 				{ user: { _eq: 'user-a' } },
 				{
-					role: {
-						_null: true,
-					},
-					user: {
-						_null: true,
-					},
+					_and: [
+						{
+							role: {
+								_null: true,
+							},
+						},
+						{
+							user: {
+								_null: true,
+							},
+						},
+					],
 				},
 			],
 		},
@@ -50,12 +56,18 @@ test('Fetches policies for public role when no roles and user are given', async 
 
 	expect(AccessService.prototype.readByQuery).toHaveBeenCalledWith({
 		filter: {
-			role: {
-				_null: true,
-			},
-			user: {
-				_null: true,
-			},
+			_and: [
+				{
+					role: {
+						_null: true,
+					},
+				},
+				{
+					user: {
+						_null: true,
+					},
+				},
+			],
 		},
 		fields: ['policy.id', 'policy.ip_access'],
 		limit: -1,

--- a/api/src/permissions/lib/fetch-policies.ts
+++ b/api/src/permissions/lib/fetch-policies.ts
@@ -20,7 +20,7 @@ export async function _fetchPolicies(
 
 	if (roles.length === 0) {
 		// Users without role assumes the Public role permissions along with their attached policies
-		roleFilter = { role: { _null: true }, user: { _null: true } };
+		roleFilter = { _and: [{ role: { _null: true } }, { user: { _null: true } }] };
 	} else {
 		roleFilter = { role: { _in: roles } };
 	}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The `roleFilter` needs an explicit `_and` clause for the public role policies, otherwise the resulting query will look something like this 

```sql
select `directus_access`.`policy`, `directus_access`.`id` 
  from `directus_access` 
  where (`directus_access`.`user` = ? or `directus_access`.`role` is null or `directus_access`.`user` is null) 
  order by `directus_access`.`sort` asc
```

What's changed:

- Add `_and` wrapper to `roleFilter`

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #22935
