### PR TITLE
Add cache-busting to image asset URLs in the studio

### DIFF
--- a/.changeset/kind-baths-thank.md
+++ b/.changeset/kind-baths-thank.md
@@ -1,0 +1,6 @@
+---
+'@directus/types': patch
+'@directus/app': patch
+---
+
+Added cache-busting to image asset URLs in the studio to ensure updated images are always loaded

--- a/app/src/displays/file/file.vue
+++ b/app/src/displays/file/file.vue
@@ -7,6 +7,7 @@ type File = {
 	id: string;
 	type: string;
 	title: string;
+	modified_on: Date;
 };
 
 const props = withDefaults(
@@ -30,7 +31,11 @@ const imageThumbnail = computed(() => {
 	if (!props.value) return null;
 	if (props.value.type?.includes('svg')) return getAssetUrl(props.value.id);
 	if (props.value.type?.includes('image') === false) return null;
-	return getAssetUrl(`${props.value.id}?key=system-small-cover`);
+
+	return getAssetUrl(props.value.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: props.value.modified_on,
+	});
 });
 </script>
 

--- a/app/src/displays/file/file.vue
+++ b/app/src/displays/file/file.vue
@@ -12,7 +12,7 @@ type File = {
 
 const props = withDefaults(
 	defineProps<{
-		value: File | null;
+		value?: File | null;
 	}>(),
 	{
 		value: null,

--- a/app/src/displays/file/index.ts
+++ b/app/src/displays/file/index.ts
@@ -10,5 +10,5 @@ export default defineDisplay({
 	types: ['uuid'],
 	localTypes: ['file'],
 	options: [],
-	fields: ['id', 'type', 'title'],
+	fields: ['id', 'type', 'title', 'modified_on'],
 });

--- a/app/src/displays/image/image.vue
+++ b/app/src/displays/image/image.vue
@@ -6,6 +6,7 @@ type Image = {
 	id: string;
 	type: string;
 	title: string;
+	modified_on: Date;
 };
 
 const props = defineProps<{
@@ -17,7 +18,11 @@ const imageError = ref(false);
 
 const src = computed(() => {
 	if (props.value?.id === null || props.value?.id === undefined) return null;
-	return getAssetUrl(`${props.value.id}?key=system-small-cover`);
+
+	return getAssetUrl(props.value.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: props.value.modified_on,
+	});
 });
 </script>
 

--- a/app/src/displays/image/index.ts
+++ b/app/src/displays/image/index.ts
@@ -26,5 +26,5 @@ export default defineDisplay({
 			},
 		},
 	],
-	fields: ['id', 'type', 'title'],
+	fields: ['id', 'type', 'title', 'modified_on'],
 });

--- a/app/src/displays/user/index.ts
+++ b/app/src/displays/user/index.ts
@@ -56,5 +56,5 @@ export default defineDisplay({
 			},
 		},
 	],
-	fields: ['id', 'avatar.id', 'email', 'first_name', 'last_name'],
+	fields: ['id', 'avatar.id', 'avatar.modified_on', 'email', 'first_name', 'last_name'],
 });

--- a/app/src/displays/user/user.vue
+++ b/app/src/displays/user/user.vue
@@ -16,13 +16,12 @@ const props = withDefaults(
 );
 
 const src = computed(() => {
-	if (props.value === null) return null;
+	if (props.value === null || !props.value.avatar?.id) return null;
 
-	if (props.value.avatar?.id) {
-		return getAssetUrl(`${props.value.avatar.id}?key=system-small-cover`);
-	}
-
-	return null;
+	return getAssetUrl(props.value.avatar.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: props.value.avatar.modified_on,
+	});
 });
 </script>
 

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -205,7 +205,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 					v-tooltip="t('download')"
 					icon
 					rounded
-					:href="getAssetUrl(image.id, true)"
+					:href="getAssetUrl(image.id, { isDownload: true })"
 					:download="image.filename_download"
 				>
 					<v-icon name="download" />
@@ -239,7 +239,13 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				@input="update"
 			>
 				<template #actions>
-					<v-button secondary rounded icon :download="image.filename_download" :href="getAssetUrl(image.id, true)">
+					<v-button
+						secondary
+						rounded
+						icon
+						:download="image.filename_download"
+						:href="getAssetUrl(image.id, { isDownload: true })"
+					>
 						<v-icon name="download" />
 					</v-button>
 				</template>

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -83,8 +83,11 @@ const src = computed(() => {
 
 	if (image.value.type.includes('image')) {
 		const fit = props.crop ? 'cover' : 'contain';
-		const url = getAssetUrl(`${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}`);
-		return url;
+
+		return getAssetUrl(image.value.id, {
+			imageKey: `system-large-${fit}`,
+			cacheBuster: image.value.modified_on,
+		});
 	}
 
 	return null;

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -3,7 +3,6 @@ import api from '@/api';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
 import { useRelationPermissionsM2O } from '@/composables/use-relation-permissions';
 import { RelationQuerySingle, useRelationSingle } from '@/composables/use-relation-single';
-import { addQueryToPath } from '@/utils/add-query-to-path';
 import { getAssetUrl } from '@/utils/get-asset-url';
 import { parseFilter } from '@/utils/parse-filter';
 import { readableMimeType } from '@/utils/readable-mime-type';
@@ -78,16 +77,24 @@ const fileExtension = computed(() => {
 	return readableMimeType(file.value.type, true);
 });
 
-const assetURL = computed(() => {
-	const id = typeof props.value === 'string' ? props.value : props.value?.id;
-	return getAssetUrl(id);
-});
-
 const imageThumbnail = computed(() => {
 	if (file.value === null || props.value === null) return null;
-	if (file.value.type.includes('svg')) return assetURL.value;
+
+	const isValueString = typeof props.value === 'string';
+	const assetID = isValueString ? props.value : props.value?.id;
+
+	if (file.value.type.includes('svg')) return getAssetUrl(assetID);
 	if (file.value.type.includes('image') === false) return null;
-	return addQueryToPath(assetURL.value, { key: 'system-small-cover' });
+
+	return getAssetUrl(assetID, {
+		imageKey: 'system-small-cover',
+		cacheBuster: getCacheBuster(),
+	});
+
+	function getCacheBuster() {
+		if (!isValueString && props.value?.modified_on) return props.value.modified_on;
+		return true;
+	}
 });
 
 const imageThumbnailError = ref<any>(null);

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -248,7 +248,7 @@ function useURLImport() {
 
 			<v-list>
 				<template v-if="file">
-					<v-list-item clickable :download="file.filename_download" :href="getAssetUrl(file.id, true)">
+					<v-list-item clickable :download="file.filename_download" :href="getAssetUrl(file.id, { isDownload: true })">
 						<v-list-item-icon><v-icon name="get_app" /></v-list-item-icon>
 						<v-list-item-content>{{ t('download_file') }}</v-list-item-content>
 					</v-list-item>
@@ -290,7 +290,13 @@ function useURLImport() {
 			@input="update"
 		>
 			<template #actions>
-				<v-button secondary rounded icon :download="file.filename_download" :href="getAssetUrl(file.id, true)">
+				<v-button
+					secondary
+					rounded
+					icon
+					:download="file.filename_download"
+					:href="getAssetUrl(file.id, { isDownload: true })"
+				>
 					<v-icon name="download" />
 				</v-button>
 			</template>

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -51,7 +51,7 @@ const value = computed({
 });
 
 const query = ref<RelationQuerySingle>({
-	fields: ['id', 'title', 'type', 'filename_download'],
+	fields: ['id', 'title', 'type', 'filename_download', 'modified_on'],
 });
 
 const { collection, field } = toRefs(props);
@@ -80,21 +80,18 @@ const fileExtension = computed(() => {
 const imageThumbnail = computed(() => {
 	if (file.value === null || props.value === null) return null;
 
-	const isValueString = typeof props.value === 'string';
-	const assetID = isValueString ? props.value : props.value?.id;
-
-	if (file.value.type.includes('svg')) return getAssetUrl(assetID);
 	if (file.value.type.includes('image') === false) return null;
 
-	return getAssetUrl(assetID, {
-		imageKey: 'system-small-cover',
-		cacheBuster: getCacheBuster(),
-	});
-
-	function getCacheBuster() {
-		if (!isValueString && props.value?.modified_on) return props.value.modified_on;
-		return true;
+	if (file.value.type.includes('svg')) {
+		return getAssetUrl(file.value.id, {
+			cacheBuster: file.value.modified_on,
+		});
 	}
+
+	return getAssetUrl(file.value.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: file.value.modified_on,
+	});
 });
 
 const imageThumbnailError = ref<any>(null);

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -224,7 +224,7 @@ const downloadName = computed(() => {
 
 const downloadUrl = computed(() => {
 	if (relatedPrimaryKey.value === null || relationInfo.value?.relatedCollection.collection !== 'directus_files') return;
-	return getAssetUrl(String(relatedPrimaryKey.value), true);
+	return getAssetUrl(String(relatedPrimaryKey.value), { isDownload: true });
 });
 
 function getFilename(junctionRow: Record<string, any>) {
@@ -367,7 +367,7 @@ const allowDrag = computed(
 									<v-list-item
 										clickable
 										:download="getDownloadName(element)"
-										:href="getAssetUrl(getFilename(element), true)"
+										:href="getAssetUrl(getFilename(element), { isDownload: true })"
 									>
 										<v-list-item-icon><v-icon name="download" /></v-list-item-icon>
 										<v-list-item-content>{{ t('download_file') }}</v-list-item-content>

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -58,7 +58,10 @@ const imageInfo = computed(() => {
 		key = 'system-medium-contain';
 	}
 
-	const source = getAssetUrl(`${props.file.id}?key=${key}&modified=${props.file.modified_on}`);
+	const source = getAssetUrl(props.file.id, {
+		imageKey: key,
+		cacheBuster: props.file.modified_on,
+	});
 
 	return { source, fileType };
 });

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -77,8 +77,10 @@ function parseAvatar(file: Record<string, any>) {
 	if (!file || !file.type) return;
 	if (file.type.startsWith('image') === false) return;
 
-	const url = getAssetUrl(`${file.id}?modified=${file.modified_on}&key=system-small-cover`);
-	return url;
+	return getAssetUrl(file.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: file.modified_on,
+	});
 }
 
 function cancelChanges() {

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -316,7 +316,7 @@ function revert(values: Record<string, any>) {
 				icon
 				rounded
 				:download="item?.filename_download"
-				:href="getAssetUrl(props.primaryKey, true)"
+				:href="getAssetUrl(props.primaryKey, { isDownload: true })"
 			>
 				<v-icon name="download" />
 			</v-button>

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -64,7 +64,7 @@ const {
 	primaryKey,
 	props.primaryKey !== '+'
 		? {
-				fields: ['*', 'role.*'],
+				fields: ['*', 'role.*', 'avatar.id', 'avatar.modified_on'],
 			}
 		: undefined,
 );

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -93,9 +93,14 @@ const confirmArchive = ref(false);
 // Provide the discard functionality to field interfaces
 provide('discardAllChanges', discardAndStay);
 
-const avatarSrc = computed(() =>
-	item.value?.avatar ? getAssetUrl(`${item.value.avatar}?key=system-medium-cover`) : null,
-);
+const avatarSrc = computed(() => {
+	if (!item.value?.avatar) return null;
+
+	return getAssetUrl(item.value.avatar.id, {
+		imageKey: 'system-medium-cover',
+		cacheBuster: item.value.avatar.modified_on,
+	});
+});
 
 const avatarError = ref(null);
 

--- a/app/src/utils/get-asset-url.test.ts
+++ b/app/src/utils/get-asset-url.test.ts
@@ -14,7 +14,7 @@ test('Get asset url', () => {
 
 test('Get asset url for download', () => {
 	vi.mocked(getPublicURL).mockReturnValueOnce('https://directus.io/');
-	const output = getAssetUrl('test.jpg', true);
+	const output = getAssetUrl('test.jpg', { isDownload: true });
 	expect(output).toBe(`https://directus.io/assets/test.jpg?download=`);
 });
 
@@ -26,6 +26,32 @@ test('Subdirectory Install: Get asset url', () => {
 
 test('Subdirectory Install: Get asset url for download', () => {
 	vi.mocked(getPublicURL).mockReturnValueOnce('https://directus.io/subdirectory/');
-	const output = getAssetUrl('test.jpg', true);
+	const output = getAssetUrl('test.jpg', { isDownload: true });
 	expect(output).toBe(`https://directus.io/subdirectory/assets/test.jpg?download=`);
+});
+
+test('Get asset url with image key', () => {
+	vi.mocked(getPublicURL).mockReturnValueOnce('https://directus.io/');
+	const output = getAssetUrl('test.jpg', { imageKey: '12345' });
+	expect(output).toBe(`https://directus.io/assets/test.jpg?key=12345`);
+});
+
+test('Get asset url with cache buster as date', () => {
+	vi.mocked(getPublicURL).mockReturnValueOnce('https://directus.io/');
+	const date = '2024-01-01T00:00:00.000Z';
+	const output = getAssetUrl('test.jpg', { cacheBuster: date });
+	expect(output).toBe(`https://directus.io/assets/test.jpg?v=2024-01-01T00%3A00%3A00.000Z`);
+});
+
+test('Get asset url with cache buster as true', () => {
+	vi.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+	vi.mocked(getPublicURL).mockReturnValueOnce('https://directus.io/');
+	const output = getAssetUrl('test.jpg', { cacheBuster: true });
+	expect(output).toBe(`https://directus.io/assets/test.jpg?v=1704067200000`);
+});
+
+test('Get asset url with custom params', () => {
+	vi.mocked(getPublicURL).mockReturnValueOnce('https://directus.io/');
+	const output = getAssetUrl('test.jpg', { width: 100, height: 200 });
+	expect(output).toBe(`https://directus.io/assets/test.jpg?width=100&height=200`);
 });

--- a/app/src/utils/get-asset-url.ts
+++ b/app/src/utils/get-asset-url.ts
@@ -1,11 +1,30 @@
 import { getPublicURL } from '@/utils/get-root-path';
+import type { TransformationParams } from '@directus/types';
 
-export function getAssetUrl(filename: string, isDownload?: boolean): string {
+type AssetUrlOptions = {
+	isDownload?: boolean;
+	imageKey?: TransformationParams['key'];
+	cacheBuster?: boolean | string | number | Date;
+	[key: string]: any;
+};
+
+export function getAssetUrl(
+	filename: string,
+	{ isDownload = false, imageKey = undefined, cacheBuster = false, ...params }: AssetUrlOptions = {},
+): string {
 	const assetUrl = new URL(`assets/${filename}`, getPublicURL());
 
-	if (isDownload) {
-		assetUrl.searchParams.set('download', '');
+	if (params) {
+		Object.entries(params).forEach(([key, value]) => {
+			if (value === undefined || value === null) return;
+
+			assetUrl.searchParams.set(key, String(value));
+		});
 	}
+
+	if (isDownload) assetUrl.searchParams.set('download', '');
+	if (imageKey) assetUrl.searchParams.set('key', imageKey);
+	if (cacheBuster) assetUrl.searchParams.set('v', cacheBuster === true ? Date.now().toString() : String(cacheBuster));
 
 	return assetUrl.href;
 }

--- a/app/src/views/private/components/comment-input.vue
+++ b/app/src/views/private/components/comment-input.vue
@@ -114,7 +114,7 @@ const loadUsers = throttle(async (name: string): Promise<any> => {
 		const result = await api.get('/users', {
 			params: {
 				filter: name === '' || !name ? undefined : filter,
-				fields: ['first_name', 'last_name', 'email', 'id', 'avatar.id'],
+				fields: ['first_name', 'last_name', 'email', 'id', 'avatar.id', 'avatar.modified_on'],
 			},
 			cancelToken: cancelToken.token,
 		});

--- a/app/src/views/private/components/comment-input.vue
+++ b/app/src/views/private/components/comment-input.vue
@@ -216,9 +216,13 @@ function triggerSearch({ searchQuery, caretPosition }: { searchQuery: string; ca
 	selectedKeyboardIndex.value = 0;
 }
 
-function avatarSource(url: string) {
-	if (url === null) return '';
-	return getAssetUrl(`${url}?key=system-small-cover`);
+function avatarSource(avatar: User['avatar'] | null) {
+	if (avatar === null) return '';
+
+	return getAssetUrl(avatar.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: avatar.modified_on,
+	});
 }
 
 async function postComment() {
@@ -303,7 +307,7 @@ function pressedEnter() {
 				>
 					<v-list-item-icon>
 						<v-avatar x-small>
-							<v-image v-if="user.avatar" :src="avatarSource(user.avatar.id)" />
+							<v-image v-if="user.avatar" :src="avatarSource(user.avatar)" />
 							<v-icon v-else name="person_outline" />
 						</v-avatar>
 					</v-list-item-icon>

--- a/app/src/views/private/components/comment-item-header.vue
+++ b/app/src/views/private/components/comment-item-header.vue
@@ -32,7 +32,10 @@ const formattedTime = computed(() => {
 const avatarSource = computed(() => {
 	if (!props.comment.user_created?.avatar) return null;
 
-	return getAssetUrl(`${props.comment.user_created.avatar.id}?key=system-small-cover`);
+	return getAssetUrl(props.comment.user_created.avatar.id, {
+		imageKey: 'system-small-cover',
+		cacheBuster: props.comment.user_created.avatar.modified_on,
+	});
 });
 
 const { confirmDelete, deleting, remove } = useDelete();

--- a/app/src/views/private/components/comments-sidebar-detail.vue
+++ b/app/src/views/private/components/comments-sidebar-detail.vue
@@ -93,6 +93,7 @@ function useComments(collection: Ref<string>, primaryKey: Ref<PrimaryKey>) {
 							'user_created.first_name',
 							'user_created.last_name',
 							'user_created.avatar.id',
+							'user_created.avatar.modified_on',
 						],
 					},
 				})

--- a/app/src/views/private/components/file-preview.vue
+++ b/app/src/views/private/components/file-preview.vue
@@ -19,7 +19,10 @@ defineEmits<{
 const file = toRef(props, 'file');
 
 const src = computed(() =>
-	getAssetUrl(`${file.value.id}?cache-buster=${file.value.modified_on}${props.preset ? `&key=${props.preset}` : ''}`),
+	getAssetUrl(file.value.id, {
+		imageKey: props.preset ?? undefined,
+		cacheBuster: file.value.modified_on,
+	}),
 );
 
 const type = computed<'image' | 'video' | 'audio' | string>(() => {

--- a/app/src/views/private/components/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar.vue
@@ -22,7 +22,11 @@ const signOutActive = ref(false);
 
 const avatarURL = computed<string | null>(() => {
 	if (!userStore.currentUser || !('avatar' in userStore.currentUser) || !userStore.currentUser?.avatar) return null;
-	return getAssetUrl(`${userStore.currentUser.avatar.id}?key=system-medium-cover`);
+
+	return getAssetUrl(userStore.currentUser.avatar.id, {
+		imageKey: 'system-medium-cover',
+		cacheBuster: userStore.currentUser.avatar.modified_on,
+	});
 });
 
 const avatarError = ref<null | Event>(null);

--- a/app/src/views/private/components/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar.vue
@@ -18,6 +18,8 @@ const { unread } = storeToRefs(notificationsStore);
 
 const userStore = useUserStore();
 
+(async () => await userStore.hydrateAdditionalFields(['avatar.modified_on']))();
+
 const signOutActive = ref(false);
 
 const avatarURL = computed<string | null>(() => {

--- a/app/src/views/private/components/module-bar-logo.vue
+++ b/app/src/views/private/components/module-bar-logo.vue
@@ -13,7 +13,7 @@ const settingsStore = useSettingsStore();
 const customLogoPath = computed<string | null>(() => {
 	if (settingsStore.settings === null) return null;
 	if (!settingsStore.settings?.project_logo) return null;
-	return getAssetUrl(`${settingsStore.settings.project_logo}`);
+	return getAssetUrl(settingsStore.settings.project_logo);
 });
 
 const showLoader = ref(false);

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -53,7 +53,7 @@ async function fetchUser() {
 	try {
 		const response = await api.get(`/users/${props.user}`, {
 			params: {
-				fields: ['id', 'first_name', 'last_name', 'avatar.id', 'role.name', 'status', 'email'],
+				fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on', 'role.name', 'status', 'email'],
 			},
 		});
 

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -23,7 +23,10 @@ const avatarSrc = computed(() => {
 	if (data.value === null) return null;
 
 	if (data.value.avatar?.id) {
-		return getAssetUrl(`${data.value.avatar.id}?key=system-medium-cover`);
+		return getAssetUrl(data.value.avatar.id, {
+			imageKey: 'system-medium-cover',
+			cacheBuster: data.value.avatar.modified_on,
+		});
 	}
 
 	return null;

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -11,6 +11,7 @@ export type Role = {
 
 export type Avatar = {
 	id: string;
+	modified_on?: Date;
 };
 
 export type User = {


### PR DESCRIPTION
## Scope

What's changed:

- Refactored getAssetUrl() util to enhance parameter handling for consistency — especially cache-busting query keys
- Refactored occurences of getAssetUrl()
- Added cache-busting for image URLs in the Studio
- Ensured Displays fetch the modified_on column in order to use it for cache-busting
- Updated the Avatar type

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Tested all affected fiels in the Studio

## Review Notes / Questions

- Be sure to run `pnpm --filter types build` first
- I recommend to review the commits

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25501
