### PR TITLE
 Hide "Expand All/None" buttons under Data Model when there are no expandable collections

### DIFF
--- a/.changeset/seven-clocks-sit.md
+++ b/.changeset/seven-clocks-sit.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensured the "Expand All/None" buttons are only shown if there are collections
+Ensured the "Expand All/None" buttons under Data Model are only shown if there are expandable collections

--- a/.changeset/seven-clocks-sit.md
+++ b/.changeset/seven-clocks-sit.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensured the "Expand All/None" buttons under Data Model are only shown if there are expandable collections
+Ensured the "Expand All/None" buttons under Data Model are only shown if there are grouped collections

--- a/app/src/modules/settings/routes/data-model/collections/composables/use-expand-collapse.ts
+++ b/app/src/modules/settings/routes/data-model/collections/composables/use-expand-collapse.ts
@@ -1,0 +1,30 @@
+import { useCollectionsStore } from '@/stores/collections';
+import { useLocalStorage } from '@vueuse/core';
+import { computed } from 'vue';
+
+export function useExpandCollapse() {
+	const collectionsStore = useCollectionsStore();
+	const collapsedIds = useLocalStorage<string[]>('collapsed-collection-ids', []);
+
+	const hasExpandableCollections = computed(() => collectionsStore.allCollections.some(({ meta }) => meta?.group));
+
+	return { collapsedIds, hasExpandableCollections, expandAll, collapseAll, toggleCollapse };
+
+	function expandAll() {
+		collapsedIds.value = [];
+	}
+
+	function collapseAll() {
+		collapsedIds.value = collectionsStore.allCollections.map(({ collection }) => collection);
+	}
+
+	function toggleCollapse(collection: string) {
+		const isCollapsed = collapsedIds.value.includes(collection);
+
+		if (isCollapsed) {
+			collapsedIds.value = collapsedIds.value.filter((id) => id !== collection);
+		} else {
+			collapsedIds.value = [...collapsedIds.value, collection];
+		}
+	}
+}


### PR DESCRIPTION
## Scope

Follow-up on #22989 to ensure the buttons are only shown if there are some _expandable_ collections.
Also moved code into a composable.

Opted for an "expand" effect:

https://github.com/directus/directus/assets/5363448/fd8cbcec-7340-4820-b832-9739f38ea61b

Also tried with "fade" effect for less disruption but the occupying space feels like a bit too much:

https://github.com/directus/directus/assets/5363448/bf585547-4314-493c-ac93-ff938e5a16a9

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A

---

Addresses https://github.com/directus/directus/pull/22989#issuecomment-2223711064 
