### PR TITLE
Fix initial focus on license banner dialog

### DIFF
--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -12,7 +12,6 @@ interface Props {
 	placement?: 'right' | 'center';
 	/** Lets other overlays (drawer) open on top */
 	keepBehind?: boolean;
-	noInitialFocus?: boolean;
 	applyShortcut?: ApplyShortcut;
 }
 
@@ -83,7 +82,7 @@ function useOverlayFocusTrap() {
 
 	const { activate, deactivate } = useFocusTrap(overlayEl, {
 		escapeDeactivates: false,
-		initialFocus: props.noInitialFocus ? false : undefined,
+		initialFocus: false,
 	});
 
 	watch(

--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -12,6 +12,7 @@ interface Props {
 	placement?: 'right' | 'center';
 	/** Lets other overlays (drawer) open on top */
 	keepBehind?: boolean;
+	noInitialFocus?: boolean;
 	applyShortcut?: ApplyShortcut;
 }
 
@@ -82,6 +83,7 @@ function useOverlayFocusTrap() {
 
 	const { activate, deactivate } = useFocusTrap(overlayEl, {
 		escapeDeactivates: false,
+		initialFocus: props.noInitialFocus ? false : undefined,
 	});
 
 	watch(

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -142,6 +142,7 @@ function useActiveState() {
 
 	const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } = useFocusTrap([menuEl, activator], {
 		escapeDeactivates: false,
+		initialFocus: false,
 		returnFocusOnDeactivate: !props.noFocusReturn,
 		allowOutsideClick: true,
 		clickOutsideDeactivates: props.closeOnClick,

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -18,7 +18,7 @@ const { info } = storeToRefs(useServerStore());
 </script>
 
 <template>
-	<v-dialog>
+	<v-dialog no-initial-focus>
 		<v-card>
 			<div class="inner">
 				<!-- eslint-disable-next-line vue/no-v-html -->

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -18,7 +18,7 @@ const { info } = storeToRefs(useServerStore());
 </script>
 
 <template>
-	<v-dialog no-initial-focus>
+	<v-dialog>
 		<v-card>
 			<div class="inner">
 				<!-- eslint-disable-next-line vue/no-v-html -->

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -76,6 +76,11 @@ const { info } = storeToRefs(useServerStore());
 	color: var(--theme--primary);
 	text-decoration: underline;
 	font-weight: 600;
+	transition: color var(--fast) var(--transition);
+
+	&:hover {
+		color: var(--theme--foreground);
+	}
 }
 
 .v-card .inner {

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -256,7 +256,7 @@ function getWidth(input: unknown, fallback: number): number {
 	return input && !Number.isNaN(input) ? Number(input) : fallback;
 }
 
-const showDialog = computed(() => userStore.isAdmin && settingsStore.settings?.accepted_terms === false);
+const showLicenseBanner = computed(() => userStore.isAdmin && settingsStore.settings?.accepted_terms === false);
 </script>
 
 <template>
@@ -269,7 +269,6 @@ const showDialog = computed(() => userStore.isAdmin && settingsStore.settings?.a
 	</v-info>
 
 	<div v-else class="private-view" :class="{ appearance, 'full-screen': fullScreen, splitView }">
-		<LicenseBanner v-model="showDialog" />
 		<skip-menu section="nav" />
 
 		<aside
@@ -364,6 +363,8 @@ const showDialog = computed(() => userStore.isAdmin && settingsStore.settings?.a
 		<notifications-drawer />
 		<notifications-group v-if="notificationsPreviewActive === false" :sidebar-open="sidebarOpen" />
 		<notification-dialogs />
+
+		<license-banner v-model="showLicenseBanner" />
 	</div>
 </template>
 


### PR DESCRIPTION
## Scope

What's changed:

- set initialFocus to false for every focusTrap instance
- add missing hover effect for links in license banner component
- use kebab case for LicenseBanner component for consitency
- move component to the other overlays for improved structure
- rename showDialog to showLicenseBanner for clarity

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- feel free to revert any of the additional commits
- no changeset needed

---

Closes NOW-1006
