### PR TITLE
Fix `<scope>.delete` filter hook running after permission check

### DIFF
--- a/.changeset/hot-kings-remain.md
+++ b/.changeset/hot-kings-remain.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `items.delete` filter hook running after permission check

--- a/.changeset/hot-kings-remain.md
+++ b/.changeset/hot-kings-remain.md
@@ -2,4 +2,12 @@
 '@directus/api': major
 ---
 
-Fixed `items.delete` filter hook running after permission check
+Fixed `items.delete` filter hook running after permission check. Fixed keys returned by the hook not being used in place of the original keys.
+
+::: notice
+
+- Keys returned by the hook are now used in place of the original keys.
+- The hook will trigger regardless of user permissions. Ensure any necessary permission checks are performed prior to any data processing.
+
+:::
+

--- a/.changeset/hot-kings-remain.md
+++ b/.changeset/hot-kings-remain.md
@@ -2,7 +2,7 @@
 '@directus/api': major
 ---
 
-Fixed `items.delete` filter hook running after permission check. Fixed keys returned by the hook not being used in place of the original keys.
+Fixed `<scope>.delete` filter hook running after permission check. Fixed keys returned by the hook not being used in place of the original keys.
 
 ::: notice
 

--- a/.changeset/hot-kings-remain.md
+++ b/.changeset/hot-kings-remain.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': patch
+'@directus/api': major
 ---
 
 Fixed `items.delete` filter hook running after permission check


### PR DESCRIPTION
## Scope

What's changed:

- Moved the delete filter hook to be BEFORE permission check so we are inline with the update equivalent
- The hook payload is now utilized when applicable for the query instead of the original keys

## Potential Risks / Drawbacks

- This hook will now run before permissions are checked which may result in unexpected triggers for users depending on the old functionality

## Tested Scenarios

- [x] Expect item delete to succeed
- [x] Expect item delete query to be executed with hook changed keys when changed
- [x] Expect item delete hook to trigger BEFORE permission validation
- [x] Expect item delete accountability to use hook changed keys when changed
- [x] Expect item delete to trigger action with hook changed keys when changed

## Review Notes / Questions

- N/A

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #26028
Docs PR: https://github.com/directus/docs/pull/492
