### PR TITLE
add props package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN npm install --global \
 	pm2@5 \
 	corepack@latest # Remove again once corepack >= 0.31 made it into base image
 
+
+RUN apk add --no-cache procps
+
 USER node
 
 WORKDIR /directus


### PR DESCRIPTION
I added the procps package to the Dockerfile because the pm2 package requires the ps command, to skip the warnings shown in the screenshot.


<img width="1920" height="741" alt="Screenshot from 2025-08-18 17-51-59" src="https://github.com/user-attachments/assets/35ad2690-a236-4a83-be21-5c010860d604" />
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR adds the procps package to the Dockerfile to resolve dependency warnings from pm2. The change ensures the ps command is available, improving system compatibility and enabling warning-free application startup.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>