### PR TITLE
Added an `Error on Reject` option to webhook flows

### DIFF
--- a/.changeset/evil-suns-talk.md
+++ b/.changeset/evil-suns-talk.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Added option to error in webhook flows

--- a/.changeset/evil-suns-talk.md
+++ b/.changeset/evil-suns-talk.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Added option to error in webhook flows
+Added an `Error on Reject` option to webhook flows

--- a/.changeset/red-pets-watch.md
+++ b/.changeset/red-pets-watch.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': major
+---
+
+Properly error out on webhook flow

--- a/.changeset/red-pets-watch.md
+++ b/.changeset/red-pets-watch.md
@@ -1,5 +1,0 @@
----
-'@directus/api': major
----
-
-Properly error out on webhook flow

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -401,6 +401,10 @@ class FlowManager {
 			throw keyedData[LAST_KEY];
 		}
 
+		if (flow.trigger === 'webhook' && lastOperationStatus === 'reject') {
+			throw keyedData[LAST_KEY]
+		}
+
 		if (flow.options['return'] === '$all') {
 			return keyedData;
 		} else if (flow.options['return']) {

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -402,7 +402,7 @@ class FlowManager {
 		}
 
 		if (flow.trigger === 'webhook' && lastOperationStatus === 'reject') {
-			throw keyedData[LAST_KEY]
+			throw keyedData[LAST_KEY];
 		}
 
 		if (flow.options['return'] === '$all') {

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -389,7 +389,7 @@ class FlowManager {
 		}
 
 		if (
-			flow.trigger === 'manual' &&
+			(flow.trigger === 'manual' || flow.trigger === 'webhook') &&
 			flow.options['async'] !== true &&
 			flow.options['error_on_reject'] === true &&
 			lastOperationStatus === 'reject'
@@ -398,10 +398,6 @@ class FlowManager {
 		}
 
 		if (flow.trigger === 'event' && flow.options['type'] === 'filter' && lastOperationStatus === 'reject') {
-			throw keyedData[LAST_KEY];
-		}
-
-		if (flow.trigger === 'webhook' && lastOperationStatus === 'reject') {
 			throw keyedData[LAST_KEY];
 		}
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2405,6 +2405,7 @@ triggers:
     filter: 'Filter (Blocking)'
   webhook:
     name: Webhook
+    error_on_reject: Error on Reject
     description: Triggers on an incoming HTTP request
     method: Method
     async: Asynchronous
@@ -2419,7 +2420,6 @@ triggers:
   manual:
     name: Manual
     description: Triggers on manual run within selected collection(s)
-    error_on_reject: Error on Reject
     collection_and_item: Collection & Item Pages
     collection_only: Collection Page Only
     item_only: Item Page Only

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2406,7 +2406,6 @@ triggers:
   webhook:
     name: Webhook
     description: Triggers on an incoming HTTP request
-    error_on_reject: Error on Reject
     method: Method
     async: Asynchronous
   operation:

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2406,6 +2406,7 @@ triggers:
   webhook:
     name: Webhook
     description: Triggers on an incoming HTTP request
+    error_on_reject: Error on Reject
     method: Method
     async: Asynchronous
   operation:

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -229,7 +229,7 @@ export function getTriggers() {
 				},
 				{
 					field: 'error_on_reject',
-					name: t('triggers.manual.error_on_reject'),
+					name: t('triggers.webhook.error_on_reject'),
 					type: 'boolean',
 					meta: {
 						width: 'half' as Width,
@@ -403,7 +403,7 @@ export function getTriggers() {
 				},
 				{
 					field: 'error_on_reject',
-					name: t('triggers.manual.error_on_reject'),
+					name: t('triggers.webhook.error_on_reject'),
 					type: 'boolean',
 					meta: {
 						width: 'half' as Width,

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -229,7 +229,7 @@ export function getTriggers() {
 				},
 				{
 					field: 'error_on_reject',
-					name: t('triggers.webhook.error_on_reject'),
+					name: t('triggers.manual.error_on_reject'),
 					type: 'boolean',
 					meta: {
 						width: 'half' as Width,

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -371,7 +371,7 @@ export function getTriggers() {
 
 				return labels;
 			},
-			options: [
+			options: ({ async }) => [
 				{
 					field: 'collections',
 					name: t('collections'),
@@ -399,16 +399,7 @@ export function getTriggers() {
 					meta: {
 						width: 'half' as Width,
 						interface: 'toggle',
-						conditions: [
-							{
-								rule: {
-									async: {
-										_eq: true,
-									},
-								},
-								hidden: true,
-							},
-						],
+						hidden: async,
 					},
 					schema: {
 						default_value: false,

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -228,28 +228,6 @@ export function getTriggers() {
 					},
 				},
 				{
-					field: 'error_on_reject',
-					name: t('triggers.webhook.error_on_reject'),
-					type: 'boolean',
-					meta: {
-						width: 'half' as Width,
-						interface: 'toggle',
-						conditions: [
-							{
-								rule: {
-									async: {
-										_eq: true,
-									},
-								},
-								hidden: true,
-							},
-						],
-					},
-					schema: {
-						default_value: false,
-					},
-				},
-				{
 					field: 'async',
 					name: t('triggers.webhook.async'),
 					type: 'boolean',
@@ -257,6 +235,19 @@ export function getTriggers() {
 						width: 'half',
 						interface: 'toggle',
 						required: true,
+					},
+					schema: {
+						default_value: false,
+					},
+				},
+				{
+					field: 'error_on_reject',
+					name: t('triggers.webhook.error_on_reject'),
+					type: 'boolean',
+					meta: {
+						width: 'half' as Width,
+						interface: 'toggle',
+						hidden: async,
 					},
 					schema: {
 						default_value: false,

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -228,6 +228,28 @@ export function getTriggers() {
 					},
 				},
 				{
+					field: 'error_on_reject',
+					name: t('triggers.webhook.error_on_reject'),
+					type: 'boolean',
+					meta: {
+						width: 'half' as Width,
+						interface: 'toggle',
+						conditions: [
+							{
+								rule: {
+									async: {
+										_eq: true,
+									},
+								},
+								hidden: true,
+							},
+						],
+					},
+					schema: {
+						default_value: false,
+					},
+				},
+				{
 					field: 'async',
 					name: t('triggers.webhook.async'),
 					type: 'boolean',


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- You can now opt in to erroring out on a webhook if the reject path data

## Reproduction

1. Create a flow that has a run-script operation
2. Make the run-script always throw an error
3. See that it returns an empty object `{}` instead of returning an error or any other data.

## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- The error get's properly obfuscated for non admin users
