### PR TITLE
App: Fix SVG support on image interface

### DIFF
--- a/.changeset/few-mayflies-smash.md
+++ b/.changeset/few-mayflies-smash.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed SVG support on image interface

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -57,6 +57,8 @@ const {
 	Pick<File, 'id' | 'title' | 'width' | 'height' | 'filesize' | 'type' | 'filename_download' | 'modified_on'>
 >(value, query, relationInfo, { enabled: computed(() => !props.loading) });
 
+const isImage = ref(true);
+
 const { t, n, te } = useI18n();
 
 const lightboxActive = ref(false);
@@ -96,6 +98,7 @@ const editImageDetails = ref(false);
 const editImageEditor = ref(false);
 
 async function imageErrorHandler() {
+	isImage.value = false;
 	if (!src.value) return;
 
 	try {
@@ -149,16 +152,8 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				</span>
 			</div>
 
-			<div v-else-if="!image.height && !image.width" class="image-error">
-				<v-icon large name="error" />
-
-				<span class="message">
-					{{ t('errors.UNSUPPORTED_MEDIA_TYPE') }}
-				</span>
-			</div>
-
 			<v-image
-				v-else-if="image.type?.startsWith('image')"
+				v-else-if="image.type?.startsWith('image') && isImage"
 				:src="src"
 				:width="image.width"
 				:height="image.height"

--- a/app/src/utils/readable-mime-type/extensions.json
+++ b/app/src/utils/readable-mime-type/extensions.json
@@ -74,5 +74,7 @@
 	"video/3gpp2": "3g2",
 	"audio/3gpp": "3gp",
 	"audio/3gpp2": "3g2",
-	"application/x-7z-compressed": "7z"
+	"application/x-7z-compressed": "7z",
+	"image/heic": "heic",
+	"image/heif": "heif"
 }

--- a/app/src/utils/readable-mime-type/types.json
+++ b/app/src/utils/readable-mime-type/types.json
@@ -692,5 +692,7 @@
 	"application/vnd.zul": "Z.U.L. Geometry",
 	"application/zip": "Zip Archive",
 	"application/vnd.handheld-entertainment+xml": "ZVUE Media Manager",
-	"application/vnd.zzazz.deck+xml": "Zzazz Deck"
+	"application/vnd.zzazz.deck+xml": "Zzazz Deck",
+	"image/heic": "High Efficiency Image Container",
+	"image/heif": "High Efficiency Image Format"
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

On PR https://github.com/directus/directus/pull/22307, the support for SVG on `image` interface was removed, because SVG files do not have width or height like HEIC files.

To fix that, we just rely on the `error` event from `img` HTML element. If `img` can renders good, otherwise it will fallback to the icon with the file extension.

What's changed:

- Support back SVG on Image interface

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

## Comparison
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/459eee1d-f980-4bfd-a0b0-ebc1867beb8f"></video>| <video src="https://github.com/user-attachments/assets/a29bf538-797d-40d1-9d60-0730bd0da6ab"></video>|


---

Fixes #22461
