### PR TITLE
Report app users as all users that can access the app

### DIFF
--- a/.changeset/modern-schools-lay.md
+++ b/.changeset/modern-schools-lay.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that caused the reported app users to be inconsistent with the app user limit environment variable

--- a/api/src/services/roles.ts
+++ b/api/src/services/roles.ts
@@ -218,6 +218,10 @@ export class RolesService extends ItemsService {
 				const type = this.getRoleAccessType(data);
 				increasedCounts[type] += data['users'].length;
 
+				if (type === 'admin') {
+					increasedCounts['app'] += data['users'].length;
+				}
+
 				for (const user of data['users']) {
 					if (typeof user === 'string') {
 						existingIds.push(user);
@@ -250,6 +254,10 @@ export class RolesService extends ItemsService {
 			if (needsUserLimitCheck && 'users' in partialItem) {
 				const type = this.getRoleAccessType(partialItem);
 				increasedCounts[type] += partialItem['users'].length;
+
+				if (type === 'admin') {
+					increasedCounts['app'] += partialItem['users'].length;
+				}
 
 				for (const user of partialItem['users']) {
 					if (typeof user === 'string') {
@@ -388,9 +396,17 @@ export class RolesService extends ItemsService {
 
 				if (isAccessChanged) {
 					increasedCounts[accessType] += Number(existingRole.count);
+
+					if (accessType === 'admin') {
+						increasedCounts['app'] += Number(existingRole.count);
+					}
 				}
 
 				increasedCounts[accessType] += increasedUsers;
+
+				if (accessType === 'admin') {
+					increasedCounts['app'] += increasedUsers;
+				}
 
 				await checkIncreasedUserLimits(this.knex, increasedCounts, existingIds);
 			}
@@ -458,6 +474,10 @@ export class RolesService extends ItemsService {
 				for (const [existingType, existingCount] of Object.entries(existingCounts)) {
 					if (existingType === type) continue;
 					increasedCounts[type] += existingCount;
+
+					if (type === 'admin') {
+						increasedCounts['app'] += existingCount;
+					}
 				}
 
 				await checkIncreasedUserLimits(this.knex, increasedCounts);

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -215,6 +215,7 @@ export class UsersService extends ItemsService {
 				if (typeof data['role'] === 'object') {
 					if ('admin_access' in data['role'] && data['role']['admin_access'] === true) {
 						increasedCounts.admin++;
+						increasedCounts.app++;
 					} else if ('app_access' in data['role'] && data['role']['app_access'] === true) {
 						increasedCounts.app++;
 					} else {
@@ -265,6 +266,7 @@ export class UsersService extends ItemsService {
 					if (typeof role === 'object') {
 						if ('admin_access' in role && role['admin_access'] === true) {
 							increasedCounts.admin++;
+							increasedCounts.app++;
 						} else if ('app_access' in role && role['app_access'] === true) {
 							increasedCounts.app++;
 						} else {
@@ -331,6 +333,7 @@ export class UsersService extends ItemsService {
 
 					if (toBoolean(newRole.admin_access)) {
 						increasedCounts.admin = keys.length - existingCounts.admin;
+						increasedCounts.app = keys.length - existingCounts.app;
 					} else if (toBoolean(newRole.app_access)) {
 						increasedCounts.app = keys.length - existingCounts.app;
 					} else {

--- a/api/src/telemetry/utils/check-increased-user-limits.ts
+++ b/api/src/telemetry/utils/check-increased-user-limits.ts
@@ -18,10 +18,6 @@ export async function checkIncreasedUserLimits(
 
 	const userCounts = await getUserCount(db, ignoreIds);
 
-	// Admins have full permissions, therefore should count under app access limit
-	const existingAppUsersCount = userCounts.admin + userCounts.app;
-	const newAppUsersCount = increasedUserCounts.admin + increasedUserCounts.app;
-
 	if (
 		increasedUserCounts.admin > 0 &&
 		increasedUserCounts.admin + userCounts.admin > Number(env['USERS_ADMIN_ACCESS_LIMIT'])
@@ -29,7 +25,7 @@ export async function checkIncreasedUserLimits(
 		throw new LimitExceededError({ category: 'Active Admin users' });
 	}
 
-	if (newAppUsersCount > 0 && newAppUsersCount + existingAppUsersCount > Number(env['USERS_APP_ACCESS_LIMIT'])) {
+	if (increasedUserCounts.app > 0 && increasedUserCounts.app + userCounts.app > Number(env['USERS_APP_ACCESS_LIMIT'])) {
 		throw new LimitExceededError({ category: 'Active App users' });
 	}
 

--- a/api/src/telemetry/utils/get-role-counts-by-roles.ts
+++ b/api/src/telemetry/utils/get-role-counts-by-roles.ts
@@ -22,6 +22,7 @@ export async function getRoleCountsByRoles(db: Knex, roles: string[]): Promise<A
 
 		if (adminAccess) {
 			counts.admin++;
+			counts.app++;
 		} else if (appAccess) {
 			counts.app++;
 		} else {

--- a/api/src/telemetry/utils/get-role-counts-by-users.ts
+++ b/api/src/telemetry/utils/get-role-counts-by-users.ts
@@ -37,6 +37,7 @@ export async function getRoleCountsByUsers(
 
 		if (adminAccess) {
 			counts.admin += count;
+			counts.app += count;
 		} else if (appAccess) {
 			counts.app += count;
 		} else {

--- a/api/src/telemetry/utils/get-user-count.ts
+++ b/api/src/telemetry/utils/get-user-count.ts
@@ -34,6 +34,7 @@ export const getUserCount = async (db: Knex, ignoreIds: PrimaryKey[] = []): Prom
 
 		if (adminAccess) {
 			counts.admin += count;
+			counts.app += count;
 		} else if (appAccess) {
 			counts.app += count;
 		} else {

--- a/api/src/telemetry/utils/get-user-counts-by-roles.ts
+++ b/api/src/telemetry/utils/get-user-counts-by-roles.ts
@@ -31,6 +31,7 @@ export async function getUserCountsByRoles(db: Knex, roleIds: PrimaryKey[]): Pro
 
 		if (adminAccess) {
 			counts.admin += count;
+			counts.app += count;
 		} else if (appAccess) {
 			counts.app += count;
 		} else {


### PR DESCRIPTION
For people relying on the telemetry output, the usage of the app user limit environment variable is inconsistent with the reporting on app users from the telemetry. This PR fixes that by reporting 'app users' as all users that can access the app, including admin users.