### PR TITLE
Enhance CSV export functionality by adding UTF-8 BOM support for Excel compatibility

### DIFF
--- a/.changeset/old-snails-watch.md
+++ b/.changeset/old-snails-watch.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Enhance CSV export functionality by adding UTF-8 BOM support for Excel compatibility
+Enhanced CSV export functionality by adding UTF-8 BOM support for Excel compatibility

--- a/.changeset/old-snails-watch.md
+++ b/.changeset/old-snails-watch.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Enhance CSV export functionality by adding UTF-8 BOM support for Excel compatibility

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -88,7 +88,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 
 		if (req.sanitizedQuery.export === 'csv') {
 			res.attachment(`${filename}.csv`);
-			res.set('Content-Type', 'text/csv');
+			res.set('Content-Type', 'text/csv; charset=utf-8');
 			return res.status(200).send(exportService.transform(res.locals['payload']?.data, 'csv'));
 		}
 

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -727,8 +727,8 @@ Your export of ${collection} is ready. <a href="${href}">Click here to view.</a>
 			const header = options?.includeHeader !== false;
 
 			const transformOptions = options?.fields
-				? { transforms, header, fields: options?.fields }
-				: { transforms, header };
+				? { transforms, header, fields: options?.fields, withBOM: header }
+				: { transforms, header, withBOM: header };
 
 			let string = new CSVParser(transformOptions).parse(input);
 

--- a/app/src/utils/save-as-csv.ts
+++ b/app/src/utils/save-as-csv.ts
@@ -65,7 +65,7 @@ export async function saveAsCSV(collection: string, fields: string[], items: Ite
 		parsedItems.push(parsedItem);
 	}
 
-	const parser = new Parser();
+	const parser = new Parser({ withBOM: true });
 	const csvContent = parser.parse(parsedItems);
 
 	const now = new Date();


### PR DESCRIPTION
## Scope

What's changed:

- Added UTF-8 BOM (Byte Order Mark) to CSV exports to fix special character display issues in Excel
- Updated backend CSV export service to use `withBOM: true` option from json2csv library
- Updated frontend CSV export utility to use `withBOM: true` option from @json2csv/plainjs library
- Added explicit `charset=utf-8` to CSV Content-Type header in response middleware
- Added comprehensive test suite for UTF-8 BOM behavior in CSV exports

## Potential Risks / Drawbacks

I’m not aware of that

## Tested Scenarios

- Multi-batch CSV export with BOM only on first batch

## Review Notes / Questions

- The `withBOM` option is now the default for all CSV exports (when `includeHeader !== false`)

## Checklist

- [X] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #16818, #25981 
