### PR TITLE
Fix address undefined for `graphql` and `websocket` logs

### DIFF
--- a/.changeset/heavy-frogs-think.md
+++ b/.changeset/heavy-frogs-think.md
@@ -1,0 +1,6 @@
+---
+'@directus/env': patch
+'@directus/api': patch
+---
+
+Fixed server address undefined for `graphql` and `websocket` logs

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -158,7 +158,7 @@ export async function startServer(): Promise<void> {
 
 	const host = env['HOST'] as string;
 	const path = env['UNIX_SOCKET_PATH'] as string | undefined;
-	const port = env['PORT'] as string | undefined;
+	const port = env['PORT'] as string;
 
 	let listenOptions: ListenOptions;
 
@@ -167,7 +167,7 @@ export async function startServer(): Promise<void> {
 	} else {
 		listenOptions = {
 			host,
-			port: parseInt(port || '8055'),
+			port: parseInt(port),
 		};
 	}
 

--- a/api/src/utils/get-address.ts
+++ b/api/src/utils/get-address.ts
@@ -1,11 +1,18 @@
 import * as http from 'http';
+import { useEnv } from '@directus/env';
 
 export function getAddress(server: http.Server) {
+	const env = useEnv();
 	const address = server.address();
 
 	if (address === null) {
 		// Before the 'listening' event has been emitted or after calling server.close()
-		return;
+
+		if (env['UNIX_SOCKET_PATH']) {
+			return env['UNIX_SOCKET_PATH'];
+		}
+
+		return `${env['HOST']}:${env['PORT']}`;
 	}
 
 	if (typeof address === 'string') {

--- a/api/src/websocket/controllers/graphql.ts
+++ b/api/src/websocket/controllers/graphql.ts
@@ -13,10 +13,8 @@ import { ConnectionParams, WebSocketMessage } from '../messages.js';
 import type { AuthenticationState, GraphQLSocket, UpgradeContext, WebSocketClient } from '../types.js';
 import { getMessageType } from '../utils/message.js';
 import SocketController from './base.js';
-import { useEnv } from '@directus/env';
 
 const logger = useLogger();
-const env = useEnv();
 
 export class GraphQLSubscriptionController extends SocketController {
 	gql: Server<GraphQLSocket>;
@@ -44,11 +42,7 @@ export class GraphQLSubscriptionController extends SocketController {
 
 		bindPubSub();
 
-		logger.info(
-			`GraphQL Subscriptions started at ${env['UNIX_SOCKET_PATH'] ? '' : 'ws://'}${getAddress(httpServer)}${
-				this.endpoint
-			}`,
-		);
+		logger.info(`GraphQL Subscriptions started at ${getAddress(httpServer)}${this.endpoint}`);
 	}
 
 	private bindEvents(client: WebSocketClient) {

--- a/api/src/websocket/controllers/graphql.ts
+++ b/api/src/websocket/controllers/graphql.ts
@@ -13,8 +13,10 @@ import { ConnectionParams, WebSocketMessage } from '../messages.js';
 import type { AuthenticationState, GraphQLSocket, UpgradeContext, WebSocketClient } from '../types.js';
 import { getMessageType } from '../utils/message.js';
 import SocketController from './base.js';
+import { useEnv } from '@directus/env';
 
 const logger = useLogger();
+const env = useEnv();
 
 export class GraphQLSubscriptionController extends SocketController {
 	gql: Server<GraphQLSocket>;
@@ -41,7 +43,12 @@ export class GraphQLSubscriptionController extends SocketController {
 		});
 
 		bindPubSub();
-		logger.info(`GraphQL Subscriptions started at ws://${getAddress(httpServer)}${this.endpoint}`);
+
+		logger.info(
+			`GraphQL Subscriptions started at ${env['UNIX_SOCKET_PATH'] ? '' : 'ws://'}${getAddress(httpServer)}${
+				this.endpoint
+			}`,
+		);
 	}
 
 	private bindEvents(client: WebSocketClient) {

--- a/api/src/websocket/controllers/rest.ts
+++ b/api/src/websocket/controllers/rest.ts
@@ -8,8 +8,10 @@ import { WebSocketError, handleWebSocketError } from '../errors.js';
 import { WebSocketMessage } from '../messages.js';
 import type { AuthenticationState, WebSocketClient } from '../types.js';
 import SocketController from './base.js';
+import { useEnv } from '@directus/env';
 
 const logger = useLogger();
+const env = useEnv();
 
 export class WebSocketController extends SocketController {
 	constructor(httpServer: httpServer) {
@@ -19,7 +21,9 @@ export class WebSocketController extends SocketController {
 			this.bindEvents(this.createClient(ws, auth));
 		});
 
-		logger.info(`WebSocket Server started at ws://${getAddress(httpServer)}${this.endpoint}`);
+		logger.info(
+			`WebSocket Server started at ${env['UNIX_SOCKET_PATH'] ? '' : 'ws://'}${getAddress(httpServer)}${this.endpoint}`,
+		);
 	}
 
 	private bindEvents(client: WebSocketClient) {

--- a/api/src/websocket/controllers/rest.ts
+++ b/api/src/websocket/controllers/rest.ts
@@ -8,10 +8,8 @@ import { WebSocketError, handleWebSocketError } from '../errors.js';
 import { WebSocketMessage } from '../messages.js';
 import type { AuthenticationState, WebSocketClient } from '../types.js';
 import SocketController from './base.js';
-import { useEnv } from '@directus/env';
 
 const logger = useLogger();
-const env = useEnv();
 
 export class WebSocketController extends SocketController {
 	constructor(httpServer: httpServer) {
@@ -21,9 +19,7 @@ export class WebSocketController extends SocketController {
 			this.bindEvents(this.createClient(ws, auth));
 		});
 
-		logger.info(
-			`WebSocket Server started at ${env['UNIX_SOCKET_PATH'] ? '' : 'ws://'}${getAddress(httpServer)}${this.endpoint}`,
-		);
+		logger.info(`WebSocket Server started at ${getAddress(httpServer)}${this.endpoint}`);
 	}
 
 	private bindEvents(client: WebSocketClient) {

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -5,6 +5,7 @@ export const DEFAULTS = {
 	CONFIG_PATH: resolve(cwd(), '.env'),
 
 	HOST: '0.0.0.0',
+	PORT: 8055,
 	PUBLIC_URL: '/',
 	MAX_PAYLOAD_SIZE: '1mb',
 	MAX_RELATIONAL_DEPTH: 10,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- `getAddress` now uses env values as defaults when the server is not active/listening

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- ~~Any alternative to checking for the socket before appending the `ws://` protocol is appreciated.~~

---

Fixes #23484
