### PR TITLE
Fix pagination for O2M and M2M interface

### DIFF
--- a/.changeset/tiny-tips-cough.md
+++ b/.changeset/tiny-tips-cough.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed regression to item count displaying after vue-i18n upgrade

--- a/app/src/composables/use-format-items-count.ts
+++ b/app/src/composables/use-format-items-count.ts
@@ -1,0 +1,8 @@
+import { formatItemsCountPaginated, type FormatItemsCountPaginatedOptions } from '@/utils/format-items-count';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+export function useFormatItemsCountPaginated(options: Omit<FormatItemsCountPaginatedOptions, 'i18n'>) {
+	const i18n = useI18n();
+	return computed(() => formatItemsCountPaginated({ ...options, i18n }));
+}

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Sort } from '@/components/v-table/types';
+import { useFormatItemsCountPaginated } from '@/composables/use-format-items-count';
 import { useRelationM2M } from '@/composables/use-relation-m2m';
 import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
 import { useRelationPermissionsM2M } from '@/composables/use-relation-permissions';
@@ -7,7 +8,6 @@ import { useFieldsStore } from '@/stores/fields';
 import { LAYOUTS } from '@/types/interfaces';
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
-import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getItemRoute } from '@/utils/get-route';
 import { parseFilter } from '@/utils/parse-filter';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
@@ -183,14 +183,12 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 
 const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
-const showingCount = computed(() =>
-	formatItemsCountPaginated({
-		currentItems: totalItemCount.value,
-		currentPage: page.value,
-		perPage: limit.value,
-		isFiltered: !!(search.value || searchFilter.value),
-	}),
-);
+const showingCount = useFormatItemsCountPaginated({
+	currentItems: totalItemCount.value,
+	currentPage: page.value,
+	perPage: limit.value,
+	isFiltered: !!(search.value || searchFilter.value),
+});
 
 const headers = ref<Array<any>>([]);
 

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Sort } from '@/components/v-table/types';
+import { useFormatItemsCountPaginated } from '@/composables/use-format-items-count';
 import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
 import { useRelationO2M } from '@/composables/use-relation-o2m';
 import { useRelationPermissionsO2M } from '@/composables/use-relation-permissions';
@@ -7,7 +8,6 @@ import { useFieldsStore } from '@/stores/fields';
 import { LAYOUTS } from '@/types/interfaces';
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
-import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getItemRoute } from '@/utils/get-route';
 import { parseFilter } from '@/utils/parse-filter';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
@@ -154,14 +154,12 @@ const { createAllowed, deleteAllowed, updateAllowed } = useRelationPermissionsO2
 
 const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
-const showingCount = computed(() =>
-	formatItemsCountPaginated({
-		currentItems: totalItemCount.value,
-		currentPage: page.value,
-		perPage: limit.value,
-		isFiltered: !!(search.value || searchFilter.value),
-	}),
-);
+const showingCount = useFormatItemsCountPaginated({
+	currentItems: totalItemCount.value,
+	currentPage: page.value,
+	perPage: limit.value,
+	isFiltered: !!(search.value || searchFilter.value),
+});
 
 const headers = ref<Array<any>>([]);
 

--- a/app/src/modules/settings/routes/marketplace/routes/registry/components/inline-filter.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/components/inline-filter.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { formatItemsCountPaginated } from '@/utils/format-items-count';
+import { useFormatItemsCountPaginated } from '@/composables/use-format-items-count';
 import { EXTENSION_TYPES } from '@directus/extensions';
 import { watchDebounced } from '@vueuse/core';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const type = defineModel<string | null>('type');
@@ -33,14 +33,12 @@ watchDebounced(
 
 const { t } = useI18n();
 
-const showingCount = computed(() =>
-	formatItemsCountPaginated({
-		currentItems: props.filterCount,
-		currentPage: props.page,
-		perPage: props.perPage,
-		isFiltered: !!search.value,
-	}),
-);
+const showingCount = useFormatItemsCountPaginated({
+	currentItems: props.filterCount,
+	currentPage: props.page,
+	perPage: props.perPage,
+	isFiltered: !!search.value,
+});
 
 const typeOptions = [
 	{


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Looks like the upgrade to vue-i18n v10 introduced a breaking change, that does not allow `useI18n` to be called from computeds, causing #23963.

What's changed:

- Create a wrapper composable that is used instead

---

Fixes #23963
