### PR TITLE
Improve positioning of notifications

### DIFF
--- a/app/src/modules/visual/routes/visual-editor.vue
+++ b/app/src/modules/visual/routes/visual-editor.vue
@@ -103,7 +103,7 @@ function onSelectUrl(newUrl: string, oldUrl: string) {
 		</live-preview>
 
 		<notification-dialogs />
-		<notifications-group />
+		<notifications-group no-sidebar />
 	</div>
 </template>
 
@@ -124,15 +124,5 @@ function onSelectUrl(newUrl: string, oldUrl: string) {
 
 .spacer {
 	flex: 1;
-}
-
-.notifications-group {
-	inset-block: auto 12px;
-	inset-inline: auto 12px;
-
-	@media (min-width: 960px) {
-		inset-block: auto 12px;
-		inset-inline: auto 12px;
-	}
 }
 </style>

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -5,6 +5,7 @@ import NotificationItem from './notification-item.vue';
 
 defineProps<{
 	sidebarOpen?: boolean;
+	noSidebar?: boolean;
 }>();
 
 const notificationsStore = useNotificationsStore();
@@ -12,7 +13,12 @@ const queue = toRefs(notificationsStore).queue;
 </script>
 
 <template>
-	<transition-group class="notifications-group" :class="{ 'sidebar-open': sidebarOpen }" name="slide-fade" tag="div">
+	<transition-group
+		class="notifications-group"
+		:class="{ 'sidebar-open': sidebarOpen, 'no-sidebar': noSidebar }"
+		name="slide-fade"
+		tag="div"
+	>
 		<slot />
 		<notification-item
 			v-for="(notification, index) in queue"
@@ -38,8 +44,8 @@ const queue = toRefs(notificationsStore).queue;
 <style lang="scss" scoped>
 .notifications-group {
 	position: fixed;
-	inset-block-start: 0;
-	inset-inline: 8px;
+	inset-block-end: 24px;
+	inset-inline-end: 12px;
 	z-index: 50;
 	display: flex;
 	flex-direction: column;
@@ -47,13 +53,13 @@ const queue = toRefs(notificationsStore).queue;
 	inline-size: 256px;
 
 	&.sidebar-open {
-		inset-block: auto 76px;
-		inset-inline: auto 12px;
+		inset-block-end: 76px;
 	}
 
 	@media (min-width: 960px) {
-		inset-block: auto 76px;
-		inset-inline: auto 12px;
+		&:not(.no-sidebar) {
+			inset-block-end: 76px;
+		}
 	}
 }
 


### PR DESCRIPTION
## Scope

Notifications seem to appear on a random position on smaller viewports.

What's changed:

- Notifications are always positioned in the bottom right corner
- Updated the positioning in the visual editor accordingly

| Before | After |
|--------|--------|
| <img width="1600" height="1600" alt="issue" src="https://github.com/user-attachments/assets/1fd5a367-7400-4dd2-b2d2-9ddc45e778f6" /> | <img width="1600" height="1600" alt="fix" src="https://github.com/user-attachments/assets/c1be73a4-2a72-41dc-9e1b-a2ec1bdc8006" /> |

## Potential Risks / Drawbacks

—

## Tested Scenarios

- different viewport widths
- saving items with the visual editor

## Review Notes / Questions

- This is a follow-up to https://github.com/directus/directus/pull/25499. However, the issue already existed before that.
- No changeset needed, since this should have been included in the mentioned PR.

## Checklist

—

