### PR TITLE
fix: (re)allow excess arguments in cli commands

### DIFF
--- a/.changeset/public-dots-glow.md
+++ b/.changeset/public-dots-glow.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed failed Directus startup caused by additional arguments to the `start` command

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -18,6 +18,7 @@ import { loadExtensions } from './load-extensions.js';
 
 export async function createCli(): Promise<Command> {
 	const program = new Command();
+	program.allowExcessArguments();
 
 	await loadExtensions();
 


### PR DESCRIPTION
## Scope

This is a breaking change in the [command.js@v13.0.0](https://github.com/tj/commander.js/releases/tag/v13.0.0-0) release, causing the startup of Directus to fail if launched with `pm2`.

What's changed:

- Added `allowAccessArguments` to the cli `Command` creation to restore the previous behavior

## Potential Risks / Drawbacks

- This re-enables the 

## Tested Scenarios

- Launching a build with `pm2-runtime start ../ecosystem.config.cjs` from `~/directus`

## Review Notes / Questions

- console logging the `process.argv` on startup shows that this are the arguments it is called with:

```
  '/Users/.../.nvm/versions/node/v22.13.1/bin/node',
  '/Users/.../Library/pnpm/global/5/.pnpm/pm2@5.4.3/node_modules/pm2/lib/ProcessContainer.js',
  'start',
  '../ecosystem.config.cjs',
  'start'
```

this seems somewhat weird to have `start` in there twice, one time from `pm2-runtime start` and one from our own `start` command. Seems like a coincidence that both of our commands are called `start` and that it works at all.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25673 
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a critical bug in CLI command handling by re-enabling acceptance of excess arguments, ensuring Directus can work properly with pm2. The targeted change restores behavior in commander.js that was previously altered, preventing startup failures and ensuring stability. This update maintains expected CLI functionality while properly handling additional arguments.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>