### PR TITLE
Add check for selectItems to field-detail-advanced-interface

### DIFF
--- a/.changeset/hungry-comics-clap.md
+++ b/.changeset/hungry-comics-clap.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Add check for selectItems to field-detail-advanced-interface when rendering interface select

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
@@ -76,6 +76,8 @@ const interfaceIsSelectable = computed(
 	() => !!selectItems.value.find((selectItem) => selectItem.value === interfaceId.value),
 );
 
+const interfaceHasNoSelectItems = computed(() => selectItems.value.length === 0);
+
 const selectedInterface = useExtension('interface', interfaceId);
 
 const customOptionsFields = computed(() => {
@@ -109,14 +111,18 @@ const options = computed({
 
 		<v-skeleton-loader v-if="loading" />
 		<template v-else>
-			<v-notice v-if="interfaceId && (!selectedInterface || !interfaceIsSelectable)" class="not-found" type="danger">
+			<v-notice
+				v-if="interfaceId && !interfaceHasNoSelectItems && (!selectedInterface || !interfaceIsSelectable)"
+				class="not-found"
+				type="danger"
+			>
 				{{ t('interface_not_found', { interface: interfaceId }) }}
 				<div class="spacer" />
 				<button @click="interfaceId = null">{{ t('reset_interface') }}</button>
 			</v-notice>
 
 			<extension-options
-				v-if="interfaceId && selectedInterface && interfaceIsSelectable"
+				v-if="(interfaceId && selectedInterface && interfaceIsSelectable) || interfaceHasNoSelectItems"
 				v-model="options"
 				type="interface"
 				:options="customOptionsFields"


### PR DESCRIPTION
## Scope

What's changed:

- This PR add's an extra level of assertion to fix a regression introduced in https://github.com/directus/directus/pull/24824
- Adds `interfaceHasNoSelectItems` computed in order to account for interfaces that do not `selectItems` available, as is the case when creating an M2O -> `directus_files`

## Potential Risks / Drawbacks

- NA

## Review Notes / Questions

- Is there a better check we could perform?
---

Fixes ENG-1254
