### PR TITLE
fix: Big interger -> Grand nombre entier

### DIFF
--- a/app/src/lang/translations/fr-CA.yaml
+++ b/app/src/lang/translations/fr-CA.yaml
@@ -597,7 +597,7 @@ created_on: Créé le
 creating_collection_info: Nommez la collection et configurez son champ unique « clé »...
 creating_collection_system: Activer et renommer l'un de ces champs optionnels.
 auto_increment_integer: Entier auto-incrémenté
-auto_increment_big_integer: Big interger auto-incrémenté
+auto_increment_big_integer: Grand nombre entier auto-incrémenté
 generated_uuid: UUID généré
 manual_string: Chaîne de caractère saisie manuellement
 save_and_create_new: Enregistrer et en créer un nouveau

--- a/app/src/lang/translations/fr-FR.yaml
+++ b/app/src/lang/translations/fr-FR.yaml
@@ -597,7 +597,7 @@ created_on: Créé le
 creating_collection_info: Donnez un nom à la collection et configurez son champ de « clé » unique...
 creating_collection_system: Vous pouvez activer et renommer les champs optionnels suivants.
 auto_increment_integer: Entier auto-incrémenté
-auto_increment_big_integer: Big interger auto-incrémenté
+auto_increment_big_integer: Grand nombre entier auto-incrémenté
 generated_uuid: UUID généré
 manual_string: Chaîne de caractère saisie manuellement
 save_and_create_new: Enregistrer et en créer un nouveau

--- a/contributors.yml
+++ b/contributors.yml
@@ -224,3 +224,4 @@
 - timio23
 - khanahmad4527
 - gaetansenn
+- dix


### PR DESCRIPTION
## Scope

What's changed:

- The French translation (for FR and CA locales) was using `Big interger` which is neither French nor English. The PR is proposing a correct French translation for "Big integer", fixing the incorrect English label and translating it to actual French.

## Potential Risks / Drawbacks

- None, it's a fix in translation labels

No Changeset

