### PR TITLE
Add `files.upload` event for resumable uploads

### DIFF
--- a/.changeset/sour-teachers-cross.md
+++ b/.changeset/sour-teachers-cross.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Added `files.upload` event for resumable uploads

--- a/api/src/services/tus/server.ts
+++ b/api/src/services/tus/server.ts
@@ -16,6 +16,8 @@ import { ItemsService } from '../index.js';
 import { TusDataStore } from './data-store.js';
 import { getTusLocker } from './lockers.js';
 import { pick } from 'lodash-es';
+import emitter from '../../emitter.js';
+import getDatabase from '../../database/index.js';
 
 type Context = {
 	schema: SchemaOverview;
@@ -89,6 +91,20 @@ export async function createTusServer(context: Context): Promise<[Server, () => 
 					tus_data: null,
 				});
 			}
+
+			const eventMeta = {
+				payload: await service.readOne(file.id),
+				key: file.id,
+				collection: 'directus_files',
+			};
+
+			const eventContext = {
+				database: getDatabase(),
+				schema: req.schema,
+				accountability: req.accountability,
+			};
+
+			emitter.emitAction('files.upload', eventMeta, eventContext);
 
 			return res;
 		},


### PR DESCRIPTION
## Scope

What's changed:

- Emits the `files.upload` event when using TUS uploads

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- The compatibilty between minio and the s3 driver seems to be broken

---

Fixes #24542 
