### PR TITLE
Fix duplicate and save for files

### DIFF
--- a/.changeset/silly-banks-act.md
+++ b/.changeset/silly-banks-act.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed duplicate and save for files

--- a/.changeset/silly-banks-act.md
+++ b/.changeset/silly-banks-act.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed duplicate and save for files
+Fixed the “Save as Copy” action for files

--- a/app/src/composables/use-item/lib/get-graphql-query-fields.ts
+++ b/app/src/composables/use-item/lib/get-graphql-query-fields.ts
@@ -13,7 +13,7 @@ export function getGraphqlQueryFields(fields: string[], collection: string): Que
 			? fields
 			: fieldsStore
 					.getFieldsForCollection(collection)
-					.filter((field) => !field.meta?.special?.includes('no-data'))
+					.filter((field) => !field.meta?.special?.includes('no-data') && field.field.startsWith('$') === false)
 					.map((field) => field.field);
 
 	const queryFields: QueryFields = {};


### PR DESCRIPTION
## Scope

What's changed:

- Small but sneaky edge case that we have `$thumbnail` in the app for files but it doesn't exist in the api so we have to filter it out here.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- Fixes small regression caused in #24457

---

Fixes #25345
Closes ENG-1335 
