### PR TITLE
modified the entry condition for password policy check in update user scenario. Skip only in case of "password" missing in payload.

### DIFF
--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -271,7 +271,7 @@ export class UsersService extends ItemsService {
 				await this.checkUniqueEmails([data['email']], keys[0]);
 			}
 
-			if (data['password']!== undefined) {
+			if (data['password'] !== undefined) {
 				await this.checkPasswordPolicy([data['password']]);
 			}
 

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -271,7 +271,7 @@ export class UsersService extends ItemsService {
 				await this.checkUniqueEmails([data['email']], keys[0]);
 			}
 
-			if (data['password']) {
+			if (data['password']!== undefined) {
 				await this.checkPasswordPolicy([data['password']]);
 			}
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -222,3 +222,4 @@
 - 8byr0
 - jekuer
 - timio23
+- aniruddhav2510

--- a/contributors.yml
+++ b/contributors.yml
@@ -222,4 +222,4 @@
 - 8byr0
 - jekuer
 - timio23
-- aniruddhav2510
+- aniruddhav25


### PR DESCRIPTION
Scope:
fix(security): missing password validation in Profile leading to invalid password after logout (closes #25701)

What's changed:
- Modified password policy check in user update to only skip validation when "password" field is completely missing from payload
- Empty password strings now trigger validation when password policy is active
- Null passwords now only accepted when authorization policy is explicitly set to "None"

Potential Risks / Drawbacks:
- Existing users with blank passwords might encounter validation errors if policy is enabled
- Requires careful handling of null/empty string distinction in client implementations

Tested Scenarios:
- Verified blank password acceptance when policy is set to "None"
- Confirmed rejection of empty passwords when Weak/Strong policies are active
- Tested password update flow with both null and empty string values
- Validated behavior after logout/login cycle

Checklist:
- [ ] Added or updated tests
- [ ] Documentation PR created (not required for bugfix)

Fixes #25701 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a bug in user update validation by modifying password policy check conditions. It ensures validation is only skipped when the password field is completely absent, not when empty. The update distinguishes between empty and null passwords to properly enforce security policies.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>