### PR TITLE
Fix bug with file interface menu in drawer

### DIFF
--- a/.changeset/salty-trams-pick.md
+++ b/.changeset/salty-trams-pick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug that was preventing the file interface menu from appearing in the drawer

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -176,7 +176,7 @@ function useURLImport() {
 
 <template>
 	<div class="file">
-		<v-menu attached :disabled="loading || internalDisabled" keep-behind>
+		<v-menu attached :disabled="loading || internalDisabled">
 			<template #activator="{ toggle, active }">
 				<div>
 					<v-skeleton-loader v-if="loading" type="input" />

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -177,7 +177,7 @@ function useURLImport() {
 <template>
 	<div class="file">
 		<v-menu attached :disabled="loading || internalDisabled">
-			<template #activator="{ toggle, active }">
+			<template #activator="{ toggle, active, deactivate }">
 				<div>
 					<v-skeleton-loader v-if="loading" type="input" />
 
@@ -221,7 +221,15 @@ function useURLImport() {
 
 						<div class="item-actions">
 							<template v-if="file">
-								<v-icon v-tooltip="t('edit_item')" name="edit" clickable @click.stop="editDrawerActive = true" />
+								<v-icon
+									v-tooltip="t('edit_item')"
+									name="edit"
+									clickable
+									@click.stop="
+										deactivate();
+										editDrawerActive = true;
+									"
+								/>
 
 								<v-remove
 									v-if="!internalDisabled"


### PR DESCRIPTION
## Scope

What's changed:

- remover keep-behind attribute to prevent wrong z-index inside drawer
- deactivated file menu before opening drawer

## Potential Risks / Drawbacks

—

## Review Notes / Questions

The `keep-behind` property was initially added to ensure that the file menu does not appear above the drawer when the drawer is positioned behind it.

![initial-bug](https://github.com/user-attachments/assets/9827895d-7994-4cdd-ac18-f580eb9cd364)

---

Fixes #25373
