### PR TITLE
Ensure primary key field is auto-injected when absent from the fields array

### DIFF
--- a/.changeset/famous-turtles-bow.md
+++ b/.changeset/famous-turtles-bow.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed primary key field was not auto injected when not present in fields array

--- a/.changeset/famous-turtles-bow.md
+++ b/.changeset/famous-turtles-bow.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed primary key field was not auto injected when not present in fields array
+Ensured primary key field is auto-injected when absent from the fields array

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -94,25 +94,30 @@ export class CollectionsService {
 						throw new InvalidPayloadError({ reason: `"fields" must be an array` });
 					}
 
-					// Directus heavily relies on the primary key of a collection, so we have to make sure that
-					// every collection that is created has a primary key. If no primary key field is created
-					// while making the collection, we default to an auto incremented id named `id`
+					/**
+					 * Directus heavily relies on the primary key of a collection, so we have to make sure that
+					 * every collection that is created has a primary key. If no primary key field is created
+					 * while making the collection, we default to an auto incremented id named `id`
+					 */
+
+					const injectedPrimaryKeyField: RawField = {
+						field: 'id',
+						type: 'integer',
+						meta: {
+							hidden: true,
+							interface: 'numeric',
+							readonly: true,
+						},
+						schema: {
+							is_primary_key: true,
+							has_auto_increment: true,
+						},
+					};
+
 					if (!payload.fields || payload.fields.length === 0) {
-						payload.fields = [
-							{
-								field: 'id',
-								type: 'integer',
-								meta: {
-									hidden: true,
-									interface: 'numeric',
-									readonly: true,
-								},
-								schema: {
-									is_primary_key: true,
-									has_auto_increment: true,
-								},
-							},
-						];
+						payload.fields = [injectedPrimaryKeyField];
+					} else if (payload.fields.some((f) => f.schema?.is_primary_key === true) === false) {
+						payload.fields = [injectedPrimaryKeyField, ...payload.fields];
 					}
 
 					// Ensure that every field meta has the field/collection fields filled correctly

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -116,7 +116,7 @@ export class CollectionsService {
 
 					if (!payload.fields || payload.fields.length === 0) {
 						payload.fields = [injectedPrimaryKeyField];
-					} else if (payload.fields.some((f) => f.schema?.is_primary_key === true) === false) {
+					} else if (!payload.fields.some((f) => f.schema?.is_primary_key === true)) {
 						payload.fields = [injectedPrimaryKeyField, ...payload.fields];
 					}
 

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -199,6 +199,171 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 				});
 			});
 
+			describe('Creates a new collection without any field', () => {
+				TEST_USERS.forEach((userKey) => {
+					describe(USER[userKey].NAME, () => {
+						it.each(vendors)('%s', async (vendor) => {
+							// Setup
+							const db = databases.get(vendor)!;
+							currentVendor = vendor;
+
+							// Action
+							const response = await request(getUrl(vendor))
+								.post('/collections')
+								.send({ collection: TEST_COLLECTION_NAME, meta: {}, schema: {} })
+								.set('Authorization', `Bearer ${USER[userKey].TOKEN}`);
+
+							// Assert
+							if (userKey === USER.ADMIN.KEY) {
+								expect(response.statusCode).toBe(200);
+
+								expect(response.body.data).toEqual({
+									collection: TEST_COLLECTION_NAME,
+									meta: expect.objectContaining({
+										collection: TEST_COLLECTION_NAME,
+									}),
+									schema: expect.objectContaining({
+										name: TEST_COLLECTION_NAME,
+									}),
+								});
+
+								expect(await db.schema.hasTable(TEST_COLLECTION_NAME)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, 'id')).toBe(true);
+							} else {
+								expect(response.statusCode).toBe(403);
+							}
+						});
+					});
+				});
+			});
+
+			describe('Creates a new collection auto creates primary key', () => {
+				TEST_USERS.forEach((userKey) => {
+					describe(USER[userKey].NAME, () => {
+						it.each(vendors)('%s', async (vendor) => {
+							// Setup
+							const db = databases.get(vendor)!;
+							currentVendor = vendor;
+							const fieldName = `name_${pkType}`;
+
+							const fields = [
+								{
+									field: fieldName,
+									type: 'string',
+									meta: { interface: 'input', special: null },
+								},
+							];
+
+							// Action
+							const response = await request(getUrl(vendor))
+								.post('/collections')
+								.send({ collection: TEST_COLLECTION_NAME, meta: {}, schema: {}, fields })
+								.set('Authorization', `Bearer ${USER[userKey].TOKEN}`);
+
+							// Assert
+							if (userKey === USER.ADMIN.KEY) {
+								expect(response.statusCode).toBe(200);
+
+								expect(response.body.data).toEqual({
+									collection: TEST_COLLECTION_NAME,
+									meta: expect.objectContaining({
+										collection: TEST_COLLECTION_NAME,
+									}),
+									schema: expect.objectContaining({
+										name: TEST_COLLECTION_NAME,
+									}),
+								});
+
+								expect(await db.schema.hasTable(TEST_COLLECTION_NAME)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, fieldName)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, 'id')).toBe(true);
+							} else {
+								expect(response.statusCode).toBe(403);
+							}
+						});
+					});
+				});
+			});
+
+			describe('Creates a new collection with fields including primary key', () => {
+				TEST_USERS.forEach((userKey) => {
+					describe(USER[userKey].NAME, () => {
+						it.each(vendors)('%s', async (vendor) => {
+							// Setup
+							const db = databases.get(vendor)!;
+							currentVendor = vendor;
+							const pkName = `id_${pkType}`;
+							const fieldName = `name_${pkType}`;
+
+							const fields: any = [
+								{
+									field: fieldName,
+									type: 'string',
+									meta: { interface: 'input', special: null },
+								},
+							];
+
+							switch (pkType) {
+								case 'uuid':
+									fields.push({
+										field: pkName,
+										type: 'uuid',
+										meta: { hidden: true, readonly: true, interface: 'input', special: ['uuid'] },
+										schema: { is_primary_key: true, length: 36, has_auto_increment: false },
+									});
+
+									break;
+								case 'string':
+									fields.push({
+										field: pkName,
+										type: 'string',
+										meta: { hidden: false, readonly: false, interface: 'input' },
+										schema: { is_primary_key: true, length: 255, has_auto_increment: false },
+									});
+
+									break;
+								case 'integer':
+									fields.push({
+										field: pkName,
+										type: 'integer',
+										meta: { hidden: true, interface: 'input', readonly: true },
+										schema: { is_primary_key: true, has_auto_increment: true },
+									});
+
+									break;
+							}
+
+							// Action
+							const response = await request(getUrl(vendor))
+								.post('/collections')
+								.send({ collection: TEST_COLLECTION_NAME, meta: {}, schema: {}, fields })
+								.set('Authorization', `Bearer ${USER[userKey].TOKEN}`);
+
+							// Assert
+							if (userKey === USER.ADMIN.KEY) {
+								expect(response.statusCode).toBe(200);
+
+								expect(response.body.data).toEqual({
+									collection: TEST_COLLECTION_NAME,
+									meta: expect.objectContaining({
+										collection: TEST_COLLECTION_NAME,
+									}),
+									schema: expect.objectContaining({
+										name: TEST_COLLECTION_NAME,
+									}),
+								});
+
+								expect(await db.schema.hasTable(TEST_COLLECTION_NAME)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, fieldName)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, pkName)).toBe(true);
+							} else {
+								expect(response.statusCode).toBe(403);
+							}
+						});
+					});
+				});
+			});
+
 			describe('Creates a new folder', () => {
 				TEST_USERS.forEach((userKey) => {
 					describe(USER[userKey].NAME, () => {

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -237,6 +237,45 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 				});
 			});
 
+			describe('Creates a new collection with auto created primary key for empty fields array', () => {
+				TEST_USERS.forEach((userKey) => {
+					describe(USER[userKey].NAME, () => {
+						it.each(vendors)('%s', async (vendor) => {
+							// Setup
+							const db = databases.get(vendor)!;
+							currentVendor = vendor;
+							const fields: any = [];
+
+							// Action
+							const response = await request(getUrl(vendor))
+								.post('/collections')
+								.send({ collection: TEST_COLLECTION_NAME, meta: {}, schema: {}, fields })
+								.set('Authorization', `Bearer ${USER[userKey].TOKEN}`);
+
+							// Assert
+							if (userKey === USER.ADMIN.KEY) {
+								expect(response.statusCode).toBe(200);
+
+								expect(response.body.data).toEqual({
+									collection: TEST_COLLECTION_NAME,
+									meta: expect.objectContaining({
+										collection: TEST_COLLECTION_NAME,
+									}),
+									schema: expect.objectContaining({
+										name: TEST_COLLECTION_NAME,
+									}),
+								});
+
+								expect(await db.schema.hasTable(TEST_COLLECTION_NAME)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, 'id')).toBe(true);
+							} else {
+								expect(response.statusCode).toBe(403);
+							}
+						});
+					});
+				});
+			});
+
 			describe('Creates a new collection with auto created primary key when no primary key is in the fields array', () => {
 				TEST_USERS.forEach((userKey) => {
 					describe(USER[userKey].NAME, () => {

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -395,6 +395,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 								expect(await db.schema.hasTable(TEST_COLLECTION_NAME)).toBe(true);
 								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, fieldName)).toBe(true);
 								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, pkName)).toBe(true);
+								expect(await db.schema.hasColumn(TEST_COLLECTION_NAME, 'id')).toBe(false);
 							} else {
 								expect(response.statusCode).toBe(403);
 							}

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -630,7 +630,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 
 				// Assert
 				expect(response.statusCode).toBe(200);
-				expect(response.body.data.length).toBe(13);
+				expect(response.body.data.length).toBe(14);
 
 				for (const log of response.body.data) {
 					expect(log.value).toBe('1');

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -590,7 +590,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 
 				// Assert
 				expect(response.statusCode).toBe(200);
-				expect(response.body.data.length).toBe(10);
+				expect(response.body.data.length).toBe(13);
 
 				for (const log of response.body.data) {
 					expect(log.value).toBe('1');

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -199,7 +199,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 				});
 			});
 
-			describe('Creates a new collection without any field', () => {
+			describe('Creates a new collection with auto created primary key when no fields is present in schema', () => {
 				TEST_USERS.forEach((userKey) => {
 					describe(USER[userKey].NAME, () => {
 						it.each(vendors)('%s', async (vendor) => {
@@ -237,7 +237,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 				});
 			});
 
-			describe('Creates a new collection auto creates primary key', () => {
+			describe('Creates a new collection with auto created primary key when no primary key is in the fields array', () => {
 				TEST_USERS.forEach((userKey) => {
 					describe(USER[userKey].NAME, () => {
 						it.each(vendors)('%s', async (vendor) => {
@@ -285,7 +285,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 				});
 			});
 
-			describe('Creates a new collection with fields including primary key', () => {
+			describe('Creates a new collection with specified primary key in fields array', () => {
 				TEST_USERS.forEach((userKey) => {
 					describe(USER[userKey].NAME, () => {
 						it.each(vendors)('%s', async (vendor) => {


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- The primary key is now auto injected if a fields array is provided that does not contain the `set_primary_key:true` property

## Potential Risks / Drawbacks

- Should be none 🤔 

## Review Notes / Questions

- N/A

---

Fixes #24956

--- 

### Tested
- [x] Expect a primary key field to be automatically injected when creating a collection, if the `fields` array does not include `is_primary_key: true`
- [x] Expect a primary key field to NOT be automatically injected when creating a collection, if the `fields` array includes a field with `is_primary_key: true` 
- [x] Expect creating an empty collection (i.e. folder) should work as previous
- [x] Expect Bring Your Own Database (BYOD) table configuration to work as previous
- [x] Expect a primary key field to be automatically injected when creating a collection, if the `fields` array is empty or not present

