### PR TITLE
Remove version from `docker-compose.yml`

### DIFF
--- a/docs/self-hosted/quickstart.md
+++ b/docs/self-hosted/quickstart.md
@@ -37,7 +37,6 @@ Open a text editor such as Visual Studio Code, nano, Vim, TextEdit, or Notepad.
 Copy and paste the following and save the file as `docker-compose.yml`:
 
 ```yaml-vue
-version: "3"
 services:
   directus:
     image: directus/directus:{{ packages.directus.version.full }}


### PR DESCRIPTION
When running this for the first time, terminal said `WARN[0000] [path redacted by me]/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`