### PR TITLE
Improve output types for relational fields in the SDK

### DIFF
--- a/.changeset/slow-toes-study.md
+++ b/.changeset/slow-toes-study.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Improved output types for relational fields in the SDK

--- a/sdk/src/types/output.ts
+++ b/sdk/src/types/output.ts
@@ -23,7 +23,11 @@ export type ApplyQueryFields<
 	Prettify<
 		Merge<
 			MappedFunctionFields<Schema, CollectionItem> extends infer FF
-				? MapFlatFields<RemoveRelationships<Schema, CollectionItem>, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>
+				? MapFlatFields<
+						RemoveRelationships<Schema, CollectionItem>,
+						FlatFields,
+						FF extends Record<string, string> ? FF : Record<string, string>
+				  >
 				: never,
 			RelationalFields extends never
 				? never
@@ -106,7 +110,7 @@ export type MapFlatFields<
 		? FunctionOutputType
 		: Extract<Item[F], keyof FieldOutputMap> extends infer A
 		  ? A[] extends never[]
-				? Item[F]				
+				? Item[F]
 				: A extends keyof FieldOutputMap
 				  ? FieldOutputMap[A] | Exclude<Item[F], A>
 				  : Item[F]

--- a/sdk/src/types/output.ts
+++ b/sdk/src/types/output.ts
@@ -1,6 +1,6 @@
 import type { FieldsWildcard, HasManyToAnyRelation, PickRelationalFields } from './fields.js';
 import type { MappedFunctionFields } from './functions.js';
-import type { ItemType } from './schema.js';
+import type { ItemType, RemoveRelationships } from './schema.js';
 import type { IfAny, IsNullable, Merge, Mutable, UnpackList, Prettify } from './utils.js';
 
 /**
@@ -23,7 +23,7 @@ export type ApplyQueryFields<
 	Prettify<
 		Merge<
 			MappedFunctionFields<Schema, CollectionItem> extends infer FF
-				? MapFlatFields<CollectionItem, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>
+				? MapFlatFields<RemoveRelationships<Schema, CollectionItem>, FlatFields, FF extends Record<string, string> ? FF : Record<string, string>>
 				: never,
 			RelationalFields extends never
 				? never
@@ -106,7 +106,7 @@ export type MapFlatFields<
 		? FunctionOutputType
 		: Extract<Item[F], keyof FieldOutputMap> extends infer A
 		  ? A[] extends never[]
-				? Item[F]
+				? Item[F]				
 				: A extends keyof FieldOutputMap
 				  ? FieldOutputMap[A] | Exclude<Item[F], A>
 				  : Item[F]

--- a/sdk/tests/relations.test-d.ts
+++ b/sdk/tests/relations.test-d.ts
@@ -1,71 +1,91 @@
 import { describe, expectTypeOf, test } from 'vitest';
-import { createDirectus, readItems, rest, type Prettify } from '../src/index.js';
-import type { CollectionA, CollectionAB_Any, CollectionAB_Many, CollectionB, CollectionC, TestSchema } from './schema.js';
+import { createDirectus, readItems, rest } from '../src/index.js';
+import type {
+	CollectionA,
+	CollectionAB_Any,
+	CollectionAB_Many,
+	CollectionB,
+	CollectionC,
+	TestSchema,
+} from './schema.js';
 
 describe('Test relational return typing (issue #23545)', () => {
+	test('Flat relational field return type', () => {
+		const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
 
-    test('Flat relational field return type', () => {
-        const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
+		const _itemFlatRelations = () =>
+			client.request(
+				readItems('collection_a', {
+					fields: ['m2o', 'o2m', 'm2m', 'm2a'],
+				}),
+			);
 
-        const _itemFlatRelations = () => client.request(readItems('collection_a', {
-            fields: ['m2o', 'o2m', 'm2m', 'm2a']
-        }));
+		type Item = Awaited<ReturnType<typeof _itemFlatRelations>>[0];
 
-        type Item = Awaited<ReturnType<typeof _itemFlatRelations>>[0];
-        
-        const result: Item = {
-            m2o: 123,
-            o2m: [123],
-            m2m: [123],
-            m2a: [123],
-        };
+		const result: Item = {
+			m2o: 123,
+			o2m: [123],
+			m2m: [123],
+			m2a: [123],
+		};
 
-        type Expected = {
-            m2o: Exclude<CollectionA['m2o'], CollectionB>;
-            o2m: Exclude<CollectionA['o2m'], CollectionC[]>;
-            m2m: Exclude<CollectionA['m2m'], CollectionAB_Many[]>;
-            m2a: Exclude<CollectionA['m2a'], CollectionAB_Any[]>;
-        };
+		type Expected = {
+			m2o: Exclude<CollectionA['m2o'], CollectionB>;
+			o2m: Exclude<CollectionA['o2m'], CollectionC[]>;
+			m2m: Exclude<CollectionA['m2m'], CollectionAB_Many[]>;
+			m2a: Exclude<CollectionA['m2a'], CollectionAB_Any[]>;
+		};
 
-        expectTypeOf(result).toEqualTypeOf<Expected>();
-    });
-    
-    test('Nested relational ID #23545', () => {
-        const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
+		expectTypeOf(result).toEqualTypeOf<Expected>();
+	});
 
-        const _itemNestedRelations = () => client.request(readItems('collection_a', {
-            fields: [{
-                'm2o': ['id'],
-                'o2m': ['id'],
-                'm2m': ['id'],
-                'm2a': ['id'],
-            }],
-        }));
+	test('Nested relational ID #23545', () => {
+		const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
 
-        type Item = Awaited<ReturnType<typeof _itemNestedRelations>>[0];
+		const _itemNestedRelations = () =>
+			client.request(
+				readItems('collection_a', {
+					fields: [
+						{
+							m2o: ['id'],
+							o2m: ['id'],
+							m2m: ['id'],
+							m2a: ['id'],
+						},
+					],
+				}),
+			);
 
-        const result: Item = {
-            m2o: {
-                id: 123,
-            },
-            o2m: [{
-                id: 123,
-            }],
-            m2m: [{
-                id: 123,
-            }],
-            m2a: [{
-                id: 123,
-            }],
-        };
+		type Item = Awaited<ReturnType<typeof _itemNestedRelations>>[0];
 
-        type Expected = {
-            m2o: Pick<CollectionB, "id">;
-            o2m: Pick<CollectionC, "id">[] | null;
-            m2m: Pick<CollectionAB_Many, "id">[] | null;
-            m2a: Pick<CollectionAB_Any, "id">[] | null;
-        };
+		const result: Item = {
+			m2o: {
+				id: 123,
+			},
+			o2m: [
+				{
+					id: 123,
+				},
+			],
+			m2m: [
+				{
+					id: 123,
+				},
+			],
+			m2a: [
+				{
+					id: 123,
+				},
+			],
+		};
 
-        expectTypeOf(result).toEqualTypeOf<Expected>();
-    });
+		type Expected = {
+			m2o: Pick<CollectionB, 'id'>;
+			o2m: Pick<CollectionC, 'id'>[] | null;
+			m2m: Pick<CollectionAB_Many, 'id'>[] | null;
+			m2a: Pick<CollectionAB_Any, 'id'>[] | null;
+		};
+
+		expectTypeOf(result).toEqualTypeOf<Expected>();
+	});
 });

--- a/sdk/tests/relations.test-d.ts
+++ b/sdk/tests/relations.test-d.ts
@@ -1,0 +1,50 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import { createDirectus, readItems, rest } from '../src/index.js';
+import type { CollectionA, CollectionB, TestSchema } from './schema.js';
+
+describe('Test Relational return typing', () => {
+
+    test('Flat relational ID #23545', () => {
+        const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
+
+        const _itemFlatRelation = () => client.request(readItems('collection_a', {
+            fields: ['m2o']
+        }));
+
+        type Item = Awaited<ReturnType<typeof _itemFlatRelation>>[0];
+        
+        const result: Item = {
+            m2o: 123
+        };
+
+        type Expected = {
+            m2o: Exclude<CollectionA['m2o'], CollectionB>; // number
+        };
+
+        expectTypeOf(result).toEqualTypeOf<Expected>();
+    });
+    
+    test('Nested relational ID #23545', () => {
+        const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
+
+        const _itemNestedRelation = () => client.request(readItems('collection_a', {
+            fields: [
+                { 'm2o': ['id'] }
+            ]
+        }));
+
+        type Item = Awaited<ReturnType<typeof _itemNestedRelation>>[0];
+
+        const result: Item = {
+            m2o: {
+                id: 123
+            }
+        };
+
+        type Expected = {
+            m2o: Pick<CollectionB, "id">
+        };
+
+        expectTypeOf(result).toEqualTypeOf<Expected>();
+    });
+});

--- a/sdk/tests/relations.test-d.ts
+++ b/sdk/tests/relations.test-d.ts
@@ -1,24 +1,30 @@
 import { describe, expectTypeOf, test } from 'vitest';
-import { createDirectus, readItems, rest } from '../src/index.js';
-import type { CollectionA, CollectionB, TestSchema } from './schema.js';
+import { createDirectus, readItems, rest, type Prettify } from '../src/index.js';
+import type { CollectionA, CollectionAB_Any, CollectionAB_Many, CollectionB, CollectionC, TestSchema } from './schema.js';
 
-describe('Test Relational return typing', () => {
+describe('Test relational return typing (issue #23545)', () => {
 
-    test('Flat relational ID #23545', () => {
+    test('Flat relational field return type', () => {
         const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
 
-        const _itemFlatRelation = () => client.request(readItems('collection_a', {
-            fields: ['m2o']
+        const _itemFlatRelations = () => client.request(readItems('collection_a', {
+            fields: ['m2o', 'o2m', 'm2m', 'm2a']
         }));
 
-        type Item = Awaited<ReturnType<typeof _itemFlatRelation>>[0];
+        type Item = Awaited<ReturnType<typeof _itemFlatRelations>>[0];
         
         const result: Item = {
-            m2o: 123
+            m2o: 123,
+            o2m: [123],
+            m2m: [123],
+            m2a: [123],
         };
 
         type Expected = {
-            m2o: Exclude<CollectionA['m2o'], CollectionB>; // number
+            m2o: Exclude<CollectionA['m2o'], CollectionB>;
+            o2m: Exclude<CollectionA['o2m'], CollectionC[]>;
+            m2m: Exclude<CollectionA['m2m'], CollectionAB_Many[]>;
+            m2a: Exclude<CollectionA['m2a'], CollectionAB_Any[]>;
         };
 
         expectTypeOf(result).toEqualTypeOf<Expected>();
@@ -27,22 +33,37 @@ describe('Test Relational return typing', () => {
     test('Nested relational ID #23545', () => {
         const client = createDirectus<TestSchema>('https://directus.example.com').with(rest());
 
-        const _itemNestedRelation = () => client.request(readItems('collection_a', {
-            fields: [
-                { 'm2o': ['id'] }
-            ]
+        const _itemNestedRelations = () => client.request(readItems('collection_a', {
+            fields: [{
+                'm2o': ['id'],
+                'o2m': ['id'],
+                'm2m': ['id'],
+                'm2a': ['id'],
+            }],
         }));
 
-        type Item = Awaited<ReturnType<typeof _itemNestedRelation>>[0];
+        type Item = Awaited<ReturnType<typeof _itemNestedRelations>>[0];
 
         const result: Item = {
             m2o: {
-                id: 123
-            }
+                id: 123,
+            },
+            o2m: [{
+                id: 123,
+            }],
+            m2m: [{
+                id: 123,
+            }],
+            m2a: [{
+                id: 123,
+            }],
         };
 
         type Expected = {
-            m2o: Pick<CollectionB, "id">
+            m2o: Pick<CollectionB, "id">;
+            o2m: Pick<CollectionC, "id">[] | null;
+            m2m: Pick<CollectionAB_Many, "id">[] | null;
+            m2a: Pick<CollectionAB_Any, "id">[] | null;
         };
 
         expectTypeOf(result).toEqualTypeOf<Expected>();


### PR DESCRIPTION
## Scope

What's changed:

This change remove the nested collection type when only requesting the flat field of a relation.

**Before:**

When requesting the flat field of a relation it is currently typed as `number | CollectionItem` where it should be just the primaryKey `number`.

<img width="1204" height="350" alt="image" src="https://github.com/user-attachments/assets/7e7104b1-506d-4168-8826-a6025e5172d5" />


[TypeScript Playground Reproduction](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYygUwIYzQEWO5GAVwGcAaOdDAEwElsRzK0T4BfOAMyghDgCIAAtXxpCpAPQlqAa34BuAFCK0AD0iw4MAJ5g0cACosYAZWQALNCAxwAvIkUBIZBAA2rsTGAQAdgH0MAC44AGE3D0JvHwBBAG0AXSVncM8ovwAjYLD3VN8AIQSlNiVFCQlQlMjfOGiVdWh4HT0KnKqYuwdHYGpgnyIQdLQoJJAAJghe-sGoOAAfFoivfKKSsoXcnzg8uo1G3X1sxai8joQnbsmBoaSAKxJfP05gNFceuAByO993ubg+9ySyBIADdHs9XsF3kDgT95v9XCtlC4fKwUK5nj54PZUJhsHgCMQSAAeIysMyWawAPgAFO9zDAYGASIEyiICaQAHRqDDgDwclwgd4ASg5AHdgDBzNT0KxqUKhSVkaiZURXFi4BhRRgJWiMTAOegAI5EYzSzB0BgkWkuVpLfwYd4UM5wF1ccHUZlwWLvMYQd7xMiKNjykpNfQAJRYqvVYYgnGYJGjof2cAAYu6DCn7JHE2rYgAGeLe33+pRrF0APQA-IogA)

**After:**

<img width="1198" height="454" alt="image" src="https://github.com/user-attachments/assets/62507e12-bef7-4c4d-bd4b-8102526dfa2c" />


## Potential Risks / Drawbacks

- I havent found any side effects so far but there is always a risk of unintended changes with these complex types

## Review Notes / Questions

- Do I need more extensive tests on the types touched in this PR

---

Fixes #23545
