### PR TITLE
Fix bug where M2O displays are cut off

### DIFF
--- a/.changeset/solid-doors-scream.md
+++ b/.changeset/solid-doors-scream.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug that caused the M2O display to shift and cut off

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -292,9 +292,8 @@ function getLinkForItem() {
 }
 
 .preview {
-	display: block;
 	flex-grow: 1;
-	block-size: calc(100% - 16px);
+	block-size: 100%;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Changed display height in m2o interface to prevent clipping its content

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Tested with text and image displays
- Test various displays

---

Fixes #25448


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a visual issue with the Many-to-One (M2O) display component to prevent shifting and clipping, ensuring proper alignment and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->