### PR TITLE
Return `InvalidPayload` if `Content-Type` is not provided

### DIFF
--- a/.changeset/big-deer-poke.md
+++ b/.changeset/big-deer-poke.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Empty `Content-Type` requests are no longer allowed

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -196,7 +196,7 @@ export default async function createApp(): Promise<express.Application> {
 				limit: env['MAX_PAYLOAD_SIZE'] as string,
 			}) as RequestHandler
 		)(req, res, (err: any) => {
-			if (req.method !== 'GET' && typeof req.headers['content-type'] === 'undefined') {
+			if (req.method !== 'GET' && typeof req.headers['content-type'] !== 'string') {
 				return next(new InvalidPayloadError({ reason: 'A Content-Type is required' }));
 			}
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -196,6 +196,10 @@ export default async function createApp(): Promise<express.Application> {
 				limit: env['MAX_PAYLOAD_SIZE'] as string,
 			}) as RequestHandler
 		)(req, res, (err: any) => {
+			if (req.method !== 'GET' && typeof req.headers['content-type'] === 'undefined') {
+				return next(new InvalidPayloadError({ reason: 'A Content-Type is required' }));
+			}
+
 			if (err) {
 				return next(new InvalidPayloadError({ reason: err.message }));
 			}

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -196,7 +196,7 @@ export default async function createApp(): Promise<express.Application> {
 				limit: env['MAX_PAYLOAD_SIZE'] as string,
 			}) as RequestHandler
 		)(req, res, (err: any) => {
-			if (req.method !== 'GET' && typeof req.headers['content-type'] !== 'string') {
+			if (req.method !== 'GET' && req.headers['content-length'] && typeof req.headers['content-type'] !== 'string') {
 				return next(new InvalidPayloadError({ reason: 'A Content-Type is required' }));
 			}
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The `Content-Type` header is now required for all non `GET` requests.

## Potential Risks / Drawbacks

- Should be none, before this change the body was ignored if no `Content-Type` was set.

## Review Notes / Questions

- We still allow missing `Content-Type` for `GET` requests as those do not require a body

---

Fixes directus/docs#326
