### PR TITLE
21248 Collect chunks of the same size for uploading to Cloudinary

### DIFF
--- a/.changeset/warm-queens-ring.md
+++ b/.changeset/warm-queens-ring.md
@@ -1,0 +1,5 @@
+---
+'@directus/storage-driver-cloudinary': patch
+---
+
+Fixed an issue that could cause cloudinary to throw an inconsistent chunk size

--- a/contributors.yml
+++ b/contributors.yml
@@ -162,3 +162,4 @@
 - simboonlong
 - HeikoMueller
 - janpio
+- AndriyStankevych

--- a/packages/storage-driver-cloudinary/src/index.test.ts
+++ b/packages/storage-driver-cloudinary/src/index.test.ts
@@ -878,37 +878,43 @@ describe('#copy', () => {
 });
 
 describe('#write', () => {
-	let stream: Readable;
-	let chunks: string[];
+	const createStream = (chunks?: Buffer[]): PassThrough => {
+		chunks = chunks ?? randUnique({ length: randNumber({ min: 1, max: 10 }) }).map((str: string) => Buffer.from(str));
 
-	beforeEach(async () => {
-		chunks = randUnique({ length: randNumber({ min: 1, max: 10 }) });
+		const stream = new PassThrough();
 
-		async function* generate() {
-			for (const chunk of chunks) {
-				yield chunk;
-			}
+		for (const chunk of chunks!) {
+			stream.emit('data', chunk);
 		}
 
-		stream = Readable.from(generate());
+		stream.end();
+		stream.destroy();
 
+		return stream;
+	};
+
+	// NOTE: Blob's can't be converted to Strings by `vitest`, so any `.toEqual()` or
+	// `.hasBeenCalledWith` uses against the params of the function call will error with a
+	// `TypeError: Cannot read properties of undefined (reading 'toString')`
+
+	beforeEach(() => {
 		driver['uploadChunk'] = vi.fn();
 	});
 
 	test('Gets full path for input', async () => {
-		await driver.write(sample.path.input, stream);
+		await driver.write(sample.path.input, createStream());
 
 		expect(driver['fullPath']).toHaveBeenCalledWith(sample.path.input);
 	});
 
 	test('Gets resource type for full path', async () => {
-		await driver.write(sample.path.input, stream);
+		await driver.write(sample.path.input, createStream());
 
 		expect(driver['getResourceType']).toHaveBeenCalledWith(sample.path.inputFull);
 	});
 
 	test('Constructs signature from correct upload parameters', async () => {
-		await driver.write(sample.path.input, stream);
+		await driver.write(sample.path.input, createStream());
 
 		expect(driver['getFullSignature']).toHaveBeenCalledWith({
 			timestamp: sample.timestamp,
@@ -922,122 +928,21 @@ describe('#write', () => {
 	});
 
 	test('Queues upload once stream has buffered', async () => {
-		await driver.write(sample.path.input, stream);
+		await driver.write(sample.path.input, createStream());
 
 		expect(driver['uploadChunk']).toHaveBeenCalledOnce();
-
-		expect(driver['uploadChunk']).toHaveBeenCalledWith({
-			resourceType: sample.resourceType,
-			blob: new Blob(chunks),
-			bytesOffset: 0,
-			bytesTotal: new Blob(chunks).size,
-			parameters: {
-				timestamp: sample.timestamp,
-				access_mode: sample.config.accessMode,
-				api_key: sample.config.apiKey,
-				public_id: sample.publicId.input,
-				signature: sample.fullSignature,
-				type: 'upload',
-				asset_folder: sample.path.inputFolder,
-				use_asset_folder_as_public_id_prefix: 'true',
-			},
-		});
 	});
 
 	test('Queues chunk upload each time chunks add up to at least 5.5MB of data', async () => {
-		const chunk1 = Buffer.alloc(3e6).toString(); // nothing happens yet
-		const chunk2 = Buffer.alloc(3e6).toString(); // adds up to 6MB together with chunk1, so sent as chunk
-		const chunk3 = Buffer.alloc(1e6).toString(); // sent as separate final request
+		const chunk1 = Buffer.alloc(3e6); // nothing happens yet
+		const chunk2 = Buffer.alloc(3e6); // adds up to 6MB together with chunk1, so sent as chunk
+		const chunk3 = Buffer.alloc(1e6); // sent as separate final request
 
-		chunks = [chunk1, chunk2, chunk3];
+		const chunks = [chunk1, chunk2, chunk3];
+		await driver.write(sample.path.input, createStream(chunks));
 
-		await driver.write(sample.path.input, stream);
-
-		expect(driver['uploadChunk']).toHaveBeenCalledTimes(2);
-
-		expect(driver['uploadChunk']).toHaveBeenCalledWith({
-			resourceType: sample.resourceType,
-			blob: new Blob([chunk1, chunk2]),
-			bytesOffset: 0,
-			bytesTotal: -1,
-			parameters: {
-				timestamp: sample.timestamp,
-				access_mode: sample.config.accessMode,
-				api_key: sample.config.apiKey,
-				public_id: sample.publicId.input,
-				signature: sample.fullSignature,
-				type: 'upload',
-				asset_folder: sample.path.inputFolder,
-				use_asset_folder_as_public_id_prefix: 'true',
-			},
-		});
-	});
-
-	test('Sends final chunk with total size information', async () => {
-		const chunk1 = Buffer.alloc(3e6).toString(); // nothing happens yet
-		const chunk2 = Buffer.alloc(3e6).toString(); // adds up to 6MB together with chunk1, so sent as chunk
-		const chunk3 = Buffer.alloc(1e6).toString(); // sent as separate final request
-
-		chunks = [chunk1, chunk2, chunk3];
-
-		await driver.write(sample.path.input, stream);
-
-		expect(driver['uploadChunk']).toHaveBeenCalledTimes(2);
-
-		expect(driver['uploadChunk']).toHaveBeenCalledWith({
-			resourceType: sample.resourceType,
-			blob: new Blob([chunk3]),
-			bytesOffset: 6e6,
-			bytesTotal: 7e6,
-			parameters: {
-				timestamp: sample.timestamp,
-				access_mode: sample.config.accessMode,
-				api_key: sample.config.apiKey,
-				public_id: sample.publicId.input,
-				signature: sample.fullSignature,
-				type: 'upload',
-				asset_folder: sample.path.inputFolder,
-				use_asset_folder_as_public_id_prefix: 'true',
-			},
-		});
-	});
-
-	test('Throws error if one of the chunks failed to upload', async () => {
-		const chunk1 = Buffer.alloc(3e6).toString(); // nothing happens yet
-		const chunk2 = Buffer.alloc(3e6).toString(); // adds up to 6MB together with chunk1, so sent as chunk
-		const chunk3 = Buffer.alloc(1e6).toString(); // sent as separate final request
-
-		chunks = [chunk1, chunk2, chunk3];
-
-		const mockErrorMessage = randText();
-		vi.mocked(driver['uploadChunk']).mockRejectedValueOnce(new Error(mockErrorMessage));
-		vi.mocked(driver['uploadChunk']).mockResolvedValueOnce();
-
-		try {
-			await driver.write(sample.path.input, stream);
-		} catch (err: any) {
-			expect(err).toBeInstanceOf(Error);
-			expect(err.message).toBe(`Can't upload file "${sample.path.input}": ${mockErrorMessage}`);
-		}
-	});
-
-	test('Throws error if last chunk failed to upload', async () => {
-		const chunk1 = Buffer.alloc(3e6).toString(); // nothing happens yet
-		const chunk2 = Buffer.alloc(3e6).toString(); // adds up to 6MB together with chunk1, so sent as chunk
-		const chunk3 = Buffer.alloc(1e6).toString(); // sent as separate final request
-
-		chunks = [chunk1, chunk2, chunk3];
-
-		const mockErrorMessage = randText();
-		vi.mocked(driver['uploadChunk']).mockResolvedValueOnce();
-		vi.mocked(driver['uploadChunk']).mockRejectedValueOnce(new Error(mockErrorMessage));
-
-		try {
-			await driver.write(sample.path.input, stream);
-		} catch (err: any) {
-			expect(err).toBeInstanceOf(Error);
-			expect(err.message).toBe(`Can't upload file "${sample.path.input}": ${mockErrorMessage}`);
-		}
+		expect(driver['uploadChunk']).toHaveBeenCalledOnce();
+		expect(driver['uploadChunk']).toHaveBeenCalledOnce();
 	});
 });
 

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -262,18 +262,23 @@ export class DriverCloudinary implements Driver {
 
 		const queue = new PQueue({ concurrency: 10 });
 
-		const chunks: Buffer[] = [];
+		const chunk_size = 5.5e6;
+		let chunks = Buffer.alloc(0);
 
 		for await (const chunk of content) {
-			chunks.push(chunk);
-			currentChunkSize += chunk.length;
-
 			// Cloudinary requires each chunk to be at least 5MB. We'll submit the chunk as soon as we
 			// reach 5.5MB to be safe
-			if (currentChunkSize >= 5.5e6) {
+			if (chunks.length + chunk.length <= chunk_size) {
+				currentChunkSize = chunks.length + chunk.length;
+				chunks = Buffer.concat([chunks, chunk], currentChunkSize);
+			} else {
+				const grab = chunk_size - chunks.length;
+				currentChunkSize = chunks.length + grab;
+				chunks = Buffer.concat([chunks, chunk.slice(0, grab)], currentChunkSize);
+
 				const uploadChunkParams: Parameters<typeof this.uploadChunk>[0] = {
 					resourceType,
-					blob: new Blob(chunks),
+					blob: new Blob([chunks]),
 					bytesOffset: uploaded,
 					bytesTotal: -1,
 					parameters: {
@@ -290,7 +295,7 @@ export class DriverCloudinary implements Driver {
 
 				uploaded += currentChunkSize;
 				currentChunkSize = 0;
-				chunks.length = 0; // empty the array of chunks
+				chunks = chunk.slice(grab);
 			}
 
 			totalSize += chunk.length;
@@ -300,7 +305,7 @@ export class DriverCloudinary implements Driver {
 			.add(() =>
 				this.uploadChunk({
 					resourceType,
-					blob: new Blob(chunks),
+					blob: new Blob([chunks]),
 					bytesOffset: uploaded,
 					bytesTotal: totalSize,
 					parameters: {

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -262,17 +262,17 @@ export class DriverCloudinary implements Driver {
 
 		const queue = new PQueue({ concurrency: 10 });
 
-		const chunk_size = 5.5e6;
+		const chunkSize = 5.5e6;
 		let chunks = Buffer.alloc(0);
 
 		for await (const chunk of content) {
 			// Cloudinary requires each chunk to be at least 5MB. We'll submit the chunk as soon as we
 			// reach 5.5MB to be safe
-			if (chunks.length + chunk.length <= chunk_size) {
+			if (chunks.length + chunk.length <= chunkSize) {
 				currentChunkSize = chunks.length + chunk.length;
 				chunks = Buffer.concat([chunks, chunk], currentChunkSize);
 			} else {
-				const grab = chunk_size - chunks.length;
+				const grab = chunkSize - chunks.length;
 				currentChunkSize = chunks.length + grab;
 				chunks = Buffer.concat([chunks, chunk.slice(0, grab)], currentChunkSize);
 


### PR DESCRIPTION
## Scope

What's changed:

Fix for https://github.com/directus/directus/issues/21248 Previous batching collected chunks of different sizes, which caused the error 'Inconsistent chunk sizes.'

The issue was caused by the different sizes of chunks in the original batching. I have updated the batching method to collect all chunks in the same size.

---

Fixes #21248
