### PR TITLE
Add id_filter_operators to GQL

### DIFF
--- a/.changeset/tall-pillows-learn.md
+++ b/.changeset/tall-pillows-learn.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added id_filter_operators to GQL

--- a/api/src/services/graphql/schema/read.ts
+++ b/api/src/services/graphql/schema/read.ts
@@ -51,6 +51,69 @@ export function getReadableTypes(
 	const AggregatedFields: Record<string, ObjectTypeComposer<any, any>> = {};
 	const AggregateMethods: Record<string, ObjectTypeComposerFieldConfigMapDefinition<any, any>> = {};
 
+	const IDFilterOperators = schemaComposer.createInputTC({
+		name: 'id_filter_operators',
+		fields: {
+			_eq: {
+				type: GraphQLID,
+			},
+			_neq: {
+				type: GraphQLID,
+			},
+			_contains: {
+				type: GraphQLID,
+			},
+			_icontains: {
+				type: GraphQLID,
+			},
+			_ncontains: {
+				type: GraphQLID,
+			},
+			_starts_with: {
+				type: GraphQLID,
+			},
+			_nstarts_with: {
+				type: GraphQLID,
+			},
+			_istarts_with: {
+				type: GraphQLID,
+			},
+			_nistarts_with: {
+				type: GraphQLID,
+			},
+			_ends_with: {
+				type: GraphQLID,
+			},
+			_nends_with: {
+				type: GraphQLID,
+			},
+			_iends_with: {
+				type: GraphQLID,
+			},
+			_niends_with: {
+				type: GraphQLID,
+			},
+			_in: {
+				type: new GraphQLList(GraphQLID),
+			},
+			_nin: {
+				type: new GraphQLList(GraphQLID),
+			},
+			_null: {
+				type: GraphQLBoolean,
+			},
+			_nnull: {
+				type: GraphQLBoolean,
+			},
+			_empty: {
+				type: GraphQLBoolean,
+			},
+			_nempty: {
+				type: GraphQLBoolean,
+			},
+		},
+	});
+
 	const StringFilterOperators = schemaComposer.createInputTC({
 		name: 'string_filter_operators',
 		fields: {
@@ -399,6 +462,9 @@ export function getReadableTypes(
 						break;
 					case GraphQLHash:
 						filterOperatorType = HashFilterOperators;
+						break;
+					case GraphQLID:
+						filterOperatorType = IDFilterOperators;
 						break;
 					default:
 						filterOperatorType = StringFilterOperators;

--- a/api/src/utils/get-graphql-type.ts
+++ b/api/src/utils/get-graphql-type.ts
@@ -1,6 +1,14 @@
 import type { Type } from '@directus/types';
 import type { GraphQLType } from 'graphql';
-import { GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLScalarType, GraphQLString } from 'graphql';
+import {
+	GraphQLBoolean,
+	GraphQLFloat,
+	GraphQLID,
+	GraphQLInt,
+	GraphQLList,
+	GraphQLScalarType,
+	GraphQLString,
+} from 'graphql';
 import { GraphQLJSON } from 'graphql-compose';
 import { GraphQLBigInt } from '../services/graphql/types/bigint.js';
 import { GraphQLDate } from '../services/graphql/types/date.js';
@@ -38,6 +46,8 @@ export function getGraphQLType(
 			return GraphQLDate;
 		case 'hash':
 			return GraphQLHash;
+		case 'uuid':
+			return GraphQLID;
 		default:
 			return GraphQLString;
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Basically duplicated the `string_filter_operators`, changed the types from `String` to `ID` and renamed it to `id_filter_operators`.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- None

---

Fixes #21266
