### PR TITLE
Ensured that WYSIWYG uses the correct CSS var to display fonts correctly

### DIFF
--- a/.changeset/wet-onions-grab.md
+++ b/.changeset/wet-onions-grab.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Ensured that WYSIWYG uses the correct CSS var to display fonts correctly.

--- a/.changeset/wet-onions-grab.md
+++ b/.changeset/wet-onions-grab.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': minor
+'@directus/app': patch
 ---
 
-Ensured that WYSIWYG uses the correct CSS var to display fonts correctly.
+Fixed the WYSIWYG interface to correctly apply the font configured in the interface settings

--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -2,10 +2,7 @@ import firaMono2 from '../../assets/fonts/FiraMono-Medium.woff2';
 import firaMono from '../../assets/fonts/FiraMono-Medium.woff';
 import merriweatherRegular2 from '../../assets/fonts/merriweather-regular.woff2';
 import merriweatherRegular from '../../assets/fonts/merriweather-regular.woff';
-
-function cssVar(name: string) {
-	return getComputedStyle(document.body).getPropertyValue(name);
-}
+import { cssVar } from '@directus/utils/browser';
 
 export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospace'): string {
 	return `

--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -3,6 +3,8 @@ import merriweatherRegular from '../../assets/fonts/merriweather-regular.woff2';
 import { cssVar } from '@directus/utils/browser';
 
 export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospace'): string {
+	const userFontFamily = cssVar(`--theme--fonts--${font}--font-family`);
+
 	return `
 @font-face {
 	font-family: 'Fira Mono';
@@ -36,7 +38,7 @@ body.mce-content-readonly {
 	display: none;
 }
 h1, h2, h3, h4, h5, h6 {
-	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
+	font-family: ${userFontFamily}, serif;
 	color: ${cssVar('--theme--form--field--input--foreground-accent')};
 	font-weight: 700;
 	margin-bottom: 0;
@@ -75,7 +77,7 @@ h6 {
 	margin-top: 2em;
 }
 p {
-	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
+	font-family: ${userFontFamily}, serif;
 	font-size: 15px;
 	line-height: 24px;
 	font-weight: 500;
@@ -86,7 +88,7 @@ a {
 	text-decoration: none;
 }
 ul, ol {
-	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
+	font-family: ${userFontFamily}, serif;
 	font-size: 15px;
 	line-height: 24px;
 	font-weight: 500;
@@ -122,7 +124,7 @@ pre {
 	overflow: auto;
 }
 blockquote {
-	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
+	font-family: ${userFontFamily}, serif;
 	font-size: 15px;
 	line-height: 24px;
 	font-weight: 500;

--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -1,7 +1,5 @@
-import firaMono2 from '../../assets/fonts/FiraMono-Medium.woff2';
-import firaMono from '../../assets/fonts/FiraMono-Medium.woff';
-import merriweatherRegular2 from '../../assets/fonts/merriweather-regular.woff2';
-import merriweatherRegular from '../../assets/fonts/merriweather-regular.woff';
+import firaMono from '../../assets/fonts/FiraMono-Medium.woff2';
+import merriweatherRegular from '../../assets/fonts/merriweather-regular.woff2';
 import { cssVar } from '@directus/utils/browser';
 
 export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospace'): string {
@@ -9,15 +7,13 @@ export default function getEditorStyles(font: 'sans-serif' | 'serif' | 'monospac
 @font-face {
 	font-family: 'Fira Mono';
 	font-style: normal;
-	src: url(${firaMono2}) format('woff2'),
-	url(${firaMono}) format('woff');
+	src: url(${firaMono}) format('woff2');
 }
 
 @font-face {
 	font-family: 'Merriweather';
 	font-style: normal;
-	src: url(${merriweatherRegular2}) format('woff2'),
-	url(${merriweatherRegular}) format('woff');
+	src: url(${merriweatherRegular}) format('woff2');
 }
 
 ::selection {

--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -43,7 +43,7 @@ body.mce-content-readonly {
 	display: none;
 }
 h1, h2, h3, h4, h5, h6 {
-	font-family: ${cssVar(`--family-${font}`)}, serif;
+	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
 	color: ${cssVar('--theme--form--field--input--foreground-accent')};
 	font-weight: 700;
 	margin-bottom: 0;
@@ -82,7 +82,7 @@ h6 {
 	margin-top: 2em;
 }
 p {
-	font-family: ${cssVar(`--family-${font}`)}, serif;
+	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
 	font-size: 15px;
 	line-height: 24px;
 	font-weight: 500;
@@ -93,7 +93,7 @@ a {
 	text-decoration: none;
 }
 ul, ol {
-	font-family: ${cssVar(`--family-${font}`)}, serif;
+	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
 	font-size: 15px;
 	line-height: 24px;
 	font-weight: 500;
@@ -129,7 +129,7 @@ pre {
 	overflow: auto;
 }
 blockquote {
-	font-family: ${cssVar(`--family-${font}`)}, serif;
+	font-family: ${cssVar(`--theme--fonts--${font}--font-family`)}, serif;
 	font-size: 15px;
 	line-height: 24px;
 	font-weight: 500;


### PR DESCRIPTION
## Scope

Before:
![issue](https://github.com/user-attachments/assets/90dab010-5c9a-43c9-83a4-b1f88873a4e3)

After:
![fix](https://github.com/user-attachments/assets/1820900a-06ee-466b-a1f7-2ef0b1bc3802)

What's changed:

- [ensure that wysiwyg uses the correct css var](https://github.com/directus/directus/commit/653b64ea051ee3077cdf45cdb9093f2c3101af09)
- [replace inline function with existing from @directus/utils/browser](https://github.com/directus/directus/commit/a16ebc9ec35c468c1d015c365a510e69e685d96b)
- [use only woff2 as it is supported in all browsers (except IE)](https://github.com/directus/directus/commit/08f54e9ada2309a3c272a09e9d872fce59736cd0)
  - https://caniuse.com/woff2

## Potential Risks / Drawbacks

- No one ever minds 🤣 

## Review Notes / Questions

- Feel free to revert individual commits

---

Fixes #23342
