### PR TITLE
Fix translation interface border spacing

### DIFF
--- a/.changeset/clever-turkeys-call.md
+++ b/.changeset/clever-turkeys-call.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Prevented the checkbox transition in the translation interface when switching languages

--- a/.changeset/proud-kiwis-type.md
+++ b/.changeset/proud-kiwis-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug causing the translation interface's bottom border to lose margin-top when it was the first visible field.

--- a/.changeset/proud-kiwis-type.md
+++ b/.changeset/proud-kiwis-type.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed a bug causing the translation interface's bottom border to lose margin-top when it was the first visible field.

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -425,7 +425,7 @@ function useRawEditor() {
 .v-form {
 	@include mixins.form-grid;
 
-	.first-visible-field :deep(.v-divider) {
+	.first-visible-field :deep(.presentation-divider) {
 		margin-top: 0;
 	}
 

--- a/app/src/interfaces/presentation-divider/presentation-divider.vue
+++ b/app/src/interfaces/presentation-divider/presentation-divider.vue
@@ -9,6 +9,7 @@ defineProps<{
 
 <template>
 	<v-divider
+		class="presentation-divider"
 		:class="{ 'add-margin-top': icon || title }"
 		:style="{
 			'--v-divider-label-color': color,


### PR DESCRIPTION
## Scope

What's changed:

The problem was that any `<v-divider>` inside the `.first-visible-field` lost its `margin-top`. The corresponding CSS rule was introduced with https://github.com/directus/directus/pull/8467. According to that discussion, the rule should have applied only to the `<presentation-interface>` instead of to each `<v-divider>` component. That's why this PR ensures that the CSS rule of `margin-top: 0` only applies to the `<presentation-interface>`.

Before:
![bug](https://github.com/user-attachments/assets/2749b807-c088-49b2-af4d-0357a7f01939)

After:
![fix](https://github.com/user-attachments/assets/54e02adb-155e-4fa4-930b-b3c5edbe7dd7)

## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- tiny one

---

Fixes #24350
