### PR TITLE
Allow the login timeout for OpenID SSO login to be adjusted

### DIFF
--- a/.changeset/violet-drinks-jump.md
+++ b/.changeset/violet-drinks-jump.md
@@ -1,0 +1,6 @@
+---
+"@directus/api": patch
+"docs": patch
+---
+
+Allow the login timeout for OpenID SSO login to be adjusted

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -352,7 +352,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 			}
 
 			const token = jwt.sign({ verifier: codeVerifier, redirect, prompt }, getSecret(), {
-				expiresIn: '5m',
+				expiresIn: (env[`AUTH_${providerName.toUpperCase()}_LOGIN_TIMEOUT`] ?? '5m') as string,
 				issuer: 'directus',
 			});
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -176,3 +176,4 @@
 - bartoszpijet
 - osmandvc
 - ztickm
+- g-pichler

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -831,6 +831,7 @@ OpenID is an authentication protocol built on OAuth 2.0, and should be preferred
 | `AUTH_<PROVIDER>_LABEL`                     | Text to be presented on SSO button within App.                                                            | `<PROVIDER>`           |
 | `AUTH_<PROVIDER>_PARAMS`                    | Custom query parameters applied to the authorization URL.                                                 | --                     |
 | `AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST`       | A comma-separated list of external URLs (including paths) allowed for redirecting after successful login. | --                     |
+| `AUTH_<PROVIDER>_LOGIN_TIMEOUT`             | Time-Out for successful login in SSO.		     	  	      		  		   	  | `5m`                   |
 
 <sup>[1]</sup> When authenticating, Directus will match the identifier value from the external user profile to a
 Directus users "External Identifier".

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -831,7 +831,7 @@ OpenID is an authentication protocol built on OAuth 2.0, and should be preferred
 | `AUTH_<PROVIDER>_LABEL`                     | Text to be presented on SSO button within App.                                                            | `<PROVIDER>`           |
 | `AUTH_<PROVIDER>_PARAMS`                    | Custom query parameters applied to the authorization URL.                                                 | --                     |
 | `AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST`       | A comma-separated list of external URLs (including paths) allowed for redirecting after successful login. | --                     |
-| `AUTH_<PROVIDER>_LOGIN_TIMEOUT`             | Time-Out for successful login in SSO.		     	  	      		  		   	  | `5m`                   |
+| `AUTH_<PROVIDER>_LOGIN_TIMEOUT`             | Time-Out for successful login in SSO.                                                                     | `5m`                   |
 
 <sup>[1]</sup> When authenticating, Directus will match the identifier value from the external user profile to a
 Directus users "External Identifier".


### PR DESCRIPTION

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope
When logging in using OpenID, there is currently a hard-coded 5m timeout in place that, if exceeded, leads to a "INVALID_CREDENTIALS" error page. This is due to the expration of the JWT Token in the `openid.<provider>` cookie.

In general, 5m seems like a good default, however in some circumstances this might not be applicable: When a login flow, e.g., involves the delivery of a login token by email or other 2FA mechanisms, this 5m timeout can easily be exceeded.

AFAIK, there is currently no way of increasing this timeout. This PR allows for it to be set in the per-provider configuration. It retains the `5m` default for backward compatibility.

## What's changed:

- Changed `5m` default to be read from the environment.
- Added documentation for the `AUTH_<PROVIDER>_LOGIN_TIMEOUT` setting.

## Potential Risks / Drawbacks

- I cannot see any, as the default behaviour is unaffected.


## Review Notes / Questions

TBD

