### PR TITLE
Fix WYSIWYG table button by enabling support for editors in scrollable containers 

### DIFF
--- a/.changeset/salty-pans-tap.md
+++ b/.changeset/salty-pans-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+WYSIWYG - tinymce init in split mode for compatibility

--- a/.changeset/salty-pans-tap.md
+++ b/.changeset/salty-pans-tap.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-WYSIWYG - tinymce init in split mode for compatibility
+Fixed a bug that prevented popups from working in the WYSIWYG interface when opened in a drawer

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -223,6 +223,7 @@ const editorOptions = computed(() => {
 		paste_data_images: false,
 		setup,
 		language: i18n.global.locale.value,
+		ui_mode: 'split',
 		...(props.tinymceOverrides && cloneDeep(props.tinymceOverrides)),
 	};
 });

--- a/contributors.yml
+++ b/contributors.yml
@@ -217,3 +217,4 @@
 - Mehdi-YC
 - MrGreenTea
 - smgrol
+- DantonMariano


### PR DESCRIPTION
## Scope

What's changed:

- Changed TinyMCE to initialize in 'split' mode so it enables support for editors in scrollable containers

---

Fixes #25423 
