### PR TITLE
Fix issue preventing "other" option from working in select dropdowns when some options contain icons

### DIFF
--- a/.changeset/mean-llamas-cross.md
+++ b/.changeset/mean-llamas-cross.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed issue preventing "other" option from working in select dropdowns where some options contained icons.

--- a/app/src/interfaces/select-dropdown/select-dropdown.vue
+++ b/app/src/interfaces/select-dropdown/select-dropdown.vue
@@ -40,15 +40,13 @@ const items = computed(() => {
 	}
 
 	return props.choices.map((choice) => {
-		if (choice.icon) {
-			return choice;
+		const choiceCopy = { ...choice };
+
+		if (!choiceCopy.icon && !choiceCopy.color) {
+			choiceCopy.icon = props.icon ?? null;
 		}
 
-		if (!choice.icon && !choice.color) {
-			choice.icon = props.icon ?? null;
-		}
-
-		return choice;
+		return choiceCopy;
 	});
 });
 


### PR DESCRIPTION
## Scope

What's changed:

- Fixed reactivity bug that was preventing the "allowOther" option from updating in select dropdown fields where some options contained icons.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

Issue [24516](https://github.com/directus/directus/issues/24516) clearly explains how to recreate the issue and what the expectations are.

---

Fixes #24516
