### PR TITLE
Fix comma decimal separator handling for decimal inputs

### DIFF
--- a/.changeset/bumpy-pumas-rescue.md
+++ b/.changeset/bumpy-pumas-rescue.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed comma decimal separator handling for decimal inputs

--- a/app/src/components/v-input.test.ts
+++ b/app/src/components/v-input.test.ts
@@ -2,7 +2,7 @@ import { Focus } from '@/__utils__/focus';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
 import { mount } from '@vue/test-utils';
-import { describe, expect, test, vi, afterEach } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import VInput from './v-input.vue';
 
 const global: GlobalMountOptions = {
@@ -173,6 +173,36 @@ describe('emitValue', () => {
 		await wrapper.find('input').trigger('input');
 
 		expect(wrapper.emitted()['update:modelValue']?.[0]).toEqual([1]);
+	});
+
+	test('should replace "," with "." for decimal separator when decimal types marked as text', async () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'text',
+				modelValue: '1,22',
+				float: true,
+			},
+			global,
+		});
+
+		await wrapper.find('input').trigger('input');
+
+		expect(wrapper.emitted()['update:modelValue']?.[0]).toEqual(['1.22']);
+	});
+
+	test('should emit number without a thousandths separator', async () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'text',
+				modelValue: '1,222,220',
+				float: true,
+			},
+			global,
+		});
+
+		await wrapper.find('input').trigger('input');
+
+		expect(wrapper.emitted()['update:modelValue']?.[0]).toEqual(['1.222220']);
 	});
 
 	test('should turn ending space into slug separator for slug input', async () => {

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -238,7 +238,7 @@ function emitValue(event: InputEvent) {
 		// decimal input
 		if (props.float === true) {
 			/**
-			 * Normalize decimal separator to '.'
+			 * Normalize decimal separator from ',' to '.'
 			 * Thousands separators are not supported in the input
 			 */
 			value = value.replace(',', '.');

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -235,7 +235,7 @@ function emitValue(event: InputEvent) {
 			emit('update:modelValue', parsedNumber);
 		}
 	} else {
-		// decimal input
+		// decimal input marked as text
 		if (props.float === true) {
 			/**
 			 * Normalize decimal separator from ',' to '.'

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -235,6 +235,15 @@ function emitValue(event: InputEvent) {
 			emit('update:modelValue', parsedNumber);
 		}
 	} else {
+		// decimal input
+		if (props.float === true) {
+			/**
+			 * Normalize decimal separator to '.'
+			 * Thousands separators are not supported in the input
+			 */
+			value = value.replace(',', '.');
+		}
+
 		if (props.slug === true) {
 			const endsWithSpace = value.endsWith(' ');
 			value = slugify(value, { separator: props.slugSeparator, preserveTrailingDash: true });


### PR DESCRIPTION
## Scope

What's changed:

- Corrected decimal inputs to correctly replace `,` with `.` to ensure it can be saved to the db

## Potential Risks / Drawbacks

- As the change is fairly localized to decimal inputs risk should be minimal

## Tested Scenarios

- Non decimal inputs do not enter the relevant code section
- decimal inputs marked as text replace `,` with `.`

## Review Notes / Questions

- Added an additional test that will fail if we ever add thousandth separator support to our inputs. This should hopefully reduce possibility of a regression.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #25727
