### PR TITLE
Remove accepted terms

### DIFF
--- a/.changeset/cute-bees-laugh.md
+++ b/.changeset/cute-bees-laugh.md
@@ -1,0 +1,5 @@
+---
+'@directus/system-data': patch
+---
+
+Removed defunct accepted_terms settings field

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -575,15 +575,6 @@ fields:
   - field: project_id
     hidden: true
 
-  - field: accepted_terms
-    interface: boolean
-    width: half
-    hidden: true
-    options:
-      label: $t:accepted
-    special:
-      - cast-boolean
-
   ### Appearance Settings ###
   # The theming_group is rendered on the Appearance page in the app
 


### PR DESCRIPTION
Directus after updating doesn't work, since accepted_terms is being requested