### PR TITLE
Fix collection not required in item operations

### DIFF
--- a/.changeset/floppy-trains-prove.md
+++ b/.changeset/floppy-trains-prove.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed collection not required in item operations

--- a/app/src/operations/item-create/index.ts
+++ b/app/src/operations/item-create/index.ts
@@ -21,6 +21,7 @@ export default defineOperationApp({
 			name: '$t:collection',
 			type: 'string',
 			meta: {
+				required: true,
 				width: 'half',
 				interface: 'system-collection',
 			},

--- a/app/src/operations/item-delete/index.ts
+++ b/app/src/operations/item-delete/index.ts
@@ -26,6 +26,7 @@ export default defineOperationApp({
 			name: '$t:collection',
 			type: 'string',
 			meta: {
+				required: true,
 				width: 'half',
 				interface: 'system-collection',
 			},

--- a/app/src/operations/item-read/index.ts
+++ b/app/src/operations/item-read/index.ts
@@ -55,6 +55,7 @@ export default defineOperationApp({
 			name: '$t:collection',
 			type: 'string',
 			meta: {
+				required: true,
 				width: 'half',
 				interface: 'system-collection',
 			},

--- a/app/src/operations/item-update/index.ts
+++ b/app/src/operations/item-update/index.ts
@@ -26,6 +26,7 @@ export default defineOperationApp({
 			name: '$t:collection',
 			type: 'string',
 			meta: {
+				required: true,
 				width: 'half',
 				interface: 'system-collection',
 			},


### PR DESCRIPTION
## Scope

What's changed:

- `collection` is now marked as required in item operations

## Potential Risks / Drawbacks

- Should be none
## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25933
