### PR TITLE
Fix server error on root m2a query

### DIFF
--- a/.changeset/dull-spies-worry.md
+++ b/.changeset/dull-spies-worry.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that would cause the API to return an error when a root field in a m2a builder was queried

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -133,6 +133,12 @@ export async function parseFields(options: ParseFieldsOptions, context: ParseFie
 				}
 			}
 
+			if (name.includes(':')) {
+				const [key, scope] = name.split(':');
+				relationalStructure[key!] = { [scope!]: [] };
+				continue;
+			}
+
 			children.push({ type: 'field', name, fieldKey, whenCase: [] });
 		}
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Fixed an issue that would cause the API to return a 500 error when a builder m2a field was queried without specifying nested fields.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Simple fix, simple review 🤞🏻 

---

Fixes #23179 
