### PR TITLE
Fix Invalid date parse in calendar component

### DIFF
--- a/.changeset/warm-pugs-tell.md
+++ b/.changeset/warm-pugs-tell.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that could cause the calendar layout to crash on invalid dates

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -310,7 +310,7 @@ export default defineLayout<LayoutOptions>({
 			// last all day
 			const allDay = endDateFieldInfo.value && endDateFieldInfo.value.type === 'date';
 
-			if (endDateField.value) {
+			if (endDateField.value && item[endDateField.value]) {
 				const date = parse(item[endDateField.value], 'yyyy-MM-dd', new Date());
 
 				if (allDay && isValid(date)) {


### PR DESCRIPTION
## Scope
When two collection set calendar layout, one collection has a null data on start date field/ end date field.
It will lead calendar break, not show any event on calendar.
And then, switch to another calendar layout collection,  the calendar would still not show any event.

What's changed:
- Fix Invalid date parse 
- If start date null, it will not show in calendar 
- If end date null, it will show one day long

### setting

https://github.com/user-attachments/assets/64a006b7-9eba-4fea-ac79-437a37ad2d95

### issue demo

https://github.com/user-attachments/assets/db7f90cf-5768-44e4-a654-6384c6301320

### fixed demo

https://github.com/user-attachments/assets/027f67e6-9aef-4455-9b83-587dd2ee723c



## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #22854
