### PR TITLE
Fix parsing of byte values in environment variables

### DIFF
--- a/.changeset/nice-bears-matter.md
+++ b/.changeset/nice-bears-matter.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed environment variable parsing to always convert to number of bytes

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -99,8 +99,8 @@ export const SUPPORTED_IMAGE_METADATA_FORMATS = [
 /** Resumable uploads */
 export const RESUMABLE_UPLOADS = {
 	ENABLED: toBoolean(env['TUS_ENABLED']),
-	CHUNK_SIZE: bytes(env['TUS_CHUNK_SIZE'] as string),
-	MAX_SIZE: bytes(env['FILES_MAX_UPLOAD_SIZE'] as string),
+	CHUNK_SIZE: bytes.parse(env['TUS_CHUNK_SIZE'] as string),
+	MAX_SIZE: bytes.parse(env['FILES_MAX_UPLOAD_SIZE'] as string),
 	EXPIRATION_TIME: getMilliseconds(env['TUS_UPLOAD_EXPIRATION'], 600_000 /* 10min */),
 	SCHEDULE: String(env['TUS_CLEANUP_SCHEDULE'] as string),
 };

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -41,7 +41,7 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 		headers,
 		defParamCharset: 'utf8',
 		limits: {
-			fileSize: env['FILES_MAX_UPLOAD_SIZE'] ? bytes(env['FILES_MAX_UPLOAD_SIZE'] as string) : undefined,
+			fileSize: env['FILES_MAX_UPLOAD_SIZE'] ? bytes.parse(env['FILES_MAX_UPLOAD_SIZE'] as string) : undefined,
 		},
 	});
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

We use the [bytes](https://www.npmjs.com/package/bytes) package to convert from `'1kb'` to `'1024'`. However, so far we've only used the default converter, which also does the reverse conversion if the variable is set to `'1024'` it returns `'1kb'`, which is unintended for our use-case.

What's changed:

- Switch over to `bytes.parse` which always does the conversion to the bytes representation, this ensures that both `10mb` and `10485760` are valid environment variable values that get converted to the number of bytes.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

