### PR TITLE
Respect system language on display translations

### DIFF
--- a/.changeset/short-bats-grab.md
+++ b/.changeset/short-bats-grab.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that would cause the translations display not to use the correct language if the user relied on "system
+language"

--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { useRelationM2M } from '@/composables/use-relation-m2m';
+import { getCurrentLanguage } from '@/lang/get-current-language';
 import { useFieldsStore } from '@/stores/fields';
-import { useUserStore } from '@/stores/user';
-import type { User } from '@directus/types';
 import { isNil } from 'lodash';
 import { computed, toRefs } from 'vue';
 
@@ -48,8 +47,8 @@ const displayItem = computed(() => {
 	let item = props.value.find((val) => val?.[langField]?.[langPkField] === props.defaultLanguage) ?? props.value[0];
 
 	if (props.userLanguage) {
-		const user = useUserStore();
-		item = props.value.find((val) => val?.[langField]?.[langPkField] === (user.currentUser as User)?.language) ?? item;
+		const lang = getCurrentLanguage();
+		item = props.value.find((val) => val?.[langField]?.[langPkField] === lang) ?? item;
 	}
 
 	return item ?? {};

--- a/contributors.yml
+++ b/contributors.yml
@@ -145,3 +145,4 @@
 - SP12893678
 - AndriyAntonenko
 - jacobwise
+- danilobuerger


### PR DESCRIPTION
## Scope

What's changed:

display translation now use `getCurrentLanguage` to use the system language if the user has not set his own language.

---

Fixes #23239
