### PR TITLE
Comparison modal - Hidden field indicators

### DIFF
--- a/.changeset/few-grapes-dream.md
+++ b/.changeset/few-grapes-dream.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Created conditionals allowing hidden fields to show when those fields are part of a comparison

--- a/app/src/components/v-form/form-field-label.vue
+++ b/app/src/components/v-form/form-field-label.vue
@@ -55,6 +55,7 @@ const { t } = useI18n();
 			/>
 			<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>
 			<v-text-overflow :text="field.name" />
+			<span v-if="comparison?.mode && field.meta?.hidden" class="hidden-indicator">({{ t('hidden') }})</span>
 			<v-icon
 				v-if="field.meta?.required === true"
 				class="required"
@@ -126,6 +127,12 @@ const { t } = useI18n();
 		&.active {
 			opacity: 1;
 		}
+	}
+
+	.hidden-indicator {
+		margin-inline-start: 4px;
+		color: var(--theme--foreground-subdued);
+		font-size: 0.875em;
 	}
 
 	&:focus-within,

--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -1,8 +1,8 @@
 import { Field } from '@directus/types';
 
-export function updateFieldWidths(fields: Field[], comparisonFields?: Set<string>) {
+export function updateFieldWidths(fields: Field[], comparisonFields: Set<string> = new Set()) {
 	for (const [index, field] of fields.entries()) {
-		const isVisible = !field.meta?.hidden || (comparisonFields && comparisonFields.has(field.field));
+		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
 
 		if (index !== 0 && field.meta?.width === 'half' && isVisible) {
 			let prevNonHiddenField;
@@ -10,8 +10,7 @@ export function updateFieldWidths(fields: Field[], comparisonFields?: Set<string
 			for (const formField of fields) {
 				if (formField.meta?.group !== field.meta?.group) continue;
 
-				const isPrevFieldVisible =
-					!formField.meta?.hidden || (comparisonFields && comparisonFields.has(formField.field));
+				const isPrevFieldVisible = !formField.meta?.hidden || comparisonFields.has(formField.field);
 
 				if (!isPrevFieldVisible) continue;
 				if (formField === field) break;

--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -1,12 +1,19 @@
 import { Field } from '@directus/types';
 
-export function updateFieldWidths(fields: Field[]) {
+export function updateFieldWidths(fields: Field[], comparisonFields?: Set<string>) {
 	for (const [index, field] of fields.entries()) {
-		if (index !== 0 && field.meta?.width === 'half' && field.meta.hidden !== true) {
+		const isVisible = !field.meta?.hidden || (comparisonFields && comparisonFields.has(field.field));
+
+		if (index !== 0 && field.meta?.width === 'half' && isVisible) {
 			let prevNonHiddenField;
 
 			for (const formField of fields) {
-				if (formField.meta?.group !== field.meta?.group || formField.meta?.hidden) continue;
+				if (formField.meta?.group !== field.meta?.group) continue;
+
+				const isPrevFieldVisible =
+					!formField.meta?.hidden || (comparisonFields && comparisonFields.has(formField.field));
+
+				if (!isPrevFieldVisible) continue;
 				if (formField === field) break;
 				prevNonHiddenField = formField;
 			}

--- a/app/src/components/v-form/utils/update-system-divider.ts
+++ b/app/src/components/v-form/utils/update-system-divider.ts
@@ -1,6 +1,6 @@
 import type { Field } from '@directus/types';
 
-export function updateSystemDivider(fields: Field[], comparisonFields?: Set<string>) {
+export function updateSystemDivider(fields: Field[], comparisonFields: Set<string> = new Set()) {
 	let hasVisibleSystemFields = false;
 	let hasVisibleUserFields = false;
 	let systemDivider;
@@ -11,7 +11,7 @@ export function updateSystemDivider(fields: Field[], comparisonFields?: Set<stri
 			continue;
 		}
 
-		const isVisible = !field.meta?.hidden || (comparisonFields && comparisonFields.has(field.field));
+		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
 		if (!isVisible) continue;
 
 		if (field.meta?.system) {

--- a/app/src/components/v-form/utils/update-system-divider.ts
+++ b/app/src/components/v-form/utils/update-system-divider.ts
@@ -1,6 +1,6 @@
 import type { Field } from '@directus/types';
 
-export function updateSystemDivider(fields: Field[]) {
+export function updateSystemDivider(fields: Field[], comparisonFields?: Set<string>) {
 	let hasVisibleSystemFields = false;
 	let hasVisibleUserFields = false;
 	let systemDivider;
@@ -11,7 +11,8 @@ export function updateSystemDivider(fields: Field[]) {
 			continue;
 		}
 
-		if (field.meta?.hidden) continue;
+		const isVisible = !field.meta?.hidden || (comparisonFields && comparisonFields.has(field.field));
+		if (!isVisible) continue;
 
 		if (field.meta?.system) {
 			hasVisibleSystemFields = true;

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -166,7 +166,7 @@ function useForm() {
 
 		fields = pushGroupOptionsDown(fields);
 		updateSystemDivider(fields, props.comparison?.fields);
-		updateFieldWidths(fields);
+		updateFieldWidths(fields, props.comparison?.fields);
 
 		return fields;
 	});

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -98,7 +98,7 @@ const firstEditableFieldIndex = computed(() => {
 	for (const [index, fieldName] of fieldNames.value.entries()) {
 		const field = fieldsMap.value[fieldName];
 
-		if (field?.meta && !field.meta?.readonly && !field.meta?.hidden) {
+		if (field?.meta && !field.meta?.readonly && isVisibleField(fieldName)) {
 			return index;
 		}
 	}
@@ -110,7 +110,7 @@ const firstVisibleFieldIndex = computed(() => {
 	for (const [index, fieldName] of fieldNames.value.entries()) {
 		const field = fieldsMap.value[fieldName];
 
-		if (field?.meta && !field.meta?.hidden) {
+		if (field?.meta && isVisibleField(fieldName)) {
 			return index;
 		}
 	}
@@ -118,10 +118,13 @@ const firstVisibleFieldIndex = computed(() => {
 	return null;
 });
 
+const isVisibleField = (fieldName: string) => {
+	const field = fieldsMap.value[fieldName];
+	return !field?.meta?.hidden || (props.comparison?.mode && props.comparison?.fields?.has(fieldName));
+};
+
 const noVisibleFields = computed(() => {
-	return Object.keys(fieldsMap.value).every((fieldKey) => {
-		return fieldsMap.value[fieldKey]?.meta?.hidden === true;
-	});
+	return Object.keys(fieldsMap.value).every((fieldKey) => !isVisibleField(fieldKey));
 });
 
 watch(
@@ -162,7 +165,7 @@ function useForm() {
 		);
 
 		fields = pushGroupOptionsDown(fields);
-		updateSystemDivider(fields);
+		updateSystemDivider(fields, props.comparison?.fields);
 		updateFieldWidths(fields);
 
 		return fields;
@@ -372,7 +375,7 @@ function toggleComparisonField(field: TFormField | undefined) {
 			<template v-if="fieldsMap[fieldName]">
 				<component
 					:is="`interface-${fieldsMap[fieldName]!.meta?.interface || 'group-standard'}`"
-					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group') && !fieldsMap[fieldName]!.meta?.hidden"
+					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group') && isVisibleField(fieldName)"
 					:ref="
 						(el: Element) => {
 							formFieldEls[fieldName] = el;
@@ -402,7 +405,7 @@ function toggleComparisonField(field: TFormField | undefined) {
 				/>
 
 				<form-field
-					v-else-if="!fieldsMap[fieldName]!.meta?.hidden"
+					v-else-if="isVisibleField(fieldName)"
 					:ref="
 						(el) => {
 							formFieldEls[fieldName] = el;

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -94,6 +94,11 @@ const { fields: finalFields, fieldNames, fieldsMap, getFieldsForGroup, fieldsFor
 const { toggleBatchField, batchActiveFields } = useBatch();
 const { toggleRawField, rawActiveFields } = useRawEditor();
 
+const isVisibleField = (fieldName: string) => {
+	const field = fieldsMap.value[fieldName];
+	return !field?.meta?.hidden || (props.comparison?.mode && props.comparison?.fields?.has(fieldName));
+};
+
 const firstEditableFieldIndex = computed(() => {
 	for (const [index, fieldName] of fieldNames.value.entries()) {
 		const field = fieldsMap.value[fieldName];
@@ -117,11 +122,6 @@ const firstVisibleFieldIndex = computed(() => {
 
 	return null;
 });
-
-const isVisibleField = (fieldName: string) => {
-	const field = fieldsMap.value[fieldName];
-	return !field?.meta?.hidden || (props.comparison?.mode && props.comparison?.fields?.has(fieldName));
-};
 
 const noVisibleFields = computed(() => {
 	return Object.keys(fieldsMap.value).every((fieldKey) => !isVisibleField(fieldKey));


### PR DESCRIPTION
## Scope

What's changed:

- When a field is hidden, but part of a comparison, we now show the field and indicate its hidden status by appending "(Hidden)" to the field label.

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- Created a collection with a hidden field. Created a version and modified a few fields, including the hidden field. Verified the hidden field rendered as expected when inside the comparison modal.

## Review Notes / Questions

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required


<img width="800" alt="CleanShot 2025-09-15 at 11 15 55@2x" src="https://github.com/user-attachments/assets/60b52f41-6470-43dd-8a76-3c7e6c5219e2" />


---

Fixes #CMS-1299
