### PR TITLE
Fix Opening of Split Pane Overriding 2nd lang when not needed

### DIFF
--- a/.changeset/little-ligers-heal.md
+++ b/.changeset/little-ligers-heal.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed Opening of Translation Split Pane Overriding 2nd lang when not needed

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -63,7 +63,7 @@ const firstLang = ref<string>();
 const secondLang = ref<string>();
 
 watch(splitView, (splitViewEnabled) => {
-	if (splitViewEnabled) {
+	if (splitViewEnabled && secondLang.value === firstLang.value) {
 		const lang = languageOptions.value;
 		const alternativeLang = lang.find((l) => l.value !== firstLang.value);
 		secondLang.value = alternativeLang?.value ?? lang[0]?.value;


### PR DESCRIPTION
## Scope

What's changed:

- Only change the 2nd language in the split pane translation interface if it is the same as the first when opening split pane interface.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- This edge case only occurs when the below config is used, and the user language is different than the default. This should result in the first language being the user's language and the 2nd being the default language if the default and user language are different when the split pane is opened. If the config is set to default to open it works as expected.
![image](https://github.com/user-attachments/assets/2985dbbd-cc9b-4d3b-8c57-1749ce044e1a)


---

Fixes #24624
