### PR TITLE
Adding firstDayOfWeek to v-date-picker

### DIFF
--- a/app/src/components/v-date-picker.vue
+++ b/app/src/components/v-date-picker.vue
@@ -11,6 +11,7 @@ interface Props {
 	disabled?: boolean;
 	includeSeconds?: boolean;
 	use24?: boolean;
+	firstDayOfWeek?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
 	disabled: false,
 	includeSeconds: false,
 	use24: true,
+	firstDayOfWeek: 0,
 });
 
 const emit = defineEmits<{ 'update:modelValue': [value: string | null]; close: [] }>();
@@ -94,6 +96,7 @@ const flatpickrOptions = computed<Record<string, any>>(() => {
 		enableTime: ['dateTime', 'time', 'timestamp'].includes(props.type),
 		noCalendar: props.type === 'time',
 		time_24hr: props.use24,
+		firstDayOfWeek: props.firstDayOfWeek,
 	});
 });
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -224,3 +224,4 @@
 - timio23
 - khanahmad4527
 - gaetansenn
+- SaucaVictor


### PR DESCRIPTION
##Scope

This PR introduces a new firstDayOfWeek prop to the v-date-picker component, allowing consumers to customize which day the calendar week starts on.