### PR TITLE
Add missing permission-check on Add File Button (#23929)

### DIFF
--- a/.changeset/brown-donkeys-fix.md
+++ b/.changeset/brown-donkeys-fix.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed disabled state of the "Add File" empty state button for users without permissions

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -487,7 +487,11 @@ function useFileUpload() {
 						{{ t('no_files_copy') }}
 
 						<template #append>
-							<v-button :to="folder ? { path: `/files/folders/${folder}/+` } : { path: '/files/+' }">
+							<v-button
+								:disabled="createAllowed === false"
+								v-tooltip.bottom="createAllowed ? t('add_file') : t('not_allowed')"
+								:to="folder ? { path: `/files/folders/${folder}/+` } : { path: '/files/+' }"
+							>
 								{{ t('add_file') }}
 							</v-button>
 						</template>

--- a/contributors.yml
+++ b/contributors.yml
@@ -173,3 +173,4 @@
 - Julias0
 - anassarfraz
 - shaietz
+- osmandvc


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The missing permission check for the "Add File" Button in File Library was added, so users with no CREATE Permission can not press it


## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I followed the current approach of disabling the button like the "Upload File" Button (on the top right with the "+" sign), but maybe not showing the button at all is better for this one? Let me know if this approach is better so I can change it asap

---

Fixes #23929 


If the user has no create file permission the button is now disabled (can change to not even rendering the button if needed, let me know):
![image](https://github.com/user-attachments/assets/bccecf7c-aaf3-4068-aa5f-df7f118b0c89)
