### PR TITLE
Fix requesting a versioned item with the 'main' keyword returning forbidden

### DIFF
--- a/.changeset/green-houses-stick.md
+++ b/.changeset/green-houses-stick.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed requesting main version
+Fixed requesting a versioned item with the 'main' keyword returning forbidden

--- a/.changeset/green-houses-stick.md
+++ b/.changeset/green-houses-stick.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed requesting main version

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -71,6 +71,12 @@ describe('Integration Tests', () => {
 			test('on readSingleton', async () => {
 				vi.mocked(handleVersion).mockReturnValueOnce(new Promise((resolve) => resolve([{ id: 1 }])));
 
+				vi.spyOn(db, 'select').mockReturnValueOnce({
+					from: () => ({
+						first: async () => ({ id: 1 }),
+					}),
+				} as any);
+
 				await service.readSingleton({ version: 'test' });
 
 				expect(handleVersion).toHaveBeenCalled();

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -2,10 +2,11 @@ import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
 import { MockClient, Tracker, createTracker } from 'knex-mock-client';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, test, vi, type MockedFunction } from 'vitest';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { getDatabaseClient } from '../database/index.js';
 import { ItemsService } from './index.js';
+import { handleVersion } from '../utils/versioning/handle-version.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
@@ -13,10 +14,17 @@ vi.mock('../../src/database/index', () => ({
 }));
 
 vi.mock('../utils/validate-user-count-integrity.js');
+vi.mock('../utils/versioning/handle-version.js', { spy: true });
 
 const schema = new SchemaBuilder()
 	.collection('test', (c) => {
 		c.field('id').id();
+	})
+	.collection('directus_versions', (c) => {
+		c.field('id').id();
+		c.field('item').string();
+		c.field('collection').string();
+		c.field('key').string();
 	})
 	.build();
 
@@ -49,6 +57,42 @@ describe('Integration Tests', () => {
 
 		afterEach(() => {
 			vi.clearAllMocks();
+		});
+
+		describe('read with version "test"', () => {
+			test('on readOne', async () => {
+				vi.mocked(handleVersion).mockReturnValueOnce(new Promise((resolve) => resolve([{ id: 1 }])));
+
+				await service.readOne(1, { version: 'test' });
+
+				expect(handleVersion).toHaveBeenCalled();
+			});
+
+			test('on readSingleton', async () => {
+				vi.mocked(handleVersion).mockReturnValueOnce(new Promise((resolve) => resolve([{ id: 1 }])));
+
+				await service.readSingleton({ version: 'test' });
+
+				expect(handleVersion).toHaveBeenCalled();
+			});
+		});
+
+		describe('read with version "main"', () => {
+			test('on readOne', async () => {
+				service.readByQuery = vi.fn(async () => [{ id: 1 }]);
+
+				await service.readOne(1, { version: 'main' });
+
+				expect(handleVersion).not.toHaveBeenCalled();
+			});
+
+			test('on readSingleton', async () => {
+				service.readByQuery = vi.fn(async () => [{ id: 1 }]);
+
+				await service.readSingleton({ version: 'main' });
+
+				expect(handleVersion).not.toHaveBeenCalled();
+			});
 		});
 
 		describe('createOne', () => {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -590,7 +590,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		let results: Item[] = [];
 
-		if (query.version) {
+		if (query.version && query.version !== 'main') {
 			results = [await handleVersion(this, key, queryWithKey, opts)];
 		} else {
 			results = await this.readByQuery(queryWithKey, opts);

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1181,7 +1181,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		let record;
 
-		if (query.version) {
+		if (query.version && query.version !== 'main') {
 			const primaryKeyField = this.schema.collections[this.collection]!.primary;
 			const key = (await this.knex.select(primaryKeyField).from(this.collection).first())?.[primaryKeyField];
 


### PR DESCRIPTION
## Scope

What's changed:

- `?version=main` now returns the main version

## Potential Risks / Drawbacks

- In case anybody named their version main?

## Tested Scenarios

- requesting version=main

Fixes #25982
Fixes #25953
Fixes #25977
