### PR TITLE
Implement case-insensitive sorting for SQLITE databases

### DIFF
--- a/.changeset/pink-monkeys-sing.md
+++ b/.changeset/pink-monkeys-sing.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+implement case-insensitive sorting for SQLite databases

--- a/api/src/database/run-ast/lib/get-db-query.ts
+++ b/api/src/database/run-ast/lib/get-db-query.ts
@@ -169,6 +169,7 @@ export function getDBQuery(
 					} else {
 						orderByString += `?? ${sortRecord.order}`;
 					}
+
 					orderByColumn = getColumn(knex, alias!, field!, false, schema, { originalCollectionName });
 				} else {
 					dbQuery.select(getColumn(knex, table, sortRecord.column, sortAlias, schema));
@@ -179,6 +180,7 @@ export function getDBQuery(
 					} else {
 						orderByString += `?? ${sortRecord.order}`;
 					}
+
 					orderByColumn = getColumn(knex, table, sortRecord.column, false, schema);
 				}
 
@@ -214,6 +216,7 @@ export function getDBQuery(
 
 					if (sortRecord.column.includes('.')) {
 						const [alias, field] = sortRecord.column.split('.');
+
 						columnRef = getColumn(knex, alias!, field!, false, schema, {
 							originalCollectionName: getCollectionFromAlias(alias!, aliasMap),
 						});


### PR DESCRIPTION
## Scope

What's changed:

- Added new case inside get-db-query.ts for SQLITE Databases to add COLLATE NOCASE for case insensitive sorting.

## Review Notes / Questions

- This PR is a first iteration of a fix for #25443 . I wanted to open it early to get feedback on the approach before finalizing/optimizing the solution. Please let me know if you have suggestions or concerns, I’m happy to iterate on this!

---

Fixes #25443
