### PR TITLE
Fix avatar icon tamplate. #24146

### DIFF
--- a/.changeset/smart-trainers-jam.md
+++ b/.changeset/smart-trainers-jam.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Improved the default user created display template by using the avatar field

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -274,7 +274,7 @@ function getSystemFields() {
 				special: ['user-created'],
 				interface: 'select-dropdown-m2o',
 				options: {
-					template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}',
+					template: '{{avatar}} {{first_name}} {{last_name}}',
 				},
 				display: 'user',
 				readonly: true,
@@ -312,7 +312,7 @@ function getSystemFields() {
 				special: ['user-updated'],
 				interface: 'select-dropdown-m2o',
 				options: {
-					template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}',
+					template: '{{avatar}} {{first_name}} {{last_name}}',
 				},
 				display: 'user',
 				readonly: true,


### PR DESCRIPTION
https://github.com/directus/directus/issues/24146

Interface icon for user_updated and user_created was templated as avatar.$thumbnail which reflect direct path of file (i think). 

This lead to icon have square shape even is is "show in circle" enabled. When i remove the "$thumbnail" and just use {{avatar}} as placeholder. everything starts working properly.

## Scope

What's changed:

- template icon placeholder for user_updated and user_created

## Potential Risks / Drawbacks

- it was tested on my current test directus, but not on production server

## Review Notes / Questions

---

Fixes #24146 