### PR TITLE
Fix existing operation keys should filter deleted operations (#18973)

### DIFF
--- a/.changeset/rude-penguins-double.md
+++ b/.changeset/rude-penguins-double.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Add filter get existing operation keys without deleted operation keys

--- a/.changeset/rude-penguins-double.md
+++ b/.changeset/rude-penguins-double.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Add filter get existing operation keys without deleted operation keys
+Ensured new operation can reuse same key as previously deleted one in current flow editing session

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -68,15 +68,6 @@ const flow = computed<FlowRaw | undefined>({
 
 const loading = ref(false);
 
-const existingOperationKeys = computed(() => {
-	return [
-		...(flow.value?.operations || [])
-			.filter((operation) => !panelsToBeDeleted.value.includes(operation.id))
-			.map((operation) => operation.key),
-		...stagedPanels.value.filter((stagedPanel) => stagedPanel.key !== undefined).map((stagedPanel) => stagedPanel.key!),
-	];
-});
-
 const editMode = ref(flow.value?.operations.length === 0 || props.operationId !== undefined);
 
 const confirmDelete = ref(false);
@@ -160,6 +151,19 @@ const currentOperation = computed(() => {
 	return panels.value.find((panel) => {
 		return panel.id === props.operationId;
 	});
+});
+
+const existingOperationKeys = computed(() => {
+	const t = [
+		...(flow.value?.operations || [])
+			.filter((operation) => !panelsToBeDeleted.value.includes(operation.id))
+			.map((operation) => operation.key),
+		...stagedPanels.value.filter((stagedPanel) => stagedPanel.key !== undefined).map((stagedPanel) => stagedPanel.key!),
+	];
+
+	console.log(t);
+
+	return t;
 });
 
 const parentPanels = computed(() => {

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -68,10 +68,14 @@ const flow = computed<FlowRaw | undefined>({
 
 const loading = ref(false);
 
-const exitingOperationKeys = computed(() => [
-	...(flow.value?.operations || []).map((operation) => operation.key),
-	...stagedPanels.value.filter((stagedPanel) => stagedPanel.key !== undefined).map((stagedPanel) => stagedPanel.key!),
-]);
+const existingOperationKeys = computed(() => {
+	return [
+		...(flow.value?.operations || [])
+			.filter((operation) => !panelsToBeDeleted.value.includes(operation.id))
+			.map((operation) => operation.key),
+		...stagedPanels.value.filter((stagedPanel) => stagedPanel.key !== undefined).map((stagedPanel) => stagedPanel.key!),
+	];
+});
 
 const editMode = ref(flow.value?.operations.length === 0 || props.operationId !== undefined);
 
@@ -705,7 +709,7 @@ function discardAndLeave() {
 
 		<router-view
 			:operation="currentOperation"
-			:existing-operation-keys="exitingOperationKeys"
+			:existing-operation-keys="existingOperationKeys"
 			:flow="flow"
 			@save="stageOperation"
 			@cancel="cancelOperation"

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -153,18 +153,12 @@ const currentOperation = computed(() => {
 	});
 });
 
-const existingOperationKeys = computed(() => {
-	const t = [
-		...(flow.value?.operations || [])
-			.filter((operation) => !panelsToBeDeleted.value.includes(operation.id))
-			.map((operation) => operation.key),
-		...stagedPanels.value.filter((stagedPanel) => stagedPanel.key !== undefined).map((stagedPanel) => stagedPanel.key!),
-	];
-
-	console.log(t);
-
-	return t;
-});
+const existingOperationKeys = computed(() => [
+	...(flow.value?.operations || [])
+		.filter((operation) => !panelsToBeDeleted.value.includes(operation.id))
+		.map((operation) => operation.key),
+	...stagedPanels.value.filter((stagedPanel) => stagedPanel.key !== undefined).map((stagedPanel) => stagedPanel.key!),
+]);
 
 const parentPanels = computed(() => {
 	const parents = panels.value.reduce<Record<string, ParentInfo>>((acc, panel) => {


### PR DESCRIPTION
## Scope
When user create a new operation which key same as local deleted, it will get validate error for key duplicated.

What's changed:

- Add filter to get existing operation keys without deleted operation keys

| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/24efb5d4-c5ae-4408-bc8d-7dbe40e7e05e"> | <video src="https://github.com/user-attachments/assets/cd51e633-11f8-469c-9af9-ffcbbcb29194"> |


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #18973
