### PR TITLE
Add unsaved changes notice to custom flow dialog

### DIFF
--- a/.changeset/healthy-cows-grin.md
+++ b/.changeset/healthy-cows-grin.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Add a warning about unsaved changes to the custom flow confirmation dialog.
+Ensured warning about unsaved changes is displayed for Flows with custom confirmation config too

--- a/.changeset/healthy-cows-grin.md
+++ b/.changeset/healthy-cows-grin.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Add a warning about unsaved changes to the custom flow confirmation dialog.

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -195,7 +195,7 @@ const runManualFlow = async (flowId: string) => {
 							type="warning"
 						>
 							<div>
-								<p><strong>{{ t('unsaved_changes') }}</strong></p>
+								<div><strong>{{ t('unsaved_changes') }}</strong></div>
 								<div>{{ t('run_flow_on_current_edited_confirm') }}</div>
 							</div>
 						</v-notice>

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -190,12 +190,11 @@ const runManualFlow = async (flowId: string) => {
 					<v-card-title>{{ confirmDetails.description ?? t('run_flow_confirm') }}</v-card-title>
 
 					<v-card-text class="confirm-form">
-						<v-notice
-							v-if="hasEdits"
-							type="warning"
-						>
+						<v-notice v-if="hasEdits" type="warning">
 							<div>
-								<div><strong>{{ t('unsaved_changes') }}</strong></div>
+								<div>
+									<strong>{{ t('unsaved_changes') }}</strong>
+								</div>
 								<div>{{ t('run_flow_on_current_edited_confirm') }}</div>
 							</div>
 						</v-notice>

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -190,6 +190,16 @@ const runManualFlow = async (flowId: string) => {
 					<v-card-title>{{ confirmDetails.description ?? t('run_flow_confirm') }}</v-card-title>
 
 					<v-card-text class="confirm-form">
+						<v-notice
+							v-if="hasEdits"
+							type="warning"
+						>
+							<div>
+								<p><strong>{{ t('unsaved_changes') }}</strong></p>
+								<div>{{ t('run_flow_on_current_edited_confirm') }}</div>
+							</div>
+						</v-notice>
+
 						<v-form
 							v-if="confirmDetails.fields && confirmDetails.fields.length > 0"
 							:fields="confirmDetails.fields"
@@ -250,6 +260,10 @@ const runManualFlow = async (flowId: string) => {
 
 	:deep(.type-label) {
 		font-size: 1rem;
+	}
+
+	.v-notice {
+		margin-bottom: var(--v-card-padding, 16px);
 	}
 }
 </style>

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -97,9 +97,13 @@ const confirmDetails = computed(() => {
 	};
 });
 
-const displayUnsavedChangesDialog = computed(() => !!confirmRunFlow.value && hasEdits.value && !confirmedUnsavedChanges.value);
+const displayUnsavedChangesDialog = computed(
+	() => !!confirmRunFlow.value && hasEdits.value && !confirmedUnsavedChanges.value,
+);
 
-const displayCustomConfirmDialog = computed(() => !!confirmRunFlow.value && confirmDetails.value && (!hasEdits.value || confirmedUnsavedChanges.value));
+const displayCustomConfirmDialog = computed(
+	() => !!confirmRunFlow.value && confirmDetails.value && (!hasEdits.value || confirmedUnsavedChanges.value),
+);
 
 const resetConfirm = () => {
 	confirmRunFlow.value = null;

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -54,6 +54,7 @@ const runningFlows = ref<string[]>([]);
 
 const confirmRunFlow = ref<string | null>(null);
 const confirmValues = ref<Record<string, any> | null>();
+const confirmedUnsavedChanges = ref(false);
 
 const isConfirmButtonDisabled = computed(() => {
 	if (!confirmRunFlow.value) return true;
@@ -96,9 +97,14 @@ const confirmDetails = computed(() => {
 	};
 });
 
+const displayUnsavedChangesDialog = computed(() => !!confirmRunFlow.value && hasEdits.value && !confirmedUnsavedChanges.value);
+
+const displayCustomConfirmDialog = computed(() => !!confirmRunFlow.value && confirmDetails.value && (!hasEdits.value || confirmedUnsavedChanges.value));
+
 const resetConfirm = () => {
 	confirmRunFlow.value = null;
 	confirmValues.value = null;
+	confirmedUnsavedChanges.value = false;
 };
 
 const getFlowTooltip = (manualFlow: FlowRaw) => {
@@ -124,6 +130,14 @@ const onFlowClick = async (flowId: string) => {
 	if (hasEdits.value || flow.options?.requireConfirmation) {
 		confirmRunFlow.value = flowId;
 	} else {
+		runManualFlow(flowId);
+	}
+};
+
+const confirmUnsavedChanges = async (flowId: string) => {
+	confirmedUnsavedChanges.value = true;
+
+	if (!confirmDetails.value) {
 		runManualFlow(flowId);
 	}
 };
@@ -184,27 +198,35 @@ const runManualFlow = async (flowId: string) => {
 			</div>
 		</div>
 
-		<v-dialog :model-value="!!confirmRunFlow" @esc="resetConfirm">
+		<v-dialog :model-value="displayUnsavedChangesDialog" @esc="resetConfirm">
 			<v-card class="allow-drawer">
-				<template v-if="confirmDetails">
-					<v-card-title>{{ confirmDetails.description ?? t('run_flow_confirm') }}</v-card-title>
+				<v-card-title>{{ t('unsaved_changes') }}</v-card-title>
+				<v-card-text>{{ t('run_flow_on_current_edited_confirm') }}</v-card-text>
 
-					<v-card-text class="confirm-form">
-						<v-form
-							v-if="confirmDetails.fields && confirmDetails.fields.length > 0"
-							:fields="confirmDetails.fields"
-							:model-value="confirmValues"
-							autofocus
-							primary-key="+"
-							@update:model-value="confirmValues = $event"
-						/>
-					</v-card-text>
-				</template>
+				<v-card-actions>
+					<v-button secondary @click="resetConfirm">
+						{{ t('cancel') }}
+					</v-button>
+					<v-button :disabled="isConfirmButtonDisabled" @click="confirmUnsavedChanges(confirmRunFlow!)">
+						{{ confirmButtonCTA }}
+					</v-button>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
 
-				<template v-else>
-					<v-card-title>{{ t('unsaved_changes') }}</v-card-title>
-					<v-card-text>{{ t('run_flow_on_current_edited_confirm') }}</v-card-text>
-				</template>
+		<v-dialog :model-value="displayCustomConfirmDialog" @esc="resetConfirm">
+			<v-card class="allow-drawer">
+				<v-card-title>{{ confirmDetails!.description ?? t('run_flow_confirm') }}</v-card-title>
+				<v-card-text class="confirm-form">
+					<v-form
+						v-if="confirmDetails!.fields && confirmDetails!.fields.length > 0"
+						:fields="confirmDetails!.fields"
+						:model-value="confirmValues"
+						autofocus
+						primary-key="+"
+						@update:model-value="confirmValues = $event"
+					/>
+				</v-card-text>
 
 				<v-card-actions>
 					<v-button secondary @click="resetConfirm">

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -190,15 +190,6 @@ const runManualFlow = async (flowId: string) => {
 					<v-card-title>{{ confirmDetails.description ?? t('run_flow_confirm') }}</v-card-title>
 
 					<v-card-text class="confirm-form">
-						<v-notice v-if="hasEdits" type="warning">
-							<div>
-								<div>
-									<strong>{{ t('unsaved_changes') }}</strong>
-								</div>
-								<div>{{ t('run_flow_on_current_edited_confirm') }}</div>
-							</div>
-						</v-notice>
-
 						<v-form
 							v-if="confirmDetails.fields && confirmDetails.fields.length > 0"
 							:fields="confirmDetails.fields"
@@ -259,10 +250,6 @@ const runManualFlow = async (flowId: string) => {
 
 	:deep(.type-label) {
 		font-size: 1rem;
-	}
-
-	.v-notice {
-		margin-bottom: var(--v-card-padding, 16px);
 	}
 }
 </style>


### PR DESCRIPTION
_I know that the issue #23406 hasn't even accepted yet, but was faster to add it right now while checking the source than coming back later. Feel free to close the PR if it's not intended to add._ 

## Scope

What's changed:

- Adds the warning about unsaved changes to the custom flow-contirmation.dialog

**Before**
- Warning about unsaved-changes in case of no custom confirmation dialog
- No warning about unsaved-changes in case of a custom confirmation dialog

https://github.com/user-attachments/assets/9ebde693-f920-4841-902d-dcb74e060e8a



**After**
- Added a notice about unsaved changes to the custom confirmation dialog

https://github.com/user-attachments/assets/8436fc9f-f676-4923-8481-e33f5b08187d



## Potential Risks / Drawbacks

- /

## Review Notes / Questions

- I think ideally the `v-notice` component should have a `title` prop. As it doesn't have one I created a custom content-template
- Discuss weather the title "unsaved changes" should be separated from the body-message or just be separated by a colon
![Bildschirmfoto 2024-08-19 um 12 42 08](https://github.com/user-attachments/assets/85dda790-2ba1-4f3f-9996-2e96e1746f25)

👆🏼 Inline-code for this version would be:
```vue
<v-notice
	v-if="hasEdits"
	type="warning"
>
	<div>
		<strong>{{ t('unsaved_changes') }}:</strong> {{ t('run_flow_on_current_edited_confirm') }}
	</div>
</v-notice>
```

---

Fixes #23406
