### PR TITLE
Fix SDK policy type and updateRole function

### DIFF
--- a/.changeset/breezy-pans-kneel.md
+++ b/.changeset/breezy-pans-kneel.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fixed SDK policy type and updateRole function

--- a/sdk/src/rest/commands/update/roles.ts
+++ b/sdk/src/rest/commands/update/roles.ts
@@ -1,5 +1,5 @@
 import type { DirectusRole } from '../../../schema/role.js';
-import type { ApplyQueryFields, Query } from '../../../types/index.js';
+import type { ApplyQueryFields, NestedPartial, Query } from '../../../types/index.js';
 import { throwIfEmpty } from '../../utils/index.js';
 import type { RestCommand } from '../../types.js';
 
@@ -20,7 +20,7 @@ export type UpdateRoleOutput<
 export const updateRoles =
 	<Schema, const TQuery extends Query<Schema, DirectusRole<Schema>>>(
 		keys: DirectusRole<Schema>['id'][],
-		item: Partial<DirectusRole<Schema>>,
+		item: NestedPartial<DirectusRole<Schema>>,
 		query?: TQuery,
 	): RestCommand<UpdateRoleOutput<Schema, TQuery>[], Schema> =>
 	() => {
@@ -42,7 +42,7 @@ export const updateRoles =
  */
 export const updateRolesBatch =
 	<Schema, const TQuery extends Query<Schema, DirectusRole<Schema>>>(
-		items: Partial<DirectusRole<Schema>>[],
+		items: NestedPartial<DirectusRole<Schema>>[],
 		query?: TQuery,
 	): RestCommand<UpdateRoleOutput<Schema, TQuery>[], Schema> =>
 	() => ({
@@ -63,7 +63,7 @@ export const updateRolesBatch =
 export const updateRole =
 	<Schema, const TQuery extends Query<Schema, DirectusRole<Schema>>>(
 		key: DirectusRole<Schema>['id'],
-		item: Partial<DirectusRole<Schema>>,
+		item: NestedPartial<DirectusRole<Schema>>,
 		query?: TQuery,
 	): RestCommand<UpdateRoleOutput<Schema, TQuery>, Schema> =>
 	() => {

--- a/sdk/src/schema/access.ts
+++ b/sdk/src/schema/access.ts
@@ -9,7 +9,7 @@ export type DirectusAccess<Schema = any> = MergeCoreCollection<
 		id: string; // uuid
 		role: string | DirectusRole<Schema>;
 		user: string | DirectusUser<Schema>;
-		policy: string | DirectusRole<Schema>;
+		policy: string | DirectusPolicy<Schema>;
 		sort: number;
 	}
 >;

--- a/sdk/src/schema/access.ts
+++ b/sdk/src/schema/access.ts
@@ -1,4 +1,5 @@
 import type { MergeCoreCollection } from '../index.js';
+import type { DirectusPolicy } from './policy.js';
 import type { DirectusRole } from './role.js';
 import type { DirectusUser } from './user.js';
 

--- a/sdk/src/schema/access.ts
+++ b/sdk/src/schema/access.ts
@@ -1,0 +1,15 @@
+import type { MergeCoreCollection } from '../index.js';
+import type { DirectusRole } from './role.js';
+import type { DirectusUser } from './user.js';
+
+export type DirectusAccess<Schema = any> = MergeCoreCollection<
+	Schema,
+	'directus_access',
+	{
+		id: string; // uuid
+		role: string | DirectusRole<Schema>;
+		user: string | DirectusUser<Schema>;
+		policy: string | DirectusRole<Schema>;
+		sort: number;
+	}
+>;

--- a/sdk/src/schema/index.ts
+++ b/sdk/src/schema/index.ts
@@ -1,3 +1,4 @@
+export * from './access.js';
 export * from './activity.js';
 export * from './collection.js';
 export * from './core.js';

--- a/sdk/src/schema/role.ts
+++ b/sdk/src/schema/role.ts
@@ -1,6 +1,6 @@
 import type { MergeCoreCollection } from '../index.js';
 import type { DirectusUser } from './user.js';
-import type { DirectusPolicy } from './policy.js';
+import type { DirectusAccess } from './access.js';
 
 export type DirectusRole<Schema = any> = MergeCoreCollection<
 	Schema,
@@ -12,7 +12,7 @@ export type DirectusRole<Schema = any> = MergeCoreCollection<
 		description: string | null;
 		parent: string | DirectusRole<Schema>;
 		children: string[] | DirectusRole<Schema>[];
-		policies: string[] | DirectusPolicy<Schema>[];
+		policies: string[] | DirectusAccess<Schema>[];
 		users: string[] | DirectusUser<Schema>[];
 	}
 >;

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -38,15 +38,35 @@ export type IsDateTime<T, Y, N> = T extends 'datetime' ? Y : N;
 export type IsNumber<T, Y, N> = T extends number ? Y : N;
 export type IsString<T, Y, N> = T extends string ? Y : N;
 
-export type NestedPartial<Item extends object> = {
-	[Key in keyof Item]?: NonNullable<Item[Key]> extends infer NestedItem
-		? NestedItem extends object[]
-			? NestedPartial<UnpackList<NestedItem>>[] | Exclude<Item[Key], NestedItem>
-			: NestedItem extends object
-			  ? NestedPartial<NestedItem> | Exclude<Item[Key], NestedItem>
-			  : Item[Key]
-		: Item[Key];
-};
+/**
+ * Helpers for working with unions
+ */
+type UnionToParm<U> = U extends any ? (k: U) => void : never;
+type UnionToSect<U> = UnionToParm<U> extends ((k: infer I) => void) ? I : never;
+type ExtractParm<F> = F extends { (a: infer A): void } ? A : never;
+
+type SpliceOne<Union> = Exclude<Union, ExtractOne<Union>>;
+type ExtractOne<Union> = ExtractParm<UnionToSect<UnionToParm<Union>>>;
+
+type ToTuple<Union> = ToTupleRec<Union, []>;
+type ToTupleRec<Union, Rslt extends any[]> =
+    SpliceOne<Union> extends never ? [NestedPartial<ExtractOne<Union>>, ...Rslt]
+    : ToTupleRec<SpliceOne<Union>, [NestedPartial<ExtractOne<Union>>, ...Rslt]>
+;
+
+type TupleToUnion<T extends unknown[]> = T[number];
+
+/**
+ * Recursively make properties optional
+ */
+export type NestedPartial<Item> = Item extends any[]
+	? UnpackList<Item> extends infer RawItem
+		? NestedPartial<RawItem>[]
+		: never
+	: Item extends object
+		? { [Key in keyof Item]?: TupleToUnion<ToTuple<Item[Key]>> }
+		: Item;
+
 
 /**
  * Reduces a complex object type to make it readable in IDEs.

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -48,12 +48,13 @@ type ExtractParm<F> = F extends { (a: infer A): void } ? A : never;
 type SpliceOne<Union> = Exclude<Union, ExtractOne<Union>>;
 type ExtractOne<Union> = ExtractParm<UnionToSect<UnionToParm<Union>>>;
 
-type ToTuple<Union> = ToTupleRec<Union, []>;
-type ToTupleRec<Union, Rslt extends any[]> = SpliceOne<Union> extends never
-	? [NestedPartial<ExtractOne<Union>>, ...Rslt]
-	: ToTupleRec<SpliceOne<Union>, [NestedPartial<ExtractOne<Union>>, ...Rslt]>;
+export type ToTuple<Union> = ToTupleRec<Union, []>;
 
-type TupleToUnion<T extends unknown[]> = T[number];
+type ToTupleRec<Union, Rslt extends any[]> = SpliceOne<Union> extends never
+	? [ExtractOne<Union>, ...Rslt]
+	: ToTupleRec<SpliceOne<Union>, [ExtractOne<Union>, ...Rslt]>;
+
+export type TupleToUnion<T extends unknown[]> = T[number];
 
 /**
  * Recursively make properties optional
@@ -63,8 +64,15 @@ export type NestedPartial<Item> = Item extends any[]
 		? NestedPartial<RawItem>[]
 		: never
 	: Item extends object
-	  ? { [Key in keyof Item]?: TupleToUnion<ToTuple<Item[Key]>> }
+	  ? { [Key in keyof Item]?: NestedUnion<Item[Key]> }
 	  : Item;
+
+type NestedUnion<Item> = TupleToUnion<ToTuplePartial<Item>>;
+
+type ToTuplePartial<Union> = ToTuplePartialRec<Union, []>;
+type ToTuplePartialRec<Union, Rslt extends any[]> = SpliceOne<Union> extends never
+	? [NestedPartial<ExtractOne<Union>>, ...Rslt]
+	: ToTuplePartialRec<SpliceOne<Union>, [NestedPartial<ExtractOne<Union>>, ...Rslt]>;
 
 /**
  * Reduces a complex object type to make it readable in IDEs.

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -42,17 +42,16 @@ export type IsString<T, Y, N> = T extends string ? Y : N;
  * Helpers for working with unions
  */
 type UnionToParm<U> = U extends any ? (k: U) => void : never;
-type UnionToSect<U> = UnionToParm<U> extends ((k: infer I) => void) ? I : never;
+type UnionToSect<U> = UnionToParm<U> extends (k: infer I) => void ? I : never;
 type ExtractParm<F> = F extends { (a: infer A): void } ? A : never;
 
 type SpliceOne<Union> = Exclude<Union, ExtractOne<Union>>;
 type ExtractOne<Union> = ExtractParm<UnionToSect<UnionToParm<Union>>>;
 
 type ToTuple<Union> = ToTupleRec<Union, []>;
-type ToTupleRec<Union, Rslt extends any[]> =
-    SpliceOne<Union> extends never ? [NestedPartial<ExtractOne<Union>>, ...Rslt]
-    : ToTupleRec<SpliceOne<Union>, [NestedPartial<ExtractOne<Union>>, ...Rslt]>
-;
+type ToTupleRec<Union, Rslt extends any[]> = SpliceOne<Union> extends never
+	? [NestedPartial<ExtractOne<Union>>, ...Rslt]
+	: ToTupleRec<SpliceOne<Union>, [NestedPartial<ExtractOne<Union>>, ...Rslt]>;
 
 type TupleToUnion<T extends unknown[]> = T[number];
 
@@ -64,9 +63,8 @@ export type NestedPartial<Item> = Item extends any[]
 		? NestedPartial<RawItem>[]
 		: never
 	: Item extends object
-		? { [Key in keyof Item]?: TupleToUnion<ToTuple<Item[Key]>> }
-		: Item;
-
+	  ? { [Key in keyof Item]?: TupleToUnion<ToTuple<Item[Key]>> }
+	  : Item;
 
 /**
  * Reduces a complex object type to make it readable in IDEs.


### PR DESCRIPTION
Fixes #24206
Fixes #23313

## Scope

There are 2 underlying issues addressed here:
1. The new `directus_access` schema was missing for relating to policies
2. The `updateUser*` were not using `NestedPartial` for input types and `NestedPartial` failed to loop through unions like `string[] | DirectusRole<Schema>[]`

What's changed:

- Added missing `directus_access` schema
- Updated `directus_role` type
- Updated `NestedPartial` type to support unions
- Added `NestedPartial` to `updateRole*` functions

## Potential Risks / Drawbacks

- Type issues

## Review Notes / Questions

- The `ToTuple` helper type allows us to split up union types and treat each part individually. Example usage:
```ts
type T = ToTuple<'a' | 'b' | 1>;
//   ^? ['a', 'b', 1]
```
---

