### PR TITLE
Fix search applying minimum app permissions when full access is allowed

### DIFF
--- a/.changeset/busy-sloths-draw.md
+++ b/.changeset/busy-sloths-draw.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed search applying minimum app permissions when full access is allowed

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -28,12 +28,12 @@ const FAKE_SCHEMA: SchemaOverview = {
 					validation: null,
 					alias: false,
 				},
-				text1: {
-					field: 'text',
+				string: {
+					field: 'string',
 					defaultValue: null,
 					nullable: false,
 					generated: false,
-					type: 'text',
+					type: 'string',
 					dbType: null,
 					precision: null,
 					scale: null,
@@ -209,100 +209,6 @@ describe('applySearch', () => {
 		expect(queryBuilder['orWhereRaw']).toBeCalledWith('1 = 0');
 	});
 
-	test('Remove forbidden field "text" from search', () => {
-		const db = mockDatabase();
-		const queryBuilder = db as any;
-
-		db['andWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		queryBuilder['orWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		applySearch(db as any, FAKE_SCHEMA, queryBuilder, 'directus', 'test', {}, [
-			{
-				collection: 'test',
-				action: 'read',
-				fields: ['text1'],
-				permissions: {
-					text: {},
-				},
-			} as unknown as Permission,
-		]);
-
-		expect(db['andWhere']).toBeCalledTimes(1);
-		expect(queryBuilder['orWhere']).toBeCalledTimes(1);
-		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
-		expect(queryBuilder['and']['whereRaw']).toBeCalledTimes(1);
-		expect(queryBuilder['and']['whereRaw']).toBeCalledWith('LOWER(??) LIKE ?', ['test.text1', `%directus%`]);
-	});
-
-	test('Add all fields for * field rule and no item rule', () => {
-		const db = mockDatabase();
-		const queryBuilder = db as any;
-
-		db['andWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		queryBuilder['orWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		applySearch(db as any, FAKE_SCHEMA, queryBuilder, `1`, 'test', {}, [
-			{
-				collection: 'test',
-				action: 'read',
-				fields: ['*'],
-				permissions: null,
-			} as unknown as Permission,
-		]);
-
-		expect(db['andWhere']).toBeCalledTimes(1);
-		expect(queryBuilder['orWhere']).toBeCalledTimes(0);
-		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
-		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(2);
-		expect(queryBuilder['or']['where']).toBeCalledTimes(2);
-	});
-
-	test('Add all fields for * field rule and item rules', () => {
-		const db = mockDatabase();
-		const queryBuilder = db as any;
-
-		db['andWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		queryBuilder['orWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		applySearch(db as any, FAKE_SCHEMA, queryBuilder, '1', 'test', {}, [
-			{
-				collection: 'test',
-				action: 'read',
-				fields: ['*'],
-				permissions: {
-					text: {},
-				},
-			} as unknown as Permission,
-		]);
-
-		expect(db['andWhere']).toBeCalledTimes(1);
-		expect(queryBuilder['orWhere']).toBeCalledTimes(0);
-		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
-		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(2);
-		expect(queryBuilder['or']['where']).toBeCalledTimes(2);
-	});
-
 	test('Exclude non uuid searchable field(s) when searchQuery has valid uuid value', () => {
 		const db = mockDatabase();
 		const queryBuilder = db as any;
@@ -321,22 +227,20 @@ describe('applySearch', () => {
 			{
 				collection: 'test',
 				action: 'read',
-				fields: ['*', 'id'],
-				permissions: {
-					id: {},
-				},
+				fields: ['id', 'text'],
+				permissions: null,
 			} as unknown as Permission,
 		]);
 
 		expect(db['andWhere']).toBeCalledTimes(1);
-		expect(queryBuilder['orWhere']).toBeCalledTimes(0);
+		expect(queryBuilder['orWhere']).toBeCalledTimes(2);
 		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
-		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(2);
+		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(1);
 		expect(queryBuilder['or']['where']).toBeCalledTimes(1);
 		expect(queryBuilder['or']['where']).toBeCalledWith({ 'test.id': '4b9adc65-4ad8-4242-9144-fbfc58400d74' });
 	});
 
-	test('Add all fields for * field rule and minimum app_access item rule', () => {
+	test('Remove forbidden field(s) from search', () => {
 		const db = mockDatabase();
 		const queryBuilder = db as any;
 
@@ -350,52 +254,44 @@ describe('applySearch', () => {
 			return queryBuilder;
 		});
 
-		applySearch(db as any, FAKE_SCHEMA, queryBuilder, '1', 'test', {}, [
+		applySearch(db as any, FAKE_SCHEMA, queryBuilder, 'directus', 'test', {}, [
 			{
 				collection: 'test',
 				action: 'read',
-				fields: ['*', 'id'],
-				permissions: {
-					id: {},
-				},
-			} as unknown as Permission,
-		]);
-
-		expect(db['andWhere']).toBeCalledTimes(1);
-		expect(queryBuilder['orWhere']).toBeCalledTimes(0);
-		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
-		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(2);
-		expect(queryBuilder['or']['where']).toBeCalledTimes(2);
-	});
-
-	test('Add all fields when at least one policy contains a * field rule', () => {
-		const db = mockDatabase();
-		const queryBuilder = db as any;
-
-		db['andWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		queryBuilder['orWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
-			callback(queryBuilder);
-			return queryBuilder;
-		});
-
-		applySearch(db as any, FAKE_SCHEMA, queryBuilder, '1', 'test', {}, [
-			{
-				collection: 'test',
-				action: 'read',
-				fields: ['text'],
+				fields: ['string'],
 				permissions: {
 					text: {},
 				},
 			} as unknown as Permission,
+		]);
+
+		expect(db['andWhere']).toBeCalledTimes(1);
+		expect(queryBuilder['orWhere']).toBeCalledTimes(1);
+		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
+		expect(queryBuilder['and']['whereRaw']).toBeCalledTimes(1);
+		expect(queryBuilder['and']['whereRaw']).toBeCalledWith('LOWER(??) LIKE ?', ['test.string', `%directus%`]);
+	});
+
+	test('Add all fields for * field rule', () => {
+		const db = mockDatabase();
+		const queryBuilder = db as any;
+
+		db['andWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
+			callback(queryBuilder);
+			return queryBuilder;
+		});
+
+		queryBuilder['orWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
+			callback(queryBuilder);
+			return queryBuilder;
+		});
+
+		applySearch(db as any, FAKE_SCHEMA, queryBuilder, '1', 'test', {}, [
 			{
 				collection: 'test',
 				action: 'read',
 				fields: ['*'],
-				permissions: {},
+				permissions: null,
 			} as unknown as Permission,
 		]);
 
@@ -406,7 +302,39 @@ describe('applySearch', () => {
 		expect(queryBuilder['or']['where']).toBeCalledTimes(2);
 	});
 
-	test('Add field(s) without permissions for admin', () => {
+	test('Add all fields when * is present in field rule with permission rule present', () => {
+		const db = mockDatabase();
+		const queryBuilder = db as any;
+
+		db['andWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
+			callback(queryBuilder);
+			return queryBuilder;
+		});
+
+		queryBuilder['orWhere'].mockImplementation((callback: (queryBuilder: Knex.QueryBuilder) => void) => {
+			callback(queryBuilder);
+			return queryBuilder;
+		});
+
+		applySearch(db as any, FAKE_SCHEMA, queryBuilder, '1', 'test', {}, [
+			{
+				collection: 'test',
+				action: 'read',
+				fields: ['*', 'text'],
+				permissions: {
+					text: {},
+				},
+			} as unknown as Permission,
+		]);
+
+		expect(db['andWhere']).toBeCalledTimes(1);
+		expect(queryBuilder['orWhere']).toBeCalledTimes(0);
+		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
+		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(2);
+		expect(queryBuilder['or']['where']).toBeCalledTimes(2);
+	});
+
+	test('All field(s) are searched for admin', () => {
 		const db = mockDatabase();
 		const queryBuilder = db as any;
 
@@ -425,6 +353,7 @@ describe('applySearch', () => {
 		expect(db['andWhere']).toBeCalledTimes(1);
 		expect(queryBuilder['orWhere']).toBeCalledTimes(0);
 		expect(queryBuilder['orWhereRaw']).toBeCalledTimes(0);
+		expect(queryBuilder['and']['whereRaw']).toBeCalledTimes(2);
 		expect(queryBuilder['or']['whereRaw']).toBeCalledTimes(2);
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -957,7 +957,8 @@ export function applySearch(
 		let needsFallbackCondition = true;
 
 		fields.forEach(([name, field]) => {
-			const whenCases = (caseMap[name] ?? []).map((caseIndex) => cases[caseIndex]!);
+			// only account for when cases when full access is not given
+			const whenCases = allowedFields.has('*') ? [] : (caseMap[name] ?? []).map((caseIndex) => cases[caseIndex]!);
 
 			const fieldType = getFieldType(field);
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- We no longer apply any `whenCases` if the user has full read access 

## Potential Risks / Drawbacks

- None 🤔 

## Review Notes / Questions

- This issue arises when `app_access` is enabled on the policy. Even if full read permission are set we still have `whenCases` due to item minimum permission rules from `app_access`

---

Fixes SER-682
