### PR TITLE
fix(retention): handle revision parent foreign key constraint

### DIFF
--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -92,6 +92,25 @@ export async function handleRetentionJob() {
 					}
 				}
 
+				if (task.collection === 'directus_activity') {
+					const activityIds = isMySQL ? records : await subquery.then((r) => r.map((r) => r.id));
+
+					if (activityIds.length > 0) {
+						const revisionsToDelete = await database
+							.select('id')
+							.from('directus_revisions')
+							.whereIn('activity', activityIds);
+
+						if (revisionsToDelete.length > 0) {
+							const revisionIds = revisionsToDelete.map((record) => record.id);
+
+							await database('directus_revisions')
+								.update({ parent: null })
+								.whereIn('parent', revisionIds);
+						}
+					}
+				}
+
 				count = await database(task.collection)
 					.whereIn('id', isMySQL ? records : subquery)
 					.delete();


### PR DESCRIPTION
Prevent foreign key violations by setting parent field to null for orphaned revisions before deletion during retention cleanup.

## Scope

What's changed:

- Added logic to identify revisions that will be deleted during retention
- Set parent field to null for child revisions before deletion
- Prevents directus_revisions_parent_foreign constraint violations

## Potential Risks / Drawbacks

- Child revisions lose their parent relationship (intended behavior)

## Tested Scenarios

- Manual retention job execution with parent/child revision relationships
- Verified orphaned revisions have parent set to null after cleanup
- Confirmed no foreign key constraint errors occur

## Review Notes / Questions
- Logic mirrors existing implementation in CollectionsService.deleteOne()

## Checklist
- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

------
Fixes #25163