### PR TITLE
Fix Date Formatting Options Interface/Display, extract to Utilities

### DIFF
--- a/.changeset/yellow-bobcats-shop.md
+++ b/.changeset/yellow-bobcats-shop.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Enhanced Date Formatting Options for DateTime Interface/Display

--- a/app/src/components/use-datetime.test.ts
+++ b/app/src/components/use-datetime.test.ts
@@ -3,7 +3,7 @@ import { i18n } from '@/lang';
 import { mount } from '@vue/test-utils';
 import { afterAll, beforeAll, expect, test, vi } from 'vitest';
 import { nextTick } from 'vue';
-import Datetime from './datetime.vue';
+import UseDatetime from './use-datetime.vue';
 
 const global: GlobalMountOptions = {
 	plugins: [i18n],
@@ -29,53 +29,33 @@ function getCurrentTestDate() {
 	return nowUTC;
 }
 
-test.each([
-	{ format: 'long', expected: 'January 1st, 2023 12:00 AM' },
-	{ format: 'short', expected: 'Jan 1, 2023 12:00AM' },
-])('should display $format formatted string of current timestamp value', ({ format, expected }) => {
+test('should provide datetime value', () => {
 	const now = getCurrentTestDate();
 
-	const wrapper = mount(Datetime, {
+	const wrapper = mount(UseDatetime, {
+		slots: {
+			default: '<template v-slot="{ datetime }">{{ datetime }}</template>',
+		},
 		props: {
 			value: now.toISOString(),
 			type: 'timestamp',
-			format,
 		},
 		global,
 	});
 
-	expect(wrapper.find('.datetime').element.textContent).toBe(expected);
+	expect(wrapper.html()).toBe('January 1st, 2023 12:00 AM');
 });
 
-test.each([
-	{ strict: true, expected: '0 seconds ago' },
-	{ strict: false, expected: 'less than a minute ago' },
-])('should display "$expected" relative formatted string when strict is $strict', async ({ strict, expected }) => {
+test('should refresh the value every minute when relative is true', async () => {
 	const now = getCurrentTestDate();
 
 	// set system time to be the same time as the tested time
 	vi.setSystemTime(now.valueOf());
 
-	const wrapper = mount(Datetime, {
-		props: {
-			value: now.toISOString(),
-			type: 'timestamp',
-			relative: true,
-			strict,
+	const wrapper = mount(UseDatetime, {
+		slots: {
+			default: '<template v-slot="{ datetime }">{{ datetime }}</template>',
 		},
-		global,
-	});
-
-	expect(wrapper.find('.datetime').element.textContent).toBe(expected);
-});
-
-test('should refresh the display every minute when relative is true', async () => {
-	const now = getCurrentTestDate();
-
-	// set system time to be the same time as the tested time
-	vi.setSystemTime(now.valueOf());
-
-	const wrapper = mount(Datetime, {
 		props: {
 			value: now.toISOString(),
 			type: 'timestamp',
@@ -84,7 +64,7 @@ test('should refresh the display every minute when relative is true', async () =
 		global,
 	});
 
-	expect(wrapper.find('.datetime').element.textContent).toBe('less than a minute ago');
+	expect(wrapper.html()).toBe('less than a minute ago');
 
 	// fast forward one minute
 	vi.advanceTimersByTime(60000);
@@ -92,7 +72,7 @@ test('should refresh the display every minute when relative is true', async () =
 	// make sure the dom is updated
 	await nextTick();
 
-	expect(wrapper.find('.datetime').element.textContent).toBe('1 minute ago');
+	expect(wrapper.html()).toBe('1 minute ago');
 
 	// fast forward one minute again
 	vi.advanceTimersByTime(60000);
@@ -100,5 +80,5 @@ test('should refresh the display every minute when relative is true', async () =
 	// make sure the dom is updated again
 	await nextTick();
 
-	expect(wrapper.find('.datetime').element.textContent).toBe('2 minutes ago');
+	expect(wrapper.html()).toBe('2 minutes ago');
 });

--- a/app/src/components/use-datetime.vue
+++ b/app/src/components/use-datetime.vue
@@ -1,19 +1,17 @@
 <script setup lang="ts">
-import { localizedFormat } from '@/utils/localized-format';
-import { localizedFormatDistance } from '@/utils/localized-format-distance';
-import { localizedFormatDistanceStrict } from '@/utils/localized-format-distance-strict';
-import { parse, parseISO } from 'date-fns';
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { formatDate } from '@/utils/format-date';
 
 export interface Props {
 	value: string;
 	type: 'dateTime' | 'date' | 'time' | 'timestamp';
-	format?: string;
+	format?: string | 'short' | 'long';
 	relative?: boolean;
 	strict?: boolean;
 	round?: 'floor' | 'round' | 'ceil';
 	suffix?: boolean;
+	includeSeconds?: boolean;
+	use24?: boolean;
 }
 
 defineOptions({ inheritAttrs: false });
@@ -26,66 +24,12 @@ const props = withDefaults(defineProps<Props>(), {
 	suffix: true,
 });
 
-const { t } = useI18n();
-
 const displayValue = ref<string | null>(null);
 
-const localValue = computed(() => {
-	if (!props.value) return null;
-
-	if (props.type === 'timestamp') {
-		return parseISO(props.value);
-	} else if (props.type === 'dateTime') {
-		return parse(props.value, "yyyy-MM-dd'T'HH:mm:ss", new Date());
-	} else if (props.type === 'date') {
-		return parse(props.value, 'yyyy-MM-dd', new Date());
-	} else if (props.type === 'time') {
-		return parse(props.value, 'HH:mm:ss', new Date());
-	}
-
-	return null;
-});
-
-const relativeFormat = (value: Date) => {
-	if (props.strict) {
-		return localizedFormatDistanceStrict(value, new Date(), {
-			addSuffix: props.suffix,
-			roundingMethod: props.round,
-		});
-	} else {
-		return localizedFormatDistance(value, new Date(), {
-			addSuffix: props.suffix,
-		});
-	}
-};
-
 watch(
-	localValue,
+	() => props.value,
 	(newValue) => {
-		if (newValue === null) {
-			displayValue.value = null;
-			return;
-		}
-
-		if (props.relative) {
-			displayValue.value = relativeFormat(newValue);
-		} else {
-			let format;
-
-			if (props.format === 'long') {
-				format = `${t('date-fns_date')} ${t('date-fns_time')}`;
-				if (props.type === 'date') format = String(t('date-fns_date'));
-				if (props.type === 'time') format = String(t('date-fns_time'));
-			} else if (props.format === 'short') {
-				format = `${t('date-fns_date_short')} ${t('date-fns_time_short')}`;
-				if (props.type === 'date') format = String(t('date-fns_date_short'));
-				if (props.type === 'time') format = String(t('date-fns_time_short'));
-			} else {
-				format = props.format;
-			}
-
-			displayValue.value = localizedFormat(newValue, format);
-		}
+		displayValue.value = formatDate(newValue, props);
 	},
 	{ immediate: true },
 );
@@ -96,8 +40,8 @@ onMounted(() => {
 	if (!props.relative) return;
 
 	refreshInterval = window.setInterval(() => {
-		if (!localValue.value) return;
-		displayValue.value = relativeFormat(localValue.value);
+		if (!props.value) return;
+		displayValue.value = formatDate(props.value, props);
 	}, 60_000);
 });
 

--- a/app/src/components/use-datetime.vue
+++ b/app/src/components/use-datetime.vue
@@ -1,17 +1,9 @@
 <script setup lang="ts">
+import { formatDate, type FormatDateOptions } from '@/utils/format-date';
 import { onMounted, onUnmounted, ref, watch } from 'vue';
-import { formatDate } from '@/utils/format-date';
 
-export interface Props {
+export interface Props extends FormatDateOptions {
 	value: string;
-	type: 'dateTime' | 'date' | 'time' | 'timestamp';
-	format?: string | 'short' | 'long';
-	relative?: boolean;
-	strict?: boolean;
-	round?: 'floor' | 'round' | 'ceil';
-	suffix?: boolean;
-	includeSeconds?: boolean;
-	use24?: boolean;
 }
 
 defineOptions({ inheritAttrs: false });
@@ -40,7 +32,6 @@ onMounted(() => {
 	if (!props.relative) return;
 
 	refreshInterval = window.setInterval(() => {
-		if (!props.value) return;
 		displayValue.value = formatDate(props.value, props);
 	}, 60_000);
 });

--- a/app/src/displays/datetime/datetime.test.ts
+++ b/app/src/displays/datetime/datetime.test.ts
@@ -30,7 +30,7 @@ function getCurrentTestDate() {
 }
 
 test.each([
-	{ format: 'long', expected: 'January 1st, 2023 12:00:00 AM' },
+	{ format: 'long', expected: 'January 1st, 2023 12:00 AM' },
 	{ format: 'short', expected: 'Jan 1, 2023 12:00AM' },
 ])('should display $format formatted string of current timestamp value', ({ format, expected }) => {
 	const now = getCurrentTestDate();

--- a/app/src/displays/datetime/datetime.vue
+++ b/app/src/displays/datetime/datetime.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import UseDatetime, { type Props } from '@/components/use-datetime.vue';
+import UseDatetime, { type Props as UseDatetimeProps } from '@/components/use-datetime.vue';
 
-withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<UseDatetimeProps>(), {
 	format: 'long',
 	relative: false,
 	strict: false,

--- a/app/src/displays/datetime/datetime.vue
+++ b/app/src/displays/datetime/datetime.vue
@@ -7,6 +7,7 @@ withDefaults(defineProps<Props>(), {
 	strict: false,
 	round: 'round',
 	suffix: true,
+	use24: false,
 });
 </script>
 

--- a/app/src/displays/datetime/index.ts
+++ b/app/src/displays/datetime/index.ts
@@ -1,11 +1,7 @@
 import type { DeepPartial, Field } from '@directus/types';
 import { defineDisplay } from '@directus/extensions';
-import { formatDate } from '@/utils/format-date';
+import { formatDate, FormatDateOptions } from '@/utils/format-date';
 import DisplayDateTime from './datetime.vue';
-
-function isFormatDateType(type: unknown): type is 'dateTime' | 'date' | 'time' | 'timestamp' {
-	return ['dateTime', 'date', 'time', 'timestamp'].includes(type as any);
-}
 
 export default defineDisplay({
 	id: 'datetime',
@@ -15,10 +11,9 @@ export default defineDisplay({
 	component: DisplayDateTime,
 	handler: (value, options, { field }) => {
 		if (!value) return value;
-		if (!field?.type || !isFormatDateType(field?.type)) return value;
 
 		return formatDate(value, {
-			type: field.type,
+			type: field!.type as FormatDateOptions['type'],
 			...options,
 		});
 	},
@@ -44,52 +39,55 @@ export default defineDisplay({
 		];
 
 		if (!options.relative) {
-			fields.push(
-				{
-					field: 'format',
-					name: '$t:displays.datetime.format',
-					type: 'string',
-					meta: {
-						interface: 'select-dropdown',
-						width: 'half',
-						options: {
-							choices: [
-								{ text: '$t:displays.datetime.long', value: 'long' },
-								{ text: '$t:displays.datetime.short', value: 'short' },
-							],
-							allowOther: true,
+			fields.push({
+				field: 'format',
+				name: '$t:displays.datetime.format',
+				type: 'string',
+				meta: {
+					interface: 'select-dropdown',
+					width: 'half',
+					options: {
+						choices: [
+							{ text: '$t:displays.datetime.long', value: 'long' },
+							{ text: '$t:displays.datetime.short', value: 'short' },
+						],
+						allowOther: true,
+					},
+					note: '$t:displays.datetime.format_note',
+				},
+				schema: {
+					default_value: 'long',
+				},
+			});
+
+			if (field.type !== 'date') {
+				fields.push(
+					{
+						field: 'includeSeconds',
+						name: '$t:interfaces.datetime.include_seconds',
+						type: 'boolean',
+						meta: {
+							width: 'half',
+							interface: 'boolean',
 						},
-						note: '$t:displays.datetime.format_note',
+						schema: {
+							default_value: false,
+						},
 					},
-					schema: {
-						default_value: 'long',
+					{
+						field: 'use24',
+						name: '$t:interfaces.datetime.use_24',
+						type: 'boolean',
+						meta: {
+							width: 'half',
+							interface: 'boolean',
+						},
+						schema: {
+							default_value: false,
+						},
 					},
-				},
-				{
-					field: 'includeSeconds',
-					name: '$t:interfaces.datetime.include_seconds',
-					type: 'boolean',
-					meta: {
-						width: 'half',
-						interface: 'boolean',
-					},
-					schema: {
-						default_value: false,
-					},
-				},
-				{
-					field: 'use24',
-					name: '$t:interfaces.datetime.use_24',
-					type: 'boolean',
-					meta: {
-						width: 'half',
-						interface: 'boolean',
-					},
-					schema: {
-						default_value: false,
-					},
-				},
-			);
+				);
+			}
 		} else {
 			fields.push(
 				{

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -1,63 +1,30 @@
 <script setup lang="ts">
 import { isValid } from 'date-fns';
-import { computed, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { computed, ref } from 'vue';
 import { parseDate } from '@/utils/parse-date';
-import { formatDate } from '@/utils/format-date';
+import UseDatetime, { type Props as UseDatetimeProps } from '@/components/use-datetime.vue';
 
-const props = withDefaults(
-	defineProps<{
-		value: string | null;
-		type: 'timestamp' | 'dateTime' | 'time' | 'date';
-		disabled?: boolean;
-		includeSeconds?: boolean;
-		use24?: boolean;
-		relative?: boolean;
-		suffix?: boolean;
-		strict?: boolean;
-		round?: 'round' | 'floor' | 'ceil';
-		format?: 'short' | 'long';
-	}>(),
-	{
-		use24: true,
-		format: 'long',
-		relative: false,
-		strict: false,
-		round: 'round',
-		suffix: true,
-	},
-);
+interface Props extends Omit<UseDatetimeProps, 'value'> {
+	value: string | null;
+	disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	use24: true,
+	format: 'long',
+	relative: false,
+	strict: false,
+	round: 'round',
+	suffix: true,
+});
 
 const emit = defineEmits<{
 	(e: 'input', value: string | null): void;
 }>();
 
-const { t } = useI18n();
-
 const dateTimeMenu = ref();
 
-const { displayValue, isValidValue } = useDisplayValue();
-
-function useDisplayValue() {
-	const displayValue = ref<string | null>(null);
-
-	const isValidValue = computed(() => (props.value ? isValid(parseDate(props.value, props.type)) : false));
-
-	watch(() => props.value, setDisplayValue, { immediate: true });
-
-	return { displayValue, isValidValue };
-
-	function setDisplayValue() {
-		if (!props.value || !isValidValue.value) {
-			displayValue.value = null;
-			return;
-		}
-
-		displayValue.value = formatDate(props.value, {
-			...props,
-		});
-	}
-}
+const isValidValue = computed(() => (props.value ? isValid(parseDate(props.value, props.type)) : false));
 
 function unsetValue(e: any) {
 	e.preventDefault();
@@ -73,11 +40,15 @@ function unsetValue(e: any) {
 				:active="active"
 				clickable
 				readonly
-				:model-value="displayValue"
 				:disabled="disabled"
-				:placeholder="!isValidValue ? value : t('enter_a_value')"
+				:placeholder="!isValidValue ? value : undefined"
 				@click="toggle"
 			>
+				<template v-if="isValidValue" #prepend>
+					<use-datetime v-slot="{ datetime }" v-bind="$props as UseDatetimeProps">
+						{{ datetime }}
+					</use-datetime>
+				</template>
 				<template v-if="!disabled" #append>
 					<v-icon
 						:name="value ? 'clear' : 'today'"

--- a/app/src/interfaces/datetime/index.ts
+++ b/app/src/interfaces/datetime/index.ts
@@ -1,4 +1,5 @@
 import { defineInterface } from '@directus/extensions';
+import type { DeepPartial, Field } from '@directus/types';
 import InterfaceDateTime from './datetime.vue';
 import PreviewSVG from './preview.svg?raw';
 
@@ -11,36 +12,134 @@ export default defineInterface({
 	types: ['dateTime', 'date', 'time', 'timestamp'],
 	group: 'selection',
 	options: ({ field }) => {
-		if (field.type === 'date') {
-			return [];
-		}
+		const options = field.meta?.options || {};
 
-		return [
+		const fields: DeepPartial<Field>[] = [
 			{
-				field: 'includeSeconds',
-				name: '$t:interfaces.datetime.include_seconds',
+				field: 'relative',
+				name: '$t:displays.datetime.relative',
 				type: 'boolean',
 				meta: {
 					width: 'half',
 					interface: 'boolean',
+					options: {
+						label: '$t:displays.datetime.relative_label',
+					},
 				},
 				schema: {
 					default_value: false,
 				},
 			},
-			{
-				field: 'use24',
-				name: '$t:interfaces.datetime.use_24',
-				type: 'boolean',
+		];
+
+		if (field.type !== 'date') {
+			fields.unshift(
+				{
+					field: 'includeSeconds',
+					name: '$t:interfaces.datetime.include_seconds',
+					type: 'boolean',
+					meta: {
+						width: 'half',
+						interface: 'boolean',
+					},
+					schema: {
+						default_value: false,
+					},
+				},
+				{
+					field: 'use24',
+					name: '$t:interfaces.datetime.use_24',
+					type: 'boolean',
+					meta: {
+						width: 'half',
+						interface: 'boolean',
+					},
+					schema: {
+						default_value: true,
+					},
+				},
+			);
+		}
+
+		if (!options.relative) {
+			fields.push({
+				field: 'format',
+				name: '$t:displays.datetime.format',
+				type: 'string',
 				meta: {
+					interface: 'select-dropdown',
 					width: 'half',
-					interface: 'boolean',
+					options: {
+						choices: [
+							{ text: '$t:displays.datetime.long', value: 'long' },
+							{ text: '$t:displays.datetime.short', value: 'short' },
+						],
+						allowOther: true,
+					},
+					note: '$t:displays.datetime.format_note',
 				},
 				schema: {
-					default_value: true,
+					default_value: 'long',
 				},
-			},
-		];
+			});
+		} else {
+			fields.push(
+				{
+					field: 'suffix',
+					name: '$t:displays.datetime.suffix',
+					type: 'boolean',
+					meta: {
+						width: 'half',
+						interface: 'boolean',
+						options: {
+							label: '$t:displays.datetime.suffix_label',
+						},
+						note: '$t:displays.datetime.suffix_note',
+					},
+					schema: {
+						default_value: true,
+					},
+				},
+				{
+					field: 'strict',
+					name: '$t:displays.datetime.strict',
+					type: 'boolean',
+					meta: {
+						width: 'half',
+						interface: 'boolean',
+						options: {
+							label: '$t:displays.datetime.strict_label',
+						},
+						note: '$t:displays.datetime.strict_note',
+					},
+					schema: {
+						default_value: false,
+					},
+				},
+				{
+					field: 'round',
+					name: '$t:displays.datetime.round',
+					type: 'string',
+					meta: {
+						width: 'half',
+						interface: 'select-dropdown',
+						options: {
+							choices: [
+								{ text: '$t:displays.datetime.down', value: 'floor' },
+								{ text: '$t:displays.datetime.nearest', value: 'round' },
+								{ text: '$t:displays.datetime.up', value: 'ceil' },
+							],
+						},
+						note: '$t:displays.datetime.round_note',
+					},
+					schema: {
+						default_value: 'round',
+					},
+				},
+			);
+		}
+
+		return fields;
 	},
 	recommendedDisplays: ['datetime'],
 	preview: PreviewSVG,

--- a/app/src/interfaces/datetime/index.ts
+++ b/app/src/interfaces/datetime/index.ts
@@ -32,35 +32,6 @@ export default defineInterface({
 			},
 		];
 
-		if (field.type !== 'date') {
-			fields.unshift(
-				{
-					field: 'includeSeconds',
-					name: '$t:interfaces.datetime.include_seconds',
-					type: 'boolean',
-					meta: {
-						width: 'half',
-						interface: 'boolean',
-					},
-					schema: {
-						default_value: false,
-					},
-				},
-				{
-					field: 'use24',
-					name: '$t:interfaces.datetime.use_24',
-					type: 'boolean',
-					meta: {
-						width: 'half',
-						interface: 'boolean',
-					},
-					schema: {
-						default_value: true,
-					},
-				},
-			);
-		}
-
 		if (!options.relative) {
 			fields.push({
 				field: 'format',
@@ -82,6 +53,35 @@ export default defineInterface({
 					default_value: 'long',
 				},
 			});
+
+			if (field.type !== 'date') {
+				fields.push(
+					{
+						field: 'includeSeconds',
+						name: '$t:interfaces.datetime.include_seconds',
+						type: 'boolean',
+						meta: {
+							width: 'half',
+							interface: 'boolean',
+						},
+						schema: {
+							default_value: false,
+						},
+					},
+					{
+						field: 'use24',
+						name: '$t:interfaces.datetime.use_24',
+						type: 'boolean',
+						meta: {
+							width: 'half',
+							interface: 'boolean',
+						},
+						schema: {
+							default_value: true,
+						},
+					},
+				);
+			}
 		} else {
 			fields.push(
 				{

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -534,6 +534,7 @@ date-fns_time_24hour: 'HH:mm:ss'
 date-fns_time_no_seconds_24hour: 'HH:mm'
 date-fns_date_short: 'MMM d, u'
 date-fns_time_short: 'h:mma'
+date-fns_time_short_seconds: 'h:mm:ssa'
 date-fns_date_short_no_year: MMM d
 minutes: Minutes
 hours: Hours

--- a/app/src/utils/format-date.test.ts
+++ b/app/src/utils/format-date.test.ts
@@ -45,278 +45,230 @@ function getCurrentTestDate() {
 	return nowUTC;
 }
 
-describe('formatDate - Relative Formatting', () => {
-	const relativeTestCases = [
+describe('relative formatting', () => {
+	const relativeTestCases: { options: Omit<FormatDateOptions, 'type'>; expected: string }[] = [
 		{
-			relative: true,
-			strict: false,
-			suffix: true,
+			options: {
+				relative: true,
+				suffix: true,
+			},
 			expected: 'less than a minute ago',
-			description: 'relative: true, strict: false, suffix: true',
 		},
 		{
-			relative: true,
-			strict: false,
-			suffix: false,
+			options: {
+				relative: true,
+			},
 			expected: 'less than a minute',
-			description: 'relative: true, strict: false, suffix: false',
 		},
 		{
-			relative: true,
-			strict: true,
-			suffix: true,
-			round: 'floor',
+			options: {
+				relative: true,
+				strict: true,
+				suffix: true,
+				round: 'floor',
+			},
 			expected: '0 seconds ago',
-			description: 'relative: true, strict: true, suffix: true, round: floor',
 		},
 		{
-			relative: true,
-			strict: true,
-			suffix: false,
-			round: 'ceil',
+			options: {
+				relative: true,
+				strict: true,
+				round: 'ceil',
+			},
 			expected: '0 seconds',
-			description: 'relative: true, strict: true, suffix: false, round: ceil',
 		},
 		{
-			relative: true,
-			strict: true,
-			suffix: true,
-			round: 'round',
+			options: {
+				relative: true,
+				strict: true,
+				suffix: true,
+				round: 'round',
+			},
 			expected: '0 seconds ago',
-			description: 'relative: true, strict: true, suffix: true, round: round',
 		},
 	];
 
-	test.each(relativeTestCases)(
-		'should display "$expected" for $description',
-		({ relative, strict, suffix, round, expected }) => {
-			const now = getCurrentTestDate();
-			vi.setSystemTime(now.valueOf());
+	test.each(relativeTestCases)('should display $expected for $options', ({ options, expected }) => {
+		const now = getCurrentTestDate();
+		vi.setSystemTime(now.valueOf());
 
-			const options: FormatDateOptions = {
-				type: 'timestamp',
-				relative,
-				strict: strict ?? false,
-				suffix: suffix ?? false,
-				round: round as 'floor' | 'round' | 'ceil' | undefined,
-			};
+		const result = formatDate(now.toISOString(), {
+			type: 'timestamp',
+			...options,
+		});
 
-			const result = formatDate(now.toISOString(), options);
-
-			expect(result).toBe(expected);
-		},
-	);
+		expect(result).toBe(expected);
+	});
 });
 
-describe('formatDate - Absolute Formatting', () => {
-	const absoluteTestCases = [
+describe('absolute formatting', () => {
+	const absoluteTestCases: { options: FormatDateOptions; expected: string }[] = [
 		{
-			type: 'dateTime',
-			format: 'long',
-			includeSeconds: false,
-			use24: false,
+			options: {
+				type: 'dateTime',
+			},
 			expected: 'January 1st, 2023 12:00 AM',
-			description: 'type: dateTime, format: long, includeSeconds: false, use24: false',
 		},
 		{
-			type: 'dateTime',
-			format: 'short',
-			includeSeconds: false,
-			use24: false,
+			options: {
+				type: 'dateTime',
+				format: 'long',
+			},
+			expected: 'January 1st, 2023 12:00 AM',
+		},
+		{
+			options: {
+				type: 'dateTime',
+				format: 'short',
+			},
 			expected: 'Jan 1, 2023 12:00AM',
-			description: 'type: dateTime, format: short, includeSeconds: false, use24: false',
 		},
 		{
-			type: 'dateTime',
-			format: 'long',
-			includeSeconds: true,
-			use24: false,
+			options: {
+				type: 'dateTime',
+				format: 'long',
+				includeSeconds: true,
+			},
 			expected: 'January 1st, 2023 12:00:00 AM',
-			description: 'type: dateTime, format: long, includeSeconds: true, use24: false',
 		},
 		{
-			type: 'dateTime',
-			format: 'long',
-			includeSeconds: false,
-			use24: true,
+			options: {
+				type: 'dateTime',
+				format: 'long',
+				use24: true,
+			},
 			expected: 'January 1st, 2023 00:00',
-			description: 'type: dateTime, format: long, includeSeconds: false, use24: true',
 		},
 		{
-			type: 'dateTime',
-			format: 'long',
-			includeSeconds: true,
-			use24: true,
+			options: {
+				type: 'dateTime',
+				format: 'long',
+				includeSeconds: true,
+				use24: true,
+			},
 			expected: 'January 1st, 2023 00:00:00',
-			description: 'type: dateTime, format: long, includeSeconds: true, use24: true',
 		},
 		{
-			type: 'date',
-			format: 'long',
-			includeSeconds: false,
-			use24: false,
-			expected: 'January 1st, 2023',
-			description: 'type: date, format: long',
-		},
-		{
-			type: 'date',
-			format: 'short',
-			includeSeconds: false,
-			use24: false,
-			expected: 'Jan 1, 2023',
-			description: 'type: date, format: short',
-		},
-		{
-			type: 'date',
-			format: 'long',
-			includeSeconds: true,
-			use24: false,
-			expected: 'January 1st, 2023',
-			description: 'type: date, format: long, includeSeconds: true',
-		},
-		{
-			type: 'date',
-			format: 'short',
-			includeSeconds: false,
-			use24: true,
-			expected: 'Jan 1, 2023',
-			description: 'type: date, format: short, use24: true',
-		},
-		{
-			type: 'time',
-			format: 'long',
-			includeSeconds: false,
-			use24: false,
-			expected: '12:00 AM',
-			description: 'type: time, format: long, includeSeconds: false, use24: false',
-		},
-		{
-			type: 'time',
-			format: 'short',
-			includeSeconds: false,
-			use24: false,
-			expected: '12:00AM',
-			description: 'type: time, format: short, includeSeconds: false, use24: false',
-		},
-		{
-			type: 'time',
-			format: 'long',
-			includeSeconds: true,
-			use24: false,
-			expected: '12:00:00 AM',
-			description: 'type: time, format: long, includeSeconds: true, use24: false',
-		},
-		{
-			type: 'time',
-			format: 'short',
-			includeSeconds: true,
-			use24: false,
-			expected: '12:00:00AM',
-			description: 'type: time, format: short, includeSeconds: true, use24: false',
-		},
-		{
-			type: 'time',
-			format: 'long',
-			includeSeconds: false,
-			use24: true,
-			expected: '00:00',
-			description: 'type: time, format: long, includeSeconds: false, use24: true',
-		},
-		{
-			type: 'time',
-			format: 'short',
-			includeSeconds: false,
-			use24: true,
-			expected: '00:00',
-			description: 'type: time, format: short, includeSeconds: false, use24: true',
-		},
-		{
-			type: 'time',
-			format: 'short',
-			includeSeconds: true,
-			use24: true,
-			expected: '00:00:00',
-			description: 'type: time, format: short, includeSeconds: true, use24: true',
-		},
-		{
-			type: 'timestamp',
-			format: 'MM/dd/yyyy',
-			includeSeconds: false,
-			use24: false,
-			expected: '01/01/2023',
-			description: 'type: timestamp, custom format',
-		},
-		{
-			type: 'dateTime',
-			format: 'yyyy-MM-dd HH:mm',
-			includeSeconds: false,
-			use24: true,
+			options: {
+				type: 'dateTime',
+				format: 'yyyy-MM-dd HH:mm',
+			},
 			expected: '2023-01-01 00:00',
-			description: 'custom format string',
 		},
 		{
-			type: 'dateTime',
-			format: undefined,
-			includeSeconds: false,
-			use24: false,
-			expected: 'January 1st, 2023 12:00 AM',
-			description: 'format: undefined, fallback to long',
-		},
-		{
-			type: 'date',
-			format: undefined,
-			includeSeconds: false,
-			use24: false,
+			options: {
+				type: 'date',
+			},
 			expected: 'January 1st, 2023',
-			description: 'type: date, format: undefined, fallback to long',
 		},
 		{
-			type: 'time',
-			format: undefined,
-			includeSeconds: false,
-			use24: false,
+			options: {
+				type: 'date',
+				format: 'long',
+			},
+			expected: 'January 1st, 2023',
+		},
+		{
+			options: {
+				type: 'date',
+				format: 'short',
+			},
+			expected: 'Jan 1, 2023',
+		},
+		{
+			options: {
+				type: 'time',
+			},
 			expected: '12:00 AM',
-			description: 'type: time, format: undefined, fallback to long',
 		},
 		{
-			type: 'timestamp',
-			format: undefined,
-			includeSeconds: false,
-			use24: false,
+			options: {
+				type: 'time',
+				format: 'long',
+			},
+			expected: '12:00 AM',
+		},
+		{
+			options: {
+				type: 'time',
+				format: 'short',
+			},
+			expected: '12:00AM',
+		},
+		{
+			options: {
+				type: 'time',
+				format: 'long',
+				includeSeconds: true,
+			},
+			expected: '12:00:00 AM',
+		},
+		{
+			options: {
+				type: 'time',
+				format: 'short',
+				includeSeconds: true,
+			},
+			expected: '12:00:00AM',
+		},
+		{
+			options: {
+				type: 'time',
+				format: 'long',
+				use24: true,
+			},
+			expected: '00:00',
+		},
+		{
+			options: {
+				type: 'time',
+				format: 'short',
+				use24: true,
+			},
+			expected: '00:00',
+		},
+		{
+			options: {
+				type: 'time',
+				format: 'short',
+				includeSeconds: true,
+				use24: true,
+			},
+			expected: '00:00:00',
+		},
+		{
+			options: {
+				type: 'timestamp',
+			},
 			expected: 'January 1st, 2023 12:00 AM',
-			description: 'type: timestamp, format: undefined, fallback to long',
 		},
-	] as const;
-
-	test.each(absoluteTestCases)(
-		'should display "$expected" for $description',
-		({ type, format, includeSeconds, use24, expected }) => {
-			const now = getCurrentTestDate();
-			vi.setSystemTime(now.valueOf());
-
-			let dateString;
-
-			if (type === 'timestamp') {
-				dateString = now.toISOString();
-			} else if (type === 'dateTime') {
-				dateString = formatDateFns(now, "yyyy-MM-dd'T'HH:mm:ss");
-			} else if (type === 'date') {
-				dateString = formatDateFns(now, 'yyyy-MM-dd');
-			} else {
-				dateString = formatDateFns(now, 'HH:mm:ss');
-			}
-
-			const options: FormatDateOptions = {
-				type,
-				format: format as string | undefined,
-				relative: false,
-				includeSeconds,
-				use24,
-			};
-
-			const result = formatDate(dateString, options);
-
-			expect(result).toBe(expected);
+		{
+			options: {
+				type: 'timestamp',
+				format: 'MM/dd/yyyy',
+			},
+			expected: '01/01/2023',
 		},
-	);
+	];
+
+	test.each(absoluteTestCases)('should display $expected for $options', ({ options, expected }) => {
+		const now = getCurrentTestDate();
+		vi.setSystemTime(now.valueOf());
+
+		let dateString;
+
+		if (options.type === 'timestamp') {
+			dateString = now.toISOString();
+		} else if (options.type === 'dateTime') {
+			dateString = formatDateFns(now, "yyyy-MM-dd'T'HH:mm:ss");
+		} else if (options.type === 'date') {
+			dateString = formatDateFns(now, 'yyyy-MM-dd');
+		} else {
+			dateString = formatDateFns(now, 'HH:mm:ss');
+		}
+
+		const result = formatDate(dateString, options);
+
+		expect(result).toBe(expected);
+	});
 });

--- a/app/src/utils/format-date.test.ts
+++ b/app/src/utils/format-date.test.ts
@@ -1,0 +1,322 @@
+import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { formatDate, FormatDateOptions } from '@/utils/format-date';
+import { format as formatDateFns } from 'date-fns';
+
+vi.mock('@/lang', () => {
+	return {
+		i18n: createI18n({
+			legacy: false,
+			locale: 'en-US',
+			messages: {
+				'en-US': {
+					'date-fns_date': 'PPP',
+					'date-fns_time': 'h:mm:ss a',
+					'date-fns_time_no_seconds': 'h:mm a',
+					'date-fns_time_24hour': 'HH:mm:ss',
+					'date-fns_time_no_seconds_24hour': 'HH:mm',
+					'date-fns_date_short': 'MMM d, u',
+					'date-fns_time_short': 'h:mma',
+					'date-fns_time_short_seconds': 'h:mm:ssa',
+					'date-fns_date_short_no_year': 'MMM d',
+				},
+			},
+		}),
+	};
+});
+
+beforeAll(() => {
+	vi.useFakeTimers();
+});
+
+afterAll(() => {
+	vi.useRealTimers();
+});
+
+function getCurrentTestDate() {
+	const isoTestDate = '2023-01-01T00:00:00.000Z';
+
+	// account for timezone difference depending on the machine where this test is ran
+	const now = new Date(isoTestDate);
+	const timezoneOffsetInMinutes = now.getTimezoneOffset();
+	const timezoneOffsetInMilliseconds = timezoneOffsetInMinutes * 60 * 1000;
+	const nowUTC = new Date(new Date(isoTestDate).valueOf() + timezoneOffsetInMilliseconds);
+
+	return nowUTC;
+}
+
+describe('formatDate - Relative Formatting', () => {
+	const relativeTestCases = [
+		{
+			relative: true,
+			strict: false,
+			suffix: true,
+			expected: 'less than a minute ago',
+			description: 'relative: true, strict: false, suffix: true',
+		},
+		{
+			relative: true,
+			strict: false,
+			suffix: false,
+			expected: 'less than a minute',
+			description: 'relative: true, strict: false, suffix: false',
+		},
+		{
+			relative: true,
+			strict: true,
+			suffix: true,
+			round: 'floor',
+			expected: '0 seconds ago',
+			description: 'relative: true, strict: true, suffix: true, round: floor',
+		},
+		{
+			relative: true,
+			strict: true,
+			suffix: false,
+			round: 'ceil',
+			expected: '0 seconds',
+			description: 'relative: true, strict: true, suffix: false, round: ceil',
+		},
+		{
+			relative: true,
+			strict: true,
+			suffix: true,
+			round: 'round',
+			expected: '0 seconds ago',
+			description: 'relative: true, strict: true, suffix: true, round: round',
+		},
+	];
+
+	test.each(relativeTestCases)(
+		'should display "$expected" for $description',
+		({ relative, strict, suffix, round, expected }) => {
+			const now = getCurrentTestDate();
+			vi.setSystemTime(now.valueOf());
+
+			const options: FormatDateOptions = {
+				type: 'timestamp',
+				relative,
+				strict: strict ?? false,
+				suffix: suffix ?? false,
+				round: round as 'floor' | 'round' | 'ceil' | undefined,
+			};
+
+			const result = formatDate(now.toISOString(), options);
+
+			expect(result).toBe(expected);
+		},
+	);
+});
+
+describe('formatDate - Absolute Formatting', () => {
+	const absoluteTestCases = [
+		{
+			type: 'dateTime',
+			format: 'long',
+			includeSeconds: false,
+			use24: false,
+			expected: 'January 1st, 2023 12:00 AM',
+			description: 'type: dateTime, format: long, includeSeconds: false, use24: false',
+		},
+		{
+			type: 'dateTime',
+			format: 'short',
+			includeSeconds: false,
+			use24: false,
+			expected: 'Jan 1, 2023 12:00AM',
+			description: 'type: dateTime, format: short, includeSeconds: false, use24: false',
+		},
+		{
+			type: 'dateTime',
+			format: 'long',
+			includeSeconds: true,
+			use24: false,
+			expected: 'January 1st, 2023 12:00:00 AM',
+			description: 'type: dateTime, format: long, includeSeconds: true, use24: false',
+		},
+		{
+			type: 'dateTime',
+			format: 'long',
+			includeSeconds: false,
+			use24: true,
+			expected: 'January 1st, 2023 00:00',
+			description: 'type: dateTime, format: long, includeSeconds: false, use24: true',
+		},
+		{
+			type: 'dateTime',
+			format: 'long',
+			includeSeconds: true,
+			use24: true,
+			expected: 'January 1st, 2023 00:00:00',
+			description: 'type: dateTime, format: long, includeSeconds: true, use24: true',
+		},
+		{
+			type: 'date',
+			format: 'long',
+			includeSeconds: false,
+			use24: false,
+			expected: 'January 1st, 2023',
+			description: 'type: date, format: long',
+		},
+		{
+			type: 'date',
+			format: 'short',
+			includeSeconds: false,
+			use24: false,
+			expected: 'Jan 1, 2023',
+			description: 'type: date, format: short',
+		},
+		{
+			type: 'date',
+			format: 'long',
+			includeSeconds: true,
+			use24: false,
+			expected: 'January 1st, 2023',
+			description: 'type: date, format: long, includeSeconds: true',
+		},
+		{
+			type: 'date',
+			format: 'short',
+			includeSeconds: false,
+			use24: true,
+			expected: 'Jan 1, 2023',
+			description: 'type: date, format: short, use24: true',
+		},
+		{
+			type: 'time',
+			format: 'long',
+			includeSeconds: false,
+			use24: false,
+			expected: '12:00 AM',
+			description: 'type: time, format: long, includeSeconds: false, use24: false',
+		},
+		{
+			type: 'time',
+			format: 'short',
+			includeSeconds: false,
+			use24: false,
+			expected: '12:00AM',
+			description: 'type: time, format: short, includeSeconds: false, use24: false',
+		},
+		{
+			type: 'time',
+			format: 'long',
+			includeSeconds: true,
+			use24: false,
+			expected: '12:00:00 AM',
+			description: 'type: time, format: long, includeSeconds: true, use24: false',
+		},
+		{
+			type: 'time',
+			format: 'short',
+			includeSeconds: true,
+			use24: false,
+			expected: '12:00:00AM',
+			description: 'type: time, format: short, includeSeconds: true, use24: false',
+		},
+		{
+			type: 'time',
+			format: 'long',
+			includeSeconds: false,
+			use24: true,
+			expected: '00:00',
+			description: 'type: time, format: long, includeSeconds: false, use24: true',
+		},
+		{
+			type: 'time',
+			format: 'short',
+			includeSeconds: false,
+			use24: true,
+			expected: '00:00',
+			description: 'type: time, format: short, includeSeconds: false, use24: true',
+		},
+		{
+			type: 'time',
+			format: 'short',
+			includeSeconds: true,
+			use24: true,
+			expected: '00:00:00',
+			description: 'type: time, format: short, includeSeconds: true, use24: true',
+		},
+		{
+			type: 'timestamp',
+			format: 'MM/dd/yyyy',
+			includeSeconds: false,
+			use24: false,
+			expected: '01/01/2023',
+			description: 'type: timestamp, custom format',
+		},
+		{
+			type: 'dateTime',
+			format: 'yyyy-MM-dd HH:mm',
+			includeSeconds: false,
+			use24: true,
+			expected: '2023-01-01 00:00',
+			description: 'custom format string',
+		},
+		{
+			type: 'dateTime',
+			format: undefined,
+			includeSeconds: false,
+			use24: false,
+			expected: 'January 1st, 2023 12:00 AM',
+			description: 'format: undefined, fallback to long',
+		},
+		{
+			type: 'date',
+			format: undefined,
+			includeSeconds: false,
+			use24: false,
+			expected: 'January 1st, 2023',
+			description: 'type: date, format: undefined, fallback to long',
+		},
+		{
+			type: 'time',
+			format: undefined,
+			includeSeconds: false,
+			use24: false,
+			expected: '12:00 AM',
+			description: 'type: time, format: undefined, fallback to long',
+		},
+		{
+			type: 'timestamp',
+			format: undefined,
+			includeSeconds: false,
+			use24: false,
+			expected: 'January 1st, 2023 12:00 AM',
+			description: 'type: timestamp, format: undefined, fallback to long',
+		},
+	] as const;
+
+	test.each(absoluteTestCases)(
+		'should display "$expected" for $description',
+		({ type, format, includeSeconds, use24, expected }) => {
+			const now = getCurrentTestDate();
+			vi.setSystemTime(now.valueOf());
+
+			let dateString;
+
+			if (type === 'timestamp') {
+				dateString = now.toISOString();
+			} else if (type === 'dateTime') {
+				dateString = formatDateFns(now, "yyyy-MM-dd'T'HH:mm:ss");
+			} else if (type === 'date') {
+				dateString = formatDateFns(now, 'yyyy-MM-dd');
+			} else {
+				dateString = formatDateFns(now, 'HH:mm:ss');
+			}
+
+			const options: FormatDateOptions = {
+				type,
+				format: format as string | undefined,
+				relative: false,
+				includeSeconds,
+				use24,
+			};
+
+			const result = formatDate(dateString, options);
+
+			expect(result).toBe(expected);
+		},
+	);
+});

--- a/app/src/utils/format-date.ts
+++ b/app/src/utils/format-date.ts
@@ -1,0 +1,69 @@
+import { i18n } from '@/lang';
+import { localizedFormatDistance } from '@/utils/localized-format-distance';
+import { localizedFormatDistanceStrict } from '@/utils/localized-format-distance-strict';
+import { localizedFormat } from '@/utils/localized-format';
+import { parseDate } from '@/utils/parse-date';
+
+export interface FormatDateOptions {
+	type: 'dateTime' | 'date' | 'time' | 'timestamp';
+	format?: string | 'short' | 'long';
+	relative?: boolean;
+	strict?: boolean;
+	round?: 'floor' | 'round' | 'ceil';
+	suffix?: boolean;
+	includeSeconds?: boolean;
+	use24?: boolean;
+}
+
+/**
+ * Formats a date string using the provided options
+ *
+ * @param value - The value to format
+ * @param options - Configuration object for datetime formating options
+ *
+ * @example
+ * ```js
+ * formatDate({ type: 'dateTime', format: 'short', relative: false, strict: false, round: 'round', suffix: false, includeSeconds: false, use24: false });
+ * // => "YYYY-MM-DD HH:mm"
+ * ```
+ */
+export function formatDate(value: string, options: FormatDateOptions) {
+	if (options.relative) {
+		if (options.strict) {
+			return localizedFormatDistanceStrict(parseDate(value, options.type), new Date(), {
+				addSuffix: options.suffix,
+				roundingMethod: options.round,
+			});
+		} else {
+			return localizedFormatDistance(parseDate(value, options.type), new Date(), {
+				addSuffix: options.suffix,
+			});
+		}
+	}
+
+	let timeFormat;
+
+	if (options.use24) {
+		timeFormat = options.includeSeconds ? 'date-fns_time_24hour' : 'date-fns_time_no_seconds_24hour';
+	} else if (options.format === 'short') {
+		timeFormat = options.includeSeconds ? 'date-fns_time_short_seconds' : 'date-fns_time_short';
+	} else {
+		timeFormat = options.includeSeconds ? 'date-fns_time' : 'date-fns_time_no_seconds';
+	}
+
+	let format;
+
+	if (options?.format === undefined || options.format === 'long') {
+		format = `${i18n.global.t('date-fns_date')} ${i18n.global.t(timeFormat)}`;
+		if (options?.type === 'date') format = String(i18n.global.t('date-fns_date'));
+		if (options?.type === 'time') format = String(i18n.global.t(timeFormat));
+	} else if (options.format === 'short') {
+		format = `${i18n.global.t('date-fns_date_short')} ${i18n.global.t(timeFormat)}`;
+		if (options?.type === 'date') format = String(i18n.global.t('date-fns_date_short'));
+		if (options?.type === 'time') format = String(i18n.global.t(timeFormat));
+	} else {
+		format = options.format;
+	}
+
+	return localizedFormat(parseDate(value, options.type), format);
+}

--- a/app/src/utils/format-date.ts
+++ b/app/src/utils/format-date.ts
@@ -6,7 +6,8 @@ import { parseDate } from '@/utils/parse-date';
 
 export interface FormatDateOptions {
 	type: 'dateTime' | 'date' | 'time' | 'timestamp';
-	format?: string | 'short' | 'long';
+	/** 'short', 'long' or custom (https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table) */
+	format?: string;
 	relative?: boolean;
 	strict?: boolean;
 	round?: 'floor' | 'round' | 'ceil';

--- a/app/src/utils/parse-date.ts
+++ b/app/src/utils/parse-date.ts
@@ -1,0 +1,28 @@
+import { parse, parseISO } from 'date-fns';
+
+/**
+ * Renders a function-wrapped field as the formatted function name and translated field key
+ *
+ * @param value - The string value to format
+ * @param type - 'dateTime' | 'date' | 'time' | 'timestamp'
+ *
+ * @example
+ * ```js
+ * parseDate('2021-09-01T12:00:00', 'dateTime');
+ * // => "Wed Sep 01 2021 12:00:00 GMT+0000"
+ * ```
+ */
+export function parseDate(value: string, type: string): Date {
+	switch (type) {
+		case 'dateTime':
+			return parse(value, "yyyy-MM-dd'T'HH:mm:ss", new Date());
+		case 'date':
+			return parse(value, 'yyyy-MM-dd', new Date());
+		case 'time':
+			return parse(value, 'HH:mm:ss', new Date());
+		case 'timestamp':
+			return parseISO(value);
+		default:
+			return new Date(value);
+	}
+}


### PR DESCRIPTION
What's changed:

- Moved date formatting to a utility function with tests.
- Added 24hr/seconds to display options
- Added relative formatting to interface options
- Hide 24hr/seconds options showing up on date type fields

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Do these tests look alright?

---

Fixes #24041
