### PR TITLE
Fix bug where action buttons didn't appear in the drawer

### DIFF
--- a/.changeset/vast-zebras-rest.md
+++ b/.changeset/vast-zebras-rest.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug where action buttons didn't appear in the drawer.

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -11,5 +11,9 @@ defineEmits<OverlayItemEmits>();
 		overlay="drawer"
 		@update:active="$emit('update:active', $event)"
 		@input="$emit('input', $event)"
-	/>
+	>
+		<template #actions>
+			<slot name="actions" />
+		</template>
+	</overlay-item>
 </template>


### PR DESCRIPTION
## Scope

What's changed:

- Added actions slot to drawer-item component

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—

---

Fixes #25081
