### PR TITLE
Make the Add Collection Button for Policies More Visible

### DIFF
--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -265,7 +265,14 @@ function useDisplayValue() {
 				<slot name="preview">{{ displayValue.text || placeholder }}</slot>
 				<v-icon name="expand_more" :class="{ active }" />
 			</div>
-			<slot v-else name="preview">
+			<slot
+				v-else
+				name="preview"
+				v-bind="{
+					toggle: toggle,
+					active: active,
+				}"
+			>
 				<v-input
 					:full-width="fullWidth"
 					readonly

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -58,14 +58,13 @@ function notExcluded({ collection }: Collection) {
 				item-text="collection"
 				item-value="collection"
 				:show-arrow="false"
-				:placeholder="t('permission_add_collection')"
 				placement="bottom-start"
 				item-label-font-family="var(--theme--fonts--monospace--font-family)"
 				@update:model-value="$emit('select', $event)"
 			>
 				<template #preview="{toggle}">
 					<v-button x-small @click="toggle">
-						{{ t('add_existing') }}
+						{{ t('permission_add_collection') }}
 						<v-icon name="arrow_drop_down" right />
 					</v-button>
 				</template>

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -62,7 +62,7 @@ function notExcluded({ collection }: Collection) {
 				item-label-font-family="var(--theme--fonts--monospace--font-family)"
 				@update:model-value="$emit('select', $event)"
 			>
-				<template #preview="{toggle}">
+				<template #preview="{ toggle }">
 					<v-button x-small @click="toggle">
 						{{ t('permission_add_collection') }}
 						<v-icon name="arrow_drop_down" right />

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -63,9 +63,9 @@ function notExcluded({ collection }: Collection) {
 				@update:model-value="$emit('select', $event)"
 			>
 				<template #preview="{ toggle }">
-					<v-button x-small @click="toggle">
+					<v-button @click="toggle">
 						{{ t('permission_add_collection') }}
-						<v-icon name="arrow_drop_down" right />
+						<v-icon name="arrow_drop_down" />
 					</v-button>
 				</template>
 			</v-select>
@@ -86,6 +86,13 @@ function notExcluded({ collection }: Collection) {
 
 	.v-select:hover {
 		--v-select-placeholder-color: var(--theme--foreground-accent);
+	}
+
+	.v-button {
+		--v-button-padding: 0 6px 0 12px;
+		--v-button-height: 28px;
+		--v-button-font-size: 12px;
+		--v-button-min-width: 60px;
 	}
 }
 </style>

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -60,10 +60,16 @@ function notExcluded({ collection }: Collection) {
 				:show-arrow="false"
 				:placeholder="t('permission_add_collection')"
 				placement="bottom-start"
-				inline
 				item-label-font-family="var(--theme--fonts--monospace--font-family)"
 				@update:model-value="$emit('select', $event)"
-			/>
+			>
+				<template #preview="{toggle}">
+					<v-button x-small @click="toggle">
+						{{ t('add_existing') }}
+						<v-icon name="arrow_drop_down" right />
+					</v-button>
+				</template>
+			</v-select>
 		</td>
 	</tr>
 </template>

--- a/app/src/interfaces/_system/system-permissions/add-collection-row.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection-row.vue
@@ -63,7 +63,7 @@ function notExcluded({ collection }: Collection) {
 				@update:model-value="$emit('select', $event)"
 			>
 				<template #preview="{ toggle }">
-					<v-button @click="toggle">
+					<v-button small @click="toggle">
 						{{ t('permission_add_collection') }}
 						<v-icon name="arrow_drop_down" />
 					</v-button>
@@ -86,13 +86,6 @@ function notExcluded({ collection }: Collection) {
 
 	.v-select:hover {
 		--v-select-placeholder-color: var(--theme--foreground-accent);
-	}
-
-	.v-button {
-		--v-button-padding: 0 6px 0 12px;
-		--v-button-height: 28px;
-		--v-button-font-size: 12px;
-		--v-button-min-width: 60px;
 	}
 }
 </style>

--- a/app/src/interfaces/_system/system-permissions/add-collection.vue
+++ b/app/src/interfaces/_system/system-permissions/add-collection.vue
@@ -7,7 +7,6 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-	disabled?: boolean;
 	excludeCollections?: string[];
 }>();
 
@@ -51,41 +50,21 @@ function notExcluded({ collection }: Collection) {
 </script>
 
 <template>
-	<tr class="add-collection-row">
-		<td colspan="7">
-			<v-select
-				:items="displayItems"
-				item-text="collection"
-				item-value="collection"
-				:show-arrow="false"
-				placement="bottom-start"
-				item-label-font-family="var(--theme--fonts--monospace--font-family)"
-				@update:model-value="$emit('select', $event)"
-			>
-				<template #preview="{ toggle }">
-					<v-button small @click="toggle">
-						{{ t('permission_add_collection') }}
-						<v-icon name="arrow_drop_down" />
-					</v-button>
-				</template>
-			</v-select>
-		</td>
-	</tr>
+	<div>
+		<v-select
+			:items="displayItems"
+			item-text="collection"
+			item-value="collection"
+			placement="bottom-start"
+			item-label-font-family="var(--theme--fonts--monospace--font-family)"
+			@update:model-value="$emit('select', $event)"
+		>
+			<template #preview="{ toggle }">
+				<v-button @click="toggle">
+					{{ t('permission_add_collection') }}
+					<v-icon name="arrow_drop_down" right />
+				</v-button>
+			</template>
+		</v-select>
+	</div>
 </template>
-
-<style scoped lang="scss">
-.add-collection-row {
-	td {
-		padding: 12px;
-		border-top: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
-	}
-
-	.monospace {
-		font-family: var(--theme--fonts--monospace--font-family);
-	}
-
-	.v-select:hover {
-		--v-select-placeholder-color: var(--theme--foreground-accent);
-	}
-}
-</style>

--- a/app/src/interfaces/_system/system-permissions/system-permissions.vue
+++ b/app/src/interfaces/_system/system-permissions/system-permissions.vue
@@ -13,7 +13,7 @@ import { getEndpoint } from '@directus/utils';
 import { cloneDeep, get, groupBy, isNil, merge, orderBy, sortBy } from 'lodash';
 import { computed, inject, nextTick, type Ref, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import AddCollectionRow from './add-collection-row.vue';
+import AddCollection from './add-collection.vue';
 import PermissionsDetail from './detail/permissions-detail.vue';
 import PermissionsHeader from './permissions-header.vue';
 import PermissionsRow from './permissions-row.vue';
@@ -655,15 +655,16 @@ function useGroupedPermissions() {
 							</span>
 						</td>
 					</tr>
-
-					<add-collection-row
-						:exclude-collections="
-							[...regularPermissions, ...systemPermissions].map(({ collection }) => collection.collection)
-						"
-						@select="addEmptyPermission($event)"
-					/>
 				</tfoot>
 			</table>
+
+			<add-collection
+				class="add-collection"
+				:exclude-collections="
+					[...regularPermissions, ...systemPermissions].map(({ collection }) => collection.collection)
+				"
+				@select="addEmptyPermission($event)"
+			/>
 		</div>
 
 		<permissions-detail
@@ -759,7 +760,7 @@ function useGroupedPermissions() {
 	}
 }
 
-.system-collections {
-	margin-top: 14px;
+.add-collection {
+	margin-top: 12px;
 }
 </style>


### PR DESCRIPTION
## Scope

What's changed:

- Exposes `v-menu`'s `toggle(), active` through the `v-select`'s preview slot so overriding the preview of the v-select allows you to control it still.
- Changes the preview/activator of the Add Collection dropdown on the permissions page to the primary button instead of the `inline-dropdown`.

| Before | After |
|--------|--------|
| <img width="313" alt="image" src="https://github.com/user-attachments/assets/d53e2830-24d3-4b2f-a055-9e4e37ced378" /> | <img width="268" alt="image" src="https://github.com/user-attachments/assets/3c58331e-7c79-4a24-8cc3-893da9dcf800" /> |

## Potential Risks / Drawbacks

- Change to UX

## Review Notes / Questions

- None

---

Fixes #23237
