### PR TITLE
Add optional subject parameter to password reset request

### DIFF
--- a/.changeset/warm-dots-press.md
+++ b/.changeset/warm-dots-press.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Add optional subject parameter to password reset request

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -217,7 +217,7 @@ router.post(
 		const service = new UsersService({ accountability, schema: req.schema });
 
 		try {
-			await service.requestPasswordReset(req.body.email, req.body.reset_url || null);
+			await service.requestPasswordReset(req.body.email, req.body.reset_url || null, req.body.subject || null);
 			return next();
 		} catch (err: any) {
 			if (isDirectusError(err, ErrorCode.InvalidPayload)) {

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -2415,6 +2415,7 @@ export class GraphQLService {
 				args: {
 					email: new GraphQLNonNull(GraphQLString),
 					reset_url: GraphQLString,
+					subject: GraphQLString,
 				},
 				resolve: async (_, args, { req }) => {
 					const accountability: Accountability = { role: null };
@@ -2429,7 +2430,7 @@ export class GraphQLService {
 					const service = new UsersService({ accountability, schema: this.schema });
 
 					try {
-						await service.requestPasswordReset(args['email'], args['reset_url'] || null);
+						await service.requestPasswordReset(args['email'], args['reset_url'] || null, args['subject'] || null);
 					} catch (err: any) {
 						if (isDirectusError(err, ErrorCode.InvalidPayload)) {
 							throw err;

--- a/contributors.yml
+++ b/contributors.yml
@@ -141,3 +141,4 @@
 - Dominic-Preap
 - brandondrew
 - alantiller
+- samuelfranzini

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -666,6 +666,9 @@ Provide a custom reset url which the link in the email will lead to. The reset t
 **Note**: You need to configure the
 [`PASSWORD_RESET_URL_ALLOW_LIST` environment variable](/self-hosted/config-options#security) to enable this feature.
 
+`subject`\
+Provide a custom subject for the email title.
+
 ### Example
 
 <SnippetToggler :choices="['REST', 'GraphQL', 'SDK']" group="api">


### PR DESCRIPTION
## Scope

The `requestPasswordReset` function in the `users` service accepts `subject` as an optional field, only this parameter is not passed in the `/auth/password/request` API route parameters. 

I have no idea why, but I'd like to propose a pull request to implement this oversight.

I've just added the parameter in the API + GraphQL service as a third argument, with the option of leaving it empty by default.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #23011
