### PR TITLE
Fix reactivity of `useFormatItemsCountPaginated`

### DIFF
--- a/.changeset/stupid-timers-heal.md
+++ b/.changeset/stupid-timers-heal.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed broken reactivity in format item count composable

--- a/app/src/composables/use-format-items-count.ts
+++ b/app/src/composables/use-format-items-count.ts
@@ -3,10 +3,11 @@ import { mapValues } from 'lodash';
 import { computed, type ToRefs, unref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export function useFormatItemsCountPaginated(options: ToRefs<Omit<FormatItemsCountPaginatedOptions, 'i18n'>>) {
+type OptionsWithoutI18n = Omit<FormatItemsCountPaginatedOptions, 'i18n'>;
+
+export function useFormatItemsCountPaginated(options: ToRefs<OptionsWithoutI18n>) {
 	const i18n = useI18n();
-	return computed(() => {
-		const opts = mapValues(options, unref);
-		return formatItemsCountPaginated({ ...opts, i18n });
-	});
+	return computed(() =>
+		formatItemsCountPaginated({ ...(mapValues(options, unref) as unknown as OptionsWithoutI18n), i18n }),
+	);
 }

--- a/app/src/composables/use-format-items-count.ts
+++ b/app/src/composables/use-format-items-count.ts
@@ -5,5 +5,8 @@ import { useI18n } from 'vue-i18n';
 
 export function useFormatItemsCountPaginated(options: ToRefs<Omit<FormatItemsCountPaginatedOptions, 'i18n'>>) {
 	const i18n = useI18n();
-	return computed(() => formatItemsCountPaginated({ ...mapValues(options, unref), i18n }));
+	return computed(() => {
+		const opts = mapValues(options, unref);
+		return formatItemsCountPaginated({ ...opts, i18n });
+	});
 }

--- a/app/src/composables/use-format-items-count.ts
+++ b/app/src/composables/use-format-items-count.ts
@@ -1,8 +1,9 @@
 import { formatItemsCountPaginated, type FormatItemsCountPaginatedOptions } from '@/utils/format-items-count';
-import { computed } from 'vue';
+import { mapValues } from 'lodash';
+import { computed, type ToRefs, unref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export function useFormatItemsCountPaginated(options: Omit<FormatItemsCountPaginatedOptions, 'i18n'>) {
+export function useFormatItemsCountPaginated(options: ToRefs<Omit<FormatItemsCountPaginatedOptions, 'i18n'>>) {
 	const i18n = useI18n();
-	return computed(() => formatItemsCountPaginated({ ...options, i18n }));
+	return computed(() => formatItemsCountPaginated({ ...mapValues(options, unref), i18n }));
 }

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -184,10 +184,10 @@ const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelati
 const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
 const showingCount = useFormatItemsCountPaginated({
-	currentItems: totalItemCount.value,
-	currentPage: page.value,
-	perPage: limit.value,
-	isFiltered: !!(search.value || searchFilter.value),
+	currentItems: totalItemCount,
+	currentPage: page,
+	perPage: limit,
+	isFiltered: computed(() => !!(search.value || searchFilter.value)),
 });
 
 const headers = ref<Array<any>>([]);

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -155,10 +155,10 @@ const { createAllowed, deleteAllowed, updateAllowed } = useRelationPermissionsO2
 const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
 const showingCount = useFormatItemsCountPaginated({
-	currentItems: totalItemCount.value,
-	currentPage: page.value,
-	perPage: limit.value,
-	isFiltered: !!(search.value || searchFilter.value),
+	currentItems: totalItemCount,
+	currentPage: page,
+	perPage: limit,
+	isFiltered: computed(() => !!(search.value || searchFilter.value)),
 });
 
 const headers = ref<Array<any>>([]);

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -246,6 +246,7 @@ export default defineLayout<LayoutOptions>({
 				totalItems: totalCount.value,
 				currentItems: itemCount.value,
 				isFiltered: !!props.filterUser,
+				i18n: { t, n },
 			});
 		});
 

--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -1,6 +1,6 @@
+import { useFormatItemsCountPaginated } from '@/composables/use-format-items-count';
 import { useRelationsStore } from '@/stores/relations';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
-import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getItemRoute } from '@/utils/get-route';
 import { saveAsCSV } from '@/utils/save-as-csv';
 import { syncRefProperty } from '@/utils/sync-ref-property';
@@ -66,17 +66,19 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				filterSystem,
 			});
 
+		const formattedCount = useFormatItemsCountPaginated({
+			currentItems: itemCount,
+			currentPage: page,
+			perPage: limit,
+			isFiltered: filterUser,
+			totalItems: totalCount,
+		});
+
 		const showingCount = computed(() => {
 			// Don't show count if there are no items
 			if (!totalCount.value || !itemCount.value) return;
 
-			return formatItemsCountPaginated({
-				currentItems: itemCount.value,
-				currentPage: page.value,
-				perPage: limit.value,
-				isFiltered: !!filterUser.value,
-				totalItems: totalCount.value,
-			});
+			return formattedCount.value;
 		});
 
 		const width = ref(0);

--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -8,7 +8,7 @@ import { useCollection, useItems, useSync } from '@directus/composables';
 import { defineLayout } from '@directus/extensions';
 import { getFieldsFromTemplate } from '@directus/utils';
 import { clone } from 'lodash';
-import { computed, ref, toRefs } from 'vue';
+import { computed, Ref, ref, toRefs } from 'vue';
 import CardsActions from './actions.vue';
 import CardsLayout from './cards.vue';
 import CardsOptions from './options.vue';
@@ -67,11 +67,11 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			});
 
 		const formattedCount = useFormatItemsCountPaginated({
-			currentItems: itemCount,
+			currentItems: itemCount as Ref<number>,
 			currentPage: page,
 			perPage: limit,
-			isFiltered: filterUser,
-			totalItems: totalCount,
+			isFiltered: computed(() => !!filterUser.value),
+			totalItems: totalCount as Ref<number>,
 		});
 
 		const showingCount = computed(() => {

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -241,6 +241,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				totalItems: totalCount.value,
 				currentItems: displayedCount,
 				isFiltered: !!props.filterUser,
+				i18n: { t, n },
 			});
 		});
 

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -248,12 +248,14 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					perPage: limit.value,
 					isFiltered: !!props.filterUser,
 					totalItems: totalCount.value,
+					i18n: { t, n },
 				});
 
 			return formatItemsCountRelative({
 				totalItems: totalCount.value,
 				currentItems: itemCount.value,
 				isFiltered: !!props.filterUser,
+				i18n: { t, n },
 			});
 		});
 

--- a/app/src/modules/settings/routes/marketplace/routes/registry/components/inline-filter.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/registry/components/inline-filter.vue
@@ -2,7 +2,7 @@
 import { useFormatItemsCountPaginated } from '@/composables/use-format-items-count';
 import { EXTENSION_TYPES } from '@directus/extensions';
 import { watchDebounced } from '@vueuse/core';
-import { ref } from 'vue';
+import { ref, computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const type = defineModel<string | null>('type');
@@ -32,12 +32,13 @@ watchDebounced(
 );
 
 const { t } = useI18n();
+const { filterCount, page, perPage } = toRefs(props);
 
 const showingCount = useFormatItemsCountPaginated({
-	currentItems: props.filterCount,
-	currentPage: props.page,
-	perPage: props.perPage,
-	isFiltered: !!search.value,
+	currentItems: filterCount,
+	currentPage: page,
+	perPage: perPage,
+	isFiltered: computed(() => !!search.value),
 });
 
 const typeOptions = [

--- a/app/src/utils/format-items-count.ts
+++ b/app/src/utils/format-items-count.ts
@@ -1,4 +1,4 @@
-import { ComposerNumberFormatting, ComposerTranslation, useI18n } from 'vue-i18n';
+import { ComposerNumberFormatting, ComposerTranslation } from 'vue-i18n';
 
 export type FormatItemsCountPaginatedOptions = {
 	currentItems: number;

--- a/app/src/utils/format-items-count.ts
+++ b/app/src/utils/format-items-count.ts
@@ -6,7 +6,7 @@ export type FormatItemsCountPaginatedOptions = {
 	perPage: number;
 	isFiltered?: boolean;
 	totalItems?: number;
-	i18n?: { t: ComposerTranslation; n: ComposerNumberFormatting };
+	i18n: { t: ComposerTranslation; n: ComposerNumberFormatting };
 };
 
 export function formatItemsCountPaginated({
@@ -17,7 +17,7 @@ export function formatItemsCountPaginated({
 	totalItems,
 	i18n,
 }: FormatItemsCountPaginatedOptions) {
-	const { t, n } = i18n ? i18n : useI18n();
+	const { t, n } = i18n;
 
 	const values = {
 		start: n((currentPage - 1) * perPage + 1),
@@ -41,7 +41,7 @@ export type FormatItemsCountRelativeOptions = {
 	totalItems: number;
 	currentItems: number;
 	isFiltered?: boolean;
-	i18n?: { t: ComposerTranslation; n: ComposerNumberFormatting };
+	i18n: { t: ComposerTranslation; n: ComposerNumberFormatting };
 };
 
 export function formatItemsCountRelative({
@@ -50,7 +50,7 @@ export function formatItemsCountRelative({
 	isFiltered = false,
 	i18n,
 }: FormatItemsCountRelativeOptions) {
-	const { t, n } = i18n ? i18n : useI18n();
+	const { t, n } = i18n;
 
 	const values = {
 		count: n(currentItems),

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -20,7 +20,7 @@ type LocalNotification = Notification & {
 	to?: string;
 };
 
-const { t, n } = useI18n();
+const { t } = useI18n();
 const appStore = useAppStore();
 const userStore = useUserStore();
 const collectionsStore = useCollectionsStore();

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import api from '@/api';
 import useDatetime from '@/components/use-datetime.vue';
+import { useFormatItemsCountPaginated } from '@/composables/use-format-items-count';
 import { useCollectionsStore } from '@/stores/collections';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
-import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import SearchInput from '@/views/private/components/search-input.vue';
 import { useItems } from '@directus/composables';
@@ -103,18 +103,19 @@ const notifications = computed<LocalNotification[]>(() => {
 	});
 });
 
+const formattedCount = useFormatItemsCountPaginated({
+	currentItems: itemCount,
+	currentPage: page,
+	perPage: limit,
+	totalItems: totalCount,
+	isFiltered: computed(() => !!filter.value),
+});
+
 const showingCount = computed(() => {
 	// Don't show count if there are no items
 	if (!totalCount.value || !itemCount.value) return;
 
-	return formatItemsCountPaginated({
-		currentItems: itemCount.value,
-		currentPage: page.value,
-		perPage: limit.value,
-		isFiltered: !!filter.value,
-		totalItems: totalCount.value,
-		i18n: { t, n },
-	});
+	return formattedCount.value;
 });
 
 async function refresh() {

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -104,10 +104,10 @@ const notifications = computed<LocalNotification[]>(() => {
 });
 
 const formattedCount = useFormatItemsCountPaginated({
-	currentItems: itemCount,
+	currentItems: itemCount as Ref<number>,
 	currentPage: page,
 	perPage: limit,
-	totalItems: totalCount,
+	totalItems: totalCount as Ref<number>,
 	isFiltered: computed(() => !!filter.value),
 });
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Reactivity can be hard sometimes. Make sure that the arguments passed to the composable are actually reactive and correctly unreffed when used.

---

Fixes #24037 
