### PR TITLE
Fix dark header bar shadow

### DIFF
--- a/.changeset/modern-parrots-invite.md
+++ b/.changeset/modern-parrots-invite.md
@@ -1,0 +1,5 @@
+---
+'@directus/themes': patch
+---
+
+Fixed shadow of header bar to be present in default dark mode

--- a/app/src/views/private/components/header-bar.vue
+++ b/app/src/views/private/components/header-bar.vue
@@ -96,7 +96,7 @@ onUnmounted(() => {
 	margin: 0;
 	padding: 0 10px;
 	background-color: var(--theme--header--background);
-	box-shadow: 0;
+	box-shadow: none;
 	transition:
 		box-shadow var(--medium) var(--transition),
 		margin var(--fast) var(--transition);

--- a/packages/themes/src/themes/dark/default.ts
+++ b/packages/themes/src/themes/dark/default.ts
@@ -124,7 +124,7 @@ export default defineTheme({
 			background: 'var(--theme--background)',
 			borderColor: 'transparent',
 			borderWidth: '0px',
-			boxShadow: '0 4px 7px -4px rgb(var(--black) / 0.2)',
+			boxShadow: '0 4px 7px -4px black',
 			headline: {
 				foreground: 'var(--theme--foreground-subdued)',
 				fontFamily: 'var(--theme--fonts--sans--font-family)',


### PR DESCRIPTION
## Scope

Noticed that the header bar shadow is missing in the default dark theme.
The issue is that the `rgb` function doesn't support hex input [^1], and also the color defined in `--black` with the applied transparency would give a contrast ratio of 1:

<img width="400" alt="contrast" src="https://github.com/user-attachments/assets/9cdeca33-b4e4-4dd9-b1a9-aac3f207d085" />

By using `black` we get a contrast that is actually visible.

Additionally, the default value for `box-shadow` (when no shadow is applied to the header bar) was incorrectly set to `0` which is not a valid value [^2]. This has been fixed by using `none`.

### Before

![Editing Item in Article · Directus](https://github.com/user-attachments/assets/f0d441fa-0790-4ac0-8d19-37ad1686f111)

### After

![Editing Item in Article · Directus](https://github.com/user-attachments/assets/efdb7513-7f30-485e-b4d5-4794aef20eb1)

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow