### PR TITLE
Fix cards layout should always show error (#21524)

### DIFF
--- a/.changeset/rotten-cougars-grab.md
+++ b/.changeset/rotten-cougars-grab.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix cards layout should always show error

--- a/.changeset/rotten-cougars-grab.md
+++ b/.changeset/rotten-cougars-grab.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix cards layout should always show error
+Ensured errors occured within the cards layout are always shown

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -87,7 +87,7 @@ watch(innerWidth, (value) => {
 
 <template>
 	<div ref="layoutElement" class="layout-cards" :style="{ '--size': size * 40 + 'px' }">
-		<template v-if="loading || (itemCount ?? 0) > 0">
+		<template v-if="loading || ((itemCount ?? 0) > 0 && !error)">
 			<cards-header
 				v-model:size="sizeWritable"
 				v-model:selection="selectionWritable"


### PR DESCRIPTION
## Scope
When delete field used on card layout sort. 
It will lead card layout not showing any data & sort field will not display anything. 

What's changed:

- Fix cards layout should always show error

#### Reproduce:

| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/ead9aee5-7520-482c-a0ee-eaf14b0eea35"> | <video src="https://github.com/user-attachments/assets/ef708de5-2e46-438b-a47a-af5219d9138d"> |


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #21524
