### PR TITLE
Clear system and local caches on apply snapshot

### DIFF
--- a/.changeset/nasty-meals-melt.md
+++ b/.changeset/nasty-meals-melt.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed an issue that could cause the schema cache to not be invalidated on schema apply

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -1,6 +1,6 @@
 import type { SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
-import { clearSystemCache } from '../cache.js';
+import { flushCaches } from '../cache.js';
 import getDatabase from '../database/index.js';
 import type { Snapshot, SnapshotDiff } from '../types/index.js';
 import { applyDiff } from './apply-diff.js';
@@ -19,5 +19,5 @@ export async function applySnapshot(
 
 	await applyDiff(current, snapshotDiff, { database, schema });
 
-	await clearSystemCache();
+	await flushCaches();
 }

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -1,12 +1,12 @@
 import type { SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
+import { clearSystemCache } from '../cache.js';
 import getDatabase from '../database/index.js';
 import type { Snapshot, SnapshotDiff } from '../types/index.js';
 import { applyDiff } from './apply-diff.js';
 import { getSchema } from './get-schema.js';
-import { getSnapshot } from './get-snapshot.js';
 import { getSnapshotDiff } from './get-snapshot-diff.js';
-import { clearSystemCache } from '../cache.js';
+import { getSnapshot } from './get-snapshot.js';
 
 export async function applySnapshot(
 	snapshot: Snapshot,

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -1,12 +1,12 @@
 import type { SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
-import { getCache } from '../cache.js';
 import getDatabase from '../database/index.js';
 import type { Snapshot, SnapshotDiff } from '../types/index.js';
 import { applyDiff } from './apply-diff.js';
 import { getSchema } from './get-schema.js';
 import { getSnapshot } from './get-snapshot.js';
 import { getSnapshotDiff } from './get-snapshot-diff.js';
+import { clearSystemCache } from '../cache.js';
 
 export async function applySnapshot(
 	snapshot: Snapshot,
@@ -14,12 +14,10 @@ export async function applySnapshot(
 ): Promise<void> {
 	const database = options?.database ?? getDatabase();
 	const schema = options?.schema ?? (await getSchema({ database, bypassCache: true }));
-	const { systemCache } = getCache();
-
 	const current = options?.current ?? (await getSnapshot({ database, schema }));
 	const snapshotDiff = options?.diff ?? getSnapshotDiff(current, snapshot);
 
 	await applyDiff(current, snapshotDiff, { database, schema });
 
-	await systemCache?.clear();
+	await clearSystemCache();
 }


### PR DESCRIPTION
## Scope

What's changed:

- Replaces the `cache.clear()` call with a call to the `clearSystemCache()` utility. That's also the utility used by the collections service.

## Potential Risks / Drawbacks

- It might cache a bit more than intended, although because this is the same call as the collection/field service use I don't think there's any unintended side-effects

## Review Notes / Questions

- n/a

---

Fixes #17117
