### PR TITLE
Implement user copy on tabular (#19411)

### DIFF
--- a/app/src/components/v-table/table-row.vue
+++ b/app/src/components/v-table/table-row.vue
@@ -26,7 +26,7 @@ const props = withDefaults(
 	},
 );
 
-defineEmits(['click', 'item-selected']);
+const emit = defineEmits(['click', 'item-selected']);
 
 const cssHeight = computed(() => {
 	return {
@@ -34,10 +34,16 @@ const cssHeight = computed(() => {
 		renderTemplateImage: props.height - 16 + 'px',
 	};
 });
+
+function onClick(event) {
+	if (window.getSelection().toString()) return;
+
+	emit('click', event);
+}
 </script>
 
 <template>
-	<tr class="table-row" :class="{ subdued: subdued, clickable: hasClickListener }" @click="$emit('click', $event)">
+	<tr class="table-row" :class="{ subdued: subdued, clickable: hasClickListener }" @click="onClick">
 		<td v-if="showManualSort" class="manual cell" @click.stop>
 			<v-icon name="drag_handle" class="drag-handle" :class="{ 'sorted-manually': sortedManually }" />
 		</td>
@@ -51,7 +57,7 @@ const cssHeight = computed(() => {
 			/>
 		</td>
 
-		<td v-for="header in headers" :key="header.value" class="cell" :class="`align-${header.align}`">
+		<td v-for="header in headers" :key="header.value" class="cell text-selectable" :class="`align-${header.align}`">
 			<slot :name="`item.${header.value}`" :item="item">
 				<v-text-overflow
 					v-if="
@@ -89,6 +95,14 @@ const cssHeight = computed(() => {
 		text-overflow: ellipsis;
 		background-color: var(--v-table-background-color, transparent);
 		border-bottom: var(--theme--border-width) solid var(--theme--border-color-subdued);
+		position: relative;
+
+		&.text-selectable {
+			user-select: text;
+			* {
+				user-select: text;
+			}
+		}
 
 		&:last-child {
 			padding: 0 12px;

--- a/app/src/displays/boolean/boolean.vue
+++ b/app/src/displays/boolean/boolean.vue
@@ -40,6 +40,7 @@ const styles = computed(() => {
 		<template v-else>
 			<v-icon v-if="iconOn !== null && iconOff !== null" :name="value ? iconOn : iconOff"></v-icon>
 			<span v-if="labelOn !== null && labelOff !== null">{{ value ? labelOn : labelOff }}</span>
+			<slot :copy-value="value ? labelOn : labelOff" />
 		</template>
 	</div>
 </template>

--- a/app/src/displays/collection/collection.vue
+++ b/app/src/displays/collection/collection.vue
@@ -22,5 +22,6 @@ const { info } = useCollection(collection);
 	<div v-else>
 		<v-icon v-if="icon" :name="info.icon" left small />
 		{{ info.name }}
+		<slot :copy-value="info.name" />
 	</div>
 </template>

--- a/app/src/displays/datetime/datetime.vue
+++ b/app/src/displays/datetime/datetime.vue
@@ -13,6 +13,8 @@ withDefaults(defineProps<Props>(), {
 <template>
 	<use-datetime v-slot="{ datetime }" v-bind="$props">
 		<span class="datetime">{{ datetime }}</span>
+
+		<slot :copy-value="datetime" />
 	</use-datetime>
 </template>
 

--- a/app/src/displays/filesize/index.ts
+++ b/app/src/displays/filesize/index.ts
@@ -1,13 +1,26 @@
 import { defineDisplay } from '@directus/extensions';
 import { formatFilesize } from '@/utils/format-filesize';
-import { h } from 'vue';
+import { h, defineComponent } from 'vue';
 
 export default defineDisplay({
 	id: 'filesize',
 	name: '$t:displays.filesize.filesize',
 	description: '$t:displays.filesize.description',
 	icon: 'description',
-	component: ({ value }: { value: number }) => h('span', null, formatFilesize(value)),
+	component: defineComponent({
+		props: {
+			value: {
+				type: Number,
+				required: true,
+			},
+		},
+		setup(props, { slots }) {
+			return () => [
+				h('span', null, formatFilesize(props.value)),
+				slots.default && slots.default({ copyValue: formatFilesize(props.value) }),
+			];
+		},
+	}),
 	handler: (value: number) => formatFilesize(value),
 	options: [],
 	types: ['integer', 'bigInteger'],

--- a/app/src/displays/formatted-json-value/formatted-json-value.vue
+++ b/app/src/displays/formatted-json-value/formatted-json-value.vue
@@ -61,5 +61,6 @@ function renderValue(input: Record<string, any> | Record<string, any>[]) {
 	</v-menu>
 	<span v-else>
 		{{ displayValue[0] }}
+		<slot :copy-value="displayValue[0]" />
 	</span>
 </template>

--- a/app/src/displays/formatted-value/formatted-value.vue
+++ b/app/src/displays/formatted-value/formatted-value.vue
@@ -179,6 +179,8 @@ function matchNumber(left: number, right: number, operator: string) {
 		<span class="value">
 			{{ displayValue }}
 		</span>
+
+		<slot :copy-value="displayValue" />
 	</div>
 </template>
 

--- a/app/src/displays/mime-type/index.ts
+++ b/app/src/displays/mime-type/index.ts
@@ -1,7 +1,7 @@
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { defineDisplay } from '@directus/extensions';
 import mime from 'mime/lite';
-import { h } from 'vue';
+import { h, defineComponent } from 'vue';
 
 export default defineDisplay({
 	id: 'mime-type',
@@ -25,13 +25,31 @@ export default defineDisplay({
 		},
 	],
 	types: ['string'],
-	component: ({ value, showAsExtension }: { value: string; showAsExtension: boolean }) => {
-		if (showAsExtension) {
-			return h('span', mime.getExtension(value) as string);
-		}
+	component: defineComponent({
+		props: {
+			value: {
+				type: String,
+				required: true,
+			},
+			showAsExtension: {
+				type: Boolean,
+				required: true,
+			},
+		},
+		setup(props, { slots }) {
+			if (props.showAsExtension) {
+				return () => [
+					h('span', mime.getExtension(props.value) as string),
+					slots.default && slots.default({ copyValue: mime.getExtension(props.value) }),
+				];
+			}
 
-		return h('span', readableMimeType(value) as string);
-	},
+			return () => [
+				h('span', readableMimeType(props.value) as string),
+				slots.default && slots.default({ copyValue: readableMimeType(props.value) }),
+			];
+		},
+	}),
 	handler: (value, options) => {
 		if (options.showAsExtension) {
 			return mime.getExtension(value);

--- a/app/src/displays/raw/index.ts
+++ b/app/src/displays/raw/index.ts
@@ -1,11 +1,23 @@
 import { defineDisplay } from '@directus/extensions';
 import { TYPES, LOCAL_TYPES } from '@directus/constants';
+import { defineComponent, PropType } from 'vue';
 
 export default defineDisplay({
 	id: 'raw',
 	name: '$t:displays.raw.raw',
 	icon: 'code',
-	component: ({ value }) => (typeof value === 'string' ? value : JSON.stringify(value)),
+	component: defineComponent({
+		props: {
+			value: {
+				type: Object as PropType<any>,
+				required: true,
+			},
+		},
+		setup(props, { slots }) {
+			const value = typeof props.value === 'string' ? props.value : JSON.stringify(props.value);
+			return () => [value, slots.default && slots.default({ copyValue: value })];
+		},
+	}),
 	options: [],
 	types: TYPES,
 	localTypes: LOCAL_TYPES,

--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -90,10 +90,13 @@ const translations = computed(() => {
 	<value-null v-if="!relationInfo?.junctionCollection?.collection" />
 	<div v-else class="display-translations">
 		<render-template
+			v-slot="{ copyValue }"
 			:template="internalTemplate"
 			:item="displayItem"
 			:collection="relationInfo.junctionCollection.collection"
-		/>
+		>
+			<slot :copy-value="copyValue" />
+		</render-template>
 		<v-menu class="menu" show-arrow :disabled="value.length === 0">
 			<template #activator="{ toggle, deactivate, active }">
 				<v-icon small class="icon" :class="{ active }" name="info" @click.stop="toggle" @focusout="deactivate"></v-icon>

--- a/app/src/displays/user/user.vue
+++ b/app/src/displays/user/user.vue
@@ -43,7 +43,10 @@ const src = computed(() => {
 				:alt="value && userName(value)"
 				:class="{ circle }"
 			/>
-			<span v-if="display === 'name' || display === 'both'">{{ userName(value) }}</span>
+			<span v-if="display === 'name' || display === 'both'">
+				{{ userName(value) }}
+				<slot :copy-value="userName(value)" />
+			</span>
 		</div>
 	</user-popover>
 </template>

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -10,6 +10,7 @@ import type { ShowSelect } from '@directus/extensions';
 import type { Field, Filter, Item } from '@directus/types';
 import { ComponentPublicInstance, Ref, inject, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useClipboard } from '@/composables/use-clipboard';
 
 defineOptions({ inheritAttrs: false });
 
@@ -65,6 +66,7 @@ const { t } = useI18n();
 const { collection } = toRefs(props);
 
 const { sortAllowed } = useCollectionPermissions(collection);
+const { copyToClipboard, pasteFromClipboard } = useClipboard();
 
 const selectionWritable = useSync(props, 'selection', emit);
 const tableHeadersWritable = useSync(props, 'tableHeaders', emit);
@@ -137,6 +139,7 @@ function removeField(fieldKey: string) {
 		>
 			<template v-for="header in tableHeaders" :key="header.value" #[`item.${header.value}`]="{ item }">
 				<render-display
+					v-slot="{ copyValue }"
 					:value="getFromAliasedItem(item, header.value)"
 					:display="header.field.display"
 					:options="header.field.displayOptions"
@@ -145,7 +148,9 @@ function removeField(fieldKey: string) {
 					:type="header.field.type"
 					:collection="header.field.collection"
 					:field="header.field.field"
-				/>
+				>
+					<v-icon class="clipboard-icon" name="content_copy" @click.stop="copyToClipboard(copyValue)" />
+				</render-display>
 			</template>
 
 			<template #header-context-menu="{ header }">
@@ -290,6 +295,27 @@ function removeField(fieldKey: string) {
 
 		tr {
 			margin-right: var(--content-padding);
+		}
+	}
+
+	.table-row {
+		.cell {
+			.clipboard-icon {
+				--v-icon-color: var(--theme--foreground-subdued);
+				--v-icon-color-hover: var(--theme--foreground);
+				position: absolute;
+				right: 0;
+				top: 0;
+				opacity: 0;
+				visibility: hidden;
+				transform: translate(-50%, 50%);
+				transition: 0.3s;
+			}
+
+			&:hover .clipboard-icon {
+				opacity: 1;
+				visibility: visible;
+			}
 		}
 	}
 }

--- a/app/src/views/private/components/render-display.vue
+++ b/app/src/views/private/components/render-display.vue
@@ -25,14 +25,16 @@ const displayInfo = useExtension('display', display);
 		<component
 			:is="`display-${display}`"
 			v-bind="options"
+			v-slot="{ copyValue }"
 			:interface="interface"
 			:interface-options="interfaceOptions"
 			:value="value"
 			:type="type"
 			:collection="collection"
 			:field="field"
-		/>
-
+		>
+			<slot :copy-value="copyValue" />
+		</component>
 		<template #fallback>
 			<v-text-overflow class="display" :text="value" />
 		</template>

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -146,6 +146,7 @@ function handleObject(fieldKey: string) {
 			<v-error-boundary v-else-if="typeof part === 'object' && part.component" :name="`display-${part.component}`">
 				<component
 					:is="`display-${part.component}`"
+					v-slot="{ copyValue }"
 					v-bind="part.options"
 					:value="part.value"
 					:interface="part.interface"
@@ -153,14 +154,22 @@ function handleObject(fieldKey: string) {
 					:type="part.type"
 					:collection="part.collection"
 					:field="part.field"
-				/>
+				>
+					<slot :copy-value="copyValue" />
+				</component>
 
 				<template #fallback>
 					<span>{{ part.value }}</span>
 				</template>
 			</v-error-boundary>
-			<span v-else-if="typeof part === 'string'" :dir="direction">{{ translate(part) }}</span>
-			<span v-else>{{ part }}</span>
+			<span v-else-if="typeof part === 'string'" :dir="direction">
+				{{ translate(part) }}
+				<slot :copy-value="translate(part)" />
+			</span>
+			<span v-else>
+				{{ part }}
+				<slot :copy-value="part" />
+			</span>
 		</template>
 	</div>
 </template>


### PR DESCRIPTION
## Scope
Provide user copyable in table layout

What's changed:

- Show copy icon in table cell item when user hover the cell item
- Set each display component should be copy value
- Add text selectable in table cell item


https://github.com/user-attachments/assets/2919fc8a-667f-4262-b32b-18ec6ffd5071



## Potential Risks / Drawbacks

By the following default style setting, it would not text selectable.
I am not sure what better way to overwrite it.

```css
 *:not(svg *) {
    user-select: none;
 }
```

## Review Notes / Questions

- 

---

Fixes #19411
