### PR TITLE
Add underline and pointer cursor styling for WYSIWYG links

### DIFF
--- a/.changeset/common-trees-film.md
+++ b/.changeset/common-trees-film.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': major
+'@directus/app': minor
 ---
 
 Fixed links in WYSIWYG missing underline and pointer cursor styling

--- a/.changeset/common-trees-film.md
+++ b/.changeset/common-trees-film.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': major
+---
+
+Fixed links in WYSIWYG missing underline and pointer cursor styling

--- a/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
+++ b/app/src/interfaces/input-rich-text-html/get-editor-styles.ts
@@ -85,7 +85,8 @@ p {
 }
 a {
 	color: ${cssVar('--theme--primary-accent')};
-	text-decoration: none;
+	text-decoration: underline;
+	cursor: pointer;
 }
 ul, ol {
 	font-family: ${userFontFamily}, serif;


### PR DESCRIPTION
## Scope

What's changed:

- Added CSS styling to ensure links in WYSIWYG fields display with underlined text and pointer cursor

## Tested Scenarios

- Verified links in WYSIWYG fields now displayed with underlined.
- Confirmed pointer cursor appears on hover.

## Potential Risks / Drawbacks

N/A

## Review Notes / Questions

N/A

## Checklist

N/A

---

Fixes [#25733](https://github.com/directus/directus/issues/25733)
