### PR TITLE
Jw feature request redirect template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,4 +1,4 @@
-title: "Feature Request - Please use our Public Roadmap"
+title: 'Feature Request - Please use our Public Roadmap'
 labels:
   - redirect
 body:
@@ -6,23 +6,23 @@ body:
     attributes:
       value: |
         **Feature requests have moved to our Public Roadmap**
-        
+
         Please submit your request here: https://roadmap.directus.io/roadmap
-        
+
         This allows you to:
         - ✅ Vote on features you'd like to see
         - 📊 See what we're currently working on
         - 📅 See what is planned
         - 🎯 Track feature status in real-time, directly integrated with our Linear projects
-        
+
         **Not a feature request?** If you'd like to engage with our community, ask questions, or get help, please visit [community.directus.io](https://community.directus.io)
-        
+
         Please note: New discussions opened here will be automatically closed. We appreciate your understanding!
 
   - type: checkboxes
     id: understand
     attributes:
-      label: "Next steps"
+      label: 'Next steps'
       options:
         - label: "I'll submit my feature request at roadmap.directus.io (please do not start discussion)"
           required: true

--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -1,0 +1,28 @@
+title: "Feature Request - Please use our Public Roadmap"
+labels:
+  - redirect
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Feature requests have moved to our Public Roadmap**
+        
+        Please submit your request here: https://roadmap.directus.io/roadmap
+        
+        This allows you to:
+        - ✅ Vote on features you'd like to see
+        - 📊 See what we're currently working on
+        - 📅 See what is planned
+        - 🎯 Track feature status in real-time, directly integrated with our Linear projects
+        
+        **Not a feature request?** If you'd like to engage with our community, ask questions, or get help, please visit [community.directus.io](https://community.directus.io)
+        
+        Please note: New discussions opened here will be automatically closed. We appreciate your understanding!
+
+  - type: checkboxes
+    id: understand
+    attributes:
+      label: "Next steps"
+      options:
+        - label: "I'll submit my feature request at roadmap.directus.io (please do not start discussion)"
+          required: true

--- a/.github/workflows/close-feature-requests.yml
+++ b/.github/workflows/close-feature-requests.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           script: |
             const discussionId = context.payload.discussion.node_id;
-            
+
             // Add comment first
             await github.graphql(`
               mutation($discussionId: ID!, $body: String!) {
@@ -31,7 +31,7 @@ jobs:
               discussionId: discussionId,
               body: 'This discussion has been automatically closed. Please submit feature requests at https://roadmap.directus.io/roadmap'
             });
-            
+
             // Close the discussion
             await github.graphql(`
               mutation($discussionId: ID!) {

--- a/.github/workflows/close-feature-requests.yml
+++ b/.github/workflows/close-feature-requests.yml
@@ -1,0 +1,46 @@
+name: Close Feature Request Discussions
+
+on:
+  discussion:
+    types: [created]
+
+permissions:
+  discussions: write
+
+jobs:
+  close-discussion:
+    runs-on: ubuntu-latest
+    if: github.event.discussion.category.name == 'Feature Requests'
+    steps:
+      - name: Close discussion and add comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const discussionId = context.payload.discussion.node_id;
+            
+            // Add comment first
+            await github.graphql(`
+              mutation($discussionId: ID!, $body: String!) {
+                addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                  comment {
+                    id
+                  }
+                }
+              }
+            `, {
+              discussionId: discussionId,
+              body: 'This discussion has been automatically closed. Please submit feature requests at https://roadmap.directus.io/roadmap'
+            });
+            
+            // Close the discussion
+            await github.graphql(`
+              mutation($discussionId: ID!) {
+                closeDiscussion(input: {discussionId: $discussionId}) {
+                  discussion {
+                    id
+                  }
+                }
+              }
+            `, {
+              discussionId: discussionId
+            });

--- a/contributors.yml
+++ b/contributors.yml
@@ -226,3 +226,4 @@
 - khanahmad4527
 - gaetansenn
 - Shashank188
+- JamesW1


### PR DESCRIPTION
## Scope

What's changed:

- Redirect users that attempt to open new feature request discussion
- Auto-close any new feature requests that are opened

## Tested Scenarios

- Validate template formatting
- Close new discussion workflow

## Review Notes / Questions

- Note that we do not want to disable discussions as there are valuable historical threads
- However, we do wish to stop new requests being opened on GitHub. 
- Instead, they should be submitted via the [Public Roadmap ](https://roadmap.directus.io/roadmap)

## Checklist

- [N/A] Added or updated tests
- [N/A] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #\<num\>
