### PR TITLE
Update VS Code settings to use single quotes for SCSS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
+	"scssFormatter.singleQuote": true,
 	"stylelint.validate": ["css", "scss", "vue"]
 }


### PR DESCRIPTION
## Scope

What's changed:

- Added a rule to the .vscode/settings.json file to ensure that the local formatter uses single quotes within the repository. This way we prevent ESLint from failing after making changes in SCSS.

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Changeset not included. Do we mention this in the release notes?

