### PR TITLE
Add ESLint plugin for accessibility

### DIFF
--- a/.changeset/loose-chefs-repeat.md
+++ b/.changeset/loose-chefs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added ESLint plugin for accessibility

--- a/app/src/components/__snapshots__/v-divider.test.ts.snap
+++ b/app/src/components/__snapshots__/v-divider.test.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`Mount component 1`] = `
 "<div data-v-51167fde="" class="v-divider inlineTitle"><span data-v-51167fde="" class="wrapper"><span data-v-51167fde="" class="type-text">Default slot</span></span>
-  <hr data-v-51167fde="" role="separator" aria-orientation="horizontal">
+  <hr data-v-51167fde="" aria-orientation="horizontal">
 </div>"
 `;

--- a/app/src/components/v-checkbox-tree/__snapshots__/v-checkbox-tree.test.ts.snap
+++ b/app/src/components/v-checkbox-tree/__snapshots__/v-checkbox-tree.test.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Mount component 1`] = `"<ul data-v-ff20e609="" class="v-list"></ul>"`;
+exports[`Mount component 1`] = `"<ul data-v-ff20e609="" class="v-list" role="group"></ul>"`;

--- a/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
+++ b/app/src/components/v-checkbox-tree/v-checkbox-tree.vue
@@ -143,7 +143,7 @@ function findSelectedChoices(choices: Record<string, any>[], checked: (string | 
 </script>
 
 <template>
-	<v-list v-model="openSelection" :mandatory="false" @toggle="$emit('group-toggle', $event)">
+	<v-list v-model="openSelection" role="group" :mandatory="false" @toggle="$emit('group-toggle', $event)">
 		<v-checkbox-tree-checkbox
 			v-for="choice in choices"
 			:key="choice[itemValue]"

--- a/app/src/components/v-divider.vue
+++ b/app/src/components/v-divider.vue
@@ -21,7 +21,7 @@ withDefaults(defineProps<Props>(), {
 			<slot name="icon" class="icon" />
 			<span v-if="!vertical && $slots.default" class="type-text"><slot /></span>
 		</span>
-		<hr role="separator" :aria-orientation="vertical ? 'vertical' : 'horizontal'" />
+		<hr :aria-orientation="vertical ? 'vertical' : 'horizontal'" />
 	</div>
 </template>
 

--- a/app/src/interfaces/_system/system-permissions/detail/components/fields.vue
+++ b/app/src/interfaces/_system/system-permissions/detail/components/fields.vue
@@ -2,7 +2,7 @@
 import { useFieldTree, type FieldNode } from '@/composables/use-field-tree';
 import { useSync } from '@directus/composables';
 import type { Permission, Policy } from '@directus/types';
-import { ref, computed } from 'vue';
+import { ref, computed, useId } from 'vue';
 import { useI18n } from 'vue-i18n';
 import AppMinimal from './app-minimal.vue';
 
@@ -23,6 +23,7 @@ const emit = defineEmits(['update:permission']);
 
 const { t } = useI18n();
 
+const labelId = useId();
 const permissionSync = useSync(props, 'permission', emit);
 const collection = computed(() => props.permission.collection);
 const isReadAction = computed(() => props.permission.action === 'read');
@@ -138,7 +139,7 @@ function useExpandCollapseAll() {
 		</v-notice>
 
 		<div class="label-wrapper">
-			<label class="type-label">{{ t('field', 0) }}</label>
+			<div :id="labelId" class="type-label">{{ t('field', 0) }}ssss</div>
 
 			<div v-if="isExpandable" class="expand-collapse-action">
 				{{ t('expand') }}
@@ -151,6 +152,7 @@ function useExpandCollapseAll() {
 		<v-checkbox-tree
 			class="permissions-field-tree"
 			:model-value="selectedValues"
+			:aria-labelledby="labelId"
 			:choices="treeFields"
 			value-combining="indeterminate"
 			:open-groups="openGroups"

--- a/app/src/interfaces/_system/system-permissions/detail/components/fields.vue
+++ b/app/src/interfaces/_system/system-permissions/detail/components/fields.vue
@@ -139,7 +139,7 @@ function useExpandCollapseAll() {
 		</v-notice>
 
 		<div class="label-wrapper">
-			<div :id="labelId" class="type-label">{{ t('field', 0) }}ssss</div>
+			<div :id="labelId" class="type-label">{{ t('field', 0) }}</div>
 
 			<div v-if="isExpandable" class="expand-collapse-action">
 				{{ t('expand') }}

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -513,6 +513,7 @@ onMounted(() => {
 							</video>
 							<iframe
 								v-if="mediaSelection.tag === 'iframe'"
+								:title="$t('interfaces.input-rich-text-html.media_preview_iframe_title')"
 								class="media-preview"
 								:src="mediaSelection.previewUrl"
 							></iframe>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1625,6 +1625,7 @@ live_preview:
   new_window: Open in New Window
   close_window: Open in Split View
   toggle_3d: Toggle 3D
+  iframe_title: Live Website Preview
 shares: Shares
 unlimited_usage: Unlimited usage
 uses_left: No uses left | One use left | {n} uses left
@@ -2077,6 +2078,7 @@ interfaces:
     folder_note: Folder for uploaded files. Does not affect existing files.
     imageToken: Static Access Token
     imageToken_label: Static access token is appended to the assets' URL
+    media_preview_iframe_title: Media Preview
   input-block-editor:
     input-block-editor: Block Editor
     description: Block-styled editor for rich media stories, outputs clean data in JSON using Editor.js

--- a/app/src/views/private/components/basic-import-sidebar-detail.vue
+++ b/app/src/views/private/components/basic-import-sidebar-detail.vue
@@ -120,15 +120,15 @@ function useUpload() {
 								</div>
 							</template>
 							<template #input>
-								<input
-									id="import-file"
-									ref="fileInput"
-									type="file"
-									accept="text/csv, application/json"
-									hidden
-									@change="onChange"
-								/>
-								<label v-tooltip="file && file.name" for="import-file" class="import-file-label"></label>
+								<label v-tooltip="file && file.name" for="import-file" class="import-file-label">
+									<input
+										id="import-file"
+										ref="fileInput"
+										type="file"
+										accept="text/csv, application/json"
+										@change="onChange"
+									/>
+								</label>
 								<span class="import-file-text" :class="{ 'no-file': !file }">
 									{{ file ? file.name : t('import_data_input_placeholder') }}
 								</span>
@@ -256,6 +256,7 @@ function useUpload() {
 	cursor: pointer;
 	opacity: 0;
 	appearance: none;
+	overflow: hidden;
 }
 
 .import-file-text {

--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -326,7 +326,13 @@ function useUrls() {
 						transformOrigin: zoom >= 1 ? 'top left' : 'center center',
 					}"
 				>
-					<iframe id="frame" ref="frameEl" :src="frameSrc" @load="onIframeLoad" />
+					<iframe
+						id="frame"
+						ref="frameEl"
+						:src="frameSrc"
+						:title="$t('live_preview.iframe_title')"
+						@load="onIframeLoad"
+					/>
 					<slot name="overlay" :frame-el :frame-src />
 				</div>
 			</div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default typescriptEslint.config(
 
 	// Ignored files
 	{
-		ignores: ['**/dist/', 'packages/extensions-sdk/templates/', 'docs/.vitepress/cache/', 'api/extensions/'],
+		ignores: ['**/dist/', 'packages/extensions-sdk/templates/', 'docs/', 'api/extensions/'],
 	},
 
 	// Enable recommended rules for JS files

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,7 +95,8 @@ export default typescriptEslint.config(
 	...eslintPluginVueA11y.configs['flat/recommended'],
 	{
 		rules: {
-			'vuejs-accessibility/anchor-has-content': 'off',
+			'vuejs-accessibility/anchor-has-content': ['error', { accessibleChildren: ['VTextOverflow'] }],
+
 			// 1093
 			'vuejs-accessibility/heading-has-content': 'off',
 			'vuejs-accessibility/alt-text': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,7 +95,6 @@ export default typescriptEslint.config(
 	...eslintPluginVueA11y.configs['flat/recommended'],
 	{
 		rules: {
-			'vuejs-accessibility/no-redundant-roles': 'off',
 			'vuejs-accessibility/label-has-for': 'off',
 			'vuejs-accessibility/anchor-has-content': 'off',
 			'vuejs-accessibility/iframe-has-title': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,7 +96,6 @@ export default typescriptEslint.config(
 	{
 		rules: {
 			'vuejs-accessibility/anchor-has-content': 'off',
-			'vuejs-accessibility/iframe-has-title': 'off',
 			// 1093
 			'vuejs-accessibility/heading-has-content': 'off',
 			'vuejs-accessibility/alt-text': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
 import eslintJs from '@eslint/js';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import eslintPluginVue from 'eslint-plugin-vue';
+import eslintPluginVueA11y from 'eslint-plugin-vuejs-accessibility';
 import globals from 'globals';
 import process from 'node:process';
 import typescriptEslint from 'typescript-eslint';
@@ -88,6 +89,29 @@ export default typescriptEslint.config(
 		// Apply recommended TypeScript rules to Vue files as well
 		// @ts-expect-error wrong type assertion
 		rules: typescriptEslint.configs.recommended.reduce((rules, config) => ({ ...rules, ...config.rules }), {}),
+	},
+
+	// Accessibility rules for Vue files
+	...eslintPluginVueA11y.configs['flat/recommended'],
+	{
+		rules: {
+			'vuejs-accessibility/no-redundant-roles': 'off',
+			'vuejs-accessibility/label-has-for': 'off',
+			'vuejs-accessibility/anchor-has-content': 'off',
+			'vuejs-accessibility/iframe-has-title': 'off',
+			// 1093
+			'vuejs-accessibility/heading-has-content': 'off',
+			'vuejs-accessibility/alt-text': 'off',
+			'vuejs-accessibility/media-has-caption': 'off',
+			'vuejs-accessibility/mouse-events-have-key-events': 'off',
+			// 1094
+			'vuejs-accessibility/form-control-has-label': 'off',
+			// 1095
+			'vuejs-accessibility/no-static-element-interactions': 'off',
+			'vuejs-accessibility/click-events-have-key-events': 'off',
+			// 1097
+			'vuejs-accessibility/no-autofocus': 'off',
+		},
 	},
 
 	// Custom TypeScript rules

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,7 +95,6 @@ export default typescriptEslint.config(
 	...eslintPluginVueA11y.configs['flat/recommended'],
 	{
 		rules: {
-			'vuejs-accessibility/label-has-for': 'off',
 			'vuejs-accessibility/anchor-has-content': 'off',
 			'vuejs-accessibility/iframe-has-title': 'off',
 			// 1093

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"eslint": "9.21.0",
 		"eslint-config-prettier": "9.1.0",
 		"eslint-plugin-vue": "9.32.0",
+		"eslint-plugin-vuejs-accessibility": "2.4.1",
 		"globals": "15.15.0",
 		"postcss-html": "1.8.0",
 		"prettier": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       eslint-plugin-vue:
         specifier: 9.32.0
         version: 9.32.0(eslint@9.21.0(jiti@1.21.7))
+      eslint-plugin-vuejs-accessibility:
+        specifier: 2.4.1
+        version: 2.4.1(eslint@9.21.0(jiti@1.21.7))
       globals:
         specifier: 15.15.0
         version: 15.15.0
@@ -6279,6 +6282,10 @@ packages:
     resolution: {integrity: sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==}
     engines: {node: '>= 6.0.0'}
 
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-back@2.0.0:
     resolution: {integrity: sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==}
     engines: {node: '>=4'}
@@ -7703,6 +7710,12 @@ packages:
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-plugin-vuejs-accessibility@2.4.1:
+    resolution: {integrity: sha512-ZRZhPdslplZXSF71MtSG+zXYRAT5KiHR4JVuo/DERQf9noAkDvi5W418VOE1qllmJd7wTenndxi1q8XeDMxdHw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -17917,6 +17930,8 @@ snapshots:
       leven: 2.1.0
       mri: 1.1.4
 
+  aria-query@5.3.2: {}
+
   array-back@2.0.0:
     dependencies:
       typical: 2.6.1
@@ -19264,6 +19279,15 @@ snapshots:
       semver: 7.7.2
       vue-eslint-parser: 9.4.3(eslint@9.21.0(jiti@1.21.7))
       xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.21.0(jiti@1.21.7)):
+    dependencies:
+      aria-query: 5.3.2
+      emoji-regex: 10.4.0
+      eslint: 9.21.0(jiti@1.21.7)
+      vue-eslint-parser: 9.4.3(eslint@9.21.0(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Scope

What's changed:

- Added ESLint plugin for accessibility and enabled the first set of rules
  - [anchor-has-content](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rules/anchor-has-content.html)
  - [iframe-has-title](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rules/iframe-has-title.html)
  - [label-has-for](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rules/label-has-for.html)
  - [no-redundant-roles](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rules/no-redundant-roles.html)



## Potential Risks / Drawbacks

—

## Review Notes / Questions

- Review the commits and test changed functionality
