### PR TITLE
Ignore missing foreign key constraint in policies migration

### DIFF
--- a/.changeset/afraid-berries-nail.md
+++ b/.changeset/afraid-berries-nail.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Improved permission migration to handle a missing foreign key more gracefully
+Improved policies migration to handle a missing foreign key on `directus_permissions.role` more gracefully

--- a/.changeset/afraid-berries-nail.md
+++ b/.changeset/afraid-berries-nail.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved permission migration to handle a missing foreign key more gracefully


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Gracefully handle the missing foreign key constraint in the up migration of policies. Normally the foreign key constraint should not be missing, but apparently it might. Since we're dropping the column in the next step anyways we should be safe to ignore the failed foreign key constraint.

---

Fixes #23228
