### PR TITLE
Fix coercion of values only for rest

### DIFF
--- a/.changeset/late-pans-draw.md
+++ b/.changeset/late-pans-draw.md
@@ -1,0 +1,6 @@
+---
+'@directus/utils': patch
+'@directus/api': patch
+---
+
+Fixed cohersion of values only in rest

--- a/.changeset/late-pans-draw.md
+++ b/.changeset/late-pans-draw.md
@@ -3,4 +3,4 @@
 '@directus/api': patch
 ---
 
-Fixed cohersion of values only in rest
+Fixed coercion of values only in rest

--- a/api/src/middleware/sanitize-query.ts
+++ b/api/src/middleware/sanitize-query.ts
@@ -6,7 +6,6 @@
 import type { RequestHandler } from 'express';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
 import { validateQuery } from '../utils/validate-query.js';
-import { mapValuesDeep } from '../utils/map-values-deep.js';
 
 const sanitizeQueryMiddleware: RequestHandler = async (req, _res, next) => {
 	req.sanitizedQuery = {};
@@ -27,16 +26,6 @@ const sanitizeQueryMiddleware: RequestHandler = async (req, _res, next) => {
 			req.schema,
 			req.accountability || null,
 		);
-
-		req.sanitizedQuery = mapValuesDeep(req.sanitizedQuery, (key, value) => {
-			if (key.startsWith('filter.') || (key.startsWith('deep.') && key.includes('._filter.'))) {
-				if (value === 'true') return true;
-				if (value === 'false') return false;
-				if (value === 'null' || value === 'NULL') return null;
-			}
-
-			return value;
-		});
 
 		Object.freeze(req.sanitizedQuery);
 

--- a/api/src/operations/condition/index.ts
+++ b/api/src/operations/condition/index.ts
@@ -11,7 +11,7 @@ export default defineOperationApi<Options>({
 	id: 'condition',
 
 	handler: ({ filter }, { data, accountability }) => {
-		const parsedFilter = parseFilter(filter, accountability);
+		const parsedFilter = parseFilter(filter, accountability, undefined, true);
 
 		if (!parsedFilter) {
 			return null;

--- a/packages/utils/shared/deep-map.test.ts
+++ b/packages/utils/shared/deep-map.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { deepMap } from './deep-map.js';
 
 describe('deepMap', () => {
@@ -12,18 +12,18 @@ describe('deepMap', () => {
 		expect(deepMap(mockObject, (val) => val)).toStrictEqual({ key: now });
 	});
 
-	it('returns an object mapped where values are the return of the iterator', () => {
+	test('object mapped where values are the return of the iterator', () => {
 		const mockObject = { _and: [{ field: { _eq: 'field' } }] };
 		expect(deepMap(mockObject, mockIterator)).toStrictEqual({ _and: [{ field: { _eq: 'Test field' } }] });
 	});
 
-	it('returns object param when passed neither an object or an array.', () => {
+	test('returns object param when passed neither an object or an array.', () => {
 		const mockObject = 'test string';
 
 		expect(deepMap(mockObject, mockIterator)).toBe(mockObject);
 	});
 
-	it('returns an array of the iterators vals', () => {
+	test('array of the iterators vals', () => {
 		const mockObject = ['test', 'test2'];
 
 		expect(deepMap(mockObject, mockIterator)).toStrictEqual(['Test test', 'Test test2']);

--- a/packages/utils/shared/deep-map.test.ts
+++ b/packages/utils/shared/deep-map.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { deepMap } from './deep-map.js';
 
 describe('deepMap', () => {
 	const mockIterator = (val: any, _key: string | number) => {
 		return `Test ${val}`;
 	};
+
+	test('keep complex objects', () => {
+		const now = new Date();
+		const mockObject = { key: now };
+		expect(deepMap(mockObject, (val) => val)).toStrictEqual({ key: now });
+	});
 
 	it('returns an object mapped where values are the return of the iterator', () => {
 		const mockObject = { _and: [{ field: { _eq: 'field' } }] };

--- a/packages/utils/shared/deep-map.test.ts
+++ b/packages/utils/shared/deep-map.test.ts
@@ -17,7 +17,7 @@ describe('deepMap', () => {
 		expect(deepMap(mockObject, mockIterator)).toStrictEqual({ _and: [{ field: { _eq: 'Test field' } }] });
 	});
 
-	test('returns object param when passed neither an object or an array.', () => {
+	test('object param when passed neither an object or an array.', () => {
 		const mockObject = 'test string';
 
 		expect(deepMap(mockObject, mockIterator)).toBe(mockObject);

--- a/packages/utils/shared/deep-map.ts
+++ b/packages/utils/shared/deep-map.ts
@@ -1,11 +1,11 @@
-import { isObjectLike } from 'lodash-es';
+import { isObjectLike, isPlainObject } from 'lodash-es';
 
 export function deepMap(object: any, iterator: (value: any, key: string | number) => any, context?: any): any {
 	if (Array.isArray(object)) {
 		return object.map(function (val, key) {
 			return isObjectLike(val) ? deepMap(val, iterator, context) : iterator.call(context, val, key);
 		});
-	} else if (isObjectLike(object)) {
+	} else if (isPlainObject(object)) {
 		const res: Record<string, any> = {};
 
 		for (const key in object) {

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -489,7 +489,52 @@ describe('#parseFilter', () => {
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockFilter);
 	});
 
-	it('should not do any type casting', () => {
+	it('does proper type casting', () => {
+		const mockFilter = {
+			_and: [
+				{
+					status: {
+						_eq: 'true',
+					},
+				},
+				{
+					field: {
+						_eq: 'false',
+					},
+				},
+				{
+					field2: {
+						_eq: 'null',
+					},
+				},
+			],
+		} as Filter;
+
+		const mockResult = {
+			_and: [
+				{
+					status: {
+						_eq: true,
+					},
+				},
+				{
+					field: {
+						_eq: false,
+					},
+				},
+				{
+					field2: {
+						_eq: null,
+					},
+				},
+			],
+		};
+
+		const mockAccountability = { role: 'admin' };
+		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+	});
+
+	it('properly skips type casting', () => {
 		const mockFilter = {
 			_and: [
 				{
@@ -531,7 +576,7 @@ describe('#parseFilter', () => {
 		};
 
 		const mockAccountability = { role: 'admin' };
-		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
+		expect(parseFilter(mockFilter, mockAccountability, undefined, true)).toStrictEqual(mockResult);
 	});
 
 	it('replaces the user from accountability to $CURRENT_USER', () => {

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -489,7 +489,7 @@ describe('#parseFilter', () => {
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockFilter);
 	});
 
-	it('does proper type casting', () => {
+	it('should not do any type casting', () => {
 		const mockFilter = {
 			_and: [
 				{
@@ -514,17 +514,17 @@ describe('#parseFilter', () => {
 			_and: [
 				{
 					status: {
-						_eq: true,
+						_eq: 'true',
 					},
 				},
 				{
 					field: {
-						_eq: false,
+						_eq: 'false',
 					},
 				},
 				{
 					field2: {
-						_eq: null,
+						_eq: 'null',
 					},
 				},
 			],

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -22,7 +22,7 @@ export function parseFilter(
 	filter: Filter | null,
 	accountability: BasicAccountability | null,
 	context: ParseFilterContext = {},
-	skipCoercion = false
+	skipCoercion = false,
 ): Filter | null {
 	let parsedFilter = parseFilterRecursive(filter, accountability, context);
 
@@ -36,11 +36,11 @@ export function parseFilter(
 			if (value === 'false') return false;
 			if (value === 'null' || value === 'NULL') return null;
 
-			return value
+			return value;
 		});
 	}
 
-	return shiftLogicalOperatorsUp(parsedFilter)
+	return shiftLogicalOperatorsUp(parsedFilter);
 }
 
 const logicalFilterOperators = ['_and', '_or'];
@@ -109,7 +109,7 @@ export function parsePreset(
 		if (value === 'false') return false;
 		if (value === 'null' || value === 'NULL') return null;
 
-		return parseDynamicVariable(value, accountability, context)
+		return parseDynamicVariable(value, accountability, context);
 	});
 }
 
@@ -143,7 +143,7 @@ function parseFilterEntry(
 
 function parseDynamicVariable(value: any, accountability: BasicAccountability | null, context: ParseFilterContext) {
 	if (typeof value !== 'string') {
-		return value
+		return value;
 	}
 
 	if (value.startsWith('$NOW')) {

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -4,7 +4,6 @@ import { isObjectLike } from 'lodash-es';
 import { adjustDate } from './adjust-date.js';
 import { deepMap } from './deep-map.js';
 import { get } from './get-with-arrays.js';
-import { isDynamicVariable } from './is-dynamic-variable.js';
 import { isObject } from './is-object.js';
 import { parseJSON } from './parse-json.js';
 import { toArray } from './to-array.js';
@@ -74,7 +73,7 @@ function parseFilterRecursive(
 	}
 
 	if (!isObjectLike(filter)) {
-		return { _eq: parseFilterValue(filter, accountability, context) };
+		return { _eq: parseDynamicVariable(filter, accountability, context) };
 	}
 
 	const filters = Object.entries(filter).map((entry) => parseFilterEntry(entry, accountability, context));
@@ -94,7 +93,7 @@ export function parsePreset(
 	context: ParseFilterContext,
 ) {
 	if (!preset) return preset;
-	return deepMap(preset, (value) => parseFilterValue(value, accountability, context));
+	return deepMap(preset, (value) => parseDynamicVariable(value, accountability, context));
 }
 
 function parseFilterEntry(
@@ -109,26 +108,20 @@ function parseFilterEntry(
 		// the query parser (qs) parses them as a key-value pair object instead of an array,
 		// so we will need to convert them back to an array
 		const val = isObject(value) ? Object.values(value) : value;
-		return { [key]: toArray(val).flatMap((value) => parseFilterValue(value, accountability, context)) } as Filter;
+		return { [key]: toArray(val).flatMap((value) => parseDynamicVariable(value, accountability, context)) } as Filter;
 	} else if (['_intersects', '_nintersects', '_intersects_bbox', '_nintersects_bbox'].includes(String(key))) {
 		// Geometry filters always expect to operate against a GeoJSON object. Parse the
 		// value to JSON in case a stringified JSON blob is passed
-		return { [key]: parseFilterValue(typeof value === 'string' ? parseJSON(value) : value, accountability, context) };
+		return {
+			[key]: parseDynamicVariable(typeof value === 'string' ? parseJSON(value) : value, accountability, context),
+		};
 	} else if (String(key).startsWith('_') && !bypassOperators.includes(key)) {
-		return { [key]: parseFilterValue(value, accountability, context) };
+		return { [key]: parseDynamicVariable(value, accountability, context) };
 	} else if (String(key).startsWith('item__') && isObjectLike(value)) {
 		return { [`item:${String(key).split('item__')[1]}`]: parseFilter(value, accountability, context) } as Filter;
 	} else {
 		return { [key]: parseFilterRecursive(value, accountability, context) } as Filter;
 	}
-}
-
-function parseFilterValue(value: any, accountability: BasicAccountability | null, context: ParseFilterContext) {
-	if (value === 'true') return true;
-	if (value === 'false') return false;
-	if (value === 'null' || value === 'NULL') return null;
-	if (isDynamicVariable(value)) return parseDynamicVariable(value, accountability, context);
-	return value;
 }
 
 function parseDynamicVariable(value: any, accountability: BasicAccountability | null, context: ParseFilterContext) {
@@ -162,4 +155,6 @@ function parseDynamicVariable(value: any, accountability: BasicAccountability | 
 			return (get(context, value, null) as Policy[] | null)?.map(({ id }) => id) ?? null;
 		return get(context, value, null);
 	}
+
+	return value;
 }


### PR DESCRIPTION
## Scope

What's changed:

- Now coercing `"true"` -> `true`, `"false"` -> `false` and `"null"` -> `null` only for Rest requests, as all other ways of defining filters allow for having proper json types.

## Potential Risks / Drawbacks

- This is likely a breaking change, will be discussed further...

## Review Notes / Questions

- I already went over all uses of `parseFilter` but will do it once more to make sure we don't want the behavior somewhere else as well.

---

Fixes #25191, Closes NOW-955
