### PR TITLE
Fix chunked uploads

### DIFF
--- a/.changeset/fast-peaches-tan.md
+++ b/.changeset/fast-peaches-tan.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fix chunked uploads

--- a/app/src/utils/upload-file.ts
+++ b/app/src/utils/upload-file.ts
@@ -2,7 +2,7 @@ import api from '@/api';
 import { emitter, Events } from '@/events';
 import { i18n } from '@/lang';
 import { useServerStore } from '@/stores/server';
-import { getRootPath } from '@/utils/get-root-path';
+import { getPublicURL } from '@/utils/get-root-path';
 import { notify } from '@/utils/notify';
 import { DEFAULT_CHUNK_SIZE } from '@directus/constants';
 import type { File } from '@directus/types';
@@ -39,7 +39,7 @@ export async function uploadFile(
 
 		return new Promise((resolve, reject) => {
 			const upload = new Upload(file, {
-				endpoint: getRootPath() + `files/tus`,
+				endpoint: getPublicURL() + `files/tus`,
 				chunkSize: server.info.uploads?.chunkSize ?? DEFAULT_CHUNK_SIZE,
 				metadata: fileInfo as Record<string, string>,
 				// Allow user to re-upload of the same file

--- a/contributors.yml
+++ b/contributors.yml
@@ -211,3 +211,4 @@
 - ngluunhatson
 - jacobcons
 - danielBreitlauch
+- jshbrntt


### PR DESCRIPTION
The endpoint options of the [tus-js-client expects an absolute URL](https://github.com/tus/tus-js-client/blob/main/docs/api.md#tusdefaultoptions).

## Scope

What's changed:

- Using an absolute URL for the `endpoint` option of the `tus-js-client`, getting this using `getPublicURL` instead of `getRootPath`.

## Potential Risks / Drawbacks

- Not sure if it should be `getPublicURL() + getRootPath()`, if so these need to be combined and normalized otherwise it'll be `'http://directus.localhost:8055/' + '/'`, with two trailing slashes.

---

Fixes #25093
