### PR TITLE
`searchable` updates

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -5,7 +5,6 @@ import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { TranslateResult, useI18n } from 'vue-i18n';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
-import { SEARCHABLE_TYPES } from '@directus/constants';
 
 type FieldTypeOption = { value: Type; text: TranslateResult | string; children?: FieldTypeOption[] };
 
@@ -121,7 +120,6 @@ const nullable = syncFieldDetailStoreProperty('field.schema.is_nullable', true);
 const unique = syncFieldDetailStoreProperty('field.schema.is_unique', false);
 const indexed = syncFieldDetailStoreProperty('field.schema.is_indexed', false);
 const numericScale = syncFieldDetailStoreProperty('field.schema.numeric_scale');
-const searchable = syncFieldDetailStoreProperty('field.meta.searchable', true);
 
 const { t } = useI18n();
 
@@ -154,16 +152,6 @@ const isPrimaryKey = computed(() => {
 
 const isGenerated = computed(() => {
 	return fieldDetailStore.field.schema?.is_generated;
-});
-
-const isSearchableType = computed(() => {
-	// exclude alias fields (o2m, m2m, m2a) as they don't store searchable data
-	if (type.value === 'alias') return false;
-
-	// exclude relational fields except m2o, which stores foreign keys that are typically not useful for search
-	if (localType.value && localType.value !== 'standard') return false;
-
-	return SEARCHABLE_TYPES.includes(type.value);
 });
 
 function useOnCreate() {
@@ -463,11 +451,6 @@ function useOnUpdate() {
 			<div v-if="!isAlias" class="field half-left">
 				<div class="label type-label">{{ t('index') }}</div>
 				<v-checkbox v-model="indexed" :disabled="isGenerated || isPrimaryKey" :label="t('value_index')" block />
-			</div>
-
-			<div v-if="!isAlias && isSearchableType" class="field half-right">
-				<div class="label type-label">{{ t('searchable') }}</div>
-				<v-checkbox v-model="searchable" :label="t('field_searchable')" block />
 			</div>
 		</div>
 	</div>

--- a/sdk/src/schema/field.ts
+++ b/sdk/src/schema/field.ts
@@ -24,6 +24,7 @@ export type DirectusField<Schema = any> = {
 			note: string | null;
 			conditions: FieldMetaConditionType[] | null;
 			required: boolean;
+			searchable: boolean;
 			group: string | null;
 			validation: Record<string, any> | null;
 			validation_message: string | null;


### PR DESCRIPTION
## Scope

What's changed:

- Moved `searchable` option to "meta" tab
- Added new `searchable` property to sdk field type

## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- `searchable` was not added to conditions as those are Studio only and this field is used Engine only 
- No changeset as this is an unreleased change
- Their seems to be no consistency for the translation keys so left as is

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes N/A
