### PR TITLE
Prevent nesting bundle extensions via the `extensions-sdk` add command

### DIFF
--- a/.changeset/great-planets-move.md
+++ b/.changeset/great-planets-move.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+Prevented nesting bundle extensions via the `extensions-sdk` add command

--- a/packages/extensions-sdk/src/cli/commands/add.ts
+++ b/packages/extensions-sdk/src/cli/commands/add.ts
@@ -78,7 +78,7 @@ export default async function add(options: AddOptions): Promise<void> {
 				type: 'list',
 				name: 'type',
 				message: 'Choose the extension type',
-				choices: EXTENSION_TYPES,
+				choices: () => EXTENSION_TYPES.filter((e) => e !== 'bundle'),
 			},
 			{
 				type: 'input',
@@ -186,7 +186,7 @@ export default async function add(options: AddOptions): Promise<void> {
 				type: 'list',
 				name: 'type',
 				message: 'Choose the extension type',
-				choices: EXTENSION_TYPES,
+				choices: () => EXTENSION_TYPES.filter((e) => e !== 'bundle'),
 			},
 			{
 				type: 'input',


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We no longer display `bundle` as a valid extension type to nest within a bundle extension

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #23533
