### PR TITLE
Update default report feature URL

### DIFF
--- a/.changeset/witty-carrots-divide.md
+++ b/.changeset/witty-carrots-divide.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Updated the feature request URL

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -165,6 +165,6 @@ export const AUTH_SSO_DRIVERS = ['oauth2', 'openid', 'saml'];
 
 export const DEFAULT_REPORT_BUG_URL = 'https://github.com/directus/directus/issues/new?template=bug_report.yml';
 export const DEFAULT_REPORT_FEATURE_URL =
-	'https://github.com/directus/directus/discussions/new?category=draft-feature-requests';
+	'https://roadmap.directus.io/';
 
 export const SDK_AUTH_REFRESH_BEFORE_EXPIRES = 10_000;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -164,7 +164,6 @@ export const DEFAULT_AUTH_DRIVER = 'default';
 export const AUTH_SSO_DRIVERS = ['oauth2', 'openid', 'saml'];
 
 export const DEFAULT_REPORT_BUG_URL = 'https://github.com/directus/directus/issues/new?template=bug_report.yml';
-export const DEFAULT_REPORT_FEATURE_URL =
-	'https://roadmap.directus.io/';
+export const DEFAULT_REPORT_FEATURE_URL = 'https://roadmap.directus.io/';
 
 export const SDK_AUTH_REFRESH_BEFORE_EXPIRES = 10_000;


### PR DESCRIPTION
## Scope

What's changed:

- Change the default request feature URL from GH Discussions to Roadmap

## Potential Risks / Drawbacks

- None