### PR TITLE
Fix Translations/Formatted JSON Displays in Template Rendering

### DIFF
--- a/.changeset/hip-hairs-design.md
+++ b/.changeset/hip-hairs-design.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed Translations/Formatted JSON Displays in Template Rendering

--- a/.changeset/hip-hairs-design.md
+++ b/.changeset/hip-hairs-design.md
@@ -1,5 +1,0 @@
----
-"@directus/app": patch
----
-
-Fixed Translations/Formatted JSON Displays in Template Rendering

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -75,7 +75,7 @@ const parts = computed(() =>
 
 			if (!displayInfo.value) return value;
 
-			if (component && ['related-values', 'formatted-value'].includes(component)) {
+			if (component && ['related-values', 'formatted-value', 'formatted-json-value', 'translations'].includes(component)) {
 				// These displays natively support rendering arrays of values
 				return [
 					{
@@ -119,7 +119,7 @@ const parts = computed(() =>
 					<value-null
 						v-if="
 							subPart === null ||
-							(typeof subPart === 'object' && (subPart.value === null || subPart.value === undefined))
+							(typeof subPart === 'object' && (subPart.value === null))
 						"
 					/>
 					<template v-else-if="subPart?.component">

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -170,6 +170,10 @@ const parts = computed(() =>
 	}
 }
 
+.render-template:has(.display-translations) {
+	text-overflow: clip;
+}
+
 .subdued {
 	color: var(--theme--foreground-subdued);
 }

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -75,7 +75,10 @@ const parts = computed(() =>
 
 			if (!displayInfo.value) return value;
 
-			if (component && ['related-values', 'formatted-value', 'formatted-json-value', 'translations'].includes(component)) {
+			if (
+				component &&
+				['related-values', 'formatted-value', 'formatted-json-value', 'translations'].includes(component)
+			) {
 				// These displays natively support rendering arrays of values
 				return [
 					{
@@ -116,12 +119,7 @@ const parts = computed(() =>
 		<template v-for="(part, index) in parts" :key="index">
 			<template v-for="(subPart, subIndex) in part" :key="subIndex">
 				<v-error-boundary>
-					<value-null
-						v-if="
-							subPart === null ||
-							(typeof subPart === 'object' && (subPart.value === null))
-						"
-					/>
+					<value-null v-if="subPart === null || (typeof subPart === 'object' && subPart.value === null)" />
 					<template v-else-if="subPart?.component">
 						<component
 							:is="`display-${subPart.component}`"


### PR DESCRIPTION
## Scope

What's changed:

- Correctly render Translation Displays and Formatted JSON Displays correctly in the `render-template` component.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- Check Translation Display and Formatted JSON Displays 

---

Fixes #24407
Closes WEB-533
