### PR TITLE
Fixed typo in fr-FR translation (crypté -> chiffré)

### DIFF
--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -760,7 +760,7 @@ errors:
   VALUE_OUT_OF_RANGE: La valeur est en dehors des limites
   VALUE_TOO_LONG: La valeur est trop longue
 security: Sécurité
-value_hashed: Valeur cryptée sécurisée
+value_hashed: Valeur chiffrée sécurisée
 bookmark_name: Nom du favori...
 create_bookmark: Ajouter comme favori
 edit_bookmark: Modifier le favori


### PR DESCRIPTION
## Scope

What's changed:

- In the fr-FR translation, fixed typo using `Valeur chiffrée sécurisée` instead of `Valeur cryptée sécurisée`, which is not a French word (https://chiffrer.info/)

## Potential Risks / Drawbacks

- Misunderstanding

## Review Notes / Questions

- N/A
