### PR TITLE
Fix CSV import for files containing Byte Order Mark (BOM)

### DIFF
--- a/.changeset/good-bats-shake.md
+++ b/.changeset/good-bats-shake.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-fix CSV import for files containing BOM
+fixed CSV import for files containing BOM

--- a/.changeset/good-bats-shake.md
+++ b/.changeset/good-bats-shake.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-fixed CSV import for files containing BOM
+Fixed an issue where the first column would be missing when importing UTF-8 BOM CSV files

--- a/.changeset/good-bats-shake.md
+++ b/.changeset/good-bats-shake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+fix CSV import for files containing BOM

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -178,6 +178,8 @@ export class ImportService {
 
 			const PapaOptions: Papa.ParseConfig = {
 				header: true,
+				// Trim whitespaces in headers, including the byte order mark (BOM) zero-width no-break space
+				transformHeader: (header) => header.trim(),
 				transform,
 			};
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Seems like this turns out to be a UTF-8 byte order mark (BOM) issue. Although it was resolved back in #12970 for `csv-parser`, `csv-parser` was then changed to `papaparse` in #19739, hence BOM isn't being handled again.

Related issues in PapaParse's repo:

- https://github.com/mholt/PapaParse/issues/372
- https://github.com/mholt/PapaParse/issues/855

With the `sample.csv` reproduction file provided in #21727 which contains BOM (if you open it with vscode or notepad, the bottom right corner should say `UTF-8 with BOM`), as well as using the [`transformHeader` config option](https://www.papaparse.com/docs#config) as a quick test:

```js
transformHeader: (header) => {
    console.log(header);
    return header;
},
```

That allows us to identify the problem, which is the first column `always_ignored` actually gets processed as ` always_ignored` (notice the visible leading space):

![](https://github.com/user-attachments/assets/053a0b65-c789-4db2-aaec-1f21a63b65b2)

This causes the import process to attempt to import to a technically non-existing column, hence the missing data for users that are using CSV with BOM for their _first_ column every time.

This PR opted to use a simplistic `.trim()` as brought up in PapaParse's issues, but other potential alternatives could be:

- only trimming it when `index === 0` to make it clearer we're cleaning up just the first column
- Only cleaning up BOM specifically which a slightly more elaborate code such as:

    ```js
    transformHeader: (header) => {
        if (header.charCodeAt(0) === 0xFEFF) {
            return header.substring(1);
        }
        return header;
    },
    ```

What's changed:

- added `transformHeader` papaparse config for CSV imports to trim the headers

## Potential Risks / Drawbacks

- Maybe a tiny overhead for trimming the headers

## Review Notes / Questions

- Whether the simple `trim()` is acceptable, or other alternatives mentioned above are more preferred since they are more specific in terms of code readability/maintainability

---

Fixes #21727
