### PR TITLE
Add Integer Prop to v-input and prevent non numeric characters

### DIFF
--- a/.changeset/orange-beds-reply.md
+++ b/.changeset/orange-beds-reply.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed being able to input non-integer values into an integer input.

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -75,7 +75,7 @@ const props = withDefaults(defineProps<Props>(), {
 	hideArrows: false,
 	max: undefined,
 	min: undefined,
-	step: undefined,
+	step: 1,
 	active: false,
 	dbSafe: false,
 	trim: false,

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -189,7 +189,8 @@ function emitValue(event: InputEvent) {
 	if (props.type === 'number') {
 		const parsedNumber = Number(value);
 
-		if (props.integer === true && !Number.isInteger(parsedNumber)) {
+		if (props.integer === true && !Number.isInteger(parsedNumber) && Number.isNaN(parsedNumber) === false) {
+			emit('update:modelValue', Math.floor(parsedNumber));
 			return;
 		}
 

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -55,6 +55,8 @@ interface Props {
 	autocomplete?: string;
 	/** Makes the input smaller */
 	small?: boolean;
+	/** If the input should be an integer */
+	integer?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -73,7 +75,7 @@ const props = withDefaults(defineProps<Props>(), {
 	hideArrows: false,
 	max: undefined,
 	min: undefined,
-	step: 1,
+	step: undefined,
 	active: false,
 	dbSafe: false,
 	trim: false,
@@ -124,6 +126,11 @@ function processValue(event: KeyboardEvent) {
 	if (!key) return;
 
 	const value = (event.target as HTMLInputElement).value;
+
+	if (props.integer === true && ['.', ','].includes(key)) {
+		event.preventDefault();
+		return;
+	}
 
 	if (props.slug === true) {
 		const slugSafeCharacters = 'abcdefghijklmnopqrstuvwxyz0123456789-_~ '.split('');
@@ -181,6 +188,10 @@ function emitValue(event: InputEvent) {
 
 	if (props.type === 'number') {
 		const parsedNumber = Number(value);
+
+		if (props.integer === true && !Number.isInteger(parsedNumber)) {
+			return;
+		}
 
 		// Ignore if numeric value remains unchanged
 		if (props.modelValue !== parsedNumber) {

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -59,6 +59,8 @@ const inputType = computed(() => {
 	if (['bigInteger', 'integer', 'float', 'decimal'].includes(props.type!)) return 'number';
 	return 'text';
 });
+
+const isInteger = computed(() => ['bigInteger', 'integer'].includes(props.type!));
 </script>
 
 <template>
@@ -78,6 +80,7 @@ const inputType = computed(() => {
 		:max-length="length"
 		:step="step"
 		:dir="direction"
+		:integer="isInteger"
 		:autocomplete="masked ? 'new-password' : 'off'"
 		@update:model-value="$emit('input', $event)"
 	>


### PR DESCRIPTION
## Scope

What's changed:

- Added Integer prop to `v-input` and preview `.` or `,` from being entered and Math.floor() any non-integer numbers entered.
- If field type is integer in `input` interface, enable integer prop on `v-input`

## Potential Risks / Drawbacks

- Doesn't throw validation errors, just mutates the values entered into the input to conform to integer

## Review Notes / Questions

- Is this how we want to handle this?

---

Fixes #24479
