### PR TITLE
Fix the pasting of numeric values including commas in the filter input

### DIFF
--- a/.changeset/young-bottles-sit.md
+++ b/.changeset/young-bottles-sit.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed pasting of multiple, comma separated numbers into the filter input

--- a/app/src/interfaces/_system/system-filter/input-component.vue
+++ b/app/src/interfaces/_system/system-filter/input-component.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
 		is: string;
 		type: string;
 		value: string | number | Record<string, unknown> | boolean | null;
+		commaAllowed?: boolean;
 		focus?: boolean;
 		choices?: Choice[];
 	}>(),
@@ -78,7 +79,13 @@ watch(
 );
 
 function isValueValid(value: any): boolean {
-	if (value === '' || typeof value !== 'string' || !inputPattern.value || new RegExp(inputPattern.value).test(value)) {
+	if (
+		value === '' ||
+		typeof value !== 'string' ||
+		(props.commaAllowed && value.includes(',')) ||
+		!inputPattern.value ||
+		new RegExp(inputPattern.value).test(value)
+	) {
 		return true;
 	}
 

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -149,6 +149,7 @@ function setValueAt(index: number, newVal: any) {
 				:value="val"
 				:focus="false"
 				:choices="choices"
+				comma-allowed
 				@input="setValueAt(index, $event)"
 			/>
 		</div>


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

The filter node input is made of a `input-group` and an `input-component`. If a value emitted from an `input-component` contains a comma and the filter accepts a list of values (`_in` or `_nin`) the values are split and multiple inputs are created.

Numeric values that contain commas did not pass the input validation in the `input-component`, and as such were not emitted to the containing `input-group` which takes care of separating the values. This was only a problem for numeric values (and uuids) since only they are validated against a regex.

What's changed:

- Added an extra flag that allows commas in values, so the value is emitted and split properly.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A
---

Fixes #23902 
