### PR TITLE
Fix including aliases in wildcard selection

### DIFF
--- a/.changeset/mean-bottles-brush.md
+++ b/.changeset/mean-bottles-brush.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed including aliases in wildcard selection

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
@@ -47,6 +47,17 @@ test('converting * without any permissions', async () => {
 	expect(result).toEqual([]);
 });
 
+test('converting * without any permissions and alias is null', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: null, accountability },
+		{ knex: db, schema },
+	);
+
+	expect(result).toEqual([]);
+});
+
 test('converting * with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
@@ -1,167 +1,212 @@
-import { SchemaBuilder } from "@directus/schema-builder";
+import { SchemaBuilder } from '@directus/schema-builder';
 
-import { expect, test, vi } from "vitest";
-import { Client_SQLite3 } from "../../run-ast/lib/apply-query/mock.js";
-import { convertWildcards } from "./convert-wildcards.js";
-import { fetchAllowedFields } from "../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js";
-import type { Accountability } from "@directus/types";
-import knex from "knex";
+import { expect, test, vi } from 'vitest';
+import { Client_SQLite3 } from '../../run-ast/lib/apply-query/mock.js';
+import { convertWildcards } from './convert-wildcards.js';
+import { fetchAllowedFields } from '../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
+import type { Accountability } from '@directus/types';
+import knex from 'knex';
 
-vi.mock('../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js')
+vi.mock('../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js');
 
-const fetchAllowedFieldsMock = vi.mocked(fetchAllowedFields)
+const fetchAllowedFieldsMock = vi.mocked(fetchAllowedFields);
 
 const accountability = {
-	admin: false
-} as Accountability
+	admin: false,
+} as Accountability;
 
 const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 
 const schema = new SchemaBuilder()
 	.collection('articles', (c) => {
 		c.field('id').id();
-		c.field('title').string()
-		c.field('date').dateTime()
+		c.field('title').string();
+		c.field('date').dateTime();
 	})
 	.build();
 
 test('converting nothing without any permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: [], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	fetchAllowedFieldsMock.mockResolvedValueOnce([])
-
-	const result = await convertWildcards({ collection: 'articles', fields: [], alias: {}, accountability }, { knex: db, schema })
-
-	expect(result).toEqual([])
+	expect(result).toEqual([]);
 });
 
 test('converting * without any permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce([])
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual([])
+	expect(result).toEqual([]);
 });
 
 test('converting * with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['id', 'title', 'date'])
+	expect(result).toEqual(['id', 'title', 'date']);
 });
 
 test('converting * with just id permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['id'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['id']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['id'])
+	expect(result).toEqual(['id']);
 });
 
 test('converting title with any permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['title'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['title']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['title'], alias: {}, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['title'], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['title'])
+	expect(result).toEqual(['title']);
 });
 
 test('converting invalid field with any permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['invalid'], alias: {}, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['invalid'], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['invalid'])
+	expect(result).toEqual(['invalid']);
 });
 
 test('converting invalid field with id, title permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['id', 'title'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['id', 'title']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['invalid'], alias: {}, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['invalid'], alias: {}, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['invalid'])
+	expect(result).toEqual(['invalid']);
 });
 
 test('converting * with admin permissions', async () => {
-	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability: { admin: true } as Accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability: { admin: true } as Accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['id', 'title', 'date'])
+	expect(result).toEqual(['id', 'title', 'date']);
 });
 
 test('converting title with admin permissions', async () => {
-	const result = await convertWildcards({ collection: 'articles', fields: ['title'], alias: {}, accountability: { admin: true } as Accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['title'], alias: {}, accountability: { admin: true } as Accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['title'])
+	expect(result).toEqual(['title']);
 });
 
 test('converting alias field with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: { alias: 'id' }, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: { alias: 'id' }, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['id', 'title', 'date', 'alias'])
+	expect(result).toEqual(['id', 'title', 'date', 'alias']);
 });
 
 test('converting invalid alias field with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: { alias: 'invalid' }, accountability }, { knex: db, schema })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*'], alias: { alias: 'invalid' }, accountability },
+		{ knex: db, schema },
+	);
 
-	expect(result).toEqual(['id', 'title', 'date'])
+	expect(result).toEqual(['id', 'title', 'date']);
 });
 
 const schemaRelational = new SchemaBuilder()
 	.collection('articles', (c) => {
 		c.field('id').id();
-		c.field('title').string()
-		c.field('date').dateTime()
-		c.field('author').m2o('users')
-		c.field('tags').m2m('tags')
+		c.field('title').string();
+		c.field('date').dateTime();
+		c.field('author').m2o('users');
+		c.field('tags').m2m('tags');
 	})
 	.collection('users', (c) => {
-		c.field('id').id()
-		c.field('name').string()
+		c.field('id').id();
+		c.field('name').string();
 	})
 	.build();
 
 test('converting *.* with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: {}, accountability }, { knex: db, schema: schemaRelational })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*.*'], alias: {}, accountability },
+		{ knex: db, schema: schemaRelational },
+	);
 
-	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date'])
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date']);
 });
 
 test('converting *.*.* with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*.*.*'], alias: {}, accountability }, { knex: db, schema: schemaRelational })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*.*.*'], alias: {}, accountability },
+		{ knex: db, schema: schemaRelational },
+	);
 
-	expect(result).toEqual(['author.*.*', 'tags.*.*', 'id', 'title', 'date'])
+	expect(result).toEqual(['author.*.*', 'tags.*.*', 'id', 'title', 'date']);
 });
 
 test('converting *.* and alias with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: { alias: 'title' }, accountability }, { knex: db, schema: schemaRelational })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*.*'], alias: { alias: 'title' }, accountability },
+		{ knex: db, schema: schemaRelational },
+	);
 
-	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'alias'])
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'alias']);
 });
 
 test('converting alias as year(date) with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: { alias: 'year(date)' }, accountability }, { knex: db, schema: schemaRelational })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*.*'], alias: { alias: 'year(date)' }, accountability },
+		{ knex: db, schema: schemaRelational },
+	);
 
-	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'alias'])
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'alias']);
 });
 
 test('converting year(alias) as date with * permissions', async () => {
-	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
-	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: { 'year(alias)': 'date' }, accountability }, { knex: db, schema: schemaRelational })
+	const result = await convertWildcards(
+		{ collection: 'articles', fields: ['*.*'], alias: { 'year(alias)': 'date' }, accountability },
+		{ knex: db, schema: schemaRelational },
+	);
 
-	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'year(alias)'])
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'year(alias)']);
 });
-

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
@@ -1,0 +1,167 @@
+import { SchemaBuilder } from "@directus/schema-builder";
+
+import { expect, test, vi } from "vitest";
+import { Client_SQLite3 } from "../../run-ast/lib/apply-query/mock.js";
+import { convertWildcards } from "./convert-wildcards.js";
+import { fetchAllowedFields } from "../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js";
+import type { Accountability } from "@directus/types";
+import knex from "knex";
+
+vi.mock('../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js')
+
+const fetchAllowedFieldsMock = vi.mocked(fetchAllowedFields)
+
+const accountability = {
+	admin: false
+} as Accountability
+
+const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+
+const schema = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('title').string()
+		c.field('date').dateTime()
+	})
+	.build();
+
+test('converting nothing without any permissions', async () => {
+
+
+	fetchAllowedFieldsMock.mockResolvedValueOnce([])
+
+	const result = await convertWildcards({ collection: 'articles', fields: [], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual([])
+});
+
+test('converting * without any permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual([])
+});
+
+test('converting * with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['id', 'title', 'date'])
+});
+
+test('converting * with just id permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['id'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['id'])
+});
+
+test('converting title with any permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['title'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['title'], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['title'])
+});
+
+test('converting invalid field with any permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['invalid'], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['invalid'])
+});
+
+test('converting invalid field with id, title permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['id', 'title'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['invalid'], alias: {}, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['invalid'])
+});
+
+test('converting * with admin permissions', async () => {
+	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: {}, accountability: { admin: true } as Accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['id', 'title', 'date'])
+});
+
+test('converting title with admin permissions', async () => {
+	const result = await convertWildcards({ collection: 'articles', fields: ['title'], alias: {}, accountability: { admin: true } as Accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['title'])
+});
+
+test('converting alias field with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: { alias: 'id' }, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['id', 'title', 'date', 'alias'])
+});
+
+test('converting invalid alias field with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*'], alias: { alias: 'invalid' }, accountability }, { knex: db, schema })
+
+	expect(result).toEqual(['id', 'title', 'date'])
+});
+
+const schemaRelational = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('title').string()
+		c.field('date').dateTime()
+		c.field('author').m2o('users')
+		c.field('tags').m2m('tags')
+	})
+	.collection('users', (c) => {
+		c.field('id').id()
+		c.field('name').string()
+	})
+	.build();
+
+test('converting *.* with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: {}, accountability }, { knex: db, schema: schemaRelational })
+
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date'])
+});
+
+test('converting *.*.* with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*.*.*'], alias: {}, accountability }, { knex: db, schema: schemaRelational })
+
+	expect(result).toEqual(['author.*.*', 'tags.*.*', 'id', 'title', 'date'])
+});
+
+test('converting *.* and alias with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: { alias: 'title' }, accountability }, { knex: db, schema: schemaRelational })
+
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'alias'])
+});
+
+test('converting alias as year(date) with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: { alias: 'year(date)' }, accountability }, { knex: db, schema: schemaRelational })
+
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'alias'])
+});
+
+test('converting year(alias) as date with * permissions', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce(['*'])
+
+	const result = await convertWildcards({ collection: 'articles', fields: ['*.*'], alias: { 'year(alias)': 'date' }, accountability }, { knex: db, schema: schemaRelational })
+
+	expect(result).toEqual(['author.*', 'tags.*', 'id', 'title', 'date', 'year(alias)'])
+});
+

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
@@ -3,11 +3,12 @@ import { getRelation } from '@directus/utils';
 import type { Knex } from 'knex';
 import { cloneDeep } from 'lodash-es';
 import { fetchAllowedFields } from '../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
+import { parseFilterKey } from '../../../utils/parse-filter-key.js';
 
 export interface ConvertWildcardsOptions {
-	parentCollection: string;
+	collection: string;
 	fields: string[];
-	query: Query;
+	alias: Query['alias'];
 	accountability: Accountability | null;
 }
 
@@ -19,7 +20,7 @@ export interface ConvertWildCardsContext {
 export async function convertWildcards(options: ConvertWildcardsOptions, context: ConvertWildCardsContext) {
 	const fields = cloneDeep(options.fields);
 
-	const fieldsInCollection = Object.entries(context.schema.collections[options.parentCollection]!.fields).map(
+	const fieldsInCollection = Object.entries(context.schema.collections[options.collection]!.fields).map(
 		([name]) => name,
 	);
 
@@ -28,7 +29,7 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 	if (options.accountability && options.accountability.admin === false) {
 		allowedFields = await fetchAllowedFields(
 			{
-				collection: options.parentCollection,
+				collection: options.collection,
 				action: 'read',
 				accountability: options.accountability,
 			},
@@ -47,7 +48,7 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 		if (fieldKey.includes('*') === false) continue;
 
 		if (fieldKey === '*') {
-			const aliases = Object.keys(options.query.alias ?? {});
+			const aliases = Object.keys(options.alias ?? {});
 
 			// Set to all fields in collection
 			if (allowedFields.includes('*')) {
@@ -55,8 +56,8 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 			} else {
 				// Set to all allowed fields
 				const allowedAliases = aliases.filter((fieldKey) => {
-					const name = options.query.alias![fieldKey]!;
-					return allowedFields!.includes(name);
+					const { fieldName } = parseFilterKey(options.alias![fieldKey]!);
+					return allowedFields!.includes(fieldName);
 				});
 
 				fields.splice(index, 1, ...allowedFields, ...allowedAliases);
@@ -69,23 +70,23 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 
 			const relationalFields = allowedFields.includes('*')
 				? context.schema.relations
-						.filter(
-							(relation) =>
-								relation.collection === options.parentCollection ||
-								relation.related_collection === options.parentCollection,
-						)
-						.map((relation) => {
-							const isMany = relation.collection === options.parentCollection;
-							return isMany ? relation.field : relation.meta?.one_field;
-						})
+					.filter(
+						(relation) =>
+							relation.collection === options.collection ||
+							relation.related_collection === options.collection,
+					)
+					.map((relation) => {
+						const isMany = relation.collection === options.collection;
+						return isMany ? relation.field : relation.meta?.one_field;
+					})
 				: allowedFields.filter(
-						(fieldKey) => !!getRelation(context.schema.relations, options.parentCollection, fieldKey),
-				  );
+					(fieldKey) => !!getRelation(context.schema.relations, options.collection, fieldKey),
+				);
 
 			const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
 
-			const aliasFields = Object.keys(options.query.alias ?? {}).map((fieldKey) => {
-				const name = options.query.alias![fieldKey];
+			const aliasFields = Object.keys(options.alias ?? {}).map((fieldKey) => {
+				const name = options.alias![fieldKey];
 
 				if (relationalFields.includes(name)) {
 					return `${fieldKey}.${parts.slice(1).join('.')}`;

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
@@ -70,18 +70,15 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 
 			const relationalFields = allowedFields.includes('*')
 				? context.schema.relations
-					.filter(
-						(relation) =>
-							relation.collection === options.collection ||
-							relation.related_collection === options.collection,
-					)
-					.map((relation) => {
-						const isMany = relation.collection === options.collection;
-						return isMany ? relation.field : relation.meta?.one_field;
-					})
-				: allowedFields.filter(
-					(fieldKey) => !!getRelation(context.schema.relations, options.collection, fieldKey),
-				);
+						.filter(
+							(relation) =>
+								relation.collection === options.collection || relation.related_collection === options.collection,
+						)
+						.map((relation) => {
+							const isMany = relation.collection === options.collection;
+							return isMany ? relation.field : relation.meta?.one_field;
+						})
+				: allowedFields.filter((fieldKey) => !!getRelation(context.schema.relations, options.collection, fieldKey));
 
 			const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
 

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -39,8 +39,8 @@ export async function parseFields(
 	fields = await convertWildcards(
 		{
 			fields,
-			parentCollection: options.parentCollection,
-			query: options.query,
+			collection: options.parentCollection,
+			alias: options.query.alias,
 			accountability: options.accountability,
 		},
 		context,


### PR DESCRIPTION
## Scope

What's changed:

- Before, having a `fields=*&alias[test]=year(date)` didn't include the `test` field in the returning payload.

## Potential Risks / Drawbacks

- none

## Review Notes / Questions

- none

---

Fixes #25121
