### PR TITLE
Do not re-parse already parsed version delta in migration

### DIFF
--- a/.changeset/brave-buttons-tap.md
+++ b/.changeset/brave-buttons-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue where the version delta migrations failed due to being re-parsed

--- a/api/src/database/migrations/20240924B-populate-versioning-deltas.ts
+++ b/api/src/database/migrations/20240924B-populate-versioning-deltas.ts
@@ -22,7 +22,10 @@ export async function up(knex: Knex): Promise<void> {
 					.where('version', '=', missingDeltaVersion.id)
 					.orderBy('id');
 
-				const deltas = revisions.map((revision) => parseJSON(revision.delta));
+				const deltas = revisions.map((revision) =>
+					revision.delta === 'string' ? parseJSON(revision.delta) : revision.delta ?? {},
+				);
+
 				const consolidatedDelta = assign({}, ...deltas);
 
 				await trx('directus_versions')

--- a/api/src/database/migrations/20240924B-populate-versioning-deltas.ts
+++ b/api/src/database/migrations/20240924B-populate-versioning-deltas.ts
@@ -23,7 +23,7 @@ export async function up(knex: Knex): Promise<void> {
 					.orderBy('id');
 
 				const deltas = revisions.map((revision) =>
-					revision.delta === 'string' ? parseJSON(revision.delta) : revision.delta ?? {},
+					typeof revision.delta === 'string' ? parseJSON(revision.delta) : revision.delta ?? {},
 				);
 
 				const consolidatedDelta = assign({}, ...deltas);


### PR DESCRIPTION
Fixed an issue where the version delta migrations failed due to being re-parsed