### PR TITLE
Change release branch format

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           VERSION=${{ github.event.inputs.version }}
           TAG="v$VERSION"
-          BRANCH_NAME="release/$VERSION"
+          BRANCH_NAME="release-$VERSION"
           PR_TITLE="Release $VERSION"
 
           # Build the PR body content


### PR DESCRIPTION
## Scope

What's changed:

- We have a `release` branch, so the new release branch `release/vX.Y.Z` errors
  - Git views `refs/heads/release/11.12.0` as a child of `refs/heads/release`
  - Git’s ref namespace forbids a ref and a folder with the same name