### PR TITLE
fix: force utf-8 encoding for excel

### DIFF
--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -508,7 +508,8 @@ Your export of ${collection} is ready. <a href="${href}">Click here to view.</a>
 				string = '\n' + string;
 			}
 
-			return string;
+			// Add BOM to the beginning of the file to ensure that Excel opens it correctly
+			return '\uFEFF' + string;
 		}
 
 		if (format === 'yaml') {

--- a/app/src/utils/save-as-csv.ts
+++ b/app/src/utils/save-as-csv.ts
@@ -75,5 +75,5 @@ export async function saveAsCSV(collection: string, fields: string[], items: Ite
 		.toString()
 		.padStart(2, '0')}`;
 
-	saveAs(new Blob([csvContent], { type: 'text/csv;charset=utf-8' }), `${collection}-${dateString}.csv`);
+	saveAs(new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8' }), `${collection}-${dateString}.csv`);
 }


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

Allow special characters when exporting CSV files by prepending CSV strings with the `\uFEFF` (BOM) character.

## Potential Risks / Drawbacks

Since the charset is already set to "utf-8", I don't think there's any risk?

## Review Notes / Questions

I'm a bit surprised the issue wasn't raised by more people as this basically makes the CSV export feature unusable for any item that has a special character, but there may be something I'm not seeing?

---

Fixes #16818 

Thanks for all your amazing work ❤️