### PR TITLE
Api: Emit filter for `email.send`

### DIFF
--- a/.changeset/stale-chicken-perform.md
+++ b/.changeset/stale-chicken-perform.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": minor
+"@directus/app": patch
+---
+
+Introduced the `email.send` filter event, allowing to modify email options via Flows or Custom Extensions

--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -53,14 +53,14 @@ export class MailService {
 		}
 	}
 
-	async send<T>(options: EmailOptions): Promise<T> {
+	async send<T>(options: EmailOptions): Promise<T | null> {
 		const payload = await emitter.emitFilter(`email.send`, options, {
 			database: getDatabase(),
 			schema: null,
 			accountability: null,
 		});
 
-		if (!payload) return null as T;
+		if (!payload) return null;
 
 		const { template, ...emailOptions } = payload;
 

--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -12,6 +12,7 @@ import { useLogger } from '../../logger/index.js';
 import getMailer from '../../mailer.js';
 import type { AbstractServiceOptions } from '../../types/index.js';
 import { Url } from '../../utils/url.js';
+import emitter from '../../emitter.js';
 
 const env = useEnv();
 const logger = useLogger();
@@ -53,7 +54,16 @@ export class MailService {
 	}
 
 	async send<T>(options: EmailOptions): Promise<T> {
-		const { template, ...emailOptions } = options;
+		const payload = await emitter.emitFilter(`email.send`, options, {
+			database: getDatabase(),
+			schema: null,
+			accountability: null,
+		});
+
+		if (!payload) return null as T;
+
+		const { template, ...emailOptions } = payload;
+
 		let { html } = options;
 
 		const defaultTemplateData = await this.getDefaultTemplateData();

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -134,6 +134,7 @@ export function getTriggers() {
 									'auth.create',
 									'auth.update',
 									'authenticate',
+									'email.send',
 								],
 								font: 'monospace',
 							},

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -205,6 +205,7 @@ export default ({ embed }, { env }) => {
 | `auth.create`<sup>[1]</sup>    | The created user                     | `identifier`, `provider`, `providerPayload` |
 | `auth.update`<sup>[2]</sup>    | The updated auth token<sup>[3]</sup> | `identifier`, `provider`, `providerPayload` |
 | `authenticate`                 | The empty accountability object      | `req`                                       |
+| `email.send`                   | The email payload                    | --                                          |
 | `(<collection>.)items.query`   | The items query                      | `collection`                                |
 | `(<collection>.)items.read`    | The read item                        | `query`, `collection`                       |
 | `(<collection>.)items.create`  | The new item                         | `collection`                                |


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope
This PR introduces the filter event for `email.send`.
At the moment we have the `EMAIL_TEMPLATES_PATH` which allows to do some styling and a bit more on emails.
Although, if we want more complex customization like translations or change subject, that's currently not possible.

With the introduction of this `email.send` `filter`, it is possible to customize the content based on other data or change email subject or even using with other operations within Flows.

What's changed:

- Add `emitFilter("email.send")` which allows to change the email payload before sending it or even prevent the sending 

## Potential Risks / Drawbacks

- The destination of the email can also be changed, but since only Admins have control over this I don't think there's much a problem

## Review Notes / Questions

- N/A

## Example
This Flow example shows how we can use the `email.send` `filter` to use Send Email operation instead of sending the default email.
We could also use the Transform Payload operation, but we would like to use the WYSIWYG or Markdown interface instead:

https://github.com/user-attachments/assets/b4cd5515-8339-4cf3-87f4-ed382a41cb62


