### PR TITLE
Fix: Import CSV with nested dot notation does not work

### DIFF
--- a/.changeset/flat-islands-prove.md
+++ b/.changeset/flat-islands-prove.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed importing CSV with nested dot notation

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -40,6 +40,7 @@ import { FilesService } from './files.js';
 import { NotificationsService } from './notifications.js';
 import { UsersService } from './users.js';
 import { parseFields } from '../database/get-ast-from-query/lib/parse-fields.js';
+import { set } from 'lodash-es';
 
 const env = useEnv();
 const logger = useLogger();
@@ -218,14 +219,16 @@ export class ImportService {
 						fileReadStream
 							.pipe(Papa.parse(Papa.NODE_STREAM_INPUT, PapaOptions))
 							.on('data', (obj: Record<string, unknown>) => {
+								const result = {};
+
 								// Filter out all undefined fields
 								for (const field in obj) {
-									if (obj[field] === undefined) {
-										delete obj[field];
+									if (obj[field] !== undefined) {
+										set(result, field, obj[field]);
 									}
 								}
 
-								saveQueue.push(obj);
+								saveQueue.push(result);
 							})
 							.on('error', (error) => {
 								cleanup();


### PR DESCRIPTION
## Scope
This was something that was already working but stopped on version 10.11.0, so just putting the functionality back.

What's changed:

- Allow nested relations in CSV headers

## Potential Risks / Drawbacks

- None 🤔

## Review Notes / Questions

- None 🤔

---

Fixes #25453 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with importing CSV files containing nested fields using dot notation, ensuring such data is now processed correctly during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->