### PR TITLE
Fix `filename_download` not respected on upload

### DIFF
--- a/.changeset/rare-flies-nail.md
+++ b/.changeset/rare-flies-nail.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `filename_download` not respected on upload

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -94,7 +94,7 @@ export const multipartHandler: RequestHandler = (req, res, next) => {
 			}
 		}
 
-		payload.filename_download = filename;
+		payload.filename_download ||= filename;
 
 		const payloadWithRequiredFields = {
 			...payload,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

-`filename_download` is respected if provided on upload

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

---

Fixes #25055
