### PR TITLE
fix: reset login error message on successful credentials

### DIFF
--- a/.changeset/funny-coins-sort.md
+++ b/.changeset/funny-coins-sort.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Cleared login error message on successful credentials when TFA is enabled

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -42,12 +42,6 @@ watch(provider, () => {
 	requiresTFA.value = false;
 });
 
-watch(requiresTFA, (newValue: boolean) => {
-  if (newValue) {
-    error.value = null;
-  }
-});
-
 const errorFormatted = computed(() => {
 	// Show "Wrong username or password" for wrongly formatted emails as well
 	if (error.value === 'INVALID_PAYLOAD') {
@@ -96,6 +90,7 @@ async function onSubmit() {
 	} catch (err: any) {
 		if (err.errors?.[0]?.extensions?.code === 'INVALID_OTP' && requiresTFA.value === false) {
 			requiresTFA.value = true;
+			error.value = null;
 		} else {
 			error.value = err.errors?.[0]?.extensions?.code || err;
 		}

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -42,6 +42,12 @@ watch(provider, () => {
 	requiresTFA.value = false;
 });
 
+watch(requiresTFA, (newValue: boolean) => {
+  if (newValue) {
+    error.value = null;
+  }
+});
+
 const errorFormatted = computed(() => {
 	// Show "Wrong username or password" for wrongly formatted emails as well
 	if (error.value === 'INVALID_PAYLOAD') {

--- a/contributors.yml
+++ b/contributors.yml
@@ -194,3 +194,4 @@
 - clonefetch
 - gloriarodrife
 - blazingh
+- bwp91


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Hide the invalid credentials error message on the login form when a correct username/password combination is entered.

To reproduce, 2fa needs to be enabled - using the initial admin account is okay.

1. Attempt to login with the admin username but an incorrect password - the invalid credentials message appears
2. Next, login with the correct credentials so that the field for the 2fa code appears
3. At this point, the invalid credentials error is still visible (and in my opinion it should have been hidden when the 2fa input box appears)

## Potential Risks / Drawbacks

## Review Notes / Questions

---

Fixes #\<num\>
