### PR TITLE
Redirect to profile after registration

### DIFF
--- a/.changeset/sad-moose-grow.md
+++ b/.changeset/sad-moose-grow.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added redirect to profile page when user registers and not required to verify by email.

--- a/app/src/routes/register/register-form.vue
+++ b/app/src/routes/register/register-form.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import api, { RequestError } from '@/api';
+import { login } from '@/auth';
 import { translateAPIError } from '@/lang';
+import { useServerStore } from '@/stores/server';
+import { useUserStore } from '@/stores/user';
 import { ErrorCode } from '@directus/errors';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
 type Credentials = {
 	email: string;
@@ -11,6 +15,9 @@ type Credentials = {
 };
 
 const { t } = useI18n();
+const router = useRouter();
+const serverStore = useServerStore();
+const userStore = useUserStore();
 const isLoading = ref(false);
 const email = ref<string | null>(null);
 const password = ref<string | null>(null);
@@ -19,6 +26,8 @@ const error = ref<RequestError | string | null>(null);
 const emit = defineEmits<{
 	wasSuccessful: [boolean];
 }>();
+
+const requiresEmailVerification = computed(() => serverStore.info.project?.public_registration_verify_email);
 
 const errorFormatted = computed(() => {
 	// Show "Wrong username or password" for wrongly formatted emails as well
@@ -52,7 +61,20 @@ async function onSubmit() {
 
 		await api.post('/users/register', credentials);
 
-		emit('wasSuccessful', true);
+		// If email verification is not required, automatically log in the user
+		if (!requiresEmailVerification.value) {
+			await login({ credentials });
+			const currentUser = userStore.currentUser;
+
+			if (currentUser && 'id' in currentUser) {
+				router.push(`/users/${currentUser.id}`);
+			} else {
+				router.push('/login');
+			}
+		} else {
+			// If email verification is required, show success message
+			emit('wasSuccessful', true);
+		}
 	} catch (err: any) {
 		error.value = err.errors?.[0]?.extensions?.code || err;
 		emit('wasSuccessful', false);


### PR DESCRIPTION
## Scope

What's changed:

- Added redirect after user registers and verify by email is not enabled

## Potential Risks / Drawbacks

- This doesn't change the behavior of any backend services, so risk should be minimal

## Review Notes / Questions

- Turn on user registration in settings
- Make sure verify by email is disabled
- Register a user

Expected: you should be redirected to the profile page

- Turn on verify by email
- Register a user

Confirm this path works the same as before - flashes success message informing user to verify account


---

Fixes #22466
