### PR TITLE
add save options to role/policies item pages

### DIFF
--- a/.changeset/loud-foxes-applaud.md
+++ b/.changeset/loud-foxes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added save options to role and policies item pages

--- a/app/src/modules/settings/routes/policies/item.vue
+++ b/app/src/modules/settings/routes/policies/item.vue
@@ -4,6 +4,7 @@ import { useItem } from '@/composables/use-item';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useUserStore } from '@/stores/user';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
+import SaveOptions from '@/views/private/components/save-options.vue';
 import { Policy } from '@directus/types';
 import { ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -35,6 +36,10 @@ useShortcut('meta+s', () => {
 	if (hasEdits.value) saveAndStay();
 });
 
+useShortcut('meta+shift+s', () => {
+	if (hasEdits.value) saveAndAddNew();
+});
+
 const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 /**
@@ -54,11 +59,21 @@ async function saveAndStay() {
 	}
 }
 
+async function saveAndAddNew() {
+	try {
+		await save();
+		await userStore.hydrate();
+		router.push(`/settings/policies/+`);
+	} catch {
+		// `save` shows unexpected error dialog
+	}
+}
+
 async function saveAndQuit() {
 	try {
 		await save();
-		router.push(`/settings/policies`);
 		await userStore.hydrate();
+		router.push(`/settings/policies`);
 	} catch {
 		// 'save' shows unexpected error dialog
 	}
@@ -79,6 +94,11 @@ function discardAndLeave() {
 	edits.value = {};
 	confirmLeave.value = false;
 	router.push(leaveTo.value);
+}
+
+function discardAndStay() {
+	edits.value = {};
+	confirmLeave.value = false;
 }
 </script>
 
@@ -122,15 +142,18 @@ function discardAndLeave() {
 				</v-card>
 			</v-dialog>
 
-			<v-button
-				v-tooltip.bottom="t('save')"
-				rounded
-				icon
-				:loading="saving"
-				:disabled="hasEdits === false"
-				@click="saveAndQuit"
-			>
+			<v-button rounded icon :tooltip="t('save')" :loading="saving" :disabled="!hasEdits" @click="saveAndQuit">
 				<v-icon name="check" />
+
+				<template #append-outer>
+					<save-options
+						v-if="hasEdits"
+						:disabled-options="['save-as-copy']"
+						@save-and-stay="saveAndStay"
+						@save-and-add-new="saveAndAddNew"
+						@discard-and-stay="discardAndStay"
+					/>
+				</template>
 			</v-button>
 		</template>
 

--- a/app/src/modules/settings/routes/roles/item.vue
+++ b/app/src/modules/settings/routes/roles/item.vue
@@ -43,6 +43,10 @@ useShortcut('meta+s', () => {
 	if (hasEdits.value) saveAndStay();
 });
 
+useShortcut('meta+shift+s', () => {
+	if (hasEdits.value) saveAndAddNew();
+});
+
 const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
 const { createAllowed: usersCreateAllowed } = useCollectionPermissions('directus_users');

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -4,6 +4,7 @@ import { useShortcut } from '@/composables/use-shortcut';
 import { useFieldsStore } from '@/stores/fields';
 import { unexpectedError } from '@/utils/unexpected-error';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
+import SaveOptions from '@/views/private/components/save-options.vue';
 import { useApi } from '@directus/composables';
 import { Alterations, Item, Policy } from '@directus/types';
 import { cloneDeep, isEmpty, isEqual, isObjectLike } from 'lodash';
@@ -86,6 +87,10 @@ useShortcut('meta+s', () => {
 	if (hasEdits.value) saveAndStay();
 });
 
+useShortcut('meta+shift+s', () => {
+	if (hasEdits.value) saveAndAddNew();
+});
+
 onMounted(() => {
 	fetchPolicies();
 });
@@ -156,6 +161,15 @@ async function saveAndStay() {
 	}
 }
 
+async function saveAndAddNew() {
+	try {
+		await save();
+		router.push(`/settings/roles/+`);
+	} catch {
+		// `save` shows unexpected error dialog
+	}
+}
+
 async function saveAndQuit() {
 	try {
 		await save();
@@ -170,6 +184,11 @@ function discardAndLeave() {
 	edits.value = {};
 	confirmLeave.value = false;
 	router.push(leaveTo.value);
+}
+
+function discardAndStay() {
+	edits.value = {};
+	confirmLeave.value = false;
 }
 
 function isAlterations<T extends Item>(value: any): value is Alterations<T> {
@@ -189,15 +208,18 @@ function isAlterations<T extends Item>(value: any): value is Alterations<T> {
 		</template>
 
 		<template #actions>
-			<v-button
-				v-tooltip.bottom="t('save')"
-				rounded
-				icon
-				:loading="saving"
-				:disabled="hasEdits === false"
-				@click="saveAndQuit"
-			>
+			<v-button rounded icon :tooltip="t('save')" :loading="saving" :disabled="!hasEdits" @click="saveAndQuit">
 				<v-icon name="check" />
+
+				<template #append-outer>
+					<save-options
+						v-if="hasEdits"
+						:disabled-options="['save-as-copy']"
+						@save-and-stay="saveAndStay"
+						@save-and-add-new="saveAndAddNew"
+						@discard-and-stay="discardAndStay"
+					/>
+				</template>
 			</v-button>
 		</template>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -169,3 +169,4 @@
 - fapspirit
 - Khairo-kh
 - mmsardar
+- ubercj


### PR DESCRIPTION
## Scope

What's changed:

- Added the save options context menu next to the Save button on the User Role item page.
- I added the "save and stay", "discard and stay", and "save and add new" options.
- I disabled "save as copy" because it led to unexpected behavior for relational fields, i.e. if the role being copied is directly linked to any users

<img width="983" alt="Screenshot 2024-10-08 at 6 54 04 PM" src="https://github.com/user-attachments/assets/b1ef2dcb-1251-459c-8307-05df0352bb94">

## Potential Risks / Drawbacks

- None that I can tell. I replicated the existing save functions the best I could.

## Review Notes / Questions

- I only did this for the User Roles item page. I considered adding the save options to the Policy item page as well, but I figured that's better left for a separate PR.

---

Fixes #23524 
