### PR TITLE
Move error packages dependencies

### DIFF
--- a/.changeset/stale-geckos-enjoy.md
+++ b/.changeset/stale-geckos-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@directus/errors': patch
+---
+
+Moved dependency

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -28,12 +28,12 @@
 	},
 	"dependencies": {
 		"@directus/storage": "workspace:*",
-		"ms": "2.1.3"
+		"ms": "catalog:"
 	},
 	"devDependencies": {
 		"@directus/random": "workspace:*",
 		"@directus/tsconfig": "catalog:",
-		"@types/ms": "2.1.0",
+		"@types/ms": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"tsup": "catalog:",
 		"typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@types/lodash-es':
       specifier: 4.17.12
       version: 4.17.12
+    '@types/ms':
+      specifier: 2.1.0
+      version: 2.1.0
     '@types/node':
       specifier: 22.13.14
       version: 22.13.14
@@ -48,6 +51,9 @@ catalogs:
     log-symbols:
       specifier: 7.0.1
       version: 7.0.1
+    ms:
+      specifier: 2.1.3
+      version: 2.1.3
     nanoid:
       specifier: 5.1.5
       version: 5.1.5
@@ -1234,7 +1240,7 @@ importers:
         specifier: workspace:*
         version: link:../storage
       ms:
-        specifier: 2.1.3
+        specifier: 'catalog:'
         version: 2.1.3
     devDependencies:
       '@directus/random':
@@ -1244,7 +1250,7 @@ importers:
         specifier: 'catalog:'
         version: 3.0.0
       '@types/ms':
-        specifier: 2.1.0
+        specifier: 'catalog:'
         version: 2.1.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
 catalog:
   '@directus/tsconfig': 3.0.0
   '@types/lodash-es': 4.17.12
+  '@types/ms': 2.1.0
   '@types/node': 22.13.14
   '@vitest/coverage-v8': 3.2.4
   '@vue/test-utils': 2.4.6
@@ -22,6 +23,7 @@ catalog:
   inquirer: 12.9.0
   lodash-es: 4.17.21
   log-symbols: 7.0.1
+  ms: 2.1.3
   nanoid: 5.1.5
   ora: 8.2.0
   tsup: 8.5.0


### PR DESCRIPTION
No changes, just moving the (already latest) version of `ms` to the catalog