### PR TITLE
Explicit headings in CSV export

### DIFF
--- a/.changeset/rude-peas-confess.md
+++ b/.changeset/rude-peas-confess.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Used explicit headings for CSV export

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -28,7 +28,10 @@ export interface ParseFieldsContext {
 	knex: Knex;
 }
 
-export async function parseFields(options: ParseFieldsOptions, context: ParseFieldsContext) {
+export async function parseFields(
+	options: ParseFieldsOptions,
+	context: ParseFieldsContext,
+): Promise<[] | (NestedCollectionNode | FieldNode | FunctionFieldNode)[]> {
 	let { fields } = options;
 	if (!fields) return [];
 

--- a/api/src/services/import-export.test.ts
+++ b/api/src/services/import-export.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from 'vitest';
+import { getAllFieldNames } from './import-export.js';
+import type { FieldNode, FunctionFieldNode, NestedCollectionNode } from '../types/ast.js';
+
+test('getAllFieldNames', () => {
+	const parsedFields: (NestedCollectionNode | FieldNode | FunctionFieldNode)[] = [
+		{
+			type: 'field',
+			name: 'id',
+			fieldKey: 'id',
+			whenCase: [],
+		},
+		{
+			type: 'field',
+			name: 'title',
+			fieldKey: 'title',
+			whenCase: [],
+		},
+		{
+			type: 'm2o',
+			name: 'authors',
+			fieldKey: 'author',
+			parentKey: 'id',
+			relatedKey: 'id',
+			relation: {
+				collection: 'articles',
+				field: 'author',
+				related_collection: 'authors',
+				schema: {
+					constraint_name: 'articles_author_foreign',
+					table: 'articles',
+					column: 'author',
+					foreign_key_schema: 'public',
+					foreign_key_table: 'authors',
+					foreign_key_column: 'id',
+					on_update: 'NO ACTION',
+					on_delete: 'SET NULL',
+				},
+				meta: {
+					id: 1,
+					many_collection: 'articles',
+					many_field: 'author',
+					one_collection: 'authors',
+					one_field: null,
+					one_collection_field: null,
+					one_allowed_collections: null,
+					junction_field: null,
+					sort_field: null,
+					one_deselect_action: 'nullify',
+				},
+			},
+			query: {},
+			children: [
+				{
+					type: 'field',
+					name: 'id',
+					fieldKey: 'id',
+					whenCase: [],
+				},
+				{
+					type: 'field',
+					name: 'first_name',
+					fieldKey: 'first_name',
+					whenCase: [],
+				},
+				{
+					type: 'field',
+					name: 'last_name',
+					fieldKey: 'last_name',
+					whenCase: [],
+				},
+				{
+					type: 'm2o',
+					name: 'addresses',
+					fieldKey: 'address',
+					parentKey: 'id',
+					relatedKey: 'id',
+					relation: {
+						collection: 'addresses',
+						field: 'address',
+						related_collection: 'authors',
+						schema: {
+							constraint_name: 'articles_author_foreign',
+							table: 'articles',
+							column: 'author',
+							foreign_key_schema: 'public',
+							foreign_key_table: 'authors',
+							foreign_key_column: 'id',
+							on_update: 'NO ACTION',
+							on_delete: 'SET NULL',
+						},
+						meta: {
+							id: 1,
+							many_collection: 'articles',
+							many_field: 'author',
+							one_collection: 'authors',
+							one_field: null,
+							one_collection_field: null,
+							one_allowed_collections: null,
+							junction_field: null,
+							sort_field: null,
+							one_deselect_action: 'nullify',
+						},
+					},
+					query: {},
+					children: [
+						{
+							type: 'field',
+							name: 'id',
+							fieldKey: 'id',
+							whenCase: [],
+						},
+						{
+							type: 'field',
+							name: 'street',
+							fieldKey: 'street',
+							whenCase: [],
+						},
+						{
+							type: 'field',
+							name: 'city',
+							fieldKey: 'city',
+							whenCase: [],
+						},
+					],
+					cases: [],
+					whenCase: [],
+				},
+			],
+			cases: [],
+			whenCase: [],
+		},
+	];
+
+	const res = getAllFieldNames(parsedFields);
+
+	expect(res).toEqual([
+		'id',
+		'title',
+		'author.id',
+		'author.first_name',
+		'author.last_name',
+		'author.address.id',
+		'author.address.street',
+		'author.address.city',
+	]);
+});

--- a/api/src/services/import-export.test.ts
+++ b/api/src/services/import-export.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { getAllFieldNames } from './import-export.js';
+import { getHeadingsForCsvExport } from './import-export.js';
 import type { FieldNode, FunctionFieldNode, NestedCollectionNode } from '../types/ast.js';
 
 test('getAllFieldNames', () => {
@@ -250,7 +250,7 @@ test('getAllFieldNames', () => {
 		},
 	];
 
-	const res = getAllFieldNames(parsedFields);
+	const res = getHeadingsForCsvExport(parsedFields);
 
 	expect(res).toEqual([
 		'id',

--- a/api/src/services/import-export.test.ts
+++ b/api/src/services/import-export.test.ts
@@ -3,6 +3,15 @@ import { getHeadingsForCsvExport } from './import-export.js';
 import type { FieldNode, FunctionFieldNode, NestedCollectionNode } from '../types/ast.js';
 
 test('Get the headings for CSV export from the field node tree', () => {
+	/**
+	 * this is an example result from parseFields
+	 * It includes the following:
+	 * - a field node
+	 * - a m2o node with a nested m2o node
+	 * - a o2m node
+	 * - a o2m node which is the parsing result of a m2a relationship
+	 */
+
 	const parsedFields: (NestedCollectionNode | FieldNode | FunctionFieldNode)[] = [
 		{
 			type: 'field',
@@ -252,16 +261,22 @@ test('Get the headings for CSV export from the field node tree', () => {
 
 	const res = getHeadingsForCsvExport(parsedFields);
 
-	expect(res).toEqual([
+	const expectedHeadlinesForCsvExport = [
 		'id',
 		'title',
+
+		// headings for m2o node with another nested m2o node
 		'author.id',
 		'author.first_name',
 		'author.last_name',
 		'author.address.id',
 		'author.address.street',
 		'author.address.city',
+
+		// headings for the o2m nodes
 		'headings',
 		'some-m2a',
-	]);
+	];
+
+	expect(res).toEqual(expectedHeadlinesForCsvExport);
 });

--- a/api/src/services/import-export.test.ts
+++ b/api/src/services/import-export.test.ts
@@ -183,6 +183,71 @@ test('getAllFieldNames', () => {
 			cases: [],
 			whenCase: [],
 		},
+		{
+			type: 'o2m',
+			name: 'articles_m2a',
+			fieldKey: 'some-m2a',
+			parentKey: 'id',
+			relatedKey: 'id',
+			relation: {
+				collection: 'articles_m2a',
+				field: 'articles_id',
+				related_collection: 'articles',
+				schema: {
+					constraint_name: 'articles_m2a_articles_id_foreign',
+					table: 'articles_m2a',
+					column: 'articles_id',
+					foreign_key_schema: 'public',
+					foreign_key_table: 'articles',
+					foreign_key_column: 'id',
+					on_update: 'NO ACTION',
+					on_delete: 'SET NULL',
+				},
+				meta: {
+					id: 5,
+					many_collection: 'articles_m2a',
+					many_field: 'articles_id',
+					one_collection: 'articles',
+					one_field: 'some-m2a',
+					one_collection_field: null,
+					one_allowed_collections: null,
+					junction_field: 'item',
+					sort_field: null,
+					one_deselect_action: 'nullify',
+				},
+			},
+			query: {
+				sort: ['id'],
+			},
+			children: [
+				{
+					type: 'field',
+					name: 'id',
+					fieldKey: 'id',
+					whenCase: [],
+				},
+				{
+					type: 'field',
+					name: 'articles_id',
+					fieldKey: 'articles_id',
+					whenCase: [],
+				},
+				{
+					type: 'field',
+					name: 'item',
+					fieldKey: 'item',
+					whenCase: [],
+				},
+				{
+					type: 'field',
+					name: 'collection',
+					fieldKey: 'collection',
+					whenCase: [],
+				},
+			],
+			cases: [],
+			whenCase: [],
+		},
 	];
 
 	const res = getAllFieldNames(parsedFields);
@@ -197,5 +262,6 @@ test('getAllFieldNames', () => {
 		'author.address.street',
 		'author.address.city',
 		'headings',
+		'some-m2a',
 	]);
 });

--- a/api/src/services/import-export.test.ts
+++ b/api/src/services/import-export.test.ts
@@ -130,6 +130,59 @@ test('getAllFieldNames', () => {
 			cases: [],
 			whenCase: [],
 		},
+		{
+			type: 'o2m',
+			name: 'headlines',
+			fieldKey: 'headings',
+			parentKey: 'id',
+			relatedKey: 'id',
+			relation: {
+				collection: 'headlines',
+				field: 'article',
+				related_collection: 'articles',
+				schema: {
+					constraint_name: 'headlines_article_foreign',
+					table: 'headlines',
+					column: 'article',
+					foreign_key_schema: 'public',
+					foreign_key_table: 'articles',
+					foreign_key_column: 'id',
+					on_update: 'NO ACTION',
+					on_delete: 'SET NULL',
+				},
+				meta: {
+					id: 3,
+					many_collection: 'headlines',
+					many_field: 'article',
+					one_collection: 'articles',
+					one_field: 'headings',
+					one_collection_field: null,
+					one_allowed_collections: null,
+					junction_field: null,
+					sort_field: null,
+					one_deselect_action: 'nullify',
+				},
+			},
+			query: {
+				sort: ['id'],
+			},
+			children: [
+				{
+					type: 'field',
+					name: 'id',
+					fieldKey: 'id',
+					whenCase: [],
+				},
+				{
+					type: 'field',
+					name: 'title',
+					fieldKey: 'title',
+					whenCase: [],
+				},
+			],
+			cases: [],
+			whenCase: [],
+		},
 	];
 
 	const res = getAllFieldNames(parsedFields);
@@ -143,5 +196,6 @@ test('getAllFieldNames', () => {
 		'author.address.id',
 		'author.address.street',
 		'author.address.city',
+		'headings',
 	]);
 });

--- a/api/src/services/import-export.test.ts
+++ b/api/src/services/import-export.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest';
 import { getHeadingsForCsvExport } from './import-export.js';
 import type { FieldNode, FunctionFieldNode, NestedCollectionNode } from '../types/ast.js';
 
-test('getAllFieldNames', () => {
+test('Get the headings for CSV export from the field node tree', () => {
 	const parsedFields: (NestedCollectionNode | FieldNode | FunctionFieldNode)[] = [
 		{
 			type: 'field',

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -518,7 +518,12 @@ Your export of ${collection} is ready. <a href="${href}">Click here to view.</a>
 		throw new ServiceUnavailableError({ service: 'export', reason: `Illegal export type used: "${format}"` });
 	}
 }
-
+/*
+ * Recursive function to traverse all field nodes to get the heading names for CSV export.
+ *
+ * Nested field names for o2m and a2o are not going to be revolved.
+ * Instead, when those relationships are resolved, the resulting list of items will be stored as a single value/cell of the CSV file.
+ */
 export function getAllFieldNames(
 	nodes: (NestedCollectionNode | FieldNode | FunctionFieldNode)[] | undefined,
 	prefix: string = '',
@@ -542,17 +547,17 @@ export function getAllFieldNames(
 			case 'o2m':
 				fieldNames.push(prefix ? `${prefix}.${node.fieldKey}` : node.fieldKey);
 				break;
-			case 'a2o':
-				for (const collection in node.children) {
-					fieldNames = fieldNames.concat(
-						getAllFieldNames(
-							node.children[collection],
-							prefix ? `${prefix}.${node.fieldKey}.${collection}` : `${node.fieldKey}.${collection}`,
-						),
-					);
-				}
+			// case 'a2o':
+			// 	for (const collection in node.children) {
+			// 		fieldNames = fieldNames.concat(
+			// 			getAllFieldNames(
+			// 				node.children[collection],
+			// 				prefix ? `${prefix}.${node.fieldKey}.${collection}` : `${node.fieldKey}.${collection}`,
+			// 			),
+			// 		);
+			// 	}
 
-				break;
+			// 	break;
 		}
 	});
 

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -534,11 +534,13 @@ export function getAllFieldNames(
 				fieldNames.push(prefix ? `${prefix}.${node.fieldKey}` : node.fieldKey);
 				break;
 			case 'm2o':
-			case 'o2m':
 				fieldNames = fieldNames.concat(
 					getAllFieldNames(node.children, prefix ? `${prefix}.${node.fieldKey}` : node.fieldKey),
 				);
 
+				break;
+			case 'o2m':
+				fieldNames.push(prefix ? `${prefix}.${node.fieldKey}` : node.fieldKey);
 				break;
 			case 'a2o':
 				for (const collection in node.children) {

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -345,7 +345,7 @@ export class ExportService {
 					readCount += result.length;
 
 					if (result.length) {
-						let flattenedFields = null;
+						let csvHeadings = null;
 
 						if (format === 'csv') {
 							if (!query.fields) query.fields = ['*'];
@@ -365,7 +365,7 @@ export class ExportService {
 								},
 							);
 
-							flattenedFields = getHeadingsForCsvExport(parsedFields);
+							csvHeadings = getHeadingsForCsvExport(parsedFields);
 						}
 
 						await appendFile(
@@ -373,7 +373,7 @@ export class ExportService {
 							this.transform(result, format, {
 								includeHeader: batch === 0,
 								includeFooter: batch + 1 === batchesRequired,
-								fields: flattenedFields,
+								fields: csvHeadings,
 							}),
 						);
 					}
@@ -461,7 +461,7 @@ Your export of ${collection} is ready. <a href="${href}">Click here to view.</a>
 		options?: {
 			includeHeader?: boolean;
 			includeFooter?: boolean;
-			fields: string[] | null;
+			fields?: string[] | null;
 		},
 	): string {
 		if (format === 'json') {


### PR DESCRIPTION
## Scope

Currently when exporting a collection to CSV, the headings of the file were deducted from the first batch of the query result. In case the user choose to include relational data in the export and the first batch of items did not include any relational data, the headings did not exist and therefore the `json2scv` library put the values in the wrong 'column'.

In this PR, the field names which should be exported and hence the headings of the csv file, are determined beforehand instead of deducting those from the first batch. 
 
### An example
- setup 13 articles, first 10 don't have an author related to it
- set `EXPORT_BATCH_SIZE` of 10
- specify those fields: id, title, author, author.first_name

#### Before
For the first batch, the author is always null. When deducting the headings this way, no `first_name` column is present in the export. For the second batch though, this value existed in the database response and was added in the CSV file in the wrong place. within the author column there should be the ID, and "Jan" should be in a column which doesn't exit.

| title    | sort | author |
|----------|------|--------|
| sgdfg    |    1 |        |
| efa      |    2 |        |
| sccx     |    3 |        |
| sdfgdf   |    4 |        |
| sdf      |    5 |        |
| dsgfdghf |    6 |        |
| fgh      |    7 |        |
| drg      |    8 |        |
| d        |    9 |        |
| hk       |   10 |        |
| dg       |   11 | Jan    |
| fyjk     |   12 | Jan    |
| as       |   13 | Jan    |


### After
With the fields specified explicitly, the columns of the export did not rely on the first batch result anymore. This way the shifting could be eliminated.

| id | title    |  author.first_name |
|----|----------|-------------------|
|  5 | sgdfg    |                         |
|  6 | efa      |                           |
|  9 | sccx     |                           |
|  8 | sdfgdf   |                           |
|  4 | sdf      |                         |
| 10 | dsgfdghf |                          |
|  7 | fgh      |                       |
| 14 | drg      |                        |
| 15 | d        |                          |
| 11 | hk       |                           |
| 12 | dg       |        Jan               |
| 13 | fyjk     |         Jan               |
|  3 | as       |         Jan               |


NOTE: I could not test it with the dataset provided in the linked issue, since this is a dump from v10.

---

Fixes https://github.com/directus/directus/issues/22298
