### PR TITLE
Add simple snapshot download button

### DIFF
--- a/.changeset/pretty-emus-reply.md
+++ b/.changeset/pretty-emus-reply.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Added snapshot download button to the admin view of the app
+Added schema snapshot download button to the admin view of the studio

--- a/.changeset/pretty-emus-reply.md
+++ b/.changeset/pretty-emus-reply.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added snapshot download button to the admin view of the app

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
       label: To Reproduce
       description:
         Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce
-        the bug. If applicable, please provide a schema snapshot instead of describing the schema in words.
+        the bug. If applicable, export and attach a schema snapshot from **Settings > Data Model** sidebar.```
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
       label: To Reproduce
       description:
         Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce
-        the bug.
+        the bug. If applicable, please provide a schema snapshot instead of describing the schema in words.
     validations:
       required: true
   - type: input

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -517,7 +517,7 @@ import_data_error: This file's data structure doesn't match the collection.
 snapshot:
   export: Export Schema
   download: Download Snapshot (JSON)
-  info: Exports the schema without content for quick sharing and reproduction
+  info: Schema-only export for sharing or debugging
 label_import: Import
 label_export: Export
 import_export: Import / Export

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -515,8 +515,8 @@ import_data_indeterminate: Importing Data...
 import_data_success: Data successfully imported from {filename}
 import_data_error: This file's data structure doesn't match the collection.
 snapshot:
-  export: Export Snapshot
-  download: Download snapshot.json
+  export: Export Schema
+  download: Download Snapshot (JSON)
 label_import: Import
 label_export: Export
 import_export: Import / Export

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -517,6 +517,7 @@ import_data_error: This file's data structure doesn't match the collection.
 snapshot:
   export: Export Schema
   download: Download Snapshot (JSON)
+  info: Exports the schema without content for quick sharing and reproduction
 label_import: Import
 label_export: Export
 import_export: Import / Export

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -514,6 +514,9 @@ import_data_button: Start Import
 import_data_indeterminate: Importing Data...
 import_data_success: Data successfully imported from {filename}
 import_data_error: This file's data structure doesn't match the collection.
+snapshot:
+  export: Export Snapshot
+  download: Download snapshot.json
 label_import: Import
 label_export: Export
 import_export: Import / Export

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -267,14 +267,10 @@ async function downloadSnapshot() {
 				<div v-md="t('page_help_settings_datamodel_collections')" class="page-description" />
 			</sidebar-detail>
 			<sidebar-detail icon="download" :title="t('snapshot.export')">
-				<div class="fields">
-					<div v-md="t('snapshot.info')" class="page-description" />
-					<div class="field full">
-						<v-button small full-width @click="downloadSnapshot">
-							{{ t('snapshot.download') }}
-						</v-button>
-					</div>
-				</div>
+				<div v-md="t('snapshot.info')" class="page-description" />
+				<v-button small full-width class="snapshot-download" @click="downloadSnapshot">
+					{{ t('snapshot.download') }}
+				</v-button>
 			</sidebar-detail>
 		</template>
 
@@ -356,5 +352,9 @@ async function downloadSnapshot() {
 
 .v-list.draggable-list {
 	padding-block-start: 0;
+}
+
+.snapshot-download {
+	margin-block-start: 12px;
 }
 </style>

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -268,6 +268,7 @@ async function downloadSnapshot() {
 			</sidebar-detail>
 			<sidebar-detail icon="download" :title="t('snapshot.export')">
 				<div class="fields">
+					<div v-md="t('snapshot.info')" class="page-description" />
 					<div class="field full">
 						<v-button small full-width @click="downloadSnapshot">
 							{{ t('snapshot.download') }}

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -14,6 +14,7 @@ import CollectionDialog from './components/collection-dialog.vue';
 import CollectionItem from './components/collection-item.vue';
 import CollectionOptions from './components/collection-options.vue';
 import { useExpandCollapse } from './composables/use-expand-collapse';
+import { saveAs } from 'file-saver';
 
 const { t } = useI18n();
 
@@ -127,6 +128,15 @@ async function onSort(updates: Collection[], removeGroup = false) {
 	} catch (error) {
 		unexpectedError(error);
 	}
+}
+
+async function downloadSnapshot() {
+	const snapshot = await api.get(`/schema/snapshot`);
+
+	saveAs(
+		new Blob([JSON.stringify(snapshot.data, null, 2)], { type: 'application/json;charset=utf-8' }),
+		`snapshot.json`,
+	);
 }
 </script>
 
@@ -255,6 +265,15 @@ async function onSort(updates: Collection[], removeGroup = false) {
 		<template #sidebar>
 			<sidebar-detail icon="info" :title="t('information')" close>
 				<div v-md="t('page_help_settings_datamodel_collections')" class="page-description" />
+			</sidebar-detail>
+			<sidebar-detail icon="download" :title="t('snapshot.export')">
+				<div class="fields">
+					<div class="field full">
+						<v-button small full-width @click="downloadSnapshot">
+							{{ t('snapshot.download') }}
+						</v-button>
+					</div>
+				</div>
 			</sidebar-detail>
 		</template>
 


### PR DESCRIPTION
Added quick and hacky way to download snapshots from the admin interface of the app. We should update the issue template after this PR to ask people to provide their schema if possible for easier debugging.

I just added a button for now but it might be worth considering adding a quick explainer above that button on what it's intended use is and that it will only export the schema and no data except for default values.

<img width="2294" height="1329" alt="grafik" src="https://github.com/user-attachments/assets/bcba4c65-641e-422b-b822-5f4c2914c1e1" />
