### PR TITLE
Remove read permissions check during files deletion

### DIFF
--- a/.changeset/new-candles-design.md
+++ b/.changeset/new-candles-design.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Removed read permissions check during files deletion

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -1,5 +1,5 @@
 import { useEnv } from '@directus/env';
-import { ContentTooLargeError, ForbiddenError, InvalidPayloadError, ServiceUnavailableError } from '@directus/errors';
+import { ContentTooLargeError, InvalidPayloadError, ServiceUnavailableError } from '@directus/errors';
 import formatTitle from '@directus/format-title';
 import type { BusboyFileStream, File, PrimaryKey, Query } from '@directus/types';
 import { toArray } from '@directus/utils';
@@ -273,10 +273,6 @@ export class FilesService extends ItemsService<File> {
 		});
 
 		const files = await sudoFilesItemsService.readMany(keys, { fields: ['id', 'storage', 'filename_disk'], limit: -1 });
-
-		if (!files) {
-			throw new ForbiddenError();
-		}
 
 		await super.deleteMany(keys);
 

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -266,7 +266,13 @@ export class FilesService extends ItemsService<File> {
 	 */
 	override async deleteMany(keys: PrimaryKey[]): Promise<PrimaryKey[]> {
 		const storage = await getStorage();
-		const files = await super.readMany(keys, { fields: ['id', 'storage', 'filename_disk'], limit: -1 });
+
+		const sudoFilesItemsService = new FilesService({
+			knex: this.knex,
+			schema: this.schema,
+		});
+
+		const files = await sudoFilesItemsService.readMany(keys, { fields: ['id', 'storage', 'filename_disk'], limit: -1 });
 
 		if (!files) {
 			throw new ForbiddenError();


### PR DESCRIPTION
## Scope

What's changed:

- Removed read permissions check during files deletion

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- 

---

Fixes #24336
