### PR TITLE
Drop token from upload coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -105,5 +105,5 @@ jobs:
             echo "Uploading coverage for $folder_name from $coverage_file"
 
             # Upload to codecov with folder name as flag
-            ./codecov upload-coverage -t ${{ secrets.CODECOV_TOKEN }} -f "$coverage_file" -F "$folder_name" -Z --disable-search
+            ./codecov upload-coverage -f "$coverage_file" -F "$folder_name" -Z --disable-search
           done


### PR DESCRIPTION
## Scope

What's changed:

- No longer explicitly set the token
- This should resolve the unit test action failing for PRs contributed from forks

## Potential Risks / Drawbacks

- This _should_ be fine for public repos, but the codecov docs are a bit confusing