### PR TITLE
Fix aliases on GQL M2A filters

### DIFF
--- a/.changeset/funny-months-wonder.md
+++ b/.changeset/funny-months-wonder.md
@@ -1,0 +1,6 @@
+---
+'@directus/types': patch
+'@directus/api': patch
+---
+
+Fixed aliases on GQL M2A filters

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -138,10 +138,10 @@ export async function getQuery(
 
 	if (collection) {
 		if (query.filter) {
-			query.filter = filterReplaceM2A(query.filter, collection, schema);
+			query.filter = filterReplaceM2A(query.filter, collection, schema, { aliasMap: query.alias });
 		}
 
-		query.deep = filterReplaceM2ADeep(query.deep, collection, schema);
+		query.deep = filterReplaceM2ADeep(query.deep, collection, schema, { aliasMap: query.alias });
 	}
 
 	validateQuery(query);

--- a/api/src/services/graphql/utils/filter-replace-m2a.test.ts
+++ b/api/src/services/graphql/utils/filter-replace-m2a.test.ts
@@ -1,5 +1,5 @@
 import { RelationBuilder, SchemaBuilder } from '@directus/schema-builder';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { filterReplaceM2A, filterReplaceM2ADeep } from './filter-replace-m2a.js';
 
 const schema = new SchemaBuilder()
@@ -22,87 +22,101 @@ const schema = new SchemaBuilder()
 	})
 	.build();
 
-test('empty filter', () => {
-	const result = filterReplaceM2A({}, 'article', { collections: {}, relations: [] });
+describe('filterReplaceM2A', () => {
+	test('empty filter', () => {
+		const result = filterReplaceM2A({}, 'article', { collections: {}, relations: [] });
 
-	expect(result).toEqual({});
-});
+		expect(result).toEqual({});
+	});
 
-test('filter with no relations', () => {
-	const result = filterReplaceM2A(
-		{
+	test('filter with no relations', () => {
+		const result = filterReplaceM2A(
+			{
+				id: {
+					_eq: 1,
+				},
+				some: {
+					_eq: 'value',
+				},
+			},
+			'article',
+			{ collections: {}, relations: [] },
+		);
+
+		expect(result).toEqual({
 			id: {
 				_eq: 1,
 			},
 			some: {
 				_eq: 'value',
 			},
-		},
-		'article',
-		{ collections: {}, relations: [] },
-	);
-
-	expect(result).toEqual({
-		id: {
-			_eq: 1,
-		},
-		some: {
-			_eq: 'value',
-		},
+		});
 	});
-});
 
-test('filter with a m2o relation', () => {
-	const result = filterReplaceM2A(
-		{
+	test('filter with a m2o relation', () => {
+		const result = filterReplaceM2A(
+			{
+				id: { _eq: 1 },
+				author: {
+					id: { _eq: 1 },
+					name: { _eq: 'John Doe' },
+				},
+			},
+			'article',
+			schema,
+		);
+
+		expect(result).toEqual({
 			id: { _eq: 1 },
 			author: {
 				id: { _eq: 1 },
 				name: { _eq: 'John Doe' },
 			},
-		},
-		'article',
-		schema,
-	);
-
-	expect(result).toEqual({
-		id: { _eq: 1 },
-		author: {
-			id: { _eq: 1 },
-			name: { _eq: 'John Doe' },
-		},
+		});
 	});
-});
 
-test('filter with a a2o relation', () => {
-	const result = filterReplaceM2A(
-		{
+	test('filter with a a2o relation', () => {
+		const result = filterReplaceM2A(
+			{
+				id: { _eq: 1 },
+				blocks: {
+					anyitem__text: {
+						id: { _eq: 1 },
+						content: { _eq: 'Hello World' },
+					},
+				},
+			},
+			'article',
+			schema,
+		);
+
+		expect(result).toEqual({
 			id: { _eq: 1 },
 			blocks: {
-				anyitem__text: {
+				'anyitem:text': {
 					id: { _eq: 1 },
 					content: { _eq: 'Hello World' },
 				},
 			},
-		},
-		'article',
-		schema,
-	);
-
-	expect(result).toEqual({
-		id: { _eq: 1 },
-		blocks: {
-			'anyitem:text': {
-				id: { _eq: 1 },
-				content: { _eq: 'Hello World' },
-			},
-		},
+		});
 	});
-});
 
-test('filter with a fake a2o relation', () => {
-	const result = filterReplaceM2A(
-		{
+	test('filter with a fake a2o relation', () => {
+		const result = filterReplaceM2A(
+			{
+				id: { _eq: 1 },
+				blocks: {
+					item__text: {
+						id: { _eq: 1 },
+						content: { _eq: 'Hello World' },
+					},
+				},
+			},
+			'article',
+			schema,
+		);
+
+		expect(result).toEqual({
 			id: { _eq: 1 },
 			blocks: {
 				item__text: {
@@ -110,57 +124,57 @@ test('filter with a fake a2o relation', () => {
 					content: { _eq: 'Hello World' },
 				},
 			},
-		},
-		'article',
-		schema,
-	);
-
-	expect(result).toEqual({
-		id: { _eq: 1 },
-		blocks: {
-			item__text: {
-				id: { _eq: 1 },
-				content: { _eq: 'Hello World' },
-			},
-		},
+		});
 	});
-});
 
-test('filter with a a2o relation inside _and', () => {
-	const result = filterReplaceM2A(
-		{
+	test('filter with a a2o relation inside _and', () => {
+		const result = filterReplaceM2A(
+			{
+				_and: [
+					{
+						blocks: {
+							anyitem__text: {
+								id: { _eq: 1 },
+								content: { _eq: 'Hello World' },
+							},
+						},
+					},
+				],
+			},
+			'article',
+			schema,
+		);
+
+		expect(result).toEqual({
 			_and: [
 				{
 					blocks: {
-						anyitem__text: {
+						'anyitem:text': {
 							id: { _eq: 1 },
 							content: { _eq: 'Hello World' },
 						},
 					},
 				},
 			],
-		},
-		'article',
-		schema,
-	);
+		});
+	});
 
-	expect(result).toEqual({
-		_and: [
+	test('filter with a a2o relation and wrong target collection', () => {
+		const result = filterReplaceM2A(
 			{
+				id: { _eq: 1 },
 				blocks: {
-					'anyitem:text': {
+					anyitem__wrong: {
 						id: { _eq: 1 },
 						content: { _eq: 'Hello World' },
 					},
 				},
 			},
-		],
-	});
-});
+			'article',
+			schema,
+		);
 
-test('filter with a a2o relation and wrong target collection', () => {
-	const result = filterReplaceM2A(
-		{
+		expect(result).toEqual({
 			id: { _eq: 1 },
 			blocks: {
 				anyitem__wrong: {
@@ -168,79 +182,83 @@ test('filter with a a2o relation and wrong target collection', () => {
 					content: { _eq: 'Hello World' },
 				},
 			},
-		},
-		'article',
-		schema,
-	);
-
-	expect(result).toEqual({
-		id: { _eq: 1 },
-		blocks: {
-			anyitem__wrong: {
-				id: { _eq: 1 },
-				content: { _eq: 'Hello World' },
-			},
-		},
+		});
 	});
 });
 
-test('deep with filter', () => {
-	const result = filterReplaceM2ADeep(
-		{
-			blocks: {
-				_filter: {
-					id: { _eq: 1 },
-					content: { _eq: 'Hello World' },
-				},
-			},
-		},
-		'article',
-		schema,
-	);
-
-	expect(result).toEqual({
-		blocks: {
-			_filter: {
-				id: { _eq: 1 },
-				content: { _eq: 'Hello World' },
-			},
-		},
-	});
-});
-
-test('deep with filter having a2o', () => {
-	const result = filterReplaceM2ADeep(
-		{
-			blocks: {
-				_filter: {
-					anyitem__text: {
+describe('filterReplaceM2aDeep', () => {
+	test('deep with filter', () => {
+		const result = filterReplaceM2ADeep(
+			{
+				blocks: {
+					_filter: {
 						id: { _eq: 1 },
 						content: { _eq: 'Hello World' },
 					},
 				},
 			},
-		},
-		'article',
-		schema,
-	);
+			'article',
+			schema,
+		);
 
-	expect(result).toEqual({
-		blocks: {
-			_filter: {
-				'anyitem:text': {
+		expect(result).toEqual({
+			blocks: {
+				_filter: {
 					id: { _eq: 1 },
 					content: { _eq: 'Hello World' },
 				},
 			},
-		},
+		});
 	});
-});
 
-test('deep with nested filter having a2o', () => {
-	const result = filterReplaceM2ADeep(
-		{
+	test('deep with filter having a2o', () => {
+		const result = filterReplaceM2ADeep(
+			{
+				blocks: {
+					_filter: {
+						anyitem__text: {
+							id: { _eq: 1 },
+							content: { _eq: 'Hello World' },
+						},
+					},
+				},
+			},
+			'article',
+			schema,
+		);
+
+		expect(result).toEqual({
 			blocks: {
-				anyitem__text: {
+				_filter: {
+					'anyitem:text': {
+						id: { _eq: 1 },
+						content: { _eq: 'Hello World' },
+					},
+				},
+			},
+		});
+	});
+
+	test('deep with nested filter having a2o', () => {
+		const result = filterReplaceM2ADeep(
+			{
+				blocks: {
+					anyitem__text: {
+						blocks: {
+							_filter: {
+								id: { _eq: 1 },
+							},
+						},
+					},
+				},
+			},
+			'article',
+			schema,
+		);
+
+		expect(result).toEqual({
+			blocks: {
+				'anyitem:text': {
 					blocks: {
 						_filter: {
 							id: { _eq: 1 },
@@ -248,27 +266,26 @@ test('deep with nested filter having a2o', () => {
 					},
 				},
 			},
-		},
-		'article',
-		schema,
-	);
+		});
+	});
 
-	expect(result).toEqual({
-		blocks: {
-			'anyitem:text': {
-				blocks: {
+	test('deep with filter having a2o on wrong deep', () => {
+		const result = filterReplaceM2ADeep(
+			{
+				wrong: {
 					_filter: {
-						id: { _eq: 1 },
+						anyitem__text: {
+							id: { _eq: 1 },
+							content: { _eq: 'Hello World' },
+						},
 					},
 				},
 			},
-		},
-	});
-});
+			'article',
+			schema,
+		);
 
-test('deep with filter having a2o on wrong deep', () => {
-	const result = filterReplaceM2ADeep(
-		{
+		expect(result).toEqual({
 			wrong: {
 				_filter: {
 					anyitem__text: {
@@ -277,19 +294,6 @@ test('deep with filter having a2o on wrong deep', () => {
 					},
 				},
 			},
-		},
-		'article',
-		schema,
-	);
-
-	expect(result).toEqual({
-		wrong: {
-			_filter: {
-				anyitem__text: {
-					id: { _eq: 1 },
-					content: { _eq: 'Hello World' },
-				},
-			},
-		},
+		});
 	});
 });

--- a/api/src/services/graphql/utils/filter-replace-m2a.test.ts
+++ b/api/src/services/graphql/utils/filter-replace-m2a.test.ts
@@ -29,6 +29,33 @@ describe('filterReplaceM2A', () => {
 		expect(result).toEqual({});
 	});
 
+	test('filter with aliases field', () => {
+		const result = filterReplaceM2A(
+			{
+				id: { _eq: 1 },
+				aliased_blocks: {
+					anyitem__text: {
+						id: { _eq: 1 },
+						content: { _eq: 'Hello World' },
+					},
+				},
+			},
+			'article',
+			schema,
+			{ aliasMap: { aliased_blocks: 'blocks' } },
+		);
+
+		expect(result).toEqual({
+			id: { _eq: 1 },
+			aliased_blocks: {
+				'anyitem:text': {
+					id: { _eq: 1 },
+					content: { _eq: 'Hello World' },
+				},
+			},
+		});
+	});
+
 	test('filter with no relations', () => {
 		const result = filterReplaceM2A(
 			{
@@ -187,6 +214,12 @@ describe('filterReplaceM2A', () => {
 });
 
 describe('filterReplaceM2aDeep', () => {
+	test('empty filter', () => {
+		const result = filterReplaceM2ADeep({}, 'article', { collections: {}, relations: [] });
+
+		expect(result).toEqual({});
+	});
+
 	test('deep with filter', () => {
 		const result = filterReplaceM2ADeep(
 			{
@@ -206,6 +239,88 @@ describe('filterReplaceM2aDeep', () => {
 				_filter: {
 					id: { _eq: 1 },
 					content: { _eq: 'Hello World' },
+				},
+			},
+		});
+	});
+
+	test('filter with aliased relation', () => {
+		const result = filterReplaceM2ADeep(
+			{
+				aliased_blocks: {
+					_filter: {
+						anyitem__text: {
+							id: { _eq: 1 },
+							content: { _eq: 'Hello World' },
+						},
+					},
+				},
+			},
+			'article',
+			schema,
+			{ aliasMap: { aliased_blocks: 'blocks' } },
+		);
+
+		expect(result).toEqual({
+			aliased_blocks: {
+				_filter: {
+					'anyitem:text': {
+						id: { _eq: 1 },
+						content: { _eq: 'Hello World' },
+					},
+				},
+			},
+		});
+	});
+
+	test('filter with nested aliased relation', () => {
+		const result = filterReplaceM2ADeep(
+			{
+				aliased_blocks: {
+					article_id: {
+						_alias: { aliased_blocks: 'blocks' },
+						aliased_blocks: {
+							_filter: {
+								anyitem__text: {
+									id: { _eq: 1 },
+									content: { _eq: 'Hello World' },
+								},
+							},
+						},
+					},
+					_filter: {
+						anyitem__text: {
+							id: { _eq: 1 },
+							content: { _eq: 'Hello World' },
+						},
+					},
+				},
+			},
+			'article',
+			schema,
+			{ aliasMap: { aliased_blocks: 'blocks' } },
+		);
+
+		expect(result).toEqual({
+			aliased_blocks: {
+				article_id: {
+					_alias: {
+						aliased_blocks: 'blocks',
+					},
+					aliased_blocks: {
+						_filter: {
+							'anyitem:text': {
+								id: { _eq: 1 },
+								content: { _eq: 'Hello World' },
+							},
+						},
+					},
+				},
+				_filter: {
+					'anyitem:text': {
+						id: { _eq: 1 },
+						content: { _eq: 'Hello World' },
+					},
 				},
 			},
 		});

--- a/api/src/services/graphql/utils/filter-replace-m2a.ts
+++ b/api/src/services/graphql/utils/filter-replace-m2a.ts
@@ -1,4 +1,4 @@
-import type { Filter, NestedDeepQuery, Query, SchemaOverview } from '@directus/types';
+import type { DeepQuery, Filter, NestedDeepQuery, Query, SchemaOverview } from '@directus/types';
 import { getRelation } from '@directus/utils';
 import { getRelationType } from '../../../utils/get-relation-type.js';
 
@@ -23,21 +23,21 @@ export function filterReplaceM2A(
 		const type = relation ? getRelationType({ relation, collection, field }) : null;
 
 		if (type === 'o2m' && relation) {
-			filter[key] = filterReplaceM2A(filter[key], relation.collection, schema);
+			filter[key] = filterReplaceM2A(filter[key], relation.collection, schema, options);
 		} else if (type === 'm2o' && relation) {
-			filter[key] = filterReplaceM2A(filter[key], relation.related_collection!, schema);
+			filter[key] = filterReplaceM2A(filter[key], relation.related_collection!, schema, options);
 		} else if (
 			type === 'a2o' &&
 			relation &&
 			any_collection &&
 			relation.meta?.one_allowed_collections?.includes(any_collection)
 		) {
-			filter[`${field}:${any_collection}`] = filterReplaceM2A(filter[key], any_collection, schema);
+			filter[`${field}:${any_collection}`] = filterReplaceM2A(filter[key], any_collection, schema, options);
 			delete filter[key];
 		} else if (Array.isArray(filter[key])) {
-			filter[key] = filter[key].map((item) => filterReplaceM2A(item, collection, schema));
+			filter[key] = filter[key].map((item) => filterReplaceM2A(item, collection, schema, options));
 		} else if (typeof filter[key] === 'object') {
-			filter[key] = filterReplaceM2A(filter[key], collection, schema);
+			filter[key] = filterReplaceM2A(filter[key], collection, schema, options);
 		}
 	}
 
@@ -60,7 +60,7 @@ export function filterReplaceM2ADeep(
 
 			if (!field) continue;
 
-			field = options?.aliasMap?.[field] ?? field;
+			field = options?.aliasMap?.[field] || (deep as DeepQuery)._alias?.[field] || field;
 
 			const relation = getRelation(schema.relations, collection, field);
 
@@ -69,17 +69,17 @@ export function filterReplaceM2ADeep(
 			const type = getRelationType({ relation, collection, field });
 
 			if (type === 'o2m') {
-				deep[key] = filterReplaceM2ADeep(deep[key], relation.collection, schema, options);
+				deep[key] = filterReplaceM2ADeep(deep[key], relation.collection, schema);
 			} else if (type === 'm2o') {
-				deep[key] = filterReplaceM2ADeep(deep[key], relation.related_collection!, schema, options);
+				deep[key] = filterReplaceM2ADeep(deep[key], relation.related_collection!, schema);
 			} else if (type === 'a2o' && any_collection && relation.meta?.one_allowed_collections?.includes(any_collection)) {
-				deep[`${field}:${any_collection}`] = filterReplaceM2ADeep(deep[key], any_collection, schema, options);
+				deep[`${field}:${any_collection}`] = filterReplaceM2ADeep(deep[key], any_collection, schema);
 				delete deep[key];
 			}
 		}
 
 		if (key === '_filter') {
-			deep[key] = filterReplaceM2A(deep[key], collection, schema, options);
+			deep[key] = filterReplaceM2A(deep[key], collection, schema);
 		}
 	}
 

--- a/packages/types/src/query.ts
+++ b/packages/types/src/query.ts
@@ -19,6 +19,7 @@ export type Query = {
 };
 
 export type DeepQuery = {
+	_alias?: Record<string, string> | null;
 	_fields?: string[] | null;
 	_sort?: string[] | null;
 	_filter?: Filter | null;


### PR DESCRIPTION
## Scope

What's changed:

- Aliases are now accounted for when building m2a filters
- Added missing `_alias` property in type `DeepQuery`

## Potential Risks / Drawbacks

- Some filter breaks

## Tested Scenarios

- [x] Expect m2a filter to support aliases
- [x] Expect m2a deep filter to support aliases

## Review Notes / Questions

- N/A

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #26133
