### PR TITLE
Fix incorrect updating of user's role when OIDC role mapping is not set

### DIFF
--- a/.changeset/wet-laws-sort.md
+++ b/.changeset/wet-laws-sort.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Updated user's role only when OIDC role mapping is set

--- a/.changeset/wet-laws-sort.md
+++ b/.changeset/wet-laws-sort.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Updated user's role only when OIDC role mapping is set
+Fixed incorrect updating of user's role when OIDC role mapping is not set

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -244,9 +244,12 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			let emitPayload: Record<string, unknown> = {
 				auth_data: userPayload.auth_data,
-				// Make sure a user's role gets updated if his openid group or role mapping changes
-				role: role,
 			};
+
+			// Make sure a user's role gets updated if his openid group or role mapping changes
+			if (this.config['roleMapping']) {
+				emitPayload['role'] = role;
+			}
 
 			if (syncUserInfo) {
 				emitPayload = {

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -246,7 +246,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				auth_data: userPayload.auth_data,
 			};
 
-			// Make sure a user's role gets updated if his openid group or role mapping changes
+			// Make sure a user's role gets updated if their openid group or role mapping changes
 			if (this.config['roleMapping']) {
 				emitPayload['role'] = role;
 			}


### PR DESCRIPTION
## Scope

What's changed:

- Update user's role only when OIDC role mapping is set

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

---

Fixes #24247
