### PR TITLE
Always render theme-overrides LTR

### DIFF
--- a/.changeset/many-frogs-think.md
+++ b/.changeset/many-frogs-think.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue where the theme overrides interface would be rendered RTL in RTL languages

--- a/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides.vue
+++ b/app/src/interfaces/_system/system-theme-overrides/system-theme-overrides.vue
@@ -47,7 +47,7 @@ const { theme } = useTheme(darkMode, themeLight, themeDark, {}, {});
 </script>
 
 <template>
-	<div class="theme-overrides">
+	<div class="theme-overrides" lang="en-US" dir="ltr">
 		<SystemThemeOverridesGroup root :rules="theme.rules" :path="[]" :value="value ?? {}" :set="set" />
 	</div>
 </template>


### PR DESCRIPTION
## Scope

What's changed:

- Always render the theme-overrides interface as ltr and mark it as English

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- Checked in LTR and RTL

## Review Notes / Questions

- Should be a 10 second review
- Tests aren't really appropriate here I think as there's no business logic change

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25629
