### PR TITLE
Fix logging of invalid url in isUrlAllowed

### DIFF
--- a/.changeset/slimy-peas-pump.md
+++ b/.changeset/slimy-peas-pump.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed logging of invalid url in isUrlAllowed

--- a/api/src/utils/is-url-allowed.ts
+++ b/api/src/utils/is-url-allowed.ts
@@ -18,7 +18,7 @@ export default function isUrlAllowed(url: string, allowList: string | string[]):
 				const { origin, pathname } = new URL(allowedURL);
 				return origin + pathname;
 			} catch {
-				logger.warn(`Invalid URL used "${url}"`);
+				logger.warn(`Invalid URL used "${allowedURL}"`);
 			}
 
 			return null;

--- a/contributors.yml
+++ b/contributors.yml
@@ -215,3 +215,4 @@
 - amosmurmu
 - AfaqJaved
 - Mehdi-YC
+- MrGreenTea


### PR DESCRIPTION
The logger just logged the URL that is checked instead of the URL that we try to parse.


## Scope

What's changed:

- Warnings logged inside `isUrlAllowed` checks.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- I have disregarded the need for an issue because the fix is to tiny. If needed I will first open an issue though.
- I thought about changing the name of the first argument to prevent a similar oversight in the future. For example `urlToCheck` 
