### PR TITLE
Fix skipping properties with `undefined` value in SDK query parsing

### DIFF
--- a/.changeset/lovely-fans-tap.md
+++ b/.changeset/lovely-fans-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed skipping properties with `undefined` value in SDK query parsing

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -287,7 +287,7 @@ describe('queryToParams', () => {
 		});
 	});
 
-	test('should format version parameter', () => {
+	test('should format versionRaw parameter', () => {
 		const result = queryToParams({
 			versionRaw: true,
 		});

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -75,6 +75,9 @@ describe('queryToParams', () => {
 			deep: undefined,
 			alias: undefined,
 			aggregate: undefined,
+			groupBy: undefined,
+			version: undefined,
+			versionRaw: undefined,
 			customProp: undefined,
 		});
 
@@ -94,6 +97,7 @@ describe('queryToParams', () => {
 			alias: {},
 			aggregate: {},
 			groupBy: [],
+			version: '',
 			customProp: () => {},
 		});
 
@@ -270,6 +274,26 @@ describe('queryToParams', () => {
 
 		expect(result).toEqual({
 			groupBy: 'category,status',
+		});
+	});
+
+	test('should format version parameter', () => {
+		const result = queryToParams({
+			version: 'draft',
+		});
+
+		expect(result).toEqual({
+			version: 'draft',
+		});
+	});
+
+	test('should format version parameter', () => {
+		const result = queryToParams({
+			versionRaw: true,
+		});
+
+		expect(result).toEqual({
+			versionRaw: 'true',
 		});
 	});
 

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -62,443 +62,266 @@ describe('formatFields', () => {
 });
 
 describe('queryToParams', () => {
-	describe('query.fields', () => {
-		test('should format fields parameter', () => {
-			const result = queryToParams({
-				fields: ['id', 'name', { author: ['name'] }],
-			});
-
-			expect(result).toEqual({
-				fields: 'id,name,author.name',
-			});
+	test('should skip undefined parameters', () => {
+		// @ts-ignore
+		const result = queryToParams({
+			fields: undefined,
+			filter: undefined,
+			search: undefined,
+			sort: undefined,
+			limit: undefined,
+			offset: undefined,
+			page: undefined,
+			deep: undefined,
+			alias: undefined,
+			aggregate: undefined,
+			customProp: undefined,
 		});
 
-		test('should skip empty fields array', () => {
-			const result = queryToParams({
-				fields: [],
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should accept a direct string (type workaround)', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				fields: 'id,name',
-			});
-
-			expect(result).toEqual({ fields: 'id,name' });
-		});
-
-		test('should skip undefined fields', () => {
-			const result = queryToParams({
-				fields: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
+		expect(result).toEqual({});
 	});
 
-	describe('query.filter', () => {
-		test('should JSON format filter parameter', () => {
-			const result = queryToParams({
-				filter: {
-					status: { _eq: 'published' },
-				},
-			});
-
-			expect(result).toEqual({
-				filter: '{"status":{"_eq":"published"}}',
-			});
+	test('should skip empty or invalid parameters', () => {
+		const result1 = queryToParams({
+			fields: [],
+			filter: {},
+			search: '',
+			sort: [],
+			limit: -5,
+			offset: -1,
+			page: 0,
+			deep: {},
+			alias: {},
+			aggregate: {},
+			groupBy: [],
+			customProp: () => {},
 		});
 
-		test('should skip empty filter object', () => {
-			const result = queryToParams({
-				filter: {},
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined filter', () => {
-			const result = queryToParams({
-				filter: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.search', () => {
-		test('should format search parameter', () => {
-			const result = queryToParams({
-				search: 'test query',
-			});
-
-			expect(result).toEqual({
-				search: 'test query',
-			});
-		});
-
-		test('should skip empty string search', () => {
-			const result = queryToParams({
-				search: '',
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined search', () => {
-			const result = queryToParams({
-				search: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.sort', () => {
-		test('should format sort parameter as string', () => {
-			const result = queryToParams({
-				sort: 'name',
-			});
-
-			expect(result).toEqual({
-				sort: 'name',
-			});
-		});
-
-		test('should format sort parameter as array', () => {
-			const result = queryToParams({
-				sort: ['name', '-created_at'],
-			});
-
-			expect(result).toEqual({
-				sort: 'name,-created_at',
-			});
-		});
-
-		test('should skip empty sort array', () => {
-			const result = queryToParams({
-				sort: [],
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined sort', () => {
-			const result = queryToParams({
-				sort: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.limit', () => {
-		test('should format numeric limit parameter', () => {
-			const result = queryToParams({
-				limit: 10,
-			});
-
-			expect(result).toEqual({
-				limit: '10',
-			});
-		});
-
-		test('should format numeric limit -1 (all items)', () => {
-			const result = queryToParams({
-				limit: -1,
-			});
-
-			expect(result).toEqual({
-				limit: '-1',
-			});
-		});
-
-		test('should skip invalid egative numeric limit', () => {
-			const result = queryToParams({
-				limit: -5,
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should format string limit parameter', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				limit: '10',
-			});
-
-			expect(result).toEqual({
-				limit: '10',
-			});
-		});
-
-		test('should skip invalid negative string limit', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				limit: '-5',
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined limit', () => {
-			const result = queryToParams({
-				limit: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.offset', () => {
-		test('should format numeric offset parameter', () => {
-			const result = queryToParams({
-				offset: 20,
-			});
-
-			expect(result).toEqual({
-				offset: '20',
-			});
-		});
-
-		test('should skip negative numeric offset', () => {
-			const query = {
-				offset: -1,
-			};
-
-			const result = queryToParams(query);
-			expect(result).toEqual({});
-		});
-
-		test('should format string offset parameter', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				offset: '20',
-			});
-
-			expect(result).toEqual({
-				offset: '20',
-			});
-		});
-
-		test('should skip negative string offset', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				offset: '-1',
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined offset', () => {
-			const result = queryToParams({
-				offset: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.page', () => {
-		test('should format numeric page parameter', () => {
-			const result = queryToParams({
-				page: 2,
-			});
-
-			expect(result).toEqual({
-				page: '2',
-			});
-		});
-
-		test('should skip numeric page less than 1', () => {
-			const result = queryToParams({
-				page: 0,
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should format string page parameter', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				page: '2',
-			});
-
-			expect(result).toEqual({
-				page: '2',
-			});
-		});
-
-		test('should skip string page less than 1', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				page: '0',
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined page', () => {
-			const result = queryToParams({
-				page: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.deep', () => {
-		test('should JSON format deep parameter', () => {
-			const result = queryToParams({
-				deep: {
-					author: {
-						_filter: { status: { _eq: 'active' } },
-					},
-				},
-			});
-
-			expect(result).toEqual({
-				deep: '{"author":{"_filter":{"status":{"_eq":"active"}}}}',
-			});
-		});
-
-		test('should skip empty deep object', () => {
-			const result = queryToParams({
-				deep: {},
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined deep object', () => {
-			const result = queryToParams({
-				deep: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.alias', () => {
-		test('should JSON format alias parameter', () => {
-			const result = queryToParams({
-				alias: {
-					author_name: 'author.name',
-				},
-			});
-
-			expect(result).toEqual({
-				alias: '{"author_name":"author.name"}',
-			});
-		});
-
-		test('should skip empty alias object', () => {
-			const result = queryToParams({
-				alias: {},
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined alias object', () => {
-			const result = queryToParams({
-				alias: undefined,
-			});
-
-			expect(result).toEqual({});
-		});
-	});
-
-	describe('query.aggregate', () => {
-		test('should JSON format aggregate parameter', () => {
-			const result = queryToParams({
-				aggregate: {
-					count: '*',
-					avg: 'price',
-				},
-			});
-
-			expect(result).toEqual({
-				aggregate: '{"count":"*","avg":"price"}',
-			});
-		});
-
-		test('should skip empty aggregate object', () => {
-			const result = queryToParams({
-				aggregate: {},
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip undefined aggregate object', () => {
+		const result2 = queryToParams({
 			// @ts-ignore
-			const result = queryToParams({
-				aggregate: undefined,
-			});
+			fields: '',
+			sort: '',
+			// @ts-ignore
+			limit: '-5',
+			// @ts-ignore
+			offset: '-1',
+			// @ts-ignore
+			page: '0',
+			// @ts-ignore
+			groupBy: '',
+		});
 
-			expect(result).toEqual({});
+		expect(result1).toEqual({});
+		expect(result2).toEqual({});
+	});
+
+	test('should format query.fields parameter', () => {
+		const result = queryToParams({
+			fields: ['id', 'name', { author: ['name'] }],
+		});
+
+		expect(result).toEqual({
+			fields: 'id,name,author.name',
 		});
 	});
 
-	describe('query.groupBy', () => {
-		test('should format groupBy parameter', () => {
-			const result = queryToParams({
-				groupBy: ['category', 'status'],
-			});
-
-			expect(result).toEqual({
-				groupBy: 'category,status',
-			});
+	test('should accept a direct string (type workaround)', () => {
+		const result = queryToParams({
+			// @ts-ignore
+			fields: 'id,name',
 		});
 
-		test('should format string groupBy parameter', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				groupBy: 'category',
-			});
+		expect(result).toEqual({ fields: 'id,name' });
+	});
 
-			expect(result).toEqual({
-				groupBy: 'category',
-			});
+	test('should JSON format filter parameter', () => {
+		const result = queryToParams({
+			filter: {
+				status: { _eq: 'published' },
+			},
 		});
 
-		test('should skip empty groupBy array', () => {
-			const result = queryToParams({
-				groupBy: [],
-			});
-
-			expect(result).toEqual({});
-		});
-
-		test('should skip empty string groupBy array', () => {
-			const result = queryToParams({
-				// @ts-ignore
-				groupBy: '',
-			});
-
-			expect(result).toEqual({});
+		expect(result).toEqual({
+			filter: '{"status":{"_eq":"published"}}',
 		});
 	});
 
-	describe('custom query properties', () => {
-		test('should handle various custom unknown parameters', () => {
-			const result = queryToParams({
-				customString: 'value',
-				customNumber: 42,
-				customBool: true,
-				customObject: { key: 'value' },
-			});
+	test('should format search parameter', () => {
+		const result = queryToParams({
+			search: 'test query',
+		});
 
-			expect(result).toEqual({
-				customString: 'value',
-				customNumber: '42',
-				customBool: 'true',
-				customObject: '{"key":"value"}',
-			});
+		expect(result).toEqual({
+			search: 'test query',
+		});
+	});
+
+	test('should format sort parameter as string', () => {
+		const result = queryToParams({
+			sort: 'name',
+		});
+
+		expect(result).toEqual({
+			sort: 'name',
+		});
+	});
+
+	test('should format sort parameter as array', () => {
+		const result = queryToParams({
+			sort: ['name', '-created_at'],
+		});
+
+		expect(result).toEqual({
+			sort: 'name,-created_at',
+		});
+	});
+
+	test('should format numeric limit parameter', () => {
+		const result = queryToParams({
+			limit: 10,
+		});
+
+		expect(result).toEqual({
+			limit: '10',
+		});
+	});
+
+	test('should format numeric limit -1 (all items)', () => {
+		const result = queryToParams({
+			limit: -1,
+		});
+
+		expect(result).toEqual({
+			limit: '-1',
+		});
+	});
+
+	test('should format string limit parameter', () => {
+		const result = queryToParams({
+			// @ts-ignore
+			limit: '10',
+		});
+
+		expect(result).toEqual({
+			limit: '10',
+		});
+	});
+
+	test('should format numeric offset parameter', () => {
+		const result = queryToParams({
+			offset: 20,
+		});
+
+		expect(result).toEqual({
+			offset: '20',
+		});
+	});
+
+	test('should format string offset parameter', () => {
+		const result = queryToParams({
+			// @ts-ignore
+			offset: '20',
+		});
+
+		expect(result).toEqual({
+			offset: '20',
+		});
+	});
+	
+	test('should format numeric page parameter', () => {
+		const result = queryToParams({
+			page: 2,
+		});
+
+		expect(result).toEqual({
+			page: '2',
+		});
+	});
+
+	test('should format string page parameter', () => {
+		const result = queryToParams({
+			// @ts-ignore
+			page: '2',
+		});
+
+		expect(result).toEqual({
+			page: '2',
+		});
+	});
+
+	test('should JSON format deep parameter', () => {
+		const result = queryToParams({
+			deep: {
+				author: {
+					_filter: { status: { _eq: 'active' } },
+				},
+			},
+		});
+
+		expect(result).toEqual({
+			deep: '{"author":{"_filter":{"status":{"_eq":"active"}}}}',
+		});
+	});
+
+	test('should JSON format alias parameter', () => {
+		const result = queryToParams({
+			alias: {
+				author_name: 'author.name',
+			},
+		});
+
+		expect(result).toEqual({
+			alias: '{"author_name":"author.name"}',
+		});
+	});
+
+	test('should JSON format aggregate parameter', () => {
+		const result = queryToParams({
+			aggregate: {
+				count: '*',
+				avg: 'price',
+			},
+		});
+
+		expect(result).toEqual({
+			aggregate: '{"count":"*","avg":"price"}',
+		});
+	});
+
+	test('should format groupBy parameter', () => {
+		const result = queryToParams({
+			groupBy: ['category', 'status'],
+		});
+
+		expect(result).toEqual({
+			groupBy: 'category,status',
+		});
+	});
+
+	test('should format string groupBy parameter', () => {
+		const result = queryToParams({
+			// @ts-ignore
+			groupBy: 'category',
+		});
+
+		expect(result).toEqual({
+			groupBy: 'category',
+		});
+	});
+
+	test('should handle various custom unknown parameters', () => {
+		const result = queryToParams({
+			customString: 'value',
+			customNumber: 42,
+			customBool: true,
+			customObject: { key: 'value' },
+		});
+
+		expect(result).toEqual({
+			customString: 'value',
+			customNumber: '42',
+			customBool: 'true',
+			customObject: '{"key":"value"}',
 		});
 	});
 });

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -116,7 +116,7 @@ describe('queryToParams', () => {
 			const result = queryToParams({
 				filter: undefined,
 			});
-			
+
 			expect(result).toEqual({});
 		});
 	});
@@ -240,7 +240,7 @@ describe('queryToParams', () => {
 			const result = queryToParams({
 				limit: undefined,
 			});
-			
+
 			expect(result).toEqual({});
 		});
 	});
@@ -264,7 +264,7 @@ describe('queryToParams', () => {
 			const result = queryToParams(query);
 			expect(result).toEqual({});
 		});
-		
+
 		test('should format string offset parameter', () => {
 			const result = queryToParams({
 				// @ts-ignore
@@ -337,10 +337,10 @@ describe('queryToParams', () => {
 			const result = queryToParams({
 				page: undefined,
 			});
-			
+
 			expect(result).toEqual({});
 		});
-	})
+	});
 
 	describe('query.deep', () => {
 		test('should JSON format deep parameter', () => {
@@ -369,7 +369,7 @@ describe('queryToParams', () => {
 			const result = queryToParams({
 				deep: undefined,
 			});
-			
+
 			expect(result).toEqual({});
 		});
 	});
@@ -399,7 +399,7 @@ describe('queryToParams', () => {
 			const result = queryToParams({
 				alias: undefined,
 			});
-			
+
 			expect(result).toEqual({});
 		});
 	});
@@ -431,7 +431,7 @@ describe('queryToParams', () => {
 			const result = queryToParams({
 				aggregate: undefined,
 			});
-			
+
 			expect(result).toEqual({});
 		});
 	});
@@ -471,7 +471,7 @@ describe('queryToParams', () => {
 				// @ts-ignore
 				groupBy: '',
 			});
-			
+
 			expect(result).toEqual({});
 		});
 	});

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -125,6 +125,8 @@ describe('queryToParams', () => {
 			page: '2',
 			// @ts-ignore
 			groupBy: 'category',
+			// @ts-ignore
+			versionRaw: 'true'
 		});
 
 		expect(result).toEqual({
@@ -133,6 +135,7 @@ describe('queryToParams', () => {
 			offset: '20',
 			page: '2',
 			groupBy: 'category',
+			versionRaw: 'true',
 		});
 	});
 

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -123,7 +123,7 @@ describe('queryToParams', () => {
 			groupBy: 'category',
 		});
 
-		expect(result).toEqual({ 
+		expect(result).toEqual({
 			fields: 'id,name',
 			limit: '10',
 			offset: '20',
@@ -213,7 +213,7 @@ describe('queryToParams', () => {
 			offset: '20',
 		});
 	});
-	
+
 	test('should format numeric page parameter', () => {
 		const result = queryToParams({
 			page: 2,

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -1,0 +1,496 @@
+import { describe, test, expect } from 'vitest';
+import { queryToParams, formatFields } from './query-to-params.js';
+
+describe('formatFields', () => {
+	test('should format simple string fields', () => {
+		const result = formatFields(['id', 'name', 'email']);
+		expect(result).toEqual(['id', 'name', 'email']);
+	});
+
+	test('should handle empty arrays', () => {
+		const result = formatFields([]);
+		expect(result).toEqual([]);
+	});
+
+	test('should format nested object fields', () => {
+		const result = formatFields([
+			'id',
+			{
+				author: ['name', 'email'],
+			},
+		]);
+
+		expect(result).toEqual(['id', 'author.name', 'author.email']);
+	});
+
+	test('should format many-to-any nested fields with scope', () => {
+		const result = formatFields([
+			{
+				blocks: {
+					header: ['title', 'description'],
+					footer: ['title'],
+				},
+			},
+		]);
+
+		expect(result).toEqual(['blocks:header.title', 'blocks:header.description', 'blocks:footer.title']);
+	});
+
+	test('should handle complex nested structure with multiple levels', () => {
+		const result = formatFields([
+			'id',
+			{
+				author: [
+					'name',
+					{
+						avatar: ['id', 'url'],
+					},
+				],
+				categories: ['name', 'slug'],
+			},
+		]);
+
+		expect(result).toEqual([
+			'id',
+			'author.name',
+			'author.avatar.id',
+			'author.avatar.url',
+			'categories.name',
+			'categories.slug',
+		]);
+	});
+});
+
+describe('queryToParams', () => {
+	describe('query.fields', () => {
+		test('should format fields parameter', () => {
+			const result = queryToParams({
+				fields: ['id', 'name', { author: ['name'] }],
+			});
+
+			expect(result).toEqual({
+				fields: 'id,name,author.name',
+			});
+		});
+
+		test('should skip empty fields array', () => {
+			const result = queryToParams({
+				fields: [],
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should accept a direct string (type workaround)', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				fields: 'id,name',
+			});
+
+			expect(result).toEqual({ fields: 'id,name' });
+		});
+	});
+
+	describe('query.filter', () => {
+		test('should JSON format filter parameter', () => {
+			const result = queryToParams({
+				filter: {
+					status: { _eq: 'published' },
+				},
+			});
+
+			expect(result).toEqual({
+				filter: '{"status":{"_eq":"published"}}',
+			});
+		});
+
+		test('should skip empty filter object', () => {
+			const result = queryToParams({
+				filter: {},
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined filter', () => {
+			const result = queryToParams({
+				filter: undefined,
+			});
+			
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.search', () => {
+		test('should format search parameter', () => {
+			const result = queryToParams({
+				search: 'test query',
+			});
+
+			expect(result).toEqual({
+				search: 'test query',
+			});
+		});
+
+		test('should skip empty string search', () => {
+			const result = queryToParams({
+				search: '',
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined search', () => {
+			const result = queryToParams({
+				search: undefined,
+			});
+
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.sort', () => {
+		test('should format sort parameter as string', () => {
+			const result = queryToParams({
+				sort: 'name',
+			});
+
+			expect(result).toEqual({
+				sort: 'name',
+			});
+		});
+
+		test('should format sort parameter as array', () => {
+			const result = queryToParams({
+				sort: ['name', '-created_at'],
+			});
+
+			expect(result).toEqual({
+				sort: 'name,-created_at',
+			});
+		});
+
+		test('should skip empty sort array', () => {
+			const result = queryToParams({
+				sort: [],
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined sort', () => {
+			const result = queryToParams({
+				sort: undefined,
+			});
+
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.limit', () => {
+		test('should format numeric limit parameter', () => {
+			const result = queryToParams({
+				limit: 10,
+			});
+
+			expect(result).toEqual({
+				limit: '10',
+			});
+		});
+
+		test('should format numeric limit -1 (all items)', () => {
+			const result = queryToParams({
+				limit: -1,
+			});
+
+			expect(result).toEqual({
+				limit: '-1',
+			});
+		});
+
+		test('should skip invalid egative numeric limit', () => {
+			const result = queryToParams({
+				limit: -5,
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should format string limit parameter', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				limit: '10',
+			});
+
+			expect(result).toEqual({
+				limit: '10',
+			});
+		});
+
+		test('should skip invalid negative string limit', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				limit: '-5',
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined limit', () => {
+			const result = queryToParams({
+				limit: undefined,
+			});
+			
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.offset', () => {
+		test('should format numeric offset parameter', () => {
+			const result = queryToParams({
+				offset: 20,
+			});
+
+			expect(result).toEqual({
+				offset: '20',
+			});
+		});
+
+		test('should skip negative numeric offset', () => {
+			const query = {
+				offset: -1,
+			};
+
+			const result = queryToParams(query);
+			expect(result).toEqual({});
+		});
+		
+		test('should format string offset parameter', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				offset: '20',
+			});
+
+			expect(result).toEqual({
+				offset: '20',
+			});
+		});
+
+		test('should skip negative string offset', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				offset: '-1',
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined offset', () => {
+			const result = queryToParams({
+				offset: undefined,
+			});
+
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.page', () => {
+		test('should format numeric page parameter', () => {
+			const result = queryToParams({
+				page: 2,
+			});
+
+			expect(result).toEqual({
+				page: '2',
+			});
+		});
+
+		test('should skip numeric page less than 1', () => {
+			const result = queryToParams({
+				page: 0,
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should format string page parameter', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				page: '2',
+			});
+
+			expect(result).toEqual({
+				page: '2',
+			});
+		});
+
+		test('should skip string page less than 1', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				page: '0',
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined page', () => {
+			const result = queryToParams({
+				page: undefined,
+			});
+			
+			expect(result).toEqual({});
+		});
+	})
+
+	describe('query.deep', () => {
+		test('should JSON format deep parameter', () => {
+			const result = queryToParams({
+				deep: {
+					author: {
+						_filter: { status: { _eq: 'active' } },
+					},
+				},
+			});
+
+			expect(result).toEqual({
+				deep: '{"author":{"_filter":{"status":{"_eq":"active"}}}}',
+			});
+		});
+
+		test('should skip empty deep object', () => {
+			const result = queryToParams({
+				deep: {},
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined deep object', () => {
+			const result = queryToParams({
+				deep: undefined,
+			});
+			
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.alias', () => {
+		test('should JSON format alias parameter', () => {
+			const result = queryToParams({
+				alias: {
+					author_name: 'author.name',
+				},
+			});
+
+			expect(result).toEqual({
+				alias: '{"author_name":"author.name"}',
+			});
+		});
+
+		test('should skip empty alias object', () => {
+			const result = queryToParams({
+				alias: {},
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined alias object', () => {
+			const result = queryToParams({
+				alias: undefined,
+			});
+			
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.aggregate', () => {
+		test('should JSON format aggregate parameter', () => {
+			const result = queryToParams({
+				aggregate: {
+					count: '*',
+					avg: 'price',
+				},
+			});
+
+			expect(result).toEqual({
+				aggregate: '{"count":"*","avg":"price"}',
+			});
+		});
+
+		test('should skip empty aggregate object', () => {
+			const result = queryToParams({
+				aggregate: {},
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip undefined aggregate object', () => {
+			// @ts-ignore
+			const result = queryToParams({
+				aggregate: undefined,
+			});
+			
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('query.groupBy', () => {
+		test('should format groupBy parameter', () => {
+			const result = queryToParams({
+				groupBy: ['category', 'status'],
+			});
+
+			expect(result).toEqual({
+				groupBy: 'category,status',
+			});
+		});
+
+		test('should format string groupBy parameter', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				groupBy: 'category',
+			});
+
+			expect(result).toEqual({
+				groupBy: 'category',
+			});
+		});
+
+		test('should skip empty groupBy array', () => {
+			const result = queryToParams({
+				groupBy: [],
+			});
+
+			expect(result).toEqual({});
+		});
+
+		test('should skip empty string groupBy array', () => {
+			const result = queryToParams({
+				// @ts-ignore
+				groupBy: '',
+			});
+			
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('custom query properties', () => {
+		test('should handle various custom unknown parameters', () => {
+			const result = queryToParams({
+				customString: 'value',
+				customNumber: 42,
+				customBool: true,
+				customObject: { key: 'value' },
+			});
+
+			expect(result).toEqual({
+				customString: 'value',
+				customNumber: '42',
+				customBool: 'true',
+				customObject: '{"key":"value"}',
+			});
+		});
+	});
+});

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -89,6 +89,14 @@ describe('queryToParams', () => {
 
 			expect(result).toEqual({ fields: 'id,name' });
 		});
+
+		test('should skip undefined fields', () => {
+			const result = queryToParams({
+				fields: undefined,
+			});
+
+			expect(result).toEqual({});
+		});
 	});
 
 	describe('query.filter', () => {

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -109,6 +109,29 @@ describe('queryToParams', () => {
 		expect(result2).toEqual({});
 	});
 
+	test('should accept strings as type workaround', () => {
+		const result = queryToParams({
+			// @ts-ignore
+			fields: 'id,name',
+			// @ts-ignore
+			limit: '10',
+			// @ts-ignore
+			offset: '20',
+			// @ts-ignore
+			page: '2',
+			// @ts-ignore
+			groupBy: 'category',
+		});
+
+		expect(result).toEqual({ 
+			fields: 'id,name',
+			limit: '10',
+			offset: '20',
+			page: '2',
+			groupBy: 'category',
+		});
+	});
+
 	test('should format query.fields parameter', () => {
 		const result = queryToParams({
 			fields: ['id', 'name', { author: ['name'] }],
@@ -117,15 +140,6 @@ describe('queryToParams', () => {
 		expect(result).toEqual({
 			fields: 'id,name,author.name',
 		});
-	});
-
-	test('should accept a direct string (type workaround)', () => {
-		const result = queryToParams({
-			// @ts-ignore
-			fields: 'id,name',
-		});
-
-		expect(result).toEqual({ fields: 'id,name' });
 	});
 
 	test('should JSON format filter parameter', () => {
@@ -190,31 +204,9 @@ describe('queryToParams', () => {
 		});
 	});
 
-	test('should format string limit parameter', () => {
-		const result = queryToParams({
-			// @ts-ignore
-			limit: '10',
-		});
-
-		expect(result).toEqual({
-			limit: '10',
-		});
-	});
-
 	test('should format numeric offset parameter', () => {
 		const result = queryToParams({
 			offset: 20,
-		});
-
-		expect(result).toEqual({
-			offset: '20',
-		});
-	});
-
-	test('should format string offset parameter', () => {
-		const result = queryToParams({
-			// @ts-ignore
-			offset: '20',
 		});
 
 		expect(result).toEqual({
@@ -225,17 +217,6 @@ describe('queryToParams', () => {
 	test('should format numeric page parameter', () => {
 		const result = queryToParams({
 			page: 2,
-		});
-
-		expect(result).toEqual({
-			page: '2',
-		});
-	});
-
-	test('should format string page parameter', () => {
-		const result = queryToParams({
-			// @ts-ignore
-			page: '2',
 		});
 
 		expect(result).toEqual({
@@ -289,17 +270,6 @@ describe('queryToParams', () => {
 
 		expect(result).toEqual({
 			groupBy: 'category,status',
-		});
-	});
-
-	test('should format string groupBy parameter', () => {
-		const result = queryToParams({
-			// @ts-ignore
-			groupBy: 'category',
-		});
-
-		expect(result).toEqual({
-			groupBy: 'category',
 		});
 	});
 

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -102,12 +102,6 @@ describe('queryToParams', () => {
 			fields: '',
 			sort: '',
 			// @ts-ignore
-			limit: '-5',
-			// @ts-ignore
-			offset: '-1',
-			// @ts-ignore
-			page: '0',
-			// @ts-ignore
 			groupBy: '',
 		});
 

--- a/sdk/src/rest/utils/query-to-params.test.ts
+++ b/sdk/src/rest/utils/query-to-params.test.ts
@@ -126,7 +126,7 @@ describe('queryToParams', () => {
 			// @ts-ignore
 			groupBy: 'category',
 			// @ts-ignore
-			versionRaw: 'true'
+			versionRaw: 'true',
 		});
 
 		expect(result).toEqual({

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -172,13 +172,21 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 		}
 	}
 
+	// parse custom parameters
 	for (const [key, value] of Object.entries(query)) {
 		if (knownQueryKeys.includes(key)) continue;
+		let stringValue: string | undefined = undefined;
 
-		if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-			params[key] = String(value);
+		if (typeof value === 'string') {
+			stringValue = value;
 		} else {
-			params[key] = JSON.stringify(value);
+			// `JSON.stringify` can return `undefined` for types it cannot serialize
+			// Example: JSON.stringify(() => {}) -> undefined
+			stringValue = JSON.stringify(value) as (string | undefined);
+		}
+
+		if (stringValue) {
+			params[key] = stringValue;
 		}
 	}
 

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -3,6 +3,8 @@ import type { AggregationTypes, GroupByFields, Query } from '../../types/index.j
 type ExtendedQuery<Schema, Item> = Query<Schema, Item> & {
 	aggregate?: Partial<Record<keyof AggregationTypes, string>>;
 	groupBy?: (string | GroupByFields<Schema, Item>)[];
+	version?: string | undefined;
+	versionRaw?: boolean | undefined;
 } & Record<string, unknown>;
 
 export const formatFields = (fields: (string | Record<string, any>)[]) => {
@@ -54,6 +56,8 @@ const knownQueryKeys = [
 	'alias',
 	'aggregate',
 	'groupBy',
+	'version',
+	'versionRaw',
 ];
 
 /**
@@ -150,6 +154,21 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 		// backwards JS compatibility for `groupBy: "id,name"`
 		if (typeof query.groupBy === 'string') {
 			params['groupBy'] = query.groupBy;
+		}
+	}
+	
+	if (query.version && typeof query.version === 'string') {
+		params['version'] = query.version;
+	}
+	
+	if (query.versionRaw) {
+		if (typeof query.versionRaw === 'boolean') {
+			params['versionRaw'] = String(query.versionRaw);
+		}
+
+		// backwards JS compatibility for `versionRaw: "true"`
+		if (typeof query.versionRaw === 'string') {
+			params['versionRaw'] = query.versionRaw;
 		}
 	}
 

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -1,9 +1,9 @@
 import type { AggregationTypes, GroupByFields, Query } from '../../types/index.js';
 
 type ExtendedQuery<Schema, Item> = Query<Schema, Item> & {
-	aggregate?: Record<keyof AggregationTypes, string>;
+	aggregate?: Partial<Record<keyof AggregationTypes, string>>;
 	groupBy?: (string | GroupByFields<Schema, Item>)[];
-};
+} & Record<string, unknown>;
 
 export const formatFields = (fields: (string | Record<string, any>)[]) => {
 	type FieldItem = (typeof fields)[number];
@@ -68,54 +68,93 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 ): Record<string, string> => {
 	const params: Record<string, string> = {};
 
-	if (Array.isArray(query.fields) && query.fields.length > 0) {
-		params['fields'] = formatFields(query.fields).join(',');
+	if (query.fields) {
+		if (Array.isArray(query.fields) && query.fields.length > 0) {
+			params['fields'] = formatFields(query.fields).join(',');
+		}
+
+		// backwards JS compatibility for `fields: "id,name"`
+		if (typeof query.fields === 'string') {
+			params['fields'] = query.fields;
+		}
 	}
 
-	if (query.filter && Object.keys(query.filter).length > 0) {
+	if (query.filter && typeof query.filter === 'object' && Object.keys(query.filter).length > 0) {
 		params['filter'] = JSON.stringify(query.filter);
 	}
 
-	if (query.search) {
-		// covers both empty string and undefined
+	if (query.search && typeof query.search === 'string' && query.search.length > 0) {
 		params['search'] = query.search;
 	}
 
-	if ('sort' in query && query.sort) {
-		// covers empty array and undefined
-		params['sort'] = typeof query.sort === 'string' ? query.sort : query.sort.join(',');
+	if (query.sort) {
+		if (Array.isArray(query.sort) && query.sort.length > 0) {
+			params['sort'] = query.sort.join(',');
+		}
+
+		if (typeof query.sort === 'string' && query.sort.length > 0) {
+			params['sort'] = query.sort;
+		}
 	}
 
-	if (typeof query.limit === 'number' && query.limit >= -1) {
-		params['limit'] = String(query.limit);
+	if ('limit' in query) {
+		if (typeof query.limit === 'number' && query.limit >= -1) {
+			params['limit'] = String(query.limit);
+		}
+
+		// backwards JS compatibility for string limits
+		if (typeof query.limit === 'string' && Number(query.limit) >= -1) {
+			params['limit'] = query.limit;
+		}
 	}
 
-	if (typeof query.offset === 'number' && query.offset >= 0) {
-		params['offset'] = String(query.offset);
+	if ('offset' in query) {
+		if (typeof query.offset === 'number' && query.offset >= 0) {
+			params['offset'] = String(query.offset);
+		}
+
+		// backwards JS compatibility for string offsets
+		if (typeof query.offset === 'string' && Number(query.offset) >= 0) {
+			params['offset'] = query.offset;
+		}
 	}
 
-	if (typeof query.page === 'number' && query.page >= 1) {
-		params['page'] = String(query.page);
+	if ('page' in query) {
+		if (typeof query.page === 'number' && query.page >= 1) {
+			params['page'] = String(query.page);
+		}
+
+		// backwards JS compatibility for string pages
+		if (typeof query.page === 'string' && Number(query.page) >= 1) {
+			params['page'] = query.page;
+		}
 	}
 
-	if (query.deep && Object.keys(query.deep).length > 0) {
+	if (query.deep && typeof query.deep === 'object' && Object.keys(query.deep).length > 0) {
 		params['deep'] = JSON.stringify(query.deep);
 	}
 
-	if (query.alias && Object.keys(query.alias).length > 0) {
+	if (query.alias && typeof query.alias === 'object' && Object.keys(query.alias).length > 0) {
 		params['alias'] = JSON.stringify(query.alias);
 	}
 
-	if (query.aggregate && Object.keys(query.aggregate).length > 0) {
+	if (query.aggregate && typeof query.aggregate === 'object' && Object.keys(query.aggregate).length > 0) {
 		params['aggregate'] = JSON.stringify(query.aggregate);
 	}
 
-	if (query.groupBy && query.groupBy.length > 0) {
-		params['groupBy'] = query.groupBy.join(',');
+	if (query.groupBy) {
+		if (Array.isArray(query.groupBy) && query.groupBy.length > 0) {
+			params['groupBy'] = query.groupBy.join(',');
+		}
+
+		// backwards JS compatibility for string pages
+		if (typeof query.groupBy === 'string' && String(query.groupBy).length > 0) {
+			params['groupBy'] = query.groupBy;
+		}
 	}
 
 	for (const [key, value] of Object.entries(query)) {
-		if (key in knownQueryKeys) continue;
+		if (key in params || knownQueryKeys.includes(key)) continue;
 
 		if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
 			params[key] = String(value);

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -63,7 +63,9 @@ const knownQueryKeys = [
  *
  * @returns Flat query parameters
  */
-export const queryToParams = <Schema, Item>(query: ExtendedQuery<Schema, Item>): Record<string, string> => {
+export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
+	query: ExtendedQuery<Schema, Item>,
+): Record<string, string> => {
 	const params: Record<string, string> = {};
 
 	if (Array.isArray(query.fields) && query.fields.length > 0) {

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -154,7 +154,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 	}
 
 	for (const [key, value] of Object.entries(query)) {
-		if (key in params || knownQueryKeys.includes(key)) continue;
+   	if (knownQueryKeys.includes(key)) continue;
 
 		if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
 			params[key] = String(value);

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -147,7 +147,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 			params['groupBy'] = query.groupBy.join(',');
 		}
 
-		// backwards JS compatibility for string pages
+		// backwards JS compatibility for `groupBy: "id,name"`
 		if (typeof query.groupBy === 'string') {
 			params['groupBy'] = query.groupBy;
 		}

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -148,7 +148,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 		}
 
 		// backwards JS compatibility for string pages
-		if (typeof query.groupBy === 'string' && String(query.groupBy).length > 0) {
+		if (typeof query.groupBy === 'string') {
 			params['groupBy'] = query.groupBy;
 		}
 	}

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -154,7 +154,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 	}
 
 	for (const [key, value] of Object.entries(query)) {
-   	if (knownQueryKeys.includes(key)) continue;
+		if (knownQueryKeys.includes(key)) continue;
 
 		if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
 			params[key] = String(value);

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -61,6 +61,17 @@ const knownQueryKeys = [
 ];
 
 /**
+ * Local utility functions
+ */
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
+const isString = (value: unknown): value is string => typeof value === 'string' && Boolean(value);
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isArray = (value: unknown): value is unknown[] => Array.isArray(value) && value.length > 0;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !isArray(value) && Object.keys(value).length > 0;
+
+/**
  * Transform nested query object to an url compatible format
  *
  * @param query The nested query object
@@ -73,103 +84,56 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 	const params: Record<string, string> = {};
 
 	if (query.fields) {
-		if (Array.isArray(query.fields) && query.fields.length > 0) {
-			params['fields'] = formatFields(query.fields).join(',');
-		}
-
+		if (isArray(query.fields)) params['fields'] = formatFields(query.fields).join(',');
 		// backwards JS compatibility for `fields: "id,name"`
-		if (typeof query.fields === 'string') {
-			params['fields'] = query.fields;
-		}
+		if (isString(query.fields)) params['fields'] = query.fields;
 	}
 
-	if (query.filter && typeof query.filter === 'object' && Object.keys(query.filter).length > 0) {
-		params['filter'] = JSON.stringify(query.filter);
-	}
+	if (isObject(query.filter)) params['filter'] = JSON.stringify(query.filter);
 
-	if (query.search && typeof query.search === 'string') {
-		params['search'] = query.search;
-	}
+	if (isString(query.search)) params['search'] = query.search;
 
 	if (query.sort) {
-		if (Array.isArray(query.sort) && query.sort.length > 0) {
-			params['sort'] = query.sort.join(',');
-		}
-
-		if (typeof query.sort === 'string') {
-			params['sort'] = query.sort;
-		}
+		if (isArray(query.sort)) params['sort'] = query.sort.join(',');
+		if (isString(query.sort)) params['sort'] = query.sort;
 	}
 
 	if ('limit' in query) {
-		if (typeof query.limit === 'number' && query.limit >= -1) {
-			params['limit'] = String(query.limit);
-		}
-
+		if (isNumber(query.limit) && query.limit >= -1) params['limit'] = String(query.limit);
 		// backwards JS compatibility for string limits
-		if (typeof query.limit === 'string' && Number(query.limit) >= -1) {
-			params['limit'] = query.limit;
-		}
+		if (isString(query.limit)) params['limit'] = query.limit;
 	}
 
 	if ('offset' in query) {
-		if (typeof query.offset === 'number' && query.offset >= 0) {
-			params['offset'] = String(query.offset);
-		}
-
+		if (isNumber(query.offset) && query.offset >= 0) params['offset'] = String(query.offset);
 		// backwards JS compatibility for string offsets
-		if (typeof query.offset === 'string' && Number(query.offset) >= 0) {
-			params['offset'] = query.offset;
-		}
+		if (isString(query.offset)) params['offset'] = query.offset;
 	}
 
 	if ('page' in query) {
-		if (typeof query.page === 'number' && query.page >= 1) {
-			params['page'] = String(query.page);
-		}
-
+		if (isNumber(query.page) && query.page >= 1) params['page'] = String(query.page);
 		// backwards JS compatibility for string pages
-		if (typeof query.page === 'string' && Number(query.page) >= 1) {
-			params['page'] = query.page;
-		}
+		if (isString(query.page)) params['page'] = query.page;
 	}
 
-	if (query.deep && typeof query.deep === 'object' && Object.keys(query.deep).length > 0) {
-		params['deep'] = JSON.stringify(query.deep);
-	}
+	if (isObject(query.deep)) params['deep'] = JSON.stringify(query.deep);
 
-	if (query.alias && typeof query.alias === 'object' && Object.keys(query.alias).length > 0) {
-		params['alias'] = JSON.stringify(query.alias);
-	}
+	if (isObject(query.alias)) params['alias'] = JSON.stringify(query.alias);
 
-	if (query.aggregate && typeof query.aggregate === 'object' && Object.keys(query.aggregate).length > 0) {
-		params['aggregate'] = JSON.stringify(query.aggregate);
-	}
+	if (isObject(query.aggregate)) params['aggregate'] = JSON.stringify(query.aggregate);
 
 	if (query.groupBy) {
-		if (Array.isArray(query.groupBy) && query.groupBy.length > 0) {
-			params['groupBy'] = query.groupBy.join(',');
-		}
-
+		if (isArray(query.groupBy)) params['groupBy'] = query.groupBy.join(',');
 		// backwards JS compatibility for `groupBy: "id,name"`
-		if (typeof query.groupBy === 'string') {
-			params['groupBy'] = query.groupBy;
-		}
+		if (isString(query.groupBy)) params['groupBy'] = query.groupBy;
 	}
-	
-	if (query.version && typeof query.version === 'string') {
-		params['version'] = query.version;
-	}
-	
-	if (query.versionRaw) {
-		if (typeof query.versionRaw === 'boolean') {
-			params['versionRaw'] = String(query.versionRaw);
-		}
 
+	if (isString(query.version)) params['version'] = query.version;
+
+	if (query.versionRaw) {
+		if (isBoolean(query.versionRaw)) params['versionRaw'] = String(query.versionRaw);
 		// backwards JS compatibility for `versionRaw: "true"`
-		if (typeof query.versionRaw === 'string') {
-			params['versionRaw'] = query.versionRaw;
-		}
+		if (isString(query.versionRaw)) params['versionRaw'] = query.versionRaw;
 	}
 
 	// parse custom parameters
@@ -182,7 +146,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 		} else {
 			// `JSON.stringify` can return `undefined` for types it cannot serialize
 			// Example: JSON.stringify(() => {}) -> undefined
-			stringValue = JSON.stringify(value) as (string | undefined);
+			stringValue = JSON.stringify(value) as string | undefined;
 		}
 
 		if (stringValue) {

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -92,7 +92,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 			params['sort'] = query.sort.join(',');
 		}
 
-		if (typeof query.sort === 'string' && query.sort.length > 0) {
+		if (typeof query.sort === 'string') {
 			params['sort'] = query.sort;
 		}
 	}

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -83,7 +83,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 		params['filter'] = JSON.stringify(query.filter);
 	}
 
-	if (query.search && typeof query.search === 'string' && query.search.length > 0) {
+	if (query.search && typeof query.search === 'string') {
 		params['search'] = query.search;
 	}
 

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -175,7 +175,7 @@ export const queryToParams = <Schema = any, Item = Record<string, unknown>>(
 	// parse custom parameters
 	for (const [key, value] of Object.entries(query)) {
 		if (knownQueryKeys.includes(key)) continue;
-		let stringValue: string | undefined = undefined;
+		let stringValue: string | undefined;
 
 		if (typeof value === 'string') {
 			stringValue = value;

--- a/sdk/src/rest/utils/query-to-params.ts
+++ b/sdk/src/rest/utils/query-to-params.ts
@@ -41,6 +41,21 @@ export const formatFields = (fields: (string | Record<string, any>)[]) => {
 	return fields.flatMap((value) => walkFields(value));
 };
 
+const knownQueryKeys = [
+	'fields',
+	'filter',
+	'search',
+	'sort',
+	'limit',
+	'offset',
+	'page',
+	'deep',
+	'backlink',
+	'alias',
+	'aggregate',
+	'groupBy',
+];
+
 /**
  * Transform nested query object to an url compatible format
  *
@@ -98,7 +113,7 @@ export const queryToParams = <Schema, Item>(query: ExtendedQuery<Schema, Item>):
 	}
 
 	for (const [key, value] of Object.entries(query)) {
-		if (key in params) continue;
+		if (key in knownQueryKeys) continue;
 
 		if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
 			params[key] = String(value);

--- a/sdk/src/utils/request.test.ts
+++ b/sdk/src/utils/request.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, test, vi } from 'vitest';
-import { request } from '../src/utils/request.js';
+import { request } from './request.js';
 
 const fetchMock = vi.fn(async () => ({}));
 


### PR DESCRIPTION
## Scope

What's changed:

- Fixed the error case of `search: undefined` actually searching for the string `'undefined'` (linked issue)
- Fixed `undefined` handling for the other query parameters
- Attempted to make the query formatting conditions more explicit
- Added tests for the `formatFields` and `queryToParams` utilities
- Fixed the `aggregate` type by adding `Partial` (the tests showed that all aggregation keys were required before)
- Fixed the `aggregate` type by adding `& Record<string, unknown>` allowing for custom properties without type errors
- Moved the `request.test.ts` file next to the `request.ts` file (to consistently keep functional test files next to the file they're testing and type tests in the `test/` folder)

## Potential Risks / Drawbacks

- Something could break if relying on the old fall-through into custom parameter logic for "knownQueryKeys". I covered the edge cases I could think of with explicit logic to handle them.

## Tested Scenarios

- See the added test file

## Review Notes / Questions

- Did I miss any edge cases in the tests?

## Checklist

- [x] Added or updated tests

---

Fixes #25930 
