### PR TITLE
Fix Norwegian calendar locale

### DIFF
--- a/.changeset/fair-boxes-approve.md
+++ b/.changeset/fair-boxes-approve.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed calendar layout locale for "Norwegian"

--- a/app/src/utils/get-fullcalendar-locale.ts
+++ b/app/src/utils/get-fullcalendar-locale.ts
@@ -127,6 +127,7 @@ export function importCalendarLocale(locale: string): Promise<any> {
 		case 'ms':
 			return import('@fullcalendar/core/locales/ms');
 		case 'nb':
+		case 'no':
 			return import('@fullcalendar/core/locales/nb');
 		case 'ne':
 			return import('@fullcalendar/core/locales/ne');


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added `no` case for importing the Norwegian locale if Norwegian `no-NO` is the selected language


## Review Notes / Questions

- See initial issue for argument about why it is correct to use `nb` instead of `no`.

---

Fixes #24204 
