### PR TITLE
useFlows: Make primaryKey value reactive

### DIFF
--- a/.changeset/stale-onions-attend.md
+++ b/.changeset/stale-onions-attend.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added reactive primaryKey prop to useFlows composable

--- a/app/src/composables/use-flows.ts
+++ b/app/src/composables/use-flows.ts
@@ -1,5 +1,5 @@
 import api from '@/api';
-import { computed, ref, provide, inject, type Ref } from 'vue';
+import { computed, ref, provide, inject, unref, type Ref } from 'vue';
 import { FlowRaw, Item, PrimaryKey } from '@directus/types';
 import { notify } from '@/utils/notify';
 import { translate } from '@/utils/translate-object-values';
@@ -12,7 +12,7 @@ import formatTitle from '@directus/format-title';
 
 interface UseFlowsOptions {
 	collection: Ref<string>;
-	primaryKey?: PrimaryKey | null;
+	primaryKey?: Ref<PrimaryKey | null>;
 	selection?: Ref<Item[]>;
 	location: 'collection' | 'item';
 	hasEdits?: Ref<boolean>;
@@ -150,7 +150,7 @@ export function useFlows(options: UseFlowsOptions) {
 
 		function checkFlowDisabled(manualFlow: FlowRaw) {
 			if (location === 'item' || manualFlow.options?.requireSelection === false) return false;
-			return !primaryKey && selection.value.length === 0;
+			return !unref(primaryKey) && selection.value.length === 0;
 		}
 
 		return manualFlows;
@@ -231,7 +231,7 @@ export function useFlows(options: UseFlowsOptions) {
 					collection: collection.value,
 				});
 			} else {
-				const keys = primaryKey ? [primaryKey] : selection.value || [];
+				const keys = unref(primaryKey) ? [unref(primaryKey)] : selection.value || [];
 
 				await api.post(`/flows/trigger/${flowId}`, {
 					...confirmValues.value,

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -304,7 +304,7 @@ watch(
 
 const { flowDialogsContext, manualFlows, provideRunManualFlow } = useFlows({
 	collection,
-	primaryKey: actualPrimaryKey.value,
+	primaryKey: actualPrimaryKey,
 	location: 'item',
 	hasEdits,
 	onRefreshCallback: refresh,

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -244,7 +244,7 @@ const overlayItemContentProps = computed(() => {
 
 const { provideRunManualFlow } = useFlows({
 	collection,
-	primaryKey: primaryKey.value,
+	primaryKey: primaryKey,
 	location: 'item',
 	hasEdits,
 	onRefreshCallback: refresh,


### PR DESCRIPTION
## Scope

What's changed:

- Fixes issue where navigating from item to another directly does not update the `useFlows` primaryKey because it was not reactive

## Potential Risks / Drawbacks

- NA

## Tested Scenarios

- Tested running flow on item
- Tested running flow on collection
- Tested running flow on item in drawer
- Tested running flow on item after direct navigation

## Review Notes / Questions

- Tests all pass

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
