### PR TITLE
move redirects _into_ the netlify.toml

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,3 +1,12 @@
+#
+# due to our netlify configuration which declares .vitepress/dist
+# as the build directory, the _redirects file isn't detected
+#
+# to preserve the readability of the _redirects file, we've put
+# together a quick generator which still references this file,
+# but creates the appropriate entries in the netlify.toml
+#
+
 /app/data-model.html                                                                                https://directus.io/docs/getting-started/data-model
 /app/data-model/collections.html                                                                    https://directus.io/docs/guides/data-model/collections
 /app/data-model/fields.html                                                                         https://directus.io/docs/guides/data-model/fields

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,3 +11,1327 @@
 	autoLaunch = false
 	framework = "#custom"
 
+
+# generated redirects from '_redirects' file
+# (delete to the end of the file and append this output)
+# grep '^[^#]' _redirects | awk '{print "\n[[redirects]]\nfrom = \""$1"\"\nto   = \""$2"\""}'
+
+[[redirects]]
+from = "/app/data-model.html"
+to   = "https://directus.io/docs/getting-started/data-model"
+
+[[redirects]]
+from = "/app/data-model/collections.html"
+to   = "https://directus.io/docs/guides/data-model/collections"
+
+[[redirects]]
+from = "/app/data-model/fields.html"
+to   = "https://directus.io/docs/guides/data-model/fields"
+
+[[redirects]]
+from = "/app/data-model/fields/groups.html"
+to   = "https://directus.io/docs/guides/data-model/interfaces"
+
+[[redirects]]
+from = "/app/data-model/fields/other.html"
+to   = "https://directus.io/docs/guides/data-model/interfaces"
+
+[[redirects]]
+from = "/app/data-model/fields/presentation.html"
+to   = "https://directus.io/docs/guides/data-model/interfaces"
+
+[[redirects]]
+from = "/app/data-model/fields/relational.html"
+to   = "https://directus.io/docs/guides/data-model/interfaces"
+
+[[redirects]]
+from = "/app/data-model/fields/selection.html"
+to   = "https://directus.io/docs/guides/data-model/interfaces"
+
+[[redirects]]
+from = "/app/data-model/fields/text-numbers.html"
+to   = "https://directus.io/docs/guides/data-model/interfaces"
+
+[[redirects]]
+from = "/app/data-model/relationships.html"
+to   = "https://directus.io/docs/guides/data-model/relationships"
+
+[[redirects]]
+from = "/app/faq.html"
+to   = "https://directus.io/docs/community/reporting-and-support/troubleshooting-steps"
+
+[[redirects]]
+from = "/app/flows.html"
+to   = "https://directus.io/docs/guides/automate/flows"
+
+[[redirects]]
+from = "/app/flows/operations.html"
+to   = "https://directus.io/docs/guides/automate/operations"
+
+[[redirects]]
+from = "/app/flows/triggers.html"
+to   = "https://directus.io/docs/guides/automate/triggers"
+
+[[redirects]]
+from = "/app/presets-bookmarks.html"
+to   = "https://directus.io/docs/guides/content/explore"
+
+[[redirects]]
+from = "/app/security.html"
+to   = "https://directus.io/docs/configuration/security-limits"
+
+[[redirects]]
+from = "/blog/guest-author.html"
+to   = "https://directus.io/docs/community/programs/guest-authors"
+
+[[redirects]]
+from = "/blog/"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/contributing/code-of-conduct.html"
+to   = "https://directus.io/docs/community/overview/conduct"
+
+[[redirects]]
+from = "/contributing/codebase-overview.html"
+to   = "https://directus.io/docs/community/codebase/overview"
+
+[[redirects]]
+from = "/contributing/community.html"
+to   = "https://directus.io/docs/community/overview/welcome"
+
+[[redirects]]
+from = "/contributing/feature-request-process.html"
+to   = "https://directus.io/docs/community/contribution/feature-requests"
+
+[[redirects]]
+from = "/contributing/introduction.html"
+to   = "https://directus.io/docs/community/overview/welcome"
+
+[[redirects]]
+from = "/contributing/pull-request-process.html"
+to   = "https://directus.io/docs/community/contribution/pull-requests"
+
+[[redirects]]
+from = "/contributing/running-locally.html"
+to   = "https://directus.io/docs/community/codebase/dev-environment"
+
+[[redirects]]
+from = "/contributing/sponsor.html"
+to   = "https://directus.io/docs/community/overview/welcome"
+
+[[redirects]]
+from = "/contributing/tests.html"
+to   = "https://directus.io/docs/community/codebase/testing"
+
+[[redirects]]
+from = "/contributing/translations.html"
+to   = "https://directus.io/docs/community/contribution/translations"
+
+[[redirects]]
+from = "/extensions/app-composables.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/composables"
+
+[[redirects]]
+from = "/extensions/bundles.html"
+to   = "https://directus.io/docs/guides/extensions/bundles"
+
+[[redirects]]
+from = "/extensions/creating-extensions.html"
+to   = "https://directus.io/docs/guides/extensions/cli"
+
+[[redirects]]
+from = "/extensions/displays.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/displays"
+
+[[redirects]]
+from = "/extensions/endpoints.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/endpoints"
+
+[[redirects]]
+from = "/extensions/hooks.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/hooks"
+
+[[redirects]]
+from = "/extensions/installing-extensions.html"
+to   = "https://directus.io/docs/self-hosting/including-extensions"
+
+[[redirects]]
+from = "/extensions/interfaces.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/interfaces"
+
+[[redirects]]
+from = "/extensions/introduction.html"
+to   = "https://directus.io/docs/guides/extensions/overview"
+
+[[redirects]]
+from = "/extensions/layouts.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/layouts"
+
+[[redirects]]
+from = "/extensions/marketplace/publishing.html"
+to   = "https://directus.io/docs/guides/extensions/marketplace/publishing"
+
+[[redirects]]
+from = "/extensions/modules.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/modules"
+
+[[redirects]]
+from = "/extensions/operations.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/operations"
+
+[[redirects]]
+from = "/extensions/panels.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/panels"
+
+[[redirects]]
+from = "/extensions/sandbox/introduction.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
+
+[[redirects]]
+from = "/extensions/sandbox/register.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
+
+[[redirects]]
+from = "/extensions/sandbox/sandbox-sdk.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
+
+[[redirects]]
+from = "/extensions/services/accessing-files.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/services"
+
+[[redirects]]
+from = "/extensions/services/accessing-items.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/services"
+
+[[redirects]]
+from = "/extensions/services/configuring-collections.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/services"
+
+[[redirects]]
+from = "/extensions/services/introduction.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/services"
+
+[[redirects]]
+from = "/extensions/services/working-with-users.html"
+to   = "https://directus.io/docs/guides/extensions/api-extensions/services"
+
+[[redirects]]
+from = "/extensions/themes.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/themes"
+
+[[redirects]]
+from = "/extensions/using-ui-components.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/ui-library"
+
+[[redirects]]
+from = "/getting-started/architecture.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/getting-started/introduction.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/getting-started/quickstart.html"
+to   = "https://directus.io/docs/getting-started/create-a-project"
+
+[[redirects]]
+from = "/getting-started/resources.html"
+to   = "https://directus.io/docs/getting-started/resources"
+
+[[redirects]]
+from = "/getting-started/support.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/guides/extensions/displays-date-to-age.html"
+to   = "https://directus.io/docs/tutorials/extensions/"
+
+[[redirects]]
+from = "/guides/extensions/displays-relational-summaries.html"
+to   = "https://directus.io/docs/tutorials/extensions/summarize-relational-items-in-a-custom-display-extension"
+
+[[redirects]]
+from = "/guides/extensions/email-template.html"
+to   = "https://directus.io/docs/tutorials/extensions/use-dynamic-values-in-custom-email-templates"
+
+[[redirects]]
+from = "/guides/extensions/endpoints-api-proxy-twilio.html"
+to   = "https://directus.io/docs/tutorials/extensions/proxy-an-external-api-in-a-custom-endpoint-extension"
+
+[[redirects]]
+from = "/guides/extensions/endpoints-api-proxy.html"
+to   = "https://directus.io/docs/tutorials/extensions/proxy-an-external-api-in-a-custom-endpoint-extension"
+
+[[redirects]]
+from = "/guides/extensions/endpoints-privileged-endpoint-stripe.html"
+to   = "https://directus.io/docs/tutorials/extensions/check-permissions-in-a-custom-endpoint"
+
+[[redirects]]
+from = "/guides/extensions/hooks-add-stripe-customer.html"
+to   = "https://directus.io/docs/tutorials/extensions/create-new-customers-in-stripe-in-a-custom-hook"
+
+[[redirects]]
+from = "/guides/extensions/hooks-validate-number-twilio.html"
+to   = "https://directus.io/docs/tutorials/extensions/validate-phone-numbers-with-twilio-in-a-custom-hook"
+
+[[redirects]]
+from = "/guides/extensions/interfaces-radio-selector-icons.html"
+to   = "https://directus.io/docs/tutorials/extensions/"
+
+[[redirects]]
+from = "/guides/extensions/interfaces-relational-dropdown.html"
+to   = "https://directus.io/docs/tutorials/extensions/"
+
+[[redirects]]
+from = "/guides/extensions/layouts-getting-started.html"
+to   = "https://directus.io/docs/tutorials/extensions/"
+
+[[redirects]]
+from = "/guides/extensions/modules-build-landing-page.html"
+to   = "https://directus.io/docs/tutorials/extensions/implement-navigation-in-multipage-custom-modules"
+
+[[redirects]]
+from = "/guides/extensions/modules-native-layout-features.html"
+to   = "https://directus.io/docs/tutorials/extensions/understand-available-slots-in-custom-modules"
+
+[[redirects]]
+from = "/guides/extensions/operations-add-record-comments.html"
+to   = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-operations"
+
+[[redirects]]
+from = "/guides/extensions/operations-bulk-email-sendgrid.html"
+to   = "https://directus.io/docs/tutorials/extensions/"
+
+[[redirects]]
+from = "/guides/extensions/operations-npm-package.html"
+to   = "https://directus.io/docs/tutorials/extensions/use-npm-packages-in-custom-operations"
+
+[[redirects]]
+from = "/guides/extensions/operations-send-sms-twilio.html"
+to   = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-operations"
+
+[[redirects]]
+from = "/guides/extensions/panels-create-items.html"
+to   = "https://directus.io/docs/tutorials/extensions/create-collection-items-in-custom-panels"
+
+[[redirects]]
+from = "/guides/extensions/panels-display-data-vonage.html"
+to   = "https://directus.io/docs/tutorials/extensions/display-external-api-data-from-vonage-in-custom-panels"
+
+[[redirects]]
+from = "/guides/extensions/panels-send-sms-twilio.html"
+to   = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-panels"
+
+[[redirects]]
+from = "/guides/flows/flows-for-loop.html"
+to   = "https://directus.io/docs/tutorials/extensions/use-dynamic-values-in-custom-email-templates"
+
+[[redirects]]
+from = "/guides/flows/slugify-text-with-run-script.html"
+to   = "https://directus.io/docs/tutorials/workflows"
+
+[[redirects]]
+from = "/guides/headless-cms/approval-workflows.html"
+to   = "https://directus.io/docs/tutorials/workflows/build-content-approval-workflows-with-custom-permissions"
+
+[[redirects]]
+from = "/guides/headless-cms/build-static-website/"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nextjs"
+
+[[redirects]]
+from = "/guides/headless-cms/build-static-website/next.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nextjs"
+
+[[redirects]]
+from = "/guides/headless-cms/build-static-website/nuxt-3.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nuxt"
+
+[[redirects]]
+from = "/guides/headless-cms/content-translations.html"
+to   = "https://directus.io/docs/configuration/translations"
+
+[[redirects]]
+from = "/guides/headless-cms/content-versioning.html"
+to   = "https://directus.io/docs/guides/content/content-versioning"
+
+[[redirects]]
+from = "/guides/headless-cms/live-preview/"
+to   = "https://directus.io/docs/guides/content/live-preview"
+
+[[redirects]]
+from = "/guides/headless-cms/live-preview/nextjs.html"
+to   = "https://directus.io/docs/tutorials/getting-started/set-up-live-preview-with-next-js"
+
+[[redirects]]
+from = "/guides/headless-cms/live-preview/nuxt-3.html"
+to   = "https://directus.io/docs/tutorials/getting-started/set-up-live-preview-with-nuxt"
+
+[[redirects]]
+from = "/guides/headless-cms/reusable-components.html"
+to   = "https://directus.io/docs/tutorials/getting-started/create-reusable-blocks-with-many-to-any-relationships"
+
+[[redirects]]
+from = "/guides/headless-cms/schedule-content/dynamic-sites.html"
+to   = "https://directus.io/docs/tutorials/workflows/schedule-future-content-with-directus-automate"
+
+[[redirects]]
+from = "/guides/headless-cms/schedule-content/"
+to   = "https://directus.io/docs/tutorials/workflows/schedule-future-content-with-directus-automate"
+
+[[redirects]]
+from = "/guides/headless-cms/schedule-content/static-sites.html"
+to   = "https://directus.io/docs/tutorials/workflows/schedule-future-content-with-directus-automate"
+
+[[redirects]]
+from = "/guides/headless-cms/trigger-static-builds/"
+to   = "https://directus.io/docs/tutorials/workflows/trigger-netlify-site-builds-with-directus-automate"
+
+[[redirects]]
+from = "/guides/headless-cms/trigger-static-builds/netlify.html"
+to   = "https://directus.io/docs/tutorials/workflows/trigger-netlify-site-builds-with-directus-automate"
+
+[[redirects]]
+from = "/guides/headless-cms/trigger-static-builds/vercel.html"
+to   = "https://directus.io/docs/tutorials/workflows/trigger-vercel-site-builds-with-directus-automate"
+
+[[redirects]]
+from = "/guides/"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/guides/migration/hoppscotch.html"
+to   = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+
+[[redirects]]
+from = "/guides/migration/"
+to   = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+
+[[redirects]]
+from = "/guides/migration/node.html"
+to   = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+
+[[redirects]]
+from = "/guides/real-time/authentication.html"
+to   = "https://directus.io/docs/configuration/realtime"
+
+[[redirects]]
+from = "/guides/real-time/chat/"
+to   = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-javascript-and-directus-realtime"
+
+[[redirects]]
+from = "/guides/real-time/chat/javascript.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-javascript-and-directus-realtime"
+
+[[redirects]]
+from = "/guides/real-time/chat/react.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-react-and-directus-realtime"
+
+[[redirects]]
+from = "/guides/real-time/chat/vue.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-vue-js-and-directus-realtime"
+
+[[redirects]]
+from = "/guides/real-time/getting-started/graphql.html"
+to   = "https://directus.io/docs/configuration/realtime"
+
+[[redirects]]
+from = "/guides/real-time/getting-started/"
+to   = "https://directus.io/docs/configuration/realtime"
+
+[[redirects]]
+from = "/guides/real-time/getting-started/websockets-js.html"
+to   = "https://directus.io/docs/configuration/realtime"
+
+[[redirects]]
+from = "/guides/real-time/getting-started/websockets.html"
+to   = "https://directus.io/docs/configuration/realtime"
+
+[[redirects]]
+from = "/guides/real-time/live-poll.html"
+to   = "https://directus.io/docs/guides/realtime"
+
+[[redirects]]
+from = "/guides/real-time/operations.html"
+to   = "https://directus.io/docs/guides/realtime/actions"
+
+[[redirects]]
+from = "/guides/real-time/subscriptions/graphql.html"
+to   = "https://directus.io/docs/guides/realtime/subscriptions"
+
+[[redirects]]
+from = "/guides/real-time/subscriptions/"
+to   = "https://directus.io/docs/guides/realtime/subscriptions"
+
+[[redirects]]
+from = "/guides/real-time/subscriptions/websockets.html"
+to   = "https://directus.io/docs/guides/realtime/subscriptions"
+
+[[redirects]]
+from = "/guides/sdk/authentication.html"
+to   = "https://directus.io/docs/guides/connect/sdk"
+
+[[redirects]]
+from = "/guides/sdk/getting-started.html"
+to   = "https://directus.io/docs/guides/connect/sdk"
+
+[[redirects]]
+from = "/guides/sdk/types.html"
+to   = "https://directus.io/docs/guides/connect/sdk"
+
+[[redirects]]
+from = "/guides/template_shell.html"
+to   = "https://directus.io/docs/"
+
+[[redirects]]
+from = "/"
+to   = "https://directus.io/docs/"
+
+[[redirects]]
+from = "/plus/"
+to   = "https://directus.io/docs/"
+
+[[redirects]]
+from = "/reference/authentication.html"
+to   = "https://directus.io/docs/api/authentication"
+
+[[redirects]]
+from = "/reference/files.html"
+to   = "https://directus.io/docs/api/files"
+
+[[redirects]]
+from = "/reference/filter-rules.html"
+to   = "https://directus.io/docs/api"
+
+[[redirects]]
+from = "/reference/introduction.html"
+to   = "https://directus.io/docs/api"
+
+[[redirects]]
+from = "/reference/items.html"
+to   = "https://directus.io/docs/api/items"
+
+[[redirects]]
+from = "/reference/old-sdk.html"
+to   = "https://directus.io/docs/api"
+
+[[redirects]]
+from = "/reference/query.html"
+to   = "https://directus.io/docs/api"
+
+[[redirects]]
+from = "/reference/system/activity.html"
+to   = "https://directus.io/docs/api"
+
+[[redirects]]
+from = "/reference/system/collections.html"
+to   = "https://directus.io/docs/api/collections"
+
+[[redirects]]
+from = "/reference/system/comments.html"
+to   = "https://directus.io/docs/api/comments"
+
+[[redirects]]
+from = "/reference/system/dashboards.html"
+to   = "https://directus.io/docs/api/dashboards"
+
+[[redirects]]
+from = "/reference/system/extensions.html"
+to   = "https://directus.io/docs/api/extensions"
+
+[[redirects]]
+from = "/reference/system/fields.html"
+to   = "https://directus.io/docs/api/fields"
+
+[[redirects]]
+from = "/reference/system/flows.html"
+to   = "https://directus.io/docs/api/flows"
+
+[[redirects]]
+from = "/reference/system/folders.html"
+to   = "https://directus.io/docs/api/folders"
+
+[[redirects]]
+from = "/reference/system/notifications.html"
+to   = "https://directus.io/docs/api/notifications"
+
+[[redirects]]
+from = "/reference/system/operations.html"
+to   = "https://directus.io/docs/api/operations"
+
+[[redirects]]
+from = "/reference/system/panels.html"
+to   = "https://directus.io/docs/api/panels"
+
+[[redirects]]
+from = "/reference/system/permissions.html"
+to   = "https://directus.io/docs/api/permissions"
+
+[[redirects]]
+from = "/reference/system/policies.html"
+to   = "https://directus.io/docs/api/policies"
+
+[[redirects]]
+from = "/reference/system/presets.html"
+to   = "https://directus.io/docs/api/presets"
+
+[[redirects]]
+from = "/reference/system/relations.html"
+to   = "https://directus.io/docs/api/relations"
+
+[[redirects]]
+from = "/reference/system/revisions.html"
+to   = "https://directus.io/docs/api/revisions"
+
+[[redirects]]
+from = "/reference/system/roles.html"
+to   = "https://directus.io/docs/api/roles"
+
+[[redirects]]
+from = "/reference/system/schema.html"
+to   = "https://directus.io/docs/api/schema"
+
+[[redirects]]
+from = "/reference/system/server.html"
+to   = "https://directus.io/docs/api/server"
+
+[[redirects]]
+from = "/reference/system/settings.html"
+to   = "https://directus.io/docs/api/settings"
+
+[[redirects]]
+from = "/reference/system/shares.html"
+to   = "https://directus.io/docs/api/shares"
+
+[[redirects]]
+from = "/reference/system/translations.html"
+to   = "https://directus.io/docs/api/translations"
+
+[[redirects]]
+from = "/reference/system/users.html"
+to   = "https://directus.io/docs/api/users"
+
+[[redirects]]
+from = "/reference/system/utilities.html"
+to   = "https://directus.io/docs/api/utilities"
+
+[[redirects]]
+from = "/reference/system/versions.html"
+to   = "https://directus.io/docs/api/versions"
+
+[[redirects]]
+from = "/reference/system/webhooks.html"
+to   = "https://directus.io/docs/api"
+
+[[redirects]]
+from = "/releases/breaking-changes.html"
+to   = "https://directus.io/docs/releases/breaking-changes"
+
+[[redirects]]
+from = "/self-hosted/cli.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/self-hosted/config-options.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/self-hosted/docker-guide.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/self-hosted/email-templates.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/self-hosted/migrations.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/self-hosted/quickstart.html"
+to   = "https://directus.io/docs/getting-started/create-a-project"
+
+[[redirects]]
+from = "/self-hosted/sso-examples.html"
+to   = "https://directus.io/docs/guides/auth/sso"
+
+[[redirects]]
+from = "/self-hosted/sso.html"
+to   = "https://directus.io/docs/guides/auth/sso"
+
+[[redirects]]
+from = "/self-hosted/upgrades-migrations.html"
+to   = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+
+[[redirects]]
+from = "/use-cases/headless-cms/concepts.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/use-cases/headless-cms/introduction.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/use-cases/headless-cms/security.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/user-guide/cloud/accounts.html"
+to   = "https://directus.io/docs/cloud/getting-started/accounts"
+
+[[redirects]]
+from = "/user-guide/cloud/glossary.html"
+to   = "https://directus.io/docs/getting-started/overview"
+
+[[redirects]]
+from = "/user-guide/cloud/overview.html"
+to   = "https://directus.io/docs/cloud/getting-started/introduction"
+
+[[redirects]]
+from = "/user-guide/cloud/projects.html"
+to   = "https://directus.io/docs/cloud/projects/create"
+
+[[redirects]]
+from = "/user-guide/cloud/teams.html"
+to   = "https://directus.io/docs/cloud/getting-started/teams"
+
+[[redirects]]
+from = "/user-guide/cloud/variables.html"
+to   = "https://directus.io/docs/cloud/configuration/environment-variables"
+
+[[redirects]]
+from = "/user-guide/content-module/content.html"
+to   = "https://directus.io/docs/guides/content/explore"
+
+[[redirects]]
+from = "/user-guide/content-module/content/collections.html"
+to   = "https://directus.io/docs/guides/content/explore"
+
+[[redirects]]
+from = "/user-guide/content-module/content/items.html"
+to   = "https://directus.io/docs/guides/content/editor"
+
+[[redirects]]
+from = "/user-guide/content-module/content/shares.html"
+to   = "https://directus.io/docs/guides/content/editor"
+
+[[redirects]]
+from = "/user-guide/content-module/display-templates.html"
+to   = "https://directus.io/docs/guides/content/layouts"
+
+[[redirects]]
+from = "/user-guide/content-module/filters.html"
+to   = "https://directus.io/docs/guides/content/explore"
+
+[[redirects]]
+from = "/user-guide/content-module/import-export.html"
+to   = "https://directus.io/docs/guides/content/import-export"
+
+[[redirects]]
+from = "/user-guide/content-module/layouts.html"
+to   = "https://directus.io/docs/guides/content/layouts"
+
+[[redirects]]
+from = "/user-guide/content-module/translation-strings.html"
+to   = "https://directus.io/docs/guides/content/translations"
+
+[[redirects]]
+from = "/user-guide/file-library/files.html"
+to   = "https://directus.io/docs/getting-started/upload-files"
+
+[[redirects]]
+from = "/user-guide/file-library/folders.html"
+to   = "https://directus.io/docs/guides/files/manage"
+
+[[redirects]]
+from = "/user-guide/insights/charts.html"
+to   = "https://directus.io/docs/guides/insights/panels"
+
+[[redirects]]
+from = "/user-guide/insights/dashboards.html"
+to   = "https://directus.io/docs/guides/insights/overview"
+
+[[redirects]]
+from = "/user-guide/insights/panels.html"
+to   = "https://directus.io/docs/guides/insights/panels"
+
+[[redirects]]
+from = "/user-guide/marketplace/overview.html"
+to   = "https://directus.io/docs/guides/extensions/marketplace"
+
+[[redirects]]
+from = "/user-guide/overview/data-studio-app.html"
+to   = "https://directus.io/docs/guides/content/editor"
+
+[[redirects]]
+from = "/user-guide/overview/glossary.html"
+to   = "https://directus.io/docs/guides/content/editor"
+
+[[redirects]]
+from = "/user-guide/overview/quickstart.html"
+to   = "https://directus.io/docs/guides/content/editor"
+
+[[redirects]]
+from = "/user-guide/settings/activity-log.html"
+to   = "https://directus.io/docs/guides/auth/accountability"
+
+[[redirects]]
+from = "/user-guide/settings/presets-bookmarks.html"
+to   = "https://directus.io/docs/guides/content/explore"
+
+[[redirects]]
+from = "/user-guide/settings/project-settings.html"
+to   = "https://directus.io/docs/configuration/general"
+
+[[redirects]]
+from = "/user-guide/settings/system-logs.html"
+to   = "https://directus.io/docs/configuration/general"
+
+[[redirects]]
+from = "/user-guide/settings/theming.html"
+to   = "https://directus.io/docs/configuration/theming"
+
+[[redirects]]
+from = "/user-guide/user-management/permissions.html"
+to   = "https://directus.io/docs/guides/auth/access-control"
+
+[[redirects]]
+from = "/user-guide/user-management/roles.html"
+to   = "https://directus.io/docs/guides/auth/access-control"
+
+[[redirects]]
+from = "/user-guide/user-management/user-directory.html"
+to   = "https://directus.io/docs/guides/auth/creating-users"
+
+[[redirects]]
+from = "/user-guide/user-management/users-roles-permissions.html"
+to   = "https://directus.io/docs/guides/auth/access-control"
+
+[[redirects]]
+from = "/user-guide/user-management/users.html"
+to   = "https://directus.io/docs/guides/auth/creating-users"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-angular.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-angular"
+
+[[redirects]]
+from = "/blog/migrating-notion-to-directus.html"
+to   = "https://directus.io/docs/tutorials/migration/migrate-from-notion-to-directus"
+
+[[redirects]]
+from = "/blog/hello-world.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/getting-started-directus-astro.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-astro"
+
+[[redirects]]
+from = "/blog/creating-git-hub-issues-with-directus-automate.html"
+to   = "https://directus.io/docs/tutorials/workflows/create-github-issues-with-directus-automate"
+
+[[redirects]]
+from = "/blog/directus-auth-nextauth.html"
+to   = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-next-js"
+
+[[redirects]]
+from = "/blog/migrating-nuxt-content-to-directus.html"
+to   = "https://directus.io/docs/tutorials/migration/migrate-from-nuxt-content-to-directus"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-flutter.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-flutter"
+
+[[redirects]]
+from = "/blog/implementing-internationalization-with-svelte-kit-and-directus.html"
+to   = "https://directus.io/docs/tutorials/getting-started/implement-multilingual-content-with-directus-and-svelte-kit"
+
+[[redirects]]
+from = "/blog/tagging-files-automatically-clarifai-directus-automate.html"
+to   = "https://directus.io/docs/tutorials/workflows/tag-images-with-clarifai-and-directus-automate"
+
+[[redirects]]
+from = "/blog/generating-images-with-dalle-and-directus-automate.html"
+to   = "https://directus.io/docs/tutorials/workflows/generate-images-with-dall-e-and-directus-automate"
+
+[[redirects]]
+from = "/blog/generating-social-posts-gpt-4-directus-automa.html"
+to   = "https://directus.io/docs/tutorials/workflows/generate-social-posts-with-gpt-4-and-directus-automate"
+
+[[redirects]]
+from = "/blog/configuring-okta-sso.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/configure-okta-as-a-single-sign-on-provider"
+
+[[redirects]]
+from = "/blog/monitoring-pipeline-flows-extensions.html"
+to   = "https://directus.io/docs/tutorials/tips-and-tricks/build-a-monitoring-pipeline-for-flows-and-extensions"
+
+[[redirects]]
+from = "/blog/the-changelog-1.html"
+to   = "https://directus.io/docs/releases/changelog"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-django.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-django"
+
+[[redirects]]
+from = "/blog/build-an-e-commerce-website-with-directus-and-next-js.html"
+to   = "https://directus.io/docs/tutorials/projects/build-an-ecommerce-platform-with-next-js-stripe-and-directus-automate"
+
+[[redirects]]
+from = "/blog/getting-started-directus-and-eleventy-11ty-3.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-eleventy-3"
+
+[[redirects]]
+from = "/blog/devcycle-feature-flag-control-panel.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-flask.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-flask"
+
+[[redirects]]
+from = "/blog/announcing-panel-quest-hackathon.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/building-directus-garden.html"
+to   = "https://directus.io/docs/tutorials/projects/build-directus-garden-a-passive-collaborative-event-booth-demo"
+
+[[redirects]]
+from = "/blog/ai-santa-roast-app-with-directus-nuxt.html"
+to   = "https://directus.io/docs/tutorials/projects/how-i-built-an-ai-open-source-santa-roast-app-with-directus-and-nuxt#naughty-or-nice-scoring-algorithm"
+
+[[redirects]]
+from = "/blog/getting-started-directus-hugo.html"
+to   = "https://directus.io/docs/tutorials/getting-started"
+
+[[redirects]]
+from = "/blog/external-weather-api-data-custom-panel-extension.html"
+to   = "https://directus.io/docs/tutorials/extensions/display-external-weather-api-data-in-custom-panels"
+
+[[redirects]]
+from = "/blog/hooks-monitoring-error-tracking-sentry.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/using-directus-as-a-baby-health-tracker.html"
+to   = "https://directus.io/docs/tutorials/projects/use-directus-as-a-baby-health-tracker-with-owlet-and-ops-genie"
+
+[[redirects]]
+from = "/blog/preview-and-content-versioning-with-nextjs.html"
+to   = "https://directus.io/docs/tutorials/workflows/combine-live-preview-and-content-versioning-with-next-js"
+
+[[redirects]]
+from = "/blog/the-changelog-3.html"
+to   = "https://directus.io/docs/releases/changelog"
+
+[[redirects]]
+from = "/blog/the-changelog-4.html"
+to   = "https://directus.io/docs/releases/changelog"
+
+[[redirects]]
+from = "/blog/the-changelog-2.html"
+to   = "https://directus.io/docs/releases/changelog"
+
+[[redirects]]
+from = "/blog/the-changelog-5.html"
+to   = "https://directus.io/docs/releases/changelog"
+
+[[redirects]]
+from = "/blog/directus-ai-hackathon-vote.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/directus-panel-quest-hackathon-projects.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/directus-and-iot-sensor-data-with-an-esp-32.html"
+to   = "https://directus.io/docs/tutorials/projects/integrate-directus-with-esp-32-hardware-sensors"
+
+[[redirects]]
+from = "/blog/integrating-algolia-indexing-and-directus.html"
+to   = "https://directus.io/docs/tutorials/extensions/integrate-algolia-indexing-with-custom-hooks"
+
+[[redirects]]
+from = "/blog/integrating-elasticsearch-indexing-with-directus.html"
+to   = "https://directus.io/docs/tutorials/extensions/integrate-elasticsearch-indexing-with-custom-hooks"
+
+[[redirects]]
+from = "/blog/integrating-meilisearch-indexing-with-directus.html"
+to   = "https://directus.io/docs/tutorials/extensions/integrate-meilisearch-indexing-with-custom-hooks"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-gatsby.html"
+to   = "https://directus.io/docs/tutorials/getting-started"
+
+[[redirects]]
+from = "/blog/nuxt-directus-getting-started.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nuxt"
+
+[[redirects]]
+from = "/blog/directus-auth-sveltekit.html"
+to   = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-sveltekit"
+
+[[redirects]]
+from = "/blog/deploy-directus-digital-ocean-docker.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-digital-ocean"
+
+[[redirects]]
+from = "/blog/sync-google-calendar-directus-automate.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/importing-files-in-directus-automate.html"
+to   = "https://directus.io/docs/tutorials/tips-and-tricks/importing-files-in-directus-automate"
+
+[[redirects]]
+from = "/blog/building-a-personal-travel-journal-with-vue-js-and-directus.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/passwordless-sms-authentication-with-plivo-and-directus-automate.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/build-a-url-shortener-with-react-type-script-and-directus.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/building-a-testimonial-widget-with-sveltekit-and-directus.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-testimonial-widget-with-sveltekit-and-directus"
+
+[[redirects]]
+from = "/blog/building-a-job-board-platform-with-directus-and-solid-start-js.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/building-a-hotel-booking-system-with-directus-next-js-and-stripe.html"
+to   = "https://directus.io/docs/tutorials/projects/build-an-hotel-booking-platform-with-next-js-stripe-and-directus-automate"
+
+[[redirects]]
+from = "/blog/building-a-video-streaming-app-with-sveltekit-and-directus.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-video-streaming-app-with-sveltekit-and-directus"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-laravel.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-laravel"
+
+[[redirects]]
+from = "/blog/getting-started-directus-ios.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-in-ios-with-swift"
+
+[[redirects]]
+from = "/blog/using-directus-auth-with-ios.html"
+to   = "https://directus.io/docs/tutorials/getting-started/implement-directus-auth-with-ios"
+
+[[redirects]]
+from = "/blog/deploy-directus-ubuntu-server.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-an-ubuntu-server"
+
+[[redirects]]
+from = "/blog/deploying-directus-to-aws-ec2-with-docker.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-aws-ec2"
+
+[[redirects]]
+from = "/blog/deploying-directus-to-google-cloud-platform-with-docker.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-google-cloud-platform"
+
+[[redirects]]
+from = "/blog/implement-directus-auth-in-next-js-14.html"
+to   = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-next-js"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-android-with-kotlin.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-in-android-with-kotlin"
+
+[[redirects]]
+from = "/blog/tracking-github-issues-and-pull-requests-with-directus-automate.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/advanced-filtering-dates-aggregation-and-grouping-and-combining-filters.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/migrating-from-word-press-to-directus.html"
+to   = "https://directus.io/docs/tutorials/migration/migrate-from-wordpress-to-directus"
+
+[[redirects]]
+from = "/blog/understanding-policy-based-access-control.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/building-the-leap-week-registration-and-referral-system.html"
+to   = "https://directus.io/docs/tutorials/projects/build-the-leap-week-registration-and-referral-system"
+
+[[redirects]]
+from = "/blog/building-a-job-board.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/5-automations-to-level-up-your-blog-with-directus.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/wedding-invite-vonage.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/building-user-feedback-widget-with-vuejs-directus.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-user-feedback-widget-with-vue-js"
+
+[[redirects]]
+from = "/blog/mastering-multilingual-content-crowdin.html"
+to   = "https://directus.io/docs/tutorials/workflows/integrating-multilingual-content-with-directus-and-crowdin"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-preact.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-qwik-city.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-and-remix.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/directus-seo-tips-tricks.html"
+to   = "https://directus.io/docs/tutorials/tips-and-tricks/search-engine-optimization-best-practices"
+
+[[redirects]]
+from = "/blog/getting-started-solidstart.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-solidstart"
+
+[[redirects]]
+from = "/blog/getting-started-directus-sveltekit.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-sveltekit"
+
+[[redirects]]
+from = "/blog/enrich-user-data-clearbit-directus-automate.html"
+to   = "https://directus.io/docs/tutorials/workflows/enrich-user-data-with-clearbit-and-directus-automate"
+
+[[redirects]]
+from = "/blog/devs-intro-to-composable.html"
+to   = "https://directus.io/docs/guides/extensions/app-extensions/composables"
+
+[[redirects]]
+from = "/blog/building-a-notebook-chrome-extension-with-directus.html"
+to   = "https://directus.io/docs/tutorials/projects/build-a-notebook-chrome-extension-with-directus-auth"
+
+[[redirects]]
+from = "/blog/building-a-support-system-in-the-directus-data-studio.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/deploying-directus-to-azure-web-apps-with-docker.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-azure-web-apps"
+
+[[redirects]]
+from = "/blog/getting-started-with-directus-spring-boot.html"
+to   = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-spring-boot"
+
+[[redirects]]
+from = "/blog/google-docs-preview.html"
+to   = "https://directus.io/docs/tutorials/tips-and-tricks/preview-files-in-live-preview-with-google-docs-previews"
+
+[[redirects]]
+from = "/blog/automatic-transcripts-deepgram.html"
+to   = "https://directus.io/docs/tutorials/workflows/generate-transcripts-with-deepgram-and-directus-automate"
+
+[[redirects]]
+from = "/blog/building-a-form-data-collection-and-email-notification-system-with-directus-and-next-js.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/announcing-directus-ai-hackathon.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/detecting-high-risk-phone-numbers-vonage-automate.html"
+to   = "https://directus.io/docs/tutorials/workflows/detect-high-risk-phone-numbers-with-vonage-and-directus-automate"
+
+[[redirects]]
+from = "/blog/implementing-pagination-and-infinite-scrolling-in-next-js.html"
+to   = "https://directus.io/docs/tutorials/tips-and-tricks/implement-pagination-and-infinite-scrolling-in-next-js"
+
+[[redirects]]
+from = "/blog/understanding-kubernetes.html"
+to   = "https://directus.io/docs/tutorials/self-hosting/understanding-kubernetes"
+
+[[redirects]]
+from = "/blog/building-ai-venture-game.html"
+to   = "https://directus.io/docs/tutorials/projects/building-ai-venture-an-ai-powered-game-with-directus"
+
+[[redirects]]
+from = "/blog/content-versioning-pre-release.html"
+to   = "https://directus.io/docs/guides/content/content-versioning"
+
+[[redirects]]
+from = "/blog/tags/connect.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/automate.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/concept.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/extensions.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/nuxt.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/vue.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/auth.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/guest-author.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/vonage.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/netlify.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/ios.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/migration.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/solid-js.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/next.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/getting-started.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/insights.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/react.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/tips-tricks.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/changelog.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/svelte.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/project.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/node.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/update.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/self-hosting.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/astro.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/deployment.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/blog/tags/ai.html"
+to   = "https://directus.io/docs/tutorials"
+
+[[redirects]]
+from = "/guides/sdk.html"
+to   = "https://directus.io/docs/guides/connect/sdk"
+
+[[redirects]]
+from = "/guides/frameworks.html"
+to   = "https://directus.io/docs/tutorials/getting-started"
+
+[[redirects]]
+from = "/guides/use-cases.html"
+to   = "https://directus.io/docs/tutorials/projects"
+
+[[redirects]]
+from = "/guides/real-time.html"
+to   = "https://directus.io/docs/guides/realtime/authentication"
+
+[[redirects]]
+from = "/guides/extensions.html"
+to   = "https://directus.io/docs/guides/extensions/overview"
+
+[[redirects]]
+from = "/guides/administration.html"
+to   = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+
+[[redirects]]
+from = "/plus/multi-tenant-saas.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/onboarding-checklist.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/streaming-platform.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/introduction.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/pim.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/plus-installation.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/headless-lms.html"
+to   = "https://directus.io/plus"
+
+[[redirects]]
+from = "/plus/status-page.html"
+to   = "https://directus.io/plus"


### PR DESCRIPTION
@hola-soy-milk here we could try moving these into the netlify.toml instead.

I've kept the redirects file since it's a bit easier to read / edit, but we could certainly remove it if we think it is confusing or clutter.