### PR TITLE
Tip  to the "Creating Extensions" section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -150,3 +150,4 @@
 - danilobuerger
 - joggienl
 - EdwardLi-coder
+- Xchos

--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -1,7 +1,7 @@
 ---
 description: A guide on how to scaffold your Directus Extension.
 readTime: 5 min read
-contributors: Rijk Van Zanten, Esther Agbaje, Kevin Lewis
+contributors: Rijk Van Zanten, Esther Agbaje, Kevin Lewis, Lukas Zelenka
 ---
 
 # Creating Extensions

--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -49,6 +49,13 @@ The CLI supports rebuilding extensions whenever a file has changed by using the 
 
 :::
 
+::: tip Automatically Reload Extensions
+
+To automatically reload extensions every time you make a change, without having to restart Directus, in your
+`docker-compose.yml` file, set `EXTENSIONS_AUTO_RELOAD=true`.
+
+:::
+
 ### Configuring the CLI
 
 Most of the time, it should be sufficient to use the CLI as is. But, in some cases it might be necessary to customize it


### PR DESCRIPTION
Adds tip about automatic reloading extensions using the EXTENSIONS_AUTO_RELOAD environment variable.

fixes: #23382

## Scope

What's changed:

- Documentation for creating extensions

## Potential Risks / Drawbacks

- None identified

## Review Notes / Questions

- I'd like to provide developers with guidance on efficiently developing extensions locally.

---

Fixes #23382
