### PR TITLE
Fix issue preventing version menu interaction while split view is enabled

### DIFF
--- a/.changeset/curly-baboons-guess.md
+++ b/.changeset/curly-baboons-guess.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixes issue preventing version menu interaction when preview mode is enabled

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -478,5 +478,6 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 	&:hover {
 		color: var(--theme--foreground);
 	}
+	pointer-events: all;
 }
 </style>


### PR DESCRIPTION
This PR Fixes an issue preventing version menu interaction while split view is enabled.

## Scope

What's changed:

- allowed pointer events on version-button class

## Potential Risks / Drawbacks

- Though the change is limited to the version-button class, it's worth checking that split view drag and drop is not effected in any cases.

## Review Notes / Questions

- Create a collection with versioning and preview enabled.
- Verify you can interact with the version menu with preview enabled.

---

Fixes #25030
#WEB-679
