### PR TITLE
Ensure Kanban layout resets group title only when group field changes within the same collection

### DIFF
--- a/.changeset/angry-ants-design.md
+++ b/.changeset/angry-ants-design.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that the Kanban layout only resets the group title when the group field changes within the same collection

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -403,8 +403,10 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const selectedGroup = computed(() => fieldGroups.value.group.find((group) => group.field === groupField.value));
 
-			watch(groupField, () => {
-				groupTitle.value = null;
+			watch([groupField, () => props.collection], ([newField, newCollection], [oldField, oldCollection]) => {
+				if (groupTitle.value === null) return;
+				const groupFieldChangedWithinCollection = newCollection === oldCollection && newField !== oldField;
+				if (groupFieldChangedWithinCollection) groupTitle.value = null;
 			});
 
 			const userFieldJunction = computed(() => {


### PR DESCRIPTION
## Scope

What's changed:

- Ensured that the Kanban layout only resets the group title when the group field changes within the same collection

## Potential Risks / Drawbacks

…

## Review Notes / Questions

- Check if it also fixes https://github.com/directus/directus/issues/23544

---

Fixes #24562
