### PR TITLE
Fix disabled state for `datetime`, `file`, `select-dropdown-m2o` & `collection-item dropdowns` interfaces

### DIFF
--- a/.changeset/chilly-poems-play.md
+++ b/.changeset/chilly-poems-play.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed disabled state for `datetime`, `file`, `select-dropdown-m2o` & `collection-item dropdowns` interfaces

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -146,8 +146,8 @@ function onSelection(selectedIds: (number | string)[] | null) {
 		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
 	}
 
-	&:focus-within:not(.disabled),
-	&:focus-visible:not(.disabled) {
+	&:focus-within
+	&:focus-visible {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);
 

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -146,7 +146,7 @@ function onSelection(selectedIds: (number | string)[] | null) {
 		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
 	}
 
-	&:focus-within
+	&:focus-within,
 	&:focus-visible {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -143,9 +143,7 @@ function onSelection(selectedIds: (number | string)[] | null) {
 
 .v-list-item {
 	&.disabled:not(.non-editable) {
-		--v-list-item-color: var(--theme--foreground-subdued);
 		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
-		--v-list-item-border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
 	}
 
 	&:focus-within:not(.disabled),

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -100,7 +100,11 @@ async function getDisplayItem() {
 
 function onSelection(selectedIds: (number | string)[] | null) {
 	selectDrawerOpen.value = false;
-	value.value = { key: Array.isArray(selectedIds) ? selectedIds[0] : null, collection: unref(selectedCollection) };
+
+	value.value = {
+		key: Array.isArray(selectedIds) && selectedIds[0] ? selectedIds[0] : null,
+		collection: unref(selectedCollection),
+	};
 }
 </script>
 

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -121,7 +121,7 @@ function onSelection(selectedIds: (number | string)[] | null) {
 			<div class="spacer" />
 
 			<div v-if="!nonEditable" class="item-actions">
-				<v-remove v-if="displayItem" deselect @action="value = null" />
+				<v-remove v-if="displayItem" deselect :disabled @action="value = null" />
 
 				<v-icon v-else class="expand" name="expand_more" />
 			</div>

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -138,8 +138,14 @@ function onSelection(selectedIds: (number | string)[] | null) {
 @use '@/styles/mixins';
 
 .v-list-item {
-	&:focus-within,
-	&:focus-visible {
+	&.disabled:not(.non-editable) {
+		--v-list-item-color: var(--theme--foreground-subdued);
+		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
+		--v-list-item-border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
+	}
+
+	&:focus-within:not(.disabled),
+	&:focus-visible:not(.disabled) {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);
 

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -78,14 +78,12 @@ function unsetValue(e: any) {
 	);
 
 	&.disabled:not(.non-editable) {
-		--v-list-item-color: var(--theme--foreground-subdued);
 		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
-		--v-list-item-border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
 	}
 
-	&.active:not(.disabled),
-	&:focus-within:not(.disabled),
-	&:focus-visible:not(.disabled) {
+	&.active,
+	&:focus-within
+	&:focus-visible {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);
 

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -82,7 +82,7 @@ function unsetValue(e: any) {
 	}
 
 	&.active,
-	&:focus-within
+	&:focus-within,
 	&:focus-visible {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import UseDatetime, { type Props as UseDatetimeProps } from '@/components/use-datetime.vue';
+import { parseDate } from '@/utils/parse-date';
 import { isValid } from 'date-fns';
 import { computed, ref } from 'vue';
-import { parseDate } from '@/utils/parse-date';
-import UseDatetime, { type Props as UseDatetimeProps } from '@/components/use-datetime.vue';
 
 interface Props extends Omit<UseDatetimeProps, 'value'> {
 	value: string | null;
@@ -77,9 +77,15 @@ function unsetValue(e: any) {
 		var(--v-list-background-color, var(--theme--form--field--input--background))
 	);
 
-	&.active,
-	&:focus-within,
-	&:focus-visible {
+	&.disabled:not(.non-editable) {
+		--v-list-item-color: var(--theme--foreground-subdued);
+		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
+		--v-list-item-border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
+	}
+
+	&.active:not(.disabled),
+	&:focus-within:not(.disabled),
+	&:focus-visible:not(.disabled) {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);
 

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -365,9 +365,15 @@ function useURLImport() {
 		var(--v-list-background-color, var(--theme--form--field--input--background))
 	);
 
-	&.active,
-	&:focus-within,
-	&:focus-visible {
+	&.disabled:not(.non-editable) {
+		--v-list-item-color: var(--theme--foreground-subdued);
+		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
+		--v-list-item-border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
+	}
+
+	&.active:not(.disabled),
+	&:focus-within:not(.disabled),
+	&:focus-visible:not(.disabled) {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);
 

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -4,6 +4,7 @@ import { useRelationPermissionsM2O } from '@/composables/use-relation-permission
 import { RelationQuerySingle, useRelationSingle } from '@/composables/use-relation-single';
 import { useCollectionsStore } from '@/stores/collections';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { getItemRoute } from '@/utils/get-route';
 import { parseFilter } from '@/utils/parse-filter';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
@@ -12,7 +13,6 @@ import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { get } from 'lodash';
 import { render } from 'micromustache';
 import { computed, inject, ref, toRefs } from 'vue';
-import { getItemRoute } from '@/utils/get-route';
 
 const props = withDefaults(
 	defineProps<{
@@ -273,8 +273,14 @@ function getLinkForItem() {
 }
 
 .v-list-item {
-	&:focus-within,
-	&:focus-visible {
+	&.disabled:not(.non-editable) {
+		--v-list-item-color: var(--theme--foreground-subdued);
+		--v-list-item-background-color: var(--theme--form--field--input--background-subdued);
+		--v-list-item-border-color: var(--v-input-border-color, var(--theme--form--field--input--border-color));
+	}
+
+	&:focus-within:not(.disabled),
+	&:focus-visible:not(.disabled) {
 		--v-list-item-border-color: var(--v-input-border-color-focus, var(--theme--form--field--input--border-color-focus));
 		--v-list-item-border-color-hover: var(--v-list-item-border-color);
 


### PR DESCRIPTION
## Scope

What's changed:

- Fixed disable state for our `datetime`, `file`, `select-dropdown-m2o` and `collection-item-dropdown` interfaces 
- Fixes a typing error for `onSelection` in `collection-item-dropdown`

### Before

https://github.com/user-attachments/assets/cd9cda5d-0a05-41aa-bd16-b88d34e90a54

### After

https://github.com/user-attachments/assets/0d9f6712-34af-4e55-b1a4-40fb24b8622f

### 11.8.0

https://github.com/user-attachments/assets/b9f35c88-ad35-4da8-aa44-20a0184c1465


## Potential Risks / Drawbacks

- Should be none as these are expected to be the equivalent styles before https://github.com/directus/directus/pull/25214

## Tested Scenarios

Fields were set to `readonly` to simulate disabled

- [x] Expect active field to have active styles
- [x] Expect disabled field to have disabled styles

## Review Notes / Questions

- N/A

## Checklist

- [x] Added or updated tests - N/A no style tests exist
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25547
