### PR TITLE
Improved querying of `languages` collection in translations interface

### DIFF
--- a/.changeset/chilly-ladybugs-cough.md
+++ b/.changeset/chilly-ladybugs-cough.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed translations interface that attempted to query the language direction field, even if unconfigured and unavailable

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -166,6 +166,7 @@ function useLanguages() {
 	const languages = ref<Record<string, any>[]>([]);
 	const loading = ref(false);
 	const error = ref<any>(null);
+	const fieldsStore = useFieldsStore();
 
 	watch(relationInfo, fetchLanguages, { immediate: true });
 
@@ -208,12 +209,13 @@ function useLanguages() {
 		if (!relationInfo.value) return;
 
 		const fields = new Set<string>();
+		const collection = relationInfo.value.relatedCollection.collection;
 
-		if (props.languageField !== null) {
+		if (props.languageField !== null && fieldsStore.getField(collection, props.languageField)) {
 			fields.add(props.languageField);
 		}
 
-		if (props.languageDirectionField !== null) {
+		if (props.languageDirectionField !== null && fieldsStore.getField(collection, props.languageDirectionField)) {
 			fields.add(props.languageDirectionField);
 		}
 
@@ -225,15 +227,12 @@ function useLanguages() {
 		loading.value = true;
 
 		try {
-			languages.value = await fetchAll<Record<string, any>[]>(
-				getEndpoint(relationInfo.value.relatedCollection.collection),
-				{
-					params: {
-						fields: Array.from(fields),
-						sort: sortField ?? props.languageField ?? pkField,
-					},
+			languages.value = await fetchAll<Record<string, any>[]>(getEndpoint(collection), {
+				params: {
+					fields: Array.from(fields),
+					sort: sortField ?? props.languageField ?? pkField,
 				},
-			);
+			});
 
 			if (!firstLang.value) {
 				const userLocale = userLanguage.value ? locale.value : defaultLanguage.value;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Since the `languageDirectionField` always defaults to `direction` if left unconfigured it might lead to problems if the field does not exist and the more stringent field existence checks in v11.

What's changed:

- Confirm that the fields requested on the collection actually exist before adding them to the fields

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

- The interface can deal with `direction: undefined` as this is the default in case a direction field is explicitly not set

---

Fixes #23299
