### PR TITLE
Fix bookmark incorrect save on debounce in collection route change (#18318)

### DIFF
--- a/.changeset/chatty-lions-grab.md
+++ b/.changeset/chatty-lions-grab.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed bookmark duplication when rapidly switching between bookmarks

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -3,7 +3,7 @@ import { useUserStore } from '@/stores/user';
 import { translate } from '@/utils/translate-literal';
 import type { User } from '@directus/types';
 import { Filter, Preset } from '@directus/types';
-import { assign, debounce, isEqual } from 'lodash';
+import { assign, cloneDeep, debounce, isEqual } from 'lodash';
 import { ComputedRef, Ref, computed, ref, watch } from 'vue';
 
 type UsablePreset = {
@@ -69,8 +69,8 @@ export function usePreset(
 		return updatedValues;
 	};
 
-	const autoSave = debounce(async () => {
-		savePreset();
+	const autoSave = debounce(async (preset?: Partial<Preset>) => {
+		savePreset(preset);
 	}, 450);
 
 	/**
@@ -82,7 +82,8 @@ export function usePreset(
 			const bookmarkInStore = presetsStore.getBookmark(Number(bookmark.value));
 			bookmarkSaved.value = isEqual(localPreset.value, bookmarkInStore);
 		} else {
-			autoSave();
+			const preset = cloneDeep(localPreset.value);
+			autoSave(preset);
 		}
 	}
 


### PR DESCRIPTION
## Scope
When click collection navigation, it will trigger autosave preset with debounce.
When user rapidly click collection navigation, and then click another collection bookmark navigation
It will save the new bookmark preset becasue preset value is changed before debounce trigger.

What's changed:

- fix bookmark incorrect save on debounce in collection route change

Issue Demo:

https://github.com/user-attachments/assets/e093e80a-9e35-4990-a284-0b184cc71665


Fixed Demo: 

https://github.com/user-attachments/assets/9cff9e83-a2d7-42b0-bee6-d6b97b7bce28



## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #18318
