### PR TITLE
Fixed applying of snapshot changes to/from alias fields

### DIFF
--- a/.changeset/tiny-deers-scream.md
+++ b/.changeset/tiny-deers-scream.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed applying of snapshot changes to/from alias fields


### PR DESCRIPTION
## Scope

What's changed:

- Changing to/from alias fields now results in a field deletion & creation instead of updating it.

## Potential Risks / Drawbacks

- 🤔 

## Review Notes / Questions

- The `FieldsService` is recreated to refresh the schema so we don't need to add schema refreshing within the service.

---

Fixes #18770
