### PR TITLE
Enhancements to the notifications drawer 

### DIFF
--- a/.changeset/heavy-ties-return.md
+++ b/.changeset/heavy-ties-return.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added notice in notifications drawer when no items are found due to applied search/filter


### PR DESCRIPTION
## Scope

- Add a notice when no items are found due to applied search/filter with the possibility to reset, as in other layouts
- Only load the notifications once the drawer is actually opened - previously, fetched on each app load
- Clean-up `page` resets as the `useItems` composable already takes care of this

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None

---

Addresses stuff noticed while working on #23411 et al.