### PR TITLE
Fix operation extension options when using a vue component

### DIFF
--- a/.changeset/sad-spies-look.md
+++ b/.changeset/sad-spies-look.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed operation extension options when using a vue component

--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -109,7 +109,7 @@ const displayOperations = computed(() =>
 const operationOptions = computed(() => {
 	if (typeof selectedOperation.value?.options === 'function') {
 		return translate(selectedOperation.value.options(options.value));
-	} else if (typeof selectedOperation.value?.options === 'object') {
+	} else if (Array.isArray(selectedOperation.value?.options)) {
 		return selectedOperation.value.options;
 	}
 
@@ -121,7 +121,7 @@ function saveOperation() {
 
 	saving.value = true;
 
-	const defaultValues = Array.isArray(operationOptions.value)
+	const defaultValues = operationOptions.value
 		? getDefaultValuesFromFields(operationOptions.value as Field[]).value
 		: null;
 

--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -121,7 +121,7 @@ function saveOperation() {
 
 	saving.value = true;
 
-	const defaultValues = operationOptions.value
+	const defaultValues = Array.isArray(operationOptions.value)
 		? getDefaultValuesFromFields(operationOptions.value as Field[]).value
 		: null;
 


### PR DESCRIPTION
## Scope

This regression was caused by https://github.com/directus/directus/pull/25047 and https://github.com/directus/directus/pull/24963 introducing the `getDefaultValuesFromFields` function

What's changed:

- Only use the `getDefaultValuesFromFields` function if there is an array (this function was throwing the `().reduce` error for non-array input)

## Potential Risks / Drawbacks

- Not sure but i think this is fairly isolated

## Tested Scenarios

- Install the Hubspot Operation from Directus Labs and use it in a flow

## Review Notes / Questions

- Is this the right solution?
- Are there unforeseen issues with bypassing the defaults like this?

Fixes #25900
