### PR TITLE
Separate schema needed for operations from schema used to generate api spec

### DIFF
--- a/.changeset/tiny-jeans-matter.md
+++ b/.changeset/tiny-jeans-matter.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed the OpenAPI specifications to include POST, PATCH and DELETE paths again

--- a/.changeset/tiny-jeans-matter.md
+++ b/.changeset/tiny-jeans-matter.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed the OpenAPI specifications to include POST, PATCH and DELETE paths again
+Fixed the generated OpenAPI specs to include POST, PATCH and DELETE paths again

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -61,8 +61,7 @@ class OASSpecsService implements SpecificationSubService {
 	}
 
 	async generate(host?: string) {
-		const schema = this.schema;
-		let schemaForSpec = schema;
+		let schemaForSpec = this.schema;
 		let permissions: Permission[] = [];
 
 		if (this.accountability && this.accountability.admin !== true) {
@@ -71,16 +70,16 @@ class OASSpecsService implements SpecificationSubService {
 					accountability: this.accountability,
 					action: 'read',
 				},
-				{ schema, knex: this.knex },
+				{ schema: this.schema, knex: this.knex },
 			);
 
-			schemaForSpec = reduceSchema(schema, allowedFields);
+			schemaForSpec = reduceSchema(this.schema, allowedFields);
 
-			const policies = await fetchPolicies(this.accountability, { schema, knex: this.knex });
+			const policies = await fetchPolicies(this.accountability, { schema: this.schema, knex: this.knex });
 
 			permissions = await fetchPermissions(
 				{ policies, accountability: this.accountability },
-				{ schema, knex: this.knex },
+				{ schema: this.schema, knex: this.knex },
 			);
 		}
 

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -79,7 +79,7 @@ class OASSpecsService implements SpecificationSubService {
 			const policies = await fetchPolicies(this.accountability, { schema, knex: this.knex });
 
 			permissions = await fetchPermissions(
-				{ action: 'read', policies, accountability: this.accountability },
+				{ policies, accountability: this.accountability },
 				{ schema, knex: this.knex },
 			);
 		}

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -61,7 +61,8 @@ class OASSpecsService implements SpecificationSubService {
 	}
 
 	async generate(host?: string) {
-		let schema = this.schema;
+		const schema = this.schema;
+		let schemaForSpec = schema;
 		let permissions: Permission[] = [];
 
 		if (this.accountability && this.accountability.admin !== true) {
@@ -73,7 +74,7 @@ class OASSpecsService implements SpecificationSubService {
 				{ schema, knex: this.knex },
 			);
 
-			schema = reduceSchema(schema, allowedFields);
+			schemaForSpec = reduceSchema(schema, allowedFields);
 
 			const policies = await fetchPolicies(this.accountability, { schema, knex: this.knex });
 
@@ -83,9 +84,9 @@ class OASSpecsService implements SpecificationSubService {
 			);
 		}
 
-		const tags = await this.generateTags(schema);
+		const tags = await this.generateTags(schemaForSpec);
 		const paths = await this.generatePaths(permissions, tags);
-		const components = await this.generateComponents(schema, tags);
+		const components = await this.generateComponents(schemaForSpec, tags);
 
 		const isDefaultPublicUrl = env['PUBLIC_URL'] === '/';
 		const url = isDefaultPublicUrl && host ? host : (env['PUBLIC_URL'] as string);


### PR DESCRIPTION
The issue was using a reduced schema `reducedSchema`, which is used as the context in many functions during the `fetchPermissions` call.

```
schema = reduceSchema(schema, allowedFields);
// ^^^ THIS SCHEMA IS NOT THE ENTIRE ONE ANY MORE, BREAKING THE FOLLOWING TWO CALLS
const policies = await fetchPolicies(this.accountability, { schema, knex: this.knex });
permissions = await fetchPermissions({ policies, accountability: this.accountability }, { schema, knex: this.knex });
```

## Scope

What's changed:

The OAS Spec generated is now fixed to once again display POST, DELETE AND PATCH paths

## Potential Risks / Drawbacks

- None that I could find

## Review Notes / Questions

- Tests should be added so this doesn't fail again.

---

Fixes #23451
