### PR TITLE
Restore saveAndQuit when saving items without content versioning

### DIFF
--- a/.changeset/thin-bears-unite.md
+++ b/.changeset/thin-bears-unite.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+restores correct save redirect when saving items, i.e., the user is redirected back to the main item list.

--- a/.changeset/thin-bears-unite.md
+++ b/.changeset/thin-bears-unite.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-restores correct save redirect when saving items, i.e., the user is redirected back to the main item list.

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -156,9 +156,7 @@ useShortcut(
 useShortcut(
 	'meta+alt+s',
 	() => {
-		if (unref(currentVersion) === null) {
-			saveAndReturnToMain();
-		} else {
+		if (unref(currentVersion) !== null) {
 			saveVersionAction('main');
 		}
 	},
@@ -403,19 +401,6 @@ async function saveAndAddNew() {
 		} else {
 			router.push(getItemRoute(props.collection, '+'));
 		}
-	} catch {
-		// Save shows unexpected error dialog
-	}
-}
-
-async function saveAndReturnToMain() {
-	if (isSavable.value === false) return;
-	if (unref(currentVersion) !== null) return;
-
-	try {
-		await save();
-		currentVersion.value = null;
-		refresh();
 	} catch {
 		// Save shows unexpected error dialog
 	}

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -431,6 +431,17 @@ async function saveAsCopyAndNavigate() {
 	}
 }
 
+async function saveAndQuit() {
+	if (isSavable.value === false) return;
+
+	try {
+		await save();
+		if (props.singleton === false) router.push(getCollectionRoute(props.collection));
+	} catch {
+		// Save shows unexpected error dialog
+	}
+}
+
 async function deleteAndQuit() {
 	try {
 		await remove();
@@ -658,7 +669,7 @@ const shouldShowVersioning = computed(
 				:tooltip="saveAllowed ? t('save') : t('not_allowed')"
 				:loading="saving"
 				:disabled="!isSavable"
-				@click="saveAndStay"
+				@click="saveAndQuit"
 			>
 				<v-icon name="check" />
 


### PR DESCRIPTION
## Scope

What's changed:

- restores saveAndQuit functionality when saving collection items that are not versioned.


## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- Create a collection without content versioning. Save an item. Verify you are redirected to the list of items (saveAndQuit).
- Create a collection with content versioning enabled. Save an item. Verify you remain on the version you just saved (saveAndStay).

---

Fixes #web-628

