### PR TITLE
API: Fix filter `email.send` to be used in Flows

### DIFF
--- a/.changeset/smart-boats-rule.md
+++ b/.changeset/smart-boats-rule.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed filter `email.send` to be used in Flows

--- a/.changeset/smart-boats-rule.md
+++ b/.changeset/smart-boats-rule.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed filter `email.send` to be used in Flows
+Fixed the `email.send` filter to be usable in Flows in conjunction with the "Run Script" operation

--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -54,11 +54,7 @@ export class MailService {
 	}
 
 	async send<T>(options: EmailOptions): Promise<T | null> {
-		const payload = await emitter.emitFilter(`email.send`, options, {
-			database: getDatabase(),
-			schema: null,
-			accountability: null,
-		});
+		const payload = await emitter.emitFilter(`email.send`, options, {});
 
 		if (!payload) return null;
 


### PR DESCRIPTION
## Scope
In PR https://github.com/directus/directus/pull/23024 we have introduced a new filter for `email.send` which allows emails to be changed before they are sent.
Although, in this PR, the `context` of the filter was passed into `meta` which is now causing issues for Flows, as Flows are not able to serialize functions. This is the error we are receiving:
```
function knex(tableName, options) {\n    return createQueryBuilder(knex.context, tableName, options);\n  } could not be cloned.
```

To resolve this, we just pass an empty `meta` object and let the [emitFilter](https://github.com/directus/directus/blob/main/api/src/emitter.ts#L51) function to handle the `context`

What's changed:

- Fix filter `email.send` to be used in Flows 

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None
