### PR TITLE
Ensure the created revision uses the correct label

### DIFF
--- a/.changeset/orange-rats-burn.md
+++ b/.changeset/orange-rats-burn.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': major
+'@directus/app': patch
 ---
 
 fix(revisions): use correct label for create revision

--- a/.changeset/orange-rats-burn.md
+++ b/.changeset/orange-rats-burn.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': major
+---
+
+fix(revisions): use correct label for create revision

--- a/.changeset/orange-rats-burn.md
+++ b/.changeset/orange-rats-burn.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-fix(revisions): use correct label for create revision
+Ensured the created revision uses the correct label

--- a/app/src/views/private/components/revision-item.vue
+++ b/app/src/views/private/components/revision-item.vue
@@ -30,7 +30,7 @@ const revisionCount = computed(() => {
 const headerMessage = computed(() => {
 	switch (props.revision.activity.action.toLowerCase()) {
 		case 'create':
-			return t('revision_delta_created', revisionCount.value);
+			return t('revision_delta_created');
 		case 'update':
 			return t('revision_delta_updated', revisionCount.value);
 		case 'delete':

--- a/app/src/views/private/components/revision-item.vue
+++ b/app/src/views/private/components/revision-item.vue
@@ -30,7 +30,7 @@ const revisionCount = computed(() => {
 const headerMessage = computed(() => {
 	switch (props.revision.activity.action.toLowerCase()) {
 		case 'create':
-			return t('revision_delta_updated', revisionCount.value);
+			return t('revision_delta_created', revisionCount.value);
 		case 'update':
 			return t('revision_delta_updated', revisionCount.value);
 		case 'delete':

--- a/contributors.yml
+++ b/contributors.yml
@@ -231,3 +231,4 @@
 - JamesW1
 - dstockton
 - johnson-jnr
+- vizzv


### PR DESCRIPTION
## Scope

What's changed:

- Corrected the revision sidebar label for **create** revision entries.
- Replaced the incorrect `revision_delta_updated` translation key with `revision_delta_created`.
- Ensures newly created items display **“Created”** instead of **“Updated”** in the Revisions panel across all supported databases.

## Potential Risks / Drawbacks

- Very low risk: this change only updates the translation key used at runtime and does not modify revision logic or database behavior.

## Tested Scenarios

- Created new items in **SQLite**.
- Verified the revision sidebar now correctly displays **"Created"** for creation events.

## Review Notes / Questions

- Although the translation key `revision_delta_created` currently resolves to `"Created"` and does not include a `{count}` placeholder, I kept the existing pattern:

```js
  t('revision_delta_created', revisionCount.value);
```

This preserves consistency with other revision actions and ensures future compatibility with:

- locales that may use {count}
- potential pluralization changes
- consistent function signatures across all actions

Fixes #26273

If there's anything you'd like adjusted or improved, feel free to let me know!