### PR TITLE
fix marketplace extension detail back button

### DIFF
--- a/.changeset/dry-pears-remember.md
+++ b/.changeset/dry-pears-remember.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+inside an extension's detail page in the marketplace, the back state is not valid if it's a nullish value and it should
+redirect to the extensions list

--- a/app/src/modules/settings/routes/marketplace/routes/extension/extension.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/extension/extension.vue
@@ -40,7 +40,9 @@ watchEffect(async () => {
 const navigateBack = () => {
 	const backState = router.options.history.state.back;
 
-	if (typeof backState !== 'string' || !backState.startsWith('/login')) {
+	const isBackStateValid = backState && !(typeof backState === 'string' && backState.startsWith('/login'));
+
+	if (isBackStateValid) {
 		router.back();
 		return;
 	}

--- a/contributors.yml
+++ b/contributors.yml
@@ -203,3 +203,4 @@
 - robluton
 - wrynegade
 - hola-soy-milk
+- ciaccodavide

--- a/contributors.yml
+++ b/contributors.yml
@@ -203,4 +203,4 @@
 - robluton
 - wrynegade
 - hola-soy-milk
-- ciaccodavide
+- CiaccoDavide


### PR DESCRIPTION
## Scope

What's changed:

- added a check on the nullishness of `backState` in the `navigateBack` function for the back button in the extensions detail's page of the marketplace

## Potential Risks / Drawbacks

none

---

Fixes #24702
