### PR TITLE
Ensure that clicking the chevron button in the icon interface closes the icon picker menu

### DIFF
--- a/.changeset/neat-adults-shave.md
+++ b/.changeset/neat-adults-shave.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that clicking the chevron button in the icon interface closes the icon picker menu

--- a/app/src/interfaces/select-icon/select-icon.vue
+++ b/app/src/interfaces/select-icon/select-icon.vue
@@ -52,7 +52,7 @@ function setIcon(icon: string | null) {
 
 <template>
 	<v-menu attached :disabled="disabled">
-		<template #activator="{ active, activate }">
+		<template #activator="{ active, activate, deactivate, toggle }">
 			<v-input
 				v-model="searchQuery"
 				:disabled="disabled"
@@ -67,7 +67,16 @@ function setIcon(icon: string | null) {
 
 				<template #append>
 					<div class="item-actions">
-						<v-remove v-if="value !== null" deselect @action="setIcon(null)" />
+						<v-remove
+							v-if="value !== null"
+							deselect
+							@action="
+								() => {
+									setIcon(null);
+									deactivate();
+								}
+							"
+						/>
 
 						<v-icon
 							v-else
@@ -75,7 +84,7 @@ function setIcon(icon: string | null) {
 							name="expand_more"
 							class="open-indicator"
 							:class="{ open: active }"
-							@click="activate"
+							@click="toggle"
 						/>
 					</div>
 				</template>


### PR DESCRIPTION
## Scope

What's changed:

- Ensured that clicking the chevron button in the icon interface closes the icon picker menu

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—

---

Fixes #25003
