### PR TITLE
Fix mysql wrongly reporting index as `true` in some cases

### DIFF
--- a/.changeset/moody-parrots-check.md
+++ b/.changeset/moody-parrots-check.md
@@ -1,0 +1,5 @@
+---
+'@directus/schema': patch
+---
+
+Fixed an issue that could report indexed falsy as enabled for mysql columns with the same name in different schemas

--- a/packages/schema/src/dialects/mysql.ts
+++ b/packages/schema/src/dialects/mysql.ts
@@ -276,7 +276,8 @@ export default class MySQL implements SchemaInspector {
 					.andOn('rc.CONSTRAINT_SCHEMA', '=', 'fk.CONSTRAINT_SCHEMA');
 			})
 			.leftJoin('INFORMATION_SCHEMA.STATISTICS as stats', function () {
-				this.on('stats.TABLE_NAME', '=', 'c.TABLE_NAME')
+				this.on('stats.TABLE_SCHEMA', '=', 'c.TABLE_SCHEMA')
+					.andOn('stats.TABLE_NAME', '=', 'c.TABLE_NAME')
 					.andOn('stats.COLUMN_NAME', '=', 'c.COLUMN_NAME')
 					.andOnVal('stats.NON_UNIQUE', 1)
 					.andOnVal('stats.SEQ_IN_INDEX', 1);


### PR DESCRIPTION
## Scope

What's changed:

Index lookup wasn't joining against table schema, causing it to return a false positive true if another schema contains a table and column with the same name.

## Tested Scenarios

Checked against original report.

Fixes #25645
