### PR TITLE
Check telemetry environment setting before scheduling project status report

### DIFF
--- a/api/src/schedules/project.test.ts
+++ b/api/src/schedules/project.test.ts
@@ -51,6 +51,14 @@ test('Doesnt send report if not pending', async () => {
 	expect(vi.mocked(sendReport)).not.toHaveBeenCalledOnce();
 });
 
+test('Doesnt send report if telemetry is disabled', async () => {
+	vi.mocked(useEnv).mockReturnValue({ TELEMETRY: false });
+
+	await projectSchedule();
+
+	expect(vi.mocked(sendReport)).not.toHaveBeenCalledOnce();
+});
+
 test('Sends report when pending', async () => {
 	tracker.on.select('directus_settings').response([
 		{

--- a/api/src/schedules/project.ts
+++ b/api/src/schedules/project.ts
@@ -8,6 +8,10 @@ import { version } from 'directus/version';
  * Schedule the project status job
  */
 export default async function schedule() {
+	const env = useEnv();
+
+	if (toBoolean(env['TELEMETRY']) === false) return;
+
 	const db = getDatabase();
 
 	// Schedules a job at a random time of the day to avoid overloading the telemetry server


### PR DESCRIPTION
## Scope

What's changed:

- `TELEMETRY` option is checked before scheduling project status report

## Potential Risks / Drawbacks

—

## Tested Scenarios

- `sendReport` is not called when `TELEMETRY` is `false`.

## Review Notes / Questions

—

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] ~~OpenAPI package PR created [here](https://github.com/directus/openapi) or not required~~