### PR TITLE
Add encryption support to special flags

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -99,7 +99,7 @@ export default async function createApp(): Promise<express.Application> {
 		);
 	}
 
-	if (typeof env['SECRET'] === 'string' && env['SECRET'].length < 32) {
+	if (typeof env['SECRET'] === 'string' && Buffer.byteLength(env['SECRET']) < 32) {
 		logger.warn('"SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.');
 	}
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -100,7 +100,9 @@ export default async function createApp(): Promise<express.Application> {
 	}
 
 	if (typeof env['SECRET'] === 'string' && Buffer.byteLength(env['SECRET']) < 32) {
-		logger.warn('"SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.');
+		logger.warn(
+			'"SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.',
+		);
 	}
 
 	if (!new Url(env['PUBLIC_URL'] as string).isAbsolute()) {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -99,6 +99,10 @@ export default async function createApp(): Promise<express.Application> {
 		);
 	}
 
+	if (typeof env['SECRET'] === 'string' && env['SECRET'].length < 32) {
+		logger.warn('"SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.');
+	}
+
 	if (!new Url(env['PUBLIC_URL'] as string).isAbsolute()) {
 		logger.warn('"PUBLIC_URL" should be a full URL');
 	}

--- a/api/src/database/run-ast/run-ast.ts
+++ b/api/src/database/run-ast/run-ast.ts
@@ -88,7 +88,7 @@ export async function runAst(
 		if (!rawItems) return null;
 
 		// Run the items through the special transforms
-		const payloadService = new PayloadService(collection, { knex, schema });
+		const payloadService = new PayloadService(collection, { accountability, knex, schema });
 
 		let items: null | Item | Item[] = await payloadService.processValues(
 			'read',

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -174,7 +174,7 @@ export class PayloadService {
 			}
 
 			return value;
-		}
+		},
 	};
 
 	processValues(action: PayloadAction, payloads: Partial<Item>[]): Promise<Partial<Item>[]>;

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -28,6 +28,8 @@ import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase from '../database/index.js';
 import { generateHash } from '../utils/generate-hash.js';
+import { encrypt } from '../utils/encrypt.js';
+import { getSecret } from '../utils/get-secret.js';
 
 type Transformers = {
 	[type: string]: (context: {
@@ -163,6 +165,16 @@ export class PayloadService {
 
 			return value;
 		},
+		async encrypt({ action, value }) {
+			if (action === 'read') return value ? '**********' : null;
+
+			if (typeof value === 'string') {
+				const key = getSecret();
+				return encrypt(value, key);
+			}
+
+			return value;
+		}
 	};
 
 	processValues(action: PayloadAction, payloads: Partial<Item>[]): Promise<Partial<Item>[]>;

--- a/api/src/utils/encrypt.test.ts
+++ b/api/src/utils/encrypt.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { encrypt, decrypt, createAesKey } from './encrypt.js';
+
+const isBase64 = (s: string) => /^[A-Za-z0-9+/]+={0,2}$/.test(s);
+
+describe('createAesKey', () => {
+	it('returns a Buffer of exactly 32 bytes for short keys by repeating and truncating', () => {
+		const key = 'secret'; // 6 bytes
+		const buf = createAesKey(key);
+		expect(Buffer.isBuffer(buf)).toBe(true);
+		expect(buf.byteLength).toBe(32);
+		// starts with original bytes
+		expect(buf.subarray(0, Buffer.byteLength(key, 'utf8')).toString('utf8')).toBe(key);
+	});
+
+	it('returns the same 32-byte content when already 32 bytes', () => {
+		const key = 'a'.repeat(32);
+		const buf = createAesKey(key);
+		expect(buf.byteLength).toBe(32);
+		expect(buf.toString('utf8')).toBe(key);
+	});
+
+	it('truncates to 32 bytes when result would exceed 32', () => {
+		const key = 'x'.repeat(17); // repeating would yield 34 bytes; should truncate to 32
+		const buf = createAesKey(key);
+		expect(buf.byteLength).toBe(32);
+		expect(buf.toString('utf8')).toBe('x'.repeat(32));
+	});
+});
+
+describe('encrypt/decrypt (AES-256-GCM)', () => {
+	it('round-trips plaintext with the same key', () => {
+		const key = 'super-secret-key';
+		const plaintext = 'Hello, world! 👋';
+		const out = encrypt(plaintext, key);
+		const decrypted = decrypt(out, key);
+		expect(decrypted).toBe(plaintext);
+	});
+
+	it('produces base64 iv, ciphertext, and tag fields', () => {
+		const key = 'k'.repeat(10);
+		const plaintext = 'data';
+		const out = encrypt(plaintext, key);
+		const parts = out.split('||');
+		expect(parts).toHaveLength(3);
+		const iv = parts[0]!;
+		const cipherText = parts[1]!;
+		const tag = parts[2]!;
+		expect(isBase64(iv)).toBe(true);
+		expect(isBase64(cipherText)).toBe(true);
+		expect(isBase64(tag)).toBe(true);
+	});
+
+	it('uses a random IV so encrypting the same input twice yields different outputs', () => {
+		const key = 'repeatable-key';
+		const plaintext = 'same input';
+		const a = encrypt(plaintext, key);
+		const b = encrypt(plaintext, key);
+		expect(a).not.toBe(b);
+		// Still decrypts to the same plaintext
+		expect(decrypt(a, key)).toBe(plaintext);
+		expect(decrypt(b, key)).toBe(plaintext);
+	});
+
+	it('throws when decrypting with the wrong key', () => {
+		const key = 'correct-key';
+		const wrong = 'incorrect-key';
+		const plaintext = 'top secret';
+		const out = encrypt(plaintext, key);
+		expect(() => decrypt(out, wrong)).toThrow();
+	});
+
+	it('throws when the tag is tampered with', () => {
+		const key = 'another-key';
+		const plaintext = 'payload';
+		const out = encrypt(plaintext, key);
+		const parts = out.split('||');
+		const iv = parts[0]!;
+		const cipherText = parts[1]!;
+		const tag = parts[2]!;
+		// Flip a character in the tag (keep valid base64 padding)
+		const tamperedTag = tag.replace(/[A-Za-z0-9]/, (c: string) => (c === 'A' ? 'B' : 'A'));
+		const tampered = `${iv}||${cipherText}||${tamperedTag}`;
+		expect(() => decrypt(tampered, key)).toThrow();
+	});
+
+	it('handles empty plaintext', () => {
+		const key = 'empty-key';
+		const plaintext = '';
+		const out = encrypt(plaintext, key);
+		const decrypted = decrypt(out, key);
+		expect(decrypted).toBe('');
+	});
+});

--- a/api/src/utils/encrypt.test.ts
+++ b/api/src/utils/encrypt.test.ts
@@ -69,7 +69,7 @@ describe('encrypt/decrypt (AES-256-GCM with scrypt KDF, v1 envelope)', () => {
 		const tamperedTag = tag.replace(/[A-Za-z0-9]/, (c: string) => (c === 'A' ? 'B' : 'A'));
 
 		const tampered = [parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], iv, cipherText, tamperedTag].join(
-			'|',
+			'||',
 		);
 
 		await expect(decrypt(tampered, key)).rejects.toThrow();

--- a/api/src/utils/encrypt.test.ts
+++ b/api/src/utils/encrypt.test.ts
@@ -1,94 +1,136 @@
 import { describe, it, expect } from 'vitest';
-import { encrypt, decrypt, createAesKey } from './encrypt.js';
+import { encrypt, decrypt } from './encrypt.js';
 
 const isBase64 = (s: string) => /^[A-Za-z0-9+/]+={0,2}$/.test(s);
 
-describe('createAesKey', () => {
-	it('returns a Buffer of exactly 32 bytes for short keys by repeating and truncating', () => {
-		const key = 'secret'; // 6 bytes
-		const buf = createAesKey(key);
-		expect(Buffer.isBuffer(buf)).toBe(true);
-		expect(buf.byteLength).toBe(32);
-		// starts with original bytes
-		expect(buf.subarray(0, Buffer.byteLength(key, 'utf8')).toString('utf8')).toBe(key);
-	});
-
-	it('returns the same 32-byte content when already 32 bytes', () => {
-		const key = 'a'.repeat(32);
-		const buf = createAesKey(key);
-		expect(buf.byteLength).toBe(32);
-		expect(buf.toString('utf8')).toBe(key);
-	});
-
-	it('truncates to 32 bytes when result would exceed 32', () => {
-		const key = 'x'.repeat(17); // repeating would yield 34 bytes; should truncate to 32
-		const buf = createAesKey(key);
-		expect(buf.byteLength).toBe(32);
-		expect(buf.toString('utf8')).toBe('x'.repeat(32));
-	});
-});
-
-describe('encrypt/decrypt (AES-256-GCM)', () => {
-	it('round-trips plaintext with the same key', () => {
+describe('encrypt/decrypt (AES-256-GCM with scrypt KDF, v1 envelope)', () => {
+	it('round-trips plaintext with the same key', async () => {
 		const key = 'super-secret-key';
 		const plaintext = 'Hello, world! 👋';
-		const out = encrypt(plaintext, key);
-		const decrypted = decrypt(out, key);
+		const out = await encrypt(plaintext, key);
+		const decrypted = await decrypt(out, key);
 		expect(decrypted).toBe(plaintext);
 	});
 
-	it('produces base64 iv, ciphertext, and tag fields', () => {
+	it('produces versioned envelope with KDF params and base64 fields', async () => {
 		const key = 'k'.repeat(10);
 		const plaintext = 'data';
-		const out = encrypt(plaintext, key);
+		const out = await encrypt(plaintext, key);
 		const parts = out.split('||');
-		expect(parts).toHaveLength(3);
-		const iv = parts[0]!;
-		const cipherText = parts[1]!;
-		const tag = parts[2]!;
-		expect(isBase64(iv)).toBe(true);
+		expect(parts.length).toBeGreaterThanOrEqual(9);
+		const v = parts[0]!;
+		const kdf = parts[1]!;
+		const N = parts[2]!;
+		const r = parts[3]!;
+		const p = parts[4]!;
+		const saltB64 = parts[5]!;
+		const ivB64 = parts[6]!;
+		const cipherText = parts[7]!;
+		const tagB64 = parts[8]!;
+		expect(v).toBe('1');
+		expect(kdf).toBe('scrypt');
+		expect(Number.isFinite(Number(N))).toBe(true);
+		expect(Number.isFinite(Number(r))).toBe(true);
+		expect(Number.isFinite(Number(p))).toBe(true);
+		expect(isBase64(saltB64)).toBe(true);
+		expect(isBase64(ivB64)).toBe(true);
 		expect(isBase64(cipherText)).toBe(true);
-		expect(isBase64(tag)).toBe(true);
+		expect(isBase64(tagB64)).toBe(true);
 	});
 
-	it('uses a random IV so encrypting the same input twice yields different outputs', () => {
+	it('uses a random IV so encrypting the same input twice yields different outputs', async () => {
 		const key = 'repeatable-key';
 		const plaintext = 'same input';
-		const a = encrypt(plaintext, key);
-		const b = encrypt(plaintext, key);
+		const a = await encrypt(plaintext, key);
+		const b = await encrypt(plaintext, key);
 		expect(a).not.toBe(b);
 		// Still decrypts to the same plaintext
-		expect(decrypt(a, key)).toBe(plaintext);
-		expect(decrypt(b, key)).toBe(plaintext);
+		expect(await decrypt(a, key)).toBe(plaintext);
+		expect(await decrypt(b, key)).toBe(plaintext);
 	});
 
-	it('throws when decrypting with the wrong key', () => {
+	it('throws when decrypting with the wrong key', async () => {
 		const key = 'correct-key';
 		const wrong = 'incorrect-key';
 		const plaintext = 'top secret';
-		const out = encrypt(plaintext, key);
-		expect(() => decrypt(out, wrong)).toThrow();
+		const out = await encrypt(plaintext, key);
+		await expect(decrypt(out, wrong)).rejects.toThrow();
 	});
 
-	it('throws when the tag is tampered with', () => {
+	it('throws when the tag is tampered with', async () => {
 		const key = 'another-key';
 		const plaintext = 'payload';
-		const out = encrypt(plaintext, key);
+		const out = await encrypt(plaintext, key);
 		const parts = out.split('||');
-		const iv = parts[0]!;
-		const cipherText = parts[1]!;
-		const tag = parts[2]!;
+		const iv = parts[6]!;
+		const cipherText = parts[7]!;
+		const tag = parts[8]!;
 		// Flip a character in the tag (keep valid base64 padding)
 		const tamperedTag = tag.replace(/[A-Za-z0-9]/, (c: string) => (c === 'A' ? 'B' : 'A'));
-		const tampered = `${iv}||${cipherText}||${tamperedTag}`;
-		expect(() => decrypt(tampered, key)).toThrow();
+
+		const tampered = [parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], iv, cipherText, tamperedTag].join(
+			'|',
+		);
+
+		await expect(decrypt(tampered, key)).rejects.toThrow();
 	});
 
-	it('handles empty plaintext', () => {
+	it('handles empty plaintext', async () => {
 		const key = 'empty-key';
 		const plaintext = '';
-		const out = encrypt(plaintext, key);
-		const decrypted = decrypt(out, key);
+		const out = await encrypt(plaintext, key);
+		const decrypted = await decrypt(out, key);
 		expect(decrypted).toBe('');
+	});
+});
+
+describe('decrypt error handling', () => {
+	it('throws on invalid encrypted payload (too few parts)', async () => {
+		await expect(decrypt('only||two', 'key')).rejects.toThrow('Invalid encrypted payload');
+	});
+
+	it('throws on unsupported version', async () => {
+		const key = 'k';
+		const out = await encrypt('data', key);
+		const parts = out.split('||');
+		parts[0] = '999';
+		const mutated = parts.join('||');
+		await expect(decrypt(mutated, key)).rejects.toThrow('Unsupported version: 999');
+	});
+
+	it('throws on unsupported kdf', async () => {
+		const key = 'k';
+		const out = await encrypt('data', key);
+		const parts = out.split('||');
+		parts[1] = 'pbkdf2';
+		const mutated = parts.join('||');
+		await expect(decrypt(mutated, key)).rejects.toThrow('Unsupported kdf: pbkdf2');
+	});
+
+	it('throws when salt is missing (empty)', async () => {
+		const key = 'k';
+		const out = await encrypt('data', key);
+		const parts = out.split('||');
+		parts[5] = '';
+		const mutated = parts.join('||');
+		await expect(decrypt(mutated, key)).rejects.toThrow('No salt in encrypted string');
+	});
+
+	it('throws when iv is missing (empty)', async () => {
+		const key = 'k';
+		const out = await encrypt('data', key);
+		const parts = out.split('||');
+		parts[6] = '';
+		const mutated = parts.join('||');
+		await expect(decrypt(mutated, key)).rejects.toThrow('No iv in encrypted string');
+	});
+
+	it('throws when tag is missing (empty)', async () => {
+		const key = 'k';
+		const out = await encrypt('data', key);
+		const parts = out.split('||');
+		parts[8] = '';
+		const mutated = parts.join('||');
+		await expect(decrypt(mutated, key)).rejects.toThrow('No tag in encrypted string');
 	});
 });

--- a/api/src/utils/encrypt.ts
+++ b/api/src/utils/encrypt.ts
@@ -1,8 +1,26 @@
 import crypto from 'node:crypto';
+import { promisify } from 'node:util';
 
-export const encrypt = (plainText: string, key: string): string => {
-	// Ensure the key is exactly 32 bytes for AES-256
-	const keyBuf = createAesKey(key);
+const VERSION = '1';
+const KDF = 'scrypt';
+const SCRYPT_DEFAULTS = { N: 2 ** 14, r: 8, p: 1 } as const; // ~16MB mem, good server default
+
+type ScryptOpts = { N: number; r: number; p: number };
+
+const scryptAsync = promisify(crypto.scrypt) as (
+	password: string | Buffer,
+	salt: string | Buffer,
+	keylen: number,
+	options: crypto.ScryptOptions
+) => Promise<Buffer>;
+
+const deriveKey = async (password: string, salt: Buffer, opts: ScryptOpts = SCRYPT_DEFAULTS): Promise<Buffer> => {
+	return await scryptAsync(password, salt, 32, opts as crypto.ScryptOptions);
+};
+
+export const encrypt = async (plainText: string, password: string): Promise<string> => {
+	const salt = crypto.randomBytes(16);
+	const keyBuf = await deriveKey(password, salt, SCRYPT_DEFAULTS);
 
 	// Generate a 12-byte IV for GCM and keep base64 string for storage
 	const ivBuf = crypto.randomBytes(12);
@@ -13,40 +31,49 @@ export const encrypt = (plainText: string, key: string): string => {
 	cipherText += cipher.final('base64');
 	const tag = cipher.getAuthTag().toString('base64');
 
-	return `${iv}||${cipherText}||${tag}`;
+	// 1||scrypt||N||r||p||salt||iv||cipherText||tag
+	return [
+		VERSION,
+		KDF,
+		SCRYPT_DEFAULTS.N,
+		SCRYPT_DEFAULTS.r,
+		SCRYPT_DEFAULTS.p,
+		salt.toString('base64'),
+		iv,
+		cipherText,
+		tag,
+	].join('||');
 };
 
-export const decrypt = (encryptedText: string, key: string): string => {
-	// Ensure the key is exactly 32 bytes for AES-256
-	const keyBuf = createAesKey(key);
+export const decrypt = async (encryptedText: string, password: string): Promise<string> => {
+	const parts = encryptedText.split('||');
 
-	const [iv, cipherText, tag] = encryptedText.split('||');
+	if (parts.length < 9) throw new Error('Invalid encrypted payload');
+	const [version, kdf, nStr, rStr, pStr, saltB64, ivB64, cipherText, tagB64] = parts;
 
-	if (iv === undefined || iv === '') throw new Error('No iv in encrypted string');
+	if (version !== VERSION) throw new Error(`Unsupported version: ${version}`);
+	if (kdf !== KDF) throw new Error(`Unsupported kdf: ${kdf}`);
+	if (!saltB64) throw new Error('No salt in encrypted string');
+	if (!ivB64) throw new Error('No iv in encrypted string');
 	if (cipherText === undefined) throw new Error('No cipherText in encrypted string');
-	if (tag === undefined || tag === '') throw new Error('No tag in encrypted string');
+	if (!tagB64) throw new Error('No tag in encrypted string');
 
-	const decipher = crypto.createDecipheriv('aes-256-gcm', keyBuf, Buffer.from(iv, 'base64'));
-	decipher.setAuthTag(Buffer.from(tag, 'base64'));
+	const opts: ScryptOpts = {
+		N: Number(nStr) || SCRYPT_DEFAULTS.N,
+		r: Number(rStr) || SCRYPT_DEFAULTS.r,
+		p: Number(pStr) || SCRYPT_DEFAULTS.p,
+	};
+
+	const salt = Buffer.from(saltB64, 'base64');
+	const keyBuf = await deriveKey(password, salt, opts);
+	const iv = Buffer.from(ivB64, 'base64');
+	const tag = Buffer.from(tagB64, 'base64');
+
+	const decipher = crypto.createDecipheriv('aes-256-gcm', keyBuf, iv);
+	decipher.setAuthTag(tag);
 
 	let plaintext = decipher.update(cipherText, 'base64', 'utf8');
 	plaintext += decipher.final('utf8');
 
 	return plaintext;
 };
-
-export const createAesKey = (key: string): Buffer => {
-	// Grow by repetition until we have at least 32 bytes
-	let result = Buffer.from(key, 'utf8');
-
-	while (result.byteLength < 32) {
-		result = Buffer.concat([result, Buffer.from(key, 'utf8')]);
-	}
-
-	// If longer than 32 bytes, truncate on byte boundaries
-	if (result.byteLength > 32) {
-		return result.subarray(0, 32);
-	}
-
-	return result;
-}

--- a/api/src/utils/encrypt.ts
+++ b/api/src/utils/encrypt.ts
@@ -1,0 +1,52 @@
+import crypto from 'node:crypto';
+
+export const encrypt = (plainText: string, key: string): string => {
+	// Ensure the key is exactly 32 bytes for AES-256
+	const keyBuf = createAesKey(key);
+
+	// Generate a 12-byte IV for GCM and keep base64 string for storage
+	const ivBuf = crypto.randomBytes(12);
+	const iv = ivBuf.toString('base64');
+
+	const cipher = crypto.createCipheriv('aes-256-gcm', keyBuf, ivBuf);
+	let cipherText = cipher.update(plainText, 'utf8', 'base64');
+	cipherText += cipher.final('base64');
+	const tag = cipher.getAuthTag().toString('base64');
+
+	return `${iv}||${cipherText}||${tag}`;
+};
+
+export const decrypt = (encryptedText: string, key: string): string => {
+	// Ensure the key is exactly 32 bytes for AES-256
+	const keyBuf = createAesKey(key);
+
+	const [iv, cipherText, tag] = encryptedText.split('||');
+
+	if (iv === undefined || iv === '') throw new Error('No iv in encrypted string');
+	if (cipherText === undefined) throw new Error('No cipherText in encrypted string');
+	if (tag === undefined || tag === '') throw new Error('No tag in encrypted string');
+
+	const decipher = crypto.createDecipheriv('aes-256-gcm', keyBuf, Buffer.from(iv, 'base64'));
+	decipher.setAuthTag(Buffer.from(tag, 'base64'));
+
+	let plaintext = decipher.update(cipherText, 'base64', 'utf8');
+	plaintext += decipher.final('utf8');
+
+	return plaintext;
+};
+
+export const createAesKey = (key: string): Buffer => {
+	// Grow by repetition until we have at least 32 bytes
+	let result = Buffer.from(key, 'utf8');
+
+	while (result.byteLength < 32) {
+		result = Buffer.concat([result, Buffer.from(key, 'utf8')]);
+	}
+
+	// If longer than 32 bytes, truncate on byte boundaries
+	if (result.byteLength > 32) {
+		return result.subarray(0, 32);
+	}
+
+	return result;
+}

--- a/api/src/utils/encrypt.ts
+++ b/api/src/utils/encrypt.ts
@@ -11,7 +11,7 @@ const scryptAsync = promisify(crypto.scrypt) as (
 	password: string | Buffer,
 	salt: string | Buffer,
 	keylen: number,
-	options: crypto.ScryptOptions
+	options: crypto.ScryptOptions,
 ) => Promise<Buffer>;
 
 const deriveKey = async (password: string, salt: Buffer, opts: ScryptOpts = SCRYPT_DEFAULTS): Promise<Buffer> => {


### PR DESCRIPTION
- Adds `encrypt` special flag for columns (intended for LLM service API keys)
  - Conceals on API reads to be consistent with `hash` special flag
- Added `decrypt` function for later use where you need access to the key
- Warn on server startup when `SECRET` isn't 32 bytes

---

### AI Summary

This pull request introduces encryption support for sensitive payload values and adds related utilities and tests. The main changes include the implementation of AES-256-GCM 
encryption and decryption functions, integration of encryption into the payload service, and new warnings for insecure secret configuration.

**Encryption utilities and tests:**
* Added new AES-256-GCM encryption and decryption functions (`encrypt`, `decrypt`, and `createAesKey`) in `api/src/utils/encrypt.ts`, ensuring keys are always 32 bytes and supporting secure, authenticated encryption.
* Added comprehensive unit tests in `api/src/utils/encrypt.test.ts` to verify encryption, decryption, key handling, base64 encoding, and error scenarios.

**Payload service integration:**
* Integrated encryption into the payload service by adding an `encrypt` transformer method in `api/src/services/payload.ts`. This method uses the secret key and masks values on read actions.
* Updated imports in `api/src/services/payload.ts` to include the new encryption utilities.

**Configuration and security:**
* Added a warning in `api/src/app.ts` when the `SECRET` environment variable is shorter than 32 bytes, highlighting insecure production configurations.