### PR TITLE
Fix caching for dynamic variables

### DIFF
--- a/.changeset/famous-tables-reflect.md
+++ b/.changeset/famous-tables-reflect.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed caching behavior of permissions that contain dynamic variables

--- a/api/src/permissions/lib/fetch-permissions.test.ts
+++ b/api/src/permissions/lib/fetch-permissions.test.ts
@@ -4,7 +4,7 @@ import { PermissionsService } from '../../services/permissions.js';
 import type { Context } from '../types.js';
 import { fetchDynamicVariableContext } from '../utils/fetch-dynamic-variable-context.js';
 import { processPermissions } from '../utils/process-permissions.js';
-import { _fetchPermissions as fetchPermissions } from './fetch-permissions.js';
+import { fetchPermissions } from './fetch-permissions.js';
 import { withAppMinimalPermissions } from './with-app-minimal-permissions.js';
 
 vi.mock('../../services/permissions.js', () => ({

--- a/api/src/permissions/lib/fetch-permissions.ts
+++ b/api/src/permissions/lib/fetch-permissions.ts
@@ -1,22 +1,9 @@
-import type { Accountability, Filter, Permission, PermissionsAction } from '@directus/types';
-import { pick, sortBy } from 'lodash-es';
+import type { Accountability, Filter, PermissionsAction } from '@directus/types';
 import type { Context } from '../types.js';
 import { fetchDynamicVariableContext } from '../utils/fetch-dynamic-variable-context.js';
+import { fetchRawPermissions } from '../utils/fetch-raw-permissions.js';
 import { processPermissions } from '../utils/process-permissions.js';
-import { withCache } from '../utils/with-cache.js';
 import { withAppMinimalPermissions } from './with-app-minimal-permissions.js';
-
-export const fetchPermissions = withCache(
-	'permissions',
-	_fetchPermissions,
-	({ action, policies, collections, accountability, bypassDynamicVariableProcessing }) => ({
-		policies, // we assume that policies always come from the same source, so they should be in the same order
-		...(action && { action }),
-		...(collections && { collections: sortBy(collections) }),
-		...(accountability && { accountability: pick(accountability, ['user', 'role', 'roles', 'app']) }),
-		...(bypassDynamicVariableProcessing && { bypassDynamicVariableProcessing }),
-	}),
-);
 
 export interface FetchPermissionsOptions {
 	action?: PermissionsAction;
@@ -26,40 +13,31 @@ export interface FetchPermissionsOptions {
 	bypassDynamicVariableProcessing?: boolean;
 }
 
-export async function _fetchPermissions(options: FetchPermissionsOptions, context: Context) {
-	const { PermissionsService } = await import('../../services/permissions.js');
-	const permissionsService = new PermissionsService(context);
-
-	const filter: Filter = {
-		_and: [{ policy: { _in: options.policies } }],
-	};
-
-	if (options.action) {
-		filter._and.push({ action: { _eq: options.action } });
-	}
-
-	if (options.collections) {
-		filter._and.push({ collection: { _in: options.collections } });
-	}
-
-	let permissions = (await permissionsService.readByQuery({
-		filter,
-		limit: -1,
-	})) as Permission[];
-
-	// Sort permissions by their order in the policies array
-	// This ensures that if a sorted array of policies is passed in the permissions are returned in the same order
-	// which is necessary for correctly applying the presets in order
-	permissions = sortBy(permissions, (permission) => options.policies.indexOf(permission.policy!));
+export async function fetchPermissions(options: FetchPermissionsOptions, context: Context) {
+	const permissions = await fetchRawPermissions(options, context);
 
 	if (options.accountability && !options.bypassDynamicVariableProcessing) {
+		const filter: Filter = {
+			_and: [],
+		};
+
+		if (options.action) {
+			filter._and.push({ action: { _eq: options.action } });
+		}
+
+		if (options.collections) {
+			filter._and.push({ collection: { _in: options.collections } });
+		}
+
 		// Add app minimal permissions for the request accountability, if applicable.
 		// Normally this is done in the permissions service readByQuery, but it also needs to do it here
 		// since the permissions service is created without accountability.
 		// We call it without the policies filter, since the static minimal app permissions don't have a policy attached.
-		const permissionsWithAppPermissions = withAppMinimalPermissions(options.accountability ?? null, permissions, {
-			_and: filter._and.slice(1),
-		});
+		const permissionsWithAppPermissions = withAppMinimalPermissions(
+			options.accountability ?? null,
+			permissions,
+			filter,
+		);
 
 		const permissionsContext = await fetchDynamicVariableContext(
 			{

--- a/api/src/permissions/modules/fetch-allowed-collections/fetch-allowed-collections.ts
+++ b/api/src/permissions/modules/fetch-allowed-collections/fetch-allowed-collections.ts
@@ -2,7 +2,6 @@ import type { Accountability, PermissionsAction } from '@directus/types';
 import { uniq } from 'lodash-es';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { withCache } from '../../utils/with-cache.js';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 
 export interface FetchAllowedCollectionsOptions {
@@ -10,23 +9,7 @@ export interface FetchAllowedCollectionsOptions {
 	accountability: Pick<Accountability, 'user' | 'role' | 'roles' | 'ip' | 'admin' | 'app'>;
 }
 
-export const fetchAllowedCollections = withCache(
-	'allowed-collections',
-	_fetchAllowedCollections,
-	({ action, accountability: { user, role, roles, ip, admin, app } }) => ({
-		action,
-		accountability: {
-			user,
-			role,
-			roles,
-			ip,
-			admin,
-			app,
-		},
-	}),
-);
-
-export async function _fetchAllowedCollections(
+export async function fetchAllowedCollections(
 	{ action, accountability }: FetchAllowedCollectionsOptions,
 	{ knex, schema }: Context,
 ): Promise<string[]> {

--- a/api/src/permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.test.ts
+++ b/api/src/permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.test.ts
@@ -2,7 +2,7 @@ import type { Accountability, SchemaOverview } from '@directus/types';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { _fetchAllowedFieldMap as fetchAllowedFieldMap } from './fetch-allowed-field-map.js';
+import { fetchAllowedFieldMap } from './fetch-allowed-field-map.js';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 import type { Permission } from '@directus/types';
 

--- a/api/src/permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.ts
+++ b/api/src/permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.ts
@@ -2,7 +2,6 @@ import type { Accountability, PermissionsAction } from '@directus/types';
 import { uniq } from 'lodash-es';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { withCache } from '../../utils/with-cache.js';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 
 export type FieldMap = Record<string, string[]>;
@@ -12,16 +11,7 @@ export interface FetchAllowedFieldMapOptions {
 	action: PermissionsAction;
 }
 
-export const fetchAllowedFieldMap = withCache(
-	'allowed-field-map',
-	_fetchAllowedFieldMap,
-	({ action, accountability: { user, role, roles, ip, admin, app } }) => ({
-		action,
-		accountability: { user, role, roles, ip, admin, app },
-	}),
-);
-
-export async function _fetchAllowedFieldMap(
+export async function fetchAllowedFieldMap(
 	{ accountability, action }: FetchAllowedFieldMapOptions,
 	{ knex, schema }: Context,
 ) {

--- a/api/src/permissions/modules/fetch-allowed-fields/fetch-allowed-fields.test.ts
+++ b/api/src/permissions/modules/fetch-allowed-fields/fetch-allowed-fields.test.ts
@@ -2,7 +2,7 @@ import type { Accountability, Permission, SchemaOverview } from '@directus/types
 import { beforeEach, expect, test, vi } from 'vitest';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { _fetchAllowedFields as fetchAllowedFields } from './fetch-allowed-fields.js';
+import { fetchAllowedFields } from './fetch-allowed-fields.js';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 
 vi.mock('../../lib/fetch-policies.js');

--- a/api/src/permissions/modules/fetch-allowed-fields/fetch-allowed-fields.ts
+++ b/api/src/permissions/modules/fetch-allowed-fields/fetch-allowed-fields.ts
@@ -3,23 +3,12 @@ import { uniq } from 'lodash-es';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { withCache } from '../../utils/with-cache.js';
 
 export interface FetchAllowedFieldsOptions {
 	collection: string;
 	action: PermissionsAction;
 	accountability: Pick<Accountability, 'user' | 'role' | 'roles' | 'ip' | 'app'>;
 }
-
-export const fetchAllowedFields = withCache(
-	'allowed-fields',
-	_fetchAllowedFields,
-	({ action, collection, accountability: { user, role, roles, ip, app } }) => ({
-		action,
-		collection,
-		accountability: { user, role, roles, ip, app },
-	}),
-);
 
 /**
  * Look up all fields that are allowed to be used for the given collection and action for the given
@@ -28,7 +17,7 @@ export const fetchAllowedFields = withCache(
  * Done by looking up all available policies for the current accountability object, and reading all
  * permissions that exist for the collection+action+policy combination
  */
-export async function _fetchAllowedFields(
+export async function fetchAllowedFields(
 	{ accountability, action, collection }: FetchAllowedFieldsOptions,
 	{ knex, schema }: Context,
 ): Promise<string[]> {

--- a/api/src/permissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.test.ts
+++ b/api/src/permissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { _fetchInconsistentFieldMap as fetchInconsistentFieldMap } from './fetch-inconsistent-field-map.js';
+import { fetchInconsistentFieldMap } from './fetch-inconsistent-field-map.js';
 
 vi.mock('../../lib/fetch-policies.js');
 vi.mock('../../lib/fetch-permissions.js', () => ({ fetchPermissions: vi.fn() }));

--- a/api/src/permissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.ts
+++ b/api/src/permissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.ts
@@ -1,8 +1,7 @@
 import type { Accountability, PermissionsAction } from '@directus/types';
-import { uniq, intersection, difference, pick } from 'lodash-es';
+import { uniq, intersection, difference } from 'lodash-es';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { withCache } from '../../utils/with-cache.js';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 
 export type FieldMap = Record<string, string[]>;
@@ -15,16 +14,7 @@ export interface FetchInconsistentFieldMapOptions {
 /**
  * Fetch a field map for fields that may or may not be null based on item-by-item permissions.
  */
-export const fetchInconsistentFieldMap = withCache(
-	'inconsistent-field-map',
-	_fetchInconsistentFieldMap,
-	({ action, accountability }) => ({
-		action,
-		accountability: accountability ? pick(accountability, ['user', 'role', 'roles', 'ip', 'admin', 'app']) : null,
-	}),
-);
-
-export async function _fetchInconsistentFieldMap(
+export async function fetchInconsistentFieldMap(
 	{ accountability, action }: FetchInconsistentFieldMapOptions,
 	{ knex, schema }: Context,
 ) {

--- a/api/src/permissions/utils/fetch-dynamic-variable-context.test.ts
+++ b/api/src/permissions/utils/fetch-dynamic-variable-context.test.ts
@@ -4,7 +4,7 @@ import { PoliciesService } from '../../services/policies.js';
 import { UsersService } from '../../services/users.js';
 import { RolesService } from '../../services/roles.js';
 import type { Context } from '../types.js';
-import { _fetchDynamicVariableContext as fetchDynamicVariableContext } from './fetch-dynamic-variable-context.js';
+import { fetchDynamicVariableContext } from './fetch-dynamic-variable-context.js';
 
 vi.mock('../../services/users.js', () => ({
 	UsersService: vi.fn(),

--- a/api/src/permissions/utils/fetch-dynamic-variable-context.ts
+++ b/api/src/permissions/utils/fetch-dynamic-variable-context.ts
@@ -96,7 +96,10 @@ async function fetchContextData(
 	const env = useEnv();
 
 	const fields = Array.from(permissionContext[key]!);
-	const cacheKey = cache ? `filter-context-${key.slice(1)}-${getSimpleHash(JSON.stringify(cacheContext))}` : '';
+
+	const cacheKey = cache
+		? `filter-context-${key.slice(1)}-${getSimpleHash(JSON.stringify({ ...cacheContext, fields }))}`
+		: '';
 
 	let data = undefined;
 

--- a/api/src/permissions/utils/fetch-dynamic-variable-context.ts
+++ b/api/src/permissions/utils/fetch-dynamic-variable-context.ts
@@ -1,21 +1,12 @@
+import { useEnv } from '@directus/env';
 import type { Accountability, Permission } from '@directus/types';
+import { getSimpleHash } from '@directus/utils';
+import { getCache, getCacheValue, setCacheValue } from '../../cache.js';
 import type { Context } from '../types.js';
-import { extractRequiredDynamicVariableContext } from './extract-required-dynamic-variable-context.js';
-import { withCache } from './with-cache.js';
-
-export const fetchDynamicVariableContext = withCache(
-	'permission-dynamic-variables',
-	_fetchDynamicVariableContext,
-	({ policies, permissions, accountability: { user, role, roles } }) => ({
-		policies,
-		permissions,
-		accountability: {
-			user,
-			role,
-			roles,
-		},
-	}),
-);
+import {
+	extractRequiredDynamicVariableContext,
+	type RequiredPermissionContext,
+} from './extract-required-dynamic-variable-context.js';
 
 export interface FetchDynamicVariableContext {
 	accountability: Pick<Accountability, 'user' | 'role' | 'roles'>;
@@ -23,7 +14,7 @@ export interface FetchDynamicVariableContext {
 	permissions: Permission[];
 }
 
-export async function _fetchDynamicVariableContext(options: FetchDynamicVariableContext, context: Context) {
+export async function fetchDynamicVariableContext(options: FetchDynamicVariableContext, context: Context) {
 	const { UsersService } = await import('../../services/users.js');
 	const { RolesService } = await import('../../services/roles.js');
 	const { PoliciesService } = await import('../../services/policies.js');
@@ -33,36 +24,93 @@ export async function _fetchDynamicVariableContext(options: FetchDynamicVariable
 	const permissionContext = extractRequiredDynamicVariableContext(options.permissions);
 
 	if (options.accountability.user && (permissionContext.$CURRENT_USER?.size ?? 0) > 0) {
-		const usersService = new UsersService(context);
+		contextData['$CURRENT_USER'] = await fetchContextData(
+			'$CURRENT_USER',
+			permissionContext,
+			{ user: options.accountability.user },
+			async (fields) => {
+				const usersService = new UsersService(context);
 
-		contextData['$CURRENT_USER'] = await usersService.readOne(options.accountability.user, {
-			fields: Array.from(permissionContext.$CURRENT_USER!),
-		});
+				return await usersService.readOne(options.accountability.user!, {
+					fields,
+				});
+			},
+		);
 	}
 
 	if (options.accountability.role && (permissionContext.$CURRENT_ROLE?.size ?? 0) > 0) {
-		const rolesService = new RolesService(context);
+		contextData['$CURRENT_ROLE'] = await fetchContextData(
+			'$CURRENT_ROLE',
+			permissionContext,
+			{ role: options.accountability.role },
+			async (fields) => {
+				const usersService = new RolesService(context);
 
-		contextData['$CURRENT_ROLE'] = await rolesService.readOne(options.accountability.role, {
-			fields: Array.from(permissionContext.$CURRENT_ROLE!),
-		});
+				return await usersService.readOne(options.accountability.role!, {
+					fields,
+				});
+			},
+		);
 	}
 
 	if (options.accountability.roles.length > 0 && (permissionContext.$CURRENT_ROLES?.size ?? 0) > 0) {
-		const rolesService = new RolesService(context);
+		contextData['$CURRENT_ROLES'] = await fetchContextData(
+			'$CURRENT_ROLES',
+			permissionContext,
+			{ roles: options.accountability.roles },
+			async (fields) => {
+				const rolesService = new RolesService(context);
 
-		contextData['$CURRENT_ROLES'] = await rolesService.readMany(options.accountability.roles, {
-			fields: Array.from(permissionContext.$CURRENT_ROLES!),
-		});
+				return await rolesService.readMany(options.accountability.roles, {
+					fields,
+				});
+			},
+		);
 	}
 
 	if (options.policies.length > 0 && (permissionContext.$CURRENT_POLICIES?.size ?? 0) > 0) {
-		const policiesService = new PoliciesService(context);
+		contextData['$CURRENT_POLICIES'] = await fetchContextData(
+			'$CURRENT_POLICIES',
+			permissionContext,
+			{ policies: options.policies },
+			async (fields) => {
+				const policiesService = new PoliciesService(context);
 
-		contextData['$CURRENT_POLICIES'] = await policiesService.readMany(options.policies, {
-			fields: Array.from(permissionContext.$CURRENT_POLICIES!),
-		});
+				return await policiesService.readMany(options.policies, {
+					fields,
+				});
+			},
+		);
 	}
 
 	return contextData;
+}
+
+async function fetchContextData(
+	key: keyof RequiredPermissionContext,
+	permissionContext: RequiredPermissionContext,
+	cacheContext: Record<string, any>,
+	fetch: (fields: string[]) => Promise<Record<string, any>>,
+) {
+	const { cache } = getCache();
+	const env = useEnv();
+
+	const fields = Array.from(permissionContext[key]!);
+	const cacheKey = cache ? `filter-context-${key.slice(1)}-${getSimpleHash(JSON.stringify(cacheContext))}` : '';
+
+	let data = undefined;
+
+	if (cache) {
+		data = await getCacheValue(cache, cacheKey);
+	}
+
+	if (!data) {
+		data = await fetch(fields);
+
+		if (cache && env['CACHE_ENABLED'] !== false) {
+			await setCacheValue(cache, cacheKey, data);
+		}
+	}
+
+	return data;
 }

--- a/api/src/permissions/utils/fetch-raw-permissions.ts
+++ b/api/src/permissions/utils/fetch-raw-permissions.ts
@@ -1,0 +1,51 @@
+import type { Accountability, Filter, Permission, PermissionsAction } from '@directus/types';
+import { pick, sortBy } from 'lodash-es';
+import type { Context } from '../types.js';
+import { withCache } from './with-cache.js';
+
+export const fetchRawPermissions = withCache(
+	'raw-permissions',
+	_fetchRawPermissions,
+	({ action, policies, collections, accountability }) => ({
+		policies, // we assume that policies always come from the same source, so they should be in the same order
+		...(action && { action }),
+		...(collections && { collections: sortBy(collections) }),
+		...(accountability && { accountability: pick(accountability, ['user', 'role', 'roles', 'app']) }),
+	}),
+);
+
+export interface FetchRawPermissionsOptions {
+	action?: PermissionsAction;
+	policies: string[];
+	collections?: string[];
+	accountability?: Pick<Accountability, 'user' | 'role' | 'roles' | 'app'>;
+}
+
+export async function _fetchRawPermissions(options: FetchRawPermissionsOptions, context: Context) {
+	const { PermissionsService } = await import('../../services/permissions.js');
+	const permissionsService = new PermissionsService(context);
+
+	const filter: Filter = {
+		_and: [{ policy: { _in: options.policies } }],
+	};
+
+	if (options.action) {
+		filter._and.push({ action: { _eq: options.action } });
+	}
+
+	if (options.collections) {
+		filter._and.push({ collection: { _in: options.collections } });
+	}
+
+	let permissions = (await permissionsService.readByQuery({
+		filter,
+		limit: -1,
+	})) as Permission[];
+
+	// Sort permissions by their order in the policies array
+	// This ensures that if a sorted array of policies is passed in the permissions are returned in the same order
+	// which is necessary for correctly applying the presets in order
+	permissions = sortBy(permissions, (permission) => options.policies.indexOf(permission.policy!));
+
+	return permissions;
+}

--- a/api/src/permissions/utils/fetch-raw-permissions.ts
+++ b/api/src/permissions/utils/fetch-raw-permissions.ts
@@ -7,11 +7,12 @@ import { withCache } from './with-cache.js';
 export const fetchRawPermissions = withCache(
 	'raw-permissions',
 	_fetchRawPermissions,
-	({ action, policies, collections, accountability }) => ({
+	({ action, policies, collections, accountability, bypassMinimalAppPermissions }) => ({
 		policies, // we assume that policies always come from the same source, so they should be in the same order
 		...(action && { action }),
 		...(collections && { collections: sortBy(collections) }),
 		...(accountability && { accountability: pick(accountability, ['user', 'role', 'roles', 'app']) }),
+		...(bypassMinimalAppPermissions && { bypassMinimalAppPermissions }),
 	}),
 );
 

--- a/api/src/permissions/utils/fetch-raw-permissions.ts
+++ b/api/src/permissions/utils/fetch-raw-permissions.ts
@@ -1,5 +1,5 @@
 import type { Accountability, Filter, Permission, PermissionsAction } from '@directus/types';
-import { pick, sortBy } from 'lodash-es';
+import { sortBy } from 'lodash-es';
 import { withAppMinimalPermissions } from '../lib/with-app-minimal-permissions.js';
 import type { Context } from '../types.js';
 import { withCache } from './with-cache.js';
@@ -11,7 +11,7 @@ export const fetchRawPermissions = withCache(
 		policies, // we assume that policies always come from the same source, so they should be in the same order
 		...(action && { action }),
 		...(collections && { collections: sortBy(collections) }),
-		...(accountability && { accountability: pick(accountability, ['user', 'role', 'roles', 'app']) }),
+		...(accountability && { accountability: { app: accountability.app } }),
 		...(bypassMinimalAppPermissions && { bypassMinimalAppPermissions }),
 	}),
 );
@@ -20,7 +20,7 @@ export interface FetchRawPermissionsOptions {
 	action?: PermissionsAction;
 	policies: string[];
 	collections?: string[];
-	accountability?: Pick<Accountability, 'user' | 'role' | 'roles' | 'app'>;
+	accountability?: Pick<Accountability, 'app'>;
 	bypassMinimalAppPermissions?: boolean;
 }
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Due to an oversight in the new policies implementation the permissions were cached after the replacement of the dynamic variables happened, so for example `$NOW` got turned into the current timestamp at the time of the first function call and then it was cached like that until the cache eviction happened.

What's changed:

- Independently cache the raw permissions and the dynamic filter context and always join them in every call of `fetchPermissions`
- The filter context is cached in the normal cache, if available, and is affected by `CACHE_AUTO_PURGE`, similar to the request level cache
- Updated function that use `fetchPermissions` to not be cached themselves, since that would result in the same problem, higher up in the call stack

## Potential Risks / Drawbacks

- Now more queries hit the database for retrieving the dynamic variable context. This should be offset somewhat by the usage of the independent global cache used for caching each set of context variables.  
- More work is being performed. We might want to revisit this at a later point in time to introduce split caching for permissions that have dynamic variables and for those that don't.

## Review Notes / Questions

- I would like to lorem ipsum
- This PR does not solve https://github.com/directus/directus/issues/22492 which is an existing bug in v10

---

Fixes #23319
