### PR TITLE
Fix bug with conditional styles display

### DIFF
--- a/.changeset/six-houses-stick.md
+++ b/.changeset/six-houses-stick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug where conditional styles were not applied when using the “less than” or “greater than” operations

--- a/app/src/displays/formatted-value/formatted-value.vue
+++ b/app/src/displays/formatted-value/formatted-value.vue
@@ -42,7 +42,7 @@ const { t, n } = useI18n();
 
 const matchedConditions = computed(() =>
 	(props.conditionalFormatting || []).filter(({ operator, value }) => {
-		if (['string', 'text', ...APP_NUMERIC_STRING_TYPES].includes(props.type)) {
+		if (['string', 'text'].includes(props.type)) {
 			const left = String(props.value);
 			const right = String(value);
 			return matchString(left, right, operator);


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a bug where conditional styles were not applied when using the “less than” or “greater than” operations

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- This reverts the type check introduced when BigInteger and Decimal were changed to be treated as strings

---

Fixes #25082
