### PR TITLE
Update TypeScript to 5.6.2

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -221,7 +221,7 @@
 		"form-data": "4.0.0",
 		"get-port": "7.1.0",
 		"knex-mock-client": "2.0.1",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	},
 	"optionalDependencies": {

--- a/api/src/database/migrations/20210518A-add-foreign-key-constraints.ts
+++ b/api/src/database/migrations/20210518A-add-foreign-key-constraints.ts
@@ -73,7 +73,7 @@ export async function up(knex: Knex): Promise<void> {
 				await knex(constraint.many_collection)
 					.update({ [constraint.many_field]: null })
 					.whereIn(currentPrimaryKeyField, ids);
-			} catch (err: any) {
+			} catch {
 				logger.error(
 					`${constraint.many_collection}.${constraint.many_field} contains illegal foreign keys which couldn't be set to NULL. Please fix these references and rerun this migration to complete the upgrade.`,
 				);

--- a/api/src/database/migrations/20240806A-permissions-policies.ts
+++ b/api/src/database/migrations/20240806A-permissions-policies.ts
@@ -248,7 +248,7 @@ export async function up(knex: Knex) {
 			// Drop the foreign key constraint here in order to update `null` role to public policy ID
 			table.dropForeign('role', foreignConstraint);
 		});
-	} catch (err) {
+	} catch {
 		logger.warn('Failed to drop foreign key constraint on `role` column in `directus_permissions` table');
 	}
 

--- a/api/src/permissions/modules/validate-remaining-admin/validate-remaining-admin-users.ts
+++ b/api/src/permissions/modules/validate-remaining-admin/validate-remaining-admin-users.ts
@@ -2,8 +2,10 @@ import { fetchUserCount, type FetchUserCountOptions } from '../../../utils/fetch
 import type { Context } from '../../types.js';
 import { validateRemainingAdminCount } from './validate-remaining-admin-count.js';
 
-export interface ValidateRemainingAdminUsersOptions
-	extends Pick<FetchUserCountOptions, 'excludeAccessRows' | 'excludePolicies' | 'excludeUsers' | 'excludeRoles'> {}
+export type ValidateRemainingAdminUsersOptions = Pick<
+	FetchUserCountOptions,
+	'excludeAccessRows' | 'excludePolicies' | 'excludeUsers' | 'excludeRoles'
+>;
 
 export async function validateRemainingAdminUsers(options: ValidateRemainingAdminUsersOptions, context: Context) {
 	const { admin } = await fetchUserCount({

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,13 +1,13 @@
 import { InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { randomUUID } from '@directus/random';
 import type { Accountability, SchemaOverview } from '@directus/types';
-import knex, { type Knex } from 'knex';
-import { MockClient, Tracker, createTracker } from 'knex-mock-client';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import knex from 'knex';
+import { MockClient, createTracker } from 'knex-mock-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import type { MutationOptions } from '../types/items.js';
 import { UserIntegrityCheckFlag } from '../utils/validate-user-count-integrity.js';
 import { ItemsService, MailService, UsersService } from './index.js';
-import { randomUUID } from '@directus/random';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),

--- a/api/src/utils/delete-from-require-cache.ts
+++ b/api/src/utils/delete-from-require-cache.ts
@@ -9,7 +9,7 @@ export function deleteFromRequireCache(modulePath: string): void {
 	try {
 		const moduleCachePath = require.resolve(modulePath);
 		delete require.cache[moduleCachePath];
-	} catch (error) {
+	} catch {
 		logger.trace(`Module cache not found for ${modulePath}, skipped cache delete.`);
 	}
 }

--- a/api/src/utils/fetch-user-count/fetch-user-count.ts
+++ b/api/src/utils/fetch-user-count/fetch-user-count.ts
@@ -3,7 +3,7 @@ import { fetchAccessLookup, type FetchAccessLookupOptions } from './fetch-access
 import { fetchAccessRoles } from './fetch-access-roles.js';
 import { getUserCountQuery } from './get-user-count-query.js';
 
-export interface FetchUserCountOptions extends FetchAccessLookupOptions {}
+export type FetchUserCountOptions = FetchAccessLookupOptions;
 
 export interface UserCount {
 	admin: number;

--- a/api/src/utils/generate-hash.ts
+++ b/api/src/utils/generate-hash.ts
@@ -5,8 +5,8 @@ export function generateHash(stringToHash: string): Promise<string> {
 	const argon2HashConfigOptions = getConfigFromEnv('HASH_', 'HASH_RAW'); // Disallow the HASH_RAW option, see https://github.com/directus/directus/discussions/7670#discussioncomment-1255805
 
 	// associatedData, if specified, must be passed as a Buffer to argon2.hash, see https://github.com/ranisalt/node-argon2/wiki/Options#associateddata
-	'associatedData' in argon2HashConfigOptions &&
-		(argon2HashConfigOptions['associatedData'] = Buffer.from(argon2HashConfigOptions['associatedData']));
+	if ('associatedData' in argon2HashConfigOptions)
+		argon2HashConfigOptions['associatedData'] = Buffer.from(argon2HashConfigOptions['associatedData']);
 
 	return argon2.hash(stringToHash, argon2HashConfigOptions);
 }

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -239,7 +239,7 @@ function sanitizeAlias(rawAlias: any) {
 	if (typeof rawAlias === 'string') {
 		try {
 			alias = parseJSON(rawAlias);
-		} catch (err) {
+		} catch {
 			logger.warn('Invalid value passed for alias query parameter.');
 		}
 	}

--- a/api/src/websocket/authenticate.ts
+++ b/api/src/websocket/authenticate.ts
@@ -35,7 +35,7 @@ export async function authenticateConnection(
 		const accountability = await getAccountabilityForToken(access_token);
 		const expires_at = getExpiresAtForToken(access_token);
 		return { accountability, expires_at, refresh_token } as AuthenticationState;
-	} catch (error) {
+	} catch {
 		throw new WebSocketError('auth', 'AUTH_FAILED', 'Authentication failed.', message['uid']);
 	}
 }

--- a/api/src/websocket/controllers/base.ts
+++ b/api/src/websocket/controllers/base.ts
@@ -296,7 +296,7 @@ export default abstract class SocketController {
 
 		try {
 			message = WebSocketMessage.parse(parseJSON(data));
-		} catch (err: any) {
+		} catch {
 			throw new WebSocketError('server', 'INVALID_PAYLOAD', 'Unable to parse the incoming message.');
 		}
 

--- a/api/src/websocket/controllers/rest.ts
+++ b/api/src/websocket/controllers/rest.ts
@@ -51,7 +51,7 @@ export class WebSocketController extends SocketController {
 
 		try {
 			message = parseJSON(data);
-		} catch (err: any) {
+		} catch {
 			throw new WebSocketError('server', 'INVALID_PAYLOAD', 'Unable to parse the incoming message.');
 		}
 

--- a/app/package.json
+++ b/app/package.json
@@ -142,7 +142,7 @@
 		"string-width": "7.2.0",
 		"tinymce": "7.3.0",
 		"tus-js-client": "4.2.3",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vite": "5.2.11",
 		"vitest": "1.5.3",
 		"vue": "3.4.27",

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -106,7 +106,7 @@ function useRaw() {
 
 		try {
 			internalValue.value = parseJSON(pastedValue);
-		} catch (e) {
+		} catch {
 			internalValue.value = pastedValue;
 		}
 

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -130,7 +130,7 @@ function useUpload() {
 					preset,
 				});
 
-				uploadedFiles &&
+				if (uploadedFiles)
 					emit(
 						'input',
 						uploadedFiles.filter((f): f is File => !!f),
@@ -149,7 +149,7 @@ function useUpload() {
 					preset,
 				});
 
-				uploadedFile && emit('input', uploadedFile);
+				if (uploadedFile) emit('input', uploadedFile);
 				uploadController = null;
 			}
 		} catch (error) {

--- a/app/src/composables/use-clipboard.ts
+++ b/app/src/composables/use-clipboard.ts
@@ -30,7 +30,7 @@ export function useClipboard() {
 			});
 
 			return true;
-		} catch (err: any) {
+		} catch {
 			notify({
 				type: 'error',
 				title: message?.fail ?? t('copy_raw_value_fail'),
@@ -49,7 +49,7 @@ export function useClipboard() {
 			});
 
 			return pasteValue;
-		} catch (err: any) {
+		} catch {
 			notify({
 				type: 'error',
 				title: message?.fail ?? t('paste_raw_value_fail'),

--- a/app/src/composables/use-permissions/item/utils/fetch-item-permissions.ts
+++ b/app/src/composables/use-permissions/item/utils/fetch-item-permissions.ts
@@ -23,7 +23,7 @@ export const fetchItemPermissions = (collection: Collection, primaryKey: Primary
 
 	const fetchedItemPermissions = computedAsync(
 		async () => {
-			refreshKey.value;
+			void refreshKey.value;
 
 			const primaryKeyValue = unref(primaryKey);
 

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -89,7 +89,12 @@ export function usePreset(
 
 	function updatePreset(preset: Partial<Preset>, immediate?: boolean) {
 		localPreset.value = assign({}, localPreset.value, preset);
-		immediate ? savePreset() : handleChanges();
+
+		if (immediate) {
+			savePreset();
+		} else {
+			handleChanges();
+		}
 	}
 
 	watch([collection, bookmark], () => {

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -157,7 +157,7 @@ function useColor() {
 		() => {
 			try {
 				color.value = valueWithoutVariables.value !== null ? Color(valueWithoutVariables.value) : null;
-			} catch (error) {
+			} catch {
 				color.value = null;
 			}
 		},
@@ -230,7 +230,7 @@ function useColor() {
 
 				try {
 					color.value = Color(cssVar(newInput.substring(4, newInput.length - 1)));
-				} catch (error) {
+				} catch {
 					// Color or cssVar could not resolve the color to a color in JS, however, the CSS Var may still be a valid color.
 					// So we keep the input value as is and set the internal color to null.
 					// This way the user can still edit the input and we can still show the color in the swatch.
@@ -242,7 +242,7 @@ function useColor() {
 					// If the input is a valid color, we set the color and emit the input as a hex value which is consistent with the dropdown selector and HTML color picker
 					const newColor = Color(newInput);
 					setColor(newColor);
-				} catch (e) {
+				} catch {
 					// The input is not a valid color, but we still want to let the user edit/type in the input so we emit the input
 					emit('input', newInput);
 				}

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -92,7 +92,11 @@ function onInput(event: KeyboardEvent) {
 }
 
 function toggleTag(tag: string) {
-	selectedVals.value.includes(tag) ? removeTag(tag) : addTag(tag);
+	if (selectedVals.value.includes(tag)) {
+		removeTag(tag);
+	} else {
+		addTag(tag);
+	}
 }
 
 function addTag(tag: string) {

--- a/app/src/lang/translations.test.ts
+++ b/app/src/lang/translations.test.ts
@@ -43,7 +43,7 @@ async function importLanguageFile(locale: string): Promise<{ isImported: boolean
 	try {
 		const { default: translations } = await import(`./translations/${locale}.yaml`);
 		return { isImported: true, translations };
-	} catch (e) {
+	} catch {
 		return { isImported: false, translations: {} };
 	}
 }

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -293,7 +293,7 @@ async function refreshLivePreview() {
 		await fetchTemplateValues();
 		window.refreshLivePreview(previewUrl.value);
 		if (popupWindow) popupWindow.refreshLivePreview(previewUrl.value);
-	} catch (error) {
+	} catch {
 		// noop
 	}
 }

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -468,7 +468,7 @@ function revert(values: Record<string, any>) {
 		v-if="error || !collectionInfo || (collectionInfo?.meta?.singleton === true && primaryKey !== null)"
 	/>
 
-	<private-view v-else v-model:splitView="splitView" :split-view-min-width="310" :title="title">
+	<private-view v-else v-model:split-view="splitView" :split-view-min-width="310" :title="title">
 		<template v-if="collectionInfo.meta && collectionInfo.meta.singleton === true" #title>
 			<h1 class="type-title">
 				{{ collectionInfo.name }}

--- a/app/src/shims.d.ts
+++ b/app/src/shims.d.ts
@@ -1,6 +1,6 @@
 declare module '*.md' {
 	import { DefineComponent } from 'vue';
-	// eslint-disable-next-line @typescript-eslint/ban-types
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 	const component: DefineComponent<{}, {}, any>;
 	export default component;
 }

--- a/app/src/stores/translations.ts
+++ b/app/src/stores/translations.ts
@@ -31,7 +31,7 @@ export const useTranslationsStore = defineStore('translations', () => {
 			});
 
 			lang.value = newLang;
-		} catch (error) {
+		} catch {
 			// No public permissions for translations
 		} finally {
 			loading.value = false;

--- a/app/src/stores/user.ts
+++ b/app/src/stores/user.ts
@@ -54,7 +54,7 @@ export const useUserStore = defineStore({
 				const { data } = await api.get(`/users/me`, { params: { fields } });
 
 				this.currentUser = merge({}, this.currentUser, data.data);
-			} catch (error: any) {
+			} catch {
 				// Do nothing
 			}
 		},

--- a/app/src/utils/format-number.ts
+++ b/app/src/utils/format-number.ts
@@ -144,7 +144,7 @@ export function formatNumber(value: number, locales: string | string[], options?
 	try {
 		const formatter: Intl.NumberFormat = new Intl.NumberFormat(locales, options);
 		return formatter.format(value);
-	} catch (e) {
+	} catch {
 		return String(value);
 	}
 }

--- a/app/src/utils/get-minimal-grid-class.test.ts
+++ b/app/src/utils/get-minimal-grid-class.test.ts
@@ -1,5 +1,5 @@
 import { getMinimalGridClass } from '@/utils/get-minimal-grid-class';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 describe('getMinimalGridClass', () => {
 	test('Returns null when choices are undefined', () => {

--- a/docs/.vitepress/theme/components/VPSidebarItem.vue
+++ b/docs/.vitepress/theme/components/VPSidebarItem.vue
@@ -3,9 +3,7 @@ https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/components
 
 <script setup lang="ts">
 import { useData } from 'vitepress';
-// @ts-ignore
 import VPLink from 'vitepress/dist/client/theme-default/components/VPLink.vue';
-// @ts-ignore
 import VPIconChevronRight from 'vitepress/dist/client/theme-default/components/icons/VPIconChevronRight.vue';
 // @ts-ignore
 import { useSidebarControl } from 'vitepress/dist/client/theme-default/composables/sidebar';
@@ -65,11 +63,11 @@ function onItemInteraction(e: MouseEvent | Event) {
 		return;
 	}
 
-	!props.item.link && toggle();
+	if (!props.item.link) toggle();
 }
 
 function onCaretClick() {
-	props.item.link && toggle();
+	if (props.item.link) toggle();
 }
 </script>
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,7 +34,7 @@
 		"typedoc-plugin-markdown": "4.0.0-next.53",
 		"typedoc-plugin-zod": "1.2.1",
 		"typedoc-vitepress-theme": "1.0.1",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitepress": "1.0.0-rc.4",
 		"vitepress-plugin-tabs": "0.3.0",
 		"vue": "3.4.27"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
 	"devDependencies": {
 		"@changesets/cli": "2.27.7",
 		"@directus/release-notes-generator": "workspace:*",
-		"@typescript-eslint/eslint-plugin": "7.8.0",
-		"@typescript-eslint/parser": "7.8.0",
-		"eslint": "8.57.0",
+		"@typescript-eslint/eslint-plugin": "8.7.0",
+		"@typescript-eslint/parser": "8.7.0",
+		"eslint": "8.57.1",
 		"eslint-config-prettier": "9.1.0",
 		"eslint-plugin-vue": "9.28.0",
 		"prettier": "3.1.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
 		"histoire": "0.17.17",
 		"pinia": "2.2.2",
 		"rollup-plugin-node-externals": "7.1.3",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vite": "5.2.11",
 		"vite-plugin-dts": "3.9.1",
 		"vitest": "1.5.3",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -42,7 +42,7 @@
 		"@vitest/coverage-v8": "1.5.3",
 		"@vue/test-utils": "2.4.6",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3",
 		"vue": "3.4.27"
 	},

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -28,6 +28,6 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5"
+		"typescript": "5.6.2"
 	}
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -31,7 +31,7 @@
 		"@types/node": "18.19.50",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	},
 	"dependencies": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -35,7 +35,7 @@
 		"@types/ms": "0.7.34",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/extensions-registry/package.json
+++ b/packages/extensions-registry/package.json
@@ -40,7 +40,7 @@
 		"@types/validate-npm-package-name": "4.0.2",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -62,7 +62,7 @@
 		"@types/fs-extra": "11.0.4",
 		"@types/inquirer": "9.0.7",
 		"@vitest/coverage-v8": "1.5.3",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	},
 	"engines": {

--- a/packages/extensions-sdk/src/cli/commands/link.ts
+++ b/packages/extensions-sdk/src/cli/commands/link.ts
@@ -24,7 +24,7 @@ export default async function link(extensionsPath: string): Promise<void> {
 
 	try {
 		manifestFile = await fs.readJSON(packagePath);
-	} catch (err) {
+	} catch {
 		log(`Current directory is not a valid Directus extension.`, 'error');
 		return;
 	}

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -51,7 +51,7 @@
 		"pino": "9.4.0",
 		"tmp": "0.2.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3",
 		"vue": "3.4.27",
 		"vue-router": "4.4.3"

--- a/packages/format-title/package.json
+++ b/packages/format-title/package.json
@@ -39,7 +39,7 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	},
 	"engines": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "18.19.50",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -34,7 +34,7 @@
 		"@types/express": "4.17.21",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -31,7 +31,7 @@
 		"@types/node": "18.19.50",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/release-notes-generator/package.json
+++ b/packages/release-notes-generator/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "18.19.50",
 		"@types/semver": "7.5.8",
 		"@vitest/coverage-v8": "1.5.3",
-		"typescript": "5.4.5",
+		"typescript": "5.5.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -40,6 +40,6 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5"
+		"typescript": "5.6.2"
 	}
 }

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -35,7 +35,7 @@
 		"@ngneat/falso": "7.2.0",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -36,7 +36,7 @@
 		"@ngneat/falso": "7.2.0",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -35,7 +35,7 @@
 		"@ngneat/falso": "7.2.0",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -34,7 +34,7 @@
 		"@types/node": "18.19.50",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -39,7 +39,7 @@
 		"@ngneat/falso": "7.2.0",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -36,7 +36,7 @@
 		"@ngneat/falso": "7.2.0",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,7 +30,7 @@
 		"@types/node": "18.19.50",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -32,7 +32,7 @@
 		"@vueuse/shared": "10.9.0",
 		"pinia": "2.2.2",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vue": "3.4.27"
 	},
 	"peerDependencies": {

--- a/packages/stores/src/app.ts
+++ b/packages/stores/src/app.ts
@@ -1,5 +1,4 @@
 import { useLocalStorage } from '@vueuse/core';
-import type {} from '@vueuse/shared';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 

--- a/packages/system-data/package.json
+++ b/packages/system-data/package.json
@@ -32,6 +32,6 @@
 		"esbuild": "0.20.2",
 		"esbuild-yaml": "1.2.0",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5"
+		"typescript": "5.6.2"
 	}
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -40,7 +40,7 @@
 		"@vitejs/plugin-vue": "5.0.4",
 		"pinia": "2.2.2",
 		"rollup-plugin-node-externals": "7.1.3",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vite": "5.2.11",
 		"vite-plugin-dts": "3.9.1",
 		"vue": "3.4.27"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -32,7 +32,7 @@
 	"devDependencies": {
 		"@directus/tsconfig": "workspace:*",
 		"knex": "3.1.0",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vue": "3.4.27"
 	},
 	"peerDependencies": {

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -41,7 +41,7 @@
 		"@vitest/coverage-v8": "1.5.3",
 		"strip-ansi": "7.1.0",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	}
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,7 +52,7 @@
 		"@vitest/coverage-v8": "1.5.3",
 		"tmp": "0.2.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3",
 		"vue": "3.4.27"
 	},

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -30,7 +30,7 @@
 		"@directus/types": "workspace:*",
 		"@vitest/coverage-v8": "1.5.3",
 		"tsup": "8.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: link:packages/release-notes-generator
       '@typescript-eslint/eslint-plugin':
         specifier: 7.8.0
-        version: 7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/parser':
         specifier: 7.8.0
-        version: 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.8.0(eslint@8.57.0)(typescript@5.6.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -521,8 +521,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(knex@3.1.0(mysql2@3.11.2)(pg@8.12.0)(sqlite3@5.1.7)(tedious@18.6.1))
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -645,7 +645,7 @@ importers:
         version: 6.1.7(@fullcalendar/core@6.1.7)
       '@histoire/plugin-vue':
         specifier: 0.17.17
-        version: 0.17.17(histoire@0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)))(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 0.17.17(histoire@0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)))(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       '@joeattardi/emoji-button':
         specifier: 4.6.4
         version: 4.6.4
@@ -666,7 +666,7 @@ importers:
         version: 7.2.0
       '@pinia/testing':
         specifier: 0.1.5
-        version: 0.1.5(pinia@2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5)))(vue@3.4.27(typescript@5.4.5))
+        version: 0.1.5(pinia@2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2)))(vue@3.4.27(typescript@5.6.2))
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -678,7 +678,7 @@ importers:
         version: 2.2.1
       '@tinymce/tinymce-vue':
         specifier: 5.1.1
-        version: 5.1.1(vue@3.4.27(typescript@5.4.5))
+        version: 5.1.1(vue@3.4.27(typescript@5.6.2))
       '@turf/meta':
         specifier: 6.5.0
         version: 6.5.0
@@ -732,19 +732,19 @@ importers:
         version: 1.9.9(rollup@4.21.2)
       '@unhead/vue':
         specifier: 1.9.9
-        version: 1.9.9(vue@3.4.27(typescript@5.4.5))
+        version: 1.9.9(vue@3.4.27(typescript@5.6.2))
       '@vitejs/plugin-vue':
         specifier: 5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
       '@vueuse/core':
         specifier: 10.9.0
-        version: 10.9.0(vue@3.4.27(typescript@5.4.5))
+        version: 10.9.0(vue@3.4.27(typescript@5.6.2))
       '@vueuse/router':
         specifier: 10.9.0
-        version: 10.9.0(vue-router@4.4.3(vue@3.4.27(typescript@5.4.5)))(vue@3.4.27(typescript@5.4.5))
+        version: 10.9.0(vue-router@4.4.3(vue@3.4.27(typescript@5.6.2)))(vue@3.4.27(typescript@5.6.2))
       apexcharts:
         specifier: 3.52.0
         version: 3.52.0
@@ -843,7 +843,7 @@ importers:
         version: 8.0.1
       pinia:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
+        version: 2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2))
       pretty-ms:
         specifier: 9.1.0
         version: 9.1.0
@@ -866,8 +866,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vite:
         specifier: 5.2.11
         version: 5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
@@ -876,22 +876,22 @@ importers:
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
       vue-i18n:
         specifier: 9.14.0
-        version: 9.14.0(vue@3.4.27(typescript@5.4.5))
+        version: 9.14.0(vue@3.4.27(typescript@5.6.2))
       vue-router:
         specifier: 4.4.3
-        version: 4.4.3(vue@3.4.27(typescript@5.4.5))
+        version: 4.4.3(vue@3.4.27(typescript@5.6.2))
       vue-tsc:
         specifier: 2.0.29
-        version: 2.0.29(typescript@5.4.5)
+        version: 2.0.29(typescript@5.6.2)
       vue-virtual-scroller:
         specifier: 2.0.0-beta.8
-        version: 2.0.0-beta.8(vue@3.4.27(typescript@5.4.5))
+        version: 2.0.0-beta.8(vue@3.4.27(typescript@5.6.2))
       vuedraggable:
         specifier: 4.1.0
-        version: 4.1.0(vue@3.4.27(typescript@5.4.5))
+        version: 4.1.0(vue@3.4.27(typescript@5.6.2))
       wellknown:
         specifier: 0.5.0
         version: 0.5.0
@@ -949,31 +949,31 @@ importers:
         version: 6.2.0
       typedoc:
         specifier: 0.26.7
-        version: 0.26.7(typescript@5.4.5)
+        version: 0.26.7(typescript@5.6.2)
       typedoc-plugin-frontmatter:
         specifier: 0.0.2
         version: 0.0.2
       typedoc-plugin-markdown:
         specifier: 4.0.0-next.53
-        version: 4.0.0-next.53(typedoc@0.26.7(typescript@5.4.5))
+        version: 4.0.0-next.53(typedoc@0.26.7(typescript@5.6.2))
       typedoc-plugin-zod:
         specifier: 1.2.1
-        version: 1.2.1(typedoc@0.26.7(typescript@5.4.5))
+        version: 1.2.1(typedoc@0.26.7(typescript@5.6.2))
       typedoc-vitepress-theme:
         specifier: 1.0.1
-        version: 1.0.1(typedoc-plugin-markdown@4.0.0-next.53(typedoc@0.26.7(typescript@5.4.5)))
+        version: 1.0.1(typedoc-plugin-markdown@4.0.0-next.53(typedoc@0.26.7(typescript@5.6.2)))
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitepress:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.4.5)
+        version: 1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.6.2)
       vitepress-plugin-tabs:
         specifier: 0.3.0
-        version: 0.3.0(vitepress@1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
+        version: 0.3.0(vitepress@1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.6.2))(vue@3.4.27(typescript@5.6.2))
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
 
   packages/components:
     devDependencies:
@@ -982,10 +982,10 @@ importers:
         version: link:../tsconfig
       '@histoire/plugin-vue':
         specifier: 0.17.17
-        version: 0.17.17(histoire@0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)))(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 0.17.17(histoire@0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)))(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       '@vitejs/plugin-vue':
         specifier: 5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       '@vitest/coverage-v8':
         specifier: 1.5.3
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
@@ -994,31 +994,31 @@ importers:
         version: 0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
       pinia:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
+        version: 2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2))
       rollup-plugin-node-externals:
         specifier: 7.1.3
         version: 7.1.3(rollup@4.21.2)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vite:
         specifier: 5.2.11
         version: 5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(@types/node@18.19.50)(rollup@4.21.2)(typescript@5.4.5)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
+        version: 3.9.1(@types/node@18.19.50)(rollup@4.21.2)(typescript@5.6.2)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
       vue-i18n:
         specifier: 9.14.0
-        version: 9.14.0(vue@3.4.27(typescript@5.4.5))
+        version: 9.14.0(vue@3.4.27(typescript@5.6.2))
       vue-router:
         specifier: 4.4.3
-        version: 4.4.3(vue@3.4.27(typescript@5.4.5))
+        version: 4.4.3(vue@3.4.27(typescript@5.6.2))
 
   packages/composables:
     dependencies:
@@ -1061,16 +1061,16 @@ importers:
         version: 2.4.6
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
 
   packages/constants:
     devDependencies:
@@ -1079,10 +1079,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
 
   packages/create-directus-extension:
     dependencies:
@@ -1149,10 +1149,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1180,10 +1180,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1244,19 +1244,19 @@ importers:
         version: 0.2.3
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
       vue-router:
         specifier: 4.4.3
-        version: 4.4.3(vue@3.4.27(typescript@5.4.5))
+        version: 4.4.3(vue@3.4.27(typescript@5.6.2))
 
   packages/extensions-registry:
     dependencies:
@@ -1296,10 +1296,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1344,7 +1344,7 @@ importers:
         version: 3.0.2(rollup@3.29.4)
       '@vitejs/plugin-vue':
         specifier: 4.6.2
-        version: 4.6.2(vite@4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 4.6.2(vite@4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       chalk:
         specifier: 5.3.0
         version: 5.3.0
@@ -1380,7 +1380,7 @@ importers:
         version: 4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
@@ -1395,8 +1395,8 @@ importers:
         specifier: 1.5.3
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1408,10 +1408,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1445,10 +1445,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1473,10 +1473,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1494,10 +1494,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1533,8 +1533,8 @@ importers:
         specifier: 1.5.3
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.5.2
+        version: 5.5.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1550,10 +1550,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
 
   packages/specs:
     dependencies:
@@ -1584,10 +1584,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1615,10 +1615,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1649,10 +1649,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1680,10 +1680,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1708,10 +1708,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1751,10 +1751,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1785,10 +1785,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -1797,26 +1797,26 @@ importers:
     dependencies:
       '@vueuse/core':
         specifier: 10.9.0
-        version: 10.9.0(vue@3.4.27(typescript@5.4.5))
+        version: 10.9.0(vue@3.4.27(typescript@5.6.2))
     devDependencies:
       '@directus/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@vueuse/shared':
         specifier: 10.9.0
-        version: 10.9.0(vue@3.4.27(typescript@5.4.5))
+        version: 10.9.0(vue@3.4.27(typescript@5.6.2))
       pinia:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
+        version: 2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
 
   packages/system-data:
     devDependencies:
@@ -1831,10 +1831,10 @@ importers:
         version: 1.2.0(esbuild@0.20.2)
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
 
   packages/themes:
     dependencies:
@@ -1865,28 +1865,28 @@ importers:
         version: 4.17.12
       '@unhead/vue':
         specifier: 1.9.9
-        version: 1.9.9(vue@3.4.27(typescript@5.4.5))
+        version: 1.9.9(vue@3.4.27(typescript@5.6.2))
       '@vitejs/plugin-vue':
         specifier: 5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       pinia:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
+        version: 2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2))
       rollup-plugin-node-externals:
         specifier: 7.1.3
         version: 7.1.3(rollup@4.21.2)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vite:
         specifier: 5.2.11
         version: 5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(@types/node@18.19.50)(rollup@4.21.2)(typescript@5.4.5)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
+        version: 3.9.1(@types/node@18.19.50)(rollup@4.21.2)(typescript@5.6.2)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
 
   packages/tsconfig: {}
 
@@ -1909,11 +1909,11 @@ importers:
         specifier: 3.1.0
         version: 3.1.0(mysql2@3.11.2)(pg@8.12.0)(sqlite3@5.1.7)(tedious@18.6.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
 
   packages/update-check:
     dependencies:
@@ -1956,10 +1956,10 @@ importers:
         version: 7.1.0
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -2020,16 +2020,16 @@ importers:
         version: 0.2.3
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
       vue:
         specifier: 3.4.27
-        version: 3.4.27(typescript@5.4.5)
+        version: 3.4.27(typescript@5.6.2)
 
   packages/validation:
     dependencies:
@@ -2054,10 +2054,10 @@ importers:
         version: 1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -2078,10 +2078,10 @@ importers:
         version: 1.4.0
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1)
+        version: 8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       vitest:
         specifier: 1.5.3
         version: 1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -2155,14 +2155,14 @@ importers:
         specifier: 7.0.0
         version: 7.0.0
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.6.2
+        version: 5.6.2
       uuid:
         specifier: 9.0.1
         version: 9.0.1
       vite-tsconfig-paths:
         specifier: 4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
+        version: 4.3.2(typescript@5.6.2)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
       vitest:
         specifier: 1.6.0
         version: 1.6.0(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6)
@@ -11220,8 +11220,13 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -12225,8 +12230,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.569.0
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.568.0
@@ -12330,11 +12335,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.569.0':
+  '@aws-sdk/client-sso-oidc@3.569.0(@aws-sdk/client-sts@3.569.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-host-header': 3.567.0
@@ -12373,6 +12378,7 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.7.0
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -12506,11 +12512,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.569.0(@aws-sdk/client-sso-oidc@3.569.0)':
+  '@aws-sdk/client-sts@3.569.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.569.0
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-host-header': 3.567.0
@@ -12549,7 +12555,6 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.7.0
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -12660,7 +12665,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.568.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/credential-provider-env': 3.568.0
       '@aws-sdk/credential-provider-process': 3.568.0
       '@aws-sdk/credential-provider-sso': 3.568.0(@aws-sdk/client-sso-oidc@3.569.0)
@@ -12775,7 +12780,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.568.0(@aws-sdk/client-sts@3.569.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
@@ -12947,7 +12952,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.568.0(@aws-sdk/client-sso-oidc@3.569.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.569.0
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
@@ -13930,7 +13935,7 @@ snapshots:
     transitivePeerDependencies:
       - vite
 
-  '@histoire/plugin-vue@0.17.17(histoire@0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)))(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))':
+  '@histoire/plugin-vue@0.17.17(histoire@0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)))(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       '@histoire/controls': 0.17.17(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
       '@histoire/shared': 0.17.17(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
@@ -13940,7 +13945,7 @@ snapshots:
       histoire: 0.17.17(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))
       launch-editor: 2.9.1
       pathe: 1.1.2
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
     transitivePeerDependencies:
       - vite
 
@@ -14396,10 +14401,10 @@ snapshots:
 
   '@phc/format@1.0.0': {}
 
-  '@pinia/testing@0.1.5(pinia@2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5)))(vue@3.4.27(typescript@5.4.5))':
+  '@pinia/testing@0.1.5(pinia@2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2)))(vue@3.4.27(typescript@5.6.2))':
     dependencies:
-      pinia: 2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      pinia: 2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -15620,10 +15625,10 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tinymce/tinymce-vue@5.1.1(vue@3.4.27(typescript@5.4.5))':
+  '@tinymce/tinymce-vue@5.1.1(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       tinymce: 6.8.4
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
   '@tootallnate/once@1.1.2':
     optional: true
@@ -15998,13 +16003,13 @@ snapshots:
     dependencies:
       '@types/node': 18.19.50
 
-  '@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 7.8.0
-      '@typescript-eslint/type-utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.6(supports-color@5.5.0)
       eslint: 8.57.0
@@ -16012,22 +16017,22 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.8.0
       '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.6(supports-color@5.5.0)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -16036,21 +16041,21 @@ snapshots:
       '@typescript-eslint/types': 7.8.0
       '@typescript-eslint/visitor-keys': 7.8.0
 
-  '@typescript-eslint/type-utils@7.8.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@7.8.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
       debug: 4.3.6(supports-color@5.5.0)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@7.8.0': {}
 
-  '@typescript-eslint/typescript-estree@7.8.0(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@7.8.0(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/types': 7.8.0
       '@typescript-eslint/visitor-keys': 7.8.0
@@ -16059,20 +16064,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.8.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@7.8.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 7.8.0
       '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.6.2)
       eslint: 8.57.0
       semver: 7.6.3
     transitivePeerDependencies:
@@ -16114,23 +16119,23 @@ snapshots:
     dependencies:
       '@unhead/schema': 1.9.9
 
-  '@unhead/vue@1.9.9(vue@3.4.27(typescript@5.4.5))':
+  '@unhead/vue@1.9.9(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       '@unhead/schema': 1.9.9
       '@unhead/shared': 1.9.9
       hookable: 5.5.3
       unhead: 1.9.9
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
-  '@vitejs/plugin-vue@4.6.2(vite@4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))':
+  '@vitejs/plugin-vue@4.6.2(vite@4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       vite: 4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.0.4(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       vite: 5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
   '@vitest/coverage-v8@1.5.3(vitest@1.5.3(@types/node@18.19.50)(happy-dom@15.7.4)(jsdom@20.0.3)(sass@1.78.0)(terser@5.31.6))':
     dependencies:
@@ -16284,7 +16289,7 @@ snapshots:
 
   '@vue/devtools-api@6.6.3': {}
 
-  '@vue/language-core@1.8.27(typescript@5.4.5)':
+  '@vue/language-core@1.8.27(typescript@5.6.2)':
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
@@ -16296,9 +16301,9 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
-  '@vue/language-core@2.0.29(typescript@5.4.5)':
+  '@vue/language-core@2.0.29(typescript@5.6.2)':
     dependencies:
       '@volar/language-core': 2.4.2
       '@vue/compiler-dom': 3.5.2
@@ -16309,7 +16314,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
   '@vue/reactivity@3.4.27':
     dependencies:
@@ -16326,11 +16331,11 @@ snapshots:
       '@vue/shared': 3.4.27
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.27(vue@3.4.27(typescript@5.4.5))':
+  '@vue/server-renderer@3.4.27(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       '@vue/compiler-ssr': 3.4.27
       '@vue/shared': 3.4.27
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
   '@vue/shared@3.4.27': {}
 
@@ -16341,31 +16346,31 @@ snapshots:
       js-beautify: 1.15.1
       vue-component-type-helpers: 2.1.6
 
-  '@vueuse/core@10.11.1(vue@3.4.27(typescript@5.4.5))':
+  '@vueuse/core@10.11.1(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.4.27(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      '@vueuse/shared': 10.11.1(vue@3.4.27(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@10.9.0(vue@3.4.27(typescript@5.4.5))':
+  '@vueuse/core@10.9.0(vue@3.4.27(typescript@5.6.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.9.0
-      '@vueuse/shared': 10.9.0(vue@3.4.27(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      '@vueuse/shared': 10.9.0(vue@3.4.27(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@10.11.1(axios@1.7.7)(change-case@4.1.2)(focus-trap@7.5.4)(qrcode@1.5.4)(sortablejs@1.14.0)(vue@3.4.27(typescript@5.4.5))':
+  '@vueuse/integrations@10.11.1(axios@1.7.7)(change-case@4.1.2)(focus-trap@7.5.4)(qrcode@1.5.4)(sortablejs@1.14.0)(vue@3.4.27(typescript@5.6.2))':
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.4.27(typescript@5.4.5))
-      '@vueuse/shared': 10.11.1(vue@3.4.27(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      '@vueuse/core': 10.11.1(vue@3.4.27(typescript@5.6.2))
+      '@vueuse/shared': 10.11.1(vue@3.4.27(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     optionalDependencies:
       axios: 1.7.7
       change-case: 4.1.2
@@ -16380,25 +16385,25 @@ snapshots:
 
   '@vueuse/metadata@10.9.0': {}
 
-  '@vueuse/router@10.9.0(vue-router@4.4.3(vue@3.4.27(typescript@5.4.5)))(vue@3.4.27(typescript@5.4.5))':
+  '@vueuse/router@10.9.0(vue-router@4.4.3(vue@3.4.27(typescript@5.6.2)))(vue@3.4.27(typescript@5.6.2))':
     dependencies:
-      '@vueuse/shared': 10.9.0(vue@3.4.27(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
-      vue-router: 4.4.3(vue@3.4.27(typescript@5.4.5))
+      '@vueuse/shared': 10.9.0(vue@3.4.27(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
+      vue-router: 4.4.3(vue@3.4.27(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@10.11.1(vue@3.4.27(typescript@5.4.5))':
+  '@vueuse/shared@10.11.1(vue@3.4.27(typescript@5.6.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@10.9.0(vue@3.4.27(typescript@5.4.5))':
+  '@vueuse/shared@10.9.0(vue@3.4.27(typescript@5.6.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -21013,13 +21018,13 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pinia@2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5)):
+  pinia@2.2.2(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2)):
     dependencies:
       '@vue/devtools-api': 6.6.3
-      vue: 3.4.27(typescript@5.4.5)
-      vue-demi: 0.14.10(vue@3.4.27(typescript@5.4.5))
+      vue: 3.4.27(typescript@5.6.2)
+      vue-demi: 0.14.10(vue@3.4.27(typescript@5.6.2))
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
   pino-abstract-transport@0.4.0:
     dependencies:
@@ -22926,21 +22931,21 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@1.3.0(typescript@5.4.5):
+  ts-api-utils@1.3.0(typescript@5.6.2):
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.3(typescript@5.4.5):
+  tsconfck@3.1.3(typescript@5.6.2):
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
   tslib@1.14.1: {}
 
   tslib@2.7.0: {}
 
-  tsup@8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.4.5)(yaml@2.5.1):
+  tsup@8.2.4(@microsoft/api-extractor@7.43.0(@types/node@18.19.50))(jiti@1.21.6)(postcss@8.4.45)(tsx@4.17.0)(typescript@5.6.2)(yaml@2.5.1):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -22961,7 +22966,7 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@18.19.50)
       postcss: 8.4.45
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -23068,30 +23073,32 @@ snapshots:
     dependencies:
       yaml: 2.5.1
 
-  typedoc-plugin-markdown@4.0.0-next.53(typedoc@0.26.7(typescript@5.4.5)):
+  typedoc-plugin-markdown@4.0.0-next.53(typedoc@0.26.7(typescript@5.6.2)):
     dependencies:
-      typedoc: 0.26.7(typescript@5.4.5)
+      typedoc: 0.26.7(typescript@5.6.2)
 
-  typedoc-plugin-zod@1.2.1(typedoc@0.26.7(typescript@5.4.5)):
+  typedoc-plugin-zod@1.2.1(typedoc@0.26.7(typescript@5.6.2)):
     dependencies:
-      typedoc: 0.26.7(typescript@5.4.5)
+      typedoc: 0.26.7(typescript@5.6.2)
 
-  typedoc-vitepress-theme@1.0.1(typedoc-plugin-markdown@4.0.0-next.53(typedoc@0.26.7(typescript@5.4.5))):
+  typedoc-vitepress-theme@1.0.1(typedoc-plugin-markdown@4.0.0-next.53(typedoc@0.26.7(typescript@5.6.2))):
     dependencies:
-      typedoc-plugin-markdown: 4.0.0-next.53(typedoc@0.26.7(typescript@5.4.5))
+      typedoc-plugin-markdown: 4.0.0-next.53(typedoc@0.26.7(typescript@5.6.2))
 
-  typedoc@0.26.7(typescript@5.4.5):
+  typedoc@0.26.7(typescript@5.6.2):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
       shiki: 1.17.6
-      typescript: 5.4.5
+      typescript: 5.6.2
       yaml: 2.5.1
 
   typescript@5.4.2: {}
 
-  typescript@5.4.5: {}
+  typescript@5.5.2: {}
+
+  typescript@5.6.2: {}
 
   typical@2.6.1: {}
 
@@ -23444,16 +23451,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.1(@types/node@18.19.50)(rollup@4.21.2)(typescript@5.4.5)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)):
+  vite-plugin-dts@3.9.1(@types/node@18.19.50)(rollup@4.21.2)(typescript@5.6.2)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@18.19.50)
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      '@vue/language-core': 1.8.27(typescript@5.4.5)
+      '@vue/language-core': 1.8.27(typescript@5.6.2)
       debug: 4.3.6(supports-color@5.5.0)
       kolorist: 1.8.0
       magic-string: 0.30.11
-      typescript: 5.4.5
-      vue-tsc: 1.8.27(typescript@5.4.5)
+      typescript: 5.6.2
+      vue-tsc: 1.8.27(typescript@5.6.2)
     optionalDependencies:
       vite: 5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
     transitivePeerDependencies:
@@ -23461,11 +23468,11 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)):
+  vite-tsconfig-paths@4.3.2(typescript@5.6.2)(vite@5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)):
     dependencies:
       debug: 4.3.6(supports-color@5.5.0)
       globrex: 0.1.2
-      tsconfck: 3.1.3(typescript@5.4.5)
+      tsconfck: 3.1.3(typescript@5.6.2)
     optionalDependencies:
       vite: 5.2.11(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
     transitivePeerDependencies:
@@ -23494,26 +23501,26 @@ snapshots:
       sass: 1.78.0
       terser: 5.31.6
 
-  vitepress-plugin-tabs@0.3.0(vitepress@1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5)):
+  vitepress-plugin-tabs@0.3.0(vitepress@1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.6.2))(vue@3.4.27(typescript@5.6.2)):
     dependencies:
-      vitepress: 1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.4.5)
-      vue: 3.4.27(typescript@5.4.5)
+      vitepress: 1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.6.2)
+      vue: 3.4.27(typescript@5.6.2)
 
-  vitepress@1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.4.5):
+  vitepress@1.0.0-rc.4(@algolia/client-search@4.24.0)(@types/node@18.19.50)(axios@1.7.7)(change-case@4.1.2)(qrcode@1.5.4)(sass@1.78.0)(search-insights@2.17.1)(sortablejs@1.14.0)(terser@5.31.6)(typescript@5.6.2):
     dependencies:
       '@docsearch/css': 3.6.1
       '@docsearch/js': 3.6.1(@algolia/client-search@4.24.0)(search-insights@2.17.1)
-      '@vitejs/plugin-vue': 4.6.2(vite@4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+      '@vitejs/plugin-vue': 4.6.2(vite@4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6))(vue@3.4.27(typescript@5.6.2))
       '@vue/devtools-api': 6.6.3
-      '@vueuse/core': 10.9.0(vue@3.4.27(typescript@5.4.5))
-      '@vueuse/integrations': 10.11.1(axios@1.7.7)(change-case@4.1.2)(focus-trap@7.5.4)(qrcode@1.5.4)(sortablejs@1.14.0)(vue@3.4.27(typescript@5.4.5))
+      '@vueuse/core': 10.9.0(vue@3.4.27(typescript@5.6.2))
+      '@vueuse/integrations': 10.11.1(axios@1.7.7)(change-case@4.1.2)(focus-trap@7.5.4)(qrcode@1.5.4)(sortablejs@1.14.0)(vue@3.4.27(typescript@5.6.2))
       body-scroll-lock: 4.0.0-beta.0
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 0.14.7
       vite: 4.5.2(@types/node@18.19.50)(sass@1.78.0)(terser@5.31.6)
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -23625,9 +23632,9 @@ snapshots:
 
   vue-component-type-helpers@2.1.6: {}
 
-  vue-demi@0.14.10(vue@3.4.27(typescript@5.4.5)):
+  vue-demi@0.14.10(vue@3.4.27(typescript@5.6.2)):
     dependencies:
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
   vue-eslint-parser@9.4.3(eslint@8.57.0):
     dependencies:
@@ -23642,66 +23649,66 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@9.14.0(vue@3.4.27(typescript@5.4.5)):
+  vue-i18n@9.14.0(vue@3.4.27(typescript@5.6.2)):
     dependencies:
       '@intlify/core-base': 9.14.0
       '@intlify/shared': 9.14.0
       '@vue/devtools-api': 6.6.3
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
-  vue-observe-visibility@2.0.0-alpha.1(vue@3.4.27(typescript@5.4.5)):
+  vue-observe-visibility@2.0.0-alpha.1(vue@3.4.27(typescript@5.6.2)):
     dependencies:
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
-  vue-resize@2.0.0-alpha.1(vue@3.4.27(typescript@5.4.5)):
+  vue-resize@2.0.0-alpha.1(vue@3.4.27(typescript@5.6.2)):
     dependencies:
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
-  vue-router@4.4.3(vue@3.4.27(typescript@5.4.5)):
+  vue-router@4.4.3(vue@3.4.27(typescript@5.6.2)):
     dependencies:
       '@vue/devtools-api': 6.6.3
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
   vue-template-compiler@2.7.16:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-tsc@1.8.27(typescript@5.4.5):
+  vue-tsc@1.8.27(typescript@5.6.2):
     dependencies:
       '@volar/typescript': 1.11.1
-      '@vue/language-core': 1.8.27(typescript@5.4.5)
+      '@vue/language-core': 1.8.27(typescript@5.6.2)
       semver: 7.6.3
-      typescript: 5.4.5
+      typescript: 5.6.2
 
-  vue-tsc@2.0.29(typescript@5.4.5):
+  vue-tsc@2.0.29(typescript@5.6.2):
     dependencies:
       '@volar/typescript': 2.4.2
-      '@vue/language-core': 2.0.29(typescript@5.4.5)
+      '@vue/language-core': 2.0.29(typescript@5.6.2)
       semver: 7.6.3
-      typescript: 5.4.5
+      typescript: 5.6.2
 
-  vue-virtual-scroller@2.0.0-beta.8(vue@3.4.27(typescript@5.4.5)):
+  vue-virtual-scroller@2.0.0-beta.8(vue@3.4.27(typescript@5.6.2)):
     dependencies:
       mitt: 2.1.0
-      vue: 3.4.27(typescript@5.4.5)
-      vue-observe-visibility: 2.0.0-alpha.1(vue@3.4.27(typescript@5.4.5))
-      vue-resize: 2.0.0-alpha.1(vue@3.4.27(typescript@5.4.5))
+      vue: 3.4.27(typescript@5.6.2)
+      vue-observe-visibility: 2.0.0-alpha.1(vue@3.4.27(typescript@5.6.2))
+      vue-resize: 2.0.0-alpha.1(vue@3.4.27(typescript@5.6.2))
 
-  vue@3.4.27(typescript@5.4.5):
+  vue@3.4.27(typescript@5.6.2):
     dependencies:
       '@vue/compiler-dom': 3.4.27
       '@vue/compiler-sfc': 3.4.27
       '@vue/runtime-dom': 3.4.27
-      '@vue/server-renderer': 3.4.27(vue@3.4.27(typescript@5.4.5))
+      '@vue/server-renderer': 3.4.27(vue@3.4.27(typescript@5.6.2))
       '@vue/shared': 3.4.27
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
-  vuedraggable@4.1.0(vue@3.4.27(typescript@5.4.5)):
+  vuedraggable@4.1.0(vue@3.4.27(typescript@5.6.2)):
     dependencies:
       sortablejs: 1.14.0
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.4.27(typescript@5.6.2)
 
   w3c-keyname@2.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,20 +15,20 @@ importers:
         specifier: workspace:*
         version: link:packages/release-notes-generator
       '@typescript-eslint/eslint-plugin':
-        specifier: 7.8.0
-        version: 7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
+        specifier: 8.7.0
+        version: 8.7.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
       '@typescript-eslint/parser':
-        specifier: 7.8.0
-        version: 7.8.0(eslint@8.57.0)(typescript@5.6.2)
+        specifier: 8.7.0
+        version: 8.7.0(eslint@8.57.1)(typescript@5.6.2)
       eslint:
-        specifier: 8.57.0
-        version: 8.57.0
+        specifier: 8.57.1
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 9.1.0
-        version: 9.1.0(eslint@8.57.0)
+        version: 9.1.0(eslint@8.57.1)
       eslint-plugin-vue:
         specifier: 9.28.0
-        version: 9.28.0(eslint@8.57.0)
+        version: 9.28.0(eslint@8.57.1)
       prettier:
         specifier: 3.1.0
         version: 3.1.0
@@ -931,13 +931,13 @@ importers:
         version: 0.1.0
       eslint-plugin-markdown:
         specifier: 3.0.1
-        version: 3.0.1(eslint@8.57.0)
+        version: 3.0.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: npm:@paescuj/eslint-plugin-prettier@5.0.1-1
-        version: '@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.1.0)'
+        version: '@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.1.0)'
       eslint-plugin-react:
         specifier: 7.35.0
-        version: 7.35.0(eslint@8.57.0)
+        version: 7.35.0(eslint@8.57.1)
       markdown-it-for-inline:
         specifier: 2.0.1
         version: 2.0.1
@@ -3412,8 +3412,8 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@eslint/js@8.57.0':
-    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@fortawesome/fontawesome-common-types@0.2.36':
@@ -3519,8 +3519,8 @@ packages:
   '@histoire/vendors@0.17.17':
     resolution: {integrity: sha512-QZvmffdoJlLuYftPIkOU5Q2FPAdG2JjMuQ5jF7NmEl0n1XnmbMqtRkdYTZ4eF6CO1KLZ0Zyf6gBQvoT1uWNcjA==}
 
-  '@humanwhocodes/config-array@0.11.14':
-    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
 
@@ -5024,9 +5024,6 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
   '@types/json2csv@5.0.7':
     resolution: {integrity: sha512-Ma25zw9G9GEBnX8b12R4EYvnFT6dBh8L3jwsN5EUFXa+fl2dqmbLDbNWN0XuQU3rSXdsbBeCYjI9uHU2PUBxhA==}
 
@@ -5204,63 +5201,62 @@ packages:
   '@types/ws@8.5.12':
     resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
 
-  '@typescript-eslint/eslint-plugin@7.8.0':
-    resolution: {integrity: sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/eslint-plugin@8.7.0':
+    resolution: {integrity: sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@7.8.0':
-    resolution: {integrity: sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/parser@8.7.0':
+    resolution: {integrity: sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@7.8.0':
-    resolution: {integrity: sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/scope-manager@8.7.0':
+    resolution: {integrity: sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@7.8.0':
-    resolution: {integrity: sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/types@7.8.0':
-    resolution: {integrity: sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/typescript-estree@7.8.0':
-    resolution: {integrity: sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/type-utils@8.7.0':
+    resolution: {integrity: sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/utils@7.8.0':
-    resolution: {integrity: sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
+  '@typescript-eslint/types@8.7.0':
+    resolution: {integrity: sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@7.8.0':
-    resolution: {integrity: sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/typescript-estree@8.7.0':
+    resolution: {integrity: sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@8.7.0':
+    resolution: {integrity: sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@typescript-eslint/visitor-keys@8.7.0':
+    resolution: {integrity: sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -6997,8 +6993,8 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint@8.57.0:
-    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
 
@@ -13797,9 +13793,9 @@ snapshots:
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
+  '@eslint-community/eslint-utils@4.4.0(eslint@8.57.1)':
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.11.0': {}
@@ -13818,7 +13814,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@8.57.0': {}
+  '@eslint/js@8.57.1': {}
 
   '@fortawesome/fontawesome-common-types@0.2.36': {}
 
@@ -13961,7 +13957,7 @@ snapshots:
 
   '@histoire/vendors@0.17.17': {}
 
-  '@humanwhocodes/config-array@0.11.14':
+  '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.3.6(supports-color@5.5.0)
@@ -14390,14 +14386,14 @@ snapshots:
       '@otplib/plugin-crypto': 12.0.1
       '@otplib/plugin-thirty-two': 12.0.1
 
-  '@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.1.0)':
+  '@paescuj/eslint-plugin-prettier@5.0.1-1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.1.0)':
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
       prettier: 3.1.0
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
     optionalDependencies:
-      eslint-config-prettier: 9.1.0(eslint@8.57.0)
+      eslint-config-prettier: 9.1.0(eslint@8.57.1)
 
   '@phc/format@1.0.0': {}
 
@@ -15800,8 +15796,6 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
-  '@types/json-schema@7.0.15': {}
-
   '@types/json2csv@5.0.7':
     dependencies:
       '@types/node': 18.19.50
@@ -16003,64 +15997,62 @@ snapshots:
     dependencies:
       '@types/node': 18.19.50
 
-  '@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)':
+  '@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/scope-manager': 7.8.0
-      '@typescript-eslint/type-utils': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.6(supports-color@5.5.0)
-      eslint: 8.57.0
+      '@typescript-eslint/parser': 8.7.0(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 8.7.0
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.6.3
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.6.2)':
+  '@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 7.8.0
-      '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.6.2)
-      '@typescript-eslint/visitor-keys': 7.8.0
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 8.7.0
       debug: 4.3.6(supports-color@5.5.0)
-      eslint: 8.57.0
+      eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@7.8.0':
+  '@typescript-eslint/scope-manager@8.7.0':
     dependencies:
-      '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/visitor-keys': 7.8.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/visitor-keys': 8.7.0
 
-  '@typescript-eslint/type-utils@7.8.0(eslint@8.57.0)(typescript@5.6.2)':
+  '@typescript-eslint/type-utils@8.7.0(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.1)(typescript@5.6.2)
       debug: 4.3.6(supports-color@5.5.0)
-      eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
+      - eslint
       - supports-color
 
-  '@typescript-eslint/types@7.8.0': {}
+  '@typescript-eslint/types@8.7.0': {}
 
-  '@typescript-eslint/typescript-estree@7.8.0(typescript@5.6.2)':
+  '@typescript-eslint/typescript-estree@8.7.0(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/visitor-keys': 7.8.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/visitor-keys': 8.7.0
       debug: 4.3.6(supports-color@5.5.0)
-      globby: 11.1.0
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
@@ -16070,23 +16062,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.8.0(eslint@8.57.0)(typescript@5.6.2)':
+  '@typescript-eslint/utils@8.7.0(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 7.8.0
-      '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.6.2)
-      eslint: 8.57.0
-      semver: 7.6.3
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
+      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/visitor-keys@7.8.0':
+  '@typescript-eslint/visitor-keys@8.7.0':
     dependencies:
-      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/types': 8.7.0
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -17971,20 +17960,20 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@9.1.0(eslint@8.57.0):
+  eslint-config-prettier@9.1.0(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
 
   eslint-parser-plain@0.1.0: {}
 
-  eslint-plugin-markdown@3.0.1(eslint@8.57.0):
+  eslint-plugin-markdown@3.0.1(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.35.0(eslint@8.57.0):
+  eslint-plugin-react@7.35.0(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -17992,7 +17981,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
-      eslint: 8.57.0
+      eslint: 8.57.1
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -18006,16 +17995,16 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-vue@9.28.0(eslint@8.57.0):
+  eslint-plugin-vue@9.28.0(eslint@8.57.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      eslint: 8.57.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
+      eslint: 8.57.1
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      vue-eslint-parser: 9.4.3(eslint@8.57.0)
+      vue-eslint-parser: 9.4.3(eslint@8.57.1)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -18027,13 +18016,13 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.57.0:
+  eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
       '@eslint-community/regexpp': 4.11.0
       '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.0
-      '@humanwhocodes/config-array': 0.11.14
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
@@ -23636,10 +23625,10 @@ snapshots:
     dependencies:
       vue: 3.4.27(typescript@5.6.2)
 
-  vue-eslint-parser@9.4.3(eslint@8.57.0):
+  vue-eslint-parser@9.4.3(eslint@8.57.1):
     dependencies:
       debug: 4.3.6(supports-color@5.5.0)
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -31,9 +31,9 @@
 		"@directus/system-data": "workspace:*",
 		"@directus/tsconfig": "workspace:*",
 		"@types/node-fetch": "2.6.11",
-		"tsup": "8.2.4",
 		"esbuild-plugin-replace": "1.4.0",
-		"typescript": "5.4.5",
+		"tsup": "8.2.4",
+		"typescript": "5.6.2",
 		"vitest": "1.5.3"
 	},
 	"engines": {

--- a/sdk/src/realtime/utils/message-callback.ts
+++ b/sdk/src/realtime/utils/message-callback.ts
@@ -25,7 +25,7 @@ export const messageCallback = (socket: WebSocketInterface, timeout = 1000) =>
 					unbind();
 					abort();
 				}
-			} catch (err) {
+			} catch {
 				// return the original event to allow customization
 				unbind();
 				resolve(data);

--- a/sdk/tests/filters.test-d.ts
+++ b/sdk/tests/filters.test-d.ts
@@ -6,7 +6,7 @@ describe('Test QueryFilters', () => {
 	test('resolving _and/_or filters (issue #20633)', () => {
 		const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
 
-		const withConditional = () =>
+		const _withConditional = () =>
 			client.request(
 				readItems('collection_a', {
 					fields: [
@@ -22,7 +22,7 @@ describe('Test QueryFilters', () => {
 				}),
 			);
 
-		const withoutConditional = () =>
+		const _withoutConditional = () =>
 			client.request(
 				readItems('collection_a', {
 					fields: [
@@ -36,8 +36,8 @@ describe('Test QueryFilters', () => {
 				}),
 			);
 
-		type TypeWithConditional = Awaited<ReturnType<typeof withConditional>>;
-		type TypeWithoutConditional = Awaited<ReturnType<typeof withoutConditional>>;
+		type TypeWithConditional = Awaited<ReturnType<typeof _withConditional>>;
+		type TypeWithoutConditional = Awaited<ReturnType<typeof _withoutConditional>>;
 
 		const resultA: TypeWithConditional = [
 			{

--- a/tests/blackbox/package.json
+++ b/tests/blackbox/package.json
@@ -30,7 +30,7 @@
 		"lodash-es": "4.17.21",
 		"seedrandom": "3.0.5",
 		"supertest": "7.0.0",
-		"typescript": "5.4.5",
+		"typescript": "5.6.2",
 		"uuid": "9.0.1",
 		"vite-tsconfig-paths": "4.3.2",
 		"vitest": "1.6.0",

--- a/tests/blackbox/setup/environment.ts
+++ b/tests/blackbox/setup/environment.ts
@@ -38,7 +38,7 @@ export default <Environment>{
 				} else if (totalTestsCount + testIndex === completedCount) {
 					break;
 				}
-			} catch (err) {
+			} catch {
 				continue;
 			}
 

--- a/tests/blackbox/setup/setup.ts
+++ b/tests/blackbox/setup/setup.ts
@@ -124,7 +124,7 @@ export async function setup() {
 							process.env['serverUrl'] = serverUrl;
 							break;
 						}
-					} catch (err) {
+					} catch {
 						continue;
 					}
 				}

--- a/tests/blackbox/tests/db/query/filter/index.ts
+++ b/tests/blackbox/tests/db/query/filter/index.ts
@@ -212,7 +212,7 @@ function processValidation(
 						found = true;
 						break;
 					}
-				} catch (_err) {
+				} catch {
 					continue;
 				}
 			}
@@ -238,7 +238,7 @@ function processValidation(
 
 			try {
 				validationResult = filter.validatorFunction(get(data, keys[0]), filter.value);
-			} catch (_err) {
+			} catch {
 				validationResult = false;
 			}
 

--- a/tests/blackbox/utils/await-connection.ts
+++ b/tests/blackbox/utils/await-connection.ts
@@ -7,7 +7,7 @@ export async function awaitDatabaseConnection(database: Knex, checkSQL: string):
 		try {
 			await database.raw(checkSQL);
 			return null; // success
-		} catch (error) {
+		} catch {
 			await sleep(5000);
 			continue;
 		}


### PR DESCRIPTION
## Scope

Updates TypeScript to 5.6.2, along with the ESLint TypeScript plugin and in turn contains lint fixes that have surfaced with the new version. Details in individual commits.

