### PR TITLE
Optimize record fetching for relational updates

### DIFF
--- a/.changeset/tall-badgers-trade.md
+++ b/.changeset/tall-badgers-trade.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Optimized record fetching for relational updates


### PR DESCRIPTION
## Scope

What's changed:

- Fetch existing records by reducing from multiple `where` DB queries to a single `whereIn`.

## Potential Risks / Drawbacks

- We may want to add batching to better support large key sets

## Review Notes / Questions

- Optimization for #24609
  - Similar testing from original PR should be done to confirm that #23876 remains fixed
- Ref: https://discord.com/channels/725371605378924594/1151320093565927504/1354917077554561054
