### PR TITLE
Remove unused `current_tab` translation

### DIFF
--- a/.changeset/polite-zoos-shop.md
+++ b/.changeset/polite-zoos-shop.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Dropped unused translations

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1051,8 +1051,7 @@ tooltip: Tooltip
 tooltip_placeholder: Enter a tooltip...
 unlimited: Unlimited
 open_link_in: Open link in
-new_tab: New tab
-current_tab: Current tab
+new_tab: New Tab
 save_image: Save Image
 save_media: Save Media
 wysiwyg_options:


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Addition to #23502, since `current_tab` is now unused.

