### PR TITLE
Revert PapaParse version bump

### DIFF
--- a/.changeset/mighty-baboons-sip.md
+++ b/.changeset/mighty-baboons-sip.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Reverted version bump of CSV parser dependency due to a regression

--- a/api/package.json
+++ b/api/package.json
@@ -158,7 +158,7 @@
 		"otplib": "12.0.1",
 		"p-limit": "6.2.0",
 		"p-queue": "8.0.1",
-		"papaparse": "5.5.0",
+		"papaparse": "5.4.1",
 		"pino": "9.6.0",
 		"pino-http": "10.3.0",
 		"pino-http-print": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,8 +321,8 @@ importers:
         specifier: 8.0.1
         version: 8.0.1
       papaparse:
-        specifier: 5.5.0
-        version: 5.5.0
+        specifier: 5.4.1
+        version: 5.4.1
       pino:
         specifier: 9.6.0
         version: 9.6.0
@@ -9515,8 +9515,8 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
-  papaparse@5.5.0:
-    resolution: {integrity: sha512-rlVJyYL5QMvue8f/RNGpchWAiTc42GzJD/dqD/YgxJxmQ7TWQh5/7aN3p/aqxkYTRl/BkODi6Qsau1r2bt42JQ==}
+  papaparse@5.4.1:
+    resolution: {integrity: sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==}
 
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -20784,7 +20784,7 @@ snapshots:
 
   pako@1.0.11: {}
 
-  papaparse@5.5.0: {}
+  papaparse@5.4.1: {}
 
   param-case@3.0.4:
     dependencies:


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Revert version bump of PapaParse from `5.4.1` to `5.5.0`

The is an upstream issue that surfaced in PapaParse 5.5.0 and 5.5.1 that causes transform header to be called even for data rows, causing invalid data transforms on the supposed header, see https://github.com/mholt/PapaParse/issues/1083

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Easily reproduced with the linked issue #24440 

---

Fixes #24440
