### PR TITLE
API: Only prevent infinite loop if the schema is not cached

### DIFF
--- a/.changeset/wild-squids-approve.md
+++ b/.changeset/wild-squids-approve.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed cached schema infinite loop in slow network environments

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -35,10 +35,6 @@ export async function getSchema(
 
 	const env = useEnv();
 
-	if (attempt >= MAX_ATTEMPTS) {
-		throw new Error(`Failed to get Schema information: hit infinite loop`);
-	}
-
 	if (options?.bypassCache || env['CACHE_SCHEMA'] === false) {
 		const database = options?.database || getDatabase();
 		const schemaInspector = createInspector(database);
@@ -50,6 +46,10 @@ export async function getSchema(
 
 	if (cached) {
 		return cached;
+	}
+
+	if (attempt >= MAX_ATTEMPTS) {
+		throw new Error(`Failed to get Schema information: hit infinite loop`);
 	}
 
 	const lock = useLock();


### PR DESCRIPTION
## Scope
When the Redis connection is slow, we can face the isse `Failed to get Schema information: hit infinite loop`.
This may happen because while the "producer" node is computing the schema and publishes it, the "consumer" nodes may have not subscribed to the result yet because it took too long.

In order to solve that, we just need to check if the schema is already computed and in cache before we check if we are entering an infinite loop

What's changed:

- Prevent schema infinite loop in slow network environments

## Potential Risks / Drawbacks

- For each new attempt, it needs to make a "get" request to Redis, but I don't think it should be a problem

## Review Notes / Questions

- None
