### PR TITLE
fix(storage-driver-supabase): failure with empty string root folder

### DIFF
--- a/.changeset/major-forks-run.md
+++ b/.changeset/major-forks-run.md
@@ -1,0 +1,5 @@
+---
+'@directus/storage-driver-supabase': patch
+---
+
+Fixed an issue where the Supabase storage driver would fail if the root folder is the empty string.

--- a/contributors.yml
+++ b/contributors.yml
@@ -232,3 +232,4 @@
 - dstockton
 - johnson-jnr
 - vizzv
+- aderugy

--- a/packages/storage-driver-supabase/src/index.test.ts
+++ b/packages/storage-driver-supabase/src/index.test.ts
@@ -380,6 +380,24 @@ describe('#stat', () => {
 		});
 	});
 
+	test('Uses empty string instead of "." when root is the empty string', async () => {
+		const filename = 'test.png';
+
+		driver['bucket'] = {
+			list: vi.fn().mockReturnValue({
+				data: [{ metadata: { contentLength: sample.file.size, lastModified: sample.file.modified } }],
+				error: null,
+			}),
+		} as any;
+
+		await driver.stat(filename);
+
+		expect(driver['bucket'].list).toHaveBeenCalledWith('', {
+			limit: 1,
+			search: filename,
+		});
+	});
+
 	test('Throws an error no file is returned by list', async () => {
 		driver['bucket'] = {
 			list: vi.fn().mockReturnValue({

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -106,7 +106,7 @@ export class DriverSupabase implements TusDriver {
 	}
 
 	async stat(filepath: string) {
-		let rootPath = join(this.config.root, dirname(filepath))
+		let rootPath = join(this.config.root, dirname(filepath));
 		// Supabase expects an empty string for current directory
 		if (rootPath === '.') rootPath = '';
 

--- a/packages/storage-driver-supabase/src/index.ts
+++ b/packages/storage-driver-supabase/src/index.ts
@@ -106,7 +106,11 @@ export class DriverSupabase implements TusDriver {
 	}
 
 	async stat(filepath: string) {
-		const rootFolder = normalizePath(join(this.config.root, dirname(filepath)));
+		let rootPath = join(this.config.root, dirname(filepath))
+		// Supabase expects an empty string for current directory
+		if (rootPath === '.') rootPath = '';
+
+		const rootFolder = normalizePath(rootPath);
 
 		const { data, error } = await this.bucket.list(rootFolder, {
 			search: basename(filepath),


### PR DESCRIPTION
## Scope

What's changed:
In the stat function of the Supabase storage driver, set the rootFolder to the empty string if the node:path.join function returns "." (cf. the fullPath function which handled correctly the default behavior of the path function.)

## Potential Risks / Drawbacks

None.

## Tested Scenarios

- Retrieving an asset
- Creating an asset

## Review Notes / Questions

- Any feedback would be great, I would like to contribute more in the future

## Checklist

- [ X] Added or updated tests
- [ X] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ X] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
failure with empty string root folder
