### PR TITLE
Fixed relational interfaces not using field-level display template

### DIFF
--- a/.changeset/funny-towns-invent.md
+++ b/.changeset/funny-towns-invent.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-fix display template bug on fields
+Fixed relational interfaces not using field-level display template

--- a/.changeset/funny-towns-invent.md
+++ b/.changeset/funny-towns-invent.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+fix display template bug on fields

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -69,6 +69,7 @@ const value = computed(() =>
 				:length="field.schema && field.schema.max_length"
 				:direction="direction"
 				:raw-editor-enabled="rawEditorEnabled"
+				:template="field.meta?.display_options?.template"
 				@input="$emit('update:modelValue', $event)"
 				@set-field-value="$emit('setFieldValue', $event)"
 			/>

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -28,6 +28,7 @@ const props = withDefaults(
 		enableSelect?: boolean;
 		limit?: number;
 		prefix?: string;
+		template?: string | null;
 		allowDuplicates?: boolean;
 	}>(),
 	{
@@ -36,6 +37,7 @@ const props = withDefaults(
 		enableCreate: true,
 		enableSelect: true,
 		limit: 15,
+		template: null,
 		allowDuplicates: false,
 	},
 );
@@ -63,7 +65,9 @@ const templates = computed(() => {
 
 	for (const collection of allowedCollections.value) {
 		const primaryKeyField = relationInfo.value.relationPrimaryKeyFields[collection.collection];
-		templates[collection.collection] = collection.meta?.display_template || `{{${primaryKeyField?.field}}}`;
+
+		templates[collection.collection] =
+			props.template || collection.meta?.display_template || `{{${primaryKeyField?.field}}}`;
 	}
 
 	return templates;


### PR DESCRIPTION
## Scope

What's changed:

In @directus/app, edited form-field-interface to bind display template from props.

## Potential Risks / Drawbacks

Just add one more bind, no big risk I think

## Tested Scenarios
@directus/app test passed.

## Review Notes / Questions

Does have some place  use collection display template instead of use field displate template too?

And for display newly created records, there have no primary key on it at that moment, when the fallback display template would use primary key to display. I think it is a another case need to discuss and fix.

Forget the issue id on commit msg, I writed it wrongly.

Fixes #26051 
