### PR TITLE
Fix permissions table interface for mobile

### DIFF
--- a/.changeset/lucky-humans-carry.md
+++ b/.changeset/lucky-humans-carry.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Ensured the permissions table under policies is displayed correctly on mobile devices

--- a/app/src/interfaces/_system/system-permissions/permissions-header.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-header.vue
@@ -15,12 +15,6 @@ const { t } = useI18n();
 
 <style lang="scss" scoped>
 .permissions-overview-header {
-	tr:last-child {
-		z-index: 4;
-		position: sticky;
-		top: calc(var(--header-bar-height) - 2px); // minus 1px to avoid gaps
-	}
-
 	th {
 		text-align: start;
 		padding: 12px;

--- a/app/src/interfaces/_system/system-permissions/permissions-row.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-row.vue
@@ -27,7 +27,7 @@ const { t } = useI18n();
 
 <template>
 	<tr class="permissions-row">
-		<td>
+		<td class="collection">
 			<span v-tooltip.left="collection.name" class="name">{{ collection.collection }}</span>
 			<span class="shortcuts">
 				<span class="all" @click="emit('setFullAccessAll')">{{ t('all') }}</span>
@@ -59,6 +59,10 @@ const { t } = useI18n();
 .permissions-row {
 	td:first-child {
 		width: 100%;
+	}
+
+	.collection {
+		white-space: nowrap;
 	}
 
 	.name {

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -8,10 +8,10 @@ import { Collection } from '@/types/collections';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PERMISSION_ACTIONS } from '@directus/constants';
 import { appAccessMinimalPermissions, isSystemCollection } from '@directus/system-data';
-import { Filter, Permission, PermissionsAction, type Alterations } from '@directus/types';
+import { type Alterations, Filter, Permission, PermissionsAction } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
 import { cloneDeep, get, groupBy, isNil, merge, orderBy, sortBy } from 'lodash';
-import { Ref, computed, inject, nextTick, ref, toRefs, watch } from 'vue';
+import { computed, inject, nextTick, Ref, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import AddCollectionRow from './add-collection-row.vue';
 import PermissionsDetail from './detail/permissions-detail.vue';
@@ -589,16 +589,16 @@ function useGroupedPermissions() {
 			{{ t('admins_have_all_permissions') }}
 		</v-notice>
 
-	<div v-else-if="!loading || allPermissions.length > 0" class="permissions-list">
-		<table>
-			<permissions-header />
+		<div v-else-if="!loading || allPermissions.length > 0" class="permissions-list">
+			<table ref="permissionsTable">
+				<permissions-header />
 
 				<tbody>
 					<tr v-if="allPermissions.length === 0">
-            <td class="empty-state" colspan="7">
-              {{ t('no_permissions') }}
-            </td>
-          </tr>
+						<td class="empty-state" colspan="7">
+							{{ t('no_permissions') }}
+						</td>
+					</tr>
 
 					<permissions-row
 						v-for="group in regularPermissions"
@@ -642,10 +642,10 @@ function useGroupedPermissions() {
 						@set-full-access="setFullAccess(group.collection.collection, $event)"
 						@set-no-access="setNoAccess(group.collection.collection, $event)"
 					/>
-			</tbody>
+				</tbody>
 
-			<tfoot>
-				<tr v-if="appAccess">
+				<tfoot>
+					<tr v-if="appAccess">
 						<td colspan="7" class="reset-toggle">
 							<span>
 								{{ t('reset_system_permissions_to') }}

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -574,18 +574,16 @@ function useGroupedPermissions() {
 		{{ t('admins_have_all_permissions') }}
 	</v-notice>
 
-	<div v-else class="permissions-list">
-		<table v-if="!loading || allPermissions.length > 0">
+	<div v-else-if="!loading || allPermissions.length > 0" class="permissions-list">
+		<table>
 			<permissions-header />
 
 			<tbody>
-				<template v-if="allPermissions.length === 0">
-					<tr>
-						<td class="empty-state" colspan="7">
-							{{ t('no_permissions') }}
-						</td>
-					</tr>
-				</template>
+				<tr v-if="allPermissions.length === 0">
+					<td class="empty-state" colspan="7">
+						{{ t('no_permissions') }}
+					</td>
+				</tr>
 
 				<permissions-row
 					v-for="group in regularPermissions"
@@ -600,9 +598,9 @@ function useGroupedPermissions() {
 					@set-no-access="setNoAccess(group.collection.collection, $event)"
 				/>
 
-				<tr>
+				<tr v-if="regularPermissions.length > 0 && systemPermissions.length > 0">
 					<td colspan="7" class="system-divider">
-						<v-divider v-if="regularPermissions.length > 0 && systemPermissions.length > 0">
+						<v-divider>
 							{{ t('system_collections') }}
 						</v-divider>
 					</td>
@@ -629,7 +627,9 @@ function useGroupedPermissions() {
 					@set-full-access="setFullAccess(group.collection.collection, $event)"
 					@set-no-access="setNoAccess(group.collection.collection, $event)"
 				/>
+			</tbody>
 
+			<tfoot>
 				<tr v-if="appAccess">
 					<td colspan="7" class="reset-toggle">
 						<span>
@@ -647,7 +647,7 @@ function useGroupedPermissions() {
 					"
 					@select="addEmptyPermission($event)"
 				/>
-			</tbody>
+			</tfoot>
 		</table>
 	</div>
 
@@ -678,9 +678,10 @@ function useGroupedPermissions() {
 
 <style scoped lang="scss">
 .permissions-list {
+	overflow: auto;
+
 	table {
 		width: 100%;
-		max-width: 792px;
 		border: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 		border-radius: var(--theme--border-radius);
 		border-spacing: 0;

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -11,7 +11,7 @@ import { appAccessMinimalPermissions, isSystemCollection } from '@directus/syste
 import { type Alterations, Filter, Permission, PermissionsAction } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
 import { cloneDeep, get, groupBy, isNil, merge, orderBy, sortBy } from 'lodash';
-import { computed, inject, nextTick, Ref, ref, toRefs, watch } from 'vue';
+import { computed, inject, nextTick, type Ref, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import AddCollectionRow from './add-collection-row.vue';
 import PermissionsDetail from './detail/permissions-detail.vue';


### PR DESCRIPTION
## Scope

Ensure the permissions table under policies is displayed correctly on mobile devices:
- Drop stickiness of header (as discussed in #22952)
- Make table scrollable
- Prevent wrapping of "All / None" buttons

https://github.com/directus/directus/assets/5363448/f582a40c-0274-49df-9a10-70b0a3bce43c

https://github.com/directus/directus/assets/5363448/7fef1849-154b-4f3c-9d1f-bb72287bae98

## Potential Risks / Drawbacks

- Header not sticky anymore, though acceptable as described in https://github.com/directus/directus/pull/22952#issuecomment-2222449006

## Review Notes / Questions

- Down arrow of button in footer moves along with the scroll - this will addressed separately in the button component itself