### PR TITLE
Add configurable system collections access for MCP

### DIFF
--- a/api/src/controllers/mcp.ts
+++ b/api/src/controllers/mcp.ts
@@ -11,16 +11,23 @@ const mcpHandler = asyncHandler(async (req, res) => {
 		schema: req.schema,
 	});
 
-	const { mcp_enabled, mcp_allow_deletes, mcp_prompts_collection, mcp_system_prompt, mcp_system_prompt_enabled } =
-		await settings.readSingleton({
-			fields: [
-				'mcp_enabled',
-				'mcp_allow_deletes',
-				'mcp_prompts_collection',
-				'mcp_system_prompt',
-				'mcp_system_prompt_enabled',
-			],
-		});
+	const {
+		mcp_enabled,
+		mcp_allow_deletes,
+		mcp_allow_system_collections,
+		mcp_prompts_collection,
+		mcp_system_prompt,
+		mcp_system_prompt_enabled,
+	} = await settings.readSingleton({
+		fields: [
+			'mcp_enabled',
+			'mcp_allow_deletes',
+			'mcp_allow_system_collections',
+			'mcp_prompts_collection',
+			'mcp_system_prompt',
+			'mcp_system_prompt_enabled',
+		],
+	});
 
 	if (!mcp_enabled) {
 		throw new ForbiddenError({ reason: 'MCP must be enabled' });
@@ -29,6 +36,7 @@ const mcpHandler = asyncHandler(async (req, res) => {
 	const mcp = new DirectusMCP({
 		promptsCollection: mcp_prompts_collection,
 		allowDeletes: mcp_allow_deletes,
+		allowSystemCollections: mcp_allow_system_collections,
 		systemPromptEnabled: mcp_system_prompt_enabled,
 		systemPrompt: mcp_system_prompt,
 	});

--- a/api/src/database/migrations/20251105A-add-mcp-allow-system-collections.ts
+++ b/api/src/database/migrations/20251105A-add-mcp-allow-system-collections.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.boolean('mcp_allow_system_collections').defaultTo(false).notNullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.dropColumn('mcp_allow_system_collections');
+	});
+}

--- a/api/src/mcp/tools/items.ts
+++ b/api/src/mcp/tools/items.ts
@@ -1,5 +1,4 @@
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
-import { isSystemCollection } from '@directus/system-data';
 import type { PrimaryKey } from '@directus/types';
 import { toArray } from '@directus/utils';
 import { isObject } from 'graphql-compose';
@@ -67,10 +66,6 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		return ['content', input.collection, data['id']];
 	},
 	async handler({ args, schema, accountability, sanitizedQuery }) {
-		if (isSystemCollection(args.collection)) {
-			throw new InvalidPayloadError({ reason: 'Cannot provide a core collection' });
-		}
-
 		if (args.collection in schema.collections === false) {
 			throw new ForbiddenError();
 		}

--- a/api/src/mcp/types.ts
+++ b/api/src/mcp/types.ts
@@ -54,6 +54,7 @@ export interface Prompt {
 export interface MCPOptions {
 	promptsCollection?: string;
 	allowDeletes?: boolean;
+	allowSystemCollections?: boolean;
 	systemPromptEnabled?: boolean;
 	systemPrompt?: string | null;
 }

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -192,4 +192,5 @@ export const DEFAULTS = {
 	ACCEPT_TERMS: false,
 
 	MCP_ENABLED: true,
+	MCP_ALLOW_SYSTEM_COLLECTIONS: false,
 } as const;

--- a/packages/env/src/constants/directus-variables.ts
+++ b/packages/env/src/constants/directus-variables.ts
@@ -258,6 +258,7 @@ export const DIRECTUS_VARIABLES = [
 
 	// mcp
 	'MCP_ENABLED',
+	'MCP_ALLOW_SYSTEM_COLLECTIONS',
 ] as const;
 
 /**

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -768,6 +768,22 @@ fields:
             _neq: true
         readonly: true
 
+  - field: mcp_allow_system_collections
+    interface: boolean
+    group: ai_group
+    special:
+      - cast-boolean
+    note: $t:fields.directus_settings.mcp_allow_system_collections_note
+    width: half
+    options:
+      label: $t:fields.directus_settings.mcp_allow_system_collections
+    conditions:
+      - name: mcp_enabled
+        rule:
+          mcp_enabled:
+            _neq: true
+        readonly: true
+
   - field: mcp_prompts_collection
     interface: system-collection
     group: ai_group


### PR DESCRIPTION
DirectusCMS MCP support now allows configuring access to native directus_* system collections via environment variable and database setting.

Changes:
- Add MCP_ALLOW_SYSTEM_COLLECTIONS environment variable (default: false)
- Add mcp_allow_system_collections boolean field to directus_settings
- Move system collection check from items tool to server level
- Update DirectusMCP class to support allowSystemCollections option
- Add database migration 20251105A-add-mcp-allow-system-collections

System collections remain blocked by default for security, but can now be enabled when needed via MCP_ALLOW_SYSTEM_COLLECTIONS env var or settings.

## Scope

What's changed:

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit
- Sed do eiusmod tempor incididunt

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #\<num\>
