### PR TITLE
Fix the "add-system-fk-triggers" migration for mysql2

### DIFF
--- a/.changeset/curvy-bears-smile.md
+++ b/.changeset/curvy-bears-smile.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Ensured the migrations are properly executed when bootstrapping MySQL

--- a/api/src/database/migrations/20210519A-add-system-fk-triggers.ts
+++ b/api/src/database/migrations/20210519A-add-system-fk-triggers.ts
@@ -1,6 +1,7 @@
 import { createInspector } from '@directus/schema';
 import type { Knex } from 'knex';
 import { useLogger } from '../../logger/index.js';
+import { getDatabaseClient } from '../index.js';
 
 /**
  * Things to keep in mind:
@@ -110,7 +111,7 @@ export async function up(knex: Knex): Promise<void> {
 			 * MySQL won't delete the index when you drop the foreign key constraint. Gotta make
 			 * sure to clean those up as well
 			 */
-			if (knex.client.constructor.name === 'Client_MySQL') {
+			if (getDatabaseClient(knex) === 'mysql') {
 				try {
 					await knex.schema.alterTable(update.table, (table) => {
 						// Knex uses a default convention for index names: `table_column_type`
@@ -155,7 +156,7 @@ export async function down(knex: Knex): Promise<void> {
 			 * MySQL won't delete the index when you drop the foreign key constraint. Gotta make
 			 * sure to clean those up as well
 			 */
-			if (knex.client.constructor.name === 'Client_MySQL') {
+			if (getDatabaseClient(knex) === 'mysql') {
 				try {
 					await knex.schema.alterTable(update.table, (table) => {
 						// Knex uses a default convention for index names: `table_column_type`

--- a/api/src/database/migrations/20230721A-require-shares-fields.ts
+++ b/api/src/database/migrations/20230721A-require-shares-fields.ts
@@ -1,11 +1,10 @@
 import { createInspector } from '@directus/schema';
 import type { Knex } from 'knex';
 import { useLogger } from '../../logger/index.js';
-import { getHelpers } from '../helpers/index.js';
+import { getDatabaseClient } from '../index.js';
 
 export async function up(knex: Knex): Promise<void> {
-	const helper = getHelpers(knex).schema;
-	const isMysql = helper.isOneOfClients(['mysql']);
+	const isMysql = getDatabaseClient(knex) === 'mysql';
 
 	if (isMysql) {
 		await dropConstraint(knex);
@@ -22,8 +21,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-	const helper = getHelpers(knex).schema;
-	const isMysql = helper.isOneOfClients(['mysql']);
+	const isMysql = getDatabaseClient(knex) === 'mysql';
 
 	if (isMysql) {
 		await dropConstraint(knex);

--- a/api/src/database/migrations/20240716A-update-files-date-fields.ts
+++ b/api/src/database/migrations/20240716A-update-files-date-fields.ts
@@ -1,11 +1,8 @@
 import type { Knex } from 'knex';
-import { getHelpers } from '../helpers/index.js';
+import { getDatabaseClient } from '../index.js';
 
 export async function up(knex: Knex): Promise<void> {
-	const helper = getHelpers(knex).schema;
-	const isMysql = helper.isOneOfClients(['mysql']);
-
-	if (isMysql) {
+	if (getDatabaseClient(knex) === 'mysql') {
 		// Knex creates invalid statement on MySQL, see https://github.com/knex/knex/issues/1888
 		await knex.schema.raw(
 			'ALTER TABLE `directus_files` CHANGE `uploaded_on` `created_on` TIMESTAMP NOT NULL DEFAULT current_timestamp();',
@@ -28,10 +25,7 @@ export async function down(knex: Knex): Promise<void> {
 		table.dropColumn('uploaded_on');
 	});
 
-	const helper = getHelpers(knex).schema;
-	const isMysql = helper.isOneOfClients(['mysql']);
-
-	if (isMysql) {
+	if (getDatabaseClient(knex) === 'mysql') {
 		await knex.schema.raw(
 			'ALTER TABLE `directus_files` CHANGE `created_on` `uploaded_on` TIMESTAMP NOT NULL DEFAULT current_timestamp();',
 		);


### PR DESCRIPTION
## Scope

Adjust the database client check in the "add-system-fk-triggers" migration to account for mysql2.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes #23227
