### PR TITLE
Fix large duplications returning error 414

### DIFF
--- a/.changeset/ten-coats-ring.md
+++ b/.changeset/ten-coats-ring.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed `Save as Copy` returning error 414 when a large amount of duplication fields are present

--- a/app/src/composables/use-item.test.ts
+++ b/app/src/composables/use-item.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/utils/notify', () => ({
 vi.mock('@/api', () => {
 	return {
 		default: {
-			get: vi.fn(),
+			request: vi.fn(),
 			post: vi.fn(),
 		},
 	};
@@ -37,8 +37,14 @@ afterEach(() => {
 });
 
 describe('Save As Copy', () => {
-	const apiGetSpy = vi.spyOn(api, 'get');
+	const apiSearchSpy = vi.spyOn(api, 'request');
 	const apiPostSpy = vi.spyOn(api, 'post');
+
+	const mockSearchResponse = {
+		data: {
+			data: [{ id: 1 }],
+		},
+	};
 
 	const mockResponse = {
 		data: {
@@ -57,7 +63,7 @@ describe('Save As Copy', () => {
 	} as AppCollection;
 
 	test('should keep manual primary key', async () => {
-		apiGetSpy.mockResolvedValue(mockResponse);
+		apiSearchSpy.mockResolvedValue(mockSearchResponse);
 		apiPostSpy.mockResolvedValue(mockResponse);
 
 		const mockPrimaryKeyFieldName = 'id';
@@ -113,7 +119,7 @@ describe('Save As Copy', () => {
 	});
 
 	test('should omit auto incremented primary key', async () => {
-		apiGetSpy.mockResolvedValue(mockResponse);
+		apiSearchSpy.mockResolvedValue(mockSearchResponse);
 		apiPostSpy.mockResolvedValue(mockResponse);
 
 		const mockPrimaryKeyFieldName = 'id';
@@ -169,7 +175,7 @@ describe('Save As Copy', () => {
 	});
 
 	test('should omit special uuid primary key', async () => {
-		apiGetSpy.mockResolvedValue(mockResponse);
+		apiSearchSpy.mockResolvedValue(mockSearchResponse);
 		apiPostSpy.mockResolvedValue(mockResponse);
 
 		const mockPrimaryKeyFieldName = 'id';

--- a/app/src/composables/use-item.ts
+++ b/app/src/composables/use-item.ts
@@ -1,4 +1,5 @@
 import api from '@/api';
+import { useNestedValidation } from '@/composables/use-nested-validation';
 import { VALIDATION_TYPES } from '@/constants';
 import { i18n } from '@/lang';
 import { useFieldsStore } from '@/stores/fields';
@@ -10,7 +11,6 @@ import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
-import { useNestedValidation } from '@/composables/use-nested-validation';
 import { useCollection } from '@directus/composables';
 import { isSystemCollection } from '@directus/system-data';
 import { Alterations, Field, Item, PrimaryKey, Query, Relation } from '@directus/types';
@@ -185,10 +185,23 @@ export function useItem<T extends Item>(
 
 		const fields = collectionInfo.value?.meta?.item_duplication_fields || ['*'];
 
-		const itemData = await api.get(itemEndpoint.value, { params: { fields } });
+		const itemData = await api.request({
+			method: 'SEARCH',
+			url: getEndpoint(collection.value),
+			data: {
+				query: {
+					fields,
+					filter: {
+						id: {
+							_eq: primaryKey.value,
+						},
+					},
+				},
+			},
+		});
 
 		const newItem: Item = {
-			...(itemData.data.data || {}),
+			...(itemData.data.data[0] || {}),
 			...edits.value,
 		};
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now utilize `SEARCH` over a `GET` request for `Save as Copy` to circumvent URL limitations when large amounts of fields are selected to be duplicated

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

## Tests
- Existing Save and Copy still works
  -  items
  - files
  - users
  - translation strings
- large field selection for duplication no longer returns 414
- only selected fields are duplicated  

---

Fixes #24237
