### PR TITLE
Log out user when deleting own account

### DIFF
--- a/.changeset/rare-doors-notice.md
+++ b/.changeset/rare-doors-notice.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added logout flow when user removes own account.

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -16,6 +16,8 @@ import { useI18n } from 'vue-i18n';
 import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
 import useNavigation from '../composables/use-navigation';
+import { logout } from '@/auth';
+import { useUserStore } from '@/stores/user';
 
 type Item = {
 	[field: string]: any;
@@ -29,9 +31,10 @@ const { t } = useI18n();
 const { roles } = useNavigation(role);
 const userInviteModalActive = ref(false);
 const serverStore = useServerStore();
+const userStore = useUserStore();
 
 const layoutRef = ref();
-const selection = ref<Item[]>([]);
+const selection = ref<string[]>([]);
 
 const { layout, layoutOptions, layoutQuery, filter, search, resetPreset } = usePreset(ref('directus_users'));
 const { addNewLink } = useLinks();
@@ -107,6 +110,19 @@ function useBatch() {
 			await api.delete('/users', {
 				data: batchPrimaryKeys,
 			});
+
+			// Check if the current user was among the deleted users
+			const currentUserId = userStore.currentUser && 'id' in userStore.currentUser ? userStore.currentUser.id : null;
+
+			if (
+				currentUserId &&
+				batchPrimaryKeys.some((key) => {
+					return key === currentUserId;
+				})
+			) {
+				await logout();
+				return;
+			}
 
 			await refresh();
 

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -19,10 +19,6 @@ import useNavigation from '../composables/use-navigation';
 import { logout } from '@/auth';
 import { useUserStore } from '@/stores/user';
 
-type Item = {
-	[field: string]: any;
-};
-
 const props = defineProps<{ role?: string }>();
 
 const { role } = toRefs(props);

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -19,6 +19,7 @@ import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
 import UserInfoSidebarDetail from '../components/user-info-sidebar-detail.vue';
+import { logout } from '@/auth';
 
 const props = defineProps<{
 	primaryKey: string;
@@ -205,6 +206,15 @@ async function deleteAndQuit() {
 	if (deleting.value) return;
 
 	try {
+		const currentUserId = userStore.currentUser && 'id' in userStore.currentUser ? userStore.currentUser.id : null;
+
+		// If the deleted user is the current user, we want to log them out
+		if (currentUserId && currentUserId === item.value?.id) {
+			await remove();
+			await logout();
+			return;
+		}
+
 		await remove();
 		edits.value = {};
 		router.replace(`/users`);


### PR DESCRIPTION
## Scope

What's changed:

- Fixed type error in batch delete functionality where selection was incorrectly typed as Item[] instead of string[]
- Added logout flow when current user is deleted
- Ensured consistent behavior between single user deletion (item view) and batch deletion (collection view)

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

1. Logging Out When Deleting Yourself from Profile
Steps:
- Create a user with admin rights 
- login with the user just created and navigate to the profile page
- Click on the trash icon at the top of the profile to delete
Expected Result:
Your account is deleted
You are logged out and redirected to the login page
You should not be able to log back in since your account was removed

2. Logging Out When Deleting Yourself from Profile
Steps:
- Create two users (at least one should have admin rights) 
- log in using the user with admin rights and navigate to the users page.
- select the user you logged in with in addition to the other user you created.
- click the delete button.
Expected Result:
Both accounts are deleted
You are logged out and redirected to the login page
You should not be able to log back in with either account that you removed.
---

Fixes  #24258
