### PR TITLE
Update file list when file imported by url

### DIFF
--- a/.changeset/twelve-pugs-play.md
+++ b/.changeset/twelve-pugs-play.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added code to update the file list ui when importing a file via url

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -241,6 +241,8 @@ function useSelection() {
 function useURLImport() {
 	const url = ref('');
 	const loading = ref(false);
+	const filesStore = useFilesStore();
+	const newUpload = filesStore.upload();
 
 	const isValidURL = computed(() => {
 		try {
@@ -257,6 +259,7 @@ function useURLImport() {
 		if (!isValidURL.value || loading.value) return;
 
 		loading.value = true;
+		newUpload.start(1);
 
 		const data = {
 			...props.preset,
@@ -269,6 +272,9 @@ function useURLImport() {
 				url: url.value,
 				data,
 			});
+
+			newUpload.progress.value = 100;
+			newUpload.done.value = 1;
 
 			emitter.emit(Events.upload);
 
@@ -284,6 +290,7 @@ function useURLImport() {
 			unexpectedError(error);
 		} finally {
 			loading.value = false;
+			newUpload.finish();
 		}
 	}
 }


### PR DESCRIPTION
## Scope


What's changed:

- useURLImport composable in v-upload component now updates the files store so that the interface reflects the changes right away.

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

Go to the files page and add a new image by selecting the import option. You should see the file render in the list once the import completes.

---

Fixes #25419
