### PR TITLE
App: Fix Markdown preview

### DIFF
--- a/.changeset/chatty-knives-shop.md
+++ b/.changeset/chatty-knives-shop.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed preview on Markdown interface

--- a/.changeset/chatty-knives-shop.md
+++ b/.changeset/chatty-knives-shop.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Fixed preview on Markdown interface
+Fixed empty preview in Markdown interface

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -107,7 +107,7 @@ onMounted(async () => {
 	}
 
 	if (markdownInterface.value) {
-		const previewBox = markdownInterface.value.getElementsByClassName('preview-box')[0];
+		const previewBox = markdownInterface.value.getElementsByClassName('preview-box')[0] as HTMLDivElement;
 
 		const observer = new MutationObserver(() => {
 			count.value = previewBox?.textContent?.replace('\n', '')?.length ?? 0;
@@ -206,13 +206,8 @@ function edit(type: Alteration, options?: Record<string, any>) {
 <template>
 	<div ref="markdownInterface" class="interface-input-rich-text-md" :class="[view, { disabled }]">
 		<div class="toolbar">
-			<template v-if="view !== 'preview'">
-				<v-menu
-					v-if="toolbar?.includes('heading')"
-					show-arrow
-					placement="bottom-start"
-					:class="[{ active: view !== 'preview' }]"
-				>
+			<template v-if="view === 'editor'">
+				<v-menu v-if="toolbar?.includes('heading')" show-arrow placement="bottom-start">
 					<template #activator="{ toggle }">
 						<v-button v-tooltip="t('wysiwyg_options.heading')" :disabled="disabled" small icon @click="toggle">
 							<v-icon name="format_size" />

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -398,7 +398,7 @@ function edit(type: Alteration, options?: Record<string, any>) {
 		<div
 			v-md="markdownString"
 			class="preview-box"
-			:style="{ display: view[0] === 'preview' ? 'block' : 'none', direction: direction === 'rtl' ? direction : 'ltr' }"
+			:style="{ display: view === 'preview' ? 'block' : 'none', direction: direction === 'rtl' ? direction : 'ltr' }"
 		></div>
 
 		<v-dialog


### PR DESCRIPTION
## Scope
On latest version (11.1.0), the markdown preview is not working.
The reason seems that in this PR: https://github.com/directus/directus/pull/23353 the change to code is missing a little refactor which is fixed in this PR.

What's changed:

- Fixed preview on Markdown interface (regression)

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

### Comparison

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/1e364d51-d4f4-4e9e-8ce5-910854394a30"></video>|<video src="https://github.com/user-attachments/assets/0aaf7a82-ad01-493f-8f2e-de4ffcbf11d8"></video>|


