### PR TITLE
AI ← Tabular Spacing

### DIFF
--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -272,6 +272,10 @@ function removeField(fieldKey: string) {
 </template>
 
 <style lang="scss" scoped>
+.layout-tabular {
+	padding-block-start: var(--content-padding);
+}
+
 .v-table {
 	--v-table-sticky-offset-top: var(--layout-offset-top);
 


### PR DESCRIPTION
This PR adds back the top spacing to the tabular layout, that was removed with this commit :https://github.com/directus/directus/pull/26309/commits/6b2cf8fdbbc1d722aee2abb4982e9b1739f61fd7.
