### PR TITLE
Fix issue of icons getting cutoff

### DIFF
--- a/app/src/interfaces/select-icon/select-icon.vue
+++ b/app/src/interfaces/select-icon/select-icon.vue
@@ -117,7 +117,7 @@ function useIconsPerRow(
 	menuActive: Ref<boolean>,
 	config: IconsPerRowConfig = {},
 ) {
-	const { iconSize = 24, gap = 8, contentPadding = 16, rowPadding = 8, defaultIconsPerRow = 7 } = config;
+	const { iconSize = 24, gap = 8, contentPadding = 16, rowPadding = 8, defaultIconsPerRow = 1 } = config;
 
 	const iconsPerRow = ref(defaultIconsPerRow);
 	let resizeObserver: ResizeObserver | null = null;
@@ -295,7 +295,7 @@ function useIconsPerRow(
 .icon-row {
 	display: grid;
 	grid-gap: var(--gap, 8px);
-	grid-template-columns: repeat(var(--icons-per-row, 7), var(--icon-size, 24px));
+	grid-template-columns: repeat(var(--icons-per-row, 1), var(--icon-size, 24px));
 	justify-content: start;
 	color: var(--theme--form--field--input--foreground-subdued);
 	padding: 4px;


### PR DESCRIPTION
Following up with a fix for the icons selector. I had assumed 7 icons per row was a reasonable default, but there are some cases where the select field is not wide enough to support that many.

<img width="300" alt="CleanShot 2025-07-30 at 08 25 09@2x" src="https://github.com/user-attachments/assets/1aea4344-f248-4125-894f-5c503ee7b9c6" />


Fixes #25490
