### PR TITLE
Fix related field permissions

### DIFF
--- a/.changeset/slow-rats-smoke.md
+++ b/.changeset/slow-rats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed permission checking for o2m related fields

--- a/api/src/permissions/modules/process-ast/lib/inject-cases.ts
+++ b/api/src/permissions/modules/process-ast/lib/inject-cases.ts
@@ -44,8 +44,8 @@ function processChildren(
 			throw new Error(`Cannot extract access permissions for field "${fieldKey}" in collection "${collection}"`);
 		}
 
-		// If there's one or more permissions that allow full access to this field, we can safe some
-		// query perf overhead by ignoring the whole case/when system
+		// The case/when system only needs to take place if no full access is given on this field,
+		// otherwise we can skip and thus safe some query perf overhead
 		if (!allowedFields.has('*') && !allowedFields.has(fieldKey)) {
 			// Global and field can't both be undefined as per the error check prior
 			child.whenCase = [...(globalWhenCase ?? []), ...(fieldWhenCase ?? [])];

--- a/api/src/permissions/modules/process-ast/lib/inject-cases.ts
+++ b/api/src/permissions/modules/process-ast/lib/inject-cases.ts
@@ -45,7 +45,7 @@ function processChildren(
 		}
 
 		// If there's one or more permissions that allow full access to this field, we can safe some
-		// query perf overhead by ignoring the whole case/where system
+		// query perf overhead by ignoring the whole case/when system
 		if (!allowedFields.has('*') && !allowedFields.has(fieldKey)) {
 			// Global and field can't both be undefined as per the error check prior
 			child.whenCase = [...(globalWhenCase ?? []), ...(fieldWhenCase ?? [])];

--- a/api/src/permissions/modules/process-ast/lib/inject-cases.ts
+++ b/api/src/permissions/modules/process-ast/lib/inject-cases.ts
@@ -32,11 +32,7 @@ function processChildren(
 	//
 
 	for (const child of children) {
-		// If there's one or more permissions that allow full access to this field, we can safe some
-		// query perf overhead by ignoring the whole case/where system
 		const fieldKey = getUnaliasedFieldKey(child);
-
-		if (allowedFields.has('*') || allowedFields.has(fieldKey)) continue;
 
 		const globalWhenCase = caseMap['*'];
 		const fieldWhenCase = caseMap[fieldKey];
@@ -48,8 +44,12 @@ function processChildren(
 			throw new Error(`Cannot extract access permissions for field "${fieldKey}" in collection "${collection}"`);
 		}
 
-		// Global and field can't both be undefined as per the error check prior
-		child.whenCase = [...(globalWhenCase ?? []), ...(fieldWhenCase ?? [])];
+		// If there's one or more permissions that allow full access to this field, we can safe some
+		// query perf overhead by ignoring the whole case/where system
+		if (!allowedFields.has('*') && !allowedFields.has(fieldKey)) {
+			// Global and field can't both be undefined as per the error check prior
+			child.whenCase = [...(globalWhenCase ?? []), ...(fieldWhenCase ?? [])];
+		}
 
 		if (child.type === 'm2o') {
 			child.cases = processChildren(child.relation.related_collection!, child.children, permissions);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

Instead of skipping over the full AST node if the field is allowed (in a policy that does not have a filter), only skip the `whenCase` injection, but still process the AST children. Otherwise the permissions of the related collection are not correctly injected into the `cases` of the AST child. But those are necessary for the related query that is run based on the AST.

---

Fixes #23197
