### PR TITLE
Fix SSO social icons alignment in Safari

### DIFF
--- a/.changeset/thirty-doors-attack.md
+++ b/.changeset/thirty-doors-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed alignment of SSO social icons in Safari

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -99,19 +99,15 @@ const errorFormatted = computed(() => {
 	transition: border-color var(--fast) var(--transition);
 
 	.sso-icon {
+		--v-icon-size: 28px;
+
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		aspect-ratio: 1;
+		width: var(--theme--form--field--input--height);
 		margin: -$sso-link-border-width;
 		background-color: var(--theme--background-accent);
 		border-radius: var(--theme--border-radius);
-
-		span {
-			--v-icon-size: 28px;
-			display: flex;
-			align-items: center;
-		}
 	}
 
 	.sso-title {


### PR DESCRIPTION
## Scope

- Reported issue in #24472 has already been partial fixed via #23223 (see [`v-icon.vue`](https://github.com/directus/directus/pull/23223/files#diff-eb4fc72f6189e7c695c4b89e691eb1120ead3acf79e33e39b09454b540237d23R151-R152))
- But unfortunately, in Safari `aspect-ratio` doesn't work as expected in some cases, which now leads to another alignment issue (see below) - therefore we're basically reverting #24119

### Before

<img width="300" src="https://github.com/user-attachments/assets/97290e2b-197c-416e-b465-87cb64a4b99e" />

### After

<img width="300" src="https://github.com/user-attachments/assets/16e6f568-a63b-433d-8901-96458342ddde" />

---

Tested in Safari, Firefox, Chrome

Fixes #24472 
