### PR TITLE
Fix retention time based query not being database agnostic

### DIFF
--- a/.changeset/lemon-beers-tap.md
+++ b/.changeset/lemon-beers-tap.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed retention timestamp not being database specific
+Fixed retention time based query not being database agnostic

--- a/.changeset/lemon-beers-tap.md
+++ b/.changeset/lemon-beers-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed retention timestamp not being database specific

--- a/api/src/database/helpers/date/dialects/oracle.ts
+++ b/api/src/database/helpers/date/dialects/oracle.ts
@@ -1,6 +1,24 @@
 import { DateHelper } from '../types.js';
 
 export class DateHelperOracle extends DateHelper {
+	// Required to handle timezoned offset
+	override parse(date: string | Date): string {
+		if (!date) {
+			return date;
+		}
+
+		if (date instanceof Date) {
+			return String(date.toISOString());
+		}
+
+		// Return YY-MM-DD as is for date support
+		if (date.length <= 10 && date.includes('-')) {
+			return date;
+		}
+
+		return String(new Date(date).toISOString());
+	}
+
 	override fieldFlagForField(fieldType: string): string {
 		switch (fieldType) {
 			case 'dateTime':

--- a/api/src/database/helpers/date/dialects/oracle.ts
+++ b/api/src/database/helpers/date/dialects/oracle.ts
@@ -11,6 +11,11 @@ export class DateHelperOracle extends DateHelper {
 			return String(date.toISOString().substring(0, 19));
 		}
 
+		// Return YY-MM-DD as is for date support
+		if (date.length <= 10 && date.includes('-')) {
+			return date;
+		}
+
 		return String(new Date(date).toISOString().substring(0, 19));
 	}
 

--- a/api/src/database/helpers/date/dialects/oracle.ts
+++ b/api/src/database/helpers/date/dialects/oracle.ts
@@ -1,6 +1,19 @@
 import { DateHelper } from '../types.js';
 
 export class DateHelperOracle extends DateHelper {
+	// Oracle does not support decimal with Z date/timestamp fields and requires format: 2024-12-08 14:27:00
+	override parse(date: string | Date): string {
+		if (!date) {
+			return date;
+		}
+
+		if (date instanceof Date) {
+			return String(date.toISOString().substring(0, 19));
+		}
+
+		return String(new Date(date).toISOString().substring(0, 19));
+	}
+
 	override fieldFlagForField(fieldType: string): string {
 		switch (fieldType) {
 			case 'dateTime':

--- a/api/src/database/helpers/date/dialects/oracle.ts
+++ b/api/src/database/helpers/date/dialects/oracle.ts
@@ -1,24 +1,6 @@
 import { DateHelper } from '../types.js';
 
 export class DateHelperOracle extends DateHelper {
-	// Oracle does not support decimal with Z date/timestamp fields and requires format: 2024-12-08 14:27:00
-	override parse(date: string | Date): string {
-		if (!date) {
-			return date;
-		}
-
-		if (date instanceof Date) {
-			return String(date.toISOString().substring(0, 19));
-		}
-
-		// Return YY-MM-DD as is for date support
-		if (date.length <= 10 && date.includes('-')) {
-			return date;
-		}
-
-		return String(new Date(date).toISOString().substring(0, 19));
-	}
-
 	override fieldFlagForField(fieldType: string): string {
 		switch (fieldType) {
 			case 'dateTime':

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -148,7 +148,7 @@ export function getDatabase(): Knex {
 			logger.trace('Setting OracleDB NLS_DATE_FORMAT and NLS_TIMESTAMP_FORMAT');
 
 			// enforce proper ISO standard date as default
-			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SS\'');
+			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SS.FF3"Z"\'');
 			// enforce YY-MM-DD date formet
 			await conn.executeAsync("ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'");
 

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -143,6 +143,17 @@ export function getDatabase(): Knex {
 		};
 	}
 
+	if (client === 'oracledb') {
+		poolConfig.afterCreate = async (conn: any, callback: any) => {
+			logger.trace('Setting OracleDB NLS_TIMESTAMP_FORMAT');
+
+			// enforce proper ISO standard date as default
+			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YY-MM-DD"T"HH24:MI:SS\'');
+
+			callback(null, conn);
+		};
+	}
+
 	if (client === 'mysql') {
 		// Remove the conflicting `filename` option, defined by default in the Docker Image
 		if (isObject(knexConfig.connection)) delete knexConfig.connection['filename'];

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -148,9 +148,9 @@ export function getDatabase(): Knex {
 			logger.trace('Setting OracleDB NLS_DATE_FORMAT and NLS_TIMESTAMP_FORMAT');
 
 			// enforce proper ISO standard date as default
-			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YY-MM-DD"T"HH24:MI:SS\'');
+			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SS\'');
 			// enforce YY-MM-DD date formet
-			await conn.executeAsync("ALTER SESSION SET NLS_DATE_FORMAT = 'YY-MM-DD'");
+			await conn.executeAsync("ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'");
 
 			callback(null, conn);
 		};

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -145,10 +145,12 @@ export function getDatabase(): Knex {
 
 	if (client === 'oracledb') {
 		poolConfig.afterCreate = async (conn: any, callback: any) => {
-			logger.trace('Setting OracleDB NLS_TIMESTAMP_FORMAT');
+			logger.trace('Setting OracleDB NLS_DATE_FORMAT and NLS_TIMESTAMP_FORMAT');
 
 			// enforce proper ISO standard date as default
 			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YY-MM-DD"T"HH24:MI:SS\'');
+			// enforce YY-MM-DD date formet
+			await conn.executeAsync("ALTER SESSION SET NLS_DATE_FORMAT = 'YY-MM-DD'");
 
 			callback(null, conn);
 		};

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -145,12 +145,16 @@ export function getDatabase(): Knex {
 
 	if (client === 'oracledb') {
 		poolConfig.afterCreate = async (conn: any, callback: any) => {
-			logger.trace('Setting OracleDB NLS_DATE_FORMAT and NLS_TIMESTAMP_FORMAT');
+			logger.trace('Setting OracleDB NLS_DATE_FORMAT, NLS_TIMESTAMP_FORMAT and NLS_TIMESTAMP_TZ_FORMAT');
 
-			// enforce proper ISO standard date as default
+			// enforce proper ISO standard 2024-12-10T10:54:00.123Z for datetime/timestamp
 			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SS.FF3"Z"\'');
-			// enforce YY-MM-DD date formet
+
+			// enforce 2024-12-10 date formet
 			await conn.executeAsync("ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'");
+
+			// enforce for 2024-12-10T10:54:00-05:00 timezoned requests
+			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_TZ_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SSTZH:TZM\'');
 
 			callback(null, conn);
 		};

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -145,16 +145,13 @@ export function getDatabase(): Knex {
 
 	if (client === 'oracledb') {
 		poolConfig.afterCreate = async (conn: any, callback: any) => {
-			logger.trace('Setting OracleDB NLS_DATE_FORMAT, NLS_TIMESTAMP_FORMAT and NLS_TIMESTAMP_TZ_FORMAT');
+			logger.trace('Setting OracleDB NLS_DATE_FORMAT and NLS_TIMESTAMP_FORMAT');
 
 			// enforce proper ISO standard 2024-12-10T10:54:00.123Z for datetime/timestamp
 			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SS.FF3"Z"\'');
 
 			// enforce 2024-12-10 date formet
 			await conn.executeAsync("ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'");
-
-			// enforce for 2024-12-10T10:54:00-05:00 timezoned requests
-			await conn.executeAsync('ALTER SESSION SET NLS_TIMESTAMP_TZ_FORMAT = \'YYYY-MM-DD"T"HH24:MI:SSTZH:TZM\'');
 
 			callback(null, conn);
 		};

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -80,11 +80,11 @@ export async function handleRetentionJob() {
 
 			try {
 				let records = [];
-				const isMysql = helpers.schema.isOneOfClients(['mysql']);
+				const isMySQL = helpers.schema.isOneOfClients(['mysql']);
 
 				// mysql/maria does not allow limit within a subquery
 				// https://dev.mysql.com/doc/refman/8.4/en/subquery-restrictions.html
-				if (isMysql) {
+				if (isMySQL) {
 					records = await subquery.then((r) => r.map((r) => r.id));
 
 					if (records.length === 0) {
@@ -93,7 +93,7 @@ export async function handleRetentionJob() {
 				}
 
 				count = await database(task.collection)
-					.whereIn('id', isMysql ? records : subquery)
+					.whereIn('id', isMySQL ? records : subquery)
 					.delete();
 			} catch (error) {
 				logger.error(error, `Retention failed for Collection ${task.collection}`);

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -79,7 +79,17 @@ export async function handleRetentionJob() {
 			}
 
 			try {
-				count = await database(task.collection).where('id', 'in', subquery).delete();
+				const records = await subquery;
+
+				if (records.length !== 0) {
+					count = await database(task.collection)
+						.where(
+							'id',
+							'in',
+							records.map((r) => r.id),
+						)
+						.delete();
+				}
 			} catch (error) {
 				logger.error(error, `Retention failed for Collection ${task.collection}`);
 

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -79,6 +79,7 @@ export async function handleRetentionJob() {
 			}
 
 			try {
+				// subquery executed here as mysql/maria does not allow limit within an IN statement
 				const records = await subquery;
 
 				if (records.length !== 0) {

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -79,6 +79,9 @@ export async function handleRetentionJob() {
 			}
 
 			try {
+				// reset count
+				count = 0;
+
 				// subquery executed here as mysql/maria does not allow limit within an IN statement
 				const records = await subquery;
 

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -87,9 +87,8 @@ export async function handleRetentionJob() {
 
 				if (records.length !== 0) {
 					count = await database(task.collection)
-						.where(
+						.whereIn(
 							'id',
-							'in',
 							records.map((r) => r.id),
 						)
 						.delete();

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -67,7 +67,7 @@ export async function handleRetentionJob() {
 				.queryBuilder()
 				.select(`${task.collection}.id`)
 				.from(task.collection)
-				.where('timestamp', '<', helpers.date.parse(new Date(Date.now() - task.timeframe).toISOString()))
+				.where('timestamp', '<', helpers.date.parse(new Date(Date.now() - task.timeframe)))
 				.limit(batch);
 
 			if (task.where) {

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -67,7 +67,7 @@ export async function handleRetentionJob() {
 				.queryBuilder()
 				.select(`${task.collection}.id`)
 				.from(task.collection)
-				.where('timestamp', '<', helpers.date.parse(new Date(Date.now() - task.timeframe)))
+				.where('timestamp', '<', helpers.date.parse(new Date(Date.now() - task.timeframe).toISOString()))
 				.limit(batch);
 
 			if (task.where) {

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -2,6 +2,7 @@ import { Action } from '@directus/constants';
 import { useEnv } from '@directus/env';
 import { toBoolean } from '@directus/utils';
 import type { Knex } from 'knex';
+import { getHelpers } from '../database/helpers/index.js';
 import getDatabase from '../database/index.js';
 import { useLock } from '../lock/index.js';
 import { useLogger } from '../logger/index.js';
@@ -44,6 +45,7 @@ export async function handleRetentionJob() {
 	const batch = Number(env['RETENTION_BATCH']);
 	const lockTime = await lock.get(retentionLockKey);
 	const now = Date.now();
+	const helpers = getHelpers(database);
 
 	if (lockTime && Number(lockTime) > now - retentionLockTimeout) {
 		// ensure only one connected process
@@ -65,7 +67,7 @@ export async function handleRetentionJob() {
 				.queryBuilder()
 				.select(`${task.collection}.id`)
 				.from(task.collection)
-				.where('timestamp', '<', Date.now() - task.timeframe)
+				.where('timestamp', '<', helpers.date.parse(new Date(Date.now() - task.timeframe)))
 				.limit(batch);
 
 			if (task.where) {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now utilize the db helpers to generate a db specific timestamp for the retention query
- The subquery is executed outside the delete to adhere to the `mysql`/`maria` restriction of no `LIMIT` within a subquery
- Fixed `oracledb` to properly query date fields

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Any suggested alternative solutions are welcome

## Testing
- DB
   - [x] sqlite
   - [x] pg
   - [x] cockroach
   - [x] mysql
   - [x] maria
   - [x] mssql
   - [x] oracle
- General Checks (done with PG)
  - While the query is being processed for large batches there was no visible degradation observed
     - Degradation observed with sqlite even at 250 for frequent runs (every second), I assume due to no pool?
  - The job lock preventing subsequent jobs seems to work as expected when queries take more time than expected
- Performance
      - Batch of 10k:  ~`140000ms - 180000ms `
      - Batch of 1k: ~`15000ms - 15600ms`
      - Batch of 500: ~`7400ms - 7900ms`
      - Batch of 250: ~`3800ms - 4000ms`

P.S. Performance testing was done with a sample size of `1000000` records in PG and may vary depending on setup

---

Fixes #24176
