### PR TITLE
Fix docker image to allow subsequent pnpm setups again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,8 @@
 ## Build Packages
 
 FROM node:18-alpine AS builder
-WORKDIR /directus
 
 ARG TARGETPLATFORM
-
-ENV NODE_OPTIONS=--max-old-space-size=8192
-
 RUN <<EOF
   if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then
   	apk --no-cache add python3 build-base
@@ -17,13 +13,22 @@ RUN <<EOF
   fi
 EOF
 
+WORKDIR /directus
+
 COPY package.json .
 RUN corepack enable && corepack prepare
+
+# Deploy as 'node' user to match pnpm setups in production image
+# (see https://github.com/directus/directus/issues/23822)
+RUN chown node:node .
+USER node
+
+ENV NODE_OPTIONS=--max-old-space-size=8192
 
 COPY pnpm-lock.yaml .
 RUN pnpm fetch
 
-COPY . .
+COPY --chown=node:node . .
 RUN <<EOF
 	pnpm install --recursive --offline --frozen-lockfile
 	npm_config_workspace_concurrency=1 pnpm run build
@@ -49,8 +54,6 @@ USER node
 
 WORKDIR /directus
 
-EXPOSE 8055
-
 ENV \
 	DB_CLIENT="sqlite3" \
 	DB_FILENAME="/directus/database/database.sqlite" \
@@ -59,6 +62,8 @@ ENV \
 
 COPY --from=builder --chown=node:node /directus/ecosystem.config.cjs .
 COPY --from=builder --chown=node:node /directus/dist .
+
+EXPOSE 8055
 
 CMD : \
 	&& node cli.js bootstrap \


### PR DESCRIPTION
## Scope

In the latest docker image (v11.1.1), installing extensions via pnpm no longer works as intended [^1].
This is due to https://github.com/pnpm/pnpm/pull/8465, which ensures the `.modules.yaml` meta file is correctly located in the dist folder produced when running `pnpm deploy`. This fix has been incorporated into our codebase via a recent pnpm version bump.
In the `builder` stage of our docker image, we used to run `pnpm deploy` under the `root` user. In contrast, when installing and using pnpm in a production build of our docker image, pnpm runs under the `node` user.
Due to the supplied `.modules.yaml` file, this discrepancy (different pnpm store dir, due to different user) is now detected by pnpm and installation of additional packages is blocked.

To fix this issue, this PR ensures that the pnpm setup in the builder stage will match potential subsequent pnpm setups in production images by running `pnpm deploy` under the `node` user as well. Since we've pinned down the pnpm version via `package.json`, setups should be exactly the same and therefore no further problems are expected. 
This solution is preferred over less elegant ways such as deleting the `.modules.yaml` file or manual configuration of the pnpm store dir, as these could lead to unforeseeable changes & issues in the future again.

Successfully tested with [^1] ✅ 

---

Fixes #23822

[^1]: https://docs.directus.io/extensions/installing-extensions.html#installing-via-the-npm-registry