### PR TITLE
Append user supplied `filename_disk` with file extension if not present

### DIFF
--- a/.changeset/wild-chicken-leave.md
+++ b/.changeset/wild-chicken-leave.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed appending file extension to filename_disk if not present

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -199,6 +199,58 @@ describe('Integration Tests', () => {
 
 				vi.useRealTimers();
 			});
+
+			it('should not append the extension to `filename_disk` if extension is present', async () => {
+				tracker.on
+					.select(
+						'select "folder", "filename_download", "filename_disk", "title", "description", "metadata" from "directus_files" where "id" = ?',
+					)
+					.response(null);
+
+				const mockDataJPG = {
+					storage: 'local',
+					type: 'image/jpeg',
+					filename_download: 'test.jpg',
+					filename_disk: 'test.jpg',
+				};
+
+				const mockDataPNG = {
+					storage: 'local',
+					type: 'image/png',
+					filename_download: 'test.png',
+					filename_disk: 'test.png',
+				};
+
+				const mockDate = new Date();
+
+				vi.setSystemTime(mockDate);
+
+				await service.uploadOne(new PassThrough(), mockDataJPG);
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					sample.id,
+					expect.objectContaining({
+						...mockDataJPG,
+						uploaded_on: mockDate.toISOString(),
+						filename_disk: 'test.jpg',
+					}),
+					{ emitEvents: false },
+				);
+
+				await service.uploadOne(new PassThrough(), mockDataPNG);
+
+				expect(superUpdateOne).toHaveBeenCalledWith(
+					sample.id,
+					expect.objectContaining({
+						...mockDataPNG,
+						uploaded_on: mockDate.toISOString(),
+						filename_disk: 'test.png',
+					}),
+					{ emitEvents: false },
+				);
+
+				vi.useRealTimers();
+			});
 		});
 	});
 });

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -87,10 +87,10 @@ export class FilesService extends ItemsService<File> {
 			payload.filename_disk = primaryKey + (fileExtension || '');
 		}
 
-			// If the filename_disk doesn't include an extension, append it
-			if (!path.extname(payload.filename_disk!)) {
-				payload.filename_disk = payload.filename_disk + (fileExtension || '');
-			}
+		// If the filename_disk doesn't include an extension, append it
+		if (!path.extname(payload.filename_disk!)) {
+			payload.filename_disk += fileExtension || '';
+		}
 
 		// Temp filename is used for replacements
 		const tempFilenameDisk = 'temp_' + payload.filename_disk;

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -87,6 +87,11 @@ export class FilesService extends ItemsService<File> {
 			payload.filename_disk = primaryKey + (fileExtension || '');
 		}
 
+			// If the filename_disk doesn't include an extension, append it
+			if (!path.extname(payload.filename_disk!)) {
+				payload.filename_disk = payload.filename_disk + (fileExtension || '');
+			}
+
 		// Temp filename is used for replacements
 		const tempFilenameDisk = 'temp_' + payload.filename_disk;
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Append file extension when supplied `filename_disk` is not present.

## Potential Risks / Drawbacks

- Changes what users expect in a specific scenario for `filename_disk` when supplied with a custom value.

## Review Notes / Questions

- Creates a standard that `filename_disk` is consistent with extension.

---

Fixes #23200 
