### PR TITLE
Allow setting knex connection options containing underscores (e.g. application_name)

### DIFF
--- a/.changeset/gold-dragons-lay.md
+++ b/.changeset/gold-dragons-lay.md
@@ -1,0 +1,6 @@
+---
+'docs': patch
+'@directus/api': patch
+---
+
+Allow setting knex connection options containing underscores (e.g. application_name)

--- a/api/src/utils/get-config-from-env.test.ts
+++ b/api/src/utils/get-config-from-env.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
 		OBJECT_BRAND__HEX: '#6644FF',
 		CAMELCASE_OBJECT__FIRST_KEY: 'firstValue',
 		CAMELCASE_OBJECT__SECOND_KEY: 'secondValue',
+		TRIPLE_APPLICATION___NAME: 'directus',
 	});
 });
 
@@ -26,5 +27,10 @@ describe('get config from env', () => {
 		expect(getConfigFromEnv('CAMELCASE_')).toStrictEqual({
 			object: { firstKey: 'firstValue', secondKey: 'secondValue' },
 		});
+	});
+
+	test('Keys with triple underscore should transform to single underscore', () => {
+		expect(getConfigFromEnv('TRIPLE_', 'camelcase')).toStrictEqual({ application_name: 'directus' });
+		expect(getConfigFromEnv('TRIPLE_', 'underscore')).toStrictEqual({ application_name: 'directus' });
 	});
 });

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -26,7 +26,9 @@ export function getConfigFromEnv(
 			if (matches) continue;
 		}
 
-		if (key.includes('__')) {
+		if (key.includes('___')) {
+			config[key.slice(prefix.length).replace('___', '_').toLowerCase()] = value;
+		} else if (key.includes('__')) {
 			const path = key
 				.split('__')
 				.map((key, index) => (index === 0 ? transform(transform(key.slice(prefix.length))) : transform(key)));

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -321,6 +321,9 @@ This includes:
     Note: `DB_SSL__CA_FILE` may be preferred to load the CA directly from a file, see
     [Environment Variable Files](#environment-variable-files) for more information.
 
+- Options including triple underscores `___` will be transformed to single underscores, enabling setting options like
+  `application_name` via `DB_APPLICATION___NAME`.
+
 :::
 
 ## Redis


### PR DESCRIPTION
## Scope

What's changed:

Allow setting knex connection options containing underscores (e.g. application_name)

## Potential Risks / Drawbacks

- Unable to set nested configs starting with an underscore

---

Fixes #23241
