### PR TITLE
Bump pnpm to 9.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"eslint-plugin-vue": "9.27.0",
 		"prettier": "3.1.0"
 	},
-	"packageManager": "pnpm@9.4.0",
+	"packageManager": "pnpm@9.10.0",
 	"engines": {
 		"node": ">=18.18.0",
 		"pnpm": "9"


### PR DESCRIPTION
## Scope

Bump pnpm to [v9.10.0](https://github.com/pnpm/pnpm/releases/tag/v9.10.0)

## Potential Risks / Drawbacks

No breaking changes affecting us

## Review Notes / Questions

None
