### PR TITLE
feat:applying_flow_colors_to_flow_buttons

### DIFF
--- a/.changeset/gold-news-stay.md
+++ b/.changeset/gold-news-stay.md
@@ -1,5 +1,5 @@
 ---
-'@directus/components': patch
+'@directus/app': minor
 ---
 
 Now flow buttons will have the same color selected when creating the flow instead of having the default primary

--- a/.changeset/gold-news-stay.md
+++ b/.changeset/gold-news-stay.md
@@ -1,0 +1,5 @@
+---
+'@directus/components': patch
+---
+
+Now flow buttons will have the same color selected when creating the flow instead of having the default primary

--- a/.changeset/gold-news-stay.md
+++ b/.changeset/gold-news-stay.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Now flow buttons will have the same color selected when creating the flow instead of having the default primary
+Enhanced the appearance of the flow trigger buttons in the sidebar by applying their custom colors

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -73,7 +73,7 @@ const props = withDefaults(defineProps<Props>(), {
 	align: 'center',
 	/** Must be explicitly undefined */
 	active: undefined,
-	color:undefined,
+	color: undefined,
 });
 
 const emit = defineEmits(['click']);
@@ -149,7 +149,7 @@ async function onClick(event: MouseEvent) {
 </script>
 
 <template>
-	<div class="v-button" :class="{ secondary, warning, danger, 'full-width': fullWidth, rounded } ">
+	<div class="v-button" :class="{ secondary, warning, danger, 'full-width': fullWidth, rounded }">
 		<slot name="prepend-outer" />
 		<component
 			:is="component"

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -9,6 +9,8 @@ interface Props {
 	autofocus?: boolean;
 	/** Styling of the button */
 	kind?: 'normal' | 'info' | 'success' | 'warning' | 'danger';
+	/** Sets the background color to it's flow's color */
+	color?: string;
 	/** Stretches the button to it's maximal width */
 	fullWidth?: boolean;
 	/** Enable rounded corners */
@@ -71,6 +73,7 @@ const props = withDefaults(defineProps<Props>(), {
 	align: 'center',
 	/** Must be explicitly undefined */
 	active: undefined,
+	color:undefined,
 });
 
 const emit = defineEmits(['click']);
@@ -127,6 +130,16 @@ const isActiveRoute = computed(() => {
 	return false;
 });
 
+const customStyle = computed(() => {
+	if (!props.color) return {};
+
+	return {
+		'--v-button-background-color': props.color,
+		'--v-button-background-color-hover': props.color,
+		'--v-button-background-color-active': props.color,
+	};
+});
+
 async function onClick(event: MouseEvent) {
 	if (props.loading === true) return;
 	// Toggles the active state in the parent groupable element. Allows buttons to work ootb in button-groups
@@ -136,13 +149,14 @@ async function onClick(event: MouseEvent) {
 </script>
 
 <template>
-	<div class="v-button" :class="{ secondary, warning, danger, 'full-width': fullWidth, rounded }">
+	<div class="v-button" :class="{ secondary, warning, danger, 'full-width': fullWidth, rounded } ">
 		<slot name="prepend-outer" />
 		<component
 			:is="component"
 			v-focus="autofocus"
 			v-tooltip.bottom="tooltip"
 			:download="download"
+			:style="customStyle"
 			class="button"
 			:class="[
 				sizeClass,

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -9,8 +9,6 @@ interface Props {
 	autofocus?: boolean;
 	/** Styling of the button */
 	kind?: 'normal' | 'info' | 'success' | 'warning' | 'danger';
-	/** Sets the background color to it's flow's color */
-	color?: string;
 	/** Stretches the button to it's maximal width */
 	fullWidth?: boolean;
 	/** Enable rounded corners */
@@ -73,7 +71,6 @@ const props = withDefaults(defineProps<Props>(), {
 	align: 'center',
 	/** Must be explicitly undefined */
 	active: undefined,
-	color: undefined,
 });
 
 const emit = defineEmits(['click']);
@@ -130,16 +127,6 @@ const isActiveRoute = computed(() => {
 	return false;
 });
 
-const customStyle = computed(() => {
-	if (!props.color) return {};
-
-	return {
-		'--v-button-background-color': props.color,
-		'--v-button-background-color-hover': props.color,
-		'--v-button-background-color-active': props.color,
-	};
-});
-
 async function onClick(event: MouseEvent) {
 	if (props.loading === true) return;
 	// Toggles the active state in the parent groupable element. Allows buttons to work ootb in button-groups
@@ -156,7 +143,6 @@ async function onClick(event: MouseEvent) {
 			v-focus="autofocus"
 			v-tooltip.bottom="tooltip"
 			:download="download"
-			:style="customStyle"
 			class="button"
 			:class="[
 				sizeClass,

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -192,11 +192,7 @@ const runManualFlow = async (flowId: string) => {
 					v-tooltip="getFlowTooltip(manualFlow)"
 					small
 					full-width
-					:style="{
-						'--v-button-background-color': manualFlow.color,
-						'--v-button-background-color-hover': manualFlow.color,
-						'--v-button-background-color-active': manualFlow.color,
-					}"
+					:style="{ '--v-button-background-color': manualFlow.color }"
 					:loading="runningFlows.includes(manualFlow.id)"
 					:disabled="isFlowDisabled(manualFlow)"
 					@click="onFlowClick(manualFlow.id)"

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -189,6 +189,7 @@ const runManualFlow = async (flowId: string) => {
 		<div class="fields">
 			<div v-for="manualFlow in manualFlows" :key="manualFlow.id" class="field full">
 				<v-button
+					:color="manualFlow.color"
 					v-tooltip="getFlowTooltip(manualFlow)"
 					small
 					full-width
@@ -197,7 +198,7 @@ const runManualFlow = async (flowId: string) => {
 					@click="onFlowClick(manualFlow.id)"
 				>
 					<v-icon :name="manualFlow.icon ?? 'bolt'" small left />
-					{{ manualFlow.name }}
+					{{ manualFlow.name }} 
 				</v-button>
 			</div>
 		</div>

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -189,7 +189,11 @@ const runManualFlow = async (flowId: string) => {
 		<div class="fields">
 			<div v-for="manualFlow in manualFlows" :key="manualFlow.id" class="field full">
 				<v-button
-					:color="manualFlow.color"
+					:style="{
+						'--v-button-background-color': manualFlow.color,
+						'--v-button-background-color-hover': manualFlow.color,
+						'--v-button-background-color-active': manualFlow.color,
+					}"
 					v-tooltip="getFlowTooltip(manualFlow)"
 					small
 					full-width

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -252,21 +252,29 @@ const runManualFlow = async (flowId: string) => {
 
 <style lang="scss" scoped>
 @use '@/styles/mixins';
+@use '@/styles/colors';
 
 .fields {
+	--theme--form--row-gap: 16px;
+
 	@include mixins.form-grid;
-}
 
-.fields {
-	--theme--form--row-gap: 24px;
+	.v-button {
+		--v-button-background-color-disabled: var(--theme--background-accent);
+		--v-button-background-color-hover: color-mix(
+			in srgb,
+			var(--v-button-background-color),
+			#{colors.$light-theme-shade} 25%
+		);
 
-	.type-label {
-		font-size: 1rem;
+		.dark & {
+			--v-button-background-color-hover: color-mix(
+				in srgb,
+				var(--v-button-background-color),
+				#{colors.$dark-theme-shade} 25%
+			);
+		}
 	}
-}
-
-:deep(.v-button) .button:disabled {
-	--v-button-background-color-disabled: var(--theme--background-accent);
 }
 
 .v-icon {

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -198,7 +198,7 @@ const runManualFlow = async (flowId: string) => {
 					@click="onFlowClick(manualFlow.id)"
 				>
 					<v-icon :name="manualFlow.icon ?? 'bolt'" small left />
-					{{ manualFlow.name }} 
+					{{ manualFlow.name }}
 				</v-button>
 			</div>
 		</div>

--- a/app/src/views/private/components/flow-sidebar-detail.vue
+++ b/app/src/views/private/components/flow-sidebar-detail.vue
@@ -189,14 +189,14 @@ const runManualFlow = async (flowId: string) => {
 		<div class="fields">
 			<div v-for="manualFlow in manualFlows" :key="manualFlow.id" class="field full">
 				<v-button
+					v-tooltip="getFlowTooltip(manualFlow)"
+					small
+					full-width
 					:style="{
 						'--v-button-background-color': manualFlow.color,
 						'--v-button-background-color-hover': manualFlow.color,
 						'--v-button-background-color-active': manualFlow.color,
 					}"
-					v-tooltip="getFlowTooltip(manualFlow)"
-					small
-					full-width
 					:loading="runningFlows.includes(manualFlow.id)"
 					:disabled="isFlowDisabled(manualFlow)"
 					@click="onFlowClick(manualFlow.id)"

--- a/contributors.yml
+++ b/contributors.yml
@@ -212,3 +212,4 @@
 - jacobcons
 - danielBreitlauch
 - AfaqJaved
+- Mehdi-YC


### PR DESCRIPTION
This PR's origin is this feature request approuved by the team:
https://github.com/directus/directus/discussions/22539

- Tests  are passing locally for the updated code (v-button)
   
- Documentation was added (jsdoc comments)


## Scope

What's changed:
[directus flow colors.webm](https://github.com/user-attachments/assets/2df5b58f-d818-4789-9478-3ccb642da0d9)

- coloring the button with the same flow selected color

## Potential Risks / Drawbacks
- there is no drawback, and the feature is simple to implement

## Review Notes / Questions
 - this is the simplest way to add this feature without interfering with a lot of the existing code , if there is a better way to do it, please let me know
---

It does not fix an issue, it is a feature request accepted by @rijkvanzanten 
