### PR TITLE
Fix error when making unchanged edits to O2M

### DIFF
--- a/.changeset/late-files-hammer.md
+++ b/.changeset/late-files-hammer.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug that caused an error when making unchanged edits to an O2M field

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -470,7 +470,7 @@ function useActions() {
 			set(internalEdits.value, [props.junctionField, relatedPrimaryKeyField.value.field], props.relatedPrimaryKey);
 		}
 
-		if (!isEmpty(internalEdits.value) && props.primaryKey && props.primaryKey !== '+' && primaryKeyField.value) {
+		if (props.primaryKey && props.primaryKey !== '+' && primaryKeyField.value) {
 			internalEdits.value[primaryKeyField.value.field] = props.primaryKey;
 		}
 


### PR DESCRIPTION
## Scope

What's changed:

- Fix regression that caused an error when making unchanged edits to an O2M field

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—

---

Fixes #25383
