### PR TITLE
Replace jboss/keycloak with quay.io/keycloak/keycloak

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -149,3 +149,4 @@
 - McSundae
 - danilobuerger
 - joggienl
+- EdwardLi-coder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,16 +159,14 @@ services:
       - 5107:10000
 
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: secret
-      KC_HTTP_PORT: 8080
     ports:
       - 5110:8080
     command:
       - start-dev
-      - --http-relative-path=/auth
 
   maildev:
     image: maildev/maildev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,14 +159,16 @@ services:
       - 5107:10000
 
   keycloak:
-    image: jboss/keycloak
+    image: quay.io/keycloak/keycloak:latest
     environment:
-      KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: secret
-      DB_ADDR: ''
-      DB_VENDOR: h2
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: secret
+      KC_HTTP_PORT: 8080
     ports:
       - 5110:8080
+    command:
+      - start-dev
+      - --http-relative-path=/auth
 
   maildev:
     image: maildev/maildev


### PR DESCRIPTION
## Scope

Replace the deprecated `jboss/keycloak` image with `quay.io/keycloak/keycloak`.

---

Fixes #23367
