### PR TITLE
Bypass dynamic variable processing when migrating down

### DIFF
--- a/api/src/database/migrations/20240710A-permissions-policies.ts
+++ b/api/src/database/migrations/20240710A-permissions-policies.ts
@@ -341,7 +341,11 @@ export async function down(knex: Knex) {
 
 			//  fetch all of the policies permissions
 			const rawPermissions = await fetchPermissions(
-				{ accountability: { role: null, roles: roleTree, user: null, app: roleAccess?.app_access || false }, policies },
+				{
+					accountability: { role: null, roles: roleTree, user: null, app: roleAccess?.app_access || false },
+					policies,
+					bypassDynamicVariableProcessing: true,
+				},
 				context,
 			);
 


### PR DESCRIPTION
## Scope

What's changed:

- Bypass the processing of dynamic variables when migrating down

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

---

Follow-up of #23097 where the dynamic vars were processed, resulting in nullish values instead of keeping the dynamic variables as is.
