### PR TITLE
Prevent websocket heartbeat handler from erroring on startup

### DIFF
--- a/.changeset/eight-seas-call.md
+++ b/.changeset/eight-seas-call.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Prevent websocket heartbeat handler from erroring on startup
+Prevented websocket heartbeat handler from erroring on startup

--- a/.changeset/eight-seas-call.md
+++ b/.changeset/eight-seas-call.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Prevent websocket heartbeat handler from erroring on startup

--- a/api/src/websocket/handlers/index.ts
+++ b/api/src/websocket/handlers/index.ts
@@ -13,10 +13,12 @@ export function startWebSocketHandlers() {
 	const graphqlEnabled = toBoolean(env['WEBSOCKETS_GRAPHQL_ENABLED']);
 	const logsEnabled = toBoolean(env['WEBSOCKETS_LOGS_ENABLED']);
 
+
+	if (restEnabled && heartbeatEnabled) {
+		new HeartbeatHandler();
+	}
+
 	if (restEnabled || graphqlEnabled) {
-		if (heartbeatEnabled) {
-			new HeartbeatHandler();
-		}
 
 		new ItemsHandler();
 	}

--- a/api/src/websocket/handlers/index.ts
+++ b/api/src/websocket/handlers/index.ts
@@ -13,11 +13,11 @@ export function startWebSocketHandlers() {
 	const graphqlEnabled = toBoolean(env['WEBSOCKETS_GRAPHQL_ENABLED']);
 	const logsEnabled = toBoolean(env['WEBSOCKETS_LOGS_ENABLED']);
 
-	if (heartbeatEnabled) {
-		new HeartbeatHandler();
-	}
-
 	if (restEnabled || graphqlEnabled) {
+		if (heartbeatEnabled) {
+			new HeartbeatHandler();
+		}
+
 		new ItemsHandler();
 	}
 

--- a/api/src/websocket/handlers/index.ts
+++ b/api/src/websocket/handlers/index.ts
@@ -19,7 +19,6 @@ export function startWebSocketHandlers() {
 	}
 
 	if (restEnabled || graphqlEnabled) {
-
 		new ItemsHandler();
 	}
 

--- a/api/src/websocket/handlers/index.ts
+++ b/api/src/websocket/handlers/index.ts
@@ -13,7 +13,6 @@ export function startWebSocketHandlers() {
 	const graphqlEnabled = toBoolean(env['WEBSOCKETS_GRAPHQL_ENABLED']);
 	const logsEnabled = toBoolean(env['WEBSOCKETS_LOGS_ENABLED']);
 
-
 	if (restEnabled && heartbeatEnabled) {
 		new HeartbeatHandler();
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Required websocket REST to be enabled before starting up the heartbeat handler

## Potential Risks / Drawbacks

- None i think

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

---

Fixes #24210
