### PR TITLE
fix bug caused by stylelint PR

### DIFF
--- a/app/src/modules/insights/routes/panel-configuration.vue
+++ b/app/src/modules/insights/routes/panel-configuration.vue
@@ -172,7 +172,6 @@ const stageChanges = () => {
 								type="panel"
 								:extension="panel.type"
 								raw-editor-enabled
-								style="grid-template-columns: unset"
 								@update:model-value="edits.options = $event"
 							/>
 							<v-divider :inline-title="false" large>


### PR DESCRIPTION
## Scope

What's changed:

- fixed bug caused by fixing inline style for grid-template-columns

Before 

<img width="2530" height="1518" alt="before" src="https://github.com/user-attachments/assets/e41be719-d795-4e11-a7ca-62af5ae38ee3" />

After

<img width="2536" height="1522" alt="after" src="https://github.com/user-attachments/assets/8252d4eb-69a1-431e-aae1-cbbe893bbd17" />


## Potential Risks / Drawbacks

—

## Review Notes / Questions

- caused by a bug Stylelint made visible `style="{'grid-template-columns': 'unset'}"`. This line should never have worked, though.
- no changeset needed
