### PR TITLE
Fix select dropdown null choices display problem

### DIFF
--- a/.changeset/clean-cameras-jump.md
+++ b/.changeset/clean-cameras-jump.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured dropdown interface correctly handles case when no options are provided

--- a/app/src/components/v-select/__snapshots__/v-select.test.ts.snap
+++ b/app/src/components/v-select/__snapshots__/v-select.test.ts.snap
@@ -5,6 +5,7 @@ exports[`should hide items not matching search value > object items 1`] = `
   <div data-v-cdcb6889="" id="v-input-stub" full-width="true" readonly="" clickable="" disabled="false"></div>
   <ul data-v-ff20e609="" data-v-cdcb6889="" class="v-list list">
     <!--v-if-->
+    <!--v-if-->
     <div data-v-cdcb6889="" data-v-ff20e609-s="" id="v-list-item-stub">
       <div data-v-cdcb6889="" id="v-list-item-content-stub">
         <div data-v-cdcb6889="" id="v-input-stub" autofocus="" small="" placeholder="search" modelvalue="Item 1"></div>
@@ -64,6 +65,7 @@ exports[`should hide items not matching search value > string items 1`] = `
 "<div data-v-cdcb6889="" id="v-menu-stub" class="v-select" disabled="false" attached="true" show-arrow="false" close-on-content-click="true" placement="bottom" full-height="false">
   <div data-v-cdcb6889="" id="v-input-stub" full-width="true" readonly="" clickable="" disabled="false"></div>
   <ul data-v-ff20e609="" data-v-cdcb6889="" class="v-list list">
+    <!--v-if-->
     <!--v-if-->
     <div data-v-cdcb6889="" data-v-ff20e609-s="" id="v-list-item-stub">
       <div data-v-cdcb6889="" id="v-list-item-content-stub">
@@ -126,6 +128,7 @@ exports[`should render with object items 1`] = `
   <ul data-v-ff20e609="" data-v-cdcb6889="" class="v-list list">
     <!--v-if-->
     <!--v-if-->
+    <!--v-if-->
     <div data-v-e8b3360c="" data-v-cdcb6889="" data-v-ff20e609-s="" id="v-list-item-stub" active="false" clickable="" value="item1">
       <!--v-if-->
       <div data-v-e8b3360c="" id="v-list-item-content-stub"><span data-v-e8b3360c="" class="item-text">Item 1</span></div>
@@ -148,6 +151,7 @@ exports[`should render with string items 1`] = `
 "<div data-v-cdcb6889="" id="v-menu-stub" class="v-select" disabled="false" attached="true" show-arrow="false" close-on-content-click="true" placement="bottom" full-height="false">
   <v-input-stub data-v-cdcb6889="" full-width="true" readonly="" clickable="" disabled="false"></v-input-stub>
   <ul data-v-ff20e609="" data-v-cdcb6889="" class="v-list list">
+    <!--v-if-->
     <!--v-if-->
     <!--v-if-->
     <div data-v-e8b3360c="" data-v-cdcb6889="" data-v-ff20e609-s="" id="v-list-item-stub" active="false" clickable="" value="Item 1">

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -298,9 +298,9 @@ function useDisplayValue() {
 				<v-divider />
 			</template>
 
-			<v-list-item v-if="internalItemsCount <= 0 && !allowOther">
+			<v-list-item v-if="internalItemsCount === 0 && !allowOther">
 				<v-list-item-content>
-					{{ t("no_options_available") }}
+					{{ t('no_options_available') }}
 				</v-list-item-content>
 			</v-list-item>
 

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -298,6 +298,12 @@ function useDisplayValue() {
 				<v-divider />
 			</template>
 
+			<v-list-item v-if="internalItemsCount <= 0 && !allowOther">
+				<v-list-item-content>
+					{{ t("no_options_available") }}
+				</v-list-item-content>
+			</v-list-item>
+
 			<v-list-item v-if="internalItemsCount > 10 || search">
 				<v-list-item-content>
 					<v-input v-model="search" autofocus small :placeholder="t('search')" @click.stop.prevent>

--- a/app/src/interfaces/select-dropdown/select-dropdown.vue
+++ b/app/src/interfaces/select-dropdown/select-dropdown.vue
@@ -35,10 +35,10 @@ const applyGlobalIcon = computed(() => props.choices?.some((choice) => choice.ic
 
 const items = computed(() => {
 	if (!applyGlobalIcon.value) {
-		return props.choices;
+		return props.choices || [];
 	}
 
-	return props.choices?.map((choice) => {
+	return (props.choices || [])?.map((choice) => {
 		if (choice.icon) {
 			return choice;
 		}

--- a/app/src/interfaces/select-dropdown/select-dropdown.vue
+++ b/app/src/interfaces/select-dropdown/select-dropdown.vue
@@ -34,11 +34,15 @@ const { t } = useI18n();
 const applyGlobalIcon = computed(() => props.choices?.some((choice) => choice.icon));
 
 const items = computed(() => {
-	if (!applyGlobalIcon.value) {
-		return props.choices || [];
+	if (!props.choices) {
+		return [];
 	}
 
-	return (props.choices || [])?.map((choice) => {
+	if (!applyGlobalIcon.value) {
+		return props.choices;
+	}
+
+	return props.choices.map((choice) => {
 		if (choice.icon) {
 			return choice;
 		}


### PR DESCRIPTION
## Scope
When select dropsown choices be null value, it will display warning notice (choices option configured incorrectly)
The user might think there is an break with the form, but in reality, there are simply no options available.

What's changed:
In use case, field should display empty value or selected value, and dropdown would show no options hint will be better.

### Situational setting

https://github.com/user-attachments/assets/ada2ce9e-de63-41fe-8202-0e730d597d64

### General case demo

https://github.com/user-attachments/assets/3aa57ac7-3d75-40f7-affe-ce5d2edcdfec


### Remove all options demo

https://github.com/user-attachments/assets/09315907-15c0-4d71-9d64-dd1873c7dd74


### Fix demo

https://github.com/user-attachments/assets/c5a4901b-9775-485c-a784-f56b1dfa5801



## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #21972
