### PR TITLE
Add missing call to getRootPath() in /routes/system-logs/logs.vue

### DIFF
--- a/.changeset/small-bags-listen.md
+++ b/.changeset/small-bags-listen.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that would cause log streaming to fail on Directus installations that use a subpath in the URL

--- a/app/src/modules/settings/routes/system-logs/logs.vue
+++ b/app/src/modules/settings/routes/system-logs/logs.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useClipboard } from '@/composables/use-clipboard';
 import { useShortcut } from '@/composables/use-shortcut';
+import { getRootPath } from '@/utils/get-root-path';
 import { sdk } from '@/sdk';
 import { useServerStore } from '@/stores/server';
 import { realtime } from '@directus/sdk';
@@ -47,7 +48,7 @@ const softWrap = useLocalStorage('system-logs-soft-wrap', true);
 const client = sdk.with(
 	realtime({
 		authMode: 'strict',
-		url: `${sdk.url.protocol === 'https:' ? 'wss' : 'ws'}://${sdk.url.host}/websocket/logs`,
+		url: `${sdk.url.protocol === 'https:' ? 'wss' : 'ws'}://${sdk.url.host}${getRootPath()}websocket/logs`,
 		reconnect: reconnectionParams,
 	}),
 );


### PR DESCRIPTION
## Scope

What's changed:

- Respect the root path for the new Directus admin app system logs viewer for instances located at subpaths relative to the domain root.

## Potential Risks / Drawbacks

- Hopefully none

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

---

Fixes #23568
