### PR TITLE
Show hidden fields in comparison view

### DIFF
--- a/.changeset/few-grapes-dream.md
+++ b/.changeset/few-grapes-dream.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Created conditionals allowing hidden fields to show when those fields are part of a comparison

--- a/.changeset/few-grapes-dream.md
+++ b/.changeset/few-grapes-dream.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Created conditionals allowing hidden fields to show when those fields are part of a comparison

--- a/app/src/components/v-form/form-field-label.vue
+++ b/app/src/components/v-form/form-field-label.vue
@@ -143,9 +143,8 @@ const { t } = useI18n();
 	}
 
 	.hidden-indicator {
-		margin-inline-start: 4px;
+		margin-inline-start: 0.25em;
 		color: var(--theme--foreground-subdued);
-		font-size: 0.875em;
 	}
 
 	&:focus-within,

--- a/app/src/components/v-form/form-field-label.vue
+++ b/app/src/components/v-form/form-field-label.vue
@@ -56,6 +56,9 @@ const { t } = useI18n();
 			/>
 			<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>
 			<v-text-overflow :text="field.name" />
+			<span v-if="comparison?.fields?.has(field.field) && field.meta?.hidden" class="hidden-indicator">
+				({{ t('hidden') }})
+			</span>
 			<v-icon
 				v-if="field.meta?.required === true"
 				class="required"
@@ -137,6 +140,12 @@ const { t } = useI18n();
 		&.active {
 			opacity: 1;
 		}
+	}
+
+	.hidden-indicator {
+		margin-inline-start: 4px;
+		color: var(--theme--foreground-subdued);
+		font-size: 0.875em;
 	}
 
 	&:focus-within,

--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -6,7 +6,8 @@ export function updateFieldWidths(fields: Field[], isFieldVisible = (field: Fiel
 			let prevNonHiddenField;
 
 			for (const formField of fields) {
-				if (formField.meta?.group !== field.meta?.group || isFieldVisible(field)) continue;
+				if (formField.meta?.group !== field.meta?.group) continue;
+				if (!isFieldVisible(formField)) continue;
 				if (formField === field) break;
 				prevNonHiddenField = formField;
 			}

--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -1,12 +1,18 @@
 import { Field } from '@directus/types';
 
-export function updateFieldWidths(fields: Field[]) {
+export function updateFieldWidths(fields: Field[], comparisonFields: Set<string> = new Set()) {
 	for (const [index, field] of fields.entries()) {
-		if (index !== 0 && field.meta?.width === 'half' && field.meta.hidden !== true) {
+		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
+
+		if (index !== 0 && field.meta?.width === 'half' && isVisible) {
 			let prevNonHiddenField;
 
 			for (const formField of fields) {
-				if (formField.meta?.group !== field.meta?.group || formField.meta?.hidden) continue;
+				if (formField.meta?.group !== field.meta?.group) continue;
+
+				const isPrevFieldVisible = !formField.meta?.hidden || comparisonFields.has(formField.field);
+
+				if (!isPrevFieldVisible) continue;
 				if (formField === field) break;
 				prevNonHiddenField = formField;
 			}

--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -1,18 +1,12 @@
 import { Field } from '@directus/types';
 
-export function updateFieldWidths(fields: Field[], comparisonFields: Set<string> = new Set()) {
+export function updateFieldWidths(fields: Field[], isFieldVisible = (field: Field) => field.meta?.hidden !== true) {
 	for (const [index, field] of fields.entries()) {
-		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
-
-		if (index !== 0 && field.meta?.width === 'half' && isVisible) {
+		if (index !== 0 && field.meta?.width === 'half' && isFieldVisible(field)) {
 			let prevNonHiddenField;
 
 			for (const formField of fields) {
-				if (formField.meta?.group !== field.meta?.group) continue;
-
-				const isPrevFieldVisible = !formField.meta?.hidden || comparisonFields.has(formField.field);
-
-				if (!isPrevFieldVisible) continue;
+				if (formField.meta?.group !== field.meta?.group || isFieldVisible(field)) continue;
 				if (formField === field) break;
 				prevNonHiddenField = formField;
 			}

--- a/app/src/components/v-form/utils/update-system-divider.ts
+++ b/app/src/components/v-form/utils/update-system-divider.ts
@@ -1,6 +1,6 @@
 import type { Field } from '@directus/types';
 
-export function updateSystemDivider(fields: Field[], comparisonFields: Set<string> = new Set()) {
+export function updateSystemDivider(fields: Field[], isFieldVisible = (field: Field) => field.meta?.hidden !== true) {
 	let hasVisibleSystemFields = false;
 	let hasVisibleUserFields = false;
 	let systemDivider;
@@ -11,8 +11,7 @@ export function updateSystemDivider(fields: Field[], comparisonFields: Set<strin
 			continue;
 		}
 
-		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
-		if (!isVisible) continue;
+		if (!isFieldVisible(field)) continue;
 
 		if (field.meta?.system) {
 			hasVisibleSystemFields = true;

--- a/app/src/components/v-form/utils/update-system-divider.ts
+++ b/app/src/components/v-form/utils/update-system-divider.ts
@@ -1,6 +1,6 @@
 import type { Field } from '@directus/types';
 
-export function updateSystemDivider(fields: Field[]) {
+export function updateSystemDivider(fields: Field[], comparisonFields: Set<string> = new Set()) {
 	let hasVisibleSystemFields = false;
 	let hasVisibleUserFields = false;
 	let systemDivider;
@@ -11,7 +11,8 @@ export function updateSystemDivider(fields: Field[]) {
 			continue;
 		}
 
-		if (field.meta?.hidden) continue;
+		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
+		if (!isVisible) continue;
 
 		if (field.meta?.system) {
 			hasVisibleSystemFields = true;

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -90,20 +90,24 @@ onBeforeUpdate(() => {
 	formFieldEls.value = {};
 });
 
-const { fields: finalFields, fieldNames, fieldsMap, getFieldsForGroup, fieldsForGroup, isDisabled } = useForm();
+const {
+	fields: finalFields,
+	fieldNames,
+	fieldsMap,
+	fieldsForGroup,
+	isDisabled,
+	getFieldsForGroup,
+	isFieldVisible,
+} = useForm();
+
 const { toggleBatchField, batchActiveFields } = useBatch();
 const { toggleRawField, rawActiveFields } = useRawEditor();
-
-const isVisibleField = (fieldName: string) => {
-	const field = fieldsMap.value[fieldName];
-	return !field?.meta?.hidden || (props.comparison && props.comparison?.fields?.has(fieldName));
-};
 
 const firstEditableFieldIndex = computed(() => {
 	for (const [index, fieldName] of fieldNames.value.entries()) {
 		const field = fieldsMap.value[fieldName];
 
-		if (field?.meta && !field.meta?.readonly && isVisibleField(fieldName)) {
+		if (field?.meta && !field.meta?.readonly && isFieldVisible(field)) {
 			return index;
 		}
 	}
@@ -115,7 +119,7 @@ const firstVisibleFieldIndex = computed(() => {
 	for (const [index, fieldName] of fieldNames.value.entries()) {
 		const field = fieldsMap.value[fieldName];
 
-		if (field?.meta && isVisibleField(fieldName)) {
+		if (field?.meta && isFieldVisible(field)) {
 			return index;
 		}
 	}
@@ -124,7 +128,9 @@ const firstVisibleFieldIndex = computed(() => {
 });
 
 const noVisibleFields = computed(() => {
-	return Object.keys(fieldsMap.value).every((fieldKey) => !isVisibleField(fieldKey));
+	return Object.keys(fieldsMap.value).every((fieldKey) => {
+		return !isFieldVisible(fieldsMap.value[fieldKey]!);
+	});
 });
 
 watch(
@@ -165,8 +171,8 @@ function useForm() {
 		);
 
 		fields = pushGroupOptionsDown(fields);
-		updateSystemDivider(fields, props.comparison?.fields);
-		updateFieldWidths(fields, props.comparison?.fields);
+		updateSystemDivider(fields, isFieldVisible);
+		updateFieldWidths(fields, isFieldVisible);
 
 		return fields;
 	});
@@ -187,7 +193,7 @@ function useForm() {
 		return fieldNames.value.map((name) => getFieldsForGroup(fieldsMap.value[name]?.meta?.field || null));
 	});
 
-	return { fields, fieldNames, fieldsMap, isDisabled, getFieldsForGroup, fieldsForGroup };
+	return { fields, fieldNames, fieldsMap, fieldsForGroup, isDisabled, getFieldsForGroup, isFieldVisible };
 
 	function isDisabled(field: TFormField | undefined) {
 		if (!field) return true;
@@ -244,6 +250,10 @@ function useForm() {
 		}
 
 		return field;
+	}
+
+	function isFieldVisible(field: Field | TFormField) {
+		return field.meta?.hidden !== true || !!props.comparison?.fields?.has(field.field);
 	}
 }
 
@@ -370,7 +380,7 @@ function useRawEditor() {
 			<template v-if="fieldsMap[fieldName]">
 				<component
 					:is="`interface-${fieldsMap[fieldName]!.meta?.interface || 'group-standard'}`"
-					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group') && isVisibleField(fieldName)"
+					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group') && isFieldVisible(fieldsMap[fieldName])"
 					:ref="
 						(el: Element) => {
 							formFieldEls[fieldName] = el;
@@ -400,7 +410,7 @@ function useRawEditor() {
 				/>
 
 				<form-field
-					v-else-if="isVisibleField(fieldName)"
+					v-else-if="isFieldVisible(fieldsMap[fieldName])"
 					:ref="
 						(el) => {
 							formFieldEls[fieldName] = el;


### PR DESCRIPTION
## Scope

What's changed:

- When a field is hidden, but part of a comparison, we now show the field and indicate its hidden status by appending "(Hidden)" to the field label.

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- Created a collection with a hidden field. Created a version and modified a few fields, including the hidden field. Verified the hidden field rendered as expected when inside the comparison modal.

## Review Notes / Questions

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required


<img width="800" alt="CleanShot 2025-09-15 at 11 15 55@2x" src="https://github.com/user-attachments/assets/60b52f41-6470-43dd-8a76-3c7e6c5219e2" />


---

Fixes #CMS-1299
