### PR TITLE
Fix incorrect positioning of notifications

### DIFF
--- a/.changeset/brown-pandas-attack.md
+++ b/.changeset/brown-pandas-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that could cause the notifications to be rendered in the wrong location

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -41,13 +41,10 @@ const queue = toRefs(notificationsStore).queue;
 	inset-block-start: 0;
 	inset-inline: 8px;
 	z-index: 50;
+	display: flex;
+	flex-direction: column;
+	align-items: end;
 	inline-size: 256px;
-	direction: rtl;
-
-	> *,
-	> :deep(*) {
-		direction: ltr;
-	}
 
 	&.sidebar-open {
 		inset-block: auto 76px;


### PR DESCRIPTION
## Scope

What's changed:

- This bug is the result of the initial incorrect implementation of the `direction` CSS property, which is now exposed through the recently merged Logical Props/Vals PR.

## Potential Risks / Drawbacks

—

## Review Notes / Questions

- No changeset is needed since the unreleased PR mentioned above exposes this bug.

