### PR TITLE
fix: added ADMIN_PASSWORD, ADMIN_TOKEN, KEY, and SECRET to TYPE_MAP to treat them as strings by default

### DIFF
--- a/.changeset/neat-wasps-change.md
+++ b/.changeset/neat-wasps-change.md
@@ -1,0 +1,5 @@
+---
+"@directus/env": patch
+---
+
+fix: Fixed ADMIN_PASSWORD, ADMIN_TOKEN, KEY, and SECRET to always be interpreted as strings 

--- a/.changeset/neat-wasps-change.md
+++ b/.changeset/neat-wasps-change.md
@@ -2,4 +2,4 @@
 "@directus/env": patch
 ---
 
-fix: Fixed ADMIN_PASSWORD, ADMIN_TOKEN, KEY, and SECRET to always be interpreted as strings 
+Fixed `ADMIN_PASSWORD`, `ADMIN_TOKEN`, `KEY`, and `SECRET` to always be interpreted as strings 

--- a/packages/env/src/constants/type-map.ts
+++ b/packages/env/src/constants/type-map.ts
@@ -41,4 +41,9 @@ export const TYPE_MAP: Record<string, EnvType> = {
 	METRICS_SERVICES: 'array',
 
 	DB_SSL__CA_FILE: 'string',
+
+	ADMIN_PASSWORD: 'string',
+	ADMIN_TOKEN: 'string',
+	KEY: 'string',
+	SECRET: 'string',
 } as const;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- added `ADMIN_PASSWORD`, `ADMIN_TOKEN`, `KEY`, and `SECRET` to `TYPE_MAP` to treat them as strings by default

## Potential Risks / Drawbacks

- This would be a breaking change for people who rely on the automatic conversion.

---

Fixes #25195
