### PR TITLE
Prevent crash when switching to Date type in Datetime interface

### DIFF
--- a/.changeset/plenty-flies-yawn.md
+++ b/.changeset/plenty-flies-yawn.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevented a crash in the Data Studio when switching to the "Date" type while configuring Datetime interface

--- a/app/src/interfaces/datetime/index.ts
+++ b/app/src/interfaces/datetime/index.ts
@@ -12,10 +12,6 @@ export default defineInterface({
 	group: 'selection',
 	options: ({ field }) => {
 		if (field.type === 'date') {
-			if (field.meta?.options) {
-				field.meta.options = {};
-			}
-
 			return [];
 		}
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -8,7 +8,6 @@ import { useI18n } from 'vue-i18n';
 import ExtensionOptions from '../shared/extension-options.vue';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store/';
 import RelationshipConfiguration from './relationship-configuration.vue';
-import { isArray, some } from 'lodash';
 
 defineProps<{
 	row?: number;
@@ -81,24 +80,6 @@ const options = computed({
 			},
 		});
 	},
-});
-
-watch(customOptionsFields, (newVal) => {
-	if (fieldDetailStore.field.meta?.options) {
-		const options = fieldDetailStore.field.meta?.options;
-
-		Object.keys(options).forEach((field) => {
-			if (isArray(newVal) && !some(newVal, { field })) {
-				delete options[field];
-			}
-
-			if (newVal && 'standard' in newVal) {
-				if (!some([...newVal.standard, newVal.advanced], { field })) {
-					delete options[field];
-				}
-			}
-		});
-	}
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -8,6 +8,7 @@ import { useI18n } from 'vue-i18n';
 import ExtensionOptions from '../shared/extension-options.vue';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store/';
 import RelationshipConfiguration from './relationship-configuration.vue';
+import { isArray, some } from 'lodash';
 
 defineProps<{
 	row?: number;
@@ -80,6 +81,24 @@ const options = computed({
 			},
 		});
 	},
+});
+
+watch(customOptionsFields, (newVal) => {
+    if (fieldDetailStore.field.meta?.options) {
+        const options = fieldDetailStore.field.meta?.options;
+
+        Object.keys(options).forEach((field) => {
+			if(isArray(newVal) && !some(newVal,{field})) {
+				delete options[field];
+			}
+
+			if(newVal && 'standard' in newVal) {
+				if(!some([...newVal.standard, newVal.advanced],{field})) {
+					delete options[field];
+				}
+			}
+        });
+    }
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -84,21 +84,21 @@ const options = computed({
 });
 
 watch(customOptionsFields, (newVal) => {
-    if (fieldDetailStore.field.meta?.options) {
-        const options = fieldDetailStore.field.meta?.options;
+	if (fieldDetailStore.field.meta?.options) {
+		const options = fieldDetailStore.field.meta?.options;
 
-        Object.keys(options).forEach((field) => {
-			if(isArray(newVal) && !some(newVal,{field})) {
+		Object.keys(options).forEach((field) => {
+			if (isArray(newVal) && !some(newVal, { field })) {
 				delete options[field];
 			}
 
-			if(newVal && 'standard' in newVal) {
-				if(!some([...newVal.standard, newVal.advanced],{field})) {
+			if (newVal && 'standard' in newVal) {
+				if (!some([...newVal.standard, newVal.advanced], { field })) {
 					delete options[field];
 				}
 			}
-        });
-    }
+		});
+	}
 });
 </script>
 


### PR DESCRIPTION
## Scope
When switch field type, it should automatic clear field option not contain in current options.
Instead of modify in interface options scoped.

What's changed:

- Add a watch to automatic clear field option not contain in current options.

Issue Demo:

https://github.com/user-attachments/assets/90509106-6df8-4eb7-992f-00fdf6e8d63d

Fixed Demo:

https://github.com/user-attachments/assets/7b3eaf8e-b2ff-4b49-8946-6074c9d80aea



## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- N/A

---

Fixes #23331
