### PR TITLE
ensure that confirmation prompt closes when clicked

### DIFF
--- a/app/src/components/v-remove.vue
+++ b/app/src/components/v-remove.vue
@@ -22,7 +22,7 @@ const emit = defineEmits(['action']);
 
 const { t } = useI18n();
 
-const { needsConfirmation, confirmDelete } = useConfirmation();
+const { needsConfirmation, confirmDelete, onConfirmDelete } = useConfirmation();
 
 const deselectable = computed(() => deselect || itemIsLocal);
 
@@ -57,7 +57,12 @@ function useConfirmation() {
 		return confirm || hasItemEdits();
 	});
 
-	return { needsConfirmation, confirmDelete };
+	return { needsConfirmation, confirmDelete, onConfirmDelete };
+
+	function onConfirmDelete() {
+		confirmDelete.value = false;
+		emit('action');
+	}
 
 	function hasItemEdits() {
 		if (!itemInfo?.type || !itemEdits) return false;
@@ -136,7 +141,7 @@ function useConfirmation() {
 				<v-button secondary @click="confirmDelete = false">
 					{{ t('cancel') }}
 				</v-button>
-				<v-button kind="danger" @click="emit('action')">
+				<v-button kind="danger" @click="onConfirmDelete">
 					{{ t('delete_label') }}
 				</v-button>
 			</v-card-actions>


### PR DESCRIPTION
## Scope

What's changed:

- ensured that confirmation prompt closes when clicked

Bug occurs when deleting the first element of a repeater – modal should close:

https://github.com/user-attachments/assets/7cf3057f-d001-4b16-a0f8-3b55fcb5f6b3


## Review Notes / Questions

- Regression of https://github.com/directus/directus/pull/24462 (unreleased)


