### PR TITLE
Solution to 24785

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -703,7 +703,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					action: 'update',
 					collection: this.collection,
 					primaryKeys: keys,
-					fields: Object.keys(payload).filter(f => f in this.schema.collections[this.collection]!.fields);
+					fields: Object.keys(payload).filter(f => f in this.schema.collections[this.collection]!.fields),
 				},
 				{
 					schema: this.schema,


### PR DESCRIPTION
Checks incoming payload before filter hooks, allows to change the payload programatically without needing to ensure user has access to fields meant to be set programatically.

Fixes #24785
