### PR TITLE
Fix notification archive all

### DIFF
--- a/.changeset/lemon-dots-swim.md
+++ b/.changeset/lemon-dots-swim.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix the notifications "archive all" button

--- a/.changeset/lemon-dots-swim.md
+++ b/.changeset/lemon-dots-swim.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix the notifications "archive all" button
+Fixed the "Archive All" notifications functionality

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -10,7 +10,7 @@ import { useItems } from '@directus/composables';
 import { useAppStore } from '@directus/stores';
 import { Filter, Notification } from '@directus/types';
 import { storeToRefs } from 'pinia';
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, unref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
@@ -124,7 +124,9 @@ async function refresh() {
 
 async function archiveAll() {
 	await api.patch('/notifications', {
-		keys: items.value.map((item) => item.id),
+		query: {
+			filter: unref(filter),
+		},
 		data: {
 			status: 'archived',
 		},

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -34,7 +34,7 @@ const openNotifications = ref<string[]>([]);
 const page = ref(1);
 const limit = ref(25);
 const search = ref<string | null>(null);
-const userFilter = ref<Filter>({});
+const filter = ref<Filter | null>(null);
 const mouseDownTarget = ref<EventTarget | null>(null);
 const { notificationsDrawerOpen } = storeToRefs(appStore);
 
@@ -45,7 +45,7 @@ watch(tab, (newTab, oldTab) => {
 	}
 });
 
-watch([search, userFilter], () => {
+watch([search, filter], () => {
 	page.value = 1;
 });
 
@@ -90,7 +90,7 @@ const filterSystem = computed(
 );
 
 const { items, loading, totalPages, totalCount, itemCount, getItems, getItemCount, getTotalCount } = useItems(
-	collection,
+	ref('directus_notifications'),
 	{
 		filter: computed(() => mergeFilters(filter.value, filterSystem.value)),
 		filterSystem,

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -12,7 +12,7 @@ import { useAppStore } from '@directus/stores';
 import { Filter, Notification } from '@directus/types';
 import { mergeFilters } from '@directus/utils';
 import { storeToRefs } from 'pinia';
-import { computed, ref, watch, unref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
@@ -148,7 +148,20 @@ async function refresh() {
 async function archiveAll() {
 	await api.patch('/notifications', {
 		query: {
-			filter: unref(filter),
+			filter: {
+				_and: [
+					{
+						recipient: {
+							_eq: userStore.currentUser!.id,
+						},
+					},
+					{
+						status: {
+							_eq: 'index',
+						},
+					},
+				],
+			},
 		},
 		data: {
 			status: 'archived',

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -124,11 +124,7 @@ async function refresh() {
 
 async function archiveAll() {
 	await api.patch('/notifications', {
-		query: {
-			recipient: {
-				_eq: userStore.currentUser!.id,
-			},
-		},
+		keys: items.value.map((item) => item.id),
 		data: {
 			status: 'archived',
 		},


### PR DESCRIPTION
## Scope

The query used for the "Archive All" notifications request was invalid, not being passed as a `filter` thus not having any effect.

- For non-admin users the request would fail since users are usually only allowed to update their own notifications: https://github.com/directus/directus/blob/772b2901f196f425b0f91c5e189a64ed9c3bbfe0/packages/system-data/src/app-access-permissions/app-access-permissions.yaml#L73-L77
- Even more importantly, for admin users (or users having extended permission on `directus_notifications`), notifications for **any users** up to `QUERY_LIMIT_DEFAULT` would have been archived

## Potential Risks / Drawbacks

None

## Review Notes / Questions

- Additionally, limiting the patch request to only update items which are not yet archived as suggested in https://github.com/directus/directus/pull/23411#pullrequestreview-2245604875
- Includes a fix for the user filter which I (@paescuj) forgot to commit in #23414

---

Related to #22265 - not considering it as fully fixed yet, since the issue with `QUERY_LIMIT_DEFAULT` still exists (though the situation should be better now)