### PR TITLE
Fix bug where field template buttons appear unstyled

### DIFF
--- a/.changeset/loud-doodles-wash.md
+++ b/.changeset/loud-doodles-wash.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug that caused the buttons in the field template to appear unstyled after saving

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -262,7 +262,7 @@ function setContent() {
 
 				return `<button type="button" contenteditable="false" data-field="${fieldKey}" ${
 					props.disabled ? 'disabled' : ''
-				}>${field.name}</button>`;
+				} class="selected-field">${field.name}</button>`;
 			})
 			.join('');
 


### PR DESCRIPTION
## Scope

What's changed:

- Fix bug where field template buttons appear unstyled after saving and reopening

| Before | After |
|--------|--------|
| <img width="1268" height="300" alt="bug" src="https://github.com/user-attachments/assets/d33494a2-0fe2-4014-936a-2f7ca01da8f7" /> | <img width="1268" height="284" alt="fix" src="https://github.com/user-attachments/assets/0b4f7974-868a-4fc0-ac50-56576618f383" /> | 

## Potential Risks / Drawbacks

—

## Review Notes / Questions

—
