### PR TITLE
Allow selecting custom collections for 'items.sort' action hook

### DIFF
--- a/.changeset/proud-zebras-appear.md
+++ b/.changeset/proud-zebras-appear.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Allowed selecting custom collections for `items.sort` action hook

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -107,11 +107,12 @@ export function getTriggers() {
 							width: 'full' as Width,
 							readonly:
 								!scope ||
-								['items.create', 'items.update', 'items.delete', 'items.promote'].every(
+								['items.create', 'items.update', 'items.delete', 'items.promote', 'items.sort'].every(
 									(t) => scope?.includes(t) === false,
 								),
 							options: {
-								includeSystem: !scope || scope?.filter((t: string) => t !== 'items.promote').length > 0,
+								includeSystem:
+									!scope || scope?.filter((t: string) => t !== 'items.promote' && t !== 'items.sort').length > 0,
 							},
 						},
 					},


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Custom collections can now be selected for `items.sort` action hook

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- N/A

---

Fixes #25324
