### PR TITLE
Update renovate to include security patches & ignore tinymce v7

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
 	"extends": ["config:recommended", ":disableDependencyDashboard"],
 	"labels": [":robot: Dependency"],
 	"enabledManagers": ["npm", "github-actions"],
+	"vulnerabilityAlerts": {
+		"enabled": false
+	},
 	"packageRules": [
 		{
 			"groupName": "all non-major dependencies",
@@ -41,6 +44,12 @@
 		{
 			"description": "hold - https://github.com/prettier/prettier/issues/15783",
 			"matchPackageNames": ["prettier"],
+			"enabled": false
+		},
+		{
+			"description": "hold - https://github.com/directus/directus/pull/24181",
+			"matchPackageNames": ["tinymce"],
+			"matchUpdateTypes": ["major"],
 			"enabled": false
 		},
 		{


### PR DESCRIPTION
## Scope

Update renovate config to
- not treat security patches separately
  - if unscheduled security patches should be required, we can do this manually, otherwise they should be part of the regular configured PR groups
- ignore TinyMCE v7 (next major), see #24181
