### PR TITLE
Treat BigInts as Strings

### DIFF
--- a/.changeset/soft-beds-bake.md
+++ b/.changeset/soft-beds-bake.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed BigInt rounding errors by treating BigInt's as strings in app

--- a/app/src/interfaces/input/index.ts
+++ b/app/src/interfaces/input/index.ts
@@ -223,7 +223,7 @@ export default defineInterface({
 			},
 		];
 
-		if (field.type && ['bigInteger', 'integer', 'float', 'decimal'].includes(field.type)) {
+		if (field.type && ['integer', 'float', 'decimal'].includes(field.type)) {
 			return numberOptions;
 		}
 

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -56,7 +56,7 @@ const percentageRemaining = computed(() => {
 
 const inputType = computed(() => {
 	if (props.masked) return 'password';
-	if (['bigInteger', 'integer', 'float', 'decimal'].includes(props.type!)) return 'number';
+	if (['integer', 'float', 'decimal'].includes(props.type!)) return 'number';
 	return 'text';
 });
 

--- a/app/src/interfaces/slider/index.ts
+++ b/app/src/interfaces/slider/index.ts
@@ -8,7 +8,7 @@ export default defineInterface({
 	description: '$t:interfaces.slider.description',
 	icon: 'linear_scale',
 	component: InterfaceSlider,
-	types: ['integer', 'decimal', 'float', 'bigInteger'],
+	types: ['integer', 'decimal', 'float'],
 	group: 'other',
 	options: [
 		{

--- a/app/src/utils/get-js-type.test.ts
+++ b/app/src/utils/get-js-type.test.ts
@@ -21,7 +21,7 @@ test('Returns object for relational fields', () => {
 });
 
 test('Returns number for numeric fields', () => {
-	const numericTypes = ['bigInteger', 'integer', 'float', 'decimal'];
+	const numericTypes = ['integer', 'float', 'decimal'];
 
 	for (const fieldType of numericTypes) {
 		expect(
@@ -36,7 +36,7 @@ test('Returns number for numeric fields', () => {
 });
 
 test('Returns string for string fields', () => {
-	const stringTypes = ['string', 'text', 'uuid', 'hash'];
+	const stringTypes = ['string', 'text', 'uuid', 'hash', 'bigInteger'];
 
 	for (const fieldType of stringTypes) {
 		expect(

--- a/app/src/utils/get-js-type.ts
+++ b/app/src/utils/get-js-type.ts
@@ -9,11 +9,11 @@ export function getJSType(field: Field): string {
 	}
 
 	switch (field.type) {
-		case 'bigInteger':
 		case 'integer':
 		case 'float':
 		case 'decimal':
 			return 'number';
+		case 'bigInteger':
 		case 'string':
 		case 'text':
 		case 'uuid':


### PR DESCRIPTION
## Scope

What's changed:

- Treat BigInt's as strings in interfaces / raw values to avoid unexpected behavior when you exceed javascripts safe number.

## Potential Risks / Drawbacks

- Lose number functionality when bigint is below the safe number limit, however, you gain precision and ability to actually input bigints that are larger than javascripts safe number limit.

## Review Notes / Questions

-

---

Fixes #20287
