### PR TITLE
Fix filter hook altered payload not passed to action hook on `create`

### DIFF
--- a/.changeset/good-colts-own.md
+++ b/.changeset/good-colts-own.md
@@ -2,4 +2,4 @@
 '@directus/api': major
 ---
 
-Fixed filter hook altered payload not passed to action hook
+Fixed filter hook altered payload not passed to action hook on `create`

--- a/.changeset/good-colts-own.md
+++ b/.changeset/good-colts-own.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': major
+---
+
+Fixed filter hook altered payload not passed to action hook

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -187,6 +187,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				throw opts.preMutationError;
 			}
 
+			// Ensure the action hook payload has the post filter hook + preset changes
 			actionHookPayload = payloadWithPresets;
 
 			// We're creating new services instances so they can use the transaction as their Knex interface


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The final payload (i.e. after filter hook and preset changes) is now passed down to the action hook

## Potential Risks / Drawbacks

- This will break all existing users who depend on the original payload being provided in the action hook

## Review Notes / Questions

- A changeset of`major` seemed appropriate due to the payload changes
- This change seems to already be present for all other relevant hooks and did not look intentional

---

Fixes #19473
Related Doc PR: https://github.com/directus/docs/pull/247
