### PR TITLE
Only post codecov comments if changes are required

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,3 +10,4 @@ flag_management:
 
 comment:
   layout: 'header, diff, flags'
+  require_changes: true


### PR DESCRIPTION
Tiny tweak to avoid needless comments if no changes are required. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR introduces a minor configuration update to the codecov.yaml file, adding the 'require_changes' flag to optimize notification behavior. The change ensures that codecov comments are posted only when there are actual changes, preventing unnecessary notifications. The modification is focused solely on improving the comment logic to reduce notification noise.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>