### PR TITLE
Remove `metadata: read` from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
       discussions: write
       id-token: write
       issues: write
-      metadata: read
       models: read
       packages: write
       pages: write
@@ -93,7 +92,6 @@ jobs:
       discussions: write
       id-token: write
       issues: write
-      metadata: read
       models: read
       packages: write
       pages: write


### PR DESCRIPTION
I'm back (hah)! https://github.com/directus/directus/pull/25140 << we fixed the build permissions but apparently `metadata` read access is implicit and unchangeable. Not a valid api under the `permissions:` tag.