### PR TITLE
Make delete icon only visible for O2M/M2M/M2A fields if at least one of the add buttons is visible

### DIFF
--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -381,7 +381,11 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 						/>
 						<div class="spacer" />
 						<v-icon
-							v-if="!disabled && (enableCreate || enableSelect) && (deleteAllowed[element[relationInfo.collectionField.field]] || isLocalItem(element))"
+							v-if="
+								!disabled &&
+								(enableCreate || enableSelect) &&
+								(deleteAllowed[element[relationInfo.collectionField.field]] || isLocalItem(element))
+							"
 							class="clear-icon"
 							:name="getDeselectIcon(element)"
 							@click.stop="deleteItem(element)"

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -381,7 +381,7 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 						/>
 						<div class="spacer" />
 						<v-icon
-							v-if="!disabled && (deleteAllowed[element[relationInfo.collectionField.field]] || isLocalItem(element))"
+							v-if="!disabled && (enableCreate || enableSelect) && (deleteAllowed[element[relationInfo.collectionField.field]] || isLocalItem(element))"
 							class="clear-icon"
 							:name="getDeselectIcon(element)"
 							@click.stop="deleteItem(element)"

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -564,7 +564,7 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 								<v-icon name="launch" />
 							</router-link>
 							<v-icon
-								v-if="!disabled && (deleteAllowed || isLocalItem(element))"
+								v-if="!disabled && (enableCreate || enableSelect) && (deleteAllowed || isLocalItem(element))"
 								v-tooltip="t(getDeselectTooltip(element))"
 								class="deselect"
 								:name="getDeselectIcon(element)"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -513,7 +513,7 @@ function getLinkForItem(item: DisplayItem) {
 								<v-icon name="launch" />
 							</router-link>
 							<v-icon
-								v-if="!disabled && (deleteAllowed || isLocalItem(element))"
+								v-if="!disabled && (enableCreate || enableSelect) && (deleteAllowed || isLocalItem(element))"
 								v-tooltip="t(getDeselectTooltip(element))"
 								class="deselect"
 								:name="getDeselectIcon(element)"

--- a/contributors.yml
+++ b/contributors.yml
@@ -149,3 +149,4 @@
 - McSundae
 - danilobuerger
 - joggienl
+- terbshaeusser


### PR DESCRIPTION
## Scope

What's changed:

- Delete icon in O2M/M2M/M2A fields is only visible if at least one of the add buttons is visible

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #23285
