### PR TITLE
Retry transaction also for SQLITE_BUSY

### DIFF
--- a/.changeset/stale-eyes-complain.md
+++ b/.changeset/stale-eyes-complain.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': patch
+'@directus/api': minor
 ---
 
-For `sqlite` retry a failed transaction when SQLITE_BUSY happens.
+Added transaction retry mechanism for SQLite if a `SQLITE_BUSY` errors occurs

--- a/.changeset/stale-eyes-complain.md
+++ b/.changeset/stale-eyes-complain.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+For `sqlite` retry a failed transaction when SQLITE_BUSY happens.

--- a/api/src/utils/transaction.ts
+++ b/api/src/utils/transaction.ts
@@ -28,7 +28,23 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 			 */
 			const COCKROACH_RETRY_ERROR_CODE = '40001';
 
-			if (client !== 'cockroachdb' || error?.code !== COCKROACH_RETRY_ERROR_CODE) throw error;
+			/**
+			 * SQLITE_BUSY is an error code returned by SQLite when an operation can't be
+			 * performed due to a locked database file. This often arises due to multiple
+			 * processes trying to simultaneously access the database, causing potential
+			 * data inconsistencies. To handle this, one can utilize a retry mechanism
+			 * where the operation is attempted again after a short delay. Further
+			 * solutions include using serialized or Write-Ahead Logging (WAL) modes
+			 * in SQLite, both facilitating simultaneous access by multiple applications.
+			 *
+			 * @link https://www.sqlite.org/rescode.html#busy
+			 */
+			const SQLITE_BUSY_ERROR_CODE = 'SQLITE_BUSY';
+
+			if (
+				(client === 'cockroachdb' && error?.code !== COCKROACH_RETRY_ERROR_CODE) ||
+				(client === 'sqlite' && error?.code !== SQLITE_BUSY_ERROR_CODE)
+			) throw error;
 
 			const MAX_ATTEMPTS = 3;
 			const BASE_DELAY = 100;
@@ -45,7 +61,7 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 				try {
 					return await knex.transaction((trx) => handler(trx));
 				} catch (error: any) {
-					if (error?.code !== COCKROACH_RETRY_ERROR_CODE) throw error;
+					if (error?.code !== COCKROACH_RETRY_ERROR_CODE && error?.code !== SQLITE_BUSY_ERROR_CODE) throw error;
 				}
 			}
 

--- a/api/src/utils/transaction.ts
+++ b/api/src/utils/transaction.ts
@@ -33,10 +33,9 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 			 * SQLITE_BUSY is an error code returned by SQLite when an operation can't be
 			 * performed due to a locked database file. This often arises due to multiple
 			 * processes trying to simultaneously access the database, causing potential
-			 * data inconsistencies. To handle this, one can utilize a retry mechanism
-			 * where the operation is attempted again after a short delay. Further
-			 * solutions include using serialized or Write-Ahead Logging (WAL) modes
-			 * in SQLite, both facilitating simultaneous access by multiple applications.
+			 * data inconsistencies. There are a few mechanisms to handle this case,
+			 * one of which is to retry the complete transaction again
+			 * on client-side after a short delay.
 			 *
 			 * @link https://www.sqlite.org/rescode.html#busy
 			 */

--- a/api/src/utils/transaction.ts
+++ b/api/src/utils/transaction.ts
@@ -44,7 +44,8 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 			if (
 				(client === 'cockroachdb' && error?.code !== COCKROACH_RETRY_ERROR_CODE) ||
 				(client === 'sqlite' && error?.code !== SQLITE_BUSY_ERROR_CODE)
-			) throw error;
+			)
+				throw error;
 
 			const MAX_ATTEMPTS = 3;
 			const BASE_DELAY = 100;

--- a/api/src/utils/transaction.ts
+++ b/api/src/utils/transaction.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@directus/utils';
 import { type Knex } from 'knex';
 import { getDatabaseClient } from '../database/index.js';
 import { useLogger } from '../logger/index.js';
@@ -15,7 +16,7 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 	} else {
 		try {
 			return await knex.transaction((trx) => handler(trx));
-		} catch (error: any) {
+		} catch (error) {
 			const client = getDatabaseClient(knex);
 
 			/**
@@ -42,8 +43,9 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 			const SQLITE_BUSY_ERROR_CODE = 'SQLITE_BUSY';
 
 			if (
-				(client === 'cockroachdb' && error?.code !== COCKROACH_RETRY_ERROR_CODE) ||
-				(client === 'sqlite' && error?.code !== SQLITE_BUSY_ERROR_CODE)
+				!isObject(error) ||
+				(client === 'cockroachdb' && error['code'] !== COCKROACH_RETRY_ERROR_CODE) ||
+				(client === 'sqlite' && error['code'] !== SQLITE_BUSY_ERROR_CODE)
 			)
 				throw error;
 

--- a/api/src/utils/transaction.ts
+++ b/api/src/utils/transaction.ts
@@ -2,6 +2,7 @@ import { isObject } from '@directus/utils';
 import { type Knex } from 'knex';
 import { getDatabaseClient } from '../database/index.js';
 import { useLogger } from '../logger/index.js';
+import type { DatabaseClient } from '../types/index.js';
 
 /**
  * Execute the given handler within the current transaction or a newly created one
@@ -19,34 +20,7 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 		} catch (error) {
 			const client = getDatabaseClient(knex);
 
-			/**
-			 * This error code indicates that the transaction failed due to another
-			 * concurrent or recent transaction attempting to write to the same data.
-			 * This can usually be solved by restarting the transaction on client-side
-			 * after a short delay, so that it is executed against the latest state.
-			 *
-			 * @link https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference
-			 */
-			const COCKROACH_RETRY_ERROR_CODE = '40001';
-
-			/**
-			 * SQLITE_BUSY is an error code returned by SQLite when an operation can't be
-			 * performed due to a locked database file. This often arises due to multiple
-			 * processes trying to simultaneously access the database, causing potential
-			 * data inconsistencies. There are a few mechanisms to handle this case,
-			 * one of which is to retry the complete transaction again
-			 * on client-side after a short delay.
-			 *
-			 * @link https://www.sqlite.org/rescode.html#busy
-			 */
-			const SQLITE_BUSY_ERROR_CODE = 'SQLITE_BUSY';
-
-			if (
-				!isObject(error) ||
-				(client === 'cockroachdb' && error['code'] !== COCKROACH_RETRY_ERROR_CODE) ||
-				(client === 'sqlite' && error['code'] !== SQLITE_BUSY_ERROR_CODE)
-			)
-				throw error;
+			if (!shouldRetryTransaction(client, error)) throw error;
 
 			const MAX_ATTEMPTS = 3;
 			const BASE_DELAY = 100;
@@ -62,8 +36,8 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 
 				try {
 					return await knex.transaction((trx) => handler(trx));
-				} catch (error: any) {
-					if (error?.code !== COCKROACH_RETRY_ERROR_CODE && error?.code !== SQLITE_BUSY_ERROR_CODE) throw error;
+				} catch (error) {
+					if (!shouldRetryTransaction(client, error)) throw error;
 				}
 			}
 
@@ -73,3 +47,33 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 		}
 	}
 };
+
+function shouldRetryTransaction(client: DatabaseClient, error: unknown): boolean {
+	/**
+	 * This error code indicates that the transaction failed due to another
+	 * concurrent or recent transaction attempting to write to the same data.
+	 * This can usually be solved by restarting the transaction on client-side
+	 * after a short delay, so that it is executed against the latest state.
+	 *
+	 * @link https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference
+	 */
+	const COCKROACH_RETRY_ERROR_CODE = '40001';
+
+	/**
+	 * SQLITE_BUSY is an error code returned by SQLite when an operation can't be
+	 * performed due to a locked database file. This often arises due to multiple
+	 * processes trying to simultaneously access the database, causing potential
+	 * data inconsistencies. There are a few mechanisms to handle this case,
+	 * one of which is to retry the complete transaction again
+	 * on client-side after a short delay.
+	 *
+	 * @link https://www.sqlite.org/rescode.html#busy
+	 */
+	const SQLITE_BUSY_ERROR_CODE = 'SQLITE_BUSY';
+
+	return (
+		isObject(error) &&
+		((client === 'cockroachdb' && error['code'] === COCKROACH_RETRY_ERROR_CODE) ||
+			(client === 'sqlite' && error['code'] === SQLITE_BUSY_ERROR_CODE))
+	);
+}

--- a/contributors.yml
+++ b/contributors.yml
@@ -145,3 +145,4 @@
 - SP12893678
 - AndriyAntonenko
 - jacobwise
+- joggienl


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added to also retry a failed transaction when `SQLITE_BUSY` happens.
- The if that previously checked for `client === 'cockroachdb' OR error.code !== COCKROACH_RETRY_ERROR_CODE` has been changed to `client === 'cockroachdb' AND error?.code !== COCKROACH_RETRY_ERROR_CODE` so that error codes can be unique per client (for instance, what if MySQL also has an error_code `40001`?).

## Potential Risks / Drawbacks

- I do not think anything _should_ break from this but it is deep in the code (a lot of code uses the `transaction` helper). So that is a "risk" I suppose.

## Review Notes / Questions

- The if I changed from OR to AND, I am not aware if that might have happened with special reasoning.

---

Fixes #23242 
