### PR TITLE
Add empty state

### DIFF
--- a/app/src/ai/components/ai-conversation.vue
+++ b/app/src/ai/components/ai-conversation.vue
@@ -2,6 +2,7 @@
 import { useAiStore } from '../stores/use-ai';
 import AiMessageList from './ai-message-list.vue';
 import AiInput from './ai-input.vue';
+import VInfo from '@/components/v-info.vue';
 
 const aiStore = useAiStore();
 </script>
@@ -15,6 +16,11 @@ const aiStore = useAiStore();
 				should-auto-scroll
 				should-scroll-to-bottom
 			/>
+
+			<VInfo v-if="aiStore.messages.length === 0" icon="smart_toy" :title="$t('ai.build_with_chat')" type="primary" class="empty-state">
+				{{ $t('ai.responses_may_be_inaccurate') }}
+			</VInfo>
+
 			<v-notice v-if="aiStore.error" multiline type="danger" class="error-notice">
 				<template #title>
 					{{ $t('ai.error') }}
@@ -82,4 +88,7 @@ const aiStore = useAiStore();
 	}
 }
 
+.empty-state {
+	margin-block-start: 30%;
+}
 </style>

--- a/app/src/components/v-info.vue
+++ b/app/src/components/v-info.vue
@@ -7,7 +7,7 @@ interface Props {
 	/** What icon to render above the title */
 	icon?: string | false;
 	/** Styling of the info */
-	type?: 'info' | 'success' | 'warning' | 'danger';
+	type?: 'info' | 'success' | 'warning' | 'danger' | 'primary';
 	/** Displays the info centered */
 	center?: boolean;
 }
@@ -66,6 +66,11 @@ withDefaults(defineProps<Props>(), {
 .danger .icon {
 	color: var(--theme--danger);
 	background-color: var(--danger-alt);
+}
+
+.primary .icon {
+	color: var(--theme--primary);
+	background-color: var(--primary-alt);
 }
 
 .title {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1680,6 +1680,8 @@ ai:
   unknown_error: Unknown Error
   prompt_input_placeholder: Type your message here...
   clear_conversation: Clear Conversation
+  build_with_chat: Build with AI Chat
+  responses_may_be_inaccurate: AI responses may be inaccurate
 mcp_prompts_collection:
   no_collection_selected: No collection selected
   no_collection_selected_copy: Select a collection to enable reusable prompt templates.


### PR DESCRIPTION
This pull request enhances the AI conversation interface by improving the empty state user experience and updating the `v-info` component to support a new styling option. The main changes include displaying a helpful message when there are no AI messages, introducing a new "primary" info type, and updating translations.

**AI Conversation UI Improvements:**

* Added a `VInfo` component to `ai-conversation.vue` that displays a "Build with AI Chat" message and a note about potential inaccuracies when the conversation is empty. [[1]](diffhunk://#diff-2b3a7ccbe47e868097cce7f2eba46e4ffaf3761267ca2bea7319889858e7af16R5) [[2]](diffhunk://#diff-2b3a7ccbe47e868097cce7f2eba46e4ffaf3761267ca2bea7319889858e7af16R19-R23)
* Styled the empty state message with a new `.empty-state` class for better visual placement.

**Component Enhancements:**

* Extended the `v-info.vue` component to support a new `type="primary"` prop and corresponding styles for primary info messages. [[1]](diffhunk://#diff-70ec4872ff116dfc436faf26df4346404e1659a99f02ef9ed279b7b7a8022229L10-R10) [[2]](diffhunk://#diff-70ec4872ff116dfc436faf26df4346404e1659a99f02ef9ed279b7b7a8022229R71-R75)

**Localization:**

* Added new translation keys for the empty state message and AI response disclaimer in the English locale.