### PR TITLE
Update incorrect `UsersService` usage in `Working with Users` doc example

### DIFF
--- a/.changeset/shiny-rings-hope.md
+++ b/.changeset/shiny-rings-hope.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Updated incorrect UsersService example in the docs

--- a/docs/extensions/services/working-with-users.md
+++ b/docs/extensions/services/working-with-users.md
@@ -39,7 +39,10 @@ router.get('/', async (req, res) => {
     accountability: req.accountability
   });
 
-  const data = await usersService.getUserByEmail('email');
+  const data = await usersService.readByQuery({
+    fields: ['*'],
+		filter: { email: { _eq: 'email' } },
+	});
 
   res.json(data);
 });

--- a/docs/extensions/services/working-with-users.md
+++ b/docs/extensions/services/working-with-users.md
@@ -40,7 +40,7 @@ router.get('/', async (req, res) => {
   });
 
   const data = await usersService.readByQuery({
-    fields: ['*'],
+		fields: ['*'],
 		filter: { email: { _eq: 'email' } },
 	});
 


### PR DESCRIPTION
## Scope

What's changed:

- Updated incorrect `UsersService` example in the old docs
- [Created issue on the new docs repo to add these missing examples](https://github.com/directus/docs/issues/184)

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Do we still update the old docs when there are blatantly incorrect examples/data in it?

---

Fixes #24720
