### PR TITLE
Hide accepted terms field in settings

### DIFF
--- a/.changeset/brave-bushes-judge.md
+++ b/.changeset/brave-bushes-judge.md
@@ -1,0 +1,5 @@
+---
+'@directus/system-data': patch
+---
+
+Hide accepted terms field in settings

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -683,6 +683,7 @@ fields:
   - field: accepted_terms
     interface: boolean
     width: half
+    hidden: true
     options:
       label: $t:accepted
     special:


### PR DESCRIPTION
## Scope

What's changed:

- Hide accepted terms field in settings

## Potential Risks / Drawbacks

- 

## Review Notes / Questions

- 

---
