### PR TITLE
Issue #24163: Fixes sorting bug in M2A Builders due to ignored sortField

### DIFF
--- a/.changeset/hip-cups-call.md
+++ b/.changeset/hip-cups-call.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-fixes sorting bug when editing items in m2a builder (#24163)
+Fixed an issue with unintentional sorting after editing items in relational interfaces (#24163)

--- a/.changeset/hip-cups-call.md
+++ b/.changeset/hip-cups-call.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+fixes sorting bug when editing items in m2a builder (#24163)

--- a/.changeset/hip-cups-call.md
+++ b/.changeset/hip-cups-call.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed an issue with unintentional sorting after editing items in relational interfaces (#24163)
+Fixed an issue with unintentional sorting after editing items in relational interfaces

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -648,9 +648,9 @@ export function useRelationMultiple(
 	}
 
 	function useUtil() {
-		const sortField = relation.value?.sortField;
-
 		function applySort(item: Record<string, any>, totalSortCount = 0): Record<string, any> {
+			const sortField = relation.value?.sortField;
+
 			if (!sortField || totalSortCount > previewQuery.value.limit || item[sortField] !== undefined) return item;
 
 			return {
@@ -726,6 +726,7 @@ export function useRelationMultiple(
 		}
 
 		function getItemEdits(item: DisplayItem) {
+			const sortField = relation.value?.sortField;
 			let edits: DisplayItem = {};
 
 			if ('$type' in item && item.$index !== undefined) {

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -31,13 +31,6 @@ export type ChangesItem = {
 	delete: (string | number)[];
 };
 
-type EditsType = {
-	$edits?: number;
-	$type?: 'created' | 'updated' | 'deleted';
-	$index?: number;
-	[sortField: string]: any;
-};
-
 export function useRelationMultiple(
 	value: Ref<Record<string, any> | any[] | undefined>,
 	previewQuery: Ref<RelationQueryMultiple>,
@@ -732,8 +725,8 @@ export function useRelationMultiple(
 			return items.slice(start, end);
 		}
 
-		function getItemEdits(item: DisplayItem): EditsType {
-			const edits: EditsType = {};
+		function getItemEdits(item: DisplayItem) {
+			let edits: DisplayItem = {};
 			const sortField = relation.value?.sortField;
 
 			if (sortField && item[sortField] !== undefined) {
@@ -742,21 +735,21 @@ export function useRelationMultiple(
 
 			if ('$type' in item && item.$index !== undefined) {
 				if (item.$type === 'created') {
-					return {
+					edits = {
 						...edits,
 						..._value.value.create[item.$index],
 						$type: 'created',
 						$index: item.$index,
 					};
 				} else if (item.$type === 'updated') {
-					return {
+					edits = {
 						...edits,
 						..._value.value.update[item.$index],
 						$type: 'updated',
 						$index: item.$index,
 					};
 				} else if (item.$type === 'deleted' && item.$edits !== undefined) {
-					return {
+					edits = {
 						...edits,
 						..._value.value.update[item.$edits],
 						$type: 'deleted',

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -31,6 +31,13 @@ export type ChangesItem = {
 	delete: (string | number)[];
 };
 
+type EditsType = {
+	$edits?: number;
+	$type?: 'created' | 'updated' | 'deleted';
+	$index?: number;
+	[sortField: string]: any;
+};
+
 export function useRelationMultiple(
 	value: Ref<Record<string, any> | any[] | undefined>,
 	previewQuery: Ref<RelationQueryMultiple>,
@@ -725,22 +732,32 @@ export function useRelationMultiple(
 			return items.slice(start, end);
 		}
 
-		function getItemEdits(item: DisplayItem) {
+		function getItemEdits(item: DisplayItem): EditsType {
+			const edits: EditsType = {};
+			const sortField = relation.value?.sortField;
+
+			if (sortField && item[sortField] !== undefined) {
+				edits[sortField] = item[sortField];
+			}
+
 			if ('$type' in item && item.$index !== undefined) {
 				if (item.$type === 'created') {
 					return {
+						...edits,
 						..._value.value.create[item.$index],
 						$type: 'created',
 						$index: item.$index,
 					};
 				} else if (item.$type === 'updated') {
 					return {
+						...edits,
 						..._value.value.update[item.$index],
 						$type: 'updated',
 						$index: item.$index,
 					};
 				} else if (item.$type === 'deleted' && item.$edits !== undefined) {
 					return {
+						...edits,
 						..._value.value.update[item.$edits],
 						$type: 'deleted',
 						$index: item.$index,
@@ -749,7 +766,7 @@ export function useRelationMultiple(
 				}
 			}
 
-			return {};
+			return edits;
 		}
 
 		return { applySort, cleanItem, getPage, isLocalItem, getItemEdits, isEmpty };

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -648,9 +648,9 @@ export function useRelationMultiple(
 	}
 
 	function useUtil() {
-		function applySort(item: Record<string, any>, totalSortCount = 0): Record<string, any> {
-			const sortField = relation.value?.sortField;
+		const sortField = relation.value?.sortField;
 
+		function applySort(item: Record<string, any>, totalSortCount = 0): Record<string, any> {
 			if (!sortField || totalSortCount > previewQuery.value.limit || item[sortField] !== undefined) return item;
 
 			return {
@@ -727,36 +727,32 @@ export function useRelationMultiple(
 
 		function getItemEdits(item: DisplayItem) {
 			let edits: DisplayItem = {};
-			const sortField = relation.value?.sortField;
-
-			if (sortField && item[sortField] !== undefined) {
-				edits[sortField] = item[sortField];
-			}
 
 			if ('$type' in item && item.$index !== undefined) {
 				if (item.$type === 'created') {
 					edits = {
-						...edits,
 						..._value.value.create[item.$index],
-						$type: 'created',
+						$type: item.$type,
 						$index: item.$index,
 					};
 				} else if (item.$type === 'updated') {
 					edits = {
-						...edits,
 						..._value.value.update[item.$index],
-						$type: 'updated',
+						$type: item.$type,
 						$index: item.$index,
 					};
 				} else if (item.$type === 'deleted' && item.$edits !== undefined) {
 					edits = {
-						...edits,
 						..._value.value.update[item.$edits],
-						$type: 'deleted',
+						$type: item.$type,
 						$index: item.$index,
 						$edits: item.$edits,
 					};
 				}
+			}
+
+			if (sortField && item[sortField] !== undefined && edits[sortField] === undefined) {
+				edits[sortField] = item[sortField];
 			}
 
 			return edits;

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -205,6 +205,7 @@ function editItem(item: DisplayItem) {
 		...getItemEdits(item),
 		[relationInfo.value.collectionField.field]: item[relationInfo.value.collectionField.field],
 	};
+
 	if (sortField && item[sortField] !== undefined) {
 		editsAtStart.value[sortField] = item[sortField];
 	}

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -197,7 +197,6 @@ function editItem(item: DisplayItem) {
 
 	const junctionField = relationInfo.value.junctionField.field;
 	const junctionPkField = relationInfo.value.junctionPrimaryKeyField.field;
-	const sortField = relationInfo.value.sortField;
 
 	newItem = false;
 
@@ -205,10 +204,6 @@ function editItem(item: DisplayItem) {
 		...getItemEdits(item),
 		[relationInfo.value.collectionField.field]: item[relationInfo.value.collectionField.field],
 	};
-
-	if (sortField && item[sortField] !== undefined) {
-		editsAtStart.value[sortField] = item[sortField];
-	}
 
 	editModalActive.value = true;
 	editingCollection.value = item[relationInfo.value.collectionField.field];

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -197,6 +197,7 @@ function editItem(item: DisplayItem) {
 
 	const junctionField = relationInfo.value.junctionField.field;
 	const junctionPkField = relationInfo.value.junctionPrimaryKeyField.field;
+	const sortField = relationInfo.value.sortField;
 
 	newItem = false;
 
@@ -204,6 +205,9 @@ function editItem(item: DisplayItem) {
 		...getItemEdits(item),
 		[relationInfo.value.collectionField.field]: item[relationInfo.value.collectionField.field],
 	};
+	if (sortField && item[sortField] !== undefined) {
+		editsAtStart.value[sortField] = item[sortField];
+	}
 
 	editModalActive.value = true;
 	editingCollection.value = item[relationInfo.value.collectionField.field];


### PR DESCRIPTION
## Scope

What's changed:

- The ignored `sortField` field is now included when editing M2A Items in the UI

---

Fixes #24163 
