### PR TITLE
Fix custom interface data loss when nested inside group

### DIFF
--- a/.changeset/good-horses-tan.md
+++ b/.changeset/good-horses-tan.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevented custom interfaces from unmounting when nested inside group detail field.

--- a/app/src/components/v-detail.vue
+++ b/app/src/components/v-detail.vue
@@ -56,7 +56,7 @@ function toggle() {
 			</v-divider>
 		</slot>
 		<transition-expand>
-			<div v-if="internalActive" class="content">
+			<div v-show="internalActive" class="content">
 				<slot />
 			</div>
 		</transition-expand>


### PR DESCRIPTION

## Scope

What's changed:

Changed v-if to v-show to prevent component from unmounting and losing ephemeral state.

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

**Reproduce**
- Create a custom interface extension that handles file uploads
- Create a collection that uses this interface and nest it within a group-detail toggle
- Use the custom interface to select a file
- click the parent group toggle to close the group and then click it once more to open it again
- the file information will no longer be in memory and you will have to select the file again

**With this PR**
- Run through the above steps again
- the file information should still be in memory and you should be able to save the uploaded file

### Without fix
https://github.com/user-attachments/assets/007dd328-144a-4d7a-9b8f-eb91ed1813c3

### With fix
https://github.com/user-attachments/assets/85482ebe-94a3-4c6d-b49e-a72d0f85a15e



---

Fixes WEB-489
