### PR TITLE
Fix file export is ready notification for user without `create` permission to `directus_notifications`

### DIFF
--- a/.changeset/shiny-tips-sell.md
+++ b/.changeset/shiny-tips-sell.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed file export is ready notification for user without `create` permission to `directus_notifications`

--- a/.changeset/shiny-tips-sell.md
+++ b/.changeset/shiny-tips-sell.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed file export is ready notification for user without `create` permission to `directus_notifications`
+Fixed the notification for finished file exports to be sent out to users without requiring any permissions on `directus_notifications`

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -402,7 +402,6 @@ export class ExportService {
 
 			if (this.accountability?.user) {
 				const notificationsService = new NotificationsService({
-					accountability: this.accountability,
 					schema: this.schema,
 				});
 
@@ -436,7 +435,6 @@ Your export of ${collection} is ready. <a href="${href}">Click here to view.</a>
 
 			if (this.accountability?.user) {
 				const notificationsService = new NotificationsService({
-					accountability: this.accountability,
 					schema: this.schema,
 				});
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When creating a comment to mention another user, which creates a notification to said user:

https://github.com/directus/directus/blob/b6aa277f3a007acd5387a0fd8da9f7f37c513175/api/src/services/activity.ts#L115-L122

The `NotificationService` is created _without_ accountability:

https://github.com/directus/directus/blob/b6aa277f3a007acd5387a0fd8da9f7f37c513175/api/src/services/activity.ts#L28

So there's no `create` permission required for the user that is mentioning other users via comment.

This PR follows the same approach to ensure the `Your export of <collection> is ready` notification can be created without the need for explicit `create` permission for said user on `directus_notifications` whenever they export to file library.

What's changed:

- Removed accountability in NotificationsService for export to file library action

## Potential Risks / Drawbacks

- I can't seem to think of a scenario where this approach has a negative/unintended effect, but I could be _very_ wrong or missing something here. A second (or more) perspective would be greatly appreciated!

---

Fixes #22602
