### PR TITLE
Add redirect to login page for OpenID SSO error

### DIFF
--- a/.changeset/fluffy-mangos-call.md
+++ b/.changeset/fluffy-mangos-call.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added redirect to login page for OpenID SSO error

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -423,6 +423,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 	router.get(
 		'/callback',
 		asyncHandler(async (req, res, next) => {
+			const env = useEnv();
 			const logger = useLogger();
 
 			let tokenData;
@@ -435,7 +436,8 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 				};
 			} catch (e: any) {
 				logger.warn(e, `[OpenID] Couldn't verify OpenID cookie`);
-				throw new InvalidCredentialsError();
+				const url = new Url(env['PUBLIC_URL'] as string).addPath('admin', 'login');
+				return res.redirect(`${url.toString()}?reason=${ErrorCode.InvalidCredentials}`);
 			}
 
 			const { verifier, redirect, prompt } = tokenData;


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Now redirects to the app login instead of landing on a api error page

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- This is only fixed/improved for OpenID as the issue didn't state which SSO Driver it was using and I was able to reproduce the issue exactly as described using OpenID

---
closes NOW-956
