### PR TITLE
Skip unnecessary fetching of dynamic variables

### DIFF
--- a/.changeset/wet-ads-sniff.md
+++ b/.changeset/wet-ads-sniff.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Skipped unnecessary fetching of dynamic variables

--- a/api/src/permissions/modules/process-payload/process-payload.ts
+++ b/api/src/permissions/modules/process-payload/process-payload.ts
@@ -6,9 +6,10 @@ import { assign, difference, uniq } from 'lodash-es';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
-import { isFieldNullable } from './lib/is-field-nullable.js';
-import { fetchDynamicVariableData } from '../../utils/fetch-dynamic-variable-data.js';
 import { extractRequiredDynamicVariableContext } from '../../utils/extract-required-dynamic-variable-context.js';
+import { fetchDynamicVariableData } from '../../utils/fetch-dynamic-variable-data.js';
+import { contextHasDynamicVariables } from '../process-ast/utils/context-has-dynamic-variables.js';
+import { isFieldNullable } from './lib/is-field-nullable.js';
 
 export interface ProcessPayloadOptions {
 	accountability: Accountability;
@@ -84,20 +85,24 @@ export async function processPayload(options: ProcessPayloadOptions, context: Co
 			});
 		}
 
-		const permissionContext = extractRequiredDynamicVariableContext(field.validation);
+		if (field.validation) {
+			const permissionContext = extractRequiredDynamicVariableContext(field.validation);
 
-		const filterContext = await fetchDynamicVariableData(
-			{
-				accountability: options.accountability,
-				policies,
-				dynamicVariableContext: permissionContext,
-			},
-			context,
-		);
+			const filterContext = contextHasDynamicVariables(permissionContext)
+				? await fetchDynamicVariableData(
+						{
+							accountability: options.accountability,
+							policies,
+							dynamicVariableContext: permissionContext,
+						},
+						context,
+				  )
+				: undefined;
 
-		const validationFilter = parseFilter(field.validation, options.accountability, filterContext);
+			const validationFilter = parseFilter(field.validation, options.accountability, filterContext);
 
-		fieldValidationRules.push(validationFilter);
+			fieldValidationRules.push(validationFilter);
+		}
 	}
 
 	const presets = (permissions ?? []).map((permission) => permission.presets);


### PR DESCRIPTION
## Scope

What's changed:

- Skip unnecessary fetching of dynamic variables
    - when `field.validation` is nullish
    - when it does not contain dynamic variables

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- Addressing changes added in #24634
- We could potentially do similar for the following, but it was not changed recently https://github.com/directus/directus/blob/10fc141e58415c7990786db8c5083cb735f1accf/api/src/permissions/lib/fetch-permissions.ts#L24-L40
