### PR TITLE
Fix M2O sort field SQL generation

### DIFF
--- a/.changeset/smooth-dolphins-worry.md
+++ b/.changeset/smooth-dolphins-worry.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed SQL generation for relational sort fields with permissions

--- a/api/src/database/helpers/schema/dialects/cockroachdb.ts
+++ b/api/src/database/helpers/schema/dialects/cockroachdb.ts
@@ -48,9 +48,9 @@ export class SchemaHelperCockroachDb extends SchemaHelper {
 	override addInnerSortFieldsToGroupBy(
 		groupByFields: (string | Knex.Raw)[],
 		sortRecords: SortRecord[],
-		hasMultiRelationalSort: boolean,
+		hasRelationalSort: boolean,
 	) {
-		if (hasMultiRelationalSort) {
+		if (hasRelationalSort) {
 			/*
 			Cockroach allows aliases to be used in the GROUP BY clause and only needs columns in the GROUP BY clause that
 			are not functionally dependent on the primary key.

--- a/api/src/database/helpers/schema/dialects/mssql.ts
+++ b/api/src/database/helpers/schema/dialects/mssql.ts
@@ -39,7 +39,7 @@ export class SchemaHelperMSSQL extends SchemaHelper {
 	override addInnerSortFieldsToGroupBy(
 		groupByFields: (string | Knex.Raw)[],
 		sortRecords: SortRecord[],
-		_hasMultiRelationalSort: boolean,
+		_hasRelationalSort: boolean,
 	) {
 		/*
 		MSSQL requires all selected columns that are not aggregated over are to be present in the GROUP BY clause

--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -53,9 +53,9 @@ export class SchemaHelperMySQL extends SchemaHelper {
 	override addInnerSortFieldsToGroupBy(
 		groupByFields: (string | Knex.Raw)[],
 		sortRecords: SortRecord[],
-		hasMultiRelationalSort: boolean,
+		hasRelationalSort: boolean,
 	) {
-		if (hasMultiRelationalSort) {
+		if (hasRelationalSort) {
 			/*
 			** MySQL **
 

--- a/api/src/database/helpers/schema/dialects/oracle.ts
+++ b/api/src/database/helpers/schema/dialects/oracle.ts
@@ -60,7 +60,7 @@ export class SchemaHelperOracle extends SchemaHelper {
 	override addInnerSortFieldsToGroupBy(
 		groupByFields: (string | Knex.Raw)[],
 		sortRecords: SortRecord[],
-		_hasMultiRelationalSort: boolean,
+		_hasRelationalSort: boolean,
 	) {
 		/*
 		Oracle requires all selected columns that are not aggregated over to be present in the GROUP BY clause

--- a/api/src/database/helpers/schema/dialects/postgres.ts
+++ b/api/src/database/helpers/schema/dialects/postgres.ts
@@ -23,13 +23,13 @@ export class SchemaHelperPostgres extends SchemaHelper {
 	override addInnerSortFieldsToGroupBy(
 		groupByFields: (string | Knex.Raw)[],
 		sortRecords: SortRecord[],
-		hasMultiRelationalSort: boolean,
+		hasRelationalSort: boolean,
 	) {
-		if (hasMultiRelationalSort) {
+		if (hasRelationalSort) {
 			/*
 			Postgres only requires selected columns that are not functionally dependent on the primary key to be
 			included in the GROUP BY clause. Since the results are already grouped by the primary key, we don't need to
-			always include the sort columns in the GROUP BY but only if there is a multi relational sort involved, eg.
+			always include the sort columns in the GROUP BY but only if there is a relational sort involved, eg.
 			a sort column that comes from a related M2O relation.
 
 			> When GROUP BY is present, or any aggregate functions are present, it is not valid for the SELECT list

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -164,7 +164,7 @@ export abstract class SchemaHelper extends DatabaseHelper {
 	addInnerSortFieldsToGroupBy(
 		_groupByFields: (string | Knex.Raw)[],
 		_sortRecords: SortRecord[],
-		_hasMultiRelationalSort: boolean,
+		_hasRelationalSort: boolean,
 	): void {
 		// no-op by default
 	}

--- a/api/src/database/run-ast/lib/get-db-query.ts
+++ b/api/src/database/run-ast/lib/get-db-query.ts
@@ -250,7 +250,11 @@ export function getDBQuery(
 		// group by without influencing the result.
 
 		// This inclusion depends on the DB vendor, as such it is handled in a dialect specific helper.
-		helpers.schema.addInnerSortFieldsToGroupBy(groupByFields, innerQuerySortRecords, hasMultiRelationalSort ?? false);
+		helpers.schema.addInnerSortFieldsToGroupBy(
+			groupByFields,
+			innerQuerySortRecords,
+			(hasMultiRelationalSort || sortRecords?.some(({ column }) => column.includes('.'))) ?? false,
+		);
 
 		dbQuery.groupBy(groupByFields);
 	}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

This is a follow up of #23518. 

In #23518 I wrongly assumed `hasMultiRelationalSort` would also include M2O relations, turns out, it does not. The M2O sort columns still need to be considered, when deciding if the sort columns need to be added to the `GROUP BY` clause, since the DB can't determine if the column from a joined table is functionally dependent or not.

This is fixed by passing this information (determined by the `.` in the sort field name) down to the DB helpers and including the sort fields in more cases than previously, the way it was intended to work.

What's changed:

- If `hasMultiRelationalSort` is `false` consider if any sort column has a `.` in the field key. 

## Potential Risks / Drawbacks

- It runs slower now in some cases, but that is the necessary evil if it needs to be correct.

## Review Notes / Questions

The underlying reproduced can be tested by have a non-admin user with a policy and the following filter on the `directus_users` `read` permission

```json
{
    "_and": [
        {
            "policies": {
                "policy": {
                    "id": {
                        "_in": [
                            "$CURRENT_POLICIES"
                        ]
                    }
                }
            }
        }
    ]
}
```

and then querying `/users?fields=role,email,policies&sort=role.name`

---

Fixes #23838
