### PR TITLE
Fix "Update Files Date Fields" migration for MySQL

### DIFF
--- a/api/src/database/migrations/20240305A-change-useragent-type.ts
+++ b/api/src/database/migrations/20240305A-change-useragent-type.ts
@@ -11,7 +11,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-	const helper = await getHelpers(knex).schema;
+	const helper = getHelpers(knex).schema;
 
 	const opts = {
 		nullable: false,

--- a/api/src/database/migrations/20240716A-update-files-date-fields.ts
+++ b/api/src/database/migrations/20240716A-update-files-date-fields.ts
@@ -1,9 +1,20 @@
 import type { Knex } from 'knex';
+import { getHelpers } from '../helpers/index.js';
 
 export async function up(knex: Knex): Promise<void> {
-	await knex.schema.alterTable('directus_files', (table) => {
-		table.renameColumn('uploaded_on', 'created_on');
-	});
+	const helper = getHelpers(knex).schema;
+	const isMysql = helper.isOneOfClients(['mysql']);
+
+	if (isMysql) {
+		// Knex creates invalid statement on MySQL, see https://github.com/knex/knex/issues/1888
+		await knex.schema.raw(
+			'ALTER TABLE `directus_files` CHANGE `uploaded_on` `created_on` TIMESTAMP NOT NULL DEFAULT current_timestamp();',
+		);
+	} else {
+		await knex.schema.alterTable('directus_files', (table) => {
+			table.renameColumn('uploaded_on', 'created_on');
+		});
+	}
 
 	await knex.schema.alterTable('directus_files', (table) => {
 		table.timestamp('uploaded_on');
@@ -17,7 +28,16 @@ export async function down(knex: Knex): Promise<void> {
 		table.dropColumn('uploaded_on');
 	});
 
-	await knex.schema.alterTable('directus_files', (table) => {
-		table.renameColumn('created_on', 'uploaded_on');
-	});
+	const helper = getHelpers(knex).schema;
+	const isMysql = helper.isOneOfClients(['mysql']);
+
+	if (isMysql) {
+		await knex.schema.raw(
+			'ALTER TABLE `directus_files` CHANGE `created_on` `uploaded_on` TIMESTAMP NOT NULL DEFAULT current_timestamp();',
+		);
+	} else {
+		await knex.schema.alterTable('directus_files', (table) => {
+			table.renameColumn('created_on', 'uploaded_on');
+		});
+	}
 }


### PR DESCRIPTION
## Scope

The migration added in #23035 doesn't work for MySQL databases, due to a bug in Knex (https://github.com/knex/knex/issues/1888).
As a workaround the column is now renamed via a raw query on MySQL.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Follow-up on #23035, noticed while testing #23093
