### PR TITLE
Fix BlockEditor Emitted Events

### DIFF
--- a/.changeset/rude-bottles-prove.md
+++ b/.changeset/rude-bottles-prove.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fix BlockEditor Duplicating Translated Items

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -13,8 +13,8 @@ import { useFileHandler } from './use-file-handler';
 
 import './editorjs-overrides.css';
 
-// https://github.com/codex-team/editor.js/blob/057bf17a6fc2d5e05c662107918d7c3e943d077c/src/components/events/RedactorDomChanged.ts#L4
-const RedactorDomChanged = 'redactor dom changed';
+// https://github.com/codex-team/editor.js/blob/7399e55f7e2ea6cf019cf659cb6cbd937e7d2e0c/src/components/events/BlockChanged.ts#L6
+const BlockChanged = 'block changed';
 
 const props = withDefaults(
 	defineProps<{
@@ -94,7 +94,8 @@ onMounted(async () => {
 		editorjsRef.value.focus();
 	}
 
-	editorjsRef.value.on(RedactorDomChanged, () => {
+	editorjsRef.value.on(BlockChanged, () => {
+		if(!editorjsRef.value || !editorjsIsReady.value) return;
 		emitValue(editorjsRef.value!);
 	});
 

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -95,7 +95,6 @@ onMounted(async () => {
 	}
 
 	editorjsRef.value.on(BlockChanged, () => {
-		if (!editorjsRef.value || !editorjsIsReady.value) return;
 		emitValue(editorjsRef.value!);
 	});
 

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -95,7 +95,7 @@ onMounted(async () => {
 	}
 
 	editorjsRef.value.on(BlockChanged, () => {
-		if(!editorjsRef.value || !editorjsIsReady.value) return;
+		if (!editorjsRef.value || !editorjsIsReady.value) return;
 		emitValue(editorjsRef.value!);
 	});
 


### PR DESCRIPTION
In a previous PR the BlockEditor was changed to emit events via the redactor in addition to the `onChange` callback because editorjs delays the onChange to collect events. The change to the redactor resulted in the block editor emitting every value change twice at once. This caused issues with translations resulting in two instances of the field value being created.

## Scope

What's changed:

- Changed from redactor event to block changed event.

## Potential Risks / Drawbacks

- Unknown

## Review Notes / Questions

- Try with translations and also saving a field quickly before the `onChanged` callback is called.

---

Fixes #24607
