### PR TITLE
Cleanup changesets from dependency updates

### DIFF
--- a/.changeset/afraid-spiders-grin.md
+++ b/.changeset/afraid-spiders-grin.md
@@ -33,29 +33,4 @@
 '@directus/sdk': patch
 ---
 
-Updated the following dependencies:
-- Updated @aws-sdk/client-s3 dependency from 3.913.0 to 3.918.0
-- Updated @aws-sdk/client-sesv2 dependency from 3.913.0 to 3.918.0
-- Updated @aws-sdk/lib-storage dependency from 3.913.0 to 3.918.0
-- Updated @google-cloud/storage dependency from 7.17.0 to 7.17.2
-- Updated @modelcontextprotocol/sdk dependency from 1.20.1 to 1.20.2
-- Updated @pnpm/workspace.find-packages dependency from 1000.0.42 to 1000.0.43
-- Updated @pnpm/workspace.pkgs-graph dependency from 1000.0.24 to 1000.0.25
-- Updated @rollup/plugin-commonjs dependency from 28.0.8 to 28.0.9
-- Updated @smithy/node-http-handler dependency from 4.4.2 to 4.4.3
-- Updated @types/chroma-js dependency from 3.1.1 to 3.1.2
-- Updated @types/cookie-parser dependency from 1.4.9 to 1.4.10
-- Updated @types/nodemailer dependency from 7.0.2 to 7.0.3
-- Updated @types/qrcode dependency from 1.5.5 to 1.5.6
-- Updated commander dependency from 14.0.1 to 14.0.2
-- Updated focus-trap dependency from 7.6.5 to 7.6.6
-- Updated happy-dom dependency from 20.0.8 to 20.0.10
-- Updated liquidjs dependency from 10.23.0 to 10.24.0
-- Updated minimatch dependency from 10.0.3 to 10.1.1
-- Updated ofetch dependency from 1.4.1 to 1.5.0
-- Updated tsdown dependency from 0.15.8 to 0.15.11
-- Updated typescript-eslint dependency from 8.46.1 to 8.46.2
-- Updated unplugin-yaml dependency from 3.0.6 to 3.0.7
-- Updated vite dependency from 7.1.11 to 7.1.12
-- Updated vue-tsc dependency from 3.1.1 to 3.1.2
-- Updated zod-validation-error dependency from 4.0.1 to 4.0.2
+Updated dependencies

--- a/.changeset/few-phones-sniff.md
+++ b/.changeset/few-phones-sniff.md
@@ -27,16 +27,4 @@
 '@directus/validation': patch
 ---
 
-Updated the following dependencies:
-- Updated @changesets/cli dependency from 2.29.5 to 2.29.7
-- Updated @pnpm/logger dependency from 1001.0.0 to 1001.0.1
-- Updated @pnpm/workspace.find-packages dependency from 1000.0.31 to 1000.0.42
-- Updated @pnpm/workspace.pkgs-graph dependency from 1000.0.18 to 1000.0.24
-- Updated @sinclair/typebox dependency from 0.34.38 to 0.34.41
-- Updated @types/semver dependency from 7.7.0 to 7.7.1
-- Updated eslint dependency from 9.32.0 to 9.38.0
-- Updated eslint-plugin-vue dependency from 10.4.0 to 10.5.1
-- Updated ky dependency from 1.8.2 to 1.13.0
-- Updated semver dependency from 7.7.2 to 7.7.3
-- Updated strip-ansi dependency from 7.1.0 to 7.1.2
-- Updated cross-spawn dependency from 7.0.3 to 7.0.6
+Updated dependencies

--- a/.changeset/giant-lines-battle.md
+++ b/.changeset/giant-lines-battle.md
@@ -12,17 +12,4 @@
 '@directus/update-check': patch
 ---
 
-Updated the following dependencies:
-- Updated argon2 dependency from 0.43.1 to 0.44.0
-- Updated axios dependency from 1.11.0 to 1.12.0
-- Updated @aws-sdk/client-s3 dependency from 3.858.0 to 3.913.0
-- Updated @aws-sdk/client-sesv2 dependency from 3.864.0 to 3.913.0
-- Updated @aws-sdk/lib-storage dependency from 3.858.0 to 3.913.0
-- Updated @azure/storage-blob dependency from 12.28.0 to 12.29.1
-- Updated @google-cloud/storage dependency from 7.16.0 to 7.17.2
-- Updated @modelcontextprotocol/sdk dependency from 1.17.1 to 1.20.1
-- Updated @rollup/plugin-commonjs dependency from 28.0.6 to 28.0.8
-- Updated @rollup/plugin-node-resolve dependency from 16.0.1 to 16.0.3
-- Updated @smithy/node-http-handler dependency from 4.1.0 to 4.4.2
-- Updated @supabase/storage-js dependency from 2.12.1 to 2.76.1
-- Updated @types/async dependency from 3.2.24 to 3.2.25
+Updated dependencies

--- a/.changeset/puny-fans-guess.md
+++ b/.changeset/puny-fans-guess.md
@@ -33,20 +33,4 @@
 'create-directus-project': patch
 ---
 
-Updated the following dependencies 
-- Updated oracledb from 6.9.0 to 6.10.0
-- Updated p-limit from 7.1.1 to 7.2.0
-- Updated pino-pretty from 13.1.1 to 13.1.2
-- Updated pm2 from 6.0.8 to 6.0.13
-- Updated rollup-plugin-node-externals from 8.0.1 to 8.1.1
-- Updated rollup from 4.46.2 to 4.52.5
-- Updated sharp from 0.34.3 to 0.34.4
-- Updated snappy from 7.3.0 to 7.3.3
-- Updated tar from 7.4.3 to 7.5.1
-- Updated tsdown from 0.14.2 to 0.15.8
-- Updated tsx from 4.20.3 to 4.20.6
-- Updated typescript-eslint from 8.38.0 to 8.46.1
-- Updated typescript from 5.8.3 to 5.9.3
-- Updated undici from 7.13.0 to 7.16.0
-- Updated unplugin-yaml from 3.0.4 to 3.0.6
-- Updated zod from 4.0.14 to 4.1.12
+Updated dependencies

--- a/.changeset/puny-rice-decide.md
+++ b/.changeset/puny-rice-decide.md
@@ -2,14 +2,4 @@
 '@directus/app': patch
 ---
 
-Updated the following dependencies:
-- Updated @editorjs/attaches dependency from 1.3.0 to 1.3.2
-- Updated @editorjs/editorjs dependency from 2.30.8 to 2.31.0
-- Updated @eslint/js dependency from 9.32.0 to 9.38.0
-- Updated @fullcalendar/core dependency from 6.1.18 to 6.1.19
-- Updated @fullcalendar/daygrid dependency from 6.1.18 to 6.1.19
-- Updated @fullcalendar/interaction dependency from 6.1.18 to 6.1.19
-- Updated @fullcalendar/list dependency from 6.1.18 to 6.1.19
-- Updated @fullcalendar/timegrid dependency from 6.1.18 to 6.1.19
-- Updated @mapbox/mapbox-gl-geocoder dependency from 5.1.0 to 5.1.2
-- Updated @types/mapbox__mapbox-gl-geocoder dependency from 5.0.0 to 5.1.0
+Updated dependencies

--- a/.changeset/silly-walls-open.md
+++ b/.changeset/silly-walls-open.md
@@ -24,24 +24,7 @@
 '@directus/validation': patch
 'create-directus-extension': patch
 'create-directus-project': patch
-'sdk': patch
+'@directus/sdk': patch
 ---
 
-Updated the following dependencies:
-- Updated axios-cache-interceptor dependency from 1.8.0 to 1.8.3
-- Updated chalk dependency from 5.4.1 to 5.6.2
-- Updated commander dependency from 14.0.0 to 14.0.1
-- Updated decamelize dependency from 6.0.0 to 6.0.1
-- Updated dotenv dependency from 17.2.1 to 17.2.3
-- Updated esbuild dependency from 0.25.9 to 0.25.11
-- Updated fs-extra dependency from 11.3.0 to 11.3.2
-- Updated globals dependency from 16.3.0 to 16.4.0
-- Updated inquirer dependency from 12.9.0 to 12.10.0
-- Updated @types/inquirer dependency from 9.0.8 to 9.0.9
-- Updated ioredis dependency from 5.7.0 to 5.8.2
-- Updated keyv dependency from 5.4.0 to 5.5.3
-- Updated liquidjs dependency from 10.21.1 to 10.23.0
-- Updated lru-cache dependency from 11.1.0 to 11.2.2
-- Updated mysql2 dependency from 3.14.3 to 3.15.3
-- Updated nodemailer dependency from 7.0.5 to 7.0.10
-- Updated @types/nodemailer dependency from 6.4.17 to 7.0.2
+Updated dependencies

--- a/.changeset/wicked-bats-turn.md
+++ b/.changeset/wicked-bats-turn.md
@@ -7,14 +7,4 @@
 '@directus/stores': patch
 ---
 
-Updated the following dependencies:
-- Updated @vueuse/core dependency from 13.6.0 to 14.0.0
-- Updated @vueuse/integrations dependency from 13.6.0 to 14.0.0
-- Updated @vueuse/router dependency from 13.6.0 to 14.0.0
-- Updated @apexcharts dependency from 4.5.0 to 4.7.0
-- Updated color dependency from 5.0.0 to 5.0.2
-- Updated dompurify dependency from 3.2.6 to 3.3.0
-- Updated marked dependency from 16.1.1 to 16.4.1
-- Updated mime dependency from 4.0.7 to 4.1.0
-- Updated nanoid dependency from 5.1.5 to 5.1.6
-- Updated pretty-ms dependency from 9.2.0 to 9.3.0
+Updated dependencies

--- a/.changeset/wild-taxis-wash.md
+++ b/.changeset/wild-taxis-wash.md
@@ -25,13 +25,4 @@
 '@directus/validation': patch
 ---
 
-Updated the following dependencies:
-- Updated sass-embedded dependency from 1.89.2 to 1.93.2
-- Updated stylelint-config-standard dependency from 39.0.0 to 39.0.1
-- Updated stylelint dependency from 16.23.0 to 16.25.0
-- Updated tinymce dependency from 6.8.5 to 6.8.6
-- Updated vite dependency from 7.1.3 to 7.1.11
-- Updated vue-i18n dependency from 11.1.11 to 11.1.12
-- Updated vue-router dependency from 4.5.1 to 4.6.3
-- Updated vue-tsc dependency from 3.0.5 to 3.1.1
-- Updated vue dependency from 3.5.18 to 3.5.22
+Updated dependencies


### PR DESCRIPTION
The list of dependency updates will be automatically generated in the future.

```
### ⬆️ Dependency Updates

- **@aws-sdk/client-s3**: `3.858.0` → `3.918.0`
- **@aws-sdk/client-sesv2**: `3.864.0` → `3.918.0`
- **@aws-sdk/lib-storage**: `3.858.0` → `3.918.0`
- **@azure/storage-blob**: `12.28.0` → `12.29.1`
- **@changesets/cli**: `2.29.5` → `2.29.7`
- **@editorjs/attaches**: `1.3.0` → `1.3.2`
- **@editorjs/editorjs**: `2.30.8` → `2.31.0`
- **@eslint/js**: `9.32.0` → `9.38.0`
- **@fullcalendar/core**: `6.1.18` → `6.1.19`
- **@fullcalendar/daygrid**: `6.1.18` → `6.1.19`
- **@fullcalendar/interaction**: `6.1.18` → `6.1.19`
- **@fullcalendar/list**: `6.1.18` → `6.1.19`
- **@fullcalendar/timegrid**: `6.1.18` → `6.1.19`
- **@google-cloud/storage**: `7.16.0` → `7.17.2`
- **@mapbox/mapbox-gl-geocoder**: `5.1.0` → `5.1.2`
- **@modelcontextprotocol/sdk**: `1.17.1` → `1.20.2`
- **@pnpm/logger**: `1001.0.0` → `1001.0.1`
- **@pnpm/workspace.find-packages**: `1000.0.31` → `1000.0.43`
- **@pnpm/workspace.pkgs-graph**: `1000.0.18` → `1000.0.25`
- **@rollup/plugin-commonjs**: `28.0.6` → `28.0.9`
- **@rollup/plugin-node-resolve**: `16.0.1` → `16.0.3`
- **@sinclair/typebox**: `0.34.38` → `0.34.41`
- **@smithy/node-http-handler**: `4.1.0` → `4.4.3`
- **@supabase/storage-js**: `2.10.4` → `2.76.1`
- **@tus/server**: `1.10.2` → `2.3.0`
- **@tus/utils**: `0.5.1` → `0.6.0`
- **@types/async**: `3.2.24` → `3.2.25`
- **@types/chroma-js**: `3.1.1` → `3.1.2`
- **@types/cookie-parser**: `1.4.9` → `1.4.10`
- **@types/inquirer**: `9.0.8` → `9.0.9`
- **@types/mapbox__mapbox-gl-geocoder**: `5.0.0` → `5.1.0`
- **@types/nodemailer**: `6.4.17` → `7.0.3`
- **@types/qrcode**: `1.5.5` → `1.5.6`
- **@types/semver**: `7.7.0` → `7.7.1`
- **@vueuse/core**: `13.6.0` → `14.0.0`
- **@vueuse/integrations**: `13.6.0` → `14.0.0`
- **@vueuse/router**: `13.6.0` → `14.0.0`
- **apexcharts**: `4.5.0` → `4.7.0`
- **argon2**: `0.43.1` → `0.44.0`
- **axios**: `1.11.0` → `1.12.2`
- **axios-cache-interceptor**: `1.8.0` → `1.8.3`
- **chalk**: `5.4.1` → `5.6.2`
- **color**: `5.0.0` → `5.0.2`
- **commander**: `14.0.0` → `14.0.2`
- **decamelize**: `6.0.0` → `6.0.1`
- **dompurify**: `3.2.6` → `3.3.0`
- **dotenv**: `17.2.1` → `17.2.3`
- **esbuild**: `0.25.9` → `0.25.11`
- **eslint**: `9.32.0` → `9.38.0`
- **eslint-plugin-vue**: `10.4.0` → `10.5.1`
- **focus-trap**: `7.6.5` → `7.6.6`
- **fs-extra**: `11.3.0` → `11.3.2`
- **globals**: `16.3.0` → `16.4.0`
- **happy-dom**: `18.0.1` → `20.0.10`
- **inquirer**: `12.9.0` → `12.10.0`
- **ioredis**: `5.7.0` → `5.8.2`
- **keyv**: `5.4.0` → `5.5.3`
- **ky**: `1.8.2` → `1.13.0`
- **liquidjs**: `10.21.1` → `10.24.0`
- **lru-cache**: `11.1.0` → `11.2.2`
- **marked**: `16.1.1` → `16.4.1`
- **mime**: `4.0.7` → `4.1.0`
- **minimatch**: `10.0.3` → `10.1.1`
- **mysql2**: `3.14.3` → `3.15.3`
- **nanoid**: `5.1.5` → `5.1.6`
- **nodemailer**: `7.0.5` → `7.0.10`
- **ofetch**: `1.4.1` → `1.5.0`
- **oracledb**: `6.9.0` → `6.10.0`
- **p-limit**: `6.2.0` → `7.2.0`
- **pino-pretty**: `13.1.1` → `13.1.2`
- **pm2**: `6.0.8` → `6.0.13`
- **pretty-ms**: `9.2.0` → `9.3.0`
- **rollup**: `4.46.2` → `4.52.5`
- **rollup-plugin-node-externals**: `8.0.1` → `8.1.1`
- **sass-embedded**: `1.89.2` → `1.93.2`
- **semver**: `7.7.2` → `7.7.3`
- **sharp**: `0.34.3` → `0.34.4`
- **snappy**: `7.3.0` → `7.3.3`
- **strip-ansi**: `7.1.0` → `7.1.2`
- **stylelint**: `16.23.0` → `16.25.0`
- **stylelint-config-standard**: `39.0.0` → `39.0.1`
- **tar**: `7.4.3` → `7.5.2`
- **tinymce**: `6.8.5` → `6.8.6`
- **tsdown**: `0.14.2` → `0.15.11`
- **tsx**: `4.20.3` → `4.20.6`
- **typescript**: `5.8.3` → `5.9.3`
- **typescript-eslint**: `8.38.0` → `8.46.2`
- **undici**: `7.13.0` → `7.16.0`
- **unplugin-yaml**: `3.0.4` → `3.0.7`
- **vite**: `7.1.3` → `7.1.12`
- **vue**: `3.5.18` → `3.5.22`
- **vue-i18n**: `11.1.11` → `11.1.12`
- **vue-router**: `4.5.1` → `4.6.3`
- **vue-tsc**: `3.0.5` → `3.1.2`
- **zod**: `4.0.14` → `4.1.12`
- **zod-validation-error**: `4.0.1` → `4.0.2`
```