### PR TITLE
Fix content versioning for singleton collections

### DIFF
--- a/.changeset/curly-jars-divide.md
+++ b/.changeset/curly-jars-divide.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed versioning on singletons

--- a/.changeset/curly-jars-divide.md
+++ b/.changeset/curly-jars-divide.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed content versioning for singletons
+Fixed content versioning for singleton

--- a/.changeset/curly-jars-divide.md
+++ b/.changeset/curly-jars-divide.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed content versioning for singleton
+Fixed content versioning for singleton collections

--- a/.changeset/curly-jars-divide.md
+++ b/.changeset/curly-jars-divide.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed versioning on singletons
+Fixed content versioning for singletons

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1183,7 +1183,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		if (query.version) {
 			const primaryKeyField = this.schema.collections[this.collection]!.primary;
-			const key = (await this.readByQuery({ limit: 1, fields: [primaryKeyField] }))[0]?.[primaryKeyField];
+			const key = (await this.knex.select(primaryKeyField).from(this.collection).limit(1).first())[primaryKeyField];
 			record = await handleVersion(this, key, query, opts);
 		} else {
 			record = (await this.readByQuery(query, opts))[0];

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1179,8 +1179,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		query.limit = 1;
 
-		const records = await this.readByQuery(query, opts);
-		const record = records[0];
+		let record;
+
+		if (query.version) {
+			const primaryKeyField = this.schema.collections[this.collection]!.primary;
+			const key = (await this.readByQuery({ limit: 1, fields: [primaryKeyField] }))[0]?.[primaryKeyField];
+			record = await handleVersion(this, key, query, opts);
+		} else {
+			record = (await this.readByQuery(query, opts))[0];
+		}
 
 		if (!record) {
 			let fields = Object.entries(this.schema.collections[this.collection]!.fields);

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1183,8 +1183,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		if (query.version) {
 			const primaryKeyField = this.schema.collections[this.collection]!.primary;
-			const key = (await this.knex.select(primaryKeyField).from(this.collection).limit(1).first())[primaryKeyField];
-			record = await handleVersion(this, key, query, opts);
+			const key = (await this.knex.select(primaryKeyField).from(this.collection).first())?.[primaryKeyField];
+
+			if (key) {
+				record = await handleVersion(this, key, query, opts);
+			}
 		} else {
 			record = (await this.readByQuery(query, opts))[0];
 		}


### PR DESCRIPTION
## Scope

What's changed:

- Handle versioning in readSingleton

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- Querying version on singletons

## Review Notes / Questions

- Pretty clear oversight of assuming that `readSingleton` uses `readOne` but instead, it uses `readByQuery`.

---

Fixes #25923
