### PR TITLE
Run cleanup in mutex error case when getting schema

### DIFF
--- a/.changeset/popular-keys-impress.md
+++ b/.changeset/popular-keys-impress.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Run cleanup in mutex error case when getting schema

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -76,11 +76,12 @@ export async function getSchema(
 			bus.subscribe(messageKey, busListener).catch(reject);
 
 			function busListener(options: { schema: SchemaOverview | null }) {
+				cleanup();
+
 				if (options.schema === null) {
 					return reject();
 				}
 
-				cleanup();
 				setLocalSchemaCache(options.schema).catch(reject);
 				resolve(options.schema);
 			}


### PR DESCRIPTION
## Scope

What's changed:

- Run cleanup in error case to prevent hanging subscriptions

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- Thank you @ComfortablyCoding for spotting this!
