### PR TITLE
Add Visual Editing to Live Preview pane

### DIFF
--- a/app/src/composables/use-visual-editing.ts
+++ b/app/src/composables/use-visual-editing.ts
@@ -1,0 +1,44 @@
+import { computed, unref, type MaybeRef } from 'vue';
+import { MODULE_BAR_DEFAULT } from '@/constants';
+import { useSettingsStore } from '@/stores/settings';
+import { normalizeUrl } from '@/utils/normalize-url';
+
+interface UseVisualEditingOptions {
+	/** Preview URL to check (will be normalized internally) */
+	previewUrl: MaybeRef<string | null>;
+	/** Whether this is a new item - visual editing is disabled for new items. Defaults to false. */
+	isNew?: MaybeRef<boolean>;
+}
+
+/**
+ * Handles visual editing prerequisites check.
+ * Returns whether visual editing can be enabled and the allowed URLs for sameOrigin validation.
+ *
+ * Note: This checks prerequisites only. The live-preview component does the final
+ * sameOrigin validation against the currently displayed URL.
+ */
+export function useVisualEditing({ previewUrl, isNew = false }: UseVisualEditingOptions) {
+	const settingsStore = useSettingsStore();
+	const moduleBar = computed(() => settingsStore.settings?.module_bar ?? MODULE_BAR_DEFAULT);
+
+	const visualEditorUrls = computed(
+		() => settingsStore.settings?.visual_editor_urls?.map(({ url }) => url).filter(Boolean) ?? [],
+	);
+
+	const visualModuleEnabled = computed(() =>
+		moduleBar.value.some((part) => part.type === 'module' && part.id === 'visual' && part.enabled),
+	);
+
+	const normalizedPreviewUrl = computed(() => normalizeUrl(unref(previewUrl)));
+
+	/** Prerequisites check - live-preview does the final sameOrigin validation */
+	const visualEditingEnabled = computed(
+		() =>
+			!!normalizedPreviewUrl.value &&
+			!unref(isNew) &&
+			visualModuleEnabled.value &&
+			visualEditorUrls.value.length > 0,
+	);
+
+	return { visualEditingEnabled, visualEditorUrls };
+}

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -983,10 +983,4 @@ function useCollectionRoute() {
 .content-split.sp-collapsed :deep(.sp-end) {
 	border-inline-start: none;
 }
-
-/* Disable pointer events on iframe during drag to prevent jank */
-.content-split.sp-dragging :deep(iframe),
-.content-split:active :deep(iframe) {
-	pointer-events: none !important;
-}
 </style>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -364,6 +364,10 @@ async function refreshLivePreview() {
 	}
 }
 
+function onVisualEditorSaved() {
+	refresh();
+}
+
 watch(saving, async (newVal, oldVal) => {
 	if (newVal === true || oldVal === false) return;
 
@@ -787,6 +791,7 @@ function useCollectionRoute() {
 					:can-enable-visual-editing="visualEditingEnabled"
 					:visual-editor-urls="visualEditorUrls"
 					@new-window="livePreviewMode = 'popup'"
+					@saved="onVisualEditorSaved"
 				>
 					<template #prepend-header>
 						<v-button

--- a/app/src/modules/content/routes/preview.vue
+++ b/app/src/modules/content/routes/preview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
+import { useVisualEditing } from '@/composables/use-visual-editing';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import LivePreview from '@/views/private/components/live-preview.vue';
 import { useCollection } from '@directus/composables';
@@ -29,11 +30,20 @@ const previewUrl = computed(() => {
 	return displayValue.value || null;
 });
 
+const { visualEditingEnabled, visualEditorUrls } = useVisualEditing({ previewUrl });
+
 function closePopup() {
 	window.close();
 }
 </script>
 
 <template>
-	<live-preview v-if="previewUrl" :url="previewUrl" in-popup @new-window="closePopup" />
+	<live-preview
+		v-if="previewUrl"
+		:url="previewUrl"
+		in-popup
+		:can-enable-visual-editing="visualEditingEnabled"
+		:visual-editor-urls="visualEditorUrls"
+		@new-window="closePopup"
+	/>
 </template>

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -20,7 +20,10 @@ const { frameSrc, frameEl, showEditableElements } = defineProps<{
 	showEditableElements?: boolean;
 }>();
 
-const emit = defineEmits(['navigation']);
+const emit = defineEmits<{
+	navigation: [data: NavigationData];
+	saved: [data: { collection: string; primaryKey: PrimaryKey }];
+}>();
 
 const { t } = useI18n();
 
@@ -160,6 +163,8 @@ function useItemWithEdits() {
 				item: primaryKey.value,
 				payload: JSON.parse(JSON.stringify(edits.value)),
 			});
+
+			emit('saved', { collection: collection.value, primaryKey: primaryKey.value });
 
 			resetEdits();
 		} catch (error) {

--- a/app/src/styles/_base.scss
+++ b/app/src/styles/_base.scss
@@ -157,3 +157,8 @@ input[type='search']::-webkit-search-results-button,
 input[type='search']::-webkit-search-results-decoration {
 	-webkit-appearance: none;
 }
+
+// Disable pointer events on iframes during split panel drag to prevent jank
+.sp-dragging iframe {
+	pointer-events: none !important;
+}

--- a/app/src/utils/normalize-url.ts
+++ b/app/src/utils/normalize-url.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalizes a URL string by resolving it against the current window location.
+ * Returns null if the URL is invalid or empty.
+ */
+export function normalizeUrl(url: string | null): string | null {
+	if (!url) return null;
+
+	try {
+		return new URL(url, window.location.href).href;
+	} catch {
+		return null;
+	}
+}

--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -41,6 +41,7 @@ const {
 const emit = defineEmits<{
 	'new-window': [];
 	selectUrl: [newUrl: string, oldUrl: string];
+	saved: [data: { collection: string; primaryKey: string | number }];
 }>();
 
 const { t } = useI18n();
@@ -393,6 +394,7 @@ function useUrls() {
 						:frame-el="frameEl"
 						:frame-src="frameSrc"
 						:show-editable-elements="showEditableElements"
+						@saved="(data) => emit('saved', data)"
 					/>
 				</div>
 			</div>


### PR DESCRIPTION


https://github.com/user-attachments/assets/b4253c56-8eb7-4e07-827d-7ea17917afde



Adds visual editing capability to the live preview pane. This is a nice improvement for content editors where visual editing is enabled because it uses the live preview URLs to render the visual editor on the same page without having to navigate to the module. No context switching.

---


This pull request introduces a robust visual editing integration for live previews, improving the user experience for editing content in-place. The changes add a two-layer validation for visual editing (prerequisites and same-origin checks), enable toggling of a full-width preview mode, and streamline the handling of editable overlays and their state. Additionally, code organization and UX are improved for both regular and popup preview modes.

Key changes include:

**Visual Editing Integration & Validation:**

* Added a new composable `useVisualEditing` to centralize the logic for determining if visual editing can be enabled, including checks for module activation, URL configuration, and item state (`use-visual-editing.ts`).
* Updated `live-preview.vue` to accept new props for visual editing capability and allowed URLs, and to perform a same-origin check on the currently displayed URL before enabling editing. [[1]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR20-R22) [[2]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR34-R48) [[3]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR103-R119)
* Integrated visual editing prerequisites and state into both the main content item view and the preview popup, ensuring consistent behavior and UI. [[1]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R308-R313) [[2]](diffhunk://#diff-6f26469543a19133a152f90fcb3e4f7cd904fbda089fea14afefddfe2db159c7R33-R48)

**UI/UX Enhancements:**

* Added a full-width toggle button for the live preview panel, with state persisted via local storage and UI updates for split panel sizing. [[1]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R271) [[2]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L291-R293) [[3]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L751-R763) [[4]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L777-R808)
* Provided a toolbar button to toggle the visibility of editable elements in the live preview, and ensured overlay state resets on URL change or when editing is disabled. [[1]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR60-R61) [[2]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR242-R254) [[3]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR147-R157)

**Communication & State Management:**

* Enabled the `editing-layer.vue` component to emit a `saved` event after a successful save, allowing parent components to refresh data as needed. [[1]](diffhunk://#diff-2a60012f4d682c4396335b1de0fc81ab717a97bd0e75dfc6ea3fadffa2587b75L23-R26) [[2]](diffhunk://#diff-2a60012f4d682c4396335b1de0fc81ab717a97bd0e75dfc6ea3fadffa2587b75R167-R168) [[3]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR34-R48) [[4]](diffhunk://#diff-0ad571e69c8b7a9fb744dce3e5fd4d12ae5a23693e8dd64681aaa74a40997e4eR392-R398) [[5]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820R367-R370)

**Code Organization & Utilities:**

* Added a utility function `normalizeUrl` to standardize preview URLs and prevent errors from malformed inputs.
* Moved the CSS rule for disabling pointer events on iframes during split panel dragging into the global styles for better maintainability. [[1]](diffhunk://#diff-e81f28221eb4877d6d4beb6f3dd7ee95ed38e899656dcb8725a45c3f18c89732R160-R164) [[2]](diffhunk://#diff-2687766e0be3926666a68a860ddc5cc0daa26a2bc3e5edbeec33941036d7e820L955-L960)

These changes collectively make visual editing more robust, user-friendly, and maintainable.