### PR TITLE
Improve invalid asset transformation parameter value error handling

### DIFF
--- a/.changeset/green-areas-design.md
+++ b/.changeset/green-areas-design.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Produce InvalidQuery error when /assets/:id is passed an invalid transformation instead of a generic 500
+Improved invalid asset transformation parameter value error handling

--- a/.changeset/green-areas-design.md
+++ b/.changeset/green-areas-design.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Produce InvalidQuery error when /assets/:id is passed an invalid transformation instead of a generic 500

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -4,7 +4,7 @@ import {
 	IllegalAssetTransformationError,
 	InvalidQueryError,
 	RangeNotSatisfiableError,
-	ServiceUnavailableError
+	ServiceUnavailableError,
 } from '@directus/errors';
 import type { Range, Stat } from '@directus/storage';
 import type { Accountability, File, SchemaOverview } from '@directus/types';
@@ -199,7 +199,7 @@ export class AssetsService {
 
 			transforms.forEach(([method, ...args]) => {
 				try {
-					(transformer[method] as any).apply(transformer, args)
+					(transformer[method] as any).apply(transformer, args);
 				} catch (error: Error) {
 					throw error.message.startsWith('Expected') ? new InvalidQueryError({ reason: error.message }) : error;
 				}

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -197,17 +197,17 @@ export class AssetsService {
 
 			if (transforms.find((transform) => transform[0] === 'rotate') === undefined) transformer.rotate();
 
-			transforms.forEach(([method, ...args]) => {
-				try {
+			try {
+				for (const [method, ...args] of transforms) {
 					(transformer[method] as any).apply(transformer, args);
-				} catch (error) {
-					if (error instanceof Error && error.message.startsWith('Expected')) {
-						throw new InvalidQueryError({ reason: error.message });
-					}
-
-					throw error;
 				}
-			});
+			} catch (error) {
+				if (error instanceof Error && error.message.startsWith('Expected')) {
+					throw new InvalidQueryError({ reason: error.message });
+				}
+
+				throw error;
+			}
 
 			const readStream = await storage.location(file.storage).read(file.filename_disk, { range, version });
 

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -200,8 +200,12 @@ export class AssetsService {
 			transforms.forEach(([method, ...args]) => {
 				try {
 					(transformer[method] as any).apply(transformer, args);
-				} catch (error: Error) {
-					throw error.message.startsWith('Expected') ? new InvalidQueryError({ reason: error.message }) : error;
+				} catch (error) {
+					if (error instanceof Error && error.message.startsWith('Expected')) {
+						throw new InvalidQueryError({ reason: error.message });
+					}
+
+					throw error;
 				}
 			});
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -208,3 +208,4 @@
 - CiaccoDavide
 - subtirelumihail
 - ngluunhatson
+- jacobcons


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Throw InvalidQuery error when /assets/:id is passed an invalid transformation instead of producing a generic 500

## Potential Risks / Drawbacks

- Sharp doesn't provide anything to indicate error types so I'm just going off the fact that the invalid params error starts with the string "Expected"

## Review Notes / Questions

- Just keeping it simple by throwing an InvalidQueryError in the service layer. If you're worried about separation of concerns/semantic correctness, I'm happy to create a new error type like InvalidTransformationParamsError. This can then be thrown in the service layer. After which I can catch it in the controller, which could then throw the InvalidQuerryError.

---

Fixes #24442 
