### PR TITLE
Added user existence check when migrating legacy comments

### DIFF
--- a/.changeset/stale-jeans-pull.md
+++ b/.changeset/stale-jeans-pull.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added user existence check when migrating legacy comments

--- a/api/src/database/migrations/20240924A-migrate-legacy-comments.ts
+++ b/api/src/database/migrations/20240924A-migrate-legacy-comments.ts
@@ -15,8 +15,8 @@ export async function up(knex: Knex): Promise<void> {
 	const rowsLimit = 50;
 	let hasMore = true;
 
-	const existingUsers: string[] = [];
-	const missingUsers: string[] = [];
+	const existingUsers = new Set();
+	const missingUsers = new Set();
 
 	while (hasMore) {
 		const legacyComments = await knex
@@ -41,9 +41,9 @@ export async function up(knex: Knex): Promise<void> {
 					let legacyCommentUserId = legacyComment.user;
 
 					if (legacyCommentUserId) {
-						if (missingUsers.includes(legacyCommentUserId)) {
+						if (missingUsers.has(legacyCommentUserId)) {
 							legacyCommentUserId = null;
-						} else if (!existingUsers.includes(legacyCommentUserId)) {
+						} else if (!existingUsers.has(legacyCommentUserId)) {
 							const userFound = await trx
 								.select('id')
 								.from('directus_users')
@@ -51,9 +51,9 @@ export async function up(knex: Knex): Promise<void> {
 								.first();
 
 							if (userFound) {
-								existingUsers.push(legacyCommentUserId);
+								existingUsers.add(legacyCommentUserId);
 							} else {
-								missingUsers.push(legacyCommentUserId);
+								missingUsers.add(legacyCommentUserId);
 								legacyCommentUserId = null;
 							}
 						}

--- a/api/src/database/migrations/20240924A-migrate-legacy-comments.ts
+++ b/api/src/database/migrations/20240924A-migrate-legacy-comments.ts
@@ -44,13 +44,13 @@ export async function up(knex: Knex): Promise<void> {
 						if (missingUsers.has(legacyCommentUserId)) {
 							legacyCommentUserId = null;
 						} else if (!existingUsers.has(legacyCommentUserId)) {
-							const userFound = await trx
+							const userExists = await trx
 								.select('id')
 								.from('directus_users')
 								.where('id', '=', legacyCommentUserId)
 								.first();
 
-							if (userFound) {
+							if (userExists) {
 								existingUsers.add(legacyCommentUserId);
 							} else {
 								missingUsers.add(legacyCommentUserId);


### PR DESCRIPTION
## Scope

What's changed:

- Added user existence check when migrating legacy comments to prevent invalid foreign key errors on `user_created`
- Added a simple array-based caching to reduce need to check user existence
