### PR TITLE
Only Update Fetched Items When Data Changes

### DIFF
--- a/.changeset/lazy-dragons-tap.md
+++ b/.changeset/lazy-dragons-tap.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Changed `useRelationMultiple` to only update fetched items when dependents change, not just update

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -79,7 +79,15 @@ export function useRelationMultiple(
 		}
 	});
 
-	watch([previewQuery, itemId, relation], updateFetchedItems, { immediate: true });
+	watch(
+		[previewQuery, itemId, relation],
+		(newData, oldData) => {
+			if (!isEqual(newData, oldData)) {
+				updateFetchedItems();
+			}
+		},
+		{ immediate: true },
+	);
 
 	const { fetchedSelectItems, selected, isItemSelected, selectedOnPage } = useSelected();
 


### PR DESCRIPTION
## Scope

What's changed:

- `useRelationMultiple()` watches for changes in `previewQuery, itemId, relation` and then triggers `updateFetchedItems()` to fetch the data. It did NOT check to see if there actually was changes between the new and old data, this change does. It will only trigger `updateFetchedItems()` now if there was a change between the new and old state.

## Potential Risks / Drawbacks

- If there are any usages that relied on the updating of data even when the dependents didn't change.

## Review Notes / Questions

- Check the different usages of `useRelationMultiple()`

---

Fixes #23750
