### PR TITLE
Fix sort ordering for bulk updates

### DIFF
--- a/.changeset/violet-ducks-reply.md
+++ b/.changeset/violet-ducks-reply.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixes sort ordering for bulk updates and m2a relationships

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -447,14 +447,14 @@ Article           Many|Any: article_m2a                    ┌─Text
 │id       ├───┐   │id: junctionPKField             │    ┌──┼─┤id       │
 │content  │   └──►│article_id: reverseJunctionField│    │  │ │text     │
 └─────────┘       │item: junctionField             │◄───┤  │ └─────────┘
-                  │sort: sortField                 │    │  │
-                  │collection: collectionField     │◄───┼──┤
-                  └────────────────────────────────┘    │  │
-                                                        │  └─Code
-                  AllowedCollection: [Text,Code]		    │    ┌─────────┐
-                relatedPKFields: {Text: id,Code: id}    └────┤id       │
-                                                             │code     │
-                                                             └─────────┘
+				      │sort: sortField                 │    │  │
+				      │collection: collectionField     │◄───┼──┤
+				      └────────────────────────────────┘    │  │
+														              │  └─Code
+				AllowedCollection: [Text,Code]		        │    ┌─────────┐
+				relatedPKFields: {Text: id,Code: id}        └────┤id       │
+															                │code     │
+															                └─────────┘
 */
 
 describe('test m2a relation', () => {
@@ -507,113 +507,5 @@ describe('test m2a relation', () => {
 				$edits: 1,
 			},
 		]);
-	});
-});
-
-const relationO2MSort: RelationO2M = {
-	...relationO2M,
-	sortField: 'sort',
-};
-
-describe('test o2m relation with sort', () => {
-	test('creating an item', async () => {
-		const wrapper = mount(TestComponent, {
-			props: { relation: relationO2MSort, value: [], id: 1 },
-		});
-
-		await flushPromises();
-
-		wrapper.vm.create({
-			name: 'test5',
-			facility: 1,
-		});
-
-		await flushPromises();
-
-		expect(wrapper.vm.displayItems).toEqual([
-			...workerData,
-			{ name: 'test5', facility: 1, $type: 'created', $index: 0, sort: 5 },
-		]);
-
-		expect(wrapper.vm.value).toEqual({
-			create: [
-				{
-					name: 'test5',
-					facility: 1,
-					sort: 5,
-				},
-			],
-			update: [],
-			delete: [],
-		});
-	});
-
-	test('editing a created item', async () => {
-		const wrapper = mount(TestComponent, {
-			props: { relation: relationO2MSort, value: [], id: 1 },
-		});
-
-		await flushPromises();
-
-		wrapper.vm.create({
-			name: 'test5',
-			facility: 1,
-		});
-
-		await flushPromises();
-
-		wrapper.vm.update({
-			name: 'test5 edited',
-			facility: 2,
-			$type: 'created',
-			$index: 0,
-			sort: 5,
-		});
-
-		await flushPromises();
-
-		expect(wrapper.vm.displayItems).toEqual([
-			...workerData,
-			{ name: 'test5 edited', facility: 2, $type: 'created', $index: 0, sort: 5 },
-		]);
-
-		expect(wrapper.vm.value).toEqual({
-			create: [
-				{
-					name: 'test5 edited',
-					facility: 2,
-					sort: 5,
-				},
-			],
-			update: [],
-			delete: [],
-		});
-
-		await flushPromises();
-
-		wrapper.vm.update({
-			name: 'test5 edited',
-			facility: 2,
-			$type: 'created',
-			$index: 0,
-		});
-
-		await flushPromises();
-
-		expect(wrapper.vm.displayItems).toEqual([
-			...workerData,
-			{ name: 'test5 edited', facility: 2, $type: 'created', $index: 0 },
-		]);
-
-		expect(wrapper.vm.value).toEqual({
-			create: [
-				{
-					name: 'test5 edited',
-					facility: 2,
-				},
-			],
-			update: [],
-			delete: [],
-		});
 	});
 });

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -447,14 +447,14 @@ Article           Many|Any: article_m2a                    ┌─Text
 │id       ├───┐   │id: junctionPKField             │    ┌──┼─┤id       │
 │content  │   └──►│article_id: reverseJunctionField│    │  │ │text     │
 └─────────┘       │item: junctionField             │◄───┤  │ └─────────┘
-				      │sort: sortField                 │    │  │
-				      │collection: collectionField     │◄───┼──┤
-				      └────────────────────────────────┘    │  │
-														              │  └─Code
-				AllowedCollection: [Text,Code]		        │    ┌─────────┐
-				relatedPKFields: {Text: id,Code: id}        └────┤id       │
-															                │code     │
-															                └─────────┘
+				  │sort: sortField                 │    │  │
+				  │collection: collectionField     │◄───┼──┤
+				  └────────────────────────────────┘    │  │
+														│  └─Code
+				AllowedCollection: [Text,Code]		    │    ┌─────────┐
+				relatedPKFields: {Text: id,Code: id}    └────┤id       │
+															 │code     │
+															 └─────────┘
 */
 
 describe('test m2a relation', () => {

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -447,14 +447,14 @@ Article           Many|Any: article_m2a                    ┌─Text
 │id       ├───┐   │id: junctionPKField             │    ┌──┼─┤id       │
 │content  │   └──►│article_id: reverseJunctionField│    │  │ │text     │
 └─────────┘       │item: junctionField             │◄───┤  │ └─────────┘
-				  │sort: sortField                 │    │  │
-				  │collection: collectionField     │◄───┼──┤
-				  └────────────────────────────────┘    │  │
-														│  └─Code
-				AllowedCollection: [Text,Code]		    │    ┌─────────┐
-				relatedPKFields: {Text: id,Code: id}    └────┤id       │
-															 │code     │
-															 └─────────┘
+				      │sort: sortField                 │    │  │
+				      │collection: collectionField     │◄───┼──┤
+				      └────────────────────────────────┘    │  │
+														              │  └─Code
+				AllowedCollection: [Text,Code]		        │    ┌─────────┐
+				relatedPKFields: {Text: id,Code: id}        └────┤id       │
+															                │code     │
+															                └─────────┘
 */
 
 describe('test m2a relation', () => {

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -716,37 +716,30 @@ export function useRelationMultiple(
 		}
 
 		function getItemEdits(item: DisplayItem) {
-			const sortField = relation.value?.sortField;
-			let edits: DisplayItem = {};
-
 			if ('$type' in item && item.$index !== undefined) {
 				if (item.$type === 'created') {
-					edits = {
+					return {
 						..._value.value.create[item.$index],
-						$type: item.$type,
+						$type: 'created',
 						$index: item.$index,
 					};
 				} else if (item.$type === 'updated') {
-					edits = {
+					return {
 						..._value.value.update[item.$index],
-						$type: item.$type,
+						$type: 'updated',
 						$index: item.$index,
 					};
 				} else if (item.$type === 'deleted' && item.$edits !== undefined) {
-					edits = {
+					return {
 						..._value.value.update[item.$edits],
-						$type: item.$type,
+						$type: 'deleted',
 						$index: item.$index,
 						$edits: item.$edits,
 					};
 				}
 			}
 
-			if (sortField && item[sortField] !== undefined && edits[sortField] === undefined) {
-				edits[sortField] = item[sortField];
-			}
-
-			return edits;
+			return {};
 		}
 
 		return { cleanItem, getPage, isLocalItem, getItemEdits, isEmpty };

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -176,8 +176,11 @@ export function useRelationMultiple(
 					case 'm2a': {
 						const itemCollection = item[relation.value.collectionField.field];
 						const editCollection = edit[relation.value.collectionField.field];
-						const itemPkField = relation.value.relationPrimaryKeyFields[itemCollection].field;
-						const editPkField = relation.value.relationPrimaryKeyFields[editCollection].field;
+						const itemPkField = relation.value.relationPrimaryKeyFields[itemCollection]?.field;
+						const editPkField = relation.value.relationPrimaryKeyFields[editCollection]?.field;
+
+						if (!itemPkField) throw new Error(`No primary key field found for collection ${itemCollection}`);
+						if (!editPkField) throw new Error(`No primary key field found for collection ${editCollection}`);
 
 						return (
 							itemCollection === editCollection &&
@@ -304,12 +307,15 @@ export function useRelationMultiple(
 
 					case 'm2a': {
 						if (!collection) throw new Error('You need to provide a collection on an m2a');
+						const pkField = info.relationPrimaryKeyFields[collection];
+
+						if (!pkField) throw new Error(`No primary key field found for collection ${collection}`);
 
 						return {
 							[info.reverseJunctionField.field]: itemId.value,
 							[info.collectionField.field]: collection,
 							[info.junctionField.field]: {
-								[info.relationPrimaryKeyFields[collection].field]: item,
+								[pkField.field]: item,
 							},
 						};
 					}
@@ -345,6 +351,7 @@ export function useRelationMultiple(
 
 				for (const collection of relation.value.allowedCollections) {
 					const pkField = relation.value.relationPrimaryKeyFields[collection.collection];
+					if (!pkField) throw new Error(`No primary key field found for collection ${collection.collection}`);
 					fields.add(`${relation.value.junctionField.field}:${collection.collection}.${pkField.field}`);
 				}
 
@@ -502,7 +509,9 @@ export function useRelationMultiple(
 
 				case 'm2a': {
 					const collection = item[relation.value.collectionField.field];
-					return item[relation.value.junctionField.field][relation.value.relationPrimaryKeyFields[collection].field];
+					const pkField = relation.value.relationPrimaryKeyFields[collection]?.field;
+					if (!pkField) throw new Error(`No primary key field found for collection ${collection}`);
+					return item[relation.value.junctionField.field][pkField];
 				}
 			}
 
@@ -606,7 +615,8 @@ export function useRelationMultiple(
 
 			const responses = await Promise.all(
 				Object.entries(selectGrouped).map(([collection, items]) => {
-					const pkField = relation.relationPrimaryKeyFields[collection].field;
+					const pkField = relation.relationPrimaryKeyFields[collection]?.field;
+					if (!pkField) throw new Error(`No primary key field found for collection ${collection}`);
 
 					const fields = new Set(
 						previewQuery.value.fields.reduce<string[]>((acc, field) => {

--- a/contributors.yml
+++ b/contributors.yml
@@ -200,3 +200,4 @@
 - obafemitayor
 - highvibesonly
 - sidartaveloso
+- robluton


### PR DESCRIPTION
## Scope

What's changed:

- Reverted commits that were applying sort values and sending those to the api. The api handles the sort values automatically when sort value is not sent for new items.

## Potential Risks / Drawbacks

- Because the sort value cannot be calculated on the client without making several api calls, the sort value will not be displayed until the user has saved.

Fixes #24223
