### PR TITLE
Add database schema for deployment module with encrypted credentials support

### DIFF
--- a/.changeset/lucky-parks-push.md
+++ b/.changeset/lucky-parks-push.md
@@ -1,0 +1,6 @@
+---
+'@directus/system-data': minor
+'@directus/api': minor
+---
+
+Added database schema for deployment module with encrypted credentials support

--- a/api/src/database/migrations/20251223A-add-deployment.ts
+++ b/api/src/database/migrations/20251223A-add-deployment.ts
@@ -1,0 +1,28 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('directus_deployment', (table) => {
+    table.uuid('id').primary().notNullable();
+    table.string('type').notNullable();
+    table.text('credentials');
+    table.text('options');
+    table.timestamp('date_created').defaultTo(knex.fn.now());
+    table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+  });
+
+  await knex.schema.createTable('directus_deployment_projects', (table) => {
+    table.uuid('id').primary().notNullable();
+    table.uuid('deployment').notNullable().references('id').inTable('directus_deployment').onDelete('CASCADE');
+    table.string('external_id').notNullable();
+    table.string('name').notNullable();
+    table.timestamp('date_created').defaultTo(knex.fn.now());
+    table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+    table.unique(['deployment', 'external_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('directus_deployment_projects');
+  await knex.schema.dropTable('directus_deployment');
+}
+

--- a/api/src/database/migrations/20251223A-add-deployment.ts
+++ b/api/src/database/migrations/20251223A-add-deployment.ts
@@ -1,38 +1,38 @@
 import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.createTable('directus_deployment', (table) => {
-    table.uuid('id').primary().notNullable();
-    table.string('type').notNullable().unique();
-    table.text('credentials');
-    table.text('options');
-    table.timestamp('date_created').defaultTo(knex.fn.now());
-    table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-  });
+	await knex.schema.createTable('directus_deployment', (table) => {
+		table.uuid('id').primary().notNullable();
+		table.string('provider').notNullable().unique();
+		table.text('credentials');
+		table.text('options');
+		table.timestamp('date_created').defaultTo(knex.fn.now());
+		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+	});
 
-  await knex.schema.createTable('directus_deployment_projects', (table) => {
-    table.uuid('id').primary().notNullable();
-    table.uuid('deployment').notNullable().references('id').inTable('directus_deployment').onDelete('CASCADE');
-    table.string('external_id').notNullable();
-    table.string('name').notNullable();
-    table.timestamp('date_created').defaultTo(knex.fn.now());
-    table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-    table.unique(['deployment', 'external_id']);
-  });
+	await knex.schema.createTable('directus_deployment_projects', (table) => {
+		table.uuid('id').primary().notNullable();
+		table.uuid('deployment').notNullable().references('id').inTable('directus_deployment').onDelete('CASCADE');
+		table.string('external_id').notNullable();
+		table.string('name').notNullable();
+		table.timestamp('date_created').defaultTo(knex.fn.now());
+		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+		table.unique(['deployment', 'external_id']);
+	});
 
-  await knex.schema.createTable('directus_deployment_runs', (table) => {
-    table.uuid('id').primary().notNullable();
-    table.uuid('project').notNullable().references('id').inTable('directus_deployment_projects').onDelete('CASCADE');
-    table.string('external_id').notNullable();
-    table.string('target').notNullable(); // 'production' or 'preview'
-    table.timestamp('date_created').defaultTo(knex.fn.now());
-    table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-  });
+	await knex.schema.createTable('directus_deployment_runs', (table) => {
+		table.uuid('id').primary().notNullable();
+		table.uuid('project').notNullable().references('id').inTable('directus_deployment_projects').onDelete('CASCADE');
+		table.string('external_id').notNullable();
+		table.string('target').notNullable(); // 'production' or 'preview'
+		table.timestamp('date_created').defaultTo(knex.fn.now());
+		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+	});
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.dropTable('directus_deployment_runs');
-  await knex.schema.dropTable('directus_deployment_projects');
-  await knex.schema.dropTable('directus_deployment');
+	await knex.schema.dropTable('directus_deployment_runs');
+	await knex.schema.dropTable('directus_deployment_projects');
+	await knex.schema.dropTable('directus_deployment');
 }
 

--- a/api/src/database/migrations/20251223A-add-deployment.ts
+++ b/api/src/database/migrations/20251223A-add-deployment.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('directus_deployment', (table) => {
     table.uuid('id').primary().notNullable();
-    table.string('type').notNullable().unique();
+    table.string('type').unique().notNullable();
     table.text('credentials');
     table.text('options');
     table.timestamp('date_created').defaultTo(knex.fn.now());

--- a/api/src/database/migrations/20251223A-add-deployment.ts
+++ b/api/src/database/migrations/20251223A-add-deployment.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('directus_deployment', (table) => {
     table.uuid('id').primary().notNullable();
-    table.string('type').unique().notNullable();
+    table.string('type').notNullable().unique();
     table.text('credentials');
     table.text('options');
     table.timestamp('date_created').defaultTo(knex.fn.now());
@@ -19,9 +19,19 @@ export async function up(knex: Knex): Promise<void> {
     table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
     table.unique(['deployment', 'external_id']);
   });
+
+  await knex.schema.createTable('directus_deployment_runs', (table) => {
+    table.uuid('id').primary().notNullable();
+    table.uuid('project').notNullable().references('id').inTable('directus_deployment_projects').onDelete('CASCADE');
+    table.string('external_id').notNullable();
+    table.string('target').notNullable(); // 'production' or 'preview'
+    table.timestamp('date_created').defaultTo(knex.fn.now());
+    table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+  });
 }
 
 export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('directus_deployment_runs');
   await knex.schema.dropTable('directus_deployment_projects');
   await knex.schema.dropTable('directus_deployment');
 }

--- a/api/src/database/migrations/20251223A-add-deployment.ts
+++ b/api/src/database/migrations/20251223A-add-deployment.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('directus_deployment', (table) => {
     table.uuid('id').primary().notNullable();
-    table.string('type').notNullable();
+    table.string('type').notNullable().unique();
     table.text('credentials');
     table.text('options');
     table.timestamp('date_created').defaultTo(knex.fn.now());

--- a/packages/system-data/src/collections/collections.yaml
+++ b/packages/system-data/src/collections/collections.yaml
@@ -114,3 +114,10 @@ data:
 
   - collection: directus_extensions
     note: $t:directus_collection.directus_extensions
+
+  - collection: directus_deployment
+    icon: cloud_upload
+    note: $t:directus_collection.directus_deployment
+
+  - collection: directus_deployment_projects
+    note: $t:directus_collection.directus_deployment_projects

--- a/packages/system-data/src/collections/collections.yaml
+++ b/packages/system-data/src/collections/collections.yaml
@@ -121,3 +121,6 @@ data:
 
   - collection: directus_deployment_projects
     note: $t:directus_collection.directus_deployment_projects
+
+  - collection: directus_deployment_runs
+    note: $t:directus_collection.directus_deployment_runs

--- a/packages/system-data/src/fields/deployment-projects.yaml
+++ b/packages/system-data/src/fields/deployment-projects.yaml
@@ -1,0 +1,17 @@
+table: directus_deployment_projects
+
+fields:
+  - field: id
+    special:
+      - uuid
+  - field: deployment
+  - field: external_id
+  - field: name
+  - field: date_created
+    special:
+      - date-created
+      - cast-timestamp
+  - field: user_created
+    special:
+      - user-created
+

--- a/packages/system-data/src/fields/deployment-projects.yaml
+++ b/packages/system-data/src/fields/deployment-projects.yaml
@@ -7,6 +7,9 @@ fields:
   - field: deployment
   - field: external_id
   - field: name
+  - field: runs
+    special:
+      - o2m
   - field: date_created
     special:
       - date-created

--- a/packages/system-data/src/fields/deployment-runs.yaml
+++ b/packages/system-data/src/fields/deployment-runs.yaml
@@ -1,0 +1,13 @@
+table: directus_deployment_runs
+
+fields:
+  - field: id
+    special: [uuid]
+  - field: project
+  - field: external_id
+  - field: target
+  - field: date_created
+    special: [date-created, cast-timestamp]
+  - field: user_created
+    special: [user-created]
+

--- a/packages/system-data/src/fields/deployment.yaml
+++ b/packages/system-data/src/fields/deployment.yaml
@@ -4,7 +4,7 @@ fields:
   - field: id
     special:
       - uuid
-  - field: type
+  - field: provider
   - field: credentials
     special:
       - encrypt

--- a/packages/system-data/src/fields/deployment.yaml
+++ b/packages/system-data/src/fields/deployment.yaml
@@ -1,0 +1,24 @@
+table: directus_deployment
+
+fields:
+  - field: id
+    special:
+      - uuid
+  - field: type
+  - field: credentials
+    special:
+      - encrypt
+  - field: options
+    special:
+      - cast-json
+  - field: projects
+    special:
+      - o2m
+  - field: date_created
+    special:
+      - date-created
+      - cast-timestamp
+  - field: user_created
+    special:
+      - user-created
+

--- a/packages/system-data/src/fields/index.ts
+++ b/packages/system-data/src/fields/index.ts
@@ -27,6 +27,8 @@ import translationFields from './translations.yaml';
 import userFields from './users.yaml';
 import versionFields from './versions.yaml';
 import webhookFields from './webhooks.yaml';
+import deploymentFields from './deployment.yaml';
+import deploymentProjectsFields from './deployment-projects.yaml';
 
 import type { FieldIndex, FieldMeta } from '../types.js';
 
@@ -70,6 +72,8 @@ processFields(translationFields);
 processFields(userFields);
 processFields(versionFields);
 processFields(webhookFields);
+processFields(deploymentFields);
+processFields(deploymentProjectsFields);
 
 function processFields(systemFields: Record<string, any>) {
 	const {

--- a/packages/system-data/src/fields/index.ts
+++ b/packages/system-data/src/fields/index.ts
@@ -29,6 +29,7 @@ import versionFields from './versions.yaml';
 import webhookFields from './webhooks.yaml';
 import deploymentFields from './deployment.yaml';
 import deploymentProjectsFields from './deployment-projects.yaml';
+import deploymentRunsFields from './deployment-runs.yaml';
 
 import type { FieldIndex, FieldMeta } from '../types.js';
 
@@ -74,6 +75,7 @@ processFields(versionFields);
 processFields(webhookFields);
 processFields(deploymentFields);
 processFields(deploymentProjectsFields);
+processFields(deploymentRunsFields);
 
 function processFields(systemFields: Record<string, any>) {
 	const {

--- a/packages/system-data/src/relations/relations.yaml
+++ b/packages/system-data/src/relations/relations.yaml
@@ -256,3 +256,18 @@ data:
   - many_collection: directus_webhooks
     many_field: migrated_flow
     one_collection: directus_flows
+
+  ### Deployment
+  - many_collection: directus_deployment_projects
+    many_field: deployment
+    one_collection: directus_deployment
+    one_field: projects
+    one_deselect_action: delete
+
+  - many_collection: directus_deployment
+    many_field: user_created
+    one_collection: directus_users
+
+  - many_collection: directus_deployment_projects
+    many_field: user_created
+    one_collection: directus_users

--- a/packages/system-data/src/relations/relations.yaml
+++ b/packages/system-data/src/relations/relations.yaml
@@ -271,3 +271,13 @@ data:
   - many_collection: directus_deployment_projects
     many_field: user_created
     one_collection: directus_users
+
+  - many_collection: directus_deployment_runs
+    many_field: project
+    one_collection: directus_deployment_projects
+    one_field: runs
+    one_deselect_action: delete
+
+  - many_collection: directus_deployment_runs
+    many_field: user_created
+    one_collection: directus_users


### PR DESCRIPTION
## Scope

What's changed:

- Added `directus_deployment` table for storing deployment provider configurations
- Added `directus_deployment_projects` table for tracking selected projects per provider
- Added `directus_deployment_runs` table for the deployment history triggered from Directus
- Credentials field uses `encrypt` special
- Options field uses `cast-json` for non-sensitive provider config (region, account_id)
- Registered both as system collections with proper relations

## Potential Risks / Drawbacks

- None new tables new features

## Tested Scenarios

- Migration runs successfully (up/down)

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
