### PR TITLE
Fix handling of multiple _and conditions on the same relation

### DIFF
--- a/.changeset/eight-women-listen.md
+++ b/.changeset/eight-women-listen.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed incorrect results when using multiple \_and conditions on the same m2o relation


### PR DESCRIPTION
## Scope
What's changed:
- Fixed relation filtering logic to properly handle multiple conditions on the same relation field in an `_and` clause
- Updated filter combination logic to ensure all conditions are applied with correct AND logic

## Potential Risks / Drawbacks
- Slight performance impact when processing complex nested relation filters

## Review Notes / Questions
- There should probably be new tests to ensure this filtering scenario works as expected in future versions

---
Fixes #24985 

Now returns expected result:
```
[
  {
    "name": "Canada",
    "ratings": [
      {
        "type": "nature",
        "score": 3
      },
      {
        "type": "climate",
        "score": 3
      }
    ]
  }
]
```