### PR TITLE
add `skipTracking` option to `ItemsService`

### DIFF
--- a/.changeset/few-cases-pay.md
+++ b/.changeset/few-cases-pay.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Added a `skipTracking` flag to disable `activity` and/or `revisions` from being generated for a record

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -339,7 +339,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				});
 
 				// If revisions are tracked, create revisions record
-				if (this.schema.collections[this.collection]!.accountability === 'all' && opts.skipTracking !== 'activity') {
+				if (this.schema.collections[this.collection]!.accountability === 'all' && opts.skipTracking !== 'revisions') {
 					const revisionsService = new RevisionsService({
 						knex: trx,
 						schema: this.schema,
@@ -857,7 +857,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					{ bypassLimits: true },
 				);
 
-				if (this.schema.collections[this.collection]!.accountability === 'all' && opts.skipTracking !== 'activity') {
+				if (this.schema.collections[this.collection]!.accountability === 'all' && opts.skipTracking !== 'revisions') {
 					const itemsService = new ItemsService(this.collection, {
 						knex: trx,
 						schema: this.schema,

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -318,7 +318,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			}
 
 			// If this is an authenticated action, and accountability tracking is enabled, save activity row
-			if (this.accountability && this.schema.collections[this.collection]!.accountability !== null) {
+			if (
+				this.accountability &&
+				this.schema.collections[this.collection]!.accountability !== null &&
+				opts.skipTracking !== 'all'
+			) {
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
@@ -335,7 +339,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				});
 
 				// If revisions are tracked, create revisions record
-				if (this.schema.collections[this.collection]!.accountability === 'all') {
+				if (this.schema.collections[this.collection]!.accountability === 'all' && opts.skipTracking !== 'activity') {
 					const revisionsService = new RevisionsService({
 						knex: trx,
 						schema: this.schema,
@@ -830,7 +834,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			}
 
 			// If this is an authenticated action, and accountability tracking is enabled, save activity row
-			if (this.accountability && this.schema.collections[this.collection]!.accountability !== null) {
+			if (
+				this.accountability &&
+				this.schema.collections[this.collection]!.accountability !== null &&
+				opts.skipTracking !== 'all'
+			) {
 				const activityService = new ActivityService({
 					knex: trx,
 					schema: this.schema,
@@ -849,7 +857,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					{ bypassLimits: true },
 				);
 
-				if (this.schema.collections[this.collection]!.accountability === 'all') {
+				if (this.schema.collections[this.collection]!.accountability === 'all' && opts.skipTracking !== 'activity') {
 					const itemsService = new ItemsService(this.collection, {
 						knex: trx,
 						schema: this.schema,

--- a/api/src/types/items.ts
+++ b/api/src/types/items.ts
@@ -5,6 +5,10 @@ import type { UserIntegrityCheckFlag } from '../utils/validate-user-count-integr
 
 export type MutationOptions = {
 	/**
+	 * Flag to disabling tracking activity and/or revisions. Useful for non user initiated changes.
+	 */
+	skipTracking?: 'all' | 'activity' | undefined;
+	/**
 	 * Callback function that's fired whenever a revision is made in the mutation
 	 */
 	onRevisionCreate?: ((pk: PrimaryKey) => void) | undefined;

--- a/api/src/types/items.ts
+++ b/api/src/types/items.ts
@@ -7,7 +7,7 @@ export type MutationOptions = {
 	/**
 	 * Flag to disabling tracking activity and/or revisions. Useful for non user initiated changes.
 	 */
-	skipTracking?: 'all' | 'activity' | undefined;
+	skipTracking?: 'all' | 'revisions' | undefined;
 	/**
 	 * Callback function that's fired whenever a revision is made in the mutation
 	 */


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- `activity` and/or `revision` record creation can now be skipped via a new `skipTracking` option on the `ItemsService`

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

---

Fixes #24047
