### PR TITLE
Add error logging for invalid `PUBLIC_URL` on SSO redirection

### DIFF
--- a/.changeset/some-pigs-greet.md
+++ b/.changeset/some-pigs-greet.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Improved SSO redirection error message
+Added error logging for invalid `PUBLIC_URL` on SSO redirection

--- a/.changeset/some-pigs-greet.md
+++ b/.changeset/some-pigs-greet.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved SSO redirection error message

--- a/api/src/utils/is-login-redirect-allowed.test.ts
+++ b/api/src/utils/is-login-redirect-allowed.test.ts
@@ -1,8 +1,21 @@
 import { useEnv } from '@directus/env';
-import { afterEach, expect, test, vi } from 'vitest';
+import type { Logger } from 'pino';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { useLogger } from '../logger/index.js';
 import { isLoginRedirectAllowed } from './is-login-redirect-allowed.js';
 
 vi.mock('@directus/env');
+vi.mock('../logger');
+
+let mockLogger: Logger;
+
+beforeEach(() => {
+	mockLogger = {
+		error: vi.fn(),
+	} as unknown as Logger;
+
+	vi.mocked(useLogger).mockReturnValue(mockLogger);
+});
 
 afterEach(() => {
 	vi.clearAllMocks();
@@ -84,11 +97,6 @@ test('isLoginRedirectAllowed throws error if PUBLIC_URL is misconfigured', () =>
 		PUBLIC_URL: '/',
 	});
 
-	try {
-		isLoginRedirectAllowed('http://public.example.com', provider);
-	} catch (err: any) {
-		expect(err.message).toBe('PUBLIC_URL is not parsable');
-	}
-
-	expect.assertions(1);
+	expect(isLoginRedirectAllowed('http://public.example.com', provider)).toBe(false);
+	expect(mockLogger.error).toHaveBeenCalledWith('Invalid PUBLIC_URL for login redirect');
 });

--- a/api/src/utils/is-login-redirect-allowed.test.ts
+++ b/api/src/utils/is-login-redirect-allowed.test.ts
@@ -1,5 +1,5 @@
-import { vi, expect, test, afterEach } from 'vitest';
 import { useEnv } from '@directus/env';
+import { afterEach, expect, test, vi } from 'vitest';
 import { isLoginRedirectAllowed } from './is-login-redirect-allowed.js';
 
 vi.mock('@directus/env');
@@ -75,4 +75,20 @@ test('isLoginRedirectAllowed returns false if missing protocol', () => {
 
 	expect(isLoginRedirectAllowed('//example.com/admin/content', provider)).toBe(false);
 	expect(isLoginRedirectAllowed('//user@password:example.com/', provider)).toBe(false);
+});
+
+test('isLoginRedirectAllowed throws error if PUBLIC_URL is misconfigured', () => {
+	const provider = 'local';
+
+	vi.mocked(useEnv).mockReturnValue({
+		PUBLIC_URL: '/',
+	});
+
+	try {
+		isLoginRedirectAllowed('http://public.example.com', provider);
+	} catch (err: any) {
+		expect(err.message).toBe('PUBLIC_URL is not parsable');
+	}
+
+	expect.assertions(1);
 });

--- a/api/src/utils/is-login-redirect-allowed.ts
+++ b/api/src/utils/is-login-redirect-allowed.ts
@@ -1,4 +1,5 @@
 import { useEnv } from '@directus/env';
+import { createError, ErrorCode } from '@directus/errors';
 import { toArray } from '@directus/utils';
 import isUrlAllowed from './is-url-allowed.js';
 
@@ -31,7 +32,7 @@ export function isLoginRedirectAllowed(redirect: unknown, provider: string): boo
 	}
 
 	if (URL.canParse(publicUrl) === false) {
-		return false;
+		throw new (createError(ErrorCode.Internal, 'PUBLIC_URL is not parsable', 500))();
 	}
 
 	// allow redirects to the defined PUBLIC_URL

--- a/api/src/utils/is-login-redirect-allowed.ts
+++ b/api/src/utils/is-login-redirect-allowed.ts
@@ -1,6 +1,6 @@
 import { useEnv } from '@directus/env';
-import { createError, ErrorCode } from '@directus/errors';
 import { toArray } from '@directus/utils';
+import { useLogger } from '../logger/index.js';
 import isUrlAllowed from './is-url-allowed.js';
 
 /**
@@ -32,7 +32,8 @@ export function isLoginRedirectAllowed(redirect: unknown, provider: string): boo
 	}
 
 	if (URL.canParse(publicUrl) === false) {
-		throw new (createError(ErrorCode.Internal, 'PUBLIC_URL is not parsable', 500))();
+		useLogger().error('Invalid PUBLIC_URL for login redirect');
+		return false;
 	}
 
 	// allow redirects to the defined PUBLIC_URL


### PR DESCRIPTION
## Scope

What's changed:

- Add error logging for invalid `PUBLIC_URL` on SSO redirection

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- Login redirect check was introduced in #21238

---

Fixes #21940, Fixes SER-44
