### PR TITLE
Feat/persist sidebar detail group

### DIFF
--- a/.changeset/breezy-pianos-wink.md
+++ b/.changeset/breezy-pianos-wink.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': patch
+'@directus/app': minor
 ---
 
-Persisted the opened detail in the sidebar-detail-group to maintain state across site navigation and reloads
+Ensured the opened detail in the sidebar is persisted across site navigation and reloads (per browser tab) 

--- a/.changeset/breezy-pianos-wink.md
+++ b/.changeset/breezy-pianos-wink.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Persisted the opened detail in the sidebar-detail-group to maintain state across site navigation and reloads

--- a/app/src/views/private/components/sidebar-detail-group.vue
+++ b/app/src/views/private/components/sidebar-detail-group.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { nextTick, ref, watch } from 'vue';
+import { useLocalStorage } from '@vueuse/core';
 
 const props = defineProps<{
 	sidebarOpen?: boolean;
 }>();
 
 // By syncing the opened item here, we can force close the module once the sidebar closes
-const openDetail = ref<string[]>([]);
+const openDetail = useLocalStorage('sidebar-open-detail', [] as string[]);
 
 const mandatory = ref(false);
 

--- a/app/src/views/private/components/sidebar-detail-group.vue
+++ b/app/src/views/private/components/sidebar-detail-group.vue
@@ -1,23 +1,22 @@
 <script setup lang="ts">
+import { useSessionStorage } from '@vueuse/core';
 import { nextTick, ref, watch } from 'vue';
-import { useLocalStorage } from '@vueuse/core';
 
 const props = defineProps<{
 	sidebarOpen?: boolean;
 }>();
 
-// By syncing the opened item here, we can force close the module once the sidebar closes
-const openDetail = useLocalStorage('sidebar-open-detail', [] as string[]);
-
+const openDetail = useSessionStorage<string[]>('sidebar-open-detail', []);
 const mandatory = ref(false);
 
 watch(
 	() => props.sidebarOpen,
 	async (newOpenState) => {
 		if (newOpenState === false) {
+			// Force close the module once the sidebar closes
 			openDetail.value = [];
 		} else {
-			// Ensures the first item in the sidebar is automatically opened whenever the sidebar opens.
+			// Ensures the first item in the sidebar is automatically opened whenever the sidebar opens
 			mandatory.value = true;
 			await nextTick();
 


### PR DESCRIPTION
## Scope

What's changed:

- Persists the open-detail state of the sidebar in the session storage

### Before
Nothing get's persisted, the sidebar-items always go back to their initial state.

[Bildschirmaufnahme 2024-08-16 um 17.09.07.webm](https://github.com/user-attachments/assets/d395c26c-aaa4-40af-be09-f65beed35593)


### After
The selection get's persisted. As soon as the previously selected item exists, it will be opened.

[Bildschirmaufnahme 2024-08-16 um 17.09.46.webm](https://github.com/user-attachments/assets/c08b1edd-8a86-4e30-b4b0-61f97f3449f2)

## Potential Risks / Drawbacks

- New behavior

## Review Notes / Questions

Related to comment of @hanneskuettner ([comment](https://github.com/directus/directus/issues/23304#issuecomment-2288405784_)):

> It would need to take care of making sure the sections actually exist I think.

I did not reset the state in case the selection doesn't exists to make sure it always opens the latest option as soon as it exists. I don't see any issue in having a non-existing item in the "opened" state.

This way e.g we can open `Flows`, navigate to a page where flows won't exist and once we're back to a page where it exists it will be opened again.

---

Fixes #23304
