### PR TITLE
Remove non-relational types from `RELATIONAL_TYPES` constant

### DIFF
--- a/.changeset/khaki-plums-enjoy.md
+++ b/.changeset/khaki-plums-enjoy.md
@@ -1,0 +1,13 @@
+---
+'@directus/constants': major
+'@directus/types': patch
+'@directus/app': patch
+---
+
+Revived unused RELATIONAL_TYPES constant by removing non-relational types and applying where applicable
+
+::: notice
+
+Reintroducing and modifying the RELATIONAL_TYPES constant may break extensions or external code relying on the previous structure
+
+:::

--- a/.changeset/khaki-plums-enjoy.md
+++ b/.changeset/khaki-plums-enjoy.md
@@ -4,10 +4,10 @@
 '@directus/app': patch
 ---
 
-Revived unused RELATIONAL_TYPES constant by removing non-relational types and applying where applicable
+Removed non-relational types from `RELATIONAL_TYPES` constant
 
 ::: notice
 
-Reintroducing and modifying the RELATIONAL_TYPES constant may break extensions or external code relying on the previous structure
+Extensions or external code using `RELATIONAL_TYPES` should note the excluded `presentation` and `group`.
 
 :::

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { useClipboard } from '@/composables/use-clipboard';
+import { RELATIONAL_TYPES } from '@directus/constants';
+import type { RelationalType } from '@directus/types';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { FormField } from './types';
@@ -76,10 +78,7 @@ const showDivider = computed(() => {
 });
 
 const relational = computed(
-	() =>
-		props.field.meta?.special?.find((type) =>
-			['file', 'files', 'm2o', 'o2m', 'm2m', 'm2a', 'translations'].includes(type),
-		) !== undefined,
+	() => props.field.meta?.special?.find((type) => RELATIONAL_TYPES.includes(type as RelationalType)) !== undefined,
 );
 </script>
 

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -4,6 +4,7 @@ import { useRelationsStore } from '@/stores/relations';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { renderPlainStringTemplate } from '@/utils/render-string-template';
+import { RELATIONAL_TYPES } from '@directus/constants';
 import { defineDisplay } from '@directus/extensions';
 import type { Field } from '@directus/types';
 import { getFieldsFromTemplate } from '@directus/utils';
@@ -97,7 +98,7 @@ export default defineDisplay({
 		return renderPlainStringTemplate(options.template, stringValues);
 	},
 	types: ['alias', 'string', 'uuid', 'integer', 'bigInteger', 'json'],
-	localTypes: ['m2m', 'm2o', 'o2m', 'translations', 'm2a', 'file', 'files'],
+	localTypes: RELATIONAL_TYPES,
 	fields: (options: Options | null, { field, collection }) => {
 		const relatedCollectionData = getRelatedCollection(collection, field);
 

--- a/packages/constants/src/fields.ts
+++ b/packages/constants/src/fields.ts
@@ -56,16 +56,6 @@ export const LOCAL_TYPES = [
 	'group',
 ] as const;
 
-export const RELATIONAL_TYPES = [
-	'file',
-	'files',
-	'm2o',
-	'o2m',
-	'm2m',
-	'm2a',
-	'presentation',
-	'translations',
-	'group',
-] as const;
+export const RELATIONAL_TYPES = ['file', 'files', 'm2o', 'o2m', 'm2m', 'm2a', 'translations'] as const;
 
 export const FUNCTIONS = ['year', 'month', 'week', 'day', 'weekday', 'hour', 'minute', 'second', 'count'] as const;

--- a/packages/types/src/fields.ts
+++ b/packages/types/src/fields.ts
@@ -3,6 +3,7 @@ import type {
 	FUNCTIONS,
 	GEOMETRY_FORMATS,
 	GEOMETRY_TYPES,
+	RELATIONAL_TYPES,
 	LOCAL_TYPES,
 	TYPES,
 	NUMERIC_TYPES,
@@ -29,6 +30,8 @@ export type NumericType = (typeof NUMERIC_TYPES)[number];
 export type GeometryType = (typeof GEOMETRY_TYPES)[number] | 'GeometryCollection' | undefined;
 
 export type GeometryFormat = (typeof GEOMETRY_FORMATS)[number];
+
+export type RelationalType = (typeof RELATIONAL_TYPES)[number];
 
 export type FieldMeta = {
 	id: number;


### PR DESCRIPTION
## Scope

The RELATIONAL_TYPES constant was introduced with [this PR](https://github.com/directus/directus/pull/17959) and since [this PR](https://github.com/directus/directus/pull/21338) it has been unused.

What's changed:

- removed non-relational types from unused RELATIONAL_TYPES constant
- added RelationalType type
- applied the constant where applicable

## Potential Risks / Drawbacks

- This constant could be used outside the core repo

## Tested Scenarios

—

## Review Notes / Questions

- quick one
- don’t forget to `pnpm --filter constants --filter types build`

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
