### PR TITLE
add multiple sort function to o2m interface

### DIFF
--- a/app/src/interfaces/list-o2m/index.ts
+++ b/app/src/interfaces/list-o2m/index.ts
@@ -243,7 +243,7 @@ export default defineInterface({
 					options: {
 						fields: [
 							{
-								field: "field",
+								field: 'field',
 								name: '$t:sort',
 								type: 'string',
 								meta: {
@@ -252,7 +252,7 @@ export default defineInterface({
 										collectionName: collection,
 									},
 									width: 'half',
-								}
+								},
 							},
 							{
 								field: 'sortDirection',
@@ -294,8 +294,7 @@ export default defineInterface({
 					validation: null,
 					validation_message: null,
 				},
-			}
-
+			},
 		];
 	},
 	recommendedDisplays: ['related-values'],

--- a/app/src/interfaces/list-o2m/index.ts
+++ b/app/src/interfaces/list-o2m/index.ts
@@ -233,6 +233,69 @@ export default defineInterface({
 					width: 'half',
 				},
 			},
+			{
+				field: 'multipleSort',
+				name: 'Multiple Sort',
+				type: 'json',
+				meta: {
+					special: ['cast-json'],
+					interface: 'list',
+					options: {
+						fields: [
+							{
+								field: "field",
+								name: '$t:sort',
+								type: 'string',
+								meta: {
+									interface: 'system-field',
+									options: {
+										collectionName: collection,
+									},
+									width: 'half',
+								}
+							},
+							{
+								field: 'sortDirection',
+								name: '$t:sort_direction',
+								schema: {
+									default_value: '+',
+								},
+								type: 'string',
+								meta: {
+									interface: 'select-dropdown',
+									options: {
+										choices: [
+											{
+												text: '$t:sort_asc',
+												value: '+',
+											},
+											{
+												text: '$t:sort_desc',
+												value: '-',
+											},
+										],
+									},
+									width: 'half',
+								},
+							},
+						],
+					},
+					display: null,
+					display_options: null,
+					readonly: false,
+					hidden: false,
+					sort: 4,
+					width: 'full',
+					translations: null,
+					note: null,
+					conditions: null,
+					required: false,
+					group: null,
+					validation: null,
+					validation_message: null,
+				},
+			}
+
 		];
 	},
 	recommendedDisplays: ['related-values'],

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -42,6 +42,7 @@ const props = withDefaults(
 		limit?: number;
 		sort?: string;
 		sortDirection?: '+' | '-';
+		multipleSort?: { field: string; sortDirection?: '+' | '-' }[];
 	}>(),
 	{
 		value: () => [],
@@ -56,6 +57,7 @@ const props = withDefaults(
 		enableSearchFilter: false,
 		enableLink: false,
 		limit: 15,
+		multipleSort: () => [],
 	},
 );
 
@@ -123,6 +125,10 @@ const query = computed<RelationQueryMultiple>(() => {
 
 	if (search.value) {
 		q.search = search.value;
+	}
+
+	if (props.multipleSort.length > 0) {
+		q.sort = props.multipleSort.map((i) => `${i.sortDirection === '-' ? '-' : ''}${i.field}`);
 	}
 
 	if (manualSort.value) {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Add json repeater field on o2m interface. This will allow multiple sort
- The sort array is added in to the o2m query.


https://github.com/user-attachments/assets/063122dc-19be-4c5f-9205-17a028b6f038


## Potential Risks / Drawbacks

- Previous PR introduced a single sort field which could be deprecated.
- This still doesn't support sorting on related columns, unless you "edit raw value"

## Review Notes / Questions

- How do we handle the old 'sort' and 'sortDirection' fields. We could just remove the field from the config?
- Is the order of the multiple sort fields respected?
- is the field labelling ok? 
- 

---

Fixes #\<num\>
