### PR TITLE
Fix typo for Invalid aggregate query parameter warning log

### DIFF
--- a/.changeset/many-chicken-invite.md
+++ b/.changeset/many-chicken-invite.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed typo for invalid aggregate query parameter log

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -125,7 +125,7 @@ function sanitizeAggregate(rawAggregate: any): Aggregate {
 		try {
 			aggregate = parseJSON(rawAggregate);
 		} catch {
-			logger.warn('Invalid value passed for filter query parameter.');
+			logger.warn('Invalid value passed for aggregate query parameter.');
 		}
 	}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

presumably a typo, based on other similar warning logs for `sanitizeDeep` and `sanitizeAlias`:

https://github.com/directus/directus/blob/b6aa277f3a007acd5387a0fd8da9f7f37c513175/api/src/utils/sanitize-query.ts#L196

https://github.com/directus/directus/blob/b6aa277f3a007acd5387a0fd8da9f7f37c513175/api/src/utils/sanitize-query.ts#L243

---

Fixes #23333
