### PR TITLE
Fix WYSIWYG interface conditionally reinitialized (#23683)

### DIFF
--- a/.changeset/little-lamps-cheer.md
+++ b/.changeset/little-lamps-cheer.md
@@ -2,4 +2,5 @@
 '@directus/app': patch
 ---
 
-Fix WYSIWYG interface conditionally reinitialized
+Fixed WYSIWYG interface to be updated when interface options are changed via conditions
+

--- a/.changeset/little-lamps-cheer.md
+++ b/.changeset/little-lamps-cheer.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix WYSIWYG interface conditionally reinitialized

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -79,6 +79,8 @@ const emit = defineEmits(['input']);
 const { t } = useI18n();
 const editorRef = ref<any | null>(null);
 const editorElement = ref<ComponentPublicInstance | null>(null);
+const editorKey = ref(0);
+
 const { imageToken } = toRefs(props);
 const settingsStore = useSettingsStore();
 
@@ -148,6 +150,15 @@ watch(
 				editorRef.value.editorCommands?.commands?.exec?.mcedirectionltr();
 			}
 		}
+	},
+);
+
+watch(
+	() => JSON.stringify([props.toolbar, props.font, props.customFormats]),
+	() => {
+		editorRef.value.remove();
+		editorInitialized.value = false;
+		editorKey.value++;
 	},
 );
 
@@ -306,6 +317,7 @@ function setFocus(val: boolean) {
 <template>
 	<div :id="field" class="wysiwyg" :class="{ disabled }">
 		<editor
+			:key="editorKey"
 			ref="editorElement"
 			v-model="internalValue"
 			:init="editorOptions"

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -3,6 +3,7 @@ import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
 import { SettingsStorageAssetPreset } from '@directus/types';
 import Editor from '@tinymce/tinymce-vue';
+import { isEqual } from 'lodash';
 import { ComponentPublicInstance, computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import getEditorStyles from './get-editor-styles';
@@ -154,8 +155,10 @@ watch(
 );
 
 watch(
-	() => JSON.stringify([props.toolbar, props.font, props.customFormats]),
-	() => {
+	() => [props.toolbar, props.font, props.customFormats, props.tinymceOverrides],
+	(newOptions, oldOptions) => {
+		if (isEqual(newOptions, oldOptions)) return;
+
 		editorRef.value.remove();
 		editorInitialized.value = false;
 		editorKey.value++;


### PR DESCRIPTION
## Scope
When editor option changed, it would not be configured to render correct UI.

What's changed:

- Append watch to reinitialize editor

#### Reproduce setting:
|  | |
|  ----  | ----  |
|  ![image](https://github.com/user-attachments/assets/4a696fac-1550-4c35-94da-06c14073a56a) | ![image](https://github.com/user-attachments/assets/46c2464b-6957-4fe0-9a63-15085632082a) |

---
#### Reproduce:

| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/350e177d-a659-40c0-b86f-aae60a61fe5f"> | <video src="https://github.com/user-attachments/assets/4aee55ee-b6c7-479a-845d-90c5041e8bfd"> |


## Potential Risks / Drawbacks

- I found toolbars options seems merged when default options length greater than conditional case options

## Review Notes / Questions

- 

---

Fixes #23683
