### PR TITLE
Update docs redirect for config options

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -170,7 +170,7 @@
 /releases/breaking-changes.html                                                                     https://directus.io/docs/releases/breaking-changes
 
 /self-hosted/cli.html                                                                               https://directus.io/docs/getting-started/overview
-/self-hosted/config-options.html                                                                    https://directus.io/docs/getting-started/overview
+/self-hosted/config-options.html                                                                    https://directus.io/docs/configuration/general
 /self-hosted/docker-guide.html                                                                      https://directus.io/docs/getting-started/overview
 /self-hosted/email-templates.html                                                                   https://directus.io/docs/getting-started/overview
 /self-hosted/migrations.html                                                                        https://directus.io/docs/getting-started/overview
@@ -210,7 +210,7 @@
 /user-guide/settings/activity-log.html                                                              https://directus.io/docs/guides/auth/accountability
 /user-guide/settings/presets-bookmarks.html                                                         https://directus.io/docs/guides/content/explore
 /user-guide/settings/project-settings.html                                                          https://directus.io/docs/configuration/general
-/user-guide/settings/system-logs.html                                                               https://directus.io/docs/configuration/general
+/user-guide/settings/system-logs.html                                                               https://directus.io/docs/configuration/logging
 /user-guide/settings/theming.html                                                                   https://directus.io/docs/configuration/theming
 /user-guide/user-management/permissions.html                                                        https://directus.io/docs/guides/auth/access-control
 /user-guide/user-management/roles.html                                                              https://directus.io/docs/guides/auth/access-control

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -634,7 +634,7 @@ to   = "https://directus.io/docs/getting-started/overview"
 
 [[redirects]]
 from = "/self-hosted/config-options.html"
-to   = "https://directus.io/docs/getting-started/overview"
+to   = "https://directus.io/docs/configuration/general"
 
 [[redirects]]
 from = "/self-hosted/docker-guide.html"
@@ -786,7 +786,7 @@ to   = "https://directus.io/docs/configuration/general"
 
 [[redirects]]
 from = "/user-guide/settings/system-logs.html"
-to   = "https://directus.io/docs/configuration/general"
+to   = "https://directus.io/docs/configuration/logging"
 
 [[redirects]]
 from = "/user-guide/settings/theming.html"


### PR DESCRIPTION
Chanced upon two redirects which might have better target pages

1. [config-options.md](https://github.com/directus/directus/blob/6fb13625cf1729595ae0429f119b524c2577feb9/docs/self-hosted/config-options.md) to point to the [configuration options](https://directus.io/docs/configuration/general) instead of getting started.
2. [system-logs.md](https://github.com/directus/directus/blob/6fb13625cf1729595ae0429f119b524c2577feb9/docs/user-guide/settings/system-logs.md) to point [logging configuration](https://directus.io/docs/configuration/logging) containing realtime logs