### PR TITLE
Add the `validate` command to the `package.json` template

### DIFF
--- a/.changeset/strong-weeks-battle.md
+++ b/.changeset/strong-weeks-battle.md
@@ -1,0 +1,5 @@
+---
+"@directus/extensions-sdk": patch
+---
+
+Added the `validate` command to the `package.json` template

--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -188,6 +188,7 @@ function getPackageManifest(name: string, options: ExtensionOptions, deps: Recor
 			build: 'directus-extension build',
 			dev: 'directus-extension build -w --no-minify',
 			link: 'directus-extension link',
+			validate: 'directus-extension validate',
 		},
 		devDependencies: deps,
 	};


### PR DESCRIPTION
## Scope

What's changed:

- Addition of `validate` command to the `package.json` template

Follow-up of https://github.com/directus/directus/pull/24269