### PR TITLE
Increase raw-editor max-height

### DIFF
--- a/.changeset/tidy-mails-yawn.md
+++ b/.changeset/tidy-mails-yawn.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Increase raw-editor max-height

--- a/app/src/components/v-form/form-field-raw-editor.vue
+++ b/app/src/components/v-form/form-field-raw-editor.vue
@@ -103,7 +103,7 @@ const setRawValue = () => {
 	.input-code {
 		:deep(.CodeMirror),
 		:deep(.CodeMirror-scroll) {
-			max-height: var(--input-height-tall);
+			max-height: var(--input-height-max);
 		}
 	}
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -191,3 +191,4 @@
 - Audiotape-2
 - vst-name
 - clonefetch
+- gloriarodrife


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

Increase raw-editor max-height from:
<img width="559" alt="Screenshot 2024-12-11 at 4 43 47 PM" src="https://github.com/user-attachments/assets/34ab4086-f488-48c1-bf40-ca22649de92b" />

To:
<img width="560" alt="Screenshot 2024-12-11 at 4 43 33 PM" src="https://github.com/user-attachments/assets/5c9ededf-b8dc-44ae-8a6a-d6c8696f6ccd" />


## Potential Risks / Drawbacks

None?

## Review Notes / Questions

I was seeing the very small height...

And I saw that there are these two variables:
https://github.com/directus/directus/blob/feeda04ad8046b27b6965cefb557db2fa35c786e/app/src/styles/_variables.scss#L12-L13

And this max-height is using `--input-height-tall`, but I guess it should use `--input-height-max`.

---

Fixes #24200