### PR TITLE
Hide the “no group” column in the Kanban layout when group field is not nullable

### DIFF
--- a/.changeset/curvy-buttons-swim.md
+++ b/.changeset/curvy-buttons-swim.md
@@ -3,4 +3,4 @@
 ---
 
 Ensured that the “Show Ungrouped” option is disabled and that the “No Group” column doesn’t appear in Kanban layouts if
-the group field is not nullable.
+the group field is not nullable

--- a/.changeset/curvy-buttons-swim.md
+++ b/.changeset/curvy-buttons-swim.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Ensured that the “Show Ungrouped” option is disabled and that the “No Group” column doesn’t appear in Kanban layouts if
+the group field is not nullable.

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -178,7 +178,9 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				};
 			});
 
-			if (!ungroupedDisabled.value && showUngrouped.value) {
+			if (ungroupedDisabled.value) {
+				showUngrouped.value = false;
+			} else if (showUngrouped.value) {
 				itemGroups['_ungrouped'] = {
 					id: null,
 					items: [],

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -153,6 +153,10 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			filterSystem,
 		});
 
+		watch(ungroupedDisabled, (disabled) => {
+			if (disabled && showUngrouped.value) showUngrouped.value = false;
+		});
+
 		const groupedItems = computed<Group[]>(() => {
 			const groupsCollectionPrimaryKeyField = groupsPrimaryKeyField.value?.field;
 			const groupTitleField = groupTitle?.value || groupsCollectionPrimaryKeyField;
@@ -178,9 +182,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				};
 			});
 
-			if (ungroupedDisabled.value) {
-				showUngrouped.value = false;
-			} else if (showUngrouped.value) {
+			if (!ungroupedDisabled.value && showUngrouped.value) {
 				itemGroups['_ungrouped'] = {
 					id: null,
 					items: [],

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -129,6 +129,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			editGroup,
 			deleteGroup,
 			isRelational,
+			ungroupedDisabled,
 		} = useGrouping();
 
 		const {
@@ -177,7 +178,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				};
 			});
 
-			if (showUngrouped.value) {
+			if (!ungroupedDisabled.value && showUngrouped.value) {
 				itemGroups['_ungrouped'] = {
 					id: null,
 					items: [],
@@ -241,6 +242,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 		return {
 			isRelational,
+			ungroupedDisabled,
 			canReorderGroups,
 			canReorderItems,
 			canUpdateGroupTitle,
@@ -550,6 +552,11 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				return choices.value;
 			});
 
+			const ungroupedDisabled = computed(() => {
+				if (isRelational.value || selectedGroup.value?.schema?.is_nullable) return false;
+				return true;
+			});
+
 			return {
 				groups,
 				groupsLoading,
@@ -567,6 +574,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				deleteGroup,
 				changeGroupSort,
 				isRelational,
+				ungroupedDisabled,
 			};
 
 			async function deleteGroup(id: string | number) {

--- a/app/src/layouts/kanban/options.vue
+++ b/app/src/layouts/kanban/options.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
 		tagsField?: string | null;
 		userField?: string | null;
 		showUngrouped: boolean;
+		ungroupedDisabled: boolean;
 	}>(),
 	{
 		groupTitleFields: () => [],
@@ -173,7 +174,7 @@ const userFieldSync = useSync(props, 'userField', emit);
 
 			<div class="field">
 				<div class="type-label">{{ t('layouts.kanban.show_ungrouped') }}</div>
-				<v-checkbox v-model="showUngroupedSync" block :label="t('layouts.kanban.show')" />
+				<v-checkbox v-model="showUngroupedSync" block :disabled="ungroupedDisabled" :label="t('layouts.kanban.show')" />
 			</div>
 		</div>
 	</v-detail>


### PR DESCRIPTION
## Scope

What's changed:

- Ensured that the “Show Ungrouped” option is disabled and that the “No Group” column doesn’t appear in Kanban layouts if the group field is not nullable

## Potential Risks / Drawbacks

…

## Review Notes / Questions

…

---

Fixes #24561
