### PR TITLE
Improve field permissions

### DIFF
--- a/.changeset/yellow-news-report.md
+++ b/.changeset/yellow-news-report.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Improved the UX of the field permissions by changing its interface to a checkbox tree

--- a/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree-checkbox.vue
@@ -406,7 +406,7 @@ function getRecursiveChildrenValues(mode: 'all' | 'branch' | 'leaf', children: R
 			:text="choice[itemText]"
 			:value="choice[itemValue]"
 			:children="choice[itemChildren]"
-			:disabled="disabled"
+			:disabled="disabled || choice.disabled"
 			:show-selection-only="showSelectionOnly"
 			:parent-value="value"
 		/>

--- a/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
@@ -154,7 +154,7 @@ function findSelectedChoices(choices: Record<string, any>[], checked: (string | 
 			:hidden="visibleChildrenValues.includes(choice[itemValue]) === false"
 			:value="choice[itemValue]"
 			:children="choice[itemChildren]"
-			:disabled="disabled"
+			:disabled="disabled || choice.disabled"
 			:show-selection-only="showSelectionOnly"
 		/>
 	</v-list>

--- a/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
@@ -23,6 +23,8 @@ const props = withDefaults(
 		disabled?: boolean;
 		/** Show only the selected choices */
 		showSelectionOnly?: boolean;
+		/** Opens all groups included in the array. `[]` collapses all groups. Ignored if not an array. */
+		openGroups?: string[] | null;
 	}>(),
 	{
 		choices: () => [],
@@ -76,6 +78,7 @@ const searchOpenSelection = computed(() =>
 
 const openSelection = computed({
 	get() {
+		if (Array.isArray(props.openGroups)) return props.openGroups;
 		return Array.from(new Set([...manualOpenSelection.value, ...searchOpenSelection.value]));
 	},
 	set(newValue) {

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -29,6 +29,7 @@ export function useFieldTree(
 	inject?: Ref<{ fields: Field[]; relations?: Relation[] } | null>,
 	filter: (field: Field, parent?: FieldNode) => boolean = () => true,
 	includeRelations = true,
+	includeAliasFields = false,
 ): FieldTreeContext {
 	const fieldsStore = useFieldsStore();
 	const relationsStore = useRelationsStore();
@@ -62,6 +63,7 @@ export function useFieldTree(
 			.concat(injectedFields || [])
 			.filter(
 				(field) =>
+					includeAliasFields ||
 					field.meta?.special?.includes('group') ||
 					(!field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data')),
 			)

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -28,6 +28,7 @@ export function useFieldTree(
 	collection: Ref<string | null>,
 	inject?: Ref<{ fields: Field[]; relations?: Relation[] } | null>,
 	filter: (field: Field, parent?: FieldNode) => boolean = () => true,
+	includeRelations = true,
 ): FieldTreeContext {
 	const fieldsStore = useFieldsStore();
 	const relationsStore = useRelationsStore();
@@ -77,9 +78,7 @@ export function useFieldTree(
 	}
 
 	function makeNode(field: Field, parent?: FieldNode): FieldNode | FieldNode[] {
-		const { relationType, relatedCollections } = getRelationTypeAndRelatedCollections(field);
 		const pathContext = parent?.path ? parent.path + '.' : '';
-		const keyContext = parent?.key ? parent.key + '.' : '';
 
 		if (field?.meta?.special?.includes('group')) {
 			const node: FieldNode = {
@@ -95,7 +94,7 @@ export function useFieldTree(
 
 			const children = getTree(field.collection, node);
 
-			if (children) {
+			if (includeRelations && children) {
 				for (const child of children) {
 					if (child.relatedCollection) {
 						child.children = [
@@ -110,6 +109,21 @@ export function useFieldTree(
 				children,
 			};
 		}
+
+		if (!includeRelations) {
+			return {
+				name: field.name,
+				field: field.field,
+				collection: field.collection,
+				relatedCollection: undefined,
+				key: field.field,
+				path: field.field,
+				type: field.type,
+			};
+		}
+
+		const { relationType, relatedCollections } = getRelationTypeAndRelatedCollections(field);
+		const keyContext = parent?.key ? parent.key + '.' : '';
 
 		if (relatedCollections.length <= 1 && relationType !== 'm2a') {
 			return {


### PR DESCRIPTION
## Scope

What's changed:

- Changed field permissions interface to checkbox tree
- Refactored useFieldTree to be able to include non-data alias fields and exclude relations
- Added the ability to disable single checkboxes in a checkbox tree
- Added a toggle button, that expands/collapses all nodes to improve UX

Benefits:
- Selecting a field automatically selects its parent groups as well.
- Now, we can select all fields of a group at once.
- No adaptation is needed, and it is no breaking change. Even if a field was selected but its parent wasn’t, the checkbox tree component will handle it and won’t produce any errors.

## Potential Risks / Drawbacks

- don’t think so

## Review Notes / Questions

- Other than before: Write and update permissions exclude no-data alias fields, since they are irrelevant here.

---

Fixes #23525
