### PR TITLE
Added backlink query param

### DIFF
--- a/.changeset/shaggy-bears-begin.md
+++ b/.changeset/shaggy-bears-begin.md
@@ -1,0 +1,7 @@
+---
+"@directus/api": patch
+"@directus/sdk": patch
+"@directus/types": patch
+---
+
+Added backlink query parameter to not include back-relations when expanding `*.*` in the fields query parameter.

--- a/.changeset/shaggy-bears-begin.md
+++ b/.changeset/shaggy-bears-begin.md
@@ -1,7 +1,7 @@
 ---
-"@directus/api": patch
-"@directus/sdk": patch
-"@directus/types": patch
+"@directus/api": minor
+"@directus/sdk": minor
+"@directus/types": minor
 ---
 
-Added backlink query parameter to not include back-relations when expanding `*.*` in the fields query parameter.
+Added `backlink` query parameter to exclude back-relations when expanding `*.*` in the fields query parameter

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
@@ -29,7 +29,7 @@ test('converting nothing without any permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: [], alias: {}, accountability },
+		{ collection: 'articles', fields: [], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -40,7 +40,7 @@ test('converting * without any permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -51,7 +51,7 @@ test('converting * without any permissions and alias is null', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: null, accountability },
+		{ collection: 'articles', fields: ['*'], alias: null, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -62,7 +62,7 @@ test('converting * with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -73,7 +73,7 @@ test('converting * with just id permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['id']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -84,7 +84,7 @@ test('converting title with any permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['title']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['title'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['title'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -95,7 +95,7 @@ test('converting invalid field with any permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['invalid'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['invalid'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -106,7 +106,7 @@ test('converting invalid field with id, title permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['id', 'title']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['invalid'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['invalid'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -115,7 +115,7 @@ test('converting invalid field with id, title permissions', async () => {
 
 test('converting * with admin permissions', async () => {
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: {}, accountability: { admin: true } as Accountability },
+		{ collection: 'articles', fields: ['*'], alias: {}, accountability: { admin: true } as Accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -124,7 +124,7 @@ test('converting * with admin permissions', async () => {
 
 test('converting title with admin permissions', async () => {
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['title'], alias: {}, accountability: { admin: true } as Accountability },
+		{ collection: 'articles', fields: ['title'], alias: {}, accountability: { admin: true } as Accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -135,7 +135,7 @@ test('converting alias field with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: { alias: 'id' }, accountability },
+		{ collection: 'articles', fields: ['*'], alias: { alias: 'id' }, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -146,7 +146,7 @@ test('converting invalid alias field with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: { alias: 'invalid' }, accountability },
+		{ collection: 'articles', fields: ['*'], alias: { alias: 'invalid' }, accountability, backlink: true },
 		{ knex: db, schema },
 	);
 
@@ -171,7 +171,7 @@ test('converting *.* with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*.*'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['*.*'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema: schemaRelational },
 	);
 
@@ -182,7 +182,7 @@ test('converting *.*.* with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*.*.*'], alias: {}, accountability },
+		{ collection: 'articles', fields: ['*.*.*'], alias: {}, accountability, backlink: true },
 		{ knex: db, schema: schemaRelational },
 	);
 
@@ -193,7 +193,7 @@ test('converting *.* and alias with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*.*'], alias: { alias: 'title' }, accountability },
+		{ collection: 'articles', fields: ['*.*'], alias: { alias: 'title' }, accountability, backlink: true },
 		{ knex: db, schema: schemaRelational },
 	);
 
@@ -204,7 +204,7 @@ test('converting alias as year(date) with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*.*'], alias: { alias: 'year(date)' }, accountability },
+		{ collection: 'articles', fields: ['*.*'], alias: { alias: 'year(date)' }, accountability, backlink: true },
 		{ knex: db, schema: schemaRelational },
 	);
 
@@ -215,7 +215,7 @@ test('converting year(alias) as date with * permissions', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce(['*']);
 
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*.*'], alias: { 'year(alias)': 'date' }, accountability },
+		{ collection: 'articles', fields: ['*.*'], alias: { 'year(alias)': 'date' }, accountability, backlink: true },
 		{ knex: db, schema: schemaRelational },
 	);
 

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
@@ -115,7 +115,13 @@ test('converting invalid field with id, title permissions', async () => {
 
 test('converting * with admin permissions', async () => {
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['*'], alias: {}, accountability: { admin: true } as Accountability, backlink: true },
+		{
+			collection: 'articles',
+			fields: ['*'],
+			alias: {},
+			accountability: { admin: true } as Accountability,
+			backlink: true,
+		},
 		{ knex: db, schema },
 	);
 
@@ -124,7 +130,13 @@ test('converting * with admin permissions', async () => {
 
 test('converting title with admin permissions', async () => {
 	const result = await convertWildcards(
-		{ collection: 'articles', fields: ['title'], alias: {}, accountability: { admin: true } as Accountability, backlink: true },
+		{
+			collection: 'articles',
+			fields: ['title'],
+			alias: {},
+			accountability: { admin: true } as Accountability,
+			backlink: true,
+		},
 		{ knex: db, schema },
 	);
 

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.test.ts
@@ -251,7 +251,11 @@ test('backlink set to true', async () => {
 
 	const result = await convertWildcards(
 		{ collection: 'articles_tags_junction', fields: ['*.*'], alias: {}, accountability, backlink: true },
-		{ knex: db, schema: schemaRelational, parentRelation: getRelation(schemaRelational.relations, 'articles', 'tags')! },
+		{
+			knex: db,
+			schema: schemaRelational,
+			parentRelation: getRelation(schemaRelational.relations, 'articles', 'tags')!,
+		},
 	);
 
 	expect(result).toEqual(['articles_id.*', 'tags_id.*', 'id']);
@@ -262,7 +266,11 @@ test('backlink set to false', async () => {
 
 	const result = await convertWildcards(
 		{ collection: 'articles_tags_junction', fields: ['*.*'], alias: {}, accountability, backlink: false },
-		{ knex: db, schema: schemaRelational, parentRelation: getRelation(schemaRelational.relations, 'articles', 'tags')! },
+		{
+			knex: db,
+			schema: schemaRelational,
+			parentRelation: getRelation(schemaRelational.relations, 'articles', 'tags')!,
+		},
 	);
 
 	expect(result).toEqual(['tags_id.*', 'id', 'articles_id']);

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
@@ -71,7 +71,6 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 			const parts = fieldKey.split('.');
 
 			let relationalFields: string[] = [];
-			const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
 
 			if (allowedFields.includes('*')) {
 				relationalFields = context.schema.relations.reduce<string[]>((acc, relation) => {
@@ -92,6 +91,8 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 						getRelation(context.schema.relations, options.collection, relationField) !== context.parentRelation,
 				);
 			}
+
+			const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
 
 			const aliasFields = Object.keys(options.alias ?? {}).map((fieldKey) => {
 				const name = options.alias![fieldKey];

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
@@ -74,8 +74,13 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 
 			if (allowedFields.includes('*')) {
 				relationalFields = context.schema.relations.reduce<string[]>((acc, relation) => {
-					if (relation.collection === options.collection) acc.push(relation.field);
-					if (relation.related_collection === options.collection) acc.push(relation.meta!.one_field!);
+					if (relation.collection === options.collection && !acc.includes(relation.field)) {
+						acc.push(relation.field);
+					}
+
+					if (relation.related_collection === options.collection && !acc.includes(relation.meta!.one_field!)) {
+						acc.push(relation.meta!.one_field!);
+					}
 
 					return acc;
 				}, []);

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
@@ -10,13 +10,13 @@ export interface ConvertWildcardsOptions {
 	fields: string[];
 	alias: Query['alias'];
 	accountability: Accountability | null;
-	backlink: boolean | undefined
+	backlink: boolean | undefined;
 }
 
 export interface ConvertWildCardsContext {
 	schema: SchemaOverview;
 	knex: Knex;
-	parentRelation?: Relation
+	parentRelation?: Relation;
 }
 
 export async function convertWildcards(options: ConvertWildcardsOptions, context: ConvertWildCardsContext) {
@@ -70,22 +70,27 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 		if (fieldKey.includes('.') && fieldKey.split('.')[0] === '*') {
 			const parts = fieldKey.split('.');
 
-			let relationalFields: string[] = []
+			let relationalFields: string[] = [];
 			const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
 
 			if (allowedFields.includes('*')) {
 				relationalFields = context.schema.relations.reduce<string[]>((acc, relation) => {
-					if (relation.collection === options.collection) acc.push(relation.field)
-					if (relation.related_collection === options.collection) acc.push(relation.meta!.one_field!)
+					if (relation.collection === options.collection) acc.push(relation.field);
+					if (relation.related_collection === options.collection) acc.push(relation.meta!.one_field!);
 
-					return acc
-				}, [])
+					return acc;
+				}, []);
 			} else {
-				relationalFields = allowedFields.filter((fieldKey) => getRelation(context.schema.relations, options.collection, fieldKey) !== undefined)
+				relationalFields = allowedFields.filter(
+					(fieldKey) => getRelation(context.schema.relations, options.collection, fieldKey) !== undefined,
+				);
 			}
 
 			if (options.backlink === false) {
-				relationalFields = relationalFields.filter(relationField => getRelation(context.schema.relations, options.collection, relationField) !== context.parentRelation)
+				relationalFields = relationalFields.filter(
+					(relationField) =>
+						getRelation(context.schema.relations, options.collection, relationField) !== context.parentRelation,
+				);
 			}
 
 			const aliasFields = Object.keys(options.alias ?? {}).map((fieldKey) => {

--- a/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
+++ b/api/src/database/get-ast-from-query/lib/convert-wildcards.ts
@@ -1,4 +1,4 @@
-import type { Accountability, Query, SchemaOverview } from '@directus/types';
+import type { Accountability, Query, Relation, SchemaOverview } from '@directus/types';
 import { getRelation } from '@directus/utils';
 import type { Knex } from 'knex';
 import { cloneDeep } from 'lodash-es';
@@ -10,11 +10,13 @@ export interface ConvertWildcardsOptions {
 	fields: string[];
 	alias: Query['alias'];
 	accountability: Accountability | null;
+	backlink: boolean | undefined
 }
 
 export interface ConvertWildCardsContext {
 	schema: SchemaOverview;
 	knex: Knex;
+	parentRelation?: Relation
 }
 
 export async function convertWildcards(options: ConvertWildcardsOptions, context: ConvertWildCardsContext) {
@@ -68,24 +70,28 @@ export async function convertWildcards(options: ConvertWildcardsOptions, context
 		if (fieldKey.includes('.') && fieldKey.split('.')[0] === '*') {
 			const parts = fieldKey.split('.');
 
-			const relationalFields = allowedFields.includes('*')
-				? context.schema.relations
-						.filter(
-							(relation) =>
-								relation.collection === options.collection || relation.related_collection === options.collection,
-						)
-						.map((relation) => {
-							const isMany = relation.collection === options.collection;
-							return isMany ? relation.field : relation.meta?.one_field;
-						})
-				: allowedFields.filter((fieldKey) => !!getRelation(context.schema.relations, options.collection, fieldKey));
-
+			let relationalFields: string[] = []
 			const nonRelationalFields = allowedFields.filter((fieldKey) => relationalFields.includes(fieldKey) === false);
+
+			if (allowedFields.includes('*')) {
+				relationalFields = context.schema.relations.reduce<string[]>((acc, relation) => {
+					if (relation.collection === options.collection) acc.push(relation.field)
+					if (relation.related_collection === options.collection) acc.push(relation.meta!.one_field!)
+
+					return acc
+				}, [])
+			} else {
+				relationalFields = allowedFields.filter((fieldKey) => getRelation(context.schema.relations, options.collection, fieldKey) !== undefined)
+			}
+
+			if (options.backlink === false) {
+				relationalFields = relationalFields.filter(relationField => getRelation(context.schema.relations, options.collection, relationField) !== context.parentRelation)
+			}
 
 			const aliasFields = Object.keys(options.alias ?? {}).map((fieldKey) => {
 				const name = options.alias![fieldKey];
 
-				if (relationalFields.includes(name)) {
+				if (relationalFields.includes(name!)) {
 					return `${fieldKey}.${parts.slice(1).join('.')}`;
 				}
 

--- a/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
@@ -48,17 +48,17 @@ test('parse fields with id and title', async () => {
 
 	expect(result).toEqual([
 		{
-			fieldKey: "id",
-			name: "id",
-			type: "field",
-			whenCase: []
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
 		},
 		{
-			fieldKey: "title",
-			name: "title",
-			type: "field",
-			whenCase: []
-		}
+			fieldKey: 'title',
+			name: 'title',
+			type: 'field',
+			whenCase: [],
+		},
 	]);
 });
 
@@ -77,7 +77,6 @@ const schemaRelational = new SchemaBuilder()
 	})
 	.build();
 
-
 test('parse fields with m2o relation', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
@@ -88,31 +87,31 @@ test('parse fields with m2o relation', async () => {
 
 	expect(result).toEqual([
 		{
-			"fieldKey": "id",
-			"name": "id",
-			"type": "field",
-			"whenCase": [],
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
 		},
 		{
-			"cases": [],
-			"children": [
+			cases: [],
+			children: [
 				{
-					"fieldKey": "name",
-					"name": "name",
-					"type": "field",
-					"whenCase": [],
+					fieldKey: 'name',
+					name: 'name',
+					type: 'field',
+					whenCase: [],
 				},
 			],
-			"fieldKey": "author",
-			"name": "users",
-			"parentKey": "id",
-			"query": {},
-			"relatedKey": "id",
-			"relation": getRelation(schemaRelational.relations, 'articles', 'author'),
-			"type": "m2o",
-			"whenCase": [],
+			fieldKey: 'author',
+			name: 'users',
+			parentKey: 'id',
+			query: {},
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'articles', 'author'),
+			type: 'm2o',
+			whenCase: [],
 		},
-	])
+	]);
 });
 
 test('parse fields with o2m relation', async () => {
@@ -125,37 +124,34 @@ test('parse fields with o2m relation', async () => {
 
 	expect(result).toEqual([
 		{
-			"fieldKey": "id",
-			"name": "id",
-			"type": "field",
-			"whenCase": [],
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
 		},
 		{
-			"cases": [],
-			"children": [
+			cases: [],
+			children: [
 				{
-					"fieldKey": "id",
-					"name": "id",
-					"type": "field",
-					"whenCase": [],
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
 				},
 			],
-			"fieldKey": "links",
-			"name": "links",
-			"parentKey": "id",
-			"query": {
-				"sort": [
-					"id",
-				],
+			fieldKey: 'links',
+			name: 'links',
+			parentKey: 'id',
+			query: {
+				sort: ['id'],
 			},
-			"relatedKey": "id",
-			"relation": getRelation(schemaRelational.relations, 'articles', 'links'),
-			"type": "o2m",
-			"whenCase": [],
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'articles', 'links'),
+			type: 'o2m',
+			whenCase: [],
 		},
 	]);
 });
-
 
 test('parse fields with m2m relation', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
@@ -167,48 +163,46 @@ test('parse fields with m2m relation', async () => {
 
 	expect(result).toEqual([
 		{
-			"fieldKey": "id",
-			"name": "id",
-			"type": "field",
-			"whenCase": [],
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
 		},
 		{
-			"cases": [],
-			"children": [
+			cases: [],
+			children: [
 				{
-					"cases": [],
-					"children": [
+					cases: [],
+					children: [
 						{
-							"fieldKey": "id",
-							"name": "id",
-							"type": "field",
-							"whenCase": [],
+							fieldKey: 'id',
+							name: 'id',
+							type: 'field',
+							whenCase: [],
 						},
 					],
-					"fieldKey": "tags_id",
-					"name": "tags",
-					"parentKey": "id",
-					"query": {},
-					"relatedKey": "id",
-					"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'tags_id'),
-					"type": "m2o",
-					"whenCase": [],
+					fieldKey: 'tags_id',
+					name: 'tags',
+					parentKey: 'id',
+					query: {},
+					relatedKey: 'id',
+					relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'tags_id'),
+					type: 'm2o',
+					whenCase: [],
 				},
 			],
-			"fieldKey": "tags",
-			"name": "articles_tags_junction",
-			"parentKey": "id",
-			"query": {
-				"sort": [
-					"id",
-				],
+			fieldKey: 'tags',
+			name: 'articles_tags_junction',
+			parentKey: 'id',
+			query: {
+				sort: ['id'],
 			},
-			"relatedKey": "id",
-			"relation": getRelation(schemaRelational.relations, 'articles', 'tags'),
-			"type": "o2m",
-			"whenCase": [],
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'articles', 'tags'),
+			type: 'o2m',
+			whenCase: [],
 		},
-	])
+	]);
 });
 
 test('parse fields with *.*.*', async () => {
@@ -219,256 +213,242 @@ test('parse fields with *.*.*', async () => {
 		{ knex: db, schema: schemaRelational },
 	);
 
-	expect(result).toEqual(
-		[
-			{
-				"fieldKey": "id",
-				"name": "id",
-				"type": "field",
-				"whenCase": [],
-			},
-			{
-				"fieldKey": "title",
-				"name": "title",
-				"type": "field",
-				"whenCase": [],
-			},
-			{
-				"fieldKey": "date",
-				"name": "date",
-				"type": "field",
-				"whenCase": [],
-			},
-			{
-				"cases": [],
-				"children": [
-					{
-						"fieldKey": "id",
-						"name": "id",
-						"type": "field",
-						"whenCase": [],
-					},
-					{
-						"fieldKey": "name",
-						"name": "name",
-						"type": "field",
-						"whenCase": [],
-					},
-				],
-				"fieldKey": "author",
-				"name": "users",
-				"parentKey": "id",
-				"query": {},
-				"relatedKey": "id",
-				"relation": getRelation(schemaRelational.relations, 'articles', 'author'),
-				"type": "m2o",
-				"whenCase": [],
-			},
-			{
-				"cases": [],
-				"children": [
-					{
-						"fieldKey": "id",
-						"name": "id",
-						"type": "field",
-						"whenCase": [],
-					},
-					{
-						"cases": [],
-						"children": [
-							{
-								"fieldKey": "id",
-								"name": "id",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"fieldKey": "title",
-								"name": "title",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"fieldKey": "date",
-								"name": "date",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"fieldKey": "author",
-								"name": "author",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"cases": [],
-								"children": [],
-								"fieldKey": "links",
-								"name": "links",
-								"parentKey": "id",
-								"query": {
-									"sort": [
-										"id",
-									],
-								},
-								"relatedKey": "id",
-								"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
-								"type": "o2m",
-								"whenCase": [],
-							},
-							{
-								"cases": [],
-								"children": [],
-								"fieldKey": "tags",
-								"name": "articles_tags_junction",
-								"parentKey": "id",
-								"query": {
-									"sort": [
-										"id",
-									],
-								},
-								"relatedKey": "id",
-								"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
-								"type": "o2m",
-								"whenCase": [],
-							},
-						],
-						"fieldKey": "article_id",
-						"name": "articles",
-						"parentKey": "id",
-						"query": {},
-						"relatedKey": "id",
-						"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
-						"type": "m2o",
-						"whenCase": [],
-					},
-				],
-				"fieldKey": "links",
-				"name": "links",
-				"parentKey": "id",
-				"query": {
-					"sort": [
-						"id",
-					],
+	expect(result).toEqual([
+		{
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			fieldKey: 'title',
+			name: 'title',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			fieldKey: 'date',
+			name: 'date',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			cases: [],
+			children: [
+				{
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
 				},
-				"relatedKey": "id",
-				"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
-				"type": "o2m",
-				"whenCase": [],
-			},
-			{
-				"cases": [],
-				"children": [
-					{
-						"fieldKey": "id",
-						"name": "id",
-						"type": "field",
-						"whenCase": [],
-					},
-					{
-						"cases": [],
-						"children": [
-							{
-								"fieldKey": "id",
-								"name": "id",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"fieldKey": "title",
-								"name": "title",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"fieldKey": "date",
-								"name": "date",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"fieldKey": "author",
-								"name": "author",
-								"type": "field",
-								"whenCase": [],
-							},
-							{
-								"cases": [],
-								"children": [],
-								"fieldKey": "links",
-								"name": "links",
-								"parentKey": "id",
-								"query": {
-									"sort": [
-										"id",
-									],
-								},
-								"relatedKey": "id",
-								"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
-								"type": "o2m",
-								"whenCase": [],
-							},
-							{
-								"cases": [],
-								"children": [],
-								"fieldKey": "tags",
-								"name": "articles_tags_junction",
-								"parentKey": "id",
-								"query": {
-									"sort": [
-										"id",
-									],
-								},
-								"relatedKey": "id",
-								"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
-								"type": "o2m",
-								"whenCase": [],
-							},
-						],
-						"fieldKey": "articles_id",
-						"name": "articles",
-						"parentKey": "id",
-						"query": {},
-						"relatedKey": "id",
-						"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
-						"type": "m2o",
-						"whenCase": [],
-					},
-					{
-						"cases": [],
-						"children": [
-							{
-								"fieldKey": "id",
-								"name": "id",
-								"type": "field",
-								"whenCase": [],
-							},
-						],
-						"fieldKey": "tags_id",
-						"name": "tags",
-						"parentKey": "id",
-						"query": {},
-						"relatedKey": "id",
-						"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'tags_id'),
-						"type": "m2o",
-						"whenCase": [],
-					},
-				],
-				"fieldKey": "tags",
-				"name": "articles_tags_junction",
-				"parentKey": "id",
-				"query": {
-					"sort": [
-						"id",
-					],
+				{
+					fieldKey: 'name',
+					name: 'name',
+					type: 'field',
+					whenCase: [],
 				},
-				"relatedKey": "id",
-				"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
-				"type": "o2m",
-				"whenCase": [],
+			],
+			fieldKey: 'author',
+			name: 'users',
+			parentKey: 'id',
+			query: {},
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'articles', 'author'),
+			type: 'm2o',
+			whenCase: [],
+		},
+		{
+			cases: [],
+			children: [
+				{
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
+				},
+				{
+					cases: [],
+					children: [
+						{
+							fieldKey: 'id',
+							name: 'id',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							fieldKey: 'title',
+							name: 'title',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							fieldKey: 'date',
+							name: 'date',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							fieldKey: 'author',
+							name: 'author',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							cases: [],
+							children: [],
+							fieldKey: 'links',
+							name: 'links',
+							parentKey: 'id',
+							query: {
+								sort: ['id'],
+							},
+							relatedKey: 'id',
+							relation: getRelation(schemaRelational.relations, 'links', 'article_id'),
+							type: 'o2m',
+							whenCase: [],
+						},
+						{
+							cases: [],
+							children: [],
+							fieldKey: 'tags',
+							name: 'articles_tags_junction',
+							parentKey: 'id',
+							query: {
+								sort: ['id'],
+							},
+							relatedKey: 'id',
+							relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+							type: 'o2m',
+							whenCase: [],
+						},
+					],
+					fieldKey: 'article_id',
+					name: 'articles',
+					parentKey: 'id',
+					query: {},
+					relatedKey: 'id',
+					relation: getRelation(schemaRelational.relations, 'links', 'article_id'),
+					type: 'm2o',
+					whenCase: [],
+				},
+			],
+			fieldKey: 'links',
+			name: 'links',
+			parentKey: 'id',
+			query: {
+				sort: ['id'],
 			},
-		]
-	)
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'links', 'article_id'),
+			type: 'o2m',
+			whenCase: [],
+		},
+		{
+			cases: [],
+			children: [
+				{
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
+				},
+				{
+					cases: [],
+					children: [
+						{
+							fieldKey: 'id',
+							name: 'id',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							fieldKey: 'title',
+							name: 'title',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							fieldKey: 'date',
+							name: 'date',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							fieldKey: 'author',
+							name: 'author',
+							type: 'field',
+							whenCase: [],
+						},
+						{
+							cases: [],
+							children: [],
+							fieldKey: 'links',
+							name: 'links',
+							parentKey: 'id',
+							query: {
+								sort: ['id'],
+							},
+							relatedKey: 'id',
+							relation: getRelation(schemaRelational.relations, 'links', 'article_id'),
+							type: 'o2m',
+							whenCase: [],
+						},
+						{
+							cases: [],
+							children: [],
+							fieldKey: 'tags',
+							name: 'articles_tags_junction',
+							parentKey: 'id',
+							query: {
+								sort: ['id'],
+							},
+							relatedKey: 'id',
+							relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+							type: 'o2m',
+							whenCase: [],
+						},
+					],
+					fieldKey: 'articles_id',
+					name: 'articles',
+					parentKey: 'id',
+					query: {},
+					relatedKey: 'id',
+					relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+					type: 'm2o',
+					whenCase: [],
+				},
+				{
+					cases: [],
+					children: [
+						{
+							fieldKey: 'id',
+							name: 'id',
+							type: 'field',
+							whenCase: [],
+						},
+					],
+					fieldKey: 'tags_id',
+					name: 'tags',
+					parentKey: 'id',
+					query: {},
+					relatedKey: 'id',
+					relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'tags_id'),
+					type: 'm2o',
+					whenCase: [],
+				},
+			],
+			fieldKey: 'tags',
+			name: 'articles_tags_junction',
+			parentKey: 'id',
+			query: {
+				sort: ['id'],
+			},
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+			type: 'o2m',
+			whenCase: [],
+		},
+	]);
 });
 
 test('parse fields with links.*.* and backlinks disabled', async () => {
@@ -479,38 +459,33 @@ test('parse fields with links.*.* and backlinks disabled', async () => {
 		{ knex: db, schema: schemaRelational },
 	);
 
-	expect(result).toEqual(
-		[
-			{
-				"cases": [],
-				"children": [
-					{
-						"fieldKey": "id",
-						"name": "id",
-						"type": "field",
-						"whenCase": [],
-					},
-					{
-						"fieldKey": "article_id",
-						"name": "article_id",
-						"type": "field",
-						"whenCase": [],
-					},
-				],
-				"fieldKey": "links",
-				"name": "links",
-				"parentKey": "id",
-				"query": {
-					"sort": [
-						"id",
-					],
+	expect(result).toEqual([
+		{
+			cases: [],
+			children: [
+				{
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
 				},
-				"relatedKey": "id",
-				"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
-				"type": "o2m",
-				"whenCase": [],
+				{
+					fieldKey: 'article_id',
+					name: 'article_id',
+					type: 'field',
+					whenCase: [],
+				},
+			],
+			fieldKey: 'links',
+			name: 'links',
+			parentKey: 'id',
+			query: {
+				sort: ['id'],
 			},
-		]
-	)
-
+			relatedKey: 'id',
+			relation: getRelation(schemaRelational.relations, 'links', 'article_id'),
+			type: 'o2m',
+			whenCase: [],
+		},
+	]);
 });

--- a/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
@@ -1,0 +1,516 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+
+import { expect, test, vi } from 'vitest';
+import { Client_SQLite3 } from '../../run-ast/lib/apply-query/mock.js';
+import { convertWildcards } from './convert-wildcards.js';
+import { fetchAllowedFields } from '../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
+import type { Accountability } from '@directus/types';
+import knex from 'knex';
+import { parseFields } from './parse-fields.js';
+import { getRelation } from '@directus/utils';
+
+vi.mock('../../../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js');
+
+const fetchAllowedFieldsMock = vi.mocked(fetchAllowedFields);
+
+const accountability = {
+	admin: true,
+} as Accountability;
+
+const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+
+const schema = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('title').string();
+		c.field('date').dateTime();
+	})
+	.build();
+
+test('parse fields without any fields', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: [], parentCollection: 'articles', query: {} },
+		{ knex: db, schema },
+	);
+
+	expect(result).toEqual([]);
+});
+
+test('parse fields with id and title', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', 'title'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema },
+	);
+
+	expect(result).toEqual([
+		{
+			fieldKey: "id",
+			name: "id",
+			type: "field",
+			whenCase: []
+		},
+		{
+			fieldKey: "title",
+			name: "title",
+			type: "field",
+			whenCase: []
+		}
+	]);
+});
+
+const schemaRelational = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('title').string();
+		c.field('date').dateTime();
+		c.field('author').m2o('users');
+		c.field('links').o2m('links', 'article_id');
+		c.field('tags').m2m('tags');
+	})
+	.collection('users', (c) => {
+		c.field('id').id();
+		c.field('name').string();
+	})
+	.build();
+
+
+test('parse fields with m2o relation', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', 'author.name'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaRelational },
+	);
+
+	expect(result).toEqual([
+		{
+			"fieldKey": "id",
+			"name": "id",
+			"type": "field",
+			"whenCase": [],
+		},
+		{
+			"cases": [],
+			"children": [
+				{
+					"fieldKey": "name",
+					"name": "name",
+					"type": "field",
+					"whenCase": [],
+				},
+			],
+			"fieldKey": "author",
+			"name": "users",
+			"parentKey": "id",
+			"query": {},
+			"relatedKey": "id",
+			"relation": getRelation(schemaRelational.relations, 'articles', 'author'),
+			"type": "m2o",
+			"whenCase": [],
+		},
+	])
+});
+
+test('parse fields with o2m relation', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', 'links.id'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaRelational },
+	);
+
+	expect(result).toEqual([
+		{
+			"fieldKey": "id",
+			"name": "id",
+			"type": "field",
+			"whenCase": [],
+		},
+		{
+			"cases": [],
+			"children": [
+				{
+					"fieldKey": "id",
+					"name": "id",
+					"type": "field",
+					"whenCase": [],
+				},
+			],
+			"fieldKey": "links",
+			"name": "links",
+			"parentKey": "id",
+			"query": {
+				"sort": [
+					"id",
+				],
+			},
+			"relatedKey": "id",
+			"relation": getRelation(schemaRelational.relations, 'articles', 'links'),
+			"type": "o2m",
+			"whenCase": [],
+		},
+	]);
+});
+
+
+test('parse fields with m2m relation', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', 'tags.tags_id.id'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaRelational },
+	);
+
+	expect(result).toEqual([
+		{
+			"fieldKey": "id",
+			"name": "id",
+			"type": "field",
+			"whenCase": [],
+		},
+		{
+			"cases": [],
+			"children": [
+				{
+					"cases": [],
+					"children": [
+						{
+							"fieldKey": "id",
+							"name": "id",
+							"type": "field",
+							"whenCase": [],
+						},
+					],
+					"fieldKey": "tags_id",
+					"name": "tags",
+					"parentKey": "id",
+					"query": {},
+					"relatedKey": "id",
+					"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'tags_id'),
+					"type": "m2o",
+					"whenCase": [],
+				},
+			],
+			"fieldKey": "tags",
+			"name": "articles_tags_junction",
+			"parentKey": "id",
+			"query": {
+				"sort": [
+					"id",
+				],
+			},
+			"relatedKey": "id",
+			"relation": getRelation(schemaRelational.relations, 'articles', 'tags'),
+			"type": "o2m",
+			"whenCase": [],
+		},
+	])
+});
+
+test('parse fields with *.*.*', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['*.*.*'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaRelational },
+	);
+
+	expect(result).toEqual(
+		[
+			{
+				"fieldKey": "id",
+				"name": "id",
+				"type": "field",
+				"whenCase": [],
+			},
+			{
+				"fieldKey": "title",
+				"name": "title",
+				"type": "field",
+				"whenCase": [],
+			},
+			{
+				"fieldKey": "date",
+				"name": "date",
+				"type": "field",
+				"whenCase": [],
+			},
+			{
+				"cases": [],
+				"children": [
+					{
+						"fieldKey": "id",
+						"name": "id",
+						"type": "field",
+						"whenCase": [],
+					},
+					{
+						"fieldKey": "name",
+						"name": "name",
+						"type": "field",
+						"whenCase": [],
+					},
+				],
+				"fieldKey": "author",
+				"name": "users",
+				"parentKey": "id",
+				"query": {},
+				"relatedKey": "id",
+				"relation": getRelation(schemaRelational.relations, 'articles', 'author'),
+				"type": "m2o",
+				"whenCase": [],
+			},
+			{
+				"cases": [],
+				"children": [
+					{
+						"fieldKey": "id",
+						"name": "id",
+						"type": "field",
+						"whenCase": [],
+					},
+					{
+						"cases": [],
+						"children": [
+							{
+								"fieldKey": "id",
+								"name": "id",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"fieldKey": "title",
+								"name": "title",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"fieldKey": "date",
+								"name": "date",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"fieldKey": "author",
+								"name": "author",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"cases": [],
+								"children": [],
+								"fieldKey": "links",
+								"name": "links",
+								"parentKey": "id",
+								"query": {
+									"sort": [
+										"id",
+									],
+								},
+								"relatedKey": "id",
+								"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
+								"type": "o2m",
+								"whenCase": [],
+							},
+							{
+								"cases": [],
+								"children": [],
+								"fieldKey": "tags",
+								"name": "articles_tags_junction",
+								"parentKey": "id",
+								"query": {
+									"sort": [
+										"id",
+									],
+								},
+								"relatedKey": "id",
+								"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+								"type": "o2m",
+								"whenCase": [],
+							},
+						],
+						"fieldKey": "article_id",
+						"name": "articles",
+						"parentKey": "id",
+						"query": {},
+						"relatedKey": "id",
+						"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
+						"type": "m2o",
+						"whenCase": [],
+					},
+				],
+				"fieldKey": "links",
+				"name": "links",
+				"parentKey": "id",
+				"query": {
+					"sort": [
+						"id",
+					],
+				},
+				"relatedKey": "id",
+				"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
+				"type": "o2m",
+				"whenCase": [],
+			},
+			{
+				"cases": [],
+				"children": [
+					{
+						"fieldKey": "id",
+						"name": "id",
+						"type": "field",
+						"whenCase": [],
+					},
+					{
+						"cases": [],
+						"children": [
+							{
+								"fieldKey": "id",
+								"name": "id",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"fieldKey": "title",
+								"name": "title",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"fieldKey": "date",
+								"name": "date",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"fieldKey": "author",
+								"name": "author",
+								"type": "field",
+								"whenCase": [],
+							},
+							{
+								"cases": [],
+								"children": [],
+								"fieldKey": "links",
+								"name": "links",
+								"parentKey": "id",
+								"query": {
+									"sort": [
+										"id",
+									],
+								},
+								"relatedKey": "id",
+								"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
+								"type": "o2m",
+								"whenCase": [],
+							},
+							{
+								"cases": [],
+								"children": [],
+								"fieldKey": "tags",
+								"name": "articles_tags_junction",
+								"parentKey": "id",
+								"query": {
+									"sort": [
+										"id",
+									],
+								},
+								"relatedKey": "id",
+								"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+								"type": "o2m",
+								"whenCase": [],
+							},
+						],
+						"fieldKey": "articles_id",
+						"name": "articles",
+						"parentKey": "id",
+						"query": {},
+						"relatedKey": "id",
+						"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+						"type": "m2o",
+						"whenCase": [],
+					},
+					{
+						"cases": [],
+						"children": [
+							{
+								"fieldKey": "id",
+								"name": "id",
+								"type": "field",
+								"whenCase": [],
+							},
+						],
+						"fieldKey": "tags_id",
+						"name": "tags",
+						"parentKey": "id",
+						"query": {},
+						"relatedKey": "id",
+						"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'tags_id'),
+						"type": "m2o",
+						"whenCase": [],
+					},
+				],
+				"fieldKey": "tags",
+				"name": "articles_tags_junction",
+				"parentKey": "id",
+				"query": {
+					"sort": [
+						"id",
+					],
+				},
+				"relatedKey": "id",
+				"relation": getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
+				"type": "o2m",
+				"whenCase": [],
+			},
+		]
+	)
+});
+
+test('parse fields with links.*.* and backlinks disabled', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['links.*.*'], parentCollection: 'articles', query: { backlink: false } },
+		{ knex: db, schema: schemaRelational },
+	);
+
+	expect(result).toEqual(
+		[
+			{
+				"cases": [],
+				"children": [
+					{
+						"fieldKey": "id",
+						"name": "id",
+						"type": "field",
+						"whenCase": [],
+					},
+					{
+						"fieldKey": "article_id",
+						"name": "article_id",
+						"type": "field",
+						"whenCase": [],
+					},
+				],
+				"fieldKey": "links",
+				"name": "links",
+				"parentKey": "id",
+				"query": {
+					"sort": [
+						"id",
+					],
+				},
+				"relatedKey": "id",
+				"relation": getRelation(schemaRelational.relations, 'links', 'article_id'),
+				"type": "o2m",
+				"whenCase": [],
+			},
+		]
+	)
+
+});

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -27,7 +27,7 @@ export interface ParseFieldsOptions {
 export interface ParseFieldsContext {
 	schema: SchemaOverview;
 	knex: Knex;
-	parentRelation?: Relation
+	parentRelation?: Relation;
 }
 
 export async function parseFields(
@@ -43,7 +43,7 @@ export async function parseFields(
 			collection: options.parentCollection,
 			alias: options.query.alias,
 			accountability: options.accountability,
-			backlink: options.query.backlink
+			backlink: options.query.backlink,
 		},
 		context,
 	);

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -1,5 +1,5 @@
 import { REGEX_BETWEEN_PARENS } from '@directus/constants';
-import type { Accountability, Query, SchemaOverview } from '@directus/types';
+import type { Accountability, Query, Relation, SchemaOverview } from '@directus/types';
 import { getRelation } from '@directus/utils';
 import type { Knex } from 'knex';
 import { isEmpty } from 'lodash-es';
@@ -27,6 +27,7 @@ export interface ParseFieldsOptions {
 export interface ParseFieldsContext {
 	schema: SchemaOverview;
 	knex: Knex;
+	parentRelation?: Relation
 }
 
 export async function parseFields(
@@ -42,6 +43,7 @@ export async function parseFields(
 			collection: options.parentCollection,
 			alias: options.query.alias,
 			accountability: options.accountability,
+			backlink: options.query.backlink
 		},
 		context,
 	);
@@ -218,7 +220,7 @@ export async function parseFields(
 						deep: options.deep?.[`${fieldKey}:${relatedCollection}`],
 						accountability: options.accountability,
 					},
-					context,
+					{ ...context, parentRelation: relation },
 				);
 
 				child.query[relatedCollection] = getDeepQuery(options.deep?.[`${fieldKey}:${relatedCollection}`] || {});
@@ -267,7 +269,7 @@ export async function parseFields(
 						deep: options.deep?.[fieldKey] || {},
 						accountability: options.accountability,
 					},
-					context,
+					{ ...context, parentRelation: relation },
 				),
 				cases: [],
 				whenCase: [],

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -100,7 +100,7 @@ export async function sanitizeQuery(
 	}
 
 	if (rawQuery['backlink']) {
-		query.backlink = sanitizeBacklink(rawQuery['backlink'])
+		query.backlink = sanitizeBacklink(rawQuery['backlink']);
 	}
 
 	return query;
@@ -228,7 +228,7 @@ function sanitizeMeta(rawMeta: any) {
 }
 
 function sanitizeBacklink(rawBacklink: unknown) {
-	return !(rawBacklink === "false")
+	return !(rawBacklink === 'false');
 }
 
 async function sanitizeDeep(deep: Record<string, any>, schema: SchemaOverview, accountability?: Accountability | null) {

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -228,7 +228,7 @@ function sanitizeMeta(rawMeta: any) {
 }
 
 function sanitizeBacklink(rawBacklink: unknown) {
-	return !(rawBacklink === 'false');
+	return rawBacklink !== false && rawBacklink !== 'false';
 }
 
 async function sanitizeDeep(deep: Record<string, any>, schema: SchemaOverview, accountability?: Accountability | null) {

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -99,7 +99,7 @@ export async function sanitizeQuery(
 		query.alias = sanitizeAlias(rawQuery['alias']);
 	}
 
-	if (rawQuery['backlink']) {
+	if ('backlink' in rawQuery) {
 		query.backlink = sanitizeBacklink(rawQuery['backlink']);
 	}
 

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -99,6 +99,10 @@ export async function sanitizeQuery(
 		query.alias = sanitizeAlias(rawQuery['alias']);
 	}
 
+	if (rawQuery['backlink']) {
+		query.backlink = sanitizeBacklink(rawQuery['backlink'])
+	}
+
 	return query;
 }
 
@@ -221,6 +225,10 @@ function sanitizeMeta(rawMeta: any) {
 	}
 
 	return [rawMeta];
+}
+
+function sanitizeBacklink(rawBacklink: unknown) {
+	return !(rawBacklink === "false")
 }
 
 async function sanitizeDeep(deep: Record<string, any>, schema: SchemaOverview, accountability?: Accountability | null) {

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -16,9 +16,9 @@ const querySchema = Joi.object({
 	limit:
 		'QUERY_LIMIT_MAX' in env && env['QUERY_LIMIT_MAX'] !== -1
 			? Joi.number()
-					.integer()
-					.min(-1)
-					.max(env['QUERY_LIMIT_MAX'] as number) // min should be 0
+				.integer()
+				.min(-1)
+				.max(env['QUERY_LIMIT_MAX'] as number) // min should be 0
 			: Joi.number().integer().min(-1),
 	offset: Joi.number().integer().min(0),
 	page: Joi.number().integer().min(0),
@@ -30,6 +30,7 @@ const querySchema = Joi.object({
 	aggregate: Joi.object(),
 	deep: Joi.object(),
 	alias: Joi.object(),
+	backlink: Joi.boolean()
 }).id('query');
 
 export function validateQuery(query: Query): Query {

--- a/api/src/utils/validate-query.ts
+++ b/api/src/utils/validate-query.ts
@@ -16,9 +16,9 @@ const querySchema = Joi.object({
 	limit:
 		'QUERY_LIMIT_MAX' in env && env['QUERY_LIMIT_MAX'] !== -1
 			? Joi.number()
-				.integer()
-				.min(-1)
-				.max(env['QUERY_LIMIT_MAX'] as number) // min should be 0
+					.integer()
+					.min(-1)
+					.max(env['QUERY_LIMIT_MAX'] as number) // min should be 0
 			: Joi.number().integer().min(-1),
 	offset: Joi.number().integer().min(0),
 	page: Joi.number().integer().min(0),
@@ -30,7 +30,7 @@ const querySchema = Joi.object({
 	aggregate: Joi.object(),
 	deep: Joi.object(),
 	alias: Joi.object(),
-	backlink: Joi.boolean()
+	backlink: Joi.boolean(),
 }).id('query');
 
 export function validateQuery(query: Query): Query {

--- a/packages/types/src/query.ts
+++ b/packages/types/src/query.ts
@@ -15,7 +15,7 @@ export type Query = {
 	aggregate?: Aggregate | null;
 	deep?: NestedDeepQuery | null;
 	alias?: Record<string, string> | null;
-	backlink?: boolean
+	backlink?: boolean;
 };
 
 export type DeepQuery = {

--- a/packages/types/src/query.ts
+++ b/packages/types/src/query.ts
@@ -15,6 +15,7 @@ export type Query = {
 	aggregate?: Aggregate | null;
 	deep?: NestedDeepQuery | null;
 	alias?: Record<string, string> | null;
+	backlink?: boolean
 };
 
 export type DeepQuery = {

--- a/sdk/src/types/query.ts
+++ b/sdk/src/types/query.ts
@@ -16,6 +16,7 @@ export interface Query<Schema, Item> {
 	offset?: number | undefined;
 	page?: number | undefined;
 	deep?: IfAny<Schema, Record<string, any>, QueryDeep<Schema, Item>> | undefined;
+	backlink?: boolean | undefined;
 	readonly alias?: IfAny<Schema, Record<string, string>, QueryAlias<Schema, Item>> | undefined;
 }
 
@@ -44,8 +45,8 @@ export type ExtractRelation<Schema, Item extends object, Key> = Key extends keyo
  */
 export type MergeRelationalFields<FieldList> = Exclude<UnpackList<FieldList>, string> extends infer RelatedFields
 	? {
-			[Key in RelatedFields extends any ? keyof RelatedFields : never]-?: Exclude<RelatedFields[Key], undefined>;
-	  }
+		[Key in RelatedFields extends any ? keyof RelatedFields : never]-?: Exclude<RelatedFields[Key], undefined>;
+	}
 	: never;
 
 /**
@@ -61,8 +62,8 @@ export type MergeFields<FieldList> = HasNestedFields<FieldList> extends never
  */
 export type QuerySort<_Schema, Item> = UnpackList<Item> extends infer FlatItem
 	? {
-			[Field in keyof FlatItem]: Field | `-${Field & string}`;
-	  }[keyof FlatItem]
+		[Field in keyof FlatItem]: Field | `-${Field & string}`;
+	}[keyof FlatItem]
 	: never;
 
 export type MergeObjects<A, B> = object extends A ? (object extends B ? A & B : A) : object extends B ? B : never;

--- a/sdk/src/types/query.ts
+++ b/sdk/src/types/query.ts
@@ -45,8 +45,8 @@ export type ExtractRelation<Schema, Item extends object, Key> = Key extends keyo
  */
 export type MergeRelationalFields<FieldList> = Exclude<UnpackList<FieldList>, string> extends infer RelatedFields
 	? {
-		[Key in RelatedFields extends any ? keyof RelatedFields : never]-?: Exclude<RelatedFields[Key], undefined>;
-	}
+			[Key in RelatedFields extends any ? keyof RelatedFields : never]-?: Exclude<RelatedFields[Key], undefined>;
+	  }
 	: never;
 
 /**
@@ -62,8 +62,8 @@ export type MergeFields<FieldList> = HasNestedFields<FieldList> extends never
  */
 export type QuerySort<_Schema, Item> = UnpackList<Item> extends infer FlatItem
 	? {
-		[Field in keyof FlatItem]: Field | `-${Field & string}`;
-	}[keyof FlatItem]
+			[Field in keyof FlatItem]: Field | `-${Field & string}`;
+	  }[keyof FlatItem]
 	: never;
 
 export type MergeObjects<A, B> = object extends A ? (object extends B ? A & B : A) : object extends B ? B : never;


### PR DESCRIPTION
## Scope

What's changed:

- Added backlink query parameter which when set to false does not autofill and return the reverse relations in the repsonse.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- [x] Rest
- [x] Websockets
- [x] SDK
- This is not relevant for GQL as that doesn't have the `*` symbol
- See new tests in `convert-wildcards.test.ts` and `parse-fields.test.ts` for some examples.

---

Closes NOW-967 NOW-973
