### PR TITLE
Fix filtering of M2A allowed collections in AST construction

### DIFF
--- a/.changeset/three-adults-occur.md
+++ b/.changeset/three-adults-occur.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed M2A querying when the user does not have access to all related collections

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -176,7 +176,23 @@ export async function parseFields(
 		let child: NestedCollectionNode | null = null;
 
 		if (relationType === 'a2o') {
-			const allowedCollections = relation.meta!.one_allowed_collections!;
+			let allowedCollections = relation.meta!.one_allowed_collections!;
+
+			if (options.accountability && options.accountability.admin === false && policies) {
+				const permissions = await fetchPermissions(
+					{
+						action: 'read',
+						collections: allowedCollections,
+						policies: policies,
+						accountability: options.accountability,
+					},
+					context,
+				);
+
+				allowedCollections = allowedCollections.filter((collection) =>
+					permissions.some((permission) => permission.collection === collection),
+				);
+			}
 
 			child = {
 				type: 'a2o',


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

In v10 the allowed collections of the M2A relation were filtered down here

https://github.com/directus/directus/blob/e5ba369c242896f3c446da533a99abac2f66d2b4/api/src/utils/get-ast-from-query.ts#L219-L222

This PR reintroduces the filtering based on the users permissions, that already are available for similar logic for other relations.

To reproduce, create a M2A relation with multiple allowed collections, but only give the user access to some of those collections. 

## Scope

What's changed:

- Re-add `allowedCollections` filtering

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- I would like to lorem ipsum

---

Fixes #23338
