### PR TITLE
Add markdown default view option

### DIFF
--- a/.changeset/wise-bikes-suffer.md
+++ b/.changeset/wise-bikes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added default view option to the markdown interface to select which view should be shown by default

--- a/app/src/interfaces/input-rich-text-md/index.ts
+++ b/app/src/interfaces/input-rich-text-md/index.ts
@@ -172,6 +172,24 @@ export default defineInterface({
 				},
 			},
 			{
+				field: 'defaultView',
+				name: '$t:interfaces.input-rich-text-md.default_view',
+				type: 'string',
+				meta: {
+					width: 'half',
+					interface: 'select-dropdown',
+					options: {
+						choices: [
+							{ text: '$t:interfaces.input-rich-text-md.default_view_editor', value: 'editor' },
+							{ text: '$t:interfaces.input-rich-text-md.default_view_preview', value: 'preview' },
+						],
+					},
+				},
+				schema: {
+					default_value: 'editor',
+				},
+			},
+			{
 				field: 'customSyntax',
 				name: '$t:interfaces.input-rich-text-md.customSyntax',
 				type: 'json',

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -20,6 +20,7 @@ const props = withDefaults(
 		placeholder?: string;
 		editorFont?: 'sans-serif' | 'serif' | 'monospace';
 		previewFont?: 'sans-serif' | 'serif' | 'monospace';
+		defaultView?: 'editor' | 'preview';
 		toolbar?: string[];
 		customSyntax?: CustomSyntax[];
 		imageToken?: string;
@@ -30,6 +31,7 @@ const props = withDefaults(
 	{
 		editorFont: 'sans-serif',
 		previewFont: 'sans-serif',
+		defaultView: 'editor',
 		toolbar: () => [
 			'heading',
 			'bold',
@@ -60,7 +62,7 @@ const codemirrorEl = ref<HTMLTextAreaElement>();
 let codemirror: CodeMirror.Editor | null = null;
 let previousContent: string | null = null;
 
-const view = ref(['editor']);
+const view = ref(props.defaultView);
 
 const imageDialogOpen = ref(false);
 
@@ -202,14 +204,14 @@ function edit(type: Alteration, options?: Record<string, any>) {
 </script>
 
 <template>
-	<div ref="markdownInterface" class="interface-input-rich-text-md" :class="[view[0], { disabled }]">
+	<div ref="markdownInterface" class="interface-input-rich-text-md" :class="[view, { disabled }]">
 		<div class="toolbar">
-			<template v-if="view[0] !== 'preview'">
+			<template v-if="view !== 'preview'">
 				<v-menu
 					v-if="toolbar?.includes('heading')"
 					show-arrow
 					placement="bottom-start"
-					:class="[{ active: view[0] !== 'preview' }]"
+					:class="[{ active: view !== 'preview' }]"
 				>
 					<template #activator="{ toggle }">
 						<v-button v-tooltip="t('wysiwyg_options.heading')" :disabled="disabled" small icon @click="toggle">
@@ -365,11 +367,17 @@ function edit(type: Alteration, options?: Record<string, any>) {
 
 			<div class="spacer"></div>
 
-			<v-item-group v-model="view" class="view" mandatory rounded>
-				<v-button x-small value="editor" :class="[{ active: view[0] !== 'preview' }]">
+			<v-item-group
+				:model-value="[view]"
+				class="view"
+				mandatory
+				rounded
+				@update:model-value="([value]) => (view = value)"
+			>
+				<v-button x-small value="editor" :class="[{ active: view !== 'preview' }]">
 					{{ t('interfaces.input-rich-text-md.edit') }}
 				</v-button>
-				<v-button x-small value="preview" :class="[{ active: view[0] === 'preview' }]">
+				<v-button x-small value="preview" :class="[{ active: view === 'preview' }]">
 					{{ t('interfaces.input-rich-text-md.preview') }}
 				</v-button>
 			</v-item-group>

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -372,7 +372,7 @@ function edit(type: Alteration, options?: Record<string, any>) {
 				class="view"
 				mandatory
 				rounded
-				@update:model-value="([value]) => (view = value)"
+				@update:model-value="([value]: ['editor' | 'preview']) => (view = value)"
 			>
 				<v-button x-small value="editor" :class="[{ active: view !== 'preview' }]">
 					{{ t('interfaces.input-rich-text-md.edit') }}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1891,6 +1891,9 @@ interfaces:
     preview: Preview
     editorFont: Editor Font
     previewFont: Preview Font
+    default_view: Default View
+    default_view_editor: Editor
+    default_view_preview: Preview
     customSyntax: Custom Blocks
     customSyntax_label: Add custom syntax types
     customSyntax_add: Add custom syntax


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Added a default view option that allows selecting which view to show when rendering the markdown editor interface.

What's changed:

- Added option

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23352
