### PR TITLE
Add loading indicator when saving setup forms

### DIFF
--- a/.changeset/little-hands-allow.md
+++ b/.changeset/little-hands-allow.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added loading indicator when saving setup forms

--- a/app/src/interfaces/_system/system-owner/system-owner.vue
+++ b/app/src/interfaces/_system/system-owner/system-owner.vue
@@ -25,6 +25,7 @@ const emit = defineEmits<{
 
 const errors = ref<Record<string, any>[]>([]);
 const editing = ref(false);
+const isSaving = ref(false);
 
 const allowSave = computed(
 	() => form.value.project_owner || form.value.project_usage || form.value.org_name || form.value.product_updates,
@@ -37,9 +38,11 @@ async function save() {
 
 	if (errors.value.length > 0) return;
 
+	isSaving.value = true;
 	await settingsStore.setOwner(value as Form);
 	await settingsStore.hydrate();
 	emit('input', form.value.project_owner ?? initialValues.value.project_owner);
+	isSaving.value = false;
 	editing.value = false;
 }
 
@@ -76,7 +79,7 @@ const fields = useFormFields(false, form);
 		@apply="save"
 	>
 		<template #actions>
-			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!allowSave" @click="save">
+			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!allowSave" :loading="isSaving" @click="save">
 				<v-icon name="check" />
 			</v-button>
 		</template>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2721,10 +2721,10 @@ percent: Percent
 show_password: Show password
 hide_password: Hide password
 bsl_banner:
-  title: You have not set an instance owner.
+  title: You have not set a project owner.
   license:
     We need this to ensure compliance with our BSL 1.1 license. This should be the primary contact responsible for your
-    instance.
+    project.
   set_owner: Set Owner
   remind_later: Remind Later
   remind_next_login: We'll remind you again on your next login.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1944,8 +1944,8 @@ interfaces:
     description: Select between existing collections
     include_system_collections: Include System Collections
   system-owner:
-    update: Update Instance Owner
-    edit: Edit Instance Owner
+    update: Update Project Owner
+    edit: Edit Project Owner
     system-owner: System Owner
     description: System Owner Interface
   system-collections:

--- a/app/src/routes/setup/form.ts
+++ b/app/src/routes/setup/form.ts
@@ -172,9 +172,7 @@ export function useFormFields(
 				meta: {
 					required: true,
 					interface: 'input',
-					options: {
-						label: t('organization_name_optional'),
-					},
+					options: {},
 					width: 'full',
 				},
 			});

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -23,6 +23,7 @@ const router = useRouter();
 const fields = useFormFields(true, form);
 const errors = ref<ValidationError[]>([]);
 const error = ref<any>(null);
+const isSaving = ref(false);
 
 async function launch() {
 	errors.value = validate(form.value, fields, true);
@@ -30,6 +31,7 @@ async function launch() {
 	if (errors.value.length > 0) return;
 
 	try {
+		isSaving.value = true;
 		await api.post('server/setup', form.value);
 
 		await login({
@@ -42,6 +44,8 @@ async function launch() {
 		router.push('/content');
 	} catch (err: any) {
 		error.value = err;
+	} finally {
+		isSaving.value = false;
 	}
 }
 
@@ -55,7 +59,7 @@ const formComplete = computed(() => FormValidator.safeParse(form.value).success)
 <template>
 	<public-view wide>
 		<setup-form v-model="form" :errors="errors" utm-location="onboarding"></setup-form>
-		<v-button full-width :disabled="!formComplete" @click="launch()">
+		<v-button full-width :disabled="!formComplete" :loading="isSaving" @click="launch()">
 			<v-icon name="rocket_launch" />
 			{{ t('setup_launch') }}
 		</v-button>

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -21,13 +21,17 @@ const isSaveDisabled = computed(
 		(form.value.project_usage === 'commercial' && !form.value.org_name),
 );
 
+const isSaving = ref(false);
+
 async function setOwner() {
 	errors.value = validate(form.value, fields);
 
 	if (errors.value.length > 0) return;
 
+	isSaving.value = true;
 	await settingsStore.setOwner(form.value);
 	await settingsStore.hydrate();
+	isSaving.value = false;
 }
 
 async function remindLater() {
@@ -61,7 +65,7 @@ const fields = useFormFields(false, form);
 					<v-button secondary @click="remindLater">
 						{{ t('bsl_banner.remind_later') }}
 					</v-button>
-					<v-button :disabled="isSaveDisabled" @click="setOwner">
+					<v-button :disabled="isSaveDisabled" :loading="isSaving" @click="setOwner">
 						{{ t('bsl_banner.set_owner') }}
 					</v-button>
 				</v-card-actions>


### PR DESCRIPTION
## Scope

What's changed:

- Added loading indicator when saving
- Renamed instance to project for consistency
- Removed invalid label

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- Saving from the setup page, pop-up and editing forms

https://github.com/user-attachments/assets/e000e12f-7a1d-45a6-8a86-598c2ed3d861

https://github.com/user-attachments/assets/6d85fe56-30c3-4de7-b250-92df28048276

https://github.com/user-attachments/assets/87d05076-aaaa-4e96-b746-b8f8b64c3e21

## Review Notes / Questions

- 

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes CMS-1473
Fixes CMS-1474
