### PR TITLE
Add `isDirectusError` type guard to the SDK

### DIFF
--- a/.changeset/early-cougars-turn.md
+++ b/.changeset/early-cougars-turn.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': minor
+---
+
+Added an `isDirectusError` type guard function ot improve SDK error handling

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -7,3 +7,4 @@ export * from './realtime/index.js';
 export * from './rest/index.js';
 export * from './schema/index.js';
 export type * from './types/index.js';
+export * from './utils/is-directus-error.js';

--- a/sdk/src/types/error.ts
+++ b/sdk/src/types/error.ts
@@ -1,0 +1,12 @@
+export interface DirectusApiError {
+	message: string;
+	extensions: {
+		code: string;
+		[key: string]: any;
+	};
+}
+
+export interface DirectusError {
+	errors: DirectusApiError[];
+	response: Response;
+}

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './aggregate.js';
 export * from './assets.js';
 export * from './client.js';
 export * from './deep.js';
+export * from './error.js';
 export * from './fields.js';
 export * from './filters.js';
 export * from './functions.js';

--- a/sdk/src/utils/is-directus-error.ts
+++ b/sdk/src/utils/is-directus-error.ts
@@ -1,5 +1,8 @@
 import type { DirectusError } from '../types/error.js';
 
+/**
+ * A type guard to check if an error is a Directus API error
+ */
 export function isDirectusError(error: unknown): error is DirectusError {
 	return (
 		typeof error === 'object' &&
@@ -8,7 +11,6 @@ export function isDirectusError(error: unknown): error is DirectusError {
 		Array.isArray(error.errors) &&
 		'message' in error.errors[0] &&
 		'extensions' in error.errors[0] &&
-		'code' in error.errors[0].extensions &&
-		'response' in error
+		'code' in error.errors[0].extensions
 	);
 }

--- a/sdk/src/utils/is-directus-error.ts
+++ b/sdk/src/utils/is-directus-error.ts
@@ -1,0 +1,14 @@
+import type { DirectusError } from '../types/error.js';
+
+export function isDirectusError(error: unknown): error is DirectusError {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'errors' in error &&
+		Array.isArray(error.errors) &&
+		'message' in error.errors[0] &&
+		'extensions' in error.errors[0] &&
+		'code' in error.errors[0].extensions &&
+		'response' in error
+	);
+}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- An `isDirectusError` type guard has been added as an exported util to improve the sdk error handling experience

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- Docs PR: https://github.com/directus/docs/pull/192

---

Fixes #23297
Fixes #20651
