### PR TITLE
Ability to toggle variable input for filters

### DIFF
--- a/.changeset/three-chairs-strive.md
+++ b/.changeset/three-chairs-strive.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added the ability to toggle a variable input for the \_in and \_nin filters.

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -68,6 +68,7 @@ const value = computed(() =>
 				:primary-key="primaryKey"
 				:length="field.schema && field.schema.max_length"
 				:direction="direction"
+				:raw-editor-enabled="rawEditorEnabled"
 				@input="$emit('update:modelValue', $event)"
 				@set-field-value="$emit('setFieldValue', $event)"
 			/>

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -4,7 +4,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { FieldFilter } from '@directus/types';
 import { clone, get } from 'lodash';
-import { computed, nextTick, ref, toRef } from 'vue';
+import { ref, computed, onBeforeMount, toRef, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import InputComponent from './input-component.vue';
 import { fieldToFilter, getComparator, getField } from './utils';
@@ -13,6 +13,7 @@ import { useCollection } from '@directus/composables';
 const props = defineProps<{
 	field: FieldFilter;
 	collection: string;
+	variableInputEnabled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -79,30 +80,36 @@ const interfaceType = computed(() => {
 	return 'interface-' + types[fieldInfo.value?.type || 'string'];
 });
 
+const fieldValue = computed(() => {
+	return get(props.field, `${field.value}.${comparator.value}`);
+});
+
+const {
+	isVariableInputActive,
+	isVariableInputComparator,
+	variableInputDisplay,
+	onToggleVariableInput,
+	onVariableInput,
+} = useVariableInput();
+
 const value = computed<unknown | unknown[]>({
 	get() {
-		const fieldPath = getField(props.field);
-
-		const value = get(props.field, `${fieldPath}.${comparator.value}`);
-
-		if (['_in', '_nin'].includes(comparator.value)) {
-			return [...(value as string[]).filter((val) => val !== null && val !== ''), null];
-		} else {
-			return value;
+		if (!isVariableInputActive.value && ['_in', '_nin'].includes(comparator.value)) {
+			return [...(fieldValue.value as string[]).filter((val) => val !== null && val !== ''), null];
 		}
+
+		return fieldValue.value;
 	},
 	set(newVal) {
-		const fieldPath = getField(props.field);
-
 		let value;
 
-		if (['_in', '_nin'].includes(comparator.value)) {
+		if (!isVariableInputActive.value && ['_in', '_nin'].includes(comparator.value)) {
 			value = (newVal as string[]).filter((val) => val !== null && val !== '').map((val) => val.trim());
 		} else {
 			value = newVal;
 		}
 
-		emit('update:field', fieldToFilter(fieldPath, comparator.value, value));
+		emit('update:field', fieldToFilter(field.value, comparator.value, value));
 	},
 });
 
@@ -138,82 +145,224 @@ function handleCommaValuePasted(newValue: string) {
 	value.value = newValueArray;
 	focusInputAtIndex(newValueArray.length - 1);
 }
+
+function useVariableInput() {
+	const arrayComparators = ['_in', '_nin', '_between', '_nbetween'];
+	const variableInputComparators = ['_in', '_nin'];
+	const isVariableInputActive = ref(false);
+	const variableInputDisplay = computed(inputDisplay);
+	const isArrayComparator = computed(() => props.variableInputEnabled && arrayComparators.includes(comparator.value));
+
+	const isVariableInputComparator = computed(
+		() => props.variableInputEnabled && variableInputComparators.includes(comparator.value),
+	);
+
+	onBeforeMount(determineVariableInput);
+
+	return {
+		isVariableInputActive,
+		isVariableInputComparator,
+		onToggleVariableInput,
+		onVariableInput,
+		variableInputDisplay,
+	};
+
+	function determineVariableInput() {
+		if (!isVariableInputComparator.value) return;
+		isVariableInputActive.value = !Array.isArray(fieldValue.value);
+	}
+
+	function onToggleVariableInput() {
+		const showVariableInput = !isVariableInputActive.value;
+
+		if (showVariableInput) {
+			// Note: first toggle, then set value
+
+			isVariableInputActive.value = showVariableInput;
+
+			if (isArrayComparator.value && Array.isArray(value.value)) {
+				value.value = value.value.join(',');
+			}
+		} else {
+			// Note: first set value, then toggle
+
+			if (isArrayComparator.value) {
+				if (typeof value.value === 'string') {
+					value.value = (value.value as string).split(',');
+				} else if (value.value === null) {
+					value.value = [];
+				} else {
+					value.value = [value.value];
+				}
+			}
+
+			isVariableInputActive.value = showVariableInput;
+		}
+	}
+
+	function onVariableInput(newValue: unknown) {
+		if (newValue === null) {
+			value.value = '';
+			return;
+		}
+
+		newValue = String(newValue).replace(/{{/g, '').replace(/}}/g, '');
+		value.value = `{{${newValue}}}`;
+	}
+
+	function inputDisplay() {
+		if (isVariableInputActive.value && typeof value.value === 'string') {
+			return value.value.replace(/{{/g, '').replace(/}}/g, '');
+		}
+
+		return '';
+	}
+}
 </script>
 
 <template>
-	<template v-if="['_eq', '_neq', '_lt', '_gt', '_lte', '_gte'].includes(comparator)">
-		<input-component
-			:is="interfaceType"
-			:choices="choices"
-			:type="fieldInfo?.type ?? 'unknown'"
-			:value="value"
-			@input="value = $event"
-		/>
-	</template>
-	<template
-		v-else-if="
-			[
-				'_contains',
-				'_ncontains',
-				'_icontains',
-				'_starts_with',
-				'_istarts_with',
-				'_nstarts_with',
-				'_nistarts_with',
-				'_ends_with',
-				'_iends_with',
-				'_nends_with',
-				'_niends_with',
-				'_regex',
-			].includes(comparator)
-		"
-	>
+	<v-icon
+		v-if="isVariableInputComparator"
+		v-tooltip="$t('toggle_variable_input')"
+		class="variable-input-toggle"
+		:class="{ active: isVariableInputActive }"
+		name="data_object"
+		small
+		clickable
+		@click="onToggleVariableInput"
+	/>
+
+	<template v-if="isVariableInputActive">
+		<span class="variable-input-braces">{{ '\{\{' }}</span>
+
 		<input-component
 			is="interface-input"
-			:choices="choices"
-			:type="fieldInfo?.type ?? 'unknown'"
-			:value="value"
-			@input="value = $event"
+			class="variable-input"
+			type="unknown"
+			:value="variableInputDisplay"
+			@input="onVariableInput"
 		/>
+
+		<span class="variable-input-braces">{{ '\}\}' }}</span>
 	</template>
 
-	<div v-else-if="['_in', '_nin'].includes(comparator)" class="list">
-		<div v-for="(val, index) in value" :key="index" class="value">
+	<template v-else>
+		<template v-if="['_eq', '_neq', '_lt', '_gt', '_lte', '_gte'].includes(comparator)">
 			<input-component
 				:is="interfaceType"
-				:ref="(el) => (inputRefs[index] = el)"
-				:type="fieldInfo?.type ?? 'unknown'"
-				:value="val"
-				:focus="false"
 				:choices="choices"
-				comma-allowed
-				@input="setValueAt(index, $event)"
-				@comma-key-pressed="handleCommaKeyPressed(index)"
-				@comma-value-pasted="handleCommaValuePasted($event)"
+				:type="fieldInfo?.type ?? 'unknown'"
+				:value="String(value)"
+				@input="value = $event"
 			/>
-		</div>
-	</div>
+		</template>
+		<template
+			v-else-if="
+				[
+					'_contains',
+					'_ncontains',
+					'_icontains',
+					'_starts_with',
+					'_istarts_with',
+					'_nstarts_with',
+					'_nistarts_with',
+					'_ends_with',
+					'_iends_with',
+					'_nends_with',
+					'_niends_with',
+					'_regex',
+				].includes(comparator)
+			"
+		>
+			<input-component
+				is="interface-input"
+				:choices="choices"
+				:type="fieldInfo?.type ?? 'unknown'"
+				:value="String(value)"
+				@input="value = $event"
+			/>
+		</template>
 
-	<template v-else-if="['_between', '_nbetween'].includes(comparator)">
-		<input-component
-			:is="interfaceType"
-			:choices="choices"
-			:type="fieldInfo?.type ?? 'unknown'"
-			:value="(value as (string | number)[])[0] ?? ''"
-			@input="setValueAt(0, $event)"
-		/>
-		<div class="and">{{ t('interfaces.filter.and') }}</div>
-		<input-component
-			:is="interfaceType"
-			:choices="choices"
-			:type="fieldInfo?.type ?? 'unknown'"
-			:value="(value as (string | number)[])[1] ?? ''"
-			@input="setValueAt(1, $event)"
-		/>
+		<div v-else-if="['_in', '_nin'].includes(comparator)" class="list">
+			<div v-for="(val, index) in value" :key="index" class="value">
+				<input-component
+					:is="interfaceType"
+					:ref="(el) => (inputRefs[index] = el)"
+					:type="fieldInfo?.type ?? 'unknown'"
+					:value="val"
+					:focus="false"
+					:choices="choices"
+					comma-allowed
+					@input="setValueAt(index, $event)"
+					@comma-key-pressed="handleCommaKeyPressed(index)"
+					@comma-value-pasted="handleCommaValuePasted($event)"
+				/>
+			</div>
+		</div>
+
+		<template v-else-if="['_between', '_nbetween'].includes(comparator)">
+			<input-component
+				:is="interfaceType"
+				:choices="choices"
+				:type="fieldInfo?.type ?? 'unknown'"
+				:value="(value as (string | number)[])[0] ?? ''"
+				@input="setValueAt(0, $event)"
+			/>
+			<div class="and">{{ t('interfaces.filter.and') }}</div>
+			<input-component
+				:is="interfaceType"
+				:choices="choices"
+				:type="fieldInfo?.type ?? 'unknown'"
+				:value="(value as (string | number)[])[1] ?? ''"
+				@input="setValueAt(1, $event)"
+			/>
+		</template>
 	</template>
 </template>
 
 <style lang="scss" scoped>
+.variable-input-toggle {
+	--v-icon-color: var(--theme--foreground-subdued);
+	--v-icon-color-hover: var(--theme--foreground);
+
+	margin-right: 4px;
+
+	.comparator + & {
+		margin-left: -4px;
+	}
+
+	&.v-icon {
+		width: 24px !important;
+		height: 24px !important;
+		border-radius: 50%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	&.active {
+		--v-icon-color: var(--theme--primary);
+		--v-icon-color-hover: var(--theme--primary-accent);
+
+		background-color: var(--theme--primary-background);
+	}
+}
+
+.variable-input {
+	color: var(--theme--secondary);
+	padding-inline: 0;
+}
+
+.variable-input-braces {
+	font-family: var(--theme--fonts--monospace--font-family);
+	color: var(--theme--form--field--input--foreground-subdued);
+	margin-left: 2px;
+
+	.variable-input + & {
+		margin-left: 0;
+	}
+}
+
 .value {
 	display: flex;
 	align-items: center;

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -46,6 +46,7 @@ interface Props {
 	includeRelations?: boolean;
 	relationalFieldSelectable?: boolean;
 	rawFieldNames?: boolean;
+	variableInputEnabled: boolean | undefined;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -330,7 +331,12 @@ function isExistingField(node: Record<string, any>): boolean {
 							:items="getCompareOptions((filterInfo[index] as FilterInfoField).field)"
 							@update:model-value="updateComparator(index, $event)"
 						/>
-						<input-group :field="element" :collection="collection" @update:field="replaceNode(index, $event)" />
+						<input-group
+							:field="element"
+							:collection="collection"
+							:variable-input-enabled="variableInputEnabled"
+							@update:field="replaceNode(index, $event)"
+						/>
 						<span class="delete">
 							<v-icon
 								v-tooltip="t('delete_label')"
@@ -378,6 +384,7 @@ function isExistingField(node: Record<string, any>): boolean {
 						:depth="depth + 1"
 						:inline="inline"
 						:raw-field-names="rawFieldNames"
+						:variable-input-enabled="variableInputEnabled"
 						@change="$emit('change')"
 						@remove-node="$emit('remove-node', [`${index}.${filterInfo[index].name}`, ...$event])"
 						@update:filter="replaceNode(index, { [filterInfo[index].name]: $event })"

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -32,6 +32,7 @@ interface Props {
 	injectVersionField?: boolean;
 	relationalFieldSelectable?: boolean;
 	rawFieldNames?: boolean;
+	rawEditorEnabled?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -186,6 +187,7 @@ function addKeyAsNode() {
 				:include-relations="includeRelations"
 				:relational-field-selectable="relationalFieldSelectable"
 				:raw-field-names="rawFieldNames"
+				:variable-input-enabled="rawEditorEnabled"
 				@remove-node="removeNode($event)"
 				@change="emitValue"
 			/>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -440,6 +440,7 @@ field_key: Field Key
 finish_setup: Finish Setup
 dismiss: Dismiss
 toggle_raw_editor: Toggle Raw Editor
+toggle_variable_input: Toggle Variable Input
 raw_editor_placeholder: "{'{'}{'{'}$trigger.payload.example{'}'}{'}'}"
 raw_value: Raw value
 copy_raw_value: Copy Raw Value


### PR DESCRIPTION
## Scope

What's changed:

- Added a “Toggle Variable Input” button to the `_in` and `_nin` filters.
- The toggle button is only enabled if the parent form’s `rawEditorEnabled` property is enabled.
- Added the `rawEditorEnabled` prop to the `<form-field-interface>` component and drilled it down to `<system-filter>` > `<nodes>` > `<input-group>` as `variableInputEnabled` to determine if the “Variable Input” can be enabled.
- Added an I18n message for the toggle button

## Potential Risks / Drawbacks

There could be other occurrences, where the toggle button is not expected.

## Review Notes / Questions

- We could also enable the variable input also for the `'_between', '_nbetween'` operators
- With a bit of refactoring, we could also enable the variable input for all operators.

---

Fixes #23778
