### PR TITLE
Add sticky table component

### DIFF
--- a/app/src/views/private/components/sticky-table.vue
+++ b/app/src/views/private/components/sticky-table.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { useElementBounding, useEventListener, useMutationObserver } from '@vueuse/core';
+import { computed, onMounted, ref, watch } from 'vue';
+
+withDefaults(
+	defineProps<{
+		stickyTop?: string;
+	}>(),
+	{
+		stickyTop: '0',
+	},
+);
+
+const tableContainer = ref<HTMLDivElement | null>(null);
+const table = ref<HTMLTableElement | null>(null);
+const headerContainer = ref<HTMLDivElement | null>(null);
+const header = ref<HTMLDivElement | null>(null);
+const headerOriginal = ref<HTMLTableSectionElement | null>(null);
+const lastRow = ref<HTMLTableRowElement | null>(null);
+
+onMounted(() => {
+	const updateElements = () => {
+		if (!table.value) return;
+
+		headerOriginal.value = table.value.querySelector(':scope > thead');
+		lastRow.value = table.value.querySelector(':scope > tbody > tr:last-child');
+	};
+
+	useMutationObserver(table, updateElements, {
+		childList: true,
+		subtree: true,
+	});
+
+	updateElements();
+});
+
+useEventListener(tableContainer, 'scroll', () =>
+	window.requestAnimationFrame(() => {
+		if (!header.value || !tableContainer.value) return;
+
+		header.value.scrollLeft = tableContainer.value.scrollLeft;
+	}),
+);
+
+const { height: tableHeight } = useElementBounding(table);
+const { top: lastRowTop } = useElementBounding(lastRow);
+const { height: headerHeight } = useElementBounding(headerOriginal);
+
+const headerContainerHeight = computed(() => {
+	if (!lastRow.value || !table.value) return;
+
+	const height = lastRowTop.value - table.value.getBoundingClientRect().top;
+
+	const outerBorder = getComputedStyle(lastRow.value).borderTopWidth;
+	const cell = lastRow.value.firstElementChild;
+	const innerBorder = cell ? getComputedStyle(cell).borderTopWidth : '0px';
+
+	return `calc(${height}px + ${outerBorder} + ${innerBorder})`;
+});
+
+watch(
+	[headerContainer, headerContainerHeight, tableHeight],
+	([headerContainer, headerContainerHeight, tableHeight]) => {
+		if (!headerContainer) return;
+
+		headerContainer.style.height = headerContainerHeight ?? `${tableHeight}px`;
+	},
+);
+
+watch([header, headerOriginal, headerHeight, table, tableHeight], ([header, headerOriginal, headerHeight, table]) => {
+	if (!header || !headerOriginal || !table) return;
+
+	const spacingTop = headerOriginal.getBoundingClientRect().top - table.getBoundingClientRect().top;
+
+	header.style.height = `${spacingTop + headerHeight}px`;
+});
+</script>
+
+<template>
+	<div class="main-container">
+		<div ref="tableContainer" class="table-container">
+			<table ref="table">
+				<slot />
+			</table>
+		</div>
+		<div ref="headerContainer" class="header-container">
+			<div ref="header" class="header">
+				<table>
+					<slot />
+				</table>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.main-container {
+	position: relative;
+
+	.table-container {
+		overflow: auto;
+		/*
+		 * disable scroll "bounce" effect
+		 * - to prevent overflow of fixed header
+		 * - for immediate scroll sync
+		 */
+		overscroll-behavior-x: none;
+
+		> table {
+			:slotted(> thead) {
+				visibility: hidden;
+			}
+		}
+	}
+
+	.header-container {
+		position: absolute;
+		top: 0;
+		width: 100%;
+		pointer-events: none;
+
+		.header {
+			position: sticky;
+			top: v-bind(stickyTop);
+			overflow: hidden;
+			pointer-events: auto;
+
+			> table {
+				border-color: transparent;
+
+				:slotted(> *:not(thead)) {
+					visibility: hidden;
+				}
+			}
+		}
+	}
+}
+</style>


### PR DESCRIPTION
We've decided to go with a non-sticky permissions table. This PR has been updated to only contain the sticky table component, so that we can easily make usage of it if there's a need for it - the PR is "archived" for now.

---

<details><summary><b>Original description</b></summary>

## Scope

On smaller screens, the permissions table didn't adhere to the maximum interface width, generating vertical page scroll:

https://github.com/directus/directus/assets/5363448/4bfb4437-738c-4116-adf6-db93d4125592

We couldn't address this issue on the quick, as the table header is sticky, which is something that doesn't work with a hidden overflow in pure CSS [^1].

Therefore, I came up with a trick, which is to clone the tables, rendering the body in one and the header in the other, whereby we can then make the entire header table sticky. This could also be helpful in other places later on.

https://github.com/directus/directus/assets/5363448/ee938278-d61f-4814-a9e7-2e65c2d86199

## Potential Risks / Drawbacks

- More logic necessary

## Review Notes / Questions

- The stickiness now stops before the last row in the table body, which makes more sense in my opinion, as the header content is not related to the footer and has no benefit when covering the last row. WDYT?

- PR contains some very small unrelated commits touching the same files
- Down arrow of button in footer moves along with the scroll - this will addressed separately in the button component itself

---

[^1] https://github.com/w3c/csswg-drafts/issues/865

</details>