### PR TITLE
Remove unessesary validation check

### DIFF
--- a/.changeset/cool-taxis-shout.md
+++ b/.changeset/cool-taxis-shout.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Allowed `_eq: ""`

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -127,12 +127,6 @@ function validateFilterPrimitive(value: any, key: string) {
 		throw new InvalidQueryError({ reason: `The filter value for "${key}" is not a valid number` });
 	}
 
-	if (typeof value === 'string' && value.length === 0) {
-		throw new InvalidQueryError({
-			reason: `You can't filter for an empty string in "${key}". Use "_empty" or "_nempty" instead`,
-		});
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Don't throw an error when we're filtering for `_eq: ""`

## Potential Risks / Drawbacks

- Shouldn't have any as we're doing the same in `_empty` with the addition of also checking for `null` there

---

Fixes #20422
