### PR TITLE
Fix `DB_CLIENT` expected before project initialized

### DIFF
--- a/.changeset/tender-dragons-teach.md
+++ b/.changeset/tender-dragons-teach.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `"DB_CLIENT" Environment Variable is missing.` appearing during `directus init`

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -191,12 +191,12 @@ export function getDatabase(): Knex {
 	return database;
 }
 
-export function getSchemaInspector(): SchemaInspector {
+export function getSchemaInspector(database?: Knex): SchemaInspector {
 	if (inspector) {
 		return inspector;
 	}
 
-	const database = getDatabase();
+	database = database ?? getDatabase();
 
 	inspector = createInspector(database);
 

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -196,7 +196,7 @@ export function getSchemaInspector(database?: Knex): SchemaInspector {
 		return inspector;
 	}
 
-	database = database ?? getDatabase();
+	database ??= getDatabase();
 
 	inspector = createInspector(database);
 

--- a/api/src/database/migrations/20240806A-permissions-policies.ts
+++ b/api/src/database/migrations/20240806A-permissions-policies.ts
@@ -237,7 +237,7 @@ export async function up(knex: Knex) {
 	});
 
 	try {
-		const inspector = await getSchemaInspector();
+		const inspector = await getSchemaInspector(knex);
 		const foreignKeys = await inspector.foreignKeys('directus_permissions');
 
 		const foreignConstraint =


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Updated `getSchemaInspector` to accept passing in the database to bypass `getDatabase` being called

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #23255
