### PR TITLE
Fix truncation of long collection names

### DIFF
--- a/.changeset/wicked-poems-tell.md
+++ b/.changeset/wicked-poems-tell.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the truncation of long collection names in the permission configuration interface

--- a/app/src/interfaces/_system/system-permissions/permissions-row.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-row.vue
@@ -28,12 +28,14 @@ const { t } = useI18n();
 <template>
 	<tr class="permissions-row" :data-collection="collection.collection">
 		<td class="collection">
-			<span v-tooltip.left="collection.name" class="name">{{ collection.collection }}</span>
-			<span class="shortcuts">
-				<span class="all" @click="emit('setFullAccessAll')">{{ t('all') }}</span>
-				<span class="divider">/</span>
-				<span class="none" @click="emit('setNoAccessAll')">{{ t('none') }}</span>
-			</span>
+			<div>
+				<span v-tooltip.left="collection.name" class="name">{{ collection.collection }}</span>
+				<span class="shortcuts">
+					<span class="all" @click="emit('setFullAccessAll')">{{ t('all') }}</span>
+					<span class="divider">/</span>
+					<span class="none" @click="emit('setNoAccessAll')">{{ t('none') }}</span>
+				</span>
+			</div>
 		</td>
 
 		<td v-for="action in editablePermissionActions" :key="action" class="action">
@@ -57,15 +59,19 @@ const { t } = useI18n();
 
 <style lang="scss" scoped>
 .permissions-row {
-	td:first-child {
+	.collection {
+		white-space: nowrap;
 		width: 100%;
 	}
 
-	.collection {
-		white-space: nowrap;
+	.collection > div {
+		display: flex;
+		position: relative;
 	}
 
 	.name {
+		flex: 1;
+		width: 1px;
 		padding: 0 12px;
 		font-family: var(--theme--fonts--monospace--font-family);
 		overflow: hidden;
@@ -73,6 +79,10 @@ const { t } = useI18n();
 	}
 
 	.shortcuts {
+		position: absolute;
+		right: 0;
+		padding: 0 12px;
+		background: var(--theme--background);
 		font-family: var(--theme--fonts--monospace--font-family);
 		color: var(--theme--foreground-subdued);
 		font-size: 12px;

--- a/app/src/interfaces/_system/system-permissions/permissions-row.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-row.vue
@@ -81,13 +81,16 @@ const { t } = useI18n();
 	.shortcuts {
 		position: absolute;
 		right: 0;
-		padding: 0 12px;
 		background: var(--theme--background);
 		font-family: var(--theme--fonts--monospace--font-family);
 		color: var(--theme--foreground-subdued);
 		font-size: 12px;
 		opacity: 0;
 		transition: opacity var(--fast) var(--transition);
+		padding-right: 12px;
+		box-shadow:
+			-12px 0 10px 2px var(--theme--background),
+			-12px 0 12px 2px var(--theme--background);
 
 		span {
 			cursor: pointer;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Some CSS voodoo to ensure that the collection names are properly truncated

**Before**

https://github.com/user-attachments/assets/45ce637c-7832-431d-ae49-81d858acaeed

**After**

https://github.com/user-attachments/assets/301a1054-a1bb-47d1-9774-bcaf5e61ee61


## Review Notes / Questions

- Tested it in Safari as well, the IE of browsers

---

Fixes #23434 