### PR TITLE
Comparison ← fix reactivity issue

### DIFF
--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -17,12 +17,12 @@ interface Props {
 	primaryKey: PrimaryKey;
 	mode: 'version' | 'revision';
 	currentVersion: ContentVersion | null | undefined;
-	currentRevision?: Revision | null;
 	revisions?: Revision[] | null;
 }
 
 const props = defineProps<Props>();
 const active = defineModel<boolean>();
+const currentRevision = defineModel<Revision | null>('current-revision');
 
 const emit = defineEmits<{
 	cancel: [];
@@ -33,8 +33,6 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const { deleteVersionsAllowed, collection, primaryKey, mode, currentVersion, revisions } = toRefs(props);
-const internalRevision = ref<Revision | null>(null);
-const currentRevision = computed(() => internalRevision.value ?? props.currentRevision);
 
 const {
 	comparisonData,
@@ -160,7 +158,7 @@ function usePromoteDialog() {
 function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 	if (props.mode !== 'revision') return;
 
-	internalRevision.value = revisions.value?.find((revision) => revision.id === newDeltaId) ?? null;
+	currentRevision.value = revisions.value?.find((revision) => revision.id === newDeltaId) ?? null;
 }
 </script>
 

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -106,12 +106,12 @@ defineExpose({
 
 		<comparison-modal
 			v-model="comparisonModalActive"
+			v-model:current-revision="currentRevision"
 			:delete-versions-allowed="false"
 			:collection
 			:primary-key
 			mode="revision"
 			:current-version="version"
-			:current-revision
 			:revisions="revisions as Revision[]"
 			@confirm="$emit('revert', $event)"
 			@cancel="closeModal"


### PR DESCRIPTION
## Scope

What's changed:

- fixed reactivity issue by changing currentRevision from prop to model

Bug reproduction:
- create an item, make edits, save
- update the item so you have two revision entries: Revision A and Revision B
- Open Revision A in the modal
- Inside the modal use the dropdown to switch to Revision B and close the modal
- Open Revision A again …

… the modal shows Revision B instead of A.