### PR TITLE
Fix permission checks for related items

### DIFF
--- a/.changeset/dirty-cooks-jog.md
+++ b/.changeset/dirty-cooks-jog.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed permission checks when creating or editing related items

--- a/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
+++ b/app/src/interfaces/_system/system-input-translated-string/input-translated-string.vue
@@ -202,7 +202,7 @@ function openNewCustomTranslationDrawer() {
 			</v-list>
 		</v-menu>
 
-		<DrawerItem
+		<drawer-item
 			v-model:active="isCustomTranslationDrawerOpen"
 			collection="directus_translations"
 			primary-key="+"

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -204,7 +204,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 			<drawer-item
 				v-if="image"
 				v-model:active="editImageDetails"
-				:disabled="disabled || !updateAllowed"
+				:disabled="disabled"
 				collection="directus_files"
 				:primary-key="image.id"
 				:edits="edits"

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -230,7 +230,7 @@ function useURLImport() {
 			collection="directus_files"
 			:primary-key="file.id"
 			:edits="edits"
-			:disabled="disabled || !updateAllowed"
+			:disabled="disabled"
 			@input="update"
 		>
 			<template #actions>

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -54,7 +54,7 @@ const {
 	enabled: computed(() => !props.loading),
 });
 
-const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo);
+const { createAllowed } = useRelationPermissionsM2O(relationInfo);
 
 const { t } = useI18n();
 

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -316,7 +316,7 @@ const allowDrag = computed(
 					<v-list-item
 						:class="{ deleted: element.$type === 'deleted' }"
 						:dense="totalItemCount > 4"
-						:disabled="disabled || !updateAllowed"
+						:disabled="disabled"
 						block
 						clickable
 						@click="editItem(element)"
@@ -371,7 +371,7 @@ const allowDrag = computed(
 
 		<drawer-item
 			v-model:active="editModalActive"
-			:disabled="disabled || (!updateAllowed && currentlyEditing !== null)"
+			:disabled="disabled"
 			:collection="relationInfo.junctionCollection.collection"
 			:primary-key="currentlyEditing || '+'"
 			:related-primary-key="relatedPrimaryKey || '+'"

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -477,9 +477,7 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 
 		<drawer-item
 			v-model:active="editModalActive"
-			:disabled="
-				disabled || (editingCollection !== null && !updateAllowed[editingCollection] && currentlyEditing !== null)
-			"
+			:disabled="disabled"
 			:collection="relationInfo.junctionCollection.collection"
 			:primary-key="currentlyEditing || '+'"
 			:related-primary-key="relatedPrimaryKey || '+'"

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -538,7 +538,7 @@ function getLinkForItem(item: DisplayItem) {
 				:loading="loading"
 				:items="displayItems"
 				:row-height="tableRowHeight"
-				:disabled="!updateAllowed"
+				:disabled="disabled"
 				:show-manual-sort="allowDrag"
 				:manual-sort-key="relationInfo?.sortField"
 				:show-select="!disabled && updateAllowed ? 'multiple' : 'none'"
@@ -671,7 +671,7 @@ function getLinkForItem(item: DisplayItem) {
 
 		<drawer-item
 			v-model:active="editModalActive"
-			:disabled="disabled || (!updateAllowed && currentlyEditing !== null)"
+			:disabled="disabled"
 			:collection="relationInfo.junctionCollection.collection"
 			:primary-key="currentlyEditing || '+'"
 			:related-primary-key="relatedPrimaryKey || '+'"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -612,7 +612,7 @@ function getLinkForItem(item: DisplayItem) {
 		</div>
 
 		<drawer-item
-			:disabled="disabled || (!updateAllowed && currentlyEditing !== '+')"
+			:disabled="disabled"
 			:active="currentlyEditing !== null"
 			:collection="relationInfo.relatedCollection.collection"
 			:primary-key="currentlyEditing || '+'"

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -101,7 +101,7 @@ const { update, remove, displayItem, loading } = useRelationSingle(value, query,
 	enabled: computed(() => !props.loading),
 });
 
-const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo);
+const { createAllowed } = useRelationPermissionsM2O(relationInfo);
 
 const currentPrimaryKey = computed<string | number>(() => {
 	if (!displayItem.value || !props.value || !relationInfo.value) return '+';
@@ -205,9 +205,9 @@ function getLinkForItem() {
 					<router-link
 						v-if="enableLink"
 						v-tooltip="t('navigate_to_item')"
-						@click.stop
 						:to="getLinkForItem()"
 						class="item-link"
+						@click.stop
 					>
 						<v-icon name="launch" />
 					</router-link>
@@ -239,7 +239,7 @@ function getLinkForItem() {
 			:primary-key="currentPrimaryKey"
 			:edits="edits"
 			:circular-field="relationInfo.relation.meta?.one_field ?? undefined"
-			:disabled="!updateAllowed || disabled"
+			:disabled="disabled"
 			@input="onDrawerItemInput"
 		/>
 

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -103,7 +103,7 @@ const title = computed(() => {
 });
 
 const {
-	itemPermissions: { fields: fieldsWithPermissions, updateAllowed, saveAllowed },
+	itemPermissions: { fields: fieldsWithPermissions, saveAllowed },
 } = usePermissions(
 	collection,
 	primaryKey,
@@ -111,11 +111,7 @@ const {
 );
 
 const {
-	itemPermissions: {
-		fields: relatedCollectionFields,
-		updateAllowed: updateRelatedCollectionAllowed,
-		saveAllowed: saveRelatedCollectionAllowed,
-	},
+	itemPermissions: { fields: relatedCollectionFields, saveAllowed: saveRelatedCollectionAllowed },
 } = usePermissions(
 	relatedCollection as Ref<string>,
 	relatedPrimaryKey,

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import api from '@/api';
 import { useEditsGuard } from '@/composables/use-edits-guard';
-import { useItemPermissions } from '@/composables/use-permissions';
+import { usePermissions } from '@/composables/use-permissions';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
@@ -102,16 +102,24 @@ const title = computed(() => {
 		: t('editing_in', { collection: collection.name });
 });
 
-const { fields: fieldsWithPermissions, updateAllowed } = useItemPermissions(
+const {
+	itemPermissions: { fields: fieldsWithPermissions, updateAllowed, saveAllowed },
+} = usePermissions(
 	collection,
 	primaryKey,
 	computed(() => props.primaryKey === '+'),
 );
 
-const { fields: relatedCollectionFields, updateAllowed: updateRelatedCollectionAllowed } = useItemPermissions(
+const {
+	itemPermissions: {
+		fields: relatedCollectionFields,
+		updateAllowed: updateRelatedCollectionAllowed,
+		saveAllowed: saveRelatedCollectionAllowed,
+	},
+} = usePermissions(
 	relatedCollection as Ref<string>,
 	relatedPrimaryKey,
-	computed(() => props.primaryKey === '+'),
+	computed(() => props.relatedPrimaryKey === '+'),
 );
 
 const fields = computed(() => {
@@ -154,10 +162,8 @@ const templateCollection = computed(() => relatedCollectionInfo.value || collect
 
 const isSavable = computed(() => {
 	if (props.disabled) return false;
-	if (isNew.value) return true;
-	if (updateAllowed.value && !props.junctionField) return true;
-	if (updateAllowed.value && props.junctionField && updateRelatedCollectionAllowed.value) return true;
-	return false;
+	if (!relatedCollection.value) return saveAllowed.value;
+	return saveAllowed.value || saveRelatedCollectionAllowed.value;
 });
 
 const {
@@ -414,7 +420,7 @@ function useActions() {
 			<div v-else class="drawer-item-order" :class="{ swap: swapFormOrder }">
 				<v-form
 					v-if="junctionField"
-					:disabled="disabled || (!updateRelatedCollectionAllowed && !isNew)"
+					:disabled="disabled"
 					:loading="loading"
 					:show-no-visible-fields="false"
 					:initial-values="initialValues?.[junctionField]"
@@ -429,7 +435,7 @@ function useActions() {
 
 				<v-form
 					v-model="internalEdits"
-					:disabled="disabled || (!updateAllowed && !isNew)"
+					:disabled="disabled"
 					:loading="loading"
 					:show-no-visible-fields="false"
 					:initial-values="initialValues"


### PR DESCRIPTION
## Scope

Fixes permission checks for related items created/updated via drawer item component:
- Check if item is savable (`isSavable`):
  - Reuse `saveAllowed` from `usePermissions` composable
  - For relations without junction: Only consider permissions of related collection
  - For relations with junction: Consider both, the permissions of the related as well as the junction collection. That means, it is still savable if only one of these are allowed. (see #24165)
- Fix `isNew` value for `usePermissions` of related collection, thanks @ComfortablyCoding for pointing out
- Fix `disabled` state for the forms: These only need to be disabled if the whole field is disabled/read-only (`props.disabled`). The individual field permissions are already checked & applied via `usePermissions` composable.

Additionally, all usages of `drawer-item` are fixed to only pass down the `disabled` state and leave remaining permissions checks to `drawer-item`.

---

Fixes #24165
