### PR TITLE
Fix system filters

### DIFF
--- a/.changeset/green-paws-rhyme.md
+++ b/.changeset/green-paws-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed system filters showing null

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -252,7 +252,7 @@ function useVariableInput() {
 				:is="interfaceType"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="(value as string | null)"
+				:value="(value as string | boolean | number | null)"
 				@input="value = $event"
 			/>
 		</template>
@@ -278,7 +278,7 @@ function useVariableInput() {
 				is="interface-input"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="(value as string | null)"
+				:value="(value as string | boolean | number | null)"
 				@input="value = $event"
 			/>
 		</template>

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -252,7 +252,7 @@ function useVariableInput() {
 				:is="interfaceType"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="String(value)"
+				:value="(value as string | null)"
 				@input="value = $event"
 			/>
 		</template>
@@ -278,7 +278,7 @@ function useVariableInput() {
 				is="interface-input"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="String(value)"
+				:value="(value as string | null)"
 				@input="value = $event"
 			/>
 		</template>

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -24,8 +24,8 @@ const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
 const { t } = useI18n();
 
-const field = computed(() => getField(props.field));
-const isVersionField = computed(() => field.value === '$version');
+const fieldPath = computed(() => getField(props.field));
+const isVersionField = computed(() => fieldPath.value === '$version');
 
 const { info: collectionInfo } = useCollection(computed(() => props.collection));
 const versioningEnabled = computed(() => !!collectionInfo.value?.meta?.versioning && isVersionField.value);
@@ -36,11 +36,11 @@ const fieldInfo = computed(() => {
 		return fakeVersionField.value;
 	}
 
-	const fieldInfo = fieldsStore.getField(props.collection, field.value);
+	const fieldInfo = fieldsStore.getField(props.collection, fieldPath.value);
 
 	// Alias uses the foreign key type
 	if (fieldInfo?.type === 'alias') {
-		const relations = relationsStore.getRelationsForField(props.collection, field.value);
+		const relations = relationsStore.getRelationsForField(props.collection, fieldPath.value);
 
 		if (relations[0]) {
 			return fieldsStore.getField(relations[0].collection, relations[0].field);
@@ -81,7 +81,7 @@ const interfaceType = computed(() => {
 });
 
 const fieldValue = computed(() => {
-	return get(props.field, `${field.value}.${comparator.value}`);
+	return get(props.field, `${fieldPath.value}.${comparator.value}`);
 });
 
 const {
@@ -109,7 +109,7 @@ const value = computed<unknown | unknown[]>({
 			value = newVal;
 		}
 
-		emit('update:field', fieldToFilter(field.value, comparator.value, value));
+		emit('update:field', fieldToFilter(fieldPath.value, comparator.value, value));
 	},
 });
 

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -252,7 +252,7 @@ function useVariableInput() {
 				:is="interfaceType"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="(value as string | boolean | number | null)"
+				:value="value as string | boolean | number | null"
 				@input="value = $event"
 			/>
 		</template>
@@ -278,7 +278,7 @@ function useVariableInput() {
 				is="interface-input"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="(value as string | boolean | number | null)"
+				:value="value as string | boolean | number | null"
 				@input="value = $event"
 			/>
 		</template>

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -10,6 +10,10 @@ import InputComponent from './input-component.vue';
 import { fieldToFilter, getComparator, getField } from './utils';
 import { useCollection } from '@directus/composables';
 
+// Workaround because you cannot cast directly to union types inside
+// the template block without running into esling/prettier issues
+type ScalarValue = string | boolean | number | null;
+
 const props = defineProps<{
 	field: FieldFilter;
 	collection: string;
@@ -252,7 +256,7 @@ function useVariableInput() {
 				:is="interfaceType"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="value as string | boolean | number | null"
+				:value="value as ScalarValue"
 				@input="value = $event"
 			/>
 		</template>
@@ -278,7 +282,7 @@ function useVariableInput() {
 				is="interface-input"
 				:choices="choices"
 				:type="fieldInfo?.type ?? 'unknown'"
-				:value="value as string | boolean | number | null"
+				:value="value as ScalarValue"
 				@input="value = $event"
 			/>
 		</template>

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -11,7 +11,7 @@ import { fieldToFilter, getComparator, getField } from './utils';
 import { useCollection } from '@directus/composables';
 
 // Workaround because you cannot cast directly to union types inside
-// the template block without running into esling/prettier issues
+// the template block without running into eslint/prettier issues
 type ScalarValue = string | boolean | number | null;
 
 const props = defineProps<{


### PR DESCRIPTION
## Scope

What's changed:

- removed the string casting which was introduced in #25245 resulting in the `undefined` value getting cast to empty string `""` which in turn was cast to `null`

## Potential Risks / Drawbacks

- Could potentially affect other filter or the original fix

## Review Notes / Questions

- The original PR introduced this `value="String(value)"` casting for filters other than `_in/_nin`, I think this was an unintentional change but not sure what the actual reason behind it was.
- Should I leave in the comment about the type casting eslint issue?

---

Fixes #25290
Fixes #25282
