### PR TITLE
Fix drop folder to file library with bad request

### DIFF
--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -292,7 +292,7 @@ function useFileUpload() {
 			notificationsStore.remove(dragNotificationID);
 		}
 
-		const files = [...(event.dataTransfer.files as any)];
+		const files = Array.from(event.dataTransfer.files).filter((file) => file.type);
 
 		fileUploadNotificationID = notificationsStore.add({
 			title: t(


### PR DESCRIPTION
## Scope
When user drag and drop some files which contain folder, it will got bad request.
Becasue folder is not a file.

What's changed:

- Add filter to check file mine type is valid (folder's mine type is empty string)

Issue Demo:

https://github.com/user-attachments/assets/9bfe6c9d-7717-43d3-aa03-7d03e1daaa1d


Fixed Demo:

https://github.com/user-attachments/assets/050ceb7a-c2f1-4f82-9e85-10d05e33842d


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- User might expect drag and drop folder to upload nested structure folder and files, maybe it could be a new feature?
- If support folder structure upload, it might consider same folder name problem, or always create new folder for it.

---

Fixes #23132
