### PR TITLE
Ensure relational interfaces reset saved edits in versions

### DIFF
--- a/.changeset/eight-symbols-grow.md
+++ b/.changeset/eight-symbols-grow.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that relational interfaces could reset their saved edits in versions

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -389,6 +389,7 @@ function useRawEditor() {
 					:badge="badge"
 					:raw-editor-enabled="rawEditorEnabled"
 					:direction="direction"
+					:version
 					v-bind="fieldsMap[fieldName]!.meta?.options || {}"
 					@apply="apply"
 				/>

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -108,7 +108,7 @@ const TestComponent = defineComponent({
 		});
 
 		// eslint-disable-next-line vue/no-dupe-keys
-		return { value: valueRef, ...useRelationMultiple(valueRef, query, relation, id) };
+		return { value: valueRef, ...useRelationMultiple(valueRef, query, relation, id, ref(null)) };
 	},
 	render: () => h('div'),
 });
@@ -436,7 +436,7 @@ const TestComponentM2A = defineComponent({
 		});
 
 		// eslint-disable-next-line vue/no-dupe-keys
-		return { value: valueRef, ...useRelationMultiple(valueRef, query, relation, id) };
+		return { value: valueRef, ...useRelationMultiple(valueRef, query, relation, id, ref(null)) };
 	},
 	render: () => h('div'),
 });

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -7,7 +7,7 @@ import { getAssetUrl } from '@/utils/get-asset-url';
 import { parseFilter } from '@/utils/parse-filter';
 import DrawerFiles from '@/views/private/components/drawer-files.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
-import { Filter } from '@directus/types';
+import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil, set } from 'lodash';
 import { render } from 'micromustache';
@@ -21,8 +21,9 @@ const props = withDefaults(
 		primaryKey: string | number;
 		collection: string;
 		field: string;
-		template?: string | null;
 		disabled?: boolean;
+		version: ContentVersion | null;
+		template?: string | null;
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		folder?: string;
@@ -43,7 +44,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { collection, field, primaryKey, limit } = toRefs(props);
+const { collection, field, primaryKey, limit, version } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 
 const value = computed({
@@ -108,7 +109,7 @@ const {
 	isItemSelected,
 	isLocalItem,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey);
+} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
 
 const { createAllowed, updateAllowed, selectAllowed, deleteAllowed } = useRelationPermissionsM2M(relationInfo);
 

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -132,7 +132,7 @@ function sortItems(items: DisplayItem[]) {
 	const sortedItems = items.map((item, index) => {
 		const junctionId = item?.[info.junctionPrimaryKeyField.field];
 		const collection = item?.[info.collectionField.field];
-		const pkField = info.relationPrimaryKeyFields[collection].field;
+		const pkField = info.relationPrimaryKeyFields[collection]!.field;
 		const relatedId = item?.[info.junctionField.field]?.[pkField];
 
 		const changes: Record<string, any> = {
@@ -188,7 +188,7 @@ function editItem(item: DisplayItem) {
 	if (!relationInfo.value) return;
 
 	const relationPkField =
-		relationInfo.value.relationPrimaryKeyFields[item[relationInfo.value.collectionField.field]].field;
+		relationInfo.value.relationPrimaryKeyFields[item[relationInfo.value.collectionField.field]]!.field;
 
 	const junctionField = relationInfo.value.junctionField.field;
 	const junctionPkField = relationInfo.value.junctionPrimaryKeyField.field;
@@ -298,7 +298,7 @@ const customFilter = computed(() => {
 
 	const selectedPrimaryKeys = selected.value.reduce(
 		(acc, item) => {
-			const relatedPKField = info.relationPrimaryKeyFields[item[info.collectionField.field]].field;
+			const relatedPKField = info.relationPrimaryKeyFields[item[info.collectionField.field]]!.field;
 			if (item[info.collectionField.field] === selectingFrom.value) acc.push(item[junctionField][relatedPKField]);
 			return acc;
 		},
@@ -307,7 +307,7 @@ const customFilter = computed(() => {
 
 	if (selectedPrimaryKeys.length > 0) {
 		filter._and.push({
-			[info.relationPrimaryKeyFields[selectingFrom.value].field]: {
+			[info.relationPrimaryKeyFields[selectingFrom.value]!.field]: {
 				_nin: selectedPrimaryKeys,
 			},
 		});

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -9,7 +9,7 @@ import { hideDragImage } from '@/utils/hide-drag-image';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
-import { Filter } from '@directus/types';
+import type { ContentVersion, Filter } from '@directus/types';
 import { getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil, set } from 'lodash';
 import { computed, ref, toRefs, unref, watch } from 'vue';
@@ -23,6 +23,7 @@ const props = withDefaults(
 		collection: string;
 		field: string;
 		disabled?: boolean;
+		version: ContentVersion | null;
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		limit?: number;
@@ -41,7 +42,7 @@ const props = withDefaults(
 
 const emit = defineEmits(['input']);
 const { t, te } = useI18n();
-const { collection, field, primaryKey, limit } = toRefs(props);
+const { collection, field, primaryKey, limit, version } = toRefs(props);
 const { relationInfo } = useRelationM2A(collection, field);
 
 const value = computed({
@@ -121,7 +122,7 @@ const {
 	isItemSelected,
 	isLocalItem,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey);
+} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
 
 function sortItems(items: DisplayItem[]) {
 	const info = relationInfo.value;

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -14,7 +14,7 @@ import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
-import { Filter } from '@directus/types';
+import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil, merge, set } from 'lodash';
 import { render } from 'micromustache';
@@ -29,6 +29,7 @@ const props = withDefaults(
 		collection: string;
 		field: string;
 		width: string;
+		version: ContentVersion | null;
 		layout?: LAYOUTS;
 		tableSpacing?: 'compact' | 'cozy' | 'comfortable';
 		fields?: Array<string>;
@@ -64,7 +65,7 @@ const props = withDefaults(
 
 const emit = defineEmits(['input']);
 const { t, n } = useI18n();
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, version } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 const fieldsStore = useFieldsStore();
 
@@ -177,7 +178,7 @@ const {
 	isItemSelected,
 	isLocalItem,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey);
+} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
 
 const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelationPermissionsM2M(relationInfo);
 

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -230,7 +230,7 @@ watch(
 				return {
 					text: field.name,
 					value: key,
-					width: contentWidth[key] < 10 ? contentWidth[key] * 16 + 10 : 160,
+					width: contentWidth[key] !== undefined && contentWidth[key] < 10 ? contentWidth[key] * 16 + 10 : 160,
 					sortable: !['json'].includes(field.type),
 				};
 			})

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -4,7 +4,7 @@ import { useRelationO2M } from '@/composables/use-relation-o2m';
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { parseFilter } from '@/utils/parse-filter';
-import { Filter } from '@directus/types';
+import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { render } from 'micromustache';
 import { computed, inject, ref, toRefs } from 'vue';
@@ -14,11 +14,12 @@ import NestedDraggable from './nested-draggable.vue';
 const props = withDefaults(
 	defineProps<{
 		value?: (number | string | Record<string, any>)[] | Record<string, any>;
-		displayTemplate?: string;
 		disabled?: boolean;
 		collection: string;
 		field: string;
 		primaryKey: string | number;
+		version: ContentVersion | null;
+		displayTemplate?: string;
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		filter?: Filter | null;
@@ -135,6 +136,7 @@ const fields = computed(() => {
 			:enable-select="enableSelect"
 			:custom-filter="customFilter"
 			:items-moved="itemsMoved"
+			:version
 			root
 		/>
 	</div>

--- a/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/nested-draggable.vue
@@ -9,7 +9,7 @@ import { RelationO2M } from '@/composables/use-relation-o2m';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
-import { Filter } from '@directus/types';
+import type { ContentVersion, Filter } from '@directus/types';
 import { moveInArray } from '@directus/utils';
 import { cloneDeep } from 'lodash';
 import { computed, ref, toRefs } from 'vue';
@@ -41,11 +41,12 @@ type ChangeEvent =
 const props = withDefaults(
 	defineProps<{
 		modelValue?: ChangesItem;
-		template: string;
-		disabled?: boolean;
 		collection: string;
 		field: string;
 		primaryKey: string | number;
+		disabled?: boolean;
+		version: ContentVersion | null;
+		template: string;
 		filter?: Filter | null;
 		fields: string[];
 		relationInfo: RelationO2M;
@@ -76,7 +77,7 @@ const value = computed<ChangesItem | any[]>({
 	},
 });
 
-const { collection, field, primaryKey, relationInfo, root, fields, template, customFilter } = toRefs(props);
+const { collection, field, primaryKey, relationInfo, root, fields, template, customFilter, version } = toRefs(props);
 
 const drag = ref(false);
 const open = ref<Record<string, boolean>>({});
@@ -91,7 +92,7 @@ const query = computed<RelationQueryMultiple>(() => ({
 }));
 
 const { displayItems, loading, create, update, remove, select, cleanItem, isLocalItem, getItemEdits } =
-	useRelationMultiple(value, query, relationInfo, primaryKey);
+	useRelationMultiple(value, query, relationInfo, primaryKey, version);
 
 const selectDrawer = ref(false);
 

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -14,7 +14,7 @@ import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
-import { Filter } from '@directus/types';
+import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil } from 'lodash';
 import { render } from 'micromustache';
@@ -29,11 +29,12 @@ const props = withDefaults(
 		collection: string;
 		field: string;
 		width: string;
+		disabled?: boolean;
+		version: ContentVersion | null;
 		layout?: LAYOUTS;
 		tableSpacing?: 'compact' | 'cozy' | 'comfortable';
 		fields?: Array<string>;
 		template?: string | null;
-		disabled?: boolean;
 		enableCreate?: boolean;
 		enableSelect?: boolean;
 		filter?: Filter | null;
@@ -61,7 +62,7 @@ const props = withDefaults(
 
 const emit = defineEmits(['input']);
 const { t, n } = useI18n();
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, version } = toRefs(props);
 const { relationInfo } = useRelationO2M(collection, field);
 const fieldsStore = useFieldsStore();
 
@@ -148,7 +149,7 @@ const {
 	isItemSelected,
 	isLocalItem,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey);
+} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
 
 const { createAllowed, deleteAllowed, updateAllowed } = useRelationPermissionsO2M(relationInfo);
 

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -201,7 +201,7 @@ watch(
 				return {
 					text: field.name,
 					value: key,
-					width: contentWidth[key] < 10 ? contentWidth[key] * 16 + 10 : 160,
+					width: contentWidth[key] !== undefined && contentWidth[key] < 10 ? contentWidth[key] * 16 + 10 : 160,
 					sortable: !['json'].includes(field.type),
 				};
 			})

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -7,6 +7,7 @@ import { useInjectNestedValidation } from '@/composables/use-nested-validation';
 import vTooltip from '@/directives/tooltip';
 import { useFieldsStore } from '@/stores/fields';
 import { fetchAll } from '@/utils/fetch-all';
+import type { ContentVersion } from '@directus/types';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { getEndpoint } from '@directus/utils';
 import { isNil } from 'lodash';
@@ -28,6 +29,7 @@ const props = withDefaults(
 		value: (number | string | Record<string, any>)[] | Record<string, any> | null;
 		autofocus?: boolean;
 		disabled?: boolean;
+		version: ContentVersion | null;
 	}>(),
 	{
 		languageField: null,
@@ -50,7 +52,7 @@ const value = computed({
 	},
 });
 
-const { collection, field, primaryKey } = toRefs(props);
+const { collection, field, primaryKey, version } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 const { t, locale } = useI18n();
 
@@ -107,7 +109,7 @@ const {
 	loading: itemsLoading,
 	fetchedItems,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey);
+} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
 
 useNestedValidation();
 


### PR DESCRIPTION
## Scope

What's changed:

- reset value to value (pk array) of main version if edits are removed and refactor accordingly
- refactored to reuse global targetPKField computed across the file
- updated tests
- fixed types of touched files

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Set up an item with the following relational interfaces/fields and don’t add a value on the main version.
- Create another item where you add at least 1 item to each of the relational fields/interfaces.
- Create another version for each item where you add another item to each of the relational fields/interfaces and save the version.
- Then, try to remove what you added to that version.

Interfaces to test:
- files
- m2a
- m2m
- o2m
- o2m tree
- translations

Also, set up the above relational fields with names other than "id" for the primary key to test if it works.

---

Fixes #24006
