### PR TITLE
Fix system owner interface behaving unexpectedly

### DIFF
--- a/.changeset/slow-aliens-nail.md
+++ b/.changeset/slow-aliens-nail.md
@@ -1,0 +1,6 @@
+---
+'@directus/types': patch
+'@directus/app': patch
+---
+
+Fixed system owner interface behaving unexpectedly

--- a/app/src/interfaces/_system/system-owner/system-owner.vue
+++ b/app/src/interfaces/_system/system-owner/system-owner.vue
@@ -17,7 +17,7 @@ const isSaving = ref(false);
 const form = ref<Partial<Form>>({});
 const fields = useFormFields(false, form);
 
-const allowSave = computed(
+const isSaveAllowed = computed(
 	() =>
 		form.value.project_owner ||
 		form.value.project_usage ||
@@ -65,7 +65,7 @@ async function reset() {
 
 	<v-drawer v-model="editing" :title="t('interfaces.system-owner.update')" icon="link" @cancel="reset" @apply="save">
 		<template #actions>
-			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!allowSave" :loading="isSaving" @click="save">
+			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!isSaveAllowed" :loading="isSaving" @click="save">
 				<v-icon name="check" />
 			</v-button>
 		</template>

--- a/app/src/interfaces/_system/system-owner/system-owner.vue
+++ b/app/src/interfaces/_system/system-owner/system-owner.vue
@@ -13,13 +13,22 @@ const { t } = useI18n();
 const errors = ref<Record<string, any>[]>([]);
 const editing = ref(false);
 
+const form = ref<Partial<Form>>({});
+const fields = useFormFields(false, form);
+
 const allowSave = computed(
 	() =>
 		form.value.project_owner ||
 		form.value.project_usage ||
-		form.value.org_name ||
 		('product_updates' in form.value && form.value.product_updates !== initialValues.value.product_updates),
 );
+
+const initialValues = computed(() => ({
+	project_owner: settingsStore.settings?.project_owner,
+	project_usage: settingsStore.settings?.project_usage,
+	org_name: settingsStore.settings?.org_name,
+	product_updates: settingsStore.settings?.product_updates,
+}));
 
 async function save() {
 	const value = { ...initialValues.value, ...form.value };
@@ -30,19 +39,14 @@ async function save() {
 
 	await settingsStore.setOwner(value as Form);
 	await settingsStore.hydrate();
-	editing.value = false;
+	reset();
 }
 
-const initialValues = computed(() => ({
-	project_owner: settingsStore.settings?.project_owner,
-	project_usage: settingsStore.settings?.project_usage,
-	org_name: settingsStore.settings?.org_name,
-	product_updates: settingsStore.settings?.product_updates,
-}));
-
-const form = ref<Partial<Form>>({});
-
-const fields = useFormFields(false, form);
+async function reset() {
+	form.value = {};
+	editing.value = false;
+	errors.value = [];
+}
 </script>
 
 <template>
@@ -56,13 +60,7 @@ const fields = useFormFields(false, form);
 		</v-list-item>
 	</div>
 
-	<v-drawer
-		v-model="editing"
-		:title="t('interfaces.system-owner.update')"
-		icon="link"
-		@cancel="editing = false"
-		@apply="save"
-	>
+	<v-drawer v-model="editing" :title="t('interfaces.system-owner.update')" icon="link" @cancel="reset" @apply="save">
 		<template #actions>
 			<v-button v-tooltip.bottom="t('save')" icon rounded :disabled="!allowSave" @click="save">
 				<v-icon name="check" />

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -33,7 +33,7 @@ const initialValues = toRef(props, 'initialValues');
 const value = defineModel<SetupForm>();
 
 const license = computed({
-	get: () => value.value?.license ?? false,
+	get: () => value.value?.license ?? initialValues.value.license,
 	set: (val: boolean) => {
 		if (value.value) {
 			value.value.license = val;
@@ -42,7 +42,7 @@ const license = computed({
 });
 
 const product_updates = computed({
-	get: () => value.value?.product_updates ?? false,
+	get: () => value.value?.product_updates ?? initialValues.value.product_updates,
 	set: (val: boolean) => {
 		if (value.value) {
 			value.value.product_updates = val;

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -10,6 +10,7 @@ import { SetupForm as Form } from '@directus/types';
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { FormValidator, defaultValues, useFormFields, validate, ValidationError } from './form';
+import { watch } from 'vue';
 
 const { t } = useI18n();
 
@@ -50,6 +51,12 @@ const errorMessage = computed(() => {
 });
 
 const formComplete = computed(() => FormValidator.safeParse(form.value).success);
+
+watch(form, () => {
+	if (form.value.project_usage !== 'commercial') {
+		form.value.org_name = null;
+	}
+});
 </script>
 
 <template>

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -36,7 +36,6 @@ export type Settings = {
 	project_name: string;
 	project_descriptor: string | null;
 	project_url: string | null;
-	project_owner: string | null;
 	report_error_url: string | null;
 	report_bug_url: string | null;
 	report_feature_url: string | null;
@@ -64,7 +63,7 @@ export type Settings = {
 	theme_light_overrides: Record<string, unknown> | null;
 	theme_dark_overrides: Record<string, unknown> | null;
 	project_id: string | null;
-};
+} & OwnerInformation;
 
 export type OwnerInformation = {
 	project_owner: string | null;


### PR DESCRIPTION
## Scope

What's changed:

- Use settingsStore over parent v-form for modeling data
- Allow save when product_updates is set to false
- Fix double saving in modal and then page

## Potential Risks / Drawbacks

- None

---

Fixes CMS-1472
Closes #26123
