### PR TITLE
Ensure custom validation messages are displayed in the drawer

### DIFF
--- a/.changeset/clean-dragons-design.md
+++ b/.changeset/clean-dragons-design.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured that custom validation messages are displayed in the drawer

--- a/app/src/components/v-form/__snapshots__/validation-errors.test.ts.snap
+++ b/app/src/components/v-form/__snapshots__/validation-errors.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Mount component 1`] = `
+"<v-notice data-v-4508db34="" type="danger" class="full">
+  <div data-v-4508db34="">
+    <p data-v-4508db34="">The following fields have invalid values:</p>
+    <ul data-v-4508db34="" class="validation-errors-list"></ul>
+  </div>
+</v-notice>"
+`;

--- a/app/src/components/v-form/validation-errors.test.ts
+++ b/app/src/components/v-form/validation-errors.test.ts
@@ -1,0 +1,179 @@
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+import type { Field, ValidationError } from '@directus/types';
+import { mount } from '@vue/test-utils';
+import { expect, test, describe, it } from 'vitest';
+import ValidationErrors from './validation-errors.vue';
+
+const global: GlobalMountOptions = {
+	plugins: [i18n],
+};
+
+test('Mount component', () => {
+	expect(ValidationErrors).toBeTruthy();
+
+	const wrapper = mount(ValidationErrors, {
+		props: {
+			validationErrors: [],
+			fields: [],
+		},
+		global,
+	});
+
+	expect(wrapper.html()).toMatchSnapshot();
+});
+
+describe('Custom validation message', () => {
+	const baseField: Field = {
+		collection: 'posts',
+		name: 'Title',
+		field: 'title',
+		type: 'string',
+		schema: {
+			name: 'title',
+			table: 'posts',
+			data_type: 'varchar',
+			default_value: null,
+			max_length: 255,
+			numeric_precision: null,
+			numeric_scale: null,
+			is_generated: false,
+			generation_expression: null,
+			is_nullable: true,
+			is_unique: false,
+			is_indexed: false,
+			is_primary_key: false,
+			has_auto_increment: false,
+			foreign_key_column: null,
+			foreign_key_table: null,
+		},
+		meta: {
+			id: 1,
+			collection: 'posts',
+			field: 'title',
+			special: null,
+			interface: 'input',
+			options: null,
+			display: null,
+			display_options: null,
+			readonly: false,
+			hidden: false,
+			sort: 1,
+			width: 'full',
+			translations: null,
+			note: null,
+			conditions: null,
+			required: false,
+			group: null,
+			validation: null,
+			validation_message: null,
+		},
+	};
+
+	const customValidationRule = { _and: [{ title: { _contains: 'a' } }] };
+
+	const customValidationError = {
+		field: 'title',
+		path: [],
+		type: 'contains',
+		substring: 'a',
+		hidden: false,
+		group: null,
+	} as unknown as ValidationError;
+
+	const requiredValidationError = {
+		field: 'title',
+		path: [],
+		type: 'nnull',
+		hidden: false,
+		group: null,
+	} as unknown as ValidationError;
+
+	it('appears when custom validation rule fails', () => {
+		const wrapper = mount(ValidationErrors, {
+			props: {
+				validationErrors: [customValidationError],
+				fields: [
+					{
+						...baseField,
+						meta: {
+							...baseField.meta,
+							validation: customValidationRule,
+							validation_message: 'my custom message',
+						},
+					} as Field,
+				],
+			},
+			global,
+		});
+
+		expect(wrapper.html()).toContain('my custom message');
+	});
+
+	it('appears when required rule fails, but no custom validation rule exists', () => {
+		const wrapper = mount(ValidationErrors, {
+			props: {
+				validationErrors: [requiredValidationError],
+				fields: [
+					{
+						...baseField,
+						meta: {
+							...baseField.meta,
+							validation: null,
+							validation_message: 'my custom message',
+							required: true,
+						},
+					} as Field,
+				],
+			},
+			global,
+		});
+
+		expect(wrapper.html()).toContain('my custom message');
+	});
+
+	it('does not appear when required rule fails and custom validation rule exists', () => {
+		const wrapper = mount(ValidationErrors, {
+			props: {
+				validationErrors: [requiredValidationError],
+				fields: [
+					{
+						...baseField,
+						meta: {
+							...baseField.meta,
+							validation: customValidationRule,
+							validation_message: 'my custom message',
+							required: true,
+						},
+					} as Field,
+				],
+			},
+			global,
+		});
+
+		expect(wrapper.html()).not.toContain('my custom message');
+	});
+
+	it('appears when required rule and custom validation rule fails', () => {
+		const wrapper = mount(ValidationErrors, {
+			props: {
+				validationErrors: [customValidationError, requiredValidationError],
+				fields: [
+					{
+						...baseField,
+						meta: {
+							...baseField.meta,
+							validation: customValidationRule,
+							validation_message: 'my custom message',
+							required: true,
+						},
+					} as Field,
+				],
+			},
+			global,
+		});
+
+		expect(wrapper.html()).toContain('my custom message');
+		expect(wrapper.html()).toContain('Value is required');
+	});
+});

--- a/app/src/components/v-form/validation-errors.vue
+++ b/app/src/components/v-form/validation-errors.vue
@@ -71,7 +71,7 @@ const validationErrorsWithDetails = computed<ValidationErrorWithDetails[]>(() =>
 	) as ValidationErrorWithDetails[];
 });
 
-function getDefaultValidationMessage(validationError: ValidationError) {
+function getDefaultValidationMessage(validationError: ValidationErrorWithDetails) {
 	return t(`validationError.${validationError.type}`, validationError);
 }
 </script>

--- a/app/src/components/v-form/validation-errors.vue
+++ b/app/src/components/v-form/validation-errors.vue
@@ -8,7 +8,6 @@ import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
 type ValidationErrorWithDetails = ValidationError & {
 	fieldName: string;
 	groupName: string;
-	hasCustomValidation: boolean;
 	customValidationMessage: string | null;
 };
 
@@ -29,14 +28,16 @@ const validationErrorsWithDetails = computed<ValidationErrorWithDetails[]>(() =>
 			const field = props.fields.find((field) => field.field === fieldKey);
 			const group = props.fields.find((field) => field.field === validationError.group);
 			const fieldName = getFieldName() + getNestedFieldNames(nestedFieldKeys, validationError.nestedNames);
+			const isRequiredError = field?.meta?.required && validationError.type === 'nnull';
+			const isNotUniqueError = validationError.code === 'RECORD_NOT_UNIQUE';
 
 			return {
 				...validationError,
 				field: fieldKey,
 				fieldName,
 				groupName: group?.name ?? validationError.group,
-				hasCustomValidation: !!field?.meta?.validation,
-				customValidationMessage: validationError.validation_message ?? field?.meta?.validation_message,
+				type: getValidationType(),
+				customValidationMessage: getCustomValidationMessage(),
 			};
 
 			function getFieldName() {
@@ -50,22 +51,28 @@ const validationErrorsWithDetails = computed<ValidationErrorWithDetails[]>(() =>
 				const separator = ' → ';
 				return `${separator}${nestedFieldKeys.map((name) => nestedNames?.[name] ?? name).join(separator)}`;
 			}
+
+			function getValidationType() {
+				if (isRequiredError) return 'required';
+				if (isNotUniqueError) return 'unique';
+				return validationError.type;
+			}
+
+			function getCustomValidationMessage() {
+				const customValidationMessage = validationError.validation_message ?? field?.meta?.validation_message;
+				if (!customValidationMessage) return null;
+
+				const hasCustomValidation = !!field?.meta?.validation;
+				if (hasCustomValidation && (isRequiredError || isNotUniqueError)) return null;
+
+				return customValidationMessage;
+			}
 		},
 	) as ValidationErrorWithDetails[];
 });
 
 function getDefaultValidationMessage(validationError: ValidationError) {
-	const isNotUnique = validationError.code === 'RECORD_NOT_UNIQUE';
-	if (isNotUnique) return t('validationError.unique', validationError);
-
 	return t(`validationError.${validationError.type}`, validationError);
-}
-
-function showCustomValidationMessage(validationError: ValidationErrorWithDetails) {
-	return (
-		validationError.customValidationMessage &&
-		(!validationError.hasCustomValidation || validationError.code === 'FAILED_VALIDATION')
-	);
 }
 </script>
 
@@ -90,7 +97,7 @@ function showCustomValidationMessage(validationError: ValidationErrorWithDetails
 					</strong>
 					<strong>{{ ': ' }}</strong>
 
-					<template v-if="showCustomValidationMessage(validationError)">
+					<template v-if="validationError.customValidationMessage">
 						{{ validationError.customValidationMessage }}
 						<v-icon v-tooltip="getDefaultValidationMessage(validationError)" small right name="help" />
 					</template>


### PR DESCRIPTION
## Scope

What's changed:

Ensured that custom validation messages are displayed in the drawer.

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Item View
- Drawer

## Review Notes / Questions

In order to show validation messages inside the drawer, we have to validate client-side. However, once the form is saved, validation also occurs on the server side.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25657
