### PR TITLE
Fix issue where input focus ring disappears on hover

### DIFF
--- a/.changeset/kind-aliens-mix.md
+++ b/.changeset/kind-aliens-mix.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue where input focus ring disappears on hover

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -473,8 +473,8 @@ function useInlineWarning() {
 			box-shadow: var(--theme--form--field--input--box-shadow-hover);
 		}
 
-		&:focus-within,
-		&.active {
+		&:focus-within:not(.disabled),
+		&.active:not(.disabled) {
 			--arrow-color: var(--v-input-border-color-hover, var(--theme--form--field--input--border-color-hover));
 
 			color: var(--v-input-color);


### PR DESCRIPTION
## Scope

What's changed:

- CSS selectors were updated to address a specificity issue

## Potential Risks / Drawbacks

-

## Tested Scenarios

- focus and hover states on normal, disabled, non-editable and active input

## Review Notes / Questions

- Unfortunately, there’s no way to test pseudo-selector styles like :hover …

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26314
