### PR TITLE
Change instruction around latest vs. versioned, trying to match language with code

### DIFF
--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -161,7 +161,7 @@ If you are not using the `latest` tag for the Directus image you need to adjust 
 increment the tag version number, e.g.:
 
 ```diff-vue
--   image: directus/directus:{{ packages.directus.version.major }}.0.0
+-   image: directus/directus:latest
 +   image: directus/directus:{{ packages.directus.version.full }}
 ```
 


### PR DESCRIPTION
The rendered page shows instruction like:
-   image: directus/directus:11.0.0
+   image: directus/directus:11.0.0

The intended display is
-   image: directus/latest
+   image: directus/directus:11.0.1 ... etc

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit
- Sed do eiusmod tempor incididunt

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

---

Fixes #\<num\>
