### PR TITLE
Fix WYSIWYG Code Button State

### DIFF
--- a/.changeset/mighty-yaks-spend.md
+++ b/.changeset/mighty-yaks-spend.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Fixed code button state not updating when exiting code mode in WYSIWYG.

--- a/.changeset/mighty-yaks-spend.md
+++ b/.changeset/mighty-yaks-spend.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': minor
+'@directus/app': patch
 ---
 
-Fixed code button state not updating when exiting code mode in WYSIWYG.
+Fixed code button state not updating when exiting code mode in WYSIWYG

--- a/app/src/interfaces/input-rich-text-html/useInlineCode.ts
+++ b/app/src/interfaces/input-rich-text-html/useInlineCode.ts
@@ -47,6 +47,7 @@ export default function useInlineCode(editor: Ref<any>): UsableInlineCode {
 					event.preventDefault();
 
 					editor.value.execCommand('removeformat');
+					updateActiveState();
 				}
 			};
 


### PR DESCRIPTION
## Scope

What's changed:

Resolves a UI state issue in the WYSIWYG editor: previously, the code formatting button remained visually active even after the user exited the code block. With this update, the code button state now reflects the actual editing context. 
The attached video showcases the correct state transitions.

![2](https://github.com/user-attachments/assets/0ea8c842-af7a-461c-9854-399071281fb6)

## Potential Risks / Drawbacks

N/A

## Tested Scenarios

- Pressed Enter at the end of a code block to create a new line.
- Moved the cursor outside the code block using both mouse clicks and keyboard arrow keys.
- Clicked the code button again while inside and outside the code block; verified that toggling works consistently and the button reflects the correct state after exiting.

## Review Notes / Questions
N/A 

## Checklist

N/A
---

Fixes [#25740](https://github.com/directus/directus/issues/25740)
