### PR TITLE
Do not error on existing record for O2M

### DIFF
--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -657,7 +657,7 @@ export class PayloadService {
 
 					// No relatedId means it's a new record
 					if (relatedId) {
-						await this.knex
+						existingRecord = await this.knex
 							.select(relatedPrimaryKeyField, relation.field)
 							.from(relation.collection)
 							.where({ [relatedPrimaryKeyField]: relatedId })


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We do not throw a `ForbiddenError` when the record is indeed existing on O2M record attachments

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- No changeset as this is a fix to an unreleased regression from #24609

---

Fixes N/A
