### PR TITLE
Comparison < Updates 27/1

### DIFF
--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
 	batchMode?: boolean;
 	batchActive?: boolean;
 	comparison?: ComparisonContext;
+	comparisonActive?: boolean;
 	primaryKey?: string | number | null;
 	modelValue?: string | number | boolean | Record<string, any> | Array<any>;
 	loading?: boolean;
@@ -62,7 +63,7 @@ const value = computed(() =>
 				:batch-mode="batchMode"
 				:batch-active="batchActive"
 				:comparison-mode="!!comparison"
-				:comparison-active="comparison?.selectedFields.includes(field.field)"
+				:comparison-active="comparisonActive"
 				:width="(field.meta && field.meta.width) || 'full'"
 				:type="field.type"
 				:collection="field.collection"

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -224,6 +224,7 @@ function useComputedValues() {
 			:raw-editor-active="rawEditorActive"
 			:direction="direction"
 			:comparison="comparison"
+			:comparison-active="comparisonActive"
 			@update:model-value="emitValue($event)"
 			@set-field-value="$emit('setFieldValue', $event)"
 		/>

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -19,7 +19,7 @@ export type ComparisonData = {
 	initialSelectedDeltaId?: number | string;
 };
 
-type NormalizedUser = {
+export type NormalizedUser = {
 	id: string;
 	firstName: string | null;
 	lastName: string | null;

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -349,7 +349,7 @@ function getNormalizedDateAndUser(revision: Revision | null | undefined): Pick<N
 	};
 }
 
-export function normalizeComparisonData(
+export function getNormalizedComparisonData(
 	comparisonData: ComparisonData,
 	fieldMetadata: Record<string, any>,
 ): NormalizedComparisonData {

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -297,7 +297,16 @@ function normalizeDate(dateString: string | null | undefined): NormalizedDate {
 	};
 }
 
-function normalizeVersionItem(version: ContentVersion): NormalizedItem {
+function normalizeVersionItem(version: ContentVersion | undefined): NormalizedItem {
+	if (!version) {
+		return {
+			id: undefined,
+			displayName: i18n.global.t('unknown_version'),
+			date: normalizeDate(null),
+			user: normalizeUser(null),
+		};
+	}
+
 	return {
 		id: version.id,
 		displayName: getVersionDisplayName(version),
@@ -308,26 +317,35 @@ function normalizeVersionItem(version: ContentVersion): NormalizedItem {
 	};
 }
 
-function normalizeRevisionItem(revision: Revision): NormalizedItem {
-	const user = revision.activity?.user;
-	const timestamp = revision.activity?.timestamp;
+function normalizeRevisionItem(revision: Revision | undefined): NormalizedItem {
+	const { date, user } = getNormalizedDateAndUser(revision);
+
+	if (!revision) {
+		return {
+			id: undefined,
+			displayName: i18n.global.t('unknown_revision'),
+			date,
+			user,
+		};
+	}
 
 	return {
 		id: revision.id,
 		displayName: i18n.global.t('item_revision'),
-		date: normalizeDate(timestamp),
-		user: normalizeUser(user as any),
+		date,
+		user,
 		collection: revision.collection,
 		item: revision.item,
 	};
 }
 
-function normalizeMainItem(mainData: Record<string, any>): NormalizedItem {
+function getNormalizedDateAndUser(revision: Revision | null | undefined): Pick<NormalizedItem, 'date' | 'user'> {
+	const user = revision?.activity?.user as User | string | null | undefined;
+	const timestamp = revision?.activity?.timestamp;
+
 	return {
-		id: 'base',
-		displayName: i18n.global.t('main_version'),
-		date: normalizeDate(mainData.date_updated),
-		user: normalizeUser(mainData.user_updated || mainData.user_created),
+		date: normalizeDate(timestamp),
+		user: normalizeUser(user),
 	};
 }
 
@@ -337,15 +355,23 @@ export function normalizeComparisonData(
 ): NormalizedComparisonData {
 	let base: NormalizedItem;
 
-	if (comparisonData.comparisonType === 'revision' && comparisonData.currentVersion) {
+	if (comparisonData.comparisonType === 'revision') {
+		const revisions = (comparisonData.selectableDeltas as Revision[]) || [];
+		const latestRevision = revisions?.[0] ?? null;
+		const { date, user } = getNormalizedDateAndUser(latestRevision);
+
+		const displayName = comparisonData.currentVersion
+			? getVersionDisplayName(comparisonData.currentVersion)
+			: i18n.global.t('main_version');
+
+		base = { id: 'base', displayName, date, user };
+	} else {
 		base = {
 			id: 'base',
-			displayName: getVersionDisplayName(comparisonData.currentVersion),
+			displayName: i18n.global.t('main_version'),
 			date: normalizeDate(comparisonData.base.date_updated),
 			user: normalizeUser(comparisonData.base.user_updated || comparisonData.base.user_created),
 		};
-	} else {
-		base = normalizeMainItem(comparisonData.base);
 	}
 
 	let incoming: NormalizedItem;
@@ -355,27 +381,13 @@ export function normalizeComparisonData(
 		const selectedId = (comparisonData.initialSelectedDeltaId as string | undefined) || undefined;
 		const selected = selectedId ? versions.find((v) => v.id === selectedId) : versions[0];
 
-		incoming = selected
-			? normalizeVersionItem(selected)
-			: {
-					id: undefined,
-					displayName: i18n.global.t('unknown_version'),
-					date: { raw: null, formatted: null, dateObject: null },
-					user: null,
-				};
+		incoming = normalizeVersionItem(selected);
 	} else {
 		const revisions = (comparisonData.selectableDeltas as Revision[]) || [];
 		const selectedId = (comparisonData.initialSelectedDeltaId as number | undefined) || undefined;
 		const selected = typeof selectedId !== 'undefined' ? revisions.find((r) => r.id === selectedId) : revisions[0];
 
-		incoming = selected
-			? normalizeRevisionItem(selected)
-			: {
-					id: undefined,
-					displayName: i18n.global.t('unknown_revision'),
-					date: { raw: null, formatted: null, dateObject: null },
-					user: null,
-				};
+		incoming = normalizeRevisionItem(selected);
 	}
 
 	const selectableDeltas: NormalizedItem[] = (comparisonData.selectableDeltas || []).map((item) => {

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -351,7 +351,7 @@ function getNormalizedDateAndUser(revision: Revision | null | undefined): Pick<N
 
 export function normalizeComparisonData(
 	comparisonData: ComparisonData,
-	fieldMetadata?: Record<string, any>,
+	fieldMetadata: Record<string, any>,
 ): NormalizedComparisonData {
 	let base: NormalizedItem;
 

--- a/app/src/modules/content/comparison-utils.ts
+++ b/app/src/modules/content/comparison-utils.ts
@@ -1,5 +1,6 @@
 import { i18n } from '@/lang';
 import type { Revision } from '@/types/revisions';
+import type { Activity } from '@/types/activity';
 import { RELATIONAL_TYPES } from '@directus/constants';
 import formatTitle from '@directus/format-title';
 import type { ContentVersion, Field, RelationalType, User } from '@directus/types';
@@ -8,6 +9,7 @@ import { isNil, isEqual } from 'lodash';
 export type ComparisonData = {
 	base: Record<string, any>;
 	incoming: Record<string, any>;
+	mainVersionMeta?: Pick<Activity, 'timestamp' | 'user'>;
 	selectableDeltas?: Revision[] | ContentVersion[];
 	revisionFields?: Set<string>;
 	comparisonType: 'version' | 'revision';
@@ -369,8 +371,10 @@ export function getNormalizedComparisonData(
 		base = {
 			id: 'base',
 			displayName: i18n.global.t('main_version'),
-			date: normalizeDate(comparisonData.base.date_updated),
-			user: normalizeUser(comparisonData.base.user_updated || comparisonData.base.user_created),
+			date: normalizeDate(comparisonData.mainVersionMeta?.timestamp || comparisonData.base.date_updated),
+			user: normalizeUser(
+				comparisonData.mainVersionMeta?.user || comparisonData.base.user_updated || comparisonData.base.user_created,
+			),
 		};
 	}
 

--- a/app/src/modules/content/components/comparison-modal.vue
+++ b/app/src/modules/content/components/comparison-modal.vue
@@ -53,6 +53,7 @@ const {
 } = useComparison({
 	comparisonData,
 	collection,
+	primaryKey,
 });
 
 const modalLoading = ref(false);

--- a/app/src/modules/content/components/comparison-modal.vue
+++ b/app/src/modules/content/components/comparison-modal.vue
@@ -11,7 +11,6 @@ import ComparisonHeader from './comparison-header.vue';
 import { isEqual } from 'lodash';
 import { ref, toRefs, unref, watch, computed, type Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRoute } from 'vue-router';
 
 interface Props {
 	active: boolean;
@@ -21,7 +20,6 @@ interface Props {
 }
 
 const { t } = useI18n();
-const route = useRoute();
 
 const props = defineProps<Props>();
 
@@ -47,7 +45,6 @@ const {
 	baseDisplayName,
 	deltaDisplayName,
 	normalizedData,
-	debugComparison,
 	toggleSelectAll,
 	toggleComparisonField,
 	fetchUserUpdated,
@@ -59,9 +56,6 @@ const {
 });
 
 const modalLoading = ref(false);
-
-// Show debug button only when debug query parameter is present
-const showDebugButton = computed(() => route.query.debug !== undefined);
 
 const incomingTooltipMessage = computed(() => {
 	if (isRevisionMode.value) return `${t('changes_made')} ${t('no_relational_data')}`;
@@ -311,10 +305,6 @@ async function onDeltaSelectionChange(newDeltaId: string | number) {
 								>
 									<v-icon name="close" left />
 									<span class="button-text">{{ t('cancel') }}</span>
-								</v-button>
-								<v-button v-if="showDebugButton" secondary @click="debugComparison('Manual debug')">
-									<v-icon name="bug_report" left />
-									<span class="button-text">Debug</span>
 								</v-button>
 								<v-button
 									v-tooltip.top="

--- a/app/src/modules/content/components/comparison-modal.vue
+++ b/app/src/modules/content/components/comparison-modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ContentVersion } from '@directus/types';
+import type { ContentVersion, PrimaryKey } from '@directus/types';
 import api from '@/api';
 import VSkeletonLoader from '@/components/v-skeleton-loader.vue';
 import type { Revision } from '@/types/revisions';
@@ -16,7 +16,7 @@ interface Props {
 	active: boolean;
 	deleteVersionsAllowed: boolean;
 	collection: string;
-	primaryKey: string | number;
+	primaryKey: PrimaryKey;
 }
 
 const { t } = useI18n();

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -2,7 +2,7 @@
 import api from '@/api';
 import { useCollectionPermissions } from '@/composables/use-permissions';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { ContentVersion } from '@directus/types';
+import { ContentVersion, PrimaryKey } from '@directus/types';
 import slugify from '@sindresorhus/slugify';
 import { useComparison } from '../composables/use-comparison';
 import { type ComparisonData, getVersionDisplayName } from '../comparison-utils';
@@ -12,7 +12,7 @@ import { useI18n } from 'vue-i18n';
 
 interface Props {
 	collection: string;
-	primaryKey: string | number;
+	primaryKey: PrimaryKey;
 	updateAllowed: boolean;
 	hasEdits: boolean;
 	currentVersion: ContentVersion | null;

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -38,6 +38,7 @@ const comparisonData = ref<ComparisonData | null>(null);
 const { normalizeComparisonData } = useComparison({
 	comparisonData,
 	collection,
+	primaryKey,
 });
 
 const {

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -35,7 +35,10 @@ const { collection, primaryKey, hasEdits, currentVersion, versions } = toRefs(pr
 const isComparisonModalOpen = ref(false);
 const comparisonData = ref<ComparisonData | null>(null);
 
-const { normalizeComparisonData } = useComparison({ comparisonData });
+const { normalizeComparisonData } = useComparison({
+	comparisonData,
+	collection,
+});
 
 const {
 	createAllowed: createVersionsAllowed,

--- a/app/src/modules/content/composables/use-comparison.ts
+++ b/app/src/modules/content/composables/use-comparison.ts
@@ -24,7 +24,7 @@ import { computed, ref, watch, type Ref } from 'vue';
 
 interface UseComparisonOptions {
 	comparisonData: Ref<ComparisonData | null>;
-	collection?: Ref<string>;
+	collection: Ref<string>;
 }
 
 export function useComparison(options: UseComparisonOptions) {
@@ -40,15 +40,11 @@ export function useComparison(options: UseComparisonOptions) {
 	const isVersionMode = computed(() => comparisonData.value?.comparisonType === 'version');
 	const isRevisionMode = computed(() => comparisonData.value?.comparisonType === 'revision');
 
-	const normalizedData = computed((): NormalizedComparisonData | null => {
+	const normalizedData = computed<NormalizedComparisonData | null>(() => {
 		if (!comparisonData.value) return null;
 
-		let fieldMetadata: Record<string, any> | undefined;
-
-		if (collection?.value) {
-			const collectionFields = fieldsStore.getFieldsForCollection(collection.value);
-			fieldMetadata = Object.fromEntries(collectionFields.map((field) => [field.field, field]));
-		}
+		const collectionFields = fieldsStore.getFieldsForCollection(collection.value);
+		const fieldMetadata = Object.fromEntries(collectionFields.map((field) => [field.field, field]));
 
 		return normalizeComparisonDataUtil(comparisonData.value, fieldMetadata);
 	});
@@ -325,7 +321,7 @@ export function useComparison(options: UseComparisonOptions) {
 		const activity = revision?.activity;
 		const revisionsList = revisions || [];
 		const revisionId = 'id' in revision ? revision.id : null;
-		const targetCollection = revision.collection || collection?.value || '';
+		const targetCollection = revision.collection || collection.value || '';
 		const fields = fieldsStore.getFieldsForCollection(targetCollection);
 		const revisionDelta = Object.keys(revision.delta ?? {});
 		const revisionFields = new Set(getRevisionFields(revisionDelta, fields));

--- a/app/src/modules/content/composables/use-comparison.ts
+++ b/app/src/modules/content/composables/use-comparison.ts
@@ -10,7 +10,7 @@ import {
 	toggleAllFields,
 	areAllFieldsSelected,
 	areSomeFieldsSelected,
-	normalizeComparisonData as normalizeComparisonDataUtil,
+	getNormalizedComparisonData,
 	applyValuesToSpecialFields,
 	getRevisionFields,
 	replaceArraysInMergeCustomizer,
@@ -46,7 +46,7 @@ export function useComparison(options: UseComparisonOptions) {
 		const collectionFields = fieldsStore.getFieldsForCollection(collection.value);
 		const fieldMetadata = Object.fromEntries(collectionFields.map((field) => [field.field, field]));
 
-		return normalizeComparisonDataUtil(comparisonData.value, fieldMetadata);
+		return getNormalizedComparisonData(comparisonData.value, fieldMetadata);
 	});
 
 	const mainHash = computed(() => normalizedData.value?.mainHash ?? '');

--- a/app/src/modules/content/composables/use-comparison.ts
+++ b/app/src/modules/content/composables/use-comparison.ts
@@ -83,84 +83,6 @@ export function useComparison(options: UseComparisonOptions) {
 		return normalizedData.value?.incoming?.displayName || '';
 	});
 
-	function debugComparison(label?: string) {
-		const normalized = normalizedData.value;
-
-		let mode = 'unknown';
-
-		if (isRevisionMode.value) {
-			mode = 'revision';
-		} else if (isVersionMode.value) {
-			mode = 'version';
-		}
-
-		const fields = fieldsWithDifferences.value || [];
-		const selected = selectedComparisonFields.value || [];
-
-		const header = label ? `Comparison Debug: ${label}` : 'Comparison Debug';
-
-		// eslint-disable-next-line no-console
-		console.groupCollapsed(header);
-
-		try {
-			// eslint-disable-next-line no-console
-			console.info('Mode:', mode);
-			// eslint-disable-next-line no-console
-			console.info('Available fields with differences (%d):', fields.length, fields);
-			// eslint-disable-next-line no-console
-			console.info('Selected fields (%d):', selected.length, selected);
-
-			if (normalized) {
-				// eslint-disable-next-line no-console
-				console.info('Base item:', normalized.base);
-				// eslint-disable-next-line no-console
-				console.info('Incoming item:', normalized.incoming);
-			} else {
-				// eslint-disable-next-line no-console
-				console.warn('No normalized data available');
-			}
-
-			if (comparisonData.value?.comparisonType === 'revision') {
-				const selectedId = normalized?.initialSelectedDeltaId ?? null;
-
-				const revisions = (comparisonData.value.selectableDeltas as Revision[]) || [];
-
-				const matching =
-					typeof selectedId !== 'undefined' && selectedId !== null
-						? revisions.find((r) => r && 'id' in r && r.id === selectedId)
-						: revisions[0];
-
-				if (matching) {
-					// eslint-disable-next-line no-console
-					console.info('Revision (from drawer list):', matching);
-				} else {
-					// eslint-disable-next-line no-console
-					console.warn('No matching revision found for selectedId:', selectedId);
-				}
-
-				// Provide a quick diff map for changed fields
-
-				const diffPreview: Record<string, { base: any; incoming: any }> = {};
-
-				for (const key of fields) {
-					diffPreview[key] = {
-						base: (comparisonData.value.base as any)?.[key],
-						incoming: (comparisonData.value.incoming as any)?.[key],
-					};
-				}
-
-				// eslint-disable-next-line no-console
-				console.info('Field diffs preview:', diffPreview);
-			}
-		} catch (error) {
-			// eslint-disable-next-line no-console
-			console.error('Error in debugComparison:', error);
-		} finally {
-			// eslint-disable-next-line no-console
-			console.groupEnd();
-		}
-	}
-
 	function toggleSelectAll() {
 		selectedComparisonFields.value = toggleAllFields(
 			selectedComparisonFields.value,
@@ -452,7 +374,6 @@ export function useComparison(options: UseComparisonOptions) {
 		baseDisplayName,
 		deltaDisplayName,
 		normalizedData,
-		debugComparison,
 		toggleSelectAll,
 		toggleComparisonField,
 		fetchUserUpdated,

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -6,7 +6,7 @@ import { useComparison } from '@/modules/content/composables/use-comparison';
 import type { Revision } from '@/types/revisions';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { useGroupable } from '@directus/composables';
-import { ContentVersion } from '@directus/types';
+import { ContentVersion, PrimaryKey } from '@directus/types';
 import { abbreviateNumber } from '@directus/utils';
 import RevisionsDateGroup from './revisions-date-group.vue';
 import { computed, onMounted, ref, toRefs, watch } from 'vue';
@@ -14,7 +14,7 @@ import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
 	collection: string;
-	primaryKey: string | number;
+	primaryKey: PrimaryKey;
 	version?: ContentVersion | null;
 }>();
 

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -36,7 +36,7 @@ const selectedRevision = ref<number | undefined>(undefined);
 const comparisonData = ref<ComparisonData | null>(null);
 const page = ref<number>(1);
 
-const { normalizeComparisonData } = useComparison({ comparisonData });
+const { normalizeComparisonData } = useComparison({ comparisonData, collection });
 
 const {
 	revisions,

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -36,7 +36,7 @@ const selectedRevision = ref<number | undefined>(undefined);
 const comparisonData = ref<ComparisonData | null>(null);
 const page = ref<number>(1);
 
-const { normalizeComparisonData } = useComparison({ comparisonData, collection });
+const { normalizeComparisonData } = useComparison({ comparisonData, collection, primaryKey });
 
 const {
 	revisions,


### PR DESCRIPTION
## Scope

What's changed:

- drill down comparisonActive prop instead of recalculating
- remove debug mode
- Ensure NormalizedItem gets correct user for the base side
- refactor to use type PrimaryKey instead of string | number
- refactor to require collection parameter
- rename normalizeComparisonData to getNormalizedComparisonData for clarity
- add mainVersionMeta to ComparisonData to get activity information of latest main
- refactor user fetching logic for clarity



