### PR TITLE
 Add `defineTool` composable

### DIFF
--- a/api/src/ai/chat/lib/create-ui-stream.ts
+++ b/api/src/ai/chat/lib/create-ui-stream.ts
@@ -1,7 +1,7 @@
 import { createAnthropic, type AnthropicProvider } from '@ai-sdk/anthropic';
 import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai';
 import { ServiceUnavailableError } from '@directus/errors';
-import { convertToModelMessages, streamText, type UIMessage, type Tool } from 'ai';
+import { convertToModelMessages, stepCountIs, streamText, type Tool, type UIMessage } from 'ai';
 
 export interface CreateUiStreamOptions {
 	provider: 'openai' | 'anthropic';
@@ -32,15 +32,22 @@ export const createUiStream = (
 		throw new Error(`Unexpected provider given: "${provider}"`);
 	}
 
+	const optionalStreamingParameters: { system?: string } = {};
+
+	if (systemPrompt) {
+		optionalStreamingParameters.system = systemPrompt;
+	}
+
 	return streamText({
+		...optionalStreamingParameters,
 		model: modelProvider(model),
 		messages: convertToModelMessages(messages),
+		stopWhen: [stepCountIs(10)],
 		providerOptions: {
 			openai: {
 				reasoningSummary: 'detailed',
 			},
 		},
 		tools,
-		system: systemPrompt || '',
 	});
 };

--- a/app/src/ai/components/ai-model-selector.vue
+++ b/app/src/ai/components/ai-model-selector.vue
@@ -3,10 +3,6 @@ import { formatTitle } from '@directus/format-title';
 import { useAiStore } from '../stores/use-ai';
 
 const aiStore = useAiStore();
-
-function selectModel(model: string) {
-	aiStore.updateSelectedModel(model);
-}
 </script>
 
 <template>
@@ -24,7 +20,7 @@ function selectModel(model: string) {
 				:key="model"
 				:active="aiStore.selectedModel === model"
 				clickable
-				@click="selectModel(model)"
+				@click="aiStore.selectedModel = model"
 			>
 				<v-list-item-content>
 					<v-text-overflow :text="formatTitle(model.split('/')[1] || '')" />

--- a/app/src/ai/composables/define-tool.test.ts
+++ b/app/src/ai/composables/define-tool.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, computed, nextTick, defineComponent } from 'vue';
+import { mount } from '@vue/test-utils';
+import { z } from 'zod';
+import { defineTool, toStatic, type ToolDefinition } from './define-tool';
+
+const registerLocalTool = vi.fn();
+const replaceLocalTool = vi.fn();
+const deregisterLocalTool = vi.fn();
+
+vi.mock('../stores/use-ai', () => ({
+	useAiStore: () => ({
+		registerLocalTool,
+		replaceLocalTool,
+		deregisterLocalTool,
+	}),
+}));
+
+const schema = z.object({ foo: z.string() });
+
+describe('define-tool composable', () => {
+	beforeEach(() => {
+		registerLocalTool.mockClear();
+		replaceLocalTool.mockClear();
+		deregisterLocalTool.mockClear();
+	});
+
+	it('toStatic resolves MaybeRefOrGetter fields', () => {
+		const execA = vi.fn();
+		const name = ref('my-tool');
+		const description = computed(() => `desc:${name.value}`);
+		const execute = ref(execA);
+
+		const tool: ToolDefinition<typeof schema> = {
+			name,
+			description,
+			inputSchema: schema,
+			execute,
+		};
+
+		const stat = toStatic(tool);
+
+		expect(stat.name).toBe('my-tool');
+		expect(stat.description).toBe('desc:my-tool');
+		expect(stat.inputSchema).toBe(schema);
+		// Unwrapped function reference
+		expect(stat.execute).toBe(execA);
+	});
+
+	it('registers on mount and deregisters on unmount', async () => {
+		const toolRef = ref<ToolDefinition<typeof schema>>({
+			name: 'register-test',
+			description: 'register test tool',
+			inputSchema: schema,
+			execute: () => undefined,
+		});
+
+		const Comp = defineComponent({
+			name: 'HarnessRegister',
+			setup() {
+				defineTool(toolRef);
+				return () => null;
+			},
+		});
+
+		const wrapper = mount(Comp);
+		await nextTick();
+
+		expect(registerLocalTool).toHaveBeenCalledTimes(1);
+		const firstRegisterCall = registerLocalTool.mock.calls.at(0)!;
+		const registeredArg = firstRegisterCall[0];
+		expect(registeredArg).toMatchObject({ name: 'register-test', description: 'register test tool' });
+
+		wrapper.unmount();
+
+		expect(deregisterLocalTool).toHaveBeenCalledTimes(1);
+		expect(deregisterLocalTool).toHaveBeenCalledWith('register-test');
+	});
+
+	it('replaces tool when definition changes and deregisters latest name on unmount', async () => {
+		const execA = vi.fn();
+		const execB = vi.fn();
+
+		const toolRef = ref<ToolDefinition<typeof schema>>({
+			name: 'first-name',
+			description: 'first desc',
+			inputSchema: schema,
+			execute: execA,
+		});
+
+		const Comp = defineComponent({
+			name: 'HarnessReplace',
+			setup() {
+				defineTool(toolRef);
+				return () => null;
+			},
+		});
+
+		const wrapper = mount(Comp);
+		await nextTick();
+
+		// Update the whole definition to trigger the watcher
+		toolRef.value = {
+			name: 'second-name',
+			description: 'second desc',
+			inputSchema: schema,
+			execute: execB,
+		};
+
+		await nextTick();
+
+		// One replace call with old name and new static tool
+		expect(replaceLocalTool).toHaveBeenCalledTimes(1);
+		const firstReplaceCall = replaceLocalTool.mock.calls.at(0)!;
+		const [oldName, newTool] = firstReplaceCall;
+		expect(oldName).toBe('first-name');
+		expect(newTool).toMatchObject({ name: 'second-name', description: 'second desc' });
+		expect(newTool.execute).toBe(execB);
+
+		wrapper.unmount();
+
+		await nextTick();
+
+		// Should deregister the current (latest) name according to implementation
+		expect(deregisterLocalTool).toHaveBeenCalledWith('second-name');
+	});
+});

--- a/app/src/ai/composables/define-tool.ts
+++ b/app/src/ai/composables/define-tool.ts
@@ -1,0 +1,48 @@
+import { onMounted, onUnmounted, toValue, unref, watch, type MaybeRefOrGetter } from 'vue';
+import { z, ZodObject } from 'zod';
+import { useAiStore } from '../stores/use-ai';
+
+export interface StaticToolDefinition<T = ZodObject> {
+	name: string;
+	description: string;
+	inputSchema: T;
+	execute: (args: z.input<T>) => unknown | Promise<unknown>;
+}
+
+export interface ToolDefinition<T = ZodObject> {
+	name: MaybeRefOrGetter<string>;
+	description: MaybeRefOrGetter<string>;
+	inputSchema: MaybeRefOrGetter<T>;
+	execute: MaybeRefOrGetter<(args: z.input<T>) => unknown | Promise<unknown>>;
+}
+
+export const toStatic = <T>(toolGetter: MaybeRefOrGetter<ToolDefinition<T>>): StaticToolDefinition<T> => {
+	const tool = toValue(toolGetter);
+
+	return {
+		name: toValue(tool.name),
+		description: toValue(tool.description),
+		inputSchema: toValue(tool.inputSchema),
+		execute: unref(tool.execute),
+	};
+};
+
+export const defineTool = <T extends ZodObject>(tool: MaybeRefOrGetter<ToolDefinition<T>>) => {
+	const aiStore = useAiStore();
+
+	watch(
+		() => toValue(tool),
+		(newDef, oldDef) => {
+			aiStore.replaceLocalTool(toValue(toValue(oldDef).name), toStatic(newDef));
+		},
+		{ deep: true },
+	);
+
+	onMounted(() => {
+		aiStore.registerLocalTool(toStatic(tool));
+	});
+
+	onUnmounted(() => {
+		aiStore.deregisterLocalTool(toStatic(tool).name);
+	});
+};

--- a/app/src/ai/stores/use-ai.ts
+++ b/app/src/ai/stores/use-ai.ts
@@ -1,11 +1,13 @@
 import { useSettingsStore } from '@/stores/settings';
 import { Chat } from '@ai-sdk/vue';
-import { useLocalStorage } from '@vueuse/core';
-import { DefaultChatTransport, type UIMessage } from 'ai';
-import { defineStore } from 'pinia';
-import { computed } from 'vue';
-import { AI_MODELS } from '../models';
 import { getSimpleHash } from '@directus/utils';
+import { useLocalStorage } from '@vueuse/core';
+import { DefaultChatTransport, type UIMessage, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
+import { defineStore } from 'pinia';
+import { computed, shallowRef } from 'vue';
+import { z } from 'zod';
+import { StaticToolDefinition } from '../composables/define-tool';
+import { AI_MODELS } from '../models';
 
 export const useAiStore = defineStore('ai-store', () => {
 	const settingsStore = useSettingsStore();
@@ -18,24 +20,69 @@ export const useAiStore = defineStore('ai-store', () => {
 	);
 
 	const defaultProvider = computed(() => models.value[0]?.split('/')[0] ?? null);
-
 	const defaultModel = computed(() => models.value[0]?.split('/')[1] ?? null);
-
 	const selectedModel = useLocalStorage<string | null>('selected-ai-model', defaultModel.value);
-
 	const currentProvider = computed(() => selectedModel.value?.split('/')[0] ?? defaultProvider.value);
 	const currentModel = computed(() => selectedModel.value?.split('/')[1] ?? defaultModel.value);
+
+	const systemTools = shallowRef<string[]>([
+		'items',
+		'files',
+		'folders',
+		'assets',
+		'flows',
+		'trigger-flow',
+		'operations',
+		'schema',
+		'collections',
+		'fields',
+		'relations',
+	]);
+
+	const localTools = shallowRef<StaticToolDefinition[]>([]);
+
+	const toApiTool = (tool: StaticToolDefinition) => ({
+		name: tool.name,
+		description: tool.description,
+		inputSchema: z.toJSONSchema(tool.inputSchema, { target: 'draft-7' }),
+	});
 
 	const chat = new Chat<UIMessage>({
 		transport: new DefaultChatTransport({
 			api: '/ai/chat',
+			credentials: 'include',
 			body: () => ({
 				provider: currentProvider.value,
 				model: currentModel.value,
-				tools: [],
+				tools: [...systemTools.value, ...localTools.value.map(toApiTool)],
 			}),
-			credentials: 'include',
 		}),
+		sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+		onToolCall: async ({ toolCall }) => {
+			if (toolCall.dynamic) {
+				return;
+			}
+
+			const tool = localTools.value.find((tool) => tool.name === toolCall.toolName);
+
+			if (!tool) {
+				throw new Error(`Tool by name "${toolCall.toolName}" does not exist`);
+			}
+
+			try {
+				const output = await tool.execute(toolCall.input as Record<string, unknown>);
+				chat.addToolResult({ tool: toolCall.toolName, output, toolCallId: toolCall.toolCallId });
+			} catch (e: unknown) {
+				if (e instanceof Error) {
+					chat.addToolResult({
+						tool: toolCall.toolName,
+						state: 'output-error',
+						errorText: e.message,
+						toolCallId: toolCall.toolCallId,
+					});
+				}
+			}
+		},
 	});
 
 	const messages = computed(() =>
@@ -47,23 +94,34 @@ export const useAiStore = defineStore('ai-store', () => {
 
 	const status = computed(() => chat.status);
 
-	function updateSelectedModel(model: string) {
-		selectedModel.value = model;
-	}
-
-	function addMessage(message: string) {
+	const addMessage = (message: string) => {
 		chat.sendMessage({ text: message });
-	}
+	};
+
+	const registerLocalTool = (tool: StaticToolDefinition) => {
+		localTools.value = [...localTools.value, tool];
+	};
+
+	const replaceLocalTool = (name: string, tool: StaticToolDefinition) => {
+		localTools.value = localTools.value.map((t) => (t.name === name ? tool : t));
+	};
+
+	const deregisterLocalTool = (name: string) => {
+		localTools.value = localTools.value.filter((t) => t.name !== name);
+	};
 
 	return {
 		currentProvider,
 		currentModel,
 		addMessage,
-		chat,
 		messages,
 		status,
 		selectedModel,
-		updateSelectedModel,
 		models,
+		registerLocalTool,
+		replaceLocalTool,
+		deregisterLocalTool,
+		systemTools,
+		localTools,
 	};
 });

--- a/app/src/components/v-form/composables/use-input-schema.test.ts
+++ b/app/src/components/v-form/composables/use-input-schema.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { useInputSchema } from './use-input-schema';
+
+import type { DeepPartial, Field } from '@directus/types';
+
+// Minimal field factory using DeepPartial to keep fixtures concise
+const makeField = (overrides: DeepPartial<Field> = {}): DeepPartial<Field> => ({
+	field: 'test',
+	type: 'string',
+	meta: {},
+	...overrides,
+});
+
+describe('useInputSchema', () => {
+	it('should create a schema for a string field', () => {
+		const fields = [makeField()];
+
+		const { inputSchema } = useInputSchema(fields as unknown as Field[]);
+		const schema = inputSchema.value;
+		expect(schema.shape.test).toBeDefined();
+		expect(() => schema.parse({ test: 'hello' })).not.toThrow();
+		expect(() => schema.parse({ test: 123 })).toThrow();
+	});
+
+	it('should skip readonly fields', () => {
+		const fields = [makeField({ meta: { readonly: true } })];
+
+		const { inputSchema } = useInputSchema(fields as unknown as Field[]);
+		const schema = inputSchema.value;
+		expect(schema.shape.test).toBeUndefined();
+	});
+
+	it('should create enum for choices', () => {
+		const fields = [
+			makeField({
+				meta: {
+					options: {
+						choices: [{ value: 'A' }, { value: 'B' }],
+					},
+				},
+			}),
+		];
+
+		const { inputSchema } = useInputSchema(fields as unknown as Field[]);
+		const schema = inputSchema.value;
+		expect(() => schema.parse({ test: 'A' })).not.toThrow();
+		expect(() => schema.parse({ test: 'B' })).not.toThrow();
+		expect(() => schema.parse({ test: 'C' })).toThrow();
+	});
+
+	it('should handle multiple field types', () => {
+		const fields = [
+			makeField({ field: 'str', type: 'string' }),
+			makeField({ field: 'bool', type: 'boolean' }),
+			makeField({ field: 'int', type: 'integer' }),
+			makeField({ field: 'date', type: 'date' }),
+		];
+
+		const { inputSchema } = useInputSchema(fields as unknown as Field[]);
+		const schema = inputSchema.value;
+		expect(() => schema.parse({ str: 'abc', bool: true, int: 42, date: new Date() })).not.toThrow();
+		expect(() => schema.parse({ str: 1 })).toThrow();
+		expect(() => schema.parse({ bool: 'true' })).toThrow();
+		expect(() => schema.parse({ int: '42' })).toThrow();
+		expect(() => schema.parse({ date: '2020-01-01' })).toThrow();
+	});
+
+	it('should accept missing optional fields', () => {
+		const fields = [makeField()];
+
+		const { inputSchema } = useInputSchema(fields as unknown as Field[]);
+		const schema = inputSchema.value;
+		expect(() => schema.parse({})).not.toThrow();
+	});
+
+	it('should work with ref input', () => {
+		const fields = ref([makeField()]);
+
+		const { inputSchema } = useInputSchema(fields as unknown as any);
+		const schema = inputSchema.value;
+		expect(() => schema.parse({ test: 'hello' })).not.toThrow();
+	});
+});

--- a/app/src/components/v-form/composables/use-input-schema.ts
+++ b/app/src/components/v-form/composables/use-input-schema.ts
@@ -72,7 +72,7 @@ export const useInputSchema = (finalFields: MaybeRefOrGetter<Field[]>) => {
 					}
 
 					if (field.meta?.note) {
-						type.describe(field.meta.note);
+						type = type.describe(field.meta.note);
 					}
 
 					acc[field.field] = type.optional();

--- a/app/src/components/v-form/composables/use-input-schema.ts
+++ b/app/src/components/v-form/composables/use-input-schema.ts
@@ -1,0 +1,88 @@
+import type { Field } from '@directus/types';
+import { computed, MaybeRefOrGetter, toValue } from 'vue';
+import { z, type ZodType } from 'zod';
+
+export const useInputSchema = (finalFields: MaybeRefOrGetter<Field[]>) => {
+	const inputSchema = computed(() =>
+		z.object(
+			toValue(finalFields).reduce(
+				(acc, field) => {
+					if (field.meta?.readonly) return acc;
+
+					// TODO alias types are o2m / m2m; would be powerful, but tough as nails to get to work
+					if (field.type === 'alias') return acc;
+
+					let type;
+
+					switch (field.type) {
+						case 'string':
+						case 'text':
+						case 'hash':
+						case 'csv':
+							type = z.string();
+							break;
+						case 'boolean':
+							type = z.boolean();
+							break;
+						case 'integer':
+						case 'decimal':
+						case 'float':
+							type = z.number();
+							break;
+						case 'bigInteger':
+							type = z.bigint();
+							break;
+						case 'date':
+						case 'dateTime':
+						case 'time':
+						case 'timestamp':
+							type = z.date();
+							break;
+						case 'json':
+							type = z.json();
+							break;
+						case 'binary':
+						case 'uuid':
+							type = z.uuidv4();
+							break;
+						case 'geometry':
+						case 'geometry.Point':
+						case 'geometry.LineString':
+						case 'geometry.Polygon':
+						case 'geometry.MultiPoint':
+						case 'geometry.MultiLineString':
+						case 'geometry.MultiPolygon':
+							// TODO maybe https://github.com/reilem/zod-geojson?
+							type = z.json();
+							break;
+						// case 'alias':
+						case 'unknown':
+						default:
+							type = z.unknown();
+					}
+
+					// `choices` are the options for dropdowns and other selection interfaces
+					if (field.meta?.options?.choices) {
+						type = z.enum(
+							field.meta.options.choices.map(
+								// Only return the value of the choice to reduce size and potential for confusion.
+								(choice: { value: string }) => choice.value,
+							),
+						);
+					}
+
+					if (field.meta?.note) {
+						type.describe(field.meta.note);
+					}
+
+					acc[field.field] = type.optional();
+
+					return acc;
+				},
+				{} as { [field: string]: ZodType },
+			),
+		),
+	);
+
+	return { inputSchema };
+};

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -129,7 +129,7 @@ defineTool({
 
 		for (const [key, value] of Object.entries(args)) {
 			setValue(key, value);
-			output.push(`Successfully form field ${key} to value ${value}`);
+			output.push(`Successfully set form field ${key} to value ${value}`);
 		}
 
 		return output;

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { defineTool } from '@/ai/composables/define-tool';
 import { useFieldsStore } from '@/stores/fields';
 import { applyConditions } from '@/utils/apply-conditions';
 import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
@@ -7,8 +8,9 @@ import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 import { useElementSize } from '@directus/composables';
 import { ContentVersion, Field, ValidationError } from '@directus/types';
 import { assign, cloneDeep, isEmpty, isEqual, isNil, omit } from 'lodash';
-import { computed, onBeforeUpdate, provide, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { computed, getCurrentInstance, onBeforeUpdate, provide, ref, watch } from 'vue';
+import { z } from 'zod';
+import { useInputSchema } from './composables/use-input-schema';
 import type { MenuOptions } from './form-field-menu.vue';
 import FormField from './form-field.vue';
 import type { ComparisonContext, FormField as TFormField } from './types';
@@ -63,8 +65,6 @@ const props = withDefaults(
 	},
 );
 
-const { t } = useI18n();
-
 const emit = defineEmits(['update:modelValue']);
 
 const values = computed(() => {
@@ -100,6 +100,41 @@ const {
 	getFieldsForGroup,
 	isFieldVisible,
 } = useForm();
+
+const { inputSchema: writeInputSchema } = useInputSchema(finalFields);
+
+const componentUid = getCurrentInstance()!.uid;
+
+defineTool({
+	name: `read-form-values-${componentUid}`,
+	description: 'Read values of the form on the current page',
+	inputSchema: computed(() => z.object({ fields: z.array(z.enum(fieldNames.value)) })),
+	execute: ({ fields }) => {
+		const output: Record<string, unknown> = {};
+
+		for (const field of fields) {
+			output[field] = values.value[field];
+		}
+
+		return output;
+	},
+});
+
+defineTool({
+	name: `set-form-values-${componentUid}`,
+	description: `Set values of form on the current page`,
+	inputSchema: writeInputSchema,
+	execute: (args) => {
+		const output: string[] = [];
+
+		for (const [key, value] of Object.entries(args)) {
+			setValue(key, value);
+			output.push(`Successfully form field ${key} to value ${value}`);
+		}
+
+		return output;
+	},
+});
 
 const { toggleBatchField, batchActiveFields } = useBatch();
 const { toggleRawField, rawActiveFields } = useRawEditor();
@@ -399,11 +434,11 @@ function getComparisonIndicatorClasses(field: TFormField, isGroup = false) {
 		<v-info
 			v-if="noVisibleFields && showNoVisibleFields && !loading"
 			class="no-fields-info"
-			:title="t('no_visible_fields')"
+			:title="$t('no_visible_fields')"
 			:icon="inline ? false : 'search'"
 			:center="!inline"
 		>
-			{{ t('no_visible_fields_copy') }}
+			{{ $t('no_visible_fields_copy') }}
 		</v-info>
 		<template v-for="(fieldName, index) in fieldNames" :key="fieldName">
 			<template v-if="fieldsMap[fieldName]">

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -108,7 +108,14 @@ const componentUid = getCurrentInstance()!.uid;
 defineTool({
 	name: `read-form-values-${componentUid}`,
 	description: 'Read values of the form on the current page',
-	inputSchema: computed(() => z.object({ fields: z.array(z.enum(fieldNames.value)) })),
+	inputSchema: computed(() => {
+		return z.object({
+			fields:
+				fieldNames.value.length > 0
+					? z.array(z.enum(fieldNames.value))
+					: z.array(z.string()),
+		});
+	}),
 	execute: ({ fields }) => {
 		const output: Record<string, unknown> = {};
 


### PR DESCRIPTION
Allows local AI tools to be registered from any component in the codebase, for example from the `v-form` component:

```ts
defineTool({
	name: `read-form-values-${componentUid}`,
	description: 'Read values of the form on the current page',
	inputSchema: computed(() => z.object({ fields: z.array(z.enum(fieldNames.value)) })),
	execute: ({ fields }) => {
		const output: Record<string, unknown> = {};

		for (const field of fields) {
			output[field] = values.value[field];
		}

		return output;
	},
});
```

These tools are automatically registered and deregistered when the component mounts/unmounts. All properties are reactive, so you can dynamically change the input-schema.

---

This pull request introduces a comprehensive set of improvements to the AI tool system and form integration, focusing on dynamic tool registration, schema generation, and enhanced test coverage. The most significant changes include the addition of a composable for defining and registering tools, dynamic form tool integration, robust input schema generation, expanded store capabilities for tool management, and thorough unit tests for new features.

**AI Tool System Enhancements**

* Added a new composable `define-tool` with utilities for registering, replacing, and deregistering local AI tools, including a `toStatic` helper to resolve reactive fields. This enables components to easily expose local tools to the AI system.
* Updated the AI store (`use-ai.ts`) to support dynamic tool registration and execution, including handling tool calls, maintaining local and system tool lists, and serializing tool schemas for API calls. [[1]](diffhunk://#diff-8b76994f1c2001a07f58c0c4c4bfb8520eb7a02d942bb90810e8f10945ae1f70R3-L8) [[2]](diffhunk://#diff-8b76994f1c2001a07f58c0c4c4bfb8520eb7a02d942bb90810e8f10945ae1f70L21-R85) [[3]](diffhunk://#diff-8b76994f1c2001a07f58c0c4c4bfb8520eb7a02d942bb90810e8f10945ae1f70L50-R125)

**Form Integration and Input Schema Generation**

* Integrated form tools into `v-form.vue`, registering "read" and "set" tools for the form using `defineTool`, and generating input schemas dynamically from the form fields. [[1]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529R2) [[2]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529L10-R13) [[3]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529R104-R138)
* Added a composable `use-input-schema` to automatically generate Zod validation schemas from Directus field definitions, supporting various field types and options.

**Testing and Reliability**

* Added thorough unit tests for both the `define-tool` composable and the input schema generator, ensuring correct tool lifecycle management and schema validation for multiple field types and options. [[1]](diffhunk://#diff-88c35e6be083975c71f662f256a8f6f4b3cda88760af135981d437944a3884c9R1-R127) [[2]](diffhunk://#diff-ecaa89623641764cd47ec40823efb83be4cae3256695819661f7893c114e3e01R1-R84)

**Minor UI and API Improvements**

* Simplified model selection logic in the AI model selector component for better maintainability. [[1]](diffhunk://#diff-c72a5cf97142e9a507301270472d9c2a0ea04493b1b2a3a6a4b4138e9f5ee7afL6-L9) [[2]](diffhunk://#diff-c72a5cf97142e9a507301270472d9c2a0ea04493b1b2a3a6a4b4138e9f5ee7afL27-R23)
* Improved streaming API logic to support system prompts and step limits, enabling more controlled AI interactions. [[1]](diffhunk://#diff-ad2183175f1cdcc88650b38d8a5aafa25102c2bb44db10e74902aec59cfcafa2L4-R4) [[2]](diffhunk://#diff-ad2183175f1cdcc88650b38d8a5aafa25102c2bb44db10e74902aec59cfcafa2R35-L44)
* Fixed translation usage in the form component for consistency.