### PR TITLE
Use standardized header action button component

### DIFF
--- a/.changeset/pink-mails-wonder.md
+++ b/.changeset/pink-mails-wonder.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Cleaned up header button inconsistencies

--- a/app/package.json
+++ b/app/package.json
@@ -102,6 +102,7 @@
 		"@unhead/vue": "catalog:",
 		"@vitejs/plugin-vue": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
+		"@vue/compiler-dom": "catalog:",
 		"@vue/test-utils": "catalog:",
 		"@vueuse/core": "catalog:",
 		"@vueuse/integrations": "catalog:",

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { RouteLocationRaw, useRoute, useLink } from 'vue-router';
-import { useSizeClass, useGroupable } from '@directus/composables';
+import vFocus from '@/directives/focus';
+import vTooltip from '@/directives/tooltip';
+import { useGroupable, useSizeClass } from '@directus/composables';
 import { isEqual, isNil } from 'lodash';
+import { computed } from 'vue';
+import { RouteLocationRaw, useLink, useRoute } from 'vue-router';
+import vProgressCircular from './v-progress-circular.vue';
 
 interface Props {
 	/** Automatically focuses on the button */

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -3,6 +3,7 @@ import { MODULE_BAR_DEFAULT } from '@/constants';
 import { useExtensions } from '@/extensions';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { translate } from '@/utils/translate-object-values';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { DeepPartial, Field, Settings, SettingsModuleBarLink, SettingsModuleBarModule } from '@directus/types';
 import { assign } from 'lodash';
 import { nanoid } from 'nanoid';
@@ -256,9 +257,12 @@ function remove(id: string) {
 			@apply="save"
 		>
 			<template #actions>
-				<v-button v-tooltip.bottom="$t('save')" icon rounded :disabled="isSaveDisabled" small @click="save">
-					<v-icon name="check" small />
-				</v-button>
+				<PrivateViewHeaderBarActionButton
+					v-tooltip.bottom="$t('save')"
+					:disabled="isSaveDisabled"
+					icon="check"
+					@click="save"
+				/>
 			</template>
 
 			<div class="drawer-content">

--- a/app/src/interfaces/_system/system-owner/system-owner.vue
+++ b/app/src/interfaces/_system/system-owner/system-owner.vue
@@ -2,6 +2,7 @@
 import { useFormFields, validate } from '@/routes/setup/form';
 import SetupForm from '@/routes/setup/form.vue';
 import { useSettingsStore } from '@/stores/settings';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { SetupForm as Form } from '@directus/types';
 import { computed, ref } from 'vue';
 
@@ -62,17 +63,13 @@ async function reset() {
 
 	<v-drawer v-model="editing" :title="$t('interfaces.system-owner.update')" icon="link" @cancel="reset" @apply="save">
 		<template #actions>
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="$t('save')"
-				icon
-				rounded
-				small
 				:disabled="!isSaveAllowed"
 				:loading="isSaving"
+				icon="check"
 				@click="save"
-			>
-				<v-icon name="check" small />
-			</v-button>
+			/>
 		</template>
 
 		<div class="drawer-content">

--- a/app/src/interfaces/_system/system-permissions/detail/components/actions.vue
+++ b/app/src/interfaces/_system/system-permissions/detail/components/actions.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { Permission, PrimaryKey } from '@directus/types';
 
 defineProps<{
@@ -13,9 +14,7 @@ const emit = defineEmits<{
 
 <template>
 	<div class="actions">
-		<v-button v-tooltip.bottom="$t('save')" icon rounded @click="emit('save')">
-			<v-icon name="check" />
-		</v-button>
+		<PrivateViewHeaderBarActionButton v-tooltip.bottom="$t('save')" icon="check" @click="emit('save')" />
 	</div>
 </template>
 

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -1,28 +1,29 @@
 <script setup lang="ts">
-import { i18n } from '@/lang';
 import { useInjectFocusTrapManager } from '@/composables/use-focus-trap-manager';
+import { i18n } from '@/lang';
 import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
 import { SettingsStorageAssetPreset } from '@directus/types';
 import Editor from '@tinymce/tinymce-vue';
 import { cloneDeep, isEqual } from 'lodash';
+import tinymce from 'tinymce/tinymce';
 import { ComponentPublicInstance, computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import getEditorStyles from './get-editor-styles';
 import toolbarDefault from './toolbar-default';
 import useImage from './useImage';
+import useInlineCode from './useInlineCode';
 import useLink from './useLink';
 import useMedia from './useMedia';
-import useSourceCode from './useSourceCode';
 import usePre from './usePre';
-import useInlineCode from './useInlineCode';
-import tinymce from 'tinymce/tinymce';
+import useSourceCode from './useSourceCode';
 
 import 'tinymce/skins/ui/oxide/skin.css';
 import './tinymce-overrides.css';
 
 import 'tinymce/tinymce';
 
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import 'tinymce/icons/default';
 import 'tinymce/models/dom';
 import 'tinymce/plugins/autoresize/plugin';
@@ -468,9 +469,7 @@ onMounted(() => {
 			</div>
 
 			<template #actions>
-				<v-button icon rounded @click="saveCode">
-					<v-icon name="check" />
-				</v-button>
+				<PrivateViewHeaderBarActionButton icon="check" @click="saveCode" />
 			</template>
 		</v-drawer>
 
@@ -521,9 +520,7 @@ onMounted(() => {
 			</div>
 
 			<template #actions>
-				<v-button v-tooltip.bottom="$t('save_image')" icon rounded @click="saveImage">
-					<v-icon name="check" />
-				</v-button>
+				<PrivateViewHeaderBarActionButton v-tooltip.bottom="$t('save_image')" icon="check" @click="saveImage" />
 			</template>
 		</v-drawer>
 
@@ -583,9 +580,7 @@ onMounted(() => {
 			</div>
 
 			<template #actions>
-				<v-button v-tooltip.bottom="$t('save_media')" icon rounded @click="saveMedia">
-					<v-icon name="check" />
-				</v-button>
+				<PrivateViewHeaderBarActionButton v-tooltip.bottom="$t('save_media')" icon="check" @click="saveMedia" />
 			</template>
 		</v-drawer>
 	</div>

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { renderStringTemplate } from '@/utils/render-string-template';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import formatTitle from '@directus/format-title';
 import { DeepPartial, Field, FieldMeta } from '@directus/types';
 import { isEqual, sortBy } from 'lodash';
@@ -262,16 +263,12 @@ function closeDrawer() {
 			</template>
 
 			<template #actions>
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('save')"
-					icon
-					rounded
-					small
+					icon="check"
 					:disabled="isSaveDisabled"
 					@click="saveItem(active!)"
-				>
-					<v-icon name="check" small />
-				</v-button>
+				/>
 			</template>
 
 			<div class="drawer-item-content">

--- a/app/src/modules/activity/routes/item.vue
+++ b/app/src/modules/activity/routes/item.vue
@@ -4,6 +4,7 @@ import { useDialogRoute } from '@/composables/use-dialog-route';
 import { i18n } from '@/lang';
 import { getItemRoute } from '@/utils/get-route';
 import { userName } from '@/utils/user-name';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { isSystemCollection } from '@directus/system-data';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -133,9 +134,7 @@ function close() {
 		</div>
 
 		<template #actions>
-			<v-button v-if="openItemLink" v-tooltip.bottom="$t('open')" :to="openItemLink" icon rounded small>
-				<v-icon name="launch" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton v-if="openItemLink" v-tooltip.bottom="$t('open')" :to="openItemLink" icon="launch" />
 		</template>
 	</v-drawer>
 </template>

--- a/app/src/modules/activity/routes/item.vue
+++ b/app/src/modules/activity/routes/item.vue
@@ -134,7 +134,12 @@ function close() {
 		</div>
 
 		<template #actions>
-			<PrivateViewHeaderBarActionButton v-if="openItemLink" v-tooltip.bottom="$t('open')" :to="openItemLink" icon="launch" />
+			<PrivateViewHeaderBarActionButton
+				v-if="openItemLink"
+				v-tooltip.bottom="$t('open')"
+				:to="openItemLink"
+				icon="launch"
+			/>
 		</template>
 	</v-drawer>
 </template>

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -15,6 +15,7 @@ import FlowSidebarDetail from '@/views/private/components/flow-sidebar-detail.vu
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection, useLayout } from '@directus/composables';
 import { isSystemCollection } from '@directus/system-data';
 import { Filter } from '@directus/types';
@@ -394,18 +395,14 @@ function clearFilters() {
 
 				<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false" @apply="batchDelete">
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="batchDeleteAllowed ? $t('delete_label') : $t('not_allowed')"
 							:disabled="batchDeleteAllowed !== true"
-							rounded
-							icon
 							class="action-delete"
+							icon="delete"
 							secondary
-							small
 							@click="on"
-						>
-							<v-icon name="delete" outline small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -434,17 +431,13 @@ function clearFilters() {
 					@apply="archiveItems"
 				>
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="batchArchiveAllowed ? $t('archive') : $t('not_allowed')"
 							:disabled="batchArchiveAllowed !== true"
-							rounded
-							icon
+							icon="archive"
 							secondary
-							small
 							@click="on"
-						>
-							<v-icon name="archive" outline small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -461,29 +454,21 @@ function clearFilters() {
 					</v-card>
 				</v-dialog>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="selection.length > 0"
 					v-tooltip.bottom="batchEditAllowed ? $t('edit') : $t('not_allowed')"
-					rounded
-					icon
 					secondary
 					:disabled="batchEditAllowed === false"
-					small
+					icon="edit"
 					@click="batchEditActive = true"
-				>
-					<v-icon name="edit" outline small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="createAllowed ? $t('create_item') : $t('not_allowed')"
-					rounded
-					icon
+					icon="add"
 					:to="addNewLink"
 					:disabled="createAllowed === false"
-					small
-				>
-					<v-icon name="add" small />
-				</v-button>
+				/>
 
 				<flow-dialogs v-bind="flowDialogsContext" />
 			</template>

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -17,6 +17,7 @@ import FilesNavigation from '@/views/private/components/files-navigation.vue';
 import FolderPicker from '@/views/private/components/folder-picker.vue';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useLayout } from '@directus/composables';
 import { getDateTimeFormatted, mergeFilters } from '@directus/utils';
 import { storeToRefs } from 'pinia';
@@ -419,18 +420,14 @@ async function downloadFiles() {
 					@apply="moveToFolder"
 				>
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="batchEditAllowed ? $t('move_to_folder') : $t('not_allowed')"
-							rounded
-							icon
 							class="folder"
-							secondary
 							:disabled="!batchEditAllowed"
-							small
+							icon="folder_move"
+							secondary
 							@click="on"
-						>
-							<v-icon name="folder_move" small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -453,18 +450,14 @@ async function downloadFiles() {
 
 				<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false" @apply="batchDelete">
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="batchDeleteAllowed ? $t('delete_label') : $t('not_allowed')"
 							:disabled="batchDeleteAllowed !== true"
-							rounded
-							icon
 							class="action-delete"
 							secondary
-							small
+							icon="delete"
 							@click="on"
-						>
-							<v-icon name="delete" outline small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -481,41 +474,29 @@ async function downloadFiles() {
 					</v-card>
 				</v-dialog>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="selection.length > 0"
 					v-tooltip.bottom="batchEditAllowed ? $t('edit') : $t('not_allowed')"
-					rounded
-					icon
 					secondary
 					:disabled="batchEditAllowed === false"
-					small
+					icon="edit"
 					@click="batchEditActive = true"
-				>
-					<v-icon name="edit" outline small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="selection.length > 0"
 					v-tooltip.bottom="$t('download')"
-					rounded
-					icon
 					secondary
-					download
+					icon="download"
 					@click="downloadFiles"
-				>
-					<v-icon name="download" outline />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="createAllowed ? $t('upload_file') : $t('not_allowed')"
-					rounded
-					icon
 					:to="folder ? { path: `/files/folders/${folder}/+` } : { path: '/files/+' }"
 					:disabled="createAllowed === false"
-					small
-				>
-					<v-icon name="add" small />
-				</v-button>
+					icon="add"
+				/>
 			</template>
 
 			<template #navigation>

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -13,6 +13,7 @@ import FolderPicker from '@/views/private/components/folder-picker.vue';
 import ImageEditor from '@/views/private/components/image-editor.vue';
 import RevisionsSidebarDetail from '@/views/private/components/revisions-sidebar-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import type { Field, File } from '@directus/types';
 import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -226,18 +227,14 @@ function revert(values: Record<string, any>) {
 		<template #actions>
 			<v-dialog v-model="confirmDelete" @esc="confirmDelete = false" @apply="deleteAndQuit">
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="deleteAllowed ? $t('delete_label') : $t('not_allowed')"
-						rounded
-						icon
 						class="action-delete"
-						secondary
 						:disabled="item === null || deleteAllowed === false"
-						small
+						icon="delete"
+						secondary
 						@click="on"
-					>
-						<v-icon name="delete" outline small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -261,17 +258,13 @@ function revert(values: Record<string, any>) {
 				@apply="moveToFolder"
 			>
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="item === null || !updateAllowed ? $t('not_allowed') : $t('move_to_folder')"
-						rounded
-						icon
 						secondary
 						:disabled="item === null || !updateAllowed"
-						small
+						icon="folder_move"
 						@click="on"
-					>
-						<v-icon name="folder_move" small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -291,41 +284,30 @@ function revert(values: Record<string, any>) {
 					</v-card-actions>
 				</v-card>
 			</v-dialog>
-			<v-button
+
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="$t('download')"
 				secondary
-				icon
-				rounded
 				:download="item?.filename_download"
 				:href="getAssetUrl(props.primaryKey, { isDownload: true })"
-				small
-			>
-				<v-icon name="download" small />
-			</v-button>
+				icon="download"
+			/>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-if="item?.type?.includes('image') && updateAllowed"
 				v-tooltip.bottom="$t('edit')"
-				rounded
-				icon
 				secondary
-				small
+				icon="tune"
 				@click="editActive = true"
-			>
-				<v-icon name="tune" small />
-			</v-button>
+			/>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="saveAllowed ? $t('save') : $t('not_allowed')"
-				rounded
-				icon
 				:loading="saving"
 				:disabled="!isSavable"
-				small
+				icon="check"
 				@click="saveAndQuit"
 			>
-				<v-icon name="check" small />
-
 				<template #append-outer>
 					<save-options
 						v-if="isSavable"
@@ -335,7 +317,7 @@ function revert(values: Record<string, any>) {
 						@discard-and-stay="discardAndStay"
 					/>
 				</template>
-			</v-button>
+			</PrivateViewHeaderBarActionButton>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/insights/routes/dashboard.vue
+++ b/app/src/modules/insights/routes/dashboard.vue
@@ -9,6 +9,7 @@ import { useInsightsStore } from '@/stores/insights';
 import { pointOnLine } from '@/utils/point-on-line';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
 import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { applyOptionsData } from '@directus/utils';
 import { assign, isEmpty } from 'lodash';
 import { computed, ref, toRefs, unref, watch } from 'vue';
@@ -197,68 +198,48 @@ const refreshInterval = computed({
 
 		<template #actions>
 			<template v-if="editMode">
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('clear_changes')"
 					class="clear-changes"
-					rounded
-					icon
-					small
 					outlined
+					icon="clear"
 					@click="cancelChanges"
-				>
-					<v-icon name="clear" small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('create_panel')"
-					rounded
-					icon
 					outlined
 					:to="`/insights/${currentDashboard.id}/+`"
-					small
-				>
-					<v-icon name="add" small />
-				</v-button>
+					icon="add"
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('save')"
 					:disabled="!hasEdits"
-					rounded
-					icon
-					small
 					:loading="saving"
+					icon="check"
 					@click="saveChanges"
-				>
-					<v-icon name="check" small />
-				</v-button>
+				/>
 			</template>
 
 			<template v-else>
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('fit_to_screen')"
 					:active="zoomToFit"
 					class="zoom-to-fit"
-					rounded
-					icon
-					small
 					outlined
+					icon="aspect_ratio"
 					@click="toggleZoomToFit"
-				>
-					<v-icon name="aspect_ratio" small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('edit_panels')"
 					class="edit"
-					rounded
-					icon
 					outlined
-					small
 					:disabled="!updateAllowed"
+					icon="edit"
 					@click="editMode = !editMode"
-				>
-					<v-icon name="edit" small />
-				</v-button>
+				/>
 			</template>
 		</template>
 

--- a/app/src/modules/insights/routes/overview.vue
+++ b/app/src/modules/insights/routes/overview.vue
@@ -112,7 +112,7 @@ async function duplicateDashboard(id: string, toggle: () => void) {
 	toggle();
 }
 
-function exportDasboard(ids: string[]) {
+function exportDashboard(ids: string[]) {
 	const endpoint = getEndpoint('directus_dashboards');
 
 	// usually getEndpoint contains leading slash, but here we need to remove it
@@ -218,7 +218,7 @@ async function batchDelete() {
 				icon
 				secondary
 				small
-				@click="exportDasboard(selection)"
+				@click="exportDashboard(selection)"
 			>
 				<v-icon name="download" outline small />
 			</v-button>
@@ -330,7 +330,7 @@ async function batchDelete() {
 								</v-list-item-content>
 							</v-list-item>
 
-							<v-list-item class="warning" clickable @click="exportDasboard([item.id])">
+							<v-list-item class="warning" clickable @click="exportDashboard([item.id])">
 								<v-list-item-icon>
 									<v-icon name="download" />
 								</v-list-item-icon>

--- a/app/src/modules/insights/routes/overview.vue
+++ b/app/src/modules/insights/routes/overview.vue
@@ -9,6 +9,7 @@ import { getPublicURL } from '@/utils/get-root-path';
 import { unexpectedError } from '@/utils/unexpected-error';
 import BasicImportSidebarDetail from '@/views/private/components/basic-import-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { getEndpoint } from '@directus/utils';
 import { sortBy } from 'lodash';
 import { computed, ref } from 'vue';
@@ -210,18 +211,14 @@ async function batchDelete() {
 				small
 			/>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-if="selection.length > 0"
 				v-tooltip.bottom="createAllowed ? $t('export_dashboard') : $t('not_allowed')"
 				:disabled="createAllowed !== true"
-				rounded
-				icon
 				secondary
-				small
+				icon="download"
 				@click="exportDashboard(selection)"
-			>
-				<v-icon name="download" outline small />
-			</v-button>
+			/>
 
 			<v-dialog
 				v-if="selection.length > 0"
@@ -230,18 +227,14 @@ async function batchDelete() {
 				@apply="batchDelete"
 			>
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="batchDeleteAllowed ? $t('delete_label') : $t('not_allowed')"
 						:disabled="batchDeleteAllowed !== true"
-						rounded
-						icon
 						class="action-delete"
 						secondary
-						small
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" outline small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -260,16 +253,12 @@ async function batchDelete() {
 
 			<dashboard-dialog v-model="createDialogActive">
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="createAllowed ? $t('create_dashboard') : $t('not_allowed')"
-						rounded
-						icon
 						:disabled="createAllowed === false"
-						small
+						icon="add"
 						@click="on"
-					>
-						<v-icon name="add" small />
-					</v-button>
+					/>
 				</template>
 			</dashboard-dialog>
 		</template>

--- a/app/src/modules/insights/routes/panel-configuration.vue
+++ b/app/src/modules/insights/routes/panel-configuration.vue
@@ -3,6 +3,7 @@ import { useDialogRoute } from '@/composables/use-dialog-route';
 import { useExtension } from '@/composables/use-extension';
 import { useExtensions } from '@/extensions';
 import { CreatePanel, useInsightsStore } from '@/stores/insights';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import type { Panel } from '@directus/extensions';
 import { assign, clone, isUndefined, omitBy } from 'lodash';
 import { nanoid } from 'nanoid/non-secure';
@@ -133,9 +134,12 @@ const stageChanges = () => {
 		@apply="stageChanges"
 	>
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('done')" :disabled="!panel.type" icon rounded small @click="stageChanges">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('done')"
+				:disabled="!panel.type"
+				icon="check"
+				@click="stageChanges"
+			/>
 		</template>
 		<div class="content">
 			<div class="panel-grid">

--- a/app/src/modules/settings/routes/ai/overview.vue
+++ b/app/src/modules/settings/routes/ai/overview.vue
@@ -3,6 +3,7 @@ import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection } from '@directus/composables';
 import { clone } from 'lodash';
 import { computed, ref, unref } from 'vue';
@@ -57,9 +58,13 @@ function discardAndLeave() {
 		<template #headline><v-breadcrumb :items="[{ name: $t('settings'), to: '/settings' }]" /></template>
 
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('save')" icon rounded :disabled="!hasEdits" :loading="saving" small @click="save">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:disabled="!hasEdits"
+				:loading="saving"
+				icon="check"
+				@click="save"
+			/>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/appearance/item.vue
+++ b/app/src/modules/settings/routes/appearance/item.vue
@@ -3,6 +3,7 @@ import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection } from '@directus/composables';
 import { clone } from 'lodash';
 import { computed, ref, unref } from 'vue';
@@ -57,9 +58,13 @@ function discardAndLeave() {
 		<template #headline><v-breadcrumb :items="[{ name: $t('settings'), to: '/settings' }]" /></template>
 
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('save')" icon rounded :disabled="!hasEdits" :loading="saving" small @click="save">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:disabled="!hasEdits"
+				:loading="saving"
+				icon="check"
+				@click="save"
+			/>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -5,6 +5,8 @@ import { Collection } from '@/types/collections';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
+import { saveAs } from 'file-saver';
 import { merge } from 'lodash';
 import { computed, ref } from 'vue';
 import Draggable from 'vuedraggable';
@@ -13,7 +15,6 @@ import CollectionDialog from './components/collection-dialog.vue';
 import CollectionItem from './components/collection-item.vue';
 import CollectionOptions from './components/collection-options.vue';
 import { useExpandCollapse } from './composables/use-expand-collapse';
-import { saveAs } from 'file-saver';
 
 const search = ref<string | null>(null);
 const collectionDialogActive = ref(false);
@@ -154,15 +155,20 @@ async function downloadSnapshot() {
 
 			<collection-dialog v-model="collectionDialogActive">
 				<template #activator="{ on }">
-					<v-button v-tooltip.bottom="$t('create_folder')" rounded icon secondary small @click="on">
-						<v-icon name="create_new_folder" small />
-					</v-button>
+					<PrivateViewHeaderBarActionButton
+						v-tooltip.bottom="$t('create_folder')"
+						secondary
+						icon="create_new_folder"
+						@click="on"
+					/>
 				</template>
 			</collection-dialog>
 
-			<v-button v-tooltip.bottom="$t('create_collection')" rounded small icon to="/settings/data-model/+">
-				<v-icon name="add" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('create_collection')"
+				to="/settings/data-model/+"
+				icon="add"
+			/>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-actions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-actions.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { storeToRefs } from 'pinia';
 import { useFieldDetailStore } from '../store';
 
@@ -9,15 +10,11 @@ const { saving, readyToSave } = storeToRefs(fieldDetailStore);
 </script>
 
 <template>
-	<v-button
+	<PrivateViewHeaderBarActionButton
 		v-tooltip.bottom="$t('save')"
 		:disabled="readyToSave === false"
 		:loading="saving"
-		icon
-		rounded
-		small
+		icon="check"
 		@click="$emit('save')"
-	>
-		<v-icon name="check" small />
-	</v-button>
+	/>
 </template>

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -4,12 +4,13 @@ import { useItem } from '@/composables/use-item';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import formatTitle from '@directus/format-title';
+import { isSystemCollection } from '@directus/system-data';
 import { computed, ref, toRefs } from 'vue';
 import { useRouter } from 'vue-router';
 import SettingsNavigation from '../../../components/navigation.vue';
 import FieldsManagement from './components/fields-management.vue';
-import { isSystemCollection } from '@directus/system-data';
 
 const props = defineProps<{
 	collection: string;
@@ -76,19 +77,15 @@ function discardAndLeave() {
 		<template #actions>
 			<v-dialog v-model="confirmDelete" @esc="confirmDelete = false" @apply="deleteAndQuit">
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-if="isSystemCollection(collection) === false"
 						v-tooltip.bottom="$t('delete_collection')"
-						rounded
-						icon
 						class="action-delete"
 						secondary
 						:disabled="!item"
-						small
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -105,17 +102,13 @@ function discardAndLeave() {
 				</v-card>
 			</v-dialog>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="$t('save')"
-				rounded
-				icon
 				:loading="saving"
 				:disabled="hasEdits === false"
-				small
+				icon="check"
 				@click="saveAndQuit"
-			>
-				<v-icon name="check" small />
-			</v-button>
+			/>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -6,6 +6,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { DeepPartial, Field, Relation } from '@directus/types';
 import { cloneDeep } from 'lodash';
 import { reactive, ref, watch } from 'vue';
@@ -493,28 +494,21 @@ function onApply() {
 		</v-tabs-items>
 
 		<template #actions>
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-if="currentTab[0] === 'collection_setup'"
 				v-tooltip.bottom="$t('next')"
 				:disabled="!collectionName || collectionName.length === 0"
-				icon
-				rounded
-				small
+				icon="arrow_forward"
 				@click="currentTab = ['optional_system_fields']"
-			>
-				<v-icon name="arrow_forward" small />
-			</v-button>
-			<v-button
+			/>
+
+			<PrivateViewHeaderBarActionButton
 				v-if="currentTab[0] === 'optional_system_fields'"
 				v-tooltip.bottom="$t('finish_setup')"
 				:loading="saving"
-				icon
-				rounded
-				small
+				icon="check"
 				@click="save"
-			>
-				<v-icon name="check" small />
-			</v-button>
+			/>
 		</template>
 	</v-drawer>
 </template>

--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -5,6 +5,7 @@ import { useExtensions } from '@/extensions';
 import ExtensionOptions from '@/modules/settings/routes/data-model/field-detail/shared/extension-options.vue';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { translate } from '@/utils/translate-object-values';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { Field, FlowRaw } from '@directus/types';
 import slugify from '@sindresorhus/slugify';
 import { customAlphabet } from 'nanoid/non-secure';
@@ -146,9 +147,12 @@ function saveOperation() {
 		@apply="saveOperation"
 	>
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('done')" icon rounded :disabled="saveDisabled" small @click="saveOperation">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('done')"
+				:disabled="saveDisabled"
+				icon="check"
+				@click="saveOperation"
+			/>
 		</template>
 
 		<div class="content">

--- a/app/src/modules/settings/routes/flows/components/trigger-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/trigger-detail.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { FlowRaw, TriggerType } from '@directus/types';
 import { computed, ref } from 'vue';
 import { getTriggers } from '../triggers';
@@ -57,9 +58,12 @@ const currentTriggerOptionFields = computed(() => {
 		@cancel="$emit('update:open', false)"
 	>
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('done')" icon rounded :disabled="!currentTrigger" small @click="saveTrigger">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('done')"
+				:disabled="!currentTrigger"
+				icon="check"
+				@click="saveTrigger"
+			/>
 		</template>
 
 		<div class="content">

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -2,6 +2,7 @@
 import api from '@/api';
 import { useFlowsStore } from '@/stores/flows';
 import { unexpectedError } from '@/utils/unexpected-error';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import type { TriggerType } from '@directus/types';
 import { computed, reactive, ref, watch } from 'vue';
 import { getTriggers } from './triggers';
@@ -257,30 +258,23 @@ function onApply() {
 		</v-tabs-items>
 
 		<template #actions>
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-if="currentTab[0] === 'flow_setup'"
 				v-tooltip.bottom="isNew ? $t('next') : $t('save')"
 				:disabled="isFlowSetupDisabled"
 				:loading="saving"
-				icon
-				rounded
-				small
+				:icon="isNew ? 'arrow_forward' : 'check'"
 				@click="onApplyFlowSetup"
-			>
-				<v-icon :name="isNew ? 'arrow_forward' : 'check'" small />
-			</v-button>
-			<v-button
+			/>
+
+			<PrivateViewHeaderBarActionButton
 				v-if="currentTab[0] === 'trigger_setup'"
 				v-tooltip.bottom="isNew ? $t('finish_setup') : $t('save')"
 				:disabled="isFlowTriggerDisabled"
 				:loading="saving"
-				icon
-				rounded
-				small
+				icon="check"
 				@click="save"
-			>
-				<v-icon name="check" small />
-			</v-button>
+			/>
 		</template>
 	</v-drawer>
 </template>

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -8,6 +8,7 @@ import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { Vector2 } from '@/utils/vector2';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { FlowRaw, OperationRaw } from '@directus/types';
 import { cloneDeep, isEmpty, merge, omit } from 'lodash';
 import { customAlphabet, nanoid } from 'nanoid/non-secure';
@@ -608,39 +609,37 @@ function discardAndLeave() {
 
 		<template #actions>
 			<template v-if="editMode">
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('clear_changes')"
 					class="clear-changes"
-					rounded
-					icon
+					icon="clear"
 					outlined
-					small
 					@click="attemptCancelChanges"
-				>
-					<v-icon name="clear" small />
-				</v-button>
+				/>
 
-				<v-button v-tooltip.bottom="$t('save')" rounded icon :loading="saving" small @click="saveChanges">
-					<v-icon name="check" small />
-				</v-button>
+				<PrivateViewHeaderBarActionButton
+					v-tooltip.bottom="$t('save')"
+					:loading="saving"
+					icon="check"
+					@click="saveChanges"
+				/>
 			</template>
 
 			<template v-else>
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('delete_flow')"
 					class="delete-flow"
-					rounded
-					icon
 					secondary
-					small
+					icon="delete"
 					@click="confirmDelete = true"
-				>
-					<v-icon name="delete" small />
-				</v-button>
+				/>
 
-				<v-button v-tooltip.bottom="$t('edit_flow')" rounded icon outlined small @click="editMode = !editMode">
-					<v-icon name="edit" small />
-				</v-button>
+				<PrivateViewHeaderBarActionButton
+					v-tooltip.bottom="$t('edit_flow')"
+					outlined
+					icon="edit"
+					@click="editMode = !editMode"
+				/>
 			</template>
 		</template>
 

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -5,6 +5,7 @@ import { useCollectionPermissions } from '@/composables/use-permissions';
 import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { unexpectedError } from '@/utils/unexpected-error';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { FlowRaw } from '@directus/types';
 import { sortBy } from 'lodash';
 import { computed, ref } from 'vue';
@@ -143,16 +144,12 @@ function onFlowDrawerCompletion(id: string) {
 		</template>
 
 		<template #actions>
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="createAllowed ? $t('create_flow') : $t('not_allowed')"
-				rounded
-				icon
 				:disabled="createAllowed === false"
-				small
+				icon="add"
 				@click="editFlow = '+'"
-			>
-				<v-icon name="add" small />
-			</v-button>
+			/>
 		</template>
 
 		<v-info v-if="flows.length === 0" icon="bolt" :title="$t('no_flows')" center>

--- a/app/src/modules/settings/routes/policies/collection.vue
+++ b/app/src/modules/settings/routes/policies/collection.vue
@@ -4,6 +4,7 @@ import { fetchAll } from '@/utils/fetch-all';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { Policy } from '@directus/types';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -153,9 +154,7 @@ function navigateToPolicy({ item }: { item: Policy }) {
 				small
 			/>
 
-			<v-button v-tooltip.bottom="$t('create_policy')" rounded icon :to="addNewLink" small>
-				<v-icon name="add" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton v-tooltip.bottom="$t('create_policy')" :to="addNewLink" icon="add" />
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/policies/item.vue
+++ b/app/src/modules/settings/routes/policies/item.vue
@@ -10,6 +10,7 @@ import { ref, toRefs } from 'vue';
 import { useRouter } from 'vue-router';
 import SettingsNavigation from '../../components/navigation.vue';
 import PolicyInfoSidebarDetail from './policy-info-sidebar-detail.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 
 const props = defineProps<{
 	primaryKey: string;
@@ -111,18 +112,14 @@ function discardAndStay() {
 		<template #actions>
 			<v-dialog v-model="confirmDelete" @esc="confirmDelete = false" @apply="deleteAndQuit">
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="$t('delete_label')"
-						rounded
-						icon
 						class="action-delete"
 						secondary
 						:disabled="item === null"
-						small
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>

--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -6,6 +6,7 @@ import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection, useLayout } from '@directus/composables';
 import { ref } from 'vue';
 import SettingsNavigation from '../../../components/navigation.vue';
@@ -114,18 +115,14 @@ function clearFilters() {
 
 				<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false" @apply="batchDelete">
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="batchDeleteAllowed ? $t('delete_label') : $t('not_allowed')"
 							:disabled="batchDeleteAllowed !== true"
-							rounded
-							icon
 							class="action-delete"
 							secondary
-							small
+							icon="delete"
 							@click="on"
-						>
-							<v-icon name="delete" outline small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -142,29 +139,21 @@ function clearFilters() {
 					</v-card>
 				</v-dialog>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="selection.length > 0"
 					v-tooltip.bottom="batchEditAllowed ? $t('edit') : $t('not_allowed')"
-					rounded
-					icon
 					secondary
 					:disabled="batchEditAllowed === false"
-					small
+					icon="edit"
 					@click="batchEditActive = true"
-				>
-					<v-icon name="edit" outline small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="createAllowed ? $t('create_preset') : $t('not_allowed')"
-					rounded
-					icon
 					to="/settings/presets/+"
 					:disabled="createAllowed === false"
-					small
-				>
-					<v-icon name="add" small />
-				</v-button>
+					icon="add"
+				/>
 			</template>
 
 			<template #navigation>

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -6,6 +6,7 @@ import { useExtensions } from '@/extensions';
 import { useCollectionsStore } from '@/stores/collections';
 import { usePresetsStore } from '@/stores/presets';
 import { unexpectedError } from '@/utils/unexpected-error';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useLayout } from '@directus/composables';
 import { isSystemCollection } from '@directus/system-data';
 import { DeepPartial, Field, Filter, Preset } from '@directus/types';
@@ -478,18 +479,14 @@ function discardAndLeave() {
 			<template #actions>
 				<v-dialog v-model="confirmDelete" @esc="confirmDelete = false" @apply="deleteAndQuit">
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="$t('delete_label')"
-							rounded
-							icon
 							class="action-delete"
 							secondary
 							:disabled="preset === null || id === '+'"
-							small
+							icon="delete"
 							@click="on"
-						>
-							<v-icon name="delete" small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -506,17 +503,13 @@ function discardAndLeave() {
 					</v-card>
 				</v-dialog>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="$t('save')"
-					icon
-					rounded
 					:disabled="hasEdits === false"
 					:loading="saving"
-					small
+					icon="check"
 					@click="save"
-				>
-					<v-icon name="check" small />
-				</v-button>
+				/>
 			</template>
 
 			<div class="preset-item">

--- a/app/src/modules/settings/routes/project/project.vue
+++ b/app/src/modules/settings/routes/project/project.vue
@@ -3,6 +3,7 @@ import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection } from '@directus/composables';
 import { clone } from 'lodash';
 import { computed, ref } from 'vue';
@@ -65,9 +66,13 @@ function discardAndLeave() {
 		<template #headline><v-breadcrumb :items="[{ name: $t('settings'), to: '/settings' }]" /></template>
 
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('save')" icon rounded :disabled="!hasEdits" :loading="saving" small @click="save">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:disabled="!hasEdits"
+				:loading="saving"
+				icon="check"
+				@click="save"
+			/>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -4,6 +4,7 @@ import { fetchAll } from '@/utils/fetch-all';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { Role } from '@directus/types';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -163,9 +164,7 @@ function navigateToRole({ item }: { item: Role }) {
 				small
 			/>
 
-			<v-button v-tooltip.bottom="$t('create_role')" rounded icon :to="addNewLink" small>
-				<v-icon name="add" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton v-tooltip.bottom="$t('create_role')" :to="addNewLink" icon="add" />
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/roles/item.vue
+++ b/app/src/modules/settings/routes/roles/item.vue
@@ -7,6 +7,7 @@ import { useUserStore } from '@/stores/user';
 import RevisionsSidebarDetail from '@/views/private/components/revisions-sidebar-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
 import UsersInvite from '@/views/private/components/users-invite.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { Role } from '@directus/types';
 import { computed, ref, toRefs } from 'vue';
 import { useRouter } from 'vue-router';
@@ -120,18 +121,14 @@ function discardAndStay() {
 		<template #actions>
 			<v-dialog v-model="confirmDelete" @esc="confirmDelete = false" @apply="deleteAndQuit">
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="$t('delete_label')"
-						rounded
-						icon
 						class="action-delete"
 						secondary
 						:disabled="item === null"
-						small
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -148,21 +145,21 @@ function discardAndStay() {
 				</v-card>
 			</v-dialog>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-if="canInviteUsers"
 				v-tooltip.bottom="$t('invite_users')"
-				rounded
-				icon
 				secondary
-				small
+				icon="person_add"
 				@click="userInviteModalActive = true"
+			/>
+
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:loading="saving"
+				:disabled="!hasEdits"
+				icon="check"
+				@click="saveAndQuit"
 			>
-				<v-icon name="person_add" small />
-			</v-button>
-
-			<v-button rounded icon :tooltip="$t('save')" :loading="saving" :disabled="!hasEdits" small @click="saveAndQuit">
-				<v-icon name="check" small />
-
 				<template #append-outer>
 					<save-options
 						v-if="hasEdits"
@@ -172,7 +169,7 @@ function discardAndStay() {
 						@discard-and-stay="discardAndStay"
 					/>
 				</template>
-			</v-button>
+			</PrivateViewHeaderBarActionButton>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -208,7 +208,6 @@ function isAlterations<T extends Item>(value: any): value is Alterations<T> {
 				v-tooltip.bottom="$t('save')"
 				:loading="saving"
 				:disabled="!hasEdits"
-				small
 				icon="check"
 				@click="saveAndQuit"
 			>

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -5,6 +5,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { unexpectedError } from '@/utils/unexpected-error';
 import RevisionsSidebarDetail from '@/views/private/components/revisions-sidebar-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useApi } from '@directus/composables';
 import { Alterations, Item, Policy } from '@directus/types';
 import { cloneDeep, isEmpty, isEqual, isObjectLike } from 'lodash';
@@ -203,9 +204,14 @@ function isAlterations<T extends Item>(value: any): value is Alterations<T> {
 		</template>
 
 		<template #actions>
-			<v-button rounded icon :tooltip="$t('save')" :loading="saving" :disabled="!hasEdits" small @click="saveAndQuit">
-				<v-icon name="check" small />
-
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:loading="saving"
+				:disabled="!hasEdits"
+				small
+				icon="check"
+				@click="saveAndQuit"
+			>
 				<template #append-outer>
 					<save-options
 						v-if="hasEdits"
@@ -215,7 +221,7 @@ function isAlterations<T extends Item>(value: any): value is Alterations<T> {
 						@discard-and-stay="discardAndStay"
 					/>
 				</template>
-			</v-button>
+			</PrivateViewHeaderBarActionButton>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/system-logs/logs.vue
+++ b/app/src/modules/settings/routes/system-logs/logs.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { useClipboard } from '@/composables/use-clipboard';
 import { useShortcut } from '@/composables/use-shortcut';
-import { getRootPath } from '@/utils/get-root-path';
 import { sdk } from '@/sdk';
 import { useServerStore } from '@/stores/server';
+import { getRootPath } from '@/utils/get-root-path';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
+import PrivateView from '@/views/private/private-view/components/private-view.vue';
 import { realtime } from '@directus/sdk';
 import { useLocalStorage } from '@vueuse/core';
 import CodeMirror from 'codemirror';
@@ -423,30 +425,28 @@ onUnmounted(() => {
 			<v-button v-if="shouldStream && !streamConnected" v-tooltip.bottom="$t('loading')" rounded icon disabled small>
 				<v-progress-circular small indeterminate />
 			</v-button>
-			<v-button
+
+			<PrivateViewHeaderBarActionButton
 				v-else-if="!shouldStream"
 				v-tooltip.bottom="$t('resume_streaming_logs')"
-				rounded
-				icon
-				small
+				icon="play_arrow"
 				@click="resumeLogsStreaming"
-			>
-				<v-icon name="play_arrow" small />
-			</v-button>
-			<v-button v-else v-tooltip.bottom="$t('pause_streaming_logs')" rounded icon small @click="pauseLogsStreaming">
-				<v-icon name="pause" small />
-			</v-button>
-			<v-button
+			/>
+
+			<PrivateViewHeaderBarActionButton
+				v-else
+				v-tooltip.bottom="$t('pause_streaming_logs')"
+				icon="pause"
+				@click="pauseLogsStreaming"
+			/>
+
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="$t('clear_logs')"
-				rounded
-				icon
 				:disabled="logs.length === 0"
 				class="action-clear"
-				small
+				icon="mop"
 				@click="clearLogs"
-			>
-				<v-icon name="mop" small />
-			</v-button>
+			/>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/settings/routes/translations/collection.vue
+++ b/app/src/modules/settings/routes/translations/collection.vue
@@ -6,6 +6,7 @@ import ExportSidebarDetail from '@/views/private/components/export-sidebar-detai
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection, useLayout } from '@directus/composables';
 import { computed, ref } from 'vue';
 import SettingsNavigation from '../../components/navigation.vue';
@@ -121,17 +122,13 @@ function clearFilters() {
 
 				<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false" @apply="batchDelete">
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="$t('delete_label')"
-							rounded
-							icon
 							class="action-delete"
 							secondary
-							small
+							icon="delete"
 							@click="on"
-						>
-							<v-icon name="delete" outline small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -148,21 +145,19 @@ function clearFilters() {
 					</v-card>
 				</v-dialog>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="selection.length > 0"
 					v-tooltip.bottom="$t('edit')"
-					rounded
-					icon
+					icon="edit"
 					secondary
-					small
 					@click="batchEditActive = true"
-				>
-					<v-icon name="edit" outline small />
-				</v-button>
+				/>
 
-				<v-button v-tooltip.bottom="$t('create_custom_translation')" rounded icon :to="addNewLink" small>
-					<v-icon name="add" small />
-				</v-button>
+				<PrivateViewHeaderBarActionButton
+					v-tooltip.bottom="$t('create_custom_translation')"
+					:to="addNewLink"
+					icon="add"
+				/>
 			</template>
 
 			<template #navigation>

--- a/app/src/modules/settings/routes/translations/item.vue
+++ b/app/src/modules/settings/routes/translations/item.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { computed, ref, toRefs, unref } from 'vue';
-
 import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
 import { useShortcut } from '@/composables/use-shortcut';
@@ -8,7 +6,9 @@ import { refreshCurrentLanguage } from '@/lang/refresh-current-language';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
 import RevisionsSidebarDetail from '@/views/private/components/revisions-sidebar-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection } from '@directus/composables';
+import { computed, ref, toRefs, unref } from 'vue';
 import { useRouter } from 'vue-router';
 import SettingsNavigation from '../../components/navigation.vue';
 import ContentNotFound from '../not-found.vue';
@@ -218,19 +218,15 @@ async function revert(values: Record<string, any>) {
 		<template #actions>
 			<v-dialog v-if="!isNew" v-model="confirmDelete" @esc="confirmDelete = false" @apply="deleteAndQuit">
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-if="collectionInfo!.meta && collectionInfo!.meta.singleton === false"
 						v-tooltip.bottom="$t('delete_label')"
-						rounded
-						icon
 						class="action-delete"
 						secondary
 						:disabled="item === null"
-						small
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" outline small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -247,19 +243,16 @@ async function revert(values: Record<string, any>) {
 				</v-card>
 			</v-dialog>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="$t('save')"
-				rounded
-				icon
 				:loading="saving"
 				:disabled="!isSavable"
-				small
+				icon="check"
 				@click="saveAndQuit"
 			>
-				<v-icon name="check" small />
-
 				<template #append-outer>
 					<save-options
+						v-if="hasEdits"
 						:disabled-options="disabledOptions"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
@@ -267,7 +260,7 @@ async function revert(values: Record<string, any>) {
 						@discard-and-stay="discardAndStay"
 					/>
 				</template>
-			</v-button>
+			</PrivateViewHeaderBarActionButton>
 		</template>
 
 		<template #navigation>

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import api from '@/api';
+import { logout } from '@/auth';
 import { useCollectionPermissions } from '@/composables/use-permissions';
 import { usePreset } from '@/composables/use-preset';
 import { useServerStore } from '@/stores/server';
+import { useUserStore } from '@/stores/user';
 import { unexpectedError } from '@/utils/unexpected-error';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
 import UsersInvite from '@/views/private/components/users-invite.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useLayout } from '@directus/composables';
 import { mergeFilters } from '@directus/utils';
 import { computed, ref, toRefs } from 'vue';
@@ -15,8 +18,6 @@ import { useI18n } from 'vue-i18n';
 import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
 import useNavigation from '../composables/use-navigation';
-import { logout } from '@/auth';
-import { useUserStore } from '@/stores/user';
 
 const props = defineProps<{ role?: string }>();
 
@@ -193,18 +194,14 @@ function clearFilters() {
 
 				<v-dialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false" @apply="batchDelete">
 					<template #activator="{ on }">
-						<v-button
+						<PrivateViewHeaderBarActionButton
 							v-tooltip.bottom="batchDeleteAllowed ? $t('delete_label') : $t('not_allowed')"
 							:disabled="batchDeleteAllowed !== true"
-							rounded
-							icon
 							class="action-delete"
 							secondary
-							small
+							icon="delete"
 							@click="on"
-						>
-							<v-icon name="delete" small />
-						</v-button>
+						/>
 					</template>
 
 					<v-card>
@@ -221,41 +218,29 @@ function clearFilters() {
 					</v-card>
 				</v-dialog>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="selection.length > 0"
 					v-tooltip.bottom="batchEditAllowed ? $t('edit') : $t('not_allowed')"
-					rounded
-					icon
 					secondary
 					:disabled="batchEditAllowed === false"
-					small
+					icon="edit"
 					@click="batchEditActive = true"
-				>
-					<v-icon name="edit" small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-if="canInviteUsers"
 					v-tooltip.bottom="$t('invite_users')"
-					rounded
-					icon
 					secondary
-					small
+					icon="person_add"
 					@click="userInviteModalActive = true"
-				>
-					<v-icon name="person_add" small />
-				</v-button>
+				/>
 
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="createAllowed ? $t('create_item') : $t('not_allowed')"
-					rounded
-					icon
 					:to="addNewLink"
 					:disabled="createAllowed === false"
-					small
-				>
-					<v-icon name="add" small />
-				</v-button>
+					icon="add"
+				/>
 			</template>
 
 			<template #navigation>

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -12,9 +12,10 @@ import { userName } from '@/utils/user-name';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
 import RevisionsSidebarDetail from '@/views/private/components/revisions-sidebar-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
+import PrivateViewHeaderBarActionButton from '@/views/private/private-view/components/private-view-header-bar-action-button.vue';
 import { useCollection } from '@directus/composables';
 import type { User } from '@directus/types';
-import { computed, ref, toRefs, provide } from 'vue';
+import { computed, provide, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
@@ -281,18 +282,14 @@ function revert(values: Record<string, any>) {
 				@apply="deleteAndQuit"
 			>
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="deleteAllowed ? $t('delete_label') : $t('not_allowed')"
-						rounded
-						icon
 						class="action-delete"
 						secondary
 						:disabled="item === null || deleteAllowed !== true"
-						small
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -317,18 +314,14 @@ function revert(values: Record<string, any>) {
 				@apply="toggleArchive"
 			>
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-if="collectionInfo.meta && collectionInfo.meta.singleton === false"
 						v-tooltip.bottom="archiveTooltip"
-						rounded
-						icon
 						secondary
 						:disabled="item === null || archiveAllowed !== true"
-						small
+						:icon="isArchived ? 'unarchive' : 'archive'"
 						@click="on"
-					>
-						<v-icon :name="isArchived ? 'unarchive' : 'archive'" small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -345,17 +338,13 @@ function revert(values: Record<string, any>) {
 				</v-card>
 			</v-dialog>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="saveAllowed ? $t('save') : $t('not_allowed')"
-				rounded
-				icon
 				:loading="saving"
 				:disabled="!isSavable"
-				small
+				icon="check"
 				@click="saveAndQuit"
 			>
-				<v-icon name="check" small />
-
 				<template #append-outer>
 					<save-options
 						v-if="isSavable"
@@ -366,7 +355,7 @@ function revert(values: Record<string, any>) {
 						@discard-and-stay="discardAndStay"
 					/>
 				</template>
-			</v-button>
+			</PrivateViewHeaderBarActionButton>
 		</template>
 
 		<template #navigation>

--- a/app/src/views/private/components/drawer-batch.vue
+++ b/app/src/views/private/components/drawer-batch.vue
@@ -126,12 +126,7 @@ function useActions() {
 		@apply="save"
 	>
 		<template #actions>
-			<PrivateViewHeaderBarActionButton
-				v-tooltip.bottom="$t('save')"
-				:loading="saving"
-				icon="check"
-				@click="save"
-			/>
+			<PrivateViewHeaderBarActionButton v-tooltip.bottom="$t('save')" :loading="saving" icon="check" @click="save" />
 		</template>
 
 		<div class="drawer-batch-content">

--- a/app/src/views/private/components/drawer-batch.vue
+++ b/app/src/views/private/components/drawer-batch.vue
@@ -5,6 +5,7 @@ import { APIError } from '@/types/error';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { getEndpoint } from '@directus/utils';
 import { computed, ref, toRefs } from 'vue';
+import PrivateViewHeaderBarActionButton from '../private-view/components/private-view-header-bar-action-button.vue';
 
 const props = defineProps<{
 	collection: string;
@@ -125,9 +126,12 @@ function useActions() {
 		@apply="save"
 	>
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('save')" icon rounded small :loading="saving" @click="save">
-				<v-icon name="check" small />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:loading="saving"
+				icon="check"
+				@click="save"
+			/>
 		</template>
 
 		<div class="drawer-batch-content">

--- a/app/src/views/private/components/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection.vue
@@ -7,6 +7,7 @@ import { Filter } from '@directus/types';
 import { mergeFilters } from '@directus/utils';
 import { isEqual } from 'lodash';
 import { computed, ref, toRefs, unref, watch } from 'vue';
+import PrivateViewHeaderBarActionButton from '../private-view/components/private-view-header-bar-action-button.vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -171,9 +172,12 @@ function useActions() {
 			<template #actions>
 				<search-input v-model="search" v-model:filter="presetFilter" :collection="collection" />
 
-				<v-button v-tooltip.bottom="$t('save')" icon rounded :disabled="!hasSelectionChanged" small @click="save">
-					<v-icon name="check" small />
-				</v-button>
+				<PrivateViewHeaderBarActionButton
+					v-tooltip.bottom="$t('save')"
+					:disabled="!hasSelectionChanged"
+					icon="check"
+					@click="save"
+				/>
 			</template>
 
 			<div class="layout">

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -15,6 +15,7 @@ import type { AxiosProgressEvent } from 'axios';
 import { debounce, pick } from 'lodash';
 import { computed, reactive, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import PrivateViewHeaderBarActionButton from '../private-view/components/private-view-header-bar-action-button.vue';
 import ImportErrorDialog from './import-error-dialog.vue';
 
 type LayoutQuery = {
@@ -456,16 +457,12 @@ async function exportDataFiles() {
 			@apply="startExport"
 		>
 			<template #actions>
-				<v-button
+				<PrivateViewHeaderBarActionButton
 					v-tooltip.bottom="location === 'download' ? $t('download_file') : $t('start_export')"
-					rounded
-					icon
-					small
 					:loading="exporting"
+					:icon="location === 'download' ? 'download' : 'start'"
 					@click="startExport"
-				>
-					<v-icon :name="location === 'download' ? 'download' : 'start'" small />
-				</v-button>
+				/>
 			</template>
 			<div class="export-fields">
 				<div class="field half-left">

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -10,6 +10,7 @@ import throttle from 'lodash/throttle';
 import { nanoid } from 'nanoid/non-secure';
 import { computed, nextTick, reactive, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import PrivateViewHeaderBarActionButton from '../private-view/components/private-view-header-bar-action-button.vue';
 
 const imageFields = [
 	'type',
@@ -577,9 +578,13 @@ function setAspectRatio() {
 		</div>
 
 		<template #actions>
-			<v-button v-tooltip.bottom="$t('save')" :loading="saving" icon rounded :disabled="!hasEdits" @click="save">
-				<v-icon name="check" />
-			</v-button>
+			<PrivateViewHeaderBarActionButton
+				v-tooltip.bottom="$t('save')"
+				:loading="saving"
+				:disabled="!hasEdits"
+				icon="check"
+				@click="save"
+			/>
 		</template>
 	</v-drawer>
 </template>

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -15,6 +15,7 @@ import { storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
+import PrivateViewHeaderBarActionButton from '../private-view/components/private-view-header-bar-action-button.vue';
 
 type LocalNotification = Notification & {
 	to?: string;
@@ -227,18 +228,14 @@ function clearFilters() {
 				@apply="deleteSelected"
 			>
 				<template #activator="{ on }">
-					<v-button
+					<PrivateViewHeaderBarActionButton
 						v-tooltip.bottom="$t('delete_label')"
-						rounded
-						icon
 						class="action-delete"
 						secondary
-						small
 						:disabled="selection.length === 0"
+						icon="delete"
 						@click="on"
-					>
-						<v-icon name="delete" outline small />
-					</v-button>
+					/>
 				</template>
 
 				<v-card>
@@ -255,17 +252,13 @@ function clearFilters() {
 				</v-card>
 			</v-dialog>
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="tab[0] === 'inbox' ? $t('archive') : $t('unarchive')"
-				icon
-				rounded
 				:disabled="selection.length === 0"
 				secondary
-				small
+				:icon="tab[0] === 'inbox' ? 'archive' : 'move_to_inbox'"
 				@click="toggleArchive"
-			>
-				<v-icon :name="tab[0] === 'inbox' ? 'archive' : 'move_to_inbox'" small />
-			</v-button>
+			/>
 		</template>
 
 		<template #sidebar>

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -22,6 +22,7 @@ import { isEmpty, set } from 'lodash';
 import { computed, ref, toRefs, unref, watch, type Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
+import PrivateViewHeaderBarActionButton from '../private-view/components/private-view-header-bar-action-button.vue';
 import OverlayItemContent from './overlay-item-content.vue';
 
 export interface OverlayItemProps {
@@ -562,16 +563,12 @@ function popoverClickOutsideMiddleware(e: Event) {
 		<template #actions>
 			<slot name="actions" />
 
-			<v-button
+			<PrivateViewHeaderBarActionButton
 				v-tooltip.bottom="getTooltip('save', $t('save'))"
-				icon
-				rounded
-				small
 				:disabled="!isSavable"
+				icon="check"
 				@click="save"
-			>
-				<v-icon name="check" small />
-			</v-button>
+			/>
 		</template>
 
 		<overlay-item-content

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.test.ts
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.test.ts
@@ -1,0 +1,265 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { createRouter, createWebHistory } from 'vue-router';
+import { createTestingPinia } from '@pinia/testing';
+import PrivateViewHeaderBarActionButton from './private-view-header-bar-action-button.vue';
+
+const router = createRouter({
+	history: createWebHistory(),
+	routes: [
+		{
+			path: '/',
+			name: 'home',
+			component: { template: '<div />' },
+		},
+		{
+			path: '/some-route',
+			name: 'some-route',
+			component: { template: '<div />' },
+		},
+		{
+			path: '/test-route',
+			name: 'test-route',
+			component: { template: '<div />' },
+		},
+		{
+			path: '/:pathMatch(.*)*',
+			component: { template: '<div />' },
+		},
+	],
+});
+
+const mountOptions = {
+	global: {
+		plugins: [
+			createTestingPinia({
+				createSpy: vi.fn,
+			}),
+			router,
+		],
+	},
+};
+
+describe('PrivateViewHeaderBarActionButton', () => {
+	test('renders the component', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+			},
+		});
+
+		expect(wrapper.exists()).toBe(true);
+	});
+
+	test('renders with icon prop', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'delete',
+			},
+		});
+
+		const icon = wrapper.findComponent({ name: 'v-icon' });
+		expect(icon.exists()).toBe(true);
+		expect(icon.props('name')).toBe('delete');
+	});
+
+	test('passes icon prop to VIcon with small size', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'save',
+			},
+		});
+
+		const icon = wrapper.findComponent({ name: 'v-icon' });
+		expect(icon.props('small')).toBe(true);
+	});
+
+	test('passes disabled prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				disabled: true,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('disabled')).toBe(true);
+	});
+
+	test('passes loading prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				loading: true,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('loading')).toBe(true);
+	});
+
+	test('passes secondary prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				secondary: true,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('secondary')).toBe(true);
+	});
+
+	test('passes outlined prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				outlined: true,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('outlined')).toBe(true);
+	});
+
+	test('passes active prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				active: true,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('active')).toBe(true);
+	});
+
+	test('passes to prop (router link) to VButton', () => {
+		const to = { name: 'some-route' };
+
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				to,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('to')).toEqual(to);
+	});
+
+	test('passes href prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				href: 'https://example.com',
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('href')).toBe('https://example.com');
+	});
+
+	test('passes download prop to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+				download: 'file.pdf',
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('download')).toBe('file.pdf');
+	});
+
+	test('passes icon prop (as string) to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('icon')).toBe(true);
+	});
+
+	test('passes rounded and small props to VButton', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('rounded')).toBe(true);
+		expect(button.props('small')).toBe(true);
+	});
+
+	test('emits click event when VButton is clicked', async () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		await button.vm.$emit('click');
+
+		expect(wrapper.emitted('click')).toBeTruthy();
+		expect(wrapper.emitted('click')).toHaveLength(1);
+	});
+
+	test('renders append-outer slot', () => {
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'edit',
+			},
+			slots: {
+				'append-outer': '<span class="test-slot">Slot Content</span>',
+			},
+		});
+
+		expect(wrapper.html()).toContain('Slot Content');
+	});
+
+	test('handles multiple props simultaneously', () => {
+		const to = { name: 'test-route' };
+
+		const wrapper = mount(PrivateViewHeaderBarActionButton, {
+			...mountOptions,
+			props: {
+				icon: 'download',
+				disabled: false,
+				loading: false,
+				secondary: true,
+				outlined: true,
+				to,
+				active: true,
+			},
+		});
+
+		const button = wrapper.findComponent({ name: 'v-button' });
+		expect(button.props('icon')).toBe(true);
+		expect(button.props('disabled')).toBe(false);
+		expect(button.props('loading')).toBe(false);
+		expect(button.props('secondary')).toBe(true);
+		expect(button.props('outlined')).toBe(true);
+		expect(button.props('to')).toEqual(to);
+		expect(button.props('active')).toBe(true);
+	});
+});

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
+import type { RouteLocationRaw } from 'vue-router';
 
 defineProps<{
 	icon: string;
@@ -8,7 +9,8 @@ defineProps<{
 	loading?: boolean;
 	secondary?: boolean;
 	outlined?: boolean;
-	to?: string;
+	to?: RouteLocationRaw;
+	download?: boolean;
 }>();
 
 defineEmits<{
@@ -17,17 +19,7 @@ defineEmits<{
 </script>
 
 <template>
-	<VButton
-		:disabled
-		:loading
-		:secondary
-		:outlined
-		:to
-		icon
-		rounded
-		small
-		@click="$emit('click')"
-	>
+	<VButton :disabled :loading :secondary :outlined :to icon rounded small @click="$emit('click')">
 		<VIcon :name="icon" small />
 	</VButton>
 </template>

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -10,7 +10,8 @@ defineProps<{
 	secondary?: boolean;
 	outlined?: boolean;
 	to?: RouteLocationRaw;
-	download?: boolean;
+	href?: string;
+	download?: string;
 }>();
 
 defineEmits<{
@@ -19,7 +20,8 @@ defineEmits<{
 </script>
 
 <template>
-	<VButton :disabled :loading :secondary :outlined :to icon rounded small @click="$emit('click')">
+	<VButton :disabled :loading :secondary :outlined :to :href :download icon rounded small @click="$emit('click')">
 		<VIcon :name="icon" small />
+		<template #append-outer><slot name="append-outer" /></template>
 	</VButton>
 </template>

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import VButton from '@/components/v-button.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
+
+defineProps<{
+	icon: string;
+	disabled?: boolean;
+	loading?: boolean;
+	secondary?: boolean;
+	outlined?: boolean;
+	to?: string;
+}>();
+
+defineEmits<{
+	click: [];
+}>();
+</script>
+
+<template>
+	<VButton
+		:disabled
+		:loading
+		:secondary
+		:outlined
+		:to
+		icon
+		rounded
+		small
+		@click="$emit('click')"
+	>
+		<VIcon :name="icon" small />
+	</VButton>
+</template>

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -12,6 +12,7 @@ defineProps<{
 	to?: RouteLocationRaw;
 	href?: string;
 	download?: string;
+	active?: boolean;
 }>();
 
 defineEmits<{
@@ -20,7 +21,20 @@ defineEmits<{
 </script>
 
 <template>
-	<VButton :disabled :loading :secondary :outlined :to :href :download icon rounded small @click="$emit('click')">
+	<VButton
+		:disabled
+		:active
+		:loading
+		:secondary
+		:outlined
+		:to
+		:href
+		:download
+		icon
+		rounded
+		small
+		@click="$emit('click')"
+	>
 		<VIcon :name="icon" small />
 		<template #append-outer><slot name="append-outer" /></template>
 	</VButton>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 3.2.4
       version: 3.2.4
+    '@vue/compiler-dom':
+      specifier: 3.5.25
+      version: 3.5.25
     '@vue/test-utils':
       specifier: 2.4.6
       version: 2.4.6
@@ -1718,6 +1721,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.9.1)(happy-dom@20.0.10)(jiti@2.6.1)(jsdom@20.0.3)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vue/compiler-dom':
+        specifier: 'catalog:'
+        version: 3.5.25
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 2.4.6
@@ -7101,8 +7107,14 @@ packages:
   '@vue/compiler-core@3.5.24':
     resolution: {integrity: sha512-eDl5H57AOpNakGNAkFDH+y7kTqrQpJkZFXhWZQGyx/5Wh7B1uQYvcWkvZi11BDhscPgj8N7XV3oRwiPnx1Vrig==}
 
+  '@vue/compiler-core@3.5.25':
+    resolution: {integrity: sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==}
+
   '@vue/compiler-dom@3.5.24':
     resolution: {integrity: sha512-1QHGAvs53gXkWdd3ZMGYuvQFXHW4ksKWPG8HP8/2BscrbZ0brw183q2oNWjMrSWImYLHxHrx1ItBQr50I/q2zw==}
+
+  '@vue/compiler-dom@3.5.25':
+    resolution: {integrity: sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==}
 
   '@vue/compiler-sfc@3.5.24':
     resolution: {integrity: sha512-8EG5YPRgmTB+YxYBM3VXy8zHD9SWHUJLIGPhDovo3Z8VOgvP+O7UP5vl0J4BBPWYD9vxtBabzW1EuEZ+Cqs14g==}
@@ -7159,6 +7171,9 @@ packages:
 
   '@vue/shared@3.5.24':
     resolution: {integrity: sha512-9cwHL2EsJBdi8NY22pngYYWzkTDhld6fAD6jlaeloNGciNSJL6bLpbxVgXl96X00Jtc6YWQv96YA/0sxex/k1A==}
+
+  '@vue/shared@3.5.25':
+    resolution: {integrity: sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -19580,10 +19595,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.25':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/shared': 3.5.25
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.24':
     dependencies:
       '@vue/compiler-core': 3.5.24
       '@vue/shared': 3.5.24
+
+  '@vue/compiler-dom@3.5.25':
+    dependencies:
+      '@vue/compiler-core': 3.5.25
+      '@vue/shared': 3.5.25
 
   '@vue/compiler-sfc@3.5.24':
     dependencies:
@@ -19651,7 +19679,7 @@ snapshots:
   '@vue/language-core@3.1.3(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.24
+      '@vue/compiler-dom': 3.5.25
       '@vue/shared': 3.5.24
       alien-signals: 3.0.3
       muggle-string: 0.4.1
@@ -19683,6 +19711,8 @@ snapshots:
       vue: 3.5.24(typescript@5.9.3)
 
   '@vue/shared@3.5.24': {}
+
+  '@vue/shared@3.5.25': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -27226,7 +27256,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      '@vue/compiler-dom': 3.5.24
+      '@vue/compiler-dom': 3.5.25
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,6 +130,7 @@ catalog:
   '@unhead/vue': 1.11.20
   '@vitejs/plugin-vue': 6.0.1
   '@vitest/coverage-v8': 3.2.4
+  '@vue/compiler-dom': 3.5.25
   '@vue/test-utils': 2.4.6
   '@vueuse/core': 14.0.0
   '@vueuse/integrations': 14.0.0
@@ -270,8 +271,8 @@ catalog:
   rollup-plugin-esbuild: 6.2.1
   rollup-plugin-node-externals: 8.1.2
   rollup-plugin-styler: 2.0.0
-  sanitize-filename: 1.6.3
   samlify: 2.10.2
+  sanitize-filename: 1.6.3
   sanitize-html: 2.17.0
   sass-embedded: 1.93.3
   semver: 7.7.3


### PR DESCRIPTION
## Scope

What's changed:

- Adds a new `PrivateViewHeaderBarActionButton` component
- Replaces all private-view header bar and v-drawer header action buttons with `PrivateViewHeaderBarActionButton`

## Potential Risks / Drawbacks

- Relatively straightforward refactor

## Tested Scenarios

- Went through all the routes in which I replaced the components

## Review Notes / Questions

- Small refactor, should be pretty straightforward

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26321 
