### PR TITLE
Fix shifting logical operators up in filter parsing

### DIFF
--- a/.changeset/six-mugs-burn.md
+++ b/.changeset/six-mugs-burn.md
@@ -2,4 +2,4 @@
 '@directus/utils': patch
 ---
 
-Fix carrying up logical operators in filter
+Fixed shifting logical operators up in filter parsing

--- a/.changeset/six-mugs-burn.md
+++ b/.changeset/six-mugs-burn.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fix carrying up logical operators in filter

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -151,6 +151,79 @@ describe('#parseFilter', () => {
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
 	});
 
+	it('properly shifts up nested implicit logical operators', () => {
+		const mockFilter = {
+			i_really_dont_know: {
+				_or: [
+					{
+						article_field: {
+							date_field: {
+								_and: [
+									{
+										_gte: '2023-10-01T00:00:00',
+									},
+									{
+										_lt: '2023-11-01T00:00:00',
+									},
+								],
+							},
+						},
+					},
+					{
+						other_field: {
+							date_field: {
+								_and: [
+									{
+										_gte: '2023-10-01T00:00:00',
+									},
+									{
+										_lt: '2023-11-01T00:00:00',
+									},
+								],
+							},
+						},
+					},
+				],
+			},
+		} as Filter;
+
+		const mockResult = {
+			_or: [
+				{
+					_and: [
+						{
+							i_really_dont_know: {
+								article_field: { date_field: { _gte: '2023-10-01T00:00:00' } },
+							},
+						},
+						{
+							i_really_dont_know: {
+								article_field: { date_field: { _lt: '2023-11-01T00:00:00' } },
+							},
+						},
+					],
+				},
+				{
+					_and: [
+						{
+							i_really_dont_know: {
+								other_field: { date_field: { _gte: '2023-10-01T00:00:00' } },
+							},
+						},
+						{
+							i_really_dont_know: {
+								other_field: { date_field: { _lt: '2023-11-01T00:00:00' } },
+							},
+						},
+					],
+				},
+			],
+		} as Filter;
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
 	it('leaves explicit logical operator as is', () => {
 		const mockFilter = {
 			_and: [

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -224,6 +224,146 @@ describe('#parseFilter', () => {
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
 	});
 
+	it('properly shifts up nested implicit logical operators', () => {
+		const mockFilter = {
+			i_really_dont_know: {
+				some_field: {
+					_or: [
+						{
+							article_field: {
+								date_field: {
+									_and: [
+										{
+											_gte: '2023-10-01T00:00:00',
+										},
+										{
+											_lt: '2023-11-01T00:00:00',
+										},
+									],
+								},
+							},
+						},
+						{
+							other_field: {
+								date_field: {
+									_and: [
+										{
+											_gte: '2023-10-01T00:00:00',
+										},
+										{
+											_lt: '2023-11-01T00:00:00',
+										},
+									],
+								},
+							},
+						},
+					],
+				},
+			},
+		} as Filter;
+
+		const mockResult = {
+			_or: [
+				{
+					_and: [
+						{
+							i_really_dont_know: {
+								some_field: {
+									article_field: { date_field: { _gte: '2023-10-01T00:00:00' } },
+								},
+							},
+						},
+						{
+							i_really_dont_know: {
+								some_field: {
+									article_field: { date_field: { _lt: '2023-11-01T00:00:00' } },
+								},
+							},
+						},
+					],
+				},
+				{
+					_and: [
+						{
+							i_really_dont_know: {
+								some_field: {
+									other_field: { date_field: { _gte: '2023-10-01T00:00:00' } },
+								},
+							},
+						},
+						{
+							i_really_dont_know: {
+								some_field: {
+									other_field: { date_field: { _lt: '2023-11-01T00:00:00' } },
+								},
+							},
+						},
+					],
+				},
+			],
+		} as Filter;
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('properly shifts up nested implicit logical operators', () => {
+		const mockFilter = {
+			_and: [
+				{
+					_or: [
+						{
+							some_field: {
+								_and: [
+									{
+										article_field: {
+											date_field: {
+												_gte: '2023-10-01T00:00:00',
+											},
+										},
+									},
+									{
+										article_field: {
+											date_field: {
+												_lt: '2023-11-01T00:00:00',
+											},
+										},
+									},
+								],
+							},
+						},
+					],
+				},
+			],
+		} as Filter;
+
+		const mockResult = {
+			_and: [
+				{
+					_or: [
+						{
+							_and: [
+								{
+									some_field: {
+										article_field: { date_field: { _gte: '2023-10-01T00:00:00' } },
+									},
+								},
+								{
+									some_field: {
+										article_field: { date_field: { _lt: '2023-11-01T00:00:00' } },
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		} as Filter;
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
 	it('leaves explicit logical operator as is', () => {
 		const mockFilter = {
 			_and: [

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -67,6 +67,90 @@ describe('#parseFilter', () => {
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
 	});
 
+	it('properly shifts up implicit logical operator twice', () => {
+		const mockFilter = {
+			article_field: {
+				date_field: {
+					_and: [
+						{
+							_gte: '2023-10-01T00:00:00',
+						},
+						{
+							_lt: '2023-11-01T00:00:00',
+						},
+					],
+				},
+			},
+		} as Filter;
+
+		const mockResult = {
+			_and: [
+				{
+					article_field: {
+						date_field: {
+							_gte: '2023-10-01T00:00:00',
+						},
+					},
+				},
+				{
+					article_field: {
+						date_field: {
+							_lt: '2023-11-01T00:00:00',
+						},
+					},
+				},
+			],
+		} as Filter;
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('properly shifts up implicit logical operator three times', () => {
+		const mockFilter = {
+			i_really_dont_know: {
+				article_field: {
+					date_field: {
+						_and: [
+							{
+								_gte: '2023-10-01T00:00:00',
+							},
+							{
+								_lt: '2023-11-01T00:00:00',
+							},
+						],
+					},
+				},
+			},
+		} as Filter;
+
+		const mockResult = {
+			_and: [
+				{
+					i_really_dont_know: {
+						article_field: {
+							date_field: {
+								_gte: '2023-10-01T00:00:00',
+							},
+						},
+					},
+				},
+				{
+					i_really_dont_know: {
+						article_field: {
+							date_field: {
+								_lt: '2023-11-01T00:00:00',
+							},
+						},
+					},
+				},
+			],
+		} as Filter;
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
 	it('leaves explicit logical operator as is', () => {
 		const mockFilter = {
 			_and: [

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -63,7 +63,17 @@ function shiftLogicalOperatorsUp(filter: any): any {
 		} else if (childKey.startsWith('_')) {
 			return filter;
 		} else {
-			return { [key]: shiftLogicalOperatorsUp(filter[key]) };
+			const new_filter = { [key]: shiftLogicalOperatorsUp(filter[key]) };
+
+			const childKey = Object.keys(new_filter[key])[0];
+			if (!childKey) return filter;
+
+			// This carries deeply nested logical operators up to the top level
+			if (logicalFilterOperators.includes(childKey)) {
+				return shiftLogicalOperatorsUp(new_filter);
+			}
+
+			return new_filter;
 		}
 	}
 }

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -42,7 +42,7 @@ function shiftLogicalOperatorsUp(filter: any): any {
 
 	if (logicalFilterOperators.includes(key)) {
 		return {
-			[key]: toArray(filter[key]).map((childFilter: any) => shiftLogicalOperatorsUp(childFilter)),
+			[key]: filter[key].map(shiftLogicalOperatorsUp),
 		};
 	} else if (key.startsWith('_')) {
 		return filter;

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -41,40 +41,26 @@ function shiftLogicalOperatorsUp(filter: any): any {
 	if (!key) return filter;
 
 	if (logicalFilterOperators.includes(key)) {
-		for (const childKey of Object.keys(filter[key])) {
-			filter[key][childKey] = shiftLogicalOperatorsUp(filter[key][childKey]);
-		}
-
-		return filter;
+		return {
+			[key]: toArray(filter[key]).map((childFilter: any) => shiftLogicalOperatorsUp(childFilter)),
+		};
 	} else if (key.startsWith('_')) {
 		return filter;
 	} else {
-		const childKey = Object.keys(filter[key])[0];
-		if (!childKey) return filter;
+		const childResult = shiftLogicalOperatorsUp(filter[key]);
+		const childKey = Object.keys(childResult)[0];
+
+		if (!childKey) return { [key]: childResult };
 
 		if (logicalFilterOperators.includes(childKey)) {
-			return {
-				[childKey]: toArray(filter[key][childKey]).map((childFilter) => {
-					return { [key]: shiftLogicalOperatorsUp(childFilter) };
-				}),
-			};
-		} else if (bypassOperators.includes(childKey)) {
-			return { [key]: { [childKey]: shiftLogicalOperatorsUp(filter[key][childKey]) } };
-		} else if (childKey.startsWith('_')) {
-			return filter;
-		} else {
-			const new_filter = { [key]: shiftLogicalOperatorsUp(filter[key]) };
-
-			const childKey = Object.keys(new_filter[key])[0];
-			if (!childKey) return filter;
-
-			// This carries deeply nested logical operators up to the top level
-			if (logicalFilterOperators.includes(childKey)) {
-				return shiftLogicalOperatorsUp(new_filter);
-			}
-
-			return new_filter;
+			return shiftLogicalOperatorsUp({
+				[childKey]: childResult[childKey].map((nestedFilter: any) => ({
+					[key]: nestedFilter,
+				})),
+			});
 		}
+
+		return { [key]: childResult };
 	}
 }
 


### PR DESCRIPTION
## Scope

What's changed:
- the shiftLogicalOperatorsUp function now does what it's name said. In that before, each filter only ever got shifted once up and not all the way to the top. 

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

The problem was that the GQL query in the PR generated a filter that had a logical operator 2 layers deep.

- See tests for examples

---

Fixes #24367
