### PR TITLE
Fix `applyOptionsData` errors not appearing in the flow log

### DIFF
--- a/.changeset/all-olives-bake.md
+++ b/.changeset/all-olives-bake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `applyOptionsData` errors not appearing in the flow log

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -424,7 +424,7 @@ class FlowManager {
 		let options = operation.options;
 
 		try {
-			options = applyOptionsData(operation.options, keyedData);
+			options = applyOptionsData(options, keyedData);
 
 			let result = await handler(options, {
 				services,

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -421,9 +421,11 @@ class FlowManager {
 
 		const handler = this.operations.get(operation.type)!;
 
-		const options = applyOptionsData(operation.options, keyedData);
+		let options = null;
 
 		try {
+			options = applyOptionsData(operation.options, keyedData);
+
 			let result = await handler(options, {
 				services,
 				env: useEnv(),

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -421,7 +421,7 @@ class FlowManager {
 
 		const handler = this.operations.get(operation.type)!;
 
-		let options = null;
+		let options = operation.options;
 
 		try {
 			options = applyOptionsData(operation.options, keyedData);


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Any errors thrown by `applyOptionsData` during the flow process are now shown in the flow logs

## Potential Risks / Drawbacks

- Should be none

## Review Notes / Questions

-N/A

---

Fixes #22191
