### PR TITLE
AI → Allow divider to overlap sticky headings in main

### DIFF
--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -108,6 +108,10 @@ const splitterCollapsed = computed({
 <style scoped>
 #main-content {
 	block-size: 100%;
+
+	&:deep(.sp-divider) {
+		z-index: 5;
+	}
 }
 
 .main-split {


### PR DESCRIPTION
This pull request introduces a minor style update to the `private-view-main.vue` component. The change improves the stacking order of divider elements within the main content area to ensure they display correctly.

* Style adjustment: Added a `z-index: 5` rule to the `.sp-divider` class inside the `#main-content` scope to enhance proper layering and visibility of split dividers.