### PR TITLE
Fixed "getSchema" type definition for api extensions

### DIFF
--- a/.changeset/strange-files-know.md
+++ b/.changeset/strange-files-know.md
@@ -1,0 +1,5 @@
+---
+"@directus/extensions": patch
+---
+
+Fixed "getSchema" type definition for api extensions

--- a/packages/extensions/src/shared/types/api-extension-context.ts
+++ b/packages/extensions/src/shared/types/api-extension-context.ts
@@ -1,4 +1,4 @@
-import type { Accountability, SchemaOverview } from '@directus/types';
+import type { SchemaOverview } from '@directus/types';
 import type { Knex } from 'knex';
 import type { Logger } from 'pino';
 
@@ -7,5 +7,5 @@ export type ApiExtensionContext = {
 	database: Knex;
 	env: Record<string, any>;
 	logger: Logger;
-	getSchema: (options?: { accountability?: Accountability; database?: Knex }) => Promise<SchemaOverview>;
+	getSchema: (options?: { database?: Knex, bypassCache?: boolean; }, attempt?: number) => Promise<SchemaOverview>;
 };

--- a/packages/extensions/src/shared/types/api-extension-context.ts
+++ b/packages/extensions/src/shared/types/api-extension-context.ts
@@ -7,5 +7,5 @@ export type ApiExtensionContext = {
 	database: Knex;
 	env: Record<string, any>;
 	logger: Logger;
-	getSchema: (options?: { database?: Knex, bypassCache?: boolean; }, attempt?: number) => Promise<SchemaOverview>;
+	getSchema: (options?: { database?: Knex; bypassCache?: boolean }, attempt?: number) => Promise<SchemaOverview>;
 };


### PR DESCRIPTION
## Scope

What's changed:

- Only the type definition for the `getSchema` function exposed to extensions

## Potential Risks / Drawbacks

- None, the old type was very outdated and no longer represented the actual function signature.

## Review Notes / Questions

- I would like to lorem ipsum

---

Fixes #24315 
