### PR TITLE
AI → Re-enable notifications

### DIFF
--- a/app/src/views/private/components/notification-item.vue
+++ b/app/src/views/private/components/notification-item.vue
@@ -8,8 +8,6 @@ const props = withDefaults(
 		text?: string;
 		icon?: string | null;
 		type?: 'info' | 'success' | 'warning' | 'error';
-		tail?: boolean;
-		dense?: boolean;
 		showClose?: boolean;
 		loading?: boolean;
 		progress?: number;
@@ -37,7 +35,7 @@ const done = async () => {
 </script>
 
 <template>
-	<div class="notification-item" :class="[type, { tail, dense, 'show-text': alwaysShowText }]" @click="done">
+	<div class="notification-item" :class="[type, { 'show-text': alwaysShowText }]" @click="done">
 		<div v-if="loading || progress || icon" class="icon">
 			<v-progress-circular v-if="loading" indeterminate small />
 			<v-progress-circular v-else-if="progress" small :value="progress" />
@@ -66,12 +64,13 @@ const done = async () => {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
-	inline-size: 100%;
-	min-block-size: 44px;
 	margin-block-start: 4px;
 	padding: 12px;
 	color: var(--white);
 	border-radius: var(--theme--border-radius);
+	inline-size: max-content;
+	max-inline-size: 100%;
+	min-block-size: 44px;
 
 	.icon {
 		display: block;
@@ -79,11 +78,11 @@ const done = async () => {
 		flex-shrink: 0;
 		align-items: center;
 		justify-content: center;
-		inline-size: 44px;
-		block-size: 44px;
-		margin-inline-end: 12px;
-		background-color: rgb(255 255 255 / 0.25);
 		border-radius: 50%;
+		inline-size: auto;
+		block-size: auto;
+		margin-inline-end: 8px;
+		background-color: transparent;
 	}
 
 	.text {
@@ -113,33 +112,12 @@ const done = async () => {
 		pointer-events: none;
 	}
 
-	&.tail::after {
-		transform: rotate(45deg) translate(0, 0);
-	}
-
-	&.dense {
-		inline-size: max-content;
-		max-inline-size: 100%;
-		min-block-size: 44px;
-
-		.icon {
-			inline-size: auto;
-			block-size: auto;
-			margin-inline-end: 8px;
-			background-color: transparent;
-		}
-
-		&:not(.show-text) .text {
-			display: none;
-		}
+	&:not(.show-text) .text {
+		display: none;
 	}
 
 	&.info {
 		background-color: var(--theme--primary);
-
-		&.tail::after {
-			background-color: var(--theme--primary);
-		}
 
 		.text {
 			color: var(--theme--primary-background);
@@ -149,10 +127,6 @@ const done = async () => {
 	&.success {
 		background-color: var(--theme--success);
 
-		&.tail::after {
-			background-color: var(--theme--success);
-		}
-
 		.text {
 			color: var(--success-alt);
 		}
@@ -161,10 +135,6 @@ const done = async () => {
 	&.warning {
 		background-color: var(--theme--warning);
 
-		&.tail::after {
-			background-color: var(--theme--warning);
-		}
-
 		.text {
 			color: var(--warning-alt);
 		}
@@ -172,10 +142,6 @@ const done = async () => {
 
 	&.error {
 		background-color: var(--theme--danger);
-
-		&.tail::after {
-			background-color: var(--theme--danger);
-		}
 
 		.text {
 			color: var(--danger-alt);

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -281,6 +281,29 @@ function clearFilters() {
 					<v-list-item-content>{{ $t('archive') }}</v-list-item-content>
 				</v-tab>
 			</v-tabs>
+
+			<v-divider class="nav-divider" />
+
+			<v-list nav>
+				<v-list-item
+					clickable
+					to="/activity"
+					:active="!notificationsDrawerOpen"
+					@click="notificationsDrawerOpen = false"
+				>
+					<v-list-item-icon>
+						<v-icon name="manage_search" />
+					</v-list-item-icon>
+
+					<v-list-item-content>
+						{{ $t('activity') }}
+					</v-list-item-content>
+
+					<v-list-item-hint>
+						<v-icon name="exit_to_app" />
+					</v-list-item-hint>
+				</v-list-item>
+			</v-list>
 		</template>
 
 		<template v-if="!loading && !itemCount">
@@ -312,7 +335,7 @@ function clearFilters() {
 					@update:model-value="selectAll"
 				/>
 
-				<v-divider :class="{ dense: totalPages > 1 }" />
+				<v-divider class="select-all-divider" :class="{ dense: totalPages > 1 }" />
 
 				<v-list class="notifications">
 					<v-list-item
@@ -445,7 +468,7 @@ function clearFilters() {
 	}
 }
 
-.v-divider {
+.select-all-divider {
 	margin: 8px 0;
 
 	&.dense {
@@ -466,5 +489,9 @@ function clearFilters() {
 .fade-enter-from,
 .fade-leave-to {
 	opacity: 0;
+}
+
+.nav-divider {
+	margin-inline: 12px;
 }
 </style>

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -1,18 +1,7 @@
 <script setup lang="ts">
 import { useNotificationsStore } from '@/stores/notifications';
-import { computed, toRefs } from 'vue';
-import { useSidebarStore } from '../private-view/stores/sidebar';
+import { toRefs } from 'vue';
 import NotificationItem from './notification-item.vue';
-
-const sidebarStore = useSidebarStore();
-
-const insetInlineEnd = computed(() => {
-	if (sidebarStore.collapsed) {
-		return '78px';
-	}
-
-	return Math.max(296, Math.min(616, sidebarStore.size + 16)) + 'px';
-});
 
 const notificationsStore = useNotificationsStore();
 const queue = toRefs(notificationsStore).queue;
@@ -42,9 +31,9 @@ const queue = toRefs(notificationsStore).queue;
 
 <style lang="scss" scoped>
 .notifications-group {
-	position: fixed;
+	position: absolute;
 	inset-block-end: 16px;
-	inset-inline-end: v-bind(insetInlineEnd);
+	inset-inline-end: 16px;
 	z-index: 50;
 	display: flex;
 	flex-direction: column;

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -1,27 +1,28 @@
 <script setup lang="ts">
 import { useNotificationsStore } from '@/stores/notifications';
-import { toRefs } from 'vue';
+import { computed, toRefs } from 'vue';
+import { useSidebarStore } from '../private-view/stores/sidebar';
 import NotificationItem from './notification-item.vue';
 
-defineProps<{
-	sidebarOpen?: boolean;
-	noSidebar?: boolean;
-}>();
+const sidebarStore = useSidebarStore();
+
+const insetInlineEnd = computed(() => {
+	if (sidebarStore.collapsed) {
+		return '78px';
+	}
+
+	return Math.max(296, Math.min(616, sidebarStore.size + 16)) + 'px';
+});
 
 const notificationsStore = useNotificationsStore();
 const queue = toRefs(notificationsStore).queue;
 </script>
 
 <template>
-	<transition-group
-		class="notifications-group"
-		:class="{ 'sidebar-open': sidebarOpen, 'no-sidebar': noSidebar }"
-		name="slide-fade"
-		tag="div"
-	>
+	<transition-group class="notifications-group" name="slide-fade" tag="div">
 		<slot />
 		<notification-item
-			v-for="(notification, index) in queue"
+			v-for="notification in queue"
 			:id="notification.id"
 			:key="notification.id"
 			:title="notification.title"
@@ -30,8 +31,6 @@ const queue = toRefs(notificationsStore).queue;
 			:type="notification.type"
 			:loading="notification.loading"
 			:progress="notification.progress"
-			:tail="index === queue.length - 1"
-			:dense="sidebarOpen === false"
 			:show-close="notification.persist === true && notification.closeable !== false"
 			:always-show-text="notification.alwaysShowText"
 			:dismiss-icon="notification.dismissIcon"
@@ -44,23 +43,13 @@ const queue = toRefs(notificationsStore).queue;
 <style lang="scss" scoped>
 .notifications-group {
 	position: fixed;
-	inset-block-end: 24px;
-	inset-inline-end: 12px;
+	inset-block-end: 16px;
+	inset-inline-end: v-bind(insetInlineEnd);
 	z-index: 50;
 	display: flex;
 	flex-direction: column;
 	align-items: end;
 	inline-size: 256px;
-
-	&.sidebar-open {
-		inset-block-end: 76px;
-	}
-
-	@media (min-width: 960px) {
-		&:not(.no-sidebar) {
-			inset-block-end: 76px;
-		}
-	}
 }
 
 .notification-item {

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -50,10 +50,6 @@ const queue = toRefs(notificationsStore).queue;
 	opacity: 1;
 }
 
-.slide-fade-leave-active {
-	position: absolute;
-}
-
 .slide-fade-enter-from {
 	transform: translateX(50px) scaleY(0) scaleX(0);
 	transform-origin: right bottom;

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -83,9 +83,9 @@ const splitterCollapsed = computed({
 					<main ref="mainEl">
 						<slot />
 					</main>
-
-					<NotificationsGroup />
 				</div>
+
+				<NotificationsGroup />
 			</template>
 
 			<template #divider>
@@ -110,6 +110,10 @@ const splitterCollapsed = computed({
 <style scoped>
 #main-content {
 	block-size: 100%;
+
+	&:deep(.sp-start) {
+		position: relative;
+	}
 }
 
 .main-split {

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { SplitPanel } from '@directus/vue-split-panel';
-import { useScroll } from '@vueuse/core';
+import { breakpointsTailwind, useBreakpoints, useScroll } from '@vueuse/core';
 import { computed, provide, useTemplateRef } from 'vue';
-import PrivateViewDrawer from './private-view-drawer.vue';
+import NotificationsGroup from '../../components/notifications-group.vue';
 import SkipMenu from '../../components/skip-menu.vue';
 import { useSidebarStore } from '../stores/sidebar';
+import PrivateViewDrawer from './private-view-drawer.vue';
 import PrivateViewHeaderBar from './private-view-header-bar.vue';
 import PrivateViewResizeHandle from './private-view-resize-handle.vue';
-import type { PrivateViewProps } from './private-view.vue';
-import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
 import PrivateViewSidebar from './private-view-sidebar.vue';
+import type { PrivateViewProps } from './private-view.vue';
 
 const contentEl = useTemplateRef('content-el');
 provide('main-element', contentEl);
@@ -83,6 +83,8 @@ const splitterCollapsed = computed({
 					<main ref="mainEl">
 						<slot />
 					</main>
+
+					<NotificationsGroup />
 				</div>
 			</template>
 

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -18,11 +18,9 @@ export interface PrivateViewProps {
 import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
 import { useCookies } from '@vueuse/integrations/useCookies';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import NotificationDialogs from '../../components/notification-dialogs.vue';
 import NotificationsDrawer from '../../components/notifications-drawer.vue';
-import NotificationsGroup from '../../components/notifications-group.vue';
-import { useSidebarStore } from '../stores/sidebar';
 import PrivateViewNoAppAccess from './private-view-no-app-access.vue';
 import PrivateViewRoot from './private-view-root.vue';
 
@@ -35,10 +33,7 @@ const appAccess = computed(() => {
 
 defineProps<PrivateViewProps>();
 
-const notificationsPreviewActive = ref(false);
-
 const cookies = useCookies(['license-banner-dismissed']);
-const sidebarStore = useSidebarStore();
 const settingsStore = useSettingsStore();
 
 const showLicenseBanner = computed(
@@ -65,7 +60,6 @@ const showLicenseBanner = computed(
 	</PrivateViewRoot>
 
 	<notifications-drawer />
-	<notifications-group v-if="notificationsPreviewActive === false" :sidebar-open="!sidebarStore.collapsed" />
 	<notification-dialogs />
 
 	<license-banner v-model="showLicenseBanner" />


### PR DESCRIPTION
- Render notifications next to sidebar, even with sidebar open:
  <img width="2552" height="1328" alt="CleanShot 2025-11-24 at 15 38 58@2x" src="https://github.com/user-attachments/assets/c9f90ebc-695a-479f-bf9f-b2ff1b9c0d41" />
- Move link to `/activity` to notifications drawer
  <img width="2556" height="670" alt="CleanShot 2025-11-24 at 15 39 41@2x" src="https://github.com/user-attachments/assets/c341b29d-80bb-437f-b55c-183375701fc9" />



---

This pull request refactors the notification components to simplify their structure and styling, removes unused props and classes, and improves the integration of notifications into the main private view layout. The changes focus on making the notification system more maintainable and visually consistent, while also cleaning up legacy code and unused features.

**Notification Component Simplification and Styling Updates**
* Removed the `tail` and `dense` props and associated classes from `notification-item.vue`, simplifying both the logic and SCSS. Notification items now have a more consistent appearance and fewer conditional styles. [[1]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL11-L12) [[2]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL40-R38) [[3]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL69-R85) [[4]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL116-L143) [[5]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL152-L155) [[6]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL164-L167) [[7]](diffhunk://#diff-35d3a746a59a2f3754a727135526b0f17a419e28ede24de17c8f141eca4a4f6aL176-L179)
* Updated the styling of notification icons and containers for better alignment and responsiveness, and removed legacy styles related to `tail` and `dense` variants.

**Notifications Drawer Enhancements**
* Added an "Activity" navigation item and improved divider styling in `notifications-drawer.vue` for clearer separation and navigation. [[1]](diffhunk://#diff-41f65eb3779b161645357cca822f89c1b00ea120840d1b0fe55ad87fd5700380R284-R306) [[2]](diffhunk://#diff-41f65eb3779b161645357cca822f89c1b00ea120840d1b0fe55ad87fd5700380L315-R338) [[3]](diffhunk://#diff-41f65eb3779b161645357cca822f89c1b00ea120840d1b0fe55ad87fd5700380L448-R471) [[4]](diffhunk://#diff-41f65eb3779b161645357cca822f89c1b00ea120840d1b0fe55ad87fd5700380R493-R496)

**Notifications Group Refactor**
* Removed unused props (`sidebarOpen`, `noSidebar`) and related conditional styling from `notifications-group.vue`, making the component more focused and easier to use. Notification positioning is now handled with simpler, absolute positioning. [[1]](diffhunk://#diff-2505270a23395c2ea5ba90567458e3de517443315595cb23e64a370583497abdL6-R14) [[2]](diffhunk://#diff-2505270a23395c2ea5ba90567458e3de517443315595cb23e64a370583497abdL33-L34) [[3]](diffhunk://#diff-2505270a23395c2ea5ba90567458e3de517443315595cb23e64a370583497abdL46-L63) [[4]](diffhunk://#diff-2505270a23395c2ea5ba90567458e3de517443315595cb23e64a370583497abdL75-L78)

**Private View Layout Integration**
* Moved the `NotificationsGroup` component to be rendered directly inside the main content area of `private-view-main.vue`, and removed its usage from `private-view.vue`. This ensures notifications are always visible in the main layout and reduces prop-passing complexity. [[1]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38L3-R12) [[2]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38R87-R88) [[3]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38R113-R116) [[4]](diffhunk://#diff-7982c9699e9930780c54e9c5c1d4e55a39bc784e219e0b6896d2a921e201fb4aL21-L25) [[5]](diffhunk://#diff-7982c9699e9930780c54e9c5c1d4e55a39bc784e219e0b6896d2a921e201fb4aL38-L41) [[6]](diffhunk://#diff-7982c9699e9930780c54e9c5c1d4e55a39bc784e219e0b6896d2a921e201fb4aL68)