### PR TITLE
Ensure that code editor is always LTR

### DIFF
--- a/.changeset/moody-cows-strive.md
+++ b/.changeset/moody-cows-strive.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue that would render english code as RTL in RTL language mode

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -297,7 +297,7 @@ function isInterpolation(value: any) {
 </script>
 
 <template>
-	<div class="input-code codemirror-custom-styles" :class="{ disabled }">
+	<div class="input-code codemirror-custom-styles" :class="{ disabled }" lang="en-US" dir="ltr">
 		<div ref="codemirrorEl"></div>
 
 		<v-button v-if="template" v-tooltip.left="t('fill_template')" small icon secondary @click="fillTemplate">

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -297,7 +297,7 @@ function isInterpolation(value: any) {
 </script>
 
 <template>
-	<div class="input-code codemirror-custom-styles" :class="{ disabled }" lang="en-US" dir="ltr">
+	<div class="input-code codemirror-custom-styles" :class="{ disabled }" dir="ltr">
 		<div ref="codemirrorEl"></div>
 
 		<v-button v-if="template" v-tooltip.left="t('fill_template')" small icon secondary @click="fillTemplate">


### PR DESCRIPTION
## Scope

What's changed:

- Always render the code input as LTR

## Review Notes / Questions

- @maazamaani is there ever a case where a whole code snippet _should_ be RTL? 

---

Fixes #25625
