### PR TITLE
Move and update deps for `@directus/env`

### DIFF
--- a/.changeset/young-foxes-stare.md
+++ b/.changeset/young-foxes-stare.md
@@ -1,0 +1,5 @@
+---
+'@directus/env': patch
+---
+
+Upgrade dependencies

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -38,7 +38,7 @@
 	"dependencies": {
 		"@directus/constants": "workspace:*",
 		"@directus/utils": "workspace:*",
-		"dotenv": "16.4.7",
+		"dotenv": "catalog:",
 		"lodash-es": "catalog:"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     commander:
       specifier: 14.0.0
       version: 14.0.0
+    dotenv:
+      specifier: 17.2.1
+      version: 17.2.1
     execa:
       specifier: 9.6.0
       version: 9.6.0
@@ -1197,8 +1200,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       dotenv:
-        specifier: 16.4.7
-        version: 16.4.7
+        specifier: 'catalog:'
+        version: 17.2.1
       lodash-es:
         specifier: 'catalog:'
         version: 4.17.21
@@ -7785,6 +7788,10 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -19683,6 +19690,8 @@ snapshots:
       tslib: 2.8.1
 
   dotenv@16.4.7: {}
+
+  dotenv@17.2.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   axios: 1.11.0
   chalk: 5.4.1
   commander: 14.0.0
+  dotenv: 17.2.1
   execa: 9.6.0
   fs-extra: 11.3.0
   inquirer: 12.9.0


### PR DESCRIPTION
## Scope

What's changed:

- Updated `dotenv` to the latest version and moved it to catalog

## Potential Risks / Drawbacks

- The only breaking change in `dotenv` is that it logs by default when using `config`. This package uses `parse` so no changes are required

## Tested Scenarios

- None

## Review Notes / Questions

- No risk quick merge les goo

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required