### PR TITLE
Fix content version usage with SEARCH method

### DIFF
--- a/.changeset/fresh-tables-check.md
+++ b/.changeset/fresh-tables-check.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Added content version merging to SEARCH method endpoint

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -92,7 +92,7 @@ const readHandler = asyncHandler(async (req, res, next) => {
 	return next();
 });
 
-router.search('/:collection', collectionExists, validateBatch('read'), readHandler, respond);
+router.search('/:collection', collectionExists, validateBatch('read'), readHandler, mergeContentVersions, respond);
 router.get('/:collection', collectionExists, readHandler, mergeContentVersions, respond);
 
 router.get(


### PR DESCRIPTION
Fixes #24038 

## Scope

What's changed:

- Added the mergeContentVersion middleware to the SEARCH method request handler

## Potential Risks / Drawbacks

- None i think

## Review Notes / Questions

- I would like to lorem ipsum
