### PR TITLE
Fix dynamic variable placeholder detection in filter input validation

### DIFF
--- a/.changeset/twenty-frogs-watch.md
+++ b/.changeset/twenty-frogs-watch.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed failing validation of `$CURRENT_POLICIES` and `$CURRENT_ROLES` in the filter interface

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { isDynamicVariable } from '@directus/utils/shared';
+import { isDynamicVariable } from '@directus/utils';
 import { computed, onMounted, onUpdated, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { isDynamicVariable } from '@directus/utils/shared';
 import { computed, onMounted, onUpdated, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -81,11 +82,7 @@ function isValueValid(value: any): boolean {
 		return true;
 	}
 
-	if (
-		typeof value === 'string' &&
-		(['$NOW', '$CURRENT_USER', '$CURRENT_ROLE'].some((prefix) => value.startsWith(prefix)) ||
-			/^{{\s*?\S+?\s*?}}$/.test(value))
-	) {
+	if (isDynamicVariable(value) || /^{{\s*?\S+?\s*?}}$/.test(value)) {
 		return true;
 	}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The dynamic variable detection in the filter interface was using custom logic. Moved it over to using the shared util, so it can be updated in one place instead of many.

https://github.com/directus/directus/blob/c444a7fc526f4c1d7530a965f637d27749882163/packages/utils/shared/is-dynamic-variable.ts#L3-L5

The additional check for `typeof value === 'string'` can be dropped as that is ensured in the lines before.

Fixes #23729 