### PR TITLE
Fix navigation role missing translate in user modules (#23601)

### DIFF
--- a/.changeset/giant-plants-notice.md
+++ b/.changeset/giant-plants-notice.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that would cause custom role names to not be translated in the role navigation sidebar

--- a/app/src/modules/users/components/navigation-role.vue
+++ b/app/src/modules/users/components/navigation-role.vue
@@ -3,6 +3,7 @@ import { useUserStore } from '@/stores/user';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { BasicRole } from '../composables/use-navigation';
+import { translate } from '@/utils/translate-literal';
 
 const props = defineProps<{
 	role: BasicRole;
@@ -33,7 +34,7 @@ const settingLink = computed(() => ({
 		@click="$emit('click', { role: role.id })"
 	>
 		<v-list-item-icon><v-icon :name="role.icon" /></v-list-item-icon>
-		<v-list-item-content>{{ role.name }}</v-list-item-content>
+		<v-list-item-content>{{ translate(role.name) }}</v-list-item-content>
 	</v-list-item>
 	<v-list-group
 		v-else
@@ -47,7 +48,7 @@ const settingLink = computed(() => ({
 		<template #activator>
 			<v-list-item-icon><v-icon :name="role.icon" /></v-list-item-icon>
 			<v-list-item-content>
-				<v-text-overflow :text="role.name" />
+				<v-text-overflow :text="translate(role.name)" />
 			</v-list-item-content>
 		</template>
 


### PR DESCRIPTION
## Scope

What's changed:

- Add translate  for navigation role name in user modules

| Before | After |
|  ----  | ----  |
|   <video src="https://github.com/user-attachments/assets/2725adb6-ba12-4663-b512-8317c300e370">   | <video src="https://github.com/user-attachments/assets/7e016839-b4c7-4142-ae7d-68c74421386b"> |


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23601
