### PR TITLE
Update typings for `defineInterface`, etc

### DIFF
--- a/.changeset/gold-comics-travel.md
+++ b/.changeset/gold-comics-travel.md
@@ -1,0 +1,5 @@
+---
+'@directus/types': minor
+---
+
+Add `Prettify` type helper

--- a/.changeset/tender-parents-confess.md
+++ b/.changeset/tender-parents-confess.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions': patch
+---
+
+Improve `defineX` typings to properly type the known config options

--- a/packages/extensions/src/shared/types/displays.ts
+++ b/packages/extensions/src/shared/types/displays.ts
@@ -29,7 +29,7 @@ export interface DisplayConfig {
 		| ((
 				ctx: ExtensionOptionsContext,
 		  ) => DeepPartial<Field>[] | { standard: DeepPartial<Field>[]; advanced: DeepPartial<Field>[] })
-		| ComponentOptions
+		| Exclude<ComponentOptions, any>
 		| null;
 	types: readonly Type[];
 	localTypes?: readonly LocalType[];

--- a/packages/extensions/src/shared/types/interfaces.ts
+++ b/packages/extensions/src/shared/types/interfaces.ts
@@ -15,7 +15,7 @@ export interface InterfaceConfig {
 		| ((
 				ctx: ExtensionOptionsContext,
 		  ) => DeepPartial<Field>[] | { standard: DeepPartial<Field>[]; advanced: DeepPartial<Field>[] })
-		| ComponentOptions
+		| Exclude<ComponentOptions, any>
 		| null;
 	types: readonly Type[];
 	localTypes?: readonly LocalType[];

--- a/packages/extensions/src/shared/types/operations.ts
+++ b/packages/extensions/src/shared/types/operations.ts
@@ -25,7 +25,11 @@ export interface OperationAppConfig {
 		  ) => { label: string; text: string; copyable?: boolean }[])
 		| ComponentOptions
 		| null;
-	options: DeepPartial<Field>[] | ((options: Record<string, any>) => DeepPartial<Field>[]) | ComponentOptions | null;
+	options:
+		| DeepPartial<Field>[]
+		| ((options: Record<string, any>) => DeepPartial<Field>[])
+		| Exclude<ComponentOptions, any>
+		| null;
 }
 
 export interface OperationApiConfig<Options = Record<string, unknown>> {

--- a/packages/extensions/src/shared/types/panels.ts
+++ b/packages/extensions/src/shared/types/panels.ts
@@ -18,7 +18,7 @@ export interface PanelConfig {
 		| ((
 				ctx: Partial<Panel>,
 		  ) => DeepPartial<Field>[] | { standard: DeepPartial<Field>[]; advanced: DeepPartial<Field>[] })
-		| ComponentOptions
+		| Exclude<ComponentOptions, any>
 		| null;
 	minWidth: number;
 	minHeight: number;

--- a/packages/extensions/src/shared/utils/define-extension.ts
+++ b/packages/extensions/src/shared/utils/define-extension.ts
@@ -1,3 +1,4 @@
+import type { Prettify } from '@directus/types';
 import type {
 	DisplayConfig,
 	EndpointConfig,
@@ -10,11 +11,19 @@ import type {
 	PanelConfig,
 } from '../types/index.js';
 
-export function defineInterface<T extends InterfaceConfig>(config: T): T {
+type CustomConfig<T extends object> = { [K in string]: K extends keyof T ? never : unknown };
+
+type ExtendedConfig<T, C> = Prettify<T & Omit<C, keyof T>>;
+
+export function defineInterface<Custom extends CustomConfig<InterfaceConfig>>(
+	config: ExtendedConfig<InterfaceConfig, Custom>,
+): ExtendedConfig<InterfaceConfig, Custom> {
 	return config;
 }
 
-export function defineDisplay<T extends DisplayConfig>(config: T): T {
+export function defineDisplay<Custom extends CustomConfig<DisplayConfig>>(
+	config: ExtendedConfig<DisplayConfig, Custom>,
+): ExtendedConfig<DisplayConfig, Custom> {
 	return config;
 }
 
@@ -24,23 +33,33 @@ export function defineLayout<Options = any, Query = any>(
 	return config;
 }
 
-export function defineModule<T extends ModuleConfig>(config: T): T {
+export function defineModule<Custom extends CustomConfig<ModuleConfig>>(
+	config: ExtendedConfig<ModuleConfig, Custom>,
+): ExtendedConfig<ModuleConfig, Custom> {
 	return config;
 }
 
-export function definePanel<T extends PanelConfig>(config: T): T {
+export function definePanel<Custom extends CustomConfig<PanelConfig>>(
+	config: ExtendedConfig<PanelConfig, Custom>,
+): ExtendedConfig<PanelConfig, Custom> {
 	return config;
 }
 
-export function defineHook<T extends HookConfig>(config: T): T {
+export function defineHook<Custom extends CustomConfig<HookConfig>>(
+	config: ExtendedConfig<HookConfig, Custom>,
+): ExtendedConfig<HookConfig, Custom> {
 	return config;
 }
 
-export function defineEndpoint<T extends EndpointConfig>(config: T): T {
+export function defineEndpoint<Custom extends CustomConfig<EndpointConfig>>(
+	config: ExtendedConfig<EndpointConfig, Custom>,
+): ExtendedConfig<EndpointConfig, Custom> {
 	return config;
 }
 
-export function defineOperationApp<T extends OperationAppConfig>(config: T): T {
+export function defineOperationApp<Custom extends CustomConfig<OperationAppConfig>>(
+	config: ExtendedConfig<OperationAppConfig, Custom>,
+): ExtendedConfig<OperationAppConfig, Custom> {
 	return config;
 }
 

--- a/packages/extensions/src/shared/utils/define-extension.ts
+++ b/packages/extensions/src/shared/utils/define-extension.ts
@@ -11,7 +11,7 @@ import type {
 	PanelConfig,
 } from '../types/index.js';
 
-type CustomConfig<T extends object> = { [K in string]: K extends keyof T ? never : unknown };
+type CustomConfig<T> = { [K in string]: K extends keyof T ? never : unknown };
 
 type ExtendedConfig<T, C> = Prettify<T & Omit<C, keyof T>>;
 

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -38,3 +38,7 @@ export type Plural<T extends string> = `${T}s`;
 export type UnknownObject = Record<string | number | symbol, unknown>;
 
 export type PromiseCallback = () => void | Promise<void>;
+
+export type Prettify<T> = {
+	[K in keyof T]: T[K];
+} & unknown;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The initial problem was caused by the `T extends InterfaceConfig`. This would allow the type accepted in the `defineInterface` function to be any type that vaguely resembles the `InterfaceConfig` even with overridden types for properties defined in the `InterfaceConfig`. As such Typescript wasn't able to correctly type hint the types for `options` for example and only ever showed the type of the options the user was currently providing.

We still want the options to be user extendable and the return type of `defineX` to exactly match the input type, while enforcing the types of the known properties.

So instead of relying on the `T extends InterfaceConfig` we define a custom extension type that can have any property that is not already defined in the `InterfaceConfig` and merge that with `InterfaceConfig`. This way the correct types for known properties are guaranteed.


**Before**

![CleanShot 2024-09-16 at 15 44 24@2x](https://github.com/user-attachments/assets/0c1ddb75-fb04-41d2-ae8a-9501f145aa70)

**After**

![CleanShot 2024-09-23 at 08 15 49@2x](https://github.com/user-attachments/assets/c5903e1b-484e-4431-bb72-81b173ab1af6)

Additionally I decided to exclude `any` from the Vue provided `ComponentOptions`, as that seems to be a fallback deep in the Vue provided types that wrecks the inference of the options property, as it could potentially be any.

**Before**
![CleanShot 2024-09-23 at 08 16 42@2x](https://github.com/user-attachments/assets/8b2f28f9-24fb-427c-90ac-33030cc773c8)

**After**
![CleanShot 2024-09-23 at 08 17 07@2x](https://github.com/user-attachments/assets/803b0308-47df-43f4-9b3b-2f89a7b4d981)

## Potential Risks / Drawbacks

- I can't imagine this breaking users setups, as the extendibility is still provided, we are just more type safe in what we do. 


---

Fixes #23676
