### PR TITLE
Improve tag interface to automatically add tag when input loses focus

### DIFF
--- a/.changeset/clear-moments-sell.md
+++ b/.changeset/clear-moments-sell.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added tag on blur for tags interface

--- a/.changeset/clear-moments-sell.md
+++ b/.changeset/clear-moments-sell.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Added tag on blur for tags interface
+Improved tag interface to automatically add tag when input loses focus

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -84,7 +84,7 @@ function processArray(array: string[]): string[] {
 }
 
 function onInput(event: KeyboardEvent) {
-	if (event.target && (event.key === 'Enter' || event.key === ',' || event.type === 'blur')) {
+	if (event.target && (event.key === 'Enter' || event.key === ',' || (event.type === 'blur' && document.hasFocus()))) {
 		event.preventDefault();
 		addTag((event.target as HTMLInputElement).value);
 		(event.target as HTMLInputElement).value = '';

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -84,7 +84,7 @@ function processArray(array: string[]): string[] {
 }
 
 function onInput(event: KeyboardEvent) {
-	if (event.target && (event.key === 'Enter' || event.key === ',')) {
+	if (event.target && (event.key === 'Enter' || event.key === ',' || event.type === 'blur')) {
 		event.preventDefault();
 		addTag((event.target as HTMLInputElement).value);
 		(event.target as HTMLInputElement).value = '';
@@ -126,6 +126,7 @@ function emitValue() {
 			:disabled="disabled"
 			:dir="direction"
 			@keydown="onInput"
+			@blur="onInput"
 		>
 			<template v-if="iconLeft" #prepend><v-icon :name="iconLeft" /></template>
 			<template #append><v-icon :name="iconRight" /></template>


### PR DESCRIPTION
## Scope

What's changed:

- Tags are now automatically added when the tag input/interface loses focus

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- 

## Review Notes / Questions

- This improvement came about in a discussion on a [related topic](https://github.com/directus/directus/issues/25732). I tend to forget to press enter after input which results in unexpected behavior.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---
