### PR TITLE
Fix injection of `$CURRENT_POLICIES` into permissions

### DIFF
--- a/.changeset/eleven-roses-compete.md
+++ b/.changeset/eleven-roses-compete.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed injection of the $CURRENT_POLICIES into permissions

--- a/api/src/permissions/utils/fetch-dynamic-variable-context.test.ts
+++ b/api/src/permissions/utils/fetch-dynamic-variable-context.test.ts
@@ -100,5 +100,5 @@ test('Returns filter context for current policies', async () => {
 	);
 
 	expect(res['$CURRENT_POLICIES']).toBe(policies);
-	expect(PoliciesService.prototype.readMany).toHaveBeenCalledWith(['policy-1'], { fields: ['name'] });
+	expect(PoliciesService.prototype.readMany).toHaveBeenCalledWith(['policy-1'], { fields: ['name', 'id'] });
 });

--- a/api/src/permissions/utils/fetch-dynamic-variable-context.ts
+++ b/api/src/permissions/utils/fetch-dynamic-variable-context.ts
@@ -68,19 +68,27 @@ export async function fetchDynamicVariableContext(options: FetchDynamicVariableC
 		);
 	}
 
-	if (options.policies.length > 0 && (permissionContext.$CURRENT_POLICIES?.size ?? 0) > 0) {
-		contextData['$CURRENT_POLICIES'] = await fetchContextData(
-			'$CURRENT_POLICIES',
-			permissionContext,
-			{ policies: options.policies },
-			async (fields) => {
-				const policiesService = new PoliciesService(context);
+	if (options.policies.length > 0) {
+		if ((permissionContext.$CURRENT_POLICIES?.size ?? 0) > 0) {
+			// Always add the id field
+			permissionContext.$CURRENT_POLICIES.add('id');
 
-				return await policiesService.readMany(options.policies, {
-					fields,
-				});
-			},
-		);
+			contextData['$CURRENT_POLICIES'] = await fetchContextData(
+				'$CURRENT_POLICIES',
+				permissionContext,
+				{ policies: options.policies },
+				async (fields) => {
+					const policiesService = new PoliciesService(context);
+
+					return await policiesService.readMany(options.policies, {
+						fields,
+					});
+				},
+			);
+		} else {
+			// Always create entries for the policies with the `id` field present
+			contextData['$CURRENT_POLICIES'] = options.policies.map((id) => ({ id }));
+		}
 	}
 
 	return contextData;

--- a/api/src/permissions/utils/process-permissions.ts
+++ b/api/src/permissions/utils/process-permissions.ts
@@ -9,10 +9,11 @@ export interface ProcessPermissionsOptions {
 
 export function processPermissions({ permissions, accountability, permissionsContext }: ProcessPermissionsOptions) {
 	return permissions.map((permission) => {
-		permission.permissions = parseFilter(permission.permissions, accountability, permissionsContext);
-		permission.validation = parseFilter(permission.validation, accountability, permissionsContext);
-		permission.presets = parsePreset(permission.presets, accountability, permissionsContext);
-
-		return permission;
+		return {
+			...permission,
+			permissions: parseFilter(permission.permissions, accountability, permissionsContext),
+			validation: parseFilter(permission.validation, accountability, permissionsContext),
+			presets: parsePreset(permission.presets, accountability, permissionsContext),
+		};
 	});
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Due to an oversight of how policies are different from `$CURRENT_USER`, `$CURRENT_ROLE` and `$CURRENT_ROLES`, the policies were not correctly added to the permissions context used for replacing those dynamic placeholders. 

The fetch of the dynamic variable context only triggers if a nested key for `$CURRENT_POLICIES` is given, e.g. `$CURRENT_POLICIES.id`. In case of the user and role(s) the information is present by default in the accountability object and is looked up in the `parseFilter` logic. For policies the `$CURRENT_POLICIES` need to contain partial policy objects with at least the `id` field.

What's changed:

- Always add at least the ids of the policies to the `$CURRENT_POLICIES` context object, and make sure to always request the `id` when fetching the policy context data.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

---

Fixes #23695 
