### PR TITLE
Fix defaults reactivity in kanban layout

### DIFF
--- a/.changeset/moody-dogs-attack.md
+++ b/.changeset/moody-dogs-attack.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed reactivity of default values for kanban layout
+Fixed an issue blocking collection view after switching between Kanban bookmarks

--- a/.changeset/moody-dogs-attack.md
+++ b/.changeset/moody-dogs-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed reactivity of default values for kanban layout

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -357,16 +357,21 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		}
 
 		function useLayoutOptions() {
-			const groupField = createViewOption<string | null>('groupField', fieldGroups.value.group[0]?.field ?? null);
-			const groupTitle = createViewOption<string | null>('groupTitle', null);
-			const dateField = createViewOption<string | null>('dateField', fieldGroups.value.date[0]?.field ?? null);
-			const tagsField = createViewOption<string | null>('tagsField', fieldGroups.value.tags[0]?.field ?? null);
-			const userField = createViewOption<string | null>('userField', fieldGroups.value.user[0]?.field ?? null);
-			const titleField = createViewOption<string | null>('titleField', fieldGroups.value.title[0]?.field ?? null);
-			const textField = createViewOption<string | null>('textField', fieldGroups.value.text[0]?.field ?? null);
-			const showUngrouped = createViewOption<boolean>('showUngrouped', false);
-			const imageSource = createViewOption<string | null>('imageSource', fieldGroups.value.file[0]?.field ?? null);
-			const crop = createViewOption<boolean>('crop', true);
+			const groupField = createViewOption<string | null>('groupField', () => fieldGroups.value.group[0]?.field ?? null);
+			const groupTitle = createViewOption<string | null>('groupTitle', () => null);
+			const dateField = createViewOption<string | null>('dateField', () => fieldGroups.value.date[0]?.field ?? null);
+			const tagsField = createViewOption<string | null>('tagsField', () => fieldGroups.value.tags[0]?.field ?? null);
+			const userField = createViewOption<string | null>('userField', () => fieldGroups.value.user[0]?.field ?? null);
+			const titleField = createViewOption<string | null>('titleField', () => fieldGroups.value.title[0]?.field ?? null);
+			const textField = createViewOption<string | null>('textField', () => fieldGroups.value.text[0]?.field ?? null);
+			const showUngrouped = createViewOption<boolean>('showUngrouped', () => false);
+
+			const imageSource = createViewOption<string | null>(
+				'imageSource',
+				() => fieldGroups.value.file[0]?.field ?? null,
+			);
+
+			const crop = createViewOption<boolean>('crop', () => true);
 
 			const selectedGroup = computed(() => fieldGroups.value.group.find((group) => group.field === groupField.value));
 
@@ -406,10 +411,10 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				userFieldType,
 			};
 
-			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
+			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: () => any) {
 				return computed<T>({
 					get() {
-						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value[key] : defaultValue;
+						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value[key] : defaultValue();
 					},
 					set(newValue: T) {
 						layoutOptions.value = {
@@ -671,6 +676,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					if (val !== null) fields.push(val);
 				});
 
+				console.log('calc fields', fields);
 				return fields;
 			});
 

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -676,7 +676,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					if (val !== null) fields.push(val);
 				});
 
-				console.log('calc fields', fields);
 				return fields;
 			});
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

When switching between different collections using the kanban layout that aren't fully configured and use some automatically inferred default the defaults aren't properly recomputed, resulting in this error.

![CleanShot 2024-10-03 at 10 49 42@2x](https://github.com/user-attachments/assets/b2034e63-b4d9-40db-b00e-ec7d24a641ec)

What's changed:

- Use function for recalculating default values dynamically instead of once at layout creation.

---

Fixes #23687
