### PR TITLE
Docs: Enhance docker compose example to wait for dependent services

### DIFF
--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -98,9 +98,23 @@ services:
       POSTGRES_USER: "directus"
       POSTGRES_PASSWORD: "directus"
       POSTGRES_DB: "directus"
+    healthcheck:
+      test: ["CMD", "pg_isready", "--host=localhost", "--username=directus"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_interval: 5s
+      start_period: 30s
 
   cache:
     image: redis:6
+    healthcheck:
+      test: ["CMD-SHELL", "[ $$(redis-cli ping) = 'PONG' ]"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_interval: 5s
+      start_period: 30s
 
   directus:
     image: directus/directus:{{ packages.directus.version.full }}
@@ -110,8 +124,10 @@ services:
       - ./uploads:/directus/uploads
       - ./extensions:/directus/extensions
     depends_on:
-      - cache
-      - database
+      database:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
     environment:
       SECRET: "replace-with-secure-random-value"
 


### PR DESCRIPTION
## Scope

Enhance the docker compose example so that the `directus` service waits for the `database` and `cache` services to be ready before starting itself.
This prevents the `directus` service from failing during database initialization phase or similar situations where the dependent services are not yet available.

## Potential Risks / Drawbacks

- Additional logic in the docker compose file
- Slightly longer startup time for the service

## Review Notes / Questions

- We can use `CMD` for the standalone `pg_isready` binary and thus avoid shell overhead, but we need to use `CMD-SHELL` for the redis test which involves a small shell check
- The `--host=localhost` argument for `pg_isready` ensures the check runs via network interface and not the UNIX socket, which is already available during initialization 
- Tested locally

---

Fixes #20542
