### PR TITLE
Fix permission checking request URL for primary keys with `/`

### DIFF
--- a/.changeset/spotty-mirrors-exist.md
+++ b/.changeset/spotty-mirrors-exist.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed /permissions/me request if primary key contains a /

--- a/app/src/composables/use-permissions/item/utils/fetch-item-permissions.ts
+++ b/app/src/composables/use-permissions/item/utils/fetch-item-permissions.ts
@@ -29,7 +29,9 @@ export const fetchItemPermissions = (collection: Collection, primaryKey: Primary
 
 			try {
 				const response = await api.get<{ data: ItemPermissions }>(
-					`/permissions/me/${unref(collection)}${primaryKeyValue !== null ? `/${primaryKeyValue}` : ''}`,
+					`/permissions/me/${unref(collection)}${
+						primaryKeyValue !== null ? `/${encodeURIComponent(primaryKeyValue)}` : ''
+					}`,
 				);
 
 				return response.data.data;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

If the primary key contains a slash it needs to be URL encoded in order to be correctly inserted in the URL and recognized by the route handler. This already happens for "normal" item requests and needed to be added when calling `/permissions/me/:collection/:pk`

What's changed:

- Add `encodeURIComponent`

---

Fixes #23986 
