### PR TITLE
Fix issue preventing click events from working when sorting items

### DIFF
--- a/.changeset/major-pets-shake.md
+++ b/.changeset/major-pets-shake.md
@@ -1,0 +1,5 @@
+---
+'directus': patch
+---
+
+Fixed issue preventing click events from working on sortable items in m2a lists on mobile

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -357,6 +357,8 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 				:set-data="hideDragImage"
 				:disabled="!allowDrag"
 				v-bind="{ 'force-fallback': true }"
+				:filter="'.no-drag'"
+				handle=".drag-handle"
 				@update:model-value="sortItems"
 			>
 				<template #item="{ element }">
@@ -369,18 +371,18 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 						@click="editItem(element)"
 					>
 						<v-icon v-if="allowDrag" class="drag-handle" left name="drag_handle" @click.stop />
-
-						<span class="collection">{{ getPrefix(element) }}:</span>
+						<span class="collection no-drag">{{ getPrefix(element) }}:</span>
 
 						<render-template
 							:collection="element[relationInfo.collectionField.field]"
 							:template="templates[element[relationInfo.collectionField.field]]"
 							:item="element[relationInfo.junctionField.field]"
+							class="no-drag"
 						/>
 
 						<div class="spacer" />
 
-						<div class="item-actions">
+						<div class="item-actions no-drag">
 							<v-remove
 								v-if="!disabled && (deleteAllowed[element[relationInfo.collectionField.field]] || isLocalItem(element))"
 								:item-type="element.$type"

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -357,7 +357,6 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 				:set-data="hideDragImage"
 				:disabled="!allowDrag"
 				v-bind="{ 'force-fallback': true }"
-				:filter="'.no-drag'"
 				handle=".drag-handle"
 				@update:model-value="sortItems"
 			>
@@ -371,18 +370,17 @@ const allowDrag = computed(() => canDrag.value && totalItemCount.value <= limitW
 						@click="editItem(element)"
 					>
 						<v-icon v-if="allowDrag" class="drag-handle" left name="drag_handle" @click.stop />
-						<span class="collection no-drag">{{ getPrefix(element) }}:</span>
+						<span class="collection">{{ getPrefix(element) }}:</span>
 
 						<render-template
 							:collection="element[relationInfo.collectionField.field]"
 							:template="templates[element[relationInfo.collectionField.field]]"
 							:item="element[relationInfo.junctionField.field]"
-							class="no-drag"
 						/>
 
 						<div class="spacer" />
 
-						<div class="item-actions no-drag">
+						<div class="item-actions">
 							<v-remove
 								v-if="!disabled && (deleteAllowed[element[relationInfo.collectionField.field]] || isLocalItem(element))"
 								:item-type="element.$type"


### PR DESCRIPTION
## Scope

What's changed:

- in the draggable component in list items, prevented dragging on all elements except the designated drag handle.

## Potential Risks / Drawbacks

- May not be immediately obvious to those who got accustomed to sorting items by clicking on any part of the item, that they need to sort by using the drag handle.

## Review Notes / Questions
- I was only able to test using an android device, so hopefully someone with an iphone can also test this.
- Vue draggable is no longer being maintained. There is a newer wrapper that is being maintained that might be worth looking into in the future. https://github.com/Alfred-Skyblue/vue-draggable-plus

---

Fixes #23523
