### PR TITLE
Fix `filter_count` returning incorrect values for relational filters

### DIFF
--- a/.changeset/hot-plants-know.md
+++ b/.changeset/hot-plants-know.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `filter_count` returning incorrect values for relational filters

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -42,9 +42,11 @@ export class MetaService {
 	}
 
 	async filterCount(collection: string, query: Query): Promise<number> {
+		const primaryKeyName = this.schema.collections[collection]!.primary;
+
 		const aggregateQuery: Query = {
 			aggregate: {
-				count: ['*'],
+				countDistinct: [primaryKeyName],
 			},
 			search: query.search ?? null,
 			filter: query.filter ?? null,
@@ -71,6 +73,9 @@ export class MetaService {
 			knex: this.knex,
 		});
 
-		return Number((isArray(records) ? records[0]?.['count'] : records?.['count']) ?? 0);
+		return Number(
+			(isArray(records) ? records[0]?.['countDistinct'][primaryKeyName] : records?.['countDistinct'][primaryKeyName]) ??
+				0,
+		);
 	}
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now return the correct `filter_count` for relational data.
   - Utilizing `distinctCount` means we do a regular count for local fields but a distinct one for relationships

## Potential Risks / Drawbacks

- Some relational counts still being broken

## Review Notes / Questions
- N/A

---

Fixes #24719
