### PR TITLE
Clean-up CSS/Sass declarations below nested rules

### DIFF
--- a/app/src/components/v-checkbox.vue
+++ b/app/src/components/v-checkbox.vue
@@ -140,6 +140,7 @@ function toggleInput(): void {
 		flex-grow: 1;
 		margin-left: 8px;
 		transition: color var(--fast) var(--transition);
+		@include no-wrap;
 
 		input {
 			width: 100%;
@@ -148,8 +149,6 @@ function toggleInput(): void {
 			border-bottom: 2px solid var(--theme--form--field--input--border-color);
 			border-radius: 0;
 		}
-
-		@include no-wrap;
 	}
 
 	& .checkbox {

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -544,12 +544,11 @@ textarea {
 }
 
 .table-options {
-	@include form-grid;
-
 	--theme--form--row-gap: 12px;
 	--theme--form--column-gap: 12px;
 
 	padding: 12px;
+	@include form-grid;
 
 	.v-input {
 		min-width: 100px;

--- a/app/src/modules/content/components/live-preview.vue
+++ b/app/src/modules/content/components/live-preview.vue
@@ -212,10 +212,6 @@ onMounted(() => {
 	height: 100%;
 
 	.header {
-		.v-button.secondary {
-			--v-button-background-color: var(--theme--background-subdued);
-		}
-
 		width: 100%;
 		color: var(--foreground-inverted);
 		background-color: var(--background-inverted);
@@ -225,6 +221,10 @@ onMounted(() => {
 		z-index: 10;
 		gap: 8px;
 		padding: 0px 8px;
+
+		.v-button.secondary {
+			--v-button-background-color: var(--theme--background-subdued);
+		}
 
 		.url {
 			color: var(--theme--foreground-subdued);

--- a/app/src/modules/insights/routes/panel-configuration.vue
+++ b/app/src/modules/insights/routes/panel-configuration.vue
@@ -352,6 +352,11 @@ const stageChanges = () => {
 	--v-button-background-color-disabled: var(--theme--background-normal);
 	--columns: 1;
 
+	grid-column: 1 / span var(--columns);
+	background-color: var(--theme--background-subdued);
+	border-top: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
+	border-bottom: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
+
 	@media (min-width: 400px) {
 		--columns: 2;
 	}
@@ -363,11 +368,6 @@ const stageChanges = () => {
 	@media (min-width: 840px) {
 		--columns: 4;
 	}
-
-	grid-column: 1 / span var(--columns);
-	background-color: var(--theme--background-subdued);
-	border-top: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
-	border-bottom: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 }
 
 :deep(.v-notice.normal) {

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -153,6 +153,11 @@ const options = computed({
 	--v-button-background-color-disabled: var(--theme--background-normal);
 	--columns: 1;
 
+	grid-column: 1 / span var(--columns);
+	background-color: var(--theme--background-subdued);
+	border-top: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
+	border-bottom: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
+
 	@media (min-width: 400px) {
 		--columns: 2;
 	}
@@ -164,11 +169,6 @@ const options = computed({
 	@media (min-width: 840px) {
 		--columns: 4;
 	}
-
-	grid-column: 1 / span var(--columns);
-	background-color: var(--theme--background-subdued);
-	border-top: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
-	border-bottom: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 }
 
 .setup {

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -112,10 +112,10 @@ const availableCollections = computed(() => {
 @import '@/styles/mixins/form-grid';
 
 .relationship {
-	@include form-grid;
-
 	--v-select-font-family: var(--theme--fonts--monospace--font-family);
 	--v-input-font-family: var(--theme--fonts--monospace--font-family);
+
+	@include form-grid;
 
 	&:not(:empty) {
 		margin-bottom: 20px;

--- a/app/src/panels/variable/panel-variable.vue
+++ b/app/src/panels/variable/panel-variable.vue
@@ -45,16 +45,15 @@ const value = computed({
 
 <style lang="scss" scope>
 .variable {
+	display: grid;
+	align-content: center;
+	width: 100%;
+	height: 100%;
 	padding: 12px;
 
 	&.show-header {
 		padding-top: 6px;
 	}
-
-	display: grid;
-	align-content: center;
-	width: 100%;
-	height: 100%;
 
 	> * {
 		grid-row: 1;

--- a/app/src/styles/lib/_mapbox.scss
+++ b/app/src/styles/lib/_mapbox.scss
@@ -56,6 +56,7 @@
 .maplibregl-user-location-dot {
 	width: 12px;
 	height: 12px;
+	pointer-events: none;
 
 	&::before {
 		width: 12px;
@@ -66,7 +67,6 @@
 		width: 16px;
 		height: 16px;
 	}
-	pointer-events: none;
 }
 
 .mapboxgl-search-location-dot {

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -173,6 +173,7 @@ function handleObject(fieldKey: string) {
 	position: relative;
 	max-width: 100%;
 	padding-right: 8px;
+	@include no-wrap;
 
 	.vertical-aligner {
 		display: inline-block;
@@ -180,8 +181,6 @@ function handleObject(fieldKey: string) {
 		height: 100%;
 		vertical-align: middle;
 	}
-
-	@include no-wrap;
 
 	> * {
 		vertical-align: middle;


### PR DESCRIPTION
## Scope

Move up CSS/Sass declarations that were placed below nested rules, following the deprecation warnings from Sass.

> Deprecation Warning: Sass's behavior for declarations that appear after nested
> rules will be changing to match the behavior specified by CSS in an upcoming
> version. To keep the existing behavior, move the declaration above the nested
> rule. To opt into the new behavior, wrap the declaration in `& {}`.

See also https://sass-lang.com/d/mixed-decls

## Potential Risks / Drawbacks

None

## Review Notes / Questions

Existing behavior is kept, but briefly verified it in the Data Studio anyway ✅ 

---

Fixes #23630
