### PR TITLE
Improve custom validation message handling

### DIFF
--- a/.changeset/puny-cities-bet.md
+++ b/.changeset/puny-cities-bet.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Improved custom validation message handling

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -75,6 +75,15 @@ const validationPrefix = computed(() => {
 	return null;
 });
 
+const showCustomValidationMessage = computed(() => {
+	if (!props.validationError) return false;
+
+	const customValidationMessage = !!props.field.meta?.validation_message;
+	const hasCustomValidation = !!props.field.meta?.validation;
+
+	return customValidationMessage && (!hasCustomValidation || props.validationError.code === 'FAILED_VALIDATION');
+});
+
 function emitValue(value: any) {
 	if (
 		(isEqual(value, props.initialValue) || (props.initialValue === undefined && isEqual(value, defaultValue.value))) &&
@@ -215,7 +224,7 @@ function useComputedValues() {
 		<small v-if="field.meta && field.meta.note" v-md="{ value: field.meta.note, target: '_blank' }" class="type-note" />
 
 		<small v-if="validationError" class="validation-error selectable">
-			<template v-if="field.meta?.validation_message">
+			<template v-if="showCustomValidationMessage">
 				{{ field.meta?.validation_message }}
 				<v-icon v-tooltip="validationMessage" small right name="help" />
 			</template>

--- a/app/src/components/v-form/validation-errors.vue
+++ b/app/src/components/v-form/validation-errors.vue
@@ -5,6 +5,13 @@ import { ValidationError, Field } from '@directus/types';
 import { formatFieldFunction } from '@/utils/format-field-function';
 import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
 
+type ValidationErrorWithDetails = ValidationError & {
+	fieldName: string;
+	groupName: string;
+	hasCustomValidation: boolean;
+	customValidationMessage: string | null;
+};
+
 const props = defineProps<{
 	validationErrors: ValidationError[];
 	fields: Field[];
@@ -14,9 +21,7 @@ defineEmits(['scroll-to-field']);
 
 const { t } = useI18n();
 
-const validationErrorsWithNames = computed<
-	(ValidationError & { fieldName: string; groupName: string; customValidationMessage: string | null })[]
->(() => {
+const validationErrorsWithDetails = computed<ValidationErrorWithDetails[]>(() => {
 	return props.validationErrors.map(
 		(validationError: ValidationError & { nestedNames?: Record<string, string>; validation_message?: string }) => {
 			const { field: _fieldKey, fn: functionName } = extractFieldFromFunction(validationError.field);
@@ -30,6 +35,7 @@ const validationErrorsWithNames = computed<
 				field: fieldKey,
 				fieldName,
 				groupName: group?.name ?? validationError.group,
+				hasCustomValidation: !!field?.meta?.validation,
 				customValidationMessage: validationError.validation_message ?? field?.meta?.validation_message,
 			};
 
@@ -45,8 +51,22 @@ const validationErrorsWithNames = computed<
 				return `${separator}${nestedFieldKeys.map((name) => nestedNames?.[name] ?? name).join(separator)}`;
 			}
 		},
-	) as (ValidationError & { fieldName: string; groupName: string; customValidationMessage: string | null })[];
+	) as ValidationErrorWithDetails[];
 });
+
+function getDefaultValidationMessage(validationError: ValidationError) {
+	const isNotUnique = validationError.code === 'RECORD_NOT_UNIQUE';
+	if (isNotUnique) return t('validationError.unique', validationError);
+
+	return t(`validationError.${validationError.type}`, validationError);
+}
+
+function showCustomValidationMessage(validationError: ValidationErrorWithDetails) {
+	return (
+		validationError.customValidationMessage &&
+		(!validationError.hasCustomValidation || validationError.code === 'FAILED_VALIDATION')
+	);
+}
 </script>
 
 <template>
@@ -54,7 +74,7 @@ const validationErrorsWithNames = computed<
 		<div>
 			<p>{{ t('validation_errors_notice') }}</p>
 			<ul class="validation-errors-list">
-				<li v-for="(validationError, index) of validationErrorsWithNames" :key="index" class="validation-error">
+				<li v-for="(validationError, index) of validationErrorsWithDetails" :key="index" class="validation-error">
 					<strong class="field" @click="$emit('scroll-to-field', validationError.group || validationError.field)">
 						<template v-if="validationError.field && validationError.hidden && validationError.group">
 							{{
@@ -69,27 +89,13 @@ const validationErrorsWithNames = computed<
 						<template v-else-if="validationError.field">{{ validationError.fieldName }}</template>
 					</strong>
 					<strong>{{ ': ' }}</strong>
-					<template v-if="validationError.customValidationMessage">
+
+					<template v-if="showCustomValidationMessage(validationError)">
 						{{ validationError.customValidationMessage }}
-						<v-icon
-							v-tooltip="
-								validationError.code === 'RECORD_NOT_UNIQUE'
-									? t('validationError.unique', validationError)
-									: t(`validationError.${validationError.type}`, validationError)
-							"
-							small
-							right
-							name="help"
-						/>
+						<v-icon v-tooltip="getDefaultValidationMessage(validationError)" small right name="help" />
 					</template>
-					<template v-else>
-						<template v-if="validationError.code === 'RECORD_NOT_UNIQUE'">
-							{{ t('validationError.unique', validationError) }}
-						</template>
-						<template v-else>
-							{{ t(`validationError.${validationError.type}`, validationError) }}
-						</template>
-					</template>
+
+					<template v-else>{{ getDefaultValidationMessage(validationError) }}</template>
 				</li>
 			</ul>
 		</div>


### PR DESCRIPTION
## Scope

What's changed:

- Changed the logic for displaying custom validation messages:
  - When there is no custom validation rule, display the custom validation message for each validation error.
  - When a custom validation rule exists, only display the custom validation message if the validation fails because of that rule.
- Extracted some logic for reuse.

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Follow the reproduction steps from the original issue …
  - … and duplicate the field and remove the validation rule
  - … and duplicate the field again and remove the validation message (be sure to update the field in the validation rule as well)
  - … and duplicate the field again and remove both, the validation rule and message
- Test the validation messages for the different scenarios.

---

Fixes #18298
