### PR TITLE
Fix readonly mutation to fields in the store via item drawer

### DIFF
--- a/.changeset/eight-fishes-scream.md
+++ b/.changeset/eight-fishes-scream.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed readonly mutation to fields in the store via item drawer

--- a/app/src/composables/use-permissions/item/lib/get-fields.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.ts
@@ -16,9 +16,9 @@ export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermi
 
 		if (!collectionValue) return [];
 
-		if (userStore.isAdmin) return rawFields.value;
-
 		let fields = cloneDeep(rawFields.value);
+
+		if (userStore.isAdmin) return fields;
 
 		const readableFields = getPermission(collectionValue, 'read')?.fields;
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

In the `get-fields` function within `use-item-permissions` composable, the current logic returns the fields _without_ using `cloneDeep` for admin users:

https://github.com/directus/directus/blob/e602450d2b52f023511e4780c1383ef4f8bcfe73/app/src/composables/use-permissions/item/lib/get-fields.ts#L19-L21

However within `drawer-item` component, there is a logic to set circular fields to readonly:

https://github.com/directus/directus/blob/e602450d2b52f023511e4780c1383ef4f8bcfe73/app/src/views/private/components/drawer-item.vue#L118-L125

Hence the field in the store gets mutated, even if the admin user goes back to their own user page until they do a browser refresh to re-fetch said mutated field.

Seems like originally before the changes in #21152, the fields were actually always `cloneDeep`'d _before_ being returned as-is for admin users:

https://github.com/directus/directus/blob/ccbb34acd9423bae09831991e378fbcc3ea46abc/app/src/composables/use-permissions.ts#L55-L58

So this PR should basically be a tiny revert.

## Potential Risks / Drawbacks

- Re-introduces the perf cost with `cloneDeep` for admin users, even if this is still technically a code revert.

---

Fixes #22806
