### PR TITLE
Fix focus trap issue in TinyMCE dialogs

### DIFF
--- a/.changeset/empty-boxes-burn.md
+++ b/.changeset/empty-boxes-burn.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed focus trap issue in TinyMCE dialogs within the WYSIWYG editor

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -4,6 +4,7 @@ import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
 import { SettingsStorageAssetPreset } from '@directus/types';
 import Editor from '@tinymce/tinymce-vue';
+import { createFocusTrap, type FocusTrap } from 'focus-trap';
 import { cloneDeep, isEqual } from 'lodash';
 import { ComponentPublicInstance, computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -298,6 +299,40 @@ function setup(editor: any) {
 			}
 		}
 	});
+
+	let dialogTrap: FocusTrap | null = null;
+	editor.on('OpenWindow', activateTrap);
+	editor.on('CloseWindow', deactivateTrap);
+
+	function activateTrap() {
+		const toxDialogEl = document.querySelector('.tox-dialog');
+		if (toxDialogEl === null) return;
+
+		// TinyMCE adds tabindex="-1" to all focusable elements in the dialog
+		const notFocusableElements = toxDialogEl.querySelectorAll('[tabindex="-1"]');
+		// To apply a focus trap, we need to make these elements temporarily focusable
+		notFocusableElements.forEach(setFocusable);
+
+		deactivateTrap();
+		dialogTrap = createFocusTrap(toxDialogEl as HTMLElement);
+		dialogTrap.activate();
+
+		notFocusableElements.forEach(setNotFocusable);
+	}
+
+	function setFocusable(el: Element) {
+		el.setAttribute('tabindex', '0');
+	}
+
+	function setNotFocusable(el: Element) {
+		el.setAttribute('tabindex', '-1');
+	}
+
+	function deactivateTrap() {
+		if (dialogTrap === null) return;
+		dialogTrap.deactivate();
+		dialogTrap = null;
+	}
 }
 
 function setFocus(val: boolean) {


### PR DESCRIPTION
## Scope

What's changed:

- Fixed focus trap issue in TinyMCE dialogs within the WYSIWYG editor

## Potential Risks / Drawbacks

—

## Tested Scenarios

- drawer, nested drawer

## Review Notes / Questions

—

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25674
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR implements a focus trap system in TinyMCE dialogs to improve accessibility and keyboard navigation. It integrates the focus-trap library, adds event listeners for dialog state changes, and dynamically manages tabindex properties to control focus behavior within the editor interface.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>