### PR TITLE
App / M2O: Add option to navigate to related item

### DIFF
--- a/.changeset/itchy-bulldogs-tan.md
+++ b/.changeset/itchy-bulldogs-tan.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added "Item Link" option to M2O interface

--- a/app/src/interfaces/select-dropdown-m2o/index.ts
+++ b/app/src/interfaces/select-dropdown-m2o/index.ts
@@ -65,6 +65,20 @@ export default defineInterface({
 					},
 				},
 			},
+			{
+				field: 'enableLink',
+				name: '$t:item_link',
+				schema: {
+					default_value: false,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:show_link_to_item',
+					},
+					width: 'half',
+				},
+			},
 		];
 	},
 	recommendedDisplays: ['related-values'],

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -13,6 +13,7 @@ import { get } from 'lodash';
 import { render } from 'micromustache';
 import { computed, inject, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { getItemRoute } from '@/utils/get-route';
 
 const props = withDefaults(
 	defineProps<{
@@ -26,6 +27,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		loading?: boolean;
+		enableLink?: boolean;
 	}>(),
 	{
 		value: null,
@@ -35,6 +37,7 @@ const props = withDefaults(
 		filter: null,
 		enableCreate: true,
 		enableSelect: true,
+		enableLink: false,
 	},
 );
 
@@ -158,6 +161,11 @@ function onSelection(selection: (number | string)[] | null) {
 
 	selectModalActive.value = false;
 }
+
+const itemLink = computed(() => {
+	if (!collection.value || !currentPrimaryKey.value) return '';
+	return getItemRoute(collection.value, currentPrimaryKey.value);
+});
 </script>
 
 <template>
@@ -194,7 +202,10 @@ function onSelection(selection: (number | string)[] | null) {
 
 			<template #append>
 				<template v-if="displayItem">
-					<v-icon v-tooltip="t('edit')" name="open_in_new" class="edit" @click="editModalActive = true" />
+					<router-link v-if="enableLink" v-tooltip="t('navigate_to_item')" :to="itemLink" class="item-link">
+						<v-icon name="launch" />
+					</router-link>
+					<v-icon v-tooltip="t('edit')" name="edit" class="edit" @click="editModalActive = true" />
 					<v-icon
 						v-if="!disabled"
 						v-tooltip="t('deselect')"
@@ -271,6 +282,21 @@ function onSelection(selection: (number | string)[] | null) {
 
 	&:hover {
 		--v-icon-color: var(--theme--form--field--input--foreground);
+	}
+}
+
+.item-link {
+	--v-icon-color: var(--theme--form--field--input--foreground-subdued);
+	transition: color var(--fast) var(--transition);
+	margin: 0 4px;
+
+	&:hover {
+		--v-icon-color: var(--theme--primary);
+	}
+
+	&.disabled {
+		opacity: 0;
+		pointer-events: none;
 	}
 }
 

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -286,17 +286,10 @@ const itemLink = computed(() => {
 }
 
 .item-link {
-	--v-icon-color: var(--theme--form--field--input--foreground-subdued);
-	transition: color var(--fast) var(--transition);
 	margin: 0 4px;
 
 	&:hover {
 		--v-icon-color: var(--theme--primary);
-	}
-
-	&.disabled {
-		opacity: 0;
-		pointer-events: none;
 	}
 }
 

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -205,7 +205,13 @@ const itemLink = computed(() => {
 					<router-link v-if="enableLink" v-slot="{ navigate }" v-tooltip="t('navigate_to_item')" :to="itemLink" custom>
 						<v-icon name="launch" class="item-link" @click.stop="navigate" />
 					</router-link>
-					<v-icon v-tooltip="t('edit')" name="edit" class="edit" @click="editModalActive = true" />
+					<v-icon
+						v-if="!(disabled && enableLink)"
+						v-tooltip="t('edit')"
+						name="edit"
+						class="edit"
+						@click="editModalActive = true"
+					/>
 					<v-icon
 						v-if="!disabled"
 						v-tooltip="t('deselect')"

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -162,10 +162,10 @@ function onSelection(selection: (number | string)[] | null) {
 	selectModalActive.value = false;
 }
 
-const itemLink = computed(() => {
+function getLinkForItem() {
 	if (!collection.value || !currentPrimaryKey.value || !relationInfo.value) return '';
 	return getItemRoute(relationInfo.value.relatedCollection.collection, currentPrimaryKey.value);
-});
+}
 </script>
 
 <template>
@@ -202,16 +202,16 @@ const itemLink = computed(() => {
 
 			<template #append>
 				<template v-if="displayItem">
-					<router-link v-if="enableLink" v-slot="{ navigate }" v-tooltip="t('navigate_to_item')" :to="itemLink" custom>
-						<v-icon name="launch" class="item-link" @click.stop="navigate" />
+					<router-link
+						v-if="enableLink"
+						v-tooltip="t('navigate_to_item')"
+						@click.stop
+						:to="getLinkForItem()"
+						class="item-link"
+					>
+						<v-icon name="launch" />
 					</router-link>
-					<v-icon
-						v-if="!(disabled && enableLink)"
-						v-tooltip="t('edit')"
-						name="edit"
-						class="edit"
-						@click="editModalActive = true"
-					/>
+					<v-icon v-if="!disabled" v-tooltip="t('edit')" name="edit" class="edit" @click="editModalActive = true" />
 					<v-icon
 						v-if="!disabled"
 						v-tooltip="t('deselect')"
@@ -260,6 +260,7 @@ const itemLink = computed(() => {
 
 	:deep(.v-input .append) {
 		display: flex;
+		gap: 4px;
 	}
 }
 
@@ -283,24 +284,17 @@ const itemLink = computed(() => {
 	}
 }
 
-.edit {
-	margin-right: 4px;
-
-	&:hover {
-		--v-icon-color: var(--theme--form--field--input--foreground);
-	}
-}
-
-.item-link {
-	margin: 0 4px;
-
+.item-link,
+.add {
 	&:hover {
 		--v-icon-color: var(--theme--primary);
 	}
 }
 
-.add:hover {
-	--v-icon-color: var(--theme--primary);
+.edit {
+	&:hover {
+		--v-icon-color: var(--theme--form--field--input--foreground);
+	}
 }
 
 .deselect:hover {

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -202,8 +202,8 @@ const itemLink = computed(() => {
 
 			<template #append>
 				<template v-if="displayItem">
-					<router-link v-if="enableLink" v-tooltip="t('navigate_to_item')" :to="itemLink" class="item-link">
-						<v-icon name="launch" />
+					<router-link v-if="enableLink" v-slot="{ navigate }" v-tooltip="t('navigate_to_item')" :to="itemLink" custom>
+						<v-icon name="launch" class="item-link" @click.stop="navigate" />
 					</router-link>
 					<v-icon v-tooltip="t('edit')" name="edit" class="edit" @click="editModalActive = true" />
 					<v-icon

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -163,8 +163,8 @@ function onSelection(selection: (number | string)[] | null) {
 }
 
 const itemLink = computed(() => {
-	if (!collection.value || !currentPrimaryKey.value) return '';
-	return getItemRoute(collection.value, currentPrimaryKey.value);
+	if (!collection.value || !currentPrimaryKey.value || !relationInfo.value) return '';
+	return getItemRoute(relationInfo.value.relatedCollection.collection, currentPrimaryKey.value);
 });
 </script>
 


### PR DESCRIPTION
## Scope
Similarly to List O2M and List M2O, in this PR we include an option to show a link to the related item.
[In the original PR that have included the option to link to a related item for List O2M and List M2O](https://github.com/directus/directus/pull/12820#issuecomment-1107646913), it was mentioned that the same option could be implemented for M2O interface.
Since we felt the need to have it, we have implemented this since others may want this too.

Fixes WEB-370

What's changed:

- Add link to item for M2O interfaces

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- The "external link" icon was changed by the "pencil" icon for the drawer edits and the "external link" icon is now used to navigate to item

## Preview
|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/23f053a0-dab1-408b-a0be-159ddee6d8b5"></video> | <video src="https://github.com/user-attachments/assets/2fa8943e-cac3-4bf4-84e2-cd35ed123862"></video> |
