### PR TITLE
Prevent empty keys in env objects from double underscore prefixes

### DIFF
--- a/.changeset/cold-parks-bet.md
+++ b/.changeset/cold-parks-bet.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Prevented empty keys in env objects from double underscore prefixes

--- a/api/src/utils/get-config-from-env.test.ts
+++ b/api/src/utils/get-config-from-env.test.ts
@@ -19,6 +19,8 @@ beforeEach(() => {
 		OMIT_PREFIX_SECOND_KEY_VALUE: 'secondValue',
 		OMIT_KEY_FIRST_KEY: 'firstKey',
 		OMIT_KEY_FIRST_KEY_VALUE: 'firstValue',
+		EMPTY_KEY__SCOPE: 'scope',
+		EMPTY_KEY__NESTED__DEEP_VALUE: 'deeply_nested_value',
 	});
 });
 
@@ -67,6 +69,13 @@ describe('get config from env', () => {
 
 		expect(getConfigFromEnv('OMIT_KEY_', { omitKey: ['OMIT_KEY_FIRST_KEY_VALUE'] })).toStrictEqual({
 			firstKey: 'firstKey',
+		});
+	});
+
+	test('Keys with double underscore in prefix should not result in empty string as a key', () => {
+		expect(getConfigFromEnv('EMPTY_KEY__')).toStrictEqual({
+			scope: 'scope',
+			nested: { deepValue: 'deeply_nested_value' },
 		});
 	});
 });

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -37,7 +37,8 @@ export function getConfigFromEnv(prefix: string, options?: GetConfigFromEnvOptio
 		if (key.includes('__')) {
 			const path = key
 				.split('__')
-				.map((key, index) => (index === 0 ? transform(transform(key.slice(prefix.length))) : transform(key)));
+				.map((key, index) => (index === 0 ? transform(transform(key.slice(prefix.length))) : transform(key)))
+				.filter((p) => p !== '');
 
 			set(config, path.join('.'), value);
 		} else {

--- a/api/src/utils/get-config-from-env.ts
+++ b/api/src/utils/get-config-from-env.ts
@@ -37,7 +37,7 @@ export function getConfigFromEnv(prefix: string, options?: GetConfigFromEnvOptio
 		if (key.includes('__')) {
 			const path = key
 				.split('__')
-				.map((key, index) => (index === 0 ? transform(transform(key.slice(prefix.length))) : transform(key)))
+				.map((key, index) => (index === 0 ? transform(key.slice(prefix.length)) : transform(key)))
 				.filter((p) => p !== '');
 
 			set(config, path.join('.'), value);


### PR DESCRIPTION
## Scope

What's changed:

- Updated `getConfigFromEnv` to filter empty path segments when parsing environment variables  
  - Prefix ending in a double underscore (__) results in an object with an empty string as a key
- Removed the duplicated `transform()`

### Example
```ts
{
   EMPTY_KEY__SCOPE: 'scope',
   EMPTY_KEY__NESTED__DEEP_VALUE: 'deeply_nested_value',
}

getConfigFromEnv('EMPTY_KEY__')
```

#### Before
```json
{
   "": {
      "nested": {
        "deepValue": "deeply_nested_value",
      },
      "scope": "scope",
   },
}
```

#### After
```json
{
   "nested": {
     "deepValue": "deeply_nested_value",
   },
   "scope": "scope",
}
```

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- Tested with auth provider configurations

## Review Notes / Questions

- The core of the fix is adding `.filter(p => p !== '')` to the path generation logic

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---