### PR TITLE
Drop OS release from pnpm cache key used in GitHub workflows

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -12,30 +12,27 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Node.js
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
 
-    - name: Install pnpm
+    - name: Setup pnpm
       uses: pnpm/action-setup@v4
 
-    - name: Get cache info
-      id: cache-info
+    - name: Get pnpm cache dir
+      id: pnpm-cache-dir
       shell: bash
-      run: |
-        echo "os-release=$(node --eval 'console.log(os.release())')" >> $GITHUB_OUTPUT
-        echo "pnpm-cache-dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+      run: echo "pnpm-cache-dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
       uses: actions/cache@v4
       with:
-        path: ${{ steps.cache-info.outputs.pnpm-cache-dir }}
-        key:
-          ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        path: ${{ steps.pnpm-cache-dir.outputs.pnpm-cache-dir }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Scope

What's changed:

- No longer consider the OS release for the pnpm cache key
- This got added in #19973, because a different OS release (`ubuntu-20.04`) had to be used for MSSQL blackbox tests and has recently become obsolete with #25065
- Potentially reducing number of caches (whenever GitHub releases new OS version (`ubuntu-latest`)) and small speed up because of increased cache hits  

## Potential Risks / Drawbacks

None

## Review Notes / Questions

None