### PR TITLE
Fix kanban layout layoutOptions props type definition (#23737)

### DIFF
--- a/.changeset/afraid-games-double.md
+++ b/.changeset/afraid-games-double.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix kanban layout layoutOptions props type definition
+Fixed display error when selecting kanban layout for the first time

--- a/.changeset/afraid-games-double.md
+++ b/.changeset/afraid-games-double.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix kanban layout layoutOptions props type definition

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -28,7 +28,7 @@ const props = withDefaults(
 		sortField?: string | null;
 		userField?: string | null;
 		groupsSortField?: string | null;
-		layoutOptions: LayoutOptions;
+		layoutOptions: LayoutOptions | null;
 		resetPresetAndRefresh: () => Promise<void>;
 		error?: any;
 		selection: PrimaryKey[];
@@ -89,7 +89,7 @@ function saveChanges() {
 }
 
 const textFieldConfiguration = computed<Field | undefined>(() => {
-	return props.fieldsInCollection.find((field) => field.field === props.layoutOptions.textField);
+	return props.fieldsInCollection.find((field) => field.field === props.layoutOptions?.textField);
 });
 </script>
 


### PR DESCRIPTION
## Scope
When user choose kanban layout with none setting layout options in origin layout, layoutOptions props will be null.
It will lead insecure usage.

What's changed:

- Add null type to kanban layout layoutOptions props

| Before | After |
|  ----  | ----  |
|  <video src="https://github.com/user-attachments/assets/796eeac5-816b-4315-b02e-7f4bb5d0ad58"> | <video src="https://github.com/user-attachments/assets/499855bc-03b4-4250-9d66-0ff87d174d6c"> |

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23737
