### PR TITLE
Remove defineProps import to fix compiler warning

### DIFF
--- a/.changeset/common-trains-rhyme.md
+++ b/.changeset/common-trains-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Removed defineProps import to resolve compiler warning

--- a/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-validation-existing.vue
+++ b/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-validation-existing.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { defineProps, ref, toRef } from 'vue';
+import { ref, toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import SystemMcpPromptsCollectionGenerateDialog from './system-mcp-prompts-collection-generate-dialog.vue';
 import { useCollectionValidation } from './use-collection-validation';


### PR DESCRIPTION
## Scope

What's changed:

- Removed defineProps import to resolve compiler warning

## Potential Risks / Drawbacks

—

## Tested Scenarios

—

## Review Notes / Questions

—

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25943
