### PR TITLE
Fix existing `numeric_precision`, `numeric_scale` and `max_length` not respected on schema changes

### DIFF
--- a/.changeset/five-ads-shop.md
+++ b/.changeset/five-ads-shop.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed existing `numeric_precision`, `numeric_scale` and `max_length` not respected on schema changes

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -857,8 +857,8 @@ export class FieldsService {
 
 			column = table[type](
 				field.field,
-				field.schema?.numeric_precision ?? DEFAULT_NUMERIC_PRECISION,
-				field.schema?.numeric_scale ?? DEFAULT_NUMERIC_SCALE,
+				field.schema?.numeric_precision ?? existing?.numeric_precision ?? DEFAULT_NUMERIC_PRECISION,
+				field.schema?.numeric_scale ?? existing?.numeric_scale ?? DEFAULT_NUMERIC_SCALE,
 			);
 		} else if (field.type === 'csv') {
 			column = table.text(field.field);

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -851,7 +851,7 @@ export class FieldsService {
 				column = table.increments(field.field);
 			}
 		} else if (field.type === 'string') {
-			column = table.string(field.field, field.schema?.max_length ?? undefined);
+			column = table.string(field.field, field.schema?.max_length ?? existing?.max_length ?? undefined);
 		} else if (['float', 'decimal'].includes(field.type)) {
 			const type = field.type as 'float' | 'decimal';
 


### PR DESCRIPTION
<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion)
- Tests are added/updated and are passing locally if applicable
- Documentation was added/updated if applicable

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Existing `numeric_precision`, `numeric_scale` and `max_length` schema fields are now considered on schema changes

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Fixes #23992
