### PR TITLE
Fix bug in the select color field

### DIFF
--- a/.changeset/spicy-banks-rest.md
+++ b/.changeset/spicy-banks-rest.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug in the select color field that caused invalid color values to be stored

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -173,7 +173,7 @@ function useColor() {
 			return roundColorValues(props.opacity ? [0, 0, 0, 1] : [0, 0, 0]);
 		},
 		set(newRGB) {
-			setColor(Color.rgb(newRGB).alpha(newRGB.length === 4 ? newRGB[3] : 1));
+			setColor(Color.rgb(newRGB).alpha(newRGB.length === 4 ? newRGB[3]! : 1));
 		},
 	});
 
@@ -186,7 +186,7 @@ function useColor() {
 			return roundColorValues(props.opacity ? [0, 0, 0, 1] : [0, 0, 0]);
 		},
 		set(newHSL) {
-			setColor(Color.hsl(newHSL).alpha(newHSL.length === 4 ? newHSL[3] : 1));
+			setColor(Color.hsl(newHSL).alpha(newHSL.length === 4 ? newHSL[3]! : 1));
 		},
 	});
 
@@ -277,7 +277,7 @@ function useColor() {
 	function roundColorValues(arr: number[]): number[] {
 		if (arr.length === 4) {
 			// Do not round the opacity
-			return [...arr.slice(0, -1).map((x) => Math.round(x)), arr[3]];
+			return [...arr.slice(0, -1).map((x) => Math.round(x)), arr[3]!];
 		}
 
 		return arr.map((x) => Math.round(x));

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -261,7 +261,7 @@ function useColor() {
 			const newColor = Color(input.value);
 			setColor(newColor);
 		} catch {
-			// The input is not a valid color, but we still want to let the user edit/type in the input so we emit the input
+			// The input is not a valid color, but we still want to let the user edit/type in the input so we emit null to prevent using an invalid value
 			unsetColor();
 		}
 	}

--- a/app/src/interfaces/select-color/select-color.vue
+++ b/app/src/interfaces/select-color/select-color.vue
@@ -141,12 +141,14 @@ function useColor() {
 
 	const getHexa = (): string | null => {
 		if (color.value !== null) {
+			if (!props.opacity || color.value.rgb().array().length !== 4) return color.value.hex();
+
 			let alpha = Math.round(255 * color.value.alpha())
 				.toString(16)
 				.toUpperCase();
 
 			alpha = alpha.padStart(2, '0');
-			return color.value.rgb().array().length === 4 ? `${color.value.hex()}${alpha}` : color.value.hex();
+			return `${color.value.hex()}${alpha}`;
 		}
 
 		return null;
@@ -228,7 +230,7 @@ function useColor() {
 				return;
 			}
 
-				emit('input', newInput);
+			emit('input', newInput);
 
 			if (isCssVarUtil(newInput)) {
 				try {


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a bug in the select color field that caused invalid color values to be stored.
- Fixed type errors
- Ensured that alpha channel is only added when the opacity prop is enabled

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Test also the color interface on a collection item and test various scenarios

---

Fixes #25040
