### PR TITLE
Add null filtering to equality operators

### DIFF
--- a/.changeset/fifty-shirts-wait.md
+++ b/.changeset/fifty-shirts-wait.md
@@ -1,0 +1,6 @@
+---
+'@directus/types': patch
+'@directus/api': patch
+---
+
+Added null filtering to equality operators

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -630,12 +630,22 @@ export function applyFilter(
 			// See https://github.com/knex/knex/issues/4518 @TODO remove as any once knex is updated
 
 			// These operators don't rely on a value, and can thus be used without one (eg `?filter[field][_null]`)
-			if ((operator === '_null' && compareValue !== false) || (operator === '_nnull' && compareValue === false)) {
+			if (
+				(operator === '_null' && compareValue !== false) ||
+				(operator === '_nnull' && compareValue === false) ||
+				(operator === '_eq' && compareValue === null)
+			) {
 				dbQuery[logical].whereNull(selectionRaw);
+				return;
 			}
 
-			if ((operator === '_nnull' && compareValue !== false) || (operator === '_null' && compareValue === false)) {
+			if (
+				(operator === '_nnull' && compareValue !== false) ||
+				(operator === '_null' && compareValue === false) ||
+				(operator === '_neq' && compareValue === null)
+			) {
 				dbQuery[logical].whereNotNull(selectionRaw);
+				return;
 			}
 
 			if ((operator === '_empty' && compareValue !== false) || (operator === '_nempty' && compareValue === false)) {

--- a/packages/types/src/filter.ts
+++ b/packages/types/src/filter.ts
@@ -44,8 +44,8 @@ export type FieldFilter = {
 };
 
 export type FieldFilterOperator = {
-	_eq?: string | number | boolean;
-	_neq?: string | number | boolean;
+	_eq?: string | number | boolean | null;
+	_neq?: string | number | boolean | null;
 	_lt?: string | number;
 	_lte?: string | number;
 	_gt?: string | number;


### PR DESCRIPTION
## Scope

What's changed:

- Added null filtering to equality operators
  - `_eq: null` => `null: true`
  - `_neq: null` => `nnull: true`

## Potential Risks / Drawbacks

- Nil

## Review Notes / Questions

- Nil

---

Fixes #13778