### PR TITLE
Fix inconsistent app access permission rules

### DIFF
--- a/.changeset/spicy-singers-nail.md
+++ b/.changeset/spicy-singers-nail.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured app access rules are applied consistently regardless of selection context

--- a/.changeset/spicy-singers-nail.md
+++ b/.changeset/spicy-singers-nail.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensured app access rules are applied consistently regardless of selection context
+Ensured app access permission rules are applied consistently, regardless of the selection context

--- a/app/src/modules/settings/routes/policies/use-save.ts
+++ b/app/src/modules/settings/routes/policies/use-save.ts
@@ -1,5 +1,5 @@
 import api from '@/api';
-import { appRecommendedPermissions } from '@/app-permissions.js';
+import { appAccessMinimalPermissions } from '@directus/system-data';
 import { unexpectedError } from '@/utils/unexpected-error';
 import type { Ref } from 'vue';
 import { ref } from 'vue';
@@ -33,7 +33,7 @@ export function useSave({ name, adminAccess, appAccess }: UseSaveOptions) {
 			if (appAccess.value === true && adminAccess.value === false) {
 				await api.post(
 					'/permissions',
-					appRecommendedPermissions.map((permission) => ({
+					appAccessMinimalPermissions.map((permission) => ({
 						...permission,
 						policy: policyResponse.data.data.id,
 					})),


### PR DESCRIPTION
## Scope

What's changed:

- changed app access to minimal permissions when enabled during creation of a permission

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—
