### PR TITLE
Fix auto PK injection not accounting for `has_auto_increment` being creating a PK

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -116,7 +116,9 @@ export class CollectionsService {
 
 					if (!payload.fields || payload.fields.length === 0) {
 						payload.fields = [injectedPrimaryKeyField];
-					} else if (!payload.fields.some((f) => f.schema?.is_primary_key === true)) {
+					} else if (
+						!payload.fields.some((f) => f.schema?.is_primary_key === true || f.schema?.has_auto_increment === true)
+					) {
 						payload.fields = [injectedPrimaryKeyField, ...payload.fields];
 					}
 

--- a/tests/blackbox/tests/db/routes/collections/crud.test.ts
+++ b/tests/blackbox/tests/db/routes/collections/crud.test.ts
@@ -366,7 +366,7 @@ describe.each(PRIMARY_KEY_TYPES)('/collections', (pkType) => {
 										field: pkName,
 										type: 'integer',
 										meta: { hidden: true, interface: 'input', readonly: true },
-										schema: { is_primary_key: true, has_auto_increment: true },
+										schema: { is_primary_key: false, has_auto_increment: true },
 									});
 
 									break;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- A field with `has_auto_increment:true` is considered a PK as well and as such we will not attempt to auto inject one when a collection is created that has a field with the setup

## Potential Risks / Drawbacks

- None
## Review Notes / Questions

- N/A

---

Follow-up of #25077
