### PR TITLE
Label Display: Always convert a string to an arrayed string regardless of field type

### DIFF
--- a/.changeset/dry-dryers-pretend.md
+++ b/.changeset/dry-dryers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed label display not handling json field types in templates

--- a/app/src/displays/labels/labels.vue
+++ b/app/src/displays/labels/labels.vue
@@ -30,8 +30,8 @@ const items = computed(() => {
 	let items: string[] | number[];
 
 	if (isEmpty(props.value) && isNaN(props.value as number)) items = [];
-	else if (props.type === 'string' && isString(props.value)) items = [props.value as string];
 	else if (['integer', 'bigInteger', 'float', 'decimal'].includes(props.type)) items = [props.value as number];
+	else if (isString(props.value)) items = [props.value as string];
 	else items = props.value as string[];
 
 	return items.map((item) => {


### PR DESCRIPTION
## Scope

What's changed:

Currently the label display only converts a string to an arrayed string if the field type is a string and the value is a string. However, there are now instances like when the field type is JSON where the value is just a string. So if the value is a string then always array it. 

## Potential Risks / Drawbacks

- Are there ever instances where we don't want this behavior?

## Review Notes / Questions

- Test using recreation steps in issue.

---

Fixes #24428
