### PR TITLE
Fix integer primary keys received as strings via path parameter

### DIFF
--- a/.changeset/twelve-games-type.md
+++ b/.changeset/twelve-games-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed PK path parameter not converted to integer when applicable

--- a/.changeset/twelve-games-type.md
+++ b/.changeset/twelve-games-type.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed PK path parameter not converted to integer when applicable
+Fixed integer primary keys received as strings via path parameter

--- a/api/src/controllers/activity.ts
+++ b/api/src/controllers/activity.ts
@@ -5,6 +5,7 @@ import { validateBatch } from '../middleware/validate-batch.js';
 import { ActivityService } from '../services/activity.js';
 import { MetaService } from '../services/meta.js';
 import asyncHandler from '../utils/async-handler.js';
+import { convertPK } from '../utils/convert-pk.js';
 
 const router = express.Router();
 
@@ -52,7 +53,9 @@ router.get(
 			schema: req.schema,
 		});
 
-		const record = await service.readOne(req.params['pk']!, req.sanitizedQuery);
+		const pk = convertPK('directus_activity', req.params['pk'], { schema: req.schema });
+
+		const record = await service.readOne(pk, req.sanitizedQuery);
 
 		res.locals['payload'] = {
 			data: record || null,

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -1,11 +1,10 @@
 import { TYPES } from '@directus/constants';
-import { isDirectusError } from '@directus/errors';
+import { ErrorCode, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import type { Field, RawField, Type } from '@directus/types';
 import { Router } from 'express';
 import Joi from 'joi';
 import { ALIAS_TYPES } from '../constants.js';
-import { ErrorCode, InvalidPayloadError } from '@directus/errors';
-import validateCollection from '../middleware/collection-exists.js';
+import collectionExists from '../middleware/collection-exists.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
 import { FieldsService } from '../services/fields.js';
@@ -33,7 +32,7 @@ router.get(
 
 router.get(
 	'/:collection',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -50,7 +49,7 @@ router.get(
 
 router.get(
 	'/:collection/:field',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -84,7 +83,7 @@ const newFieldSchema = Joi.object({
 
 router.post(
 	'/:collection',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -119,7 +118,7 @@ router.post(
 
 router.patch(
 	'/:collection',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -169,7 +168,7 @@ const updateSchema = Joi.object({
 
 router.patch(
 	'/:collection/:field',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -206,7 +205,7 @@ router.patch(
 
 router.delete(
 	'/:collection/:field',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, _res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,

--- a/api/src/controllers/notifications.ts
+++ b/api/src/controllers/notifications.ts
@@ -7,6 +7,7 @@ import { validateBatch } from '../middleware/validate-batch.js';
 import { MetaService } from '../services/meta.js';
 import { NotificationsService } from '../services/notifications.js';
 import asyncHandler from '../utils/async-handler.js';
+import { convertPK } from '../utils/convert-pk.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
 
 const router = express.Router();
@@ -90,7 +91,9 @@ router.get(
 			schema: req.schema,
 		});
 
-		const record = await service.readOne(req.params['pk']!, req.sanitizedQuery);
+		const pk = convertPK('directus_notifications', req.params['pk'], { schema: req.schema });
+
+		const record = await service.readOne(pk, req.sanitizedQuery);
 
 		res.locals['payload'] = { data: record || null };
 		return next();
@@ -142,7 +145,9 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const primaryKey = await service.updateOne(req.params['pk']!, req.body);
+		const pk = convertPK('directus_notifications', req.params['pk'], { schema: req.schema });
+
+		const primaryKey = await service.updateOne(pk, req.body);
 
 		try {
 			const record = await service.readOne(primaryKey, req.sanitizedQuery);
@@ -191,7 +196,9 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		const pk = convertPK('directus_notifications', req.params['pk'], { schema: req.schema });
+
+		await service.deleteOne(pk);
 
 		return next();
 	}),

--- a/api/src/controllers/permissions.ts
+++ b/api/src/controllers/permissions.ts
@@ -9,6 +9,7 @@ import { fetchAccountabilityCollectionAccess } from '../permissions/modules/fetc
 import { MetaService } from '../services/meta.js';
 import { PermissionsService } from '../services/permissions.js';
 import asyncHandler from '../utils/async-handler.js';
+import { convertPK } from '../utils/convert-pk.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
 
 const router = express.Router();
@@ -115,7 +116,9 @@ router.get(
 			schema: req.schema,
 		});
 
-		const record = await service.readOne(req.params['pk']!, req.sanitizedQuery);
+		const pk = convertPK('directus_permissions', req.params['pk'], { schema: req.schema });
+
+		const record = await service.readOne(pk, req.sanitizedQuery);
 
 		res.locals['payload'] = { data: record };
 		return next();
@@ -167,7 +170,9 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const primaryKey = await service.updateOne(req.params['pk']!, req.body);
+		const pk = convertPK('directus_permissions', req.params['pk'], { schema: req.schema });
+
+		const primaryKey = await service.updateOne(pk, req.body);
 
 		try {
 			const item = await service.readOne(primaryKey, req.sanitizedQuery);
@@ -216,7 +221,9 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		const pk = convertPK('directus_permissions', req.params['pk'], { schema: req.schema });
+
+		await service.deleteOne(pk);
 
 		return next();
 	}),
@@ -226,14 +233,12 @@ router.delete(
 router.get(
 	'/me/:collection/:pk?',
 	asyncHandler(async (req, res, next) => {
-		const { collection, pk } = req.params;
-
 		const service = new PermissionsService({
 			accountability: req.accountability,
 			schema: req.schema,
 		});
 
-		const itemPermissions = await service.getItemPermissions(collection!, pk);
+		const itemPermissions = await service.getItemPermissions(req.collection, req.params['pk']);
 
 		res.locals['payload'] = { data: itemPermissions };
 

--- a/api/src/controllers/permissions.ts
+++ b/api/src/controllers/permissions.ts
@@ -238,7 +238,7 @@ router.get(
 			schema: req.schema,
 		});
 
-		const itemPermissions = await service.getItemPermissions(req.collection, req.params['pk']);
+		const itemPermissions = await service.getItemPermissions(req.params['collection']!, req.params['pk']);
 
 		res.locals['payload'] = { data: itemPermissions };
 

--- a/api/src/controllers/presets.ts
+++ b/api/src/controllers/presets.ts
@@ -7,6 +7,7 @@ import { validateBatch } from '../middleware/validate-batch.js';
 import { MetaService } from '../services/meta.js';
 import { PresetsService } from '../services/presets.js';
 import asyncHandler from '../utils/async-handler.js';
+import { convertPK } from '../utils/convert-pk.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
 
 const router = express.Router();
@@ -90,7 +91,9 @@ router.get(
 			schema: req.schema,
 		});
 
-		const record = await service.readOne(req.params['pk']!, req.sanitizedQuery);
+		const pk = convertPK('directus_presets', req.params['pk'], { schema: req.schema });
+
+		const record = await service.readOne(pk, req.sanitizedQuery);
 
 		res.locals['payload'] = { data: record || null };
 		return next();
@@ -142,7 +145,9 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const primaryKey = await service.updateOne(req.params['pk']!, req.body);
+		const pk = convertPK('directus_presets', req.params['pk'], { schema: req.schema });
+
+		const primaryKey = await service.updateOne(pk, req.body);
 
 		try {
 			const record = await service.readOne(primaryKey, req.sanitizedQuery);
@@ -191,7 +196,9 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		const pk = convertPK('directus_presets', req.params['pk'], { schema: req.schema });
+
+		await service.deleteOne(pk);
 
 		return next();
 	}),

--- a/api/src/controllers/relations.ts
+++ b/api/src/controllers/relations.ts
@@ -1,8 +1,7 @@
-import { isDirectusError } from '@directus/errors';
+import { ErrorCode, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import express from 'express';
 import Joi from 'joi';
-import { ErrorCode, InvalidPayloadError } from '@directus/errors';
-import validateCollection from '../middleware/collection-exists.js';
+import collectionExists from '../middleware/collection-exists.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
 import { RelationsService } from '../services/relations.js';
@@ -29,7 +28,7 @@ router.get(
 
 router.get(
 	'/:collection',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new RelationsService({
 			accountability: req.accountability,
@@ -46,7 +45,7 @@ router.get(
 
 router.get(
 	'/:collection/:field',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new RelationsService({
 			accountability: req.accountability,
@@ -119,7 +118,7 @@ const updateRelationSchema = Joi.object({
 
 router.patch(
 	'/:collection/:field',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, res, next) => {
 		const service = new RelationsService({
 			accountability: req.accountability,
@@ -152,7 +151,7 @@ router.patch(
 
 router.delete(
 	'/:collection/:field',
-	validateCollection,
+	collectionExists,
 	asyncHandler(async (req, _res, next) => {
 		const service = new RelationsService({
 			accountability: req.accountability,

--- a/api/src/controllers/revisions.ts
+++ b/api/src/controllers/revisions.ts
@@ -5,6 +5,7 @@ import { validateBatch } from '../middleware/validate-batch.js';
 import { MetaService } from '../services/meta.js';
 import { RevisionsService } from '../services/revisions.js';
 import asyncHandler from '../utils/async-handler.js';
+import { convertPK } from '../utils/convert-pk.js';
 
 const router = express.Router();
 
@@ -39,7 +40,9 @@ router.get(
 			schema: req.schema,
 		});
 
-		const record = await service.readOne(req.params['pk']!, req.sanitizedQuery);
+		const pk = convertPK('directus_revisions', req.params['pk'], { schema: req.schema });
+
+		const record = await service.readOne(pk, req.sanitizedQuery);
 
 		res.locals['payload'] = { data: record || null };
 		return next();

--- a/api/src/controllers/webhooks.ts
+++ b/api/src/controllers/webhooks.ts
@@ -6,6 +6,7 @@ import { validateBatch } from '../middleware/validate-batch.js';
 import { MetaService } from '../services/meta.js';
 import { WebhooksService } from '../services/webhooks.js';
 import asyncHandler from '../utils/async-handler.js';
+import { convertPK } from '../utils/convert-pk.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
 
 const router = express.Router();
@@ -50,7 +51,9 @@ router.get(
 			schema: req.schema,
 		});
 
-		const record = await service.readOne(req.params['pk']!, req.sanitizedQuery);
+		const pk = convertPK('directus_webhooks', req.params['pk'], { schema: req.schema });
+
+		const record = await service.readOne(pk, req.sanitizedQuery);
 
 		res.locals['payload'] = { data: record || null };
 		return next();
@@ -107,7 +110,9 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		const pk = convertPK('directus_webhooks', req.params['pk'], { schema: req.schema });
+
+		await service.deleteOne(pk);
 
 		return next();
 	}),

--- a/api/src/utils/convert-pk.ts
+++ b/api/src/utils/convert-pk.ts
@@ -8,6 +8,7 @@ export interface ConvertPKContext {
  * Attempt to convert the PK to its proper type
  */
 export function convertPK(collection: string, pk: PrimaryKey | undefined, context: ConvertPKContext): PrimaryKey {
+	// This will trigger a database error as expected, but ensures we remain within the PrimaryKey type return
 	if (!pk) return '';
 
 	const primaryKeyField = context.schema.collections[collection]?.primary;

--- a/api/src/utils/convert-pk.ts
+++ b/api/src/utils/convert-pk.ts
@@ -1,0 +1,25 @@
+import type { PrimaryKey, SchemaOverview } from '@directus/types';
+
+export interface ConvertPKContext {
+	schema: SchemaOverview;
+}
+
+/**
+ * Attempt to convert the PK to its proper type
+ */
+export function convertPK(collection: string, pk: PrimaryKey | undefined, context: ConvertPKContext): PrimaryKey {
+	if (!pk) return '';
+
+	const primaryKeyField = context.schema.collections[collection]?.primary;
+	const primaryKeyFieldType = context.schema.collections[collection]?.fields[primaryKeyField!]?.type;
+
+	if (primaryKeyFieldType !== 'integer') {
+		return pk;
+	}
+
+	if (Number.isSafeInteger(Number(pk)) === false) {
+		return pk;
+	}
+
+	return Number(pk);
+}


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now convert all applicable primary keys received via path parameters to integer when/where possible
- Small refactor to rename `validateCollection` to `collectionExists` where applicable

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

---

Fixes #24848
