### PR TITLE
AI ← Drawer & Header

### DIFF
--- a/app/src/components/v-drawer-header.vue
+++ b/app/src/components/v-drawer-header.vue
@@ -131,7 +131,7 @@ defineEmits<{
 .title {
 	display: flex;
 
-	.type-title {
+	&:deep(.type-title) {
 		line-height: 1.1em;
 	}
 }

--- a/app/src/components/v-drawer-header.vue
+++ b/app/src/components/v-drawer-header.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { translateShortcut } from '@/utils/translate-shortcut';
 import PrivateViewHeaderBarActions from '@/views/private/private-view/components/private-view-header-bar-actions.vue';
 import PrivateViewHeaderBarIcon from '@/views/private/private-view/components/private-view-header-bar-icon.vue';
 
@@ -23,7 +24,7 @@ defineEmits<{
 	<header class="header-bar" :class="{ shadow }">
 		<div class="primary">
 			<VButton
-				v-tooltip.bottom="$t('cancel')"
+				v-tooltip.bottom="`${$t('cancel')} (${translateShortcut(['esc'])})`"
 				class="cancel-button"
 				rounded
 				icon

--- a/app/src/components/v-drawer-header.vue
+++ b/app/src/components/v-drawer-header.vue
@@ -132,7 +132,7 @@ defineEmits<{
 	display: flex;
 
 	&:deep(.type-title) {
-		line-height: 1.1em;
+		line-height: 1.2em;
 	}
 }
 

--- a/app/src/components/v-drawer.vue
+++ b/app/src/components/v-drawer.vue
@@ -147,7 +147,7 @@ const showHeaderShadow = computed(() => y.value > 0);
 
 		display: none;
 		position: absolute;
-		inset-block-start: 22px;
+		inset-block-start: 12px;
 		inset-inline-start: -56px;
 
 		@media (min-width: 960px) {

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -73,7 +73,8 @@ const { width } = useElementSize(el);
 const gridClass = computed<string | null>(() => {
 	if (el.value === null) return null;
 
-	if (width.value > 792) {
+	// 856 (drawer width) - 2 * 24 (content-padding) = 808
+	if (width.value > 808) {
 		return 'grid with-fill';
 	} else {
 		return 'grid';

--- a/app/src/views/private/private-view/components/private-view-header-bar.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar.vue
@@ -162,7 +162,7 @@ const showSidebarToggle = computed(() => {
 	display: flex;
 
 	&:deep(.type-title) {
-		line-height: 1.1em;
+		line-height: 1.2em;
 	}
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Added Esc hint to cancel tooltip for consistency with the cancel button outside the drawer

- Adjusted alignment of drawer cancel button to match header bar icons
  | Before | After |
  |--------|--------|
  | <img width="1000" height="100" alt="1-before" src="https://github.com/user-attachments/assets/e71e5709-1ad3-429a-947f-ef5a9a364786" /> | <img width="1000" height="100" alt="1-after" src="https://github.com/user-attachments/assets/9d75a19e-0a37-4dfd-b586-66b7434cc671" /> | 

- Prevented extra padding-right of forms in the drawer
  | Before | After |
  |--------|--------|
  | <img width="1000" height="200" alt="2-before" src="https://github.com/user-attachments/assets/0d541fae-21ab-456b-9b6a-d8fe4e664199" /> | <img width="1000" height="200" alt="2-after" src="https://github.com/user-attachments/assets/31227e70-3306-4294-9b15-06dd69b3994e" /> | 

- Ensured that title styles are applied to the drawer header (for display templates; use same styles as item header)
  | Before | After |
  |--------|--------|
  | <img width="858" height="100" alt="3-before" src="https://github.com/user-attachments/assets/8521e38c-63b1-4ca5-9dd6-77ff627dbc8a" /> | <img width="858" height="100" alt="3-after" src="https://github.com/user-attachments/assets/1ec63ccc-82fd-4b5c-b206-f2e30c519a35" /> | 






- Prevented the title text from being cut off in the header bar and the drawer header (Note: changed line-height from 1.1. to 1.2)
