### PR TITLE
Enhance translation interface loading state

### DIFF
--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -17,6 +17,7 @@ const {
 	getItemEdits,
 	isLocalItem,
 	remove,
+	loading,
 	updateValue,
 } = defineProps<{
 	languageOptions: Record<string, any>[];
@@ -71,7 +72,7 @@ const activatorDisabled = computed(() => {
 	);
 });
 
-const { getIconName, onEnableTranslation, onMousedown, onMouseup, onTransitionEnd, transition } = useActivatorButton();
+const { transition, iconName, onEnableTranslation, onMousedown, onMouseup, onTransitionEnd } = useActivatorButton();
 const { getDeleteToggleTooltip, getDeleteToggleName, onToggleDelete } = useDeleteToggle();
 
 function useActivatorButton() {
@@ -79,23 +80,23 @@ function useActivatorButton() {
 	const pressed = ref(false);
 	const transition = ref(false);
 
+	const iconName = computed(() =>
+		(pressed.value || pressing.value) && !activatorDisabled.value ? 'check_box' : 'check_box_outline_blank',
+	);
+
 	watch([item, lang], ([newItem, newLang], [oldItem, oldLang]) => {
-		transition.value = newItem !== oldItem && newLang === oldLang;
+		const isInitialItem = isEmpty(newItem) && isEmpty(oldItem);
+		transition.value = isInitialItem ? false : newItem !== oldItem && newLang === oldLang;
 	});
 
 	return {
-		getIconName,
+		transition,
+		iconName,
 		onEnableTranslation,
 		onMousedown,
 		onMouseup,
 		onTransitionEnd,
-		transition,
 	};
-
-	function getIconName() {
-		if ((pressed.value || pressing.value) && !activatorDisabled.value) return 'check_box';
-		return 'check_box_outline_blank';
-	}
 
 	function onEnableTranslation(lang?: string, item?: DisplayItem, itemInitial?: DisplayItem) {
 		if (!isEmpty(item) || !isEmpty(itemInitial)) return;
@@ -156,7 +157,10 @@ function useDeleteToggle() {
 	<div :class="{ secondary }">
 		<language-select v-model="lang" :items="languageOptions" :danger="item?.$type === 'deleted'" :secondary>
 			<template #prepend>
+				<span v-if="loading" class="activator-loading-placeholder" />
+
 				<transition
+					v-else
 					:name="transition ? (item ? 'rotate-in' : 'rotate-out') : null"
 					:duration="transition ? null : 0"
 					mode="out-in"
@@ -169,7 +173,7 @@ function useDeleteToggle() {
 						v-else
 						v-tooltip="!activatorDisabled ? t('enable') : null"
 						:class="{ disabled: activatorDisabled }"
-						:name="getIconName()"
+						:name="iconName"
 						:disabled="activatorDisabled"
 						clickable
 						@click.stop="onEnableTranslation(lang, item, itemInitial)"
@@ -219,6 +223,14 @@ function useDeleteToggle() {
 </template>
 
 <style lang="scss" scoped>
+.activator-loading-placeholder {
+	--size: 24px;
+
+	display: inline-block;
+	width: var(--size);
+	height: var(--size);
+}
+
 .disabled {
 	--v-icon-color: var(--theme--primary-subdued);
 }

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -70,7 +70,7 @@ watch(splitView, (splitViewEnabled) => {
 	}
 });
 
-const { languageOptions } = useLanguages();
+const { languageOptions, loading: languagesLoading } = useLanguages();
 
 const splitViewAvailable = computed(() => width.value > 960 && languageOptions.value.length > 1);
 const splitViewEnabled = computed(() => splitViewAvailable.value && splitView.value);
@@ -82,12 +82,16 @@ const fields = computed(() => {
 
 const query = ref<RelationQueryMultiple>({ fields: ['*'], limit: -1, page: 1 });
 
-const { create, update, remove, isLocalItem, displayItems, loading, fetchedItems, getItemEdits } = useRelationMultiple(
-	value,
-	query,
-	relationInfo,
-	primaryKey,
-);
+const {
+	create,
+	update,
+	remove,
+	isLocalItem,
+	displayItems,
+	loading: itemsLoading,
+	fetchedItems,
+	getItemEdits,
+} = useRelationMultiple(value, query, relationInfo, primaryKey);
 
 useNestedValidation();
 
@@ -139,7 +143,7 @@ const translationProps = computed(() => ({
 	autofocus: props.autofocus,
 	relationInfo: relationInfo.value,
 	getItemWithLang,
-	loading: loading.value,
+	loading: languagesLoading.value || itemsLoading.value,
 	displayItems: displayItems.value,
 	fetchedItems: fetchedItems.value,
 	getItemEdits,


### PR DESCRIPTION
## Scope

The new checkbox -> icon transition animation from #24332 is triggered on initial load as well as on "Save & Stay" for existing items. This is a bit distracting. Therefore, this is now resolved by
- considering both the items and languages fetching for the interface loading state
- adding an empty placeholder in place of the checkbox/icon while it's still loading

https://github.com/user-attachments/assets/812357f9-cd28-41e8-9b45-15627dedf35b

https://github.com/user-attachments/assets/24b37f5f-5845-4642-847a-737ef50ae2bc



