### PR TITLE
Support local domains for email

### DIFF
--- a/api/src/auth/drivers/local.ts
+++ b/api/src/auth/drivers/local.ts
@@ -51,7 +51,9 @@ export function createLocalAuthRouter(provider: string): Router {
 	const router = Router();
 
 	const userLoginSchema = Joi.object({
-		email: Joi.string().email().required(),
+		email: env['EMAIL_TLD_VALIDATION']
+			? Joi.string().email().required()
+			: Joi.string().email({ tlds: false }).required(),
 		password: Joi.string().required(),
 		mode: Joi.string().valid('cookie', 'json', 'session'),
 		otp: Joi.string(),

--- a/api/src/cli/commands/init/index.ts
+++ b/api/src/cli/commands/init/index.ts
@@ -1,3 +1,4 @@
+import { useEnv } from '@directus/env';
 import chalk from 'chalk';
 import { execa } from 'execa';
 import inquirer from 'inquirer';
@@ -14,6 +15,8 @@ import createEnv from '../../utils/create-env/index.js';
 import { defaultAdminPolicy, defaultAdminRole, defaultAdminUser } from '../../utils/defaults.js';
 import { drivers, getDriverForClient } from '../../utils/drivers.js';
 import { databaseQuestions } from './questions.js';
+
+const env = useEnv();
 
 export default async function init(): Promise<void> {
 	const rootPath = process.cwd();
@@ -78,7 +81,9 @@ export default async function init(): Promise<void> {
 			message: 'Email',
 			default: 'admin@example.com',
 			validate: (input: string) => {
-				const emailSchema = Joi.string().email().required();
+				const emailSchema = env['EMAIL_TLD_VALIDATION']
+					? Joi.string().email().required()
+					: Joi.string().email({ tlds: false }).required();
 				const { error } = emailSchema.validate(input.trim());
 				if (error) throw new Error('The email entered is not a valid email address!');
 				return true;

--- a/api/src/controllers/users.ts
+++ b/api/src/controllers/users.ts
@@ -1,3 +1,4 @@
+import { useEnv } from '@directus/env';
 import {
 	ErrorCode,
 	ForbiddenError,
@@ -21,6 +22,7 @@ import { sanitizeQuery } from '../utils/sanitize-query.js';
 import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import { getDatabase } from '../database/index.js';
 
+const env = useEnv();
 const router = express.Router();
 
 router.use(useCollection('directus_users'));
@@ -446,7 +448,7 @@ router.post(
 );
 
 const registerSchema = Joi.object<RegisterUserInput>({
-	email: Joi.string().email().required(),
+	email: env['EMAIL_TLD_VALIDATION'] ? Joi.string().email().required() : Joi.string().email({ tlds: false }).required(),
 	password: Joi.string().required(),
 	verification_url: Joi.string().uri(),
 	first_name: Joi.string(),

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -166,7 +166,9 @@ export class UsersService extends ItemsService {
 	private validateEmail(input: string | string[]) {
 		const emails = Array.isArray(input) ? input : [input];
 
-		const schema = Joi.string().email().required();
+		const schema = env['EMAIL_TLD_VALIDATION']
+			? Joi.string().email().required()
+			: Joi.string().email({ tlds: false }).required();
 
 		for (const email of emails) {
 			const { error } = schema.validate(email);

--- a/contributors.yml
+++ b/contributors.yml
@@ -226,3 +226,4 @@
 - khanahmad4527
 - gaetansenn
 - Shashank188
+- EvgeniyZo

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -67,6 +67,8 @@ export const DEFAULTS = {
 
 	ROOT_REDIRECT: './admin',
 
+	EMAIL_TLD_VALIDATION: true,
+
 	CORS_ENABLED: false,
 	CORS_ORIGIN: false,
 	CORS_METHODS: 'GET,POST,PATCH,DELETE',

--- a/packages/env/src/constants/directus-variables.ts
+++ b/packages/env/src/constants/directus-variables.ts
@@ -73,6 +73,8 @@ export const DIRECTUS_VARIABLES = [
 	'CONTENT_SECURITY_POLICY_.+',
 	'HSTS_.+',
 
+	'EMAIL_TLD_VALIDATION',
+
 	// hashing
 	'HASH_.+',
 

--- a/packages/env/src/constants/type-map.ts
+++ b/packages/env/src/constants/type-map.ts
@@ -52,6 +52,7 @@ export const TYPE_MAP: Record<string, EnvType> = {
 	REDIS_PASSWORD: 'string',
 	'AUTH_.+_BIND_PASSWORD': 'string',
 	'STORAGE_.+_SECRET': 'string',
+	EMAIL_TLD_VALIDATION: 'boolean',
 } as const;
 
 export const TYPE_MAP_REGEX: [RegExp, EnvType][] = Object.entries(TYPE_MAP).map(([name, value]) => [


### PR DESCRIPTION
Allow use of `admin@server.local` style domains.

## Scope

What's changed:

- Added ability to disable top level domain check for email
- Added `EMAIL_TLD_VALIDATION` environment variable (TLD check is active by default)

## Potential Risks / Drawbacks

- Invalid email registration (countered by feature being disabled by default)

## Tested Scenarios

- User creation from admin GUI
- Docker compose deployment with both `EMAIL_TLD_VALIDATION` states

## Review Notes / Questions

- 

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs)

---

Fixes #\<num\>
