### PR TITLE
Api / Cloudinary: Use version to prevent cached assets

### DIFF
--- a/.changeset/silent-eagles-arrive.md
+++ b/.changeset/silent-eagles-arrive.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed thumbnails not being generated after edits using Cloudinary storage

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -122,8 +122,8 @@ export class AssetsService {
 		const type = file.type;
 		const transforms = transformation ? TransformationUtils.resolvePreset(transformation, file) : [];
 
-		const modified_on = file.modified_on ? new Date(file.modified_on) : undefined;
-		const version = modified_on ? (modified_on.getTime() / 1000).toFixed() : undefined;
+		const modifiedOn = file.modified_on ? new Date(file.modified_on) : undefined;
+		const version = modifiedOn ? (modifiedOn.getTime() / 1000).toFixed() : undefined;
 
 		if (type && transforms.length > 0 && SUPPORTED_IMAGE_TRANSFORM_FORMATS.includes(type)) {
 			const maybeNewFormat = TransformationUtils.maybeExtractFormat(transforms);

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -122,6 +122,9 @@ export class AssetsService {
 		const type = file.type;
 		const transforms = transformation ? TransformationUtils.resolvePreset(transformation, file) : [];
 
+		const modified_on = file.modified_on ? new Date(file.modified_on) : undefined;
+		const version = modified_on ? (modified_on.getTime() / 1000).toFixed() : undefined;
+
 		if (type && transforms.length > 0 && SUPPORTED_IMAGE_TRANSFORM_FORMATS.includes(type)) {
 			const maybeNewFormat = TransformationUtils.maybeExtractFormat(transforms);
 
@@ -168,9 +171,6 @@ export class AssetsService {
 				});
 			}
 
-			const version =
-				file.modified_on !== undefined ? String(Math.round(new Date(file.modified_on).getTime() / 1000)) : undefined;
-
 			const readStream = await storage.location(file.storage).read(file.filename_disk, { range, version });
 
 			const transformer = getSharpInstance();
@@ -205,12 +205,12 @@ export class AssetsService {
 			}
 
 			return {
-				stream: await storage.location(file.storage).read(assetFilename, { range }),
+				stream: await storage.location(file.storage).read(assetFilename, { range, version }),
 				stat: await storage.location(file.storage).stat(assetFilename),
 				file,
 			};
 		} else {
-			const readStream = await storage.location(file.storage).read(file.filename_disk, { range });
+			const readStream = await storage.location(file.storage).read(file.filename_disk, { range, version });
 			const stat = await storage.location(file.storage).stat(file.filename_disk);
 			return { stream: readStream, file, stat };
 		}


### PR DESCRIPTION
## Scope
There's times that when an asset is edited, the respective thumbnails are not regenerated.
It seems to be related with cache, so we just ask fresh assets from Cloudinary by passing `version` with the last modified date.
This ensures fresh assets are always requested.

Here's an example:


https://github.com/user-attachments/assets/8b9182d3-4056-4ce4-9d27-4396f5b119aa





What's changed:

- Fixed thumbnails not being generated after edit for Cloudinary storage

## Potential Risks / Drawbacks

- None 🤔

## Review Notes / Questions

- At the moment `version` is only being passed to Cloudinary driver

---

Fixes #24111
