### PR TITLE
Fix display of M2A field values in `render-template`

### DIFF
--- a/.changeset/neat-cooks-buy.md
+++ b/.changeset/neat-cooks-buy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the display of M2A fields in the related values display

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -40,8 +40,6 @@ const parts = computed(() =>
 
 			const value = get(props.item, fieldKeyBefore);
 
-			console.log(value, fieldKeyBefore);
-
 			return Array.isArray(value) ? handleArray(fieldKeyBefore, fieldKeyAfter) : handleObject(fieldKey);
 		})
 		.map((p) => p ?? null),
@@ -90,6 +88,16 @@ function handleObject(fieldKey: string) {
 
 	if (props.collection) {
 		field = fieldsStore.getField(props.collection, fieldKey);
+	}
+
+	const keyPrefix = fieldKey.split('.')[0]!;
+
+	// Check if the first part of the key is a M2A key
+	if (keyPrefix.includes(':')) {
+		// Strip out the :collection part from the field key, so that it can be used to access
+		// the correct field value in the item object
+		const fieldName = keyPrefix.split(':')[0];
+		fieldKey = `${fieldName}.${fieldKey.split('.').slice(1).join('.')}`;
 	}
 
 	/**

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -38,8 +38,9 @@ const parts = computed(() =>
 			const fieldKeyBefore = fieldKey.split('.').slice(0, -1).join('.');
 			const fieldKeyAfter = fieldKey.split('.').slice(-1)[0];
 
-			// Try getting the value from the item, return some question marks if it doesn't exist
 			const value = get(props.item, fieldKeyBefore);
+
+			console.log(value, fieldKeyBefore);
 
 			return Array.isArray(value) ? handleArray(fieldKeyBefore, fieldKeyAfter) : handleObject(fieldKey);
 		})
@@ -119,14 +120,14 @@ function handleObject(fieldKey: string) {
 
 	const displayInfo = useExtension(
 		'display',
-		computed(() => field?.meta?.display ?? null),
+		computed(() => display),
 	);
 
 	// If used display doesn't exist in the current project, return raw value
 	if (!displayInfo.value) return value;
 
 	return {
-		component: field.meta?.display,
+		component: display,
 		options: field.meta?.display_options,
 		value: value,
 		interface: field.meta?.interface,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When trying to display M2A related fields in the `related-values` display, the `render-template` component is used which does not account for the field keys containing a `item:<collection>` part. The `render-template` receives, for example a value of 

```json
{
  "collection":"page_link",
  "id":1,
  "item": {
    "name":"Page Link",
    "page_id": {
      "title":"New Page"
     }
  }
}
```

and then, when trying to render the template `{{collection}}: {{item:page_link.name}}{{item:external_link.name}}({{item:page_link.page_id.title}})` it tried to access the value with the key `item:page_link.name` which does not exist.

What's changed:

- Strip out the collection identifier after the `:` if it is in the first field name of the field key. This allows for at least top level M2A fields to be rendered in the template. This currently does not extend support to work for M2A fields nested under a M2O.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #10601 
