### PR TITLE
Revert "Fix query generation for M2M relations that share a junction table (#23879)"

### DIFF
--- a/.changeset/quick-experts-sneeze.md
+++ b/.changeset/quick-experts-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Reverted query generation for M2M relations that share the same junction table in #23879

--- a/api/src/database/run-ast/utils/apply-parent-filters.ts
+++ b/api/src/database/run-ast/utils/apply-parent-filters.ts
@@ -45,11 +45,6 @@ export function applyParentFilters(
 			const foreignIds = uniq(parentItems.map((res) => res[nestedNode.parentKey])).filter((id) => !isNil(id));
 
 			merge(nestedNode, { query: { filter: { [foreignField]: { _in: foreignIds } } } });
-
-			if (nestedNode.relation.meta?.junction_field) {
-				const junctionField = nestedNode.relation.meta.junction_field;
-				merge(nestedNode, { query: { filter: { [junctionField]: { _nnull: true } } } });
-			}
 		} else if (nestedNode.type === 'a2o') {
 			const keysPerCollection: { [collection: string]: (string | number)[] } = {};
 


### PR DESCRIPTION
## Scope

What's changed:

- Reverted #23879 as deep filtering could be utilised to filter out the duplication
  - `/policies?deep[roles][_filter][role][_nnull]=true&deep[users][_filter][user][_nnull]=true`

---

Fixes #24145
Related to #23785
