### PR TITLE
Fix cron syntax

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -142,3 +142,4 @@
 - brandondrew
 - alantiller
 - SP12893678
+- jacobwise

--- a/docs/guides/headless-cms/schedule-content/static-sites.md
+++ b/docs/guides/headless-cms/schedule-content/static-sites.md
@@ -88,8 +88,8 @@ field `status` that controls the published state.
 
    **Examples**
 
-   - `* 1 * * * *` - Would trigger this flow every minute
-   - `* 15 * * * *` – Would trigger this flow every 15 minutes
+   - `* */1 * * * *` - Would trigger this flow every minute
+   - `* */15 * * * *` – Would trigger this flow every 15 minutes
 
 ### Add an Operation to Check The Published Date and Update Data
 


### PR DESCRIPTION
The previous syntax triggers at the 1 minute or 15 mark of every hour, not on an interval.

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- syntax for cron in example

## Potential Risks / Drawbacks

- none that I can see

## Review Notes / Questions

- hopefully this helps someone stuck on this

