### PR TITLE
Prevent text in kanban card from overflowing its container

### DIFF
--- a/.changeset/thick-seals-hope.md
+++ b/.changeset/thick-seals-hope.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that text on a kanban card doesn’t overflow its container

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -412,6 +412,11 @@ const reorderGroupsDisabled = computed(() => !props.canReorderGroups || props.se
 					}
 				}
 
+				.text {
+					display: flex;
+					white-space: nowrap;
+				}
+
 				.image {
 					inline-size: 100%;
 					border-radius: var(--theme--border-radius);


### PR DESCRIPTION
## Scope

What's changed:

- CSS

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- To reproduce the issue, use a WYSIWYG/HTML field for the kanban card text and set the Display to "Formatted Value" for that field.

---

Fixes #25433
