### PR TITLE
feat(openapi): Add required fields to schema generation

### DIFF
--- a/.changeset/bright-drinks-walk.md
+++ b/.changeset/bright-drinks-walk.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Fix specifications.ts to generate required array in OpenAPI schema

--- a/.changeset/bright-drinks-walk.md
+++ b/.changeset/bright-drinks-walk.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': minor
+'@directus/api': patch
 ---
 
 Fix specifications.ts to generate required array in OpenAPI schema

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -162,6 +162,9 @@ describe('Integration Tests', () => {
 							        "type": "integer",
 							      },
 							    },
+								 "required": [
+								 	"id"
+								 ],
 							    "type": "object",
 							    "x-collection": "test_table",
 							  },

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -162,9 +162,9 @@ describe('Integration Tests', () => {
 							        "type": "integer",
 							      },
 							    },
-								 "required": [
-								 	"id"
-								 ],
+							    "required": [
+							      "id"
+							    ],
 							    "type": "object",
 							    "x-collection": "test_table",
 							  },

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -163,7 +163,7 @@ describe('Integration Tests', () => {
 							      },
 							    },
 							    "required": [
-							      "id"
+							      "id",
 							    ],
 							    "type": "object",
 							    "x-collection": "test_table",

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -388,8 +388,26 @@ class OASSpecsService implements SpecificationSubService {
 					'x-collection': collection.collection,
 				};
 
+				// Track required fields
+				const requiredFields: string[] = [];
+
 				for (const field of fieldsInCollection) {
-					schemaComponent.properties![field.field] = this.generateField(schema, collection.collection, field, tags);
+					const fieldSchema = this.generateField(schema, collection.collection, field, tags);
+					schemaComponent.properties![field.field] = fieldSchema;
+
+					// Check if field is required
+					if (
+						field.nullable === false && 
+						field.defaultValue === null && 
+						field.generated === false
+					) {
+						requiredFields.push(field.field);
+					}
+				}
+
+				// Only add required if there are actually required fields
+				if (requiredFields.length > 0) {
+					schemaComponent.required = requiredFields;
 				}
 
 				components.schemas[tag.name] = schemaComponent;

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -396,11 +396,7 @@ class OASSpecsService implements SpecificationSubService {
 					schemaComponent.properties![field.field] = fieldSchema;
 
 					// Check if field is required
-					if (
-						field.nullable === false && 
-						field.defaultValue === null && 
-						field.generated === false
-					) {
+					if (field.nullable === false && field.defaultValue === null && field.generated === false) {
 						requiredFields.push(field.field);
 					}
 				}

--- a/contributors.yml
+++ b/contributors.yml
@@ -182,3 +182,4 @@
 - Leptopoda
 - robsoncombr
 - alexey-yarmosh
+- Zyles


### PR DESCRIPTION
Fixes issue: https://github.com/directus/directus/issues/24121


feat(openapi): Add required fields to schema generation

Enhance OpenAPI specification generation to correctly mark required fields
based on database schema constraints.

Changes:
- Implement logic to track required fields in schema components
- Add 'required' array to OpenAPI spec for non-nullable fields
- Apply required field detection for both system and custom collections
- Ensure fields are marked required only when:
  * Not nullable
  * No default value
  * Not a generated field

Resolves:
- Incomplete OpenAPI specification generation
- Missing required field metadata in schema components

Validation Criteria:
- Required fields are correctly identified
- OpenAPI 3.0 specification standards are followed
- No unnecessary 'required' arrays are added