### PR TITLE
Improve appearance of v-notice components (in the MCP settings)

### DIFF
--- a/app/src/components/__snapshots__/v-notice.test.ts.snap
+++ b/app/src/components/__snapshots__/v-notice.test.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`Mount component 1`] = `
 "<div data-v-f0538e61="" class="v-notice info">
-  <v-icon-stub data-v-f0538e61="" name="info" left=""></v-icon-stub>
+  <div data-v-f0538e61="" class="v-notice-title">
+    <v-icon-stub data-v-f0538e61="" name="info" left=""></v-icon-stub>
+  </div>
+  <!--v-if-->
 </div>"
 `;

--- a/app/src/components/v-notice.vue
+++ b/app/src/components/v-notice.vue
@@ -10,6 +10,8 @@ interface Props {
 	center?: boolean;
 	/** Allow text wrapping within notice */
 	multiline?: boolean;
+	/** Align the default slot’s content with the title slot’s content */
+	indentContent?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -44,7 +46,9 @@ const iconName = computed(() => {
 			<v-icon v-if="icon !== false" :name="iconName" left></v-icon>
 			<slot name="title"></slot>
 		</div>
-		<slot></slot>
+		<div v-if="$slots.default" class="v-notice-content" :class="{ indent: indentContent && icon !== false }">
+			<slot></slot>
+		</div>
 	</div>
 </template>
 
@@ -60,6 +64,9 @@ const iconName = computed(() => {
 */
 
 .v-notice {
+	--icon-padding-inline-end: 16px;
+	--icon-size-default: 24px;
+
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -97,7 +104,11 @@ const iconName = computed(() => {
 }
 
 .v-icon.left {
-	margin-inline-end: 16px;
+	margin-inline-end: var(--icon-padding-inline-end);
+}
+
+.v-notice-content.indent {
+	padding-inline-start: calc(var(--icon-padding-inline-end) + var(--v-icon-size, var(--icon-size-default)));
 }
 
 .success {

--- a/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-validation-existing.vue
+++ b/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-validation-existing.vue
@@ -20,14 +20,14 @@ const generateCollectionDialogActive = ref(false);
 </script>
 
 <template>
-	<v-notice v-if="validationIssues.collectionNotFound" multiline type="danger">
+	<v-notice v-if="validationIssues.collectionNotFound" multiline indent-content type="danger">
 		<template #title>
 			{{ t('mcp_prompts_collection.collection_not_found') }}
 		</template>
 
 		<div class="notice-content">
 			<p>{{ t('mcp_prompts_collection.collection_not_found_description', { collection: promptsCollection }) }}</p>
-			<v-button class="generate-button" small @click="generateCollectionDialogActive = true">
+			<v-button small outlined danger @click="generateCollectionDialogActive = true">
 				{{ t('mcp_prompts_collection.generate') }}
 			</v-button>
 
@@ -38,7 +38,7 @@ const generateCollectionDialogActive = ref(false);
 		</div>
 	</v-notice>
 
-	<v-notice v-else-if="validationIssues.invalidFields.length > 0" multiline type="danger">
+	<v-notice v-else-if="validationIssues.invalidFields.length > 0" multiline indent-content type="danger">
 		<template #title>
 			{{ t('mcp_prompts_collection.validation_error_invalid') }}
 		</template>
@@ -51,7 +51,7 @@ const generateCollectionDialogActive = ref(false);
 		</div>
 	</v-notice>
 
-	<v-notice v-else-if="validationIssues.missingFields.length > 0" multiline type="danger">
+	<v-notice v-else-if="validationIssues.missingFields.length > 0" multiline indent-content type="danger">
 		<template #title>
 			{{ t('mcp_prompts_collection.validation_error_missing') }}
 		</template>
@@ -61,7 +61,7 @@ const generateCollectionDialogActive = ref(false);
 			<ul>
 				<li v-for="{ field } of validationIssues.missingFields" :key="field" class="mono">{{ field }}</li>
 			</ul>
-			<v-button class="generate-button" small @click="generateCollectionDialogActive = true">
+			<v-button small outlined danger @click="generateCollectionDialogActive = true">
 				{{ t('mcp_prompts_collection.generate_missing') }}
 			</v-button>
 
@@ -74,27 +74,21 @@ const generateCollectionDialogActive = ref(false);
 	</v-notice>
 
 	<v-notice v-else>
-		{{ t('mcp_prompts_collection.validation_success') }}
+		<template #title>
+			{{ t('mcp_prompts_collection.validation_success') }}
+		</template>
 	</v-notice>
 </template>
 
 <style scoped>
 .notice-content {
-	> * {
-		margin-block-start: 10px;
-	}
+	padding-block: 10px 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .mono {
 	font-family: var(--theme--fonts--monospace--font-family);
-}
-
-.generate-button {
-	--v-button-color: var(--theme--foreground);
-	--v-button-color-hover: var(--theme--foreground);
-	--v-button-color-active: var(--theme--foreground);
-	--v-button-background-color: var(--theme--background-accent);
-	--v-button-background-color-hover: var(--theme--background-accent);
-	--v-button-background-color-active: var(--theme--background-accent);
 }
 </style>

--- a/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-validation-new.vue
+++ b/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-validation-new.vue
@@ -13,13 +13,13 @@ defineEmits<{
 </script>
 
 <template>
-	<v-notice multiline>
+	<v-notice multiline indent-content>
 		<template #title>{{ t('mcp_prompts_collection.no_collection_selected') }}</template>
 
 		<div class="notice-content">
 			<p>{{ t('mcp_prompts_collection.no_collection_selected_copy') }}</p>
 
-			<v-button class="generate-button" small @click="generateCollectionDialogActive = true">
+			<v-button small outlined @click="generateCollectionDialogActive = true">
 				{{ t('mcp_prompts_collection.generate') }}
 			</v-button>
 
@@ -33,17 +33,9 @@ defineEmits<{
 
 <style scoped>
 .notice-content {
-	> * {
-		margin-block-start: 10px;
-	}
-}
-
-.generate-button {
-	--v-button-color: var(--theme--foreground);
-	--v-button-color-hover: var(--theme--foreground);
-	--v-button-color-active: var(--theme--foreground);
-	--v-button-background-color: var(--theme--background-accent);
-	--v-button-background-color-hover: var(--theme--background-accent);
-	--v-button-background-color-active: var(--theme--background-accent);
+	padding-block: 10px 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 </style>


### PR DESCRIPTION
## Scope

What's changed:

- add indentContent prop to v-notice for improved alignment of slot content
- change appearance of the button inside the v-notice: use the outlined variant and apply the same type as for the notice (danger, …)

## Potential Risks / Drawbacks

- There is a chance that this affects the appearance of other v-notice instances that use the default slot, because a div will wrap the slot now.

## Tested Scenarios

- Tested in MCP settings and on a view other places

## Review Notes / Questions

- Test every occurrence of v-notice in the MCP branch
- Test other instances of v-notice
- Note: At the time of writing, tests fail on the mcp branch, that’s why they also fail here!

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required


