### PR TITLE
Hide alias fields in the export sidebar

### DIFF
--- a/.changeset/new-bees-impress.md
+++ b/.changeset/new-bees-impress.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Hide alias fields when exporting
+Hide alias fields in the export sidebar

--- a/.changeset/new-bees-impress.md
+++ b/.changeset/new-bees-impress.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Hide alias fields when exporting

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -60,7 +60,8 @@ const exportSettings = reactive({
 	limit: props.layoutQuery?.limit ?? defaultLimit,
 	filter: props.filter,
 	search: props.search,
-	fields: props.layoutQuery?.fields ?? fields.value?.map((field) => field.field),
+	fields:
+		props.layoutQuery?.fields ?? fields.value?.filter((field) => field.type !== 'alias').map((field) => field.field),
 	sort: `${primaryKeyField.value?.field ?? ''}`,
 });
 
@@ -68,7 +69,7 @@ watch(
 	fields,
 	() => {
 		if (props.layoutQuery?.fields) return;
-		exportSettings.fields = fields.value?.map((field) => field.field);
+		exportSettings.fields = fields.value?.filter((field) => field.type !== 'alias').map((field) => field.field);
 	},
 	{ immediate: true },
 );


### PR DESCRIPTION
## Scope

What's changed:

- `alias` type fields such as presentation fields (dividers) are hidden from the export selection to prevent permissions errors from the "missing" fields.

## Potential Risks / Drawbacks

- Any other usage of `alias` fields that should not be hidden?

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

---
