### PR TITLE
Creating New Collection Improvements

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -625,6 +625,10 @@ created_by: Created By
 created_on: Created On
 creating_collection_info: Name the collection and setup its unique “key” field...
 creating_collection_system: Enable and rename any of these optional fields.
+creating_collection_field_names_saved: Using your saved field names from previous collections.
+creating_collection_field_names_will_save: Your custom field names will be saved automatically when you create this collection.
+creating_collection_duplicate_fields: 'Duplicate field names detected: {names}. Please ensure all enabled fields have unique names.'
+creating_collection_field_names_reset: 'Field names reset to default values.'
 auto_increment_integer: Auto-incremented integer
 auto_increment_big_integer: Auto-incremented big integer
 generated_uuid: Generated UUID
@@ -723,12 +727,14 @@ charset: Charset
 second: second
 file_moved: File Moved
 collection_created: Collection Created
+collection_already_exists: Collection already exists
 modified_on: Modified On
 card_size: Card Size
 sort_field: Sort Field
 add_sort_field: Add Sort Field
 sort: Sort
 status: Status
+slug: Slug
 remove: Remove
 toggle_manual_sorting: Toggle Manual Sorting
 bookmark_doesnt_exist: Bookmark Doesn't Exist

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -626,8 +626,10 @@ created_on: Created On
 creating_collection_info: Name the collection and setup its unique “key” field...
 creating_collection_system: Enable and rename any of these optional fields.
 creating_collection_field_names_saved: Using your saved field names from previous collections.
-creating_collection_field_names_will_save: Your custom field names will be saved automatically when you create this collection.
-creating_collection_duplicate_fields: 'Duplicate field names detected: {names}. Please ensure all enabled fields have unique names.'
+creating_collection_field_names_will_save:
+  Your custom field names will be saved automatically when you create this collection.
+creating_collection_duplicate_fields:
+  'Duplicate field names detected: {names}. Please ensure all enabled fields have unique names.'
 creating_collection_field_names_reset: 'Field names reset to default values.'
 auto_increment_integer: Auto-incremented integer
 auto_increment_big_integer: Auto-incremented big integer

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -734,6 +734,7 @@ function onApply() {
 
 .error {
 	color: var(--theme--danger);
+
 	--v-input-border-color: var(--theme--danger);
 	--v-input-border-color-hover: var(--theme--danger);
 	--v-input-border-color-focus: var(--theme--danger);

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -712,7 +712,7 @@ function onApply() {
 	align-items: center;
 	justify-content: space-between;
 	gap: 16px;
-	width: 100%;
+	inline-size: 100%;
 }
 
 .v-notice {

--- a/app/src/modules/settings/routes/data-model/utils/default-system-fields.ts
+++ b/app/src/modules/settings/routes/data-model/utils/default-system-fields.ts
@@ -1,0 +1,58 @@
+export const defaultSystemFields = {
+	title: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'title',
+		label: 'title',
+		icon: 'title',
+	},
+	slug: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'slug',
+		label: 'slug',
+		icon: 'link',
+	},
+	status: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'status',
+		label: 'status',
+		icon: 'flag',
+	},
+	sort: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'sort',
+		label: 'sort',
+		icon: 'low_priority',
+	},
+	dateCreated: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'date_created',
+		label: 'created_on',
+		icon: 'access_time',
+	},
+	userCreated: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'user_created',
+		label: 'created_by',
+		icon: 'account_circle',
+	},
+	dateUpdated: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'date_updated',
+		label: 'updated_on',
+		icon: 'access_time',
+	},
+	userUpdated: {
+		enabled: false,
+		inputDisabled: false,
+		name: 'user_updated',
+		label: 'updated_by',
+		icon: 'account_circle',
+	},
+};


### PR DESCRIPTION
## Scope
This PR addresses some of the annoying little UX issues when creating new collections and the optional system fields.

<div>
    <a href="https://www.loom.com/share/94789daeb49a4025a89e178712681d43">
      <p>New Collection Improvements - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/94789daeb49a4025a89e178712681d43">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/94789daeb49a4025a89e178712681d43-14f67677f5a112e2-full-play.gif">
    </a>
  </div>


**What's changed:**

- Two new optional fields `title` and `slug`
- Select all checkbox to cut 6 or 8 clicks down to just 1
- If you change default names, they are saved automatically and loaded by default
  <img width="1940" height="1940" alt="ScreenShot 2025-08-15 at 11 22 29@2x" src="https://github.com/user-attachments/assets/17680b4d-3d73-4bd6-b0b6-649e71e7f0e5" />
- Option to reset field names to default values
- Collision detection in case user spaces out and enters two with the same names
  <img width="1724" height="1874" alt="ScreenShot 2025-08-15 at 11 21 52@2x" src="https://github.com/user-attachments/assets/70eb3a35-7aa8-4233-8c35-c6d3e748c3dc" />


- Validation for the collection name on the first tab (previous behavior waited on API to error out when creating collection with same name
  <img width="1888" height="1356" alt="ScreenShot 2025-08-15 at 11 22 16@2x" src="https://github.com/user-attachments/assets/107250ed-07a5-4883-b064-9c39cfffdbbd" />


## Potential Risks / Drawbacks
- Uses localStorage to store the values so doesn't apply instance wide - just on a users local browser
- Not a major change - we could go further in the future and store these in the settings and even allow folks to define their own optional fields to use when creating collections.
-`title` and `slug` are more CMS focused fields. Little more opinionated than that others.

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

? 

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  > Probably not required but not 100%.

---

Fixes #\<num\> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the collection creation workflow with improved translations, form validations, auto-saving features, and UI improvements. It fixes styling issues, standardizes translation formatting, resolves indent errors in Vue components, and updates English translations for consistent key formatting, resulting in better usability and more uniform error messages.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
-->
</div>