### PR TITLE
Update de-DE.yaml: Fix Typo

### DIFF
--- a/app/src/lang/translations/de-DE.yaml
+++ b/app/src/lang/translations/de-DE.yaml
@@ -1082,7 +1082,7 @@ editing_in_batch: '{count} Elemente werden bearbeitet'
 no_options_available: Keine Optionen verfügbar
 settings_data_model: Datenmodell
 settings_roles: Benutzerrollen
-settings_permissions: '"Zugangsrichtlinien "'
+settings_permissions: Zugangsrichtlinien
 settings_project: Einstellungen
 settings_appearance: Erscheinung
 settings_webhooks: Webhooks

--- a/contributors.yml
+++ b/contributors.yml
@@ -196,3 +196,4 @@
 - blazingh
 - bwp91
 - ukmadlz
+- florian-senn


### PR DESCRIPTION
settings_permissions: Zugangsrichtlinien
removed ' and "

## Scope
Breadcrumbs[directus](https://github.com/directus/directus/tree/main)/[app](https://github.com/directus/directus/tree/main/app)/[src](https://github.com/directus/directus/tree/main/app/src)/[lang](https://github.com/directus/directus/tree/main/app/src/lang)/[translations](https://github.com/directus/directus/tree/main/app/src/lang/translations)
/
de-DE.yaml
settings_permissions: Zugangsrichtlinien

What's changed:

removed ' and "

## Potential Risks / Drawbacks

guess none

## Review Notes / Questions


---

Fixes #24414 
