### PR TITLE
Fix SDK relation type

### DIFF
--- a/.changeset/kind-bottles-share.md
+++ b/.changeset/kind-bottles-share.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Improved SDK relation function type

--- a/docs/reference/system/relations.md
+++ b/docs/reference/system/relations.md
@@ -146,7 +146,7 @@ import { createDirectus, rest, readRelations } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readRelations(query_object));
+const result = await client.request(readRelations());
 ```
 
 </template>
@@ -189,11 +189,7 @@ import { createDirectus, rest, readRelations } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	readRelations({
-		fields: ['*'],
-	})
-);
+const result = await client.request(readRelations());
 ```
 
 </template>
@@ -236,7 +232,7 @@ import { createDirectus, rest, readRelationByCollection } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readRelationByCollection(collection_name, query_object));
+const result = await client.request(readRelationByCollection(collection_name));
 ```
 
 </template>
@@ -279,11 +275,7 @@ import { createDirectus, rest, readRelationByCollection } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	readRelationByCollection('articles', {
-		fields: ['*'],
-	})
-);
+const result = await client.request(readRelationByCollection('articles'));
 ```
 
 </template>
@@ -319,7 +311,7 @@ import { createDirectus, rest, readRelation } from '@directus/sdk';
 
 const client = createDirectus('directus_project_url').with(rest());
 
-const result = await client.request(readRelation(collection_name, field_name, query_object));
+const result = await client.request(readRelation(collection_name, field_name));
 ```
 
 </template>
@@ -363,11 +355,7 @@ import { createDirectus, rest, readRelation } from '@directus/sdk';
 
 const client = createDirectus('https://directus.example.com').with(rest());
 
-const result = await client.request(
-	readRelation('articles', 'authors', {
-		fields: ['*'],
-	})
-);
+const result = await client.request(readRelation('articles', 'authors'));
 ```
 
 </template>

--- a/sdk/src/rest/commands/read/relations.ts
+++ b/sdk/src/rest/commands/read/relations.ts
@@ -7,7 +7,7 @@ export type ReadRelationOutput<Schema> = ApplyQueryFields<Schema, DirectusRelati
 
 /**
  * List all Relations that exist in Directus.
- * @returns An array of up to limit Relation objects. If no items are available, data will be an empty array.
+ * @returns An array of Relation objects. If no items are available, data will be an empty array.
  */
 export const readRelations =
 	<Schema>(): RestCommand<ReadRelationOutput<Schema>[], Schema> =>
@@ -17,23 +17,22 @@ export const readRelations =
 	});
 
 /**
- * List an existing Relation by primary key.
+ * List all Relations of a collection.
  * @param collection The collection
- * @returns Returns a Relation object if a valid primary key was provided.
- * @throws Will throw if collection is empty
+ * @returns Returns an array of Relation objects if a valid collection name was provided.
  */
 export const readRelationByCollection =
-	<Schema>(collection: DirectusRelation<Schema>['collection']): RestCommand<ReadRelationOutput<Schema>, Schema> =>
+	<Schema>(collection: DirectusRelation<Schema>['collection']): RestCommand<ReadRelationOutput<Schema>[], Schema> =>
 	() => ({
 		path: `/relations/${collection}`,
 		method: 'GET',
 	});
 
 /**
- * List an existing Relation by primary key.
+ * List an existing Relation by collection and field name.
  * @param collection The collection
  * @param field The field
- * @returns Returns a Relation object if a valid primary key was provided.
+ * @returns Returns a Relation object if a valid collection and field name was provided.
  * @throws Will throw if collection is empty
  * @throws Will throw if field is empty
  */

--- a/sdk/src/rest/commands/read/relations.ts
+++ b/sdk/src/rest/commands/read/relations.ts
@@ -7,7 +7,6 @@ export type ReadRelationOutput<Schema> = ApplyQueryFields<Schema, DirectusRelati
 
 /**
  * List all Relations that exist in Directus.
- * @param query The query parameters
  * @returns An array of up to limit Relation objects. If no items are available, data will be an empty array.
  */
 export const readRelations =

--- a/sdk/src/rest/commands/read/relations.ts
+++ b/sdk/src/rest/commands/read/relations.ts
@@ -1,13 +1,9 @@
 import type { DirectusRelation } from '../../../schema/relation.js';
-import type { ApplyQueryFields, Query } from '../../../types/index.js';
+import type { ApplyQueryFields } from '../../../types/index.js';
 import { throwIfEmpty } from '../../utils/index.js';
 import type { RestCommand } from '../../types.js';
 
-export type ReadRelationOutput<Schema, Item extends object = DirectusRelation<Schema>> = ApplyQueryFields<
-	Schema,
-	Item,
-	'*'
->;
+export type ReadRelationOutput<Schema> = ApplyQueryFields<Schema, DirectusRelation<Schema>, '*'>;
 
 /**
  * List all Relations that exist in Directus.
@@ -43,10 +39,10 @@ export const readRelationByCollection =
  * @throws Will throw if field is empty
  */
 export const readRelation =
-	<Schema, const TQuery extends Query<Schema, DirectusRelation<Schema>>>(
+	<Schema>(
 		collection: DirectusRelation<Schema>['collection'],
 		field: DirectusRelation<Schema>['field'],
-	): RestCommand<ReadRelationOutput<Schema, TQuery>, Schema> =>
+	): RestCommand<ReadRelationOutput<Schema>, Schema> =>
 	() => {
 		throwIfEmpty(collection, 'Collection cannot be empty');
 		throwIfEmpty(field, 'Field cannot be empty');


### PR DESCRIPTION
Fixes #23850 

## Scope

What's changed:

Removed the obsolete generic `TQuery` from the `readRelation` function. The `/relation/*` APIs do not support any form of query.

## Potential Risks / Drawbacks

- None i am aware of

## Review Notes / Questions

- I would like to lorem ipsum



