### PR TITLE
Fix tags interface whitespace should handle null case (#23577)

### DIFF
--- a/.changeset/nice-apricots-type.md
+++ b/.changeset/nice-apricots-type.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix tags interface whitespace should handle null case
+Fixed tags interface to correctly handle reset whitespace option

--- a/.changeset/nice-apricots-type.md
+++ b/.changeset/nice-apricots-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix tags interface whitespace should handle null case

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -65,7 +65,7 @@ function processArray(array: string[]): string[] {
 		if (props.capitalization === 'uppercase') val = val.toUpperCase();
 		if (props.capitalization === 'lowercase') val = val.toLowerCase();
 
-		const whitespace = props.whitespace === undefined ? ' ' : props.whitespace;
+		const whitespace = (props.whitespace === undefined || props.whitespace === null) ? ' ' : props.whitespace;
 
 		if (props.capitalization === 'auto-format') val = formatTitle(val, new RegExp(whitespace));
 

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -65,7 +65,7 @@ function processArray(array: string[]): string[] {
 		if (props.capitalization === 'uppercase') val = val.toUpperCase();
 		if (props.capitalization === 'lowercase') val = val.toLowerCase();
 
-		const whitespace = (props.whitespace === undefined || props.whitespace === null) ? ' ' : props.whitespace;
+		const whitespace = props.whitespace === undefined || props.whitespace === null ? ' ' : props.whitespace;
 
 		if (props.capitalization === 'auto-format') val = formatTitle(val, new RegExp(whitespace));
 

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -8,8 +8,8 @@ const props = withDefaults(
 		value: string[] | string | null;
 		disabled?: boolean;
 		placeholder?: string;
-		whitespace?: string;
-		capitalization?: 'uppercase' | 'lowercase' | 'auto-format';
+		whitespace?: string | null;
+		capitalization?: string | null;
 		alphabetize?: boolean;
 		iconLeft?: string;
 		iconRight?: string;


### PR DESCRIPTION
## Scope
Select dropdown deselect will set null value
When tags interface whitespace deselect will be set null, it let whitespace to null value.

What's changed:

- Fix tags interface whitespace should handle null case

#### Reproduce:

| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/4a10c958-c7c8-46c5-8cbd-fbaba0ad4b90"> | <video src="https://github.com/user-attachments/assets/26e8aec3-32c1-4725-a7c6-b99c261bccc3"> |


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #23577
