### PR TITLE
Add keyboard shortcuts for overlays when editing items in the Visual Editor

### DIFF
--- a/.changeset/orange-books-heal.md
+++ b/.changeset/orange-books-heal.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added keyboard shortcuts for overlays when editing items in the Visual Editor

--- a/app/src/components/v-drawer.vue
+++ b/app/src/components/v-drawer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { i18n } from '@/lang';
+import { translateShortcut } from '@/utils/translate-shortcut';
 import HeaderBar from '@/views/private/components/header-bar.vue';
 import { computed, provide, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -63,7 +64,7 @@ const internalActive = computed({
 		<article class="v-drawer">
 			<v-button
 				v-if="cancelable"
-				v-tooltip.bottom="t('cancel')"
+				v-tooltip.bottom="`${t('cancel')} (${translateShortcut(['esc'])})`"
 				class="cancel"
 				icon
 				rounded

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch, nextTick, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useEventListener } from '@vueuse/core';
 import { useCollection } from '@directus/composables';
@@ -91,6 +91,8 @@ function useItemWithEdits() {
 	const itemRoute = computed(getContentRoute);
 	const notificationsStore = useNotificationsStore();
 	const { info: collectionInfo } = useCollection(collection);
+
+	const editingLayerEl = useTemplateRef<HTMLElement>('editing-layer');
 
 	watch(edits, (newEdits) => {
 		const hasEdits = Object.keys(newEdits)?.length;
@@ -204,13 +206,32 @@ function useItemWithEdits() {
 		const success = setEditConfigData(data);
 		if (!success) return;
 		await nextTick();
+
+		// `setFocusTemporarily()` makes sure that after clicking an edit button inside the iframe, the :focus moves to the Studio module, so the shortcuts work as expected.
+		setFocusTemporarily();
+
 		editOverlayActive.value = true;
+	}
+
+	async function setFocusTemporarily() {
+		if (!editingLayerEl.value) return;
+
+		editingLayerEl.value.setAttribute('tabindex', '0');
+		editingLayerEl.value.focus();
+
+		await nextTick();
+		editingLayerEl.value.removeAttribute('tabindex');
 	}
 }
 </script>
 
 <template>
-	<div class="editing-layer" :class="{ editing: editOverlayActive }" @click="editOverlayActive = false">
+	<div
+		ref="editing-layer"
+		class="editing-layer"
+		:class="{ editing: editOverlayActive }"
+		@click="editOverlayActive = false"
+	>
 		<overlay-item
 			v-if="collection"
 			v-model:active="editOverlayActive"
@@ -219,6 +240,7 @@ function useItemWithEdits() {
 			:primary-key
 			:selected-fields="fields"
 			:edits="edits"
+			shortcuts
 			@input="(value: any) => (edits = value)"
 		>
 			<template #popover-activator>

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -2,11 +2,13 @@
 import api from '@/api';
 import { useEditsGuard } from '@/composables/use-edits-guard';
 import { usePermissions } from '@/composables/use-permissions';
+import { useShortcut } from '@/composables/use-shortcut';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useNestedValidation } from '@/composables/use-nested-validation';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
+import { translateShortcut } from '@/utils/translate-shortcut';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
 import { useCollection } from '@directus/composables';
@@ -36,6 +38,7 @@ export interface OverlayItemProps {
 	circularField?: string | null;
 	junctionFieldLocation?: string;
 	selectedFields?: string[] | null;
+	shortcuts?: boolean;
 }
 
 export interface OverlayItemEmits {
@@ -66,7 +69,7 @@ const { internalActive } = useActiveState();
 const { junctionFieldInfo, relatedCollection, relatedCollectionInfo, relatedPrimaryKeyField } = useRelation();
 
 const { internalEdits, loading, initialValues, refresh } = useItem();
-const { save, cancel, overlayActive } = useActions();
+const { save, cancel, overlayActive, getTooltip } = useActions();
 
 const { collection, primaryKey, relatedPrimaryKey } = toRefs(props);
 
@@ -382,7 +385,37 @@ function useActions() {
 		},
 	});
 
-	return { save, cancel, overlayActive };
+	useShortcut('meta+s', (_event, cancelNext) => {
+		if (!props.shortcuts || !internalActive.value) return;
+
+		save();
+		cancelNext();
+	});
+
+	useShortcut('escape', (_event, cancelNext) => {
+		// Note that drawer and modal have an existing shortcut for canceling with the Escape key.
+		if (props.overlay !== 'popover' || !props.shortcuts || !internalActive.value) return;
+
+		cancel();
+		cancelNext();
+	});
+
+	return { save, cancel, overlayActive, getTooltip };
+
+	function getTooltip(shortcutType: 'save' | 'cancel', label: string | null = null) {
+		let shortcut = null;
+
+		if (props.shortcuts) {
+			if (shortcutType === 'save') shortcut = translateShortcut(['meta', 's']);
+			else shortcut = translateShortcut(['esc']);
+		}
+
+		if (label && shortcut) return `${label} (${shortcut})`;
+		if (label) return label;
+		if (shortcut) return shortcut;
+
+		return null;
+	}
 
 	function save() {
 		const editsToValidate = props.junctionField ? internalEdits.value[props.junctionField] : internalEdits.value;
@@ -455,7 +488,7 @@ function useActions() {
 		<template #actions>
 			<slot name="actions" />
 
-			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!isSavable" @click="save">
+			<v-button v-tooltip.bottom="getTooltip('save', t('save'))" icon rounded :disabled="!isSavable" @click="save">
 				<v-icon name="check" />
 			</v-button>
 		</template>
@@ -482,8 +515,8 @@ function useActions() {
 
 			<v-card-actions>
 				<slot name="actions" />
-				<v-button secondary @click="cancel">{{ t('cancel') }}</v-button>
-				<v-button :disabled="!isSavable" @click="save">{{ t('save') }}</v-button>
+				<v-button v-tooltip="getTooltip('cancel')" secondary @click="cancel">{{ t('cancel') }}</v-button>
+				<v-button v-tooltip="getTooltip('save')" :disabled="!isSavable" @click="save">{{ t('save') }}</v-button>
 			</v-card-actions>
 		</v-card>
 	</v-dialog>
@@ -506,11 +539,11 @@ function useActions() {
 			<div class="popover-actions-inner">
 				<slot name="actions" />
 
-				<v-button v-tooltip="t('cancel')" x-small rounded icon secondary @click="cancel">
+				<v-button v-tooltip="getTooltip('cancel', t('cancel'))" x-small rounded icon secondary @click="cancel">
 					<v-icon small name="close" outline />
 				</v-button>
 
-				<v-button v-tooltip="t('save')" x-small rounded icon :disabled="!isSavable" @click="save">
+				<v-button v-tooltip="getTooltip('save', t('save'))" x-small rounded icon :disabled="!isSavable" @click="save">
 					<v-icon small name="check" outline />
 				</v-button>
 			</div>


### PR DESCRIPTION
## Scope

What's changed:

- Added keyboard shortcuts for overlays when editing items in the Visual Editor
- Added shortcuts to tooltips

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—
