### PR TITLE
Remove trailing slash from vite base URL in development mode

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -47,7 +47,7 @@ export default defineConfig({
 	resolve: {
 		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
 	},
-	base: process.env.NODE_ENV === 'production' ? '' : '/admin/',
+	base: process.env.NODE_ENV === 'production' ? '' : '/admin',
 	...(!process.env.HISTOIRE && {
 		server: {
 			port: 8080,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Anyone ever noticed that, if you start a dev instance of the `app` and navigate to `localhost:8080` you get this page?

<img width="1262" alt="Screenshot 2024-07-08 at 14 48 56" src="https://github.com/directus/directus/assets/4376726/39c02a57-6062-4809-970b-7f30516ffe2f">

Well... no more!

https://github.com/directus/directus/assets/4376726/2940193b-d34d-4629-813b-7b5afae3a78d

What's changed:

- When running vite in non production mode use `/admin` instead of `/admin/` as URL base, since that is where the app is mounted, despite what the error message is claiming.

## Potential Risks / Drawbacks

- None, since this only takes effect in `NODE_ENV != 'production'`

## Review Notes / Questions

- I would like to lorem ipsum
- Changeset? Yes/No
