### PR TITLE
AI ← Live Preview

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -921,8 +921,11 @@ function useCollectionRoute() {
 
 .content-split :deep(.sp-end) {
 	background-color: var(--theme--background-subdued);
-	border-inline-start: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 	overflow-y: auto;
+
+	@media (width > 640px) {
+		border-inline-start: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
+	}
 }
 
 .content-split.sp-collapsed :deep(.sp-divider) {

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -761,6 +761,7 @@ function useCollectionRoute() {
 			:collapse-threshold="15"
 			:min-size="isMobile ? 0 : 20"
 			:max-size="isMobile ? 100 : 80"
+			:snap-points="[livePreviewSizeDefault]"
 			:transition-duration="150"
 			class="content-split"
 			:disabled="isMobile"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -786,7 +786,11 @@ function useCollectionRoute() {
 			</template>
 
 			<template #end>
-				<live-preview v-if="previewUrl" :url="previewUrl" @new-window="livePreviewMode = 'popup'" />
+				<live-preview
+					v-if="livePreviewActive && previewUrl"
+					:url="previewUrl"
+					@new-window="livePreviewMode = 'popup'"
+				/>
 			</template>
 		</SplitPanel>
 


### PR DESCRIPTION
## Scope

What's changed:

- prevented iframe from loading when live preview is not active (fixes the layout bug mentioned in https://github.com/directus/directus/pull/26259#issuecomment-3603954645)
- added default live preview size as snap point so that we can easily resize to the default size
- ensured that the live preview panel border only appears when not displayed at full width (mobile)
