### PR TITLE
Add folderName to filename_disk

### DIFF
--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -87,6 +87,14 @@ export class FilesService extends ItemsService<File> {
 			payload.filename_disk = primaryKey + (fileExtension || '');
 		}
 
+		const folderName = payload.folder
+			? await this.knex.select('name').from('directus_folders').where({ id: payload.folder }).first()
+			: null;
+
+		if (folderName) {
+			payload.filename_disk = folderName.name + '/' + payload.filename_disk;
+		}
+
 		// Temp filename is used for replacements
 		const tempFilenameDisk = 'temp_' + payload.filename_disk;
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -211,3 +211,4 @@
 - ngluunhatson
 - jacobcons
 - danielBreitlauch
+- romanlex


### PR DESCRIPTION
This PR aims to modify the `filename_disk` field to include the folder structure from Directus, making the remote storage file structure more closely aligned with the state of the `directus_folder` and `directus_files` tables.

Current implementation:
We've added the following code to include the folder name in the `filename_disk`:

```typescript
const folderName = payload.folder
  ? await this.knex.select('name').from('directus_folders').where({ id: payload.folder }).first()
  : null;

if (folderName) {
  payload.filename_disk = folderName.name + '/' + payload.filename_disk;
}
```

Benefits of this feature:
1. Improved organization when one Directus instance serves multiple projects
2. Easier content migration, as the file storage structure would reflect the upload_folder associations

We're eager to implement this feature but would appreciate guidance on where else changes might be needed to ensure it works correctly throughout the system. Specifically:
1. Are there other parts of the codebase that rely on the current filename_disk format?
2. How should we handle file moves between folders?
3. Are there any performance considerations we should be aware of?
4. How should we approach updating existing files in the system?

We believe this feature could significantly improve file management in Directus, especially for larger, multi-project installations. We're open to feedback and suggestions on how to best implement this functionality.
