### PR TITLE
Fix query trace logger for failing queries

### DIFF
--- a/.changeset/popular-files-teach.md
+++ b/.changeset/popular-files-teach.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where the query trace logger could lead to a crash with a failing query on MySQL

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -17,6 +17,13 @@ import { getConfigFromEnv } from '../utils/get-config-from-env.js';
 import { validateEnv } from '../utils/validate-env.js';
 import { getHelpers } from './helpers/index.js';
 
+type QueryInfo = Partial<Knex.Sql> & {
+	sql: Knex.Sql['sql'];
+	__knexUid: string;
+	__knexTxId: string;
+	[key: string | number | symbol]: any;
+};
+
 let database: Knex | null = null;
 let inspector: SchemaInspector | null = null;
 let databaseVersion: string | null = null;
@@ -160,12 +167,12 @@ export function getDatabase(): Knex {
 	const times: Record<string, number> = {};
 
 	database
-		.on('query', (queryInfo) => {
+		.on('query', (queryInfo: QueryInfo) => {
 			times[queryInfo.__knexUid] = performance.now();
 		})
-		.on('query-response', (_response, queryInfo) => {
+		.on('query-response', (_response, queryInfo: QueryInfo) => {
 			const delta = performance.now() - times[queryInfo.__knexUid]!;
-			logger.trace(`[${delta.toFixed(3)}ms] ${queryInfo.sql} [${queryInfo.bindings.join(', ')}]`);
+			logger.trace(`[${delta.toFixed(3)}ms] ${queryInfo.sql} [${queryInfo.bindings?.join(', ')}]`);
 			delete times[queryInfo.__knexUid];
 		});
 


### PR DESCRIPTION
## Scope

When using MySQL/MariaDB, some query information like `bindings` aren't available for failing queries.
This could lead to a crash resp. suppress the real error message, as this was not considered when trying to `join()` the `bindings` value for the trace log.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- For consistent logging, the format is kept the same, even when not all information is available (`[?ms] <statement> []`)

---

Fixes #22683, also noticed while working on #23094
