### PR TITLE
Fixed that falsy values did not become the default value

### DIFF
--- a/.changeset/few-days-complain.md
+++ b/.changeset/few-days-complain.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Fixed falsy values not become the default value

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -862,7 +862,7 @@ export class FieldsService {
 		const defaultValue =
 			field.schema?.default_value !== undefined ? field.schema?.default_value : existing?.default_value;
 
-		if (defaultValue) {
+		if (defaultValue !== undefined && defaultValue !== null ) {
 			const newDefaultValueIsString = typeof defaultValue === 'string';
 			const newDefaultIsNowFunction = newDefaultValueIsString && defaultValue.toLowerCase() === 'now()';
 			const newDefaultIsCurrentTimestamp = newDefaultValueIsString && defaultValue === 'CURRENT_TIMESTAMP';

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -862,7 +862,7 @@ export class FieldsService {
 		const defaultValue =
 			field.schema?.default_value !== undefined ? field.schema?.default_value : existing?.default_value;
 
-		if (defaultValue !== undefined && defaultValue !== null ) {
+		if (defaultValue !== undefined && defaultValue !== null) {
 			const newDefaultValueIsString = typeof defaultValue === 'string';
 			const newDefaultIsNowFunction = newDefaultValueIsString && defaultValue.toLowerCase() === 'now()';
 			const newDefaultIsCurrentTimestamp = newDefaultValueIsString && defaultValue === 'CURRENT_TIMESTAMP';


### PR DESCRIPTION
## Scope
Currently falsy values, e.g. 0, became `null` as default value. An issue which was introduced very recently (https://github.com/directus/directus/pull/23151).

In here excluded falsy values again in the corresponding selection, so that those values can become the default value again.

## Review Notes / Questions

- Anything I missed here regarding truthy and falsy? 

---

Fixes https://github.com/directus/directus/issues/23379
