### PR TITLE
Improve Data Model page loading and unloading speed

### DIFF
--- a/.changeset/neat-dolls-complain.md
+++ b/.changeset/neat-dolls-complain.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Improved the loading and unloading speed of the data model pages

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -8,7 +8,7 @@ import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import formatTitle from '@directus/format-title';
 import { DeepPartial, Field, FieldRaw, Relation } from '@directus/types';
-import { isEqual, isNil, merge, omit, orderBy } from 'lodash';
+import { isEmpty, isEqual, isNil, merge, omit, orderBy } from 'lodash';
 import { nanoid } from 'nanoid';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
@@ -146,16 +146,26 @@ export const useFieldsStore = defineStore('fieldsStore', () => {
 
 	function translateFields() {
 		fields.value = fields.value.map((field) => {
+			const translations: Partial<Field> = {};
+
 			if (i18n.global.te(`fields.${field.collection}.${field.field}`)) {
-				field.name = i18n.global.t(`fields.${field.collection}.${field.field}`);
+				translations.name = i18n.global.t(`fields.${field.collection}.${field.field}`);
 			}
 
-			if (field.meta?.note) field.meta.note = translateLiteral(field.meta.note);
-			if (field.meta?.options) field.meta.options = translate(field.meta.options);
-			if (field.meta?.display_options) field.meta.display_options = translate(field.meta.display_options);
+			if (field.meta) {
+				translations.meta = {} as Field['meta'];
+			}
+
+			if (field.meta?.note) translations.meta!.note = translateLiteral(field.meta.note);
+			if (field.meta?.options) translations.meta!.options = translate(field.meta.options);
+			if (field.meta?.display_options) translations.meta!.display_options = translate(field.meta.display_options);
 
 			if (field.meta?.validation_message) {
-				field.meta.validation_message = translateLiteral(field.meta.validation_message);
+				translations.meta!.validation_message = translateLiteral(field.meta.validation_message);
+			}
+
+			if (!isEmpty(translations)) {
+				return merge({}, field, translations);
 			}
 
 			return field;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

As some might have noticed, the data model page is terribly slow to load and unload when navigating to a collection and away from it. This is due to the `translateFields` function in the fields store taking well over a 1 second to translate all fields. The reason is that field properties are re-assigned while mapping over the fields ref, which causes unnecessary component updates while iterating over the fields.

What's changed:

- Instead of reassigning the values, keep track of them separately and return a new, merged objects if there are translated properties


---

Fixes #23975 