### PR TITLE
Fix constraint errors not being propagated in `MSSQL`

### DIFF
--- a/.changeset/slimy-laws-relate.md
+++ b/.changeset/slimy-laws-relate.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed constraint errors not propogated with mssql

--- a/.changeset/slimy-laws-relate.md
+++ b/.changeset/slimy-laws-relate.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed constraint errors not propogated with mssql
+Fixed constraint errors not being propagated in MSSQL


### PR DESCRIPTION
## Scope

What's changed:

- The field name is now properly retrieved from the MSSQL unique constraint error.

### Before
https://github.com/user-attachments/assets/4efb7d7f-0a40-4062-9e86-623e9840c191

### After
https://github.com/user-attachments/assets/9d834058-f442-4386-b01f-85c88c360c1a


## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios

Created an `article_index` and `article_constraint` collections and executed the following queries:
  - `CREATE UNIQUE NONCLUSTERED INDEX [unique_index] ON [dbo].[article_index] ([a]);`
  - `ALTER TABLE article_constraint ADD CONSTRAINT unique_constraint UNIQUE (a);`

The following cases were tested:
- `index` unique error still propagates as expected
- `constraint` unique error propagates

## Review Notes / Questions
- If a unique constraint is set on multiple fields (e.g. `title`, `subtitle`) we will ever only show the first one (e.g. `title`) in the error. As our current codebase only supports [specifying a single field in the error](https://github.com/directus/directus/blob/main/packages/errors/src/errors/record-not-unique.ts#L10) I believe this is acceptable. Thoughts?
- The issue here was unique constraint errors have the constraint and table name swapped compared to index 

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25784
