### PR TITLE
Fix manual flows trigger

### DIFF
--- a/.changeset/orange-rules-train.md
+++ b/.changeset/orange-rules-train.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed Flows with manual triggers failing for integer primaryKeys on the item detail page

--- a/.changeset/orange-rules-train.md
+++ b/.changeset/orange-rules-train.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed Flows with manual triggers failing for integer primaryKeys on the item detail page
+Fixed Flows with manual triggers failing for integer primary keys on the item detail page

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -328,9 +328,9 @@ class FlowManager {
 								},
 							);
 
-							const allowedKeys: PrimaryKey[] = keys.map((key) => key[primaryField]);
+							const allowedKeys: PrimaryKey[] = keys.map((key) => String(key[primaryField]));
 
-							if (targetKeys.some((key: PrimaryKey) => !allowedKeys.includes(key))) {
+							if (targetKeys.some((key: PrimaryKey) => !allowedKeys.includes(String(key)))) {
 								logger.warn(`Triggering keys ${targetKeys} is not allowed`);
 								throw new ForbiddenError();
 							}


### PR DESCRIPTION
## Scope

What's changed:

- Treat all primaryKeys as string for comparison in the validation

## Potential Risks / Drawbacks

- None I can think of

## Review Notes / Questions

- With the exception of "auto-increment integer" all other PK types should already be represented as strings

---

Fixes #25405 
