### PR TITLE
Display labels for data fields in batch mode

### DIFF
--- a/.changeset/soft-memes-fall.md
+++ b/.changeset/soft-memes-fall.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that labels for data fields always display in batch mode

--- a/app/src/components/v-form/form-field.test.ts
+++ b/app/src/components/v-form/form-field.test.ts
@@ -1,0 +1,71 @@
+import VMenu from '../v-menu.vue';
+import FormField from '@/components/v-form/form-field.vue';
+import { i18n } from '@/lang';
+import { Width } from '@directus/system-data';
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+
+const baseField = {
+	field: 'test',
+	name: 'Test Field',
+	collection: 'test_collection',
+	meta: {
+		width: 'full' as Width,
+		readonly: false,
+		hideLabel: false,
+		special: [],
+		note: '',
+		validation_message: '',
+		validation: undefined,
+	},
+	schema: {
+		default_value: undefined,
+	},
+};
+
+const global = {
+	components: { VMenu },
+	plugins: [i18n],
+};
+
+describe('FormField', () => {
+	it('should show FormFieldLabel in batch mode if field.meta.special does not include "no-data"', () => {
+		const wrapper = mount(FormField, {
+			props: {
+				field: { ...baseField, hideLabel: true, meta: { ...baseField.meta, special: [] } },
+				batchMode: true,
+				batchActive: true,
+			},
+			global,
+		});
+
+		// Label should be visible
+		expect(wrapper.findComponent({ name: 'FormFieldLabel' }).exists()).toBe(true);
+	});
+
+	it('should hide FormFieldLabel in batch mode if field.meta.special includes "no-data"', () => {
+		const wrapper = mount(FormField, {
+			props: {
+				field: { ...baseField, hideLabel: true, meta: { ...baseField.meta, special: ['no-data'] } },
+				batchMode: true,
+				batchActive: true,
+			},
+			global,
+		});
+
+		// Label should be hidden
+		expect(wrapper.findComponent({ name: 'FormFieldLabel' }).exists()).toBe(false);
+	});
+
+	it('should hide FormFieldLabel if field.hideLabel is true and not in batch mode', () => {
+		const wrapper = mount(FormField, {
+			props: {
+				field: { ...baseField, hideLabel: true },
+				batchMode: false,
+			},
+			global,
+		});
+
+		expect(wrapper.findComponent({ name: 'FormFieldLabel' }).exists()).toBe(false);
+	});
+});

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -51,6 +51,11 @@ const isDisabled = computed(() => {
 	return false;
 });
 
+const isLabelHidden = computed(() => {
+	if (props.batchMode && !props.field.meta?.special?.includes('no-data')) return false;
+	return props.field.hideLabel;
+});
+
 const { internalValue, isEdited, defaultValue } = useComputedValues();
 
 const { showRaw, copyRaw, pasteRaw, onRawValueSubmit } = useRaw();
@@ -162,7 +167,7 @@ function useComputedValues() {
 		class="field"
 		:class="[field.meta?.width || 'full', { invalid: validationError }]"
 	>
-		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow arrow-placement="start">
+		<v-menu v-if="!isLabelHidden" placement="bottom-start" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"


### PR DESCRIPTION
## Scope

What's changed:

- In batch mode, if the field has no `no-data` tag, a label will appear to make the checkbox for batch editing available. Even if the interface setting is set to `hideLabel`.

| Before | After |
|--------|--------|
| <img width="1708" height="1262" alt="bug" src="https://github.com/user-attachments/assets/9631febe-c88f-4669-a1f3-00bb15922837" /> | <img width="1726" height="1314" alt="fix" src="https://github.com/user-attachments/assets/61764cd3-47db-44e1-8a6e-78b4d63519f4" /> |

## Potential Risks / Drawbacks

—

## Tested Scenarios

- presentational fields, alias fields, groups

## Review Notes / Questions

—

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25618
