### PR TITLE
Add confirmation dialog when closing overlays with edits

### DIFF
--- a/.changeset/hungry-rules-end.md
+++ b/.changeset/hungry-rules-end.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added confirmation dialog when closing overlays with edits in Visual Editor

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -210,7 +210,7 @@ function useItemWithEdits() {
 </script>
 
 <template>
-	<div class="editing-layer" :class="{ editing: editOverlayActive }" @click="editOverlayActive = false">
+	<div class="editing-layer" :class="{ editing: editOverlayActive }">
 		<overlay-item
 			v-if="collection"
 			v-model:active="editOverlayActive"
@@ -219,6 +219,7 @@ function useItemWithEdits() {
 			:primary-key
 			:selected-fields="fields"
 			:edits="edits"
+			prevent-cancel-with-edits
 			@input="(value: any) => (edits = value)"
 		>
 			<template #popover-activator>

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -36,6 +36,7 @@ export interface OverlayItemProps {
 	circularField?: string | null;
 	junctionFieldLocation?: string;
 	selectedFields?: string[] | null;
+	preventCancelWithEdits?: boolean;
 }
 
 export interface OverlayItemEmits {
@@ -84,6 +85,8 @@ function discardAndLeave() {
 	confirmLeave.value = false;
 	router.push(leaveTo.value);
 }
+
+const { confirmCancel, discardAndCancel, confirmCancellation } = useCancelGuard();
 
 const title = computed(() => {
 	const collection = relatedCollectionInfo?.value || collectionInfo.value!;
@@ -424,10 +427,37 @@ function useActions() {
 	}
 
 	function cancel() {
-		validationErrors.value = [];
-		internalActive.value = false;
-		internalEdits.value = {};
+		if (confirmCancellation.value) {
+			confirmCancel.value = true;
+			return;
+		}
+
+		discardAndCancel();
 	}
+}
+
+function useCancelGuard() {
+	const confirmCancel = ref(false);
+	const confirmCancellation = computed(() => props.preventCancelWithEdits && hasEdits.value);
+
+	return {
+		confirmCancel,
+		discardAndCancel,
+		confirmCancellation,
+	};
+
+	function discardAndCancel() {
+		validationErrors.value = [];
+		internalEdits.value = {};
+		internalActive.value = false;
+		confirmCancel.value = false;
+	}
+}
+
+function popoverClickOutsideMiddleware(e: Event) {
+	const dialogs = document.getElementById('dialog-outlet');
+	if (!dialogs) return true;
+	return !dialogs.contains(e.target as Node);
 }
 </script>
 
@@ -504,25 +534,34 @@ function useActions() {
 			<slot name="popover-activator" v-bind="activatorProps" />
 		</template>
 
-		<div class="popover-actions">
-			<div class="popover-actions-inner">
-				<slot name="actions" />
+		<div
+			v-click-outside="{
+				handler: cancel,
+				middleware: popoverClickOutsideMiddleware,
+				disabled: !preventCancelWithEdits,
+				events: ['click'],
+			}"
+		>
+			<div class="popover-actions">
+				<div class="popover-actions-inner">
+					<slot name="actions" />
 
-				<v-button v-tooltip="t('cancel')" x-small rounded icon secondary @click="cancel">
-					<v-icon small name="close" outline />
-				</v-button>
+					<v-button v-tooltip="t('cancel')" x-small rounded icon secondary @click="cancel">
+						<v-icon small name="close" outline />
+					</v-button>
 
-				<v-button v-tooltip="t('save')" x-small rounded icon :disabled="!isSavable" @click="save">
-					<v-icon small name="check" outline />
-				</v-button>
+					<v-button v-tooltip="t('save')" x-small rounded icon :disabled="!isSavable" @click="save">
+						<v-icon small name="check" outline />
+					</v-button>
+				</div>
 			</div>
-		</div>
 
-		<overlay-item-content
-			v-model:internal-edits="internalEdits"
-			v-bind="overlayItemContentProps"
-			class="popover-item-content"
-		/>
+			<overlay-item-content
+				v-model:internal-edits="internalEdits"
+				v-bind="overlayItemContentProps"
+				class="popover-item-content"
+			/>
+		</div>
 	</v-menu>
 
 	<v-dialog v-model="confirmLeave" @esc="confirmLeave = false">
@@ -534,6 +573,19 @@ function useActions() {
 					{{ t('discard_changes') }}
 				</v-button>
 				<v-button @click="confirmLeave = false">{{ t('keep_editing') }}</v-button>
+			</v-card-actions>
+		</v-card>
+	</v-dialog>
+
+	<v-dialog v-model="confirmCancel" @esc="confirmCancel = false">
+		<v-card>
+			<v-card-title>{{ t('discard_all_changes') }}</v-card-title>
+			<v-card-text>{{ t('discard_changes_copy') }}</v-card-text>
+			<v-card-actions>
+				<v-button secondary @click="discardAndCancel">
+					{{ t('discard_changes') }}
+				</v-button>
+				<v-button @click="confirmCancel = false">{{ t('keep_editing') }}</v-button>
 			</v-card-actions>
 		</v-card>
 	</v-dialog>


### PR DESCRIPTION
## Scope

What's changed:

- Added confirmation dialog when closing overlays with edits in Visual Editor

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—

---

Fixes #24814
