### PR TITLE
fix: block editor dark mode

### DIFF
--- a/.changeset/dull-berries-bake.md
+++ b/.changeset/dull-berries-bake.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the dark mode visual of the block editor popover

--- a/app/src/interfaces/input-block-editor/editorjs-overrides.css
+++ b/app/src/interfaces/input-block-editor/editorjs-overrides.css
@@ -53,7 +53,7 @@
 	border-color: var(--theme--form--field--input--border-color-hover);
 }
 
-.codex-editor .ce-popover {
+.codex-editor .ce-popover__container {
 	background: var(--theme--form--field--input--background-subdued);
 	border-color: var(--theme--form--field--input--border-color);
 	border-width: var(--theme--border-width);
@@ -98,6 +98,7 @@
 	background: transparent;
 	box-shadow: unset;
 	border: 1px solid var(--theme--foreground-subdued);
+	border-radius: 4px;
 }
 
 .codex-editor .ce-popover-item--active .ce-popover-item__icon {


### PR DESCRIPTION
## Scope

What's changed:

|Before|After|
|-|-|
| <img width="576" height="834" alt="CleanShot 2025-10-01 at 11 45 15@2x" src="https://github.com/user-attachments/assets/56c4aae2-208b-4188-ac5a-d430be56bfc6" /> | <img width="576" height="834" alt="CleanShot 2025-10-01 at 11 39 49@2x" src="https://github.com/user-attachments/assets/4fe2be27-7ba9-467e-97de-534123ccabf3" /> |

- Changed the CSS selector from `.ce-popover` to `.ce-popover__container` 
- Added in a cheeky `border-radius: 4px` for the icons

<img width="1280" height="834" alt="CleanShot 2025-10-01 at 11 39 41@2x" src="https://github.com/user-attachments/assets/4dc1c78a-e627-452b-828a-8d9190852914" />

## Potential Risks / Drawbacks

I have not been able to track down why this selector is currently broken and why it worked before.

## Tested Scenarios

- Light mode & dark mode

## Review Notes / Questions

- I would like to lorem ipsum

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25916 
