### PR TITLE
Improve interface option overwriting through conditions

### DIFF
--- a/.changeset/stupid-vans-feel.md
+++ b/.changeset/stupid-vans-feel.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Improved interface option overwriting through conditions

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -6,7 +6,7 @@ import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fiel
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 import { useElementSize } from '@directus/composables';
 import { ContentVersion, Field, ValidationError } from '@directus/types';
-import { assign, cloneDeep, isEqual, isNil, omit } from 'lodash';
+import { assign, cloneDeep, isEqual, isEmpty, isNil, omit } from 'lodash';
 import { computed, onBeforeUpdate, provide, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { MenuOptions } from './form-field-menu.vue';
@@ -293,6 +293,16 @@ function unsetValue(field: TFormField | undefined) {
 
 function useBatch() {
 	const batchActiveFields = ref<string[]>([]);
+
+	watch(
+		() => props.modelValue,
+		(newModelValue) => {
+			if (!props.batchMode || isEmpty(newModelValue) || !isEmpty(batchActiveFields.value)) return;
+
+			batchActiveFields.value = Object.keys(newModelValue);
+		},
+		{ immediate: true },
+	);
 
 	return { batchActiveFields, toggleBatchField };
 

--- a/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
+++ b/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
 	interface?: string;
 	collection?: string;
 	disabled?: boolean;
+	isConditionOptions?: boolean;
 	context?: () => ExtensionOptionsContext;
 }>();
 
@@ -101,6 +102,7 @@ const optionsFields = computed(() => {
 			:fields="optionsFields"
 			:disabled="disabled"
 			primary-key="+"
+			:batch-mode="isConditionOptions"
 		/>
 
 		<component

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { useExtension } from '@/composables/use-extension';
 import { DeepPartial, Field } from '@directus/types';
-import { isVueComponent } from '@directus/utils';
 import { storeToRefs } from 'pinia';
-import { computed, unref } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
 
@@ -13,27 +11,15 @@ const fieldDetailStore = useFieldDetailStore();
 
 const { loading, field, collection } = storeToRefs(fieldDetailStore);
 
-const conditions = syncFieldDetailStoreProperty('field.meta.conditions');
 const interfaceId = computed(() => field.value.meta?.interface ?? null);
+const conditions = syncFieldDetailStoreProperty('field.meta.conditions');
 
 const conditionsSync = computed({
 	get() {
 		return { conditions: conditions.value };
 	},
 	set(value) {
-		if (!value.conditions) {
-			conditions.value = value.conditions;
-			return;
-		}
-
-		const conditionsWithDefaults = value.conditions.map((condition: any) => {
-			const conditionOptions = condition.options ?? {};
-			const defaultValues = unref(optionDefaults);
-			condition.options = { ...defaultValues, ...conditionOptions };
-			return condition;
-		});
-
-		conditions.value = conditionsWithDefaults;
+		conditions.value = value.conditions;
 	},
 });
 
@@ -109,59 +95,13 @@ const repeaterFields = computed<DeepPartial<Field>[]>(() => [
 		meta: {
 			interface: 'system-interface-options',
 			options: {
+				isConditionOptions: true,
 				interface: interfaceId.value,
 				context: useFieldDetailStore,
 			},
 		},
 	},
 ]);
-
-const selectedInterface = useExtension('interface', interfaceId);
-
-const optionDefaults = computed(() => {
-	if (!selectedInterface.value?.options || isVueComponent(selectedInterface.value.options)) return [];
-
-	let optionsObjectOrArray;
-
-	if (typeof selectedInterface.value.options === 'function') {
-		optionsObjectOrArray = selectedInterface.value.options({
-			field: {
-				type: 'unknown',
-			},
-			editing: '+',
-			collection: collection.value,
-			relations: {
-				o2m: undefined,
-				m2o: undefined,
-				m2a: undefined,
-			},
-			collections: {
-				related: undefined,
-				junction: undefined,
-			},
-			fields: {
-				corresponding: undefined,
-				junctionCurrent: undefined,
-				junctionRelated: undefined,
-				sort: undefined,
-			},
-			items: {},
-			localType: 'standard',
-			autoGenerateJunctionRelation: false,
-			saving: false,
-		});
-	} else {
-		optionsObjectOrArray = selectedInterface.value.options;
-	}
-
-	const optionsArray = Array.isArray(optionsObjectOrArray)
-		? optionsObjectOrArray
-		: [...optionsObjectOrArray.standard, ...optionsObjectOrArray.advanced];
-
-	return optionsArray
-		.filter((option) => option.schema?.default_value !== undefined)
-		.reduce((result, option) => ({ ...result, [option.field]: option.schema.default_value }), {});
-});
 
 const fields = computed<DeepPartial<Field>[]>(() => [
 	{


### PR DESCRIPTION
## Scope

What's changed:

- Improved interface option overwriting through conditions.

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/09287348-a5b7-440b-a78e-5a7dc228dc78) | ![after](https://github.com/user-attachments/assets/23db5578-a8f7-456a-b132-f4cbc39fbf1e) | 

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Test also with existing conditions

---

Fixes #24481
