### PR TITLE
Fix wrong item limit warning after filtering

### DIFF
--- a/.changeset/red-lizards-film.md
+++ b/.changeset/red-lizards-film.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug where the item limit warning would appear even if the item count was already below the limit after filtering

--- a/app/src/layouts/calendar/calendar.vue
+++ b/app/src/layouts/calendar/calendar.vue
@@ -12,7 +12,10 @@ defineOptions({
 interface Props {
 	createCalendar: (calendarElement: HTMLElement) => void;
 	destroyCalendar: () => void;
-	itemCount?: number;
+	itemCount: number | null;
+	totalCount: number | null;
+	isFiltered: boolean;
+	limit: number;
 	resetPresetAndRefresh: () => Promise<void>;
 	error?: any;
 	selectMode: boolean;
@@ -38,13 +41,16 @@ onUnmounted(() => {
 	props.destroyCalendar();
 });
 
-const atLimit = computed(() => props.itemCount === 10000);
+const atLimit = computed(() => {
+	const count = (props.isFiltered ? props.itemCount : props.totalCount) ?? 0;
+	return count > props.limit;
+});
 </script>
 
 <template>
 	<div class="calendar-layout" :class="{ 'select-mode': selectMode, 'select-one': showSelect === 'one' }">
 		<v-notice v-if="atLimit" type="warning">
-			{{ t('dataset_too_large_currently_showing_n_items', { n: n(10000) }) }}
+			{{ t('dataset_too_large_currently_showing_n_items', { n: n(props.limit) }) }}
 		</v-notice>
 		<div v-if="!error" ref="calendarElement" />
 		<slot v-else name="error" :error="error" :reset="resetPresetAndRefresh" />

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -111,7 +111,7 @@ export default defineLayout<LayoutOptions>({
 			return fields;
 		});
 
-		const limit = info.queryLimit?.max && info.queryLimit.max !== -1 ? info.queryLimit.max : 10000;
+		const limit = computed(() => (info.queryLimit?.max && info.queryLimit.max !== -1 ? info.queryLimit.max : 1000));
 
 		const {
 			items,
@@ -127,7 +127,7 @@ export default defineLayout<LayoutOptions>({
 		} = useItems(collection, {
 			sort: computed(() => [primaryKeyField.value?.field || '']),
 			page: ref(1),
-			limit: ref(limit),
+			limit,
 			fields: queryFields,
 			filter: filterWithCalendarView,
 			search: search,
@@ -250,6 +250,8 @@ export default defineLayout<LayoutOptions>({
 			});
 		});
 
+		const isFiltered = computed(() => !!props.filterUser || !!props.search);
+
 		return {
 			items,
 			loading,
@@ -259,6 +261,8 @@ export default defineLayout<LayoutOptions>({
 			totalPages,
 			itemCount,
 			totalCount,
+			isFiltered,
+			limit,
 			changeManualSort,
 			getItems,
 			filterWithCalendarView,

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -237,6 +237,8 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			});
 		});
 
+		const isFiltered = computed(() => !!props.filterUser || !!props.search);
+
 		const { canReorderGroups, canReorderItems, canUpdateGroupTitle, canDeleteGroups } = useLayoutPermissions();
 
 		return {
@@ -263,6 +265,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			itemCount,
 			totalCount,
 			showingCount,
+			isFiltered,
 			fieldsInCollection,
 			fields,
 			limit,

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -11,7 +11,9 @@ defineOptions({ inheritAttrs: false });
 const props = withDefaults(
 	defineProps<{
 		collection?: string | null;
+		itemCount: number | null;
 		totalCount: number | null;
+		isFiltered: boolean;
 		limit: number;
 		groupCollection?: string | null;
 		fieldsInCollection?: Field[];
@@ -61,7 +63,10 @@ const { t, n } = useI18n();
 const editDialogOpen = ref<string | number | null>(null);
 const editTitle = ref('');
 
-const atLimit = computed(() => (props.totalCount ?? 0) > props.limit);
+const atLimit = computed(() => {
+	const count = (props.isFiltered ? props.itemCount : props.totalCount) ?? 0;
+	return count > props.limit;
+});
 
 function openEditGroup(group: Group) {
 	editDialogOpen.value = group.id;
@@ -126,7 +131,7 @@ const reorderGroupsDisabled = computed(() => !props.canReorderGroups || props.se
 
 		<template v-else>
 			<v-notice v-if="atLimit" type="warning" class="limit">
-				{{ t('dataset_too_large_currently_showing_n_items', { n: n(props.totalCount ?? 0) }) }}
+				{{ t('dataset_too_large_currently_showing_n_items', { n: n(props.limit ?? 0) }) }}
 			</v-notice>
 
 			<div class="kanban">


### PR DESCRIPTION
## Scope

What's changed:

- Extended the `atLimit` logic to take filters into account in Kanban & Calendar Layout

## Potential Risks / Drawbacks

…

## Review Notes / Questions

To test this, it is useful to create a flow that creates a certain number of items.

---

Fixes #24452
