### PR TITLE
Add copy button to list interface items

### DIFF
--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -2,7 +2,7 @@
 import { renderStringTemplate } from '@/utils/render-string-template';
 import formatTitle from '@directus/format-title';
 import { DeepPartial, Field, FieldMeta } from '@directus/types';
-import { isEqual, sortBy } from 'lodash';
+import { cloneDeep, isEqual, sortBy } from 'lodash';
 import { computed, ref, toRefs } from 'vue';
 import Draggable from 'vuedraggable';
 
@@ -155,6 +155,28 @@ function removeItem(item: Record<string, any>) {
 	}
 }
 
+function copyItem(item: Record<string, any>, index: number) {
+	if (!value.value || !Array.isArray(internalValue.value)) return;
+
+	// Check limit
+	if (props.limit !== undefined && internalValue.value.length >= props.limit) {
+		return;
+	}
+
+	// Create a deep copy of the item
+	const copiedItem = cloneDeep(item);
+
+	// Insert the copied item right after the original
+	const newValue = [...internalValue.value];
+	newValue.splice(index + 1, 0, copiedItem);
+
+	if (props.fields && props.sort) {
+		emitValue(sortBy(newValue, props.sort));
+	} else {
+		emitValue(newValue);
+	}
+}
+
 function addNew() {
 	isNewItem.value = true;
 
@@ -232,6 +254,13 @@ function closeDrawer() {
 					<div class="spacer" />
 
 					<div class="item-actions">
+						<v-icon
+							v-if="!disabled"
+							v-tooltip="$t('duplicate')"
+							name="content_copy"
+							clickable
+							@click.stop="copyItem(element, index)"
+						/>
 						<v-remove v-if="!disabled" confirm @action="removeItem(element)" />
 					</div>
 				</v-list-item>


### PR DESCRIPTION
## Summary
This PR adds a copy button to the list interface that allows users to duplicate items.

<img width="805" height="205" alt="Screenshot 2025-11-17 at 11 21 21" src="https://github.com/user-attachments/assets/42b3390a-5f05-48f7-afbc-639bf265a0c5" />

## Changes
- Added `copyItem` function that creates a deep copy of an item and inserts it after the original
- Added copy button with `content_copy` icon next to the remove button
- Respects the `disabled` prop and limit constraints
- Handles sorting when configured

## Testing
- [ ] Tested copying items in list interface
- [ ] Verified limit constraints are respected
- [ ] Confirmed disabled state prevents copying
- [ ] Tested with sorted lists

Fixes: #<!-- Add issue number if applicable -->