### PR TITLE
Convert item field in `validateItemAccess` to boolean

### DIFF
--- a/.changeset/proud-deers-kneel.md
+++ b/.changeset/proud-deers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue in the item access validation that caused problems with CockroachDB

--- a/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
+++ b/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
@@ -1,4 +1,5 @@
 import type { Accountability, PermissionsAction, PrimaryKey } from '@directus/types';
+import { toBoolean } from '@directus/utils';
 import { fetchPermittedAstRootFields } from '../../../../database/run-ast/modules/fetch-permitted-ast-root-fields.js';
 import type { AST } from '../../../../types/index.js';
 import type { Context } from '../../../types.js';
@@ -51,7 +52,7 @@ export async function validateItemAccess(options: ValidateItemAccessOptions, con
 		const { fields } = options;
 
 		if (fields) {
-			return items.every((item: any) => fields.every((field) => item[field] === 1));
+			return items.every((item: any) => fields.every((field) => toBoolean(item[field])));
 		}
 
 		return true;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

This is an issue I've only been able to identify in CockroachDB. The constant value of `1` is returned as a string value. Since we are comparing with `=== 1` this incorrectly fails access validation.

What's changed:

- Convert value to boolean before checking

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- This will fix it also for other DBs where the issue might not have been identified yet.
---

Fixes #24011 
