### PR TITLE
Don't prevent uploads on failure to extract file metadata

### DIFF
--- a/.changeset/lucky-plants-drum.md
+++ b/.changeset/lucky-plants-drum.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Treat exif metadata as a progressive enhancement by no longer crashing a file upload on metadata load failure

--- a/api/src/services/files/utils/get-metadata.test.ts
+++ b/api/src/services/files/utils/get-metadata.test.ts
@@ -1,0 +1,29 @@
+import { Readable, Transform } from 'node:stream';
+import type { Sharp } from 'sharp';
+import { expect, test, vi } from 'vitest';
+import { getSharpInstance } from '../lib/get-sharp-instance.js';
+import { getMetadata } from './get-metadata.js';
+
+vi.mock('../lib/get-sharp-instance.js', () => ({
+	getSharpInstance: vi.fn(),
+}));
+
+test('Resolves empty object on unexpected error in transformation', async () => {
+	const stream = new Readable();
+	stream._read = vi.fn();
+
+	vi.mocked(getSharpInstance).mockImplementation(
+		() =>
+			({
+				metadata: vi.fn().mockImplementation((fn: (err: Error) => void) => {
+					fn(new Error('test'));
+
+					return new Transform();
+				}),
+			}) as unknown as Sharp,
+	);
+
+	const result = await getMetadata(stream);
+
+	expect(result).toEqual({});
+});

--- a/api/src/services/files/utils/get-metadata.ts
+++ b/api/src/services/files/utils/get-metadata.ts
@@ -1,13 +1,13 @@
+import { useEnv } from '@directus/env';
 import type { File } from '@directus/types';
 import exif, { type GPSInfoTags, type ImageTags, type IopTags, type PhotoTags } from 'exif-reader';
 import { type IccProfile, parse as parseIcc } from 'icc';
 import { pick } from 'lodash-es';
 import type { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { useEnv } from '@directus/env';
 import { useLogger } from '../../../logger/index.js';
-import { parseIptc, parseXmp } from './parse-image-metadata.js';
 import { getSharpInstance } from '../lib/get-sharp-instance.js';
+import { parseIptc, parseXmp } from './parse-image-metadata.js';
 
 const env = useEnv();
 const logger = useLogger();
@@ -20,13 +20,13 @@ export async function getMetadata(
 ): Promise<Metadata> {
 	const transformer = getSharpInstance();
 
-	return new Promise((resolve, reject) => {
+	return new Promise((resolve) => {
 		pipeline(
 			stream,
 			transformer.metadata(async (err, sharpMetadata) => {
 				if (err) {
-					reject(err);
-					return;
+					logger.error(err);
+					return resolve({});
 				}
 
 				const metadata: Metadata = {};


### PR DESCRIPTION
## Scope

What's changed:

https://github.com/directus/directus/pull/23064 brought to light that we're currently crashing a file upload on failure to extract the file's exif/iptc metadata. We should treat that as a progressive enhancement rather than hard requirement for a file upload to succeed.

## Potential Risks / Drawbacks

- All metadata fields have always been typed and marked optional, so I don't think this'll result in any new unintended behavior

## Review Notes / Questions

- Testing callbacks in streams can be a bit tricky, but I believe this is correct

h/t to @paescuj for highlighting this
