### PR TITLE
API: Preprocess assigns wrong query bindings when there is more than one duplicated value

### DIFF
--- a/.changeset/ninety-cougars-pull.md
+++ b/.changeset/ninety-cougars-pull.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed the preprocessing of SQL bindings that is necessary to deduplicate identical value bindings for some SQL dialects

--- a/api/src/database/helpers/schema/utils/preprocess-bindings.test.ts
+++ b/api/src/database/helpers/schema/utils/preprocess-bindings.test.ts
@@ -35,3 +35,17 @@ test('Replaces question marks with $1, $2, etc. and skips duplicates', () => {
 	expect(bindings.sql).toEqual('SELECT * FROM table WHERE column = $1 AND other = $2 LIMIT $1');
 	expect(bindings.bindings).toEqual([10, 'foo']);
 });
+
+test('Replaces question marks with $1, $2, etc. and handles more than one duplicate', () => {
+	const bindings = preprocessBindings(
+		{
+			sql: `SELECT * FROM table WHERE column in [?, ?, ?] and other in [?, ?] LIMIT ?`,
+			bindings: [1, 1, 1, 100, 5, 100],
+		},
+		{ format },
+	);
+
+	expect(bindings.sql).toEqual('SELECT * FROM table WHERE column in [$1, $1, $1] and other in [$2, $3] LIMIT $2');
+
+	expect(bindings.bindings).toEqual([1, 100, 5]);
+});

--- a/api/src/database/helpers/schema/utils/preprocess-bindings.ts
+++ b/api/src/database/helpers/schema/utils/preprocess-bindings.ts
@@ -6,27 +6,34 @@ export type PreprocessBindingsOptions = {
 	format(index: number): string;
 };
 
+/**
+ * Preprocess a SQL query, such that repeated binding values are bound to the same binding index.
+ **/
 export function preprocessBindings(
 	queryParams: (Partial<Sql> & Pick<Sql, 'sql'>) | string,
 	options: PreprocessBindingsOptions,
 ) {
 	const query: Sql = { bindings: [], ...(isString(queryParams) ? { sql: queryParams } : queryParams) };
 
+	// bindingIndices[i] is the index of the first occurrence of query.bindings[i]
 	const bindingIndices: number[] = new Array(query.bindings.length);
 
 	for (let i = 0; i < query.bindings.length; i++) {
 		const binding = query.bindings[i];
 		const prevIndex = query.bindings.findIndex((b, j) => j < i && b === binding);
 
-		if (prevIndex !== -1) {
-			bindingIndices[i] = prevIndex;
-		} else {
+		if (prevIndex === -1) {
+			// The first time the value is encountered, set the index lookup to the current index
 			bindingIndices[i] = i;
+		} else {
+			// The value has been encountered before, set the index lookup to the first occurrence index
+			bindingIndices[i] = prevIndex;
 		}
 	}
 
 	let matchIndex = 0;
-	let currentBindingIndex = 0;
+	let nextBindingIndex = 0;
+	// The new, deduplicated bindings
 	const bindings: Knex.Value[] = [];
 
 	const sql = query.sql.replace(/(\\*)(\?)/g, function (_, escapes) {
@@ -37,13 +44,25 @@ export function preprocessBindings(
 			let bindingIndex;
 
 			if (bindingIndices[matchIndex] === matchIndex) {
-				bindingIndex = currentBindingIndex++;
+				// This is the first occurrence of this binding in the SQL string, as the index
+				// of its first occurrence (bindingIndices[matchIndex]) is the same as the current index (matchIndex).
+
+				// Use the nextBindingIndex to get the next unused binding index that is used in the new, deduplicated bindings
+				bindingIndex = nextBindingIndex++;
+
+				// Update the lookup table to point to the new binding index
 				bindingIndices[matchIndex] = bindingIndex;
+
+				// Add the binding value to the new bindings
 				bindings.push(query.bindings[matchIndex]!);
 			} else {
+				// This index belongs to a binding that has been encountered before.
+				// Do a double lookup, first look up the original, first occurrence index of the binding value and then
+				// use that index to look up the newly assigned index used in the deduplicated bindings.
 				bindingIndex = bindingIndices[bindingIndices[matchIndex]!]!;
 			}
 
+			// Increment the loop counter
 			matchIndex++;
 			return options.format(bindingIndex);
 		}

--- a/api/src/database/helpers/schema/utils/preprocess-bindings.ts
+++ b/api/src/database/helpers/schema/utils/preprocess-bindings.ts
@@ -26,6 +26,7 @@ export function preprocessBindings(
 
 	const sql = query.sql.replace(/(\\*)(\?)/g, (_, escapes) => {
 		if (escapes.length % 2) {
+			// Return an escaped question mark, so it stays escaped
 			return `${'\\'.repeat(escapes.length)}?`;
 		}
 

--- a/api/src/database/helpers/schema/utils/preprocess-bindings.ts
+++ b/api/src/database/helpers/schema/utils/preprocess-bindings.ts
@@ -1,6 +1,6 @@
 import { isString } from 'lodash-es';
-import type { Sql } from '../types.js';
 import type { Knex } from 'knex';
+import type { Sql } from '../types.js';
 
 export type PreprocessBindingsOptions = {
 	format(index: number): string;

--- a/api/src/database/helpers/schema/utils/preprocess-bindings.ts
+++ b/api/src/database/helpers/schema/utils/preprocess-bindings.ts
@@ -16,56 +16,36 @@ export function preprocessBindings(
 	const query: Sql = { bindings: [], ...(isString(queryParams) ? { sql: queryParams } : queryParams) };
 
 	// bindingIndices[i] is the index of the first occurrence of query.bindings[i]
-	const bindingIndices: number[] = new Array(query.bindings.length);
+	const bindingIndices = new Map<Knex.Value, number>();
 
-	for (let i = 0; i < query.bindings.length; i++) {
-		const binding = query.bindings[i];
-		const prevIndex = query.bindings.findIndex((b, j) => j < i && b === binding);
-
-		if (prevIndex === -1) {
-			// The first time the value is encountered, set the index lookup to the current index
-			bindingIndices[i] = i;
-		} else {
-			// The value has been encountered before, set the index lookup to the first occurrence index
-			bindingIndices[i] = prevIndex;
-		}
-	}
-
-	let matchIndex = 0;
-	let nextBindingIndex = 0;
 	// The new, deduplicated bindings
 	const bindings: Knex.Value[] = [];
 
-	const sql = query.sql.replace(/(\\*)(\?)/g, function (_, escapes) {
+	let matchIndex = 0;
+	let nextBindingIndex = 0;
+
+	const sql = query.sql.replace(/(\\*)(\?)/g, (_, escapes) => {
 		if (escapes.length % 2) {
-			// Return an escaped question mark, so it stays escaped
 			return `${'\\'.repeat(escapes.length)}?`;
-		} else {
-			let bindingIndex;
-
-			if (bindingIndices[matchIndex] === matchIndex) {
-				// This is the first occurrence of this binding in the SQL string, as the index
-				// of its first occurrence (bindingIndices[matchIndex]) is the same as the current index (matchIndex).
-
-				// Use the nextBindingIndex to get the next unused binding index that is used in the new, deduplicated bindings
-				bindingIndex = nextBindingIndex++;
-
-				// Update the lookup table to point to the new binding index
-				bindingIndices[matchIndex] = bindingIndex;
-
-				// Add the binding value to the new bindings
-				bindings.push(query.bindings[matchIndex]!);
-			} else {
-				// This index belongs to a binding that has been encountered before.
-				// Do a double lookup, first look up the original, first occurrence index of the binding value and then
-				// use that index to look up the newly assigned index used in the deduplicated bindings.
-				bindingIndex = bindingIndices[bindingIndices[matchIndex]!]!;
-			}
-
-			// Increment the loop counter
-			matchIndex++;
-			return options.format(bindingIndex);
 		}
+
+		const binding = query.bindings[matchIndex];
+		let bindingIndex: number;
+
+		if (bindingIndices.has(binding!)) {
+			// This index belongs to a binding that has been encountered before.
+			bindingIndex = bindingIndices.get(binding!)!;
+		} else {
+			// The first time the value is encountered, set the index lookup to the current index
+			// Use the nextBindingIndex to get the next unused binding index that is used in the new, deduplicated bindings
+			bindingIndex = nextBindingIndex++;
+			bindingIndices.set(binding!, bindingIndex);
+			bindings.push(binding!);
+		}
+
+		// Increment the loop counter
+		matchIndex++;
+		return options.format(bindingIndex);
 	});
 
 	return { ...query, sql, bindings };

--- a/api/src/database/helpers/schema/utils/preprocess-bindings.ts
+++ b/api/src/database/helpers/schema/utils/preprocess-bindings.ts
@@ -29,18 +29,18 @@ export function preprocessBindings(
 			return `${'\\'.repeat(escapes.length)}?`;
 		}
 
-		const binding = query.bindings[matchIndex];
+		const binding = query.bindings[matchIndex]!;
 		let bindingIndex: number;
 
-		if (bindingIndices.has(binding!)) {
+		if (bindingIndices.has(binding)) {
 			// This index belongs to a binding that has been encountered before.
-			bindingIndex = bindingIndices.get(binding!)!;
+			bindingIndex = bindingIndices.get(binding)!;
 		} else {
 			// The first time the value is encountered, set the index lookup to the current index
 			// Use the nextBindingIndex to get the next unused binding index that is used in the new, deduplicated bindings
 			bindingIndex = nextBindingIndex++;
-			bindingIndices.set(binding!, bindingIndex);
-			bindings.push(binding!);
+			bindingIndices.set(binding, bindingIndex);
+			bindings.push(binding);
 		}
 
 		// Increment the loop counter


### PR DESCRIPTION
## Scope
When using [Aggregation or Grouping](https://docs.directus.io/reference/query.html#aggregation-grouping) together with the `search` query we were getting the error:
```
{"errors":[{"message":"An unexpected error occurred.","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}
```

And on server logs we saw:
```
could not determine data type of parameter $5
```

After some investigation we found this to be happening when database query bindings had more than one duplicated value. For example, binding values looked like this:
```js
[ "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "%search term%", "published", "published", "draft", 100, ]
```

This caused the SQL query to look like something like
```
select ... from ... where ... = $1 ... = $2 ... =$33
```

The `$33` should be something like `$3` and that's what this PR tries to fix.

The underlying problem was that when looking up the index to use for a binding that was encountered before (`matchIndex !== bindingIndices[matchIndex]`) instead of using the binding index of the new, deduplicated binding, the index of it's original first occurrence tracked by `bindingsIndices[matchIndex]` is used. 

The fix is to replace the index of the first occurrence in the `bindingsIndices` with the newly assigned index when it is first encountered in the replacement loop. When it is encountered again we have to do a double lookup, where the first `bindingIndices[matchIndex]` yields the index of the first occurrence, and resolving that yields the newly assigned index for that binding value.

What's changed:

- Fixed the binding preprocessing to account for multiple occurrences 
- Added a test that catches the incorrect behavior on main

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None