### PR TITLE
Raw group batch mode missing #25522

### DIFF
--- a/.changeset/yellow-tree-fair.md
+++ b/.changeset/yellow-tree-fair.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Standardized batch mode for raw group fields

--- a/app/src/interfaces/group-raw/group-raw.vue
+++ b/app/src/interfaces/group-raw/group-raw.vue
@@ -36,6 +36,7 @@ defineEmits(['apply']);
 			:group="field.meta?.field"
 			:validation-errors="validationErrors"
 			:loading="loading"
+			:batch-mode="batchMode"
 			:disabled="disabled"
 			:badge="badge"
 			:raw-editor-enabled="rawEditorEnabled"

--- a/contributors.yml
+++ b/contributors.yml
@@ -221,3 +221,4 @@
 - DantonMariano
 - 8byr0
 - jekuer
+- timio23


### PR DESCRIPTION
## Scope

What's changed:

- Added batch mode boolean to raw group v-form properties

## Potential Risks / Drawbacks

- No risks
- Drawback: fields with raw group were already active in batch edit which has it's convenience, however, this change brings it in line with other groups

## Tested Scenarios

- Fields within a raw group
- Raw groups within tab extension

## Review Notes / Questions

- Documentation not required

---

Fixes #25522
