### PR TITLE
Fix adjustable column width breaking when column references related field

### DIFF
--- a/.changeset/little-jeans-brush.md
+++ b/.changeset/little-jeans-brush.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevented table column widths from having null values

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -43,9 +43,9 @@ export function usePreset(
 	});
 
 	const localPreset = ref<Partial<Preset>>({});
+	const bookmarkSaved = ref(true);
 	initLocalPreset();
 
-	const bookmarkSaved = ref(true);
 	const bookmarkIsMine = computed(() => localPreset.value.user === (userStore.currentUser as User).id);
 
 	/**
@@ -205,6 +205,7 @@ export function usePreset(
 		}
 
 		localPreset.value = preset;
+		bookmarkSaved.value = true;
 	}
 
 	/**

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -25,42 +25,6 @@ type UsablePreset = {
 	localPreset: Ref<Partial<Preset>>;
 };
 
-function ensureTabularWidths(preset: Partial<Preset>, defaultWidth = 200): void {
-	if (preset.layout !== 'tabular' || !preset.layout_query?.tabular?.fields) {
-		return;
-	}
-
-	const fields = preset.layout_query.tabular.fields;
-
-	if (!Array.isArray(fields)) {
-		return;
-	}
-
-	const widths = preset.layout_options?.tabular?.widths || {};
-
-	// Check if any field is missing a width
-	const needsUpdate = fields.some((field) => !(field in widths));
-
-	if (!needsUpdate) {
-		return;
-	}
-
-	// Add missing widths
-	fields.forEach((field: string) => {
-		if (!(field in widths)) {
-			widths[field] = defaultWidth;
-		}
-	});
-
-	preset.layout_options = {
-		...preset.layout_options,
-		tabular: {
-			...preset.layout_options?.tabular,
-			widths,
-		},
-	};
-}
-
 export function usePreset(
 	collection: Ref<string>,
 	bookmark = ref<number | null>(null),
@@ -214,15 +178,6 @@ export function usePreset(
 	function clearLocalSave() {
 		const defaultPreset = presetsStore.getBookmark(Number(bookmark.value));
 		if (defaultPreset) localPreset.value = { ...defaultPreset };
-
-		if (defaultPreset) {
-			// Deep clone to avoid reference issues
-			localPreset.value = cloneDeep(defaultPreset);
-
-			// Ensure tabular widths are properly set
-			ensureTabularWidths(localPreset.value);
-		}
-
 		bookmarkSaved.value = true;
 	}
 
@@ -248,9 +203,6 @@ export function usePreset(
 		} else if (bookmarkExists.value) {
 			assign(preset, presetsStore.getBookmark(Number(bookmark.value)));
 		}
-
-		// Ensure widths are set for tabular layout
-		ensureTabularWidths(preset);
 
 		localPreset.value = preset;
 	}

--- a/app/src/composables/use-preset.ts
+++ b/app/src/composables/use-preset.ts
@@ -25,6 +25,42 @@ type UsablePreset = {
 	localPreset: Ref<Partial<Preset>>;
 };
 
+function ensureTabularWidths(preset: Partial<Preset>, defaultWidth = 200): void {
+	if (preset.layout !== 'tabular' || !preset.layout_query?.tabular?.fields) {
+		return;
+	}
+
+	const fields = preset.layout_query.tabular.fields;
+
+	if (!Array.isArray(fields)) {
+		return;
+	}
+
+	const widths = preset.layout_options?.tabular?.widths || {};
+
+	// Check if any field is missing a width
+	const needsUpdate = fields.some((field) => !(field in widths));
+
+	if (!needsUpdate) {
+		return;
+	}
+
+	// Add missing widths
+	fields.forEach((field: string) => {
+		if (!(field in widths)) {
+			widths[field] = defaultWidth;
+		}
+	});
+
+	preset.layout_options = {
+		...preset.layout_options,
+		tabular: {
+			...preset.layout_options?.tabular,
+			widths,
+		},
+	};
+}
+
 export function usePreset(
 	collection: Ref<string>,
 	bookmark = ref<number | null>(null),
@@ -178,6 +214,15 @@ export function usePreset(
 	function clearLocalSave() {
 		const defaultPreset = presetsStore.getBookmark(Number(bookmark.value));
 		if (defaultPreset) localPreset.value = { ...defaultPreset };
+
+		if (defaultPreset) {
+			// Deep clone to avoid reference issues
+			localPreset.value = cloneDeep(defaultPreset);
+
+			// Ensure tabular widths are properly set
+			ensureTabularWidths(localPreset.value);
+		}
+
 		bookmarkSaved.value = true;
 	}
 
@@ -203,6 +248,9 @@ export function usePreset(
 		} else if (bookmarkExists.value) {
 			assign(preset, presetsStore.getBookmark(Number(bookmark.value)));
 		}
+
+		// Ensure widths are set for tabular layout
+		ensureTabularWidths(preset);
 
 		localPreset.value = preset;
 	}

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -250,11 +250,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 							description = fieldNames.join(' -> ');
 						}
 
+						const width = localWidths.value[field.key] || layoutOptions.value?.widths?.[field.key] || 200;
+
 						return {
 							text: field.name,
 							value: field.key,
 							description,
-							width: localWidths.value[field.key] || layoutOptions.value?.widths?.[field.key] || null,
+							width,
 							align: layoutOptions.value?.align?.[field.key] || 'left',
 							field: {
 								display: field.meta?.display || getDefaultDisplayForType(field.type),

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -154,6 +154,13 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			selection.value = items.value.map((item) => item[pk.field]);
 		}
 
+		function calculateDefaultWidth(fieldName: string, minWidth = 100, maxWidth = 400): number {
+			const avgCharWidth = 12;
+			const padding = 24;
+			const baseWidth = fieldName.length * avgCharWidth + padding;
+			return Math.max(minWidth, Math.min(maxWidth, baseWidth));
+		}
+
 		function useItemOptions() {
 			const page = syncRefProperty(layoutQuery, 'page', 1);
 			const limit = syncRefProperty(layoutQuery, 'limit', 25);
@@ -250,7 +257,10 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 							description = fieldNames.join(' -> ');
 						}
 
-						const width = localWidths.value[field.key] || layoutOptions.value?.widths?.[field.key] || 200;
+						const width =
+							localWidths.value[field.key] ||
+							layoutOptions.value?.widths?.[field.key] ||
+							calculateDefaultWidth(field.key);
 
 						return {
 							text: field.name,

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -154,7 +154,12 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			selection.value = items.value.map((item) => item[pk.field]);
 		}
 
-		function calculateDefaultWidth(fieldName: string, minWidth = 100, maxWidth = 400): number {
+		function calculateDefaultWidth(
+			fieldName: string,
+			options: { minWidth?: number; maxWidth?: number; defaultWidth?: number } = {},
+		): number {
+			const { minWidth = 100, maxWidth = 400, defaultWidth = 200 } = options;
+			if (!fieldName) return defaultWidth;
 			const avgCharWidth = 12;
 			const padding = 24;
 			const baseWidth = fieldName.length * avgCharWidth + padding;
@@ -260,7 +265,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 						const width =
 							localWidths.value[field.key] ||
 							layoutOptions.value?.widths?.[field.key] ||
-							calculateDefaultWidth(field.key);
+							calculateDefaultWidth(field.name);
 
 						return {
 							text: field.name,

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -154,18 +154,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			selection.value = items.value.map((item) => item[pk.field]);
 		}
 
-		function calculateDefaultWidth(
-			fieldName: string,
-			options: { minWidth?: number; maxWidth?: number; defaultWidth?: number } = {},
-		): number {
-			const { minWidth = 100, maxWidth = 400, defaultWidth = 200 } = options;
-			if (!fieldName) return defaultWidth;
-			const avgCharWidth = 12;
-			const padding = 24;
-			const baseWidth = fieldName.length * avgCharWidth + padding;
-			return Math.max(minWidth, Math.min(maxWidth, baseWidth));
-		}
-
 		function useItemOptions() {
 			const page = syncRefProperty(layoutQuery, 'page', 1);
 			const limit = syncRefProperty(layoutQuery, 'limit', 25);
@@ -262,10 +250,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 							description = fieldNames.join(' -> ');
 						}
 
-						const width =
-							localWidths.value[field.key] ||
-							layoutOptions.value?.widths?.[field.key] ||
-							calculateDefaultWidth(field.name);
+						const width = localWidths.value[field.key] || layoutOptions.value?.widths?.[field.key] || 160;
 
 						return {
 							text: field.name,
@@ -290,9 +275,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					const widths = {} as { [field: string]: number };
 
 					val.forEach((header) => {
-						if (header.width) {
-							widths[header.value] = header.width;
-						}
+						widths[header.value] = header.width ?? 160;
 					});
 
 					localWidths.value = widths;

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -351,7 +351,7 @@ function clearFilters() {
 						@save="createBookmark"
 					>
 						<template #activator="{ on }">
-							<v-icon class="toggle" name="bookmark" clickable @click="on" />
+							<v-icon v-tooltip.bottom="t('create_bookmark')" class="toggle" name="bookmark" clickable @click="on" />
 						</template>
 					</bookmark-add>
 


### PR DESCRIPTION
## Scope

What's changed:

- Prevented update of column width unless value has changed

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

#### Adjustable Column Width Fails When Column references a related field.

**Steps to Reproduce:**

*Note: I'm keeping the instructions specific, but any two related collections and fields will produce the same result.*

**Setup**
- Create two collections: `articles (title, description)` and `labels (name)`.
- On the articles collection, create an M2M field associated with the `labels` collection.
- Create a bookmark (preset) for `articles` and add `labels.name` field as a column.

**Reproduce:** You may need to repeat these steps a few times to reproduce the bug.
- Go to the articles bookmark preset and change the column order and resize some columns.
- Click the button to reset the preset.

**Result:** The first column's resizable handle will disappear.

---

Fixes #NOW-995
