### PR TITLE
Clarify SMTP config options in docs (#24019)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -176,3 +176,4 @@
 - bartoszpijet
 - osmandvc
 - ztickm
+- trespaul

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -298,6 +298,7 @@ nitty-gritty
 no-brainer
 node[^\s]*
 NodeJS
+Nodemailer
 NoSQL
 npm
 NPM
@@ -400,6 +401,7 @@ SSL
 SSO
 SSR
 StackOverflow
+STARTTLS
 stylization
 subdirectory
 subfolder

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -1034,8 +1034,8 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 | `EMAIL_SMTP_NAME`       | SMTP client hostname | --            |
 
 For more details about these options, see the
-[SMTP configuration documentation for Nodemailer](https://nodemailer.com/smtp/#general-options),
-which Directus uses under the hood.
+[SMTP configuration documentation for Nodemailer](https://nodemailer.com/smtp/#general-options), which Directus uses
+under the hood.
 
 ### Mailgun (`mailgun`)
 

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -1029,9 +1029,13 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 | `EMAIL_SMTP_USER`       | SMTP user            | --            |
 | `EMAIL_SMTP_PASSWORD`   | SMTP password        | --            |
 | `EMAIL_SMTP_POOL`       | Use SMTP pooling     | --            |
-| `EMAIL_SMTP_SECURE`     | Enable TLS           | --            |
-| `EMAIL_SMTP_IGNORE_TLS` | Ignore TLS           | --            |
+| `EMAIL_SMTP_SECURE`     | Enable initial TLS   | --            |
+| `EMAIL_SMTP_IGNORE_TLS` | Ignore STARTTLS      | --            |
 | `EMAIL_SMTP_NAME`       | SMTP client hostname | --            |
+
+For more details about these options, see the
+[SMTP configuration documentation for Nodemailer](https://nodemailer.com/smtp/#general-options),
+which Directus uses under the hood.
 
 ### Mailgun (`mailgun`)
 


### PR DESCRIPTION
## Scope

What's changed:

- Add link to Nodemailer options docs
- Add clarification in options descriptions

## Potential Risks / Drawbacks

- Link needs to be updated if Nodemailer docs URL ever changes

## Review Notes / Questions

- Should the explanation that Directus uses Nodemailer perhaps be put directly under the `## Email` section, rather than just the `### SMTP` subsection?

---

Closes #24019
