### PR TITLE
Try to speed up CI

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,14 +4,14 @@ inputs:
   build:
     description: Build the production bundle of the platform
     required: false
-    default: "true"
+    default: 'true'
   registry:
     description: NPM registry to set up for auth
     required: false
   package-filter:
     description: Ignore certain packages from being built when build is true
     required: false
-    default: "!docs"
+    default: '!docs'
 
 runs:
   using: composite
@@ -26,7 +26,7 @@ runs:
       with:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
-        cache: "pnpm"
+        cache: 'pnpm'
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -8,10 +8,10 @@ inputs:
   registry:
     description: NPM registry to set up for auth
     required: false
-  package-filter:
-    description: Ignore certain packages from being built when build is true
+  build-args:
+    description: Additional args to pass to pnpm build
     required: false
-    default: '!docs'
+    default: "--filter='!docs'"
 
 runs:
   using: composite
@@ -38,4 +38,4 @@ runs:
       env:
         npm_config_workspace_concurrency: 1
         NODE_OPTIONS: --max_old_space_size=6144
-      run: pnpm --recursive --filter '${{ inputs.package-filter }}' run build
+      run: pnpm --recursive ${{ inputs.build-args }} run build

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,16 +4,22 @@ inputs:
   build:
     description: Build the production bundle of the platform
     required: false
-    default: 'true'
+    default: "true"
   registry:
     description: NPM registry to set up for auth
     required: false
+  fetch-depth:
+    required: false
+    description: Number of commits to fetch. 0 indicates all history for all branches and tags.
+    default: "1"
 
 runs:
   using: composite
   steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
 
     - uses: pnpm/action-setup@v4
       name: Install pnpm
@@ -25,7 +31,7 @@ runs:
       with:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
-        cache: 'pnpm'
+        cache: "pnpm"
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -31,6 +31,10 @@ runs:
       run: pnpm install
       shell: bash
 
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v45
+
     - name: Build
       if: inputs.build == 'true'
       shell: bash

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,10 +1,6 @@
 name: Prepare
 description: Install dependencies and build the platform
 inputs:
-  install:
-    description: Install the dependencies to be able to build the platform
-    required: false
-    default: 'true'
   build:
     description: Build the production bundle of the platform
     required: false
@@ -16,39 +12,23 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: pnpm/action-setup@v4
+      name: Install pnpm
+      with:
+        run_install: false
+
     - name: Install Node.js
-      if: inputs.install == 'true'
       uses: actions/setup-node@v4
       with:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
 
-    - name: Install pnpm
-      if: inputs.install == 'true'
-      uses: pnpm/action-setup@v4
-
-    - name: Get cache info
-      if: inputs.install == 'true'
-      id: cache-info
-      shell: bash
-      run: |
-        echo "os-release=$(node --eval 'console.log(os.release())')" >> $GITHUB_OUTPUT
-        echo "pnpm-cache-dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-    - name: Setup pnpm cache
-      if: inputs.install == 'true'
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.cache-info.outputs.pnpm-cache-dir }}
-        key:
-          ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-
-
     - name: Install dependencies
-      if: inputs.install == 'true'
-      shell: bash
       run: pnpm install
+      shell: bash
 
     - name: Build
       if: inputs.build == 'true'

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,6 +1,10 @@
 name: Prepare
 description: Install dependencies and build the platform
 inputs:
+  install:
+    description: Install the dependencies to be able to build the platform
+    required: false
+    default: 'true'
   build:
     description: Build the production bundle of the platform
     required: false
@@ -13,15 +17,18 @@ runs:
   using: composite
   steps:
     - name: Install Node.js
+      if: inputs.install == 'true'
       uses: actions/setup-node@v4
       with:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
 
     - name: Install pnpm
+      if: inputs.install == 'true'
       uses: pnpm/action-setup@v4
 
     - name: Get cache info
+      if: inputs.install == 'true'
       id: cache-info
       shell: bash
       run: |
@@ -29,6 +36,7 @@ runs:
         echo "pnpm-cache-dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
+      if: inputs.install == 'true'
       uses: actions/cache@v4
       with:
         path: ${{ steps.cache-info.outputs.pnpm-cache-dir }}
@@ -38,6 +46,7 @@ runs:
           ${{ runner.os }}-${{ steps.cache-info.outputs.os-release }}-pnpm-store-
 
     - name: Install dependencies
+      if: inputs.install == 'true'
       shell: bash
       run: pnpm install
 

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -8,6 +8,10 @@ inputs:
   registry:
     description: NPM registry to set up for auth
     required: false
+  package-filter:
+    description: Ignore certain packages from being built when build is true
+    required: false
+    default: "!docs"
 
 runs:
   using: composite
@@ -28,14 +32,10 @@ runs:
       run: pnpm install
       shell: bash
 
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v45
-
     - name: Build
       if: inputs.build == 'true'
       shell: bash
       env:
         npm_config_workspace_concurrency: 1
         NODE_OPTIONS: --max_old_space_size=6144
-      run: pnpm run build
+      run: pnpm --recursive --filter '${{ inputs.package-filter }}' run build

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -8,19 +8,10 @@ inputs:
   registry:
     description: NPM registry to set up for auth
     required: false
-  fetch-depth:
-    required: false
-    description: Number of commits to fetch. 0 indicates all history for all branches and tags.
-    default: "1"
 
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: ${{ inputs.fetch-depth }}
-
     - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -25,6 +25,7 @@ runs:
       with:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
+        cache: 'pnpm'
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
-          build-args: "--filter '!docs' --filter '!@directus/app' --filter '!@directus/api' --filter '!@directus/sdk'"
+          build-args: "--filter '!docs' --filter '!@directus/app' --filter '!@directus/api'"
 
       - name: Run Tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,10 @@ name: Check
 
 on:
   pull_request:
+
+  push:
     branches:
       - main
-      - v11-rc
 
 concurrency:
   group: check-${{ github.ref }}
@@ -14,60 +15,45 @@ env:
   NODE_OPTIONS: --max_old_space_size=6144
 
 jobs:
-  lint:
-    name: Lint
+  setup:
+    name: Setup runner
     runs-on: ubuntu-latest
     steps:
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
           build: false
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
+  lint:
+    name: Lint
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
       - name: Run Linter
         run: pnpm exec eslint ${{ steps.changed-files.outputs.all_changed_files }}
 
   stylelint:
     name: Stylelint
+    needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Prepare
-        uses: ./.github/actions/prepare
-        with:
-          build: false
-
       - name: Run Stylelinter
         run: pnpm exec stylelint '**/*.{css,scss,vue}' --ignore-path .gitignore
 
   format:
     name: Format
+    needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Prepare
-        uses: ./.github/actions/prepare
-        with:
-          build: false
-
       - name: Run Formatter
         run: pnpm exec prettier --check --ignore-unknown ${{ steps.changed-files.outputs.all_changed_files }}
 
@@ -75,18 +61,18 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          # Vitest uses `git diff` under the hood to find the changed files in it's `--changed`
-          # option, which in turn means we need to fetch the full git history so git is able to diff
-          fetch-depth: 0
-
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          install: false
 
       - name: Run Tests
-        run: pnpm test:coverage -- --changed origin/${{ github.base_ref }} --passWithNoTests
+        run: |
+          if [ "${GITHUB_REF##*/}" != "main" ]; then
+            pnpm test:coverage --changed origin/${{ github.base_ref }} --passWithNoTests
+          else
+            pnpm test:coverage --passWithNoTests
+          fi
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,6 @@ env:
 jobs:
   lint:
     name: Lint
-    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,7 +36,6 @@ jobs:
 
   stylelint:
     name: Stylelint
-    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,7 +51,6 @@ jobs:
 
   format:
     name: Format
-    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,7 +71,6 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: prepare
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,7 +85,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
-          package-filter: '!docs,!app,!api,!sdk'
+          package-filter: "!docs,!app,!api,!sdk"
 
       - name: Run Tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,21 +24,6 @@ jobs:
         with:
           build: false
 
-  build:
-    name: Build dependencies
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - name: Prepare
-        uses: ./.github/actions/prepare
-        with:
-          build: false
-
-      - name: Prepare
-        uses: ./.github/actions/prepare
-        with:
-          install: false
-
   lint:
     name: Lint
     needs: prepare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,16 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v45
 
+  build:
+    name: Build dependencies
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          install: false
+
   lint:
     name: Lint
     needs: setup
@@ -60,18 +70,18 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        shardIndex: [1, 2, 3, 4, 5]
+        shardTotal: [5]
     steps:
-      - name: Prepare
-        uses: ./.github/actions/prepare
-        with:
-          install: false
-
       - name: Run Tests
         run: |
           if [ "${GITHUB_REF##*/}" != "main" ]; then
-            pnpm test:coverage --changed origin/${{ github.base_ref }} --passWithNoTests
+            pnpm test:coverage --changed origin/${{ github.base_ref }} --passWithNoTests --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
           else
-            pnpm test:coverage --passWithNoTests
+            pnpm test:coverage --passWithNoTests --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
           fi
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,6 +88,8 @@ jobs:
         # but that's a PR for another day
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          package-filter: '!docs,!app,!api,!sdk'
 
       - name: Run Tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,6 +73,7 @@ jobs:
           else
             pnpm test:coverage --passWithNoTests
           fi
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,16 +68,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
+        # This builds the full suite of packages as some of them are used within test files
+        #
+        # Ideally we drop reliance on any workspace packages in tests so we don't have to build
+        # the repo altogether which saves _a lot_ of time, and allows us to shard the tests,
+        # but that's a PR for another day
       - name: Prepare
         uses: ./.github/actions/prepare
-          # This builds the full suite of packages as some of them are used within test files
 
       - name: Run Tests
         run: |
           if [ "${GITHUB_REF##*/}" != "main" ]; then
-            pnpm test:coverage --changed origin/${{ github.base_ref }} --passWithNoTests --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+            pnpm test:coverage --changed origin/${{ github.base_ref }} --passWithNoTests
           else
-            pnpm test:coverage --passWithNoTests --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+            pnpm test:coverage --passWithNoTests
           fi
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,29 +15,25 @@ env:
   NODE_OPTIONS: --max_old_space_size=6144
 
 jobs:
-  setup:
-    name: Setup runner
+  prepare:
+    name: Prepare caches
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
           build: false
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-
   build:
     name: Build dependencies
     runs-on: ubuntu-latest
-    needs: setup
+    needs: prepare
     steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          build: false
+
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
@@ -45,37 +41,52 @@ jobs:
 
   lint:
     name: Lint
-    needs: setup
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          build: false
+
       - name: Run Linter
         run: pnpm exec eslint ${{ steps.changed-files.outputs.all_changed_files }}
 
   stylelint:
     name: Stylelint
-    needs: setup
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          build: false
+
       - name: Run Stylelinter
         run: pnpm exec stylelint '**/*.{css,scss,vue}' --ignore-path .gitignore
 
   format:
     name: Format
-    needs: setup
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          build: false
+
       - name: Run Formatter
         run: pnpm exec prettier --check --ignore-unknown ${{ steps.changed-files.outputs.all_changed_files }}
 
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        shardIndex: [1, 2, 3, 4, 5]
-        shardTotal: [5]
+    needs: prepare
     steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+          # This builds the full suite of packages as some of them are used within test files
+
       - name: Run Tests
         run: |
           if [ "${GITHUB_REF##*/}" != "main" ]; then

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
-          package-filter: '!docs,!@directus/app,!@directus/api,!@directus/sdk'
+          build-args: "--filter '!docs' --filter '!@directus/app' --filter '!@directus/api' --filter '!@directus/sdk'"
 
       - name: Run Tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,9 @@ jobs:
     name: Prepare caches
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
@@ -29,6 +32,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
@@ -42,6 +48,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
@@ -55,6 +64,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
@@ -68,6 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
         # This builds the full suite of packages as some of them are used within test files
         #
         # Ideally we drop reliance on any workspace packages in tests so we don't have to build
@@ -75,13 +90,11 @@ jobs:
         # but that's a PR for another day
       - name: Prepare
         uses: ./.github/actions/prepare
-        with:
-          fetch-depth: 0
 
       - name: Run Tests
         run: |
-          if [ "${GITHUB_REF##*/}" != "main" ]; then
-            pnpm test:coverage --changed origin/${{ github.base_ref }} --passWithNoTests
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            pnpm test:coverage --changed=origin/${{ github.base_ref }} --passWithNoTests
           else
             pnpm test:coverage --passWithNoTests
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,6 +75,8 @@ jobs:
         # but that's a PR for another day
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          fetch-depth: 0
 
       - name: Run Tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
-          package-filter: "!docs,!app,!api,!sdk"
+          package-filter: '!docs,!@directus/app,!@directus/api,!@directus/sdk'
 
       - name: Run Tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,18 +15,6 @@ env:
   NODE_OPTIONS: --max_old_space_size=6144
 
 jobs:
-  prepare:
-    name: Prepare caches
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Prepare
-        uses: ./.github/actions/prepare
-        with:
-          build: false
-
   lint:
     name: Lint
     needs: prepare
@@ -39,6 +27,10 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           build: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
 
       - name: Run Linter
         run: pnpm exec eslint ${{ steps.changed-files.outputs.all_changed_files }}
@@ -72,6 +64,10 @@ jobs:
         with:
           build: false
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
       - name: Run Formatter
         run: pnpm exec prettier --check --ignore-unknown ${{ steps.changed-files.outputs.all_changed_files }}
 
@@ -82,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
         # This builds the full suite of packages as some of them are used within test files
         #

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -13,6 +13,8 @@ component_management:
     statuses:
       - type: project
         target: auto
+        branches:
+          - "!main"
 
 individual_components:
   - component_id: api
@@ -95,4 +97,8 @@ individual_components:
       - packages/validation/**
 
 comment:
+<<<<<<< HEAD
   layout: 'header, diff, components'
+=======
+  layout: "header, diff, components"
+>>>>>>> a326adcf84 (Add codecov config)

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -13,8 +13,6 @@ component_management:
     statuses:
       - type: project
         target: auto
-        branches:
-          - "!main"
 
 individual_components:
   - component_id: api
@@ -97,8 +95,4 @@ individual_components:
       - packages/validation/**
 
 comment:
-<<<<<<< HEAD
   layout: 'header, diff, components'
-=======
-  layout: "header, diff, components"
->>>>>>> a326adcf84 (Add codecov config)


### PR DESCRIPTION
Running the pnpm install once before the parallel actions kick in to warm the caches. Also fixing the `--changed` parameter usage to speed up vitest. Hopefully that doesn't screw up Codecov, but the carryforward setting should catch that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow efficiency by centralizing preparation steps into a dedicated job.
  * Simplified caching and dependency setup for faster and more reliable runs.
  * Adjusted test execution so that only changed files are tested on non-main branches, while the full suite runs on main.
  * Updated workflow triggers and removed unnecessary steps for a cleaner process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->