### PR TITLE
Fix `withToken` precedence if a token is already saved in SDK client

### DIFF
--- a/.changeset/eight-pugs-crash.md
+++ b/.changeset/eight-pugs-crash.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed the precedence of `withToken` if a token is already saved in the SDK instance

--- a/sdk/src/rest/composable.ts
+++ b/sdk/src/rest/composable.ts
@@ -31,11 +31,10 @@ export const rest = (config: Partial<RestConfig> = {}) => {
 				}
 
 				// we need to use THIS here instead of client to access overridden functions
-				if ('getToken' in this) {
+				if ('getToken' in this && 'Authorization' in options.headers === false) {
 					const token = await (this.getToken as StaticTokenClient<Schema>['getToken'])();
 
 					if (token) {
-						if (!options.headers) options.headers = {};
 						options.headers['Authorization'] = `Bearer ${token}`;
 					}
 				}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Previously, if a `token` was saved in the SDK client (and retrievable with `getToken`) it would override any already set authorization headers. This would result in the reported behavior of not being able to override the saved token using the `withToken` utility, which would be the more desirable behavior.

## Review Notes / Questions

- Is this technically a breaking change? I can't really imagine a situation where one would expect the `withToken` util to not override a saved token.

---

Fixes #23176
