### PR TITLE
Close server to clean socket remnant for test reruns

### DIFF
--- a/api/src/utils/get-address.test.ts
+++ b/api/src/utils/get-address.test.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { useEnv } from '@directus/env';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi, afterEach } from 'vitest';
 import { getAddress } from './get-address.js';
 import type { ListenOptions } from 'net';
 import getPort from 'get-port';
@@ -27,19 +27,25 @@ describe('getAddress', async () => {
 	const serverSocket = '/tmp/server-test.sock';
 	const serverPort = await getPort();
 
+	let server: http.Server | undefined;
+
+	afterEach(async () => {
+		server?.close();
+		server = undefined;
+	});
+
 	test('Should return unix socket before server is listening when path is provided', async () => {
-		const server = await createServer();
+		server = await createServer();
 
 		vi.mocked(useEnv).mockReturnValue({
 			UNIX_SOCKET_PATH: serverSocket,
 		});
 
 		expect(getAddress(server)).toBe(serverSocket);
-		server.close();
 	});
 
 	test('Should return host + port before server is listening when path is undefined', async () => {
-		const server = await createServer();
+		server = await createServer();
 
 		vi.mocked(useEnv).mockReturnValue({
 			PORT: serverPort,
@@ -47,20 +53,17 @@ describe('getAddress', async () => {
 		});
 
 		expect(getAddress(server)).toBe(`${serverHost}:${serverPort}`);
-		server.close();
 	});
 
 	test('Should return unix socket when path is provided', async () => {
-		const server = await createServer({ path: serverSocket });
+		server = await createServer({ path: serverSocket });
 
 		expect(getAddress(server)).toBe(serverSocket);
-		server.close();
 	});
 
 	test('Should return host + port when path is undefined', async () => {
-		const server = await createServer({ host: serverHost, port: serverPort });
+		server = await createServer({ host: serverHost, port: serverPort });
 
 		expect(getAddress(server)).toBe(`${serverHost}:${serverPort}`);
-		server.close();
 	});
 });

--- a/api/src/utils/get-address.test.ts
+++ b/api/src/utils/get-address.test.ts
@@ -47,17 +47,20 @@ describe('getAddress', async () => {
 		});
 
 		expect(getAddress(server)).toBe(`${serverHost}:${serverPort}`);
+		server.close();
 	});
 
 	test('Should return unix socket when path is provided', async () => {
 		const server = await createServer({ path: serverSocket });
 
 		expect(getAddress(server)).toBe(serverSocket);
+		server.close();
 	});
 
 	test('Should return host + port when path is undefined', async () => {
 		const server = await createServer({ host: serverHost, port: serverPort });
 
 		expect(getAddress(server)).toBe(`${serverHost}:${serverPort}`);
+		server.close();
 	});
 });


### PR DESCRIPTION
## Scope

What's changed:

- Fix the following error in `get-address.test.ts` during unit test reruns
<img width="722" height="299" alt="image" src="https://github.com/user-attachments/assets/97f27580-9426-4c8f-9569-47cd7d9bfb6a" />

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- Reran unit tests

## Review Notes / Questions

- If there's already a `/tmp/server-test.sock`, it has to be manually deleted

## Checklist

- ~~[ ] Added or updated tests~~
- ~~[ ] Documentation PR created [here](https://github.com/directus/docs) or not required~~