### PR TITLE
Cast versioning item key to string

### DIFF
--- a/.changeset/tame-peaches-exist.md
+++ b/.changeset/tame-peaches-exist.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that would cause content versions to throw an error when used on singleton collections

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -98,7 +98,7 @@ function useCreateDialog() {
 				key: unref(newVersionKey),
 				...(unref(newVersionName) ? { name: unref(newVersionName) } : {}),
 				collection: unref(collection),
-				item: unref(primaryKey),
+				item: String(unref(primaryKey)),
 			});
 
 			emit('add', version);


### PR DESCRIPTION
## Scope

What's changed:

- New content versions would throw an error when created from a singleton, as the API expects a string for the item key, but the app would send an integer for auto-increment primary key singletons

## Potential Risks / Drawbacks

- Tiny bug, tiny fix

## Review Notes / Questions

- None

---

Fixes #24082
