### PR TITLE
Fix bug with invalid input in v-input

### DIFF
--- a/.changeset/famous-buses-accept.md
+++ b/.changeset/famous-buses-accept.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed a bug that prevented negative signs from being entered into number fields

--- a/app/src/components/__snapshots__/v-input.test.ts.snap
+++ b/app/src/components/__snapshots__/v-input.test.ts.snap
@@ -14,3 +14,31 @@ exports[`Mount component 1`] = `
   <!--v-if-->
 </div>"
 `;
+
+exports[`invalid warning > should appear for invalid input 1`] = `
+"<div data-v-418390f4="" class="v-input full-width">
+  <!--v-if-->
+  <div data-v-418390f4="" class="input">
+    <!--v-if-->
+    <!--v-if--><input data-v-418390f4="" autocomplete="off" type="number" step="1" value="">
+    <v-icon-stub data-v-418390f4="" name="warning" class="warning-invalid"></v-icon-stub>
+    <!--v-if--><span data-v-418390f4=""><v-icon-stub data-v-418390f4="" class="step-up" name="keyboard_arrow_up" tabindex="-1" clickable="" disabled="false"></v-icon-stub><v-icon-stub data-v-418390f4="" class="step-down" name="keyboard_arrow_down" tabindex="-1" clickable="" disabled="false"></v-icon-stub></span>
+    <!--v-if-->
+  </div>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`invalid warning > should not appear for valid input 1`] = `
+"<div data-v-418390f4="" class="v-input full-width">
+  <!--v-if-->
+  <div data-v-418390f4="" class="input">
+    <!--v-if-->
+    <!--v-if--><input data-v-418390f4="" autocomplete="off" type="number" step="1" value="">
+    <!--v-if-->
+    <!--v-if--><span data-v-418390f4=""><v-icon-stub data-v-418390f4="" class="step-up" name="keyboard_arrow_up" tabindex="-1" clickable="" disabled="false"></v-icon-stub><v-icon-stub data-v-418390f4="" class="step-down" name="keyboard_arrow_down" tabindex="-1" clickable="" disabled="false"></v-icon-stub></span>
+    <!--v-if-->
+  </div>
+  <!--v-if-->
+</div>"
+`;

--- a/app/src/components/__snapshots__/v-input.test.ts.snap
+++ b/app/src/components/__snapshots__/v-input.test.ts.snap
@@ -16,7 +16,7 @@ exports[`Mount component 1`] = `
 `;
 
 exports[`invalid warning > should appear for invalid input 1`] = `
-"<div data-v-418390f4="" class="v-input full-width">
+"<div data-v-418390f4="" class="v-input full-width invalid">
   <!--v-if-->
   <div data-v-418390f4="" class="input">
     <!--v-if-->

--- a/app/src/components/__snapshots__/v-input.test.ts.snap
+++ b/app/src/components/__snapshots__/v-input.test.ts.snap
@@ -9,6 +9,7 @@ exports[`Mount component 1`] = `
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>"

--- a/app/src/components/v-input.test.ts
+++ b/app/src/components/v-input.test.ts
@@ -2,7 +2,7 @@ import { Focus } from '@/__utils__/focus';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
 import { mount } from '@vue/test-utils';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi, afterEach } from 'vitest';
 import VInput from './v-input.vue';
 
 const global: GlobalMountOptions = {
@@ -229,5 +229,77 @@ describe('emitValue', () => {
 		await wrapper.find('input').trigger('input');
 
 		expect(wrapper.emitted()['update:modelValue']?.[0]).toEqual(['a_test_field']);
+	});
+});
+
+describe('invalid warning', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	const validityMock: ValidityState = {
+		badInput: false,
+		customError: false,
+		patternMismatch: false,
+		rangeOverflow: false,
+		rangeUnderflow: false,
+		stepMismatch: false,
+		tooLong: false,
+		tooShort: false,
+		typeMismatch: false,
+		valid: true,
+		valueMissing: false,
+	};
+
+	test('should appear for invalid input', async () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'number',
+				integer: true,
+			},
+			global,
+		});
+
+		const input = wrapper.find('input');
+		const inputEl = input.element as HTMLInputElement;
+		const validitySpy = vi.spyOn(inputEl, 'validity', 'get').mockReturnValue({ ...validityMock, badInput: true });
+
+		expect(inputEl.validity.badInput).toBe(true);
+		expect((wrapper.vm as any).isInvalidInput).toBe(false);
+
+		await input.trigger('input');
+		await wrapper.vm.$nextTick();
+
+		expect((wrapper.vm as any).isInvalidInput).toBe(true);
+		expect(wrapper.find('v-icon-stub.warning-invalid').exists()).toBe(true);
+		expect(validitySpy).toHaveBeenCalledTimes(2);
+
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	test('should not appear for valid input', async () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'number',
+				integer: true,
+			},
+			global,
+		});
+
+		const input = wrapper.find('input');
+		const inputEl = input.element as HTMLInputElement;
+		const validitySpy = vi.spyOn(inputEl, 'validity', 'get').mockReturnValue(validityMock);
+
+		expect(inputEl.validity.badInput).toBe(false);
+		expect((wrapper.vm as any).isInvalidInput).toBe(false);
+
+		await input.trigger('input');
+		await wrapper.vm.$nextTick();
+
+		expect((wrapper.vm as any).isInvalidInput).toBe(false);
+		expect(wrapper.find('v-icon-stub.warning-invalid').exists()).toBe(false);
+		expect(validitySpy).toHaveBeenCalledTimes(2);
+
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 });

--- a/app/src/components/v-input.test.ts
+++ b/app/src/components/v-input.test.ts
@@ -271,6 +271,7 @@ describe('invalid warning', () => {
 		await wrapper.vm.$nextTick();
 
 		expect((wrapper.vm as any).isInvalidInput).toBe(true);
+		expect(wrapper.find('.v-input.invalid').exists()).toBe(true);
 		expect(wrapper.find('v-icon-stub.warning-invalid').exists()).toBe(true);
 		expect(validitySpy).toHaveBeenCalledTimes(2);
 
@@ -297,6 +298,7 @@ describe('invalid warning', () => {
 		await wrapper.vm.$nextTick();
 
 		expect((wrapper.vm as any).isInvalidInput).toBe(false);
+		expect(wrapper.find('.v-input.invalid').exists()).toBe(false);
 		expect(wrapper.find('v-icon-stub.warning-invalid').exists()).toBe(false);
 		expect(validitySpy).toHaveBeenCalledTimes(2);
 

--- a/app/src/components/v-input.test.ts
+++ b/app/src/components/v-input.test.ts
@@ -1,11 +1,13 @@
 import { Focus } from '@/__utils__/focus';
 import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
 import { mount } from '@vue/test-utils';
 import { describe, expect, test } from 'vitest';
 import VInput from './v-input.vue';
 
 const global: GlobalMountOptions = {
 	stubs: ['v-icon'],
+	plugins: [i18n],
 	directives: {
 		focus: Focus,
 	},

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -1,15 +1,11 @@
-<script lang="ts">
-export default {
-	inheritAttrs: false,
-};
-</script>
-
 <script setup lang="ts">
 import { keyMap, systemKeys } from '@/composables/use-shortcut';
 import slugify from '@sindresorhus/slugify';
 import { omit } from 'lodash';
 import { computed, ref, useAttrs } from 'vue';
 import { useI18n } from 'vue-i18n';
+
+defineOptions({ inheritAttrs: false });
 
 interface Props {
 	/** Autofocusses the input on render */

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -142,7 +142,6 @@ function onInput(event: InputEvent) {
 		const invalidCharsRegex = /(?!^)-|[^0-9-.,]/g;
 		const duplicatePointRegex = /(.*[.,].*)[.,]/g;
 		target.value = target.value.replace(invalidCharsRegex, '').replace(duplicatePointRegex, '$1');
-		event.preventDefault();
 		return;
 	}
 }

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -292,7 +292,7 @@ function useInvalidInput() {
 		if (!isInvalidInput.value) return;
 
 		target.value = '';
-		setInvalidInput(target);
+		isInvalidInput.value = false;
 	}
 }
 </script>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -47,6 +47,8 @@ location: Location
 collection_names_are_case_sensitive: Collection names are case sensitive
 condition_rules: Condition Rules
 input: Input
+invalid_input: Invalid Input
+not_a_number: Not a Number
 maps: Maps
 switch_user: Switch User
 item_creation: Item Creation


### PR DESCRIPTION
## Scope

What's changed:

Changed the previous behavior that completely prevented invalid input in the v-input component. Now, a warning icon with a tooltip is displayed (e.g., "Invalid input" or "Not a number"), and the value is crossed out when the user moves their focus away from the input field.

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Tested in Firefox, Chrome, Safari, iOS
- Fields of type integer, float

## Review Notes / Questions

—

## Checklist

- Updated test

---

Fixes #25543
