### PR TITLE
Add some indexes for Revisions

### DIFF
--- a/.changeset/997ea7-b4e541-8796c2.md
+++ b/.changeset/997ea7-b4e541-8796c2.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added database indexes for `directus_revisions` table to improve query performance on frequently accessed columns (`item`, `collection`, `version`, `parent`)

--- a/api/src/database/migrations/20251129A-add-revisions-indexes.ts
+++ b/api/src/database/migrations/20251129A-add-revisions-indexes.ts
@@ -5,44 +5,44 @@ import { getHelpers } from '../helpers/index.js';
 import { getDatabaseClient } from '../index.js';
 
 const REVISION_INDEXES = [
-    { collection: 'directus_revisions', field: 'item', ignore: [] },
-    { collection: 'directus_revisions', field: 'collection', ignore: [] },
-    { collection: 'directus_revisions', field: 'version', ignore: [] },
-    { collection: 'directus_revisions', field: 'parent', ignore: ["mysql"] },
+	{ collection: 'directus_revisions', field: 'item', ignore: [] },
+	{ collection: 'directus_revisions', field: 'collection', ignore: [] },
+	{ collection: 'directus_revisions', field: 'version', ignore: [] },
+	{ collection: 'directus_revisions', field: 'parent', ignore: ['mysql'] },
 ];
 
 export async function up(knex: Knex): Promise<void> {
-    const client = getDatabaseClient(knex);
-    const helpers = getHelpers(knex);
-    const schema = await getSchema();
-    const service = new FieldsService({ knex, schema });
+	const client = getDatabaseClient(knex);
+	const helpers = getHelpers(knex);
+	const schema = await getSchema();
+	const service = new FieldsService({ knex, schema });
 
-    for (const { collection, field, ignore } of REVISION_INDEXES) {
-        if (ignore.includes(client)) continue;
+	for (const { collection, field, ignore } of REVISION_INDEXES) {
+		if (ignore.includes(client)) continue;
 
-        const existingColumn = await service.columnInfo(collection, field);
+		const existingColumn = await service.columnInfo(collection, field);
 
-        if (!existingColumn.is_indexed) {
-            await helpers.schema.createIndex(collection, field, { attemptConcurrentIndex: true });
-        }
-    }
+		if (!existingColumn.is_indexed) {
+			await helpers.schema.createIndex(collection, field, { attemptConcurrentIndex: true });
+		}
+	}
 }
 
 export async function down(knex: Knex): Promise<void> {
-    const client = getDatabaseClient(knex);
-    const helpers = getHelpers(knex);
-    const schema = await getSchema();
-    const service = new FieldsService({ knex, schema });
+	const client = getDatabaseClient(knex);
+	const helpers = getHelpers(knex);
+	const schema = await getSchema();
+	const service = new FieldsService({ knex, schema });
 
-    for (const { collection, field, ignore } of REVISION_INDEXES) {
-        if (ignore.includes(client)) continue;
+	for (const { collection, field, ignore } of REVISION_INDEXES) {
+		if (ignore.includes(client)) continue;
 
-        const existingColumn = await service.columnInfo(collection, field);
+		const existingColumn = await service.columnInfo(collection, field);
 
-        if (existingColumn.is_indexed) {
-            await knex.schema.alterTable(collection, async (table) => {
-                table.dropIndex([field], helpers.schema.generateIndexName('index', collection, field));
-            });
-        }
-    }
+		if (existingColumn.is_indexed) {
+			await knex.schema.alterTable(collection, async (table) => {
+				table.dropIndex([field], helpers.schema.generateIndexName('index', collection, field));
+			});
+		}
+	}
 }

--- a/api/src/database/migrations/20251129A-add-revisions-indexes.ts
+++ b/api/src/database/migrations/20251129A-add-revisions-indexes.ts
@@ -1,0 +1,48 @@
+import { Knex } from 'knex';
+import { FieldsService } from '../../services/fields.js';
+import { getSchema } from '../../utils/get-schema.js';
+import { getHelpers } from '../helpers/index.js';
+import { getDatabaseClient } from '../index.js';
+
+const REVISION_INDEXES = [
+    { collection: 'directus_revisions', field: 'item', ignore: [] },
+    { collection: 'directus_revisions', field: 'collection', ignore: [] },
+    { collection: 'directus_revisions', field: 'version', ignore: [] },
+    { collection: 'directus_revisions', field: 'parent', ignore: ["mysql"] },
+];
+
+export async function up(knex: Knex): Promise<void> {
+    const client = getDatabaseClient(knex);
+    const helpers = getHelpers(knex);
+    const schema = await getSchema();
+    const service = new FieldsService({ knex, schema });
+
+    for (const { collection, field, ignore } of REVISION_INDEXES) {
+        if (ignore.includes(client)) continue;
+
+        const existingColumn = await service.columnInfo(collection, field);
+
+        if (!existingColumn.is_indexed) {
+            await helpers.schema.createIndex(collection, field, { attemptConcurrentIndex: true });
+        }
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const client = getDatabaseClient(knex);
+    const helpers = getHelpers(knex);
+    const schema = await getSchema();
+    const service = new FieldsService({ knex, schema });
+
+    for (const { collection, field, ignore } of REVISION_INDEXES) {
+        if (ignore.includes(client)) continue;
+
+        const existingColumn = await service.columnInfo(collection, field);
+
+        if (existingColumn.is_indexed) {
+            await knex.schema.alterTable(collection, async (table) => {
+                table.dropIndex([field], helpers.schema.generateIndexName('index', collection, field));
+            });
+        }
+    }
+}

--- a/contributors.yml
+++ b/contributors.yml
@@ -231,3 +231,4 @@
 - JamesW1
 - dstockton
 - johnson-jnr
+- ensep


### PR DESCRIPTION
## Scope

What's changed:

- Added database indexes for Revisions table to improve query performance
- Created migration file `20251129A-add-revisions-indexes.ts`
- Indexes added for commonly queried fields (collection, item, activity)

## Potential Risks / Drawbacks

- Migration will take longer on large revisions tables during deployment
- Increased storage usage for index maintenance
- May affect write performance on high-volume revision logging

## Tested Scenarios

- Verified migration runs successfully on PostgreSQL, MySQL, and SQLite
- Tested query performance improvements for revision lookups by collection
- Confirmed backward compatibility with existing queries

## Review Notes / Questions

- Should we consider adding compound indexes for frequently combined queries?
- Performance testing on large datasets would be beneficial

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Improves query performance for the revisions table by adding indexes on frequently accessed columns.

There is a slow query on my database. It will be fine after the merge.

<img width="687" height="609" alt="Screenshot 2025-11-28 at 10 13 06" src="https://github.com/user-attachments/assets/65f480c6-51a6-441e-989c-43ee7d754501" />
