### PR TITLE
Fix bug where text did not appear in markdown interface when switching from preview to editor mode

### DIFF
--- a/.changeset/blue-apricots-drive.md
+++ b/.changeset/blue-apricots-drive.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug where text did not appear in the markdown interface when switching from preview to editor mode

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -513,7 +513,9 @@ textarea {
 }
 
 .interface-input-rich-text-md.preview :deep(.CodeMirror) {
-	display: none;
+	visibility: hidden;
+	position: absolute;
+	pointer-events: none;
 }
 
 .toolbar {

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -458,7 +458,7 @@ textarea {
 
 .preview-box {
 	display: none;
-	padding: 20px;
+	padding: 20px 24px;
 	font-family: v-bind(previewFamily), serif;
 
 	:deep() {
@@ -506,10 +506,6 @@ textarea {
 
 .interface-input-rich-text-md :deep(.CodeMirror .CodeMirror-lines:last-of-type) {
 	margin-bottom: 20px;
-}
-
-.interface-input-rich-text-md :deep(.CodeMirror .CodeMirror-scroll) {
-	min-height: 260px;
 }
 
 .interface-input-rich-text-md.preview :deep(.CodeMirror) {

--- a/app/src/styles/lib/_codemirror.scss
+++ b/app/src/styles/lib/_codemirror.scss
@@ -6,7 +6,7 @@
 	color: var(--theme--foreground);
 	font-weight: inherit;
 	font-family: var(--theme--fonts--monospace--font-family);
-	line-height: 22px;
+	line-height: 24px;
 	direction: ltr;
 	background-color: var(--theme--form--field--input--background);
 	border: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
@@ -139,8 +139,7 @@
 }
 
 /* Can style cursor different in overwrite (non-insert) mode */
-.CodeMirror-overwrite .CodeMirror-cursor {
-}
+// .CodeMirror-overwrite .CodeMirror-cursor { }
 
 .cm-tab {
 	display: inline-block;
@@ -202,11 +201,11 @@
 .cm-s-default .cm-def {
 	color: var(--theme--primary);
 }
-.cm-s-default .cm-variable,
-.cm-s-default .cm-punctuation,
-.cm-s-default .cm-property,
-.cm-s-default .cm-operator {
-}
+// .cm-s-default .cm-variable,
+// .cm-s-default .cm-punctuation,
+// .cm-s-default .cm-property,
+// .cm-s-default .cm-operator {
+// }
 .cm-s-default .cm-variable-2 {
 	color: var(--theme--primary);
 }
@@ -474,8 +473,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 	padding: 0.1px; /* Force widget margins to stay inside of the container */
 }
 
-.CodeMirror-widget {
-}
+// .CodeMirror-widget {}
 
 .CodeMirror-rtl pre {
 	direction: rtl;

--- a/app/src/styles/mixins/_markdown.scss
+++ b/app/src/styles/mixins/_markdown.scss
@@ -61,21 +61,15 @@
 		line-height: 22px;
 	}
 
-	p {
-		margin: 1.5em 0;
-		font-weight: 500;
-		font-size: 15px;
-		line-height: 24px;
-	}
-
 	a {
 		color: var(--theme--primary-accent);
 		text-decoration: none;
 	}
 
+	p,
 	ul,
 	ol {
-		margin: 1.5em 0;
+		margin: 1.6em 0; // 24px (line-height) / 15px (font-size) = 1.6
 		font-weight: 500;
 		font-size: 15px;
 		line-height: 24px;


### PR DESCRIPTION
## Scope

What's changed:

- changed the way how codemirror is hidden when in preview mode
- ensured that there are no visual layout shifts when switching between the two modes

## Potential Risks / Drawbacks

…

## Review Notes / Questions

…

---

Fixes #24455
