### PR TITLE
Do not enforce database specific Primary Key constraints on field updates for all vendors

### DIFF
--- a/.changeset/thin-meals-speak.md
+++ b/.changeset/thin-meals-speak.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed an issue enforcing non db agnostic PK constraints on field updates
+Fixed an issue enforcing non db agnostic Primary Key constraints on field updates

--- a/.changeset/thin-meals-speak.md
+++ b/.changeset/thin-meals-speak.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue enforcing non db agnostic PK constraints on field updates

--- a/.changeset/thin-meals-speak.md
+++ b/.changeset/thin-meals-speak.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed an issue enforcing non db agnostic Primary Key constraints on field updates
+Fixed an issue enforcing database specific Primary Key constraints on field updates for all vendors

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -516,14 +516,6 @@ export class FieldsService {
 					if (hookAdjustedField.schema?.is_nullable === true) {
 						throw new InvalidPayloadError({ reason: 'Primary key cannot be null' });
 					}
-
-					if (hookAdjustedField.schema?.is_unique === false) {
-						throw new InvalidPayloadError({ reason: 'Primary key must be unique' });
-					}
-
-					if (hookAdjustedField.schema?.is_indexed === true) {
-						throw new InvalidPayloadError({ reason: 'Primary key cannot be indexed' });
-					}
 				}
 
 				// Sanitize column only when applying snapshot diff as opts is only passed from /utils/apply-diff.ts


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Removed enforcement of `unique` and `index` constraints on a primary key field as not all db vendors apply it

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Constraints originally added in https://github.com/directus/directus/pull/23149

---

Fixes #23667
