### PR TITLE
Fixes/optimizations in `system-permissions` interface

### DIFF
--- a/.changeset/dull-rings-drive.md
+++ b/.changeset/dull-rings-drive.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Ensured collections in system permissions interface are scrolled into view when added but out of view

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -33,13 +33,14 @@ const systemCollections = computed(() =>
 const displayItems = computed(() => {
 	const items: any[] = availableCollections.value;
 
-	if (systemCollections.value.length > 0) {
-		items.push(
-			{ divider: true },
-			// Don't do a separate group, since the v-select search does not open groups, so the experience is rather unpleasant
-			...systemCollections.value,
-		);
+	// Don't use a separate group for system collections, since the v-select search does not open groups,
+	// so the experience is rather unpleasant
+
+	if (availableCollections.value.length > 0 && systemCollections.value.length > 0) {
+		items.push({ divider: true });
 	}
+
+	items.push(...systemCollections.value);
 
 	return items;
 });

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -31,7 +31,7 @@ const systemCollections = computed(() =>
 );
 
 const displayItems = computed(() => {
-	const items: any[] = availableCollections.value;
+	const items: any[] = [...availableCollections.value];
 
 	// Don't use a separate group for system collections, since the v-select search does not open groups,
 	// so the experience is rather unpleasant

--- a/app/src/interfaces/_system/system-permissions/permissions-row.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-row.vue
@@ -26,7 +26,7 @@ const { t } = useI18n();
 </script>
 
 <template>
-	<tr class="permissions-row">
+	<tr class="permissions-row" :data-collection="collection.collection">
 		<td>
 			<span v-tooltip.left="collection.name" class="name">{{ collection.collection }}</span>
 			<span class="shortcuts">

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -6,6 +6,7 @@ import { RelationO2M, useRelationO2M } from '@/composables/use-relation-o2m';
 import { useCollectionsStore } from '@/stores/collections';
 import { Collection } from '@/types/collections';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { PERMISSION_ACTIONS } from '@directus/constants';
 import { appAccessMinimalPermissions, isSystemCollection } from '@directus/system-data';
 import { Filter, Permission, PermissionsAction, type Alterations } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
@@ -16,8 +17,6 @@ import AddCollectionRow from './add-collection-row.vue';
 import PermissionsDetail from './detail/permissions-detail.vue';
 import PermissionsHeader from './permissions-header.vue';
 import PermissionsRow from './permissions-row.vue';
-
-const ACTIONS = ['create', 'read', 'update', 'delete', 'share'] as const;
 
 type PermissionGroup = {
 	collection: Collection;
@@ -114,8 +113,8 @@ function editItem(collection: string, action: PermissionsAction) {
 	currentlyEditingItem.value = existingPermission ?? null;
 }
 
-function stageEdits(item: Record<string, any>) {
-	if (newItem.value) {
+function stageEdits(item: Permission | null) {
+	if (newItem.value && item !== null) {
 		create(item);
 	} else if (item) {
 		update(item);
@@ -135,13 +134,13 @@ function removeCollection(collection: string) {
 }
 
 function setFullAccessAll(collection: string) {
-	for (const action of ACTIONS) {
+	for (const action of PERMISSION_ACTIONS) {
 		setFullAccess(collection, action);
 	}
 }
 
 function setNoAccessAll(collection: string) {
-	for (const action of ACTIONS) {
+	for (const action of PERMISSION_ACTIONS) {
 		setNoAccess(collection, action);
 	}
 }

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -677,6 +677,11 @@ function useGroupedPermissions() {
 		border: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 		border-radius: var(--theme--border-radius);
 		border-spacing: 0;
+
+		th,
+		td {
+			padding: 0;
+		}
 	}
 
 	.monospace {

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -51,8 +51,6 @@ const values = inject<Ref<Record<string, any>>>('values');
 const appAccess = computed(() => values?.value.app_access ?? false);
 const adminAccess = computed(() => values?.value.admin_access ?? false);
 
-const systemVisible = ref(false);
-
 const value = computed({
 	get: () => props.value,
 	set: (val) => {
@@ -552,11 +550,6 @@ function useGroupedPermissions() {
 			collection: info,
 			permissions: [],
 		});
-
-		// Check if the added permissions is a system collection, if so expand the system permissions
-		if (isSystemCollection(collection)) {
-			systemVisible.value = true;
-		}
 	}
 
 	function removeEmptyCollection(collection: string) {

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -44,6 +44,9 @@ const emit = defineEmits<{
 const { collection, primaryKey, field } = toRefs(props);
 const { t } = useI18n();
 
+const contentEl = inject<Ref<Element | null>>('main-element');
+const permissionsTable = ref<HTMLTableElement | null>(null);
+
 const collectionsStore = useCollectionsStore();
 const { relationInfo } = useRelationO2M(collection, field);
 
@@ -550,6 +553,25 @@ function useGroupedPermissions() {
 			collection: info,
 			permissions: [],
 		});
+
+		nextTick(() => {
+			if (!contentEl?.value) return;
+
+			const tableRow = permissionsTable.value?.querySelector(`tr[data-collection=${collection}]`);
+
+			if (!tableRow) return;
+
+			/** Header height + additional spacing */
+			const TOP_SPACING = 80;
+			const tableRowTop = tableRow.getBoundingClientRect().top - TOP_SPACING;
+
+			// Only scroll to row if it is out of view
+			if (tableRowTop > 0) return;
+
+			const top = tableRowTop + contentEl.value.scrollTop;
+
+			contentEl.value.scrollTo({ top, behavior: 'smooth' });
+		});
 	}
 
 	function removeEmptyCollection(collection: string) {
@@ -567,8 +589,8 @@ function useGroupedPermissions() {
 		{{ t('admins_have_all_permissions') }}
 	</v-notice>
 
-	<div v-else class="permissions-list">
-		<table v-if="!loading || allPermissions.length > 0">
+	<div v-else-if="!loading || allPermissions.length > 0" class="permissions-list">
+		<table ref="permissionsTable">
 			<permissions-header />
 
 			<tbody>


### PR DESCRIPTION
## Scope

- Scroll to new permission row when added and out of view (ed94034ceab89d7aadbc11d5d358493740a9de94)
  
  https://github.com/user-attachments/assets/3e201ee1-9567-4a37-b9f4-ba32e2a3b814
- Remove default cell spacing to get rid of visible gap in the system divider row (4f15b6a382e898efd2fc6c98db4e973ba5963f62)
  <img width="202" src="https://github.com/user-attachments/assets/425775fc-cddb-4021-a45b-6f8b4f73883b">
- Only show divider in "Add Collection" menu if there are both, regular and system collections (https://github.com/directus/directus/commit/63531f5c3c24241f7dc6aecab9cf46a1fbaffd9d)
- Fix duplication in "Add Collection" menu with regular collections (ba2bca2da9ed5fe43536870626d092cf9fa7139a)
- Remove unused `systemVisible` variable (d4ff8f96d7151442211e5732076a4c931ad42114)
- Re-use constant & small type fix (40b6b0285ab3e94fbd085367b1c5fc39072abf7a)
- Wrap interface in root node to swallow attributes (0607ac534c78c948a4deaf617402e9b737ca1a97)
  Fixes the following warning:
  > Extraneous non-emits event listeners (setFieldValue) were passed to component but could not be automatically inherited because component renders fragment or text root nodes.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Top spacing for scroll feature is set for #22985