### PR TITLE
Adjust the init CLI command for new `mysql2` package

### DIFF
--- a/.changeset/nervous-ladybugs-sell.md
+++ b/.changeset/nervous-ladybugs-sell.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed the init CLI command for MySQL to use the new `mysql2` package

--- a/api/src/cli/commands/init/questions.ts
+++ b/api/src/cli/commands/init/questions.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import type { Driver } from '../../../types/index.js';
 
 const filename = ({ filepath }: { filepath: string }): Record<string, string> => ({
 	type: 'input',
@@ -14,15 +15,15 @@ const host = (): Record<string, string> => ({
 	default: '127.0.0.1',
 });
 
-const port = ({ client }: { client: string }): Record<string, any> => ({
+const port = ({ client }: { client: Exclude<Driver, 'sqlite3'> }): Record<string, any> => ({
 	type: 'input',
 	name: 'port',
 	message: 'Port:',
 	default() {
-		const ports: Record<string, number> = {
+		const ports: Record<Exclude<Driver, 'sqlite3'>, number> = {
 			pg: 5432,
 			cockroachdb: 26257,
-			mysql: 3306,
+			mysql2: 3306,
 			oracledb: 1521,
 			mssql: 1433,
 		};
@@ -67,7 +68,7 @@ const ssl = (): Record<string, string | boolean> => ({
 
 export const databaseQuestions = {
 	sqlite3: [filename],
-	mysql: [host, port, database, user, password],
+	mysql2: [host, port, database, user, password],
 	pg: [host, port, database, user, password, ssl],
 	cockroachdb: [host, port, database, user, password, ssl],
 	oracledb: [host, port, database, user, password],

--- a/api/src/cli/utils/drivers.ts
+++ b/api/src/cli/utils/drivers.ts
@@ -3,7 +3,7 @@ import type { Driver } from '../../types/index.js';
 export const drivers: Record<Driver, string> = {
 	pg: 'PostgreSQL / Redshift',
 	cockroachdb: 'CockroachDB (Beta)',
-	mysql: 'MySQL / MariaDB / Aurora',
+	mysql2: 'MySQL / MariaDB / Aurora',
 	sqlite3: 'SQLite',
 	mssql: 'Microsoft SQL Server',
 	oracledb: 'Oracle Database',

--- a/api/src/types/database.ts
+++ b/api/src/types/database.ts
@@ -1,4 +1,4 @@
-export type Driver = 'mysql' | 'pg' | 'cockroachdb' | 'sqlite3' | 'oracledb' | 'mssql';
+export type Driver = 'mysql2' | 'pg' | 'cockroachdb' | 'sqlite3' | 'oracledb' | 'mssql';
 
 export const DatabaseClients = ['mysql', 'postgres', 'cockroachdb', 'sqlite', 'oracle', 'mssql', 'redshift'] as const;
 export type DatabaseClient = (typeof DatabaseClients)[number];


### PR DESCRIPTION
## Scope

Follow-up on #22534, adjusting the init CLI command to install the correct npm package (`mysql2` instead of `mysql`).

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Can be tested as follows:

```bash
# in directus repo root
pnpm build
docker compose up -d mysql

directus=$(pwd)
tmp=$(mktemp -d)

cd "$tmp"

node "${directus}/api/dist/cli/run.js" init
# answer init questions

rm -r "$tmp"
cd "$directus"
docker compose down
```

```console
? Choose your database client MySQL / MariaDB / Aurora
? Database Host: 127.0.0.1
? Port: 5101
? Database Name: directus
? Database User: root
? Database Password: ******

Create your first admin user:

? Email admin@example.com
? Password ********

Your project has been created at /var/folders/x6/r0pmjxyd1d9d2jlr489342d80000gn/T/tmp.VdPEzR7JvM.

The configuration can be found in /var/folders/x6/r0pmjxyd1d9d2jlr489342d80000gn/T/tmp.VdPEzR7JvM/.env

Start Directus by running:
  cd /var/folders/x6/r0pmjxyd1d9d2jlr489342d80000gn/T/tmp.VdPEzR7JvM
  npx directus start
```

---

Fixes #23226
