### PR TITLE
Do not throw unhandled error on passing a null query

### DIFF
--- a/.changeset/cuddly-dragons-flow.md
+++ b/.changeset/cuddly-dragons-flow.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed subscription erroring if a null query is passed

--- a/.changeset/cuddly-dragons-flow.md
+++ b/.changeset/cuddly-dragons-flow.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed subscription erroring if a null query is passed
+Fixed subscription throwing an unhandled error if a null query is passed

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -1,6 +1,5 @@
 import { InvalidPayloadError } from '@directus/errors';
 import { type Bus } from '@directus/memory';
-import { isObject } from '@directus/utils';
 import { useBus } from '../../bus/index.js';
 import emitter from '../../emitter.js';
 import { getSchema } from '../../utils/get-schema.js';
@@ -163,11 +162,7 @@ export class SubscribeHandler {
 					subscription.event = message.event as SubscriptionEvent;
 				}
 
-				if ('query' in message) {
-					if (!isObject(message.query)) {
-						throw new WebSocketError('subscribe', 'INVALID_QUERY', 'The provided query must be an object', message.uid);
-					}
-
+				if (message.query) {
 					subscription.query = sanitizeQuery(message.query, accountability);
 				}
 

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -162,12 +162,12 @@ export class SubscribeHandler {
 					subscription.event = message.event as SubscriptionEvent;
 				}
 
-				if ('query' in message) {
-					if (typeof message.query === 'object') {
+				if (message.query) {
+					if (typeof message.query === 'object' && !Array.isArray(message.query)) {
 						throw new WebSocketError('subscribe', 'INVALID_QUERY', 'The provided query must be an object', message.uid);
 					}
 
-					subscription.query = sanitizeQuery(message.query ?? {}, accountability);
+					subscription.query = sanitizeQuery(message.query, accountability);
 				}
 
 				if ('item' in message) subscription.item = String(message.item);

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -163,7 +163,7 @@ export class SubscribeHandler {
 				}
 
 				if (message.query) {
-					if (typeof message.query === 'object' && !Array.isArray(message.query)) {
+					if (typeof message.query !== 'object' || Array.isArray(message.query)) {
 						throw new WebSocketError('subscribe', 'INVALID_QUERY', 'The provided query must be an object', message.uid);
 					}
 

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -163,7 +163,7 @@ export class SubscribeHandler {
 				}
 
 				if ('query' in message) {
-					subscription.query = sanitizeQuery(message.query!, accountability);
+					subscription.query = sanitizeQuery(message.query ?? {}, accountability);
 				}
 
 				if ('item' in message) subscription.item = String(message.item);

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -1,5 +1,6 @@
 import { InvalidPayloadError } from '@directus/errors';
 import { type Bus } from '@directus/memory';
+import { isObject } from '@directus/utils';
 import { useBus } from '../../bus/index.js';
 import emitter from '../../emitter.js';
 import { getSchema } from '../../utils/get-schema.js';
@@ -162,8 +163,8 @@ export class SubscribeHandler {
 					subscription.event = message.event as SubscriptionEvent;
 				}
 
-				if (message.query) {
-					if (typeof message.query !== 'object' || Array.isArray(message.query)) {
+				if ('query' in message) {
+					if (!isObject(message.query)) {
 						throw new WebSocketError('subscribe', 'INVALID_QUERY', 'The provided query must be an object', message.uid);
 					}
 

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -163,6 +163,10 @@ export class SubscribeHandler {
 				}
 
 				if ('query' in message) {
+					if (typeof message.query === 'object') {
+						throw new WebSocketError('subscribe', 'INVALID_QUERY', 'The provided query must be an object', message.uid);
+					}
+
 					subscription.query = sanitizeQuery(message.query ?? {}, accountability);
 				}
 

--- a/api/src/websocket/messages.ts
+++ b/api/src/websocket/messages.ts
@@ -48,7 +48,7 @@ export const WebSocketSubscribeMessage = z.discriminatedUnion('type', [
 		collection: z.string(),
 		event: z.union([z.literal('create'), z.literal('update'), z.literal('delete')]).optional(),
 		item: zodStringOrNumber.optional(),
-		query: z.custom<Query>().optional(),
+		query: z.record(z.any()).optional(),
 	}),
 	WebSocketMessage.extend({
 		type: z.literal('unsubscribe'),


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now throw an `INVALID_PAYLOAD` error for invalid query types (i.e. anything aside from `undefined` or a `query` object)
![Screenshot 2025-03-05 at 2 50 26 PM](https://github.com/user-attachments/assets/79361544-9215-439a-a369-b46ac6e515c8)


## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

---

Fixes #24147
