### PR TITLE
Add support for rendering M2A items in related values display

### DIFF
--- a/.changeset/tasty-sloths-build.md
+++ b/.changeset/tasty-sloths-build.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Ensured that M2A items render in related values display
+Added support for rendering M2A items in related values display

--- a/.changeset/tasty-sloths-build.md
+++ b/.changeset/tasty-sloths-build.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Ensured that M2A items render in related values display

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -1,5 +1,6 @@
 import { useExtension } from '@/composables/use-extension';
 import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { renderPlainStringTemplate } from '@/utils/render-string-template';
@@ -117,6 +118,20 @@ export default defineDisplay({
 
 			if (!fields.includes(primaryKeyFieldValue)) {
 				fields.push(primaryKeyFieldValue);
+			}
+		}
+
+		const fieldStoreField = fieldsStore.getField(collection, field);
+
+		if (fieldStoreField?.meta?.special?.includes('m2a')) {
+			const relationsStore = useRelationsStore();
+			const relations = relationsStore.getRelationsForField(collection, field);
+
+			const collectionField = relations.find((relation) => relation.meta?.one_collection_field)?.meta
+				?.one_collection_field;
+
+			if (collectionField && !fields.find((field) => field === collectionField)) {
+				fields.push(collectionField);
 			}
 		}
 


### PR DESCRIPTION
## Scope

What's changed:

- With this PR https://github.com/directus/directus/pull/24480, we also coincidentally added support for rendering M2A items in the related values view.
- The problem with this, however, is that if multiple related any collections have the same fields, the `<render-template>` was not able to distinguish between the different collections. So if we had `{{ item:posts.color }} | {{ item:pages.color }}` in our display template for the `related-values` display, and we were to display a `posts` item, then also the slot for the `item:pages.color` would also get the data from the `posts` item.
- This PR makes the rendering of M2A items in the related values display work as expected.

| before (wrong) | after (correct) |
|---|---|
| <img src="https://github.com/user-attachments/assets/7c6149c9-91ae-49de-95a8-756cf770bb99"> | <img src="https://github.com/user-attachments/assets/9964f37a-85a9-4c24-8428-86ef58263133"> |

## Potential Risks / Drawbacks

…

## Review Notes / Questions

…

---

Fixes #10601
