### PR TITLE
Add YugabyteDB

### DIFF
--- a/api/src/cli/utils/drivers.ts
+++ b/api/src/cli/utils/drivers.ts
@@ -1,7 +1,7 @@
 import type { Driver } from '../../types/index.js';
 
 export const drivers: Record<Driver, string> = {
-	pg: 'PostgreSQL / Redshift',
+	pg: 'PostgreSQL / Redshift / YugabyteDB',
 	cockroachdb: 'CockroachDB (Beta)',
 	mysql2: 'MySQL / MariaDB / Aurora',
 	sqlite3: 'SQLite',

--- a/contributors.yml
+++ b/contributors.yml
@@ -152,3 +152,4 @@
 - EdwardLi-coder
 - EdouardDem
 - Xchos
+- franckpachot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
 
   yugabytedb:
     image: yugabytedb/yugabyte:2024.1.1.0-b137
-    command: bash -c 'rm -rf /tmp/.yb.* ; yugabyted start --enable_pg_parity_tech_preview --background=false --tserver_flags=ysql_pg_conf_csv='"{log_statement='all'}"
+    command: bash -c 'rm -rf /tmp/.yb.* ; yugabyted start --enable_pg_parity_tech_preview --background=false
     healthcheck:
       test: postgres/bin/pg_isready -h yugabytedb
       interval: '10s'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@
 #   Postgres (10):   5111
 #   Minio Admin:     5112
 #   CockroachDB:     5113
+#   YugabyteDB:      5114
 #
 # Credentials:
 #   Postgres:
@@ -72,6 +73,11 @@
 #   CockroachDB
 #     User:          admin
 #     Password:      --
+#
+#   YugabyteDB:
+#     User:          yugabyte
+#     Password:      yugabyte
+#     Database:      directus
 
 version: '3.8'
 
@@ -141,6 +147,23 @@ services:
     ports:
       - 5113:26257
 
+  yugabytedb:
+    image: yugabytedb/yugabyte:2024.1.1.0-b137
+    command: bash -c 'rm -rf /tmp/.yb.* ; yugabyted start --enable_pg_parity_tech_preview --background=false --tserver_flags=ysql_pg_conf_csv='"{log_statement='all'}"
+    healthcheck:
+      test: postgres/bin/pg_isready -h yugabytedb
+      interval: '10s'
+      timeout: '30s'
+      retries: 5
+      start_period: '20s'  
+    environment:
+      - YSQL_USER=yugabyte
+      - YSQL_PASSWORD=yugabyte
+      - YSQL_DB=directus
+    ports:
+      - 15433:15433
+      - 5114:5433
+
   redis:
     image: redis:6-alpine
     ports:
@@ -173,3 +196,4 @@ services:
     ports:
       - 1025:1025
       - 1080:1080
+

--- a/docs/self-hosted/docker-guide.md
+++ b/docs/self-hosted/docker-guide.md
@@ -179,7 +179,7 @@ containers have started you will be on the latest version (or the version you sp
 The Directus Docker Image contains all optional dependencies supported in the API. This means the Docker image can be
 used with most of the supported databases and storage adapters without having to create a custom image.
 
-Directus supports the LTS versions of PostgreSQL, MySQL, SQLite, MS SQL Server, MariaDB, CockroachDB, and OracleDB.
+Directus supports the LTS versions of PostgreSQL, MySQL, SQLite, MS SQL Server, MariaDB, CockroachDB, YugabyteDB, and OracleDB.
 Please see https://endoflife.date/ to make sure your database version is still supported.
 
 ## Requirements

--- a/docs/user-guide/overview/glossary.md
+++ b/docs/user-guide/overview/glossary.md
@@ -67,7 +67,7 @@ group data based on department, objective, business process or anything you choo
 ## Database Abstraction
 
 Directus supports mirroring all the most widely used SQL databases, including PostgreSQL, MySQL, Microsoft SQL Server,
-SQLite, OracleDB, MariaDB, CockroachDB, and other variants. Each vendor has subtle (and sometimes not so subtle)
+SQLite, OracleDB, MariaDB, CockroachDB, YugabyteDB, and other variants. Each vendor has subtle (and sometimes not so subtle)
 differences in how they function, so Directus includes an abstraction layer that helps it avoid writing different code
 for each type.
 


### PR DESCRIPTION
This adds YugabyteDB to the docker compose

YugabyteDB is Open Source, PostgreSQL-compatible, Distribtued SQL database. It is used with the same driver / dialect as PostgreSQL, so no changes required. More nodes can be added to scale-out (adding `--join=` to the command line to join the cluster dtarted by the first node). With at least 3 nodes, it is resilient to one node failure or rolling upgrade.

I changed 'PostgreSQL / Redshift' to 'PostgreSQL / Redshift / YugabyteDB' to mention it but still see the old menu item :( 

Here is how I tested:
```
# Start YugabyteDB (webconsole visible on port 15433)
docker compose up yugabytedb -d

# build the project
nvm install v18.17.0
npm init directus-project example-project

? Ok to proceed? (y)
? Choose your database client PostgreSQL / Redshift
? Database Host: 127.0.0.1
? Port: 5114
? Database Name: directus
? Database User: yugabyte
? Database Password: yugabyte
? Enable SSL: (y/N)
? Email admin@example.com
? Password *****

cd /workspace/directus/example-project
npx directus start

```
