### PR TITLE
Fix the image tune menu toggle state in the block editor interface

### DIFF
--- a/.changeset/rare-pumpkins-decide.md
+++ b/.changeset/rare-pumpkins-decide.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix issue 23504 - Set initial state of the tune in ImageTool renderSettings()
+Set initial state of tunes in BlockEditor ImageTool

--- a/.changeset/rare-pumpkins-decide.md
+++ b/.changeset/rare-pumpkins-decide.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Set initial state of tunes in BlockEditor ImageTool
+Fixed the image tune menu toggle state indication in the block editor interface

--- a/.changeset/rare-pumpkins-decide.md
+++ b/.changeset/rare-pumpkins-decide.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix issue 23504 - Set initial state of the tune in ImageTool renderSettings()

--- a/app/src/interfaces/input-block-editor/plugins.ts
+++ b/app/src/interfaces/input-block-editor/plugins.ts
@@ -179,7 +179,7 @@ export class ImageTool extends BaseImageTool {
 					bus.emit({ type: 'open-url', payload: this.data.file.fileURL });
 				},
 			},
-			...ImageTool.tunes,
+			...BaseImageTool.tunes,
 		];
 
 		const wrapperElement = document.createElement('div');
@@ -201,7 +201,7 @@ export class ImageTool extends BaseImageTool {
 			titleElement.innerHTML = tune.title;
 			tuneElement.appendChild(titleElement);
 
-			if (tune.toggle && this._data[tune.name]) {
+			if (tune.toggle && tune.name && this._data[tune.name]) {
 				tuneElement.classList.add('ce-popover-item--active');
 			}
 

--- a/app/src/interfaces/input-block-editor/plugins.ts
+++ b/app/src/interfaces/input-block-editor/plugins.ts
@@ -201,6 +201,10 @@ export class ImageTool extends BaseImageTool {
 			titleElement.innerHTML = tune.title;
 			tuneElement.appendChild(titleElement);
 
+			if (tune.toggle && this._data[tune.name]) {
+				tuneElement.classList.add('ce-popover-item--active');
+			}
+
 			if (tune.onActivate) tuneElement.addEventListener('click', tune.onActivate);
 			else if (tune.toggle)
 				tuneElement.addEventListener('click', () => {

--- a/contributors.yml
+++ b/contributors.yml
@@ -159,3 +159,4 @@
 - FatumaA
 - HZooly
 - simboonlong
+- HeikoMueller


### PR DESCRIPTION
## Scope

What's changed:

- Set initial state of the tune in ImageTool renderSettings()
- Toggleable attributes such as "streched", "withBorder", "withBackground" are now shown in sync with the data state
- If those attributes have been enabled before, they can now be disabled as expected

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Possibility to add custom image attributes would be a nice advancement for future development

---

Fixes #23504
