### PR TITLE
Fix relation creation to files and add filter to files interfaces

### DIFF
--- a/.changeset/eager-words-relax.md
+++ b/.changeset/eager-words-relax.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added filters to file(s) and image interface and fixed relation creation to `directus_files`

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import api from '@/api';
-import type { File } from '@directus/types';
+import type { File, Filter } from '@directus/types';
 import { emitter, Events } from '@/events';
 import { useFilesStore } from '@/stores/files.js';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -26,6 +26,7 @@ interface Props {
 	fromUrl?: boolean;
 	fromLibrary?: boolean;
 	folder?: string;
+	filter?: Filter;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -358,6 +359,7 @@ defineExpose({ abort });
 					:active="activeDialog === 'choose'"
 					:multiple="multiple"
 					:folder="folder"
+					:filter="filter"
 					@update:active="activeDialog = null"
 					@input="setSelection"
 				/>

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -298,8 +298,15 @@ defineExpose({ abort });
 </script>
 
 <template>
-	<div data-dropzone class="v-upload" :class="{ dragging: dragging && fromUser, uploading }"
-		@dragenter.prevent="onDragEnter" @dragover.prevent @dragleave.prevent="onDragLeave" @drop.stop.prevent="onDrop">
+	<div
+		data-dropzone
+		class="v-upload"
+		:class="{ dragging: dragging && fromUser, uploading }"
+		@dragenter.prevent="onDragEnter"
+		@dragover.prevent
+		@dragleave.prevent="onDragLeave"
+		@drop.stop.prevent="onDrop"
+	>
 		<template v-if="dragging && fromUser">
 			<v-icon class="upload-icon" x-large name="file_upload" />
 			<p class="type-label">{{ t('drop_to_upload') }}</p>
@@ -319,17 +326,28 @@ defineExpose({ abort });
 
 		<template v-else>
 			<div class="actions">
-				<v-button v-if="fromUser" v-tooltip="t('click_to_browse')" icon rounded secondary
-					@click="openFileBrowser">
+				<v-button v-if="fromUser" v-tooltip="t('click_to_browse')" icon rounded secondary @click="openFileBrowser">
 					<input ref="input" class="browse" type="file" :multiple="multiple" @input="onBrowseSelect" />
 					<v-icon name="file_upload" />
 				</v-button>
-				<v-button v-if="fromLibrary" v-tooltip="t('choose_from_library')" icon rounded secondary
-					@click="activeDialog = 'choose'">
+				<v-button
+					v-if="fromLibrary"
+					v-tooltip="t('choose_from_library')"
+					icon
+					rounded
+					secondary
+					@click="activeDialog = 'choose'"
+				>
 					<v-icon name="folder_open" />
 				</v-button>
-				<v-button v-if="fromUrl && fromUser" v-tooltip="t('import_from_url')" icon rounded secondary
-					@click="activeDialog = 'url'">
+				<v-button
+					v-if="fromUrl && fromUser"
+					v-tooltip="t('import_from_url')"
+					icon
+					rounded
+					secondary
+					@click="activeDialog = 'url'"
+				>
 					<v-icon name="link" />
 				</v-button>
 			</div>
@@ -337,16 +355,25 @@ defineExpose({ abort });
 			<p class="type-label">{{ t(fromUser ? 'drag_file_here' : 'choose_from_library') }}</p>
 
 			<template v-if="fromUrl !== false || fromLibrary !== false">
-				<drawer-files :active="activeDialog === 'choose'" :multiple="multiple" :folder="folder" :filter="filter"
-					@update:active="activeDialog = null" @input="setSelection" />
+				<drawer-files
+					:active="activeDialog === 'choose'"
+					:multiple="multiple"
+					:folder="folder"
+					:filter="filter"
+					@update:active="activeDialog = null"
+					@input="setSelection"
+				/>
 
-				<v-dialog :model-value="activeDialog === 'url'" :persistent="urlLoading" @esc="activeDialog = null"
-					@update:model-value="activeDialog = null">
+				<v-dialog
+					:model-value="activeDialog === 'url'"
+					:persistent="urlLoading"
+					@esc="activeDialog = null"
+					@update:model-value="activeDialog = null"
+				>
 					<v-card>
 						<v-card-title>{{ t('import_from_url') }}</v-card-title>
 						<v-card-text>
-							<v-input v-model="url" autofocus :placeholder="t('url')" :nullable="false"
-								:disabled="urlLoading" />
+							<v-input v-model="url" autofocus :placeholder="t('url')" :nullable="false" :disabled="urlLoading" />
 						</v-card-text>
 						<v-card-actions>
 							<v-button :disabled="urlLoading" secondary @click="activeDialog = null">

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -298,15 +298,8 @@ defineExpose({ abort });
 </script>
 
 <template>
-	<div
-		data-dropzone
-		class="v-upload"
-		:class="{ dragging: dragging && fromUser, uploading }"
-		@dragenter.prevent="onDragEnter"
-		@dragover.prevent
-		@dragleave.prevent="onDragLeave"
-		@drop.stop.prevent="onDrop"
-	>
+	<div data-dropzone class="v-upload" :class="{ dragging: dragging && fromUser, uploading }"
+		@dragenter.prevent="onDragEnter" @dragover.prevent @dragleave.prevent="onDragLeave" @drop.stop.prevent="onDrop">
 		<template v-if="dragging && fromUser">
 			<v-icon class="upload-icon" x-large name="file_upload" />
 			<p class="type-label">{{ t('drop_to_upload') }}</p>
@@ -326,28 +319,17 @@ defineExpose({ abort });
 
 		<template v-else>
 			<div class="actions">
-				<v-button v-if="fromUser" v-tooltip="t('click_to_browse')" icon rounded secondary @click="openFileBrowser">
+				<v-button v-if="fromUser" v-tooltip="t('click_to_browse')" icon rounded secondary
+					@click="openFileBrowser">
 					<input ref="input" class="browse" type="file" :multiple="multiple" @input="onBrowseSelect" />
 					<v-icon name="file_upload" />
 				</v-button>
-				<v-button
-					v-if="fromLibrary"
-					v-tooltip="t('choose_from_library')"
-					icon
-					rounded
-					secondary
-					@click="activeDialog = 'choose'"
-				>
+				<v-button v-if="fromLibrary" v-tooltip="t('choose_from_library')" icon rounded secondary
+					@click="activeDialog = 'choose'">
 					<v-icon name="folder_open" />
 				</v-button>
-				<v-button
-					v-if="fromUrl && fromUser"
-					v-tooltip="t('import_from_url')"
-					icon
-					rounded
-					secondary
-					@click="activeDialog = 'url'"
-				>
+				<v-button v-if="fromUrl && fromUser" v-tooltip="t('import_from_url')" icon rounded secondary
+					@click="activeDialog = 'url'">
 					<v-icon name="link" />
 				</v-button>
 			</div>
@@ -355,25 +337,16 @@ defineExpose({ abort });
 			<p class="type-label">{{ t(fromUser ? 'drag_file_here' : 'choose_from_library') }}</p>
 
 			<template v-if="fromUrl !== false || fromLibrary !== false">
-				<drawer-files
-					:active="activeDialog === 'choose'"
-					:multiple="multiple"
-					:folder="folder"
-					:filter="filter"
-					@update:active="activeDialog = null"
-					@input="setSelection"
-				/>
+				<drawer-files :active="activeDialog === 'choose'" :multiple="multiple" :folder="folder" :filter="filter"
+					@update:active="activeDialog = null" @input="setSelection" />
 
-				<v-dialog
-					:model-value="activeDialog === 'url'"
-					:persistent="urlLoading"
-					@esc="activeDialog = null"
-					@update:model-value="activeDialog = null"
-				>
+				<v-dialog :model-value="activeDialog === 'url'" :persistent="urlLoading" @esc="activeDialog = null"
+					@update:model-value="activeDialog = null">
 					<v-card>
 						<v-card-title>{{ t('import_from_url') }}</v-card-title>
 						<v-card-text>
-							<v-input v-model="url" autofocus :placeholder="t('url')" :nullable="false" :disabled="urlLoading" />
+							<v-input v-model="url" autofocus :placeholder="t('url')" :nullable="false"
+								:disabled="urlLoading" />
 						</v-card-text>
 						<v-card-actions>
 							<v-button :disabled="urlLoading" secondary @click="activeDialog = null">

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -34,7 +34,7 @@ const props = withDefaults(
 	{
 		crop: true,
 		enableCreate: true,
-		enableSelect: true
+		enableSelect: true,
 	},
 );
 
@@ -107,8 +107,8 @@ const editImageDetails = ref(false);
 const editImageEditor = ref(false);
 
 const _disabled = computed(() => {
-	return props.disabled || (props.enableCreate === false && props.enableSelect === false)
-})
+	return props.disabled || (props.enableCreate === false && props.enableSelect === false);
+});
 
 async function imageErrorHandler() {
 	isImage.value = false;
@@ -179,9 +179,16 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				</span>
 			</div>
 
-			<v-image v-else-if="image.type?.startsWith('image') && isImage" :src="src"
-				:class="{ 'is-letterbox': letterbox }" :width="image.width" :height="image.height" alt=""
-				role="presentation" @error="imageErrorHandler" />
+			<v-image
+				v-else-if="image.type?.startsWith('image') && isImage"
+				:src="src"
+				:class="{ 'is-letterbox': letterbox }"
+				:width="image.width"
+				:height="image.height"
+				alt=""
+				role="presentation"
+				@error="imageErrorHandler"
+			/>
 
 			<div v-else class="fallback">
 				<v-icon-file :ext="ext" />
@@ -194,8 +201,13 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 					<v-icon name="zoom_in" />
 				</v-button>
 
-				<v-button v-tooltip="t('download')" icon rounded :href="getAssetUrl(image.id, true)"
-					:download="image.filename_download">
+				<v-button
+					v-tooltip="t('download')"
+					icon
+					rounded
+					:href="getAssetUrl(image.id, true)"
+					:download="image.filename_download"
+				>
 					<v-icon name="download" />
 				</v-button>
 
@@ -204,8 +216,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 						<v-icon name="edit" />
 					</v-button>
 
-					<v-button v-if="updateAllowed" v-tooltip="t('edit_image')" icon rounded
-						@click="editImageEditor = true">
+					<v-button v-if="updateAllowed" v-tooltip="t('edit_image')" icon rounded @click="editImageEditor = true">
 						<v-icon name="tune" />
 					</v-button>
 
@@ -218,11 +229,17 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				<div class="meta">{{ meta }}</div>
 			</div>
 
-			<drawer-item v-if="image" v-model:active="editImageDetails" :disabled="_disabled"
-				collection="directus_files" :primary-key="image.id" :edits="edits" @input="update">
+			<drawer-item
+				v-if="image"
+				v-model:active="editImageDetails"
+				:disabled="_disabled"
+				collection="directus_files"
+				:primary-key="image.id"
+				:edits="edits"
+				@input="update"
+			>
 				<template #actions>
-					<v-button secondary rounded icon :download="image.filename_download"
-						:href="getAssetUrl(image.id, true)">
+					<v-button secondary rounded icon :download="image.filename_download" :href="getAssetUrl(image.id, true)">
 						<v-icon name="download" />
 					</v-button>
 				</template>
@@ -232,8 +249,15 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 
 			<file-lightbox v-model="lightboxActive" :file="image" />
 		</div>
-		<v-upload v-else from-url :from-user="createAllowed && enableCreate" :from-library="enableSelect"
-			:folder="folder" :filter="customFilter" @input="onUpload" />
+		<v-upload
+			v-else
+			from-url
+			:from-user="createAllowed && enableCreate"
+			:from-library="enableSelect"
+			:folder="folder"
+			:filter="customFilter"
+			@input="onUpload"
+		/>
 	</div>
 </template>
 
@@ -366,7 +390,6 @@ img {
 }
 
 .image {
-
 	&.full,
 	&.fill {
 		.image-preview {

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -106,7 +106,7 @@ const meta = computed(() => {
 const editImageDetails = ref(false);
 const editImageEditor = ref(false);
 
-const _disabled = computed(() => {
+const internalDisabled = computed(() => {
 	return props.disabled || (props.enableCreate === false && props.enableSelect === false);
 });
 
@@ -125,11 +125,11 @@ async function imageErrorHandler() {
 	}
 }
 
-const values = inject('values', ref<Record<string, any>>({}));
+const values = inject('values', ref<Record<string, unknown>>({}));
 
 const customFilter = computed(() => {
 	return parseFilter(
-		deepMap(props.filter, (val: any) => {
+		deepMap(props.filter, (val: unknown) => {
 			if (val && typeof val === 'string') {
 				return render(val, values.value);
 			}
@@ -166,7 +166,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 	<div class="image" :class="[width, { crop }]">
 		<v-skeleton-loader v-if="loading" type="input-tall" />
 
-		<v-notice v-else-if="_disabled && !image" class="disabled-placeholder" center icon="hide_image">
+		<v-notice v-else-if="internalDisabled && !image" class="disabled-placeholder" center icon="hide_image">
 			{{ t('no_image_selected') }}
 		</v-notice>
 
@@ -211,7 +211,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 					<v-icon name="download" />
 				</v-button>
 
-				<template v-if="!_disabled">
+				<template v-if="!internalDisabled">
 					<v-button v-tooltip="t('edit_item')" icon rounded @click="editImageDetails = true">
 						<v-icon name="edit" />
 					</v-button>
@@ -232,7 +232,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 			<drawer-item
 				v-if="image"
 				v-model:active="editImageDetails"
-				:disabled="_disabled"
+				:disabled="internalDisabled"
 				collection="directus_files"
 				:primary-key="image.id"
 				:edits="edits"
@@ -245,7 +245,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				</template>
 			</drawer-item>
 
-			<image-editor v-if="!_disabled" :id="image.id" v-model="editImageEditor" @refresh="refresh" />
+			<image-editor v-if="!internalDisabled" :id="image.id" v-model="editImageEditor" @refresh="refresh" />
 
 			<file-lightbox v-model="lightboxActive" :file="image" />
 		</div>

--- a/app/src/interfaces/file-image/index.ts
+++ b/app/src/interfaces/file-image/index.ts
@@ -53,6 +53,34 @@ export default defineInterface({
 				},
 			},
 			{
+				field: 'enableCreate',
+				name: '$t:creating_items',
+				schema: {
+					default_value: true,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:enable_create_button',
+					},
+					width: 'half',
+				},
+			},
+			{
+				field: 'enableSelect',
+				name: '$t:selecting_items',
+				schema: {
+					default_value: true,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:enable_select_button',
+					},
+					width: 'half',
+				},
+			},
+			{
 				field: 'letterbox',
 				name: '$t:interfaces.file-image.letterbox',
 				type: 'boolean',

--- a/app/src/interfaces/file-image/index.ts
+++ b/app/src/interfaces/file-image/index.ts
@@ -12,48 +12,63 @@ export default defineInterface({
 	localTypes: ['file'],
 	group: 'relational',
 	relational: true,
-	options: [
-		{
-			field: 'folder',
-			name: '$t:interfaces.system-folder.folder',
-			type: 'uuid',
-			meta: {
-				width: 'half',
-				interface: 'system-folder',
-				note: '$t:interfaces.system-folder.field_hint',
-			},
-		},
-		{
-			field: 'crop',
-			name: '$t:interfaces.file-image.crop',
-			type: 'boolean',
-			meta: {
-				width: 'half',
-				interface: 'boolean',
-				options: {
-					label: '$t:interfaces.file-image.crop_label',
+	options: ({ relations }) => {
+		const collection = relations.m2o?.related_collection;
+
+		return [
+			{
+				field: 'folder',
+				name: '$t:interfaces.system-folder.folder',
+				type: 'uuid',
+				meta: {
+					width: 'half',
+					interface: 'system-folder',
+					note: '$t:interfaces.system-folder.field_hint',
 				},
 			},
-			schema: {
-				default_value: true,
-			},
-		},
-		{
-			field: 'letterbox',
-			name: '$t:interfaces.file-image.letterbox',
-			type: 'boolean',
-			meta: {
-				width: 'half',
-				interface: 'boolean',
-				options: {
-					label: '$t:interfaces.file-image.letterbox_label',
+			{
+				field: 'crop',
+				name: '$t:interfaces.file-image.crop',
+				type: 'boolean',
+				meta: {
+					width: 'half',
+					interface: 'boolean',
+					options: {
+						label: '$t:interfaces.file-image.crop_label',
+					},
+				},
+				schema: {
+					default_value: true,
 				},
 			},
-			schema: {
-				default_value: false,
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
+					},
+				},
 			},
-		},
-	],
+			{
+				field: 'letterbox',
+				name: '$t:interfaces.file-image.letterbox',
+				type: 'boolean',
+				meta: {
+					width: 'half',
+					interface: 'boolean',
+					options: {
+						label: '$t:interfaces.file-image.letterbox_label',
+					},
+				},
+				schema: {
+					default_value: false,
+				},
+			},
+		];
+	},
 	recommendedDisplays: ['image'],
 	preview: PreviewSVG,
 });

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -36,7 +36,7 @@ const props = withDefaults(
 	}>(),
 	{
 		enableCreate: true,
-		enableSelect: true
+		enableSelect: true,
 	},
 );
 
@@ -117,8 +117,8 @@ const customFilter = computed(() => {
 });
 
 const _disabled = computed(() => {
-	return props.disabled || (props.enableCreate === false && props.enableSelect === false)
-})
+	return props.disabled || (props.enableCreate === false && props.enableSelect === false);
+});
 
 function setSelection(selection: (string | number)[] | null) {
 	if (selection![0]) {
@@ -180,15 +180,30 @@ function useURLImport() {
 			<template #activator="{ toggle, active }">
 				<div>
 					<v-skeleton-loader v-if="loading" type="input" />
-					<v-input v-else clickable readonly :active="active" :disabled="_disabled"
-						:placeholder="t('no_file_selected')" :model-value="file && file.title" @click="toggle">
+					<v-input
+						v-else
+						clickable
+						readonly
+						:active="active"
+						:disabled="_disabled"
+						:placeholder="t('no_file_selected')"
+						:model-value="file && file.title"
+						@click="toggle"
+					>
 						<template #prepend>
-							<div class="preview" :class="{
-								'has-file': file,
-								'is-svg': file?.type?.includes('svg'),
-							}">
-								<v-image v-if="imageThumbnail && !imageThumbnailError" :src="imageThumbnail"
-									:alt="file?.title" @error="imageThumbnailError = $event" />
+							<div
+								class="preview"
+								:class="{
+									'has-file': file,
+									'is-svg': file?.type?.includes('svg'),
+								}"
+							>
+								<v-image
+									v-if="imageThumbnail && !imageThumbnailError"
+									:src="imageThumbnail"
+									:alt="file?.title"
+									@error="imageThumbnailError = $event"
+								/>
 								<span v-else-if="fileExtension" class="extension">
 									{{ fileExtension }}
 								</span>
@@ -199,11 +214,9 @@ function useURLImport() {
 						<template #append>
 							<div class="item-actions">
 								<template v-if="file">
-									<v-icon v-tooltip="t('edit_item')" name="edit" clickable
-										@click.stop="editDrawerActive = true" />
+									<v-icon v-tooltip="t('edit_item')" name="edit" clickable @click.stop="editDrawerActive = true" />
 
-									<v-remove v-if="!_disabled" :item-info="relationInfo" :item-edits="edits" deselect
-										@action="remove" />
+									<v-remove v-if="!_disabled" :item-info="relationInfo" :item-edits="edits" deselect @action="remove" />
 								</template>
 
 								<v-icon v-else name="attach_file" />
@@ -247,8 +260,15 @@ function useURLImport() {
 			</v-list>
 		</v-menu>
 
-		<drawer-item v-if="file" v-model:active="editDrawerActive" collection="directus_files" :primary-key="file.id"
-			:edits="edits" :disabled="_disabled" @input="update">
+		<drawer-item
+			v-if="file"
+			v-model:active="editDrawerActive"
+			collection="directus_files"
+			:primary-key="file.id"
+			:edits="edits"
+			:disabled="_disabled"
+			@input="update"
+		>
 			<template #actions>
 				<v-button secondary rounded icon :download="file.filename_download" :href="getAssetUrl(file.id, true)">
 					<v-icon name="download" />
@@ -256,8 +276,11 @@ function useURLImport() {
 			</template>
 		</drawer-item>
 
-		<v-dialog :model-value="activeDialog === 'upload'" @esc="activeDialog = null"
-			@update:model-value="activeDialog = null">
+		<v-dialog
+			:model-value="activeDialog === 'upload'"
+			@esc="activeDialog = null"
+			@update:model-value="activeDialog = null"
+		>
 			<v-card>
 				<v-card-title>{{ t('upload_from_device') }}</v-card-title>
 				<v-card-text>
@@ -269,11 +292,21 @@ function useURLImport() {
 			</v-card>
 		</v-dialog>
 
-		<drawer-files v-if="activeDialog === 'choose'" :folder="folder" :active="activeDialog === 'choose'"
-			:filter="customFilter" @update:active="activeDialog = null" @input="setSelection" />
+		<drawer-files
+			v-if="activeDialog === 'choose'"
+			:folder="folder"
+			:active="activeDialog === 'choose'"
+			:filter="customFilter"
+			@update:active="activeDialog = null"
+			@input="setSelection"
+		/>
 
-		<v-dialog :model-value="activeDialog === 'url'" :persistent="urlLoading"
-			@update:model-value="activeDialog = null" @esc="activeDialog = null">
+		<v-dialog
+			:model-value="activeDialog === 'url'"
+			:persistent="urlLoading"
+			@update:model-value="activeDialog = null"
+			@esc="activeDialog = null"
+		>
 			<v-card>
 				<v-card-title>{{ t('import_from_url') }}</v-card-title>
 				<v-card-text>

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -22,15 +22,23 @@ type FileInfo = {
 	type: string;
 };
 
-const props = defineProps<{
-	value: string | Record<string, any> | null;
-	disabled?: boolean;
-	loading?: boolean;
-	folder?: string;
-	filter?: Filter;
-	collection: string;
-	field: string;
-}>();
+const props = withDefaults(
+	defineProps<{
+		value: string | Record<string, any> | null;
+		disabled?: boolean;
+		loading?: boolean;
+		folder?: string;
+		filter?: Filter;
+		collection: string;
+		field: string;
+		enableCreate?: boolean;
+		enableSelect?: boolean;
+	}>(),
+	{
+		enableCreate: true,
+		enableSelect: true
+	},
+);
 
 const emit = defineEmits<{
 	input: [value: string | Record<string, any> | null];
@@ -108,6 +116,10 @@ const customFilter = computed(() => {
 	);
 });
 
+const _disabled = computed(() => {
+	return props.disabled || (props.enableCreate === false && props.enableSelect === false)
+})
+
 function setSelection(selection: (string | number)[] | null) {
 	if (selection![0]) {
 		update(selection![0]);
@@ -164,34 +176,19 @@ function useURLImport() {
 
 <template>
 	<div class="file">
-		<v-menu attached :disabled="loading">
+		<v-menu attached :disabled="loading || _disabled">
 			<template #activator="{ toggle, active }">
 				<div>
 					<v-skeleton-loader v-if="loading" type="input" />
-					<v-input
-						v-else
-						clickable
-						readonly
-						:active="active"
-						:disabled="disabled"
-						:placeholder="t('no_file_selected')"
-						:model-value="file && file.title"
-						@click="toggle"
-					>
+					<v-input v-else clickable readonly :active="active" :disabled="_disabled"
+						:placeholder="t('no_file_selected')" :model-value="file && file.title" @click="toggle">
 						<template #prepend>
-							<div
-								class="preview"
-								:class="{
-									'has-file': file,
-									'is-svg': file?.type?.includes('svg'),
-								}"
-							>
-								<v-image
-									v-if="imageThumbnail && !imageThumbnailError"
-									:src="imageThumbnail"
-									:alt="file?.title"
-									@error="imageThumbnailError = $event"
-								/>
+							<div class="preview" :class="{
+								'has-file': file,
+								'is-svg': file?.type?.includes('svg'),
+							}">
+								<v-image v-if="imageThumbnail && !imageThumbnailError" :src="imageThumbnail"
+									:alt="file?.title" @error="imageThumbnailError = $event" />
 								<span v-else-if="fileExtension" class="extension">
 									{{ fileExtension }}
 								</span>
@@ -202,9 +199,11 @@ function useURLImport() {
 						<template #append>
 							<div class="item-actions">
 								<template v-if="file">
-									<v-icon v-tooltip="t('edit_item')" name="edit" clickable @click.stop="editDrawerActive = true" />
+									<v-icon v-tooltip="t('edit_item')" name="edit" clickable
+										@click.stop="editDrawerActive = true" />
 
-									<v-remove v-if="!disabled" :item-info="relationInfo" :item-edits="edits" deselect @action="remove" />
+									<v-remove v-if="!_disabled" :item-info="relationInfo" :item-edits="edits" deselect
+										@action="remove" />
 								</template>
 
 								<v-icon v-else name="attach_file" />
@@ -221,24 +220,24 @@ function useURLImport() {
 						<v-list-item-content>{{ t('download_file') }}</v-list-item-content>
 					</v-list-item>
 
-					<v-divider v-if="!disabled" />
+					<v-divider v-if="!_disabled" />
 				</template>
-				<template v-if="!disabled">
-					<v-list-item v-if="createAllowed" clickable @click="activeDialog = 'upload'">
+				<template v-if="!_disabled">
+					<v-list-item v-if="createAllowed && enableCreate" clickable @click="activeDialog = 'upload'">
 						<v-list-item-icon><v-icon name="phonelink" /></v-list-item-icon>
 						<v-list-item-content>
 							{{ t(file ? 'replace_from_device' : 'upload_from_device') }}
 						</v-list-item-content>
 					</v-list-item>
 
-					<v-list-item clickable @click="activeDialog = 'choose'">
+					<v-list-item v-if="enableSelect" clickable @click="activeDialog = 'choose'">
 						<v-list-item-icon><v-icon name="folder_open" /></v-list-item-icon>
 						<v-list-item-content>
 							{{ t(file ? 'replace_from_library' : 'choose_from_library') }}
 						</v-list-item-content>
 					</v-list-item>
 
-					<v-list-item v-if="createAllowed" clickable @click="activeDialog = 'url'">
+					<v-list-item v-if="createAllowed && enableCreate" clickable @click="activeDialog = 'url'">
 						<v-list-item-icon><v-icon name="link" /></v-list-item-icon>
 						<v-list-item-content>
 							{{ t(file ? 'replace_from_url' : 'import_from_url') }}
@@ -248,15 +247,8 @@ function useURLImport() {
 			</v-list>
 		</v-menu>
 
-		<drawer-item
-			v-if="file"
-			v-model:active="editDrawerActive"
-			collection="directus_files"
-			:primary-key="file.id"
-			:edits="edits"
-			:disabled="disabled"
-			@input="update"
-		>
+		<drawer-item v-if="file" v-model:active="editDrawerActive" collection="directus_files" :primary-key="file.id"
+			:edits="edits" :disabled="_disabled" @input="update">
 			<template #actions>
 				<v-button secondary rounded icon :download="file.filename_download" :href="getAssetUrl(file.id, true)">
 					<v-icon name="download" />
@@ -264,11 +256,8 @@ function useURLImport() {
 			</template>
 		</drawer-item>
 
-		<v-dialog
-			:model-value="activeDialog === 'upload'"
-			@esc="activeDialog = null"
-			@update:model-value="activeDialog = null"
-		>
+		<v-dialog :model-value="activeDialog === 'upload'" @esc="activeDialog = null"
+			@update:model-value="activeDialog = null">
 			<v-card>
 				<v-card-title>{{ t('upload_from_device') }}</v-card-title>
 				<v-card-text>
@@ -280,21 +269,11 @@ function useURLImport() {
 			</v-card>
 		</v-dialog>
 
-		<drawer-files
-			v-if="activeDialog === 'choose'"
-			:folder="folder"
-			:active="activeDialog === 'choose'"
-			:filter="customFilter"
-			@update:active="activeDialog = null"
-			@input="setSelection"
-		/>
+		<drawer-files v-if="activeDialog === 'choose'" :folder="folder" :active="activeDialog === 'choose'"
+			:filter="customFilter" @update:active="activeDialog = null" @input="setSelection" />
 
-		<v-dialog
-			:model-value="activeDialog === 'url'"
-			:persistent="urlLoading"
-			@update:model-value="activeDialog = null"
-			@esc="activeDialog = null"
-		>
+		<v-dialog :model-value="activeDialog === 'url'" :persistent="urlLoading"
+			@update:model-value="activeDialog = null" @esc="activeDialog = null">
 			<v-card>
 				<v-card-title>{{ t('import_from_url') }}</v-card-title>
 				<v-card-text>

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -102,11 +102,11 @@ const edits = computed(() => {
 	return props.value;
 });
 
-const values = inject('values', ref<Record<string, any>>({}));
+const values = inject('values', ref<Record<string, unknown>>({}));
 
 const customFilter = computed(() => {
 	return parseFilter(
-		deepMap(props.filter, (val: any) => {
+		deepMap(props.filter, (val: unknown) => {
 			if (val && typeof val === 'string') {
 				return render(val, values.value);
 			}
@@ -116,7 +116,7 @@ const customFilter = computed(() => {
 	);
 });
 
-const _disabled = computed(() => {
+const internalDisabled = computed(() => {
 	return props.disabled || (props.enableCreate === false && props.enableSelect === false);
 });
 
@@ -176,7 +176,7 @@ function useURLImport() {
 
 <template>
 	<div class="file">
-		<v-menu attached :disabled="loading || _disabled">
+		<v-menu attached :disabled="loading || internalDisabled">
 			<template #activator="{ toggle, active }">
 				<div>
 					<v-skeleton-loader v-if="loading" type="input" />
@@ -185,7 +185,7 @@ function useURLImport() {
 						clickable
 						readonly
 						:active="active"
-						:disabled="_disabled"
+						:disabled="internalDisabled"
 						:placeholder="t('no_file_selected')"
 						:model-value="file && file.title"
 						@click="toggle"
@@ -216,7 +216,13 @@ function useURLImport() {
 								<template v-if="file">
 									<v-icon v-tooltip="t('edit_item')" name="edit" clickable @click.stop="editDrawerActive = true" />
 
-									<v-remove v-if="!_disabled" :item-info="relationInfo" :item-edits="edits" deselect @action="remove" />
+									<v-remove
+										v-if="!internalDisabled"
+										:item-info="relationInfo"
+										:item-edits="edits"
+										deselect
+										@action="remove"
+									/>
 								</template>
 
 								<v-icon v-else name="attach_file" />
@@ -233,9 +239,9 @@ function useURLImport() {
 						<v-list-item-content>{{ t('download_file') }}</v-list-item-content>
 					</v-list-item>
 
-					<v-divider v-if="!_disabled" />
+					<v-divider v-if="!internalDisabled" />
 				</template>
-				<template v-if="!_disabled">
+				<template v-if="!internalDisabled">
 					<v-list-item v-if="createAllowed && enableCreate" clickable @click="activeDialog = 'upload'">
 						<v-list-item-icon><v-icon name="phonelink" /></v-list-item-icon>
 						<v-list-item-content>
@@ -266,7 +272,7 @@ function useURLImport() {
 			collection="directus_files"
 			:primary-key="file.id"
 			:edits="edits"
-			:disabled="_disabled"
+			:disabled="internalDisabled"
 			@input="update"
 		>
 			<template #actions>

--- a/app/src/interfaces/file/index.ts
+++ b/app/src/interfaces/file/index.ts
@@ -37,6 +37,34 @@ export default defineInterface({
 					},
 				},
 			},
+			{
+				field: 'enableCreate',
+				name: '$t:creating_items',
+				schema: {
+					default_value: true,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:enable_create_button',
+					},
+					width: 'half',
+				},
+			},
+			{
+				field: 'enableSelect',
+				name: '$t:selecting_items',
+				schema: {
+					default_value: true,
+				},
+				meta: {
+					interface: 'boolean',
+					options: {
+						label: '$t:enable_select_button',
+					},
+					width: 'half',
+				},
+			},
 		];
 	},
 	recommendedDisplays: ['file'],

--- a/app/src/interfaces/file/index.ts
+++ b/app/src/interfaces/file/index.ts
@@ -12,18 +12,33 @@ export default defineInterface({
 	localTypes: ['file'],
 	group: 'relational',
 	relational: true,
-	options: [
-		{
-			field: 'folder',
-			name: '$t:interfaces.system-folder.folder',
-			type: 'uuid',
-			meta: {
-				width: 'full',
-				interface: 'system-folder',
-				note: '$t:interfaces.system-folder.field_hint',
+	options: ({ relations }) => {
+		const collection = relations.m2o?.related_collection;
+
+		return [
+			{
+				field: 'folder',
+				name: '$t:interfaces.system-folder.folder',
+				type: 'uuid',
+				meta: {
+					width: 'full',
+					interface: 'system-folder',
+					note: '$t:interfaces.system-folder.field_hint',
+				},
 			},
-		},
-	],
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
+					},
+				},
+			},
+		];
+	},
 	recommendedDisplays: ['file'],
 	preview: PreviewSVG,
 });

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -243,7 +243,7 @@ function getDownloadName(junctionRow: Record<string, any>) {
 	return junctionRow[junctionField]?.filename_download;
 }
 
-const values = inject('values', ref<Record<string, any>>({}));
+const values = inject('values', ref<Record<string, unknown>>({}));
 
 const customFilter = computed(() => {
 	if (!relationInfo.value) return;
@@ -277,7 +277,7 @@ const customFilter = computed(() => {
 	if (props.filter) {
 		filter._and.push(
 			parseFilter(
-				deepMap(props.filter, (val: any) => {
+				deepMap(props.filter, (val: unknown) => {
 					if (val && typeof val === 'string') {
 						return render(val, values.value);
 					}

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -4,12 +4,14 @@ import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/compo
 import { useRelationPermissionsM2M } from '@/composables/use-relation-permissions';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { getAssetUrl } from '@/utils/get-asset-url';
+import { parseFilter } from '@/utils/parse-filter';
 import DrawerFiles from '@/views/private/components/drawer-files.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import { Filter } from '@directus/types';
-import { getFieldsFromTemplate } from '@directus/utils';
+import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil, set } from 'lodash';
-import { computed, ref, toRefs } from 'vue';
+import { render } from 'micromustache';
+import { computed, inject, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Draggable from 'vuedraggable';
 
@@ -24,6 +26,7 @@ const props = withDefaults(
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		folder?: string;
+		filter?: Filter;
 		showNavigation?: boolean;
 		limit?: number;
 	}>(),
@@ -240,6 +243,8 @@ function getDownloadName(junctionRow: Record<string, any>) {
 	return junctionRow[junctionField]?.filename_download;
 }
 
+const values = inject('values', ref<Record<string, any>>({}));
+
 const customFilter = computed(() => {
 	if (!relationInfo.value) return;
 
@@ -268,6 +273,20 @@ const customFilter = computed(() => {
 	}
 
 	if (props.primaryKey !== '+') filter._and.push(selectFilter);
+
+	if (props.filter) {
+		filter._and.push(
+			parseFilter(
+				deepMap(props.filter, (val: any) => {
+					if (val && typeof val === 'string') {
+						return render(val, values.value);
+					}
+
+					return val;
+				}),
+			),
+		);
+	}
 
 	return filter;
 });

--- a/app/src/interfaces/files/index.ts
+++ b/app/src/interfaces/files/index.ts
@@ -13,6 +13,8 @@ export default defineInterface({
 	localTypes: ['files'],
 	group: 'relational',
 	options: ({ relations }) => {
+		const collection = relations.m2o?.related_collection;
+
 		return [
 			{
 				field: 'folder',
@@ -31,6 +33,17 @@ export default defineInterface({
 					interface: 'system-display-template',
 					options: {
 						collectionName: relations.o2m?.collection,
+					},
+				},
+			},
+			{
+				field: 'filter',
+				name: '$t:filter',
+				type: 'json',
+				meta: {
+					interface: 'system-filter',
+					options: {
+						collectionName: collection,
 					},
 				},
 			},

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -14,7 +14,7 @@ const fieldDetailStore = useFieldDetailStore();
 const relationsStore = useRelationsStore();
 const fieldsStore = useFieldsStore();
 
-const { collection, editing, generationInfo, localType } = storeToRefs(fieldDetailStore);
+const { collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
 
 const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
 const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
@@ -96,7 +96,7 @@ const unsortableJunctionFields = computed(() => {
 
 			<div class="field">
 				<div class="type-label">{{ t('related_collection') }}</div>
-				<related-collection-select v-model="relatedCollection" :disabled="localType === 'files' || isExisting" />
+				<related-collection-select v-model="relatedCollection" :disabled="isExisting" />
 			</div>
 
 			<v-input disabled :model-value="currentPrimaryKey" />

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
@@ -77,3 +77,10 @@ export function resetRelations(updates: StateUpdates) {
 	updates.relations.m2o = undefined;
 	updates.relations.o2m = undefined;
 }
+
+export function resetInterfaceAndDisplay(updates: StateUpdates) {
+	set(updates, 'field.meta.interface', undefined);
+	set(updates, 'field.meta.options', undefined);
+	set(updates, 'field.meta.display', undefined);
+	set(updates, 'field.meta.display_options', undefined);
+}

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
@@ -78,8 +78,16 @@ export function resetRelations(updates: StateUpdates) {
 	updates.relations.o2m = undefined;
 }
 
-export function resetInterfaceAndDisplay(updates: StateUpdates) {
-	set(updates, 'field.meta.interface', undefined);
+export function switchInterfaceAndDisplay(updates: StateUpdates) {
+	let targetInterface = undefined;
+
+	if (updates.localType === 'files') {
+		targetInterface = 'files';
+	} else if (updates.localType === 'file') {
+		targetInterface = 'file';
+	}
+
+	set(updates, 'field.meta.interface', targetInterface);
 	set(updates, 'field.meta.options', undefined);
 	set(updates, 'field.meta.display', undefined);
 	set(updates, 'field.meta.display_options', undefined);

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -165,6 +165,24 @@ export const useFieldDetailStore = defineStore({
 					alterations[localType].applyChanges(updates, state, { hasChanged, getCurrent });
 				}
 
+				if (hasChanged('relations.m2o.related_collection')) {
+					const currentType = getCurrent('localType');
+					let targetType = currentType;
+
+					if (get(updates, 'relations.m2o.related_collection') === 'directus_files') {
+						if (currentType === 'm2o') targetType = 'file';
+						if (currentType === 'm2m') targetType = 'files';
+					} else {
+						if (currentType === 'file') targetType = 'm2o';
+						if (currentType === 'files') targetType = 'm2m';
+					}
+
+					if (currentType !== targetType) {
+						updates.localType = targetType;
+						alterations.global.resetInterfaceAndDisplay(updates);
+					}
+				}
+
 				const { field: fieldUpdates, items: itemUpdates, ...restUpdates } = updates;
 
 				// Handle `field` updates, shallow merge and mirror to `fieldUpdates`

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -179,7 +179,7 @@ export const useFieldDetailStore = defineStore({
 
 					if (currentType !== targetType) {
 						updates.localType = targetType;
-						alterations.global.resetInterfaceAndDisplay(updates);
+						alterations.global.switchInterfaceAndDisplay(updates);
 					}
 				}
 

--- a/app/src/views/private/components/drawer-files.vue
+++ b/app/src/views/private/components/drawer-files.vue
@@ -50,7 +50,7 @@ function onFolderChange(target: FolderTarget) {
 		v-bind="$attrs"
 		:collection="collection"
 		:drawer-props="drawerProps"
-		:filter="mergeFilters(filter, folderFilter)"
+		:filter="mergeFilters(filter ?? null, folderFilter ?? null)"
 	>
 		<template #sidebar>
 			<files-navigation


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- File, Files and Image interface now have filter options
- When selecting `directus_files` in a m2o or m2m relation, only file based interfaces will be selectable

## Potential Risks / Drawbacks

- None I can think of right now

## Review Notes / Questions

- Had to revert a small change in #15904 which made the related collection field disabled if the relation was of `files` type.

---

Closes ENG-1254
