### PR TITLE
Add Option handling Missing Data in Time Series Panel

### DIFF
--- a/.changeset/popular-comics-sit.md
+++ b/.changeset/popular-comics-sit.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Added customizable handling for missing data in time series charts, allowing continuous lines, gaps, or a set value.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2330,6 +2330,8 @@ show_legend: Show Legend
 right: Right
 left: Left
 donut: Donut
+continuous: Continuous
+gap: Gap
 
 panels:
   metric:
@@ -2346,6 +2348,7 @@ panels:
     value_field: Value Field
     fill_type: Fill Type
     curve_type: Curve Type
+    missing_data: Missing Data
   label:
     name: Label
     description: Show some text

--- a/app/src/panels/time-series/index.ts
+++ b/app/src/panels/time-series/index.ts
@@ -374,6 +374,35 @@ export default definePanel({
 			},
 		},
 		{
+			field: 'missingData',
+			type: 'string',
+			name: '$t:panels.time_series.missing_data',
+			meta: {
+				interface: 'select-dropdown',
+				width: 'half',
+				options: {
+					choices: [
+						{
+							text: '$t:continuous',
+							value: 'ignore',
+						},
+						{
+							text: '$t:gap',
+							value: 'null',
+						},
+						{
+							text: '0',
+							value: '0',
+						},
+					],
+					allowOther: true,
+				},
+			},
+			schema: {
+				default_value: null,
+			},
+		},
+		{
 			field: 'filter',
 			type: 'json',
 			name: '$t:filter',


### PR DESCRIPTION
ApexCharts doesn’t provide built-in handling for missing data in time series charts. This change adds customizability, allowing users to choose how gaps are displayed—whether to keep a continuous line, show explicit gaps, or replace missing values with a specific number.

Instead of filling all missing points, this approach only adds placeholder values at the start and end of each gap based on the selected precision. For example, if there’s a 100-day gap and the precision is set to "day," only two null values (one at the start and one at the end) are inserted, rather than filling all 100 days.

## Scope

What's changed:

* Added new field `missingData` to the panel options with a dropdown select how missing data is handled. Options are `Continuous`, `Gap`,  `0`, or other. Users can enter a number into other to set the baseline to something else.
* Added `fillGaps` function to `panel-time-series.vue` to  handle gaps in time series data.
* Added new translations for `continuous`, `gap`, and missing_data` in `en-US.yaml`.

<img width="851" alt="image" src="https://github.com/user-attachments/assets/28f2b017-fb04-41e5-8bd8-fa5a3df1e5c0" />

## Potential Risks / Drawbacks

- Change in default behavior from `Continuous` to `Gap`

## Review Notes / Questions

- Test out the panels

---

Fixes #24493 , Fixes #22284
