### PR TITLE
Fix Cloudinary image preview in the File Library

### DIFF
--- a/.changeset/cold-chairs-fry.md
+++ b/.changeset/cold-chairs-fry.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed regression preventing preview Cloudinary images on File Library
+Fixed Cloudinary image preview in the File Library

--- a/.changeset/cold-chairs-fry.md
+++ b/.changeset/cold-chairs-fry.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed regression preventing preview Cloudinary images on File Library

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -168,7 +168,8 @@ export class AssetsService {
 				});
 			}
 
-			const version = file.modified_on !== undefined ? String(new Date(file.modified_on).getTime() / 1000) : undefined;
+			const version =
+				file.modified_on !== undefined ? String(Math.round(new Date(file.modified_on).getTime() / 1000)) : undefined;
 
 			const readStream = await storage.location(file.storage).read(file.filename_disk, { range, version });
 

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -124,8 +124,15 @@ export class DriverCloudinary implements Driver {
 
 		const resourceType = this.getResourceType(filepath);
 		const fullPath = this.fullPath(filepath);
-		const signature = version !== undefined ? `v${version}` : this.getParameterSignature(fullPath);
-		const url = `https://res.cloudinary.com/${this.cloudName}/${resourceType}/upload/${signature}/${fullPath}`;
+		const signature = this.getParameterSignature(fullPath);
+
+		let url = `https://res.cloudinary.com/${this.cloudName}/${resourceType}/upload/${signature}`;
+
+		if (version) {
+			url += `/v${version}`;
+		}
+
+		url += `/${fullPath}`;
 
 		const requestInit: RequestInit = { method: 'GET' };
 


### PR DESCRIPTION
## Scope
The issue is regarding the result from a division that included decimal point.
Apparently, Cloudinary does not like dots in the version so the image was not returned.
For example, the image URL was something like this:
https://res.cloudinary.com/dkld019xp/image/upload/**v1730476766.012**/364dd67d-a1a0-46e1-ab72-6b00294ff4c2.jpeg
As you can see, the string `v1730476766.012` includes a dot

After putting the version without the dot, all was working fine:
https://res.cloudinary.com/dkld019xp/image/upload/**v1730476766**/364dd67d-a1a0-46e1-ab72-6b00294ff4c2.jpeg

What's changed:

- Fixed version to be a string without any characters other than numbers

## Potential Risks / Drawbacks

- None 🤔

## Review Notes / Questions

- None 🤔

---

Fixes #23955
