### PR TITLE
Remove options from flow logs

### DIFF
--- a/.changeset/mean-sheep-type.md
+++ b/.changeset/mean-sheep-type.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Fixed flows to store trigger options

--- a/.changeset/mean-sheep-type.md
+++ b/.changeset/mean-sheep-type.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Fixed flows to store trigger options
+Removed displaying trigger options in flow logs.

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -370,6 +370,7 @@ class FlowManager {
 					item: flow.id,
 					data: {
 						steps: steps.map((step) => redactObject(step, { values: this.envs }, getRedactedString)),
+						options: flow.options,
 						data: redactObject(
 							keyedData,
 							{

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -370,7 +370,6 @@ class FlowManager {
 					item: flow.id,
 					data: {
 						steps: steps.map((step) => redactObject(step, { values: this.envs }, getRedactedString)),
-						options: flow.options,
 						data: redactObject(
 							keyedData,
 							{

--- a/app/src/modules/settings/routes/flows/components/logs-drawer.vue
+++ b/app/src/modules/settings/routes/flows/components/logs-drawer.vue
@@ -27,12 +27,12 @@ const { revision, loading } = useRevision(revisionId);
 const triggerData = computed(() => {
 	if (!unref(revision)?.data) return { trigger: null, accountability: null, options: null };
 
-	const { data } = unref(revision)?.data as any;
+	const { data, options } = unref(revision)?.data as any;
 
 	return {
 		trigger: data.$trigger,
 		accountability: data.$accountability,
-		options: props.flow.options,
+		options: options ?? props.flow.options,
 	};
 });
 

--- a/app/src/modules/settings/routes/flows/components/logs-drawer.vue
+++ b/app/src/modules/settings/routes/flows/components/logs-drawer.vue
@@ -27,12 +27,11 @@ const { revision, loading } = useRevision(revisionId);
 const triggerData = computed(() => {
 	if (!unref(revision)?.data) return { trigger: null, accountability: null, options: null };
 
-	const { data, options } = unref(revision)?.data as any;
+	const { data } = unref(revision)?.data as any;
 
 	return {
 		trigger: data.$trigger,
 		accountability: data.$accountability,
-		options: options ?? props.flow.options,
 	};
 });
 
@@ -92,10 +91,6 @@ const steps = computed(() => {
 					</div>
 
 					<div class="inset">
-						<v-detail v-if="triggerData.options" :label="t('options')">
-							<pre class="json selectable">{{ triggerData.options }}</pre>
-						</v-detail>
-
 						<v-detail v-if="triggerData.trigger" :label="t('payload')">
 							<pre class="json selectable">{{ triggerData.trigger }}</pre>
 						</v-detail>


### PR DESCRIPTION
## Scope

What's changed:

- Remove duplicate display of trigger options in flows.

## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- It doesn't make sense to display options in logs when they have nothing to do with logs in the first place.

---

Fixes #22026
