### PR TITLE
Only run stale-issues workflow on main repo

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository == 'directus/directus'
     runs-on: ubuntu-latest
     steps:
       - uses: directus/stale-issues-action@v1


### PR DESCRIPTION
## Scope

What's changed:

- Only run stale-issues bot on main repo

This should prevent the stale-bot from running on forks. Can't test it, but based on docs: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository

## Potential Risks / Drawbacks

- Can't test it, only based on docs

## Review Notes / Questions

- 

Fixes #23591
