### PR TITLE
Fix missing policies in public role policy selection

### DIFF
--- a/.changeset/red-buckets-wink.md
+++ b/.changeset/red-buckets-wink.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed missing policies in public role policy selection

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -39,9 +39,16 @@ policiesField!.meta!.options = {
 	filter: {
 		'$FOLLOW(directus_access,policy)': {
 			_none: {
-				role: {
-					_null: true,
-				},
+				_and: [
+					{
+						role: {
+							_null: true,
+						},
+					},
+					{
+						user: { _null: true },
+					},
+				],
 			},
 		},
 	},


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The public role has a special item filter for the m2m policies interface that only looked at the `role` field of the `directus_access` rows, leading to missing policies in the selection. It should instead also look at the user and show the policies that have not been assigned to the public role (identified by not having an access row associated with the policy where `role` *and* `user` are null).

What's changed:

- Update filter

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23191 
