### PR TITLE
Fix kanban group display bug

### DIFF
--- a/.changeset/healthy-trains-pay.md
+++ b/.changeset/healthy-trains-pay.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug in the kanban layout where setting a related values display broke the layout

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -685,11 +685,18 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					}
 				}
 
-				[groupField.value, titleField.value, textField.value, tagsField.value, dateField.value].forEach((val) => {
-					if (val !== null) fields.push(val);
-				});
+				[groupField.value, tagsField.value, dateField.value].forEach(addFieldIfNotNull);
 
-				return uniq(adjustFieldsForDisplays(fields, collection.value!));
+				adjustFieldsForDisplays(
+					[titleField.value, textField.value].filter((val) => val !== null),
+					collection.value!,
+				)?.forEach(addFieldIfNotNull);
+
+				return uniq(fields);
+
+				function addFieldIfNotNull(val: string | null) {
+					if (val !== null) fields.push(val);
+				}
 			});
 
 			return { sort, limit, page, fields };


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a bug in the kanban layout where setting a related values display for the group field broke the layout


## Review Notes / Questions

- The problem was that the `groupField` was passed to `adjustFieldsForDisplays()`.

---

Fixes #24278
