### PR TITLE
API / Migrations: Fix drop foreign key if have a different name

### DIFF
--- a/.changeset/eleven-mails-walk.md
+++ b/.changeset/eleven-mails-walk.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed drop foreign key if has different constraint name on permissions policies migrations

--- a/api/src/database/migrations/20240806A-permissions-policies.ts
+++ b/api/src/database/migrations/20240806A-permissions-policies.ts
@@ -239,6 +239,7 @@ export async function up(knex: Knex) {
 	try {
 		const inspector = await getSchemaInspector();
 		const foreignKeys = await inspector.foreignKeys('directus_permissions');
+
 		const foreignConstraint =
 			foreignKeys.find((foreign) => foreign.foreign_key_table === 'directus_roles' && foreign.column === 'role')
 				?.constraint_name || undefined;

--- a/api/src/database/migrations/20240806A-permissions-policies.ts
+++ b/api/src/database/migrations/20240806A-permissions-policies.ts
@@ -166,7 +166,6 @@ const PUBLIC_POLICY_ID = 'abf8a154-5b1c-4a46-ac9c-7300570f4f17';
 
 export async function up(knex: Knex) {
 	const logger = useLogger();
-	const inspector = await getSchemaInspector();
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// If the policies table already exists the migration has already run
@@ -238,6 +237,7 @@ export async function up(knex: Knex) {
 	});
 
 	try {
+		const inspector = await getSchemaInspector();
 		const foreignKeys = await inspector.foreignKeys('directus_permissions');
 		const foreignConstraint =
 			foreignKeys.find((foreign) => foreign.foreign_key_table === 'directus_roles')?.constraint_name || undefined;

--- a/api/src/database/migrations/20240806A-permissions-policies.ts
+++ b/api/src/database/migrations/20240806A-permissions-policies.ts
@@ -240,7 +240,8 @@ export async function up(knex: Knex) {
 		const inspector = await getSchemaInspector();
 		const foreignKeys = await inspector.foreignKeys('directus_permissions');
 		const foreignConstraint =
-			foreignKeys.find((foreign) => foreign.foreign_key_table === 'directus_roles')?.constraint_name || undefined;
+			foreignKeys.find((foreign) => foreign.foreign_key_table === 'directus_roles' && foreign.column === 'role')
+				?.constraint_name || undefined;
 
 		await knex.schema.alterTable('directus_permissions', (table) => {
 			// Drop the foreign key constraint here in order to update `null` role to public policy ID


### PR DESCRIPTION
## Scope
When trying to upgrade, the migration [20240806A-permissions-policies.ts](https://github.com/directus/directus/blob/main/api/src/database/migrations/20240806A-permissions-policies.ts) failed.

After some investigation, it looks like the migration is breaking on [this line](https://github.com/directus/directus/blob/main/api/src/database/migrations/20240806A-permissions-policies.ts#L241)
It seems that Knex is expecting the foreign key to be `directus_permissions_role_foreign` but in this case the foreign key is `directus_permissions_role_directus_roles_id`

In this PR, we fix this by getting the name of the foreign constraint and use it if exists, according to [dropForeign documentation](https://knexjs.org/guide/schema-builder.html#dropforeign)

What's changed:

- Fixed drop foreign key if has different name on permissions policies migrations

## Potential Risks / Drawbacks

- Slower migration. Since we need to have the foreign constraint name, we need to request this from database

## Review Notes / Questions

- None
