### PR TITLE
Fix missing Netlify redirection for links without `.html`

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -243,7 +243,8 @@
 /blog/ai-santa-roast-app-with-directus-nuxt.html                                                    https://directus.io/docs/tutorials/projects/how-i-built-an-ai-open-source-santa-roast-app-with-directus-and-nuxt#naughty-or-nice-scoring-algorithm
 /blog/getting-started-directus-hugo.html                                                            https://directus.io/docs/tutorials/getting-started
 /blog/external-weather-api-data-custom-panel-extension.html                                         https://directus.io/docs/tutorials/extensions/display-external-weather-api-data-in-custom-panels
-/blog/hooks-monitoring-error-tracking-sentry.html                                                   https://directus.io/docs/tutorials
+# Temporarily remove 301 on sentry article https://github.com/directus/directus/pull/24828
+# /blog/hooks-monitoring-error-tracking-sentry.html                                                   https://directus.io/docs/tutorials
 /blog/using-directus-as-a-baby-health-tracker.html                                                  https://directus.io/docs/tutorials/projects/use-directus-as-a-baby-health-tracker-with-owlet-and-ops-genie
 /blog/preview-and-content-versioning-with-nextjs.html                                               https://directus.io/docs/tutorials/workflows/combine-live-preview-and-content-versioning-with-next-js
 /blog/the-changelog-3.html                                                                          https://directus.io/docs/releases/changelog

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1137,10 +1137,6 @@ to    = "https://directus.io/docs/tutorials/extensions/display-external-weather-
 force = true
 
 [[redirects]]
-from  = "/blog/hooks-monitoring-error-tracking-sentry.html"
-to    = "https://directus.io/docs/tutorials"
-
-[[redirects]]
 from  = "/blog/using-directus-as-a-baby-health-tracker.html"
 to    = "https://directus.io/docs/tutorials/projects/use-directus-as-a-baby-health-tracker-with-owlet-and-ops-genie"
 force = true

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -33,7 +33,17 @@ to    = "https://directus.io/docs/getting-started/data-model"
 force = true
 
 [[redirects]]
+from  = "/app/data-model"
+to    = "https://directus.io/docs/getting-started/data-model"
+force = true
+
+[[redirects]]
 from  = "/app/data-model/collections.html"
+to    = "https://directus.io/docs/guides/data-model/collections"
+force = true
+
+[[redirects]]
+from  = "/app/data-model/collections"
 to    = "https://directus.io/docs/guides/data-model/collections"
 force = true
 
@@ -43,7 +53,17 @@ to    = "https://directus.io/docs/guides/data-model/fields"
 force = true
 
 [[redirects]]
+from  = "/app/data-model/fields"
+to    = "https://directus.io/docs/guides/data-model/fields"
+force = true
+
+[[redirects]]
 from  = "/app/data-model/fields/groups.html"
+to    = "https://directus.io/docs/guides/data-model/interfaces"
+force = true
+
+[[redirects]]
+from  = "/app/data-model/fields/groups"
 to    = "https://directus.io/docs/guides/data-model/interfaces"
 force = true
 
@@ -53,7 +73,17 @@ to    = "https://directus.io/docs/guides/data-model/interfaces"
 force = true
 
 [[redirects]]
+from  = "/app/data-model/fields/other"
+to    = "https://directus.io/docs/guides/data-model/interfaces"
+force = true
+
+[[redirects]]
 from  = "/app/data-model/fields/presentation.html"
+to    = "https://directus.io/docs/guides/data-model/interfaces"
+force = true
+
+[[redirects]]
+from  = "/app/data-model/fields/presentation"
 to    = "https://directus.io/docs/guides/data-model/interfaces"
 force = true
 
@@ -63,7 +93,17 @@ to    = "https://directus.io/docs/guides/data-model/interfaces"
 force = true
 
 [[redirects]]
+from  = "/app/data-model/fields/relational"
+to    = "https://directus.io/docs/guides/data-model/interfaces"
+force = true
+
+[[redirects]]
 from  = "/app/data-model/fields/selection.html"
+to    = "https://directus.io/docs/guides/data-model/interfaces"
+force = true
+
+[[redirects]]
+from  = "/app/data-model/fields/selection"
 to    = "https://directus.io/docs/guides/data-model/interfaces"
 force = true
 
@@ -73,7 +113,17 @@ to    = "https://directus.io/docs/guides/data-model/interfaces"
 force = true
 
 [[redirects]]
+from  = "/app/data-model/fields/text-numbers"
+to    = "https://directus.io/docs/guides/data-model/interfaces"
+force = true
+
+[[redirects]]
 from  = "/app/data-model/relationships.html"
+to    = "https://directus.io/docs/guides/data-model/relationships"
+force = true
+
+[[redirects]]
+from  = "/app/data-model/relationships"
 to    = "https://directus.io/docs/guides/data-model/relationships"
 force = true
 
@@ -83,7 +133,17 @@ to    = "https://directus.io/docs/community/reporting-and-support/troubleshootin
 force = true
 
 [[redirects]]
+from  = "/app/faq"
+to    = "https://directus.io/docs/community/reporting-and-support/troubleshooting-steps"
+force = true
+
+[[redirects]]
 from  = "/app/flows.html"
+to    = "https://directus.io/docs/guides/automate/flows"
+force = true
+
+[[redirects]]
+from  = "/app/flows"
 to    = "https://directus.io/docs/guides/automate/flows"
 force = true
 
@@ -93,7 +153,17 @@ to    = "https://directus.io/docs/guides/automate/operations"
 force = true
 
 [[redirects]]
+from  = "/app/flows/operations"
+to    = "https://directus.io/docs/guides/automate/operations"
+force = true
+
+[[redirects]]
 from  = "/app/flows/triggers.html"
+to    = "https://directus.io/docs/guides/automate/triggers"
+force = true
+
+[[redirects]]
+from  = "/app/flows/triggers"
 to    = "https://directus.io/docs/guides/automate/triggers"
 force = true
 
@@ -103,12 +173,27 @@ to    = "https://directus.io/docs/guides/content/explore"
 force = true
 
 [[redirects]]
+from  = "/app/presets-bookmarks"
+to    = "https://directus.io/docs/guides/content/explore"
+force = true
+
+[[redirects]]
 from  = "/app/security.html"
 to    = "https://directus.io/docs/configuration/security-limits"
 force = true
 
 [[redirects]]
+from  = "/app/security"
+to    = "https://directus.io/docs/configuration/security-limits"
+force = true
+
+[[redirects]]
 from  = "/blog/guest-author.html"
+to    = "https://directus.io/docs/community/programs/guest-authors"
+force = true
+
+[[redirects]]
+from  = "/blog/guest-author"
 to    = "https://directus.io/docs/community/programs/guest-authors"
 force = true
 
@@ -123,7 +208,17 @@ to    = "https://directus.io/docs/community/overview/conduct"
 force = true
 
 [[redirects]]
+from  = "/contributing/code-of-conduct"
+to    = "https://directus.io/docs/community/overview/conduct"
+force = true
+
+[[redirects]]
 from  = "/contributing/codebase-overview.html"
+to    = "https://directus.io/docs/community/codebase/overview"
+force = true
+
+[[redirects]]
+from  = "/contributing/codebase-overview"
 to    = "https://directus.io/docs/community/codebase/overview"
 force = true
 
@@ -133,7 +228,17 @@ to    = "https://directus.io/docs/community/overview/welcome"
 force = true
 
 [[redirects]]
+from  = "/contributing/community"
+to    = "https://directus.io/docs/community/overview/welcome"
+force = true
+
+[[redirects]]
 from  = "/contributing/feature-request-process.html"
+to    = "https://directus.io/docs/community/contribution/feature-requests"
+force = true
+
+[[redirects]]
+from  = "/contributing/feature-request-process"
 to    = "https://directus.io/docs/community/contribution/feature-requests"
 force = true
 
@@ -143,7 +248,17 @@ to    = "https://directus.io/docs/community/overview/welcome"
 force = true
 
 [[redirects]]
+from  = "/contributing/introduction"
+to    = "https://directus.io/docs/community/overview/welcome"
+force = true
+
+[[redirects]]
 from  = "/contributing/pull-request-process.html"
+to    = "https://directus.io/docs/community/contribution/pull-requests"
+force = true
+
+[[redirects]]
+from  = "/contributing/pull-request-process"
 to    = "https://directus.io/docs/community/contribution/pull-requests"
 force = true
 
@@ -153,7 +268,17 @@ to    = "https://directus.io/docs/community/codebase/dev-environment"
 force = true
 
 [[redirects]]
+from  = "/contributing/running-locally"
+to    = "https://directus.io/docs/community/codebase/dev-environment"
+force = true
+
+[[redirects]]
 from  = "/contributing/sponsor.html"
+to    = "https://directus.io/docs/community/overview/welcome"
+force = true
+
+[[redirects]]
+from  = "/contributing/sponsor"
 to    = "https://directus.io/docs/community/overview/welcome"
 force = true
 
@@ -163,7 +288,17 @@ to    = "https://directus.io/docs/community/codebase/testing"
 force = true
 
 [[redirects]]
+from  = "/contributing/tests"
+to    = "https://directus.io/docs/community/codebase/testing"
+force = true
+
+[[redirects]]
 from  = "/contributing/translations.html"
+to    = "https://directus.io/docs/community/contribution/translations"
+force = true
+
+[[redirects]]
+from  = "/contributing/translations"
 to    = "https://directus.io/docs/community/contribution/translations"
 force = true
 
@@ -173,7 +308,17 @@ to    = "https://directus.io/docs/guides/extensions/app-extensions/composables"
 force = true
 
 [[redirects]]
+from  = "/extensions/app-composables"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/composables"
+force = true
+
+[[redirects]]
 from  = "/extensions/bundles.html"
+to    = "https://directus.io/docs/guides/extensions/bundles"
+force = true
+
+[[redirects]]
+from  = "/extensions/bundles"
 to    = "https://directus.io/docs/guides/extensions/bundles"
 force = true
 
@@ -183,7 +328,17 @@ to    = "https://directus.io/docs/guides/extensions/cli"
 force = true
 
 [[redirects]]
+from  = "/extensions/creating-extensions"
+to    = "https://directus.io/docs/guides/extensions/cli"
+force = true
+
+[[redirects]]
 from  = "/extensions/displays.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/displays"
+force = true
+
+[[redirects]]
+from  = "/extensions/displays"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/displays"
 force = true
 
@@ -193,7 +348,17 @@ to    = "https://directus.io/docs/guides/extensions/api-extensions/endpoints"
 force = true
 
 [[redirects]]
+from  = "/extensions/endpoints"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/endpoints"
+force = true
+
+[[redirects]]
 from  = "/extensions/hooks.html"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/hooks"
+force = true
+
+[[redirects]]
+from  = "/extensions/hooks"
 to    = "https://directus.io/docs/guides/extensions/api-extensions/hooks"
 force = true
 
@@ -203,7 +368,17 @@ to    = "https://directus.io/docs/self-hosting/including-extensions"
 force = true
 
 [[redirects]]
+from  = "/extensions/installing-extensions"
+to    = "https://directus.io/docs/self-hosting/including-extensions"
+force = true
+
+[[redirects]]
 from  = "/extensions/interfaces.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/interfaces"
+force = true
+
+[[redirects]]
+from  = "/extensions/interfaces"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/interfaces"
 force = true
 
@@ -213,7 +388,17 @@ to    = "https://directus.io/docs/guides/extensions/overview"
 force = true
 
 [[redirects]]
+from  = "/extensions/introduction"
+to    = "https://directus.io/docs/guides/extensions/overview"
+force = true
+
+[[redirects]]
 from  = "/extensions/layouts.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/layouts"
+force = true
+
+[[redirects]]
+from  = "/extensions/layouts"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/layouts"
 force = true
 
@@ -223,7 +408,17 @@ to    = "https://directus.io/docs/guides/extensions/marketplace/publishing"
 force = true
 
 [[redirects]]
+from  = "/extensions/marketplace/publishing"
+to    = "https://directus.io/docs/guides/extensions/marketplace/publishing"
+force = true
+
+[[redirects]]
 from  = "/extensions/modules.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/modules"
+force = true
+
+[[redirects]]
+from  = "/extensions/modules"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/modules"
 force = true
 
@@ -233,7 +428,17 @@ to    = "https://directus.io/docs/guides/extensions/api-extensions/operations"
 force = true
 
 [[redirects]]
+from  = "/extensions/operations"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/operations"
+force = true
+
+[[redirects]]
 from  = "/extensions/panels.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/panels"
+force = true
+
+[[redirects]]
+from  = "/extensions/panels"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/panels"
 force = true
 
@@ -243,7 +448,17 @@ to    = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
 force = true
 
 [[redirects]]
+from  = "/extensions/sandbox/introduction"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
+force = true
+
+[[redirects]]
 from  = "/extensions/sandbox/register.html"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
+force = true
+
+[[redirects]]
+from  = "/extensions/sandbox/register"
 to    = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
 force = true
 
@@ -253,7 +468,17 @@ to    = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
 force = true
 
 [[redirects]]
+from  = "/extensions/sandbox/sandbox-sdk"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/sandbox"
+force = true
+
+[[redirects]]
 from  = "/extensions/services/accessing-files.html"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
+force = true
+
+[[redirects]]
+from  = "/extensions/services/accessing-files"
 to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
 force = true
 
@@ -263,7 +488,17 @@ to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
 force = true
 
 [[redirects]]
+from  = "/extensions/services/accessing-items"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
+force = true
+
+[[redirects]]
 from  = "/extensions/services/configuring-collections.html"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
+force = true
+
+[[redirects]]
+from  = "/extensions/services/configuring-collections"
 to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
 force = true
 
@@ -273,7 +508,17 @@ to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
 force = true
 
 [[redirects]]
+from  = "/extensions/services/introduction"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
+force = true
+
+[[redirects]]
 from  = "/extensions/services/working-with-users.html"
+to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
+force = true
+
+[[redirects]]
+from  = "/extensions/services/working-with-users"
 to    = "https://directus.io/docs/guides/extensions/api-extensions/services"
 force = true
 
@@ -283,7 +528,17 @@ to    = "https://directus.io/docs/guides/extensions/app-extensions/themes"
 force = true
 
 [[redirects]]
+from  = "/extensions/themes"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/themes"
+force = true
+
+[[redirects]]
 from  = "/extensions/using-ui-components.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/ui-library"
+force = true
+
+[[redirects]]
+from  = "/extensions/using-ui-components"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/ui-library"
 force = true
 
@@ -293,7 +548,17 @@ to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
 [[redirects]]
+from  = "/getting-started/architecture"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
 from  = "/getting-started/introduction.html"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
+from  = "/getting-started/introduction"
 to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
@@ -303,7 +568,17 @@ to    = "https://directus.io/docs/getting-started/create-a-project"
 force = true
 
 [[redirects]]
+from  = "/getting-started/quickstart"
+to    = "https://directus.io/docs/getting-started/create-a-project"
+force = true
+
+[[redirects]]
 from  = "/getting-started/resources.html"
+to    = "https://directus.io/docs/getting-started/resources"
+force = true
+
+[[redirects]]
+from  = "/getting-started/resources"
 to    = "https://directus.io/docs/getting-started/resources"
 force = true
 
@@ -313,7 +588,17 @@ to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
 [[redirects]]
+from  = "/getting-started/support"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/displays-date-to-age.html"
+to    = "https://directus.io/docs/tutorials/extensions/"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/displays-date-to-age"
 to    = "https://directus.io/docs/tutorials/extensions/"
 force = true
 
@@ -323,7 +608,17 @@ to    = "https://directus.io/docs/tutorials/extensions/summarize-relational-item
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/displays-relational-summaries"
+to    = "https://directus.io/docs/tutorials/extensions/summarize-relational-items-in-a-custom-display-extension"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/email-template.html"
+to    = "https://directus.io/docs/tutorials/extensions/use-dynamic-values-in-custom-email-templates"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/email-template"
 to    = "https://directus.io/docs/tutorials/extensions/use-dynamic-values-in-custom-email-templates"
 force = true
 
@@ -333,7 +628,17 @@ to    = "https://directus.io/docs/tutorials/extensions/proxy-an-external-api-in-
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/endpoints-api-proxy-twilio"
+to    = "https://directus.io/docs/tutorials/extensions/proxy-an-external-api-in-a-custom-endpoint-extension"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/endpoints-api-proxy.html"
+to    = "https://directus.io/docs/tutorials/extensions/proxy-an-external-api-in-a-custom-endpoint-extension"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/endpoints-api-proxy"
 to    = "https://directus.io/docs/tutorials/extensions/proxy-an-external-api-in-a-custom-endpoint-extension"
 force = true
 
@@ -343,7 +648,17 @@ to    = "https://directus.io/docs/tutorials/extensions/check-permissions-in-a-cu
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/endpoints-privileged-endpoint-stripe"
+to    = "https://directus.io/docs/tutorials/extensions/check-permissions-in-a-custom-endpoint"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/hooks-add-stripe-customer.html"
+to    = "https://directus.io/docs/tutorials/extensions/create-new-customers-in-stripe-in-a-custom-hook"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/hooks-add-stripe-customer"
 to    = "https://directus.io/docs/tutorials/extensions/create-new-customers-in-stripe-in-a-custom-hook"
 force = true
 
@@ -353,7 +668,17 @@ to    = "https://directus.io/docs/tutorials/extensions/validate-phone-numbers-wi
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/hooks-validate-number-twilio"
+to    = "https://directus.io/docs/tutorials/extensions/validate-phone-numbers-with-twilio-in-a-custom-hook"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/interfaces-radio-selector-icons.html"
+to    = "https://directus.io/docs/tutorials/extensions/"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/interfaces-radio-selector-icons"
 to    = "https://directus.io/docs/tutorials/extensions/"
 force = true
 
@@ -363,7 +688,17 @@ to    = "https://directus.io/docs/tutorials/extensions/"
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/interfaces-relational-dropdown"
+to    = "https://directus.io/docs/tutorials/extensions/"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/layouts-getting-started.html"
+to    = "https://directus.io/docs/tutorials/extensions/"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/layouts-getting-started"
 to    = "https://directus.io/docs/tutorials/extensions/"
 force = true
 
@@ -373,7 +708,17 @@ to    = "https://directus.io/docs/tutorials/extensions/implement-navigation-in-m
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/modules-build-landing-page"
+to    = "https://directus.io/docs/tutorials/extensions/implement-navigation-in-multipage-custom-modules"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/modules-native-layout-features.html"
+to    = "https://directus.io/docs/tutorials/extensions/understand-available-slots-in-custom-modules"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/modules-native-layout-features"
 to    = "https://directus.io/docs/tutorials/extensions/understand-available-slots-in-custom-modules"
 force = true
 
@@ -383,7 +728,17 @@ to    = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-tw
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/operations-add-record-comments"
+to    = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-operations"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/operations-bulk-email-sendgrid.html"
+to    = "https://directus.io/docs/tutorials/extensions/"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/operations-bulk-email-sendgrid"
 to    = "https://directus.io/docs/tutorials/extensions/"
 force = true
 
@@ -393,7 +748,17 @@ to    = "https://directus.io/docs/tutorials/extensions/use-npm-packages-in-custo
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/operations-npm-package"
+to    = "https://directus.io/docs/tutorials/extensions/use-npm-packages-in-custom-operations"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/operations-send-sms-twilio.html"
+to    = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-operations"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/operations-send-sms-twilio"
 to    = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-operations"
 force = true
 
@@ -403,7 +768,17 @@ to    = "https://directus.io/docs/tutorials/extensions/create-collection-items-i
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/panels-create-items"
+to    = "https://directus.io/docs/tutorials/extensions/create-collection-items-in-custom-panels"
+force = true
+
+[[redirects]]
 from  = "/guides/extensions/panels-display-data-vonage.html"
+to    = "https://directus.io/docs/tutorials/extensions/display-external-api-data-from-vonage-in-custom-panels"
+force = true
+
+[[redirects]]
+from  = "/guides/extensions/panels-display-data-vonage"
 to    = "https://directus.io/docs/tutorials/extensions/display-external-api-data-from-vonage-in-custom-panels"
 force = true
 
@@ -413,7 +788,17 @@ to    = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-tw
 force = true
 
 [[redirects]]
+from  = "/guides/extensions/panels-send-sms-twilio"
+to    = "https://directus.io/docs/tutorials/extensions/send-sms-messages-with-twilio-in-custom-panels"
+force = true
+
+[[redirects]]
 from  = "/guides/flows/flows-for-loop.html"
+to    = "https://directus.io/docs/tutorials/extensions/use-dynamic-values-in-custom-email-templates"
+force = true
+
+[[redirects]]
+from  = "/guides/flows/flows-for-loop"
 to    = "https://directus.io/docs/tutorials/extensions/use-dynamic-values-in-custom-email-templates"
 force = true
 
@@ -423,7 +808,17 @@ to    = "https://directus.io/docs/tutorials/workflows"
 force = true
 
 [[redirects]]
+from  = "/guides/flows/slugify-text-with-run-script"
+to    = "https://directus.io/docs/tutorials/workflows"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/approval-workflows.html"
+to    = "https://directus.io/docs/tutorials/workflows/build-content-approval-workflows-with-custom-permissions"
+force = true
+
+[[redirects]]
+from  = "/guides/headless-cms/approval-workflows"
 to    = "https://directus.io/docs/tutorials/workflows/build-content-approval-workflows-with-custom-permissions"
 force = true
 
@@ -438,7 +833,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-dire
 force = true
 
 [[redirects]]
+from  = "/guides/headless-cms/build-static-website/next"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nextjs"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/build-static-website/nuxt-3.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nuxt"
+force = true
+
+[[redirects]]
+from  = "/guides/headless-cms/build-static-website/nuxt-3"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nuxt"
 force = true
 
@@ -448,7 +853,17 @@ to    = "https://directus.io/docs/configuration/translations"
 force = true
 
 [[redirects]]
+from  = "/guides/headless-cms/content-translations"
+to    = "https://directus.io/docs/configuration/translations"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/content-versioning.html"
+to    = "https://directus.io/docs/guides/content/content-versioning"
+force = true
+
+[[redirects]]
+from  = "/guides/headless-cms/content-versioning"
 to    = "https://directus.io/docs/guides/content/content-versioning"
 force = true
 
@@ -463,7 +878,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/set-up-live-preview-
 force = true
 
 [[redirects]]
+from  = "/guides/headless-cms/live-preview/nextjs"
+to    = "https://directus.io/docs/tutorials/getting-started/set-up-live-preview-with-next-js"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/live-preview/nuxt-3.html"
+to    = "https://directus.io/docs/tutorials/getting-started/set-up-live-preview-with-nuxt"
+force = true
+
+[[redirects]]
+from  = "/guides/headless-cms/live-preview/nuxt-3"
 to    = "https://directus.io/docs/tutorials/getting-started/set-up-live-preview-with-nuxt"
 force = true
 
@@ -473,7 +898,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/create-reusable-bloc
 force = true
 
 [[redirects]]
+from  = "/guides/headless-cms/reusable-components"
+to    = "https://directus.io/docs/tutorials/getting-started/create-reusable-blocks-with-many-to-any-relationships"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/schedule-content/dynamic-sites.html"
+to    = "https://directus.io/docs/tutorials/workflows/schedule-future-content-with-directus-automate"
+force = true
+
+[[redirects]]
+from  = "/guides/headless-cms/schedule-content/dynamic-sites"
 to    = "https://directus.io/docs/tutorials/workflows/schedule-future-content-with-directus-automate"
 force = true
 
@@ -488,6 +923,11 @@ to    = "https://directus.io/docs/tutorials/workflows/schedule-future-content-wi
 force = true
 
 [[redirects]]
+from  = "/guides/headless-cms/schedule-content/static-sites"
+to    = "https://directus.io/docs/tutorials/workflows/schedule-future-content-with-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/trigger-static-builds/"
 to    = "https://directus.io/docs/tutorials/workflows/trigger-netlify-site-builds-with-directus-automate"
 force = true
@@ -498,7 +938,17 @@ to    = "https://directus.io/docs/tutorials/workflows/trigger-netlify-site-build
 force = true
 
 [[redirects]]
+from  = "/guides/headless-cms/trigger-static-builds/netlify"
+to    = "https://directus.io/docs/tutorials/workflows/trigger-netlify-site-builds-with-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/guides/headless-cms/trigger-static-builds/vercel.html"
+to    = "https://directus.io/docs/tutorials/workflows/trigger-vercel-site-builds-with-directus-automate"
+force = true
+
+[[redirects]]
+from  = "/guides/headless-cms/trigger-static-builds/vercel"
 to    = "https://directus.io/docs/tutorials/workflows/trigger-vercel-site-builds-with-directus-automate"
 force = true
 
@@ -513,6 +963,11 @@ to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-
 force = true
 
 [[redirects]]
+from  = "/guides/migration/hoppscotch"
+to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+force = true
+
+[[redirects]]
 from  = "/guides/migration/"
 to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
 force = true
@@ -523,7 +978,17 @@ to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-
 force = true
 
 [[redirects]]
+from  = "/guides/migration/node"
+to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time/authentication.html"
+to    = "https://directus.io/docs/configuration/realtime"
+force = true
+
+[[redirects]]
+from  = "/guides/real-time/authentication"
 to    = "https://directus.io/docs/configuration/realtime"
 force = true
 
@@ -538,7 +1003,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-wit
 force = true
 
 [[redirects]]
+from  = "/guides/real-time/chat/javascript"
+to    = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-javascript-and-directus-realtime"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time/chat/react.html"
+to    = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-react-and-directus-realtime"
+force = true
+
+[[redirects]]
+from  = "/guides/real-time/chat/react"
 to    = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-react-and-directus-realtime"
 force = true
 
@@ -548,7 +1023,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-wit
 force = true
 
 [[redirects]]
+from  = "/guides/real-time/chat/vue"
+to    = "https://directus.io/docs/tutorials/projects/build-a-multi-user-chat-with-vue-js-and-directus-realtime"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time/getting-started/graphql.html"
+to    = "https://directus.io/docs/configuration/realtime"
+force = true
+
+[[redirects]]
+from  = "/guides/real-time/getting-started/graphql"
 to    = "https://directus.io/docs/configuration/realtime"
 force = true
 
@@ -563,7 +1048,17 @@ to    = "https://directus.io/docs/configuration/realtime"
 force = true
 
 [[redirects]]
+from  = "/guides/real-time/getting-started/websockets-js"
+to    = "https://directus.io/docs/configuration/realtime"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time/getting-started/websockets.html"
+to    = "https://directus.io/docs/configuration/realtime"
+force = true
+
+[[redirects]]
+from  = "/guides/real-time/getting-started/websockets"
 to    = "https://directus.io/docs/configuration/realtime"
 force = true
 
@@ -573,12 +1068,27 @@ to    = "https://directus.io/docs/guides/realtime"
 force = true
 
 [[redirects]]
+from  = "/guides/real-time/live-poll"
+to    = "https://directus.io/docs/guides/realtime"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time/operations.html"
 to    = "https://directus.io/docs/guides/realtime/actions"
 force = true
 
 [[redirects]]
+from  = "/guides/real-time/operations"
+to    = "https://directus.io/docs/guides/realtime/actions"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time/subscriptions/graphql.html"
+to    = "https://directus.io/docs/guides/realtime/subscriptions"
+force = true
+
+[[redirects]]
+from  = "/guides/real-time/subscriptions/graphql"
 to    = "https://directus.io/docs/guides/realtime/subscriptions"
 force = true
 
@@ -593,7 +1103,17 @@ to    = "https://directus.io/docs/guides/realtime/subscriptions"
 force = true
 
 [[redirects]]
+from  = "/guides/real-time/subscriptions/websockets"
+to    = "https://directus.io/docs/guides/realtime/subscriptions"
+force = true
+
+[[redirects]]
 from  = "/guides/sdk/authentication.html"
+to    = "https://directus.io/docs/guides/connect/sdk"
+force = true
+
+[[redirects]]
+from  = "/guides/sdk/authentication"
 to    = "https://directus.io/docs/guides/connect/sdk"
 force = true
 
@@ -603,12 +1123,27 @@ to    = "https://directus.io/docs/guides/connect/sdk"
 force = true
 
 [[redirects]]
+from  = "/guides/sdk/getting-started"
+to    = "https://directus.io/docs/guides/connect/sdk"
+force = true
+
+[[redirects]]
 from  = "/guides/sdk/types.html"
 to    = "https://directus.io/docs/guides/connect/sdk"
 force = true
 
 [[redirects]]
+from  = "/guides/sdk/types"
+to    = "https://directus.io/docs/guides/connect/sdk"
+force = true
+
+[[redirects]]
 from  = "/guides/template_shell.html"
+to    = "https://directus.io/docs/"
+force = true
+
+[[redirects]]
+from  = "/guides/template_shell"
 to    = "https://directus.io/docs/"
 force = true
 
@@ -628,7 +1163,17 @@ to    = "https://directus.io/docs/api/authentication"
 force = true
 
 [[redirects]]
+from  = "/reference/authentication"
+to    = "https://directus.io/docs/api/authentication"
+force = true
+
+[[redirects]]
 from  = "/reference/files.html"
+to    = "https://directus.io/docs/api/files"
+force = true
+
+[[redirects]]
+from  = "/reference/files"
 to    = "https://directus.io/docs/api/files"
 force = true
 
@@ -638,7 +1183,17 @@ to    = "https://directus.io/docs/api"
 force = true
 
 [[redirects]]
+from  = "/reference/filter-rules"
+to    = "https://directus.io/docs/api"
+force = true
+
+[[redirects]]
 from  = "/reference/introduction.html"
+to    = "https://directus.io/docs/api"
+force = true
+
+[[redirects]]
+from  = "/reference/introduction"
 to    = "https://directus.io/docs/api"
 force = true
 
@@ -648,7 +1203,17 @@ to    = "https://directus.io/docs/api/items"
 force = true
 
 [[redirects]]
+from  = "/reference/items"
+to    = "https://directus.io/docs/api/items"
+force = true
+
+[[redirects]]
 from  = "/reference/old-sdk.html"
+to    = "https://directus.io/docs/api"
+force = true
+
+[[redirects]]
+from  = "/reference/old-sdk"
 to    = "https://directus.io/docs/api"
 force = true
 
@@ -658,7 +1223,17 @@ to    = "https://directus.io/docs/api"
 force = true
 
 [[redirects]]
+from  = "/reference/query"
+to    = "https://directus.io/docs/api"
+force = true
+
+[[redirects]]
 from  = "/reference/system/activity.html"
+to    = "https://directus.io/docs/api"
+force = true
+
+[[redirects]]
+from  = "/reference/system/activity"
 to    = "https://directus.io/docs/api"
 force = true
 
@@ -668,7 +1243,17 @@ to    = "https://directus.io/docs/api/collections"
 force = true
 
 [[redirects]]
+from  = "/reference/system/collections"
+to    = "https://directus.io/docs/api/collections"
+force = true
+
+[[redirects]]
 from  = "/reference/system/comments.html"
+to    = "https://directus.io/docs/api/comments"
+force = true
+
+[[redirects]]
+from  = "/reference/system/comments"
 to    = "https://directus.io/docs/api/comments"
 force = true
 
@@ -678,7 +1263,17 @@ to    = "https://directus.io/docs/api/dashboards"
 force = true
 
 [[redirects]]
+from  = "/reference/system/dashboards"
+to    = "https://directus.io/docs/api/dashboards"
+force = true
+
+[[redirects]]
 from  = "/reference/system/extensions.html"
+to    = "https://directus.io/docs/api/extensions"
+force = true
+
+[[redirects]]
+from  = "/reference/system/extensions"
 to    = "https://directus.io/docs/api/extensions"
 force = true
 
@@ -688,7 +1283,17 @@ to    = "https://directus.io/docs/api/fields"
 force = true
 
 [[redirects]]
+from  = "/reference/system/fields"
+to    = "https://directus.io/docs/api/fields"
+force = true
+
+[[redirects]]
 from  = "/reference/system/flows.html"
+to    = "https://directus.io/docs/api/flows"
+force = true
+
+[[redirects]]
+from  = "/reference/system/flows"
 to    = "https://directus.io/docs/api/flows"
 force = true
 
@@ -698,7 +1303,17 @@ to    = "https://directus.io/docs/api/folders"
 force = true
 
 [[redirects]]
+from  = "/reference/system/folders"
+to    = "https://directus.io/docs/api/folders"
+force = true
+
+[[redirects]]
 from  = "/reference/system/notifications.html"
+to    = "https://directus.io/docs/api/notifications"
+force = true
+
+[[redirects]]
+from  = "/reference/system/notifications"
 to    = "https://directus.io/docs/api/notifications"
 force = true
 
@@ -708,7 +1323,17 @@ to    = "https://directus.io/docs/api/operations"
 force = true
 
 [[redirects]]
+from  = "/reference/system/operations"
+to    = "https://directus.io/docs/api/operations"
+force = true
+
+[[redirects]]
 from  = "/reference/system/panels.html"
+to    = "https://directus.io/docs/api/panels"
+force = true
+
+[[redirects]]
+from  = "/reference/system/panels"
 to    = "https://directus.io/docs/api/panels"
 force = true
 
@@ -718,7 +1343,17 @@ to    = "https://directus.io/docs/api/permissions"
 force = true
 
 [[redirects]]
+from  = "/reference/system/permissions"
+to    = "https://directus.io/docs/api/permissions"
+force = true
+
+[[redirects]]
 from  = "/reference/system/policies.html"
+to    = "https://directus.io/docs/api/policies"
+force = true
+
+[[redirects]]
+from  = "/reference/system/policies"
 to    = "https://directus.io/docs/api/policies"
 force = true
 
@@ -728,7 +1363,17 @@ to    = "https://directus.io/docs/api/presets"
 force = true
 
 [[redirects]]
+from  = "/reference/system/presets"
+to    = "https://directus.io/docs/api/presets"
+force = true
+
+[[redirects]]
 from  = "/reference/system/relations.html"
+to    = "https://directus.io/docs/api/relations"
+force = true
+
+[[redirects]]
+from  = "/reference/system/relations"
 to    = "https://directus.io/docs/api/relations"
 force = true
 
@@ -738,7 +1383,17 @@ to    = "https://directus.io/docs/api/revisions"
 force = true
 
 [[redirects]]
+from  = "/reference/system/revisions"
+to    = "https://directus.io/docs/api/revisions"
+force = true
+
+[[redirects]]
 from  = "/reference/system/roles.html"
+to    = "https://directus.io/docs/api/roles"
+force = true
+
+[[redirects]]
+from  = "/reference/system/roles"
 to    = "https://directus.io/docs/api/roles"
 force = true
 
@@ -748,7 +1403,17 @@ to    = "https://directus.io/docs/api/schema"
 force = true
 
 [[redirects]]
+from  = "/reference/system/schema"
+to    = "https://directus.io/docs/api/schema"
+force = true
+
+[[redirects]]
 from  = "/reference/system/server.html"
+to    = "https://directus.io/docs/api/server"
+force = true
+
+[[redirects]]
+from  = "/reference/system/server"
 to    = "https://directus.io/docs/api/server"
 force = true
 
@@ -758,7 +1423,17 @@ to    = "https://directus.io/docs/api/settings"
 force = true
 
 [[redirects]]
+from  = "/reference/system/settings"
+to    = "https://directus.io/docs/api/settings"
+force = true
+
+[[redirects]]
 from  = "/reference/system/shares.html"
+to    = "https://directus.io/docs/api/shares"
+force = true
+
+[[redirects]]
+from  = "/reference/system/shares"
 to    = "https://directus.io/docs/api/shares"
 force = true
 
@@ -768,7 +1443,17 @@ to    = "https://directus.io/docs/api/translations"
 force = true
 
 [[redirects]]
+from  = "/reference/system/translations"
+to    = "https://directus.io/docs/api/translations"
+force = true
+
+[[redirects]]
 from  = "/reference/system/users.html"
+to    = "https://directus.io/docs/api/users"
+force = true
+
+[[redirects]]
+from  = "/reference/system/users"
 to    = "https://directus.io/docs/api/users"
 force = true
 
@@ -778,7 +1463,17 @@ to    = "https://directus.io/docs/api/utilities"
 force = true
 
 [[redirects]]
+from  = "/reference/system/utilities"
+to    = "https://directus.io/docs/api/utilities"
+force = true
+
+[[redirects]]
 from  = "/reference/system/versions.html"
+to    = "https://directus.io/docs/api/versions"
+force = true
+
+[[redirects]]
+from  = "/reference/system/versions"
 to    = "https://directus.io/docs/api/versions"
 force = true
 
@@ -788,7 +1483,17 @@ to    = "https://directus.io/docs/api"
 force = true
 
 [[redirects]]
+from  = "/reference/system/webhooks"
+to    = "https://directus.io/docs/api"
+force = true
+
+[[redirects]]
 from  = "/releases/breaking-changes.html"
+to    = "https://directus.io/docs/releases/breaking-changes"
+force = true
+
+[[redirects]]
+from  = "/releases/breaking-changes"
 to    = "https://directus.io/docs/releases/breaking-changes"
 force = true
 
@@ -798,7 +1503,17 @@ to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
 [[redirects]]
+from  = "/self-hosted/cli"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
 from  = "/self-hosted/config-options.html"
+to    = "https://directus.io/docs/configuration/general"
+force = true
+
+[[redirects]]
+from  = "/self-hosted/config-options"
 to    = "https://directus.io/docs/configuration/general"
 force = true
 
@@ -808,7 +1523,17 @@ to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
 [[redirects]]
+from  = "/self-hosted/docker-guide"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
 from  = "/self-hosted/email-templates.html"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
+from  = "/self-hosted/email-templates"
 to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
@@ -818,7 +1543,17 @@ to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
 [[redirects]]
+from  = "/self-hosted/migrations"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
 from  = "/self-hosted/quickstart.html"
+to    = "https://directus.io/docs/getting-started/create-a-project"
+force = true
+
+[[redirects]]
+from  = "/self-hosted/quickstart"
 to    = "https://directus.io/docs/getting-started/create-a-project"
 force = true
 
@@ -828,7 +1563,17 @@ to    = "https://directus.io/docs/guides/auth/sso"
 force = true
 
 [[redirects]]
+from  = "/self-hosted/sso-examples"
+to    = "https://directus.io/docs/guides/auth/sso"
+force = true
+
+[[redirects]]
 from  = "/self-hosted/sso.html"
+to    = "https://directus.io/docs/guides/auth/sso"
+force = true
+
+[[redirects]]
+from  = "/self-hosted/sso"
 to    = "https://directus.io/docs/guides/auth/sso"
 force = true
 
@@ -838,7 +1583,17 @@ to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-
 force = true
 
 [[redirects]]
+from  = "/self-hosted/upgrades-migrations"
+to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+force = true
+
+[[redirects]]
 from  = "/use-cases/headless-cms/concepts.html"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
+from  = "/use-cases/headless-cms/concepts"
 to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
@@ -848,7 +1603,17 @@ to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
 [[redirects]]
+from  = "/use-cases/headless-cms/introduction"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
 from  = "/use-cases/headless-cms/security.html"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
+from  = "/use-cases/headless-cms/security"
 to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
@@ -858,7 +1623,17 @@ to    = "https://directus.io/docs/cloud/getting-started/accounts"
 force = true
 
 [[redirects]]
+from  = "/user-guide/cloud/accounts"
+to    = "https://directus.io/docs/cloud/getting-started/accounts"
+force = true
+
+[[redirects]]
 from  = "/user-guide/cloud/glossary.html"
+to    = "https://directus.io/docs/getting-started/overview"
+force = true
+
+[[redirects]]
+from  = "/user-guide/cloud/glossary"
 to    = "https://directus.io/docs/getting-started/overview"
 force = true
 
@@ -868,7 +1643,17 @@ to    = "https://directus.io/docs/cloud/getting-started/introduction"
 force = true
 
 [[redirects]]
+from  = "/user-guide/cloud/overview"
+to    = "https://directus.io/docs/cloud/getting-started/introduction"
+force = true
+
+[[redirects]]
 from  = "/user-guide/cloud/projects.html"
+to    = "https://directus.io/docs/cloud/projects/create"
+force = true
+
+[[redirects]]
+from  = "/user-guide/cloud/projects"
 to    = "https://directus.io/docs/cloud/projects/create"
 force = true
 
@@ -878,7 +1663,17 @@ to    = "https://directus.io/docs/cloud/getting-started/teams"
 force = true
 
 [[redirects]]
+from  = "/user-guide/cloud/teams"
+to    = "https://directus.io/docs/cloud/getting-started/teams"
+force = true
+
+[[redirects]]
 from  = "/user-guide/cloud/variables.html"
+to    = "https://directus.io/docs/cloud/configuration/environment-variables"
+force = true
+
+[[redirects]]
+from  = "/user-guide/cloud/variables"
 to    = "https://directus.io/docs/cloud/configuration/environment-variables"
 force = true
 
@@ -888,7 +1683,17 @@ to    = "https://directus.io/docs/guides/content/explore"
 force = true
 
 [[redirects]]
+from  = "/user-guide/content-module/content"
+to    = "https://directus.io/docs/guides/content/explore"
+force = true
+
+[[redirects]]
 from  = "/user-guide/content-module/content/collections.html"
+to    = "https://directus.io/docs/guides/content/explore"
+force = true
+
+[[redirects]]
+from  = "/user-guide/content-module/content/collections"
 to    = "https://directus.io/docs/guides/content/explore"
 force = true
 
@@ -898,7 +1703,17 @@ to    = "https://directus.io/docs/guides/content/editor"
 force = true
 
 [[redirects]]
+from  = "/user-guide/content-module/content/items"
+to    = "https://directus.io/docs/guides/content/editor"
+force = true
+
+[[redirects]]
 from  = "/user-guide/content-module/content/shares.html"
+to    = "https://directus.io/docs/guides/content/editor"
+force = true
+
+[[redirects]]
+from  = "/user-guide/content-module/content/shares"
 to    = "https://directus.io/docs/guides/content/editor"
 force = true
 
@@ -908,7 +1723,17 @@ to    = "https://directus.io/docs/guides/content/layouts"
 force = true
 
 [[redirects]]
+from  = "/user-guide/content-module/display-templates"
+to    = "https://directus.io/docs/guides/content/layouts"
+force = true
+
+[[redirects]]
 from  = "/user-guide/content-module/filters.html"
+to    = "https://directus.io/docs/guides/content/explore"
+force = true
+
+[[redirects]]
+from  = "/user-guide/content-module/filters"
 to    = "https://directus.io/docs/guides/content/explore"
 force = true
 
@@ -918,7 +1743,17 @@ to    = "https://directus.io/docs/guides/content/import-export"
 force = true
 
 [[redirects]]
+from  = "/user-guide/content-module/import-export"
+to    = "https://directus.io/docs/guides/content/import-export"
+force = true
+
+[[redirects]]
 from  = "/user-guide/content-module/layouts.html"
+to    = "https://directus.io/docs/guides/content/layouts"
+force = true
+
+[[redirects]]
+from  = "/user-guide/content-module/layouts"
 to    = "https://directus.io/docs/guides/content/layouts"
 force = true
 
@@ -928,7 +1763,17 @@ to    = "https://directus.io/docs/guides/content/translations"
 force = true
 
 [[redirects]]
+from  = "/user-guide/content-module/translation-strings"
+to    = "https://directus.io/docs/guides/content/translations"
+force = true
+
+[[redirects]]
 from  = "/user-guide/file-library/files.html"
+to    = "https://directus.io/docs/getting-started/upload-files"
+force = true
+
+[[redirects]]
+from  = "/user-guide/file-library/files"
 to    = "https://directus.io/docs/getting-started/upload-files"
 force = true
 
@@ -938,7 +1783,17 @@ to    = "https://directus.io/docs/guides/files/manage"
 force = true
 
 [[redirects]]
+from  = "/user-guide/file-library/folders"
+to    = "https://directus.io/docs/guides/files/manage"
+force = true
+
+[[redirects]]
 from  = "/user-guide/insights/charts.html"
+to    = "https://directus.io/docs/guides/insights/panels"
+force = true
+
+[[redirects]]
+from  = "/user-guide/insights/charts"
 to    = "https://directus.io/docs/guides/insights/panels"
 force = true
 
@@ -948,7 +1803,17 @@ to    = "https://directus.io/docs/guides/insights/overview"
 force = true
 
 [[redirects]]
+from  = "/user-guide/insights/dashboards"
+to    = "https://directus.io/docs/guides/insights/overview"
+force = true
+
+[[redirects]]
 from  = "/user-guide/insights/panels.html"
+to    = "https://directus.io/docs/guides/insights/panels"
+force = true
+
+[[redirects]]
+from  = "/user-guide/insights/panels"
 to    = "https://directus.io/docs/guides/insights/panels"
 force = true
 
@@ -958,7 +1823,17 @@ to    = "https://directus.io/docs/guides/extensions/marketplace"
 force = true
 
 [[redirects]]
+from  = "/user-guide/marketplace/overview"
+to    = "https://directus.io/docs/guides/extensions/marketplace"
+force = true
+
+[[redirects]]
 from  = "/user-guide/overview/data-studio-app.html"
+to    = "https://directus.io/docs/guides/content/editor"
+force = true
+
+[[redirects]]
+from  = "/user-guide/overview/data-studio-app"
 to    = "https://directus.io/docs/guides/content/editor"
 force = true
 
@@ -968,7 +1843,17 @@ to    = "https://directus.io/docs/guides/content/editor"
 force = true
 
 [[redirects]]
+from  = "/user-guide/overview/glossary"
+to    = "https://directus.io/docs/guides/content/editor"
+force = true
+
+[[redirects]]
 from  = "/user-guide/overview/quickstart.html"
+to    = "https://directus.io/docs/guides/content/editor"
+force = true
+
+[[redirects]]
+from  = "/user-guide/overview/quickstart"
 to    = "https://directus.io/docs/guides/content/editor"
 force = true
 
@@ -978,7 +1863,17 @@ to    = "https://directus.io/docs/guides/auth/accountability"
 force = true
 
 [[redirects]]
+from  = "/user-guide/settings/activity-log"
+to    = "https://directus.io/docs/guides/auth/accountability"
+force = true
+
+[[redirects]]
 from  = "/user-guide/settings/presets-bookmarks.html"
+to    = "https://directus.io/docs/guides/content/explore"
+force = true
+
+[[redirects]]
+from  = "/user-guide/settings/presets-bookmarks"
 to    = "https://directus.io/docs/guides/content/explore"
 force = true
 
@@ -988,7 +1883,17 @@ to    = "https://directus.io/docs/configuration/general"
 force = true
 
 [[redirects]]
+from  = "/user-guide/settings/project-settings"
+to    = "https://directus.io/docs/configuration/general"
+force = true
+
+[[redirects]]
 from  = "/user-guide/settings/system-logs.html"
+to    = "https://directus.io/docs/configuration/logging"
+force = true
+
+[[redirects]]
+from  = "/user-guide/settings/system-logs"
 to    = "https://directus.io/docs/configuration/logging"
 force = true
 
@@ -998,7 +1903,17 @@ to    = "https://directus.io/docs/configuration/theming"
 force = true
 
 [[redirects]]
+from  = "/user-guide/settings/theming"
+to    = "https://directus.io/docs/configuration/theming"
+force = true
+
+[[redirects]]
 from  = "/user-guide/user-management/permissions.html"
+to    = "https://directus.io/docs/guides/auth/access-control"
+force = true
+
+[[redirects]]
+from  = "/user-guide/user-management/permissions"
 to    = "https://directus.io/docs/guides/auth/access-control"
 force = true
 
@@ -1008,7 +1923,17 @@ to    = "https://directus.io/docs/guides/auth/access-control"
 force = true
 
 [[redirects]]
+from  = "/user-guide/user-management/roles"
+to    = "https://directus.io/docs/guides/auth/access-control"
+force = true
+
+[[redirects]]
 from  = "/user-guide/user-management/user-directory.html"
+to    = "https://directus.io/docs/guides/auth/creating-users"
+force = true
+
+[[redirects]]
+from  = "/user-guide/user-management/user-directory"
 to    = "https://directus.io/docs/guides/auth/creating-users"
 force = true
 
@@ -1018,7 +1943,17 @@ to    = "https://directus.io/docs/guides/auth/access-control"
 force = true
 
 [[redirects]]
+from  = "/user-guide/user-management/users-roles-permissions"
+to    = "https://directus.io/docs/guides/auth/access-control"
+force = true
+
+[[redirects]]
 from  = "/user-guide/user-management/users.html"
+to    = "https://directus.io/docs/guides/auth/creating-users"
+force = true
+
+[[redirects]]
+from  = "/user-guide/user-management/users"
 to    = "https://directus.io/docs/guides/auth/creating-users"
 force = true
 
@@ -1028,7 +1963,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-dire
 force = true
 
 [[redirects]]
+from  = "/blog/getting-started-with-directus-and-angular"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-angular"
+force = true
+
+[[redirects]]
 from  = "/blog/migrating-notion-to-directus.html"
+to    = "https://directus.io/docs/tutorials/migration/migrate-from-notion-to-directus"
+force = true
+
+[[redirects]]
+from  = "/blog/migrating-notion-to-directus"
 to    = "https://directus.io/docs/tutorials/migration/migrate-from-notion-to-directus"
 force = true
 
@@ -1038,7 +1983,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/hello-world"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-directus-astro.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-astro"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-directus-astro"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-astro"
 force = true
 
@@ -1048,7 +2003,17 @@ to    = "https://directus.io/docs/tutorials/workflows/create-github-issues-with-
 force = true
 
 [[redirects]]
+from  = "/blog/creating-git-hub-issues-with-directus-automate"
+to    = "https://directus.io/docs/tutorials/workflows/create-github-issues-with-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/directus-auth-nextauth.html"
+to    = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-next-js"
+force = true
+
+[[redirects]]
+from  = "/blog/directus-auth-nextauth"
 to    = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-next-js"
 force = true
 
@@ -1058,7 +2023,17 @@ to    = "https://directus.io/docs/tutorials/migration/migrate-from-nuxt-content-
 force = true
 
 [[redirects]]
+from  = "/blog/migrating-nuxt-content-to-directus"
+to    = "https://directus.io/docs/tutorials/migration/migrate-from-nuxt-content-to-directus"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-and-flutter.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-flutter"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-and-flutter"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-flutter"
 force = true
 
@@ -1068,7 +2043,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/implement-multilingu
 force = true
 
 [[redirects]]
+from  = "/blog/implementing-internationalization-with-svelte-kit-and-directus"
+to    = "https://directus.io/docs/tutorials/getting-started/implement-multilingual-content-with-directus-and-svelte-kit"
+force = true
+
+[[redirects]]
 from  = "/blog/tagging-files-automatically-clarifai-directus-automate.html"
+to    = "https://directus.io/docs/tutorials/workflows/tag-images-with-clarifai-and-directus-automate"
+force = true
+
+[[redirects]]
+from  = "/blog/tagging-files-automatically-clarifai-directus-automate"
 to    = "https://directus.io/docs/tutorials/workflows/tag-images-with-clarifai-and-directus-automate"
 force = true
 
@@ -1078,7 +2063,17 @@ to    = "https://directus.io/docs/tutorials/workflows/generate-images-with-dall-
 force = true
 
 [[redirects]]
+from  = "/blog/generating-images-with-dalle-and-directus-automate"
+to    = "https://directus.io/docs/tutorials/workflows/generate-images-with-dall-e-and-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/generating-social-posts-gpt-4-directus-automa.html"
+to    = "https://directus.io/docs/tutorials/workflows/generate-social-posts-with-gpt-4-and-directus-automate"
+force = true
+
+[[redirects]]
+from  = "/blog/generating-social-posts-gpt-4-directus-automa"
 to    = "https://directus.io/docs/tutorials/workflows/generate-social-posts-with-gpt-4-and-directus-automate"
 force = true
 
@@ -1088,7 +2083,17 @@ to    = "https://directus.io/docs/tutorials/self-hosting/configure-okta-as-a-sin
 force = true
 
 [[redirects]]
+from  = "/blog/configuring-okta-sso"
+to    = "https://directus.io/docs/tutorials/self-hosting/configure-okta-as-a-single-sign-on-provider"
+force = true
+
+[[redirects]]
 from  = "/blog/monitoring-pipeline-flows-extensions.html"
+to    = "https://directus.io/docs/tutorials/tips-and-tricks/build-a-monitoring-pipeline-for-flows-and-extensions"
+force = true
+
+[[redirects]]
+from  = "/blog/monitoring-pipeline-flows-extensions"
 to    = "https://directus.io/docs/tutorials/tips-and-tricks/build-a-monitoring-pipeline-for-flows-and-extensions"
 force = true
 
@@ -1098,7 +2103,17 @@ to    = "https://directus.io/docs/releases/changelog"
 force = true
 
 [[redirects]]
+from  = "/blog/the-changelog-1"
+to    = "https://directus.io/docs/releases/changelog"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-django.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-django"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-django"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-django"
 force = true
 
@@ -1108,7 +2123,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-an-ecommerce-platform
 force = true
 
 [[redirects]]
+from  = "/blog/build-an-e-commerce-website-with-directus-and-next-js"
+to    = "https://directus.io/docs/tutorials/projects/build-an-ecommerce-platform-with-next-js-stripe-and-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-directus-and-eleventy-11ty-3.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-eleventy-3"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-directus-and-eleventy-11ty-3"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-eleventy-3"
 force = true
 
@@ -1118,7 +2143,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/devcycle-feature-flag-control-panel"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-and-flask.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-flask"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-and-flask"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-flask"
 force = true
 
@@ -1128,7 +2163,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/announcing-panel-quest-hackathon"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/building-directus-garden.html"
+to    = "https://directus.io/docs/tutorials/projects/build-directus-garden-a-passive-collaborative-event-booth-demo"
+force = true
+
+[[redirects]]
+from  = "/blog/building-directus-garden"
 to    = "https://directus.io/docs/tutorials/projects/build-directus-garden-a-passive-collaborative-event-booth-demo"
 force = true
 
@@ -1138,7 +2183,17 @@ to    = "https://directus.io/docs/tutorials/projects/how-i-built-an-ai-open-sour
 force = true
 
 [[redirects]]
+from  = "/blog/ai-santa-roast-app-with-directus-nuxt"
+to    = "https://directus.io/docs/tutorials/projects/how-i-built-an-ai-open-source-santa-roast-app-with-directus-and-nuxt#naughty-or-nice-scoring-algorithm"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-directus-hugo.html"
+to    = "https://directus.io/docs/tutorials/getting-started"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-directus-hugo"
 to    = "https://directus.io/docs/tutorials/getting-started"
 force = true
 
@@ -1148,7 +2203,17 @@ to    = "https://directus.io/docs/tutorials/extensions/display-external-weather-
 force = true
 
 [[redirects]]
+from  = "/blog/external-weather-api-data-custom-panel-extension"
+to    = "https://directus.io/docs/tutorials/extensions/display-external-weather-api-data-in-custom-panels"
+force = true
+
+[[redirects]]
 from  = "/blog/using-directus-as-a-baby-health-tracker.html"
+to    = "https://directus.io/docs/tutorials/projects/use-directus-as-a-baby-health-tracker-with-owlet-and-ops-genie"
+force = true
+
+[[redirects]]
+from  = "/blog/using-directus-as-a-baby-health-tracker"
 to    = "https://directus.io/docs/tutorials/projects/use-directus-as-a-baby-health-tracker-with-owlet-and-ops-genie"
 force = true
 
@@ -1158,7 +2223,17 @@ to    = "https://directus.io/docs/tutorials/workflows/combine-live-preview-and-c
 force = true
 
 [[redirects]]
+from  = "/blog/preview-and-content-versioning-with-nextjs"
+to    = "https://directus.io/docs/tutorials/workflows/combine-live-preview-and-content-versioning-with-next-js"
+force = true
+
+[[redirects]]
 from  = "/blog/the-changelog-3.html"
+to    = "https://directus.io/docs/releases/changelog"
+force = true
+
+[[redirects]]
+from  = "/blog/the-changelog-3"
 to    = "https://directus.io/docs/releases/changelog"
 force = true
 
@@ -1168,7 +2243,17 @@ to    = "https://directus.io/docs/releases/changelog"
 force = true
 
 [[redirects]]
+from  = "/blog/the-changelog-4"
+to    = "https://directus.io/docs/releases/changelog"
+force = true
+
+[[redirects]]
 from  = "/blog/the-changelog-2.html"
+to    = "https://directus.io/docs/releases/changelog"
+force = true
+
+[[redirects]]
+from  = "/blog/the-changelog-2"
 to    = "https://directus.io/docs/releases/changelog"
 force = true
 
@@ -1178,7 +2263,17 @@ to    = "https://directus.io/docs/releases/changelog"
 force = true
 
 [[redirects]]
+from  = "/blog/the-changelog-5"
+to    = "https://directus.io/docs/releases/changelog"
+force = true
+
+[[redirects]]
 from  = "/blog/directus-ai-hackathon-vote.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/directus-ai-hackathon-vote"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1188,7 +2283,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/directus-panel-quest-hackathon-projects"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/directus-and-iot-sensor-data-with-an-esp-32.html"
+to    = "https://directus.io/docs/tutorials/projects/integrate-directus-with-esp-32-hardware-sensors"
+force = true
+
+[[redirects]]
+from  = "/blog/directus-and-iot-sensor-data-with-an-esp-32"
 to    = "https://directus.io/docs/tutorials/projects/integrate-directus-with-esp-32-hardware-sensors"
 force = true
 
@@ -1198,7 +2303,17 @@ to    = "https://directus.io/docs/tutorials/extensions/integrate-algolia-indexin
 force = true
 
 [[redirects]]
+from  = "/blog/integrating-algolia-indexing-and-directus"
+to    = "https://directus.io/docs/tutorials/extensions/integrate-algolia-indexing-with-custom-hooks"
+force = true
+
+[[redirects]]
 from  = "/blog/integrating-elasticsearch-indexing-with-directus.html"
+to    = "https://directus.io/docs/tutorials/extensions/integrate-elasticsearch-indexing-with-custom-hooks"
+force = true
+
+[[redirects]]
+from  = "/blog/integrating-elasticsearch-indexing-with-directus"
 to    = "https://directus.io/docs/tutorials/extensions/integrate-elasticsearch-indexing-with-custom-hooks"
 force = true
 
@@ -1208,7 +2323,17 @@ to    = "https://directus.io/docs/tutorials/extensions/integrate-meilisearch-ind
 force = true
 
 [[redirects]]
+from  = "/blog/integrating-meilisearch-indexing-with-directus"
+to    = "https://directus.io/docs/tutorials/extensions/integrate-meilisearch-indexing-with-custom-hooks"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-and-gatsby.html"
+to    = "https://directus.io/docs/tutorials/getting-started"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-and-gatsby"
 to    = "https://directus.io/docs/tutorials/getting-started"
 force = true
 
@@ -1218,7 +2343,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-dire
 force = true
 
 [[redirects]]
+from  = "/blog/nuxt-directus-getting-started"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-nuxt"
+force = true
+
+[[redirects]]
 from  = "/blog/directus-auth-sveltekit.html"
+to    = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-sveltekit"
+force = true
+
+[[redirects]]
+from  = "/blog/directus-auth-sveltekit"
 to    = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-sveltekit"
 force = true
 
@@ -1228,7 +2363,17 @@ to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-digi
 force = true
 
 [[redirects]]
+from  = "/blog/deploy-directus-digital-ocean-docker"
+to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-digital-ocean"
+force = true
+
+[[redirects]]
 from  = "/blog/sync-google-calendar-directus-automate.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/sync-google-calendar-directus-automate"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1238,7 +2383,17 @@ to    = "https://directus.io/docs/tutorials/tips-and-tricks/importing-files-in-d
 force = true
 
 [[redirects]]
+from  = "/blog/importing-files-in-directus-automate"
+to    = "https://directus.io/docs/tutorials/tips-and-tricks/importing-files-in-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/building-a-personal-travel-journal-with-vue-js-and-directus.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/building-a-personal-travel-journal-with-vue-js-and-directus"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1248,7 +2403,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/passwordless-sms-authentication-with-plivo-and-directus-automate"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/build-a-url-shortener-with-react-type-script-and-directus.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/build-a-url-shortener-with-react-type-script-and-directus"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1258,7 +2423,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-a-testimonial-widget-
 force = true
 
 [[redirects]]
+from  = "/blog/building-a-testimonial-widget-with-sveltekit-and-directus"
+to    = "https://directus.io/docs/tutorials/projects/build-a-testimonial-widget-with-sveltekit-and-directus"
+force = true
+
+[[redirects]]
 from  = "/blog/building-a-job-board-platform-with-directus-and-solid-start-js.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/building-a-job-board-platform-with-directus-and-solid-start-js"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1268,7 +2443,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-an-hotel-booking-plat
 force = true
 
 [[redirects]]
+from  = "/blog/building-a-hotel-booking-system-with-directus-next-js-and-stripe"
+to    = "https://directus.io/docs/tutorials/projects/build-an-hotel-booking-platform-with-next-js-stripe-and-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/building-a-video-streaming-app-with-sveltekit-and-directus.html"
+to    = "https://directus.io/docs/tutorials/projects/build-a-video-streaming-app-with-sveltekit-and-directus"
+force = true
+
+[[redirects]]
+from  = "/blog/building-a-video-streaming-app-with-sveltekit-and-directus"
 to    = "https://directus.io/docs/tutorials/projects/build-a-video-streaming-app-with-sveltekit-and-directus"
 force = true
 
@@ -1278,7 +2463,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-dire
 force = true
 
 [[redirects]]
+from  = "/blog/getting-started-with-directus-and-laravel"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-laravel"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-directus-ios.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-in-ios-with-swift"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-directus-ios"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-in-ios-with-swift"
 force = true
 
@@ -1288,7 +2483,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/implement-directus-a
 force = true
 
 [[redirects]]
+from  = "/blog/using-directus-auth-with-ios"
+to    = "https://directus.io/docs/tutorials/getting-started/implement-directus-auth-with-ios"
+force = true
+
+[[redirects]]
 from  = "/blog/deploy-directus-ubuntu-server.html"
+to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-an-ubuntu-server"
+force = true
+
+[[redirects]]
+from  = "/blog/deploy-directus-ubuntu-server"
 to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-an-ubuntu-server"
 force = true
 
@@ -1298,7 +2503,17 @@ to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-aws-
 force = true
 
 [[redirects]]
+from  = "/blog/deploying-directus-to-aws-ec2-with-docker"
+to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-aws-ec2"
+force = true
+
+[[redirects]]
 from  = "/blog/deploying-directus-to-google-cloud-platform-with-docker.html"
+to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-google-cloud-platform"
+force = true
+
+[[redirects]]
+from  = "/blog/deploying-directus-to-google-cloud-platform-with-docker"
 to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-google-cloud-platform"
 force = true
 
@@ -1308,7 +2523,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/using-authentication
 force = true
 
 [[redirects]]
+from  = "/blog/implement-directus-auth-in-next-js-14"
+to    = "https://directus.io/docs/tutorials/getting-started/using-authentication-in-next-js"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-and-android-with-kotlin.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-in-android-with-kotlin"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-and-android-with-kotlin"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-in-android-with-kotlin"
 force = true
 
@@ -1318,7 +2543,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tracking-github-issues-and-pull-requests-with-directus-automate"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/advanced-filtering-dates-aggregation-and-grouping-and-combining-filters.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/advanced-filtering-dates-aggregation-and-grouping-and-combining-filters"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1328,7 +2563,17 @@ to    = "https://directus.io/docs/tutorials/migration/migrate-from-wordpress-to-
 force = true
 
 [[redirects]]
+from  = "/blog/migrating-from-word-press-to-directus"
+to    = "https://directus.io/docs/tutorials/migration/migrate-from-wordpress-to-directus"
+force = true
+
+[[redirects]]
 from  = "/blog/understanding-policy-based-access-control.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/understanding-policy-based-access-control"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1338,7 +2583,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-the-leap-week-registr
 force = true
 
 [[redirects]]
+from  = "/blog/building-the-leap-week-registration-and-referral-system"
+to    = "https://directus.io/docs/tutorials/projects/build-the-leap-week-registration-and-referral-system"
+force = true
+
+[[redirects]]
 from  = "/blog/building-a-job-board.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/building-a-job-board"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1348,7 +2603,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/5-automations-to-level-up-your-blog-with-directus"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/wedding-invite-vonage.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/wedding-invite-vonage"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1358,7 +2623,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-a-user-feedback-widge
 force = true
 
 [[redirects]]
+from  = "/blog/building-user-feedback-widget-with-vuejs-directus"
+to    = "https://directus.io/docs/tutorials/projects/build-a-user-feedback-widget-with-vue-js"
+force = true
+
+[[redirects]]
 from  = "/blog/mastering-multilingual-content-crowdin.html"
+to    = "https://directus.io/docs/tutorials/workflows/integrating-multilingual-content-with-directus-and-crowdin"
+force = true
+
+[[redirects]]
+from  = "/blog/mastering-multilingual-content-crowdin"
 to    = "https://directus.io/docs/tutorials/workflows/integrating-multilingual-content-with-directus-and-crowdin"
 force = true
 
@@ -1368,7 +2643,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/getting-started-with-directus-and-preact"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-and-qwik-city.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-and-qwik-city"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1378,7 +2663,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/getting-started-with-directus-and-remix"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/directus-seo-tips-tricks.html"
+to    = "https://directus.io/docs/tutorials/tips-and-tricks/search-engine-optimization-best-practices"
+force = true
+
+[[redirects]]
+from  = "/blog/directus-seo-tips-tricks"
 to    = "https://directus.io/docs/tutorials/tips-and-tricks/search-engine-optimization-best-practices"
 force = true
 
@@ -1388,7 +2683,17 @@ to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-dire
 force = true
 
 [[redirects]]
+from  = "/blog/getting-started-solidstart"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-solidstart"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-directus-sveltekit.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-sveltekit"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-directus-sveltekit"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-sveltekit"
 force = true
 
@@ -1398,7 +2703,17 @@ to    = "https://directus.io/docs/tutorials/workflows/enrich-user-data-with-clea
 force = true
 
 [[redirects]]
+from  = "/blog/enrich-user-data-clearbit-directus-automate"
+to    = "https://directus.io/docs/tutorials/workflows/enrich-user-data-with-clearbit-and-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/devs-intro-to-composable.html"
+to    = "https://directus.io/docs/guides/extensions/app-extensions/composables"
+force = true
+
+[[redirects]]
+from  = "/blog/devs-intro-to-composable"
 to    = "https://directus.io/docs/guides/extensions/app-extensions/composables"
 force = true
 
@@ -1408,7 +2723,17 @@ to    = "https://directus.io/docs/tutorials/projects/build-a-notebook-chrome-ext
 force = true
 
 [[redirects]]
+from  = "/blog/building-a-notebook-chrome-extension-with-directus"
+to    = "https://directus.io/docs/tutorials/projects/build-a-notebook-chrome-extension-with-directus-auth"
+force = true
+
+[[redirects]]
 from  = "/blog/building-a-support-system-in-the-directus-data-studio.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/building-a-support-system-in-the-directus-data-studio"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1418,7 +2743,17 @@ to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-azur
 force = true
 
 [[redirects]]
+from  = "/blog/deploying-directus-to-azure-web-apps-with-docker"
+to    = "https://directus.io/docs/tutorials/self-hosting/deploy-directus-to-azure-web-apps"
+force = true
+
+[[redirects]]
 from  = "/blog/getting-started-with-directus-spring-boot.html"
+to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-spring-boot"
+force = true
+
+[[redirects]]
+from  = "/blog/getting-started-with-directus-spring-boot"
 to    = "https://directus.io/docs/tutorials/getting-started/fetch-data-from-directus-with-spring-boot"
 force = true
 
@@ -1428,7 +2763,17 @@ to    = "https://directus.io/docs/tutorials/tips-and-tricks/preview-files-in-liv
 force = true
 
 [[redirects]]
+from  = "/blog/google-docs-preview"
+to    = "https://directus.io/docs/tutorials/tips-and-tricks/preview-files-in-live-preview-with-google-docs-previews"
+force = true
+
+[[redirects]]
 from  = "/blog/automatic-transcripts-deepgram.html"
+to    = "https://directus.io/docs/tutorials/workflows/generate-transcripts-with-deepgram-and-directus-automate"
+force = true
+
+[[redirects]]
+from  = "/blog/automatic-transcripts-deepgram"
 to    = "https://directus.io/docs/tutorials/workflows/generate-transcripts-with-deepgram-and-directus-automate"
 force = true
 
@@ -1438,7 +2783,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/building-a-form-data-collection-and-email-notification-system-with-directus-and-next-js"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/announcing-directus-ai-hackathon.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/announcing-directus-ai-hackathon"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1448,7 +2803,17 @@ to    = "https://directus.io/docs/tutorials/workflows/detect-high-risk-phone-num
 force = true
 
 [[redirects]]
+from  = "/blog/detecting-high-risk-phone-numbers-vonage-automate"
+to    = "https://directus.io/docs/tutorials/workflows/detect-high-risk-phone-numbers-with-vonage-and-directus-automate"
+force = true
+
+[[redirects]]
 from  = "/blog/implementing-pagination-and-infinite-scrolling-in-next-js.html"
+to    = "https://directus.io/docs/tutorials/tips-and-tricks/implement-pagination-and-infinite-scrolling-in-next-js"
+force = true
+
+[[redirects]]
+from  = "/blog/implementing-pagination-and-infinite-scrolling-in-next-js"
 to    = "https://directus.io/docs/tutorials/tips-and-tricks/implement-pagination-and-infinite-scrolling-in-next-js"
 force = true
 
@@ -1458,7 +2823,17 @@ to    = "https://directus.io/docs/tutorials/self-hosting/understanding-kubernete
 force = true
 
 [[redirects]]
+from  = "/blog/understanding-kubernetes"
+to    = "https://directus.io/docs/tutorials/self-hosting/understanding-kubernetes"
+force = true
+
+[[redirects]]
 from  = "/blog/building-ai-venture-game.html"
+to    = "https://directus.io/docs/tutorials/projects/building-ai-venture-an-ai-powered-game-with-directus"
+force = true
+
+[[redirects]]
+from  = "/blog/building-ai-venture-game"
 to    = "https://directus.io/docs/tutorials/projects/building-ai-venture-an-ai-powered-game-with-directus"
 force = true
 
@@ -1468,7 +2843,17 @@ to    = "https://directus.io/docs/guides/content/content-versioning"
 force = true
 
 [[redirects]]
+from  = "/blog/content-versioning-pre-release"
+to    = "https://directus.io/docs/guides/content/content-versioning"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/connect.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/connect"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1478,7 +2863,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/automate"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/concept.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/concept"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1488,7 +2883,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/extensions"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/nuxt.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/nuxt"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1498,7 +2903,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/vue"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/auth.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/auth"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1508,7 +2923,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/guest-author"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/vonage.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/vonage"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1518,7 +2943,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/netlify"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/ios.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/ios"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1528,7 +2963,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/migration"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/solid-js.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/solid-js"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1538,7 +2983,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/next"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/getting-started.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/getting-started"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1548,7 +3003,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/insights"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/react.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/react"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1558,7 +3023,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/tips-tricks"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/changelog.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/changelog"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1568,7 +3043,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/svelte"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/project.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/project"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1578,7 +3063,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/node"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/update.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/update"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1588,7 +3083,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/self-hosting"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/astro.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/astro"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1598,7 +3103,17 @@ to    = "https://directus.io/docs/tutorials"
 force = true
 
 [[redirects]]
+from  = "/blog/tags/deployment"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
 from  = "/blog/tags/ai.html"
+to    = "https://directus.io/docs/tutorials"
+force = true
+
+[[redirects]]
+from  = "/blog/tags/ai"
 to    = "https://directus.io/docs/tutorials"
 force = true
 
@@ -1608,7 +3123,17 @@ to    = "https://directus.io/docs/guides/connect/sdk"
 force = true
 
 [[redirects]]
+from  = "/guides/sdk"
+to    = "https://directus.io/docs/guides/connect/sdk"
+force = true
+
+[[redirects]]
 from  = "/guides/frameworks.html"
+to    = "https://directus.io/docs/tutorials/getting-started"
+force = true
+
+[[redirects]]
+from  = "/guides/frameworks"
 to    = "https://directus.io/docs/tutorials/getting-started"
 force = true
 
@@ -1618,7 +3143,17 @@ to    = "https://directus.io/docs/tutorials/projects"
 force = true
 
 [[redirects]]
+from  = "/guides/use-cases"
+to    = "https://directus.io/docs/tutorials/projects"
+force = true
+
+[[redirects]]
 from  = "/guides/real-time.html"
+to    = "https://directus.io/docs/guides/realtime/authentication"
+force = true
+
+[[redirects]]
+from  = "/guides/real-time"
 to    = "https://directus.io/docs/guides/realtime/authentication"
 force = true
 
@@ -1628,7 +3163,17 @@ to    = "https://directus.io/docs/guides/extensions/overview"
 force = true
 
 [[redirects]]
+from  = "/guides/extensions"
+to    = "https://directus.io/docs/guides/extensions/overview"
+force = true
+
+[[redirects]]
 from  = "/guides/administration.html"
+to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
+force = true
+
+[[redirects]]
+from  = "/guides/administration"
 to    = "https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus"
 force = true
 
@@ -1638,7 +3183,17 @@ to    = "https://directus.io/plus"
 force = true
 
 [[redirects]]
+from  = "/plus/multi-tenant-saas"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
 from  = "/plus/onboarding-checklist.html"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
+from  = "/plus/onboarding-checklist"
 to    = "https://directus.io/plus"
 force = true
 
@@ -1648,7 +3203,17 @@ to    = "https://directus.io/plus"
 force = true
 
 [[redirects]]
+from  = "/plus/streaming-platform"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
 from  = "/plus/introduction.html"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
+from  = "/plus/introduction"
 to    = "https://directus.io/plus"
 force = true
 
@@ -1658,7 +3223,17 @@ to    = "https://directus.io/plus"
 force = true
 
 [[redirects]]
+from  = "/plus/pim"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
 from  = "/plus/plus-installation.html"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
+from  = "/plus/plus-installation"
 to    = "https://directus.io/plus"
 force = true
 
@@ -1668,6 +3243,16 @@ to    = "https://directus.io/plus"
 force = true
 
 [[redirects]]
+from  = "/plus/headless-lms"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
 from  = "/plus/status-page.html"
+to    = "https://directus.io/plus"
+force = true
+
+[[redirects]]
+from  = "/plus/status-page"
 to    = "https://directus.io/plus"
 force = true

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -14,7 +14,18 @@
 
 # generated redirects from '_redirects' file
 # (delete to the end of the file and append this output)
-# grep '^[^#]' _redirects | awk '{print "\n[[redirects]]\nfrom  = \""$1"\"\nto    = \""$2"\"\nforce = true"}'
+# grep '^[^#]' _redirects | awk '
+# {
+#   if ($1 ~ /\.html$/) {
+#     # with .html
+#     printf "\n[[redirects]]\nfrom  = \"%s\"\nto    = \"%s\"\nforce = true\n", $1, $2;
+#     # with .html stripped
+#     sub(/\.html$/, "", $1);
+#     printf "\n[[redirects]]\nfrom  = \"%s\"\nto    = \"%s\"\nforce = true\n", $1, $2;
+#   } else {
+#     printf "\n[[redirects]]\nfrom  = \"%s\"\nto    = \"%s\"\nforce = true\n", $1, $2;
+#   }
+# }'
 
 [[redirects]]
 from  = "/app/data-model.html"


### PR DESCRIPTION
## Scope

What's changed:

- Fixed missing Netlify redirection for links without `.html`
  - Eg: Both `/plus/pim.html` and `/plus/pim` should be redirected
- Updated the generation script to output another redirect block


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Temporarily disabled the redirect for a specific blog post URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->