### PR TITLE
Update relational field tags to distinguish field names on relation interface

### DIFF
--- a/.changeset/cuddly-islands-taste.md
+++ b/.changeset/cuddly-islands-taste.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+easily distinguish between relational fields on relation interface and display (Issue 25798)

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -131,6 +131,7 @@ function addField(field: FieldTree) {
 	button.classList.add('selected-field');
 
 	let displayName;
+
 	if (field.key.includes('.')) {
 		const collectionPart = field.key.split('.')[0];
 		const collectionName = collectionPart.replace(/_id$/, '');
@@ -272,6 +273,7 @@ function setContent() {
 				if (!field) return '';
 
 				let displayName;
+
 				if (field.key.includes('.')) {
 					const collectionPart = field.key.split('.')[0];
 					const collectionName = collectionPart.replace(/_id$/, '');

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -129,7 +129,18 @@ function addField(field: FieldTree) {
 	button.dataset.field = field.key;
 	button.setAttribute('contenteditable', 'false');
 	button.classList.add('selected-field');
-	button.innerText = String(field.name);
+
+	let displayName;
+	if (field.key.includes('.')) {
+		const collectionPart = field.key.split('.')[0];
+		const collectionName = collectionPart.replace(/_id$/, '');
+		const formattedCollection = collectionName.charAt(0).toUpperCase() + collectionName.slice(1) + ' ID';
+		displayName = `${formattedCollection} → ${field.name}`;
+	} else {
+		displayName = field.name;
+	}
+
+	button.innerText = String(displayName);
 
 	if (window.getSelection()?.rangeCount == 0) {
 		const range = document.createRange();
@@ -260,9 +271,19 @@ function setContent() {
 
 				if (!field) return '';
 
+				let displayName;
+				if (field.key.includes('.')) {
+					const collectionPart = field.key.split('.')[0];
+					const collectionName = collectionPart.replace(/_id$/, '');
+					const formattedCollection = collectionName.charAt(0).toUpperCase() + collectionName.slice(1) + ' ID';
+					displayName = `${formattedCollection} → ${field.name}`;
+				} else {
+					displayName = field.name;
+				}
+
 				return `<button type="button" contenteditable="false" data-field="${fieldKey}" ${
 					props.disabled ? 'disabled' : ''
-				} class="selected-field">${field.name}</button>`;
+				} class="selected-field">${displayName}</button>`;
 			})
 			.join('');
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -223,3 +223,4 @@
 - jekuer
 - timio23
 - khanahmad4527
+- JamesW1


### PR DESCRIPTION
## Scope

What's changed:

- For M2M fields in the Interface tab, it will now show the collection name as a prefix to more accurately qualify the field name

**Before**

https://github.com/user-attachments/assets/5e204917-1bd2-4f8a-85dc-af2c0dcbb567

**After** (Updated based on PR comments)

https://github.com/user-attachments/assets/f14fd47f-ff16-4af1-9b0f-8f7e67f32021


## Potential Risks / Drawbacks

- None I am aware of

## Tested Scenarios

- Tested display in Chrome/Safari
- Checked display of values in collection view

## Review Notes / Questions

- **First contribution** so would like to ensure I haven't missed anything
- **Backwards compatibility** - my understanding is this is safe due to updates to setContent() but would like confirmation 

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25798 
