### PR TITLE
AI -> Fix Items Prompt

### DIFF
--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -53,7 +53,7 @@ const ItemsInputSchema = z.object({
 	collection: z.string().describe('The name of the collection'),
 	query: QueryInputSchema.optional(),
 	keys: z.array(PrimaryKeyInputSchema).optional(),
-	data: z.array(ItemInputSchema).optional(),
+	data: z.array(ItemInputSchema).optional().describe('Always an array of objects'),
 });
 
 export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({

--- a/api/src/ai/tools/items/prompt.md
+++ b/api/src/ai/tools/items/prompt.md
@@ -3,7 +3,7 @@ Perform CRUD operations on items within Directus collections
 ## Actions
 
 - `read`: Query items with filtering/pagination/field selection
-- `create`: Add items (single/batch) with nested relations
+- `create`: Add items with nested relations
 - `update`: Modify items with partial data
 - `delete`: Remove items by primary keys
 
@@ -59,12 +59,12 @@ Core: `_eq`, `_neq`, `_in`, `_nin`, `_null`, `_nnull`, `_lt`, `_lte`, `_gt`, `_g
 {
 	"action": "create",
 	"collection": "posts",
-	"data": {
+	"data": [{
 		"title": "New Post",
 		"author": { "name": "John Doe", "email": "john@example.com" }, // Creates nested
 		"categories": [1, 2, { "name": "New Category" }], // Mix existing + new
 		"status": "draft"
-	}
+	}]
 }
 ```
 
@@ -97,7 +97,7 @@ Core: `_eq`, `_neq`, `_in`, `_nin`, `_null`, `_nnull`, `_lt`, `_lte`, `_gt`, `_g
 	"action": "update",
 	"collection": "posts",
 	"keys": ["uuid-1", "uuid-2"],
-	"data": { "status": "published" } // Partial update
+	"data": [{ "status": "published" }] // Partial update
 }
 ```
 
@@ -121,13 +121,13 @@ Core: `_eq`, `_neq`, `_in`, `_nin`, `_null`, `_nnull`, `_lt`, `_lte`, `_gt`, `_g
 	"action": "update",
 	"collection": "posts",
 	"keys": ["uuid-1"],
-	"data": {
+	"data": [{
 		"categories": {
 			"create": [{ "name": "New Category" }],
 			"update": [{ "id": 3, "name": "Renamed" }],
 			"delete": [5]
 		}
-	}
+	}]
 }
 ```
 
@@ -137,7 +137,7 @@ Core: `_eq`, `_neq`, `_in`, `_nin`, `_null`, `_nnull`, `_lt`, `_lte`, `_gt`, `_g
 // Don't update without specifying which items
 {
 	"action": "update",
-	"data": { "status": "published" } // Will fail - no keys provided
+	"data": [{ "status": "published" }] // Will fail - no keys provided
 }
 ```
 


### PR DESCRIPTION
This pull request standardizes the handling of the `data` property for item CRUD operations in Directus AI tools, ensuring it is always treated as an array of objects. It updates both the schema and documentation to reflect this, and also introduces a small improvement to the AI store in the frontend by persisting the chat open state in local storage.

**Backend and Documentation Consistency:**

* The `data` property in the `ItemsInputSchema` is now always an array of objects, with an updated description to clarify this requirement.
* All relevant API documentation and usage examples in `prompt.md` have been updated to use an array for `data` in `create` and `update` actions, improving clarity and preventing ambiguity. [[1]](diffhunk://#diff-12db8a1768ffeaf6e94c8125b9d53039d040e33138164a01d37bae894ff4cc48L62-R67) [[2]](diffhunk://#diff-12db8a1768ffeaf6e94c8125b9d53039d040e33138164a01d37bae894ff4cc48L100-R100) [[3]](diffhunk://#diff-12db8a1768ffeaf6e94c8125b9d53039d040e33138164a01d37bae894ff4cc48L124-R130) [[4]](diffhunk://#diff-12db8a1768ffeaf6e94c8125b9d53039d040e33138164a01d37bae894ff4cc48L140-R140)
* The action description for `create` in the documentation was simplified to clarify that batch and single item creation are both supported via an array.