### PR TITLE
fix: prevent 'legacy migration comments' breaking migration flow

### DIFF
--- a/api/src/database/migrations/20240924A-migrate-legacy-comments.ts
+++ b/api/src/database/migrations/20240924A-migrate-legacy-comments.ts
@@ -81,9 +81,13 @@ export async function up(knex: Knex): Promise<void> {
 		});
 	}
 
-	await knex.schema.alterTable('directus_activity', (table) => {
-		table.dropColumn('comment');
-	});
+	try {
+		await knex.schema.alterTable('directus_activity', (table) => {
+			table.dropColumn('comment');
+		});
+	} catch {
+		// ignore
+	}
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/contributors.yml
+++ b/contributors.yml
@@ -193,3 +193,4 @@
 - vst-name
 - clonefetch
 - gloriarodrife
+- camboui


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- 20240924A-migrate-legacy-comments, catch and ignore errors when droping unexisting comment  column.

## Potential Risks / Drawbacks

None, the try/catch won't do anything if column isn't dropped

## Review Notes / Questions

- A foreign key is already dropped this way at the beginning of this migration, I'm using the same process in case there is nothing to drop, i.e try/catch.


---

Fixes #24249 
