### PR TITLE
Add placeholders for error operation

### DIFF
--- a/api/src/operations/throw-error/index.test.ts
+++ b/api/src/operations/throw-error/index.test.ts
@@ -4,7 +4,7 @@ import config from './index.js';
 
 const DEFAULT_ERROR = new InternalServerError();
 
-describe('Operations / Error', () => {
+describe('Operations / Throw Error', () => {
 	test('Throws error with default values', () => {
 		expect.assertions(3);
 

--- a/api/src/operations/throw-error/index.ts
+++ b/api/src/operations/throw-error/index.ts
@@ -10,7 +10,7 @@ type Options = {
 const FALLBACK_ERROR = new InternalServerError();
 
 export default defineOperationApi<Options>({
-	id: 'error',
+	id: 'throw-error',
 
 	handler: ({ code, status, message }) => {
 		const statusCode = parseInt(status);

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2458,12 +2458,6 @@ operations:
   condition:
     name: Condition
     description: Route a flow based on If / Else logic
-  error:
-    name: Error
-    description: Throw an error in the reject path
-    code: Error Code
-    status: HTTP Status Code
-    message: Error Message
   exec:
     name: Run Script
     description: Execute arbitrary code to modify the payload
@@ -2549,6 +2543,12 @@ operations:
     name: Sleep
     description: Wait a given number of milliseconds
     milliseconds: Milliseconds
+  throw-error:
+    name: Throw Error
+    description: Throw an error in the reject path
+    code: Error Code
+    status: HTTP Status Code
+    message: Error Message
   transform:
     name: Transform Payload
     description: Alter the Flow's JSON payload

--- a/app/src/operations/error/index.ts
+++ b/app/src/operations/error/index.ts
@@ -1,23 +1,25 @@
+import { ErrorCode, InternalServerError } from '@directus/errors';
 import { defineOperationApp } from '@directus/extensions';
-import { ErrorCode } from '@directus/errors';
+
+const FALLBACK_ERROR = new InternalServerError();
 
 export default defineOperationApp({
 	id: 'error',
 	icon: 'error',
 	name: '$t:operations.error.name',
 	description: '$t:operations.error.description',
-	overview: ({ filter, status, message }) => [
+	overview: ({ code, status, message }) => [
 		{
 			label: '$t:operations.error.code',
-			text: filter,
+			text: code ?? FALLBACK_ERROR.code,
 		},
 		{
 			label: '$t:operations.error.status',
-			text: status,
+			text: status ?? FALLBACK_ERROR.status.toString(),
 		},
 		{
 			label: '$t:operations.error.message',
-			text: message,
+			text: message ?? FALLBACK_ERROR.message,
 		},
 	],
 	options: () => [
@@ -35,6 +37,9 @@ export default defineOperationApp({
 					})),
 					allowOther: true,
 				},
+			},
+			schema: {
+				default_value: FALLBACK_ERROR.code,
 			},
 		},
 		{
@@ -82,6 +87,9 @@ export default defineOperationApp({
 					allowOther: true,
 				},
 			},
+			schema: {
+				default_value: FALLBACK_ERROR.status.toString(),
+			},
 		},
 		{
 			field: 'message',
@@ -90,6 +98,9 @@ export default defineOperationApp({
 			meta: {
 				width: 'full',
 				interface: 'input',
+			},
+			schema: {
+				default_value: FALLBACK_ERROR.message,
 			},
 		},
 	],

--- a/app/src/operations/throw-error/index.ts
+++ b/app/src/operations/throw-error/index.ts
@@ -4,28 +4,28 @@ import { defineOperationApp } from '@directus/extensions';
 const FALLBACK_ERROR = new InternalServerError();
 
 export default defineOperationApp({
-	id: 'error',
+	id: 'throw-error',
 	icon: 'error',
-	name: '$t:operations.error.name',
-	description: '$t:operations.error.description',
+	name: '$t:operations.throw-error.name',
+	description: '$t:operations.throw-error.description',
 	overview: ({ code, status, message }) => [
 		{
-			label: '$t:operations.error.code',
+			label: '$t:operations.throw-error.code',
 			text: code ?? FALLBACK_ERROR.code,
 		},
 		{
-			label: '$t:operations.error.status',
+			label: '$t:operations.throw-error.status',
 			text: status ?? FALLBACK_ERROR.status.toString(),
 		},
 		{
-			label: '$t:operations.error.message',
+			label: '$t:operations.throw-error.message',
 			text: message ?? FALLBACK_ERROR.message,
 		},
 	],
 	options: () => [
 		{
 			field: 'code',
-			name: '$t:operations.error.code',
+			name: '$t:operations.throw-error.code',
 			type: 'string',
 			meta: {
 				width: 'full',
@@ -44,7 +44,7 @@ export default defineOperationApp({
 		},
 		{
 			field: 'status',
-			name: '$t:operations.error.status',
+			name: '$t:operations.throw-error.status',
 			type: 'string',
 			meta: {
 				width: 'full',
@@ -93,7 +93,7 @@ export default defineOperationApp({
 		},
 		{
 			field: 'message',
-			name: '$t:operations.error.message',
+			name: '$t:operations.throw-error.message',
 			type: 'string',
 			meta: {
 				width: 'full',

--- a/app/src/operations/throw-error/index.ts
+++ b/app/src/operations/throw-error/index.ts
@@ -36,10 +36,8 @@ export default defineOperationApp({
 						value: code,
 					})),
 					allowOther: true,
+					placeholder: FALLBACK_ERROR.code,
 				},
-			},
-			schema: {
-				default_value: FALLBACK_ERROR.code,
 			},
 		},
 		{
@@ -85,10 +83,8 @@ export default defineOperationApp({
 						},
 					],
 					allowOther: true,
+					placeholder: FALLBACK_ERROR.status.toString(),
 				},
-			},
-			schema: {
-				default_value: FALLBACK_ERROR.status.toString(),
 			},
 		},
 		{
@@ -98,9 +94,9 @@ export default defineOperationApp({
 			meta: {
 				width: 'full',
 				interface: 'input',
-			},
-			schema: {
-				default_value: FALLBACK_ERROR.message,
+				options: {
+					placeholder: FALLBACK_ERROR.message,
+				},
 			},
 		},
 	],


### PR DESCRIPTION
Follow-up of #25558

## Scope

What's changed:

- Added placeholders for error operation
- Fixed the overview
- Renamed from `error` to `throw-error` to move operation down
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces default error values for the error operation and fixes an issue in the overview function. It adds a fallback error object and updates schema definitions with default values for error code, status, and message, enhancing error handling reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>