### PR TITLE
Fix system filter permission checking in `validateItemAccess`

### DIFF
--- a/.changeset/pink-camels-press.md
+++ b/.changeset/pink-camels-press.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed item permission checking for collections that have permissions with no field access

--- a/api/src/permissions/modules/validate-access/lib/validate-item-access.test.ts
+++ b/api/src/permissions/modules/validate-access/lib/validate-item-access.test.ts
@@ -29,7 +29,7 @@ test('Throws error when primary key does not exist in given collection', async (
 test('Queries the database', async () => {
 	const schema = { collections: { 'collection-a': { primary: 'field-a' } } } as unknown as SchemaOverview;
 	const acc = {} as unknown as Accountability;
-	const ast = {} as unknown as AST;
+	const ast = { query: {} } as unknown as AST;
 
 	vi.mocked(getAstFromQuery).mockResolvedValue(ast);
 	vi.mocked(runAst).mockResolvedValue([]);
@@ -46,11 +46,6 @@ test('Queries the database', async () => {
 			query: {
 				fields: [],
 				limit: 1,
-				filter: {
-					'field-a': {
-						_in: [1],
-					},
-				},
 			},
 			accountability: acc,
 		},
@@ -66,6 +61,21 @@ test('Queries the database', async () => {
 			ast,
 		},
 		{ schema },
+	);
+
+	expect(runAst).toHaveBeenCalledWith(
+		{
+			query: {
+				filter: {
+					'field-a': {
+						_in: [1],
+					},
+				},
+			},
+		},
+		schema,
+		acc,
+		{ knex: undefined },
 	);
 });
 

--- a/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
+++ b/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
@@ -26,11 +26,6 @@ export async function validateItemAccess(options: ValidateItemAccessOptions, con
 		// whole or not
 		fields: [],
 		limit: options.primaryKeys.length,
-		filter: {
-			[primaryKeyField]: {
-				_in: options.primaryKeys,
-			},
-		},
 	};
 
 	const ast = await getAstFromQuery(
@@ -43,6 +38,12 @@ export async function validateItemAccess(options: ValidateItemAccessOptions, con
 	);
 
 	await processAst({ ast, ...options }, context);
+
+	ast.query.filter = {
+		[primaryKeyField]: {
+			_in: options.primaryKeys,
+		},
+	};
 
 	const items = await runAst(ast, context.schema, options.accountability, { knex: context.knex });
 

--- a/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
+++ b/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
@@ -39,6 +39,7 @@ export async function validateItemAccess(options: ValidateItemAccessOptions, con
 
 	await processAst({ ast, ...options }, context);
 
+	// Inject the filter after the permissions have been processed, as to not require access to the primary key
 	ast.query.filter = {
 		[primaryKeyField]: {
 			_in: options.primaryKeys,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

When doing the validation of the item access we use a system injected filter that is injected into the AST, we run that AST and ensure that the number of results is equal to expected number of results. This requires access to the primary key field, since that shows up in the query filter. However, there might be valid use cases to not have access to the primary key field (e.g. if the item is accessed directly through the single item route, or the asset use case).

In order to avoid having the `processAST` throw an error on the system injected filter we only set it *after* the permission checking has run by directly assigning it to the root query `filter` property.

## Scope

What's changed:

- See above

## Potential Risks / Drawbacks

- I can't think of any, since the filter is a system filter, so we definitely need access to the field, and the filter does not need cases or anything injected.

## Review Notes / Questions

- N/A

---

Fixes #23356