### PR TITLE
Add `help` translation

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2582,3 +2582,4 @@ search_flow: Search Flow...
 percent: Percent
 show_password: Show password
 hide_password: Hide password
+help: Help


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Added a `help` key for translations. Using it in the Super Header Interface which is becoming pretty popular and was surprised we didn't already have a key for such a common word.

![ScreenShot 2025-05-08 at 17 23 32@2x](https://github.com/user-attachments/assets/23a02e00-883b-4666-a9c1-1bb48435a64b)

## Potential Risks / Drawbacks

- None that I'm aware

## Review Notes / Questions
