### PR TITLE
Fix reactivity in the translation interface

### DIFF
--- a/.changeset/chubby-lines-fold.md
+++ b/.changeset/chubby-lines-fold.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the reactivity of props in the translation interface to ensure that conditions are applied correctly

--- a/app/src/interfaces/translations/index.ts
+++ b/app/src/interfaces/translations/index.ts
@@ -55,27 +55,6 @@ export default defineInterface({
 				},
 			},
 			{
-				field: 'defaultLanguage',
-				name: '$t:interfaces.translations.default_language',
-				meta: {
-					interface: 'input',
-					width: 'half',
-					options: {
-						placeholder: '$t:primary_key',
-					},
-					conditions: [
-						{
-							rule: {
-								userLanguage: {
-									_eq: true,
-								},
-							},
-							readonly: true,
-						},
-					],
-				},
-			},
-			{
 				field: 'userLanguage',
 				name: '$t:interfaces.translations.user_language',
 				type: 'string',
@@ -88,6 +67,17 @@ export default defineInterface({
 						label: '$t:interfaces.translations.enable',
 					},
 					width: 'half',
+				},
+			},
+			{
+				field: 'defaultLanguage',
+				name: '$t:interfaces.translations.default_language',
+				meta: {
+					interface: 'input',
+					width: 'half',
+					options: {
+						placeholder: '$t:primary_key',
+					},
 				},
 			},
 			{

--- a/app/src/interfaces/translations/index.ts
+++ b/app/src/interfaces/translations/index.ts
@@ -63,6 +63,16 @@ export default defineInterface({
 					options: {
 						placeholder: '$t:primary_key',
 					},
+					conditions: [
+						{
+							rule: {
+								userLanguage: {
+									_eq: true,
+								},
+							},
+							readonly: true,
+						},
+					],
 				},
 			},
 			{

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -72,17 +72,17 @@ function useSplitView() {
 		},
 	});
 
-watch(splitView, (splitViewEnabled) => {
-	if (splitViewEnabled && secondLang.value === firstLang.value) {
-		const lang = languageOptions.value;
-		const alternativeLang = lang.find((l) => l.value !== firstLang.value);
-		secondLang.value = alternativeLang?.value ?? lang[0]?.value;
-	}
-});
+	watch(splitView, (splitViewEnabled) => {
+		if (splitViewEnabled && secondLang.value === firstLang.value) {
+			const lang = languageOptions.value;
+			const alternativeLang = lang.find((l) => l.value !== firstLang.value);
+			secondLang.value = alternativeLang?.value ?? lang[0]?.value;
+		}
+	});
 
 	const { width } = useWindowSize();
-const splitViewAvailable = computed(() => width.value > 960 && languageOptions.value.length > 1);
-const splitViewEnabled = computed(() => splitViewAvailable.value && splitView.value);
+	const splitViewAvailable = computed(() => width.value > 960 && languageOptions.value.length > 1);
+	const splitViewEnabled = computed(() => splitViewAvailable.value && splitView.value);
 
 	return {
 		splitView,
@@ -285,7 +285,7 @@ function useLanguages() {
 			languages.value = await fetchAll<Record<string, any>[]>(
 				getEndpoint(relationInfo.value.relatedCollection.collection),
 				{
-				params: {
+					params: {
 						fields: fieldsToFetch.value,
 						sort:
 							relationInfo.value.relatedCollection.meta?.sort_field ??

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -56,12 +56,21 @@ const { t, locale } = useI18n();
 
 const fieldsStore = useFieldsStore();
 
-const { width } = useWindowSize();
-
 const { languageOptions, firstLang, secondLang, loading: languagesLoading } = useLanguages();
-const splitView = ref(props.defaultOpenSplitView);
-const firstLang = ref<string>();
-const secondLang = ref<string>();
+
+const { splitView, splitViewAvailable, splitViewEnabled } = useSplitView();
+
+function useSplitView() {
+	const selectedSplitView = ref<boolean>();
+
+	const splitView = computed({
+		get() {
+			return selectedSplitView.value ?? props.defaultOpenSplitView;
+		},
+		set(value) {
+			selectedSplitView.value = value;
+		},
+	});
 
 watch(splitView, (splitViewEnabled) => {
 	if (splitViewEnabled && secondLang.value === firstLang.value) {
@@ -71,8 +80,16 @@ watch(splitView, (splitViewEnabled) => {
 	}
 });
 
+	const { width } = useWindowSize();
 const splitViewAvailable = computed(() => width.value > 960 && languageOptions.value.length > 1);
 const splitViewEnabled = computed(() => splitViewAvailable.value && splitView.value);
+
+	return {
+		splitView,
+		splitViewAvailable,
+		splitViewEnabled,
+	};
+}
 
 const fields = computed(() => {
 	if (!relationInfo.value) return [];

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -50,7 +50,7 @@ const value = computed({
 	},
 });
 
-const { collection, field, primaryKey, defaultLanguage, userLanguage } = toRefs(props);
+const { collection, field, primaryKey } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 const { t, locale } = useI18n();
 
@@ -231,11 +231,11 @@ function useLanguages() {
 	const defaultLang = computed(() => {
 		const pkField = relationInfo.value?.relatedPrimaryKeyField.field ?? '';
 
-		const userLocale = userLanguage.value ? locale.value : defaultLanguage.value;
+		const userLocale = props.userLanguage ? locale.value : props.defaultLanguage;
 		const firstDefault = getDefaultLang(userLocale);
 		const firstLang = firstDefault?.[pkField] as string;
 
-		const defaultLocale = userLanguage.value ? defaultLanguage.value : null;
+		const defaultLocale = props.userLanguage ? props.defaultLanguage : null;
 		let secondDefault = getDefaultLang(defaultLocale);
 
 		if (!secondDefault || secondDefault[pkField] === firstLang) {


### PR DESCRIPTION
## Scope

Fixed the reactivity of props in the translation interface to ensure that conditions are applied correctly.

What's changed:

- refactor the way languages are fetched in translations component for improved reactivity and clarity
- refactor split view logic to improve clarity and reactivity
- use props directly instead of converting their properties to refs

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Test by applying conditions that change each interface setting of the translation interface.
- Note: If a condition sets the `Language Direction Field` to its default value (`direction`), the value does not apply when the condition is applied. This issue can’t be easily fixed without addressing this [issue](https://github.com/directus/directus/issues/24481) first. Update: the [related PR](https://github.com/directus/directus/pull/25119).

---

Fixes #24813
