### PR TITLE
Utilize operationOptions as selectedOperation could be a function

### DIFF
--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { useDialogRoute } from '@/composables/use-dialog-route';
+import { useExtension } from '@/composables/use-extension';
+import { useExtensions } from '@/extensions';
 import ExtensionOptions from '@/modules/settings/routes/data-model/field-detail/shared/extension-options.vue';
+import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { translate } from '@/utils/translate-object-values';
-import { FlowRaw } from '@directus/types';
+import { Field, FlowRaw } from '@directus/types';
 import slugify from '@sindresorhus/slugify';
+import { customAlphabet } from 'nanoid/non-secure';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useExtensions } from '@/extensions';
-import { useExtension } from '@/composables/use-extension';
-import { customAlphabet } from 'nanoid/non-secure';
-import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 
 const generateSuffix = customAlphabet('abcdefghijklmnopqrstuvwxyz1234567890', 5);
 
@@ -119,14 +119,16 @@ const operationOptions = computed(() => {
 function saveOperation() {
 	saving.value = true;
 
-	const defaultValues = getDefaultValuesFromFields(selectedOperation.value?.options);
+	const defaultValues = operationOptions.value
+		? getDefaultValuesFromFields(operationOptions.value as Field[]).value
+		: null;
 
 	emit('save', {
 		flow: props.primaryKey,
 		name: operationName.value || generatedName.value,
 		key: operationKey.value || generatedKey.value,
 		type: operationType.value,
-		options: { ...defaultValues.value, ...options.value },
+		options: { ...defaultValues, ...options.value },
 	});
 }
 </script>


### PR DESCRIPTION
## Scope

What's changed:

- Utilized operationOptions as selectedOperation could be a function

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- Follow-up of #24963

---

Fixes SER-703
