### PR TITLE
Paste image from clipboard into WYSIWYG

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -210,3 +210,4 @@
 - subtirelumihail
 - ngluunhatson
 - jacobcons
+- 00041275


### PR DESCRIPTION
https://github.com/directus/directus/discussions/13164
add simple  decision for function "Paste image from clipboard into WYSIWYG": add for v-upload.vue check paste event with image type and take it as file.

![image](https://github.com/user-attachments/assets/75ee3077-c4ac-4009-abfd-112c0447a399)
![image](https://github.com/user-attachments/assets/e95faff0-8ff6-4e5f-a381-7f63938a51a2)
![image](https://github.com/user-attachments/assets/b0243d5a-9b52-4c60-ab5b-207cf3f13b7c)


