### PR TITLE
Switch to own stale issues action

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -11,12 +11,10 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: directus/stale-issues-action@v1
         with:
-          days-before-stale: -1
+          stale-label: ':detective: Needs More Info'
           days-before-close: 7
-          remove-stale-when-updated: false
-          stale-issue-label: ':detective: Needs More Info'
-          close-issue-message:
+          close-message:
             "Heya! There isn't enough information available to keep investigating this issue at present time, so it'll
             be closed until more information becomes available. Thanks!"


### PR DESCRIPTION
## Scope

Switch to our own GitHub action ([directus/stale-issues-action](https://github.com/directus/stale-issues-action)) for closing stale issues.

---

Fixes #22959
