### PR TITLE
Docs: Clarify `deep` query example

### DIFF
--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -620,27 +620,19 @@ Deep allows you to set any of the other query parameters on a nested relational 
 
 ### Examples
 
-Limit the nested related articles to 3
+Only get 3 related posts, with only the top rated comment nested:
 
 ```json
 {
-	"related_articles": {
-		"_limit": 3
-	}
-}
-```
-
-Only get 3 related articles, with only the top rated comment nested
-
-```json
-{
-	"related_articles": {
-		"_limit": 3,
-		"comments": {
-			"_sort": "rating",
-			"_limit": 1
+	"deep": {
+		"related_posts": {
+			"_limit": 3,
+			"comments": {
+				"_sort": "rating",
+				"_limit": 1
+			}
 		}
-	}
+  }
 }
 ```
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -616,7 +616,10 @@ const result = await client.request(
 
 ## Deep
 
-Deep allows you to set any of the other query parameters on a nested relational dataset.
+Deep allows you to set any of the other query parameters (expect for [Fields](#fields) and [Deep](#deep) itself) on a
+nested relational dataset.
+
+The nested query parameters are to be prefixed with an underscore.
 
 ### Examples
 


### PR DESCRIPTION
## Scope

This has already come up twice, so making the usage clearer by putting the query explicitly under “deep”, and also aligning it with the new docs (reduce to one example since they are almost the same).

Corresponding PR for the new docs: https://github.com/directus/docs/pull/140

---

Fixes directus/docs#144, also mentioned in directus/directus#21472
