### PR TITLE
Fixed the sdk not returning `null` on 204 response

### DIFF
--- a/.changeset/wild-seas-rule.md
+++ b/.changeset/wild-seas-rule.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed the sdk not returning `null` on 204 response

--- a/sdk/src/utils/extract-data.ts
+++ b/sdk/src/utils/extract-data.ts
@@ -25,7 +25,7 @@ export async function extractData(response: unknown) {
 			return result;
 		}
 
-		if (response.ok && response.status === 204) {
+		if (response.status === 204) {
 			return null;
 		}
 

--- a/sdk/src/utils/extract-data.ts
+++ b/sdk/src/utils/extract-data.ts
@@ -25,6 +25,10 @@ export async function extractData(response: unknown) {
 			return result;
 		}
 
+		if (response.ok && response.status === 204) {
+			return null;
+		}
+
 		// fallback for anything else
 		return response;
 	}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now return null for a `204` response 

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Do we need to update any typings? 

#### Testing Script
```js
import { createDirectus, rest, schemaDiff, schemaSnapshot, staticToken } from '...';

const client = createDirectus('http://0.0.0.0:8055').with(staticToken('1234')).with(rest());

const schema = await client.request(schemaSnapshot());

const result = await client.request(schemaDiff(schema));

console.log({ result });
```

---

Fixes #24276
