### PR TITLE
AI -> Fix failed tool calls

### DIFF
--- a/api/src/ai/chat/controllers/chat.post.test.ts
+++ b/api/src/ai/chat/controllers/chat.post.test.ts
@@ -195,14 +195,13 @@ describe('aiChatPostHandler', () => {
 				tools: [],
 			};
 
-			await expect(aiChatPostHandler(mockReq as Request, mockRes as Response, vi.fn())).rejects.toThrow(
-				InvalidPayloadError,
-			);
+		await expect(aiChatPostHandler(mockReq as Request, mockRes as Response, vi.fn())).rejects.toThrow(
+			InvalidPayloadError,
+		);
 
-			expect(vi.mocked(safeValidateUIMessages)).toHaveBeenCalledWith({
-				messages: [{ role: 'invalid', content: 'test' }],
-				tools: {},
-			});
+		expect(vi.mocked(safeValidateUIMessages)).toHaveBeenCalledWith({
+			messages: [{ role: 'invalid', content: 'test' }],
+		});
 		});
 
 		it('should call safeValidateUIMessages with correct messages', async () => {
@@ -218,10 +217,10 @@ describe('aiChatPostHandler', () => {
 				tools: [],
 			};
 
-			await aiChatPostHandler(mockReq as Request, mockRes as Response, vi.fn());
+		await aiChatPostHandler(mockReq as Request, mockRes as Response, vi.fn());
 
-			expect(vi.mocked(safeValidateUIMessages)).toHaveBeenCalledWith({ messages, tools: {} });
-		});
+		expect(vi.mocked(safeValidateUIMessages)).toHaveBeenCalledWith({ messages });
+	});
 	});
 
 	describe('api keys handling', () => {
@@ -287,10 +286,9 @@ describe('aiChatPostHandler', () => {
 				custom: { name: 'custom', mocked: true },
 			};
 
-			expect(vi.mocked(safeValidateUIMessages)).toHaveBeenCalledWith({
-				messages: [{ role: 'user', content: 'Hello' }],
-				tools: expectedTools,
-			});
+		expect(vi.mocked(safeValidateUIMessages)).toHaveBeenCalledWith({
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
 
 			expect(vi.mocked(createUiStream)).toHaveBeenCalledWith(expect.any(Array), {
 				provider: 'openai',

--- a/api/src/ai/chat/controllers/chat.post.ts
+++ b/api/src/ai/chat/controllers/chat.post.ts
@@ -5,6 +5,7 @@ import { fromZodError } from 'zod-validation-error';
 import { createUiStream } from '../lib/create-ui-stream.js';
 import { ChatRequest } from '../models/chat-request.js';
 import { chatRequestToolToAiSdkTool } from '../utils/chat-request-tool-to-ai-sdk-tool.js';
+import { fixErrorToolCalls } from '../utils/fix-error-tool-calls.js';
 
 export const aiChatPostHandler: RequestHandler = async (req, res) => {
 	if (!req.accountability) {
@@ -30,7 +31,8 @@ export const aiChatPostHandler: RequestHandler = async (req, res) => {
 		return acc;
 	}, {});
 
-	const validationResult = await safeValidateUIMessages({ messages: rawMessages, tools: tools });
+	const fixedMessages = fixErrorToolCalls(rawMessages);
+	const validationResult = await safeValidateUIMessages({ messages: fixedMessages });
 
 	if (validationResult.success === false) {
 		throw new InvalidPayloadError({ reason: validationResult.error.message });

--- a/api/src/ai/chat/lib/create-ui-stream.ts
+++ b/api/src/ai/chat/lib/create-ui-stream.ts
@@ -45,7 +45,9 @@ export const createUiStream = (
 		stopWhen: [stepCountIs(10)],
 		providerOptions: {
 			openai: {
-				reasoningSummary: 'detailed',
+				reasoningSummary: 'auto',
+				store: false,
+				include: ['reasoning.encrypted_content'],
 			},
 		},
 		tools,

--- a/api/src/ai/chat/utils/fix-error-tool-calls.test.ts
+++ b/api/src/ai/chat/utils/fix-error-tool-calls.test.ts
@@ -318,6 +318,44 @@ describe('fixErrorToolCalls', () => {
 		]);
 	});
 
+	it('handles error tool call with input set to null explicitly', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_null',
+						toolName: 'test-tool',
+						rawInput: { should: 'copy' },
+						input: null,
+						errorText: 'Error',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual([
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_null',
+						toolName: 'test-tool',
+						rawInput: { should: 'copy' },
+						input: { should: 'copy' },
+						errorText: 'Error',
+					},
+				],
+			},
+		]);
+	});
+
 	it('handles complex nested rawInput objects', () => {
 		const messages = [
 			{

--- a/api/src/ai/chat/utils/fix-error-tool-calls.test.ts
+++ b/api/src/ai/chat/utils/fix-error-tool-calls.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, it } from 'vitest';
+import { fixErrorToolCalls } from './fix-error-tool-calls.js';
+
+describe('fixErrorToolCalls', () => {
+	it('copies rawInput to input for error tool call without input', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_123',
+						toolName: 'test-tool',
+						rawInput: { foo: 'bar' },
+						errorText: 'Something went wrong',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual([
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_123',
+						toolName: 'test-tool',
+						rawInput: { foo: 'bar' },
+						input: { foo: 'bar' },
+						errorText: 'Something went wrong',
+					},
+				],
+			},
+		]);
+	});
+
+	it('does not modify error tool call that already has input', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_456',
+						toolName: 'test-tool',
+						rawInput: { raw: 'data' },
+						input: { existing: 'input' },
+						errorText: 'Error occurred',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('does not modify error tool call with only input (no rawInput)', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_789',
+						toolName: 'test-tool',
+						input: { only: 'input' },
+						errorText: 'Error message',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('does not modify successful tool call', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-output',
+						state: 'output-available',
+						toolCallId: 'call_success',
+						toolName: 'test-tool',
+						output: { result: 'success' },
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('does not modify tool call without state field', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						toolCallId: 'call_in_progress',
+						toolName: 'test-tool',
+						input: { pending: 'data' },
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('fixes multiple error tool calls in single assistant message', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_1',
+						toolName: 'tool-1',
+						rawInput: { data: 1 },
+						errorText: 'Error 1',
+					},
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_2',
+						toolName: 'tool-2',
+						rawInput: { data: 2 },
+						errorText: 'Error 2',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual([
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_1',
+						toolName: 'tool-1',
+						rawInput: { data: 1 },
+						input: { data: 1 },
+						errorText: 'Error 1',
+					},
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_2',
+						toolName: 'tool-2',
+						rawInput: { data: 2 },
+						input: { data: 2 },
+						errorText: 'Error 2',
+					},
+				],
+			},
+		]);
+	});
+
+	it('handles assistant message with mixed parts', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'text',
+						text: 'Let me help you with that',
+					},
+					{
+						type: 'reasoning',
+						reasoning: 'I need to call a tool',
+					},
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_error',
+						toolName: 'error-tool',
+						rawInput: { x: 1 },
+						errorText: 'Failed',
+					},
+					{
+						type: 'tool-output',
+						state: 'output-available',
+						toolCallId: 'call_success',
+						toolName: 'success-tool',
+						output: { y: 2 },
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual([
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'text',
+						text: 'Let me help you with that',
+					},
+					{
+						type: 'reasoning',
+						reasoning: 'I need to call a tool',
+					},
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_error',
+						toolName: 'error-tool',
+						rawInput: { x: 1 },
+						input: { x: 1 },
+						errorText: 'Failed',
+					},
+					{
+						type: 'tool-output',
+						state: 'output-available',
+						toolCallId: 'call_success',
+						toolName: 'success-tool',
+						output: { y: 2 },
+					},
+				],
+			},
+		]);
+	});
+
+	it('does not modify user message', () => {
+		const messages = [
+			{
+				role: 'user',
+				content: 'Hello, how are you?',
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('returns empty array for empty messages array', () => {
+		const messages = [] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual([]);
+	});
+
+	it('does not modify message without parts field', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				content: 'This is a simple response',
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('handles error tool call with input set to undefined explicitly', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_undefined',
+						toolName: 'test-tool',
+						rawInput: { should: 'copy' },
+						input: undefined,
+						errorText: 'Error',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual([
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_undefined',
+						toolName: 'test-tool',
+						rawInput: { should: 'copy' },
+						input: { should: 'copy' },
+						errorText: 'Error',
+					},
+				],
+			},
+		]);
+	});
+
+	it('handles complex nested rawInput objects', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_complex',
+						toolName: 'complex-tool',
+						rawInput: {
+							nested: {
+								data: [1, 2, 3],
+								obj: { key: 'value' },
+							},
+							array: ['a', 'b', 'c'],
+						},
+						errorText: 'Complex error',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result[0]?.parts?.[0]).toHaveProperty('input', {
+			nested: {
+				data: [1, 2, 3],
+				obj: { key: 'value' },
+			},
+			array: ['a', 'b', 'c'],
+		});
+	});
+
+	it('does not modify non-tool part types', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'text',
+						text: 'Some text',
+					},
+					{
+						type: 'image',
+						url: 'https://example.com/image.png',
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result).toEqual(messages);
+	});
+
+	it('handles multiple messages with mixed scenarios', () => {
+		const messages = [
+			{
+				role: 'user',
+				content: 'User message',
+			},
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-input-available',
+						state: 'output-error',
+						toolCallId: 'call_1',
+						toolName: 'tool-1',
+						rawInput: { fix: 'me' },
+						errorText: 'Error 1',
+					},
+				],
+			},
+			{
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-output',
+						state: 'output-available',
+						toolCallId: 'call_2',
+						toolName: 'tool-2',
+						output: { success: true },
+					},
+				],
+			},
+		] as const;
+
+		const result = fixErrorToolCalls(messages as any);
+
+		expect(result[0]).toEqual(messages[0]);
+		expect(result[1]?.parts?.[0]).toHaveProperty('input', { fix: 'me' });
+		expect(result[2]).toEqual(messages[2]);
+	});
+});

--- a/api/src/ai/chat/utils/fix-error-tool-calls.ts
+++ b/api/src/ai/chat/utils/fix-error-tool-calls.ts
@@ -1,0 +1,37 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * Fixes tool calls with error states by copying rawInput to input field.
+ * This is required because error tool calls from the frontend use rawInput
+ * but the AI SDK's convertToModelMessages expects input to generate arguments
+ * for the OpenAI API.
+ * @param messages - Array of message objects from the chat request
+ * @returns Messages with error tool calls fixed, typed as UIMessage[]
+ */
+export const fixErrorToolCalls = (messages: { [x: string]: unknown }[]): UIMessage[] => {
+	return messages.map((msg) => {
+		if (msg['role'] === 'assistant' && msg['parts'] && Array.isArray(msg['parts'])) {
+			const fixedParts = (msg['parts'] as unknown[]).map((part) => {
+				if (
+					typeof part === 'object' &&
+					part !== null &&
+					'type' in part &&
+					typeof part.type === 'string' &&
+					part.type.startsWith('tool-') &&
+					'state' in part &&
+					part.state === 'output-error' &&
+					'rawInput' in part &&
+					!('input' in part && part.input !== undefined)
+				) {
+					return { ...part, input: part.rawInput };
+				}
+
+				return part;
+			});
+
+			return { ...msg, parts: fixedParts };
+		}
+
+		return msg;
+	}) as unknown as UIMessage[];
+};

--- a/api/src/ai/chat/utils/fix-error-tool-calls.ts
+++ b/api/src/ai/chat/utils/fix-error-tool-calls.ts
@@ -21,7 +21,7 @@ export const fixErrorToolCalls = (messages: { [x: string]: unknown }[]): UIMessa
 					'state' in part &&
 					part.state === 'output-error' &&
 					'rawInput' in part &&
-					!('input' in part && part.input !== undefined)
+					(!('input' in part) || part.input == null)
 				) {
 					return { ...part, input: part.rawInput };
 				}


### PR DESCRIPTION
This pull request improves the handling of tool call errors in chat messages and updates provider options for OpenAI requests. The main changes include introducing a utility to fix error tool calls before validation and refining the configuration for OpenAI chat streams.

**Error handling improvements:**

* Added a new utility function `fixErrorToolCalls` in `fix-error-tool-calls.ts` to automatically copy `rawInput` to the `input` field for tool calls with error states, ensuring compatibility with the AI SDK's message conversion.
* Updated `aiChatPostHandler` in `chat.post.ts` to preprocess incoming messages with `fixErrorToolCalls` before validation, improving robustness when handling error tool calls from the frontend. [[1]](diffhunk://#diff-ad3058ca5cba1112d57bc8b535cf793f8f211a9aa92ad96299ada6546830c99bR8) [[2]](diffhunk://#diff-ad3058ca5cba1112d57bc8b535cf793f8f211a9aa92ad96299ada6546830c99bL33-R35)

**OpenAI provider configuration:**

* Modified `createUiStream` in `create-ui-stream.ts` to set `reasoningSummary` to `'auto'`, disable storing, and include only `reasoning.encrypted_content` in the OpenAI provider options, optimizing the data sent and received.