### PR TITLE
AI ← Search input refinements

### DIFF
--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -199,22 +199,33 @@ function emitValue() {
 }
 
 .search-input {
+	--button-size: 36px;
+	--search-input-size: calc(var(--button-size) - var(--theme--border-width) * 2);
+	--search-input-radius: calc(var(--button-size) / 2);
+	--icon-size: 18px;
+	--icon-search-padding-left: 7px; // visually center in closed filter
+	--icon-search-padding-right: 4px;
+	--icon-filter-margin-right: 8px;
+
 	display: flex;
 	align-items: center;
-	inline-size: 36px;
-	min-block-size: 36px;
+	inline-size: var(--search-input-size);
+	min-block-size: var(--search-input-size);
 	max-inline-size: 100%;
 	box-sizing: content-box;
 	overflow: hidden;
 	border: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
-	border-radius: calc((36px + var(--theme--border-width) * 2) / 2);
+	border-radius: var(--search-input-radius);
 	transition:
 		inline-size var(--slow) var(--transition),
 		border-end-start-radius var(--fast) var(--transition),
 		border-end-end-radius var(--fast) var(--transition);
 
 	&.show-filter {
-		inline-size: 64px;
+		inline-size: calc(
+			var(--icon-size) * 2 + var(--icon-search-padding-left) + var(--icon-search-padding-right) +
+				var(--icon-filter-margin-right)
+		);
 	}
 
 	input {
@@ -258,11 +269,12 @@ function emitValue() {
 	}
 
 	.icon-search {
-		margin: 0 4px 0 9px; // visually center in closed filter
+		margin-block: 0;
+		margin-inline: var(--icon-search-padding-left) var(--icon-search-padding-right);
 	}
 
 	.icon-filter {
-		margin-inline-end: 8px;
+		margin-inline-end: var(--icon-filter-margin-right);
 	}
 
 	&:focus-within,
@@ -361,8 +373,8 @@ function emitValue() {
 	background-color: var(--theme--background-subdued);
 	border: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 	border-start-end-radius: 0;
-	border-end-end-radius: 22px;
-	border-end-start-radius: 22px;
+	border-end-end-radius: var(--search-input-radius);
+	border-end-start-radius: var(--search-input-radius);
 
 	&.active {
 		border-color: var(--theme--form--field--input--border-color-focus);


### PR DESCRIPTION
This PR refines the search/filter input styles to match the header button height using CSS variables. All sizing values
now depend on the button and icon sizes, with other values calculated automatically based on these. The field now
matches the new button height.

| Before | After |
|--------|--------|
| <img width="360" height="70" alt="1-before" src="https://github.com/user-attachments/assets/d2bbd05f-3ff9-4d00-b3ed-4cd70ad547db" /> | <img width="360" height="70" alt="1-after" src="https://github.com/user-attachments/assets/6f471ad3-1d08-46bb-a5e7-d4eaffbbec41" /> | 



