### PR TITLE
Remove duplicate logic

### DIFF
--- a/.changeset/lemon-stingrays-love.md
+++ b/.changeset/lemon-stingrays-love.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Removed duplicated key validation logic from updateByQuery

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -600,9 +600,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	async updateByQuery(query: Query, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const keys = await this.getKeysByQuery(query);
 
-		const primaryKeyField = this.schema.collections[this.collection]!.primary;
-		validateKeys(this.schema, this.collection, primaryKeyField, keys);
-
 		return keys.length ? await this.updateMany(keys, data, opts) : [];
 	}
 


### PR DESCRIPTION
Keys will be validated on line 685 (inside the `updateMany` function) so no need to pre-check them. Slight performance gain.
