### PR TITLE
Fix alignment of flow resolve/reject buttons

### DIFF
--- a/app/src/modules/settings/routes/flows/components/operation.vue
+++ b/app/src/modules/settings/routes/flows/components/operation.vue
@@ -413,10 +413,10 @@ function pointerLeave() {
 		align-items: center;
 		padding: 20px;
 		padding-inline-start: 60px;
-		transform: translate(-1px, -50%);
+		transform: translate(-1px, calc(-50% - 2.5px));
 
 		html[dir='rtl'] & {
-			transform: translate(1px, -50%);
+			transform: translate(1px, calc(-50% - 2.5px));
 		}
 	}
 


### PR DESCRIPTION
## Scope

What's changed:

- Reverted the y positioning of the resolve/reject buttons in flow operations, that was changed in the RTL PR

## Potential Risks / Drawbacks

—

## Tested Scenarios

- editing flow

## Review Notes / Questions

—

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25666
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a UI misalignment issue by adjusting button positioning in a Vue component. CSS transform properties were updated with calculated offsets to ensure proper alignment of flow resolve/reject buttons in both LTR and RTL layouts. The changes restore the intended positioning that was affected by previous modifications.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>