### PR TITLE
Fix save_and_create_new loading with original item state

### DIFF
--- a/.changeset/rare-icons-check.md
+++ b/.changeset/rare-icons-check.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added currentItem id check to prevent in-flight api call from returning stale data

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -293,6 +293,31 @@ describe('test o2m relation', () => {
 			$index: 0,
 		});
 	});
+
+	test('Initial data should be cleared when itemId changes to new item', async () => {
+		// Mount component with existing itemId
+		const wrapper = mount(TestComponent, {
+			props: { relation: relationO2M, value: [], id: 1 },
+		});
+
+		// Wait for initial data to load
+		await flushPromises();
+
+		// Verify initial data is loaded for existing item
+		expect(wrapper.vm.fetchedItems).toEqual(workerData);
+
+		// Change itemId to '+' (new item) - simulates "save and create new"
+		await wrapper.setProps({ id: '+' });
+
+		// Wait for the change to settle
+		await flushPromises();
+
+		// For a new item, fetchedItems should be empty
+		expect(wrapper.vm.fetchedItems).toEqual([]);
+
+		// The component should not be in loading state
+		expect(wrapper.vm.loading).toBe(false);
+	});
 });
 
 const relationM2A: RelationM2A = {

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -383,6 +383,8 @@ export function useRelationMultiple(
 			loading.value = true;
 
 			if (itemId.value !== '+') {
+				const currentItemId = itemId.value;
+
 				const filter: Filter = { _and: [{ [reverseJunctionField]: itemId.value } as Filter] };
 
 				if (previewQuery.value.filter) {
@@ -399,6 +401,14 @@ export function useRelationMultiple(
 						sort: previewQuery.value.sort,
 					},
 				});
+
+				// if itemId changed during the request, we wan't to avoid updating items with incorrect data.
+				// This can happen if the user navigates to a different item while the request is in progress.
+				// The assumption here is that there is another request that started after this one started
+				// and this one is no longer relevant.
+				if (itemId.value !== currentItemId) {
+					return;
+				}
 
 				fetchedItems.value = response.data.data;
 			}


### PR DESCRIPTION
## Scope

What's changed:

- Fixed race condition in use-relation-multiple composable where stale API responses could be applied when itemId changes during navigation

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- "Save and create new" with translation fields - new form is now completely empty
- Race condition where API call completes after navigation - stale response is ignored

## Review Notes / Questions

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #24863
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a race condition in the use-relation-multiple composable by tracking the current item and preventing stale API responses after itemId changes. The implementation adds a local tracking variable and response validation logic, enhancing data integrity during save-and-create-new workflows.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>