### PR TITLE
Fix sidebar-detail missing fetch data after navigation (#23520)

### DIFF
--- a/.changeset/rich-rings-do.md
+++ b/.changeset/rich-rings-do.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured data in sidebar is re-fetched when switching pages while a sidebar pane is already opened

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -348,6 +348,7 @@ async function saveVersionAction(action: 'main' | 'stay' | 'quit') {
 				currentVersion.value = null;
 				break;
 			case 'stay':
+				revisionsDrawerDetailRef.value?.refresh?.();
 				refresh();
 				break;
 			case 'quit':

--- a/app/src/modules/settings/routes/flows/components/logs-sidebar-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/logs-sidebar-detail.vue
@@ -7,6 +7,7 @@ import { computed, ref, toRefs, unref, watch, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { getTriggers } from '../triggers';
 import { abbreviateNumber } from '@directus/utils';
+import { useGroupable } from '@directus/composables';
 
 const props = defineProps<{
 	flow: FlowRaw;
@@ -21,6 +22,11 @@ const { operations } = useExtensions();
 
 const usedTrigger = computed(() => {
 	return triggers.find((trigger) => trigger.id === unref(flow).trigger);
+});
+
+const { active: open } = useGroupable({
+	value: t('logs'),
+	group: 'sidebar-detail',
 });
 
 const page = ref<number>(1);
@@ -44,6 +50,7 @@ watch(
 
 onMounted(() => {
 	getRevisionsCount();
+	if (open.value && revisionsByDate.value === null) getRevisions();
 });
 
 const previewing = ref();

--- a/app/src/modules/settings/routes/flows/components/logs-sidebar-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/logs-sidebar-detail.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { useRevisions } from '@/composables/use-revisions';
 import { useExtensions } from '@/extensions';
-import type { FlowRaw } from '@directus/types';
+import { useGroupable } from '@directus/composables';
 import { Action } from '@directus/constants';
-import { computed, ref, toRefs, unref, watch, onMounted } from 'vue';
+import type { FlowRaw } from '@directus/types';
+import { abbreviateNumber } from '@directus/utils';
+import { computed, onMounted, ref, toRefs, unref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { getTriggers } from '../triggers';
-import { abbreviateNumber } from '@directus/utils';
-import { useGroupable } from '@directus/composables';
 
 const props = defineProps<{
 	flow: FlowRaw;
@@ -17,16 +17,18 @@ const { flow } = toRefs(props);
 
 const { t } = useI18n();
 
+const title = computed(() => t('logs'));
+
+const { active: open } = useGroupable({
+	value: title.value,
+	group: 'sidebar-detail',
+});
+
 const { triggers } = getTriggers();
 const { operations } = useExtensions();
 
 const usedTrigger = computed(() => {
 	return triggers.find((trigger) => trigger.id === unref(flow).trigger);
-});
-
-const { active: open } = useGroupable({
-	value: t('logs'),
-	group: 'sidebar-detail',
 });
 
 const page = ref<number>(1);
@@ -50,7 +52,7 @@ watch(
 
 onMounted(() => {
 	getRevisionsCount();
-	if (open.value && revisionsByDate.value === null) getRevisions();
+	if (open.value) getRevisions();
 });
 
 const previewing = ref();
@@ -107,7 +109,7 @@ function onToggle(open: boolean) {
 
 <template>
 	<sidebar-detail
-		:title="t('logs')"
+		:title
 		icon="fact_check"
 		:badge="!loadingCount && revisionsCount > 0 ? abbreviateNumber(revisionsCount) : null"
 		@toggle="onToggle"

--- a/app/src/views/private/components/comments-sidebar-detail.vue
+++ b/app/src/views/private/components/comments-sidebar-detail.vue
@@ -11,6 +11,7 @@ import { Ref, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import CommentInput from './comment-input.vue';
 import CommentItem from './comment-item.vue';
+import { useGroupable } from '@directus/composables';
 
 type ActivityByDateDisplay = ActivityByDate & {
 	activity: (Activity & {
@@ -26,6 +27,11 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
+const { active: open } = useGroupable({
+	value: t('comments'),
+	group: 'sidebar-detail',
+});
+
 const { collection, primaryKey } = toRefs(props);
 
 const { activity, getActivity, loading, refresh, activityCount, getActivityCount, loadingCount, userPreviews } =
@@ -33,6 +39,7 @@ const { activity, getActivity, loading, refresh, activityCount, getActivityCount
 
 onMounted(() => {
 	getActivityCount();
+	if (open.value && activity.value === null) getActivity();
 });
 
 function onToggle(open: boolean) {

--- a/app/src/views/private/components/comments-sidebar-detail.vue
+++ b/app/src/views/private/components/comments-sidebar-detail.vue
@@ -3,15 +3,15 @@ import api from '@/api';
 import { Activity, ActivityByDate } from '@/types/activity';
 import { localizedFormat } from '@/utils/localized-format';
 import { userName } from '@/utils/user-name';
+import { useGroupable } from '@directus/composables';
 import type { PrimaryKey, User } from '@directus/types';
 import { abbreviateNumber } from '@directus/utils';
 import { isThisYear, isToday, isYesterday } from 'date-fns';
 import { flatten, groupBy, orderBy } from 'lodash';
-import { Ref, onMounted, ref, toRefs, watch } from 'vue';
+import { Ref, computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import CommentInput from './comment-input.vue';
 import CommentItem from './comment-item.vue';
-import { useGroupable } from '@directus/composables';
 
 type ActivityByDateDisplay = ActivityByDate & {
 	activity: (Activity & {
@@ -27,8 +27,10 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
+const title = computed(() => t('comments'));
+
 const { active: open } = useGroupable({
-	value: t('comments'),
+	value: title.value,
 	group: 'sidebar-detail',
 });
 
@@ -39,7 +41,7 @@ const { activity, getActivity, loading, refresh, activityCount, getActivityCount
 
 onMounted(() => {
 	getActivityCount();
-	if (open.value && activity.value === null) getActivity();
+	if (open.value) getActivity();
 });
 
 function onToggle(open: boolean) {
@@ -228,7 +230,7 @@ async function loadUserPreviews(comments: Record<string, any>, regex: RegExp) {
 
 <template>
 	<sidebar-detail
-		:title="t('comments')"
+		:title
 		icon="chat_bubble_outline"
 		:badge="!loadingCount && activityCount > 0 ? abbreviateNumber(activityCount) : null"
 		@toggle="onToggle"

--- a/app/src/views/private/components/revisions-drawer-detail.vue
+++ b/app/src/views/private/components/revisions-drawer-detail.vue
@@ -6,6 +6,7 @@ import { onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import RevisionsDateGroup from './revisions-date-group.vue';
 import RevisionsDrawer from './revisions-drawer.vue';
+import { useGroupable } from '@directus/composables';
 
 const props = defineProps<{
 	collection: string;
@@ -18,6 +19,11 @@ defineEmits(['revert']);
 const { t } = useI18n();
 
 const { collection, primaryKey, version } = toRefs(props);
+
+const { active: open } = useGroupable({
+	value: t('revisions'),
+	group: 'sidebar-detail',
+});
 
 const modalActive = ref(false);
 const modalCurrentRevision = ref<number | null>(null);
@@ -38,6 +44,7 @@ const {
 
 onMounted(() => {
 	getRevisionsCount();
+	if (open.value && revisions.value === null) getRevisions();
 });
 
 watch(

--- a/app/src/views/private/components/revisions-drawer-detail.vue
+++ b/app/src/views/private/components/revisions-drawer-detail.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useRevisions } from '@/composables/use-revisions';
+import { useGroupable } from '@directus/composables';
 import { ContentVersion } from '@directus/types';
 import { abbreviateNumber } from '@directus/utils';
-import { onMounted, ref, toRefs, watch } from 'vue';
+import { computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import RevisionsDateGroup from './revisions-date-group.vue';
 import RevisionsDrawer from './revisions-drawer.vue';
-import { useGroupable } from '@directus/composables';
 
 const props = defineProps<{
 	collection: string;
@@ -18,12 +18,14 @@ defineEmits(['revert']);
 
 const { t } = useI18n();
 
-const { collection, primaryKey, version } = toRefs(props);
+const title = computed(() => t('revisions'));
 
 const { active: open } = useGroupable({
-	value: t('revisions'),
+	value: title.value,
 	group: 'sidebar-detail',
 });
+
+const { collection, primaryKey, version } = toRefs(props);
 
 const modalActive = ref(false);
 const modalCurrentRevision = ref<number | null>(null);
@@ -44,7 +46,7 @@ const {
 
 onMounted(() => {
 	getRevisionsCount();
-	if (open.value && revisions.value === null) getRevisions();
+	if (open.value) getRevisions();
 });
 
 watch(
@@ -70,7 +72,7 @@ defineExpose({
 
 <template>
 	<sidebar-detail
-		:title="t('revisions')"
+		:title
 		icon="change_history"
 		:badge="!loadingCount && revisionsCount > 0 ? abbreviateNumber(revisionsCount) : null"
 		@toggle="onToggle"

--- a/app/src/views/private/components/shares-sidebar-detail.vue
+++ b/app/src/views/private/components/shares-sidebar-detail.vue
@@ -10,6 +10,7 @@ import api from '@/api';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import { abbreviateNumber } from '@directus/utils';
 import ShareItem from './share-item.vue';
+import { useGroupable } from '@directus/composables';
 
 const props = defineProps<{
 	collection: string;
@@ -20,6 +21,11 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const { collection, primaryKey } = toRefs(props);
+
+const { active: open } = useGroupable({
+	value: t('shares'),
+	group: 'sidebar-detail',
+});
 
 const { copyToClipboard } = useClipboard();
 
@@ -47,6 +53,7 @@ const {
 
 onMounted(() => {
 	getSharesCount();
+	if (open.value && shares.value === null) getShares();
 });
 
 function onToggle(open: boolean) {

--- a/app/src/views/private/components/shares-sidebar-detail.vue
+++ b/app/src/views/private/components/shares-sidebar-detail.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
+import api from '@/api';
 import { useClipboard } from '@/composables/use-clipboard';
 import { getRootPath } from '@/utils/get-root-path';
 import { unexpectedError } from '@/utils/unexpected-error';
+import DrawerItem from '@/views/private/components/drawer-item.vue';
+import { useGroupable } from '@directus/composables';
 import { PrimaryKey, Share } from '@directus/types';
+import { abbreviateNumber } from '@directus/utils';
 import { Ref, computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-
-import api from '@/api';
-import DrawerItem from '@/views/private/components/drawer-item.vue';
-import { abbreviateNumber } from '@directus/utils';
 import ShareItem from './share-item.vue';
-import { useGroupable } from '@directus/composables';
 
 const props = defineProps<{
 	collection: string;
@@ -20,10 +19,12 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
+const title = computed(() => t('shares'));
+
 const { collection, primaryKey } = toRefs(props);
 
 const { active: open } = useGroupable({
-	value: t('shares'),
+	value: title.value,
 	group: 'sidebar-detail',
 });
 
@@ -53,7 +54,7 @@ const {
 
 onMounted(() => {
 	getSharesCount();
-	if (open.value && shares.value === null) getShares();
+	if (open.value) getShares();
 });
 
 function onToggle(open: boolean) {
@@ -255,7 +256,7 @@ async function copy(id: string) {
 
 <template>
 	<sidebar-detail
-		:title="t('shares')"
+		:title
 		icon="share"
 		:badge="!loadingCount && sharesCount > 0 ? abbreviateNumber(sharesCount) : null"
 		@toggle="onToggle"


### PR DESCRIPTION
## Scope
A few sidebar detail expected fetch data after sidebar open.
But when user open the sidebar, navigation to other page and then go back.
It will not show data(no fetch data) in sidebar, but sidebar-detail is open.

What's changed:

- Append fetch data in onMounted if sidebar is open.

Issue Demo:

https://github.com/user-attachments/assets/7cd74a84-fd87-4d67-8675-7c68cd0682d4


Fixed Demo:

https://github.com/user-attachments/assets/4b41f37e-421b-4423-971b-aa1c3460a9f7


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23520
