### PR TITLE
Fix tabular view loading items after delay

### DIFF
--- a/.changeset/wild-ducks-listen.md
+++ b/.changeset/wild-ducks-listen.md
@@ -1,0 +1,5 @@
+---
+'@directus/composables': patch
+---
+
+Fixed `useItems` item list loaded after delay

--- a/.changeset/wild-ducks-listen.md
+++ b/.changeset/wild-ducks-listen.md
@@ -2,4 +2,4 @@
 '@directus/composables': patch
 ---
 
-Fixed `useItems` item list loaded after delay
+Fixed tabular view loading items after delay

--- a/packages/composables/src/use-items.test.ts
+++ b/packages/composables/src/use-items.test.ts
@@ -1,272 +1,288 @@
-import type { Field, Filter } from '@directus/types';
+import type { Filter } from '@directus/types';
 import { flushPromises } from '@vue/test-utils';
-import type { AxiosRequestConfig } from 'axios';
-import { isEqual } from 'lodash-es';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { computed, ref, unref } from 'vue';
-import { useCollection } from './use-collection.js';
+import type { AxiosInstance } from 'axios';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref, unref, type Ref } from 'vue';
 import { useItems } from './use-items.js';
+import { useApi } from './use-system.js';
 
-const mockData = { id: 1 };
-const mockCountData = { count: 2 };
-const mockCountDistinctData = { countDistinct: { id: 3 } };
+vi.mock('./use-system.js');
 
-const mockPrimaryKeyField: Field = {
-	collection: 'test_collection',
-	field: 'id',
-	name: 'id',
-	type: 'integer',
-	schema: null,
-	meta: null,
-};
-
-const mockApiGet = vi.fn();
-const mockApiPost = vi.fn();
-
-function isGetItemsRequest(config: AxiosRequestConfig) {
-	if (!config.params) return false;
-	return Object.keys(config.params).includes('fields');
-}
-
-function isTotalCountRequest(config: AxiosRequestConfig) {
-	if (!config.params) return false;
-	return isEqual(Object.keys(config.params), ['aggregate', 'filter']);
-}
-
-function isFilterCountRequest(config: AxiosRequestConfig) {
-	if (!config.params) return false;
-	return isEqual(Object.keys(config.params), ['filter', 'search', 'aggregate']);
-}
-
-vi.mock('./use-system.js', () => ({
-	useApi: vi.fn().mockImplementation(() => ({
-		get: mockApiGet.mockImplementation((_path: string, config: AxiosRequestConfig) => {
-			if (isTotalCountRequest(config) || isFilterCountRequest(config)) {
-				if (config.params.aggregate?.countDistinct) return Promise.resolve({ data: { data: [mockCountDistinctData] } });
-				return Promise.resolve({ data: { data: [mockCountData] } });
-			}
-
-			return Promise.resolve({ data: { data: [mockData] } });
-		}),
-		post: mockApiPost,
+vi.mock('./use-collection.js', () => ({
+	useCollection: vi.fn(() => ({
+		primaryKeyField: ref({ field: 'id' }),
 	})),
 }));
 
-vi.mock('./use-collection.js');
+describe('useItems', () => {
+	let mockApiGet: AxiosInstance['get'];
 
-beforeEach(() => {
-	// use fake timers to control debounce timing
-	vi.useFakeTimers();
-});
+	beforeEach(() => {
+		mockApiGet = vi.fn();
 
-afterEach(() => {
-	vi.clearAllMocks();
-});
+		vi.mocked(useApi).mockImplementation(() => ({ get: mockApiGet }) as unknown as AxiosInstance);
 
-test('should fetch filter count and total count only once', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
-
-	const { totalCount, itemCount } = useItems(ref('test_collection'), {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter: ref(null),
-		page: ref(1),
+		vi.useFakeTimers();
 	});
 
-	// advance timers past debounce delay
-	await vi.advanceTimersByTimeAsync(350);
-
-	expect(unref(totalCount)).toBe(mockCountData.count);
-	expect(unref(itemCount)).toBe(mockCountData.count);
-	expect(mockApiGet.mock.calls.filter((call) => isGetItemsRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isTotalCountRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(1);
-});
-
-test('should fetch distinct filter count and total count only once', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => mockPrimaryKeyField) } as any);
-
-	const { totalCount, itemCount } = useItems(ref('test_collection'), {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter: ref(null),
-		page: ref(1),
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+		vi.clearAllMocks();
+		vi.resetAllMocks();
 	});
 
-	// advance timers past debounce delay
-	await vi.advanceTimersByTimeAsync(350);
+	test('should call fetchItems immediately on first invocation', async () => {
+		const collection = ref('test_collection');
 
-	expect(unref(totalCount)).toBe(mockCountDistinctData.countDistinct.id);
-	expect(unref(itemCount)).toBe(mockCountDistinctData.countDistinct.id);
-	expect(mockApiGet.mock.calls.filter((call) => isGetItemsRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isTotalCountRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(1);
-});
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-test('should not re-fetch filter count when changing fields query', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
+		const query = {
+			fields: ref(['id', 'name']),
+			limit: ref(25),
+			sort: ref(['id']),
+			search: ref(''),
+			filter: ref({}),
+			page: ref(1),
+		};
 
-	const fields = ref(['*']);
+		await useItems(collection, query);
 
-	useItems(ref('test_collection'), {
-		fields,
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter: ref(null),
-		page: ref(1),
+		// Should only call once immediately (items, count, total)
+		expect(mockApiGet).toHaveBeenCalledTimes(3);
 	});
 
-	// advance timers for initial fetch
-	await vi.advanceTimersByTimeAsync(350);
+	test('should throttle multiple rapid changes to query parameters', async () => {
+		const collection = ref('test_collection');
 
-	// update fields query
-	fields.value = ['id'];
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-	// advance timers for second fetch
-	await vi.advanceTimersByTimeAsync(350);
+		const query = {
+			fields: ref(['id', 'name']),
+			limit: ref(25),
+			sort: ref(['id']),
+			search: ref(''),
+			filter: ref({}),
+			page: ref(1),
+		};
 
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(1);
-});
+		await useItems(collection, query);
 
-test('should re-fetch filter count when changing filters query', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
+		// Should only call once immediately (items, count, total)
+		expect(mockApiGet).toHaveBeenCalledTimes(3);
 
-	const filter = ref<Filter | null>(null);
+		// Trigger multiple rapid changes
+		query.search.value = 'test1';
+		query.search.value = 'test2';
+		query.search.value = 'test3';
 
-	useItems(ref('test_collection'), {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter,
-		page: ref(1),
+		// Fast-forward past throttle delay (500ms)
+		await vi.advanceTimersByTimeAsync(500);
+
+		// Should have been called once due to throttle (items(2), count(2), total(1))
+		expect(mockApiGet).toHaveBeenCalledTimes(5);
 	});
 
-	// advance timers for initial fetch
-	await vi.advanceTimersByTimeAsync(350);
+	test('should allow subsequent calls after throttle period expires', async () => {
+		const collection = ref('test_collection');
 
-	// update filter query
-	filter.value = { id: { _eq: 1 } };
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-	// advance timers for second fetch
-	await vi.advanceTimersByTimeAsync(350);
+		const query = {
+			fields: ref(['id', 'name']),
+			limit: ref(25),
+			sort: ref(['id']),
+			search: ref(''),
+			filter: ref({}),
+			page: ref(1),
+		};
 
-	expect(mockApiGet.mock.calls.filter((call) => isTotalCountRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(2);
-});
+		await useItems(collection, query);
 
-test('should re-fetch total count when changing system filter', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
+		// Should only call once immediately (items, count, total)
+		expect(mockApiGet).toHaveBeenCalledTimes(3);
 
-	const filterSystem = ref<Filter | null>(null);
+		// First change
+		query.search.value = 'first';
+		await vi.advanceTimersByTimeAsync(500);
+		// Should have been called once due to throttle (items(2), count(2), total(1))
+		expect(mockApiGet).toHaveBeenCalledTimes(5);
 
-	useItems(ref('test_collection'), {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter: ref(null),
-		filterSystem,
-		page: ref(1),
+		// Wait for throttle to reset
+		await vi.advanceTimersByTimeAsync(100);
+
+		// Second change after throttle period
+		query.search.value = 'second';
+		await vi.advanceTimersByTimeAsync(500);
+		// Should have been called once due to throttle (items(3), count(3), total(1))
+		expect(mockApiGet).toHaveBeenCalledTimes(7);
 	});
 
-	// advance timers for initial fetch
-	await vi.advanceTimersByTimeAsync(350);
+	test('should NOT call getItemCount if only limit changes', async () => {
+		const collection = ref('test_collection');
 
-	// update filter query
-	filterSystem.value = { id: { _eq: 1 } };
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-	// system filter change is not debounced, just flush promises
-	await flushPromises();
+		const limit = ref(1);
 
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isTotalCountRequest(call[1])).length).toBe(2);
-});
+		const query = {
+			fields: ref(['id', 'name']),
+			limit,
+			sort: ref(['id']),
+			search: ref(''),
+			filter: ref({}),
+			page: ref(1),
+		};
 
-test('should re-fetch filter count when changing search query', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
+		await useItems(collection, query);
 
-	const search = ref<string | null>(null);
+		// Should only call once immediately (items, count, total)
+		expect(mockApiGet).toHaveBeenCalledTimes(3);
 
-	useItems(ref('test_collection'), {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search,
-		filter: ref(null),
-		page: ref(1),
+		limit.value = 5;
+
+		// Fast-forward past throttle delay (500ms)
+		await vi.advanceTimersByTimeAsync(500);
+
+		// Should have been called once due to throttle (items(2), count(1), total(1))
+		expect(mockApiGet).toHaveBeenCalledTimes(4);
 	});
 
-	// advance timers for initial fetch
-	await vi.advanceTimersByTimeAsync(350);
+	test('should reset limit to 1 if filter changes', async () => {
+		const collection = ref('test_collection');
 
-	// update search query
-	search.value = 'test';
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-	// advance timers for second fetch
-	await vi.advanceTimersByTimeAsync(350);
+		const filter: Ref<null | Filter> = ref(null);
 
-	expect(mockApiGet.mock.calls.filter((call) => isTotalCountRequest(call[1])).length).toBe(1);
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(2);
-});
+		useItems(collection, {
+			fields: ref(['*']),
+			limit: ref(1),
+			sort: ref(null),
+			search: ref(null),
+			filter,
+			page: ref(5),
+		});
 
-test('should reset when collection changes', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
+		filter.value = { id: { _eq: 1 } };
 
-	const collection = ref('old_collection');
+		// advance throttle
+		await vi.advanceTimersByTimeAsync(500);
 
-	const { items } = useItems(collection, {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter: ref(null),
-		page: ref(1),
+		expect(mockApiGet).toHaveBeenCalledWith(
+			'/items/test_collection',
+			expect.objectContaining({
+				params: expect.objectContaining({
+					page: 1,
+				}),
+			}),
+		);
 	});
 
-	// Wait until computed values are updated
-	await flushPromises();
-	// advance timers for initial fetch
-	await vi.advanceTimersByTimeAsync(350);
+	test('should reset when collection changes', async () => {
+		const collection = ref('old_collection');
 
-	expect(unref(items)).toEqual([mockData]);
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-	// update collection ref
-	collection.value = 'new_collection';
+		useItems(collection, {
+			fields: ref(['*']),
+			limit: ref(1),
+			sort: ref(null),
+			search: ref(null),
+			filter: ref(null),
+			page: ref(1),
+		});
 
-	// Wait until computed values are updated again
-	await flushPromises();
+		expect(mockApiGet).toHaveBeenCalledWith('/items/old_collection', expect.any(Object));
 
-	expect(unref(items)).toEqual([]);
+		// update collection ref
+		collection.value = 'new_collection';
 
-	// advance timers for second fetch
-	await vi.advanceTimersByTimeAsync(350);
+		// advance throttle
+		await vi.advanceTimersByTimeAsync(500);
 
-	expect(mockApiGet.mock.calls.filter((call) => isTotalCountRequest(call[1])).length).toBe(2);
-	expect(mockApiGet.mock.calls.filter((call) => isFilterCountRequest(call[1])).length).toBe(2);
-});
-
-test('should append $thumbnail to fetched items when collection is directus_files', async () => {
-	vi.mocked(useCollection).mockReturnValueOnce({ primaryKeyField: computed(() => null) } as any);
-
-	const collection = ref('directus_files');
-
-	const { items } = useItems(collection, {
-		fields: ref(['*']),
-		limit: ref(1),
-		sort: ref(null),
-		search: ref(null),
-		filter: ref(null),
-		page: ref(1),
+		expect(mockApiGet).toHaveBeenCalledWith('/items/new_collection', expect.any(Object));
 	});
 
-	// advance timers past debounce delay
-	await vi.advanceTimersByTimeAsync(350);
+	test('should append $thumbnail to fetched items when collection is directus_files', async () => {
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 1,
+						countDistinct: { id: 1 },
+					},
+				],
+			},
+		});
 
-	expect(unref(items)).toEqual([{ id: mockData.id, $thumbnail: mockData }]);
+		const collection = ref('directus_files');
+
+		const { items } = useItems(collection, {
+			fields: ref(['*']),
+			limit: ref(1),
+			sort: ref(null),
+			search: ref(null),
+			filter: ref(null),
+			page: ref(1),
+		});
+
+		await flushPromises();
+
+		expect(unref(items.value[0]?.['$thumbnail'])).toBeOneOf([expect.any(Object)]);
+	});
 });

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -72,6 +72,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
+	// Throttle is used to ensure we send the first trigger instantly, debounce will not.
 	const fetchItems = throttle((shouldUpdateCount: boolean) => {
 		Promise.all([getItems(), shouldUpdateCount ? getItemCount() : Promise.resolve()]);
 	}, 500);

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -1,7 +1,7 @@
 import type { Item, Query } from '@directus/types';
 import { getEndpoint, moveInArray } from '@directus/utils';
 import axios from 'axios';
-import { debounce, isEqual } from 'lodash-es';
+import { isEqual, throttle } from 'lodash-es';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
 import { computed, ref, toRef, unref, watch } from 'vue';
 import { useCollection } from './use-collection.js';
@@ -72,9 +72,9 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
-	const fetchItems = debounce((shouldUpdateCount: boolean) => {
+	const fetchItems = throttle((shouldUpdateCount: boolean) => {
 		Promise.all([getItems(), shouldUpdateCount ? getItemCount() : Promise.resolve()]);
-	}, 350);
+	}, 500);
 
 	watch(
 		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep)],


### PR DESCRIPTION
## Scope

What's changed:

- Prefer throttle over debounce to ensure we always send that first request instantly.
- Updated the throttle back to 500ms as did not see a reasoning for the reduction to 350


### Before

https://github.com/user-attachments/assets/c29b8c75-321d-40e9-8732-223e3749aa1a


### After

https://github.com/user-attachments/assets/898d2862-51a7-42ca-b532-9aa901d44637



## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios

- [x] Expect app to render table list instantly
- [x] Expect search bar to succeed

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required

---

Fixes #26153
