### PR TITLE
Fix type issue in `@directus/update-check`

### DIFF
--- a/.changeset/many-toys-hope.md
+++ b/.changeset/many-toys-hope.md
@@ -1,0 +1,5 @@
+---
+"@directus/update-check": patch
+---
+
+Added missing clear cache method

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -21,9 +21,10 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "tsup src/index.ts --format=esm --dts",
-		"dev": "tsup src/index.ts --format=esm --dts --watch",
-		"test": "vitest --watch=false"
+		"build": "pnpm run '/^bundle|typecheck$/'",
+		"bundle": "tsup src/index.ts --format=esm --dts",
+		"test": "vitest --watch=false",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"axios": "1.7.7",

--- a/packages/update-check/src/cache.ts
+++ b/packages/update-check/src/cache.ts
@@ -41,8 +41,12 @@ export async function getCache() {
 		},
 
 		async clear() {
-			const files = await fs.readdir(dir);
-			await Promise.all(files.map((name) => fs.unlink(path.join(dir, name))));
+			try {
+				const files = await fs.readdir(dir);
+				await Promise.all(files.map((name) => fs.unlink(path.join(dir, name))));
+			} catch {
+				// Ignore any errors
+			}
 		},
 	});
 }

--- a/packages/update-check/src/cache.ts
+++ b/packages/update-check/src/cache.ts
@@ -39,5 +39,10 @@ export async function getCache() {
 				return undefined;
 			}
 		},
+
+		async clear() {
+			const files = await fs.readdir(dir);
+			await Promise.all(files.map((name) => fs.unlink(path.join(dir, name))));
+		},
 	});
 }


### PR DESCRIPTION
## Scope

With the recent update of `axios-cache-interceptor` in #23814, the typing of `buildStorage` has changed and the `clear` method is now required. This hasn't been caught until now, because the package didn't have a typecheck.
However, the TypeDocs generation fails because of this and thus the whole docs build.

The `clear` method will probably never be used for our use-case of `axios-cache-interceptor`. Nevertheless, it has now been implemented to fix the type issue and be on the safe side.
