### PR TITLE
Add legacy in docker build as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN <<EOF
 	set -ex
 	pnpm install --recursive --offline --frozen-lockfile
 	npm_config_workspace_concurrency=1 pnpm run build
-	pnpm --filter directus deploy --prod dist
+	pnpm --filter directus deploy --legacy --prod dist
 	cd dist
 	# Regenerate package.json file with essential fields only
 	# (see https://github.com/directus/directus/issues/20338)


### PR DESCRIPTION
This'll break again in pnpm v11, so we'll plan on refactoring this to use the injected workspace deps. Hopefully that also means we can drop the custom hacky script that recreates the package.json, but that needs some more R&D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment process to use legacy mode during the build, ensuring compatibility for the deployment of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->