### PR TITLE
MCP -> Possible Relations Tool Fix

### DIFF
--- a/api/src/mcp/schema.ts
+++ b/api/src/mcp/schema.ts
@@ -16,11 +16,11 @@ import { z } from 'zod';
 
 // PK
 export const PrimaryKeyInputSchema = z.union([z.number(), z.string()]);
-export const PrimaryKeyValidateSchema = z.custom<PrimaryKey>();
+export const PrimaryKeyValidateSchema = z.union([z.number(), z.string()]);
 
 // item
 export const ItemInputSchema = z.record(z.string(), z.any());
-export const ItemValidateSchema = z.custom<Item>();
+export const ItemValidateSchema = z.record(z.string(), z.any());
 
 // query
 export const QueryInputSchema = z.object({
@@ -203,7 +203,7 @@ export const FolderItemInputSchema = z.object({
 export const FolderItemValidateSchema = FolderItemInputSchema;
 
 // relation
-export const RelationItemSchema = z.object({
+export const RelationItemInputSchema = z.object({
 	collection: z.string(),
 	field: z.string(),
 	related_collection: z.union([z.string(), z.null()]),
@@ -211,5 +211,46 @@ export const RelationItemSchema = z.object({
 	meta: z.union([z.record(z.string(), z.any()), z.null()]),
 });
 
-export const RelationItemValidateCreateSchema = z.custom<Relation>();
-export const RelationItemValidateUpdateSchema = z.custom<Partial<Relation>>();
+const RelationMetaSchema = z.object({
+	id: z.number(),
+	many_collection: z.string(),
+	many_field: z.string(),
+	one_collection: z.string().nullable(),
+	one_field: z.string().nullable(),
+	one_collection_field: z.string().nullable(),
+	one_allowed_collections: z.array(z.string()).nullable(),
+	one_deselect_action: z.enum(['nullify', 'delete']),
+	junction_field: z.string().nullable(),
+	sort_field: z.string().nullable(),
+	system: z.boolean().optional(),
+});
+
+const FkActionEnum = z.enum(['NO ACTION', 'RESTRICT', 'CASCADE', 'SET NULL', 'SET DEFAULT']);
+
+export const ForeignKeySchema = z.object({
+	table: z.string(),
+	column: z.string(),
+	foreign_key_table: z.string(),
+	foreign_key_column: z.string(),
+	foreign_key_schema: z.string().optional(),
+	constraint_name: z.union([z.string(), z.null()]),
+	on_update: z.union([FkActionEnum, z.null()]),
+	on_delete: z.union([FkActionEnum, z.null()]),
+});
+
+export const RelationItemValidateCreateSchema = z.object({
+	collection: z.string(),
+	field: z.string(),
+	related_collection: z.string().nullable(),
+	schema: ForeignKeySchema.partial().nullable().optional(),
+	meta: RelationMetaSchema.partial().nullable(),
+});
+
+
+export const RelationItemValidateUpdateSchema = z.object({
+	collection: z.string(),
+	field: z.string(),
+	related_collection: z.string().nullable().optional(),
+	schema: ForeignKeySchema.partial().nullable().optional(),
+	meta: RelationMetaSchema.partial().nullable().optional(),
+}).optional();

--- a/api/src/mcp/schema.ts
+++ b/api/src/mcp/schema.ts
@@ -3,13 +3,10 @@ import type {
 	Field,
 	File,
 	FlowRaw,
-	Item,
 	OperationRaw,
-	PrimaryKey,
 	Query,
 	RawCollection,
 	RawField,
-	Relation,
 	Type,
 } from '@directus/types';
 import { z } from 'zod';
@@ -246,11 +243,12 @@ export const RelationItemValidateCreateSchema = z.object({
 	meta: RelationMetaSchema.partial().nullable(),
 });
 
-
-export const RelationItemValidateUpdateSchema = z.object({
-	collection: z.string(),
-	field: z.string(),
-	related_collection: z.string().nullable().optional(),
-	schema: ForeignKeySchema.partial().nullable().optional(),
-	meta: RelationMetaSchema.partial().nullable().optional(),
-}).optional();
+export const RelationItemValidateUpdateSchema = z
+	.object({
+		collection: z.string(),
+		field: z.string(),
+		related_collection: z.string().nullable().optional(),
+		schema: ForeignKeySchema.partial().nullable().optional(),
+		meta: RelationMetaSchema.partial().nullable().optional(),
+	})
+	.optional();

--- a/api/src/mcp/tools/collections.ts
+++ b/api/src/mcp/tools/collections.ts
@@ -10,7 +10,7 @@ import {
 } from '../schema.js';
 import prompts from './prompts/index.js';
 
-export const CollectionsValidateSchema = z.union([
+export const CollectionsValidateSchema = z.discriminatedUnion('action', [
 	z.strictObject({
 		action: z.literal('create'),
 		data: z.union([z.array(CollectionItemValidateCreateSchema), CollectionItemValidateCreateSchema]),

--- a/api/src/mcp/tools/fields.ts
+++ b/api/src/mcp/tools/fields.ts
@@ -16,7 +16,7 @@ export const FieldsBaseValidateSchema = z.strictObject({
 	collection: z.string(),
 });
 
-export const FieldsValidateSchema = z.union([
+export const FieldsValidateSchema = z.discriminatedUnion('action', [
 	FieldsBaseValidateSchema.extend({
 		action: z.literal('create'),
 		data: FieldItemValidateSchema,

--- a/api/src/mcp/tools/files.ts
+++ b/api/src/mcp/tools/files.ts
@@ -15,7 +15,7 @@ import {
 } from '../schema.js';
 import prompts from './prompts/index.js';
 
-export const FilesValidateSchema = z.union([
+export const FilesValidateSchema = z.discriminatedUnion('action', [
 	z.strictObject({
 		action: z.literal('create'),
 		data: z.union([z.array(FileItemValidateSchema), FileItemValidateSchema]),

--- a/api/src/mcp/tools/flows.ts
+++ b/api/src/mcp/tools/flows.ts
@@ -5,7 +5,7 @@ import { defineTool } from '../define.js';
 import { FlowItemInputSchema, FlowItemValidateSchema, QueryInputSchema, QueryValidateSchema } from '../schema.js';
 import prompts from './prompts/index.js';
 
-export const FlowsValidateSchema = z.union([
+export const FlowsValidateSchema = z.discriminatedUnion('action', [
 	z.strictObject({
 		action: z.literal('create'),
 		data: FlowItemValidateSchema,

--- a/api/src/mcp/tools/folders.ts
+++ b/api/src/mcp/tools/folders.ts
@@ -13,7 +13,7 @@ import {
 } from '../schema.js';
 import prompts from './prompts/index.js';
 
-const FoldersValidateSchema = z.union([
+const FoldersValidateSchema = z.discriminatedUnion('action', [
 	z.strictObject({
 		action: z.literal('create'),
 		data: z.union([z.array(FolderItemValidateSchema), FolderItemValidateSchema]),

--- a/api/src/mcp/tools/items.ts
+++ b/api/src/mcp/tools/items.ts
@@ -20,7 +20,7 @@ const PartialItemInputSchema = z.strictObject({
 	collection: z.string(),
 });
 
-const ItemsValidateSchema = z.union([
+const ItemsValidateSchema = z.discriminatedUnion('action', [
 	PartialItemInputSchema.extend({
 		action: z.literal('create'),
 		data: z.union([z.array(ItemValidateSchema), ItemValidateSchema]),

--- a/api/src/mcp/tools/operations.ts
+++ b/api/src/mcp/tools/operations.ts
@@ -6,7 +6,7 @@ import { OperationItemValidateSchema, QueryInputSchema, QueryValidateSchema } fr
 import { FlowsInputSchema } from './flows.js';
 import prompts from './prompts/index.js';
 
-export const OperationsValidationSchema = z.union([
+export const OperationsValidationSchema = z.discriminatedUnion('action', [
 	z.strictObject({
 		action: z.literal('create'),
 		data: OperationItemValidateSchema,

--- a/api/src/mcp/tools/relations.ts
+++ b/api/src/mcp/tools/relations.ts
@@ -1,4 +1,5 @@
 import { InvalidPayloadError } from '@directus/errors';
+import type { Relation } from '@directus/types';
 import { z } from 'zod';
 import { RelationsService } from '../../services/relations.js';
 import { defineTool } from '../define.js';
@@ -54,7 +55,7 @@ export const relations = defineTool<z.infer<typeof RelationsValidateSchema>>({
 		});
 
 		if (args.action === 'create') {
-			await service.createOne(args.data);
+			await service.createOne(args.data as Partial<Relation>);
 
 			const result = await service.readOne(args.collection, args.data.field);
 
@@ -82,7 +83,7 @@ export const relations = defineTool<z.infer<typeof RelationsValidateSchema>>({
 		}
 
 		if (args.action === 'update') {
-			await service.updateOne(args.collection, args.field, args.data);
+			await service.updateOne(args.collection, args.field, args.data as Partial<Relation>);
 
 			const result = await service.readOne(args.collection, args.field);
 


### PR DESCRIPTION
Issues this PR hopes to address

- z.custom schemas require a validator function[(more info here)](https://zod.dev/api?id=custom) otherwise they simply cast the type which was causing invalid payloads to slip through to the tool handler instead of being caught by the validate schema
- z.union schemas swapped for z.discriminatedUnion because there was some funky business in matching properties between different actions
- validation errors weren't being returned


Todo
- [x] Fix TS warnings
Still getting some issues from the compiler though because the conversion from Zod to TS doesn't seem to line up one to one with Partial<Relation>.
- [ ] Delete Action is timing out for me locally - in the studio, there's no deleting a relation individually. You delete the field, which removes the relation.
