### PR TITLE
Fix for "OpenAPI spec has a duplicate operationId" 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -153,3 +153,4 @@
 - EdouardDem
 - Xchos
 - Lfillon
+- maxbritto

--- a/packages/specs/src/paths/extensions/update-bundle.yaml
+++ b/packages/specs/src/paths/extensions/update-bundle.yaml
@@ -1,7 +1,7 @@
 patch:
   summary: Update an Extension
   description: Update an existing extension.
-  operationId: updateExtensions
+  operationId: updateExtensionBundle
   parameters:
     - in: path
       name: bundle


### PR DESCRIPTION

The `/server/specs/oas` endpoint returns an OpenAPI description of the server endpoints.
The operationId 'updateExtensions' was used twice which is not allowed in the open api spec

## Scope

What's changed:

This PR changes one of the `operationId` from "updateExtensions" to "updateExtensionBundle" for the "/extensions/{bundle}/{name}" endpoint. 
In order for the "/extensions/{name}" endpoint to keep its existing "updateExtensions" `operationId`

## Potential Risks / Drawbacks

If existing users where refering to this specific `operationId`, they were before refering to 2 different endpoints. Now they will refer to only one.

## Review Notes / Questions

See the discussion here : https://github.com/directus/directus/issues/23429


---

Fixes #23429
