### PR TITLE
Fix sqlite in docker image

### DIFF
--- a/.changeset/friendly-rats-kick.md
+++ b/.changeset/friendly-rats-kick.md
@@ -2,4 +2,4 @@
 'directus': patch
 ---
 
-Fixed docker image build
+Fixed sqlite in docker image

--- a/.changeset/friendly-rats-kick.md
+++ b/.changeset/friendly-rats-kick.md
@@ -1,0 +1,5 @@
+---
+'directus': patch
+---
+
+Fixed docker image build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,9 @@ FROM node:${NODE_VERSION}-alpine AS builder
 # (see https://github.com/directus/directus/issues/24514)
 RUN npm install --global corepack@latest
 
-ARG TARGETPLATFORM
 RUN <<EOF
-	if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then
-		apk --no-cache add python3 build-base
-		ln -sf /usr/bin/python3 /usr/bin/python
-	fi
-EOF
+	apk --no-cache add python3 build-base py3-setuptools
+	ln -sf /usr/bin/python3 /usr/bin/python
 
 WORKDIR /directus
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM node:${NODE_VERSION}-alpine AS builder
 # (see https://github.com/directus/directus/issues/24514)
 RUN npm install --global corepack@latest
 
-RUN apk --no-cache add python3 build-base py3-setuptools && ln -sf /usr/bin/python3 /usr/bin/python
+RUN apk --no-cache add python3 py3-setuptools build-base
 
 WORKDIR /directus
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN pnpm fetch
 
 COPY --chown=node:node . .
 RUN <<EOF
+	set -ex
 	pnpm install --recursive --offline --frozen-lockfile
 	npm_config_workspace_concurrency=1 pnpm run build
 	pnpm --filter directus deploy --prod dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,7 @@ FROM node:${NODE_VERSION}-alpine AS builder
 # (see https://github.com/directus/directus/issues/24514)
 RUN npm install --global corepack@latest
 
-RUN <<EOF
-	apk --no-cache add python3 build-base py3-setuptools
-	ln -sf /usr/bin/python3 /usr/bin/python
-EOF
+RUN apk --no-cache add python3 build-base py3-setuptools && ln -sf /usr/bin/python3 /usr/bin/python
 
 WORKDIR /directus
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN npm install --global corepack@latest
 RUN <<EOF
 	apk --no-cache add python3 build-base py3-setuptools
 	ln -sf /usr/bin/python3 /usr/bin/python
+EOF
 
 WORKDIR /directus
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The necessary `py3-setuptools` package has been added to the docker image build process.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- `py3-setuptools` is now required as a separate entity due to `distutils` (deprecated in favour of `py3-setuptools`) being removed from `python3` starting with `3.12.X`. When upgrading from node `node v18` to support `node v22` the `python3` version was changed from `3.11.X` to `3.12.X` in the underlying alpine image. `distutils`/`py3-setuptools` is utilized by the sqlite3 build process and results in a build error if not present
- Tested it to work with at least `linux/arm64` and `linux/amd64` (thanks @br41nslug!)

---

Fixes #24727
Fixes #24612
