### PR TITLE
Refresh kanban layout after deleting a group column

### DIFF
--- a/.changeset/gorgeous-foxes-eat.md
+++ b/.changeset/gorgeous-foxes-eat.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that the Kanban layout refreshes after deleting a group column

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -578,7 +578,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 				await api.delete(`${getEndpoint(groupsCollection.value)}/${id}`);
 
-				await getGroups();
+				refresh();
 			}
 
 			async function addGroup(title: string) {


### PR DESCRIPTION
## Scope

What's changed:

- Ensured that the Kanban layout refreshes after deleting a group column

## Potential Risks / Drawbacks

…

## Review Notes / Questions

…

---

Fixes #24556
