### PR TITLE
Ensure that M2M table rows remain clickable when disabled

### DIFF
--- a/.changeset/shaggy-lands-refuse.md
+++ b/.changeset/shaggy-lands-refuse.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that M2M table rows remain clickable when disabled

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -529,7 +529,6 @@ function getLinkForItem(item: DisplayItem) {
 				:items="displayItems"
 				:item-key="relationInfo.junctionPrimaryKeyField.field"
 				:row-height="tableRowHeight"
-				:disabled="disabled"
 				:show-manual-sort="allowDrag"
 				:manual-sort-key="relationInfo?.sortField"
 				:show-select="!disabled && updateAllowed ? 'multiple' : 'none'"

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -618,7 +618,6 @@ function getLinkForItem(item: DisplayItem) {
 									v-tooltip="t('navigate_to_item')"
 									:to="getLinkForItem(element)!"
 									class="item-link"
-									:disabled="element.$type === 'created'"
 									@click.stop
 								>
 									<v-icon name="launch" />


### PR DESCRIPTION
## Scope

What's changed:

- Ensured that M2M table rows remain clickable when disabled

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Also removed redundant condition

---

Fixes #24829
