### PR TITLE
Fix missing permission check of create dashboard button in insight module sidebar (#23527)

### DIFF
--- a/.changeset/grumpy-deers-argue.md
+++ b/.changeset/grumpy-deers-argue.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix missing permission check of create dashboard button in insight module sidebar

--- a/.changeset/grumpy-deers-argue.md
+++ b/.changeset/grumpy-deers-argue.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix missing permission check of create dashboard button in insight module sidebar
+Added condition to only show the "Create Dashboard" if the user has the correct permissions

--- a/.changeset/plenty-dogs-rule.md
+++ b/.changeset/plenty-dogs-rule.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added condition to only show the "Create Dashboard" if the user has the correct permissions

--- a/.changeset/plenty-dogs-rule.md
+++ b/.changeset/plenty-dogs-rule.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Added condition to only show the "Create Dashboard" if the user has the correct permissions

--- a/app/src/modules/insights/components/navigation.vue
+++ b/app/src/modules/insights/components/navigation.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useCollectionPermissions } from '@/composables/use-permissions';
 import { useInsightsStore } from '@/stores/insights';
 import { Dashboard } from '@/types/insights';
 import { computed } from 'vue';
@@ -8,6 +9,7 @@ defineEmits(['create']);
 
 const { t } = useI18n();
 const insightsStore = useInsightsStore();
+const { createAllowed } = useCollectionPermissions('directus_dashboards');
 
 const navItems = computed(() =>
 	insightsStore.dashboards.map((dashboard: Dashboard) => ({
@@ -21,7 +23,7 @@ const navItems = computed(() =>
 
 <template>
 	<v-list nav>
-		<v-button v-if="navItems.length === 0" full-width outlined dashed @click="$emit('create')">
+		<v-button v-if="navItems.length === 0 && createAllowed" full-width outlined dashed @click="$emit('create')">
 			{{ t('create_dashboard') }}
 		</v-button>
 


### PR DESCRIPTION
## Scope

What's changed:

- Fix missing permission check of create dashboard button in insight module sidebar

| Before | After |
|  ----  | ----  |
| ![image](https://github.com/user-attachments/assets/e8ca2e44-6221-4aad-9425-7348798a0948)  | ![image](https://github.com/user-attachments/assets/38bdbcf7-140a-45c3-9da5-43cce13d1da0) |


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #23527
