### PR TITLE
Properly quoted 'none' in the CSP

### DIFF
--- a/.changeset/poor-spiders-join.md
+++ b/.changeset/poor-spiders-join.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Properly quoted 'none' in the CSP for assets

--- a/.changeset/poor-spiders-join.md
+++ b/.changeset/poor-spiders-join.md
@@ -1,5 +1,0 @@
----
-"@directus/api": patch
----
-
-Properly quoted 'none' in the CSP for assets

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -139,7 +139,7 @@ router.get(
 				{
 					useDefaults: false,
 					directives: {
-						defaultSrc: ['none'],
+						defaultSrc: [`'none'`],
 					},
 				},
 				getConfigFromEnv('ASSETS_CONTENT_SECURITY_POLICY'),


### PR DESCRIPTION
Fixes #23849 

## Scope

After upgrading to Directus v11.1.1, which uses Helmet v8 for security headers, the application returns a 500 Internal Server Error when serving assets. The issue arises from stricter CSP validations introduced in Helmet v8. Using 'none' as a directive value without proper quoting causes the following error:

ERROR: Content-Security-Policy received an invalid directive value for "default-src"

This change in Helmet's behavior is documented in [this commit](https://github.com/helmetjs/helmet/commit/7b94a6c87a2e403c64fd9c180f6424c6295df0ab), where Helmet now throws an error if CSP directive values like 'none' are not properly quoted. This results in blocked content and pages failing to load properly.

What's changed:

- Added quotes to 'none' in the assets controller

## Potential Risks / Drawbacks

- No more 500 errors on fetching assets

## Review Notes / Questions

- I would like to lorem ipsum

