### PR TITLE
Auto-label Crowdin PRs

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,9 @@
 files:
   - source: /app/src/lang/translations/en-US.yaml
     translation: /app/src/lang/translations/%locale%.yaml
+
+pull_request_labels:
+  - ':cake: Chore'
+  - ':elevator: Web'
+  - ':file_folder: Studio Misc.'
+  - ':fire:'


### PR DESCRIPTION
## Scope

Automatically add corresponding labels to pull requests from Crowdin 🤖 

## Potential Risks / Drawbacks

None

## Review Notes / Questions

See https://developer.crowdin.com/configuration-file/#configuration-file-for-vcs-integrations.

Applied the labels from currently open PR #23362:
https://github.com/directus/directus/labels/%3Acake%3A%20Chore https://github.com/directus/directus/labels/%3Aelevator%3A%20Web https://github.com/directus/directus/labels/%3Afile_folder%3A%20Studio%20Misc%2E https://github.com/directus/directus/labels/%3Afire%3A

Are these correct? Do we e.g. want to add a label which marks those PRs as "automated" ones, allowing us to easily filter them?

