### PR TITLE
Fix incorrect `users` and `roles` types for `policy` object

### DIFF
--- a/docs/reference/system/policies.md
+++ b/docs/reference/system/policies.md
@@ -36,12 +36,12 @@ If this policy grants the user admin access. This means that users with this pol
 `app_access` **boolean**\
 Whether or not users with this policy have access to use the Data Studio.
 
-`users` **one-to-many**\
-The users this policy is assigned to directly, this does not include users which receive this policy through a role. One-to-many
-to [users](/reference/system/users).
+`users` **many-to-many**\
+The users this policy is assigned to directly via `directus_access`, this does not include users which receive this policy
+through a role. Many-to-many to [access](/reference/system/access).
 
-`roles` **one-to-many**\
-The roles this policy is assigned to. One-to-many to [roles](/reference/system/policies).
+`roles` **many-to-many**\
+The roles this policy is assigned to via `directus_access`. Many-to-many to [access](/reference/system/access).
 
 `permissions` **one-to-many**\
 The permissions assigned to this policy. One-to-many to [permissions](/reference/system/policies).

--- a/docs/reference/system/policies.md
+++ b/docs/reference/system/policies.md
@@ -44,7 +44,7 @@ through a role. Many-to-many to [access](/reference/system/access).
 The roles this policy is assigned to via `directus_access`. Many-to-many to [access](/reference/system/access).
 
 `permissions` **one-to-many**\
-The permissions assigned to this policy. One-to-many to [permissions](/reference/system/policies).
+The permissions assigned to this policy. One-to-many to [permissions](/reference/system/permissions).
 
 ```json
 {

--- a/docs/reference/system/users.md
+++ b/docs/reference/system/users.md
@@ -73,7 +73,7 @@ Role of the user. Many-to-one to [roles](/reference/system/roles).
 Static access token for the user.
 
 `policies` **many-to-many**\
-The policies in this role. Many-to-many to [policies](/reference/system/policies).
+The policies associated with this user. Many-to-many to [policies](/reference/system/policies).
 
 `last_access` **date**\
 Last time the user accessed the API.


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Updated wording for `users` and `roles` types in the `policy` object to correctly refer to `directus_access`
- Updated link for `permissions` in the `policies` object to link to `permissions`.
- Updated wording for `policies` in the `user` object.

## Potential Risks / Drawbacks

- Links to `access` are broken as we do not have that reference yet

## Review Notes / Questions

- Any suggestions on improved wording for `users` and `roles` in the `policy` object are welcome

---

Fixes #23620