### PR TITLE
Add `omitKey` option to `getConfigFromEnv`

### DIFF
--- a/.changeset/tasty-zebras-enjoy.md
+++ b/.changeset/tasty-zebras-enjoy.md
@@ -2,5 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed bug in which OpenID and OAuth2 clients couldn't be passed params starting with "id" or "secret" e.g.
-"id_token_signed_response_alg"
+Update getConfigFromEnv to accept an options object which includes a new omitKey option. Fixed bug in which OpenID and OAuth2 clients couldn't be passed params starting with "id" or "secret" e.g. "id_token_signed_response_alg".

--- a/.changeset/tasty-zebras-enjoy.md
+++ b/.changeset/tasty-zebras-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Fixed bug in which OpenID and OAuth2 clients couldn't be passed params starting with "id" or "secret" e.g.
+"id_token_signed_response_alg"

--- a/.changeset/tasty-zebras-enjoy.md
+++ b/.changeset/tasty-zebras-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': patch
+'@directus/api': minor
 ---
 
-Update getConfigFromEnv to accept an options object which includes a new omitKey option. Fixed bug in which OpenID and OAuth2 clients couldn't be passed params starting with "id" or "secret" e.g. "id_token_signed_response_alg".
+Added `omitKey` option to `getConfigFromEnv`

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -172,7 +172,7 @@ export default async function createApp(): Promise<express.Application> {
 	);
 
 	if (env['HSTS_ENABLED']) {
-		app.use(helmet.hsts(getConfigFromEnv('HSTS_', ['HSTS_ENABLED'])));
+		app.use(helmet.hsts(getConfigFromEnv('HSTS_', { omitPrefix: 'HSTS_ENABLED' })));
 	}
 
 	await emitter.emitInit('app.before', { app });

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -72,7 +72,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			issuer: additionalConfig['provider'],
 		});
 
-		// extract extra client options from env, while ignoring the CLIENT_ID and CLIENT_SECRET so the ones passed into the constructor are used instead
+		// extract client overrides/options excluding CLIENT_ID and CLIENT_SECRET as they are passed directly
 		const clientOptionsOverrides = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, {
 			omitKey: [
 				`AUTH_${config['provider'].toUpperCase()}_CLIENT_ID`,

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -72,11 +72,12 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			issuer: additionalConfig['provider'],
 		});
 
-		const clientOptionsOverrides = getConfigFromEnv(
-			`AUTH_${config['provider'].toUpperCase()}_CLIENT_`,
-			[`AUTH_${config['provider'].toUpperCase()}_CLIENT_ID`, `AUTH_${config['provider'].toUpperCase()}_CLIENT_SECRET`],
-			'underscore',
-		);
+		// extract extra client options from env, while ignoring the CLIENT_ID and CLIENT_SECRET so the ones passed into the constructor are used instead
+		const {
+			id: _,
+			secret: __,
+			...clientOptionsOverrides
+		} = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, undefined, 'underscore');
 
 		this.client = new issuer.Client({
 			client_id: clientId,

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -73,11 +73,13 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		});
 
 		// extract extra client options from env, while ignoring the CLIENT_ID and CLIENT_SECRET so the ones passed into the constructor are used instead
-		const {
-			id: _,
-			secret: __,
-			...clientOptionsOverrides
-		} = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, undefined, 'underscore');
+		const clientOptionsOverrides = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, {
+			omitKey: [
+				`AUTH_${config['provider'].toUpperCase()}_CLIENT_ID`,
+				`AUTH_${config['provider'].toUpperCase()}_CLIENT_SECRET`,
+			],
+			type: 'underscore',
+		});
 
 		this.client = new issuer.Client({
 			client_id: clientId,

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -65,11 +65,13 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		);
 
 		// extract extra client options from env, while ignoring the CLIENT_ID and CLIENT_SECRET so the ones passed into the constructor are used instead
-		const {
-			id: _,
-			secret: __,
-			...clientOptionsOverrides
-		} = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, undefined, 'underscore');
+		const clientOptionsOverrides = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, {
+			omitKey: [
+				`AUTH_${config['provider'].toUpperCase()}_CLIENT_ID`,
+				`AUTH_${config['provider'].toUpperCase()}_CLIENT_SECRET`,
+			],
+			type: 'underscore',
+		});
 
 		this.redirectUrl = redirectUrl.toString();
 		this.usersService = new UsersService({ knex: this.knex, schema: this.schema });

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -64,7 +64,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			'callback',
 		);
 
-		// extract extra client options from env, while ignoring the CLIENT_ID and CLIENT_SECRET so the ones passed into the constructor are used instead
+		// extract client overrides/options excluding CLIENT_ID and CLIENT_SECRET as they are passed directly
 		const clientOptionsOverrides = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, {
 			omitKey: [
 				`AUTH_${config['provider'].toUpperCase()}_CLIENT_ID`,

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -64,11 +64,12 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			'callback',
 		);
 
-		const clientOptionsOverrides = getConfigFromEnv(
-			`AUTH_${config['provider'].toUpperCase()}_CLIENT_`,
-			[`AUTH_${config['provider'].toUpperCase()}_CLIENT_ID`, `AUTH_${config['provider'].toUpperCase()}_CLIENT_SECRET`],
-			'underscore',
-		);
+		// extract extra client options from env, while ignoring the CLIENT_ID and CLIENT_SECRET so the ones passed into the constructor are used instead
+		const {
+			id: _,
+			secret: __,
+			...clientOptionsOverrides
+		} = getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_CLIENT_`, undefined, 'underscore');
 
 		this.redirectUrl = redirectUrl.toString();
 		this.usersService = new UsersService({ knex: this.knex, schema: this.schema });

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -50,7 +50,7 @@ export function getDatabase(): Knex {
 		connectionString,
 		pool: poolConfig = {},
 		...connectionConfig
-	} = getConfigFromEnv('DB_', ['DB_EXCLUDE_TABLES']);
+	} = getConfigFromEnv('DB_', { omitPrefix: 'DB_EXCLUDE_TABLES' });
 
 	const requiredEnvVars = ['DB_CLIENT'];
 

--- a/api/src/logger/index.ts
+++ b/api/src/logger/index.ts
@@ -62,7 +62,7 @@ export const createLogger = () => {
 		},
 	};
 
-	const loggerEnvConfig = getConfigFromEnv('LOGGER_', 'LOGGER_HTTP');
+	const loggerEnvConfig = getConfigFromEnv('LOGGER_', { omitPrefix: 'LOGGER_HTTP' });
 
 	// Expose custom log levels into formatter function
 	if (loggerEnvConfig['levels']) {
@@ -121,8 +121,8 @@ export const createLogger = () => {
 export const createExpressLogger = () => {
 	const env = useEnv();
 
-	const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', ['LOGGER_HTTP_LOGGER']);
-	const loggerEnvConfig = getConfigFromEnv('LOGGER_', 'LOGGER_HTTP');
+	const httpLoggerEnvConfig = getConfigFromEnv('LOGGER_HTTP', { omitPrefix: 'LOGGER_HTTP_LOGGER' });
+	const loggerEnvConfig = getConfigFromEnv('LOGGER_', { omitPrefix: 'LOGGER_HTTP' });
 
 	const httpLoggerOptions: LoggerOptions = {
 		level: (env['LOG_LEVEL'] as string) || 'info',

--- a/api/src/rate-limiter.ts
+++ b/api/src/rate-limiter.ts
@@ -42,7 +42,7 @@ function getConfig(
 	configPrefix = 'RATE_LIMITER',
 	overrides?: IRateLimiterOptionsOverrides,
 ): IRateLimiterOptions | IRateLimiterStoreOptions {
-	const config: any = getConfigFromEnv(`${configPrefix}_`, `${configPrefix}_${store}_`);
+	const config: any = getConfigFromEnv(`${configPrefix}_`, { omitPrefix: `${configPrefix}_${store}_` });
 
 	if (store === 'redis') {
 		const Redis = require('ioredis');

--- a/api/src/utils/generate-hash.ts
+++ b/api/src/utils/generate-hash.ts
@@ -2,7 +2,7 @@ import argon2 from 'argon2';
 import { getConfigFromEnv } from './get-config-from-env.js';
 
 export function generateHash(stringToHash: string): Promise<string> {
-	const argon2HashConfigOptions = getConfigFromEnv('HASH_', 'HASH_RAW'); // Disallow the HASH_RAW option, see https://github.com/directus/directus/discussions/7670#discussioncomment-1255805
+	const argon2HashConfigOptions = getConfigFromEnv('HASH_', { omitPrefix: 'HASH_RAW' }); // Disallow the HASH_RAW option, see https://github.com/directus/directus/discussions/7670#discussioncomment-1255805
 
 	// associatedData, if specified, must be passed as a Buffer to argon2.hash, see https://github.com/ranisalt/node-argon2/wiki/Options#associateddata
 	if ('associatedData' in argon2HashConfigOptions)

--- a/api/src/utils/get-config-from-env.test.ts
+++ b/api/src/utils/get-config-from-env.test.ts
@@ -6,13 +6,19 @@ vi.mock('@directus/env');
 
 beforeEach(() => {
 	vi.mocked(useEnv).mockReturnValue({
+		CASING_KEY: 'key',
+		CASING_KEY_value: 'value',
 		OBJECT_BRAND__COLOR: 'purple',
 		OBJECT_BRAND__HEX: '#6644FF',
 		CAMELCASE_OBJECT__FIRST_KEY: 'firstValue',
 		CAMELCASE_OBJECT__SECOND_KEY: 'secondValue',
-		OBJECT2_CLIENT_ID: 0,
-		OBJECT2_CLIENT_ID_ALG: 1,
-		OBJECT2_CLIENT_SECRET: 2,
+		OMIT_PREFIX_FIRST_KEY: 'firstKey',
+		OMIT_PREFIX_FIRST_KEY_VALUE: 'firstValue',
+		OMIT_PREFIX_FIRST_VALUE: 'firstValue',
+		OMIT_PREFIX_SECOND_KEY: 'secondKey',
+		OMIT_PREFIX_SECOND_KEY_VALUE: 'secondValue',
+		OMIT_KEY_FIRST_KEY: 'firstKey',
+		OMIT_KEY_FIRST_KEY_VALUE: 'firstValue',
 	});
 });
 
@@ -21,6 +27,10 @@ afterEach(() => {
 });
 
 describe('get config from env', () => {
+	test('Should return config irrespective of prefix or key casing', () => {
+		expect(getConfigFromEnv('CaSInG_')).toStrictEqual({ key: 'key', keyValue: 'value' });
+	});
+
 	test('Keys with double underscore should be an object', () => {
 		expect(getConfigFromEnv('OBJECT_')).toStrictEqual({ brand: { color: 'purple', hex: '#6644FF' } });
 	});
@@ -31,24 +41,26 @@ describe('get config from env', () => {
 		});
 	});
 
-	test('Any keys that start with a prefix in omitPrefix should be omitted', () => {
-		expect(getConfigFromEnv('OBJECT2_', { omitPrefix: 'OBJECT2_CLIENT_ID' })).toStrictEqual({
-			clientSecret: 2,
+	test('Keys starting with the prefix(es) listed in omitPrefix should be omitted', () => {
+		expect(getConfigFromEnv('OMIT_PREFIX_', { omitPrefix: 'OMIT_PREFIX_FIRST_KEY' })).toStrictEqual({
+			firstValue: 'firstValue',
+			secondKey: 'secondKey',
+			secondKeyValue: 'secondValue',
 		});
 
-		expect(getConfigFromEnv('OBJECT2_', { omitPrefix: ['OBJECT2_CLIENT_ID', 'OBJECT2_CLIENT_SECRET'] })).toStrictEqual(
-			{},
-		);
+		expect(getConfigFromEnv('OMIT_PREFIX_', { omitPrefix: ['OMIT_PREFIX_FIRST_'] })).toStrictEqual({
+			secondKey: 'secondKey',
+			secondKeyValue: 'secondValue',
+		});
 	});
 
-	test('Any keys equal to a key in omitKeys should be omitted', () => {
-		expect(getConfigFromEnv('OBJECT2_', { omitKey: 'OBJECT2_CLIENT_ID' })).toStrictEqual({
-			clientIdAlg: 1,
-			clientSecret: 2,
+	test('Keys equal to the key(s) listed in omitKeys should be omitted', () => {
+		expect(getConfigFromEnv('OMIT_KEY_', { omitKey: 'OMIT_KEY_FIRST_KEY' })).toStrictEqual({
+			firstKeyValue: 'firstValue',
 		});
 
-		expect(getConfigFromEnv('OBJECT2_', { omitKey: ['OBJECT2_CLIENT_ID', 'OBJECT2_CLIENT_SECRET'] })).toStrictEqual({
-			clientIdAlg: 1,
+		expect(getConfigFromEnv('OMIT_KEY_', { omitKey: ['OMIT_KEY_FIRST_KEY_VALUE'] })).toStrictEqual({
+			firstKey: 'firstKey',
 		});
 	});
 });

--- a/api/src/utils/get-config-from-env.test.ts
+++ b/api/src/utils/get-config-from-env.test.ts
@@ -10,6 +10,9 @@ beforeEach(() => {
 		OBJECT_BRAND__HEX: '#6644FF',
 		CAMELCASE_OBJECT__FIRST_KEY: 'firstValue',
 		CAMELCASE_OBJECT__SECOND_KEY: 'secondValue',
+		OBJECT2_CLIENT_ID: 0,
+		OBJECT2_CLIENT_ID_ALG: 1,
+		OBJECT2_CLIENT_SECRET: 2,
 	});
 });
 
@@ -25,6 +28,27 @@ describe('get config from env', () => {
 	test('Keys with double underscore should be an object with camelCase keys', () => {
 		expect(getConfigFromEnv('CAMELCASE_')).toStrictEqual({
 			object: { firstKey: 'firstValue', secondKey: 'secondValue' },
+		});
+	});
+
+	test('Any keys that start with a prefix in omitPrefix should be omitted', () => {
+		expect(getConfigFromEnv('OBJECT2_', { omitPrefix: 'OBJECT2_CLIENT_ID' })).toStrictEqual({
+			clientSecret: 2,
+		});
+
+		expect(getConfigFromEnv('OBJECT2_', { omitPrefix: ['OBJECT2_CLIENT_ID', 'OBJECT2_CLIENT_SECRET'] })).toStrictEqual(
+			{},
+		);
+	});
+
+	test('Any keys equal to a key in omitKeys should be omitted', () => {
+		expect(getConfigFromEnv('OBJECT2_', { omitKey: 'OBJECT2_CLIENT_ID' })).toStrictEqual({
+			clientIdAlg: 1,
+			clientSecret: 2,
+		});
+
+		expect(getConfigFromEnv('OBJECT2_', { omitKey: ['OBJECT2_CLIENT_ID', 'OBJECT2_CLIENT_SECRET'] })).toStrictEqual({
+			clientIdAlg: 1,
 		});
 	});
 });

--- a/api/src/utils/get-config-from-env.test.ts
+++ b/api/src/utils/get-config-from-env.test.ts
@@ -41,6 +41,12 @@ describe('get config from env', () => {
 		});
 	});
 
+	test('Keys with double underscore and type underscore should be an object with snake_case keys', () => {
+		expect(getConfigFromEnv('CAMELCASE_', { type: 'underscore' })).toStrictEqual({
+			object: { first_key: 'firstValue', second_key: 'secondValue' },
+		});
+	});
+
 	test('Keys starting with the prefix(es) listed in omitPrefix should be omitted', () => {
 		expect(getConfigFromEnv('OMIT_PREFIX_', { omitPrefix: 'OMIT_PREFIX_FIRST_KEY' })).toStrictEqual({
 			firstValue: 'firstValue',

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -10,7 +10,7 @@ export interface GetConfigFromEnvOptions {
 
 export function getConfigFromEnv(
 	prefix: string,
-	{ omitPrefix, omitKey, type = 'camelcase' }?: GetConfigFromEnvOptions = {},
+	{ omitPrefix, omitKey, type = 'camelcase' }: GetConfigFromEnvOptions = {},
 ): Record<string, any> {
 	const env = useEnv();
 

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -16,20 +16,20 @@ export function getConfigFromEnv(prefix: string, options?: GetConfigFromEnvOptio
 	const config: any = {};
 
 	const lowerCasePrefix = prefix.toLowerCase();
+	const omitKeys = toArray(options?.omitKey ?? []).map((key) => key.toLocaleLowerCase());
+	const omitPrefixes = toArray(options?.omitPrefix ?? []).map((prefix) => prefix.toLocaleLowerCase());
 
 	for (const [key, value] of Object.entries(env)) {
 		const lowerCaseKey = key.toLowerCase();
 		if (lowerCaseKey.startsWith(lowerCasePrefix) === false) continue;
 
-		if (options?.omitKey) {
-			const isKeyInOmitKeys = toArray(options.omitKey).some((keyToOmit) => lowerCaseKey === keyToOmit.toLowerCase());
+		if (omitKeys.length > 0) {
+			const isKeyInOmitKeys = omitKeys.some((keyToOmit) => lowerCaseKey === keyToOmit);
 			if (isKeyInOmitKeys) continue;
 		}
 
-		if (options?.omitPrefix) {
-			const keyStartsWithAnyPrefix = toArray(options.omitPrefix).some((prefix) =>
-				lowerCaseKey.startsWith(prefix.toLowerCase()),
-			);
+		if (omitPrefixes.length > 0) {
+			const keyStartsWithAnyPrefix = omitPrefixes.some((prefix) => lowerCaseKey.startsWith(prefix));
 
 			if (keyStartsWithAnyPrefix) continue;
 		}

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -1,6 +1,6 @@
 import { useEnv } from '@directus/env';
+import { toArray } from '@directus/utils';
 import camelcase from 'camelcase';
-import { toArray } from 'liquidjs/dist/util/underscore.js';
 import { set } from 'lodash-es';
 
 export interface GetConfigFromEnvOptions {

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -8,11 +8,9 @@ export interface GetConfigFromEnvOptions {
 	type?: 'camelcase' | 'underscore';
 }
 
-export function getConfigFromEnv(
-	prefix: string,
-	{ omitPrefix, omitKey, type = 'camelcase' }: GetConfigFromEnvOptions = {},
-): Record<string, any> {
+export function getConfigFromEnv(prefix: string, options?: GetConfigFromEnvOptions): Record<string, any> {
 	const env = useEnv();
+	const type = options?.type ?? 'camelcase';
 
 	const config: any = {};
 
@@ -22,14 +20,14 @@ export function getConfigFromEnv(
 		const lowerCaseKey = key.toLowerCase();
 		if (lowerCaseKey.startsWith(lowerCasePrefix) === false) continue;
 
-		if (omitKey) {
-			const omitKeyArray = Array.isArray(omitKey) ? omitKey : [omitKey];
+		if (options?.omitKey) {
+			const omitKeyArray = Array.isArray(options.omitKey) ? options.omitKey : [options.omitKey];
 			const isKeyInOmitKeys = omitKeyArray.some((keyToOmit) => lowerCaseKey === keyToOmit.toLowerCase());
 			if (isKeyInOmitKeys) continue;
 		}
 
-		if (omitPrefix) {
-			const omitPrefixArray = Array.isArray(omitPrefix) ? omitPrefix : [omitPrefix];
+		if (options?.omitPrefix) {
+			const omitPrefixArray = Array.isArray(options.omitPrefix) ? options.omitPrefix : [options.omitPrefix];
 			const keyStartsWithAnyPrefix = omitPrefixArray.some((prefix) => lowerCaseKey.startsWith(prefix.toLowerCase()));
 			if (keyStartsWithAnyPrefix) continue;
 		}

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -1,5 +1,6 @@
 import { useEnv } from '@directus/env';
 import camelcase from 'camelcase';
+import { toArray } from 'liquidjs/dist/util/underscore.js';
 import { set } from 'lodash-es';
 
 export interface GetConfigFromEnvOptions {
@@ -21,14 +22,15 @@ export function getConfigFromEnv(prefix: string, options?: GetConfigFromEnvOptio
 		if (lowerCaseKey.startsWith(lowerCasePrefix) === false) continue;
 
 		if (options?.omitKey) {
-			const omitKeyArray = Array.isArray(options.omitKey) ? options.omitKey : [options.omitKey];
-			const isKeyInOmitKeys = omitKeyArray.some((keyToOmit) => lowerCaseKey === keyToOmit.toLowerCase());
+			const isKeyInOmitKeys = toArray(options.omitKey).some((keyToOmit) => lowerCaseKey === keyToOmit.toLowerCase());
 			if (isKeyInOmitKeys) continue;
 		}
 
 		if (options?.omitPrefix) {
-			const omitPrefixArray = Array.isArray(options.omitPrefix) ? options.omitPrefix : [options.omitPrefix];
-			const keyStartsWithAnyPrefix = omitPrefixArray.some((prefix) => lowerCaseKey.startsWith(prefix.toLowerCase()));
+			const keyStartsWithAnyPrefix = toArray(options.omitPrefix).some((prefix) =>
+				lowerCaseKey.startsWith(prefix.toLowerCase()),
+			);
+
 			if (keyStartsWithAnyPrefix) continue;
 		}
 

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -16,8 +16,8 @@ export function getConfigFromEnv(prefix: string, options?: GetConfigFromEnvOptio
 	const config: any = {};
 
 	const lowerCasePrefix = prefix.toLowerCase();
-	const omitKeys = toArray(options?.omitKey ?? []).map((key) => key.toLocaleLowerCase());
-	const omitPrefixes = toArray(options?.omitPrefix ?? []).map((prefix) => prefix.toLocaleLowerCase());
+	const omitKeys = toArray(options?.omitKey ?? []).map((key) => key.toLowerCase());
+	const omitPrefixes = toArray(options?.omitPrefix ?? []).map((prefix) => prefix.toLowerCase());
 
 	for (const [key, value] of Object.entries(env)) {
 		const lowerCaseKey = key.toLowerCase();


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added an `omitKey` option to `getConfigFromEnv` that filters out direct equality for its keys

## Potential Risks / Drawbacks


## Review Notes / Questions
- This change was added to allow us to ignore specific keys while also extracting keys with the same prefix. 


---

Fixes #24637
