### PR TITLE
Fix strange behavior of the sticky header bar

### DIFF
--- a/.changeset/silver-glasses-repeat.md
+++ b/.changeset/silver-glasses-repeat.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug where the header would not collapse under certain circumstances and would unexpectedly move up when
+scrolling elements in the view

--- a/app/src/views/private/components/header-bar.vue
+++ b/app/src/views/private/components/header-bar.vue
@@ -27,7 +27,8 @@ const collapsed = ref(false);
 
 const observer = new IntersectionObserver(
 	([e]) => {
-		collapsed.value = e.boundingClientRect.y === -1;
+		if (!e) return;
+		collapsed.value = e.boundingClientRect.y < 0;
 	},
 	{ threshold: [1] },
 );

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -421,7 +421,9 @@ function getWidth(input: unknown, fallback: number): number {
 				--v-divider-color: var(--theme--navigation--list--divider--border-color);
 				--v-divider-thickness: var(--theme--navigation--list--divider--border-width);
 
-				height: calc(100% - 60px);
+				--project-header-height: 60px;
+
+				height: calc(100% - var(--project-header-height));
 				overflow-x: hidden;
 				overflow-y: auto;
 			}

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -430,6 +430,8 @@ function getWidth(input: unknown, fallback: number): number {
 		@media (min-width: 960px) {
 			position: relative;
 			transform: none;
+			// this prevents the layout from moving up when an element is automatically scrolled into the view
+			overflow-y: clip;
 		}
 	}
 

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -421,7 +421,7 @@ function getWidth(input: unknown, fallback: number): number {
 				--v-divider-color: var(--theme--navigation--list--divider--border-color);
 				--v-divider-thickness: var(--theme--navigation--list--divider--border-width);
 
-				height: calc(100% - 64px);
+				height: calc(100% - 60px);
 				overflow-x: hidden;
 				overflow-y: auto;
 			}


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a bug where the header would not collapse under certain circumstances and would unexpectedly move up when
scrolling elements in the view

Shifting bug:

https://github.com/user-attachments/assets/764506f5-a21f-470a-8b3a-4c02751f6f04


## Potential Risks / Drawbacks

- …

## Review Notes / Questions

- small one

---

Fixes #24357
