### PR TITLE
Fix drawer order for the create bookmark dialog

### DIFF
--- a/.changeset/curly-frogs-hide.md
+++ b/.changeset/curly-frogs-hide.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed dialog/drawer order when creating a bookmark in the collection view

--- a/app/src/views/private/components/bookmark-add.vue
+++ b/app/src/views/private/components/bookmark-add.vue
@@ -42,7 +42,7 @@ function cancel() {
 			<slot name="activator" v-bind="slotBinding" />
 		</template>
 
-		<v-card>
+		<v-card class="allow-drawer">
 			<v-card-title>{{ t('create_bookmark') }}</v-card-title>
 
 			<v-card-text>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Add the `allow-drawer` class to the dialog in order to render the translation drawer above the dialog.

![CleanShot 2024-08-27 at 17 14 17](https://github.com/user-attachments/assets/537098b3-6d78-4906-a092-04fc21777dd7)

What's changed:

- Add `allow-drawer` escape hatch

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #23499 
