### PR TITLE
Fix a bug where the ID of newly added M2M/M2A items was lost after editing a junction field

### DIFF
--- a/.changeset/wild-bottles-drum.md
+++ b/.changeset/wild-bottles-drum.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug where the ID of newly added M2M/M2A items was lost after editing a junction field

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -259,7 +259,7 @@ function apply(updates: { [field: string]: any }) {
 		: Object.keys(updates).filter((key) => {
 				const field = fieldsMap.value[key];
 				if (!field) return false;
-				return field.schema?.is_primary_key || !isDisabled(field);
+				return updates.$type === 'created' || field.schema?.is_primary_key || !isDisabled(field);
 		  });
 
 	if (!isNil(props.group)) {

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -260,7 +260,7 @@ function apply(updates: { [field: string]: any }) {
 				const field = fieldsMap.value[key];
 				if (!field) return false;
 				return updates.$type === 'created' || field.schema?.is_primary_key || !isDisabled(field);
-		  });
+				return (updates.$type === 'created' && field.meta?.readonly) || field.schema?.is_primary_key || !isDisabled(field);
 
 	if (!isNil(props.group)) {
 		const groupFields = getFieldsForGroup(props.group)

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -259,8 +259,10 @@ function apply(updates: { [field: string]: any }) {
 		: Object.keys(updates).filter((key) => {
 				const field = fieldsMap.value[key];
 				if (!field) return false;
-				return updates.$type === 'created' || field.schema?.is_primary_key || !isDisabled(field);
-				return (updates.$type === 'created' && field.meta?.readonly) || field.schema?.is_primary_key || !isDisabled(field);
+				return (
+					(updates.$type === 'created' && field.meta?.readonly) || field.schema?.is_primary_key || !isDisabled(field)
+				);
+		  });
 
 	if (!isNil(props.group)) {
 		const groupFields = getFieldsForGroup(props.group)


### PR DESCRIPTION
## Scope

What's changed:

- Added a condition to allow each existing field to be part of the modelValue, when `$type` is `created`

## Potential Risks / Drawbacks

- This applies to any edits made to a group's fields. There may be cases where this could cause an issue.

## Review Notes / Questions

—

---

Fixes #24568
