### PR TITLE
fix: add `idToken` to `providerPayload` in auth filter events

### DIFF
--- a/.changeset/lemon-mugs-kick.md
+++ b/.changeset/lemon-mugs-kick.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+added `idToken` to `providerPayload` in `auth.create` and `auth.update` filter hooks

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -199,7 +199,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 				{
 					identifier,
 					provider: this.config['provider'],
-					providerPayload: { accessToken: tokenSet.access_token, userInfo },
+					providerPayload: { accessToken: tokenSet.access_token, idToken: tokenSet.id_token, userInfo },
 				},
 				{ database: getDatabase(), schema: this.schema, accountability: null },
 			);
@@ -226,7 +226,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			{
 				identifier,
 				provider: this.config['provider'],
-				providerPayload: { accessToken: tokenSet.access_token, userInfo },
+				providerPayload: { accessToken: tokenSet.access_token, idToken: tokenSet.id_token, userInfo },
 			},
 			{ database: getDatabase(), schema: this.schema, accountability: null },
 		);

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -226,7 +226,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				{
 					identifier,
 					provider: this.config['provider'],
-					providerPayload: { accessToken: tokenSet.access_token, userInfo },
+					providerPayload: { accessToken: tokenSet.access_token, idToken: tokenSet.id_token, userInfo },
 				},
 				{ database: getDatabase(), schema: this.schema, accountability: null },
 			);
@@ -255,7 +255,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			{
 				identifier,
 				provider: this.config['provider'],
-				providerPayload: { accessToken: tokenSet.access_token, userInfo },
+				providerPayload: { accessToken: tokenSet.access_token, idToken: tokenSet.id_token, userInfo },
 			},
 			{ database: getDatabase(), schema: this.schema, accountability: null },
 		);

--- a/contributors.yml
+++ b/contributors.yml
@@ -185,3 +185,4 @@
 - NickSettler
 - alexey-yarmosh
 - Zyles
+- m3Lith


### PR DESCRIPTION
## Scope

What's changed:

- Added `idToken` to `providerPayload` in `auth.create` and `auth.update` filter hooks (`openid` & `oauth2`)

## Potential Risks / Drawbacks

- Current `userInfo` in `providerPayload` is a parsed `idToken`. So technically it's two fields with same info, but in different forms. However, to not break current user flows, `userInfo` is being kept

## Review Notes / Questions

- I've provided detailed context and reasoning in the linked issue - hopefully this change makes sense
- My case only relates to `openid` flow, but I've updated `oauth2` as well, since the follow a very similar auth flow, and have identical `providerPayload` formats

---

Fixes #24141 
