### PR TITLE
Ensure floating view will not scroll top after route change (#19394)

### DIFF
--- a/.changeset/curly-baboons-confess.md
+++ b/.changeset/curly-baboons-confess.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensure floating view will not scroll top after route change

--- a/app/src/modules/activity/index.ts
+++ b/app/src/modules/activity/index.ts
@@ -17,6 +17,9 @@ export default defineModule({
 				{
 					name: 'activity-item',
 					path: ':primaryKey',
+					meta: {
+						isFloatingView: true
+					},
 					components: {
 						detail: ActivityItem,
 					},

--- a/app/src/modules/activity/index.ts
+++ b/app/src/modules/activity/index.ts
@@ -18,7 +18,7 @@ export default defineModule({
 					name: 'activity-item',
 					path: ':primaryKey',
 					meta: {
-						isFloatingView: true
+						isFloatingView: true,
 					},
 					components: {
 						detail: ActivityItem,

--- a/app/src/modules/files/index.ts
+++ b/app/src/modules/files/index.ts
@@ -17,7 +17,7 @@ export default defineModule({
 					path: '+',
 					name: 'add-file',
 					meta: {
-						isFloatingView: true
+						isFloatingView: true,
 					},
 					components: {
 						addNew: AddNew,

--- a/app/src/modules/files/index.ts
+++ b/app/src/modules/files/index.ts
@@ -16,6 +16,9 @@ export default defineModule({
 				{
 					path: '+',
 					name: 'add-file',
+					meta: {
+						isFloatingView: true
+					},
 					components: {
 						addNew: AddNew,
 					},

--- a/app/src/modules/insights/index.ts
+++ b/app/src/modules/insights/index.ts
@@ -30,7 +30,7 @@ export default defineModule({
 					path: ':panelKey',
 					props: true,
 					meta: {
-						isFloatingView: true
+						isFloatingView: true,
 					},
 					components: {
 						detail: InsightsPanelConfiguration,

--- a/app/src/modules/insights/index.ts
+++ b/app/src/modules/insights/index.ts
@@ -29,6 +29,9 @@ export default defineModule({
 					name: 'panel-detail',
 					path: ':panelKey',
 					props: true,
+					meta: {
+						isFloatingView: true
+					},
 					components: {
 						detail: InsightsPanelConfiguration,
 					},

--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -69,6 +69,9 @@ export default defineModule({
 						{
 							path: '+',
 							name: 'settings-add-new',
+							meta: {
+								isFloatingView: true
+							},
 							components: {
 								add: NewCollection,
 							},
@@ -106,6 +109,9 @@ export default defineModule({
 						{
 							path: ':field',
 							name: 'settings-fields-field',
+							meta: {
+								isFloatingView: true
+							},
 							components: {
 								field: FieldDetail,
 							},
@@ -126,6 +132,9 @@ export default defineModule({
 						{
 							path: '+',
 							name: 'settings-add-new-policy',
+							meta: {
+								isFloatingView: true
+							},
 							components: {
 								add: NewPolicy,
 							},
@@ -154,6 +163,9 @@ export default defineModule({
 							name: 'settings-add-new-role',
 							components: {
 								add: NewRole,
+							},
+							meta: {
+								isFloatingView: true
 							},
 						},
 					],
@@ -234,6 +246,9 @@ export default defineModule({
 						{
 							name: 'settings-flows-operation',
 							path: ':operationId',
+							meta: {
+								isFloatingView: true
+							},
 							component: FlowOperationDetail,
 							props: true,
 						},

--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -70,7 +70,7 @@ export default defineModule({
 							path: '+',
 							name: 'settings-add-new',
 							meta: {
-								isFloatingView: true
+								isFloatingView: true,
 							},
 							components: {
 								add: NewCollection,
@@ -110,7 +110,7 @@ export default defineModule({
 							path: ':field',
 							name: 'settings-fields-field',
 							meta: {
-								isFloatingView: true
+								isFloatingView: true,
 							},
 							components: {
 								field: FieldDetail,
@@ -133,7 +133,7 @@ export default defineModule({
 							path: '+',
 							name: 'settings-add-new-policy',
 							meta: {
-								isFloatingView: true
+								isFloatingView: true,
 							},
 							components: {
 								add: NewPolicy,
@@ -165,7 +165,7 @@ export default defineModule({
 								add: NewRole,
 							},
 							meta: {
-								isFloatingView: true
+								isFloatingView: true,
 							},
 						},
 					],
@@ -247,7 +247,7 @@ export default defineModule({
 							name: 'settings-flows-operation',
 							path: ':operationId',
 							meta: {
-								isFloatingView: true
+								isFloatingView: true,
 							},
 							component: FlowOperationDetail,
 							props: true,

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -230,8 +230,10 @@ const appearance = computed(() => {
 
 provide('main-element', contentEl);
 
-router.afterEach(() => {
-	contentEl.value?.scrollTo({ top: 0 });
+router.afterEach((to, from) => {
+	if(!to.meta.isFloatingView && !from.meta.isFloatingView) {
+		contentEl.value?.scrollTo({ top: 0 });
+	}
 	fullScreen.value = false;
 });
 

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -231,9 +231,10 @@ const appearance = computed(() => {
 provide('main-element', contentEl);
 
 router.afterEach((to, from) => {
-	if(!to.meta.isFloatingView && !from.meta.isFloatingView) {
+	if (!to.meta.isFloatingView && !from.meta.isFloatingView) {
 		contentEl.value?.scrollTo({ top: 0 });
 	}
+
 	fullScreen.value = false;
 });
 


### PR DESCRIPTION
## Scope
Some route navigation render the floating component(modal, drawer) in origin view.
For user experience, not apply scroll top will be better.

What's changed:

- Add route meta isFloatingView setting for ensure floating view will not scroll top after route change


| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/b8a3448a-e7da-4e90-a74d-b1da176fe5a6"> | <video src="https://github.com/user-attachments/assets/cdd2a333-0965-4d24-9895-abe746ee7296"> |


## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- N/A

---

Fixes #19394 #23890
