### PR TITLE
Add AI Telemetry

### DIFF
--- a/api/src/telemetry/utils/get-settings.test.ts
+++ b/api/src/telemetry/utils/get-settings.test.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 import { describe, expect, it, vi } from 'vitest';
-import { getSettings } from './get-settings.js';
+import { getSettings, type TelemetrySettings, type DatabaseSettings } from './get-settings.js';
 import { SettingsService } from '../../services/settings.js';
 
 vi.mock('../../utils/get-schema.js');
@@ -15,8 +15,11 @@ describe('getSettings', () => {
 			mcp_enabled: true,
 			mcp_allow_deletes: false,
 			mcp_system_prompt_enabled: true,
-			visual_editor_urls: ['https://example.com', 'https://example.org'],
-		} as any);
+			visual_editor_urls: [{ url: 'https://example.com' }, { url: 'https://example.org' }],
+			ai_openai_api_key: 'test-openai-key',
+			ai_anthropic_api_key: 'test-anthropic-key',
+			ai_system_prompt: 'test-system-prompt',
+		} satisfies DatabaseSettings);
 
 		const result = await getSettings(mockDb);
 
@@ -26,7 +29,10 @@ describe('getSettings', () => {
 			mcp_allow_deletes: false,
 			mcp_system_prompt_enabled: true,
 			visual_editor_urls: 2,
-		});
+			ai_openai_api_key: true,
+			ai_anthropic_api_key: true,
+			ai_system_prompt: true,
+		} satisfies TelemetrySettings);
 	});
 
 	it('should coerce missing values to defaults when they are not set', async () => {
@@ -44,6 +50,9 @@ describe('getSettings', () => {
 			mcp_allow_deletes: false,
 			mcp_system_prompt_enabled: false,
 			visual_editor_urls: 0,
-		});
+			ai_openai_api_key: false,
+			ai_anthropic_api_key: false,
+			ai_system_prompt: false,
+		} satisfies TelemetrySettings);
 	});
 });

--- a/api/src/telemetry/utils/get-settings.ts
+++ b/api/src/telemetry/utils/get-settings.ts
@@ -8,6 +8,9 @@ export type TelemetrySettings = {
 	mcp_allow_deletes: boolean;
 	mcp_system_prompt_enabled: boolean;
 	visual_editor_urls: number;
+	ai_openai_api_key: boolean;
+	ai_anthropic_api_key: boolean;
+	ai_system_prompt: boolean;
 };
 
 type DatabaseSettings = {
@@ -16,6 +19,9 @@ type DatabaseSettings = {
 	mcp_allow_deletes?: boolean;
 	mcp_system_prompt_enabled?: boolean;
 	visual_editor_urls?: { url: string }[];
+	ai_openai_api_key?: string;
+	ai_anthropic_api_key?: string;
+	ai_system_prompt?: string;
 };
 
 export const getSettings = async (db: Knex): Promise<TelemetrySettings> => {
@@ -25,7 +31,16 @@ export const getSettings = async (db: Knex): Promise<TelemetrySettings> => {
 	});
 
 	const settings = (await settingsService.readSingleton({
-		fields: ['project_id', 'mcp_enabled', 'mcp_allow_deletes', 'mcp_system_prompt_enabled', 'visual_editor_urls'],
+		fields: [
+			'project_id',
+			'mcp_enabled',
+			'mcp_allow_deletes',
+			'mcp_system_prompt_enabled',
+			'visual_editor_urls',
+			'ai_openai_api_key',
+			'ai_anthropic_api_key',
+			'ai_system_prompt',
+		],
 	})) as DatabaseSettings;
 
 	return {
@@ -34,5 +49,8 @@ export const getSettings = async (db: Knex): Promise<TelemetrySettings> => {
 		mcp_allow_deletes: settings?.mcp_allow_deletes || false,
 		mcp_system_prompt_enabled: settings?.mcp_system_prompt_enabled || false,
 		visual_editor_urls: settings.visual_editor_urls?.length || 0,
+		ai_openai_api_key: settings?.ai_openai_api_key ? true : false,
+		ai_anthropic_api_key: settings?.ai_anthropic_api_key ? true : false,
+		ai_system_prompt: settings?.ai_system_prompt ? true : false,
 	};
 };

--- a/api/src/telemetry/utils/get-settings.ts
+++ b/api/src/telemetry/utils/get-settings.ts
@@ -49,8 +49,8 @@ export const getSettings = async (db: Knex): Promise<TelemetrySettings> => {
 		mcp_allow_deletes: settings?.mcp_allow_deletes || false,
 		mcp_system_prompt_enabled: settings?.mcp_system_prompt_enabled || false,
 		visual_editor_urls: settings.visual_editor_urls?.length || 0,
-		ai_openai_api_key: settings?.ai_openai_api_key ? true : false,
-		ai_anthropic_api_key: settings?.ai_anthropic_api_key ? true : false,
-		ai_system_prompt: settings?.ai_system_prompt ? true : false,
+		ai_openai_api_key: Boolean(settings?.ai_openai_api_key),
+		ai_anthropic_api_key: Boolean(settings?.ai_anthropic_api_key),
+		ai_system_prompt: Boolean(settings?.ai_system_prompt),
 	};
 };

--- a/api/src/telemetry/utils/get-settings.ts
+++ b/api/src/telemetry/utils/get-settings.ts
@@ -13,7 +13,7 @@ export type TelemetrySettings = {
 	ai_system_prompt: boolean;
 };
 
-type DatabaseSettings = {
+export type DatabaseSettings = {
 	project_id: string;
 	mcp_enabled?: boolean;
 	mcp_allow_deletes?: boolean;


### PR DESCRIPTION
This pull request extends telemetry settings to support new AI-related configuration options. The updates include adding support for whether OpenAI and Anthropic API keys and a custom system prompt are set.

What's changed:

- Added the AI settings options to telemetry, configured as booleans whether a value is set or not.

## Potential Risks / Drawbacks

- New telemetry fields

## Tested Scenarios

- None

## Review Notes / Questions

- Review Telemetry Sent

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
