### PR TITLE
Added the subject of the reset mail to the sdk function

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -1,8 +1,5 @@
-import { useEnv } from '@directus/env';
+import { DEFAULT_AUTH_PROVIDER, REFRESH_COOKIE_OPTIONS, SESSION_COOKIE_OPTIONS } from '../constants.js';
 import { ErrorCode, InvalidPayloadError, isDirectusError } from '@directus/errors';
-import type { Accountability } from '@directus/types';
-import type { Request } from 'express';
-import { Router } from 'express';
 import {
 	createLDAPAuthRouter,
 	createLocalAuthRouter,
@@ -10,18 +7,22 @@ import {
 	createOpenIDAuthRouter,
 	createSAMLAuthRouter,
 } from '../auth/drivers/index.js';
-import { DEFAULT_AUTH_PROVIDER, REFRESH_COOKIE_OPTIONS, SESSION_COOKIE_OPTIONS } from '../constants.js';
-import { useLogger } from '../logger/index.js';
-import { respond } from '../middleware/respond.js';
-import { createDefaultAccountability } from '../permissions/utils/create-default-accountability.js';
-import { AuthenticationService } from '../services/authentication.js';
-import { UsersService } from '../services/users.js';
+
+import type { Accountability } from '@directus/types';
 import type { AuthenticationMode } from '../types/auth.js';
+import { AuthenticationService } from '../services/authentication.js';
+import type { Request } from 'express';
+import { Router } from 'express';
+import { UsersService } from '../services/users.js';
 import asyncHandler from '../utils/async-handler.js';
+import { createDefaultAccountability } from '../permissions/utils/create-default-accountability.js';
 import { getAuthProviders } from '../utils/get-auth-providers.js';
 import { getIPFromReq } from '../utils/get-ip-from-req.js';
 import { getSecret } from '../utils/get-secret.js';
 import isDirectusJWT from '../utils/is-directus-jwt.js';
+import { respond } from '../middleware/respond.js';
+import { useEnv } from '@directus/env';
+import { useLogger } from '../logger/index.js';
 import { verifyAccessJWT } from '../utils/jwt.js';
 
 const router = Router();
@@ -209,7 +210,7 @@ router.post(
 		const service = new UsersService({ accountability, schema: req.schema });
 
 		try {
-			await service.requestPasswordReset(req.body.email, req.body.reset_url || null);
+			await service.requestPasswordReset(req.body.email, req.body.reset_url || null, req.body.subject || null);
 			return next();
 		} catch (err: any) {
 			if (isDirectusError(err, ErrorCode.InvalidPayload)) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -176,3 +176,4 @@
 - bartoszpijet
 - osmandvc
 - ztickm
+- lucameusburger

--- a/sdk/src/rest/commands/auth/password-request.ts
+++ b/sdk/src/rest/commands/auth/password-request.ts
@@ -5,13 +5,14 @@ import type { RestCommand } from '../../types.js';
  *
  * @param email Email address of the user you're requesting a password reset for.
  * @param reset_url Provide a custom reset url which the link in the email will lead to. The reset token will be passed as a parameter.
+ * @param subject Subject of the email. Defaults to "Reset Request".
  *
  * @returns Empty body.
  */
 export const passwordRequest =
-	<Schema>(email: string, reset_url?: string): RestCommand<void, Schema> =>
+	<Schema>(email: string, reset_url?: string, subject?: string): RestCommand<void, Schema> =>
 	() => ({
 		path: '/auth/password/request',
 		method: 'POST',
-		body: JSON.stringify({ email, ...(reset_url ? { reset_url } : {}) }),
+		body: JSON.stringify({ email, ...(reset_url ? { reset_url } : {}), subject }),
 	});


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

Added subject prop to passwordRequest in the js SDK to pass a subject for the email as there is no way to translate or change the subject from the SDK but there is in the API. This just passes it.

---

Fixes #\<num\>
