### PR TITLE
RTL: Fix context menu positioning

### DIFF
--- a/.changeset/real-kings-learn.md
+++ b/.changeset/real-kings-learn.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Add RTL support for popper context menu

--- a/.changeset/real-kings-learn.md
+++ b/.changeset/real-kings-learn.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Add RTL support for popper context menu
+Added RTL support for popper context menu

--- a/app/src/components/v-form/form-field.test.ts
+++ b/app/src/components/v-form/form-field.test.ts
@@ -3,7 +3,8 @@ import FormField from '@/components/v-form/form-field.vue';
 import { i18n } from '@/lang';
 import { Width } from '@directus/system-data';
 import { mount } from '@vue/test-utils';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
 
 const baseField = {
 	field: 'test',
@@ -25,7 +26,12 @@ const baseField = {
 
 const global = {
 	components: { VMenu },
-	plugins: [i18n],
+	plugins: [
+		i18n,
+		createTestingPinia({
+			createSpy: vi.fn,
+		}),
+	],
 };
 
 describe('FormField', () => {

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -3,7 +3,6 @@ import { useClipboard } from '@/composables/use-clipboard';
 import { formatFieldFunction } from '@/utils/format-field-function';
 import { ValidationError } from '@directus/types';
 import { parseJSON } from '@directus/utils';
-import { useUserStore } from '@/stores/user';
 import { isEqual } from 'lodash';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -44,10 +43,6 @@ const props = withDefaults(
 const emit = defineEmits(['toggle-batch', 'toggle-raw', 'unset', 'update:modelValue', 'setFieldValue']);
 
 const { t } = useI18n();
-
-const userStore = useUserStore();
-
-const isRTL = computed(() => userStore.textDirection === 'rtl');
 
 const isDisabled = computed(() => {
 	if (props.disabled) return true;
@@ -172,7 +167,7 @@ function useComputedValues() {
 		class="field"
 		:class="[field.meta?.width || 'full', { invalid: validationError }]"
 	>
-		<v-menu v-if="!isLabelHidden" :placement="isRTL ? 'bottom-end' : 'bottom-start'" show-arrow arrow-placement="start">
+		<v-menu v-if="!isLabelHidden" placement="bottom-start" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -3,6 +3,7 @@ import { useClipboard } from '@/composables/use-clipboard';
 import { formatFieldFunction } from '@/utils/format-field-function';
 import { ValidationError } from '@directus/types';
 import { parseJSON } from '@directus/utils';
+import { useUserStore } from '@/stores/user';
 import { isEqual } from 'lodash';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -43,6 +44,10 @@ const props = withDefaults(
 const emit = defineEmits(['toggle-batch', 'toggle-raw', 'unset', 'update:modelValue', 'setFieldValue']);
 
 const { t } = useI18n();
+
+const userStore = useUserStore();
+
+const isRTL = computed(() => userStore.textDirection === 'rtl');
 
 const isDisabled = computed(() => {
 	if (props.disabled) return true;
@@ -167,7 +172,7 @@ function useComputedValues() {
 		class="field"
 		:class="[field.meta?.width || 'full', { invalid: validationError }]"
 	>
-		<v-menu v-if="!isLabelHidden" placement="bottom-start" show-arrow arrow-placement="start">
+		<v-menu v-if="!isLabelHidden" :placement="isRTL ? 'bottom-end' : 'bottom-start'" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"

--- a/app/src/components/v-menu.test.ts
+++ b/app/src/components/v-menu.test.ts
@@ -141,3 +141,117 @@ test('should have pointerenter and pointerleave event listener when trigger is "
 
 	expect(wrapper.props('modelValue')).toBe(false);
 });
+
+test('should place menu at bottom-start when menu is attached and using ltr', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: true,
+		},
+		slots: {
+			default: button,
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuContent = wrapper.findComponent(TransitionBounce).find('.v-menu-popper');
+
+	expect(menuContent.attributes('data-placement')).toBe('bottom-start');
+});
+
+test('should place menu at "bottom-start" when menu is not attached and placement is "bottom-start" and using ltr', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: false,
+			placement: 'bottom-start',
+		},
+		slots: {
+			default: button,
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuContent = wrapper.findComponent(TransitionBounce).find('.v-menu-popper');
+
+	expect(menuContent.attributes('data-placement')).toBe('bottom-start');
+});
+
+test('should place menu at "bottom-end" when menu is attached and using rtl', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: true,
+		},
+		slots: {
+			default: button,
+		},
+		global: {
+			...mountOptions.global,
+			plugins: [
+				createTestingPinia({
+					createSpy: vi.fn,
+					stubActions: false,
+					initialState: {
+						userStore: {
+							currentUser: { text_direction: 'rtl' },
+						},
+					},
+				}),
+			],
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuContent = wrapper.findComponent(TransitionBounce).find('.v-menu-popper');
+
+	expect(menuContent.attributes('data-placement')).toBe('bottom-end');
+});
+
+test('should place menu at "bottom-end" when menu is not attached and placement is "bottom-start" and using rtl', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: false,
+			placement: 'bottom-start',
+		},
+		slots: {
+			default: button,
+		},
+		global: {
+			...mountOptions.global,
+			plugins: [
+				createTestingPinia({
+					createSpy: vi.fn,
+					stubActions: false,
+					initialState: {
+						userStore: {
+							currentUser: { text_direction: 'rtl' },
+						},
+					},
+				}),
+			],
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuContent = wrapper.findComponent(TransitionBounce).find('.v-menu-popper');
+
+	expect(menuContent.attributes('data-placement')).toBe('bottom-end');
+});

--- a/app/src/components/v-menu.test.ts
+++ b/app/src/components/v-menu.test.ts
@@ -255,3 +255,134 @@ test('should place menu at "bottom-end" when menu is not attached and placement 
 
 	expect(menuContent.attributes('data-placement')).toBe('bottom-end');
 });
+
+test('should place menu arrow at left when using placement "top-start" and using ltr', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: false,
+			placement: 'top-start',
+			showArrow: true,
+			arrowPlacement: 'start',
+		},
+		slots: {
+			default: button,
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuArrow = wrapper.findComponent(TransitionBounce).find('.arrow');
+
+	expect(menuArrow.attributes('style')).toContain('left: 0px');
+	expect(menuArrow.attributes('style')).toContain('transform: translate3d(6px, 0px, 0)');
+});
+
+test('should place menu arrow at left when using placement "bottom-start" and using ltr', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: false,
+			placement: 'bottom-start',
+			showArrow: true,
+			arrowPlacement: 'start',
+		},
+		slots: {
+			default: button,
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuArrow = wrapper.findComponent(TransitionBounce).find('.arrow');
+
+	expect(menuArrow.attributes('style')).toContain('left: 0px');
+	expect(menuArrow.attributes('style')).toContain('transform: translate3d(6px, 0px, 0)');
+});
+
+test('should place menu arrow right when using placement "top-start" and using rtl', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: false,
+			placement: 'top-start',
+			showArrow: true,
+			arrowPlacement: 'start',
+			arrowPadding: 6,
+		},
+		slots: {
+			default: button,
+		},
+		global: {
+			...mountOptions.global,
+			plugins: [
+				createTestingPinia({
+					createSpy: vi.fn,
+					stubActions: false,
+					initialState: {
+						userStore: {
+							currentUser: { text_direction: 'rtl' },
+						},
+					},
+				}),
+			],
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuArrow = wrapper.findComponent(TransitionBounce).find('.arrow');
+
+	expect(menuArrow.attributes('style')).toContain('left: unset');
+	expect(menuArrow.attributes('style')).toContain('right: 0px');
+	expect(menuArrow.attributes('style')).toContain('transform: translate3d(-6px, 0px, 0)');
+});
+
+test('should place menu arrow right when using placement "bottom-start" and using rtl', async () => {
+	const button = { template: '<button type="button">Content</button>' };
+
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+			attached: false,
+			placement: 'bottom-start',
+			showArrow: true,
+			arrowPlacement: 'start',
+		},
+		slots: {
+			default: button,
+		},
+		global: {
+			...mountOptions.global,
+			plugins: [
+				createTestingPinia({
+					createSpy: vi.fn,
+					stubActions: false,
+					initialState: {
+						userStore: {
+							currentUser: { text_direction: 'rtl' },
+						},
+					},
+				}),
+			],
+		},
+	});
+
+	await wrapper.find('.v-menu').trigger('click');
+
+	const menuArrow = wrapper.findComponent(TransitionBounce).find('.arrow');
+
+	expect(menuArrow.attributes('style')).toContain('left: unset');
+	expect(menuArrow.attributes('style')).toContain('right: 0px');
+	expect(menuArrow.attributes('style')).toContain('transform: translate3d(-6px, 0px, 0)');
+});

--- a/app/src/components/v-menu.test.ts
+++ b/app/src/components/v-menu.test.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { beforeEach, expect, test, vi } from 'vitest';
 import TransitionBounce from './transition/bounce.vue';
 import VMenu from './v-menu.vue';
+import { createTestingPinia } from '@pinia/testing';
 
 vi.mock('lodash', async () => {
 	const mod = await vi.importActual<{ default: typeof import('lodash') }>('lodash');
@@ -31,6 +32,11 @@ const mountOptions = {
 		components: {
 			TransitionBounce,
 		},
+		plugins: [
+			createTestingPinia({
+				createSpy: vi.fn,
+			}),
+		],
 	},
 	slots: {
 		default: Content,

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -412,6 +412,7 @@ function usePopper(
 								case 'bottom-start':
 									x = props.arrowPadding;
 									break;
+								case 'top-end':
 								case 'bottom-end':
 									x = props.arrowPadding * -1;
 									break;

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -286,19 +286,23 @@ function usePopper(
 		stop();
 	});
 
-	function checkPlacement() {
-		if (isRTL.value && options.value.placement.includes('start')) {
-			return options.value.placement.replace(/start/g, 'end');
+	function getPlacement() {
+		if (isRTL.value) {
+			if (options.value.attached) {
+				return 'bottom-end';
+			} else if (options.value.placement.includes('start') || options.value.placement.includes('end')) {
+				return options.value.placement.replace(/start|end/g, (match) => (match === 'start' ? 'end' : 'start'));
+			}
 		}
 
-		return options.value.placement;
+		return options.value.attached ? 'bottom-start' : options.value.placement;
 	}
 
 	watch(
 		options,
 		() => {
 			popperInstance.value?.setOptions({
-				placement: options.value.attached ? 'bottom-start' : (checkPlacement() as Placement),
+				placement: getPlacement() as Placement,
 				modifiers: getModifiers(),
 			});
 		},
@@ -314,7 +318,7 @@ function usePopper(
 	function start() {
 		return new Promise((resolve) => {
 			popperInstance.value = createPopper(reference.value!, popper.value!, {
-				placement: options.value.attached ? 'bottom-start' : (checkPlacement() as Placement),
+				placement: getPlacement() as Placement,
 				modifiers: getModifiers(resolve),
 				strategy: 'fixed',
 			});

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useShortcut } from '@/composables/use-shortcut';
+import { useUserStore } from '@/stores/user';
 import { Instance, Modifier, Placement, detectOverflow } from '@popperjs/core';
 import arrow from '@popperjs/core/lib/modifiers/arrow';
 import computeStyles from '@popperjs/core/lib/modifiers/computeStyles';
@@ -64,6 +65,10 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits(['update:modelValue']);
+
+const userStore = useUserStore();
+
+const isRTL = computed(() => userStore.textDirection === 'rtl');
 
 const activator = ref<HTMLElement | null>(null);
 const reference = ref<HTMLElement | null>(null);
@@ -395,6 +400,9 @@ function usePopper(
 								case 'bottom-start':
 									x = props.arrowPadding;
 									break;
+								case 'bottom-end':
+									x = props.arrowPadding * -1;
+									break;
 								case 'left-start':
 								case 'right-start':
 									y = props.arrowPadding;
@@ -402,6 +410,11 @@ function usePopper(
 							}
 
 							state.styles.arrow.transform = `translate3d(${x}px, ${y}px, 0)`;
+
+							if (isRTL.value) {
+								state.styles.arrow.right = state.styles.arrow.left;
+								state.styles.arrow.left = `unset`;
+							}
 						}
 
 						arrowStyles.value = state.styles.arrow;

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -286,11 +286,19 @@ function usePopper(
 		stop();
 	});
 
+	function checkPlacement() {
+		if (isRTL.value && options.value.placement.includes('start')) {
+			return options.value.placement.replace(/start/g, 'end');
+		}
+
+		return options.value.placement;
+	}
+
 	watch(
 		options,
 		() => {
 			popperInstance.value?.setOptions({
-				placement: options.value.attached ? 'bottom-start' : options.value.placement,
+				placement: options.value.attached ? 'bottom-start' : (checkPlacement() as Placement),
 				modifiers: getModifiers(),
 			});
 		},
@@ -306,7 +314,7 @@ function usePopper(
 	function start() {
 		return new Promise((resolve) => {
 			popperInstance.value = createPopper(reference.value!, popper.value!, {
-				placement: options.value.attached ? 'bottom-start' : options.value.placement,
+				placement: options.value.attached ? 'bottom-start' : (checkPlacement() as Placement),
 				modifiers: getModifiers(resolve),
 				strategy: 'fixed',
 			});


### PR DESCRIPTION
## Scope

What's changed:

- Context menu is now right aligned for RTL

<img width="438" height="412" alt="Screenshot 2025-08-14 at 4 22 36 PM" src="https://github.com/user-attachments/assets/3b55bdba-754c-4132-8d46-5e49f5067030" />

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- Tested both LTR and RTL
- Tested on small screen

## Review Notes / Questions

- There is a bit of a mix of logic going on here. on `form-field` I used the isRTL computed to place the `v-menu` at `bottom-end` instead of `bottom-start` so it's right aligned, is this confusing given that it should technically be `bottom-start` in relation to RTL world? 🙃If so then the style change will need to be made in `v-menu` rather than `form-field`
- The modifiers for popperjs are hella confusing, is there a better way to handle the styles than the override I went with? 

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25649 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes context menu positioning issues in RTL layouts by refactoring form-field and v-menu components with RTL support. A new checkPlacement function was implemented for correct menu placement, and conditional logic ensures consistent UI experience across LTR and RTL interfaces. Test files were updated with createTestingPinia for improved RTL testing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>