### PR TITLE
Fix handling of initial values in overlay forms with junction fields

### DIFF
--- a/.changeset/shy-needles-create.md
+++ b/.changeset/shy-needles-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug that was preventing overlay forms with junction fields from correctly applying filters in M2O fields

--- a/app/src/views/private/components/overlay-item-content.vue
+++ b/app/src/views/private/components/overlay-item-content.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { Field, PrimaryKey } from '@directus/types';
-import { computed, useTemplateRef } from 'vue';
-import { useI18n } from 'vue-i18n';
 import ValidationErrors from '@/components/v-form/validation-errors.vue';
 import FilePreviewReplace from '@/views/private/components/file-preview-replace.vue';
+import type { Field, PrimaryKey } from '@directus/types';
+import { cloneDeep } from 'lodash';
+import { computed, useTemplateRef } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 const {
 	collection,
@@ -13,6 +14,7 @@ const {
 	initialValues,
 	fields,
 	junctionFieldLocation = 'bottom',
+	relatedPrimaryKeyField,
 } = defineProps<{
 	collection: string;
 	primaryKey: PrimaryKey | null;
@@ -26,15 +28,15 @@ const {
 	junctionFieldLocation?: string;
 	relatedCollectionFields: Field[];
 	relatedPrimaryKey: PrimaryKey;
+	relatedPrimaryKeyField: string | null;
 	refresh: () => void;
 }>();
 
 const internalEdits = defineModel<Record<string, any>>('internal-edits');
 
 const { t } = useI18n();
-
+const { mainInitialValues, junctionInitialValues } = useInitialValues();
 const { file } = useFile();
-
 const { scrollToField } = useValidationScrollToField();
 
 const swapFormOrder = computed(() => junctionFieldLocation === 'top');
@@ -48,15 +50,37 @@ function setRelationEdits(edits: any) {
 	internalEdits.value[junctionField] = edits;
 }
 
+function useInitialValues() {
+	const mainInitialValues = computed(() => {
+		if (!initialValues) return null;
+		if (!junctionField || !initialValues[junctionField] || !relatedPrimaryKeyField) return initialValues;
+
+		const tempInitialValues = cloneDeep(initialValues);
+		tempInitialValues[junctionField] = initialValues[junctionField][relatedPrimaryKeyField];
+
+		return tempInitialValues;
+	});
+
+	const junctionInitialValues = computed(() => {
+		if (!initialValues || !junctionField || !initialValues[junctionField]) return null;
+		return initialValues[junctionField];
+	});
+
+	return {
+		mainInitialValues,
+		junctionInitialValues,
+	};
+}
+
 function useFile() {
 	const isDirectusFiles = computed(() => {
 		return collection === 'directus_files' || relatedCollection === 'directus_files';
 	});
 
 	const file = computed(() => {
-		if (isDirectusFiles.value === false || !initialValues) return null;
+		if (isDirectusFiles.value === false) return null;
 
-		const fileData = junctionField ? initialValues?.[junctionField] : initialValues;
+		const fileData = junctionField ? junctionInitialValues.value : mainInitialValues.value;
 
 		return fileData || null;
 	});
@@ -107,7 +131,7 @@ function useValidationScrollToField() {
 				:disabled="disabled"
 				:loading="loading"
 				:show-no-visible-fields="false"
-				:initial-values="initialValues?.[junctionField]"
+				:initial-values="junctionInitialValues"
 				:autofocus="!swapFormOrder"
 				:show-divider="!swapFormOrder && hasVisibleFieldsJunction"
 				:primary-key="relatedPrimaryKey"
@@ -121,7 +145,7 @@ function useValidationScrollToField() {
 				:disabled="disabled"
 				:loading="loading"
 				:show-no-visible-fields="false"
-				:initial-values="initialValues"
+				:initial-values="mainInitialValues"
 				:autofocus="swapFormOrder"
 				:show-divider="swapFormOrder && hasVisibleFieldsRelated"
 				:primary-key="primaryKey"

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -232,6 +232,7 @@ const overlayItemContentProps = computed(() => {
 		junctionFieldLocation: props.junctionFieldLocation,
 		relatedCollectionFields: relatedCollectionFields.value,
 		relatedPrimaryKey: props.relatedPrimaryKey,
+		relatedPrimaryKeyField: relatedPrimaryKeyField.value?.field ?? null,
 		refresh,
 	};
 });


### PR DESCRIPTION
## Scope

What's changed:

`<overlay-item-content>` used the same `initialValues` for the main and the junction fields. For example, if you have `initialValues` like `{ name: 'John', relatedFriend: 2 }`. As soon as the junction fields are displayed, the object changes to `{ name: 'John', relatedFriend: { id: 2, name: 'Flea' } }`. This is necessary for the junction fields but not for the main fields. To address this, this PR introduces separate initial values: `mainInitialValues` and `junctionInitialValues`.

## Potential Risks / Drawbacks

- This affects all drawer items with junction fields

## Review Notes / Questions

- Test with all types that could have a junction collection — m2m, m2a, files, …

---

Fixes #25224