### PR TITLE
Feat/ai system prompt

### DIFF
--- a/api/src/ai/chat/controllers/chat.post.test.ts
+++ b/api/src/ai/chat/controllers/chat.post.test.ts
@@ -246,7 +246,13 @@ describe('aiChatPostHandler', () => {
 
 			await aiChatPostHandler(mockReq as Request, mockRes as Response, vi.fn());
 
-			expect(vi.mocked(createUiStream)).toHaveBeenCalledWith('openai', 'gpt-5', expect.any(Array), {}, customApiKeys);
+			expect(vi.mocked(createUiStream)).toHaveBeenCalledWith(expect.any(Array), {
+				provider: 'openai',
+				model: 'gpt-5',
+				tools: {},
+				apiKeys: customApiKeys,
+				systemPrompt: undefined,
+			});
 		});
 	});
 
@@ -286,13 +292,13 @@ describe('aiChatPostHandler', () => {
 				tools: expectedTools,
 			});
 
-			expect(vi.mocked(createUiStream)).toHaveBeenCalledWith(
-				'openai',
-				'gpt-5',
-				expect.any(Array),
-				expectedTools,
-				mockRes.locals!['ai'].apiKeys,
-			);
+			expect(vi.mocked(createUiStream)).toHaveBeenCalledWith(expect.any(Array), {
+				provider: 'openai',
+				model: 'gpt-5',
+				tools: expectedTools,
+				apiKeys: mockRes.locals!['ai'].apiKeys,
+				systemPrompt: undefined,
+			});
 		});
 	});
 });

--- a/api/src/ai/chat/controllers/chat.post.ts
+++ b/api/src/ai/chat/controllers/chat.post.ts
@@ -36,6 +36,13 @@ export const aiChatPostHandler: RequestHandler = async (req, res) => {
 		throw new InvalidPayloadError({ reason: validationResult.error.message });
 	}
 
-	const stream = createUiStream(provider, model, validationResult.data, aiSdkTools, res.locals['ai'].apiKeys);
+	const stream = createUiStream(validationResult.data, {
+		provider,
+		model,
+		tools: aiSdkTools,
+		apiKeys: res.locals['ai'].apiKeys,
+		systemPrompt: res.locals['ai'].systemPrompt,
+	});
+
 	stream.pipeUIMessageStreamToResponse(res);
 };

--- a/api/src/ai/chat/lib/create-ui-stream.test.ts
+++ b/api/src/ai/chat/lib/create-ui-stream.test.ts
@@ -33,27 +33,55 @@ describe('createUiStream', () => {
 	const apiKeys = { openai: 'openai-key', anthropic: 'anthropic-key' };
 
 	it('should create a stream for OpenAI provider', () => {
-		const result = createUiStream('openai', 'gpt-3.5', messages, apiKeys);
+		const result = createUiStream(messages, {
+			provider: 'openai',
+			model: 'gpt-3.5',
+			tools: {},
+			apiKeys,
+		});
+
 		expect(result).toBe(mockStreamTextResult);
 	});
 
 	it('should create a stream for Anthropic provider', () => {
-		const result = createUiStream('anthropic', 'claude-2', messages, apiKeys);
+		const result = createUiStream(messages, {
+			provider: 'anthropic',
+			model: 'claude-2',
+			tools: {},
+			apiKeys,
+		});
+
 		expect(result).toBe(mockStreamTextResult);
 	});
 
 	it('should throw ServiceUnavailableError if API key is missing for provider', () => {
-		expect(() => createUiStream('openai', 'gpt-3.5', messages, { ...apiKeys, openai: null })).toThrow(
-			ServiceUnavailableError,
-		);
+		expect(() =>
+			createUiStream(messages, {
+				provider: 'openai',
+				model: 'gpt-3.5',
+				tools: {},
+				apiKeys: { ...apiKeys, openai: null },
+			}),
+		).toThrow(ServiceUnavailableError);
 
-		expect(() => createUiStream('anthropic', 'claude-2', messages, { ...apiKeys, anthropic: null })).toThrow(
-			ServiceUnavailableError,
-		);
+		expect(() =>
+			createUiStream(messages, {
+				provider: 'anthropic',
+				model: 'claude-2',
+				tools: {},
+				apiKeys: { ...apiKeys, anthropic: null },
+			}),
+		).toThrow(ServiceUnavailableError);
 	});
 
 	it('should throw Error for unknown provider', () => {
-		// @ts-expect-error Testing invalid provider
-		expect(() => createUiStream('unknown', 'model', messages, apiKeys)).toThrow('Unexpected provider given: "unknown"');
+		expect(() =>
+			createUiStream(messages, {
+				provider: 'unknown',
+				model: 'model',
+				tools: {},
+				apiKeys,
+			}),
+		).toThrow('Unexpected provider given: "unknown"');
 	});
 });

--- a/api/src/ai/chat/lib/create-ui-stream.ts
+++ b/api/src/ai/chat/lib/create-ui-stream.ts
@@ -3,12 +3,20 @@ import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai';
 import { ServiceUnavailableError } from '@directus/errors';
 import { convertToModelMessages, streamText, type UIMessage, type Tool } from 'ai';
 
+export interface CreateUiStreamOptions {
+	provider: 'openai' | 'anthropic';
+	model: string;
+	tools: { [x: string]: Tool };
+	apiKeys: {
+		openai: string | null;
+		anthropic: string | null;
+	};
+	systemPrompt?: string;
+}
+
 export const createUiStream = (
-	provider: 'openai' | 'anthropic',
-	model: string,
 	messages: UIMessage[],
-	tools: { [x: string]: Tool },
-	apiKeys: { openai: string | null; anthropic: string | null },
+	{ provider, model, tools, apiKeys, systemPrompt }: CreateUiStreamOptions,
 ) => {
 	if (apiKeys[provider] === null) {
 		throw new ServiceUnavailableError({ service: provider, reason: 'No API key configured for LLM provider' });
@@ -28,5 +36,6 @@ export const createUiStream = (
 		model: modelProvider(model),
 		messages: convertToModelMessages(messages),
 		tools,
+		system: systemPrompt || '',
 	});
 };

--- a/api/src/ai/chat/middleware/load-settings.test.ts
+++ b/api/src/ai/chat/middleware/load-settings.test.ts
@@ -35,6 +35,7 @@ describe('loadSettings', () => {
 		mockReadSingleton.mockResolvedValue({
 			ai_openai_api_key: 'test-openai-key',
 			ai_anthropic_api_key: 'test-anthropic-key',
+			ai_system_prompt: 'You are Directus.',
 		});
 
 		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
@@ -42,7 +43,7 @@ describe('loadSettings', () => {
 		expect(mockGetSchema).toHaveBeenCalledTimes(1);
 
 		expect(mockReadSingleton).toHaveBeenCalledWith({
-			fields: ['ai_openai_api_key', 'ai_anthropic_api_key'],
+			fields: ['ai_openai_api_key', 'ai_anthropic_api_key', 'ai_system_prompt'],
 		});
 
 		expect(mockResponse.locals).toEqual({
@@ -51,6 +52,7 @@ describe('loadSettings', () => {
 					openai: 'test-openai-key',
 					anthropic: 'test-anthropic-key',
 				},
+				systemPrompt: 'You are Directus.',
 			},
 		});
 
@@ -61,6 +63,7 @@ describe('loadSettings', () => {
 		mockReadSingleton.mockResolvedValue({
 			ai_openai_api_key: undefined,
 			ai_anthropic_api_key: undefined,
+			ai_system_prompt: undefined,
 		});
 
 		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
@@ -68,7 +71,7 @@ describe('loadSettings', () => {
 		expect(mockGetSchema).toHaveBeenCalledTimes(1);
 
 		expect(mockReadSingleton).toHaveBeenCalledWith({
-			fields: ['ai_openai_api_key', 'ai_anthropic_api_key'],
+			fields: ['ai_openai_api_key', 'ai_anthropic_api_key', 'ai_system_prompt'],
 		});
 
 		expect(mockResponse.locals).toEqual({
@@ -77,6 +80,7 @@ describe('loadSettings', () => {
 					openai: undefined,
 					anthropic: undefined,
 				},
+				systemPrompt: undefined,
 			},
 		});
 
@@ -87,6 +91,7 @@ describe('loadSettings', () => {
 		mockReadSingleton.mockResolvedValue({
 			ai_openai_api_key: 'test-openai-key',
 			ai_anthropic_api_key: undefined,
+			ai_system_prompt: 'System prompt here',
 		});
 
 		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
@@ -97,6 +102,7 @@ describe('loadSettings', () => {
 					openai: 'test-openai-key',
 					anthropic: undefined,
 				},
+				systemPrompt: 'System prompt here',
 			},
 		});
 
@@ -107,6 +113,7 @@ describe('loadSettings', () => {
 		mockReadSingleton.mockResolvedValue({
 			ai_openai_api_key: undefined,
 			ai_anthropic_api_key: 'test-anthropic-key',
+			ai_system_prompt: undefined,
 		});
 
 		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
@@ -117,6 +124,7 @@ describe('loadSettings', () => {
 					openai: undefined,
 					anthropic: 'test-anthropic-key',
 				},
+				systemPrompt: undefined,
 			},
 		});
 
@@ -127,9 +135,9 @@ describe('loadSettings', () => {
 		const error = new Error('Database error');
 		mockReadSingleton.mockRejectedValue(error);
 
-		await expect(
-			loadSettings(mockRequest as Request, mockResponse as Response, nextFunction),
-		).rejects.toThrow('Database error');
+		await expect(loadSettings(mockRequest as Request, mockResponse as Response, nextFunction)).rejects.toThrow(
+			'Database error',
+		);
 
 		expect(mockGetSchema).toHaveBeenCalledTimes(1);
 		expect(nextFunction).not.toHaveBeenCalled();
@@ -157,6 +165,7 @@ describe('loadSettings', () => {
 		mockReadSingleton.mockResolvedValue({
 			ai_openai_api_key: null,
 			ai_anthropic_api_key: null,
+			ai_system_prompt: null,
 		});
 
 		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
@@ -167,6 +176,7 @@ describe('loadSettings', () => {
 					openai: null,
 					anthropic: null,
 				},
+				systemPrompt: null,
 			},
 		});
 
@@ -177,6 +187,7 @@ describe('loadSettings', () => {
 		mockReadSingleton.mockResolvedValue({
 			ai_openai_api_key: '',
 			ai_anthropic_api_key: '',
+			ai_system_prompt: '',
 		});
 
 		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
@@ -187,6 +198,7 @@ describe('loadSettings', () => {
 					openai: '',
 					anthropic: '',
 				},
+				systemPrompt: '',
 			},
 		});
 

--- a/api/src/ai/chat/middleware/load-settings.ts
+++ b/api/src/ai/chat/middleware/load-settings.ts
@@ -7,8 +7,8 @@ export const loadSettings: RequestHandler = async (_req, res, next) => {
 		schema: await getSchema(),
 	});
 
-	const { ai_openai_api_key, ai_anthropic_api_key } = await service.readSingleton({
-		fields: ['ai_openai_api_key', 'ai_anthropic_api_key'],
+	const { ai_openai_api_key, ai_anthropic_api_key, ai_system_prompt } = await service.readSingleton({
+		fields: ['ai_openai_api_key', 'ai_anthropic_api_key', 'ai_system_prompt'],
 	});
 
 	res.locals['ai'] = {
@@ -16,6 +16,7 @@ export const loadSettings: RequestHandler = async (_req, res, next) => {
 			openai: ai_openai_api_key,
 			anthropic: ai_anthropic_api_key,
 		},
+		systemPrompt: ai_system_prompt,
 	};
 
 	return next();

--- a/api/src/database/migrations/20251103A-add-ai-settings.ts
+++ b/api/src/database/migrations/20251103A-add-ai-settings.ts
@@ -4,6 +4,7 @@ export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_settings', (table) => {
 		table.text('ai_openai_api_key');
 		table.text('ai_anthropic_api_key');
+		table.text('ai_system_prompt');
 	});
 }
 
@@ -11,5 +12,6 @@ export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_settings', (table) => {
 		table.dropColumn('ai_openai_api_key');
 		table.dropColumn('ai_anthropic_api_key');
+		table.dropColumn('ai_system_prompt');
 	});
 }

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1530,6 +1530,8 @@ fields:
     mcp_system_prompt: Custom System Prompt
     mcp_system_prompt_note:
       'Custom system prompt to replace the default. Leave empty to use default (if enabled above).'
+    ai_system_prompt: AI System Prompt
+    ai_system_prompt_note: 'Custom AI system prompt to guide LLM behavior in AI Chat interactions.'
 
   directus_shares:
     name: Name

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -762,6 +762,14 @@ fields:
     width: half
     group: ai_group
 
+  - field: ai_system_prompt
+    interface: input-rich-text-md
+    group: ai_group
+    width: full
+    note: $t:fields.directus_settings.ai_system_prompt_note
+    options:
+      label: $t:fields.directus_settings.ai_system_prompt
+
   - field: mcp_divider
     interface: presentation-divider
     options:


### PR DESCRIPTION
This pull request introduces support for a custom AI system prompt in the chat functionality, allowing administrators to configure a prompt that guides LLM behavior during AI Chat interactions. The changes include updating the database schema, middleware, and test coverage to handle the new setting, as well as refactoring the API and internal logic to consistently pass the system prompt to the LLM providers.

**AI System Prompt Feature:**

* Added `ai_system_prompt` column to the `directus_settings` table via a database migration, including support for rollback.
* Updated settings schema and translations to expose the new system prompt field in the admin UI, with descriptive notes for users. [[1]](diffhunk://#diff-672d29cda3e24648646c82a852e630ec2a80c1f335792bc9723182c4997e4025R765-R772) [[2]](diffhunk://#diff-df42ecafe708c5d98ddbebfb3a7238207aab0c3c3c93920d616221136c08ad6aR1533-R1534)

**Middleware and Configuration Handling:**

* Enhanced the `loadSettings` middleware to read and expose the `ai_system_prompt` value from settings, ensuring it is available in `res.locals['ai']` for downstream use.
* Expanded middleware test coverage to verify correct handling of the new system prompt field in various scenarios (set, unset, null, empty). [[1]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR38-R46) [[2]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR55) [[3]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR66-R74) [[4]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR83) [[5]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR94) [[6]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR105) [[7]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR116) [[8]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR127) [[9]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR168) [[10]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR179) [[11]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR190) [[12]](diffhunk://#diff-1f8efb973a4a9fd1a0c8374b2353c11310db0a086dd05d3f3ea35849ee0af15fR201)

**API and Internal Refactoring:**

* Refactored the `createUiStream` function and its usage to accept a single options object (including provider, model, tools, API keys, and system prompt), improving flexibility and maintainability. [[1]](diffhunk://#diff-ad2183175f1cdcc88650b38d8a5aafa25102c2bb44db10e74902aec59cfcafa2R6-R19) [[2]](diffhunk://#diff-ad2183175f1cdcc88650b38d8a5aafa25102c2bb44db10e74902aec59cfcafa2R39) [[3]](diffhunk://#diff-ad3058ca5cba1112d57bc8b535cf793f8f211a9aa92ad96299ada6546830c99bL39-R46)
* Updated all related tests to match the new `createUiStream` signature and verify correct passing of the system prompt and other options. [[1]](diffhunk://#diff-ad214b6fe5ec652e15b4940f14710d0b1f328d9385f6e70a24cdfcc63c38b7c4L36-R85) [[2]](diffhunk://#diff-ef8610857892501ef92d394c590d919481bf5370e843c18f33422805520fc315L249-R255) [[3]](diffhunk://#diff-ef8610857892501ef92d394c590d919481bf5370e843c18f33422805520fc315L289-R301)