### PR TITLE
Add tooltip to copy icon associated with flow webhook url

### DIFF
--- a/.changeset/tired-times-learn.md
+++ b/.changeset/tired-times-learn.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added tooltip that displays complete url for flow panels that have url endpoints

--- a/app/src/modules/settings/routes/flows/components/options-overview.vue
+++ b/app/src/modules/settings/routes/flows/components/options-overview.vue
@@ -28,6 +28,7 @@ const { isCopySupported, copyToClipboard } = useClipboard();
 			<dd>{{ text }}</dd>
 			<v-icon
 				v-if="isCopySupported && copyable"
+				v-tooltip="text"
 				name="content_copy"
 				small
 				clickable


### PR DESCRIPTION


## Scope

What's changed:

- Added tooltip to copy icon for flow webhooks

## Potential Risks / Drawbacks

- Nothing I can think of

## Review Notes / Questions

1. Create a flow that uses a webhook and click save.
2. Hover over the copy icon next to the url and verify a tooltip renders with the complete url.

<img width="500" alt="CleanShot 2025-07-24 at 13 37 52@2x" src="https://github.com/user-attachments/assets/ceb89ba4-570b-49cc-bc0b-d0261903e78a" />


---

Fixes #21616
