### PR TITLE
Content Comparison - Implement non editable mode for form fields

### DIFF
--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
 	modelValue?: string | number | boolean | Record<string, any> | Array<any>;
 	loading?: boolean;
 	disabled?: boolean;
+	nonEditable?: boolean;
 	autofocus?: boolean;
 	rawEditorEnabled?: boolean;
 	rawEditorActive?: boolean;
@@ -47,6 +48,7 @@ const value = computed(() =>
 		class="interface"
 		:class="{
 			subdued: batchMode && batchActive === false,
+			'non-editable': nonEditable,
 		}"
 	>
 		<v-skeleton-loader v-if="loading && field.hideLoader !== true" />
@@ -57,6 +59,7 @@ const value = computed(() =>
 				v-bind="(field.meta && field.meta.options) || {}"
 				:autofocus="disabled !== true && autofocus"
 				:disabled="disabled"
+				:non-editable="nonEditable"
 				:loading="loading"
 				:value="value"
 				:batch-mode="batchMode"
@@ -109,6 +112,10 @@ const value = computed(() =>
 
 	&.subdued {
 		opacity: 0.5;
+	}
+
+	&.non-editable {
+		pointer-events: none;
 	}
 }
 </style>

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -20,6 +20,7 @@ const props = withDefaults(
 		comparison?: ComparisonContext;
 		comparisonActive?: boolean;
 		disabled?: boolean;
+		nonEditable?: boolean;
 		modelValue?: any;
 		initialValue?: any;
 		primaryKey?: string | number;
@@ -52,6 +53,8 @@ const isDisabled = computed(() => {
 	if (props.batchMode && props.batchActive === false) return true;
 	return false;
 });
+
+const isNonEditable = computed(() => !!props.nonEditable);
 
 const isLabelHidden = computed(() => {
 	if (props.batchMode && !props.field.meta?.special?.includes('no-data')) return false;
@@ -175,7 +178,7 @@ function useComputedValues() {
 			},
 		]"
 	>
-		<v-menu v-if="!isLabelHidden" placement="bottom-start" show-arrow arrow-placement="start">
+		<v-menu v-if="!isLabelHidden && !isNonEditable" placement="bottom-start" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
 				<form-field-label
 					:field="field"
@@ -209,6 +212,23 @@ function useComputedValues() {
 				@paste-raw="pasteRaw"
 			/>
 		</v-menu>
+		<form-field-label
+			v-else-if="!isLabelHidden"
+			:field="field"
+			:toggle="() => {}"
+			:active="false"
+			:batch-mode="batchMode"
+			:batch-active="batchActive"
+			:comparison="comparison"
+			:comparison-active="comparisonActive"
+			:edited="isEdited"
+			:has-error="!!validationError"
+			:badge="badge"
+			:raw-editor-enabled="false"
+			:raw-editor-active="false"
+			:loading="loading"
+			disabled
+		/>
 		<div v-else-if="['full', 'fill'].includes(field.meta?.width ?? '') === false" class="label-spacer" />
 
 		<form-field-interface
@@ -219,6 +239,7 @@ function useComputedValues() {
 			:batch-mode="batchMode"
 			:batch-active="batchActive"
 			:disabled="isDisabled"
+			:non-editable="isNonEditable"
 			:primary-key="primaryKey"
 			:raw-editor-enabled="rawEditorEnabled"
 			:raw-editor-active="rawEditorActive"

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -31,6 +31,7 @@ const props = withDefaults(
 		batchMode?: boolean;
 		primaryKey?: string | number;
 		disabled?: boolean;
+		nonEditable?: boolean;
 		validationErrors?: ValidationError[];
 		autofocus?: boolean;
 		group?: string | null;
@@ -428,6 +429,7 @@ function useRawEditor() {
 					:initial-value="(initialValues || {})[fieldName]"
 					:disabled="isDisabled(fieldsMap[fieldName]!)"
 					:batch-mode="batchMode"
+					:non-editable="!!nonEditable"
 					:batch-active="batchActiveFields.includes(fieldName)"
 					:comparison="comparison"
 					:comparison-active="comparison?.selectedFields.includes(fieldName)"

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -410,6 +410,7 @@ function useRawEditor() {
 					:raw-editor-enabled="rawEditorEnabled"
 					:direction="direction"
 					:version
+					:non-editable="!!nonEditable"
 					:comparison="comparison"
 					v-bind="fieldsMap[fieldName]!.meta?.options || {}"
 					@apply="apply"

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -12,6 +12,8 @@ interface Props {
 	autofocus?: boolean;
 	/** Set the disabled state for the input */
 	disabled?: boolean;
+	/** Prevent interaction and hide action indicators */
+	nonEditable?: boolean;
 	/** If the input should be clickable */
 	clickable?: boolean;
 	/** Prefix the users value with a value */
@@ -61,6 +63,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
 	autofocus: false,
 	disabled: false,
+	nonEditable: false,
 	clickable: false,
 	prefix: undefined,
 	suffix: undefined,
@@ -110,6 +113,7 @@ const classes = computed(() => [
 		'full-width': props.fullWidth,
 		'has-click': props.clickable,
 		disabled: props.disabled,
+		'non-editable': props.nonEditable,
 		small: props.small,
 		invalid: isInvalidInput.value,
 	},
@@ -297,7 +301,7 @@ function useInvalidInput() {
 		<div v-if="$slots['prepend-outer']" class="prepend-outer">
 			<slot name="prepend-outer" :value="modelValue" :disabled="disabled" />
 		</div>
-		<div class="input" :class="{ disabled, active }">
+		<div class="input" :class="{ disabled, active, 'non-editable': nonEditable }">
 			<div v-if="$slots.prepend" class="prepend">
 				<slot name="prepend" :value="modelValue" :disabled="disabled" />
 			</div>
@@ -315,6 +319,7 @@ function useInvalidInput() {
 					:max="max"
 					:step="step"
 					:disabled="disabled"
+					:non-editable="nonEditable"
 					:value="modelValue === undefined || modelValue === null ? '' : String(modelValue)"
 					v-on="listeners"
 					@keydown.space="$emit('keydown:space', $event)"
@@ -381,6 +386,9 @@ function useInvalidInput() {
 	}
 
 	.input {
+		&.non-editable {
+			pointer-events: none;
+		}
 		position: relative;
 		display: flex;
 		flex-grow: 1;
@@ -465,6 +473,24 @@ function useInvalidInput() {
 		.append {
 			flex-shrink: 0;
 			margin-inline-start: 8px;
+		}
+	}
+	&.non-editable {
+		.input {
+			pointer-events: none;
+			cursor: default;
+		}
+
+		.append,
+		.prepend,
+		.warning-invalid,
+		.step-up,
+		.step-down,
+		:deep(.v-icon),
+		:deep(button),
+		:deep([clickable]),
+		:deep([role='button']) {
+			display: none;
 		}
 	}
 

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -45,6 +45,8 @@ const props = withDefaults(
 		fullWidth?: boolean;
 		/** Disables any interaction */
 		disabled?: boolean;
+		/** Prevent interaction and hide action indicators */
+		nonEditable?: boolean;
 		/** Allow to deselect all currently selected items */
 		showDeselect?: boolean;
 		/** Allow to enter custom values */
@@ -252,7 +254,7 @@ function useDisplayValue() {
 <template>
 	<v-menu
 		class="v-select"
-		:disabled="disabled"
+		:disabled="disabled || nonEditable"
 		:attached="inline === false"
 		:show-arrow="inline === true"
 		:close-on-content-click="closeOnContentClick"
@@ -263,14 +265,14 @@ function useDisplayValue() {
 			<button
 				v-if="inline"
 				type="button"
-				:disabled="disabled"
+				:disabled="disabled || nonEditable"
 				:aria-pressed="active"
 				class="inline-display"
-				:class="{ placeholder: !displayValue.text, label, active, disabled }"
+				:class="{ placeholder: !displayValue.text, label, active, disabled, 'non-editable': nonEditable }"
 				@click="toggle"
 			>
 				<slot name="preview">{{ displayValue.text || placeholder }}</slot>
-				<v-icon name="expand_more" :class="{ active }" />
+				<v-icon v-if="!nonEditable" name="expand_more" :class="{ active }" />
 			</button>
 			<slot
 				v-else
@@ -287,6 +289,7 @@ function useDisplayValue() {
 					clickable
 					:placeholder="placeholder"
 					:disabled="disabled"
+					:non-editable="nonEditable"
 					:active="active"
 					@click="toggle"
 					@keydown:enter="toggle"
@@ -298,7 +301,7 @@ function useDisplayValue() {
 						<display-color v-else-if="displayValue.color" :value="displayValue.color" />
 					</template>
 					<template #append>
-						<v-icon name="expand_more" :class="{ active }" />
+						<v-icon v-if="!nonEditable" name="expand_more" :class="{ active }" />
 						<slot name="append" />
 					</template>
 				</v-input>
@@ -427,6 +430,12 @@ function useDisplayValue() {
 	--v-input-font-family: var(--v-select-font-family, var(--theme--fonts--sans--font-family));
 
 	cursor: pointer;
+
+	&.non-editable,
+	&.non-editable .input,
+	&.non-editable :deep(input) {
+		cursor: default !important;
+	}
 }
 
 .v-input .v-icon {
@@ -457,6 +466,10 @@ function useDisplayValue() {
 
 	&:not(.disabled) {
 		cursor: pointer;
+	}
+
+	&.non-editable {
+		pointer-events: none;
 	}
 }
 

--- a/app/src/components/v-textarea.vue
+++ b/app/src/components/v-textarea.vue
@@ -4,6 +4,8 @@ import { computed } from 'vue';
 interface Props {
 	/** Disables the input */
 	disabled?: boolean;
+	/** Prevent interaction */
+	nonEditable?: boolean;
 	/** Autofocusses the input on render */
 	autofocus?: boolean;
 	/** Render the input with 100% width */
@@ -22,6 +24,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
 	disabled: false,
+	nonEditable: false,
 	autofocus: false,
 	fullWidth: true,
 	modelValue: undefined,
@@ -62,6 +65,7 @@ function trimIfEnabled() {
 		class="v-textarea"
 		:class="{
 			disabled,
+			'non-editable': nonEditable,
 			'expand-on-focus': expandOnFocus,
 			'full-width': fullWidth,
 			'has-content': hasContent,
@@ -73,6 +77,7 @@ function trimIfEnabled() {
 			v-bind="$attrs"
 			:placeholder="placeholder"
 			:disabled="disabled"
+			:non-editable="nonEditable"
 			:value="modelValue"
 			v-on="listeners"
 		/>
@@ -133,6 +138,10 @@ function trimIfEnabled() {
 
 	&.full-width {
 		inline-size: 100%;
+	}
+
+	&.non-editable {
+		pointer-events: none;
 	}
 
 	&:hover:not(.disabled) {

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -13,6 +13,7 @@ const props = withDefaults(
 		values: Record<string, unknown>;
 		initialValues: Record<string, unknown>;
 		disabled?: boolean;
+		nonEditable?: boolean;
 		batchMode?: boolean;
 		batchActiveFields?: string[];
 		comparison?: ComparisonContext;
@@ -107,6 +108,7 @@ function handleModifier(event: MouseEvent, toggle: () => void) {
 						:validation-errors="validationErrors"
 						:loading="loading"
 						:batch-mode="batchMode"
+						:non-editable="!!nonEditable"
 						:disabled="disabled"
 						:comparison="comparison"
 						:direction="direction"

--- a/app/src/interfaces/group-accordion/group-accordion.vue
+++ b/app/src/interfaces/group-accordion/group-accordion.vue
@@ -12,6 +12,7 @@ const props = withDefaults(
 		values: Record<string, unknown>;
 		initialValues: Record<string, unknown>;
 		disabled?: boolean;
+		nonEditable?: boolean;
 		batchMode?: boolean;
 		batchActiveFields?: string[];
 		comparison?: ComparisonContext;
@@ -120,6 +121,7 @@ function useComputedGroup() {
 			:values="groupValues"
 			:initial-values="initialValues"
 			:disabled="disabled"
+			:non-editable="!!nonEditable"
 			:batch-mode="batchMode"
 			:batch-active-fields="batchActiveFields"
 			:comparison="comparison"

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -10,6 +10,7 @@ const props = withDefaults(
 	defineProps<{
 		field: Field;
 		fields: Field[];
+		nonEditable?: boolean;
 		primaryKey: number | string;
 		values: Record<string, unknown>;
 		initialValues: Record<string, unknown>;
@@ -121,6 +122,7 @@ watch(validationMessages, (newVal, oldVal) => {
 			:validation-errors="validationErrors"
 			:loading="loading"
 			:batch-mode="batchMode"
+			:non-editable="!!nonEditable"
 			:disabled="disabled"
 			:badge="badge"
 			:direction="direction"

--- a/app/src/interfaces/group-raw/group-raw.vue
+++ b/app/src/interfaces/group-raw/group-raw.vue
@@ -10,6 +10,7 @@ withDefaults(
 		initialValues: Record<string, unknown>;
 		primaryKey: number | string;
 		disabled?: boolean;
+		nonEditable?: boolean;
 		batchMode?: boolean;
 		batchActiveFields?: string[];
 		comparison?: ComparisonContext;
@@ -39,6 +40,7 @@ defineEmits(['apply']);
 			:validation-errors="validationErrors"
 			:loading="loading"
 			:batch-mode="batchMode"
+			:non-editable="!!nonEditable"
 			:disabled="disabled"
 			:comparison="comparison"
 			:badge="badge"

--- a/app/src/interfaces/select-dropdown/select-dropdown.vue
+++ b/app/src/interfaces/select-dropdown/select-dropdown.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
 	defineProps<{
 		value: string | number | null;
 		disabled?: boolean;
+		nonEditable?: boolean;
 		choices?: Option[];
 		icon?: string;
 		allowNone?: boolean;
@@ -86,6 +87,7 @@ watch(
 		:model-value="value"
 		:items="items"
 		:disabled="disabled"
+		:non-editable="nonEditable"
 		:show-deselect="allowNone"
 		item-icon="icon"
 		item-color="color"

--- a/app/src/modules/content/components/comparison-modal.vue
+++ b/app/src/modules/content/components/comparison-modal.vue
@@ -207,7 +207,7 @@ async function onDeltaSelectionChange(newDeltaId: number) {
 							</template>
 							<template v-else>
 								<v-form
-									disabled
+									non-editable
 									:collection="collection"
 									:primary-key="primaryKey"
 									:initial-values="comparisonData?.base || {}"
@@ -248,7 +248,7 @@ async function onDeltaSelectionChange(newDeltaId: number) {
 							</template>
 							<template v-else>
 								<v-form
-									disabled
+									non-editable
 									:collection="collection"
 									:primary-key="primaryKey"
 									:initial-values="comparisonData?.incoming || {}"


### PR DESCRIPTION
## Scope

What's changed:

- Adds new non-editable prop that functions like disabled, but without styling that would indicate this ( such as light grays or reduction of opacity ).

## Tested Scenarios

- Verified I could not interact with basic fields, or more advanced fields such as the wysiwyg
- Verified I could not interact with non-editable fields when nested within groups

## Review Notes / Questions


## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
