### PR TITLE
Revert changes on error after drag & drop in kanban and calendar layout

### DIFF
--- a/.changeset/hot-bags-heal.md
+++ b/.changeset/hot-bags-heal.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured to revert changes on error after drag & drop in kanban and calendar layout

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -750,6 +750,7 @@ errors:
   COLLECTION_NOT_FOUND: "Collection doesn't exist"
   CONTAINS_NULL_VALUES: Field contains null values
   CONTENT_TOO_LARGE: Submitted item/file is too large
+  FAILED_VALIDATION: Validation failed
   FIELD_NOT_FOUND: Field not found
   FORBIDDEN: Forbidden
   GRAPHQL_VALIDATION: GraphQL Validation

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -199,6 +199,7 @@ export default defineLayout<LayoutOptions>({
 						await api.patch(`${endpoint}/${info.event.id}`, itemChanges);
 					} catch (error) {
 						unexpectedError(error);
+						info.revert();
 					}
 				},
 			};


### PR DESCRIPTION
## Scope

What's changed:

- revert changes on error after drag & drop in Calendar layout
- prevent dragging when an error occurs in the Kanban layout
- add missing validation error message to translations

## Potential Risks / Drawbacks

–

## Review Notes / Questions

–

---

Fixes #24853
