### PR TITLE
Aspect ratio for "circle" class

### DIFF
--- a/app/src/displays/image/image.vue
+++ b/app/src/displays/image/image.vue
@@ -44,6 +44,7 @@ img {
 
 	&.circle {
 		border-radius: 100%;
+		aspect-ratio: 1;
 	}
 }
 </style>

--- a/contributors.yml
+++ b/contributors.yml
@@ -176,3 +176,4 @@
 - bartoszpijet
 - osmandvc
 - ztickm
+- gavalierm


### PR DESCRIPTION
Circle is needs to have 1:1 aspect ratio to be "circle" not "oval" for non-symetric imagess

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Circle is needs to have 1:1 aspect ratio to be "circle" not "oval" for non-symetric imagess

## Potential Risks / Drawbacks

- nothing

## Review Notes / Questions

---

Fixes #\<num\>
