### PR TITLE
Fixed `_by_id` querying with M2A filters in GraphQL

### DIFF
--- a/.changeset/forty-wombats-wash.md
+++ b/.changeset/forty-wombats-wash.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed `_by_id` and `_by_version` querying with M2A filters in Graphql
+Fixed `_by_id` querying with M2A filters in Graphql

--- a/.changeset/forty-wombats-wash.md
+++ b/.changeset/forty-wombats-wash.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed `_by_id` querying with M2A filters in Graphql
+Fixed `_by_id` querying with M2A filters in GraphQL

--- a/.changeset/forty-wombats-wash.md
+++ b/.changeset/forty-wombats-wash.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `_by_id` and `_by_version` querying with M2A filters in Graphql

--- a/api/src/services/graphql/resolvers/query.test.ts
+++ b/api/src/services/graphql/resolvers/query.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { parseArgs } from '../schema/parse-args.js';
+import { getQuery } from '../schema/parse-query.js';
+import { getAggregateQuery } from '../utils/aggregate-query.js';
+import { replaceFragmentsInSelections } from '../utils/replace-fragments.js';
+import { resolveQuery } from './query.js';
+
+vi.mock('../utils/replace-fragments.js');
+vi.mock('../schema/parse-args.js');
+vi.mock('../utils/aggregate-query.js');
+vi.mock('../schema/parse-query.js');
+
+describe('resolveQuery', () => {
+	const mockReplaceFragments = vi.fn();
+	const mockParseArgs = vi.fn();
+	const mockGetAggregateQuery = vi.fn();
+	const mockGetQuery = vi.fn();
+
+	beforeEach(() => {
+		vi.mocked(replaceFragmentsInSelections).mockImplementation(mockReplaceFragments);
+		vi.mocked(parseArgs).mockImplementation(mockParseArgs);
+		vi.mocked(getAggregateQuery).mockImplementation(mockGetAggregateQuery);
+		vi.mocked(getQuery).mockImplementation(mockGetQuery);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.resetAllMocks();
+		vi.restoreAllMocks();
+	});
+
+	test('system scope prefixes collection with directus_', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({});
+
+		mockGetQuery.mockResolvedValue({
+			fields: [],
+		});
+
+		const gql: any = {
+			scope: 'system',
+			schema: { collections: {} },
+			accountability: {},
+			read: vi.fn(() => []),
+		};
+
+		const info: any = {
+			fieldName: 'users',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		await resolveQuery(gql, info);
+
+		expect(mockGetQuery).toHaveBeenCalled();
+		const lastCallArgs = mockGetQuery.mock.calls[mockGetQuery.mock.calls.length - 1];
+		const collectionArg = lastCallArgs?.[lastCallArgs.length - 1];
+		expect(collectionArg).toBe('directus_users');
+	});
+
+	test('returns null when selections are missing', async () => {
+		mockReplaceFragments.mockReturnValue(null);
+
+		const gql: any = {
+			scope: 'app',
+			schema: { collections: {} },
+			accountability: {},
+			read: vi.fn(),
+		};
+
+		const info: any = {
+			fieldName: 'posts',
+			fieldNodes: [{ selectionSet: undefined }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		const res = await resolveQuery(gql, info);
+
+		expect(res).toBeNull();
+		expect(mockParseArgs).not.toHaveBeenCalled();
+	});
+
+	test('aggregate branch calls getAggregateQuery with correct collection name', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({ id: 'id' });
+
+		mockGetAggregateQuery.mockReturnValue({
+			fields: [],
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: {
+				collections: {},
+			},
+			accountability: {},
+			read: vi.fn(),
+		};
+
+		const info: any = {
+			fieldName: 'posts_aggregated',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		await resolveQuery(gql, info);
+
+		const lastCallArgs = mockGetAggregateQuery.mock.calls[mockGetAggregateQuery.mock.calls.length - 1];
+		const collectionArg = lastCallArgs?.[lastCallArgs.length - 1];
+		expect(collectionArg).toBe('posts');
+	});
+
+	test('query by id calls getQuery with correct collection name', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({ id: 'abc' });
+
+		mockGetQuery.mockReturnValue({
+			fields: [],
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: {
+				collections: {},
+			},
+			accountability: {},
+			read: vi.fn(),
+		};
+
+		const info: any = {
+			fieldName: 'posts_by_id',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		await resolveQuery(gql, info);
+
+		expect(mockGetQuery).toHaveBeenCalled();
+		const lastCallArgs = mockGetQuery.mock.calls[mockGetQuery.mock.calls.length - 1];
+		const collectionArg = lastCallArgs?.[lastCallArgs.length - 1];
+		expect(collectionArg).toBe('posts');
+	});
+
+	test('query by version calls getQuery with correct collection name', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({ id: 'abc' });
+
+		mockGetQuery.mockReturnValue({
+			fields: [],
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: {
+				collections: {},
+			},
+			accountability: {},
+			read: vi.fn(),
+		};
+
+		const info: any = {
+			fieldName: 'posts_by_version',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		await resolveQuery(gql, info);
+
+		expect(mockGetQuery).toHaveBeenCalled();
+		const lastCallArgs = mockGetQuery.mock.calls[mockGetQuery.mock.calls.length - 1];
+		const collectionArg = lastCallArgs?.[lastCallArgs.length - 1];
+		expect(collectionArg).toBe('posts');
+	});
+
+	test('query by version injects versionRaw to query', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({ id: 'abc' });
+
+		mockGetQuery.mockReturnValue({
+			fields: [],
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: {
+				collections: {},
+			},
+			accountability: {},
+			read: vi.fn(),
+		};
+
+		const info: any = {
+			fieldName: 'posts_by_version',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		await resolveQuery(gql, info);
+
+		expect(gql.read).toHaveBeenCalled();
+		const lastCallArgs = gql.read.mock.calls[gql.read.mock.calls.length - 1];
+		const queryArg = lastCallArgs?.[1];
+		expect(queryArg).toEqual(expect.objectContaining({ versionRaw: true }));
+	});
+
+	test('parseFilterFunctionPath is called for each field', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({ id: 'abc' });
+
+		mockGetAggregateQuery.mockResolvedValue({
+			fields: ['count(a)', 'sum(b.c)', 'max(c.d.e)'],
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: { collections: {} },
+			accountability: {},
+			read: vi.fn(() => []),
+		};
+
+		const info: any = {
+			fieldName: 'col_aggregated',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		await resolveQuery(gql, info);
+
+		expect(gql.read).toHaveBeenCalled();
+		const lastCallArgs = gql.read.mock.calls[gql.read.mock.calls.length - 1];
+		const queryArg = lastCallArgs?.[1];
+		expect(queryArg).toEqual(expect.objectContaining({ fields: ['count(a)', 'b.sum(c)', 'c.d.max(e)'] }));
+	});
+
+	test('adds group field to each result item when query has group', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({});
+
+		mockGetAggregateQuery.mockResolvedValue({
+			group: ['category'],
+			aggregate: { count: ['id'] },
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: { collections: {} },
+			accountability: {},
+			read: vi.fn(() => [
+				{ category: 'A', count: { id: 5 } },
+				{ category: 'B', count: { id: 10 } },
+			]),
+		};
+
+		const info: any = {
+			fieldName: 'items_aggregated',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		const res = await resolveQuery(gql, info);
+
+		expect(res).toEqual([
+			{ category: 'A', count: { id: 5 }, group: { category: 'A' } },
+			{ category: 'B', count: { id: 10 }, group: { category: 'B' } },
+		]);
+	});
+});

--- a/api/src/services/graphql/resolvers/query.test.ts
+++ b/api/src/services/graphql/resolvers/query.test.ts
@@ -209,7 +209,7 @@ describe('resolveQuery', () => {
 		expect(queryArg).toEqual(expect.objectContaining({ versionRaw: true }));
 	});
 
-	test('parseFilterFunctionPath is called for each field', async () => {
+	test('properly resolves fields to correct path for each nested function field', async () => {
 		mockReplaceFragments.mockReturnValue([{}]);
 		mockParseArgs.mockReturnValue({ id: 'abc' });
 
@@ -239,7 +239,7 @@ describe('resolveQuery', () => {
 		expect(queryArg).toEqual(expect.objectContaining({ fields: ['count(a)', 'b.sum(c)', 'c.d.max(e)'] }));
 	});
 
-	test('adds group field to each result item when query has group', async () => {
+	test('inject group field for each item when grouping', async () => {
 		mockReplaceFragments.mockReturnValue([{}]);
 		mockParseArgs.mockReturnValue({});
 

--- a/api/src/services/graphql/resolvers/query.test.ts
+++ b/api/src/services/graphql/resolvers/query.test.ts
@@ -145,38 +145,6 @@ describe('resolveQuery', () => {
 		expect(collectionArg).toBe('posts');
 	});
 
-	test('query by version calls getQuery with suffixed collection name', async () => {
-		mockReplaceFragments.mockReturnValue([{}]);
-		mockParseArgs.mockReturnValue({ id: 'abc' });
-
-		mockGetQuery.mockReturnValue({
-			fields: [],
-		});
-
-		const gql: any = {
-			scope: 'app',
-			schema: {
-				collections: {},
-			},
-			accountability: {},
-			read: vi.fn(),
-		};
-
-		const info: any = {
-			fieldName: 'posts_by_version',
-			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
-			fragments: {},
-			variableValues: {},
-		};
-
-		await resolveQuery(gql, info);
-
-		expect(mockGetQuery).toHaveBeenCalled();
-		const lastCallArgs = mockGetQuery.mock.calls[mockGetQuery.mock.calls.length - 1];
-		const collectionArg = lastCallArgs?.[lastCallArgs.length - 1];
-		expect(collectionArg).toBe('posts_by_version');
-	});
-
 	test('query by version injects versionRaw to query', async () => {
 		mockReplaceFragments.mockReturnValue([{}]);
 		mockParseArgs.mockReturnValue({ id: 'abc' });

--- a/api/src/services/graphql/resolvers/query.test.ts
+++ b/api/src/services/graphql/resolvers/query.test.ts
@@ -145,7 +145,7 @@ describe('resolveQuery', () => {
 		expect(collectionArg).toBe('posts');
 	});
 
-	test('query by version calls getQuery with correct collection name', async () => {
+	test('query by version calls getQuery with suffixed collection name', async () => {
 		mockReplaceFragments.mockReturnValue([{}]);
 		mockParseArgs.mockReturnValue({ id: 'abc' });
 
@@ -174,7 +174,7 @@ describe('resolveQuery', () => {
 		expect(mockGetQuery).toHaveBeenCalled();
 		const lastCallArgs = mockGetQuery.mock.calls[mockGetQuery.mock.calls.length - 1];
 		const collectionArg = lastCallArgs?.[lastCallArgs.length - 1];
-		expect(collectionArg).toBe('posts');
+		expect(collectionArg).toBe('posts_by_version');
 	});
 
 	test('query by version injects versionRaw to query', async () => {

--- a/api/src/services/graphql/resolvers/query.ts
+++ b/api/src/services/graphql/resolvers/query.ts
@@ -32,16 +32,10 @@ export async function resolveQuery(gql: GraphQLService, info: GraphQLResolveInfo
 			collection = collection.slice(0, -6);
 		}
 
-		let isByVersion = false;
+		query = await getQuery(args, gql.schema, selections, info.variableValues, gql.accountability, collection);
 
 		if (collection.endsWith('_by_version') && collection in gql.schema.collections === false) {
 			collection = collection.slice(0, -11);
-			isByVersion = true;
-		}
-
-		query = await getQuery(args, gql.schema, selections, info.variableValues, gql.accountability, collection);
-
-		if (isByVersion) {
 			query.versionRaw = true;
 		}
 	}

--- a/api/src/services/graphql/resolvers/query.ts
+++ b/api/src/services/graphql/resolvers/query.ts
@@ -28,14 +28,20 @@ export async function resolveQuery(gql: GraphQLService, info: GraphQLResolveInfo
 		collection = collection.slice(0, -11);
 		query = await getAggregateQuery(args, selections, gql.schema, gql.accountability, collection);
 	} else {
-		query = await getQuery(args, gql.schema, selections, info.variableValues, gql.accountability, collection);
-
 		if (collection.endsWith('_by_id') && collection in gql.schema.collections === false) {
 			collection = collection.slice(0, -6);
 		}
 
+		let isByVersion = false;
+
 		if (collection.endsWith('_by_version') && collection in gql.schema.collections === false) {
 			collection = collection.slice(0, -11);
+			isByVersion = true;
+		}
+
+		query = await getQuery(args, gql.schema, selections, info.variableValues, gql.accountability, collection);
+
+		if (isByVersion) {
 			query.versionRaw = true;
 		}
 	}

--- a/api/src/services/graphql/schema/parse-query.test.ts
+++ b/api/src/services/graphql/schema/parse-query.test.ts
@@ -1,10 +1,7 @@
 import type { FieldNode, SelectionNode } from 'graphql';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { sanitizeQuery } from '../../../utils/sanitize-query.js';
-import { parseArgs } from './parse-args.js';
 import { getQuery } from './parse-query.js';
-
-vi.mock('/parse-args.js');
 
 vi.mock('../../../utils/sanitize-query.js', () => ({
 	sanitizeQuery: vi.fn(async (q) => q),
@@ -22,8 +19,6 @@ vi.mock('../utils/filter-replace-m2a.js', () => ({
 vi.mock('../utils/replace-funcs.js', () => ({
 	replaceFuncs: vi.fn((v) => v),
 }));
-
-vi.mock('./parse-args.js');
 
 const mockSchema = {} as any;
 const mockAccountability = null;
@@ -103,7 +98,6 @@ describe('parseFields', () => {
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['posts']);
-		expect(parseArgs).toHaveBeenCalledWith(selections[0]!.arguments, mockVariableValues);
 	});
 
 	test('should parse InlineFragment with arguments', async () => {


### PR DESCRIPTION
## Scope

What's changed:

- The correct collection name is now passed down for filtering m2a fields

## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios

-  [x] Expect M2A filtering with `_by_id` to succeed

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26232