### PR TITLE
add SAML config options for fetching metadata

### DIFF
--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -197,6 +197,7 @@ EC2
 eCommerce
 ELB
 Elestio
+EntraID
 entrypoint
 Entrypoint
 env

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -891,7 +891,10 @@ without a password.
 | Variable                                    | Description                                                                                               | Default Value                                                          |
 | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `AUTH_<PROVIDER>_SP_metadata`               | String containing XML metadata for service provider                                                       | --                                                                     |
+| `AUTH_<PROVIDER>_SP_entity_id`              | String containing the entity Id to be used in the service provider XML                                    | `https://sp.example.org/metadata`                                      |
+| `AUTH_<PROVIDER>_SP_acs_url`                | String containing the ACS Location URL to be used in the service provider XML                             | `http://localhost:8055/auth/login/websso/acs`                          |
 | `AUTH_<PROVIDER>_IDP_metadata`              | String containing XML metadata for identity provider                                                      | --                                                                     |
+| `AUTH_<PROVIDER>_IDP_metadata_url`          | String containing an URL to download the XML metadata for identity provider from                          | --                                                                     |
 | `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users.                                                   | `false`                                                                |
 | `AUTH_<PROVIDER>_DEFAULT_ROLE_ID`           | A Directus role ID to assign created users.                                                               | --                                                                     |
 | `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>.                                                               | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` |
@@ -905,6 +908,13 @@ Directus users "External Identifier".
 
 The `SP_metadata` and `IDP_metadata` variables should be set to the XML metadata provided by the service provider and
 identity provider respectively.
+
+As an alternative to setting the `SP_metadata` with the raw XML, you can leave `SP_metadata` empty and instead set
+`SP_entity_id` with the `entityId` given to you by your service provider and `SP_acs_url` with the url for your
+`.../acs` endpoint. The service provider XML will be generated from this.
+
+Instead of setting the `IDP_metadata`, you can set `IDP_metadata_url` with the direct link to the metadata XML document
+provided by your Identity Provider (for example the link found under "App Federation Metadata Url" in EntraID)
 
 ### Example: Multiple Auth Providers
 

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -894,7 +894,7 @@ without a password.
 | `AUTH_<PROVIDER>_SP_entity_id`              | String containing the entity Id to be used in the service provider XML                                    | `https://sp.example.org/metadata`                                      |
 | `AUTH_<PROVIDER>_SP_acs_url`                | String containing the ACS Location URL to be used in the service provider XML                             | `http://localhost:8055/auth/login/websso/acs`                          |
 | `AUTH_<PROVIDER>_IDP_metadata`              | String containing XML metadata for identity provider                                                      | --                                                                     |
-| `AUTH_<PROVIDER>_IDP_metadata_url`          | String containing an URL to download the XML metadata for identity provider from                          | --                                                                     |
+| `AUTH_<PROVIDER>_IDP_metadata_url`          | String containing a URL to download the XML metadata for identity provider from                           | --                                                                     |
 | `AUTH_<PROVIDER>_ALLOW_PUBLIC_REGISTRATION` | Automatically create accounts for authenticating users.                                                   | `false`                                                                |
 | `AUTH_<PROVIDER>_DEFAULT_ROLE_ID`           | A Directus role ID to assign created users.                                                               | --                                                                     |
 | `AUTH_<PROVIDER>_IDENTIFIER_KEY`            | User profile identifier key <sup>[1]</sup>.                                                               | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` |
@@ -914,7 +914,7 @@ As an alternative to setting the `SP_metadata` with the raw XML, you can leave `
 `.../acs` endpoint. The service provider XML will be generated from this.
 
 Instead of setting the `IDP_metadata`, you can set `IDP_metadata_url` with the direct link to the metadata XML document
-provided by your Identity Provider (for example the link found under "App Federation Metadata Url" in EntraID)
+provided by your Identity Provider (for example the link found under "App Federation Metadata URL" in EntraID)
 
 ### Example: Multiple Auth Providers
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- adds new SAML SSO config options:
  - `AUTH_<PROVIDER>_IDP_metadata_url`
  - `AUTH_<PROVIDER>_SP_entity_id`
  - `AUTH_<PROVIDER>_SP_acs_url`
- changes `getProviderInstance()` to be async
- `saml.ts` driver:
  - `SAMLAuthDriver` construction becomes a two step process in case `IDP_metadata` is not set, since the metadata will have to be pulled asynchronously, which can't be done in the constructor
  - adds `generateSAMLServiceProviderMetadata()` to generate SP XML Metadata from two parameters if `SP_metadata` is not set - this is to prevent handling raw XML
  - adds `setSAMLIdentityProviderMetadataFromUrl()` to fetch IDP XML Metadata from an URL - this is again to prevent handling raw XML and to make updating the metadata easier

## Potential Risks / Drawbacks

- IDP_metadata and SP_metadata always have precedence so no existing behaviour should change
- If configured through URL and IDP is not available at instance start, auth provider setup would fail (but if IDP is not available, auth in general would fail...)

## Review Notes / Questions

The reason for this PR is that in our setup, where we rely heavily on EntraID SSO via SAML, we had a number of case where the IdP would, for some reason or another, change their IDP metadata. This resulted in downed instances since authentication was no longer possible with the old metadata. Having to manually copy and paste the large XML into an environment proved error prone. It would have been significantly easier to just have to restart the instance (and at startup the instance would pull the latest metadata).

### Example for new config parameters

Neither `AUTH_MYSSO_SP_metadata` nor `AUTH_MYSSO_IDP_metadata` are set here.

`AUTH_WEBSSO_SP_acs_url` would actually be optional in most cases due to it defaulting to `"http://localhost:8055/auth/login/websso/acs"`

```ini
AUTH_WEBSSO_SP_entity_id="my.fancy.dev"
AUTH_WEBSSO_SP_acs_url="http://localhost:8055/auth/login/websso/acs"
AUTH_WEBSSO_IDP_metadata_url="https://login.microsoftonline.com/somethingsomething/federationmetadata/2007-06/federationmetadata.xml?appid=someotherthing"
```

---

Fixes #23698