### PR TITLE
Fix the order of preset application and payload validation

### DIFF
--- a/.changeset/warm-queens-drop.md
+++ b/.changeset/warm-queens-drop.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed the order of preset application and payload validation in `processPayload`

--- a/.changeset/warm-queens-drop.md
+++ b/.changeset/warm-queens-drop.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed the order of preset application and payload validation in `processPayload`
+Ensured payload validation accounts for preset data

--- a/api/src/permissions/modules/process-payload/process-payload.test.ts
+++ b/api/src/permissions/modules/process-payload/process-payload.test.ts
@@ -288,3 +288,27 @@ test('Merges and applies defaults from presets', async () => {
 		'field-c': 2,
 	});
 });
+
+test('Checks validation rules against payload with defaults', async () => {
+	const schema = { collections: { 'collection-a': { fields: {} } } } as unknown as SchemaOverview;
+	const acc = { admin: false } as unknown as Accountability;
+
+	vi.mocked(fetchPermissions).mockResolvedValue([
+		{ fields: ['field-a'], validation: { 'field-a': { _eq: 2 } }, presets: { 'field-a': 1 } } as unknown as Permission,
+		{ fields: [], validation: null, presets: { 'field-a': 2 } } as unknown as Permission,
+	]);
+
+	const payloadWithPresets = await processPayload(
+		{
+			accountability: acc,
+			action: 'read',
+			collection: 'collection-a',
+			payload: {},
+		},
+		{ schema } as Context,
+	);
+
+	expect(payloadWithPresets).toEqual({
+		'field-a': 2,
+	});
+});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When refactoring the `processPayload` into its own util function the order of payload + preset merging and the payload validation got flipped around, leading to the payload being verified before the presets are applied.

This is how it was in v10, first merge payload and then check against validation rules

https://github.com/directus/directus/blob/e5ba369c242896f3c446da533a99abac2f66d2b4/api/src/services/authorization.ts#L481

What's changed:

- Merge payload with presets before validating
- Extended the test to check that the merging happens before the validation

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #23345 
