### PR TITLE
Fixed RTL empty state center positioning

### DIFF
--- a/.changeset/forty-turtles-peel.md
+++ b/.changeset/forty-turtles-peel.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue for empty states not being centered in RTL languages

--- a/app/src/components/v-info.vue
+++ b/app/src/components/v-info.vue
@@ -87,5 +87,9 @@ withDefaults(defineProps<Props>(), {
 	inset-block-start: 50%;
 	inset-inline-start: 50%;
 	transform: translate(-50%, -50%);
+
+	html[dir='rtl'] & {
+		transform: translate(50%, -50%);
+	}
 }
 </style>


### PR DESCRIPTION
## Scope

What's changed:

- Adjust RTL positioning for empty state

## Potential Risks / Drawbacks

- Making a change to a shared component, could have issues I missed.

## Tested Scenarios

- Checked multiple screen sizes to ensure padding is centered properly
- Checked different areas of "empty states"

## Review Notes / Questions

- I made a change to the `v-info` component, so there could be areas I missed

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25630 
<img width="1227" height="1332" alt="Screenshot 2025-08-06 at 1 43 29 PM" src="https://github.com/user-attachments/assets/e0d5ea90-b0fc-4cb9-983c-34e6f1eec339" />
<img width="1054" height="1295" alt="Screenshot 2025-08-06 at 1 43 36 PM" src="https://github.com/user-attachments/assets/49e3d253-10b9-4e41-bd56-692dd48d01ac" />
<img width="1861" height="1300" alt="Screenshot 2025-08-06 at 1 43 49 PM" src="https://github.com/user-attachments/assets/7ed7897c-716f-4320-bb1a-030704361b52" />
<img width="1872" height="1300" alt="Screenshot 2025-08-06 at 1 44 30 PM" src="https://github.com/user-attachments/assets/30a5c12f-7ab4-4b8e-bb30-b06adf0cb8ce" />
<img width="1177" height="1252" alt="Screenshot 2025-08-06 at 1 44 36 PM" src="https://github.com/user-attachments/assets/d2b8c35e-fd91-48ff-b647-3ef0a99d94c9" />


