### PR TITLE
Prevent default Directus favicon from showing before custom favicon loads

### DIFF
--- a/.changeset/yummy-points-draw.md
+++ b/.changeset/yummy-points-draw.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevent default Directus favicon from flashing before custom favicon loads

--- a/app/index.html
+++ b/app/index.html
@@ -16,6 +16,8 @@
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<title>Loading&hellip;</title>
+		<!-- Temporary empty favicon to prevent browser from auto-requesting /favicon.ico before Vue app loads -->
+		<link id="temp-favicon" rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='transparent'/></svg>" />
 		<style id="theme"></style>
 		<style id="custom-css"></style>
 		<!-- directus-embed-head -->

--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,11 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<title>Loading&hellip;</title>
 		<!-- Temporary empty favicon to prevent browser from auto-requesting /favicon.ico before Vue app loads -->
-		<link id="temp-favicon" rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='transparent'/></svg>" />
+		<link
+			id="temp-favicon"
+			rel="icon"
+			href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='transparent'/></svg>"
+		/>
 		<style id="theme"></style>
 		<style id="custom-css"></style>
 		<!-- directus-embed-head -->

--- a/app/src/app.test.ts
+++ b/app/src/app.test.ts
@@ -13,9 +13,11 @@ import App from './app.vue';
 
 vi.mock('@/utils/generate-favicon');
 vi.mock('@/utils/get-asset-url');
+
 vi.mock('@/composables/use-system', () => ({
 	useSystem: vi.fn(),
 }));
+
 vi.mock('./idle', () => ({
 	startIdleTracking: vi.fn(),
 	stopIdleTracking: vi.fn(),

--- a/app/src/app.test.ts
+++ b/app/src/app.test.ts
@@ -1,0 +1,282 @@
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { useServerStore } from '@/stores/server';
+import { generateFavicon } from '@/utils/generate-favicon';
+import { getAssetUrl } from '@/utils/get-asset-url';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createHead } from '@unhead/vue';
+import { nextTick } from 'vue';
+import App from './app.vue';
+
+vi.mock('@/utils/generate-favicon');
+vi.mock('@/utils/get-asset-url');
+vi.mock('@/composables/use-system', () => ({
+	useSystem: vi.fn(),
+}));
+vi.mock('./idle', () => ({
+	startIdleTracking: vi.fn(),
+	stopIdleTracking: vi.fn(),
+}));
+
+const i18n = createI18n({ legacy: false });
+
+const global: GlobalMountOptions = {
+	plugins: [i18n, createHead()],
+	stubs: {
+		RouterView: true,
+		ThemeProvider: true,
+		VButton: true,
+		VError: true,
+		VInfo: true,
+		VProgressCircular: true,
+	},
+};
+
+// silences locale message not found warnings
+vi.spyOn(i18n.global, 't').mockImplementation((key: any) => key);
+
+describe('App - Favicon Management', () => {
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+			}),
+		);
+
+		// Clear DOM before each test
+		document.head.innerHTML = '';
+		document.body.innerHTML = '';
+
+		// Add custom-css element for Teleport
+		const customCssElement = document.createElement('div');
+		customCssElement.id = 'custom-css';
+		document.body.appendChild(customCssElement);
+
+		// Reset mocks
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		// Clean up DOM after each test
+		document.head.innerHTML = '';
+		document.body.innerHTML = '';
+	});
+
+	describe('Prevent default favicon from showing before custom favicon loads', () => {
+		test('should not set any favicon when serverStore.info is null', async () => {
+			const serverStore = useServerStore();
+			serverStore.info = null as any;
+
+			mount(App, { global });
+
+			await nextTick();
+
+			// Should not have any favicon link tags in the DOM
+			const faviconLinks = document.querySelectorAll('link[rel="icon"]');
+			expect(faviconLinks).toHaveLength(0);
+		});
+
+		test('should not set any favicon when serverStore.info is undefined', async () => {
+			const serverStore = useServerStore();
+			serverStore.info = undefined as any;
+
+			mount(App, { global });
+
+			await nextTick();
+
+			// Should not have any favicon link tags in the DOM
+			const faviconLinks = document.querySelectorAll('link[rel="icon"]');
+			expect(faviconLinks).toHaveLength(0);
+		});
+
+		test('should remove existing favicon links when server info is loaded', async () => {
+			const serverStore = useServerStore();
+
+			// Create existing favicon links in the DOM
+			const tempFavicon = document.createElement('link');
+			tempFavicon.id = 'temp-favicon';
+			tempFavicon.rel = 'icon';
+			tempFavicon.href = '/temp-favicon.ico';
+			document.head.appendChild(tempFavicon);
+
+			const existingFavicon = document.createElement('link');
+			existingFavicon.rel = 'icon';
+			existingFavicon.href = '/old-favicon.ico';
+			document.head.appendChild(existingFavicon);
+
+			// Verify favicons exist before
+			expect(document.querySelectorAll('link[rel="icon"]')).toHaveLength(2);
+			expect(document.getElementById('temp-favicon')).toBeTruthy();
+
+			// Set server info to trigger watchEffect
+			serverStore.info = {
+				project: {
+					public_favicon: null,
+					project_color: '#6644ff',
+					project_logo: null,
+				},
+			} as any;
+
+			vi.mocked(generateFavicon).mockReturnValue('data:image/svg+xml;base64,test');
+
+			mount(App, { global });
+
+			// Wait for nextTick to ensure DOM manipulation happens
+			await nextTick();
+			await nextTick(); // Extra tick for watchEffect
+
+			// Verify favicons are removed
+			expect(document.querySelectorAll('link[rel="icon"]')).toHaveLength(0);
+			expect(document.getElementById('temp-favicon')).toBeNull();
+		});
+
+		test('should remove temp favicon when it exists', async () => {
+			const serverStore = useServerStore();
+
+			// Create temp favicon
+			const tempFavicon = document.createElement('link');
+			tempFavicon.id = 'temp-favicon';
+			tempFavicon.rel = 'icon';
+			tempFavicon.href = '/temp-favicon.ico';
+			document.head.appendChild(tempFavicon);
+
+			expect(document.getElementById('temp-favicon')).toBeTruthy();
+
+			serverStore.info = {
+				project: {
+					public_favicon: null,
+					project_color: '#6644ff',
+					project_logo: null,
+				},
+			} as any;
+
+			vi.mocked(generateFavicon).mockReturnValue('data:image/svg+xml;base64,test');
+
+			mount(App, { global });
+
+			await nextTick();
+			await nextTick();
+
+			expect(document.getElementById('temp-favicon')).toBeNull();
+		});
+
+		test('should set favicon using public_favicon when available', async () => {
+			const serverStore = useServerStore();
+			const mockFaviconUrl = 'https://example.com/favicon.png';
+
+			serverStore.info = {
+				project: {
+					public_favicon: 'favicon-id',
+					project_color: null,
+					project_logo: null,
+				},
+			} as any;
+
+			vi.mocked(getAssetUrl).mockReturnValue(mockFaviconUrl);
+
+			mount(App, { global });
+
+			await nextTick();
+
+			expect(getAssetUrl).toHaveBeenCalledWith('favicon-id', { cacheBuster: true });
+		});
+
+		test('should set favicon using generated favicon when project_color is available', async () => {
+			const serverStore = useServerStore();
+			const mockGeneratedFavicon = 'data:image/svg+xml;base64,generated-favicon';
+
+			serverStore.info = {
+				project: {
+					public_favicon: null,
+					project_color: '#6644ff',
+					project_logo: null,
+				},
+			} as any;
+
+			vi.mocked(generateFavicon).mockReturnValue(mockGeneratedFavicon);
+
+			mount(App, { global });
+
+			await nextTick();
+
+			expect(generateFavicon).toHaveBeenCalledWith('#6644ff', true);
+		});
+
+		test('should set favicon using generated favicon with logo when project_logo exists', async () => {
+			const serverStore = useServerStore();
+			const mockGeneratedFavicon = 'data:image/svg+xml;base64,generated-favicon-with-logo';
+
+			serverStore.info = {
+				project: {
+					public_favicon: null,
+					project_color: '#6644ff',
+					project_logo: 'logo-id',
+				},
+			} as any;
+
+			vi.mocked(generateFavicon).mockReturnValue(mockGeneratedFavicon);
+
+			mount(App, { global });
+
+			await nextTick();
+
+			// When project_logo exists, addDirectusLogo should be false
+			expect(generateFavicon).toHaveBeenCalledWith('#6644ff', false);
+		});
+
+		test('should fallback to default favicon when no custom options are available', async () => {
+			const serverStore = useServerStore();
+
+			serverStore.info = {
+				project: {
+					public_favicon: null,
+					project_color: null,
+					project_logo: null,
+				},
+			} as any;
+
+			mount(App, { global });
+
+			await nextTick();
+
+			// Should not call generateFavicon or getAssetUrl
+			expect(generateFavicon).not.toHaveBeenCalled();
+			expect(getAssetUrl).not.toHaveBeenCalled();
+		});
+
+		test('should handle multiple existing favicon links removal', async () => {
+			const serverStore = useServerStore();
+
+			// Create multiple favicon links
+			for (let i = 0; i < 3; i++) {
+				const favicon = document.createElement('link');
+				favicon.rel = 'icon';
+				favicon.href = `/favicon-${i}.ico`;
+				document.head.appendChild(favicon);
+			}
+
+			expect(document.querySelectorAll('link[rel="icon"]')).toHaveLength(3);
+
+			serverStore.info = {
+				project: {
+					public_favicon: null,
+					project_color: '#6644ff',
+					project_logo: null,
+				},
+			} as any;
+
+			vi.mocked(generateFavicon).mockReturnValue('data:image/svg+xml;base64,test');
+
+			mount(App, { global });
+
+			await nextTick();
+			await nextTick();
+
+			// All favicon links should be removed
+			expect(document.querySelectorAll('link[rel="icon"]')).toHaveLength(0);
+		});
+	});
+});

--- a/app/src/app.vue
+++ b/app/src/app.vue
@@ -89,6 +89,7 @@ watchEffect(() => {
 		nextTick(() => {
 			// Remove temporary transparent favicon
 			const tempFavicon = document.getElementById('temp-favicon');
+
 			if (tempFavicon) {
 				tempFavicon.remove();
 			}
@@ -96,6 +97,7 @@ watchEffect(() => {
 			// Remove ALL existing favicon links to prevent browser from showing cached favicon
 			// This includes both the temp favicon and any previously set favicons
 			const existingFavicons = document.querySelectorAll('link[rel="icon"]');
+
 			existingFavicons.forEach((link) => {
 				link.remove();
 			});

--- a/contributors.yml
+++ b/contributors.yml
@@ -241,3 +241,4 @@
 - bruno-costa
 - DamnItAzriel
 - Joey92
+- smartdev-thu-nguyen


### PR DESCRIPTION
## Scope

What's changed:
Fixed favicon flash issue when custom favicon is uploaded
This PR fixes a bug where the default Directus favicon would briefly appear before the custom favicon loads after uploading a custom favicon in settings.
- index.html: Added a temporary transparent SVG favicon link to prevent browsers from auto-requesting /favicon.ico before the Vue app loads.
- Updated favicon logic to only set favicon after serverStore.info is loaded (prevents showing default favicon prematurely)
- Added watchEffect to remove all existing favicon links (including the temporary transparent one) before the new favicon is added by unhead
- Added cache buster (cacheBuster: true) to custom favicon URLs to force browser reload
- Added key: 'app-favicon' to the favicon link object to ensure unhead replaces it correctly

## Potential Risks / Drawbacks
- Race condition: There's a potential timing issue between removing old favicons in watchEffect and unhead adding the new one. However, using nextTick should mitigate this.
- Browser cache: Some browsers may still cache favicons aggressively. The cache buster helps, but users might need to hard refresh (Ctrl+Shift+R) in extreme cases.
- Performance: The watchEffect runs whenever serverStore.info changes, but it's lightweight and only removes DOM elements.
- Multiple favicon links: If unhead adds the favicon before watchEffect removes old ones, there might be a brief moment with multiple favicon links. This should be minimal and not affect functionality.

## Tested Scenarios

1. Custom favicon upload:
Upload a custom favicon in Directus settings
Save and refresh the page
Expected: No default favicon flash, custom favicon appears immediately
2. No custom favicon (fallback to default):
Remove custom favicon from settings
Refresh the page
Expected: Default /favicon.ico appears without flash
3. Generated favicon (project color only):
Set project color but no custom favicon
Refresh the page
Expected: Generated SVG favicon appears without flash
4. Hard refresh / cache clearing:
Upload new favicon
Hard refresh
 Expected: New favicon loads with cache buster timestamp
5. Initial page load:
Clear browser cache
Load Directus for the first time
Expected: Transparent favicon initially, then correct favicon after server info loads

## Review Notes / Questions

- Browser compatibility: Should we test on Safari, Chrome, Firefox, and Edge? Safari can be particularly aggressive with favicon caching.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25780
