### PR TITLE
refactor: unify visibility checks by replacing comparisonFields with isFieldVisible function

### DIFF
--- a/app/src/components/v-form/utils/update-field-widths.ts
+++ b/app/src/components/v-form/utils/update-field-widths.ts
@@ -1,18 +1,12 @@
 import { Field } from '@directus/types';
 
-export function updateFieldWidths(fields: Field[], comparisonFields: Set<string> = new Set()) {
+export function updateFieldWidths(fields: Field[], isFieldVisible = (field: Field) => field.meta?.hidden !== true) {
 	for (const [index, field] of fields.entries()) {
-		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
-
-		if (index !== 0 && field.meta?.width === 'half' && isVisible) {
+		if (index !== 0 && field.meta?.width === 'half' && isFieldVisible(field)) {
 			let prevNonHiddenField;
 
 			for (const formField of fields) {
-				if (formField.meta?.group !== field.meta?.group) continue;
-
-				const isPrevFieldVisible = !formField.meta?.hidden || comparisonFields.has(formField.field);
-
-				if (!isPrevFieldVisible) continue;
+				if (formField.meta?.group !== field.meta?.group || isFieldVisible(field)) continue;
 				if (formField === field) break;
 				prevNonHiddenField = formField;
 			}

--- a/app/src/components/v-form/utils/update-system-divider.ts
+++ b/app/src/components/v-form/utils/update-system-divider.ts
@@ -1,6 +1,6 @@
 import type { Field } from '@directus/types';
 
-export function updateSystemDivider(fields: Field[], comparisonFields: Set<string> = new Set()) {
+export function updateSystemDivider(fields: Field[], isFieldVisible = (field: Field) => field.meta?.hidden !== true) {
 	let hasVisibleSystemFields = false;
 	let hasVisibleUserFields = false;
 	let systemDivider;
@@ -11,8 +11,7 @@ export function updateSystemDivider(fields: Field[], comparisonFields: Set<strin
 			continue;
 		}
 
-		const isVisible = !field.meta?.hidden || comparisonFields.has(field.field);
-		if (!isVisible) continue;
+		if (!isFieldVisible(field)) continue;
 
 		if (field.meta?.system) {
 			hasVisibleSystemFields = true;

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -107,7 +107,7 @@ const firstEditableFieldIndex = computed(() => {
 	for (const [index, fieldName] of fieldNames.value.entries()) {
 		const field = fieldsMap.value[fieldName];
 
-		if (field?.meta && !field.meta?.readonly && isFieldVisible(field as Field)) {
+		if (field?.meta && !field.meta?.readonly && isFieldVisible(field)) {
 			return index;
 		}
 	}


### PR DESCRIPTION
## Scope

What's changed:

- refactor: unify visibility checks by replacing comparisonFields with isFieldVisible function
- use isFieldVisible function inside updateFieldWidths and updateSystemDivider instead of adding the comparison logic to them

## Potential Risks / Drawbacks

—

## Tested Scenarios

—

## Review Notes / Questions

—
