### PR TITLE
Fix variable scoping in `Displays To Summarize Relational Items` guide

### DIFF
--- a/docs/guides/extensions/displays-relational-summaries.md
+++ b/docs/guides/extensions/displays-relational-summaries.md
@@ -346,8 +346,10 @@ export default {
 		const { useFieldsStore } = useStores();
 		const fieldsStore = useFieldsStore();
 
+		let displayTemplateMeta;
+
 		if (editing === '+') {
-			const displayTemplateMeta = {
+			 displayTemplateMeta = {
 				interface: 'presentation-notice',
 				options: {
 					text: 'Please complete the field before attempting to configure the display.',
@@ -365,7 +367,7 @@ export default {
 				});
 			});
 
-			const displayTemplateMeta = {
+			 displayTemplateMeta = {
 				interface: 'select-dropdown',
 				options: {
 					choices: field_choices,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- `displayTemplateMeta` is now properly scoped in the `index.js` code sample

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- No changes as it is a pure doc change

---

Fixes #22710
