### PR TITLE
Ensure DB queries in notifications service run in same transaction

### DIFF
--- a/.changeset/yellow-comics-trade.md
+++ b/.changeset/yellow-comics-trade.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where creating notifications could hang on SQLite


### PR DESCRIPTION
## Scope

Inside the notifications service, the users as well as mail services were created without passing the current Knex instance.
This means the queries inside these services were run in separate transactions, which would cause it to hang on SQLite due to the already opened connection.

This has been fixed in this PR, and in addition the services are now instantiated only when actually required.

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Fixes https://github.com/directus/directus/issues/23305#issuecomment-2284577186
