### PR TITLE
Add RTL support in markdown interface for Arabic

### DIFF
--- a/.changeset/clear-mugs-tease.md
+++ b/.changeset/clear-mugs-tease.md
@@ -1,0 +1,21 @@
+---
+'@directus/app': patch
+---
+
+Problem: The content edit forms weren't passing the user's text direction setting from the user store down to form
+interfaces. Even though the system detected RTL languages correctly, the interfaces never received this information.
+
+Solution:
+
+1. Added the missing direction prop to content forms (item.vue and share-item.vue)
+
+How it works now: When you select Arabic as your interface language, the user store detects it as RTL, passes this to
+the forms, and all text interfaces including the Markdown editor automatically display right-to-left.
+
+Files changed:
+
+- Content form components to pass direction prop
+- Markdown editor to use direction prop
+
+The fix is purely language-based - no configuration needed. Select Arabic language and the Markdown editor automatically
+becomes RTL.

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -78,6 +78,11 @@ const readOnly = computed(() => {
 	}
 });
 
+// Use the direction prop directly from the form (determined by user's language)
+const textDirection = computed(() => {
+	return props.direction || 'ltr';
+});
+
 onMounted(async () => {
 	if (codemirrorEl.value) {
 		codemirror = CodeMirror(codemirrorEl.value, {
@@ -85,7 +90,7 @@ onMounted(async () => {
 			configureMouse: () => ({ addNew: false }),
 			lineWrapping: true,
 			readOnly: readOnly.value,
-			direction: props.direction === 'rtl' ? props.direction : 'ltr',
+			direction: textDirection.value as 'ltr' | 'rtl' | undefined,
 			cursorBlinkRate: props.disabled ? -1 : 530,
 			placeholder: props.placeholder,
 			value: props.value || '',
@@ -147,7 +152,7 @@ watch(
 watch(
 	() => props.direction,
 	(direction) => {
-		codemirror?.setOption('direction', direction === 'rtl' ? direction : 'ltr');
+		codemirror?.setOption('direction', textDirection.value);
 	},
 );
 
@@ -393,7 +398,7 @@ function edit(type: Alteration, options?: Record<string, any>) {
 		<div
 			v-md="markdownString"
 			class="preview-box"
-			:style="{ display: view === 'preview' ? 'block' : 'none', direction: direction === 'rtl' ? direction : 'ltr' }"
+			:style="{ display: view === 'preview' ? 'block' : 'none', direction: textDirection }"
 		></div>
 
 		<v-dialog

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -6,6 +6,7 @@ import { useItemPermissions } from '@/composables/use-permissions';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
+import { useUserStore } from '@/stores/user';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import { translateShortcut } from '@/utils/translate-shortcut';
@@ -40,6 +41,8 @@ const { t, te } = useI18n();
 
 const router = useRouter();
 const { collectionRoute } = useCollectionRoute();
+
+const userStore = useUserStore();
 
 const form = ref<HTMLElement>();
 
@@ -742,6 +745,7 @@ function useCollectionRoute() {
 			:primary-key="internalPrimaryKey"
 			:validation-errors="validationErrors"
 			:version="currentVersion"
+			:direction="userStore.textDirection"
 		/>
 
 		<v-dialog v-model="confirmLeave" @esc="confirmLeave = false" @apply="discardAndLeave">

--- a/app/src/routes/shared/components/share-item.vue
+++ b/app/src/routes/shared/components/share-item.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useItem } from '@/composables/use-item';
+import { useUserStore } from '@/stores/user';
 import { toRefs } from 'vue';
 
 const props = defineProps<{
@@ -8,6 +9,8 @@ const props = defineProps<{
 }>();
 
 const { collection, primaryKey } = toRefs(props);
+
+const userStore = useUserStore();
 
 const { edits, item, loading } = useItem(collection, primaryKey);
 </script>
@@ -20,5 +23,6 @@ const { edits, item, loading } = useItem(collection, primaryKey);
 		:primary-key="primaryKey"
 		disabled
 		:loading="loading"
+		:direction="userStore.textDirection"
 	/>
 </template>

--- a/contributors.yml
+++ b/contributors.yml
@@ -223,3 +223,4 @@
 - jekuer
 - timio23
 - khanahmad4527
+- zjpiazza


### PR DESCRIPTION
## Scope

What's changed:

• Fixed missing direction prop flow from user store to form interfaces in content edit pages
• Content forms (item.vue, share-item.vue) now pass userStore.textDirection to v-form components

## Potential Risks / Drawbacks

• None identified - this is a bug fix that enables existing RTL functionality for the Markdown interface
• Change is backward compatible and follows existing RTL detection patterns

## Tested Scenarios

• Arabic language selection automatically triggers RTL in Markdown editor
• LTR languages continue to work as expected

## Screenshots
### Arabic Editor

<img width="3375" height="1186" alt="image" src="https://github.com/user-attachments/assets/be7780d6-8403-48b6-bba7-2a47c83cc4b6" />

### English Editor

<img width="3375" height="1186" alt="image" src="https://github.com/user-attachments/assets/8bbc919a-2646-4347-97cc-2c7f5efb2262" />


## Review Notes / Questions

• I would like confirmation that the userStore usage follows Directus patterns

## Checklist

[ ] Added or updated tests
[ ] Documentation PR created here https://github.com/directus/docs or not required

Fixes #25787 