### PR TITLE
Fix bug with system filters

### DIFF
--- a/.changeset/three-pumas-act.md
+++ b/.changeset/three-pumas-act.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed a bug where the system filters’ \_in operation was not using a flattened array

--- a/app/src/modules/insights/routes/dashboard.vue
+++ b/app/src/modules/insights/routes/dashboard.vue
@@ -108,7 +108,10 @@ const tiles = computed<AppTile[]>(() => {
 				draggable: true,
 				borderRadius: [!topLeftIntersects, !topRightIntersects, !bottomRightIntersects, !bottomLeftIntersects],
 				data: {
-					options: applyOptionsData(panel.options ?? {}, unref(variables), panelType?.skipUndefinedKeys),
+					options: applyOptionsData(panel.options ?? {}, unref(variables), panelType?.skipUndefinedKeys, [
+						'_in',
+						'_nin',
+					]),
 					type: panel.type,
 				},
 			};

--- a/app/src/stores/insights.ts
+++ b/app/src/stores/insights.ts
@@ -21,6 +21,8 @@ export type CreatePanel = Partial<Panel> &
 
 const MAX_CACHE_SIZE = 3; // Max number of dashboards to keep in cache at a time
 
+const FLAT_ARRAY_KEYS = ['_in', '_nin'];
+
 export const useInsightsStore = defineStore('insightsStore', () => {
 	/** All available dashboards in the platform */
 	const dashboards = ref<Dashboard[]>([]);
@@ -318,7 +320,9 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 	function prepareQuery(panel: Pick<Panel, 'options' | 'type'>) {
 		const panelType = unref(panelTypes).find((panelType) => panelType.id === panel.type);
 		return (
-			panelType?.query?.(applyOptionsData(panel.options ?? {}, unref(variables), panelType.skipUndefinedKeys)) ?? null
+			panelType?.query?.(
+				applyOptionsData(panel.options ?? {}, unref(variables), panelType.skipUndefinedKeys, FLAT_ARRAY_KEYS),
+			) ?? null
 		);
 	}
 
@@ -347,7 +351,7 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 				const panelType = unref(panelTypes).find((panelType) => panelType.id === panel.type)!;
 
 				oldQuery = panelType.query?.(
-					applyOptionsData(panel.options ?? {}, unref(variables), panelType.skipUndefinedKeys),
+					applyOptionsData(panel.options ?? {}, unref(variables), panelType.skipUndefinedKeys, FLAT_ARRAY_KEYS),
 				);
 			}
 		}
@@ -374,7 +378,7 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 			const panelType = unref(panelTypes).find((panelType) => panelType.id === panel.type)!;
 
 			const newQuery = panelType.query?.(
-				applyOptionsData(panelEdits.options ?? {}, unref(variables), panelType.skipUndefinedKeys),
+				applyOptionsData(panelEdits.options ?? {}, unref(variables), panelType.skipUndefinedKeys, FLAT_ARRAY_KEYS),
 			);
 
 			if (JSON.stringify(oldQuery) !== JSON.stringify(newQuery)) loadPanelData(panel);
@@ -481,11 +485,11 @@ export const useInsightsStore = defineStore('insightsStore', () => {
 			if (!panelType) return false;
 
 			const oldQuery = panelType.query?.(
-				applyOptionsData(panel.options ?? {}, unref(variables), panelType.skipUndefinedKeys),
+				applyOptionsData(panel.options ?? {}, unref(variables), panelType.skipUndefinedKeys, FLAT_ARRAY_KEYS),
 			);
 
 			const newQuery = panelType.query?.(
-				applyOptionsData(panel.options ?? {}, unref(newVariables), panelType.skipUndefinedKeys),
+				applyOptionsData(panel.options ?? {}, unref(newVariables), panelType.skipUndefinedKeys, FLAT_ARRAY_KEYS),
 			);
 
 			return JSON.stringify(oldQuery) !== JSON.stringify(newQuery);

--- a/packages/utils/shared/apply-options-data.test.ts
+++ b/packages/utils/shared/apply-options-data.test.ts
@@ -18,10 +18,20 @@ describe('applyOptionsData', () => {
 	it('returns the options with any raw template replaced by the value in scope', () => {
 		expect(
 			applyOptionsData(
-				{ str: '{{ num }}', arr: ['{{ arr }}', { null: null }], obj: { str: '{{ obj }}', num: 42 } },
-				{ num: 42, arr: ['foo', 'bar'], obj: { foo: 'bar' } },
+				{
+					str: '{{ num }}',
+					arr: ['{{ arr_el_1 }}', '{{ arr_el_2 }}', { null: null }],
+					obj: { str: '{{ obj }}', num: 42 },
+				},
+				{ num: 42, arr_el_1: 'foo', arr_el_2: 'bar', obj: { foo: 'bar' } },
 			),
 		).toEqual({ str: 42, arr: ['foo', 'bar', { null: null }], obj: { str: { foo: 'bar' }, num: 42 } });
+	});
+
+	it('returns the options with arrays flattened when templates are used', () => {
+		expect(applyOptionsData({ arr: ['{{ arr }}', 'baz'] }, { arr: ['foo', 'bar'] })).toEqual({
+			arr: ['foo', 'bar', 'baz'],
+		});
 	});
 
 	it('returns the options with any non-raw template rendered with the respective stringified values from the scope', () => {

--- a/packages/utils/shared/apply-options-data.test.ts
+++ b/packages/utils/shared/apply-options-data.test.ts
@@ -29,6 +29,8 @@ describe('applyOptionsData', () => {
 			applyOptionsData(
 				{ arr_in: { _in: ['{{ arr }}', 'baz'] }, arr_nin: { _nin: ['baz', '{{ arr }}'] } },
 				{ arr: ['foo', 'bar'] },
+				[],
+				['_in', '_nin'],
 			),
 		).toEqual({
 			arr_in: { _in: ['foo', 'bar', 'baz'] },

--- a/packages/utils/shared/apply-options-data.test.ts
+++ b/packages/utils/shared/apply-options-data.test.ts
@@ -21,7 +21,7 @@ describe('applyOptionsData', () => {
 				{ str: '{{ num }}', arr: ['{{ arr }}', { null: null }], obj: { str: '{{ obj }}', num: 42 } },
 				{ num: 42, arr: ['foo', 'bar'], obj: { foo: 'bar' } },
 			),
-		).toEqual({ str: 42, arr: [['foo', 'bar'], { null: null }], obj: { str: { foo: 'bar' }, num: 42 } });
+		).toEqual({ str: 42, arr: ['foo', 'bar', { null: null }], obj: { str: { foo: 'bar' }, num: 42 } });
 	});
 
 	it('returns the options with any non-raw template rendered with the respective stringified values from the scope', () => {

--- a/packages/utils/shared/apply-options-data.test.ts
+++ b/packages/utils/shared/apply-options-data.test.ts
@@ -18,19 +18,21 @@ describe('applyOptionsData', () => {
 	it('returns the options with any raw template replaced by the value in scope', () => {
 		expect(
 			applyOptionsData(
-				{
-					str: '{{ num }}',
-					arr: ['{{ arr_el_1 }}', '{{ arr_el_2 }}', { null: null }],
-					obj: { str: '{{ obj }}', num: 42 },
-				},
-				{ num: 42, arr_el_1: 'foo', arr_el_2: 'bar', obj: { foo: 'bar' } },
+				{ str: '{{ num }}', arr: ['{{ arr }}', { null: null }], obj: { str: '{{ obj }}', num: 42 } },
+				{ num: 42, arr: ['foo', 'bar'], obj: { foo: 'bar' } },
 			),
-		).toEqual({ str: 42, arr: ['foo', 'bar', { null: null }], obj: { str: { foo: 'bar' }, num: 42 } });
+		).toEqual({ str: 42, arr: [['foo', 'bar'], { null: null }], obj: { str: { foo: 'bar' }, num: 42 } });
 	});
 
-	it('returns the options with arrays flattened when templates are used', () => {
-		expect(applyOptionsData({ arr: ['{{ arr }}', 'baz'] }, { arr: ['foo', 'bar'] })).toEqual({
-			arr: ['foo', 'bar', 'baz'],
+	it('returns the options with arrays flattened when templates are used with filters _in or _nin', () => {
+		expect(
+			applyOptionsData(
+				{ arr_in: { _in: ['{{ arr }}', 'baz'] }, arr_nin: { _nin: ['baz', '{{ arr }}'] } },
+				{ arr: ['foo', 'bar'] },
+			),
+		).toEqual({
+			arr_in: { _in: ['foo', 'bar', 'baz'] },
+			arr_nin: { _nin: ['baz', 'foo', 'bar'] },
 		});
 	});
 

--- a/packages/utils/shared/apply-options-data.ts
+++ b/packages/utils/shared/apply-options-data.ts
@@ -47,7 +47,7 @@ function renderMustache<T extends JsonValue>(item: T, scope: Scope, skipUndefine
 
 		return renderFn(item, resolveFn(skipUndefined) as ResolveFn, scope, { explicit: true }) as Mustache<T>;
 	} else if (Array.isArray(item)) {
-		return item.map((element) => renderMustache(element, scope, skipUndefined)) as Mustache<T>;
+		return item.flatMap((element) => renderMustache(element, scope, skipUndefined)) as Mustache<T>;
 	} else if (typeof item === 'object' && item !== null) {
 		return Object.fromEntries(
 			Object.entries(item).map(([key, value]) => [key, renderMustache(value, scope, skipUndefined)]),


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a bug where the system filters’ _in operation was not using a flattened array
- Flattens arrays for the `_in` and `_nin` filters, when specified in the `flatArrayKeys` parameter in `applyOptionsData`

## Potential Risks / Drawbacks

- The updated `applyOptionsData` function is used in the dashboard component (app/src/modules/insights/routes/dashboard.vue), in the InsightsStore (app/src/stores/insights.ts) as well as in the FlowManager (api/src/flows.ts).

## Review Notes / Questions

- Don’t forget to build the package `pnpm --filter utils build`


---

Fixes #23778
