### PR TITLE
Comparison < fix merge bug

### DIFF
--- a/app/src/modules/content/comparison-utils.test.ts
+++ b/app/src/modules/content/comparison-utils.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import type { Field } from '@directus/types';
-import { mergeMissingMainItemKeysIntoRevision, getFieldsWithDifferences } from './comparison-utils';
+import { mergeMainItemKeysIntoRevision, getFieldsWithDifferences } from './comparison-utils';
 
-describe('mergeMissingMainItemKeysIntoRevision', () => {
+describe('mergeMainItemKeysIntoRevision', () => {
 	const fields: Field[] = [
 		{
 			collection: 'test_collection',
@@ -98,7 +98,7 @@ describe('mergeMissingMainItemKeysIntoRevision', () => {
 			title: 'Incoming Title',
 		};
 
-		const result = mergeMissingMainItemKeysIntoRevision(revisionData, base, fields);
+		const result = mergeMainItemKeysIntoRevision(revisionData, base, fields);
 
 		expect(result).toMatchInlineSnapshot(`
 			{
@@ -120,7 +120,7 @@ describe('mergeMissingMainItemKeysIntoRevision', () => {
 			description: 'Incoming Description',
 		};
 
-		const result = mergeMissingMainItemKeysIntoRevision(revisionData, base, fields);
+		const result = mergeMainItemKeysIntoRevision(revisionData, base, fields);
 
 		expect(result).toMatchInlineSnapshot(`
 			{
@@ -141,7 +141,7 @@ describe('mergeMissingMainItemKeysIntoRevision', () => {
 			count: null,
 		};
 
-		const result = mergeMissingMainItemKeysIntoRevision(revisionData, base, fields);
+		const result = mergeMainItemKeysIntoRevision(revisionData, base, fields);
 
 		expect(result).toMatchInlineSnapshot(`
 			{

--- a/app/src/modules/content/comparison-utils.test.ts
+++ b/app/src/modules/content/comparison-utils.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import type { Field } from '@directus/types';
+import { mergeMissingMainItemKeysIntoRevision } from './comparison-utils';
+
+describe('mergeMissingMainItemKeysIntoRevision', () => {
+	const fields: Field[] = [
+		{
+			collection: 'test_collection',
+			field: 'title',
+			name: 'Title',
+			type: 'string',
+			meta: null,
+			schema: {
+				name: 'title',
+				table: 'test_collection',
+				schema: 'public',
+				is_nullable: true,
+				default_value: 'test1',
+				max_length: 255,
+				comment: null,
+				numeric_precision: null,
+				numeric_scale: null,
+				is_unique: false,
+				is_primary_key: false,
+				has_auto_increment: false,
+				foreign_key_schema: null,
+				foreign_key_table: null,
+				foreign_key_column: null,
+				data_type: 'string',
+				is_indexed: false,
+				is_generated: false,
+			},
+		},
+		{
+			collection: 'test_collection',
+			field: 'description',
+			name: 'Description',
+			type: 'string',
+			meta: null,
+			schema: {
+				name: 'description',
+				table: 'test_collection',
+				schema: 'public',
+				is_nullable: true,
+				default_value: null,
+				max_length: 255,
+				comment: null,
+				numeric_precision: null,
+				numeric_scale: null,
+				is_unique: false,
+				is_primary_key: false,
+				has_auto_increment: false,
+				foreign_key_schema: null,
+				foreign_key_table: null,
+				foreign_key_column: null,
+				data_type: 'string',
+				is_indexed: false,
+				is_generated: false,
+			},
+		},
+		{
+			collection: 'test_collection',
+			field: 'count',
+			name: 'Count',
+			type: 'string',
+			meta: null,
+			schema: {
+				name: 'count',
+				table: 'test_collection',
+				schema: 'public',
+				is_nullable: true,
+				default_value: null,
+				max_length: 255,
+				comment: null,
+				numeric_precision: null,
+				numeric_scale: null,
+				is_unique: false,
+				is_primary_key: false,
+				has_auto_increment: false,
+				foreign_key_schema: null,
+				foreign_key_table: null,
+				foreign_key_column: null,
+				data_type: 'string',
+				is_indexed: false,
+				is_generated: false,
+			},
+		},
+	];
+
+	it('should merge missing keys with default values into incoming', () => {
+		const base = {
+			title: 'Base Title',
+			description: null,
+			count: null,
+		};
+
+		const revisionData = {
+			title: 'Incoming Title',
+		};
+
+		const result = mergeMissingMainItemKeysIntoRevision(revisionData, base, fields);
+
+		expect(result).toMatchInlineSnapshot(`
+			{
+			  "count": null,
+			  "description": null,
+			  "title": "Incoming Title",
+			}
+		`);
+	});
+
+	it('should not merge keys into incoming that have a non-default value', () => {
+		const base = {
+			title: 'Base Title',
+			description: 'Base Description',
+			count: 5,
+		};
+
+		const revisionData = {
+			description: 'Incoming Description',
+		};
+
+		const result = mergeMissingMainItemKeysIntoRevision(revisionData, base, fields);
+
+		expect(result).toMatchInlineSnapshot(`
+			{
+			  "description": "Incoming Description",
+			}
+		`);
+	});
+
+	it('should merge missing keys when value equals default value', () => {
+		const base = {
+			title: 'test1',
+			description: 'Base Description',
+			count: 5,
+		};
+
+		const revisionData = {
+			description: 'Incoming Description',
+			count: null,
+		};
+
+		const result = mergeMissingMainItemKeysIntoRevision(revisionData, base, fields);
+
+		expect(result).toMatchInlineSnapshot(`
+			{
+			  "count": null,
+			  "description": "Incoming Description",
+			  "title": "test1",
+			}
+		`);
+	});
+});

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -179,7 +179,7 @@ export function areSomeFieldsSelected(selectedFields: string[], availableFields:
 	return availableFields.length > 0 && availableFields.some((field) => selectedFields.includes(field));
 }
 
-export function mergeMainItemKeysIntoRevision(
+export function mergeMissingMainItemKeysIntoRevision(
 	revisionData: Record<string, any>,
 	mainItem: Record<string, any>,
 	fields?: Field[],
@@ -188,10 +188,13 @@ export function mergeMainItemKeysIntoRevision(
 
 	const defaultValues = fields ? getDefaultValuesFromFields(fields).value : {};
 
-	for (const [key] of Object.entries(mainItem)) {
-		if (!(key in merged)) {
-			const defaultValue = defaultValues[key] ?? null;
-			merged[key] = defaultValue;
+	for (const [fieldKey, value] of Object.entries(mainItem)) {
+		if (!(fieldKey in merged)) {
+			const defaultValue = defaultValues[fieldKey] ?? null;
+			const fieldHasValue = value !== defaultValue;
+			if (fieldHasValue) continue;
+
+			merged[fieldKey] = defaultValue;
 		}
 	}
 
@@ -245,7 +248,7 @@ export function computeDifferentFields(
 			skipPrimaryKeyFields: true,
 		});
 	} else {
-		const incomingWithDefaults = mergeMainItemKeysIntoRevision(preparedIncoming, preparedBase, fields);
+		const incomingWithDefaults = mergeMissingMainItemKeysIntoRevision(preparedIncoming, preparedBase, fields);
 		const incomingWithRelational = copySpecialFieldsFromBaseToIncoming(preparedBase, incomingWithDefaults, fields);
 		const fieldMetadata = Object.fromEntries(fields.map((f) => [f.field, f]));
 

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -179,7 +179,7 @@ export function areSomeFieldsSelected(selectedFields: string[], availableFields:
 	return availableFields.length > 0 && availableFields.some((field) => selectedFields.includes(field));
 }
 
-export function mergeMissingMainItemKeysIntoRevision(
+export function mergeMainItemKeysIntoRevision(
 	revisionData: Record<string, any>,
 	mainItem: Record<string, any>,
 	fields?: Field[],
@@ -248,7 +248,7 @@ export function computeDifferentFields(
 			skipPrimaryKeyFields: true,
 		});
 	} else {
-		const incomingWithDefaults = mergeMissingMainItemKeysIntoRevision(preparedIncoming, preparedBase, fields);
+		const incomingWithDefaults = mergeMainItemKeysIntoRevision(preparedIncoming, preparedBase, fields);
 		const incomingWithRelational = copySpecialFieldsFromBaseToIncoming(preparedBase, incomingWithDefaults, fields);
 		const fieldMetadata = Object.fromEntries(fields.map((f) => [f.field, f]));
 

--- a/app/src/modules/content/composables/use-comparison.test.ts
+++ b/app/src/modules/content/composables/use-comparison.test.ts
@@ -17,7 +17,6 @@ import api from '@/api';
 import { useComparison } from './use-comparison';
 import type { Revision } from '@/types/revisions';
 import type { ContentVersion } from '@directus/types';
-import { getFieldsWithDifferences } from '../comparison-utils';
 
 const itemVersions = {
 	data: [
@@ -213,77 +212,5 @@ describe('normalizeComparisonData', () => {
 		expect(result.incoming.things).toBe(versionComparison.data.current.things);
 		expect(result.incoming.enable).toBe(versionComparison.data.current.enable);
 		expect(result.incoming.categories).toEqual(versionComparison.data.current.categories);
-	});
-});
-
-describe('getFieldsWithDifferences', () => {
-	it('excludes related item fields when comparing revisions', () => {
-		const comparedData = {
-			outdated: false,
-			mainHash: '',
-			incoming: {
-				title: 'New Title',
-				description: 'New Description',
-				related_items: [{ id: 1, name: 'Item 1' }],
-				categories: [{ id: 2, name: 'Category 1' }],
-				status: 'published',
-			},
-			base: {
-				title: 'Old Title',
-				description: 'Old Description',
-				related_items: [{ id: 2, name: 'Item 2' }],
-				categories: [{ id: 3, name: 'Category 2' }],
-				status: 'draft',
-			},
-		};
-
-		const fieldMetadata = {
-			title: { meta: { special: [] } },
-			description: { meta: { special: [] } },
-			related_items: { meta: { special: ['m2m'] } },
-			categories: { meta: { special: ['o2m'] } },
-			status: { meta: { special: [] } },
-		};
-
-		// Test version comparison - should include all fields with differences
-		const versionFields = getFieldsWithDifferences(comparedData, fieldMetadata, 'version');
-		expect(versionFields).toContain('title');
-		expect(versionFields).toContain('description');
-		expect(versionFields).toContain('related_items');
-		expect(versionFields).toContain('categories');
-		expect(versionFields).toContain('status');
-
-		// Test revision comparison - should exclude related item fields
-		const revisionFields = getFieldsWithDifferences(comparedData, fieldMetadata, 'revision');
-		expect(revisionFields).toContain('title');
-		expect(revisionFields).toContain('description');
-		expect(revisionFields).toContain('status');
-		expect(revisionFields).not.toContain('related_items');
-		expect(revisionFields).not.toContain('categories');
-	});
-
-	it('includes related item fields when comparing versions', () => {
-		const comparedData = {
-			outdated: false,
-			mainHash: '',
-			incoming: {
-				title: 'New Title',
-				related_items: [{ id: 1, name: 'Item 1' }],
-			},
-			base: {
-				title: 'Old Title',
-				related_items: [{ id: 2, name: 'Item 2' }],
-			},
-		};
-
-		const fieldMetadata = {
-			title: { meta: { special: [] } },
-			related_items: { meta: { special: ['m2m'] } },
-		};
-
-		// Version comparison should include related item fields
-		const versionFields = getFieldsWithDifferences(comparedData, fieldMetadata, 'version');
-		expect(versionFields).toContain('title');
-		expect(versionFields).toContain('related_items');
 	});
 });

--- a/app/src/modules/content/composables/use-comparison.ts
+++ b/app/src/modules/content/composables/use-comparison.ts
@@ -9,7 +9,7 @@ import {
 	areAllFieldsSelected,
 	areSomeFieldsSelected,
 	normalizeComparisonData as normalizeComparisonDataUtil,
-	mergeMainItemKeysIntoRevision,
+	mergeMissingMainItemKeysIntoRevision,
 	copySpecialFieldsFromBaseToIncoming,
 	replaceArraysInMergeCustomizer,
 	getItemEndpoint,
@@ -398,10 +398,9 @@ export function useComparison(options: UseComparisonOptions) {
 		const targetCollection = revision.collection || collection?.value || '';
 		const fields = fieldsStore.getFieldsForCollection(targetCollection);
 
-		// Merge main item keys into revision data with default values for missing fields
 		const revisionData = revision.data || {};
-		const revisionDataWithDefaults = mergeMainItemKeysIntoRevision(revisionData, baseMerged, fields);
-		const incomingMerged = mergeWith({}, revisionDataWithDefaults, replaceArraysInMergeCustomizer);
+		const revisionDataWithDefaults = mergeMissingMainItemKeysIntoRevision(revisionData, baseMerged, fields);
+		const incomingMerged = mergeWith({}, baseMerged, revisionDataWithDefaults, replaceArraysInMergeCustomizer);
 
 		if ('activity' in revision && (revision as any)?.activity?.timestamp) {
 			incomingMerged.date_updated = (revision as any).activity.timestamp;

--- a/app/src/modules/content/composables/use-comparison.ts
+++ b/app/src/modules/content/composables/use-comparison.ts
@@ -1,15 +1,15 @@
 import api from '@/api';
 import { useFieldsStore } from '@/stores/fields';
 import type { Revision } from '@/types/revisions';
+import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { unexpectedError } from '@/utils/unexpected-error';
-import type { ContentVersion, User } from '@directus/types';
+import type { ContentVersion, PrimaryKey, User } from '@directus/types';
 import {
 	toggleFieldInSelection,
 	toggleAllFields,
 	areAllFieldsSelected,
 	areSomeFieldsSelected,
 	normalizeComparisonData as normalizeComparisonDataUtil,
-	mergeMissingMainItemKeysIntoRevision,
 	copySpecialFieldsFromBaseToIncoming,
 	replaceArraysInMergeCustomizer,
 	getItemEndpoint,
@@ -306,32 +306,6 @@ export function useComparison(options: UseComparisonOptions) {
 		return null;
 	}
 
-	async function fetchVersionComparison(
-		versionId: string,
-		version?: ContentVersion,
-		versions?: ContentVersion[] | null,
-	): Promise<ComparisonData> {
-		try {
-			const response = await api.get(`/versions/${versionId}/compare`);
-			const data: VersionComparisonResponse = response.data.data;
-			const base = data.main || {};
-			const incomingMerged = mergeWith({}, base, data.current || {}, replaceArraysInMergeCustomizer);
-
-			return {
-				base,
-				incoming: incomingMerged,
-				selectableDeltas: versions ?? (version ? [version] : []),
-				comparisonType: 'version' as const,
-				outdated: data.outdated,
-				mainHash: data.mainHash,
-				initialSelectedDeltaId: version?.id,
-			};
-		} catch (error) {
-			unexpectedError(error);
-			throw error;
-		}
-	}
-
 	async function fetchRevisionComparison(
 		revisionId: number,
 		currentVersion?: ContentVersion | null,
@@ -362,59 +336,96 @@ export function useComparison(options: UseComparisonOptions) {
 		}
 	}
 
-	/**
-	 * Builds comparison data from revision data
-	 * - main: complete item state BEFORE this revision was applied
-	 * - current: complete item state AFTER this revision was applied
-	 */
+	async function fetchVersionComparison(
+		versionId: string,
+		version?: ContentVersion,
+		versions?: ContentVersion[] | null,
+	): Promise<ComparisonData> {
+		try {
+			const response = await api.get(`/versions/${versionId}/compare`);
+			const data: VersionComparisonResponse = response.data.data;
+			const base = data.main || {};
+			const incomingMerged = mergeWith({}, base, data.current || {}, replaceArraysInMergeCustomizer);
+
+			return {
+				base,
+				incoming: incomingMerged,
+				selectableDeltas: versions ?? (version ? [version] : []),
+				comparisonType: 'version' as const,
+				outdated: data.outdated,
+				mainHash: data.mainHash,
+				initialSelectedDeltaId: version?.id,
+			};
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
+	}
+
+	async function fetchVersionComparisonForRevision(versionId: string) {
+		try {
+			const response = await api.get(`/versions/${versionId}/compare`);
+			const data: VersionComparisonResponse = response.data.data;
+			const main = data.main || {};
+			const mainMergedWithVersionLatest = mergeWith({}, main, data.current || {}, replaceArraysInMergeCustomizer);
+
+			return {
+				main,
+				base: mainMergedWithVersionLatest,
+			};
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
+	}
+
+	async function fetchMainVersion(collection: string, item: PrimaryKey): Promise<Record<string, any>> {
+		const itemEndpoint = getItemEndpoint(collection, item);
+
+		try {
+			const itemResponse = await api.get(itemEndpoint);
+			return itemResponse.data?.data || {};
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
+	}
+
 	async function buildRevisionComparison(
 		revision: Revision | RevisionComparisonResponse,
 		currentVersion?: ContentVersion | null,
 		revisions?: Revision[] | null,
 	): Promise<ComparisonData> {
-		// Resolve main item and current version delta
-		let mainItem: Record<string, any> = {};
-		let versionDelta: Record<string, any> = {};
-
-		if (currentVersion) {
-			const versionComparison = await fetchVersionComparison(currentVersion.id);
-			mainItem = versionComparison.base || {};
-			versionDelta = versionComparison.incoming || {};
-		} else if ('collection' in revision && 'item' in revision) {
-			const { collection, item } = revision as { collection: string; item: string | number };
-			const itemEndpoint = getItemEndpoint(collection, item);
-
-			try {
-				const itemResponse = await api.get(itemEndpoint);
-				mainItem = itemResponse.data?.data || {};
-			} catch (error: any) {
-				unexpectedError(error);
-				mainItem = {};
-			}
-		}
-
-		const baseMerged = mergeWith({}, mainItem, versionDelta || {}, replaceArraysInMergeCustomizer);
-
+		let base: Record<string, any> = {};
+		let incoming = revision.data || {};
 		const targetCollection = revision.collection || collection?.value || '';
 		const fields = fieldsStore.getFieldsForCollection(targetCollection);
 
-		const revisionData = revision.data || {};
-		const revisionDataWithDefaults = mergeMissingMainItemKeysIntoRevision(revisionData, baseMerged, fields);
-		const incomingMerged = mergeWith({}, baseMerged, revisionDataWithDefaults, replaceArraysInMergeCustomizer);
-
-		if ('activity' in revision && (revision as any)?.activity?.timestamp) {
-			incomingMerged.date_updated = (revision as any).activity.timestamp;
+		if (currentVersion) {
+			const versionComparison = await fetchVersionComparisonForRevision(currentVersion.id);
+			base = versionComparison.base;
+			incoming = mergeWith({}, versionComparison.main, incoming, replaceArraysInMergeCustomizer);
+		} else if ('collection' in revision && 'item' in revision) {
+			const { collection, item } = revision as { collection: string; item: string | number };
+			base = await fetchMainVersion(collection, item);
+			const defaultValues = getDefaultValuesFromFields(fields).value;
+			incoming = mergeWith({}, defaultValues, incoming, replaceArraysInMergeCustomizer);
 		}
 
-		const incomingWithRelationalFields = copySpecialFieldsFromBaseToIncoming(baseMerged, incomingMerged, fields);
+		// Revisions don’t support relational fields, so we need to merge them into incoming. Primary Key and User Reference fields (user_created, user_updated) as well.
+		incoming = copySpecialFieldsFromBaseToIncoming(base, incoming, fields);
+
+		if ('activity' in revision && (revision as any)?.activity?.timestamp) {
+			incoming.date_updated = (revision as any).activity.timestamp;
+		}
+
 		const revisionsList = revisions || [];
 		const revisionId = 'id' in revision ? revision.id : null;
-
 		const revisionFields = new Set(Object.keys(revision.delta ?? {}));
 
 		return {
-			base: baseMerged,
-			incoming: incomingWithRelationalFields,
+			base,
+			incoming,
 			selectableDeltas: revisionsList,
 			revisionFields,
 			comparisonType: 'revision',


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a bug
  - Make edits to 4 fields in Main version
  - Create a version and update only one field (of the 4) a couple of times
  - Shows 4 differences in the revison comparison modal, while it should only show 1 difference
- Added a test
- Moved existing getFieldsWithDifferences test into the utils test file