### PR TITLE
Reverted changes made in 7adc27a to Re-enable hover stylings for Dark mode

### DIFF
--- a/.changeset/common-clouds-love.md
+++ b/.changeset/common-clouds-love.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Revert 7adc27a: restore hover styling for dark mode

--- a/.changeset/common-clouds-love.md
+++ b/.changeset/common-clouds-love.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Revert 7adc27a: restore hover styling for dark mode

--- a/.changeset/loose-parts-laugh.md
+++ b/.changeset/loose-parts-laugh.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Improved the readability of the primary button in dark mode

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -270,12 +270,6 @@ async function onClick(event: MouseEvent) {
 	min-inline-size: 100%;
 }
 
-body.dark .button {
-	--v-button-color: var(--theme--foreground);
-	--v-button-color-hover: var(--theme--foreground);
-	--v-button-color-active: var(--theme--foreground);
-}
-
 .button {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
## Scope

What's changed:
- Reverted changes made in [Commit 7adc27a](https://github.com/directus/directus/commit/7adc27aa85f276f7a3ff5f5bd5374396cd255bae)

## Potential Risks / Drawbacks

- Less readability on the buttons in Dark mode.

## Review Notes / Questions

- I would like to know if this is the best approach to solve this issue, I've reverted the changes because I believe it's a simple fix to solve issues with hover styling for buttons in dark mode.

---

Fixes #25442
