### PR TITLE
Improve sorting in `useRelationMultiple` to work with string sort fields

### DIFF
--- a/.changeset/light-hounds-dress.md
+++ b/.changeset/light-hounds-dress.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Fixed the sorting behavior when adding new items to a O2M relation that uses a string sort field (e.g. through manual
+sorting in the table interface)

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -195,12 +195,19 @@ export function useRelationMultiple(
 		if ((previewQuery.value.limit > 0 && totalItemCount.value > previewQuery.value.limit) || !sortField) return items;
 
 		return items.sort((a, b) => {
+			let left;
+			let right;
+
 			if (sortField.startsWith('-')) {
 				const field = sortField.substring(1);
-				return get(b, field) - get(a, field);
+				left = get(b, field);
+				right = get(a, field);
+			} else {
+				left = get(a, sortField);
+				right = get(b, sortField);
 			}
 
-			return get(a, sortField) - get(b, sortField);
+			return Number(left > right) - Number(right > left);
 		});
 	});
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Improve the sorting logic to use comparison operators instead of relying on the `-` operator that only works for numbers (and booleans)

**Before**

https://github.com/user-attachments/assets/910bc3f3-07b0-4bb4-90fc-ce8c4229b8f4


**After**


https://github.com/user-attachments/assets/3c9908f7-7240-48b8-887a-214ed7d0e005



What's changed:

- Use `>` instead of `-`

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23347 
