### PR TITLE
Enable renovate updates for blackbox tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended", ":disableDependencyDashboard"],
+	"extends": [
+		":semanticPrefixFixDepsChoreOthers",
+		"group:monorepos",
+		"group:recommended",
+		"replacements:all",
+		"workarounds:all"
+	],
 	"labels": [":robot: Dependency"],
 	"enabledManagers": ["npm", "github-actions"],
 	"vulnerabilityAlerts": {


### PR DESCRIPTION
## Scope

So far we extended from [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended) which includes the [`:ignoreModulesAndTests`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) preset. This preset ignores all `tests` directories which means the `tests/blackbox` package didn't receive any updates.

Instead of extending from the recommended config, we now select the individual config presets ourselves which gives us better/clearer control anyway (e.g. no need to define `:disableDependencyDashboard` anymore).
The default value of [`ignorePaths`](https://docs.renovatebot.com/configuration-options/#ignorepaths) already includes `node_modules` what is sufficient for us.