### PR TITLE
Some Fixes for Split Panel

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -487,6 +487,7 @@ function getComparisonIndicatorClasses(field: TFormField, isGroup = false) {
 @use '@/styles/mixins';
 
 .v-form {
+	container-type: inline-size;
 	@include mixins.form-grid;
 
 	.first-visible-field :deep(.presentation-divider) {

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -782,9 +782,7 @@ function useCollectionRoute() {
 			</template>
 
 			<template #end>
-				<div class="preview-container">
-					<live-preview :url="previewUrl" @new-window="livePreviewMode = 'popup'" />
-				</div>
+				<live-preview :url="previewUrl" @new-window="livePreviewMode = 'popup'" />
 			</template>
 		</SplitPanel>
 
@@ -873,6 +871,24 @@ function useCollectionRoute() {
 	inline-size: 260px;
 }
 
+.type-title {
+	line-height: 1;
+}
+
+:deep(.type-title) {
+	.render-template {
+		img {
+			block-size: 20px;
+		}
+	}
+}
+
+.headline-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
 .version-more-options.v-icon {
 	--focus-ring-offset: var(--focus-ring-offset-invert);
 
@@ -904,12 +920,6 @@ function useCollectionRoute() {
 		}
 	}
 
-	.headline-wrapper {
-		display: flex;
-		align-items: center;
-		gap: 0.25rem;
-	}
-
 	:deep(.header-bar.collapsed.shadow .title-container .headline) {
 		opacity: 1;
 		pointer-events: auto;
@@ -921,6 +931,12 @@ function useCollectionRoute() {
 	:deep(.header-bar.small.shadow .title-container .headline) {
 		opacity: 1;
 		pointer-events: auto;
+	}
+}
+
+.headline-wrapper.has-version-menu .headline-breadcrumb {
+	@media (max-width: 600px) {
+		display: none;
 	}
 }
 
@@ -953,5 +969,4 @@ function useCollectionRoute() {
 .content-split:active :deep(iframe) {
 	pointer-events: none !important;
 }
-
 </style>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -341,14 +341,6 @@ const { flowDialogsContext, manualFlows, provideRunManualFlow } = useFlows({
 
 provideRunManualFlow();
 
-function togglelivePreview() {
-	if (livePreviewMode.value === null) {
-		livePreviewMode.value = 'split';
-	} else {
-		livePreviewMode.value = null;
-	}
-}
-
 async function refreshLivePreview() {
 	try {
 		await fetchTemplateValues();
@@ -595,7 +587,7 @@ function useCollectionRoute() {
 				class="action-preview"
 				:secondary="livePreviewMode === null"
 				small
-				@click="togglelivePreview"
+				@click="livePreviewCollapsed = !livePreviewCollapsed"
 			>
 				<v-icon name="visibility" outline small />
 			</v-button>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -259,21 +259,10 @@ const previewUrl = computed(() => {
 });
 
 const livePreviewMode = useLocalStorage<'split' | 'popup'>('live-preview-mode', null);
-const livePreviewSizeStorage = useLocalStorage<number>('live-preview-size', 350);
+const livePreviewSizeStorage = useLocalStorage<number>('live-preview-size', 50);
 
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smaller('sm');
-
-const livePreviewSize = computed({
-	get() {
-		return livePreviewSizeStorage.value ?? 350;
-	},
-	set(value: number) {
-		if (isMobile.value) return;
-
-		livePreviewSizeStorage.value = value;
-	},
-});
 
 const livePreviewActive = computed({
 	get() {
@@ -293,6 +282,22 @@ const livePreviewCollapsed = computed({
 	},
 	set(value: boolean) {
 		livePreviewMode.value = value ? null : 'split';
+	},
+});
+
+const livePreviewSize = computed({
+	get() {
+		// On mobile, preview takes full width when active
+		if (isMobile.value && livePreviewActive.value) {
+			return 100;
+		}
+
+		return livePreviewSizeStorage.value ?? 50;
+	},
+	set(value: number) {
+		if (isMobile.value) return;
+
+		livePreviewSizeStorage.value = value;
 	},
 });
 
@@ -746,12 +751,12 @@ function useCollectionRoute() {
 			v-model:size="livePreviewSize"
 			v-model:collapsed="livePreviewCollapsed"
 			primary="end"
-			size-unit="px"
+			size-unit="%"
 			collapsible
 			:collapsed-size="0"
-			:collapse-threshold="150"
-			:min-size="isMobile ? 0 : 200"
-			:max-size="isMobile ? 1000 : 800"
+			:collapse-threshold="15"
+			:min-size="isMobile ? 0 : 20"
+			:max-size="isMobile ? 100 : 80"
 			:transition-duration="150"
 			class="content-split"
 			:disabled="isMobile"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -264,12 +264,12 @@ const livePreviewSizeStorage = useLocalStorage<number>('live-preview-size', 50);
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smaller('sm');
 
-const livePreviewActive = computed(() => {
-	if (!collectionInfo.value?.meta?.preview_url) return false;
-	if (unref(isNew)) return false;
-
-	return livePreviewMode.value === 'split';
-});
+const livePreviewActive = computed(
+	() =>
+		!!collectionInfo.value?.meta?.preview_url &&
+		!unref(isNew) &&
+		livePreviewMode.value === 'split',
+);
 
 const livePreviewCollapsed = computed({
 	get() {

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -282,9 +282,8 @@ const livePreviewCollapsed = computed({
 
 const livePreviewSize = computed({
 	get() {
-		// On mobile, preview takes full width when active
-		if (isMobile.value && livePreviewActive.value) {
-			return 100;
+		if (isMobile.value) {
+			return livePreviewActive.value ? 100 : 0;
 		}
 
 		return livePreviewSizeStorage.value ?? 50;

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -264,16 +264,11 @@ const livePreviewSizeStorage = useLocalStorage<number>('live-preview-size', 50);
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smaller('sm');
 
-const livePreviewActive = computed({
-	get() {
-		if (!collectionInfo.value?.meta?.preview_url) return false;
-		if (unref(isNew)) return false;
+const livePreviewActive = computed(() => {
+	if (!collectionInfo.value?.meta?.preview_url) return false;
+	if (unref(isNew)) return false;
 
-		return livePreviewMode.value === 'split';
-	},
-	set(value) {
-		livePreviewMode.value = value ? 'split' : null;
-	},
+	return livePreviewMode.value === 'split';
 });
 
 const livePreviewCollapsed = computed({

--- a/app/src/styles/mixins/_form-grid.scss
+++ b/app/src/styles/mixins/_form-grid.scss
@@ -17,7 +17,7 @@
 	.field {
 		grid-column: start / fill;
 
-		@media (min-width: 960px) {
+		@container (inline-size >= 375px) {
 			grid-column: start / full;
 		}
 	}
@@ -27,7 +27,7 @@
 	.half-space {
 		grid-column: start / fill;
 
-		@media (min-width: 960px) {
+		@container (inline-size >= 375px) {
 			grid-column: start / half;
 		}
 	}
@@ -36,7 +36,7 @@
 	.half-right {
 		grid-column: start / fill;
 
-		@media (min-width: 960px) {
+		@container (inline-size >= 375px) {
 			grid-column: half / full;
 		}
 	}
@@ -44,7 +44,7 @@
 	.full {
 		grid-column: start / fill;
 
-		@media (min-width: 960px) {
+		@container (inline-size >= 375px) {
 			grid-column: start / full;
 		}
 	}

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SplitPanel } from '@directus/vue-split-panel';
 import { useScroll } from '@vueuse/core';
-import { computed, provide, useTemplateRef } from 'vue';
+import { computed, inject, provide, ref, unref, useTemplateRef, type Ref } from 'vue';
 import PrivateViewDrawer from './private-view-drawer.vue';
 import SkipMenu from '../../components/skip-menu.vue';
 import { useSidebarStore } from '../stores/sidebar';
@@ -22,7 +22,9 @@ const sidebarStore = useSidebarStore();
 
 const { y } = useScroll(useTemplateRef('scroll-container'));
 
-const showHeaderShadow = computed(() => y.value > 0);
+const livePreviewActive = inject<Ref<boolean>>('live-preview-active', ref(false));
+
+const showHeaderShadow = computed(() => y.value > 0 || unref(livePreviewActive));
 
 const { sm } = useBreakpoints(breakpointsTailwind);
 
@@ -60,7 +62,7 @@ const splitterCollapsed = computed({
 			:disabled="!sm"
 		>
 			<template #start>
-				<div ref="scroll-container" class="scrolling-container">
+				<div ref="scroll-container" class="scrolling-container" :class="{ 'flex-layout': livePreviewActive }">
 					<PrivateViewHeaderBar
 						:title="props.title"
 						:shadow="showHeaderShadow"
@@ -120,6 +122,16 @@ const splitterCollapsed = computed({
 	block-size: 100%;
 	inline-size: 100%;
 	position: relative;
+}
+
+.scrolling-container.flex-layout {
+	display: flex;
+	flex-direction: column;
+}
+
+.scrolling-container.flex-layout main {
+	flex: 1;
+	min-block-size: 0;
 }
 
 .mobile-sidebar {

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SplitPanel } from '@directus/vue-split-panel';
 import { useScroll } from '@vueuse/core';
-import { computed, inject, provide, ref, unref, useTemplateRef, type Ref } from 'vue';
+import { computed, inject, provide, unref, useTemplateRef, type ComputedRef } from 'vue';
 import PrivateViewDrawer from './private-view-drawer.vue';
 import SkipMenu from '../../components/skip-menu.vue';
 import { useSidebarStore } from '../stores/sidebar';
@@ -22,7 +22,7 @@ const sidebarStore = useSidebarStore();
 
 const { y } = useScroll(useTemplateRef('scroll-container'));
 
-const livePreviewActive = inject<Ref<boolean>>('live-preview-active', ref(false));
+const livePreviewActive = inject<ComputedRef<boolean>>('live-preview-active', computed(() => false));
 
 const showHeaderShadow = computed(() => y.value > 0 || unref(livePreviewActive));
 


### PR DESCRIPTION
This pull request significantly refactors and improves the live preview split view functionality in the item view, making it more flexible, responsive, and user-friendly. The changes introduce a new `SplitPanel`-based layout for the live preview, add persistent sizing, improve mobile handling, and update styles to use CSS container queries for better layout responsiveness. Additionally, relevant state is now provided via Vue's dependency injection for better component communication.

Key changes include:

**Live Preview Split View Refactor:**
- Replaces the old split view implementation with a new `SplitPanel`-based layout, allowing users to resize and collapse the live preview panel, with the size persisted in local storage. The split view is now more responsive and disables itself on mobile devices. (`app/src/modules/content/routes/item.vue`, `@directus/vue-split-panel`) [[1]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L259-R299) [[2]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R735-R750) [[3]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R764-R788)
- The live preview state (`livePreviewActive`) is now provided via Vue's dependency injection, allowing other components (like headers) to react to its state. (`app/src/modules/content/routes/item.vue`, `app/src/views/private/private-view/components/private-view-main.vue`) [[1]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L259-R299) [[2]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38L25-R27)

**Responsive Layout Improvements:**
- Updates the form grid SCSS mixin to use CSS container queries instead of media queries, making field layouts adapt more fluidly to parent container size. (`app/src/styles/mixins/_form-grid.scss`, `app/src/components/v-form/v-form.vue`) [[1]](diffhunk://#diff-008d0b10249544b4a49b7a63db0ad63902ed3b14c6417e58e6c58c00496d1f70L20-R20) [[2]](diffhunk://#diff-008d0b10249544b4a49b7a63db0ad63902ed3b14c6417e58e6c58c00496d1f70L30-R30) [[3]](diffhunk://#diff-008d0b10249544b4a49b7a63db0ad63902ed3b14c6417e58e6c58c00496d1f70L39-R47) [[4]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529R490)

**Component and Style Enhancements:**
- Adds new and updated styles for the split view, including handling for collapsed and dragging states, and improves headline/title styling for better appearance and usability. (`app/src/modules/content/routes/item.vue`) [[1]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R860-R877) [[2]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R922-R957)
- Adjusts the main container in `private-view-main.vue` to use a flex layout when the live preview is active, ensuring the main content and preview panel are sized correctly. (`app/src/views/private/private-view/components/private-view-main.vue`) [[1]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38L63-R65) [[2]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38R127-R136)

**Code Cleanup:**
- Removes the old split view toggle logic and related template code, consolidating the split view logic into the new implementation. (`app/src/modules/content/routes/item.vue`) [[1]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L316-L323) [[2]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L515-R534) [[3]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L750-L753)

These changes collectively modernize the live preview experience, improve code maintainability, and enhance the UI's adaptability across devices.