### PR TITLE
Fix M2A query regression from #23181

### DIFF
--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -1,7 +1,7 @@
 import { REGEX_BETWEEN_PARENS } from '@directus/constants';
 import type { Accountability, Query, SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
-import { isEmpty } from 'lodash-es';
+import { isEmpty, merge } from 'lodash-es';
 import { fetchPermissions } from '../../../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../../../permissions/lib/fetch-policies.js';
 import type { FieldNode, FunctionFieldNode, NestedCollectionNode } from '../../../types/index.js';
@@ -137,8 +137,14 @@ export async function parseFields(
 			}
 
 			if (name.includes(':')) {
-				const [key, scope] = name.split(':');
-				relationalStructure[key!] = { [scope!]: [] };
+				const [key, scope] = name.split(':') as [string, string];
+
+				if (key in relationalStructure) {
+					relationalStructure[key] = merge(relationalStructure[key], { [scope]: [] });
+				} else {
+					relationalStructure[key] = { [scope]: [] };
+				}
+
 				continue;
 			}
 

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -1,7 +1,7 @@
 import { REGEX_BETWEEN_PARENS } from '@directus/constants';
 import type { Accountability, Query, SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
-import { isEmpty, merge } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 import { fetchPermissions } from '../../../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../../../permissions/lib/fetch-policies.js';
 import type { FieldNode, FunctionFieldNode, NestedCollectionNode } from '../../../types/index.js';
@@ -140,7 +140,9 @@ export async function parseFields(
 				const [key, scope] = name.split(':') as [string, string];
 
 				if (key in relationalStructure) {
-					relationalStructure[key] = merge(relationalStructure[key], { [scope]: [] });
+					if (scope in relationalStructure[key]! === false) {
+						(relationalStructure[key] as CollectionScope)[scope] = [];
+					}
 				} else {
 					relationalStructure[key] = { [scope]: [] };
 				}

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -139,12 +139,10 @@ export async function parseFields(
 			if (name.includes(':')) {
 				const [key, scope] = name.split(':') as [string, string];
 
-				if (key in relationalStructure) {
-					if (scope in relationalStructure[key]! === false) {
-						(relationalStructure[key] as CollectionScope)[scope] = [];
-					}
-				} else {
+				if (key in relationalStructure === false) {
 					relationalStructure[key] = { [scope]: [] };
+				} else if (scope in (relationalStructure[key] as CollectionScope) === false) {
+					(relationalStructure[key] as CollectionScope)[scope] = [];
 				}
 
 				continue;


### PR DESCRIPTION
During the review I overlooked a possibility, where the newly introduced logic might fail as it overrides the existing relational structure if more than one m2a field is requested, e.g. `/items/articles?fields=m2a.item:authors.title,m2a.item:categories`.

This now correctly merged the relational structure if it already exists.