### PR TITLE
Hide WYSIWYG toolbar if no items are selected

### DIFF
--- a/.changeset/silent-gifts-pay.md
+++ b/.changeset/silent-gifts-pay.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Improved WYSIWYG editor to hide the toolbar if no elements are selected
+Improved WYSIWYG editor to hide the toolbar if no toolbar items are selected

--- a/.changeset/silent-gifts-pay.md
+++ b/.changeset/silent-gifts-pay.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Disable tinymce toolbar if no elements are selected
+Improved WYSIWYG editor to hide the toolbar if no elements are selected

--- a/.changeset/silent-gifts-pay.md
+++ b/.changeset/silent-gifts-pay.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Disable tinymce toolbar if no elements are selected

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -200,7 +200,7 @@ const editorOptions = computed(() => {
 		convert_urls: false,
 		image_dimensions: false,
 		extended_valid_elements: 'audio[loop|controls],source[src|type]',
-		toolbar: toolbarString,
+		toolbar: toolbarString ? toolbarString : false,
 		style_formats: styleFormats,
 		file_picker_types: 'customImage customMedia image media',
 		link_default_protocol: 'https',


### PR DESCRIPTION
## Scope

What's changed:
Disables tinymce toolbar if no elements are selected

## Potential Risks / Drawbacks

## Review Notes / Questions


---

Fixes #23309
