### PR TITLE
Fixed OAuth/OpenID to use PUBLIC_URL for callback and allow cross-domain redirects

### DIFF
--- a/.changeset/warm-frogs-heal.md
+++ b/.changeset/warm-frogs-heal.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+used PUBLIC_URL for OAuth/OpenID callback URL generation

--- a/.changeset/warm-frogs-heal.md
+++ b/.changeset/warm-frogs-heal.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-used PUBLIC_URL for OAuth/OpenID callback URL generation
+Fixed OAuth/OpenID to use PUBLIC_URL for callback and allow cross-domain redirects

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -360,7 +360,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 			const otp = req.query['otp'];
 			const redirect = req.query['redirect'];
 
-			if (!isLoginRedirectAllowed(providerName, `${req.protocol}://${req.hostname}`, redirect)) {
+			if (!isLoginRedirectAllowed(providerName, redirect)) {
 				throw new InvalidPayloadError({ reason: `URL "${redirect}" can't be used to redirect after login` });
 			}
 

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -364,7 +364,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 				throw new InvalidPayloadError({ reason: `URL "${redirect}" can't be used to redirect after login` });
 			}
 
-			const callbackUrl = generateCallbackUrl(providerName, `${req.protocol}://${req.get('host')}`);
+			const callbackUrl = generateCallbackUrl(providerName);
 
 			const token = jwt.sign(
 				{

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -444,7 +444,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 			const redirect = req.query['redirect'];
 			const otp = req.query['otp'];
 
-			if (!isLoginRedirectAllowed(providerName, `${req.protocol}://${req.hostname}`, redirect)) {
+			if (!isLoginRedirectAllowed(providerName, redirect)) {
 				throw new InvalidPayloadError({ reason: `URL "${redirect}" can't be used to redirect after login` });
 			}
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -448,7 +448,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 				throw new InvalidPayloadError({ reason: `URL "${redirect}" can't be used to redirect after login` });
 			}
 
-			const callbackUrl = generateCallbackUrl(providerName, `${req.protocol}://${req.get('host')}`);
+			const callbackUrl = generateCallbackUrl(providerName);
 
 			const token = jwt.sign(
 				{

--- a/api/src/auth/drivers/saml.ts
+++ b/api/src/auth/drivers/saml.ts
@@ -136,7 +136,7 @@ export function createSAMLAuthRouter(providerName: string) {
 			if (req.query['redirect']) {
 				const redirect = req.query['redirect'] as string;
 
-				if (!isLoginRedirectAllowed(providerName, `${req.protocol}://${req.hostname}`, redirect)) {
+				if (!isLoginRedirectAllowed(providerName, redirect)) {
 					throw new InvalidPayloadError({ reason: `URL "${redirect}" can't be used to redirect after login` });
 				}
 

--- a/api/src/auth/utils/generate-callback-url.test.ts
+++ b/api/src/auth/utils/generate-callback-url.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { generateCallbackUrl } from './generate-callback-url.js';
+
+vi.mock('@directus/env');
+vi.mock('../../logger/index.js');
+
+import { useEnv } from '@directus/env';
 
 describe('generateCallbackUrl', () => {
 	test('generates callback URL correctly', () => {
-		const result = generateCallbackUrl('github', 'https://directus.app');
+		const PUBLIC_URL = 'https://directus.app/api';
 
-		expect(result).toBe('https://directus.app/auth/login/github/callback');
+		vi.mocked(useEnv).mockReturnValue({
+			PUBLIC_URL,
+		});
+
+		const result = generateCallbackUrl('github');
+
+		expect(result).toBe(`${PUBLIC_URL}/auth/login/github/callback`);
 	});
 });

--- a/api/src/auth/utils/generate-callback-url.ts
+++ b/api/src/auth/utils/generate-callback-url.ts
@@ -2,7 +2,7 @@ import { useEnv } from '@directus/env';
 import { Url } from '../../utils/url.js';
 
 /**
- * Generate callback URL from public URL
+ * Generate callback URL from PUBLIC_URL environment variable
  *
  * @param providerName OAuth provider name
  * @returns callback URL

--- a/api/src/auth/utils/generate-callback-url.ts
+++ b/api/src/auth/utils/generate-callback-url.ts
@@ -1,11 +1,15 @@
+import { useEnv } from '@directus/env';
 import { Url } from '../../utils/url.js';
+
 /**
- * Generate callback URL from origin
+ * Generate callback URL from public URL
  *
- * @param string Origin URL
  * @param providerName OAuth provider name
- * @returns url
+ * @returns callback URL
  */
-export function generateCallbackUrl(providerName: string, originUrl: string): string {
-	return new Url(originUrl).addPath('auth', 'login', providerName, 'callback').toString();
+export function generateCallbackUrl(providerName: string): string {
+	const env = useEnv();
+	const publicUrl = env['PUBLIC_URL'] as string;
+
+	return new Url(publicUrl).addPath('auth', 'login', providerName, 'callback').toString();
 }

--- a/api/src/auth/utils/is-login-redirect-allowed.test.ts
+++ b/api/src/auth/utils/is-login-redirect-allowed.test.ts
@@ -27,58 +27,71 @@ describe('isLoginRedirectAllowed', () => {
 
 	describe('empty or invalid redirect', () => {
 		test('returns true when redirect is undefined', () => {
-			const result = isLoginRedirectAllowed('github', PUBLIC_URL, undefined);
+			const result = isLoginRedirectAllowed('github', undefined);
 
 			expect(result).toBe(true);
 		});
 
 		test('returns true when redirect is empty string', () => {
-			const result = isLoginRedirectAllowed('github', PUBLIC_URL, '');
+			const result = isLoginRedirectAllowed('github', '');
 
 			expect(result).toBe(true);
 		});
 
 		test('returns false when redirect is not a string', () => {
-			const result = isLoginRedirectAllowed('github', PUBLIC_URL, 123);
+			const result = isLoginRedirectAllowed('github', 123);
 
 			expect(result).toBe(false);
 		});
 
 		describe('relative path redirects', () => {
 			test('returns true for relative path redirect', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, '/admin/users');
+				const result = isLoginRedirectAllowed('github', '/admin/users');
 
 				expect(result).toBe(true);
 			});
 
 			test('returns true for root path redirect', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, '/');
+				const result = isLoginRedirectAllowed('github', '/');
 
 				expect(result).toBe(true);
 			});
 
 			test('returns false for protocol-relative URL (//example.com)', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, '//malicious.com/test');
+				const result = isLoginRedirectAllowed('github', '//malicious.com/test');
 
 				expect(result).toBe(false);
 			});
 		});
 
-		describe('origin matching', () => {
-			test('returns false when redirect origin does not match request origin', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, 'https://different.com/admin');
+		describe('cross-domain redirects', () => {
+			test('allows cross-domain redirect when in ALLOW_LIST', () => {
+				vi.mocked(useEnv).mockReturnValue({
+					PUBLIC_URL: 'https://api.directus.com',
+					AUTH_GITHUB_REDIRECT_ALLOW_LIST: 'https://frontend.com/auth/callback',
+				});
+
+				const result = isLoginRedirectAllowed('github', 'https://frontend.com/auth/callback');
+
+				expect(result).toBe(true);
+			});
+
+			test('rejects cross-domain redirect when NOT in ALLOW_LIST', () => {
+				vi.mocked(useEnv).mockReturnValue({
+					PUBLIC_URL: 'https://api.directus.com',
+				});
+
+				const result = isLoginRedirectAllowed('github', 'https://frontend.com/auth/callback');
 
 				expect(result).toBe(false);
 			});
 
-			test('returns false when redirect origin differs by protocol', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, 'http://example.com/admin');
+			test('allows redirect to PUBLIC_URL origin even without ALLOW_LIST', () => {
+				vi.mocked(useEnv).mockReturnValue({
+					PUBLIC_URL: 'https://directus.app',
+				});
 
-				expect(result).toBe(false);
-			});
-
-			test('allows redirect when port differs', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, `${PUBLIC_URL}:8080/admin`);
+				const result = isLoginRedirectAllowed('github', 'https://directus.app/admin');
 
 				expect(result).toBe(true);
 			});
@@ -90,7 +103,7 @@ describe('isLoginRedirectAllowed', () => {
 					AUTH_GITHUB_REDIRECT_ALLOW_LIST: 'https://example.com/custom',
 				});
 
-				const result = isLoginRedirectAllowed('github', 'https://example.com', 'https://example.com/custom');
+				const result = isLoginRedirectAllowed('github', 'https://example.com/custom');
 
 				expect(result).toBe(true);
 			});
@@ -100,7 +113,7 @@ describe('isLoginRedirectAllowed', () => {
 					AUTH_GITHUB_REDIRECT_ALLOW_LIST: ['https://example.com/custom1', 'https://example.com/custom2'],
 				});
 
-				const result = isLoginRedirectAllowed('github', 'https://example.com', 'https://example.com/custom2');
+				const result = isLoginRedirectAllowed('github', 'https://example.com/custom2');
 
 				expect(result).toBe(true);
 			});
@@ -112,7 +125,7 @@ describe('isLoginRedirectAllowed', () => {
 				});
 
 				// Not in allow list, but matches PUBLIC_URL, so should pass
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, `${PUBLIC_URL}/forbidden`);
+				const result = isLoginRedirectAllowed('github', `${PUBLIC_URL}/forbidden`);
 
 				expect(result).toBe(true);
 			});
@@ -124,14 +137,24 @@ describe('isLoginRedirectAllowed', () => {
 					PUBLIC_URL: 'invalid-url',
 				});
 
-				const result = isLoginRedirectAllowed('github', 'https://example.com', 'https://example.com/admin');
+				const result = isLoginRedirectAllowed('github', 'https://example.com/admin');
 
 				expect(result).toBe(false);
 				expect(mockLogger.error).toHaveBeenCalledWith('Invalid PUBLIC_URL for login redirect');
 			});
 
-			test('rejects redirect when PUBLIC_URL origin does not match', () => {
-				const result = isLoginRedirectAllowed('github', 'https://example.com', 'https://example.com/admin');
+			test('rejects redirect when protocol differs from PUBLIC_URL', () => {
+				vi.mocked(useEnv).mockReturnValue({
+					PUBLIC_URL: 'https://directus.app',
+				});
+
+				const result = isLoginRedirectAllowed('github', 'http://directus.app/admin');
+
+				expect(result).toBe(false);
+			});
+
+			test('rejects redirect when not in ALLOW_LIST and not PUBLIC_URL origin', () => {
+				const result = isLoginRedirectAllowed('github', 'https://example.com/admin');
 
 				expect(result).toBe(false);
 			});
@@ -139,19 +162,19 @@ describe('isLoginRedirectAllowed', () => {
 
 		describe('edge cases', () => {
 			test('handles URL with query parameters', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, `${PUBLIC_URL}/admin?tab=users`);
+				const result = isLoginRedirectAllowed('github', `${PUBLIC_URL}/admin?tab=users`);
 
 				expect(result).toBe(true);
 			});
 
 			test('handles URL with hash fragment', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, `${PUBLIC_URL}/admin#section`);
+				const result = isLoginRedirectAllowed('github', `${PUBLIC_URL}/admin#section`);
 
 				expect(result).toBe(true);
 			});
 
 			test('handles URL with both query and hash', () => {
-				const result = isLoginRedirectAllowed('github', PUBLIC_URL, `${PUBLIC_URL}/admin?tab=users#top`);
+				const result = isLoginRedirectAllowed('github', `${PUBLIC_URL}/admin?tab=users#top`);
 
 				expect(result).toBe(true);
 			});

--- a/api/src/auth/utils/is-login-redirect-allowed.ts
+++ b/api/src/auth/utils/is-login-redirect-allowed.ts
@@ -5,12 +5,11 @@ import isUrlAllowed from '../../utils/is-url-allowed.js';
 
 /**
  * Check if the redirect URL is allowed
- * @param originUrl Origin URL
  * @param provider OAuth provider name
  * @param redirect URL to redirect to
  * @returns True if the redirect is allowed, false otherwise
  */
-export function isLoginRedirectAllowed(provider: string, originUrl: string, redirect: unknown): boolean {
+export function isLoginRedirectAllowed(provider: string, redirect: unknown): boolean {
 	if (!redirect) return true; // empty redirect
 	if (typeof redirect !== 'string') return false; // invalid type
 
@@ -29,9 +28,6 @@ export function isLoginRedirectAllowed(provider: string, originUrl: string, redi
 
 	const { protocol: redirectProtocol, hostname: redirectDomain } = new URL(redirect);
 	const redirectUrl = `${redirectProtocol}//${redirectDomain}`;
-
-	// Security check: redirect URL must match the request origin
-	if (redirectUrl !== originUrl) return false;
 
 	const envKey = `AUTH_${provider.toUpperCase()}_REDIRECT_ALLOW_LIST`;
 


### PR DESCRIPTION
## Scope

What's changed:

- OAuth/OpenID callback URLs now use PUBLIC_URL instead of request host
- Removes origin matching restriction that was blocking cross-domain setups

## Potential Risks / Drawbacks

- Requires PUBLIC_URL to be correctly configured (should already be the case)

## Tested Scenarios

- API with subpath (e.g., https://example.com/api)
- API without subpath (e.g., https://api.example.com)
- Multi-domain setup (frontend on different domain than API)
- Cross-domain redirects with AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST

## Review Notes / Questions

- This fixes issues introduced in #26074 where callback URLs didn't include API subpath and cross-domain redirects were incorrectly blocked

## Checklist

- [X] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26237 https://github.com/becem-gharbi/nuxt-directus/issues/98
