### PR TITLE
Fix spacing of expand collapse button (data model view)

### DIFF
--- a/.changeset/chilled-readers-talk.md
+++ b/.changeset/chilled-readers-talk.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix spacing of expand/collapse button in the data model view

--- a/.changeset/chilled-readers-talk.md
+++ b/.changeset/chilled-readers-talk.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix spacing of expand/collapse button in the data model view
+Fixed spacing of expand/collapse button in the data model view

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -339,6 +339,7 @@ async function onSort(updates: Collection[], removeGroup = false) {
 
 .expand-collapse-button {
 	padding-top: 4px;
+	padding-bottom: 8px;
 	text-align: right;
 	color: var(--theme--foreground-subdued);
 


### PR DESCRIPTION
## Scope

What's changed:

- spacing of expand collapse button

Before … or now:
![issue](https://github.com/user-attachments/assets/a9919224-d3dc-4001-afba-7892726dce5d)

After … or like it was before:
![fix](https://github.com/user-attachments/assets/67aae139-3d69-481f-910e-7653e2cd9b69)


## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- Somehow the spacing of v-list/draggable-list has been removed …

---

Fixes #23580
