### PR TITLE
Restore Build Permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-version
     permissions:
+      actions: write
+      attestations: write
+      checks: write
+      contents: write
+      deployments: write
+      discussions: write
       id-token: write
+      issues: write
+      metadata: read
+      models: read
+      packages: write
+      pages: write
+      pull-requests: write
+      security-events: write
+      statuses: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -71,7 +85,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-version
     permissions:
+      actions: write
+      attestations: write
+      checks: write
+      contents: write
+      deployments: write
+      discussions: write
       id-token: write
+      issues: write
+      metadata: read
+      models: read
+      packages: write
+      pages: write
+      pull-requests: write
+      security-events: write
+      statuses: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Noticing build permission errors due to a tricky details in [GitHub Actions' permissions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview):
> If you specify the access for any of these permissions, all of those that are not specified are set to `none`

Looks like [we needed id-token write permissions](https://github.com/directus/directus/pull/25058) in order to sign our builds.

Although we could probably reduce the permission set, this PR [restores the original permission set](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) while keeping the new `id-token` permission for signing.