### PR TITLE
Fix code-block formatting when made visible via containing group

### DIFF
--- a/.changeset/violet-kids-appear.md
+++ b/.changeset/violet-kids-appear.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+uses v-if instead of v-show when rendering code-editor inside a group-detail field, allowing code-mirror to refresh

--- a/.changeset/violet-kids-appear.md
+++ b/.changeset/violet-kids-appear.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-uses v-if instead of v-show when rendering code-editor inside a group-detail field, allowing code-mirror to refresh
+Fixed the appearance of the code interface when an enclosing group is made visible by a condition

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -350,8 +350,7 @@ function useRawEditor() {
 			<template v-if="fieldsMap[fieldName]">
 				<component
 					:is="`interface-${fieldsMap[fieldName]!.meta?.interface || 'group-standard'}`"
-					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group')"
-					v-show="!fieldsMap[fieldName]!.meta?.hidden"
+					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group') && !fieldsMap[fieldName]!.meta?.hidden"
 					:ref="
 						(el: Element) => {
 							formFieldEls[fieldName] = el;


### PR DESCRIPTION
## Scope

What's changed:

- Adds new prop 'parentGroupVisible' that is sent down to descendant interfaces, allowing the code-block to respond by calling its refresh method.


## Potential Risks / Drawbacks

- Touches general components, such as v-form.

## Review Notes / Questions

- Create a collection that has a code-block field (with line numbers on) nested inside of a group-detail block. In the group-detail settings, set it to 'Hidden on detail.'

Create a toggle field called 'enable group'.

Go back to the group-detail field, and add a condition that says 'when enable group is checked' and uncheck the 'Hidden on detail' checkbox. This will allow you to toggle the group-detail visibility by using the toggle field. 

Create a new item and add some code to the code block. Now view the item, check the toggle, and verify the line numbers are visible and all the code is visible.

This image shows the bug. Note that the left margin is not properly calculated, leaving the line numbers, and left-most content, out of view.

![image](https://github.com/user-attachments/assets/8e8dbc05-116c-4e82-befc-80cca8fe6797)


---

Fixes #24745
