### PR TITLE
Fix `permissionsCacheable` erroring on null operator value

### DIFF
--- a/.changeset/tangy-beans-check.md
+++ b/.changeset/tangy-beans-check.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed a bug where filter == null would error when checking to see if a permission is cachable

--- a/.changeset/tangy-beans-check.md
+++ b/.changeset/tangy-beans-check.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed a bug where filter == null would error when checking to see if a permission is cachable
+Fixed `permissionsCacheable` erroring on null operator value

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -11,7 +11,7 @@ import { getCacheKey } from '../utils/get-cache-key.js';
 import { getDateFormatted } from '../utils/get-date-formatted.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
 import { stringByteSize } from '../utils/get-string-byte-size.js';
-import { permissionsCachable } from '../utils/permissions-cachable.js';
+import { permissionsCachable } from '../utils/permissions-cacheable.js';
 
 export const respond: RequestHandler = asyncHandler(async (req, res) => {
 	const env = useEnv();

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -11,7 +11,7 @@ import { getCacheKey } from '../utils/get-cache-key.js';
 import { getDateFormatted } from '../utils/get-date-formatted.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
 import { stringByteSize } from '../utils/get-string-byte-size.js';
-import { permissionsCachable } from '../utils/permissions-cacheable.js';
+import { permissionsCacheable } from '../utils/permissions-cacheable.js';
 
 export const respond: RequestHandler = asyncHandler(async (req, res) => {
 	const env = useEnv();
@@ -35,7 +35,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		!req.sanitizedQuery.export &&
 		res.locals['cache'] !== false &&
 		exceedsMaxSize === false &&
-		(await permissionsCachable(
+		(await permissionsCacheable(
 			req.collection,
 			{
 				knex: getDatabase(),

--- a/api/src/utils/permissions-cachable.test.ts
+++ b/api/src/utils/permissions-cachable.test.ts
@@ -43,7 +43,7 @@ test('filter has $NOW', () => {
 	expect(filterHasNow(filter)).toBe(true);
 });
 
-test('filter does not have $NOW', () => {
+test('filter does not have $NOW or is null', () => {
 	let filter: Filter = {
 		created_on: {
 			_gt: '2021-01-01',
@@ -74,6 +74,14 @@ test('filter does not have $NOW', () => {
 				},
 			},
 		],
+	};
+
+	expect(filterHasNow(filter)).toBe(false);
+
+	filter = {
+		created_on: {
+			_eq: null,
+		},
 	};
 
 	expect(filterHasNow(filter)).toBe(false);
@@ -143,36 +151,6 @@ test('permissions are cacheable on many policies without $NOW', async () => {
 				created_on: {
 					_gt: '2021-01-01',
 				},
-			},
-			policy: 'policy1',
-			presets: [],
-			validation: null,
-		},
-	];
-
-	vi.mocked(fetchPermissions).mockResolvedValue(permissions);
-
-	const result = await permissionsCachable('items', {} as any, {} as any);
-
-	expect(result).toBe(true);
-});
-
-test('permissions are not cacheable when a filter is null', async () => {
-	vi.mocked(fetchPolicies).mockResolvedValue(['policy1', 'policy2', 'policy3']);
-
-	const permissions: Permission[] = [
-		{
-			action: 'read',
-			collection: 'items',
-			fields: ['*'],
-			permissions: {
-				_and: [
-					{
-						my_value: {
-							_eq: null,
-						},
-					},
-				],
 			},
 			policy: 'policy1',
 			presets: [],

--- a/api/src/utils/permissions-cachable.test.ts
+++ b/api/src/utils/permissions-cachable.test.ts
@@ -156,3 +156,33 @@ test('permissions are cacheable on many policies without $NOW', async () => {
 
 	expect(result).toBe(true);
 });
+
+test('permissions are not cacheable when a filter is null', async () => {
+	vi.mocked(fetchPolicies).mockResolvedValue(['policy1', 'policy2', 'policy3']);
+
+	const permissions: Permission[] = [
+		{
+			action: 'read',
+			collection: 'items',
+			fields: ['*'],
+			permissions: {
+				_and: [
+					{
+						my_value: {
+							_eq: null,
+						},
+					},
+				],
+			},
+			policy: 'policy1',
+			presets: [],
+			validation: null,
+		},
+	];
+
+	vi.mocked(fetchPermissions).mockResolvedValue(permissions);
+
+	const result = await permissionsCachable('items', {} as any, {} as any);
+
+	expect(result).toBe(true);
+});

--- a/api/src/utils/permissions-cachable.test.ts
+++ b/api/src/utils/permissions-cachable.test.ts
@@ -2,7 +2,7 @@ import type { Filter, Permission } from '@directus/types';
 import { expect, test, vi } from 'vitest';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../permissions/lib/fetch-policies.js';
-import { filter_has_now, permissionsCachable } from './permissions-cachable.js';
+import { filterHasNow, permissionsCachable } from './permissions-cachable.js';
 
 vi.mock('../permissions/lib/fetch-permissions.js');
 vi.mock('../permissions/lib/fetch-policies.js');
@@ -14,7 +14,7 @@ test('filter has $NOW', () => {
 		},
 	};
 
-	expect(filter_has_now(filter)).toBe(true);
+	expect(filterHasNow(filter)).toBe(true);
 
 	filter = {
 		_and: [
@@ -26,7 +26,7 @@ test('filter has $NOW', () => {
 		],
 	};
 
-	expect(filter_has_now(filter)).toBe(true);
+	expect(filterHasNow(filter)).toBe(true);
 
 	filter = {
 		_or: [
@@ -40,7 +40,7 @@ test('filter has $NOW', () => {
 		],
 	};
 
-	expect(filter_has_now(filter)).toBe(true);
+	expect(filterHasNow(filter)).toBe(true);
 });
 
 test('filter does not have $NOW', () => {
@@ -50,7 +50,7 @@ test('filter does not have $NOW', () => {
 		},
 	};
 
-	expect(filter_has_now(filter)).toBe(false);
+	expect(filterHasNow(filter)).toBe(false);
 
 	filter = {
 		_and: [
@@ -62,7 +62,7 @@ test('filter does not have $NOW', () => {
 		],
 	};
 
-	expect(filter_has_now(filter)).toBe(false);
+	expect(filterHasNow(filter)).toBe(false);
 
 	filter = {
 		_or: [
@@ -76,7 +76,7 @@ test('filter does not have $NOW', () => {
 		],
 	};
 
-	expect(filter_has_now(filter)).toBe(false);
+	expect(filterHasNow(filter)).toBe(false);
 });
 
 test('permissions are not cacheable on many policies with $NOW', async () => {

--- a/api/src/utils/permissions-cachable.ts
+++ b/api/src/utils/permissions-cachable.ts
@@ -40,6 +40,8 @@ export async function permissionsCachable(
 }
 
 export function filter_has_now(filter: Filter): boolean {
+	if (filter == null) return false;
+
 	return Object.entries(filter).some(([key, value]) => {
 		if (key === '_and' || key === '_or') {
 			return (value as Filter[]).some((sub_filter) => filter_has_now(sub_filter));

--- a/api/src/utils/permissions-cachable.ts
+++ b/api/src/utils/permissions-cachable.ts
@@ -33,20 +33,20 @@ export async function permissionsCachable(
 			return false;
 		}
 
-		return filter_has_now(permission.permissions);
+		return filterHasNow(permission.permissions);
 	});
 
 	return !has_now;
 }
 
-export function filter_has_now(filter: Filter): boolean {
+export function filterHasNow(filter: Filter): boolean {
 	if (filter == null) return false;
 
 	return Object.entries(filter).some(([key, value]) => {
 		if (key === '_and' || key === '_or') {
-			return (value as Filter[]).some((sub_filter) => filter_has_now(sub_filter));
+			return (value as Filter[]).some((sub_filter) => filterHasNow(sub_filter));
 		} else if (typeof value === 'object') {
-			return filter_has_now(value);
+			return filterHasNow(value);
 		} else if (typeof value === 'string') {
 			return value.startsWith('$NOW');
 		}

--- a/api/src/utils/permissions-cachable.ts
+++ b/api/src/utils/permissions-cachable.ts
@@ -40,7 +40,7 @@ export async function permissionsCachable(
 }
 
 export function filterHasNow(filter: Filter): boolean {
-	if (filter == null) return false;
+	if (filter === null) return false;
 
 	return Object.entries(filter).some(([key, value]) => {
 		if (key === '_and' || key === '_or') {

--- a/api/src/utils/permissions-cacheable.test.ts
+++ b/api/src/utils/permissions-cacheable.test.ts
@@ -2,7 +2,7 @@ import type { Permission } from '@directus/types';
 import { describe, expect, test, vi } from 'vitest';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../permissions/lib/fetch-policies.js';
-import { filterHasNow, permissionsCachable } from './permissions-cachable.js';
+import { filterHasNow, permissionsCacheable } from './permissions-cacheable.js';
 
 vi.mock('../permissions/lib/fetch-permissions.js');
 vi.mock('../permissions/lib/fetch-policies.js');
@@ -166,7 +166,7 @@ test('permissions are not cacheable on many policies with $NOW', async () => {
 
 	vi.mocked(fetchPermissions).mockResolvedValue(permissions);
 
-	const result = await permissionsCachable('items', {} as any, {} as any);
+	const result = await permissionsCacheable('items', {} as any, {} as any);
 
 	expect(result).toBe(false);
 });
@@ -205,7 +205,7 @@ test('permissions are cacheable on many policies without $NOW', async () => {
 
 	vi.mocked(fetchPermissions).mockResolvedValue(permissions);
 
-	const result = await permissionsCachable('items', {} as any, {} as any);
+	const result = await permissionsCacheable('items', {} as any, {} as any);
 
 	expect(result).toBe(true);
 });

--- a/api/src/utils/permissions-cacheable.ts
+++ b/api/src/utils/permissions-cacheable.ts
@@ -6,9 +6,9 @@ import { createDefaultAccountability } from '../permissions/utils/create-default
 
 /**
  * Check if the read permissions for a collection contain the dynamic variable $NOW.
- * If they do, the permissions are not cachable.
+ * If they do, the permissions are not cacheable.
  */
-export async function permissionsCachable(
+export async function permissionsCacheable(
 	collection: string | undefined,
 	context: Context,
 	accountability?: Accountability,


### PR DESCRIPTION
## Scope

What's changed:

- Added an early return to the permissions-cacheable `filter_has_now` function
- Renamed `filter_has_now` to `filterHasNow` to remove snake_case
- Renamed `permissionsCachable` to `permissionsCacheable`

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- Tested it with policy with `_eq: null` and it fixed the issue

## Review Notes / Questions

- CACHE_ENABLED must be true for reproduction

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25653 
