### PR TITLE
Fix marketplace extension metadata spacing

### DIFF
--- a/.changeset/cool-spiders-invent.md
+++ b/.changeset/cool-spiders-invent.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that the metadata of the Marketplace extension page is well aligned with the content column

--- a/app/src/modules/settings/routes/marketplace/routes/extension/components/extension-metadata.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/extension/components/extension-metadata.vue
@@ -89,6 +89,10 @@ const maintainers = computed(() => {
 	container-name: metadata;
 }
 
+.metadata .list:first-child {
+	padding-top: 0;
+}
+
 .grid {
 	@container metadata (width > 580px) {
 		--v-list-item-margin: 0;


### PR DESCRIPTION
## Scope

What's changed:

- Removed padding in the metadata column

Before:
![issue](https://github.com/directus/directus/assets/78852214/4536519a-b8d3-4385-96a7-fd0ad46c9e43)


After:
![fix](https://github.com/directus/directus/assets/78852214/805568c8-e693-4501-adf7-268a7baaeece)


## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- I like things to be perfectly aligned ;)

---

Fixes #22979
