### PR TITLE
Add Docker Image Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,6 @@ jobs:
         if: env.DOCKERHUB_IMAGE
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-          COSIGN_REPOSITORY: ${{ env.DOCKERHUB_SIGNATURE_IMAGE }}
         run: cosign sign --yes --recursive ${DOCKERHUB_IMAGE}@${DIGEST}
 
       # Temp fix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
   DOCKERHUB_IMAGE: docker.io/${{ github.repository }}
-  DOCKERHUB_SIGNATURE_IMAGE: docker.io/${{ github.repository }}-signatures
+  COSIGN_REPOSITORY: docker.io/${{ github.repository }}-signatures
 
 jobs:
   check-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
-  DOCKERHUB_IMAGE: ${{ github.repository }}
+  DOCKERHUB_IMAGE: docker.io/${{ github.repository }}
+  DOCKERHUB_SIGNATURE_IMAGE: docker.io/${{ github.repository }}-signatures
 
 jobs:
   check-version:
@@ -69,12 +70,18 @@ jobs:
     name: Build Images
     runs-on: ubuntu-latest
     needs: check-version
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        if: env.DOCKERHUB_IMAGE
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -104,6 +111,7 @@ jobs:
         uses: docker/login-action@v3
         if: env.DOCKERHUB_IMAGE
         with:
+          registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
@@ -117,6 +125,7 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        id: build-and-push
         with:
           context: .
           file: ./Dockerfile
@@ -126,6 +135,13 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Sign Docker Hub image with GitHub OIDC Token
+        if: env.DOCKERHUB_IMAGE
+        env:
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          COSIGN_REPOSITORY: ${{ env.DOCKERHUB_SIGNATURE_IMAGE }}
+        run: cosign sign --yes --recursive ${DOCKERHUB_IMAGE}@${DIGEST}
 
       # Temp fix:
       # https://github.com/docker/build-push-action/issues/252

--- a/contributors.yml
+++ b/contributors.yml
@@ -210,3 +210,4 @@
 - subtirelumihail
 - ngluunhatson
 - jacobcons
+- danielBreitlauch


### PR DESCRIPTION
What's changed:

- This adds docker image signing for `directus/directus` with [cosign](https://github.com/sigstore/cosign).
- The signatures can be found in the docker repo: `directus/directus-signatures`

What needs to be done before merging:
- [x]  docker.io/directus/directus-signatures needs to be created as public
- [x]  verify github actions write permissions for docker.io/directus/directus-signatures

How to verify signatures:
```
$ COSIGN_REPOSITORY=docker.io/directus/directus-signatures
tag:
$ cosign verify --certificate-identity-regexp 'https://github.com/directus/directus/.*' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --output text docker.io/directus/directus:<image>
digest: 
$ cosign verify --certificate-identity-regexp 'https://github.com/directus/directus/.*' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --output text docker.io/directus/directus@<sha256:digest>
```
