### PR TITLE
Improve select radio grid layout (#20034)

### DIFF
--- a/.changeset/smooth-trainers-occur.md
+++ b/.changeset/smooth-trainers-occur.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Improved the grid layout for radio and checkboxes interface

--- a/app/package.json
+++ b/app/package.json
@@ -150,5 +150,8 @@
 		"vue-tsc": "2.0.29",
 		"vuedraggable": "4.1.0",
 		"wellknown": "0.5.0"
+	},
+	"dependencies": {
+		"string-width": "7.2.0"
 	}
 }

--- a/app/package.json
+++ b/app/package.json
@@ -139,6 +139,7 @@
 		"qrcode": "1.5.3",
 		"sass": "1.77.8",
 		"semver": "7.6.3",
+		"string-width": "7.2.0",
 		"tinymce": "7.3.0",
 		"tus-js-client": "4.1.0",
 		"typescript": "5.4.5",
@@ -150,8 +151,5 @@
 		"vue-tsc": "2.0.29",
 		"vuedraggable": "4.1.0",
 		"wellknown": "0.5.0"
-	},
-	"dependencies": {
-		"string-width": "7.2.0"
 	}
 }

--- a/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
+++ b/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getMinimalGridClass } from '@/utils/get-minimal-grid-class';
 import { useCustomSelectionMultiple } from '@directus/composables';
 import { computed, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -48,24 +49,7 @@ const choicesDisplayed = computed(() => {
 
 const hiddenCount = computed(() => props.choices!.length - props.itemsShown);
 
-const gridClass = computed(() => {
-	if (choices?.value === undefined) return null;
-
-	const widestOptionLength = choices.value.reduce((acc, val) => {
-		if (val.text.length > acc.length) acc = val.text;
-		return acc;
-	}, '').length;
-
-	if (props.width?.startsWith('half')) {
-		if (widestOptionLength <= 10) return 'grid-2';
-		return 'grid-1';
-	}
-
-	if (widestOptionLength <= 10) return 'grid-4';
-	if (widestOptionLength > 10 && widestOptionLength <= 15) return 'grid-3';
-	if (widestOptionLength > 15 && widestOptionLength <= 25) return 'grid-2';
-	return 'grid-1';
-});
+const gridClass = computed(() => getMinimalGridClass(choices?.value, props?.width));
 
 const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple(value, choices, (value) =>
 	emit('input', value),

--- a/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
+++ b/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
@@ -37,19 +37,19 @@ const { t } = useI18n();
 const { choices, value } = toRefs(props);
 const showAll = ref(false);
 
-const hideChoices = computed(() => props.choices!.length > props.itemsShown);
+const hideChoices = computed(() => props.choices.length > props.itemsShown);
 
 const choicesDisplayed = computed(() => {
 	if (showAll.value || hideChoices.value === false) {
 		return props.choices;
 	}
 
-	return props.choices!.slice(0, props.itemsShown);
+	return props.choices.slice(0, props.itemsShown);
 });
 
 const hiddenCount = computed(() => props.choices!.length - props.itemsShown);
 
-const gridClass = computed(() => getMinimalGridClass(choices?.value, props?.width));
+const gridClass = computed(() => getMinimalGridClass(choices.value, props.width));
 
 const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple(value, choices, (value) =>
 	emit('input', value),

--- a/app/src/interfaces/select-radio/select-radio.vue
+++ b/app/src/interfaces/select-radio/select-radio.vue
@@ -35,7 +35,7 @@ const { t } = useI18n();
 
 const { choices, value } = toRefs(props);
 
-const gridClass = computed(() => getMinimalGridClass(choices?.value, props?.width));
+const gridClass = computed(() => getMinimalGridClass(choices.value, props.width));
 
 const { otherValue, usesOtherValue } = useCustomSelection(value as any, choices as any, (value) =>
 	emit('input', value),

--- a/app/src/interfaces/select-radio/select-radio.vue
+++ b/app/src/interfaces/select-radio/select-radio.vue
@@ -2,7 +2,7 @@
 import { useCustomSelection } from '@directus/composables';
 import { computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
-import stringWidth from 'string-width';
+import { getMinimalGridClass } from '@/utils/get-minimal-grid-class';
 
 type Option = {
 	text: string;
@@ -35,30 +35,7 @@ const { t } = useI18n();
 
 const { choices, value } = toRefs(props);
 
-const gridClass = computed(() => {
-	if (choices?.value === undefined) return null;
-
-	const widestOptionLength = choices.value.reduce((acc, val) => {
-		if (stringWidth(val.text) > acc) acc = stringWidth(val.text);
-		return acc;
-	}, 0);
-
-	const choicesLength = choices.value.length;
-
-	const getMinimalGridClassName = (size: number) => {
-		return `grid-${Math.min(choicesLength, size)}`;
-	};
-
-	if (props.width?.startsWith('half')) {
-		if (widestOptionLength <= 10) return getMinimalGridClassName(2);
-		return getMinimalGridClassName(1);
-	}
-
-	if (widestOptionLength <= 10) return getMinimalGridClassName(4);
-	if (widestOptionLength > 10 && widestOptionLength <= 15) return getMinimalGridClassName(3);
-	if (widestOptionLength > 15 && widestOptionLength <= 25) return getMinimalGridClassName(2);
-	return getMinimalGridClassName(1);
-});
+const gridClass = computed(() => getMinimalGridClass(choices?.value, props?.width));
 
 const { otherValue, usesOtherValue } = useCustomSelection(value as any, choices as any, (value) =>
 	emit('input', value),

--- a/app/src/interfaces/select-radio/select-radio.vue
+++ b/app/src/interfaces/select-radio/select-radio.vue
@@ -2,6 +2,7 @@
 import { useCustomSelection } from '@directus/composables';
 import { computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
+import stringWidth from 'string-width';
 
 type Option = {
 	text: string;
@@ -38,19 +39,25 @@ const gridClass = computed(() => {
 	if (choices?.value === undefined) return null;
 
 	const widestOptionLength = choices.value.reduce((acc, val) => {
-		if (val.text.length > acc.length) acc = val.text;
+		if (stringWidth(val.text) > acc) acc = stringWidth(val.text);
 		return acc;
-	}, '').length;
+	}, 0);
+
+	const choicesLength = choices.value.length;
+
+	const getMinimalGridClassName = (size: number) => {
+		return `grid-${Math.min(choicesLength, size)}`;
+	};
 
 	if (props.width?.startsWith('half')) {
-		if (widestOptionLength <= 10) return 'grid-2';
-		return 'grid-1';
+		if (widestOptionLength <= 10) return getMinimalGridClassName(2);
+		return getMinimalGridClassName(1);
 	}
 
-	if (widestOptionLength <= 10) return 'grid-4';
-	if (widestOptionLength > 10 && widestOptionLength <= 15) return 'grid-3';
-	if (widestOptionLength > 15 && widestOptionLength <= 25) return 'grid-2';
-	return 'grid-1';
+	if (widestOptionLength <= 10) return getMinimalGridClassName(4);
+	if (widestOptionLength > 10 && widestOptionLength <= 15) return getMinimalGridClassName(3);
+	if (widestOptionLength > 15 && widestOptionLength <= 25) return getMinimalGridClassName(2);
+	return getMinimalGridClassName(1);
 });
 
 const { otherValue, usesOtherValue } = useCustomSelection(value as any, choices as any, (value) =>

--- a/app/src/utils/get-minimal-grid-class.test.ts
+++ b/app/src/utils/get-minimal-grid-class.test.ts
@@ -1,66 +1,61 @@
-import { test, expect, describe } from 'vitest';
 import { getMinimalGridClass } from '@/utils/get-minimal-grid-class';
+import { describe, expect, test, vi } from 'vitest';
 
 describe('getMinimalGridClass', () => {
 	test('Returns null when choices are undefined', () => {
-		expect(getMinimalGridClass(undefined, 'full')).toBeNull();
+		expect(getMinimalGridClass(undefined)).toBeNull();
 	});
 
-	test('Returns grid class when width starts with "half" and widestOptionLength <= 10', () => {
-		const choices = [
-			{ text: 'short', value: '1' },
-			{ text: 'text', value: '2' },
-		];
+	test('Returns null when choices are empty', () => {
+		expect(getMinimalGridClass([])).toBeNull();
+	});
+
+	describe('Minimum is based on amount of options', () => {
+		test(`Returns "grid-1" if there's only one short option`, () => {
+			const choices = [{ text: 'short' }];
+
+			expect(getMinimalGridClass(choices)).toBe('grid-1');
+		});
+
+		test('Returns up to "grid-4" if there are multiple short options', () => {
+			const choices = [{ text: 'short' }, { text: 'short' }, { text: 'short' }, { text: 'short' }, { text: 'short' }];
+
+			expect(getMinimalGridClass(choices)).toBe('grid-4');
+		});
+	});
+
+	test('Returns "grid-2" when interface width starts with "half" and widest option is <= 10', () => {
+		const choices = [{ text: 'short' }, { text: 'short' }];
 
 		expect(getMinimalGridClass(choices, 'half')).toBe('grid-2');
 	});
 
-	test('Returns grid class when width starts with "half" and widestOptionLength > 10', () => {
-		const choices = [
-			{ text: 'a very long text', value: '1' },
-			{ text: 'another long text', value: '2' },
-		];
+	test('Returns "grid-1" when interface width starts with "half" and widest option is > 10', () => {
+		const choices = [{ text: 'short' }, { text: 'a longer text' }];
 
 		expect(getMinimalGridClass(choices, 'half')).toBe('grid-1');
 	});
 
-	test('Returns grid class when width is full and widestOptionLength <= 10', () => {
-		const choices = [
-			{ text: 'short', value: '1' },
-			{ text: 'text', value: '2' },
-			{ text: 'text', value: '3' },
-			{ text: 'text', value: '4' },
-			{ text: 'text', value: '5' },
-		];
+	test('Returns "grid-4" when interface width is full and widest option is <= 10', () => {
+		const choices = [{ text: 'short' }, { text: 'short' }, { text: 'short' }, { text: 'short' }];
 
 		expect(getMinimalGridClass(choices, 'full')).toBe('grid-4');
 	});
 
-	test('Returns grid class when width is full and 10 < widestOptionLength <= 15', () => {
-		const choices = [
-			{ text: 'medium text', value: '1' },
-			{ text: 'another text', value: '2' },
-			{ text: 'another text', value: '3' },
-		];
+	test('Returns "grid-3" when interface width is full and widest option is > 10 and <= 15', () => {
+		const choices = [{ text: 'short' }, { text: 'short' }, { text: 'a longer text' }];
 
 		expect(getMinimalGridClass(choices, 'full')).toBe('grid-3');
 	});
 
-	test('Returns grid class when width is full and 15 < widestOptionLength <= 25', () => {
-		const choices = [
-			{ text: 'longer text than usual', value: '1' },
-			{ text: 'quite long text', value: '2' },
-			{ text: 'quite long text', value: '3' },
-		];
+	test('Returns "grid-2" when interface width is full and widest option is > 15 and <= 25', () => {
+		const choices = [{ text: 'short' }, { text: 'quite long text' }];
 
 		expect(getMinimalGridClass(choices, 'full')).toBe('grid-2');
 	});
 
-	test('Returns grid class when width is full and widestOptionLength > 25', () => {
-		const choices = [
-			{ text: 'a very very long text that exceeds 25 characters', value: '1' },
-			{ text: 'another extremely long text', value: '2' },
-		];
+	test('Returns "grid-1" when interface width is full and widest option is > 25', () => {
+		const choices = [{ text: 'short' }, { text: 'a very very long text that exceeds 25 characters' }];
 
 		expect(getMinimalGridClass(choices, 'full')).toBe('grid-1');
 	});

--- a/app/src/utils/get-minimal-grid-class.test.ts
+++ b/app/src/utils/get-minimal-grid-class.test.ts
@@ -1,0 +1,67 @@
+import { test, expect, describe } from 'vitest';
+import { getMinimalGridClass } from '@/utils/get-minimal-grid-class';
+
+describe('getMinimalGridClass', () => {
+	test('Returns null when choices are undefined', () => {
+		expect(getMinimalGridClass(undefined, 'full')).toBeNull();
+	});
+
+	test('Returns grid class when width starts with "half" and widestOptionLength <= 10', () => {
+		const choices = [
+			{ text: 'short', value: '1' },
+			{ text: 'text', value: '2' },
+		];
+
+		expect(getMinimalGridClass(choices, 'half')).toBe('grid-2');
+	});
+
+	test('Returns grid class when width starts with "half" and widestOptionLength > 10', () => {
+		const choices = [
+			{ text: 'a very long text', value: '1' },
+			{ text: 'another long text', value: '2' },
+		];
+
+		expect(getMinimalGridClass(choices, 'half')).toBe('grid-1');
+	});
+
+	test('Returns grid class when width is full and widestOptionLength <= 10', () => {
+		const choices = [
+			{ text: 'short', value: '1' },
+			{ text: 'text', value: '2' },
+			{ text: 'text', value: '3' },
+			{ text: 'text', value: '4' },
+			{ text: 'text', value: '5' },
+		];
+
+		expect(getMinimalGridClass(choices, 'full')).toBe('grid-4');
+	});
+
+	test('Returns grid class when width is full and 10 < widestOptionLength <= 15', () => {
+		const choices = [
+			{ text: 'medium text', value: '1' },
+			{ text: 'another text', value: '2' },
+			{ text: 'another text', value: '3' },
+		];
+
+		expect(getMinimalGridClass(choices, 'full')).toBe('grid-3');
+	});
+
+	test('Returns grid class when width is full and 15 < widestOptionLength <= 25', () => {
+		const choices = [
+			{ text: 'longer text than usual', value: '1' },
+			{ text: 'quite long text', value: '2' },
+			{ text: 'quite long text', value: '3' },
+		];
+
+		expect(getMinimalGridClass(choices, 'full')).toBe('grid-2');
+	});
+
+	test('Returns grid class when width is full and widestOptionLength > 25', () => {
+		const choices = [
+			{ text: 'a very very long text that exceeds 25 characters', value: '1' },
+			{ text: 'another extremely long text', value: '2' },
+		];
+
+		expect(getMinimalGridClass(choices, 'full')).toBe('grid-1');
+	});
+});

--- a/app/src/utils/get-minimal-grid-class.ts
+++ b/app/src/utils/get-minimal-grid-class.ts
@@ -1,4 +1,4 @@
-import stringWidth from "string-width";
+import stringWidth from 'string-width';
 
 type Option = {
 	text: string;
@@ -27,4 +27,4 @@ export const getMinimalGridClass = (choices: Option[] | undefined, width: string
 	if (widestOptionLength > 10 && widestOptionLength <= 15) return getMinimalGridClassName(3);
 	if (widestOptionLength > 15 && widestOptionLength <= 25) return getMinimalGridClassName(2);
 	return getMinimalGridClassName(1);
-}
+};

--- a/app/src/utils/get-minimal-grid-class.ts
+++ b/app/src/utils/get-minimal-grid-class.ts
@@ -2,7 +2,6 @@ import stringWidth from 'string-width';
 
 type Option = {
 	text: string;
-	value: string | number | boolean;
 };
 
 export const getMinimalGridClass = (choices: Option[] | undefined, width: string | undefined) => {

--- a/app/src/utils/get-minimal-grid-class.ts
+++ b/app/src/utils/get-minimal-grid-class.ts
@@ -4,12 +4,12 @@ type Option = {
 	text: string;
 };
 
-export const getMinimalGridClass = (choices: Option[] | undefined, width: string | undefined) => {
-	if (!choices) return null;
+export function getMinimalGridClass(choices?: Option[], interfaceWidth?: string) {
+	if (!choices || choices.length === 0) return null;
 
-	const widestOptionLength = choices.reduce((acc, val) => {
-		const currWidth = stringWidth(val.text);
-		if (currWidth > acc) acc = currWidth;
+	const widestOptionLength = choices.reduce((acc, value) => {
+		const width = stringWidth(value.text);
+		if (width > acc) acc = width;
 		return acc;
 	}, 0);
 
@@ -17,7 +17,7 @@ export const getMinimalGridClass = (choices: Option[] | undefined, width: string
 		return `grid-${Math.min(choices.length, size)}`;
 	};
 
-	if (width?.startsWith('half')) {
+	if (interfaceWidth?.startsWith('half')) {
 		if (widestOptionLength <= 10) return getMinimalGridClassName(2);
 		return getMinimalGridClassName(1);
 	}
@@ -26,4 +26,4 @@ export const getMinimalGridClass = (choices: Option[] | undefined, width: string
 	if (widestOptionLength > 10 && widestOptionLength <= 15) return getMinimalGridClassName(3);
 	if (widestOptionLength > 15 && widestOptionLength <= 25) return getMinimalGridClassName(2);
 	return getMinimalGridClassName(1);
-};
+}

--- a/app/src/utils/get-minimal-grid-class.ts
+++ b/app/src/utils/get-minimal-grid-class.ts
@@ -1,0 +1,30 @@
+import stringWidth from "string-width";
+
+type Option = {
+	text: string;
+	value: string | number | boolean;
+};
+
+export const getMinimalGridClass = (choices: Option[] | undefined, width: string | undefined) => {
+	if (!choices) return null;
+
+	const widestOptionLength = choices.reduce((acc, val) => {
+		const currWidth = stringWidth(val.text);
+		if (currWidth > acc) acc = currWidth;
+		return acc;
+	}, 0);
+
+	const getMinimalGridClassName = (size: number) => {
+		return `grid-${Math.min(choices.length, size)}`;
+	};
+
+	if (width?.startsWith('half')) {
+		if (widestOptionLength <= 10) return getMinimalGridClassName(2);
+		return getMinimalGridClassName(1);
+	}
+
+	if (widestOptionLength <= 10) return getMinimalGridClassName(4);
+	if (widestOptionLength > 10 && widestOptionLength <= 15) return getMinimalGridClassName(3);
+	if (widestOptionLength > 15 && widestOptionLength <= 25) return getMinimalGridClassName(2);
+	return getMinimalGridClassName(1);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,10 @@ importers:
         version: 1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3)
 
   app:
+    dependencies:
+      string-width:
+        specifier: 7.2.0
+        version: 7.2.0
     devDependencies:
       '@directus/composables':
         specifier: workspace:*
@@ -1058,7 +1062,7 @@ importers:
         version: 2.4.6
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1076,7 +1080,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1146,7 +1150,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1177,7 +1181,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1241,7 +1245,7 @@ importers:
         version: 0.2.3
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1293,7 +1297,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1405,7 +1409,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1442,7 +1446,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1470,7 +1474,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1491,7 +1495,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1547,7 +1551,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1581,7 +1585,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1612,7 +1616,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1646,7 +1650,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1677,7 +1681,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1705,7 +1709,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1748,7 +1752,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1782,7 +1786,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1807,7 +1811,7 @@ importers:
         version: 2.1.7(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1828,7 +1832,7 @@ importers:
         version: 1.2.0(esbuild@0.20.2)
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1953,7 +1957,7 @@ importers:
         version: 7.1.0
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -2017,7 +2021,7 @@ importers:
         version: 0.2.3
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -2051,7 +2055,7 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3))
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -2075,7 +2079,7 @@ importers:
         version: 1.4.0
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
+        version: 8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -23162,7 +23166,7 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  tsup@8.2.2(@microsoft/api-extractor@7.43.0)(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0):
+  tsup@8.2.2(@microsoft/api-extractor@7.43.0(@types/node@18.19.43))(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.5)(typescript@5.4.5)(yaml@2.5.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,10 +531,6 @@ importers:
         version: 1.5.3(@types/node@18.19.43)(happy-dom@14.12.3)(jsdom@20.0.3)(sass@1.77.8)(terser@5.31.3)
 
   app:
-    dependencies:
-      string-width:
-        specifier: 7.2.0
-        version: 7.2.0
     devDependencies:
       '@directus/composables':
         specifier: workspace:*
@@ -863,6 +859,9 @@ importers:
       semver:
         specifier: 7.6.3
         version: 7.6.3
+      string-width:
+        specifier: 7.2.0
+        version: 7.2.0
       tinymce:
         specifier: 7.3.0
         version: 7.3.0


### PR DESCRIPTION
## Scope

What's changed:

- Use `string-width` package to get more accurate length for some language text.
- Choose minimal size as needed first in current choices length, it will fill entire row at least.

In #20034 flow case.
Chinese lang will use grid-2, becasue the choices length just 2(not grid-3 or grid-4)

![image](https://github.com/user-attachments/assets/97ea9c02-c9a6-4417-bc02-399417e1b24a)


## Potential Risks / Drawbacks

- I am not sure the logic could fit all requirement. Might has some except case?

## Review Notes / Questions

- N/A

---

Fixes #20034
