### PR TITLE
Adjust permissions migration to work with more MySQL flavors

### DIFF
--- a/.changeset/swift-sloths-reply.md
+++ b/.changeset/swift-sloths-reply.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed permissions migration to work with more MySQL flavors

--- a/api/src/database/migrations/20240806A-permissions-policies.ts
+++ b/api/src/database/migrations/20240806A-permissions-policies.ts
@@ -233,7 +233,7 @@ export async function up(knex: Knex) {
 	// Link permissions to policies instead of roles
 
 	await knex.schema.alterTable('directus_permissions', (table) => {
-		table.uuid('policy').references('directus_policies.id').onDelete('CASCADE');
+		table.uuid('policy');
 	});
 
 	try {
@@ -265,6 +265,7 @@ export async function up(knex: Knex) {
 	await knex.schema.alterTable('directus_permissions', (table) => {
 		table.dropColumns('role');
 		table.dropNullable('policy');
+		table.foreign('policy').references('directus_policies.id').onDelete('CASCADE');
 	});
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The migration was failing on some MySQL flavors and configurations, for example AWS Aurora MySQL.
This change moves the foreign key creation to after all modifications on the `policy` column have been finished.

## Potential Risks / Drawbacks

- Potential for this breaking on other DB vendors, I tested this on Postgres, Cockroach (since it was picky on the initial migration approach) and SQlite so far

## Review Notes / Questions

- I would like to lorem ipsum
- I've got a working AWS Aurora running, if anyone needs credentials for testing

---

Fixes #23281, fixed #23234 
