### PR TITLE
Fix pressing tab on raw editor

### DIFF
--- a/.changeset/tricky-things-lie.md
+++ b/.changeset/tricky-things-lie.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed pressing tab on raw editor

--- a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
+++ b/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
@@ -61,7 +61,7 @@ onMounted(async () => {
 			lineWiseCopyCut: false,
 			theme: 'default',
 			scrollbarStyle: isMultiLine.value ? 'native' : 'null',
-			extraKeys: { Ctrl: 'autocomplete' },
+			extraKeys: { Ctrl: 'autocomplete', Tab: false, "Shift-Tab": false },
 			cursorBlinkRate: props.disabled ? -1 : 530,
 			placeholder: props.placeholder !== undefined ? props.placeholder : t('raw_editor_placeholder'),
 			readOnly: readOnly.value,

--- a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
+++ b/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
@@ -61,7 +61,7 @@ onMounted(async () => {
 			lineWiseCopyCut: false,
 			theme: 'default',
 			scrollbarStyle: isMultiLine.value ? 'native' : 'null',
-			extraKeys: { Ctrl: 'autocomplete', Tab: false, "Shift-Tab": false },
+			extraKeys: { Ctrl: 'autocomplete', Tab: false, 'Shift-Tab': false },
 			cursorBlinkRate: props.disabled ? -1 : 530,
 			placeholder: props.placeholder !== undefined ? props.placeholder : t('raw_editor_placeholder'),
 			readOnly: readOnly.value,


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Pressing tab now focuses the next field instead of inserting a `\t` into the raw editor.

## Potential Risks / Drawbacks

- It's now only possible to insert these characters when copy&pasting

---

Fixes #25017 
