### PR TITLE
AI ← A11y adjustments for Skip Menu and headline elements

### DIFF
--- a/app/src/components/v-breadcrumb.vue
+++ b/app/src/components/v-breadcrumb.vue
@@ -78,8 +78,9 @@ withDefaults(defineProps<Props>(), {
 			}
 
 			&:focus-visible {
-				outline-offset: var(--focus-ring-offset-inset);
+				outline-offset: var(--focus-ring-offset-invert);
 				padding-inline: calc(var(--focus-ring-width) + var(--focus-ring-offset));
+				padding-block: var(--focus-ring-width);
 			}
 		}
 

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -498,7 +498,9 @@ async function onPromoteComplete(deleteOnPromote: boolean) {
 	}
 
 	&:focus-visible {
-		outline-offset: 0;
+		--focus-ring-offset: var(--focus-ring-offset-invert);
+
+		padding-inline-start: var(--focus-ring-width);
 		margin-inline-end: var(--focus-ring-width);
 	}
 }

--- a/app/src/views/private/components/skip-menu.test.ts
+++ b/app/src/views/private/components/skip-menu.test.ts
@@ -1,11 +1,12 @@
-import { beforeEach, expect, test } from 'vitest';
-import { h } from 'vue';
-import { mount } from '@vue/test-utils';
 import { generateRouter } from '@/__utils__/router';
 import type { GlobalMountOptions } from '@/__utils__/types';
-import VList from '@/components/v-list.vue';
 import VListItem from '@/components/v-list-item.vue';
+import VList from '@/components/v-list.vue';
 import { i18n } from '@/lang';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { h } from 'vue';
 import SkipMenu from './skip-menu.vue';
 
 let global: GlobalMountOptions;
@@ -20,7 +21,13 @@ beforeEach(async () => {
 			VListItem,
 			VList,
 		},
-		plugins: [router, i18n],
+		plugins: [
+			router,
+			i18n,
+			createTestingPinia({
+				createSpy: vi.fn,
+			}),
+		],
 	};
 });
 

--- a/app/src/views/private/components/skip-menu.test.ts
+++ b/app/src/views/private/components/skip-menu.test.ts
@@ -28,7 +28,7 @@ test('Mount component', () => {
 	expect(SkipMenu).toBeTruthy();
 
 	const wrapper = mount(SkipMenu, {
-		props: { section: 'main' },
+		props: { section: 'main-content' },
 		global,
 	});
 

--- a/app/src/views/private/components/skip-menu.vue
+++ b/app/src/views/private/components/skip-menu.vue
@@ -82,6 +82,8 @@ const items = computed(() => allItems.filter((item) => item.key !== section));
 
 <style lang="scss" scoped>
 .skip-menu.v-list {
+	--v-list-min-width: 210px;
+
 	position: absolute;
 	inline-size: 1px;
 	block-size: 1px;

--- a/app/src/views/private/components/skip-menu.vue
+++ b/app/src/views/private/components/skip-menu.vue
@@ -3,24 +3,24 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { section } = defineProps<{
-	section: 'nav' | 'moduleNav' | 'main' | 'sidebar';
+	section: 'navigation' | 'module-navigation' | 'main-content' | 'sidebar';
 }>();
 
 const { t } = useI18n();
 
 const allItems = [
 	{
-		key: 'nav',
+		key: 'navigation',
 		hash: '#navigation',
 		text: t('skip_link_nav'),
 	},
 	{
-		key: 'moduleNav',
+		key: 'module-navigation',
 		hash: '#module-navigation',
 		text: t('skip_link_module_nav'),
 	},
 	{
-		key: 'main',
+		key: 'main-content',
 		hash: '#main-content',
 		text: t('skip_link_main'),
 	},
@@ -35,7 +35,11 @@ const items = computed(() => allItems.filter((item) => item.key !== section));
 </script>
 
 <template>
-	<v-list v-if="items.length" class="skip-menu" :class="{ right: section === 'sidebar', center: section === 'main' }">
+	<v-list
+		v-if="items.length"
+		class="skip-menu"
+		:class="{ right: section === 'sidebar', center: section === 'main-content' }"
+	>
 		<v-list-item v-for="item in items" :key="item" :href="$router.resolve(item.hash).href" target="_self">
 			{{ item.text }}
 		</v-list-item>

--- a/app/src/views/private/components/skip-menu.vue
+++ b/app/src/views/private/components/skip-menu.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { BREAKPOINTS } from '@/constants';
+import { useNavBarStore } from '@/views/private/private-view/stores/nav-bar';
+import { useSidebarStore } from '@/views/private/private-view/stores/sidebar';
+import { useBreakpoints } from '@vueuse/core';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -7,27 +11,51 @@ const { section } = defineProps<{
 }>();
 
 const { t } = useI18n();
+const navBarStore = useNavBarStore();
+const sidebarStore = useSidebarStore();
+const { lg, xl, smallerOrEqual } = useBreakpoints(BREAKPOINTS);
+const isMobile = smallerOrEqual('sm');
+
+const inlineNav = computed(() => {
+	return sidebarStore.collapsed ? lg.value : xl.value;
+});
 
 const allItems = [
 	{
 		key: 'navigation',
 		hash: '#navigation',
 		text: t('skip_link_nav'),
+		action() {
+			if (!lg.value) navBarStore.expand();
+			if (isMobile.value) sidebarStore.collapse();
+		},
 	},
 	{
 		key: 'module-navigation',
 		hash: '#module-navigation',
 		text: t('skip_link_module_nav'),
+		action() {
+			if (navBarStore.collapsed) navBarStore.expand();
+			if (isMobile.value) sidebarStore.collapse();
+		},
 	},
 	{
 		key: 'main-content',
 		hash: '#main-content',
 		text: t('skip_link_main'),
+		action() {
+			if (!inlineNav.value) navBarStore.collapse();
+			if (isMobile.value) sidebarStore.collapse();
+		},
 	},
 	{
 		key: 'sidebar',
 		hash: '#sidebar',
 		text: t('skip_link_sidebar'),
+		action() {
+			if (!inlineNav.value) navBarStore.collapse();
+			sidebarStore.expand();
+		},
 	},
 ];
 
@@ -40,7 +68,13 @@ const items = computed(() => allItems.filter((item) => item.key !== section));
 		class="skip-menu"
 		:class="{ right: section === 'sidebar', center: section === 'main-content' }"
 	>
-		<v-list-item v-for="item in items" :key="item" :href="$router.resolve(item.hash).href" target="_self">
+		<v-list-item
+			v-for="item in items"
+			:key="item"
+			:href="$router.resolve(item.hash).href"
+			target="_self"
+			@click="item.action"
+		>
 			{{ item.text }}
 		</v-list-item>
 	</v-list>

--- a/app/src/views/private/components/skip-menu.vue
+++ b/app/src/views/private/components/skip-menu.vue
@@ -70,7 +70,7 @@ const items = computed(() => allItems.filter((item) => item.key !== section));
 	>
 		<v-list-item
 			v-for="item in items"
-			:key="item"
+			:key="item.key"
 			:href="$router.resolve(item.hash).href"
 			target="_self"
 			@click="item.action"

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -3,7 +3,7 @@ import { BREAKPOINTS } from '@/constants';
 import { useUserStore } from '@/stores/user';
 import { cssVar } from '@directus/utils/browser';
 import { SplitPanel } from '@directus/vue-split-panel';
-import { useBreakpoints, useScroll, useResizeObserver } from '@vueuse/core';
+import { useBreakpoints, useResizeObserver, useScroll } from '@vueuse/core';
 import { computed, inject, provide, ref, unref, useTemplateRef, watch, type ComputedRef } from 'vue';
 import NotificationsGroup from '../../components/notifications-group.vue';
 import SkipMenu from '../../components/skip-menu.vue';
@@ -14,8 +14,6 @@ import PrivateViewResizeHandle from './private-view-resize-handle.vue';
 import PrivateViewSidebar from './private-view-sidebar.vue';
 import type { PrivateViewProps } from './private-view.vue';
 
-const userStore = useUserStore();
-
 const props = defineProps<PrivateViewProps & { inlineNav: boolean }>();
 
 defineOptions({ inheritAttrs: false });
@@ -23,6 +21,7 @@ defineOptions({ inheritAttrs: false });
 const contentEl = useTemplateRef('content-el');
 provide('main-element', contentEl);
 
+const userStore = useUserStore();
 const sidebarStore = useSidebarStore();
 
 const scrollContainerRef = useTemplateRef('scroll-container');
@@ -81,9 +80,7 @@ const splitterCollapsed = computed({
 </script>
 
 <template>
-	<SkipMenu section="main" />
-
-	<div id="main-content" ref="content-el" class="content">
+	<div ref="content-el" v-bind="$attrs" class="content">
 		<SplitPanel
 			v-model:size="sidebarStore.size"
 			v-model:collapsed="splitterCollapsed"
@@ -138,12 +135,16 @@ const splitterCollapsed = computed({
 			</template>
 
 			<template #end>
-				<PrivateViewSidebar v-if="!isMobile">
-					<template #sidebar><slot name="sidebar" /></template>
-				</PrivateViewSidebar>
+				<template v-if="!isMobile">
+					<SkipMenu section="sidebar" />
+					<PrivateViewSidebar id="sidebar">
+						<template #sidebar><slot name="sidebar" /></template>
+					</PrivateViewSidebar>
+				</template>
 
 				<PrivateViewDrawer v-else v-model:collapsed="sidebarStore.collapsed" placement="right">
-					<PrivateViewSidebar class="mobile-sidebar">
+					<SkipMenu section="sidebar" />
+					<PrivateViewSidebar id="sidebar" class="mobile-sidebar">
 						<template #sidebar><slot name="sidebar" /></template>
 					</PrivateViewSidebar>
 				</PrivateViewDrawer>

--- a/app/src/views/private/private-view/components/private-view-nav.vue
+++ b/app/src/views/private/private-view/components/private-view-nav.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import PrivateViewNavProjectName from './private-view-nav-project-name.vue';
+
+// id attribute for accessibility linking doesn’t work on the top-level element
+defineProps<{ id?: string }>();
 </script>
 
 <template>
 	<aside role="navigation" aria-label="Module Navigation" class="module-nav alt-colors">
 		<PrivateViewNavProjectName />
 
-		<div class="module-nav-content">
+		<div :id class="module-nav-content">
 			<slot name="navigation" />
 		</div>
 	</aside>

--- a/app/src/views/private/private-view/components/private-view-nav.vue
+++ b/app/src/views/private/private-view/components/private-view-nav.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-import SkipMenu from '../../components/skip-menu.vue';
 import PrivateViewNavProjectName from './private-view-nav-project-name.vue';
 </script>
 
 <template>
 	<aside role="navigation" aria-label="Module Navigation" class="module-nav alt-colors">
-		<SkipMenu section="moduleNav" />
-
 		<PrivateViewNavProjectName />
 
-		<div id="module-navigation" class="module-nav-content">
+		<div class="module-nav-content">
 			<slot name="navigation" />
 		</div>
 	</aside>

--- a/app/src/views/private/private-view/components/private-view-root.vue
+++ b/app/src/views/private/private-view/components/private-view-root.vue
@@ -5,6 +5,7 @@ import { SplitPanel } from '@directus/vue-split-panel';
 import { useBreakpoints } from '@vueuse/core';
 import { computed, watch } from 'vue';
 import ModuleBar from '../../components/module-bar.vue';
+import SkipMenu from '../../components/skip-menu.vue';
 import { useNavBarStore } from '../stores/nav-bar';
 import { useSidebarStore } from '../stores/sidebar';
 import PrivateViewDrawer from './private-view-drawer.vue';
@@ -13,13 +14,13 @@ import PrivateViewNav from './private-view-nav.vue';
 import PrivateViewResizeHandle from './private-view-resize-handle.vue';
 import type { PrivateViewProps } from './private-view.vue';
 
+defineProps<PrivateViewProps>();
+
 const { lg, xl } = useBreakpoints(BREAKPOINTS);
 
 const userStore = useUserStore();
 const navBarStore = useNavBarStore();
 const sidebarStore = useSidebarStore();
-
-defineProps<PrivateViewProps>();
 
 const inlineNav = computed(() => {
 	return sidebarStore.collapsed ? lg.value : xl.value;
@@ -44,7 +45,10 @@ const splitterCollapsed = computed({
 
 <template>
 	<div class="private-view">
-		<ModuleBar v-if="lg" class="module-bar" />
+		<template v-if="lg">
+			<SkipMenu section="nav" />
+			<ModuleBar id="navigation" class="module-bar" />
+		</template>
 
 		<SplitPanel
 			v-model:size="navBarStore.size"
@@ -64,14 +68,19 @@ const splitterCollapsed = computed({
 			:disabled="!inlineNav"
 		>
 			<template #start>
-				<PrivateViewNav v-if="inlineNav">
-					<template #navigation><slot name="navigation" /></template>
-				</PrivateViewNav>
+				<template v-if="inlineNav">
+					<SkipMenu section="moduleNav" />
+					<PrivateViewNav id="module-navigation">
+						<template #navigation><slot name="navigation" /></template>
+					</PrivateViewNav>
+				</template>
 
 				<PrivateViewDrawer v-else v-model:collapsed="navBarStore.collapsed" placement="left">
-					<ModuleBar class="module-bar" />
+					<SkipMenu section="nav" />
+					<ModuleBar id="navigation" class="module-bar" />
 
-					<PrivateViewNav class="mobile-nav">
+					<SkipMenu section="moduleNav" class="mobile-skip-menu" />
+					<PrivateViewNav id="module-navigation" class="mobile-nav">
 						<template #navigation><slot name="navigation" /></template>
 					</PrivateViewNav>
 				</PrivateViewDrawer>
@@ -82,7 +91,8 @@ const splitterCollapsed = computed({
 			</template>
 
 			<template #end>
-				<PrivateViewMain v-bind="$props" :inline-nav>
+				<SkipMenu section="main" />
+				<PrivateViewMain id="main-content" v-bind="$props" :inline-nav>
 					<template #actions:append><slot name="actions:append" /></template>
 					<template #actions:prepend><slot name="actions:prepend" /></template>
 					<template #actions><slot name="actions" /></template>

--- a/app/src/views/private/private-view/components/private-view-root.vue
+++ b/app/src/views/private/private-view/components/private-view-root.vue
@@ -130,6 +130,11 @@ const splitterCollapsed = computed({
 	overflow-y: auto;
 }
 
+.v-list.skip-menu.mobile-skip-menu {
+	/* 60 (module-bar) + 4 (spacing) */
+	inset-inline-start: 64px;
+}
+
 .mobile-nav {
 	inline-size: 0;
 	max-inline-size: 340px;

--- a/app/src/views/private/private-view/components/private-view-root.vue
+++ b/app/src/views/private/private-view/components/private-view-root.vue
@@ -46,7 +46,7 @@ const splitterCollapsed = computed({
 <template>
 	<div class="private-view">
 		<template v-if="lg">
-			<SkipMenu section="nav" />
+			<SkipMenu section="navigation" />
 			<ModuleBar id="navigation" class="module-bar" />
 		</template>
 
@@ -69,17 +69,17 @@ const splitterCollapsed = computed({
 		>
 			<template #start>
 				<template v-if="inlineNav">
-					<SkipMenu section="moduleNav" />
+					<SkipMenu section="module-navigation" />
 					<PrivateViewNav id="module-navigation">
 						<template #navigation><slot name="navigation" /></template>
 					</PrivateViewNav>
 				</template>
 
 				<PrivateViewDrawer v-else v-model:collapsed="navBarStore.collapsed" placement="left">
-					<SkipMenu section="nav" />
+					<SkipMenu section="navigation" />
 					<ModuleBar id="navigation" class="module-bar" />
 
-					<SkipMenu section="moduleNav" class="mobile-skip-menu" />
+					<SkipMenu section="module-navigation" class="mobile-skip-menu" />
 					<PrivateViewNav id="module-navigation" class="mobile-nav">
 						<template #navigation><slot name="navigation" /></template>
 					</PrivateViewNav>
@@ -91,7 +91,7 @@ const splitterCollapsed = computed({
 			</template>
 
 			<template #end>
-				<SkipMenu section="main" />
+				<SkipMenu section="main-content" />
 				<PrivateViewMain id="main-content" v-bind="$props" :inline-nav>
 					<template #actions:append><slot name="actions:append" /></template>
 					<template #actions:prepend><slot name="actions:prepend" /></template>

--- a/app/src/views/private/private-view/components/private-view-sidebar.vue
+++ b/app/src/views/private/private-view/components/private-view-sidebar.vue
@@ -1,15 +1,13 @@
 <script lang="ts" setup>
 import AiSidebarDetail from '@/ai/components/ai-sidebar-detail.vue';
 import { AccordionRoot } from 'reka-ui';
-import SkipMenu from '../../components/skip-menu.vue';
 import { useSidebarStore } from '../stores/sidebar';
 
 const sidebarStore = useSidebarStore();
 </script>
 
 <template>
-	<aside id="sidebar" role="contentinfo" class="sidebar alt-colors" aria-label="Module Sidebar">
-		<SkipMenu section="sidebar" />
+	<aside role="contentinfo" class="sidebar alt-colors" aria-label="Module Sidebar">
 		<AccordionRoot v-model="sidebarStore.activeAccordionItem" type="single" collapsible class="accordion-root">
 			<slot name="sidebar" />
 			<ai-sidebar-detail class="ai-sidebar-detail" />


### PR DESCRIPTION
## Scope

What's changed:

- refactor SkipMenu usage so it appears next to its section
- refactor SkipMenu keys to match section ID naming
- ensure that sections accessed via the skip menu expand properly if they are collapsed
- adjust the SkipMenu min-width to match the sidebar min-width
- update tests
- adjust positioning for mobile skip menu inside module navigation
- add dynamic id binding to module navigation content for improved accessibility

- fix focus styles for headline elements