### PR TITLE
Add permissions to gh actions

### DIFF
--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -6,6 +6,9 @@ on:
       - synchronize
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   blackbox-tests:
     name: Blackbox Tests

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -13,6 +13,9 @@ on:
       - .github/workflows/blackbox.yml
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: blackbox-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 env:
   NODE_OPTIONS: --max_old_space_size=6144
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v[0-9]*'
 
+permissions:
+  contents: write
+  packages: write
+  attestations: write
+  id-token: write
+
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
   DOCKERHUB_IMAGE: docker.io/${{ github.repository }}

--- a/.github/workflows/sync-dockerhub-readme.yml
+++ b/.github/workflows/sync-dockerhub-readme.yml
@@ -8,6 +8,9 @@ on:
       - readme.md
       - .github/workflows/sync-dockerhub-readme.yml
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: Sync


### PR DESCRIPTION
## Scope

What's changed:

- Resolves CodeQL warnings by adding permission clauses to GH actions

## Potential Risks / Drawbacks

- Impossible to test locally, so there's a chance this breaks one of the actions unknowingly

## Review Notes / Questions

- See https://github.com/directus/directus/security/code-scanning
