### PR TITLE
Improve resiliency of schema overview in postgres

### DIFF
--- a/.changeset/fifty-bobcats-beg.md
+++ b/.changeset/fifty-bobcats-beg.md
@@ -1,0 +1,5 @@
+---
+'@directus/schema': patch
+---
+
+Fixed an issue that would cause directus to crash on unexpected database schema contents

--- a/.changeset/fifty-bobcats-beg.md
+++ b/.changeset/fifty-bobcats-beg.md
@@ -2,4 +2,4 @@
 '@directus/schema': patch
 ---
 
-Fixed an issue that would cause directus to crash on unexpected database schema contents
+Fixed an issue that would cause a server crash on unexpected PostgreSQL database schema contents

--- a/packages/schema/src/dialects/cockroachdb.ts
+++ b/packages/schema/src/dialects/cockroachdb.ts
@@ -224,7 +224,7 @@ export default class CockroachDB implements SchemaInspector {
 				}
 			} else {
 				/* eslint-disable-next-line no-console */
-				console.error(`Could not set primary key "${column_name}" for unknown table "${table_name}"`);
+				console.error(`Could not set geometry column "${column_name}" for unknown table "${table_name}"`);
 			}
 		}
 

--- a/packages/schema/src/dialects/cockroachdb.ts
+++ b/packages/schema/src/dialects/cockroachdb.ts
@@ -206,11 +206,26 @@ export default class CockroachDB implements SchemaInspector {
 		}
 
 		for (const { table_name, column_name } of primaryKeys) {
-			overview[table_name]!.primary = column_name;
+			if (overview[table_name]) {
+				overview[table_name].primary = column_name;
+			} else {
+				/* eslint-disable-next-line no-console */
+				console.error(`Could not set primary key "${column_name}" for unknown table "${table_name}"`);
+			}
 		}
 
 		for (const { table_name, column_name, data_type } of geometryColumns) {
-			overview[table_name]!.columns[column_name]!.data_type = data_type;
+			if (overview[table_name]) {
+				if (overview[table_name].columns[column_name]) {
+					overview[table_name].columns[column_name].data_type = data_type;
+				} else {
+					/* eslint-disable-next-line no-console */
+					console.error(`Could not set data type "${data_type}" for unknown column "${column_name}" in table "${table_name}"`);
+				}
+			} else {
+				/* eslint-disable-next-line no-console */
+				console.error(`Could not set primary key "${column_name}" for unknown table "${table_name}"`);
+			}
 		}
 
 		return overview;

--- a/packages/schema/src/dialects/cockroachdb.ts
+++ b/packages/schema/src/dialects/cockroachdb.ts
@@ -220,7 +220,9 @@ export default class CockroachDB implements SchemaInspector {
 					overview[table_name].columns[column_name].data_type = data_type;
 				} else {
 					/* eslint-disable-next-line no-console */
-					console.error(`Could not set data type "${data_type}" for unknown column "${column_name}" in table "${table_name}"`);
+					console.error(
+						`Could not set data type "${data_type}" for unknown column "${column_name}" in table "${table_name}"`,
+					);
 				}
 			} else {
 				/* eslint-disable-next-line no-console */

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -201,11 +201,26 @@ export default class Postgres implements SchemaInspector {
 		}
 
 		for (const { table_name, column_name } of primaryKeys) {
-			overview[table_name]!.primary = column_name;
+			if (overview[table_name]) {
+				overview[table_name].primary = column_name;
+			} else {
+				/* eslint-disable-next-line no-console */
+				console.error(`Could not set primary key "${column_name}" for unknown table "${table_name}"`);
+			}
 		}
 
 		for (const { table_name, column_name, data_type } of geometryColumns) {
-			overview[table_name]!.columns[column_name]!.data_type = data_type;
+			if (overview[table_name]) {
+				if (overview[table_name].columns[column_name]) {
+					overview[table_name].columns[column_name].data_type = data_type;
+				} else {
+					/* eslint-disable-next-line no-console */
+					console.error(`Could not set data type "${data_type}" for unknown column "${column_name}" in table "${table_name}"`);
+				}
+			} else {
+				/* eslint-disable-next-line no-console */
+				console.error(`Could not set primary key "${column_name}" for unknown table "${table_name}"`);
+			}
 		}
 
 		return overview;

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -219,7 +219,7 @@ export default class Postgres implements SchemaInspector {
 				}
 			} else {
 				/* eslint-disable-next-line no-console */
-				console.error(`Could not set primary key "${column_name}" for unknown table "${table_name}"`);
+				console.error(`Could not set geometry column "${column_name}" for unknown table "${table_name}"`);
 			}
 		}
 

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -215,7 +215,9 @@ export default class Postgres implements SchemaInspector {
 					overview[table_name].columns[column_name].data_type = data_type;
 				} else {
 					/* eslint-disable-next-line no-console */
-					console.error(`Could not set data type "${data_type}" for unknown column "${column_name}" in table "${table_name}"`);
+					console.error(
+						`Could not set data type "${data_type}" for unknown column "${column_name}" in table "${table_name}"`,
+					);
 				}
 			} else {
 				/* eslint-disable-next-line no-console */


### PR DESCRIPTION
## Scope

What's changed:

- When Postgres contains primary keys in tables that the information_schema doesn't return, we used to crash the process. Instead, console.error about the missing information and ignore the corrupted data.

## Potential Risks / Drawbacks

- 🤷🏻 

## Review Notes / Questions

- Special delivery for @joselcvarela 

