### PR TITLE
Fix creating a comment as an unauthenticated user

### DIFF
--- a/.changeset/lucky-planes-poke.md
+++ b/.changeset/lucky-planes-poke.md
@@ -1,5 +1,6 @@
 ---
-'@directus/api': patch
+'@directus/api': major
+'docs': patch
 ---
 
-Fixed creating a comment as a public user
+Restricted comment create, update and delete to authenticated user

--- a/.changeset/lucky-planes-poke.md
+++ b/.changeset/lucky-planes-poke.md
@@ -3,4 +3,4 @@
 'docs': patch
 ---
 
-Restricted comment create, update and delete to authenticated user
+Restricted comment create, update and delete to authenticated users

--- a/.changeset/lucky-planes-poke.md
+++ b/.changeset/lucky-planes-poke.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed creating a comment as a public user

--- a/api/src/utils/user-name.ts
+++ b/api/src/utils/user-name.ts
@@ -1,6 +1,6 @@
 import type { User } from '@directus/types';
 
-export function userName(user: Partial<User>): string {
+export function userName(user?: Partial<User>): string {
 	if (!user) {
 		return 'Unknown User';
 	}

--- a/api/src/utils/user-name.ts
+++ b/api/src/utils/user-name.ts
@@ -1,6 +1,6 @@
 import type { User } from '@directus/types';
 
-export function userName(user?: Partial<User>): string {
+export function userName(user: Partial<User>): string {
 	if (!user) {
 		return 'Unknown User';
 	}

--- a/docs/reference/system/activity.md
+++ b/docs/reference/system/activity.md
@@ -229,7 +229,7 @@ const result = await client.request(
 
 ## Create a Comment
 
-Creates a new comment on a given item.
+Creates a new comment on a given item. This endpoint is only available to authenticated users.
 
 ### Request
 
@@ -342,7 +342,7 @@ const result = await client.request(
 
 ## Update a Comment
 
-Updates an existing comment by activity action primary key.
+Updates an existing comment by activity action primary key. This endpoint is only available to authenticated users.
 
 ### Response
 
@@ -441,7 +441,7 @@ const result = await client.request(
 
 ## Delete a Comment
 
-Deletes a comment.
+Deletes a comment. This endpoint is only available to authenticated users.
 
 ### Request
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We no longer attempt to retrieve sender if no mentions are present in comment
- Activity comment `Create`, `Update` and `Delete` are now restricted to authenticated users only
 
## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- ~I was not sure if setting sender as null (for unknown user) in notification service would cause any issue but from what I could see it does not.~
- ~Should we be allowing this altogether? The use case for public users creating comments should be fairly small if not non-existent~

---

Fixes #22961
