### PR TITLE
Fix empty string not checked against `_regex` validation

### DIFF
--- a/.changeset/stale-rings-write.md
+++ b/.changeset/stale-rings-write.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed empty string not checked against `_regex` validation

--- a/packages/utils/shared/generate-joi.test.ts
+++ b/packages/utils/shared/generate-joi.test.ts
@@ -809,7 +809,7 @@ describe(`generateJoi`, () => {
 		const mockFieldFilter = { field: { _regex: '/.*field$/' } } as FieldFilter;
 
 		const mockSchema = Joi.object({
-			field: Joi.string().regex(new RegExp(`.*field$`)),
+			field: Joi.string().min(0).regex(new RegExp(`.*field$`)),
 		})
 			.unknown()
 			.describe();
@@ -821,7 +821,7 @@ describe(`generateJoi`, () => {
 		const mockFieldFilter = { field: { _regex: '.*field$' } } as FieldFilter;
 
 		const mockSchema = Joi.object({
-			field: Joi.string().regex(new RegExp(`.*field$`)),
+			field: Joi.string().min(0).regex(new RegExp(`.*field$`)),
 		})
 			.unknown()
 			.describe();

--- a/packages/utils/shared/generate-joi.ts
+++ b/packages/utils/shared/generate-joi.ts
@@ -367,7 +367,9 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 				const wrapped =
 					typeof compareValue === 'string' ? compareValue.startsWith('/') && compareValue.endsWith('/') : false;
 
-				schema[key] = getStringSchema().regex(new RegExp(wrapped ? (compareValue as any).slice(1, -1) : compareValue));
+				schema[key] = getStringSchema()
+					.min(0)
+					.regex(new RegExp(wrapped ? (compareValue as any).slice(1, -1) : compareValue), {});
 			}
 		}
 	}

--- a/packages/utils/shared/generate-joi.ts
+++ b/packages/utils/shared/generate-joi.ts
@@ -369,7 +369,7 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 
 				schema[key] = getStringSchema()
 					.min(0)
-					.regex(new RegExp(wrapped ? (compareValue as any).slice(1, -1) : compareValue), {});
+					.regex(new RegExp(wrapped ? (compareValue as any).slice(1, -1) : compareValue));
 			}
 		}
 	}

--- a/packages/utils/shared/validate-payload.test.ts
+++ b/packages/utils/shared/validate-payload.test.ts
@@ -200,4 +200,31 @@ describe('validatePayload', () => {
 			expect(validatePayload(mockFilter, { value: {} }, options)).toHaveLength(1);
 		});
 	});
+
+	describe('validates operator: _regex', () => {
+		const mockFilter = {
+			_and: [
+				{
+					value: {
+						_regex: '^$|foo',
+					},
+				},
+			],
+		};
+
+		const options = { requireAll: true };
+
+		test('string value', () => {
+			expect(validatePayload(mockFilter, { value: 'foo' }, options)).toHaveLength(0);
+
+			expect(validatePayload(mockFilter, { value: 'bar' }, options)).toHaveLength(1);
+		});
+
+		test('other values', () => {
+			expect(validatePayload(mockFilter, { value: '' }, options)).toHaveLength(0);
+
+			expect(validatePayload(mockFilter, { value: undefined }, options)).toHaveLength(1);
+			expect(validatePayload(mockFilter, { value: null }, options)).toHaveLength(1);
+		});
+	});
 });


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We now allow empty string to be checked against the `_regex` validation filter, it is left up to the users regex to account for this.

## Potential Risks / Drawbacks

- As we are opting in for regex only this should not have any effect as it will validate against any existing regex which would not match against an empty string unless explicitly set

## Review Notes / Questions

- `joi` by default adds [a non empty constraint for string strings](https://joi.dev/api/?v=17.13.3#string)
- Using `allow('')` as recommended in the docs results in any subsequent constraints not being applied
   - https://joi.dev/api/?v=17.13.3#anyvalidvalues---aliases-equal
![Screenshot 2025-03-28 at 5 19 17 PM](https://github.com/user-attachments/assets/2276ff83-6039-4dbd-a096-1675ef962154)
- `min(0)` is used here as it looks to be a special bypass
   -  https://github.com/hapijs/joi/blob/5685db766f6a2261c3c1839a56c3b879c3cf5a0a/lib/types/string.js#L137
   - https://github.com/hapijs/joi/issues/2687

---

Fixes #22394
Fixes: #21489
