### PR TITLE
Fix skipping marketplace for local extensions

### DIFF
--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -74,7 +74,7 @@ export const getExtensionsSettings = async ({
 	) => {
 		let marketplaceId;
 
-		if (!extension.local) {
+		if (source === 'registry') {
 			const marketplace = await list({ search: extension.name });
 			marketplaceId = marketplace.data[0]?.id;
 		}

--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -72,8 +72,14 @@ export const getExtensionsSettings = async ({
 		extension: Extension,
 		source: 'local' | 'registry' | 'module',
 	) => {
-		const marketplace = await list({ search: extension.name });
-		const id = marketplace.data[0]?.id || randomUUID();
+		let marketplaceId
+
+		if (!extension.local) {
+			const marketplace = await list({ search: extension.name });
+			marketplaceId = marketplace.data[0]?.id
+		}
+
+		const id = marketplaceId ?? randomUUID();
 
 		if (extension.type === 'bundle') {
 			newSettings.push({

--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -72,11 +72,11 @@ export const getExtensionsSettings = async ({
 		extension: Extension,
 		source: 'local' | 'registry' | 'module',
 	) => {
-		let marketplaceId
+		let marketplaceId;
 
 		if (!extension.local) {
 			const marketplace = await list({ search: extension.name });
-			marketplaceId = marketplace.data[0]?.id
+			marketplaceId = marketplace.data[0]?.id;
 		}
 
 		const id = marketplaceId ?? randomUUID();

--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -76,7 +76,7 @@ export const getExtensionsSettings = async ({
 
 		if (source === 'registry') {
 			const marketplace = await list({ search: extension.name });
-			marketplaceId = marketplace.data[0]?.id;
+			marketplaceId = marketplace.data.find((ext) => ext.name === extension.name)?.id;
 		}
 
 		const id = marketplaceId ?? randomUUID();


### PR DESCRIPTION
## Scope

What's changed:

- Small fix to @joselcvarela 's recent PR.

~~The 2nd fix which is coming later would be to implement a proper way to fetch the ID by name. The search parameter can yield results even if there is no 1 to 1 match in the extension name.~~ Resolved by using find and matching on name as a temp fix

---

Builds upon #25304
Fixes #25322
