### PR TITLE
Fix query time logging leaks memory for failed queries (#23183)

### DIFF
--- a/.changeset/modern-balloons-yawn.md
+++ b/.changeset/modern-balloons-yawn.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Append database query-error listener to ensure remove the query time tracing when qeury error

--- a/.changeset/modern-balloons-yawn.md
+++ b/.changeset/modern-balloons-yawn.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Append database query-error listener to ensure remove the query time tracing when qeury error
+Fixed query time logging leaking memory for failed queries

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -187,13 +187,8 @@ export function getDatabase(): Knex {
 
 			logger.trace(`[${delta ? delta.toFixed(3) : '?'}ms] ${queryInfo.sql} [${(queryInfo.bindings ?? []).join(', ')}]`);
 		})
-		.on('query-error', (error, queryInfo: QueryInfo) => {
-			const time = times.get(queryInfo.__knexUid);
-
-			if (time) times.delete(queryInfo.__knexUid);
-
-			logger.error(`Database query error occurred`);
-			logger.error(error);
+		.on('query-error', (_, queryInfo: QueryInfo) => {
+			times.delete(queryInfo.__knexUid);
 		});
 
 	return database;

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -186,6 +186,14 @@ export function getDatabase(): Knex {
 			}
 
 			logger.trace(`[${delta ? delta.toFixed(3) : '?'}ms] ${queryInfo.sql} [${(queryInfo.bindings ?? []).join(', ')}]`);
+		})
+		.on('query-error', (error, queryInfo: QueryInfo) => {
+			const time = times.get(queryInfo.__knexUid);
+
+			if (time) times.delete(queryInfo.__knexUid);
+
+			logger.error(`Database query error occurred`);
+			logger.error(error);
 		});
 
 	return database;


### PR DESCRIPTION
## Scope

What's changed:

- Append database query-error listener to ensure remove the query time tracing when qeury error
- Add logger error to print query error message


## Potential Risks / Drawbacks

- 

## Review Notes / Questions

-

---

Fixes #23183
