### PR TITLE
Add external option to config and docs

### DIFF
--- a/.changeset/old-kids-provide.md
+++ b/.changeset/old-kids-provide.md
@@ -1,0 +1,6 @@
+---
+'@directus/extensions-sdk': patch
+'docs': patch
+---
+
+Added the external option to extension config

--- a/docs/extensions/creating-extensions.md
+++ b/docs/extensions/creating-extensions.md
@@ -65,6 +65,7 @@ An example with the currently available options will look something like:
 ```js
 export default {
 	plugins: [],
+	external: [],
 	watch: {
 		clearScreen: false
 	}
@@ -75,6 +76,8 @@ export default {
 
 - [`plugins`](https://rollupjs.org/configuration-options/#plugins) — An array of Rollup plugins that will be used when
   building extensions in addition to the built-in ones.
+- [`external`](https://rollupjs.org/configuration-options/#external) — An array of strings representing modules which
+  should not be bundled together with your extension.
 - [`watch.clearScreen`](https://rollupjs.org/configuration-options/#watch-clearscreen) — Controls whether or not to
   clear the screen when a rebuild is triggered.
 

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -540,7 +540,7 @@ function getRollupOptions({
 
 	return {
 		input: typeof input !== 'string' ? 'entry' : input,
-		external: mode === 'browser' ? APP_SHARED_DEPS : API_SHARED_DEPS,
+		external: [...(config.external ?? []), ...(mode === 'browser' ? APP_SHARED_DEPS : API_SHARED_DEPS)],
 		plugins: [
 			typeof input !== 'string' ? virtual(input) : null,
 			mode === 'browser' ? vue({ isProduction: true }) : null,

--- a/packages/extensions-sdk/src/cli/types.ts
+++ b/packages/extensions-sdk/src/cli/types.ts
@@ -6,6 +6,7 @@ export type LanguageShort = 'js' | 'ts';
 
 export type Config = {
 	plugins?: Plugin[];
+	external?: string[];
 	watch?: {
 		clearScreen?: boolean;
 	};


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The Rollup external option can now be used in extension config

## Potential Risks / Drawbacks

- A little more config to maintain

## Review Notes / Questions

My specific case is adding [sharp](https://sharp.pixelplumbing.com/) to an extension which dynamically loads preuilt binaries based on the platform, so it can't be bundled with my extension. Adding it as an external module would let me build my extension and have sharp loaded correctly.

---

Fixes https://github.com/directus/directus/issues/19060
