### PR TITLE
Disable websocket reconnection after manual disconnection

### DIFF
--- a/.changeset/eighty-crabs-smile.md
+++ b/.changeset/eighty-crabs-smile.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Disabled websocket reconnection after manual disconnection


### PR DESCRIPTION
## Scope

What's changed:

- Added a check to disable websocket reconnection after explicitly calling `disconnect()`

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- This patch is related to #22482 which utilises websocket
---

Fixes #\<num\>
