### PR TITLE
fix(sdk): export DirectusComment type in schema index

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -199,3 +199,4 @@
 - ukmadlz
 - obafemitayor
 - highvibesonly
+- sidartaveloso

--- a/sdk/src/schema/index.ts
+++ b/sdk/src/schema/index.ts
@@ -1,6 +1,7 @@
 export * from './access.js';
 export * from './activity.js';
 export * from './collection.js';
+export * from './comment.js';
 export * from './core.js';
 export * from './dashboard.js';
 export * from './extension.js';


### PR DESCRIPTION
The `DirectusComment` type was missing from the exports in `sdk/src/schema/index.ts`.  
This commit adds the missing export to make the type available for import.  

Closes #24526  

---

## **Scope**  
**What's changed:**  
- Added missing export for `DirectusComment` in `sdk/src/schema/index.ts`.  

## **Potential Risks / Drawbacks**  
- Minimal risk, as this change only affects TypeScript typings.  

## **Review Notes / Questions**  
- No breaking changes expected.  
- This ensures that `DirectusComment` can be properly imported from `@directus/sdk`.  