### PR TITLE
Design/fix select all notification spacing

### DIFF
--- a/.changeset/fast-lies-help.md
+++ b/.changeset/fast-lies-help.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the alignment of the select-all checkbox in the notifications drawer

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -432,10 +432,10 @@ function clearFilters() {
 	align-items: center;
 	justify-content: center;
 	height: 24px;
-	margin: 0 18px;
+	margin: 0 var(--theme--form--field--input--padding);
 
 	&.dense {
-		margin: 0 10px 12px;
+		margin: 0 8px 12px;
 	}
 }
 

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -435,7 +435,7 @@ function clearFilters() {
 	margin: 0 calc(var(--theme--form--field--input--padding) + var(--theme--border-width));
 
 	&.dense {
-		margin: 0 calc(8px + var(--theme--border-width))  12px;
+		margin: 0 calc(8px + var(--theme--border-width)) 12px;
 	}
 }
 

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -432,10 +432,10 @@ function clearFilters() {
 	align-items: center;
 	justify-content: center;
 	height: 24px;
-	margin: 0 var(--theme--form--field--input--padding);
+	margin: 0 calc(var(--theme--form--field--input--padding) + var(--theme--border-width));
 
 	&.dense {
-		margin: 0 8px 12px;
+		margin: 0 calc(8px + var(--theme--border-width))  12px;
 	}
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Aligned the left-spacing of the select-all button with the notification-selection

**Before**
![Before](https://github.com/user-attachments/assets/9cfb7954-086a-40fe-9b4b-9a5413467a96)

**After**
![After-2](https://github.com/user-attachments/assets/1963cce4-3252-49e4-8c89-86ebf10e64a9)

**Before densed**
![before-densed](https://github.com/user-attachments/assets/e1bedf50-9f92-4e11-8445-8cba6216deb6)

**After densed**
![After-densed-2](https://github.com/user-attachments/assets/6baf622b-2765-40c4-af60-33c3b1a42201)

## Review Notes / Questions
- Quickly opened the PR from the browser, as I haven't an up to date directus-dev environment atm. Therewith I couldn't create a changeset - sorry 
---

Fixes #24212
