### PR TITLE
Show first and last pages on relationships

### DIFF
--- a/.changeset/young-phones-shop.md
+++ b/.changeset/young-phones-shop.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Show first and last pages on pagination of relationship interfaces

--- a/.changeset/young-phones-shop.md
+++ b/.changeset/young-phones-shop.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Show first and last pages on pagination of relationship interfaces
+Added first and last page buttons to pagination in relational interfaces

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -363,7 +363,7 @@ const allowDrag = computed(
 			<v-button v-if="enableSelect && selectAllowed" :disabled="disabled" @click="selectModalActive = true">
 				{{ t('add_existing') }}
 			</v-button>
-			<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="5" />
+			<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="2" show-first-last />
 		</div>
 
 		<drawer-item
@@ -434,6 +434,7 @@ const allowDrag = computed(
 .actions {
 	margin-top: 8px;
 	display: flex;
+	align-items: center;
 	gap: 8px;
 
 	.v-pagination {

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -434,6 +434,7 @@ const allowDrag = computed(
 .actions {
 	margin-top: 8px;
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 8px;
 

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -460,7 +460,7 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 					/>
 				</div>
 
-				<v-pagination v-model="page" :length="pageCount" :total-visible="5" />
+				<v-pagination v-model="page" :length="pageCount" :total-visible="2" show-first-last />
 			</div>
 		</div>
 

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -565,7 +565,12 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 			<div class="actions" :class="layout">
 				<template v-if="layout === LAYOUTS.TABLE">
 					<template v-if="pageCount > 1">
-						<v-pagination v-model="page" :length="pageCount" :total-visible="width.includes('half') ? 3 : 5" />
+						<v-pagination
+							v-model="page"
+							:length="pageCount"
+							:total-visible="width.includes('half') ? 1 : 2"
+							show-first-last
+						/>
 
 						<div class="spacer" />
 
@@ -583,7 +588,7 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 						{{ t('add_existing') }}
 					</v-button>
 					<div class="spacer" />
-					<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="5" />
+					<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="2" show-first-last />
 				</template>
 			</div>
 		</div>

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -672,10 +672,12 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 
 .actions {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 8px;
 
 	.v-pagination {
+		margin-left: auto;
 		:deep(.v-button) {
 			display: inline-flex;
 		}

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -626,10 +626,12 @@ function getLinkForItem(item: DisplayItem) {
 
 .actions {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 8px;
 
 	.v-pagination {
+		margin-left: auto;
 		:deep(.v-button) {
 			display: inline-flex;
 		}

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -526,7 +526,12 @@ function getLinkForItem(item: DisplayItem) {
 			<div class="actions" :class="layout">
 				<template v-if="layout === LAYOUTS.TABLE">
 					<template v-if="pageCount > 1">
-						<v-pagination v-model="page" :length="pageCount" :total-visible="width.includes('half') ? 3 : 5" />
+						<v-pagination
+							v-model="page"
+							:length="pageCount"
+							:total-visible="width.includes('half') ? 1 : 2"
+							show-first-last
+						/>
 
 						<div class="spacer" />
 
@@ -544,7 +549,7 @@ function getLinkForItem(item: DisplayItem) {
 						{{ t('add_existing') }}
 					</v-button>
 					<div class="spacer" />
-					<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="5" />
+					<v-pagination v-if="pageCount > 1" v-model="page" :length="pageCount" :total-visible="2" show-first-last />
 				</template>
 			</div>
 		</div>


### PR DESCRIPTION
## Scope
Relationship interfaces are great and they are easy to use when we have a few items.
Although, when we start to have a significant amount of items it starts to be difficult to see the amount of items we have in this relationships.
The current pagination on this interfaces does not allow to jump to the last page of the results, so if I know I have an item which is in the last pages, it will take me sometime to get there if I have a great a amount of items.

In this PR, we just take advantage of the property `show-first-last` from `v-pagination` component to show the last page on the pagination of the interface.
Also some adjustments were made so pagination does not go out of it's parent.

## What's changed:

- Show first and last pages on pagination of relationship interfaces

## Potential Risks / Drawbacks

- None I am ware of

## Review Notes / Questions

- None

## Comparison

|-|Before|After|
|-|-|-|
|Full Width| <video src="https://github.com/user-attachments/assets/0e49610a-9e9a-4b5d-9d96-fcca1c2a1bb4"></video> | <video src="https://github.com/user-attachments/assets/8376d9e1-f64c-4cdb-9e44-9c6083caa9b0"></video> | 
| Half Width| <video src="https://github.com/user-attachments/assets/10a796a1-1bf0-4c0e-a1f6-a1817554b756"></video> | <video src="https://github.com/user-attachments/assets/023461fe-4991-471a-b23c-f19054ac0210"></video> |