### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,8 +23,8 @@ body:
       label: To Reproduce
       description:
         Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce
-        the bug. If applicable, include any relevant database logs, permission configurations, or a schema snapshot
-        (exported from **Settings > Data Model**) as attachments.
+        the bug. Please include any relevant details that could help with reproduction, such as browser/server/database
+        logs, permission setup, or a schema snapshot (exported from **Settings > Data Model**) as attachments.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
       description:
         Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce
         the bug. Please include any relevant details that could help with reproduction, such as browser/server/database
-        logs, permission setup, or a schema snapshot (exported from **Settings > Data Model**) as attachments.
+        logs, permission setup, schema snapshot (exported from **Settings > Data Model**) etc.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,8 @@ body:
       label: To Reproduce
       description:
         Steps to reproduce the behavior. Contributors should be able to follow the steps provided in order to reproduce
-        the bug. If applicable, export and attach a schema snapshot from **Settings > Data Model** sidebar.```
+        the bug. If applicable, include any relevant database logs, permission configurations, or a schema snapshot
+        (exported from **Settings > Data Model**) as attachments.
     validations:
       required: true
   - type: input


### PR DESCRIPTION
## Scope

What's changed:

- updated the GitHub bug report template for improved clarity and user guidance
- also removed the unintentional ```