### PR TITLE
Fix a bug where multiple filters inside _and do not return results

### DIFF
--- a/.changeset/honest-mice-drum.md
+++ b/.changeset/honest-mice-drum.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed a bug where multiple filters inside \_and do not return results

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -222,21 +222,16 @@ function addJoin({ path, collection, aliasMap, rootQuery, schema, relations, kne
 		if (!existingAlias) {
 			const alias = generateAlias();
 
-			const aliasKey = parentFields
-				? `${parentFields}.${pathParts[0]}`
-				: pathParts[0]!;
+			const aliasKey = parentFields ? `${parentFields}.${pathParts[0]}` : pathParts[0]!;
 
 			// If we're in an _and context, make the key unique using the index
-			const finalAliasKey = indexInAndArray !== undefined
-				? `${aliasKey}__and${indexInAndArray}`
-				: aliasKey;
+			const finalAliasKey = indexInAndArray !== undefined ? `${aliasKey}__and${indexInAndArray}` : aliasKey;
 
 			aliasMap[finalAliasKey] = { alias, collection: '' };
 
 			// For parent lookup, we need to use the same suffix if it exists
-			const parentAliasKey = parentFields && indexInAndArray !== undefined
-				? `${parentFields}__and${indexInAndArray}`
-				: parentFields ?? '';
+			const parentAliasKey =
+				parentFields && indexInAndArray !== undefined ? `${parentFields}__and${indexInAndArray}` : parentFields ?? '';
 
 			const aliasedParentCollection = aliasMap[parentAliasKey]?.alias || parentCollection;
 
@@ -553,9 +548,13 @@ export function applyFilter(
 				/** @NOTE this callback function isn't called until Knex runs the query */
 				dbQuery[logical].where((subQuery) => {
 					value.forEach((subFilter: Record<string, any>, index: number) => {
-						addWhereClauses(knex, subQuery, subFilter, collection,
-						  key === '_and' ? 'and' : 'or',
-						  key === '_and' ? index : undefined
+						addWhereClauses(
+							knex,
+							subQuery,
+							subFilter,
+							collection,
+							key === '_and' ? 'and' : 'or',
+							key === '_and' ? index : undefined,
 						);
 					});
 				});
@@ -640,7 +639,7 @@ export function applyFilter(
 					relations,
 					aliasMap,
 					schema,
-					indexInAndArray
+					indexInAndArray,
 				});
 
 				if (addNestedPkField) {

--- a/api/src/utils/get-column-path.ts
+++ b/api/src/utils/get-column-path.ts
@@ -10,6 +10,7 @@ export type ColPathProps = {
 	aliasMap: AliasMap;
 	relations: Relation[];
 	schema?: SchemaOverview;
+	indexInAndArray?: number | undefined;
 };
 
 export type ColPathResult = {
@@ -24,7 +25,7 @@ export type ColPathResult = {
  * Also returns the target collection of the column: 'directus_roles'
  * If the last filter path is an alias field, a nested PK is appended to the path
  */
-export function getColumnPath({ path, collection, aliasMap, relations, schema }: ColPathProps) {
+export function getColumnPath({ path, collection, aliasMap, relations, schema, indexInAndArray }: ColPathProps) {
 	return followRelation(path);
 
 	function followRelation(
@@ -43,7 +44,14 @@ export function getColumnPath({ path, collection, aliasMap, relations, schema }:
 			throw new InvalidQueryError({ reason: `"${parentCollection}.${pathRoot}" is not a relational field` });
 		}
 
-		const alias = parentFields ? aliasMap[`${parentFields}.${pathParts[0]}`]?.alias : aliasMap[pathParts[0]!]?.alias;
+		const getAliasKey = (key: string) => {
+			return indexInAndArray !== undefined ? `${key}__and${indexInAndArray}` : key;
+		};
+
+		const alias = parentFields
+			? aliasMap[getAliasKey(`${parentFields}.${pathParts[0]}`)]?.alias
+			: aliasMap[getAliasKey(pathParts[0]!)]?.alias;
+
 		const remainingParts = pathParts.slice(1);
 
 		let parent: string;

--- a/contributors.yml
+++ b/contributors.yml
@@ -200,3 +200,4 @@
 - obafemitayor
 - highvibesonly
 - sidartaveloso
+- koljam


### PR DESCRIPTION
## Scope
What's changed:
- Fixed filtering logic to correctly handle multiple conditions on the same relation in _and clauses
- For example, searching for countries where both English AND French are spoken now returns correct results
- Implemented unique JOIN creation for each condition within _and clauses instead of reusing the same JOIN

## Potential Risks / Drawbacks
- Performance impact when dealing with multiple `_and` conditions as each condition now creates a new JOIN instead of reusing existing ones
- Local testing with 1000 requests showed negligible performance difference on smaller datasets
- Large datasets with complex filtering and multiple `_and` conditions might see increased query execution time, but this is necessary to ensure correct results

## Review Notes / Questions
- Unable to run blackbox-testing locally due to configuration issues
- Special attention should be paid to nested relation handling within `_and` clauses
---
Fixes #20614 #18863

This PR fixes a critical bug in M2M filtering where using multiple conditions on the same relation within an `_and` clause would produce incorrect results. Previously, the system would reuse the same JOIN for all conditions within an `_and`, which led to impossible constraints.

The fix introduces a way to track whether a filter condition is part of an `_and` clause by passing an `indexInAndArray` through the filter processing chain. When inside an `_and`, we generate unique aliases for each condition by appending `__andX` to the alias key, where X is the index of the condition. This ensures that each condition in the _and clause gets its own JOIN, allowing us to correctly find records that have relationships matching ALL conditions (e.g., a country that has BOTH English AND French in its spokenLanguages records). Previously, the system would incorrectly try to find a single spokenLanguages record that contained both English and French, which was impossible and resulted in zero matches.