### PR TITLE
Fix `get-address` util tests

### DIFF
--- a/.changeset/cuddly-lizards-prove.md
+++ b/.changeset/cuddly-lizards-prove.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed unit tests for get-address util

--- a/api/src/utils/get-address.test.ts
+++ b/api/src/utils/get-address.test.ts
@@ -1,9 +1,12 @@
 import * as http from 'http';
-import { describe, expect, test } from 'vitest';
+import { useEnv } from '@directus/env';
+import { describe, expect, test, vi } from 'vitest';
 import { getAddress } from './get-address.js';
 import type { ListenOptions } from 'net';
 import getPort from 'get-port';
 import { randomAlpha } from '@directus/random';
+
+vi.mock('@directus/env');
 
 function createServer(listenOptions?: ListenOptions) {
 	return new Promise<http.Server>((resolve, reject) => {
@@ -21,32 +24,41 @@ function createServer(listenOptions?: ListenOptions) {
 }
 
 describe('getAddress', async () => {
+	const serverHost = '127.0.0.1';
+	const serverSocket = `/tmp/server-${randomAlpha(5)}.sock`;
+	const serverPort = await getPort();
+
 	test('Should return unix socket before server is listening when path is provided', async () => {
-		const serverSocket = `/tmp/server${randomAlpha(5)}.sock`;
-		const server = await createServer({ path: serverSocket });
+		const server = await createServer();
+
+		vi.mocked(useEnv).mockReturnValue({
+			UNIX_SOCKET_PATH: serverSocket,
+		});
 
 		expect(getAddress(server)).toBe(serverSocket);
 		server.close();
 	});
 
 	test('Should return host + port before server is listening when path is undefined', async () => {
-		const serverPort = await getPort();
-		const server = await createServer({ host: '0.0.0.0', port: serverPort });
+		const server = await createServer();
 
-		expect(getAddress(server)).toBe(`0.0.0.0:${serverPort}`);
+		vi.mocked(useEnv).mockReturnValue({
+			PORT: serverPort,
+			HOST: serverHost,
+		});
+
+		expect(getAddress(server)).toBe(`${serverHost}:${serverPort}`);
 	});
 
 	test('Should return unix socket when path is provided', async () => {
-		const serverSocket = `/tmp/server${randomAlpha(5)}.sock`;
 		const server = await createServer({ path: serverSocket });
 
 		expect(getAddress(server)).toBe(serverSocket);
 	});
 
 	test('Should return host + port when path is undefined', async () => {
-		const serverPort = await getPort();
-		const server = await createServer({ host: '0.0.0.0', port: serverPort });
+		const server = await createServer({ host: serverHost, port: serverPort });
 
-		expect(getAddress(server)).toBe(`0.0.0.0:${serverPort}`);
+		expect(getAddress(server)).toBe(`${serverHost}:${serverPort}`);
 	});
 });


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Updated tests for `get-address` to properly check default case returns. Previously it was re-checking the same conditions twice.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None
---

Fixes N/A
