### PR TITLE
Add pip to builder stage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install --global corepack@latest
 ARG TARGETPLATFORM
 RUN <<EOF
 	if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then
-		apk --no-cache add python3 build-base
+		apk --no-cache add python3 py3-pip build-base
 		ln -sf /usr/bin/python3 /usr/bin/python
 	fi
 EOF

--- a/contributors.yml
+++ b/contributors.yml
@@ -200,3 +200,4 @@
 - obafemitayor
 - highvibesonly
 - sidartaveloso
+- trbernstein


### PR DESCRIPTION
## Scope

What's changed:

- Make `pip` available in `builder` stage of Docker file so that npm installs `sqlite3`, which is an optional dependency.

Fixes #24612
