### PR TITLE
Update dependencies → editorjs, eslint, fullcalendar, mapbox

### DIFF
--- a/.changeset/puny-rice-decide.md
+++ b/.changeset/puny-rice-decide.md
@@ -1,0 +1,15 @@
+---
+'@directus/app': patch
+---
+
+Updated the following dependencies:
+- Updated @editorjs/attaches dependency from 1.3.0 to 1.3.2
+- Updated @editorjs/editorjs dependency from 2.30.8 to 2.31.0
+- Updated @eslint/js dependency from 9.32.0 to 9.38.0
+- Updated @fullcalendar/core dependency from 6.1.18 to 6.1.19
+- Updated @fullcalendar/daygrid dependency from 6.1.18 to 6.1.19
+- Updated @fullcalendar/interaction dependency from 6.1.18 to 6.1.19
+- Updated @fullcalendar/list dependency from 6.1.18 to 6.1.19
+- Updated @fullcalendar/timegrid dependency from 6.1.18 to 6.1.19
+- Updated @mapbox/mapbox-gl-geocoder dependency from 5.1.0 to 5.1.2
+- Updated @types/mapbox__mapbox-gl-geocoder dependency from 5.0.0 to 5.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 3.0.0
       version: 3.0.0
     '@editorjs/attaches':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.3.2
+      version: 1.3.2
     '@editorjs/checklist':
       specifier: 1.6.0
       version: 1.6.0
@@ -46,8 +46,8 @@ catalogs:
       specifier: 1.4.2
       version: 1.4.2
     '@editorjs/editorjs':
-      specifier: 2.30.8
-      version: 2.30.8
+      specifier: 2.31.0
+      version: 2.31.0
     '@editorjs/embed':
       specifier: 2.7.6
       version: 2.7.6
@@ -79,8 +79,8 @@ catalogs:
       specifier: 1.2.1
       version: 1.2.1
     '@eslint/js':
-      specifier: 9.32.0
-      version: 9.32.0
+      specifier: 9.38.0
+      version: 9.38.0
     '@fortawesome/fontawesome-svg-core':
       specifier: 6.7.2
       version: 6.7.2
@@ -88,20 +88,20 @@ catalogs:
       specifier: 6.7.2
       version: 6.7.2
     '@fullcalendar/core':
-      specifier: 6.1.18
-      version: 6.1.18
+      specifier: 6.1.19
+      version: 6.1.19
     '@fullcalendar/daygrid':
-      specifier: 6.1.18
-      version: 6.1.18
+      specifier: 6.1.19
+      version: 6.1.19
     '@fullcalendar/interaction':
-      specifier: 6.1.18
-      version: 6.1.18
+      specifier: 6.1.19
+      version: 6.1.19
     '@fullcalendar/list':
-      specifier: 6.1.18
-      version: 6.1.18
+      specifier: 6.1.19
+      version: 6.1.19
     '@fullcalendar/timegrid':
-      specifier: 6.1.18
-      version: 6.1.18
+      specifier: 6.1.19
+      version: 6.1.19
     '@godaddy/terminus':
       specifier: 4.12.1
       version: 4.12.1
@@ -127,8 +127,8 @@ catalogs:
       specifier: 1.0.1
       version: 1.0.1
     '@mapbox/mapbox-gl-geocoder':
-      specifier: 5.1.0
-      version: 5.1.0
+      specifier: 5.1.2
+      version: 5.1.2
     '@modelcontextprotocol/sdk':
       specifier: 1.20.1
       version: 1.20.1
@@ -289,8 +289,8 @@ catalogs:
       specifier: 1.4.9
       version: 1.4.9
     '@types/mapbox__mapbox-gl-geocoder':
-      specifier: 5.0.0
-      version: 5.0.0
+      specifier: 5.1.0
+      version: 5.1.0
     '@types/mime-types':
       specifier: 3.0.1
       version: 3.0.1
@@ -904,7 +904,7 @@ importers:
         version: link:packages/release-notes-generator
       '@eslint/js':
         specifier: 'catalog:'
-        version: 9.32.0
+        version: 9.38.0
       eslint:
         specifier: 'catalog:'
         version: 9.32.0(jiti@2.5.1)
@@ -1503,7 +1503,7 @@ importers:
         version: link:../packages/validation
       '@editorjs/attaches':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.3.2
       '@editorjs/checklist':
         specifier: 'catalog:'
         version: 1.6.0
@@ -1515,7 +1515,7 @@ importers:
         version: 1.4.2
       '@editorjs/editorjs':
         specifier: 'catalog:'
-        version: 2.30.8
+        version: 2.31.0
       '@editorjs/embed':
         specifier: 'catalog:'
         version: 2.7.6
@@ -1554,19 +1554,19 @@ importers:
         version: 6.7.2
       '@fullcalendar/core':
         specifier: 'catalog:'
-        version: 6.1.18
+        version: 6.1.19
       '@fullcalendar/daygrid':
         specifier: 'catalog:'
-        version: 6.1.18(@fullcalendar/core@6.1.18)
+        version: 6.1.19(@fullcalendar/core@6.1.19)
       '@fullcalendar/interaction':
         specifier: 'catalog:'
-        version: 6.1.18(@fullcalendar/core@6.1.18)
+        version: 6.1.19(@fullcalendar/core@6.1.19)
       '@fullcalendar/list':
         specifier: 'catalog:'
-        version: 6.1.18(@fullcalendar/core@6.1.18)
+        version: 6.1.19(@fullcalendar/core@6.1.19)
       '@fullcalendar/timegrid':
         specifier: 'catalog:'
-        version: 6.1.18(@fullcalendar/core@6.1.18)
+        version: 6.1.19(@fullcalendar/core@6.1.19)
       '@histoire/plugin-vue':
         specifier: 'catalog:'
         version: 0.17.17(histoire@0.17.17(@types/node@24.2.0)(sass-embedded@1.89.2)(terser@5.43.1)(vite@7.1.3(@types/node@24.2.0)(jiti@2.5.1)(sass-embedded@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@7.1.3(@types/node@24.2.0)(jiti@2.5.1)(sass-embedded@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))
@@ -1584,7 +1584,7 @@ importers:
         version: 1.0.1
       '@mapbox/mapbox-gl-geocoder':
         specifier: 'catalog:'
-        version: 5.1.0
+        version: 5.1.2
       '@ngneat/falso':
         specifier: 'catalog:'
         version: 8.0.2
@@ -1635,7 +1635,7 @@ importers:
         version: 1.4.9
       '@types/mapbox__mapbox-gl-geocoder':
         specifier: 'catalog:'
-        version: 5.0.0
+        version: 5.1.0
       '@types/qrcode':
         specifier: 'catalog:'
         version: 1.5.5
@@ -3602,6 +3602,9 @@ packages:
   '@codemirror/view@6.38.1':
     resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
 
+  '@codexteam/ajax@4.2.0':
+    resolution: {integrity: sha512-54r/HZirqBPEV8rM9gZh570RCwG6M/iDAXT9Q9eGuMo9KZU49tw1dEDHjYsResGckfCsaymDqg4GnhfrBtX9JQ==}
+
   '@codexteam/icons@0.0.2':
     resolution: {integrity: sha512-KdeKj3TwaTHqM3IXd5YjeJP39PBUZTb+dtHjGlf5+b0VgsxYD4qzsZkb11lzopZbAuDsHaZJmAYQ8LFligIT6Q==}
 
@@ -3651,8 +3654,12 @@ packages:
   '@dual-bundle/import-meta-resolve@4.1.0':
     resolution: {integrity: sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==}
 
-  '@editorjs/attaches@1.3.0':
-    resolution: {integrity: sha512-D+dj55EsC5bvXV///Dh/+KN4unuI0j6SU3f5QcMA5zrfda47PNKwbKOuwMBJwn0O+o5qwqrFv67g98lAo2qqVQ==}
+  '@editorjs/attaches@1.3.2':
+    resolution: {integrity: sha512-hzwcOo/Lk1hTEzXXV0MSnwPsGIILaeM1R7SCMu4uUALftlQVugf+Vm4a9Rd66IT7TU3tfyiOwJPb/Ydp9zn36A==}
+    engines: {node: '>=20.0.0'}
+
+  '@editorjs/caret@1.0.3':
+    resolution: {integrity: sha512-VmgwQJZgL/LQjk049JunzRV1YCa0vDi+BNEpbDmr5cp3lGZllq9QQFO1eI71ZPzvFVn3vvhb+eOif4sAEyGgbw==}
 
   '@editorjs/checklist@1.6.0':
     resolution: {integrity: sha512-hRNP36DInr73mSK3noHBQeoQb7DA12ANfqTXufEkTgQzx+k4mRJ0HdeGukTIR4JbwjHJ9ecUBnnQqIEGnxCFEg==}
@@ -3666,8 +3673,11 @@ packages:
   '@editorjs/dom@0.0.5':
     resolution: {integrity: sha512-SZ78Gwpkp3EUhjBIp0lSojeQ35V9acF8SubJsMeOH/vlOUE40GOnvvwWZnF05lO7bIB0dOHhhJy4N7IIAWxP2w==}
 
-  '@editorjs/editorjs@2.30.8':
-    resolution: {integrity: sha512-ClFuxI1qZTfXPJTacQfsJtOUP6bKoIe6BQNdAvGsDTDVwMnZEzoaSOwvUpdZEE56xppVfQueNK/1MElV9SJKHg==}
+  '@editorjs/dom@1.0.1':
+    resolution: {integrity: sha512-yLO+86MYOIUr1Jl7SQw23SYT84ggv6aJW0EIRsI3NTHYgnQzmK7Bt2n5ZFupQlB0GJqmKqA5tCue3NKQb+o7Pw==}
+
+  '@editorjs/editorjs@2.31.0':
+    resolution: {integrity: sha512-CBcIZXtPlg0dSlC5clO9OfTCmcxelj723jd4d67teFlaFJobjjxU1PmMxFJdhaRep5+nqdD0jr+fdJBqEDqt1g==}
 
   '@editorjs/embed@2.7.6':
     resolution: {integrity: sha512-L3agW/23mOI0L+oksUE9UOR5VSNCqapxLH5lma+5j+idjKCC31nxbx07x53MSJ4rlOTO1L7cFVhkqptEdOliJA==}
@@ -3677,6 +3687,9 @@ packages:
 
   '@editorjs/helpers@0.0.4':
     resolution: {integrity: sha512-ieg3dzo2m1/ELze/RMNADiAiC5amXxIlVXoJ5vvXITOu/p/dPsrF+Oi3h5gBYvtGk9vg5LJUSG5YWU0tBUO1tw==}
+
+  '@editorjs/helpers@1.0.1':
+    resolution: {integrity: sha512-Lmr8ImoQvoROXtzhsIJsA1ZtXzH46DmE6O8hMjn9/AvQq62UfjREjn+Ewi6KxjIZMay2PsgDEbLlsVyNJGEaxw==}
 
   '@editorjs/image@2.10.3':
     resolution: {integrity: sha512-ekCsGICZOIdghF/U2T34H7CItqaWAoJDXbkRD+x8l/LIo/7Ozf7KovYm21qz+CluArgV4RurVFHqwlz+O0vfJA==}
@@ -4038,6 +4051,10 @@ packages:
     resolution: {integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@9.38.0':
+    resolution: {integrity: sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4074,28 +4091,28 @@ packages:
     resolution: {integrity: sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==}
     engines: {node: '>=6'}
 
-  '@fullcalendar/core@6.1.18':
-    resolution: {integrity: sha512-cD7XtZIZZ87Cg2+itnpsONCsZ89VIfLLDZ22pQX4IQVWlpYUB3bcCf878DhWkqyEen6dhi5ePtBoqYgm5K+0fQ==}
+  '@fullcalendar/core@6.1.19':
+    resolution: {integrity: sha512-z0aVlO5e4Wah6p6mouM0UEqtRf1MZZPt4mwzEyU6kusaNL+dlWQgAasF2cK23hwT4cmxkEmr4inULXgpyeExdQ==}
 
-  '@fullcalendar/daygrid@6.1.18':
-    resolution: {integrity: sha512-s452Zle1SdMEzZDw+pDczm8m3JLIZzS9ANMThXTnqeqJewW1gqNFYas18aHypJSgF9Fh9rDJjTSUw04BpXB/Mg==}
+  '@fullcalendar/daygrid@6.1.19':
+    resolution: {integrity: sha512-IAAfnMICnVWPjpT4zi87i3FEw0xxSza0avqY/HedKEz+l5MTBYvCDPOWDATpzXoLut3aACsjktIyw9thvIcRYQ==}
     peerDependencies:
-      '@fullcalendar/core': ~6.1.18
+      '@fullcalendar/core': ~6.1.19
 
-  '@fullcalendar/interaction@6.1.18':
-    resolution: {integrity: sha512-f/mD5RTjzw+Q6MGTMZrLCgIrQLIUUO9NV/58aM2J6ZBQZeRlNizDqmqldqyG+j49zj2vFhUfZibPrVKWm5yA4Q==}
+  '@fullcalendar/interaction@6.1.19':
+    resolution: {integrity: sha512-GOciy79xe8JMVp+1evAU3ytdwN/7tv35t5i1vFkifiuWcQMLC/JnLg/RA2s4sYmQwoYhTw/p4GLcP0gO5B3X5w==}
     peerDependencies:
-      '@fullcalendar/core': ~6.1.18
+      '@fullcalendar/core': ~6.1.19
 
-  '@fullcalendar/list@6.1.18':
-    resolution: {integrity: sha512-XPZI50mq3HXyDQ5sT3jmqQUuwG8zQb5H14dQIUAmOHAIFRA3WpkxlzrXO0U1SrosvGySMPyyNNxvMKI1Q/jL7A==}
+  '@fullcalendar/list@6.1.19':
+    resolution: {integrity: sha512-knZHpAVF0LbzZpSJSUmLUUzF0XlU/MRGK+Py2s0/mP93bCtno1k2L3XPs/kzh528hSjehwLm89RgKTSfW1P6cA==}
     peerDependencies:
-      '@fullcalendar/core': ~6.1.18
+      '@fullcalendar/core': ~6.1.19
 
-  '@fullcalendar/timegrid@6.1.18':
-    resolution: {integrity: sha512-T/ouhs+T1tM8JcW7Cjx+KiohL/qQWKqvRITwjol8ktJ1e1N/6noC40/obR1tyolqOxMRWHjJkYoj9fUqfoez9A==}
+  '@fullcalendar/timegrid@6.1.19':
+    resolution: {integrity: sha512-OuzpUueyO9wB5OZ8rs7TWIoqvu4v3yEqdDxZ2VcsMldCpYJRiOe7yHWKr4ap5Tb0fs7Rjbserc/b6Nt7ol6BRg==}
     peerDependencies:
-      '@fullcalendar/core': ~6.1.18
+      '@fullcalendar/core': ~6.1.19
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -4550,8 +4567,8 @@ packages:
     resolution: {integrity: sha512-uchQbTa8wiv6GWWTbxW1g5b8H6VySz4t91SmduNH6jjWinPze7cjcmsPUEzhySXsYpYr2/50gRJLZz3bx7O88A==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  '@mapbox/mapbox-gl-geocoder@5.1.0':
-    resolution: {integrity: sha512-+3MhDrE5ksDnP3R/104SOjKoGv+Z3ty/glAINw8V5GGOw5ffiLbKuyqloFZpkIR/HmxNztiw5SaePS34SvGPzQ==}
+  '@mapbox/mapbox-gl-geocoder@5.1.2':
+    resolution: {integrity: sha512-UjtGKL/bfaUTf4NfDaKCeYIvtMIJi9nr94QQB13p8uPXhSfjo931zhWNAib3YY7xkNqzVEBWzFGuB1IT5w7lGA==}
     engines: {node: '>=6'}
 
   '@mapbox/mapbox-gl-supported@1.5.0':
@@ -6204,8 +6221,8 @@ packages:
   '@types/mapbox__mapbox-gl-draw@1.4.9':
     resolution: {integrity: sha512-8OtRdlSFbF/NDKg3CYQZPbI41JUwRPHIOB1f3fc3AG0Wb7CecSuuUG5EG+IsCmTHyzF6cyKpcjR/jcv62U3w6w==}
 
-  '@types/mapbox__mapbox-gl-geocoder@5.0.0':
-    resolution: {integrity: sha512-eGBWdFiP2QgmwndPyhwK6eBeOfyB8vRscp2C6Acqasx5dH8FvTo/VgXWCrCKFR3zkWek/H4w4/CwmBFOs7OLBA==}
+  '@types/mapbox__mapbox-gl-geocoder@5.1.0':
+    resolution: {integrity: sha512-5zN8sQstmoHcFpaJn6+b7hJDigRf5sso+fuba2DrZbNHk/+vOHHo9t7IjoaDuRPkfRR7Qs4IzFfHczpJ9S6Fiw==}
 
   '@types/markdown-it@12.2.3':
     resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
@@ -7344,6 +7361,12 @@ packages:
 
   codemirror@5.65.18:
     resolution: {integrity: sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA==}
+
+  codex-notifier@1.1.2:
+    resolution: {integrity: sha512-DCp6xe/LGueJ1N5sXEwcBc3r3PyVkEEDNWCVigfvywAkeXcZMk9K41a31tkEFBW0Ptlwji6/JlAb49E3Yrxbtg==}
+
+  codex-tooltip@1.0.5:
+    resolution: {integrity: sha512-IuA8LeyLU5p1B+HyhOsqR6oxyFQ11k3i9e9aXw40CrHFTRO2Y1npNBVU3W1SvhKAbUU7R/YikUBdcYFP0RcJag==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -14510,6 +14533,8 @@ snapshots:
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
+  '@codexteam/ajax@4.2.0': {}
+
   '@codexteam/icons@0.0.2': {}
 
   '@codexteam/icons@0.0.4': {}
@@ -14542,9 +14567,14 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
-  '@editorjs/attaches@1.3.0':
+  '@editorjs/attaches@1.3.2':
     dependencies:
-      '@codexteam/icons': 0.0.4
+      '@codexteam/ajax': 4.2.0
+      '@codexteam/icons': 0.3.3
+
+  '@editorjs/caret@1.0.3':
+    dependencies:
+      '@editorjs/dom': 1.0.1
 
   '@editorjs/checklist@1.6.0':
     dependencies:
@@ -14562,18 +14592,28 @@ snapshots:
     dependencies:
       '@editorjs/helpers': 0.0.4
 
-  '@editorjs/editorjs@2.30.8': {}
+  '@editorjs/dom@1.0.1':
+    dependencies:
+      '@editorjs/helpers': 1.0.1
+
+  '@editorjs/editorjs@2.31.0':
+    dependencies:
+      '@editorjs/caret': 1.0.3
+      codex-notifier: 1.1.2
+      codex-tooltip: 1.0.5
 
   '@editorjs/embed@2.7.6':
     dependencies:
-      '@editorjs/editorjs': 2.30.8
+      '@editorjs/editorjs': 2.31.0
 
   '@editorjs/header@2.8.8':
     dependencies:
       '@codexteam/icons': 0.0.5
-      '@editorjs/editorjs': 2.30.8
+      '@editorjs/editorjs': 2.31.0
 
   '@editorjs/helpers@0.0.4': {}
+
+  '@editorjs/helpers@1.0.1': {}
 
   '@editorjs/image@2.10.3':
     dependencies:
@@ -14810,6 +14850,8 @@ snapshots:
 
   '@eslint/js@9.32.0': {}
 
+  '@eslint/js@9.38.0': {}
+
   '@eslint/object-schema@2.1.6': {}
 
   '@eslint/plugin-kit@0.3.4':
@@ -14841,26 +14883,26 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 0.2.36
 
-  '@fullcalendar/core@6.1.18':
+  '@fullcalendar/core@6.1.19':
     dependencies:
       preact: 10.12.1
 
-  '@fullcalendar/daygrid@6.1.18(@fullcalendar/core@6.1.18)':
+  '@fullcalendar/daygrid@6.1.19(@fullcalendar/core@6.1.19)':
     dependencies:
-      '@fullcalendar/core': 6.1.18
+      '@fullcalendar/core': 6.1.19
 
-  '@fullcalendar/interaction@6.1.18(@fullcalendar/core@6.1.18)':
+  '@fullcalendar/interaction@6.1.19(@fullcalendar/core@6.1.19)':
     dependencies:
-      '@fullcalendar/core': 6.1.18
+      '@fullcalendar/core': 6.1.19
 
-  '@fullcalendar/list@6.1.18(@fullcalendar/core@6.1.18)':
+  '@fullcalendar/list@6.1.19(@fullcalendar/core@6.1.19)':
     dependencies:
-      '@fullcalendar/core': 6.1.18
+      '@fullcalendar/core': 6.1.19
 
-  '@fullcalendar/timegrid@6.1.18(@fullcalendar/core@6.1.18)':
+  '@fullcalendar/timegrid@6.1.19(@fullcalendar/core@6.1.19)':
     dependencies:
-      '@fullcalendar/core': 6.1.18
-      '@fullcalendar/daygrid': 6.1.18(@fullcalendar/core@6.1.18)
+      '@fullcalendar/core': 6.1.19
+      '@fullcalendar/daygrid': 6.1.19(@fullcalendar/core@6.1.19)
 
   '@gar/promisify@1.1.3':
     optional: true
@@ -15451,7 +15493,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       nanoid: 5.1.5
 
-  '@mapbox/mapbox-gl-geocoder@5.1.0':
+  '@mapbox/mapbox-gl-geocoder@5.1.2':
     dependencies:
       '@mapbox/mapbox-sdk': 0.16.1
       events: 3.3.0
@@ -17627,7 +17669,7 @@ snapshots:
       '@types/geojson': 7946.0.16
       mapbox-gl: 1.13.3
 
-  '@types/mapbox__mapbox-gl-geocoder@5.0.0':
+  '@types/mapbox__mapbox-gl-geocoder@5.1.0':
     dependencies:
       '@types/geojson': 7946.0.16
       '@types/mapbox-gl': 3.4.1
@@ -19055,6 +19097,10 @@ snapshots:
   cmd-shim@6.0.3: {}
 
   codemirror@5.65.18: {}
+
+  codex-notifier@1.1.2: {}
+
+  codex-tooltip@1.0.5: {}
 
   color-convert@1.9.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,11 +18,11 @@ catalog:
   '@directus/schema-builder': workspace:*
   '@directus/tsconfig': 3.0.0
   '@directus/types': workspace:*
-  '@editorjs/attaches': 1.3.0
+  '@editorjs/attaches': 1.3.2
   '@editorjs/checklist': 1.6.0
   '@editorjs/code': 2.9.3
   '@editorjs/delimiter': 1.4.2
-  '@editorjs/editorjs': 2.30.8
+  '@editorjs/editorjs': 2.31.0
   '@editorjs/embed': 2.7.6
   '@editorjs/header': 2.8.8
   '@editorjs/image': 2.10.3
@@ -33,14 +33,14 @@ catalog:
   '@editorjs/raw': 2.5.1
   '@editorjs/table': 2.4.5
   '@editorjs/underline': 1.2.1
-  '@eslint/js': 9.32.0
+  '@eslint/js': 9.38.0
   '@fortawesome/fontawesome-svg-core': 6.7.2
   '@fortawesome/free-brands-svg-icons': 6.7.2
-  '@fullcalendar/core': 6.1.18
-  '@fullcalendar/daygrid': 6.1.18
-  '@fullcalendar/interaction': 6.1.18
-  '@fullcalendar/list': 6.1.18
-  '@fullcalendar/timegrid': 6.1.18
+  '@fullcalendar/core': 6.1.19
+  '@fullcalendar/daygrid': 6.1.19
+  '@fullcalendar/interaction': 6.1.19
+  '@fullcalendar/list': 6.1.19
+  '@fullcalendar/timegrid': 6.1.19
   '@godaddy/terminus': 4.12.1
   '@google-cloud/storage': 7.17.0
   '@histoire/plugin-vue': 0.17.17
@@ -49,7 +49,7 @@ catalog:
   '@keyv/redis': 3.0.1
   '@mapbox/mapbox-gl-draw': 1.5.0
   '@mapbox/mapbox-gl-draw-static-mode': 1.0.1
-  '@mapbox/mapbox-gl-geocoder': 5.1.0
+  '@mapbox/mapbox-gl-geocoder': 5.1.2
   '@modelcontextprotocol/sdk': 1.20.1
   '@ngneat/falso': 8.0.2
   '@npm/types': 2.1.0
@@ -103,7 +103,7 @@ catalog:
   '@types/lodash': 4.17.20
   '@types/lodash-es': 4.17.12
   '@types/mapbox__mapbox-gl-draw': 1.4.9
-  '@types/mapbox__mapbox-gl-geocoder': 5.0.0
+  '@types/mapbox__mapbox-gl-geocoder': 5.1.0
   '@types/mime-types': 3.0.1
   '@types/ms': 2.1.0
   '@types/node': 22.13.14


### PR DESCRIPTION
## Scope

What's changed:

- @editorjs/attaches - 1.3.0 → 1.3.2
- @editorjs/editorjs - 2.30.8 → 2.31.0
- @eslint/js - 9.32.0 → 9.38.0
- @fullcalendar/core 6.1.18 → 6.1.19
- @fullcalendar/daygrid 6.1.18 → 6.1.19
- @fullcalendar/interaction 6.1.18 → 6.1.19
- @fullcalendar/list 6.1.18 → 6.1.19
- @fullcalendar/timegrid 6.1.18 → 6.1.19
- @mapbox/mapbox-gl-geocoder - 5.1.0 → 5.1.2
- @types/mapbox__mapbox-gl-geocoder - 5.0.0 → 5.1.0

## Review Notes / Questions

- Checked Release Notes
- Ran tests locally