### PR TITLE
Pass opacity value to color presets interface

### DIFF
--- a/.changeset/full-files-sleep.md
+++ b/.changeset/full-files-sleep.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Changed select-color interface to pass opacity value to color-presets

--- a/app/src/interfaces/select-color/index.ts
+++ b/app/src/interfaces/select-color/index.ts
@@ -11,7 +11,7 @@ export default defineInterface({
 	types: ['string'],
 	recommendedDisplays: ['color'],
 	group: 'selection',
-	options: [
+	options: ({ field }) => [
 		{
 			field: 'opacity',
 			name: '$t:interfaces.select-color.opacity',
@@ -55,6 +55,9 @@ export default defineInterface({
 							meta: {
 								interface: 'select-color',
 								width: 'half',
+								options: {
+									opacity: field.meta?.options?.opacity ?? false,
+								},
 							},
 						},
 					],


### PR DESCRIPTION
## Scope

What's changed:

- Changed select-color interface so that it passes the opacity boolean to the preset child interface

## Potential Risks / Drawbacks

- None

## Review Notes / Questions

- When creating a color preset and the opacity enabled checkbox is true, make sure the opacity controls are present.

---

Fixes #25203
