### PR TITLE
Add basic AI settings

### DIFF
--- a/api/src/database/migrations/20251103A-add-ai-settings.ts
+++ b/api/src/database/migrations/20251103A-add-ai-settings.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.text('ai_openai_api_key');
+		table.text('ai_anthropic_api_key');
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.dropColumn('ai_openai_api_key');
+		table.dropColumn('ai_anthropic_api_key');
+	});
+}

--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -10,15 +10,18 @@ export default defineComponent({
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-const props = withDefaults(defineProps<{
-	value: string | null;
-	disabled?: boolean;
-	placeholder?: string;
-	masked?: boolean;
-	type?: 'password' | 'text';
-}>(), {
-	type: 'text',
-});
+const props = withDefaults(
+	defineProps<{
+		value: string | null;
+		disabled?: boolean;
+		placeholder?: string;
+		masked?: boolean;
+		type?: 'password' | 'text';
+	}>(),
+	{
+		type: 'text',
+	},
+);
 
 const emit = defineEmits(['input']);
 

--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -10,12 +10,15 @@ export default defineComponent({
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
 	value: string | null;
 	disabled?: boolean;
 	placeholder?: string;
 	masked?: boolean;
-}>();
+	type?: 'password' | 'text';
+}>(), {
+	type: 'text',
+});
 
 const emit = defineEmits(['input']);
 
@@ -46,7 +49,7 @@ function emitValue(newValue: string) {
 	<v-input
 		:placeholder="internalPlaceholder"
 		:disabled="disabled"
-		:type="masked ? 'password' : 'text'"
+		:type="type"
 		:autocomplete="masked ? 'new-password' : 'off'"
 		:model-value="localValue"
 		:class="{ hashed: isHashed && !localValue }"

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -806,7 +806,7 @@ errors:
   VALUE_OUT_OF_RANGE: Value is out of range
   VALUE_TOO_LONG: Value is too long
 security: Security
-value_hashed: Value Securely Hashed
+value_hashed: Value Securely Stored
 bookmark_name: Bookmark name...
 create_bookmark: Create Bookmark
 edit_bookmark: Edit Bookmark

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1189,6 +1189,7 @@ settings_project: Settings
 settings_appearance: Appearance
 settings_ai: AI
 model_context_protocol: Model Context Protocol
+ai_chat: AI Chat
 settings_webhooks: Webhooks
 settings_flows: Flows
 settings_system_logs: System Logs
@@ -1472,6 +1473,9 @@ fields:
     public_registration_verify_email_note:
       Sends an email to the registering user asking them to click on a verification link before they can sign in.
     visual_editor_urls: Visual Editor URLs
+    ai_notice: 'AI Chat provides an in-app sidebar to converse with an LLM. Once enabled, open the AI sidebar from the toolbar
+      to ask questions, generate content, and get help working with your project. <a href="https://directus.io/docs/guides/ai"
+      target="_blank">Learn more about configuring and using AI Chat.</a>'
     mcp_enabled: MCP Server
     mcp_enabled_note:
       'Connect AI/LLM tools to your Directus project via <a href="https://directus.io/docs/guides/ai/mcp"

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -702,6 +702,28 @@ fields:
       - no-data
       - group
 
+  - field: ai_divider
+    interface: presentation-divider
+    options:
+      icon: chat
+      title: $t:ai_chat
+    special:
+      - alias
+      - no-data
+    width: full
+    group: ai_group
+
+  - field: ai_notice
+    interface: presentation-notice
+    options:
+      icon: info
+      text: $t:fields.directus_settings.ai_notice
+    special:
+      - alias
+      - no-data
+    width: full
+    group: ai_group
+
   - field: ai_openai_api_key
     special:
       - encrypt

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -702,6 +702,26 @@ fields:
       - no-data
       - group
 
+  - field: ai_openai_api_key
+    special:
+      - encrypt
+    interface: input-hash
+    options:
+      iconRight: lock
+      masked: true
+    width: half
+    group: ai_group
+
+  - field: ai_anthropic_api_key
+    special:
+      - encrypt
+    interface: input-hash
+    options:
+      iconRight: lock
+      masked: true
+    width: half
+    group: ai_group
+
   - field: mcp_divider
     interface: presentation-divider
     options:

--- a/packages/system-data/src/fields/users.yaml
+++ b/packages/system-data/src/fields/users.yaml
@@ -27,6 +27,7 @@ fields:
     options:
       iconRight: lock
       masked: true
+      type: 'password'
     width: half
 
   - field: avatar


### PR DESCRIPTION
This pull request introduces new AI integration settings to the system, enabling support for OpenAI and Anthropic API keys. It adds the necessary database fields, user interface components, and supporting translations to allow administrators to securely configure API keys and inform users about the new AI Chat feature.

**AI Settings Integration**

* Added `ai_openai_api_key` and `ai_anthropic_api_key` fields to the `directus_settings` table via a new migration (`20251103A-add-ai-settings.ts`) to store encrypted API keys for OpenAI and Anthropic.
* Updated `settings.yaml` to include UI fields for the new API keys, an informational notice, and a divider for the AI section in system settings, grouped under `ai_group`.

**User Interface Enhancements**

* Modified `input-hash.vue` to support a configurable input type (e.g., password or text), improving flexibility for secure input fields. [[1]](diffhunk://#diff-287730703641fc991083cdae3af596a7d358a8fe1ee18431bdb727b3981329cdL13-R24) [[2]](diffhunk://#diff-287730703641fc991083cdae3af596a7d358a8fe1ee18431bdb727b3981329cdL49-R55)
* Updated the `users.yaml` field configuration to explicitly set the type of the password field for clarity and security.

**Localization and Documentation**

* Improved English translations to reflect the new AI Chat feature, including updated field descriptions and notices for users about secure storage and usage of AI features. [[1]](diffhunk://#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6aL809-R809) [[2]](diffhunk://#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6aR1192) [[3]](diffhunk://#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6aR1476-R1478)