### PR TITLE
V-Input Emit NULL if trimmed value is empty string and nullable

### DIFF
--- a/.changeset/lemon-readers-kick.md
+++ b/.changeset/lemon-readers-kick.md
@@ -2,4 +2,4 @@
 "@directus/app": patch
 ---
 
-Fixed trimmed fields no saving null for empty strings
+Fixed trimmed fields not saving null for empty strings

--- a/.changeset/lemon-readers-kick.md
+++ b/.changeset/lemon-readers-kick.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed trimmed fields no saving null for empty strings

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -161,7 +161,13 @@ function processValue(event: KeyboardEvent) {
 
 function trimIfEnabled() {
 	if (props.modelValue && props.trim && ['string', 'text'].includes(props.type)) {
-		emit('update:modelValue', String(props.modelValue).trim());
+		const trimmedValue = String(props.modelValue).trim();
+
+		if (props.nullable === true && trimmedValue === '') {
+			emit('update:modelValue', null);
+		} else {
+			emit('update:modelValue', trimmedValue);
+		}
 	}
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Modified the `trimIfEnabled` function to emit `null` when the trimmed value is an empty string and the `nullable` prop is set to `true`.

## Potential Risks / Drawbacks

- ?

## Review Notes / Questions

- Try saving empty string to a nullable and trimmed field

---

Fixes #24098
