### PR TITLE
Filter out metadata causing incorrect comparisons

### DIFF
--- a/api/src/controllers/versions.ts
+++ b/api/src/controllers/versions.ts
@@ -9,6 +9,7 @@ import { MetaService } from '../services/meta.js';
 import { VersionsService } from '../services/versions.js';
 import asyncHandler from '../utils/async-handler.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
+import { splitRecursive } from '../utils/versioning/split-recursive.js';
 
 const router = express.Router();
 
@@ -214,9 +215,12 @@ router.get(
 		const delta = version.delta ?? {};
 		delta[req.schema.collections[version.collection]!.primary] = version.item;
 
+		const excludeMetadata = req.query['excludeMetadata'] === 'true';
+		const deltaToReturn = excludeMetadata ? splitRecursive(delta).rawDelta : delta;
+
 		const main = await service.getMainItem(version['collection'], version['item']);
 
-		res.locals['payload'] = { data: { outdated, mainHash, current: delta, main } };
+		res.locals['payload'] = { data: { outdated, mainHash, current: deltaToReturn, main } };
 
 		return next();
 	}),

--- a/app/src/modules/content/composables/use-comparison.ts
+++ b/app/src/modules/content/composables/use-comparison.ts
@@ -343,7 +343,7 @@ export function useComparison(options: UseComparisonOptions) {
 		versions?: ContentVersion[] | null,
 	): Promise<ComparisonData> {
 		try {
-			const response = await api.get(`/versions/${versionId}/compare`);
+			const response = await api.get(`/versions/${versionId}/compare?excludeMetadata=true`);
 			const data: VersionComparisonResponse = response.data.data;
 			const base = data.main || {};
 			const incomingMerged = mergeWith({}, base, data.current || {}, replaceArraysInMergeCustomizer);
@@ -365,7 +365,7 @@ export function useComparison(options: UseComparisonOptions) {
 
 	async function fetchVersionComparisonForRevision(versionId: string) {
 		try {
-			const response = await api.get(`/versions/${versionId}/compare`);
+			const response = await api.get(`/versions/${versionId}/compare?excludeMetadata=true`);
 			const data: VersionComparisonResponse = response.data.data;
 			const main = data.main || {};
 			const mainMergedWithVersionLatest = mergeWith({}, main, data.current || {}, replaceArraysInMergeCustomizer);


### PR DESCRIPTION
## Scope

What's changed:
- Added param to versions controller allowing to exclude metadata from the version:compare response.



