### PR TITLE
Fix missing space between v-notice and list items in m2a

### DIFF
--- a/.changeset/metal-numbers-hope.md
+++ b/.changeset/metal-numbers-hope.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed missing space between v-notice and list items in M2A interface

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -361,6 +361,7 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 			<v-notice v-if="displayItems.length === 0">{{ t('no_items') }}</v-notice>
 
 			<draggable
+				v-else
 				:model-value="displayItems"
 				tag="v-list"
 				item-key="$index"

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -513,6 +513,10 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 
 .v-list {
 	@include mixins.list-interface($deleteable: true);
+
+	.v-notice + & {
+		margin-top: 12px;
+	}
 }
 
 .v-list-item {


### PR DESCRIPTION
## Scope

What's changed:

Before:
![bug](https://github.com/user-attachments/assets/f66df2a2-a08d-41a2-9c54-a26fe6b839ea)

After:
![fix](https://github.com/user-attachments/assets/9be4d435-13c2-46f4-9eab-1abec4295ce1)

## Potential Risks / Drawbacks

…

## Review Notes / Questions

- tiny one

---

Fixes #24465
