### PR TITLE
Fix item permissions not respected in `drawer-item`

### DIFF
--- a/.changeset/three-ladybugs-jam.md
+++ b/.changeset/three-ladybugs-jam.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed item permissions not respected in `drawer-item`

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -152,6 +152,14 @@ const templatePrimaryKey = computed(() =>
 
 const templateCollection = computed(() => relatedCollectionInfo.value || collectionInfo.value);
 
+const isSavable = computed(() => {
+	if (props.disabled) return false;
+	if (isNew.value) return true;
+	if (updateAllowed.value && !props.junctionField) return true;
+	if (updateAllowed.value && props.junctionField && updateRelatedCollectionAllowed.value) return true;
+	return false;
+});
+
 const {
 	template,
 	templateData,
@@ -391,7 +399,7 @@ function useActions() {
 
 		<template #actions>
 			<slot name="actions" />
-			<v-button v-tooltip.bottom="t('save')" icon rounded @click="save">
+			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!isSavable" @click="save">
 				<v-icon name="check" />
 			</v-button>
 		</template>

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -102,13 +102,13 @@ const title = computed(() => {
 		: t('editing_in', { collection: collection.name });
 });
 
-const { fields: fieldsWithPermissions } = useItemPermissions(
+const { fields: fieldsWithPermissions, updateAllowed } = useItemPermissions(
 	collection,
 	primaryKey,
 	computed(() => props.primaryKey === '+'),
 );
 
-const { fields: relatedCollectionFields } = useItemPermissions(
+const { fields: relatedCollectionFields, updateAllowed: updateRelatedCollectionAllowed } = useItemPermissions(
 	relatedCollection as Ref<string>,
 	relatedPrimaryKey,
 	computed(() => props.primaryKey === '+'),
@@ -406,7 +406,7 @@ function useActions() {
 			<div v-else class="drawer-item-order" :class="{ swap: swapFormOrder }">
 				<v-form
 					v-if="junctionField"
-					:disabled="disabled"
+					:disabled="disabled || (!updateRelatedCollectionAllowed && !isNew)"
 					:loading="loading"
 					:show-no-visible-fields="false"
 					:initial-values="initialValues?.[junctionField]"
@@ -421,7 +421,7 @@ function useActions() {
 
 				<v-form
 					v-model="internalEdits"
-					:disabled="disabled"
+					:disabled="disabled || (!updateAllowed && !isNew)"
 					:loading="loading"
 					:show-no-visible-fields="false"
 					:initial-values="initialValues"


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now also consider the specific items update permissions within the drawer.

## Potential Risks / Drawbacks

- A `drawer-item` view is incorrectly disabled when it should not be, per my testing I have not found anywhere this is applicable.

## Review Notes / Questions

- Any alternative suggestions at a solution are welcome

---

Fixes #23910
Fixes #24050
Closes SER-424
