### PR TITLE
Update filename_disk extension when mimetype changes on overwrite

### DIFF
--- a/.changeset/dull-ducks-shake.md
+++ b/.changeset/dull-ducks-shake.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Update filename_disk extension to match current mimetype on uploaded images
+Fixed filename_disk extension not getting updated when replacing an image with another file extension 

--- a/.changeset/dull-ducks-shake.md
+++ b/.changeset/dull-ducks-shake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Update filename_disk extension to match current mimetype on uploaded images

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -149,6 +149,56 @@ describe('Integration Tests', () => {
 					{ emitEvents: false },
 				);
 			});
+
+			it('should update the `filename_disk` extension to the correct mimetype', async () => {
+				tracker.on
+					.select(
+						'select "folder", "filename_download", "filename_disk", "title", "description", "metadata" from "directus_files" where "id" = ?',
+					)
+					.response(null);
+
+				const mockDataJPG = {
+					storage: 'local',
+					type: 'image/jpeg',
+					filename_download: 'test.jpg',
+				};
+
+				const mockDataPNG = {
+					storage: 'local',
+					type: 'image/png',
+					filename_download: 'test.png',
+				};
+
+				const mockDate = new Date();
+
+				vi.setSystemTime(mockDate);
+
+				await service.uploadOne(new PassThrough(), mockDataJPG);
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					sample.id,
+					expect.objectContaining({
+						...mockDataJPG,
+						uploaded_on: mockDate.toISOString(),
+						filename_disk: `${sample.id}.jpg`,
+					}),
+					{ emitEvents: false },
+				);
+
+				await service.uploadOne(new PassThrough(), mockDataPNG);
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					sample.id,
+					expect.objectContaining({
+						...mockDataPNG,
+						uploaded_on: mockDate.toISOString(),
+						filename_disk: `${sample.id}.png`,
+					}),
+					{ emitEvents: false },
+				);
+
+				vi.useRealTimers();
+			});
 		});
 	});
 });

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -81,6 +81,11 @@ export class FilesService extends ItemsService<File> {
 		// The filename_disk is the FINAL filename on disk
 		payload.filename_disk ||= primaryKey + (fileExtension || '');
 
+		// If the filename_disk extension doesn't match the new mimetype, update it
+		if (isReplacement === true && path.extname(payload.filename_disk!) !== fileExtension) {
+			payload.filename_disk = primaryKey + (fileExtension || '');
+		}
+
 		// Temp filename is used for replacements
 		const tempFilenameDisk = 'temp_' + payload.filename_disk;
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- When a file is replaced, the extension is updated to reflect current mimetype

## Potential Risks / Drawbacks

- There is probably some, but I am not sure.

## Review Notes / Questions

- Verify this is the correct solution

---

Fixes #23045 
