### PR TITLE
Fix `aggregate[count]=*` permission checking

### DIFF
--- a/.changeset/proud-cameras-travel.md
+++ b/.changeset/proud-cameras-travel.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed aggregation field existence and permission checks

--- a/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.test.ts
+++ b/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.test.ts
@@ -82,3 +82,13 @@ test('Returns only unique filter paths', () => {
 
 	expect(extractPathsFromQuery(query).readOnlyPaths).toEqual([['author']]);
 });
+
+test('Does not include wildcard field from aggregate', () => {
+	const query: Query = {
+		aggregate: {
+			count: ['*'],
+		},
+	};
+
+	expect(extractPathsFromQuery(query).paths).toEqual([]);
+});

--- a/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
+++ b/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
@@ -36,6 +36,11 @@ export function extractPathsFromQuery(query: Query) {
 	if (query.aggregate) {
 		for (const fields of Object.values(query.aggregate)) {
 			for (const field of fields) {
+				if (field === '*') {
+					// Don't add wildcard field to the paths
+					continue;
+				}
+
 				// Aggregate doesn't currently support aggregating on nested fields, but it doesn't hurt
 				// to standardize it in the validation layer
 				paths.push(field.split('.'));


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When requesting the a count of all items where we don't care about any specific field the `aggregate[count]=*` query is used. Previously the `*` value for the column/field was ignored when doing permission checks

https://github.com/directus/directus/blob/3fc2bb7883327f5f0a41b08e44aab38df9a6df87/api/src/services/authorization.ts#L132-L141

Since the field map is the entry point for permission/existence checking in auditus I opted to exclude the wildcard from the paths that `extractPathsFromQuery` returns, which is only used to generate the field map.

What's changed:

- Ignore field `*` in aggregate queries

## Potential Risks / Drawbacks

- ?

## Review Notes / Questions

- ?

---

Fixes #23021 
