### PR TITLE
AI ← Introduce breakpoints constant

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -81,6 +81,12 @@ export const MODULE_BAR_DEFAULT = [
 	},
 ];
 
+export const BREAKPOINTS = {
+	sm: 640,
+	lg: 1024,
+	xl: 1280,
+};
+
 export const FIELD_TYPES_SELECT: Array<{ value: Type; text: string } | { divider: true }> = [
 	{
 		text: '$t:string',

--- a/app/src/views/private/private-view/components/private-view-root.vue
+++ b/app/src/views/private/private-view/components/private-view-root.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BREAKPOINTS } from '@/constants';
 import { SplitPanel } from '@directus/vue-split-panel';
 import { useNavBarStore } from '../stores/nav-bar';
 import PrivateViewMain from './private-view-main.vue';
@@ -6,12 +7,12 @@ import PrivateViewNav from './private-view-nav.vue';
 import ModuleBar from '../../components/module-bar.vue';
 import type { PrivateViewProps } from './private-view.vue';
 import PrivateViewResizeHandle from './private-view-resize-handle.vue';
-import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
+import { useBreakpoints } from '@vueuse/core';
 import PrivateViewDrawer from './private-view-drawer.vue';
 import { computed, watch } from 'vue';
 import { useSidebarStore } from '../stores/sidebar';
 
-const { lg, xl } = useBreakpoints(breakpointsTailwind);
+const { lg, xl } = useBreakpoints(BREAKPOINTS);
 
 const navBarStore = useNavBarStore();
 const sidebarStore = useSidebarStore();


### PR DESCRIPTION
This PR replaces `breakpointsTailwind` with a new internal constant `BREAKPOINTS` that we maintain internally. This
allows us to clearly see the values behind keys like `sm` and `lg`, and gives us the flexibility to add custom
breakpoints in the future with less external dependence. `PrivateViewRoot` demonstrates the example usage. The other
occurrences of `breakpointsTailwind` weren’t replaced yet, since there might be conflicts with other change requests at
the moment. However, let’s not forget to apply them.