### PR TITLE
fix: typo in nl translation for file upload status message

### DIFF
--- a/app/src/lang/translations/nl-NL.yaml
+++ b/app/src/lang/translations/nl-NL.yaml
@@ -888,7 +888,7 @@ items: Items
 upload_file: Upload Bestand
 upload_file_indeterminate: Bestand uploaden...
 upload_file_success: Bestand geüpload
-upload_files_indeterminate: 'Bestanden can het uploaden {done}/{total}'
+upload_files_indeterminate: 'Bestanden aan het uploaden {done}/{total}'
 upload_files_success: '{count} bestanden geüpload'
 upload_pending: Uploaden in afwachting
 drag_file_here: Sleep een bestand hierheen

--- a/contributors.yml
+++ b/contributors.yml
@@ -225,5 +225,6 @@
 - timio23
 - khanahmad4527
 - gaetansenn
+- remihuigen
 - Shashank188
 - JamesW1


### PR DESCRIPTION
## Scope

What's changed:

- Fixed a typo in the NL translation file

## Potential Risks / Drawbacks

- none

