### PR TITLE
Fix reactivity issues with props in the translation interface to allow conditions to work correctly

### DIFF
--- a/.changeset/tidy-cups-whisper.md
+++ b/.changeset/tidy-cups-whisper.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed reactivity issues with props in the translation interface to allow conditions to work correctly

--- a/app/src/interfaces/translations/language-select.vue
+++ b/app/src/interfaces/translations/language-select.vue
@@ -7,11 +7,9 @@ const props = withDefaults(
 		items?: Record<string, any>[];
 		secondary?: boolean;
 		danger?: boolean;
-		defaultLanguage?: string | null;
 	}>(),
 	{
 		items: () => [],
-		defaultLanguage: null,
 	},
 );
 

--- a/app/src/interfaces/translations/language-select.vue
+++ b/app/src/interfaces/translations/language-select.vue
@@ -7,9 +7,11 @@ const props = withDefaults(
 		items?: Record<string, any>[];
 		secondary?: boolean;
 		danger?: boolean;
+		defaultLanguage?: string | null;
 	}>(),
 	{
 		items: () => [],
+		defaultLanguage: null,
 	},
 );
 

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -52,7 +52,16 @@ watch(
 
 const { t } = useI18n();
 
-const selectedLanguage = computed(() => languageOptions.find((optLang) => lang.value === optLang.value));
+const selectedLanguageData = computed(() => {
+	const langCode = lang.value ?? defaultLanguage;
+	return (
+		languageOptions.find((option) => option.value === langCode) ?? {
+			value: langCode,
+			text: langCode,
+			direction: null,
+		}
+	);
+});
 
 const item = computed(() => {
 	const item = getItemWithLang(displayItems, lang.value);
@@ -193,8 +202,8 @@ function onToggleDelete(item: DisplayItem, itemInitial?: DisplayItem) {
 		</language-select>
 
 		<v-form
-			v-if="selectedLanguage"
-			:key="selectedLanguage.value"
+			v-if="selectedLanguageData"
+			:key="selectedLanguageData.value"
 			:primary-key="
 				relationInfo?.junctionPrimaryKeyField.field ? itemInitial?.[relationInfo?.junctionPrimaryKeyField.field] : null
 			"
@@ -204,8 +213,8 @@ function onToggleDelete(item: DisplayItem, itemInitial?: DisplayItem) {
 			:fields="fields"
 			:model-value="item"
 			:initial-values="itemInitial"
-			:badge="selectedLanguage.text"
-			:direction="selectedLanguage.direction"
+			:badge="selectedLanguageData.text"
+			:direction="selectedLanguageData.direction"
 			:autofocus="autofocus"
 			inline
 			@update:model-value="updateValue($event, lang)"

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -42,7 +42,9 @@ const lang = defineModel<string>('lang');
 watch(
 	() => defaultLanguage,
 	(newDefaultLanguage, oldDefaultLanguage) => {
-		if (newDefaultLanguage && !lang.value) {
+		if (!newDefaultLanguage) return;
+
+		if (newDefaultLanguage !== oldDefaultLanguage && newDefaultLanguage !== lang.value) {
 			lang.value = newDefaultLanguage;
 		}
 	},

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -19,6 +19,7 @@ const {
 	remove,
 	loading,
 	updateValue,
+	defaultLanguage,
 } = defineProps<{
 	languageOptions: Record<string, any>[];
 	disabled?: boolean;
@@ -33,9 +34,19 @@ const {
 	remove: (...items: DisplayItem[]) => void;
 	updateValue: (item: DisplayItem | undefined, lang: string | undefined) => void;
 	secondary?: boolean;
+	defaultLanguage?: string | null;
 }>();
 
 const lang = defineModel<string>('lang');
+
+watch(
+	() => defaultLanguage,
+	(newDefaultLanguage, oldDefaultLanguage) => {
+		if (newDefaultLanguage && !lang.value) {
+			lang.value = newDefaultLanguage;
+		}
+	},
+);
 
 const { t } = useI18n();
 

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -150,7 +150,7 @@ const translationProps = computed(() => ({
 	isLocalItem,
 	updateValue,
 	remove,
-	defaultLanguage: defaultLanguage.value || undefined,
+	defaultLanguage: defaultLanguage.value || null,
 }));
 
 function useLanguages() {

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -41,6 +41,13 @@ const props = withDefaults(
 	},
 );
 
+watch(
+	() => props.defaultLanguage,
+	(newDefaultLanguage, oldDefaultLanguage) => {
+		console.log('Default language ref changed', newDefaultLanguage, oldDefaultLanguage);
+	},
+);
+
 const emit = defineEmits(['input']);
 
 const value = computed({
@@ -150,6 +157,7 @@ const translationProps = computed(() => ({
 	isLocalItem,
 	updateValue,
 	remove,
+	defaultLanguage: defaultLanguage.value || undefined,
 }));
 
 function useLanguages() {

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -41,13 +41,6 @@ const props = withDefaults(
 	},
 );
 
-watch(
-	() => props.defaultLanguage,
-	(newDefaultLanguage, oldDefaultLanguage) => {
-		console.log('Default language ref changed', newDefaultLanguage, oldDefaultLanguage);
-	},
-);
-
 const emit = defineEmits(['input']);
 
 const value = computed({


### PR DESCRIPTION
## Scope

What's changed:

- Fixed issue preventing language-select from responding to field conditions

## Potential Risks / Drawbacks

## Review Notes / Questions

Because field conditions don't typically change the values of other fields, there are some questions worth asking, such as:
- When a condition from another field changes the value of the language select field, should you be able to change the value of the language select field manually?

---

Fixes WEB-640
