### PR TITLE
Fix deleting of folder after proper reparenting

### DIFF
--- a/.changeset/many-snakes-travel.md
+++ b/.changeset/many-snakes-travel.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed deleting of folder after proper reparenting

--- a/app/src/views/private/components/files-navigation-folder.vue
+++ b/app/src/views/private/components/files-navigation-folder.vue
@@ -116,8 +116,6 @@ function useDeleteFolder() {
 			const folderKeys = foldersToUpdate.data.data.map((folder: { id: string }) => folder.id);
 			const fileKeys = filesToUpdate.data.data.map((file: { id: string }) => file.id);
 
-			await api.delete(`/folders/${props.folder.id}`);
-
 			if (folderKeys.length > 0) {
 				await api.patch(`/folders`, {
 					keys: folderKeys,
@@ -135,6 +133,8 @@ function useDeleteFolder() {
 					},
 				});
 			}
+
+			await api.delete(`/folders/${props.folder.id}`);
 
 			if (newParent) {
 				router.replace(`/files/folders/${newParent}`);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Delete a folder after sub folders/files got reparented

## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- I was really wondering since when this was broken cause I even tried it in v9.26 and it was broken there and have no idea how this was not caught earlier as the git blame also didn't reveal any insight on where this could have been broken. :confused-emoji:

---

Fixes #23108 
