### PR TITLE
Fix sorting of aggregated result

### DIFF
--- a/.changeset/two-items-joke.md
+++ b/.changeset/two-items-joke.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed broken permissions for sorting of aggregate query when using the aggregate result as sort field

--- a/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
+++ b/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
@@ -29,7 +29,16 @@ export function extractPathsFromQuery(query: Query) {
 		for (const field of query.sort) {
 			// Sort can have dot notation fields for sorting on m2o values Sort fields can start with
 			// `-` to indicate descending order, which should be dropped for permissions checks
-			readOnlyPaths.push(field.split('.').map((field) => (field.startsWith('-') ? field.substring(1) : field)));
+
+			const parts = field.split('.').map((field) => (field.startsWith('-') ? field.substring(1) : field));
+
+			if (query.aggregate && parts.length > 0 && parts[0]! in query.aggregate) {
+				// If query is an aggregate query and the first part is a requested aggregate operation ignore the whole field
+				// The field is correctly accounted for in the aggregate operation
+				continue;
+			}
+
+			readOnlyPaths.push(parts);
 		}
 	}
 

--- a/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
+++ b/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
@@ -33,8 +33,8 @@ export function extractPathsFromQuery(query: Query) {
 			const parts = field.split('.').map((field) => (field.startsWith('-') ? field.substring(1) : field));
 
 			if (query.aggregate && parts.length > 0 && parts[0]! in query.aggregate) {
-				// If query is an aggregate query and the first part is a requested aggregate operation ignore the whole field
-				// The correct field is extracted into the field map when procession the `query.aggregate` fields.
+				// If query is an aggregate query and the first part is a requested aggregate operation, ignore the whole field.
+				// The correct field is extracted into the field map when processing the `query.aggregate` fields.
 				continue;
 			}
 

--- a/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
+++ b/api/src/permissions/modules/process-ast/utils/extract-paths-from-query.ts
@@ -34,7 +34,7 @@ export function extractPathsFromQuery(query: Query) {
 
 			if (query.aggregate && parts.length > 0 && parts[0]! in query.aggregate) {
 				// If query is an aggregate query and the first part is a requested aggregate operation ignore the whole field
-				// The field is correctly accounted for in the aggregate operation
+				// The correct field is extracted into the field map when procession the `query.aggregate` fields.
 				continue;
 			}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The sorting based on aggregated fields needs to be handled in a special way.

When constructing the field map for permission checking we need to ignore all sort fields that are located in the scope of the aggregation, e.g. everything starting with `sum.` if there is a aggregate `sum` operation. 
The correct fields still show up in the field map because they are extracted from the aggregate query. 

What's changed:

- Ignore aggregated fields showing up in sort when constructing field map

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #23189 