### PR TITLE
Fix WYSIWYG interface changed check for custom formats (#23869)

### DIFF
--- a/.changeset/sixty-days-argue.md
+++ b/.changeset/sixty-days-argue.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix WYSIWYG interface changed check for custom formats
+Fixed an issue where the WYSIWYG interface would reload with every keystroke if custom formats are given

--- a/.changeset/sixty-days-argue.md
+++ b/.changeset/sixty-days-argue.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix WYSIWYG interface changed check for custom formats

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -3,7 +3,7 @@ import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
 import { SettingsStorageAssetPreset } from '@directus/types';
 import Editor from '@tinymce/tinymce-vue';
-import { isEqual } from 'lodash';
+import { isEqual, map } from 'lodash';
 import { ComponentPublicInstance, computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import getEditorStyles from './get-editor-styles';
@@ -157,8 +157,12 @@ watch(
 watch(
 	() => [props.toolbar, props.font, props.customFormats, props.tinymceOverrides],
 	(newOptions, oldOptions) => {
-		if (isEqual(newOptions, oldOptions)) return;
+		const newValue = [...newOptions];
+		const oldValue = [...oldOptions];
+		newValue[2] = map(newOptions?.[2], 'title');
+		oldValue[2] = map(oldOptions?.[2], 'title');
 
+		if (isEqual(newValue, oldValue)) return;
 		editorRef.value.remove();
 		editorInitialized.value = false;
 		editorKey.value++;

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -155,14 +155,10 @@ watch(
 );
 
 watch(
-	() => [props.toolbar, props.font, props.customFormats, props.tinymceOverrides],
+	() => [props.toolbar, props.font, map(props.customFormats, 'title'), props.tinymceOverrides],
 	(newOptions, oldOptions) => {
-		const newValue = [...newOptions];
-		const oldValue = [...oldOptions];
-		newValue[2] = map(newOptions?.[2], 'title');
-		oldValue[2] = map(oldOptions?.[2], 'title');
+		if (isEqual(newOptions, oldOptions)) return;
 
-		if (isEqual(newValue, oldValue)) return;
 		editorRef.value.remove();
 		editorInitialized.value = false;
 		editorKey.value++;

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -3,7 +3,7 @@ import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
 import { SettingsStorageAssetPreset } from '@directus/types';
 import Editor from '@tinymce/tinymce-vue';
-import { isEqual, map } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 import { ComponentPublicInstance, computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import getEditorStyles from './get-editor-styles';
@@ -155,7 +155,7 @@ watch(
 );
 
 watch(
-	() => [props.toolbar, props.font, map(props.customFormats, 'title'), props.tinymceOverrides],
+	() => [props.toolbar, props.font, props.customFormats, props.tinymceOverrides],
 	(newOptions, oldOptions) => {
 		if (isEqual(newOptions, oldOptions)) return;
 
@@ -166,15 +166,12 @@ watch(
 );
 
 const editorOptions = computed(() => {
-	let styleFormats = null;
-
-	if (Array.isArray(props.customFormats) && props.customFormats.length > 0) {
-		styleFormats = props.customFormats;
-	}
+	const styleFormats =
+		Array.isArray(props.customFormats) && props.customFormats.length > 0 ? cloneDeep(props.customFormats) : null;
 
 	let toolbarString = (props.toolbar ?? [])
-		.map((t) =>
-			t
+		.map((button) =>
+			button
 				.replace(/^link$/g, 'customLink')
 				.replace(/^media$/g, 'customMedia')
 				.replace(/^code$/g, 'customCode')
@@ -222,7 +219,7 @@ const editorOptions = computed(() => {
 		directionality: props.direction,
 		paste_data_images: false,
 		setup,
-		...(props.tinymceOverrides || {}),
+		...(props.tinymceOverrides && cloneDeep(props.tinymceOverrides)),
 	};
 });
 


### PR DESCRIPTION
## Scope

It seems that when use custom formats typing will trigger custom formats data changed.
That will occur the re-init mechanism.

What's changed:

- Check customFormats change replace by title

| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/1a78a459-8c99-4179-b0c3-019e9a8773ab"> | <video src="https://github.com/user-attachments/assets/7686ae54-d4a1-4ed6-9e88-58d9a64fe2cc"> |

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23869
