### PR TITLE
AI <- Hot Last Minute Quick Fixes

### DIFF
--- a/app/src/components/v-list-group.vue
+++ b/app/src/components/v-list-group.vue
@@ -84,7 +84,7 @@ function onClick(event: MouseEvent) {
 			:disabled="disabled"
 			:dense="dense"
 			:clickable="Boolean(clickable || to || !open)"
-			:activator="!clickable && $slots.default && arrowPlacement"
+			:activator="Boolean(!clickable && $slots.default && arrowPlacement)"
 			@click="onClick"
 		>
 			<v-list-item-icon

--- a/app/src/views/private/private-view/stores/nav-bar.ts
+++ b/app/src/views/private/private-view/stores/nav-bar.ts
@@ -1,9 +1,22 @@
-import { useLocalStorage, createEventHook } from '@vueuse/core';
+import { useLocalStorage, createEventHook, useBreakpoints } from '@vueuse/core';
 import { defineStore } from 'pinia';
+import { watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { BREAKPOINTS } from '@/constants';
 
 export const useNavBarStore = defineStore('nav-bar-store', () => {
 	const collapsed = useLocalStorage('nav-bar-collapsed', false);
 	const size = useLocalStorage('nav-bar-size', 250);
+
+	const route = useRoute();
+	const breakpoints = useBreakpoints(BREAKPOINTS);
+
+	watch(
+		() => route.fullPath,
+		() => {
+			if (breakpoints.smaller('lg').value) collapse();
+		},
+	);
 
 	const collapseHook = createEventHook();
 	const expandHook = createEventHook();

--- a/app/src/views/private/private-view/stores/nav-bar.ts
+++ b/app/src/views/private/private-view/stores/nav-bar.ts
@@ -9,12 +9,17 @@ export const useNavBarStore = defineStore('nav-bar-store', () => {
 	const size = useLocalStorage('nav-bar-size', 250);
 
 	const route = useRoute();
-	const breakpoints = useBreakpoints(BREAKPOINTS);
+	const { lg, xl } = useBreakpoints(BREAKPOINTS);
+	const sidebarStore = useSidebarStore();
+
+	const inlineNav = computed(() => {
+		return sidebarStore.collapsed ? lg.value : xl.value;
+	});
 
 	watch(
 		() => route.fullPath,
 		() => {
-			if (breakpoints.smaller('lg').value) collapse();
+			if (!inlineNav.value) collapse();
 		},
 	);
 

--- a/app/src/views/private/private-view/stores/nav-bar.ts
+++ b/app/src/views/private/private-view/stores/nav-bar.ts
@@ -1,8 +1,9 @@
 import { useLocalStorage, createEventHook, useBreakpoints } from '@vueuse/core';
 import { defineStore } from 'pinia';
-import { watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { BREAKPOINTS } from '@/constants';
+import { useSidebarStore } from '@/views/private/private-view/stores/sidebar';
 
 export const useNavBarStore = defineStore('nav-bar-store', () => {
 	const collapsed = useLocalStorage('nav-bar-collapsed', false);


### PR DESCRIPTION
- Watches route change and closes navbar on mobile widths
- Fix activator warnings within v-list-item-group
---
This pull request introduces improvements to the navigation bar's responsiveness and code clarity. The main focus is on automatically collapsing the navigation bar on route changes when the screen size is below the 'lg' breakpoint, enhancing the user experience on smaller devices. Additionally, there is a minor code clarity update in a component prop.

Navigation bar responsiveness:

* The `useNavBarStore` in `nav-bar.ts` now uses `useBreakpoints` and `useRoute` to watch for route changes, automatically collapsing the navigation bar when the viewport is smaller than 'lg'. This improves usability on smaller screens.

Code clarity:

* In `v-list-group.vue`, the `:activator` prop assignment is updated to use an explicit `Boolean` cast for consistency and clarity.