### PR TITLE
Fix enforcing `chunkSize` when TUS is not enabled and update the default `TUS_CHUNK_SIZE` to `8mb`

### DIFF
--- a/.changeset/cyan-sloths-appear.md
+++ b/.changeset/cyan-sloths-appear.md
@@ -3,7 +3,11 @@
 '@directus/storage-driver-supabase': patch
 '@directus/storage-driver-azure': patch
 '@directus/storage-driver-gcs': patch
+'@directus/constants': patch
+'@directus/env': major
+'docs': patch
 '@directus/api': patch
+'@directus/app': patch
 ---
 
 Fixed enforcing `chunkSize` when TUS is not enabled

--- a/.changeset/cyan-sloths-appear.md
+++ b/.changeset/cyan-sloths-appear.md
@@ -6,4 +6,4 @@
 '@directus/api': patch
 ---
 
-Fixed enforcing `chunkSize` when tus is not enabled
+Fixed enforcing `chunkSize` when TUS is not enabled

--- a/.changeset/cyan-sloths-appear.md
+++ b/.changeset/cyan-sloths-appear.md
@@ -10,4 +10,4 @@
 '@directus/app': patch
 ---
 
-Fixed enforcing `chunkSize` when TUS is not enabled
+Fixed enforcing `chunkSize` when TUS is not enabled and updated the default `TUS_CHUNK_SIZE` to `8mb`

--- a/.changeset/cyan-sloths-appear.md
+++ b/.changeset/cyan-sloths-appear.md
@@ -1,0 +1,9 @@
+---
+'@directus/storage-driver-cloudinary': patch
+'@directus/storage-driver-supabase': patch
+'@directus/storage-driver-azure': patch
+'@directus/storage-driver-gcs': patch
+'@directus/api': patch
+---
+
+Fixed enforcing `chunkSize` when tus is not enabled

--- a/api/src/storage/register-locations.ts
+++ b/api/src/storage/register-locations.ts
@@ -10,6 +10,7 @@ export const registerLocations = async (storage: StorageManager) => {
 	const locations = toArray(env['STORAGE_LOCATIONS'] as string);
 
 	const tus = {
+		enabled: RESUMABLE_UPLOADS.ENABLED,
 		chunkSize: RESUMABLE_UPLOADS.CHUNK_SIZE,
 	};
 

--- a/app/src/utils/upload-file.ts
+++ b/app/src/utils/upload-file.ts
@@ -1,14 +1,15 @@
 import api from '@/api';
-import type { File } from '@directus/types';
 import { emitter, Events } from '@/events';
 import { i18n } from '@/lang';
 import { useServerStore } from '@/stores/server';
-import { notify } from '@/utils/notify';
 import { getRootPath } from '@/utils/get-root-path';
+import { notify } from '@/utils/notify';
+import { DEFAULT_CHUNK_SIZE } from '@directus/constants';
+import type { File } from '@directus/types';
 import type { AxiosProgressEvent } from 'axios';
-import { unexpectedError } from './unexpected-error';
 import type { PreviousUpload } from 'tus-js-client';
 import { Upload } from 'tus-js-client';
+import { unexpectedError } from './unexpected-error';
 
 export async function uploadFile(
 	file: globalThis.File,
@@ -39,7 +40,7 @@ export async function uploadFile(
 		return new Promise((resolve, reject) => {
 			const upload = new Upload(file, {
 				endpoint: getRootPath() + `files/tus`,
-				chunkSize: server.info.uploads?.chunkSize ?? 10_000_000,
+				chunkSize: server.info.uploads?.chunkSize ?? DEFAULT_CHUNK_SIZE,
 				metadata: fileInfo as Record<string, string>,
 				// Allow user to re-upload of the same file
 				// https://github.com/tus/tus-js-client/blob/main/docs/api.md#removefingerprintonsuccess

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -714,7 +714,7 @@ the storage driver(s) being used.
 | --------------------------- | -------------------------------------------------------------------------------- |
 | `storage-driver-gcs`        | Must be a power of 2 with a minimum of `256kb` (e.g. `256kb`, `512kb`, `1024kb`) |
 | `storage-driver-azure`      | Must not be larger than `100mb`                                                  |
-| `storage-driver-cloudinary` | Must not be lower than `5mb`                                                     |
+| `storage-driver-cloudinary` | Must not be smaller than `5mb`                                                   |
 
 :::
 

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -701,7 +701,7 @@ instability or limited bandwidth. This is implemented using the [TUS protocol](h
 | Variable                | Description                                                       | Default Value |
 | ----------------------- | ----------------------------------------------------------------- | ------------- |
 | `TUS_ENABLED`           | Whether or not to enable the chunked uploads                      | `false`       |
-| `TUS_CHUNK_SIZE`        | The size of each file chunks. For example `10mb`, `1gb`, `10kb`   | `10mb`        |
+| `TUS_CHUNK_SIZE`        | The size of each file chunks. For example `10mb`, `1gb`, `10kb`   | `8mb`         |
 | `TUS_UPLOAD_EXPIRATION` | The expiry duration for uncompleted files with no upload activity | `10m`         |
 | `TUS_CLEANUP_SCHEDULE`  | Cron schedule to clean up the expired uncompleted uploads         | `0 * * * *`   |
 

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -712,6 +712,18 @@ The `TUS_CHUNK_SIZE` for `storage-driver-gcs` must be a power of 2 with a minimu
 
 :::
 
+::: warning
+
+The `TUS_CHUNK_SIZE` for `storage-driver-azure` must not be larger than `100mb`.
+
+:::
+
+::: warning
+
+The `TUS_CHUNK_SIZE` for `storage-driver-cloudinary` must not be lower than `5mb`.
+
+:::
+
 ## Assets
 
 | Variable                                 | Description                                                                                                                         | Default Value |

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -705,22 +705,16 @@ instability or limited bandwidth. This is implemented using the [TUS protocol](h
 | `TUS_UPLOAD_EXPIRATION` | The expiry duration for uncompleted files with no upload activity | `10m`         |
 | `TUS_CLEANUP_SCHEDULE`  | Cron schedule to clean up the expired uncompleted uploads         | `0 * * * *`   |
 
-::: warning
+::: warning Chunked Upload Restrictions
 
-The `TUS_CHUNK_SIZE` for `storage-driver-gcs` must be a power of 2 with a minimum of `256kb` (e.g. `256kb`, `512kb`,
-`1024kb`).
+Some storage drivers have specific chunk size restrictions. The `TUS_CHUNK_SIZE` must meet the relevant restrictions for
+the storage driver(s) being used.
 
-:::
-
-::: warning
-
-The `TUS_CHUNK_SIZE` for `storage-driver-azure` must not be larger than `100mb`.
-
-:::
-
-::: warning
-
-The `TUS_CHUNK_SIZE` for `storage-driver-cloudinary` must not be lower than `5mb`.
+| Storage Driver              | `TUS_CHUNK_SIZE` Restriction                                                     |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| `storage-driver-gcs`        | Must be a power of 2 with a minimum of `256kb` (e.g. `256kb`, `512kb`, `1024kb`) |
+| `storage-driver-azure`      | Must not be larger than `100mb`                                                  |
+| `storage-driver-cloudinary` | Must not be lower than `5mb`                                                     |
 
 :::
 

--- a/packages/constants/src/files.ts
+++ b/packages/constants/src/files.ts
@@ -1,1 +1,2 @@
 export const JAVASCRIPT_FILE_EXTS = ['js', 'mjs', 'cjs'] as const;
+export const DEFAULT_CHUNK_SIZE = 8_388_608; // 8mb in bytes

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -126,7 +126,7 @@ export const DEFAULTS = {
 	FILE_METADATA_ALLOW_LIST: 'ifd0.Make,ifd0.Model,exif.FNumber,exif.ExposureTime,exif.FocalLength,exif.ISOSpeedRatings',
 
 	TUS_ENABLED: false,
-	TUS_CHUNK_SIZE: '10mb',
+	TUS_CHUNK_SIZE: '8mb',
 	TUS_UPLOAD_EXPIRATION: '10m',
 	TUS_CLEANUP_SCHEDULE: '0 * * * *', // every hour
 

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CHUNK_SIZE } from '@directus/constants';
 import { resolve } from 'node:path';
 import { cwd } from 'node:process';
 
@@ -126,7 +127,7 @@ export const DEFAULTS = {
 	FILE_METADATA_ALLOW_LIST: 'ifd0.Make,ifd0.Model,exif.FNumber,exif.ExposureTime,exif.FocalLength,exif.ISOSpeedRatings',
 
 	TUS_ENABLED: false,
-	TUS_CHUNK_SIZE: '8mb',
+	TUS_CHUNK_SIZE: DEFAULT_CHUNK_SIZE, // 8mb
 	TUS_UPLOAD_EXPIRATION: '10m',
 	TUS_CLEANUP_SCHEDULE: '0 * * * *', // every hour
 

--- a/packages/storage-driver-azure/src/index.ts
+++ b/packages/storage-driver-azure/src/index.ts
@@ -15,7 +15,7 @@ export type DriverAzureConfig = {
 	endpoint?: string;
 	tus?: {
 		enabled: boolean;
-		chunkSize: number;
+		chunkSize?: number;
 	};
 };
 

--- a/packages/storage-driver-azure/src/index.ts
+++ b/packages/storage-driver-azure/src/index.ts
@@ -14,7 +14,8 @@ export type DriverAzureConfig = {
 	root?: string;
 	endpoint?: string;
 	tus?: {
-		chunkSize?: number;
+		enabled: boolean;
+		chunkSize: number;
 	};
 };
 
@@ -35,7 +36,7 @@ export class DriverAzure implements TusDriver {
 		this.root = config.root ? normalizePath(config.root, { removeLeading: true }) : '';
 
 		// https://learn.microsoft.com/en-us/rest/api/storageservices/append-block?tabs=microsoft-entra-id#remarks
-		if (config.tus?.chunkSize && config.tus.chunkSize > MAXIMUM_CHUNK_SIZE) {
+		if (config.tus?.enabled && config.tus.chunkSize && config.tus.chunkSize > MAXIMUM_CHUNK_SIZE) {
 			throw new Error('Invalid chunkSize provided');
 		}
 	}

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -17,7 +17,7 @@ export type DriverCloudinaryConfig = {
 	accessMode: 'public' | 'authenticated';
 	tus?: {
 		enabled: boolean;
-		chunkSize: number;
+		chunkSize?: number;
 	};
 };
 

--- a/packages/storage-driver-cloudinary/src/index.ts
+++ b/packages/storage-driver-cloudinary/src/index.ts
@@ -16,7 +16,8 @@ export type DriverCloudinaryConfig = {
 	apiSecret: string;
 	accessMode: 'public' | 'authenticated';
 	tus?: {
-		chunkSize?: number;
+		enabled: boolean;
+		chunkSize: number;
 	};
 };
 
@@ -35,7 +36,7 @@ export class DriverCloudinary implements TusDriver {
 		this.accessMode = config.accessMode;
 
 		// must be at least 5mb
-		if (config.tus?.chunkSize && config.tus?.chunkSize < MINIMUM_CHUNK_SIZE) {
+		if (config.tus?.enabled && config.tus.chunkSize && config.tus?.chunkSize < MINIMUM_CHUNK_SIZE) {
 			throw new Error('Invalid chunkSize provided');
 		}
 	}

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -26,6 +26,7 @@
 		"test": "vitest --watch=false"
 	},
 	"dependencies": {
+		"@directus/constants": "workspace:*",
 		"@directus/storage": "workspace:*",
 		"@directus/utils": "workspace:*",
 		"@google-cloud/storage": "7.13.0"

--- a/packages/storage-driver-gcs/src/index.ts
+++ b/packages/storage-driver-gcs/src/index.ts
@@ -14,7 +14,8 @@ export type DriverGCSConfig = {
 	bucket: string;
 	apiEndpoint?: string;
 	tus?: {
-		chunkSize?: number;
+		enabled: boolean;
+		chunkSize: number;
 	};
 };
 
@@ -33,20 +34,12 @@ export class DriverGCS implements TusDriver {
 		const storage = new Storage(storageOptions);
 		this.bucket = storage.bucket(bucket);
 
-		this.preferredChunkSize = this.getPreferredChunkSize(tus);
-	}
-
-	private getPreferredChunkSize(tus?: { chunkSize?: number }) {
-		if (!tus?.chunkSize) {
-			return DEFAULT_CHUNK_SIZE;
-		}
+		this.preferredChunkSize = tus?.chunkSize || DEFAULT_CHUNK_SIZE;
 
 		// chunkSize must be powers of 2 starting at 256kb
-		if (tus.chunkSize < MINIMUM_CHUNK_SIZE || Math.log2(tus.chunkSize) % 1 !== 0) {
+		if (tus?.enabled && (tus.chunkSize < MINIMUM_CHUNK_SIZE || Math.log2(tus.chunkSize) % 1 !== 0)) {
 			throw new Error('Invalid chunkSize provided');
 		}
-
-		return tus.chunkSize;
 	}
 
 	private fullPath(filepath: string) {

--- a/packages/storage-driver-gcs/src/index.ts
+++ b/packages/storage-driver-gcs/src/index.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CHUNK_SIZE } from '@directus/constants';
 import type { ChunkedUploadContext, ReadOptions, TusDriver } from '@directus/storage';
 import { normalizePath } from '@directus/utils';
 import type { Bucket, CreateReadStreamOptions, GetFilesOptions } from '@google-cloud/storage';
@@ -6,7 +7,6 @@ import { join } from 'node:path';
 import { type Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
-const DEFAULT_CHUNK_SIZE = 8_388_608; // 8mb in bytes
 const MINIMUM_CHUNK_SIZE = 262_144; // 256kb in bytes
 
 export type DriverGCSConfig = {

--- a/packages/storage-driver-gcs/src/index.ts
+++ b/packages/storage-driver-gcs/src/index.ts
@@ -15,7 +15,7 @@ export type DriverGCSConfig = {
 	apiEndpoint?: string;
 	tus?: {
 		enabled: boolean;
-		chunkSize: number;
+		chunkSize?: number;
 	};
 };
 
@@ -37,7 +37,10 @@ export class DriverGCS implements TusDriver {
 		this.preferredChunkSize = tus?.chunkSize || DEFAULT_CHUNK_SIZE;
 
 		// chunkSize must be powers of 2 starting at 256kb
-		if (tus?.enabled && (tus.chunkSize < MINIMUM_CHUNK_SIZE || Math.log2(tus.chunkSize) % 1 !== 0)) {
+		if (
+			tus?.enabled &&
+			(this.preferredChunkSize < MINIMUM_CHUNK_SIZE || Math.log2(this.preferredChunkSize) % 1 !== 0)
+		) {
 			throw new Error('Invalid chunkSize provided');
 		}
 	}

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -26,6 +26,7 @@
 		"test": "vitest --watch=false"
 	},
 	"dependencies": {
+		"@directus/constants": "workspace:*",
 		"@directus/storage": "workspace:*",
 		"@directus/utils": "workspace:*",
 		"@supabase/storage-js": "2.7.1",

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -1,13 +1,12 @@
+import { DEFAULT_CHUNK_SIZE } from '@directus/constants';
 import type { ChunkedUploadContext, ReadOptions, TusDriver } from '@directus/storage';
 import { normalizePath } from '@directus/utils';
 import { StorageClient } from '@supabase/storage-js';
-import * as tus from 'tus-js-client';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
+import * as tus from 'tus-js-client';
 import type { RequestInit } from 'undici';
 import { fetch } from 'undici';
-
-const DEFAULT_CHUNK_SIZE = 10_000_000;
 
 export type DriverSupabaseConfig = {
 	bucket: string;

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -18,7 +18,7 @@ export type DriverSupabaseConfig = {
 	root?: string;
 	tus?: {
 		enabled: boolean;
-		chunkSize: number;
+		chunkSize?: number;
 	};
 };
 

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -17,7 +17,8 @@ export type DriverSupabaseConfig = {
 	endpoint?: string;
 	root?: string;
 	tus?: {
-		chunkSize?: number;
+		enabled: boolean;
+		chunkSize: number;
 	};
 };
 

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -17,7 +17,6 @@ export type DriverSupabaseConfig = {
 	endpoint?: string;
 	root?: string;
 	tus?: {
-		enabled: boolean;
 		chunkSize?: number;
 	};
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1662,6 +1662,9 @@ importers:
 
   packages/storage-driver-gcs:
     dependencies:
+      '@directus/constants':
+        specifier: workspace:*
+        version: link:../constants
       '@directus/storage':
         specifier: workspace:*
         version: link:../storage
@@ -1764,6 +1767,9 @@ importers:
 
   packages/storage-driver-supabase:
     dependencies:
+      '@directus/constants':
+        specifier: workspace:*
+        version: link:../constants
       '@directus/storage':
         specifier: workspace:*
         version: link:../storage


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We no longer incorrectly enforce chunkSize if TUS is not enabled
- Updated the default chunkSize to `8mb`

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #24001
