### PR TITLE
AI -> Hide when No Providers / Not Configured

### DIFF
--- a/app/src/ai/components/ai-sidebar-detail.vue
+++ b/app/src/ai/components/ai-sidebar-detail.vue
@@ -33,6 +33,7 @@ useShortcut('meta+j', () => {
 			<div ref="collapsible-trigger-content" class="collapsible-trigger-content">
 				<AiMagicButton class="collapsible-trigger-icon" :animate="hovering" />
 				<span v-show="!sidebarStore.collapsed" class="collapsible-trigger-title">{{ $t('ai_chat') }}</span>
+				<v-chip v-show="!sidebarStore.collapsed" outlined primary x-small class="collapsible-trigger-beta">{{ $t('beta') }}</v-chip>
 				<VIcon v-show="!sidebarStore.collapsed" name="chevron_left" class="collapsible-trigger-chevron" />
 			</div>
 		</CollapsibleTrigger>
@@ -74,6 +75,12 @@ useShortcut('meta+j', () => {
 .collapsible-trigger-title {
 	flex-grow: 1;
 	text-align: start;
+}
+
+.collapsible-trigger-beta {
+	margin-inline-end: 8px;
+	color: var(--theme--primary);
+	border-color: var(--theme--primary);
 }
 
 .collapsible-trigger-chevron {

--- a/app/src/ai/components/ai-sidebar-detail.vue
+++ b/app/src/ai/components/ai-sidebar-detail.vue
@@ -8,7 +8,6 @@ import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger } from 'reka-ui
 import { useTemplateRef } from 'vue';
 import { useAiStore } from '../stores/use-ai';
 import AiConversation from './ai-conversation.vue';
-import AiHeader from './ai-header.vue';
 import AiMagicButton from './ai-magic-button.vue';
 
 const sidebarStore = useSidebarStore();
@@ -39,7 +38,6 @@ useShortcut('meta+j', () => {
 		</CollapsibleTrigger>
 		<CollapsibleContent class="collapsible-content">
 			<div class="ai-sidebar-content">
-				<ai-header />
 				<ai-conversation />
 			</div>
 		</CollapsibleContent>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1688,6 +1688,10 @@ ai:
   clear_conversation: Clear Conversation
   build_with_chat: Build with AI Chat
   responses_may_be_inaccurate: AI responses may be inaccurate
+  go_to_settings: Go to Settings
+  setup_ai_chat: Setup AI Chat
+  setup_ai_chat_admin_description: Add your AI provider API keys in settings to enable AI Chat.
+  setup_ai_chat_user_description: Contact your administrator to enable AI Chat.
 ai_tools:
   update_form_values: Update Form Values
   read_form_values: Read Form Values


### PR DESCRIPTION
Adds not configured empty state and beta badge

<img width="3080" height="3400" alt="ScreenShot 2025-11-26 at 16 54 37@2x" src="https://github.com/user-attachments/assets/7d714926-301e-421d-87b8-6762d3d3f7ac" />


---
This pull request enhances the AI chat interface by improving the empty state experience, adding contextual messaging and actions, and refining the sidebar UI. The most important changes are grouped below:

**AI Chat Empty State Improvements:**

* Added a new computed `emptyState` in `ai-conversation.vue` to display tailored empty state messages and actions based on whether AI providers are configured and the user's admin status. Admins are prompted to set up providers, while regular users are advised to contact an admin.
* Updated the template in `ai-conversation.vue` to use the new `emptyState` logic, displaying appropriate titles, descriptions, and a "Go to Settings" button for admins when no providers are configured.
* The AI input area is now only shown if providers are configured, preventing users from interacting with the chat when unavailable.

**Sidebar and UI Refinements:**

* Removed the redundant `ai-header` from the sidebar detail and added a "beta" chip to the sidebar trigger for clearer status indication. [[1]](diffhunk://#diff-6064b1f5e5aba0f6edde1e43e2d76e4b1fb7e5877ec377a5ed4366b2a70acf56L11) [[2]](diffhunk://#diff-6064b1f5e5aba0f6edde1e43e2d76e4b1fb7e5877ec377a5ed4366b2a70acf56R35-L41)
* Added styles for the "beta" chip in the sidebar for better visual distinction.

**Localization Updates:**

* Added new translation keys for the improved empty state messages and the "Go to Settings" button in the English locale file.