### PR TITLE
fix: add policy property in DirectusPermission type

### DIFF
--- a/.changeset/gentle-balloons-pretend.md
+++ b/.changeset/gentle-balloons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed an outdated property name in the permissions typing

--- a/contributors.yml
+++ b/contributors.yml
@@ -150,3 +150,4 @@
 - danilobuerger
 - joggienl
 - EdwardLi-coder
+- EdouardDem

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -1,12 +1,12 @@
 import type { MergeCoreCollection } from '../index.js';
-import type { DirectusRole } from './role.js';
+import type { DirectusPolicy } from './policy.js';
 
 export type DirectusPermission<Schema = any> = MergeCoreCollection<
 	Schema,
 	'directus_permissions',
 	{
 		id: number;
-		role: DirectusRole<Schema> | string | null;
+		policy: DirectusPolicy<Schema> | string | null;
 		collection: string; // TODO keyof complete schema
 		action: string;
 		permissions: Record<string, any> | null;


### PR DESCRIPTION
## Scope

What's changed:

- Replace `role` property by `policy` in DirectusPermission type

## Potential Risks / Drawbacks

- Type change

## Review Notes / Questions

- I didn't find any legacy reference to `Permission.role`.

---

Fixes #23375
