### PR TITLE
AI -> Add Animations on Set Form Value Tool

### DIFF
--- a/app/src/ai/components/ai-conversation.vue
+++ b/app/src/ai/components/ai-conversation.vue
@@ -43,7 +43,7 @@ function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
 
 			<v-info
 				v-if="aiStore.messages.length === 0"
-				icon="smart_toy"
+				icon="magic_button"
 				:title="$t('ai.build_with_chat')"
 				type="primary"
 				class="empty-state"
@@ -101,7 +101,7 @@ function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
 
 .messages-container {
 	position: relative;
-	padding-inline: 8px;
+	padding-inline-end: 12px;
 	flex: 1;
 	overflow-y: auto;
 	min-block-size: 0;

--- a/app/src/ai/components/ai-input.vue
+++ b/app/src/ai/components/ai-input.vue
@@ -86,9 +86,11 @@ function handleSubmit() {
 	align-items: center;
 	gap: 8px;
 	flex-shrink: 0;
+	inline-size: 100%;
 
 	.submit-button {
 		--v-button-background-color-disabled: var(--theme--background-accent);
+		margin-inline-start: auto;
 	}
 }
 </style>

--- a/app/src/ai/components/ai-sidebar-detail.vue
+++ b/app/src/ai/components/ai-sidebar-detail.vue
@@ -103,7 +103,7 @@ useShortcut('meta+j', () => {
 }
 
 .ai-sidebar-content {
-	padding: 12px 0 12px 12px;
+	padding: 12px 0 12px 18px;
 	block-size: 100%;
 	display: flex;
 	flex-direction: column;

--- a/app/src/ai/components/parts/ai-message-text.vue
+++ b/app/src/ai/components/parts/ai-message-text.vue
@@ -36,7 +36,7 @@ useResizeObserver(contentRef, (entries) => {
 
 <style scoped>
 .message-text {
-	inline-size: 100%;
+	max-inline-size: 100%;
 	border-radius: var(--ai-message-border-radius, var(--theme--border-radius));
 	background-color: var(--ai-message-background);
 	color: var(--ai-message-color, var(--theme--foreground));

--- a/app/src/components/v-form/composables/use-field-animations.test.ts
+++ b/app/src/components/v-form/composables/use-field-animations.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useFieldAnimations } from './use-field-animations';
+
+const FIELD_ANIMATION_STAGGER = 150;
+
+describe('useFieldAnimations', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1000);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('triggerAnimations', () => {
+		it('sets animation keys for provided fields', () => {
+			const { triggerAnimations, getAnimationKey } = useFieldAnimations();
+
+			triggerAnimations(['title', 'description']);
+
+			expect(getAnimationKey('title')).toBe(1000);
+			expect(getAnimationKey('description')).toBe(1001);
+		});
+
+		it('extracts top-level field from nested paths', () => {
+			const { triggerAnimations, getAnimationKey } = useFieldAnimations();
+
+			triggerAnimations(['author.name', 'author.email']);
+
+			expect(getAnimationKey('author')).toBeDefined();
+			expect(getAnimationKey('author.name')).toBeUndefined();
+		});
+
+		it('staggers delays for multiple fields', () => {
+			const { triggerAnimations, getAnimationDelay } = useFieldAnimations();
+
+			triggerAnimations(['a', 'b', 'c']);
+
+			expect(getAnimationDelay('a')).toBe(0);
+			expect(getAnimationDelay('b')).toBe(FIELD_ANIMATION_STAGGER);
+			expect(getAnimationDelay('c')).toBe(FIELD_ANIMATION_STAGGER * 2);
+		});
+
+		it('updates keys when re-triggered', () => {
+			const { triggerAnimations, getAnimationKey } = useFieldAnimations();
+
+			triggerAnimations(['title']);
+			const firstKey = getAnimationKey('title');
+
+			vi.setSystemTime(2000);
+			triggerAnimations(['title']);
+			const secondKey = getAnimationKey('title');
+
+			expect(secondKey).not.toBe(firstKey);
+			expect(secondKey).toBe(2000);
+		});
+	});
+
+	describe('clearAnimation', () => {
+		it('removes field from animation state', () => {
+			const { triggerAnimations, clearAnimation, getAnimationKey } = useFieldAnimations();
+
+			triggerAnimations(['title']);
+			expect(getAnimationKey('title')).toBeDefined();
+
+			clearAnimation('title');
+			expect(getAnimationKey('title')).toBeUndefined();
+		});
+
+		it('does nothing for non-animated fields', () => {
+			const { clearAnimation, getAnimationKey } = useFieldAnimations();
+
+			clearAnimation('nonexistent');
+			expect(getAnimationKey('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getAnimationKey', () => {
+		it('returns undefined for non-animated fields', () => {
+			const { getAnimationKey } = useFieldAnimations();
+
+			expect(getAnimationKey('unknown')).toBeUndefined();
+		});
+	});
+
+	describe('getAnimationDelay', () => {
+		it('returns 0 for non-animated fields', () => {
+			const { getAnimationDelay } = useFieldAnimations();
+
+			expect(getAnimationDelay('unknown')).toBe(0);
+		});
+	});
+});

--- a/app/src/components/v-form/composables/use-field-animations.ts
+++ b/app/src/components/v-form/composables/use-field-animations.ts
@@ -1,0 +1,60 @@
+import { ref, type InjectionKey } from 'vue';
+
+export interface FieldAnimations {
+	triggerAnimations: (fields: string[]) => void;
+	clearAnimation: (field: string) => void;
+	getAnimationKey: (field: string) => number | undefined;
+	getAnimationDelay: (field: string) => number;
+}
+
+export const fieldAnimationsKey: InjectionKey<FieldAnimations> = Symbol('field-animations');
+
+const FIELD_ANIMATION_STAGGER = 150; // Stagger per field for smooth cascade
+
+export function useFieldAnimations(): FieldAnimations {
+	const updatedFields = ref<Map<string, number>>(new Map());
+
+	function triggerAnimations(fields: string[]) {
+		const newMap = new Map(updatedFields.value);
+		const baseTime = Date.now();
+
+		fields.forEach((field, index) => {
+			// Handle nested paths - animate the top-level field
+			const topLevel = field.includes('.') ? field.split('.')[0]! : field;
+			// Stagger timestamps by 10ms for reliable ordering
+			newMap.set(topLevel, baseTime + index * 10);
+		});
+
+		updatedFields.value = newMap;
+	}
+
+	function clearAnimation(field: string) {
+		if (!updatedFields.value.has(field)) return;
+
+		const newMap = new Map(updatedFields.value);
+		newMap.delete(field);
+		updatedFields.value = newMap;
+	}
+
+	function getAnimationKey(field: string): number | undefined {
+		return updatedFields.value.get(field);
+	}
+
+	function getAnimationDelay(field: string): number {
+		const timestamp = updatedFields.value.get(field);
+		if (!timestamp) return 0;
+
+		// Sort by timestamp to determine animation order
+		const sorted = [...updatedFields.value.entries()].sort((a, b) => a[1] - b[1]);
+		const index = sorted.findIndex(([f]) => f === field);
+
+		return index * FIELD_ANIMATION_STAGGER;
+	}
+
+	return {
+		triggerAnimations,
+		clearAnimation,
+		getAnimationKey,
+		getAnimationDelay,
+	};
+}

--- a/app/src/components/v-form/composables/use-field-animations.ts
+++ b/app/src/components/v-form/composables/use-field-animations.ts
@@ -25,8 +25,9 @@ export function useFieldAnimations(): FieldAnimations {
 
 		fields.forEach((field, index) => {
 			const [topLevel] = field.split('.');
+			if (!topLevel) return;
 
-			newMap.set(topLevel!, {
+			newMap.set(topLevel, {
 				key: baseKey + index,
 				delay: index * FIELD_ANIMATION_STAGGER,
 			});

--- a/app/src/components/v-form/form-field-animations.vue
+++ b/app/src/components/v-form/form-field-animations.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { computed, inject } from 'vue';
+import { fieldAnimationsKey } from './composables/use-field-animations';
+
+const props = defineProps<{
+	field: string;
+}>();
+
+const fieldAnimations = inject(fieldAnimationsKey);
+
+const animationKey = computed(() => fieldAnimations?.getAnimationKey(props.field));
+const animationDelay = computed(() => fieldAnimations?.getAnimationDelay(props.field) ?? 0);
+
+function onAnimationEnd(event: AnimationEvent) {
+	if (event.animationName !== 'cursor-appear') return;
+	fieldAnimations?.clearAnimation(props.field);
+}
+</script>
+
+<template>
+	<div :key="animationKey" class="field-animations">
+		<div class="field-animation-border" />
+		<div class="field-animation-shimmer" />
+		<div class="field-cursor" @animationend="onAnimationEnd">
+			<v-icon name="magic_button" />
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+
+.field-animations {
+	display: contents;
+
+	--animation-length: 2s;
+	--animation-delay: v-bind(`${animationDelay}ms`);
+}
+
+.field-animation-border {
+	position: absolute;
+	inset: -4px;
+	border-radius: var(--theme--border-radius);
+	pointer-events: none;
+	box-shadow: 0 0 0 2px var(--theme--primary);
+	opacity: 0;
+	animation: border-pulse var(--animation-length) ease-out var(--animation-delay, 0ms);
+	z-index: 2;
+}
+
+.field-animation-shimmer {
+	position: absolute;
+	inset: 0;
+	border-radius: var(--theme--border-radius);
+	pointer-events: none;
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		transparent 25%,
+		var(--theme--primary-background) 50%,
+		transparent 75%,
+		transparent 100%
+	);
+	opacity: 0;
+	animation: text-shimmer-sweep var(--animation-length) ease-out var(--animation-delay, 0ms);
+	background-size: 200% 100%;
+	mix-blend-mode: soft-light;
+	z-index: 3;
+	overflow: hidden;
+}
+
+.field-cursor {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-end: 0;
+	pointer-events: none;
+	z-index: 10;
+	color: var(--theme--primary);
+	font-size: 32px;
+	opacity: 0;
+	animation: cursor-appear var(--animation-length) ease-out var(--animation-delay, 0ms);
+}
+
+@keyframes border-pulse {
+	0% {
+		opacity: 0;
+	}
+
+	10% {
+		opacity: 0.9;
+	}
+
+	25% {
+		opacity: 0.7;
+	}
+
+	75% {
+		opacity: 0.5;
+	}
+
+	90% {
+		opacity: 0.2;
+	}
+
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes text-shimmer-sweep {
+	0% {
+		opacity: 0;
+		background-position: 250% 0;
+	}
+
+	10% {
+		opacity: 0.8;
+	}
+
+	20% {
+		opacity: 1;
+		background-position: 150% 0;
+	}
+
+	60% {
+		opacity: 1;
+		background-position: -50% 0;
+	}
+
+	70% {
+		opacity: 0.8;
+	}
+
+	100% {
+		opacity: 0;
+		background-position: -150% 0;
+	}
+}
+
+@keyframes cursor-appear {
+	0% {
+		opacity: 0;
+		transform: scale(0.5) rotate(-10deg);
+	}
+
+	15% {
+		opacity: 1;
+		transform: scale(1.1) rotate(0deg);
+	}
+
+	25% {
+		opacity: 1;
+		transform: scale(1) rotate(0deg);
+	}
+
+	85% {
+		opacity: 1;
+		transform: scale(1) rotate(0deg);
+	}
+
+	100% {
+		opacity: 0;
+		transform: scale(0.8) rotate(5deg);
+	}
+}
+</style>

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -4,8 +4,9 @@ import { formatFieldFunction } from '@/utils/format-field-function';
 import { ValidationError } from '@directus/types';
 import { parseJSON } from '@directus/utils';
 import { isEqual } from 'lodash';
-import { computed, ref, watch } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { fieldAnimationsKey } from './composables/use-field-animations';
 import FormFieldInterface from './form-field-interface.vue';
 import FormFieldLabel from './form-field-label.vue';
 import FormFieldMenu, { type MenuOptions } from './form-field-menu.vue';
@@ -47,6 +48,17 @@ const props = withDefaults(
 const emit = defineEmits(['toggle-batch', 'toggle-raw', 'unset', 'update:modelValue', 'setFieldValue']);
 
 const { t } = useI18n();
+
+const fieldAnimations = inject(fieldAnimationsKey);
+
+const animationKey = computed(() => fieldAnimations?.getAnimationKey(props.field.field));
+const animationDelay = computed(() => fieldAnimations?.getAnimationDelay(props.field.field) ?? 0);
+
+function onAnimationEnd(event: AnimationEvent) {
+	// Only handle the cursor-appear animation, ignore bubbled events from children
+	if (event.animationName !== 'cursor-appear') return;
+	fieldAnimations?.clearAnimation(props.field.field);
+}
 
 const isDisabled = computed(() => {
 	if (props.disabled) return true;
@@ -173,8 +185,10 @@ function useComputedValues() {
 			field.meta?.width || 'full',
 			{
 				invalid: validationError,
+				'field-updated': animationKey,
 			},
 		]"
+		:style="animationKey ? { '--animation-delay': `${animationDelay}ms` } : undefined"
 	>
 		<v-menu v-if="!isLabelHidden" :disabled="disabledMenu" placement="bottom-start" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
@@ -251,6 +265,10 @@ function useComputedValues() {
 			</template>
 			<template v-else>{{ validationPrefix }}{{ validationMessage }}</template>
 		</small>
+
+		<div v-if="animationKey" :key="animationKey" class="field-cursor" @animationend="onAnimationEnd">
+			<v-icon name="magic_button" />
+		</div>
 	</div>
 </template>
 
@@ -289,5 +307,146 @@ function useComputedValues() {
 
 .label-spacer {
 	block-size: 28px;
+}
+
+.field-updated {
+	position: relative;
+	isolation: isolate;
+
+	> * {
+		position: relative;
+		z-index: 1;
+	}
+
+	/* Border pulse */
+	&::before {
+		content: '';
+		position: absolute;
+		inset: -4px;
+		border-radius: var(--theme--border-radius);
+		pointer-events: none;
+		box-shadow: 0 0 0 2px var(--theme--primary);
+		opacity: 0;
+		animation: border-pulse 2s ease-out var(--animation-delay, 0ms);
+		z-index: 2;
+	}
+
+	/* Text shimmer overlay */
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: var(--theme--border-radius);
+		pointer-events: none;
+		background: linear-gradient(
+			90deg,
+			transparent 0%,
+			transparent 25%,
+			var(--theme--primary-background) 50%,
+			transparent 75%,
+			transparent 100%
+		);
+		opacity: 0;
+		animation: text-shimmer-sweep 2s ease-out var(--animation-delay, 0ms);
+		background-size: 200% 100%;
+		mix-blend-mode: soft-light;
+		z-index: 3;
+		overflow: hidden;
+	}
+}
+
+@keyframes border-pulse {
+	0% {
+		opacity: 0;
+	}
+
+	10% {
+		opacity: 0.9;
+	}
+
+	25% {
+		opacity: 0.7;
+	}
+
+	75% {
+		opacity: 0.5;
+	}
+
+	90% {
+		opacity: 0.2;
+	}
+
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes text-shimmer-sweep {
+	0% {
+		opacity: 0;
+		background-position: 250% 0;
+	}
+
+	10% {
+		opacity: 0.8;
+	}
+
+	20% {
+		opacity: 1;
+		background-position: 150% 0;
+	}
+
+	60% {
+		opacity: 1;
+		background-position: -50% 0;
+	}
+
+	70% {
+		opacity: 0.8;
+	}
+
+	100% {
+		opacity: 0;
+		background-position: -150% 0;
+	}
+}
+
+.field-cursor {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-end: 0;
+	pointer-events: none;
+	z-index: 10;
+	color: var(--theme--primary);
+	font-size: 32px;
+	opacity: 0;
+	animation: cursor-appear 2s ease-out var(--animation-delay, 0ms);
+}
+
+@keyframes cursor-appear {
+	0% {
+		opacity: 0;
+		transform: scale(0.5) rotate(-10deg);
+	}
+
+	15% {
+		opacity: 1;
+		transform: scale(1.1) rotate(0deg);
+	}
+
+	25% {
+		opacity: 1;
+		transform: scale(1) rotate(0deg);
+	}
+
+	85% {
+		opacity: 1;
+		transform: scale(1) rotate(0deg);
+	}
+
+	100% {
+		opacity: 0;
+		transform: scale(0.8) rotate(5deg);
+	}
 }
 </style>

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -7,6 +7,7 @@ import { isEqual } from 'lodash';
 import { computed, inject, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { fieldAnimationsKey } from './composables/use-field-animations';
+import FormFieldAnimations from './form-field-animations.vue';
 import FormFieldInterface from './form-field-interface.vue';
 import FormFieldLabel from './form-field-label.vue';
 import FormFieldMenu, { type MenuOptions } from './form-field-menu.vue';
@@ -50,15 +51,7 @@ const emit = defineEmits(['toggle-batch', 'toggle-raw', 'unset', 'update:modelVa
 const { t } = useI18n();
 
 const fieldAnimations = inject(fieldAnimationsKey);
-
 const animationKey = computed(() => fieldAnimations?.getAnimationKey(props.field.field));
-const animationDelay = computed(() => fieldAnimations?.getAnimationDelay(props.field.field) ?? 0);
-
-function onAnimationEnd(event: AnimationEvent) {
-	// Only handle the cursor-appear animation, ignore bubbled events from children
-	if (event.animationName !== 'cursor-appear') return;
-	fieldAnimations?.clearAnimation(props.field.field);
-}
 
 const isDisabled = computed(() => {
 	if (props.disabled) return true;
@@ -188,7 +181,6 @@ function useComputedValues() {
 				'field-updated': animationKey,
 			},
 		]"
-		:style="animationKey ? { '--animation-delay': `${animationDelay}ms` } : undefined"
 	>
 		<v-menu v-if="!isLabelHidden" :disabled="disabledMenu" placement="bottom-start" show-arrow arrow-placement="start">
 			<template #activator="{ toggle, active }">
@@ -266,9 +258,7 @@ function useComputedValues() {
 			<template v-else>{{ validationPrefix }}{{ validationMessage }}</template>
 		</small>
 
-		<div v-if="animationKey" :key="animationKey" class="field-cursor" @animationend="onAnimationEnd">
-			<v-icon name="magic_button" />
-		</div>
+		<form-field-animations v-if="animationKey" :field="field.field" />
 	</div>
 </template>
 
@@ -316,137 +306,6 @@ function useComputedValues() {
 	> * {
 		position: relative;
 		z-index: 1;
-	}
-
-	/* Border pulse */
-	&::before {
-		content: '';
-		position: absolute;
-		inset: -4px;
-		border-radius: var(--theme--border-radius);
-		pointer-events: none;
-		box-shadow: 0 0 0 2px var(--theme--primary);
-		opacity: 0;
-		animation: border-pulse 2s ease-out var(--animation-delay, 0ms);
-		z-index: 2;
-	}
-
-	/* Text shimmer overlay */
-	&::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		border-radius: var(--theme--border-radius);
-		pointer-events: none;
-		background: linear-gradient(
-			90deg,
-			transparent 0%,
-			transparent 25%,
-			var(--theme--primary-background) 50%,
-			transparent 75%,
-			transparent 100%
-		);
-		opacity: 0;
-		animation: text-shimmer-sweep 2s ease-out var(--animation-delay, 0ms);
-		background-size: 200% 100%;
-		mix-blend-mode: soft-light;
-		z-index: 3;
-		overflow: hidden;
-	}
-}
-
-@keyframes border-pulse {
-	0% {
-		opacity: 0;
-	}
-
-	10% {
-		opacity: 0.9;
-	}
-
-	25% {
-		opacity: 0.7;
-	}
-
-	75% {
-		opacity: 0.5;
-	}
-
-	90% {
-		opacity: 0.2;
-	}
-
-	100% {
-		opacity: 0;
-	}
-}
-
-@keyframes text-shimmer-sweep {
-	0% {
-		opacity: 0;
-		background-position: 250% 0;
-	}
-
-	10% {
-		opacity: 0.8;
-	}
-
-	20% {
-		opacity: 1;
-		background-position: 150% 0;
-	}
-
-	60% {
-		opacity: 1;
-		background-position: -50% 0;
-	}
-
-	70% {
-		opacity: 0.8;
-	}
-
-	100% {
-		opacity: 0;
-		background-position: -150% 0;
-	}
-}
-
-.field-cursor {
-	position: absolute;
-	inset-block-start: 0;
-	inset-inline-end: 0;
-	pointer-events: none;
-	z-index: 10;
-	color: var(--theme--primary);
-	font-size: 32px;
-	opacity: 0;
-	animation: cursor-appear 2s ease-out var(--animation-delay, 0ms);
-}
-
-@keyframes cursor-appear {
-	0% {
-		opacity: 0;
-		transform: scale(0.5) rotate(-10deg);
-	}
-
-	15% {
-		opacity: 1;
-		transform: scale(1.1) rotate(0deg);
-	}
-
-	25% {
-		opacity: 1;
-		transform: scale(1) rotate(0deg);
-	}
-
-	85% {
-		opacity: 1;
-		transform: scale(1) rotate(0deg);
-	}
-
-	100% {
-		opacity: 0;
-		transform: scale(0.8) rotate(5deg);
 	}
 }
 </style>

--- a/app/src/modules/settings/routes/appearance/item.vue
+++ b/app/src/modules/settings/routes/appearance/item.vue
@@ -54,7 +54,7 @@ function discardAndLeave() {
 
 <template>
 	<private-view :title="$t('settings_appearance')" icon="palette">
-		<template #headline><v-breadcrumb :items="[{ name: t('settings'), to: '/settings' }]" /></template>
+		<template #headline><v-breadcrumb :items="[{ name: $t('settings'), to: '/settings' }]" /></template>
 
 		<template #actions>
 			<v-button v-tooltip.bottom="$t('save')" icon rounded :disabled="!hasEdits" :loading="saving" small @click="save">


### PR DESCRIPTION
**Add some glow up** 

https://github.com/user-attachments/assets/d56edc79-34a0-48d5-9587-dd6a23dcc477

(nevermind those values didn't change in the video)

---

This pull request introduces a new field update animation system to the form components, improving user feedback when form fields are programmatically changed (such as via AI actions). It also includes several minor UI tweaks and style adjustments across AI and settings components.

**Field Animation System for Forms:**

* Added a new composable `use-field-animations` in `use-field-animations.ts`, providing methods to trigger, clear, and manage staggered animations for updated fields.
* Integrated the animation system into the form: `v-form.vue` now provides the animation context, triggers animations on field value changes, and passes the context to child fields. [[1]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529R14) [[2]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529R94) [[3]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529L138-R149) [[4]](diffhunk://#diff-10f06643eeed24f7ffcd2b40bec49bc038db5ef8d392251c85dbedf87222d529R196)
* Updated `form-field.vue` to consume the animation context, apply animated styles and cursor indicators to updated fields, and handle animation lifecycle. This includes new CSS for border pulse, shimmer, and cursor effects. [[1]](diffhunk://#diff-a8d3a015dd652517563e174485c8d920eb95eddee32e77c6452a92f136055782L7-R9) [[2]](diffhunk://#diff-a8d3a015dd652517563e174485c8d920eb95eddee32e77c6452a92f136055782R52-R62) [[3]](diffhunk://#diff-a8d3a015dd652517563e174485c8d920eb95eddee32e77c6452a92f136055782R188-R191) [[4]](diffhunk://#diff-a8d3a015dd652517563e174485c8d920eb95eddee32e77c6452a92f136055782R268-R271) [[5]](diffhunk://#diff-a8d3a015dd652517563e174485c8d920eb95eddee32e77c6452a92f136055782R311-R451)

**Minor UI and Style Adjustments:**

* Changed the empty state icon in the AI conversation component from `smart_toy` to `magic_button`.
* Adjusted paddings and sizing in AI-related components for better layout and alignment: conversation message container, sidebar, message text, and input button. [[1]](diffhunk://#diff-2b3a7ccbe47e868097cce7f2eba46e4ffaf3761267ca2bea7319889858e7af16L104-R104) [[2]](diffhunk://#diff-6064b1f5e5aba0f6edde1e43e2d76e4b1fb7e5877ec377a5ed4366b2a70acf56L106-R106) [[3]](diffhunk://#diff-ab9b46faf461c760579c648868d5794fee02ef8423c93c768d00dcea8ec601f3L39-R39) [[4]](diffhunk://#diff-d1144a6ed74e40dbdf3808febfb586c797afddc4a2f784f46874d2e7623caa84R89-R93)
* Fixed a minor translation bug in the appearance settings route by using `$t` instead of `t` for the settings breadcrumb.