### PR TITLE
AI -> Add Back Scroll Shadows but Better

### DIFF
--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -27,7 +27,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	icon: 'view_week',
 	component: KanbanLayout,
 	headerShadow: false,
-	sidebarShadow: true,
 	slots: {
 		options: KanbanOptions,
 		sidebar: () => undefined,

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -27,6 +27,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	icon: 'view_week',
 	component: KanbanLayout,
 	headerShadow: false,
+	sidebarShadow: false,
 	slots: {
 		options: KanbanOptions,
 		sidebar: () => undefined,

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -313,6 +313,7 @@ function clearFilters() {
 			:title="bookmark ? bookmarkTitle : currentCollection.name"
 			:icon="archive ? 'archive' : currentCollection.icon"
 			:icon-color="currentCollection.color"
+			:sidebar-shadow="layoutState.sidebarShadow"
 		>
 			<template #headline>
 				<v-breadcrumb v-if="bookmark" :items="breadcrumb" />

--- a/app/src/styles/themes/_dark.scss
+++ b/app/src/styles/themes/_dark.scss
@@ -24,8 +24,8 @@
 	--background-inverted: #fff;
 	--background-mark: var(--theme--primary-subdued);
 	--overlay-color: rgb(0 0 0 / 0.9);
-	--navigation-shadow: 0px 0px 12px var(--black);
 	--sidebar-shadow: var(--navigation-shadow);
+	--shadow-color: var(--black);
 
 	// Generate color variations
 	@include mixins.generate-colors($color-mapping, colors.$dark-theme-shade, colors.$dark-theme-tint);

--- a/app/src/styles/themes/_dark.scss
+++ b/app/src/styles/themes/_dark.scss
@@ -24,7 +24,7 @@
 	--background-inverted: #fff;
 	--background-mark: var(--theme--primary-subdued);
 	--overlay-color: rgb(0 0 0 / 0.9);
-	--sidebar-shadow: var(--navigation-shadow);
+	--sidebar-shadow: 4px 0 7px -4px var(--black);
 	--shadow-color: var(--black);
 
 	// Generate color variations

--- a/app/src/styles/themes/_light.scss
+++ b/app/src/styles/themes/_light.scss
@@ -13,8 +13,8 @@
 	--background-inverted: #263238;
 	--background-mark: var(--theme--primary-subdued);
 	--overlay-color: rgb(38 50 56 / 0.8);
-	--navigation-shadow: 4px 0 7px -4px rgb(0 0 0 / 0.2);
 	--sidebar-shadow: -4px 0 7px -4px rgb(0 0 0 / 0.2);
+	--shadow-color: rgb(0 0 0 / 0.1);
 
 	// Generate color variations
 	@include mixins.generate-colors(colors.$color-mapping, colors.$light-theme-tint, colors.$light-theme-shade);

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { SplitPanel } from '@directus/vue-split-panel';
+import { cssVar } from '@directus/utils/browser';
 import { breakpointsTailwind, useBreakpoints, useScroll } from '@vueuse/core';
 import { computed, inject, provide, unref, useTemplateRef, watch, type ComputedRef } from 'vue';
 import NotificationsGroup from '../../components/notifications-group.vue';
@@ -23,7 +24,22 @@ provide('main-element', contentEl);
 
 const sidebarStore = useSidebarStore();
 
-const { y } = useScroll(useTemplateRef('scroll-container'));
+const scrollContainerRef = useTemplateRef('scroll-container');
+const { y, x } = useScroll(scrollContainerRef);
+const sidebarShadow = computed(() => props.sidebarShadow ?? false);
+const contentPadding = computed(() => parseInt(cssVar('--content-padding'), 10) || 12);
+
+const showStartShadow = computed(() => {
+	if (sidebarShadow.value) return true;
+	return x.value >= contentPadding.value;
+});
+
+const showEndShadow = computed(() => {
+	if (sidebarShadow.value) return true;
+	const el = scrollContainerRef.value;
+	if (!el) return false;
+	return el.scrollWidth - el.clientWidth - x.value >= contentPadding.value;
+});
 
 const livePreviewActive = inject<ComputedRef<boolean>>(
 	'live-preview-active',
@@ -73,6 +89,8 @@ const splitterCollapsed = computed({
 			:disabled="!sm"
 		>
 			<template #start>
+				<div class="scroll-shadow start" :class="{ visible: showStartShadow }" />
+				<div class="scroll-shadow end" :class="{ visible: showEndShadow }" />
 				<div ref="scroll-container" class="scrolling-container" :class="{ 'flex-layout': livePreviewActive }">
 					<PrivateViewHeaderBar
 						:title="props.title"
@@ -131,6 +149,38 @@ const splitterCollapsed = computed({
 	&:deep(.sp-divider) {
 		z-index: 5;
 	}
+}
+
+.scroll-shadow {
+	position: absolute;
+	inset-block: 0;
+	inline-size: 7px;
+	pointer-events: none;
+	z-index: 6;
+	opacity: 0;
+	transition: opacity var(--medium) var(--transition);
+}
+
+.scroll-shadow.visible {
+	opacity: 1;
+}
+
+.scroll-shadow.start {
+	inset-inline-start: 0;
+	background: linear-gradient(to right, var(--shadow-color, transparent), transparent);
+}
+
+.scroll-shadow.end {
+	inset-inline-end: 0;
+	background: linear-gradient(to left, var(--shadow-color, transparent), transparent);
+}
+
+:dir(rtl) .scroll-shadow.start {
+	background: linear-gradient(to left, var(--shadow-color, transparent), transparent);
+}
+
+:dir(rtl) .scroll-shadow.end {
+	background: linear-gradient(to right, var(--shadow-color, transparent), transparent);
 }
 
 .main-split {

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -11,6 +11,9 @@ export interface PrivateViewProps {
 
 	/** Render a history back button in place of the title prepend icon */
 	showBack?: boolean;
+
+	/** Whether to always show sidebar shadows (true) or only on x scroll (false) */
+	sidebarShadow?: boolean;
 }
 </script>
 

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -12,7 +12,7 @@ export interface PrivateViewProps {
 	/** Render a history back button in place of the title prepend icon */
 	showBack?: boolean;
 
-	/** Whether to always show sidebar shadows (true) or only on x scroll (false) */
+	/** Whether to always show sidebar shadows regardless of scroll state (true) or only when horizontally scrolled (false). */
 	sidebarShadow?: boolean;
 }
 </script>


### PR DESCRIPTION
This PR adds back scroll shadows to the Kanban layout AND all layouts when the x axis overflows. Shadows appears only appear when scrolling into the content container instead of always showing.

https://github.com/user-attachments/assets/d7f109e9-b53b-4d73-adf8-3c91c2ca7c6e

----

This pull request introduces improvements to how sidebar shadows are handled and displayed across the Kanban layout and private view components, along with related style updates. The main changes include making sidebar shadows configurable, updating theme variables for better shadow consistency, and enhancing the user experience with dynamic shadow visibility based on scroll position.

**Sidebar shadow configuration and dynamic display:**

* Added a `sidebarShadow` prop to `PrivateViewProps` in `private-view.vue`, allowing layouts to control whether sidebar shadows are always shown or only on horizontal scroll.
* Updated the Kanban layout in `index.ts` to remove the hardcoded sidebar shadow, making it configurable via layout state.
* Passed the `sidebarShadow` state as a prop to the collection route, ensuring consistent shadow behavior in the UI.

**Dynamic shadow rendering in private view:**

* Enhanced `private-view-main.vue` to compute and display sidebar shadows dynamically based on scroll position and the new prop, improving visual feedback for users. [[1]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38L26-R42) [[2]](diffhunk://#diff-14a8911e61ecc81b61b480e4b8df4e5a76858d2d8e5d33af7f87e0491672ae38R92-R93)
* Added CSS for `.scroll-shadow` elements, supporting both LTR and RTL layouts, and ensuring smooth transitions and proper placement of start/end shadows.

**Theme variable updates for shadow consistency:**

* Refactored theme SCSS files to introduce a unified `--shadow-color` variable, replacing previous shadow definitions for better maintainability and visual consistency in both dark and light themes. [[1]](diffhunk://#diff-4fcb056c536f71bea13be6bccb7d76f5c5b344b9c0c4905418819c9587adb52dL27-R28) [[2]](diffhunk://#diff-c07f157e9f73f2e82177c933e5404a24d96e8ae01b522b3bbae7fb429b8fd4d0L16-R17)