### PR TITLE
Fix re-linking new pointer references to existing links

### DIFF
--- a/.changeset/swift-glasses-lick.md
+++ b/.changeset/swift-glasses-lick.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed flow erroring on new pointer references to existing links
+Fixed re-linking new pointer references to existing links

--- a/.changeset/swift-glasses-lick.md
+++ b/.changeset/swift-glasses-lick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed flow erroring on new pointer references to existing links

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -105,7 +105,7 @@ const savedPanels = computed(() =>
 const resolveReferences = computed(() => {
 	const references = new Map();
 
-	for (const savedPanel of savedPanels.value) {
+	for (const savedPanel of flow.value?.operations ?? []) {
 		if (savedPanel.resolve && savedPanel.id) {
 			references.set(savedPanel.resolve, savedPanel.id);
 		}
@@ -117,7 +117,7 @@ const resolveReferences = computed(() => {
 const rejectReferences = computed(() => {
 	const references = new Map();
 
-	for (const savedPanel of savedPanels.value) {
+	for (const savedPanel of flow.value?.operations ?? []) {
 		if (savedPanel.reject && savedPanel.id) {
 			references.set(savedPanel.reject, savedPanel.id);
 		}
@@ -322,8 +322,13 @@ async function saveChanges() {
 			const operationReferenceResetUpdates = [];
 
 			/**
-			 * Prevent existing A -> B re-linked to A -> C -> B
+			 * Prevents the following from occuring:
+			 *
+			 * Existing A -> B re-linked to A -> C -> B via new panel
 			 * not nullifying A -> B link before attempting to link C -> B
+			 *
+			 * Existing A -> B -> C re-linked to A -> C via delete
+			 * not nullifying B -> C link before attempting to link A -> C
 			 */
 			for (const stagedPanel of stagedPanels.value) {
 				if (stagedPanel.resolve && !stagedPanel.resolve.startsWith('_')) {

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -329,7 +329,7 @@ async function saveChanges() {
 				if (stagedPanel.resolve && !stagedPanel.resolve.startsWith('_')) {
 					const resolve = resolveReferences.value.get(stagedPanel.resolve);
 
-					if (resolve !== stagedPanel.id) {
+					if (resolve && resolve !== stagedPanel.id) {
 						operationReferenceResetUpdates.push({ id: resolve, resolve: null });
 					}
 				}
@@ -337,7 +337,7 @@ async function saveChanges() {
 				if (stagedPanel.reject && !stagedPanel.reject.startsWith('_')) {
 					const reject = rejectReferences.value.get(stagedPanel.reject);
 
-					if (reject !== stagedPanel.id) {
+					if (reject && reject !== stagedPanel.id) {
 						operationReferenceResetUpdates.push({ id: reject, reject: null });
 					}
 				}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now reset any existing references that have been re-assigned in edits before attempting to apply those edited references

## Potential Risks / Drawbacks

- As we now run 2 API calls on save if the second one errors we cannot roll-back the first

## Review Notes / Questions

- These changes should prevent the following cases:
    - Existing A -> B re-linked to A -> C -> B via a new panel did not nullify A -> B link before attempting to link C -> B
    - Existing A -> B -> C re-linked to A -> C via deleting a panel did not nullify B -> C link before attempting to link A -> C

---

Fixes #14185
