### PR TITLE
Fix WYSIWYG interface should append cache-buster in image query (#15309)

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -28,6 +28,8 @@ import 'tinymce/plugins/pagebreak/plugin';
 import 'tinymce/plugins/preview/plugin';
 import 'tinymce/plugins/table/plugin';
 import 'tinymce/themes/silver';
+import { useItems } from '@directus/composables';
+import { getPublicURL } from '@/utils/get-root-path';
 
 type CustomFormat = {
 	title: string;
@@ -92,14 +94,19 @@ if (settingsStore.settings?.storage_asset_transform) {
 
 const count = ref(0);
 
-const { imageDrawerOpen, imageSelection, closeImageDrawer, onImageSelect, saveImage, imageButton } = useImage(
-	editorRef,
-	imageToken!,
-	{
-		storageAssetTransform,
-		storageAssetPresets,
-	},
-);
+const {
+	imageDrawerOpen,
+	imageSelection,
+	closeImageDrawer,
+	onImageSelect,
+	saveImage,
+	imageButton,
+	getImageIds,
+	replaceCacheBuster,
+} = useImage(editorRef, imageToken!, {
+	storageAssetTransform,
+	storageAssetPresets,
+});
 
 const {
 	mediaDrawerOpen,
@@ -119,9 +126,27 @@ const { linkButton, linkDrawerOpen, closeLinkDrawer, saveLink, linkSelection, li
 
 const { codeDrawerOpen, code, closeCodeDrawer, saveCode, sourceCodeButton } = useSourceCode(editorRef);
 
+const imageIds = computed(() => getImageIds(props.value));
+
+const query = computed(() => ({
+	fields: computed(() => ['id', 'uploaded_on']),
+	limit: ref(imageIds.value.length || 0),
+	page: ref(1),
+	filter: computed(() => ({
+		id: {
+			_in: imageIds.value,
+		},
+	})),
+	sort: ref(null),
+	search: ref(''),
+}));
+
+const collection = ref('directus_files');
+const { items } = useItems(collection, query.value);
+
 const internalValue = computed({
 	get() {
-		return props.value || '';
+		return replaceCacheBuster(props.value, items.value);
 	},
 	set(value) {
 		if (props.value !== value) {

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -130,7 +130,7 @@ const imageIds = computed(() => getImageIds(props.value));
 
 const query = computed(() => ({
 	fields: computed(() => ['id', 'uploaded_on']),
-	limit: ref(imageIds.value.length || 0),
+	limit: computed(()=> imageIds.value.length || 0),
 	page: ref(1),
 	filter: computed(() => ({
 		id: {
@@ -146,7 +146,7 @@ const { items } = useItems(collection, query.value);
 
 const internalValue = computed({
 	get() {
-		return replaceCacheBuster(props.value, items.value);
+		return replaceCacheBuster(props.value, items);
 	},
 	set(value) {
 		if (props.value !== value) {

--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -4,7 +4,7 @@ import { getPublicURL } from '@/utils/get-root-path';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import mime from 'mime/lite';
 import { Ref, ref, watch } from 'vue';
-import { SettingsStorageAssetPreset, File } from '@directus/types';
+import { SettingsStorageAssetPreset, File, Item } from '@directus/types';
 
 type ImageSelection = {
 	imageUrl: string;
@@ -30,6 +30,8 @@ type UsableImage = {
 	onImageSelect: (image: File) => void;
 	saveImage: () => void;
 	imageButton: ImageButton;
+	getImageIds: (value: string | null) => string[];
+	replaceCacheBuster: (value: string | null, images: Item[]) => string;
 };
 
 export default function useImage(
@@ -110,7 +112,16 @@ export default function useImage(
 		},
 	};
 
-	return { imageDrawerOpen, imageSelection, closeImageDrawer, onImageSelect, saveImage, imageButton };
+	return {
+		imageDrawerOpen,
+		imageSelection,
+		closeImageDrawer,
+		onImageSelect,
+		saveImage,
+		imageButton,
+		getImageIds,
+		replaceCacheBuster,
+	};
 
 	function closeImageDrawer() {
 		imageSelection.value = null;
@@ -189,5 +200,47 @@ export default function useImage(
 		} catch {
 			return url;
 		}
+	}
+
+	function getImageIds(value: string | null): string[] {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(value || '', 'text/html');
+		const images = doc.querySelectorAll('img');
+		const ids: string[] = [];
+
+		images.forEach((img) => {
+			const originalSrc = img.getAttribute('src') || '';
+
+			if (originalSrc.startsWith(getPublicURL() + 'assets/')) {
+				const [id] = originalSrc.replace(getPublicURL() + 'assets/', '').split('.');
+				if (id) ids.push(id);
+			}
+		});
+
+		return ids;
+	}
+
+	function replaceCacheBuster(value: string | null, items: Item[]): string {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(value || '', 'text/html');
+		const images = doc.querySelectorAll('img');
+
+		images.forEach((img) => {
+			const originalSrc = img.getAttribute('src') || '';
+
+			if (originalSrc.startsWith(getPublicURL() + 'assets/')) {
+				const [id] = originalSrc.replace(getPublicURL() + 'assets/', '').split('.');
+				const item = items.find((i) => i.id === id);
+
+				if (item) {
+					const url = new URL(originalSrc);
+					const params = url.searchParams;
+					params.set('cache-buster', item.uploaded_on);
+					img.setAttribute('src', url.toString());
+				}
+			}
+		});
+
+		return doc.body.innerHTML;
 	}
 }

--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -31,7 +31,7 @@ type UsableImage = {
 	saveImage: () => void;
 	imageButton: ImageButton;
 	getImageIds: (value: string | null) => string[];
-	replaceCacheBuster: (value: string | null, images: Item[]) => string;
+	replaceCacheBuster: (value: string | null, images: Ref<Item[]>) => string;
 };
 
 export default function useImage(
@@ -220,7 +220,7 @@ export default function useImage(
 		return ids;
 	}
 
-	function replaceCacheBuster(value: string | null, items: Item[]): string {
+	function replaceCacheBuster(value: string | null, items: Ref<Item[]>): string {
 		const parser = new DOMParser();
 		const doc = parser.parseFromString(value || '', 'text/html');
 		const images = doc.querySelectorAll('img');
@@ -230,7 +230,7 @@ export default function useImage(
 
 			if (originalSrc.startsWith(getPublicURL() + 'assets/')) {
 				const [id] = originalSrc.replace(getPublicURL() + 'assets/', '').split('.');
-				const item = items.find((i) => i.id === id);
+				const item = items.value.find((i) => i.id === id);
 
 				if (item) {
 					const url = new URL(originalSrc);


### PR DESCRIPTION
## Scope
WYSIWYG images did not have cache-buster mechanism.
It lead show old version image.

What's changed:

- Append cache-buster in image query in WYSIWYG interface 

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- I am not sure that it should use `modified_on` or `uploaded_on` for image cache-buster

---

Fixes #15309
