### PR TITLE
Patch `corepack` in Docker image

### DIFF
--- a/.changeset/tame-kiwis-invent.md
+++ b/.changeset/tame-kiwis-invent.md
@@ -1,0 +1,5 @@
+---
+directus: patch
+---
+
+Patched `corepack` in Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,16 @@ ARG NODE_VERSION=22
 
 FROM node:${NODE_VERSION}-alpine AS builder
 
+# Remove again once corepack >= 0.31 made it into base image
+# (see https://github.com/directus/directus/issues/24514)
+RUN npm install --global corepack@latest
+
 ARG TARGETPLATFORM
 RUN <<EOF
-  if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then
-  	apk --no-cache add python3 build-base
-  	ln -sf /usr/bin/python3 /usr/bin/python
-  fi
+	if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then
+		apk --no-cache add python3 build-base
+		ln -sf /usr/bin/python3 /usr/bin/python
+	fi
 EOF
 
 WORKDIR /directus
@@ -50,7 +54,9 @@ EOF
 
 FROM node:${NODE_VERSION}-alpine AS runtime
 
-RUN npm install --global pm2@5
+RUN npm install --global \
+	pm2@5 \
+	corepack@latest # Remove again once corepack >= 0.31 made it into base image
 
 USER node
 


### PR DESCRIPTION
## Scope

Patch `corepack` in Docker image. This is currently necessary since there's a verification keys mismatch in the version coming with the current latest `node:22-alpine` image. See https://github.com/nodejs/corepack/issues/612 and https://github.com/nodejs/corepack/pull/614 for the context.

Note: This can be removed again once corepack >= 0.31 made it into base image

---

Fixes #24514
