### PR TITLE
feat(app): add folder/grouping support for Flows

### DIFF
--- a/.changeset/slick-worms-run.md
+++ b/.changeset/slick-worms-run.md
@@ -1,0 +1,8 @@
+---
+'@directus/system-data': minor
+'@directus/types': minor
+'@directus/api': minor
+'@directus/app': minor
+---
+
+added folder/grouping support for Flows

--- a/api/src/ai/tools/collections/prompt.md
+++ b/api/src/ai/tools/collections/prompt.md
@@ -53,6 +53,31 @@ Perform CRUD operations on Directus Collections.
 
 </collection_structure>
 
+<organization>
+
+### Organizing Collections
+
+Use `meta.group` to organize collections into folders or nest under other collections.
+
+```json
+// Create folder (no schema)
+{ "action": "create", "data": { "collection": "cms_content", "meta": { "icon": "folder", "color": "#6644FF" } } }
+
+// Nest collection under folder or another collection
+{ "action": "update", "key": "articles", "data": { "meta": { "group": "cms_content" } } }
+
+// Remove from parent (move to root)
+{ "action": "update", "key": "articles", "data": { "meta": { "group": null } } }
+```
+
+**Notes:**
+- Folders have no `schema` property (just `meta`)
+- Both folders and regular collections can be parents
+- Use `sort` to control display order within a group
+- Use `collapse` to set default expanded/collapsed state
+
+</organization>
+
 <creating_collections>
 
 - **Primary Keys**: Use UUID primary keys (see `fields` tool `<primary_keys>` section for detailed guidance)

--- a/api/src/ai/tools/collections/prompt.md
+++ b/api/src/ai/tools/collections/prompt.md
@@ -71,6 +71,7 @@ Use `meta.group` to organize collections into folders or nest under other collec
 ```
 
 **Notes:**
+
 - Folders have no `schema` property (just `meta`)
 - Both folders and regular collections can be parents
 - Use `sort` to control display order within a group

--- a/api/src/ai/tools/flows/prompt.md
+++ b/api/src/ai/tools/flows/prompt.md
@@ -21,7 +21,8 @@ positioning, and data chain usage. </flow_concepts>
 All flows share these core fields for creation:
 
 - `name` (required) - Flow display name
-- `trigger` (required) - Trigger type: `event`, `webhook`, `schedule`, `operation`, `manual`. Use `null` to create a folder.
+- `trigger` (required) - Trigger type: `event`, `webhook`, `schedule`, `operation`, `manual`. Use `null` to create a
+  folder.
 - `status` - `active` or `inactive` (default: `active`)
 - `accountability` - `all`, `activity`, or `null` (default: `all`)
 - `icon` - Icon identifier (optional)
@@ -507,15 +508,15 @@ operation. </data_chain_warning>
 
 ```json
 {
-  "action": "create",
-  "data": {
-    "name": "[Util] Get Globals",
-    "trigger": "operation",
-    "accountability": "all",
-    "options": {
-      "return": "global_data"  // Returns data to calling flow: <operationKey>|$all|$last
-    }
-  }
+	"action": "create",
+	"data": {
+		"name": "[Util] Get Globals",
+		"trigger": "operation",
+		"accountability": "all",
+		"options": {
+			"return": "global_data" // Returns data to calling flow: <operationKey>|$all|$last
+		}
+	}
 }
 // Called by other flows using trigger operation
 ```
@@ -523,6 +524,7 @@ operation. </data_chain_warning>
 </real_world_examples>
 
 <important_notes>
+
 ## Important Notes
 
 - **Admin Required**: This tool requires admin permissions
@@ -530,10 +532,10 @@ operation. </data_chain_warning>
 - **Flow Execution**: Flows with `operations` array will include their operations
 - **Webhook URL**: After creating webhook trigger, URL is `/flows/trigger/<flow-id>`
 - **Event Blocking**: Filter events pause transaction until flow completes
-- **Logs**: Flow executions are logged (check `accountability` setting)
-</important_notes>
+- **Logs**: Flow executions are logged (check `accountability` setting) </important_notes>
 
 <common_mistakes>
+
 ## Common Mistakes to Avoid
 
 1. **DO NOT** create operations here - use the `operations` tool
@@ -541,6 +543,7 @@ operation. </data_chain_warning>
 3. **DO NOT** pass stringified JSON in data parameter
 4. **DO NOT** forget required fields: `name` and `trigger` for creation
 5. **DO NOT** put options outside of data - it goes inside the flow object:
+
    ```json
    // ✅ CORRECT
    {

--- a/api/src/ai/tools/flows/prompt.md
+++ b/api/src/ai/tools/flows/prompt.md
@@ -21,14 +21,36 @@ positioning, and data chain usage. </flow_concepts>
 All flows share these core fields for creation:
 
 - `name` (required) - Flow display name
-- `trigger` (required) - Trigger type: `event`, `webhook`, `schedule`, `operation`, `manual`
+- `trigger` (required) - Trigger type: `event`, `webhook`, `schedule`, `operation`, `manual`. Use `null` to create a folder.
 - `status` - `active` or `inactive` (default: `active`)
 - `accountability` - `all`, `activity`, or `null` (default: `all`)
 - `icon` - Icon identifier (optional)
 - `color` - Hex color code (optional)
 - `description` - Flow description (optional)
 - `options` - Trigger-specific configuration object (optional)
-- `operation` - UUID of first operation (optional, set after creating operations) </core_fields>
+- `operation` - UUID of first operation (optional, set after creating operations)
+- `group` - UUID of parent flow or folder (optional, for organizing flows hierarchically)
+- `sort` - Sort order within the parent group (optional, integer)
+- `collapse` - Folder collapse state: `open` or `closed` (default: `open`) </core_fields>
+
+<organization>
+
+### Organizing Flows
+
+Use `group` to organize flows hierarchically. Both folders (`trigger: null`) and regular flows can be parents.
+
+```json
+// Create folder
+{ "action": "create", "data": { "name": "Email Automations", "trigger": null, "icon": "folder" } }
+
+// Nest flow under folder or another flow
+{ "action": "update", "key": "flow-uuid", "data": { "group": "parent-uuid" } }
+
+// Remove from parent (move to root)
+{ "action": "update", "key": "flow-uuid", "data": { "group": null } }
+```
+
+</organization>
 
 <crud_actions>
 
@@ -299,7 +321,7 @@ UI button that users click to start flows
 
 <flow_chaining>
 
-## 🔗 Flow Chaining
+### Flow Chaining
 
 **When to Chain**: Reusable utilities, complex multi-step workflows, conditional branching
 
@@ -483,7 +505,7 @@ operation. </data_chain_warning>
 
 ### Utility Flow (Operation Trigger)
 
-````json
+```json
 {
   "action": "create",
   "data": {
@@ -497,6 +519,7 @@ operation. </data_chain_warning>
 }
 // Called by other flows using trigger operation
 ```
+
 </real_world_examples>
 
 <important_notes>
@@ -536,5 +559,5 @@ operation. </data_chain_warning>
      "options": { "type": "action" }
    }
    ```
+
 </common_mistakes>
-````

--- a/api/src/ai/tools/schema.ts
+++ b/api/src/ai/tools/schema.ts
@@ -159,6 +159,9 @@ export const FlowItemInputSchema = z
 		date_created: z.string(),
 		user_created: z.string(),
 		accountability: z.union([z.enum(['all', 'activity']), z.null()]),
+		group: z.union([z.string(), z.null()]),
+		sort: z.union([z.number(), z.null()]),
+		collapse: z.enum(['open', 'closed']),
 	})
 	.partial();
 

--- a/api/src/database/migrations/20251222A-add-flows-grouping.ts
+++ b/api/src/database/migrations/20251222A-add-flows-grouping.ts
@@ -1,0 +1,39 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	const hasSort = await knex.schema.hasColumn('directus_flows', 'sort');
+	const hasGroup = await knex.schema.hasColumn('directus_flows', 'group');
+	const hasCollapse = await knex.schema.hasColumn('directus_flows', 'collapse');
+
+	await knex.schema.alterTable('directus_flows', (table) => {
+		if (!hasSort) {
+			table.integer('sort');
+		}
+
+		if (!hasGroup) {
+			table.uuid('group').references('id').inTable('directus_flows').onDelete('SET NULL');
+		}
+
+		if (!hasCollapse) {
+			table.string('collapse').defaultTo('open').notNullable();
+		}
+	});
+
+	// Initialize sort values for existing flows based on alphabetical order
+	// This preserves the current name-based ordering as explicit sort values
+	if (!hasSort) {
+		const flows = await knex('directus_flows').select('id', 'name').orderBy('name', 'asc');
+
+		for (let i = 0; i < flows.length; i++) {
+			await knex('directus_flows').where('id', flows[i].id).update({ sort: i + 1 });
+		}
+	}
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_flows', (table) => {
+		table.dropColumn('sort');
+		table.dropColumn('group');
+		table.dropColumn('collapse');
+	});
+}

--- a/api/src/database/migrations/20251222A-add-flows-grouping.ts
+++ b/api/src/database/migrations/20251222A-add-flows-grouping.ts
@@ -25,7 +25,9 @@ export async function up(knex: Knex): Promise<void> {
 		const flows = await knex('directus_flows').select('id', 'name').orderBy('name', 'asc');
 
 		for (let i = 0; i < flows.length; i++) {
-			await knex('directus_flows').where('id', flows[i].id).update({ sort: i + 1 });
+			await knex('directus_flows')
+				.where('id', flows[i].id)
+				.update({ sort: i + 1 });
 		}
 	}
 }

--- a/app/src/components/grouped-list/group-dialog.vue
+++ b/app/src/components/grouped-list/group-dialog.vue
@@ -132,7 +132,11 @@ function save() {
 						@update:model-value="values.name = $event ?? null"
 					/>
 					<InterfaceSelectIcon width="half" :value="values.icon" @input="values.icon = $event ?? defaultIcon" />
-					<InterfaceSelectColor width="half" :value="values.color ?? undefined" @input="values.color = $event ?? null" />
+					<InterfaceSelectColor
+						width="half"
+						:value="values.color ?? undefined"
+						@input="values.color = $event ?? null"
+					/>
 					<VInput
 						v-if="showDescription"
 						:model-value="values.description ?? undefined"
@@ -144,7 +148,7 @@ function save() {
 						v-if="showTranslations"
 						width="full"
 						class="full"
-						:value="(values.translations as any)"
+						:value="values.translations as any"
 						:placeholder="$t('no_translations')"
 						template="{{ translation }} ({{ language }})"
 						:fields="[

--- a/app/src/components/grouped-list/group-dialog.vue
+++ b/app/src/components/grouped-list/group-dialog.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import VButton from '@/components/v-button.vue';
+import VCardActions from '@/components/v-card-actions.vue';
+import VCardText from '@/components/v-card-text.vue';
+import VCardTitle from '@/components/v-card-title.vue';
+import VCard from '@/components/v-card.vue';
+import VDialog from '@/components/v-dialog.vue';
+import VInput from '@/components/v-input.vue';
+import InterfaceList from '@/interfaces/list/list.vue';
+import InterfaceSelectColor from '@/interfaces/select-color/select-color.vue';
+import InterfaceSelectIcon from '@/interfaces/select-icon/select-icon.vue';
+import { isEqual } from 'lodash';
+import { reactive, watch } from 'vue';
+
+export interface GroupDialogItem {
+	id?: string;
+	name?: string | null;
+	icon?: string | null;
+	color?: string | null;
+	description?: string | null;
+	translations?: Record<string, string>[] | null;
+}
+
+export interface GroupDialogValues {
+	name: string | null;
+	icon: string;
+	color: string | null;
+	description: string | null;
+	translations: Record<string, string>[] | null;
+}
+
+const props = withDefaults(
+	defineProps<{
+		/** v-model for dialog visibility */
+		modelValue?: boolean;
+		/** Existing item to edit (null for create) */
+		item?: GroupDialogItem | null;
+		/** Translation key for create title */
+		createTitleKey?: string;
+		/** Translation key for edit title */
+		editTitleKey?: string;
+		/** Translation key for name placeholder */
+		namePlaceholderKey?: string;
+		/** Default icon for new items */
+		defaultIcon?: string;
+		/** Show translations field */
+		showTranslations?: boolean;
+		/** Show description field */
+		showDescription?: boolean;
+		/** Whether saving is in progress */
+		saving?: boolean;
+		/** Disable name editing for existing items */
+		disableNameEdit?: boolean;
+	}>(),
+	{
+		modelValue: false,
+		item: null,
+		createTitleKey: 'create_folder',
+		editTitleKey: 'edit_folder',
+		namePlaceholderKey: 'folder_key',
+		defaultIcon: 'folder',
+		showTranslations: false,
+		showDescription: true,
+		saving: false,
+		disableNameEdit: true,
+	},
+);
+
+const emit = defineEmits<{
+	'update:modelValue': [value: boolean];
+	save: [values: GroupDialogValues, isEdit: boolean];
+}>();
+
+const values = reactive<GroupDialogValues>({
+	name: props.item?.name ?? null,
+	icon: props.item?.icon ?? props.defaultIcon,
+	color: props.item?.color ?? null,
+	description: props.item?.description ?? null,
+	translations: props.item?.translations ?? null,
+});
+
+watch(
+	() => props.modelValue,
+	(newValue, oldValue) => {
+		if (isEqual(newValue, oldValue) === false) {
+			values.name = props.item?.name ?? null;
+			values.icon = props.item?.icon ?? props.defaultIcon;
+			values.color = props.item?.color ?? null;
+			values.description = props.item?.description ?? null;
+			values.translations = props.item?.translations ?? null;
+		}
+	},
+);
+
+function cancel() {
+	emit('update:modelValue', false);
+}
+
+function save() {
+	if (!values.name || props.saving) return;
+
+	emit('save', { ...values }, !!props.item);
+}
+</script>
+
+<template>
+	<VDialog
+		:model-value="modelValue"
+		persistent
+		keep-behind
+		@update:model-value="$emit('update:modelValue', $event)"
+		@esc="cancel"
+		@apply="save"
+	>
+		<template #activator="slotBinding">
+			<slot name="activator" v-bind="slotBinding" />
+		</template>
+
+		<VCard>
+			<VCardTitle v-if="!item">{{ $t(createTitleKey) }}</VCardTitle>
+			<VCardTitle v-else>{{ $t(editTitleKey) }}</VCardTitle>
+
+			<VCardText>
+				<div class="fields">
+					<VInput
+						:model-value="values.name ?? undefined"
+						:disabled="!!item && disableNameEdit"
+						class="full name-input"
+						db-safe
+						autofocus
+						:placeholder="$t(namePlaceholderKey)"
+						@update:model-value="values.name = $event ?? null"
+					/>
+					<InterfaceSelectIcon width="half" :value="values.icon" @input="values.icon = $event ?? defaultIcon" />
+					<InterfaceSelectColor width="half" :value="values.color ?? undefined" @input="values.color = $event ?? null" />
+					<VInput
+						v-if="showDescription"
+						:model-value="values.description ?? undefined"
+						class="full"
+						:placeholder="$t('note')"
+						@update:model-value="values.description = $event ?? null"
+					/>
+					<InterfaceList
+						v-if="showTranslations"
+						width="full"
+						class="full"
+						:value="(values.translations as any)"
+						:placeholder="$t('no_translations')"
+						template="{{ translation }} ({{ language }})"
+						:fields="[
+							{
+								field: 'language',
+								name: $t('language'),
+								type: 'string',
+								schema: {
+									default_value: 'en-US',
+								},
+								meta: {
+									interface: 'system-language',
+									width: 'half',
+								},
+							},
+							{
+								field: 'translation',
+								name: $t('translation'),
+								type: 'string',
+								meta: {
+									interface: 'input',
+									width: 'half',
+								},
+							},
+						]"
+						@input="values.translations = $event as any"
+					/>
+				</div>
+			</VCardText>
+
+			<VCardActions>
+				<VButton secondary @click="cancel">
+					{{ $t('cancel') }}
+				</VButton>
+				<VButton :disabled="!values.name" :loading="saving" @click="save">
+					{{ $t('save') }}
+				</VButton>
+			</VCardActions>
+		</VCard>
+	</VDialog>
+</template>
+
+<style scoped>
+.fields {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 12px;
+}
+
+.full {
+	grid-column: 1 / span 2;
+}
+
+.name-input {
+	--v-input-font-family: var(--theme--fonts--monospace--font-family);
+}
+</style>

--- a/app/src/components/grouped-list/group-options.vue
+++ b/app/src/components/grouped-list/group-options.vue
@@ -78,11 +78,7 @@ function confirmDelete() {
 				<template v-if="showCollapseOptions && (isFolder || hasChildren)">
 					<VDivider v-if="$slots.prepend" />
 
-					<VListItem
-						:active="collapseState === 'open'"
-						clickable
-						@click="updateCollapse('open')"
-					>
+					<VListItem :active="collapseState === 'open'" clickable @click="updateCollapse('open')">
 						<VListItemIcon>
 							<VIcon name="folder_open" />
 						</VListItemIcon>
@@ -91,11 +87,7 @@ function confirmDelete() {
 						</VListItemContent>
 					</VListItem>
 
-					<VListItem
-						:active="collapseState === 'closed'"
-						clickable
-						@click="updateCollapse('closed')"
-					>
+					<VListItem :active="collapseState === 'closed'" clickable @click="updateCollapse('closed')">
 						<VListItemIcon>
 							<VIcon name="folder" />
 						</VListItemIcon>
@@ -104,11 +96,7 @@ function confirmDelete() {
 						</VListItemContent>
 					</VListItem>
 
-					<VListItem
-						:active="collapseState === 'locked'"
-						clickable
-						@click="updateCollapse('locked')"
-					>
+					<VListItem :active="collapseState === 'locked'" clickable @click="updateCollapse('locked')">
 						<VListItemIcon>
 							<VIcon name="folder_lock" />
 						</VListItemIcon>

--- a/app/src/components/grouped-list/group-options.vue
+++ b/app/src/components/grouped-list/group-options.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import VButton from '@/components/v-button.vue';
+import VCardActions from '@/components/v-card-actions.vue';
+import VCardText from '@/components/v-card-text.vue';
+import VCardTitle from '@/components/v-card-title.vue';
+import VCard from '@/components/v-card.vue';
+import VDialog from '@/components/v-dialog.vue';
+import VDivider from '@/components/v-divider.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
+import VListItemContent from '@/components/v-list-item-content.vue';
+import VListItemIcon from '@/components/v-list-item-icon.vue';
+import VListItem from '@/components/v-list-item.vue';
+import VList from '@/components/v-list.vue';
+import VMenu from '@/components/v-menu.vue';
+import { ref } from 'vue';
+
+export type CollapseState = 'open' | 'closed' | 'locked';
+
+withDefaults(
+	defineProps<{
+		/** The item name for delete confirmation */
+		itemName: string;
+		/** Whether this is a folder/group (affects collapse options visibility) */
+		isFolder?: boolean;
+		/** Whether this item has children */
+		hasChildren?: boolean;
+		/** Current collapse state */
+		collapseState?: CollapseState;
+		/** Show collapse options */
+		showCollapseOptions?: boolean;
+		/** Translation key for delete confirmation title */
+		deleteConfirmTitleKey?: string;
+		/** Translation key for delete button */
+		deleteButtonKey?: string;
+		/** Whether delete is in progress */
+		deleting?: boolean;
+	}>(),
+	{
+		isFolder: false,
+		hasChildren: false,
+		collapseState: 'open',
+		showCollapseOptions: true,
+		deleteConfirmTitleKey: 'delete_are_you_sure',
+		deleteButtonKey: 'delete',
+		deleting: false,
+	},
+);
+
+const emit = defineEmits<{
+	'update:collapseState': [state: CollapseState];
+	delete: [];
+	toggleCollapse: [];
+}>();
+
+const deleteActive = ref(false);
+
+function updateCollapse(state: CollapseState) {
+	emit('update:collapseState', state);
+}
+
+function confirmDelete() {
+	emit('delete');
+	deleteActive.value = false;
+}
+</script>
+
+<template>
+	<div class="group-options">
+		<VMenu placement="left-start" show-arrow>
+			<template #activator="{ toggle }">
+				<VIcon name="more_vert" clickable class="ctx-toggle" @click.prevent="toggle" />
+			</template>
+			<VList>
+				<!-- Prepend slot for custom actions before standard options -->
+				<slot name="prepend" />
+
+				<!-- Collapse options -->
+				<template v-if="showCollapseOptions && (isFolder || hasChildren)">
+					<VDivider v-if="$slots.prepend" />
+
+					<VListItem
+						:active="collapseState === 'open'"
+						clickable
+						@click="updateCollapse('open')"
+					>
+						<VListItemIcon>
+							<VIcon name="folder_open" />
+						</VListItemIcon>
+						<VListItemContent>
+							{{ $t('start_open') }}
+						</VListItemContent>
+					</VListItem>
+
+					<VListItem
+						:active="collapseState === 'closed'"
+						clickable
+						@click="updateCollapse('closed')"
+					>
+						<VListItemIcon>
+							<VIcon name="folder" />
+						</VListItemIcon>
+						<VListItemContent>
+							{{ $t('start_collapsed') }}
+						</VListItemContent>
+					</VListItem>
+
+					<VListItem
+						:active="collapseState === 'locked'"
+						clickable
+						@click="updateCollapse('locked')"
+					>
+						<VListItemIcon>
+							<VIcon name="folder_lock" />
+						</VListItemIcon>
+						<VListItemContent>
+							{{ $t('always_open') }}
+						</VListItemContent>
+					</VListItem>
+
+					<VDivider />
+				</template>
+
+				<!-- Append slot for custom actions before delete -->
+				<slot name="append" />
+
+				<VDivider v-if="$slots.append" />
+
+				<!-- Delete action -->
+				<VListItem clickable class="danger" @click="deleteActive = true">
+					<VListItemIcon>
+						<VIcon name="delete" />
+					</VListItemIcon>
+					<VListItemContent>
+						{{ $t(deleteButtonKey) }}
+					</VListItemContent>
+				</VListItem>
+			</VList>
+		</VMenu>
+
+		<VDialog v-model="deleteActive" @esc="deleteActive = false" @apply="confirmDelete">
+			<VCard>
+				<VCardTitle>
+					{{ $t(deleteConfirmTitleKey, { name: itemName }) }}
+				</VCardTitle>
+				<VCardText>
+					<slot name="delete-warning" />
+				</VCardText>
+				<VCardActions>
+					<VButton :disabled="deleting" secondary @click="deleteActive = false">
+						{{ $t('cancel') }}
+					</VButton>
+					<VButton :loading="deleting" kind="danger" @click="confirmDelete">
+						{{ $t(deleteButtonKey) }}
+					</VButton>
+				</VCardActions>
+			</VCard>
+		</VDialog>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.ctx-toggle {
+	--v-icon-color: var(--theme--foreground-subdued);
+
+	&:hover {
+		--v-icon-color: var(--theme--foreground);
+	}
+}
+
+.v-list-item.danger {
+	--v-list-item-color: var(--theme--danger);
+	--v-list-item-color-hover: var(--theme--danger);
+	--v-list-item-icon-color: var(--theme--danger);
+}
+</style>

--- a/app/src/components/grouped-list/grouped-list-item.vue
+++ b/app/src/components/grouped-list/grouped-list-item.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import TransitionExpand from '@/components/transition/expand.vue';
+import VHighlight from '@/components/v-highlight.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
+import VListItemIcon from '@/components/v-list-item-icon.vue';
+import VListItem from '@/components/v-list-item.vue';
+import type { VisibilityTreeNode } from '@/composables/use-visibility-tree';
+import { computed, defineAsyncComponent, useSlots } from 'vue';
+import Draggable from 'vuedraggable';
+
+// Recursive component reference for nested items
+const GroupedListItem = defineAsyncComponent(() => import('./grouped-list-item.vue'));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ItemType = Record<string, any>;
+
+const slots = useSlots();
+
+const props = withDefaults(
+	defineProps<{
+		/** The current item */
+		item: ItemType;
+		/** All items (for finding nested children) */
+		items: ItemType[];
+		/** Whether this item is collapsed */
+		isCollapsed: boolean;
+		/** Visibility tree node for this item */
+		visibilityTree: VisibilityTreeNode<string>;
+		/** Disable drag-and-drop */
+		disableDrag?: boolean;
+		/** Field name for the item ID */
+		idField?: string;
+		/** Field name for the parent/group reference */
+		groupField?: string;
+		/** Draggable group name */
+		dragGroup?: string;
+		/** Link destination (if clickable) */
+		to?: string;
+		/** Function to compute link destination for any item */
+		getItemLink?: (item: ItemType) => string | undefined;
+		/** Whether the item row is clickable */
+		clickable?: boolean;
+		/** Whether this item can accept children (enables drop zone) */
+		canHaveChildren?: boolean;
+	}>(),
+	{
+		disableDrag: false,
+		idField: 'id',
+		groupField: 'group',
+		dragGroup: 'items',
+		clickable: true,
+		canHaveChildren: true,
+	},
+);
+
+// Compute the link for this item
+const itemLink = computed(() => {
+	if (props.to !== undefined) return props.to;
+	if (props.getItemLink) return props.getItemLink(props.item);
+	return undefined;
+});
+
+const emit = defineEmits<{
+	setNestedSort: [updates: { id: string; group: string }[]];
+	toggleCollapse: [id: string];
+	itemClick: [item: ItemType];
+}>();
+
+// Helper to get value at a nested path (e.g., "meta.group")
+function getNestedValue(obj: ItemType, path: string): unknown {
+	return path.split('.').reduce((acc, key) => acc?.[key], obj);
+}
+
+const itemId = computed(() => props.item[props.idField] as string);
+
+const nestedItems = computed(() =>
+	props.items.filter((item) => getNestedValue(item, props.groupField) === itemId.value),
+);
+
+function toggleCollapse() {
+	emit('toggleCollapse', itemId.value);
+}
+
+function onGroupSortChange(items: ItemType[]) {
+	const updates = items.map((item) => ({
+		id: item[props.idField] as string,
+		group: itemId.value,
+	}));
+
+	emit('setNestedSort', updates);
+}
+
+function handleItemClick() {
+	if (!itemLink.value) {
+		emit('itemClick', props.item);
+	}
+}
+</script>
+
+<template>
+	<div v-show="visibilityTree.visible" class="grouped-list-item">
+		<VListItem
+			block
+			dense
+			:clickable="clickable"
+			:to="itemLink"
+			@click.self="handleItemClick"
+		>
+			<VListItemIcon>
+				<VIcon v-if="!disableDrag" class="drag-handle" name="drag_handle" />
+			</VListItemIcon>
+
+			<div class="item-detail">
+				<!-- Icon slot -->
+				<slot name="icon" :item="item">
+					<VIcon class="item-icon" name="folder" />
+				</slot>
+
+				<!-- Content slot (default shows name with search highlight) -->
+				<slot name="content" :item="item" :search="visibilityTree.search">
+					<VHighlight
+						:query="visibilityTree.search"
+						:text="String(item.name || item[idField])"
+						class="item-name"
+					/>
+				</slot>
+			</div>
+
+			<!-- Meta slot (for status indicators, badges, etc.) -->
+			<slot name="meta" :item="item" />
+
+			<!-- Collapse toggle -->
+			<VIcon
+				v-if="nestedItems.length"
+				v-tooltip="!isCollapsed ? $t('collapse') : $t('expand')"
+				:name="!isCollapsed ? 'unfold_less' : 'unfold_more'"
+				clickable
+				class="collapse-toggle"
+				@click.stop.prevent="toggleCollapse"
+			/>
+
+			<!-- Actions slot -->
+			<slot name="actions" :item="item" :has-children="nestedItems.length > 0" />
+		</VListItem>
+
+		<TransitionExpand class="nested-items">
+			<Draggable
+				v-if="canHaveChildren && !isCollapsed"
+				:model-value="nestedItems"
+				:group="{ name: dragGroup }"
+				:swap-threshold="0.3"
+				class="drag-container draggable-list"
+				:item-key="idField"
+				handle=".drag-handle"
+				v-bind="{ 'force-fallback': true }"
+				@update:model-value="onGroupSortChange"
+			>
+				<template #item="{ element }">
+					<GroupedListItem
+						:item="element"
+						:items="items"
+						:is-collapsed="element.isCollapsed"
+						:visibility-tree="visibilityTree.findChild(element[idField])!"
+						:disable-drag="disableDrag"
+						:id-field="idField"
+						:group-field="groupField"
+						:drag-group="dragGroup"
+						:get-item-link="getItemLink"
+						:clickable="clickable"
+						:can-have-children="element.canHaveChildren ?? canHaveChildren"
+						@toggle-collapse="$emit('toggleCollapse', $event)"
+						@set-nested-sort="$emit('setNestedSort', $event)"
+						@item-click="$emit('itemClick', $event)"
+					>
+						<template v-if="slots.icon" #icon="_iconData">
+							<slot name="icon" v-bind="(_iconData as Record<string, unknown>)" />
+						</template>
+						<template v-if="slots.content" #content="_contentData">
+							<slot name="content" v-bind="(_contentData as Record<string, unknown>)" />
+						</template>
+						<template v-if="slots.meta" #meta="_metaData">
+							<slot name="meta" v-bind="(_metaData as Record<string, unknown>)" />
+						</template>
+						<template v-if="slots.actions" #actions="_actionsData">
+							<slot name="actions" v-bind="(_actionsData as Record<string, unknown>)" />
+						</template>
+					</GroupedListItem>
+				</template>
+			</Draggable>
+		</TransitionExpand>
+	</div>
+</template>
+
+<style scoped lang="scss">
+.drag-container {
+	margin-block-start: 8px;
+	margin-inline-start: 20px;
+}
+
+.grouped-list-item {
+	margin-block-end: 8px;
+}
+
+.item-detail {
+	display: flex;
+	flex-grow: 1;
+	align-items: center;
+	block-size: 100%;
+	overflow: hidden;
+	pointer-events: none;
+
+	// Ensure slot content also doesn't capture clicks
+	:deep(*) {
+		pointer-events: none;
+	}
+}
+
+.item-name {
+	flex-shrink: 0;
+}
+
+.item-icon {
+	margin-inline-end: 8px;
+}
+
+.drag-handle {
+	cursor: grab;
+}
+
+.collapse-toggle {
+	--v-icon-color: var(--theme--foreground-subdued);
+
+	&:hover {
+		--v-icon-color: var(--theme--foreground);
+	}
+}
+</style>

--- a/app/src/components/grouped-list/grouped-list-item.vue
+++ b/app/src/components/grouped-list/grouped-list-item.vue
@@ -11,7 +11,7 @@ import Draggable from 'vuedraggable';
 // Recursive component reference for nested items
 const GroupedListItem = defineAsyncComponent(() => import('./grouped-list-item.vue'));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 type ItemType = Record<string, any>;
 
 const slots = useSlots();

--- a/app/src/components/grouped-list/grouped-list-item.vue
+++ b/app/src/components/grouped-list/grouped-list-item.vue
@@ -11,7 +11,6 @@ import Draggable from 'vuedraggable';
 // Recursive component reference for nested items
 const GroupedListItem = defineAsyncComponent(() => import('./grouped-list-item.vue'));
 
- 
 type ItemType = Record<string, any>;
 
 const slots = useSlots();
@@ -99,13 +98,7 @@ function handleItemClick() {
 
 <template>
 	<div v-show="visibilityTree.visible" class="grouped-list-item">
-		<VListItem
-			block
-			dense
-			:clickable="clickable"
-			:to="itemLink"
-			@click.self="handleItemClick"
-		>
+		<VListItem block dense :clickable="clickable" :to="itemLink" @click.self="handleItemClick">
 			<VListItemIcon>
 				<VIcon v-if="!disableDrag" class="drag-handle" name="drag_handle" />
 			</VListItemIcon>
@@ -118,11 +111,7 @@ function handleItemClick() {
 
 				<!-- Content slot (default shows name with search highlight) -->
 				<slot name="content" :item="item" :search="visibilityTree.search">
-					<VHighlight
-						:query="visibilityTree.search"
-						:text="String(item.name || item[idField])"
-						class="item-name"
-					/>
+					<VHighlight :query="visibilityTree.search" :text="String(item.name || item[idField])" class="item-name" />
 				</slot>
 			</div>
 
@@ -173,16 +162,16 @@ function handleItemClick() {
 						@item-click="$emit('itemClick', $event)"
 					>
 						<template v-if="slots.icon" #icon="_iconData">
-							<slot name="icon" v-bind="(_iconData as Record<string, unknown>)" />
+							<slot name="icon" v-bind="_iconData as Record<string, unknown>" />
 						</template>
 						<template v-if="slots.content" #content="_contentData">
-							<slot name="content" v-bind="(_contentData as Record<string, unknown>)" />
+							<slot name="content" v-bind="_contentData as Record<string, unknown>" />
 						</template>
 						<template v-if="slots.meta" #meta="_metaData">
-							<slot name="meta" v-bind="(_metaData as Record<string, unknown>)" />
+							<slot name="meta" v-bind="_metaData as Record<string, unknown>" />
 						</template>
 						<template v-if="slots.actions" #actions="_actionsData">
-							<slot name="actions" v-bind="(_actionsData as Record<string, unknown>)" />
+							<slot name="actions" v-bind="_actionsData as Record<string, unknown>" />
 						</template>
 					</GroupedListItem>
 				</template>

--- a/app/src/components/grouped-list/index.ts
+++ b/app/src/components/grouped-list/index.ts
@@ -1,0 +1,3 @@
+export { default as GroupedListItem } from './grouped-list-item.vue';
+export { default as GroupDialog, type GroupDialogItem, type GroupDialogValues } from './group-dialog.vue';
+export { default as GroupOptions, type CollapseState } from './group-options.vue';

--- a/app/src/composables/use-expand-collapse.test.ts
+++ b/app/src/composables/use-expand-collapse.test.ts
@@ -1,0 +1,141 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { defineComponent, h, unref } from 'vue';
+import { useExpandCollapse, type UseExpandCollapseOptions } from './use-expand-collapse';
+
+// Mock useLocalStorage from vueuse
+vi.mock('@vueuse/core', () => ({
+	useLocalStorage: vi.fn((key: string, initialValue: string[]) => {
+		// Simple reactive mock that stores in a closure
+		let value = [...initialValue];
+		return {
+			get value() {
+				return value;
+			},
+			set value(newValue: string[]) {
+				value = newValue;
+			},
+		};
+	}),
+}));
+
+const createTestComponent = (storageKey: string, options: UseExpandCollapseOptions) => {
+	return defineComponent({
+		setup() {
+			return useExpandCollapse(storageKey, options);
+		},
+		render: () => h('div'),
+	});
+};
+
+describe('useExpandCollapse', () => {
+	const mockOptions: UseExpandCollapseOptions = {
+		getExpandableIds: () => ['parent-1', 'parent-2'],
+		getAllIds: () => ['parent-1', 'parent-2', 'child-1', 'child-2'],
+	};
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('returns all expected properties', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		expect(wrapper.vm).toHaveProperty('collapsedIds');
+		expect(wrapper.vm).toHaveProperty('hasExpandable');
+		expect(wrapper.vm).toHaveProperty('expandAll');
+		expect(wrapper.vm).toHaveProperty('collapseAll');
+		expect(wrapper.vm).toHaveProperty('toggleCollapse');
+		expect(wrapper.vm).toHaveProperty('isCollapsed');
+	});
+
+	test('hasExpandable returns true when there are expandable items', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		expect(unref(wrapper.vm.hasExpandable)).toBe(true);
+	});
+
+	test('hasExpandable returns false when there are no expandable items', () => {
+		const emptyOptions: UseExpandCollapseOptions = {
+			getExpandableIds: () => [],
+			getAllIds: () => ['item-1', 'item-2'],
+		};
+
+		const TestComponent = createTestComponent('test-key', emptyOptions);
+		const wrapper = mount(TestComponent);
+
+		expect(unref(wrapper.vm.hasExpandable)).toBe(false);
+	});
+
+	test('expandAll sets collapsedIds to empty array', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		// First collapse some items
+		wrapper.vm.collapsedIds.value = ['parent-1', 'parent-2'];
+
+		// Then expand all
+		wrapper.vm.expandAll();
+
+		expect(wrapper.vm.collapsedIds.value).toEqual([]);
+	});
+
+	test('collapseAll sets collapsedIds to all IDs', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		wrapper.vm.collapseAll();
+
+		expect(wrapper.vm.collapsedIds.value).toEqual(['parent-1', 'parent-2', 'child-1', 'child-2']);
+	});
+
+	test('toggleCollapse adds ID when not collapsed', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		// Start with empty collapsed
+		wrapper.vm.collapsedIds.value = [];
+
+		wrapper.vm.toggleCollapse('parent-1');
+
+		expect(wrapper.vm.collapsedIds.value).toContain('parent-1');
+	});
+
+	test('toggleCollapse removes ID when already collapsed', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		// Start with parent-1 collapsed
+		wrapper.vm.collapsedIds.value = ['parent-1'];
+
+		wrapper.vm.toggleCollapse('parent-1');
+
+		expect(wrapper.vm.collapsedIds.value).not.toContain('parent-1');
+	});
+
+	test('isCollapsed returns true for collapsed items', () => {
+		const TestComponent = createTestComponent('test-key', mockOptions);
+		const wrapper = mount(TestComponent);
+
+		wrapper.vm.collapsedIds.value = ['parent-1'];
+
+		expect(wrapper.vm.isCollapsed('parent-1')).toBe(true);
+		expect(wrapper.vm.isCollapsed('parent-2')).toBe(false);
+	});
+
+	test('uses different storage keys independently', () => {
+		const TestComponent1 = createTestComponent('key-1', mockOptions);
+		const TestComponent2 = createTestComponent('key-2', mockOptions);
+
+		const wrapper1 = mount(TestComponent1);
+		const wrapper2 = mount(TestComponent2);
+
+		wrapper1.vm.toggleCollapse('parent-1');
+
+		// Each instance should have independent state
+		expect(wrapper1.vm.collapsedIds.value).toContain('parent-1');
+		// Note: Due to mock, wrapper2 starts fresh
+	});
+});

--- a/app/src/composables/use-expand-collapse.test.ts
+++ b/app/src/composables/use-expand-collapse.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { defineComponent, h, unref } from 'vue';
 import { useExpandCollapse, type UseExpandCollapseOptions } from './use-expand-collapse';
 
@@ -130,7 +130,7 @@ describe('useExpandCollapse', () => {
 		const TestComponent2 = createTestComponent('key-2', mockOptions);
 
 		const wrapper1 = mount(TestComponent1);
-		const wrapper2 = mount(TestComponent2);
+		const _wrapper2 = mount(TestComponent2);
 
 		wrapper1.vm.toggleCollapse('parent-1');
 

--- a/app/src/composables/use-expand-collapse.ts
+++ b/app/src/composables/use-expand-collapse.ts
@@ -24,10 +24,7 @@ export interface UseExpandCollapseReturn {
  * @param storageKey - localStorage key for persisting collapsed state
  * @param options - Configuration options
  */
-export function useExpandCollapse(
-	storageKey: string,
-	options: UseExpandCollapseOptions,
-): UseExpandCollapseReturn {
+export function useExpandCollapse(storageKey: string, options: UseExpandCollapseOptions): UseExpandCollapseReturn {
 	const collapsedIds = useLocalStorage<string[]>(storageKey, []);
 
 	const hasExpandable = computed(() => options.getExpandableIds().length > 0);

--- a/app/src/composables/use-expand-collapse.ts
+++ b/app/src/composables/use-expand-collapse.ts
@@ -1,0 +1,65 @@
+import { useLocalStorage } from '@vueuse/core';
+import { computed, type ComputedRef } from 'vue';
+
+export interface UseExpandCollapseOptions {
+	/** Function that returns all IDs that have children (are expandable) */
+	getExpandableIds: () => string[];
+	/** Function that returns all IDs for collapse all */
+	getAllIds: () => string[];
+}
+
+export interface UseExpandCollapseReturn {
+	collapsedIds: ReturnType<typeof useLocalStorage<string[]>>;
+	hasExpandable: ComputedRef<boolean>;
+	expandAll: () => void;
+	collapseAll: () => void;
+	toggleCollapse: (id: string) => void;
+	isCollapsed: (id: string) => boolean;
+}
+
+/**
+ * Generic composable for managing expand/collapse state of hierarchical items.
+ * Used by collections, flows, and other groupable lists.
+ *
+ * @param storageKey - localStorage key for persisting collapsed state
+ * @param options - Configuration options
+ */
+export function useExpandCollapse(
+	storageKey: string,
+	options: UseExpandCollapseOptions,
+): UseExpandCollapseReturn {
+	const collapsedIds = useLocalStorage<string[]>(storageKey, []);
+
+	const hasExpandable = computed(() => options.getExpandableIds().length > 0);
+
+	function expandAll() {
+		collapsedIds.value = [];
+	}
+
+	function collapseAll() {
+		collapsedIds.value = options.getAllIds();
+	}
+
+	function toggleCollapse(id: string) {
+		const isCurrentlyCollapsed = collapsedIds.value.includes(id);
+
+		if (isCurrentlyCollapsed) {
+			collapsedIds.value = collapsedIds.value.filter((collapsedId) => collapsedId !== id);
+		} else {
+			collapsedIds.value = [...collapsedIds.value, id];
+		}
+	}
+
+	function isCollapsed(id: string): boolean {
+		return collapsedIds.value.includes(id);
+	}
+
+	return {
+		collapsedIds,
+		hasExpandable,
+		expandAll,
+		collapseAll,
+		toggleCollapse,
+		isCollapsed,
+	};
+}

--- a/app/src/composables/use-visibility-tree.test.ts
+++ b/app/src/composables/use-visibility-tree.test.ts
@@ -1,0 +1,222 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, test } from 'vitest';
+import { defineComponent, h, ref, unref } from 'vue';
+import { useVisibilityTree, type UseVisibilityTreeConfig } from './use-visibility-tree';
+
+interface TestItem {
+	id: string;
+	name: string;
+	parent: string | null;
+}
+
+const createTestComponent = (
+	items: TestItem[],
+	search: string | null,
+	config: UseVisibilityTreeConfig<TestItem, string>,
+) => {
+	return defineComponent({
+		setup() {
+			const itemsRef = ref(items);
+			const searchRef = ref(search);
+			return useVisibilityTree(itemsRef, searchRef, config);
+		},
+		render: () => h('div'),
+	});
+};
+
+const defaultConfig: UseVisibilityTreeConfig<TestItem, string> = {
+	getId: (item) => item.id,
+	getParent: (item) => item.parent,
+	matchesSearch: (item, query) => item.name.toLowerCase().includes(query),
+};
+
+describe('useVisibilityTree', () => {
+	test('returns all expected properties', () => {
+		const TestComponent = createTestComponent([], null, defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		expect(wrapper.vm).toHaveProperty('visibilityTree');
+		expect(wrapper.vm).toHaveProperty('findVisibilityNode');
+	});
+
+	test('all items visible when search is null', () => {
+		const items: TestItem[] = [
+			{ id: 'a', name: 'Alpha', parent: null },
+			{ id: 'b', name: 'Beta', parent: null },
+		];
+
+		const TestComponent = createTestComponent(items, null, defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree.length).toBe(2);
+		expect(tree[0]!.visible).toBe(true);
+		expect(tree[1]!.visible).toBe(true);
+	});
+
+	test('filters items based on search query', () => {
+		const items: TestItem[] = [
+			{ id: 'a', name: 'Alpha', parent: null },
+			{ id: 'b', name: 'Beta', parent: null },
+		];
+
+		const TestComponent = createTestComponent(items, 'alpha', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree[0]!.visible).toBe(true); // Alpha matches
+		expect(tree[1]!.visible).toBe(false); // Beta doesn't match
+	});
+
+	test('search is case-insensitive', () => {
+		const items: TestItem[] = [{ id: 'a', name: 'Alpha', parent: null }];
+
+		const TestComponent = createTestComponent(items, 'ALPHA', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree[0]!.visible).toBe(true);
+	});
+
+	test('builds nested tree structure', () => {
+		const items: TestItem[] = [
+			{ id: 'parent', name: 'Parent', parent: null },
+			{ id: 'child', name: 'Child', parent: 'parent' },
+		];
+
+		const TestComponent = createTestComponent(items, null, defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree.length).toBe(1); // Only root
+		expect(tree[0]!.id).toBe('parent');
+		expect(tree[0]!.children.length).toBe(1);
+		expect(tree[0]!.children[0]!.id).toBe('child');
+	});
+
+	test('propagates visibility backwards - parent visible if child matches', () => {
+		const items: TestItem[] = [
+			{ id: 'parent', name: 'Parent', parent: null },
+			{ id: 'child', name: 'Matching', parent: 'parent' },
+		];
+
+		const TestComponent = createTestComponent(items, 'matching', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		// Parent should be visible because child matches
+		expect(tree[0]!.visible).toBe(true);
+		expect(tree[0]!.children[0]!.visible).toBe(true);
+	});
+
+	test('parent hidden if no children match and parent does not match', () => {
+		const items: TestItem[] = [
+			{ id: 'parent', name: 'Parent', parent: null },
+			{ id: 'child', name: 'Child', parent: 'parent' },
+		];
+
+		const TestComponent = createTestComponent(items, 'nothing', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree[0]!.visible).toBe(false);
+		expect(tree[0]!.children[0]!.visible).toBe(false);
+	});
+
+	test('deeply nested backward propagation', () => {
+		const items: TestItem[] = [
+			{ id: 'root', name: 'Root', parent: null },
+			{ id: 'child', name: 'Child', parent: 'root' },
+			{ id: 'grandchild', name: 'Match', parent: 'child' },
+		];
+
+		const TestComponent = createTestComponent(items, 'match', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		const root = tree[0]!;
+		const child = root.children[0]!;
+		const grandchild = child.children[0]!;
+
+		// All ancestors should be visible due to grandchild matching
+		expect(grandchild.visible).toBe(true);
+		expect(child.visible).toBe(true);
+		expect(root.visible).toBe(true);
+	});
+
+	test('findVisibilityNode finds node by ID', () => {
+		const items: TestItem[] = [
+			{ id: 'parent', name: 'Parent', parent: null },
+			{ id: 'child', name: 'Child', parent: 'parent' },
+		];
+
+		const TestComponent = createTestComponent(items, null, defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const childNode = wrapper.vm.findVisibilityNode('child');
+		expect(childNode).toBeDefined();
+		expect(childNode!.id).toBe('child');
+	});
+
+	test('findVisibilityNode returns undefined for non-existent ID', () => {
+		const items: TestItem[] = [{ id: 'a', name: 'Alpha', parent: null }];
+
+		const TestComponent = createTestComponent(items, null, defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const node = wrapper.vm.findVisibilityNode('nonexistent');
+		expect(node).toBeUndefined();
+	});
+
+	test('node.findChild finds child within node', () => {
+		const items: TestItem[] = [
+			{ id: 'parent', name: 'Parent', parent: null },
+			{ id: 'child', name: 'Child', parent: 'parent' },
+		];
+
+		const TestComponent = createTestComponent(items, null, defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		const parent = tree[0]!;
+		const foundChild = parent.findChild('child');
+
+		expect(foundChild).toBeDefined();
+		expect(foundChild!.id).toBe('child');
+	});
+
+	test('stores search value in node', () => {
+		const items: TestItem[] = [{ id: 'a', name: 'Alpha', parent: null }];
+
+		const TestComponent = createTestComponent(items, 'test', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree[0]!.search).toBe('test');
+	});
+
+	test('handles empty items array', () => {
+		const TestComponent = createTestComponent([], 'test', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree).toEqual([]);
+	});
+
+	test('multiple root items at same level', () => {
+		const items: TestItem[] = [
+			{ id: 'a', name: 'Alpha', parent: null },
+			{ id: 'b', name: 'Beta', parent: null },
+			{ id: 'c', name: 'Charlie', parent: null },
+		];
+
+		const TestComponent = createTestComponent(items, 'beta', defaultConfig);
+		const wrapper = mount(TestComponent);
+
+		const tree = unref(wrapper.vm.visibilityTree);
+		expect(tree.length).toBe(3);
+		expect(tree.find((n) => n.id === 'a')!.visible).toBe(false);
+		expect(tree.find((n) => n.id === 'b')!.visible).toBe(true);
+		expect(tree.find((n) => n.id === 'c')!.visible).toBe(false);
+	});
+});

--- a/app/src/composables/use-visibility-tree.ts
+++ b/app/src/composables/use-visibility-tree.ts
@@ -1,0 +1,104 @@
+import { computed, type ComputedRef, type Ref } from 'vue';
+
+export interface VisibilityTreeNode<T = string> {
+	id: T;
+	visible: boolean;
+	children: VisibilityTreeNode<T>[];
+	search: string | null;
+	findChild(id: T): VisibilityTreeNode<T> | undefined;
+}
+
+export interface UseVisibilityTreeConfig<T, ID = string> {
+	/** Extract the unique ID from an item */
+	getId: (item: T) => ID;
+	/** Get the parent ID for an item (null for root items) */
+	getParent: (item: T) => ID | null;
+	/** Check if an item matches the search query */
+	matchesSearch: (item: T, search: string) => boolean;
+}
+
+export interface UseVisibilityTreeReturn<ID = string> {
+	visibilityTree: ComputedRef<VisibilityTreeNode<ID>[]>;
+	findVisibilityNode: (id: ID, tree?: VisibilityTreeNode<ID>[]) => VisibilityTreeNode<ID> | undefined;
+}
+
+/**
+ * Generic composable for managing visibility tree with search filtering.
+ * Supports hierarchical items with backward propagation (parent visible if any child matches).
+ *
+ * @param items - Reactive ref of items to build tree from
+ * @param search - Reactive ref of current search query
+ * @param config - Configuration for ID extraction, parent lookup, and search matching
+ */
+export function useVisibilityTree<T, ID = string>(
+	items: Ref<T[]>,
+	search: Ref<string | null>,
+	config: UseVisibilityTreeConfig<T, ID>,
+): UseVisibilityTreeReturn<ID> {
+	function findVisibilityNode(
+		id: ID,
+		tree: VisibilityTreeNode<ID>[] = visibilityTree.value,
+	): VisibilityTreeNode<ID> | undefined {
+		for (const node of tree) {
+			if (node.id === id) return node;
+
+			const found = findVisibilityNode(id, node.children);
+
+			if (found) return found;
+		}
+
+		return undefined;
+	}
+
+	const visibilityTree = computed(() => {
+		const tree: VisibilityTreeNode<ID>[] = makeTree(null);
+		const propagateBackwards: VisibilityTreeNode<ID>[] = [];
+
+		function makeTree(parent: ID | null): VisibilityTreeNode<ID>[] {
+			const children = items.value.filter((item) => config.getParent(item) === parent);
+
+			const normalizedSearch = search.value?.toLowerCase();
+
+			return children.map((item) => {
+				const id = config.getId(item);
+
+				return {
+					id,
+					visible: normalizedSearch ? config.matchesSearch(item, normalizedSearch) : true,
+					search: search.value,
+					children: makeTree(id),
+					findChild(childId: ID) {
+						return findVisibilityNode(childId, this.children);
+					},
+				};
+			});
+		}
+
+		// Collect nodes with children for backward propagation
+		breadthSearch(tree);
+
+		function breadthSearch(nodes: VisibilityTreeNode<ID>[]) {
+			for (const node of nodes) {
+				if (node.children.length === 0) continue;
+
+				propagateBackwards.unshift(node);
+			}
+
+			for (const node of nodes) {
+				breadthSearch(node.children);
+			}
+		}
+
+		// Propagate visibility backwards: parent visible if any child is visible
+		for (const node of propagateBackwards) {
+			node.visible = node.visible || node.children.some((child) => child.visible);
+		}
+
+		return tree;
+	});
+
+	return {
+		visibilityTree,
+		findVisibilityNode,
+	};
+}

--- a/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
@@ -87,7 +87,7 @@ function handleNestedSort(updates: { id: string; group: string }[]) {
 		<template #actions="{ item, hasChildren }">
 			<CollectionOptions
 				:has-nested-collections="hasChildren"
-				:collection="(item as Collection)"
+				:collection="item as Collection"
 				@collection-toggle="$emit('toggleCollapse', (item as Collection).collection)"
 			/>
 		</template>

--- a/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
@@ -6,7 +6,7 @@ import { Collection } from '@/types/collections';
 import { CollectionTree } from '../collections.vue';
 import CollectionOptions from './collection-options.vue';
 
-const props = defineProps<{
+defineProps<{
 	collection: Collection;
 	collections: Collection[];
 	isCollapsed: boolean;
@@ -54,8 +54,8 @@ function handleNestedSort(updates: { id: string; group: string }[]) {
 		group-field="meta.group"
 		drag-group="collections"
 		:get-item-link="getCollectionLink"
-		:clickable="true"
-		:can-have-children="true"
+		clickable
+		can-have-children
 		@toggle-collapse="$emit('toggleCollapse', $event)"
 		@set-nested-sort="handleNestedSort"
 		@item-click="handleItemClick"

--- a/app/src/modules/settings/routes/data-model/collections/composables/use-expand-collapse.ts
+++ b/app/src/modules/settings/routes/data-model/collections/composables/use-expand-collapse.ts
@@ -12,9 +12,7 @@ export function useExpandCollapse() {
 		toggleCollapse,
 	} = useExpandCollapseShared('collapsed-collection-ids', {
 		getExpandableIds: () =>
-			collectionsStore.allCollections
-				.filter(({ meta }) => meta?.group)
-				.map(({ collection }) => collection),
+			collectionsStore.allCollections.filter(({ meta }) => meta?.group).map(({ collection }) => collection),
 		getAllIds: () => collectionsStore.allCollections.map(({ collection }) => collection),
 	});
 

--- a/app/src/modules/settings/routes/data-model/collections/composables/use-expand-collapse.ts
+++ b/app/src/modules/settings/routes/data-model/collections/composables/use-expand-collapse.ts
@@ -1,30 +1,22 @@
+import { useExpandCollapse as useExpandCollapseShared } from '@/composables/use-expand-collapse';
 import { useCollectionsStore } from '@/stores/collections';
-import { useLocalStorage } from '@vueuse/core';
-import { computed } from 'vue';
 
 export function useExpandCollapse() {
 	const collectionsStore = useCollectionsStore();
-	const collapsedIds = useLocalStorage<string[]>('collapsed-collection-ids', []);
 
-	const hasExpandableCollections = computed(() => collectionsStore.allCollections.some(({ meta }) => meta?.group));
+	const {
+		collapsedIds,
+		hasExpandable: hasExpandableCollections,
+		expandAll,
+		collapseAll,
+		toggleCollapse,
+	} = useExpandCollapseShared('collapsed-collection-ids', {
+		getExpandableIds: () =>
+			collectionsStore.allCollections
+				.filter(({ meta }) => meta?.group)
+				.map(({ collection }) => collection),
+		getAllIds: () => collectionsStore.allCollections.map(({ collection }) => collection),
+	});
 
 	return { collapsedIds, hasExpandableCollections, expandAll, collapseAll, toggleCollapse };
-
-	function expandAll() {
-		collapsedIds.value = [];
-	}
-
-	function collapseAll() {
-		collapsedIds.value = collectionsStore.allCollections.map(({ collection }) => collection);
-	}
-
-	function toggleCollapse(collection: string) {
-		const isCollapsed = collapsedIds.value.includes(collection);
-
-		if (isCollapsed) {
-			collapsedIds.value = collapsedIds.value.filter((id) => id !== collection);
-		} else {
-			collapsedIds.value = [...collapsedIds.value, collection];
-		}
-	}
 }

--- a/app/src/modules/settings/routes/flows/components/flow-folder-dialog.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-folder-dialog.vue
@@ -79,7 +79,7 @@ async function handleSave(values: GroupDialogValues, isEdit: boolean) {
 		name-placeholder-key="folder_name"
 		default-icon="folder"
 		:show-translations="false"
-		:show-description="true"
+		show-description
 		@update:model-value="$emit('update:modelValue', $event)"
 		@save="handleSave"
 	>

--- a/app/src/modules/settings/routes/flows/components/flow-folder-dialog.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-folder-dialog.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { GroupDialog, type GroupDialogValues } from '@/components/grouped-list';
+import { useFlowsStore } from '@/stores/flows';
+import type { FlowRaw } from '@directus/types';
+import { ref, watch } from 'vue';
+
+const props = defineProps<{
+	modelValue?: boolean;
+	flow?: FlowRaw | null;
+}>();
+
+const emit = defineEmits<{
+	'update:modelValue': [value: boolean];
+}>();
+
+const flowsStore = useFlowsStore();
+const saving = ref(false);
+
+const dialogItem = ref<{
+	id?: string;
+	name?: string | null;
+	icon?: string | null;
+	color?: string | null;
+	description?: string | null;
+} | null>(null);
+
+watch(
+	() => props.flow,
+	(flow) => {
+		if (flow) {
+			dialogItem.value = {
+				id: flow.id,
+				name: flow.name,
+				icon: flow.icon,
+				color: flow.color,
+				description: flow.description,
+			};
+		} else {
+			dialogItem.value = null;
+		}
+	},
+	{ immediate: true },
+);
+
+async function handleSave(values: GroupDialogValues, isEdit: boolean) {
+	saving.value = true;
+
+	try {
+		if (isEdit && props.flow) {
+			await flowsStore.updateFlow(props.flow.id, {
+				name: values.name!,
+				icon: values.icon,
+				color: values.color,
+				description: values.description,
+			});
+		} else {
+			await flowsStore.createFolder({
+				name: values.name!,
+				icon: values.icon ?? undefined,
+				color: values.color ?? undefined,
+				description: values.description ?? undefined,
+			});
+		}
+
+		emit('update:modelValue', false);
+	} finally {
+		saving.value = false;
+	}
+}
+</script>
+
+<template>
+	<GroupDialog
+		:model-value="modelValue"
+		:item="dialogItem"
+		:saving="saving"
+		create-title-key="create_folder"
+		edit-title-key="edit_folder"
+		name-placeholder-key="folder_name"
+		default-icon="folder"
+		:show-translations="false"
+		:show-description="true"
+		@update:model-value="$emit('update:modelValue', $event)"
+		@save="handleSave"
+	>
+		<template #activator="slotBinding">
+			<slot name="activator" v-bind="slotBinding" />
+		</template>
+	</GroupDialog>
+</template>

--- a/app/src/modules/settings/routes/flows/components/flow-item.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-item.vue
@@ -5,10 +5,9 @@ import VHighlight from '@/components/v-highlight.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import type { VisibilityTreeNode } from '@/composables/use-visibility-tree';
 import type { FlowRaw } from '@directus/types';
-import { computed } from 'vue';
 import FlowOptions from './flow-options.vue';
 
-const props = defineProps<{
+defineProps<{
 	flow: FlowRaw & { isCollapsed?: boolean };
 	flows: (FlowRaw & { isCollapsed?: boolean })[];
 	isCollapsed: boolean;
@@ -22,13 +21,12 @@ const emit = defineEmits<{
 	toggleCollapse: [id: string];
 }>();
 
-const isFolder = computed(() => props.flow.trigger === null);
-
 // Helper functions to compute values from any flow item (used in slots)
 function getFlowIcon(item: FlowRaw): string {
 	if (item.trigger === null) {
 		return item.icon || 'folder';
 	}
+
 	return item.icon || 'bolt';
 }
 
@@ -72,8 +70,8 @@ function handleItemClick(item: Record<string, unknown>) {
 		group-field="group"
 		drag-group="flows"
 		:get-item-link="getFlowLink"
-		:clickable="true"
-		:can-have-children="true"
+		clickable
+		can-have-children
 		@toggle-collapse="$emit('toggleCollapse', $event)"
 		@set-nested-sort="$emit('setNestedSort', $event)"
 		@item-click="handleItemClick"

--- a/app/src/modules/settings/routes/flows/components/flow-item.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-item.vue
@@ -85,11 +85,7 @@ function handleItemClick(item: Record<string, unknown>) {
 		</template>
 
 		<template #content="{ item, search }">
-			<VHighlight
-				:query="search"
-				:text="(item as FlowRaw).name"
-				class="flow-name"
-			/>
+			<VHighlight :query="search" :text="(item as FlowRaw).name" class="flow-name" />
 		</template>
 
 		<template #meta="{ item }">
@@ -112,7 +108,7 @@ function handleItemClick(item: Record<string, unknown>) {
 
 		<template #actions="{ item, hasChildren }">
 			<FlowOptions
-				:flow="(item as FlowRaw)"
+				:flow="item as FlowRaw"
 				:is-folder="(item as FlowRaw).trigger === null"
 				:has-children="hasChildren"
 				@edit="$emit('editFlow', item as FlowRaw)"
@@ -129,7 +125,7 @@ function handleItemClick(item: Record<string, unknown>) {
 
 .flow-name {
 	flex-shrink: 1;
-	min-width: 80px;
+	min-inline-size: 80px;
 	overflow: hidden;
 	font-family: var(--theme--fonts--monospace--font-family);
 	text-overflow: ellipsis;

--- a/app/src/modules/settings/routes/flows/components/flow-item.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-item.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { GroupedListItem } from '@/components/grouped-list';
+import DisplayColor from '@/displays/color/color.vue';
+import VHighlight from '@/components/v-highlight.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
+import type { VisibilityTreeNode } from '@/composables/use-visibility-tree';
+import type { FlowRaw } from '@directus/types';
+import { computed } from 'vue';
+import FlowOptions from './flow-options.vue';
+
+const props = defineProps<{
+	flow: FlowRaw & { isCollapsed?: boolean };
+	flows: (FlowRaw & { isCollapsed?: boolean })[];
+	isCollapsed: boolean;
+	visibilityTree: VisibilityTreeNode<string>;
+	disableDrag?: boolean;
+}>();
+
+const emit = defineEmits<{
+	setNestedSort: [updates: { id: string; group: string }[]];
+	editFlow: [flow: FlowRaw];
+	toggleCollapse: [id: string];
+}>();
+
+const isFolder = computed(() => props.flow.trigger === null);
+
+// Helper functions to compute values from any flow item (used in slots)
+function getFlowIcon(item: FlowRaw): string {
+	if (item.trigger === null) {
+		return item.icon || 'folder';
+	}
+	return item.icon || 'bolt';
+}
+
+function getTriggerIcon(trigger: string | null): string | null {
+	switch (trigger) {
+		case 'event':
+			return 'sensors';
+		case 'webhook':
+			return 'webhook';
+		case 'schedule':
+			return 'schedule';
+		case 'operation':
+			return 'bolt';
+		case 'manual':
+			return 'touch_app';
+		default:
+			return null;
+	}
+}
+
+function getFlowLink(item: Record<string, unknown>): string | undefined {
+	const flow = item as FlowRaw;
+	// Folders don't have a detail page
+	if (flow.trigger === null) return undefined;
+	return `/settings/flows/${flow.id}`;
+}
+
+function handleItemClick(item: Record<string, unknown>) {
+	emit('editFlow', item as unknown as FlowRaw);
+}
+</script>
+
+<template>
+	<GroupedListItem
+		:item="flow"
+		:items="flows"
+		:is-collapsed="isCollapsed"
+		:visibility-tree="visibilityTree"
+		:disable-drag="disableDrag"
+		id-field="id"
+		group-field="group"
+		drag-group="flows"
+		:get-item-link="getFlowLink"
+		:clickable="true"
+		:can-have-children="true"
+		@toggle-collapse="$emit('toggleCollapse', $event)"
+		@set-nested-sort="$emit('setNestedSort', $event)"
+		@item-click="handleItemClick"
+	>
+		<template #icon="{ item }">
+			<VIcon
+				:color="(item as FlowRaw).color ?? 'var(--theme--primary)'"
+				class="flow-icon"
+				:name="getFlowIcon(item as FlowRaw)"
+			/>
+		</template>
+
+		<template #content="{ item, search }">
+			<VHighlight
+				:query="search"
+				:text="(item as FlowRaw).name"
+				class="flow-name"
+			/>
+		</template>
+
+		<template #meta="{ item }">
+			<div class="flow-meta">
+				<DisplayColor
+					v-if="(item as FlowRaw).trigger !== null"
+					v-tooltip="(item as FlowRaw).status === 'active' ? $t('active') : $t('inactive')"
+					class="status-dot"
+					:value="(item as FlowRaw).status === 'active' ? 'var(--theme--success)' : 'var(--theme--foreground-subdued)'"
+				/>
+				<VIcon
+					v-if="getTriggerIcon((item as FlowRaw).trigger)"
+					v-tooltip="$t(`triggers.${(item as FlowRaw).trigger}.name`)"
+					:name="getTriggerIcon((item as FlowRaw).trigger)!"
+					class="trigger-icon"
+					small
+				/>
+			</div>
+		</template>
+
+		<template #actions="{ item, hasChildren }">
+			<FlowOptions
+				:flow="(item as FlowRaw)"
+				:is-folder="(item as FlowRaw).trigger === null"
+				:has-children="hasChildren"
+				@edit="$emit('editFlow', item as FlowRaw)"
+				@toggle-collapse="$emit('toggleCollapse', (item as FlowRaw).id)"
+			/>
+		</template>
+	</GroupedListItem>
+</template>
+
+<style scoped lang="scss">
+.flow-icon {
+	margin-inline-end: 8px;
+}
+
+.flow-name {
+	flex-shrink: 1;
+	min-width: 80px;
+	overflow: hidden;
+	font-family: var(--theme--fonts--monospace--font-family);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.flow-meta {
+	display: flex;
+	flex-shrink: 0;
+	gap: 12px;
+	align-items: center;
+	margin-inline-start: auto;
+	padding-inline-start: 12px;
+}
+
+.status-dot {
+	cursor: help;
+}
+
+.trigger-icon {
+	--v-icon-color: var(--theme--foreground);
+
+	&:hover {
+		--v-icon-color: var(--theme--primary);
+	}
+}
+</style>

--- a/app/src/modules/settings/routes/flows/components/flow-options.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-options.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { GroupOptions, type CollapseState } from '@/components/grouped-list';
+import VIcon from '@/components/v-icon/v-icon.vue';
+import VListItemContent from '@/components/v-list-item-content.vue';
+import VListItemIcon from '@/components/v-list-item-icon.vue';
+import VListItem from '@/components/v-list-item.vue';
+import { useFlowsStore } from '@/stores/flows';
+import type { FlowRaw } from '@directus/types';
+import { computed, ref } from 'vue';
+
+const props = defineProps<{
+	flow: FlowRaw;
+	isFolder: boolean;
+	hasChildren: boolean;
+}>();
+
+const emit = defineEmits<{
+	edit: [];
+	toggleCollapse: [];
+}>();
+
+const flowsStore = useFlowsStore();
+const deleting = ref(false);
+
+const collapseState = computed<CollapseState>(() => props.flow.collapse || 'open');
+
+async function updateCollapse(state: CollapseState) {
+	await flowsStore.updateFlow(props.flow.id, { collapse: state });
+}
+
+async function toggleStatus() {
+	const newStatus = props.flow.status === 'active' ? 'inactive' : 'active';
+	await flowsStore.updateFlow(props.flow.id, { status: newStatus });
+}
+
+async function handleDelete() {
+	deleting.value = true;
+
+	try {
+		await flowsStore.deleteFlow(props.flow.id);
+	} finally {
+		deleting.value = false;
+	}
+}
+</script>
+
+<template>
+	<GroupOptions
+		:item-name="flow.name"
+		:is-folder="isFolder"
+		:has-children="hasChildren"
+		:collapse-state="collapseState"
+		:show-collapse-options="isFolder || hasChildren"
+		:delete-confirm-title-key="isFolder ? 'delete_folder_are_you_sure' : 'delete_flow_are_you_sure'"
+		:delete-button-key="isFolder ? 'delete_folder' : 'delete_flow'"
+		:deleting="deleting"
+		@update:collapse-state="updateCollapse"
+		@delete="handleDelete"
+	>
+		<template #prepend>
+			<!-- Edit flow/folder -->
+			<VListItem clickable @click="$emit('edit')">
+				<VListItemIcon>
+					<VIcon name="edit" />
+				</VListItemIcon>
+				<VListItemContent>
+					{{ isFolder ? $t('edit_folder') : $t('edit_flow') }}
+				</VListItemContent>
+			</VListItem>
+
+			<!-- Toggle status (only for flows, not folders) -->
+			<VListItem v-if="!isFolder" clickable @click="toggleStatus">
+				<template v-if="flow.status === 'active'">
+					<VListItemIcon><VIcon name="block" /></VListItemIcon>
+					<VListItemContent>{{ $t('deactivate_flow') }}</VListItemContent>
+				</template>
+				<template v-else>
+					<VListItemIcon><VIcon name="check_circle" /></VListItemIcon>
+					<VListItemContent>{{ $t('activate_flow') }}</VListItemContent>
+				</template>
+			</VListItem>
+		</template>
+
+		<template #delete-warning>
+			<template v-if="hasChildren">
+				{{ $t('delete_folder_children_warning') }}
+			</template>
+		</template>
+	</GroupOptions>
+</template>

--- a/app/src/modules/settings/routes/flows/components/flow-options.vue
+++ b/app/src/modules/settings/routes/flows/components/flow-options.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
 	hasChildren: boolean;
 }>();
 
-const emit = defineEmits<{
+defineEmits<{
 	edit: [];
 	toggleCollapse: [];
 }>();

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -236,12 +236,7 @@ function onApply() {
 					</div>
 					<div class="field full">
 						<div class="type-label">{{ $t('folder') }}</div>
-						<VSelect
-							v-model="values.group"
-							:items="folderOptions"
-							:placeholder="$t('no_folder')"
-							show-deselect
-						/>
+						<VSelect v-model="values.group" :items="folderOptions" :placeholder="$t('no_folder')" show-deselect />
 					</div>
 					<div class="field half">
 						<div class="type-label">{{ $t('icon') }}</div>

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -37,9 +37,7 @@ const { collapsedIds, hasExpandable, expandAll, collapseAll, toggleCollapse } = 
 	'collapsed-flow-ids',
 	{
 		getExpandableIds: () =>
-			flowsStore.flows
-				.filter((flow) => flowsStore.flows.some((f) => f.group === flow.id))
-				.map((flow) => flow.id),
+			flowsStore.flows.filter((flow) => flowsStore.flows.some((f) => f.group === flow.id)).map((flow) => flow.id),
 		getAllIds: () => flowsStore.flows.map((flow) => flow.id),
 	},
 );
@@ -197,7 +195,15 @@ function openFolderDialog() {
 								:flow="element"
 								:flows="flows"
 								:is-collapsed="element.isCollapsed"
-								:visibility-tree="findVisibilityNode(element.id) ?? { id: element.id, visible: true, children: [], search: null, findChild: () => undefined }"
+								:visibility-tree="
+									findVisibilityNode(element.id) ?? {
+										id: element.id,
+										visible: true,
+										children: [],
+										search: null,
+										findChild: () => undefined,
+									}
+								"
 								@edit-flow="handleEditFlow"
 								@set-nested-sort="onNestedSortChange"
 								@toggle-collapse="toggleCollapse"
@@ -209,10 +215,7 @@ function openFolderDialog() {
 		</div>
 
 		<!-- Folder dialog -->
-		<FlowFolderDialog
-			v-model="folderDialogActive"
-			:flow="editFolderFlow"
-		/>
+		<FlowFolderDialog v-model="folderDialogActive" :flow="editFolderFlow" />
 
 		<!-- Flow drawer -->
 		<FlowDrawer
@@ -256,7 +259,7 @@ function openFolderDialog() {
 }
 
 .root-drag-container {
-	min-height: 100px;
+	min-block-size: 100px;
 }
 
 .draggable-list :deep(.sortable-ghost) {

--- a/app/src/stores/flows.ts
+++ b/app/src/stores/flows.ts
@@ -1,9 +1,12 @@
+import api from '@/api';
 import { useAiStore } from '@/ai/stores/use-ai';
 import { usePermissionsStore } from '@/stores/permissions';
 import { fetchAll } from '@/utils/fetch-all';
+import { flattenGroupedItems } from '@/utils/flatten-grouped-items';
+import { unexpectedError } from '@/utils/unexpected-error';
 import type { FlowRaw } from '@directus/types';
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 export const useFlowsStore = defineStore('flowsStore', () => {
 	const aiStore = useAiStore();
@@ -16,11 +19,28 @@ export const useFlowsStore = defineStore('flowsStore', () => {
 
 	const flows = ref<FlowRaw[]>([]);
 
+	const sortedFlows = computed(() =>
+		flattenGroupedItems(flows.value, {
+			getId: (flow) => flow.id,
+			getParent: (flow) => flow.group ?? null,
+			getSort: (flow) => flow.sort ?? null,
+			getName: (flow) => flow.name ?? '',
+		}),
+	);
+
+	const folders = computed(() => flows.value.filter((flow) => flow.trigger === null));
+
 	return {
 		flows,
+		sortedFlows,
+		folders,
 		hydrate,
 		dehydrate,
 		getManualFlowsForCollection,
+		createFlow,
+		updateFlow,
+		deleteFlow,
+		createFolder,
 	};
 
 	async function hydrate() {
@@ -48,5 +68,85 @@ export const useFlowsStore = defineStore('flowsStore', () => {
 			(flow) =>
 				flow.trigger === 'manual' && flow.status === 'active' && flow.options?.collections?.includes(collection),
 		);
+	}
+
+	async function createFlow(data: Partial<FlowRaw>): Promise<string> {
+		try {
+			// Calculate sort value to place new flow at the end of its group
+			const targetGroup = data.group ?? null;
+			const siblings = flows.value.filter((flow) => (flow.group ?? null) === targetGroup);
+			const maxSort = Math.max(0, ...siblings.map((flow) => flow.sort ?? 0));
+
+			const response = await api.post('/flows', {
+				...data,
+				sort: maxSort + 1,
+			});
+
+			await hydrate();
+
+			return response.data.data.id;
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
+	}
+
+	async function updateFlow(id: string, updates: Partial<FlowRaw>) {
+		try {
+			await api.patch(`/flows/${id}`, updates);
+
+			// Optimistic update
+			flows.value = flows.value.map((flow) => (flow.id === id ? { ...flow, ...updates } : flow));
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
+	}
+
+	async function deleteFlow(id: string) {
+		try {
+			// Move children to root before deleting
+			const children = flows.value.filter((flow) => flow.group === id);
+
+			if (children.length > 0) {
+				await api.patch(
+					'/flows',
+					children.map((child) => ({ id: child.id, group: null })),
+				);
+			}
+
+			await api.delete(`/flows/${id}`);
+
+			// Update local state
+			flows.value = flows.value
+				.map((flow) => (flow.group === id ? { ...flow, group: null } : flow))
+				.filter((flow) => flow.id !== id);
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
+	}
+
+	async function createFolder(data: { name: string; icon?: string; color?: string; description?: string; group?: string | null }) {
+		try {
+			// Calculate sort value to place new folder at the end of its group
+			const siblings = flows.value.filter((flow) => (flow.group ?? null) === (data.group ?? null));
+			const maxSort = Math.max(0, ...siblings.map((flow) => flow.sort ?? 0));
+
+			const response = await api.post('/flows', {
+				...data,
+				trigger: null,
+				status: 'inactive',
+				collapse: 'open',
+				sort: maxSort + 1,
+			});
+
+			await hydrate();
+
+			return response.data.data;
+		} catch (error) {
+			unexpectedError(error);
+			throw error;
+		}
 	}
 });

--- a/app/src/stores/flows.ts
+++ b/app/src/stores/flows.ts
@@ -127,7 +127,13 @@ export const useFlowsStore = defineStore('flowsStore', () => {
 		}
 	}
 
-	async function createFolder(data: { name: string; icon?: string; color?: string; description?: string; group?: string | null }) {
+	async function createFolder(data: {
+		name: string;
+		icon?: string;
+		color?: string;
+		description?: string;
+		group?: string | null;
+	}) {
 		try {
 			// Calculate sort value to place new folder at the end of its group
 			const siblings = flows.value.filter((flow) => (flow.group ?? null) === (data.group ?? null));

--- a/app/src/utils/flatten-grouped-items.test.ts
+++ b/app/src/utils/flatten-grouped-items.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'vitest';
+import { flattenGroupedItems } from './flatten-grouped-items';
+
+interface TestItem {
+	id: string;
+	name: string;
+	group: string | null;
+	sort: number | null;
+}
+
+const config = {
+	getId: (item: TestItem) => item.id,
+	getParent: (item: TestItem) => item.group,
+	getSort: (item: TestItem) => item.sort,
+	getName: (item: TestItem) => item.name,
+};
+
+describe('flattenGroupedItems', () => {
+	test('returns empty array for empty input', () => {
+		const result = flattenGroupedItems<TestItem>([], config);
+		expect(result).toEqual([]);
+	});
+
+	test('returns items sorted by sort value for flat list', () => {
+		const items: TestItem[] = [
+			{ id: 'c', name: 'C', group: null, sort: 3 },
+			{ id: 'a', name: 'A', group: null, sort: 1 },
+			{ id: 'b', name: 'B', group: null, sort: 2 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		expect(result.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+	});
+
+	test('falls back to name sorting when sort is null', () => {
+		const items: TestItem[] = [
+			{ id: 'c', name: 'Zebra', group: null, sort: null },
+			{ id: 'a', name: 'Alpha', group: null, sort: null },
+			{ id: 'b', name: 'Beta', group: null, sort: null },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		expect(result.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+	});
+
+	test('sorts by sort value first, then by name', () => {
+		const items: TestItem[] = [
+			{ id: 'a', name: 'Zebra', group: null, sort: 1 },
+			{ id: 'b', name: 'Alpha', group: null, sort: 1 },
+			{ id: 'c', name: 'Beta', group: null, sort: 2 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		// Same sort value -> alphabetical by name
+		expect(result.map((i) => i.id)).toEqual(['b', 'a', 'c']);
+	});
+
+	test('places children under their parent', () => {
+		const items: TestItem[] = [
+			{ id: 'parent', name: 'Parent', group: null, sort: 1 },
+			{ id: 'child1', name: 'Child 1', group: 'parent', sort: 1 },
+			{ id: 'child2', name: 'Child 2', group: 'parent', sort: 2 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		expect(result.map((i) => i.id)).toEqual(['parent', 'child1', 'child2']);
+	});
+
+	test('handles nested hierarchy (grandchildren)', () => {
+		const items: TestItem[] = [
+			{ id: 'root', name: 'Root', group: null, sort: 1 },
+			{ id: 'child', name: 'Child', group: 'root', sort: 1 },
+			{ id: 'grandchild', name: 'Grandchild', group: 'child', sort: 1 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		expect(result.map((i) => i.id)).toEqual(['root', 'child', 'grandchild']);
+	});
+
+	test('handles multiple root items with nested children', () => {
+		const items: TestItem[] = [
+			{ id: 'root2', name: 'Root 2', group: null, sort: 2 },
+			{ id: 'root1', name: 'Root 1', group: null, sort: 1 },
+			{ id: 'child1a', name: 'Child 1A', group: 'root1', sort: 1 },
+			{ id: 'child2a', name: 'Child 2A', group: 'root2', sort: 1 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		expect(result.map((i) => i.id)).toEqual(['root1', 'child1a', 'root2', 'child2a']);
+	});
+
+	test('handles items with undefined parent as root items', () => {
+		const configWithUndefined = {
+			getId: (item: { id: string; group?: string }) => item.id,
+			getParent: (item: { id: string; group?: string }) => item.group ?? null,
+			getSort: () => null,
+			getName: (item: { id: string; name: string }) => item.name,
+		};
+
+		const items = [
+			{ id: 'a', name: 'A', group: undefined },
+			{ id: 'b', name: 'B' }, // no group property at all
+		];
+
+		const result = flattenGroupedItems(items, configWithUndefined);
+
+		expect(result.map((i) => i.id)).toEqual(['a', 'b']);
+	});
+
+	test('sorts children independently within each parent', () => {
+		const items: TestItem[] = [
+			{ id: 'parent1', name: 'Parent 1', group: null, sort: 1 },
+			{ id: 'parent2', name: 'Parent 2', group: null, sort: 2 },
+			{ id: 'child1b', name: 'Child B', group: 'parent1', sort: 2 },
+			{ id: 'child1a', name: 'Child A', group: 'parent1', sort: 1 },
+			{ id: 'child2b', name: 'Child B', group: 'parent2', sort: 2 },
+			{ id: 'child2a', name: 'Child A', group: 'parent2', sort: 1 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		expect(result.map((i) => i.id)).toEqual(['parent1', 'child1a', 'child1b', 'parent2', 'child2a', 'child2b']);
+	});
+
+	test('handles orphan items (parent does not exist)', () => {
+		const items: TestItem[] = [
+			{ id: 'orphan', name: 'Orphan', group: 'nonexistent', sort: 1 },
+			{ id: 'root', name: 'Root', group: null, sort: 1 },
+		];
+
+		const result = flattenGroupedItems(items, config);
+
+		// Orphan is not included since its parent doesn't exist
+		expect(result.map((i) => i.id)).toEqual(['root']);
+	});
+});

--- a/app/src/utils/flatten-grouped-items.ts
+++ b/app/src/utils/flatten-grouped-items.ts
@@ -1,0 +1,59 @@
+import { groupBy, isNil, orderBy } from 'lodash';
+
+export interface FlattenGroupedItemsConfig<T, ID = string> {
+	/** Extract the unique ID from an item */
+	getId: (item: T) => ID;
+	/** Get the parent/group ID for an item (null/undefined for root items) */
+	getParent: (item: T) => ID | null | undefined;
+	/** Get the sort value for an item (null if no sort) */
+	getSort: (item: T) => number | null | undefined;
+	/** Get the name/label for secondary sorting */
+	getName: (item: T) => string;
+}
+
+/**
+ * Create a flat list of items, in which grouped items are sorted under their parent.
+ * Sorted by sort value first, then by name.
+ *
+ * item_a                item_a
+ *   item_a_1            item_a_1
+ *   item_a_2            item_a_2
+ *     item_a_2_1   ->   item_a_2_1
+ * item_b                item_b
+ *   item_b_1            item_b_1
+ *
+ * @param items - Array of items to flatten
+ * @param config - Configuration for ID, parent, sort, and name extraction
+ */
+export function flattenGroupedItems<T, ID = string>(items: T[], config: FlattenGroupedItemsConfig<T, ID>): T[] {
+	const topLevelItems = items.filter((item) => isNil(config.getParent(item)));
+
+	const groupedItems = groupBy(
+		items.filter((item) => !isNil(config.getParent(item))),
+		(item) => config.getParent(item),
+	);
+
+	const flatten = (itemsToFlatten: T[]): T[] => {
+		const result: T[] = [];
+
+		const sorted = orderBy(
+			itemsToFlatten,
+			[(item) => config.getSort(item) ?? Infinity, (item) => config.getName(item)],
+			['asc', 'asc'],
+		);
+
+		for (const item of sorted) {
+			result.push(item);
+
+			const id = config.getId(item) as unknown as string;
+
+			if (groupedItems[id]) {
+				result.push(...flatten(groupedItems[id]!));
+			}
+		}
+
+		return result;
+	};
+
+	return flatten(topLevelItems);
+}

--- a/contributors.yml
+++ b/contributors.yml
@@ -240,3 +240,4 @@
 - DanielRubianes
 - bruno-costa
 - DamnItAzriel
+- w0kyj

--- a/packages/system-data/src/fields/flows.yaml
+++ b/packages/system-data/src/fields/flows.yaml
@@ -24,3 +24,6 @@ fields:
   - field: user_created
     special:
       - user-created
+  - field: group
+  - field: sort
+  - field: collapse

--- a/packages/system-data/src/relations/relations.yaml
+++ b/packages/system-data/src/relations/relations.yaml
@@ -140,6 +140,10 @@ data:
     many_field: user_created
     one_collection: directus_users
 
+  - many_collection: directus_flows
+    many_field: group
+    one_collection: directus_flows
+
   ### Operations
   - many_collection: directus_operations
     many_field: flow

--- a/packages/types/src/flows.ts
+++ b/packages/types/src/flows.ts
@@ -2,6 +2,8 @@ export type TriggerType = 'event' | 'schedule' | 'operation' | 'webhook' | 'manu
 
 type Status = 'active' | 'inactive';
 
+export type CollapseState = 'open' | 'closed' | 'locked';
+
 export interface Flow {
 	id: string;
 	name: string | null;
@@ -12,6 +14,9 @@ export interface Flow {
 	options: Record<string, any>;
 	operation: Operation | null;
 	accountability: 'all' | 'activity' | null;
+	group: string | null;
+	sort: number | null;
+	collapse: CollapseState;
 }
 
 export interface Operation {
@@ -40,6 +45,9 @@ export interface FlowRaw {
 	date_created: string;
 	user_created: string;
 	accountability: 'all' | 'activity' | null;
+	group: string | null;
+	sort: number | null;
+	collapse: CollapseState;
 }
 
 export interface OperationRaw {


### PR DESCRIPTION
Add hierarchical organization for Flows matching Collections behavior:
- Create folders (trigger: null) to group related flows
- Nest flows under folders or other flows
- Drag-and-drop reordering with persistent sort order
- Expand/collapse state saved in localStorage
- Search filtering with parent visibility preservation

Database changes:
- Add `group`, `sort`, `collapse` columns to directus_flows
- Migration initializes sort values alphabetically

Shared infrastructure:
- use-expand-collapse composable
- use-visibility-tree composable
- flatten-grouped-items utility
- grouped-list components (GroupedListItem, GroupDialog, GroupOptions)

Additional enhancements:
- Collections search now matches field names too
- Documentation updated for Flows and Collections organization
- AI tools prompts updated

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Scope

What's changed:

### New Capabilities
- **Folders**: Create organizational folders (`trigger: null`) to group related flows
- **Nesting**: Nest flows under folders OR other flows
- **Drag-and-drop**: Reorder flows and move between groups
- **Persistent collapse**: Expand/collapse state saved in localStorage
- **Search**: Filter by name, status, description, trigger (parents remain visible when children match)

### Database
New columns on `directus_flows`:
- `group` (UUID) - References parent flow/folder
- `sort` (integer) - Sort order within group
- `collapse` (string) - State: 'open', 'closed', 'locked'

Migration initializes sort values alphabetically for existing flows.

### Shared Infrastructure
Extracted reusable components for grouped lists:
- `use-expand-collapse` / `use-visibility-tree` composables
- `flatten-grouped-items` utility
- `grouped-list/` components

### Additional
- Collections search now matches field names
- Docs updated for Flows and Collections organization
- AI tools prompts updated

## Potential Risks / Drawbacks
Potential Performance Concerns at Scale

| Area                     | Risk   | Trigger                 | Impact                                                                   |
| ------------------------ | ------ | ----------------------- | ------------------------------------------------------------------------ |
| Collections field search | HIGH   | Search with 10K+ fields | fieldsStore.getFieldsForCollection() called per collection per keystroke |
| Visibility tree rebuild  | MEDIUM | Search input            | Full tree rebuild on every keystroke, no debounce                        |
| DOM rendering            | MEDIUM | 500+ items expanded     | All items rendered, no virtualization                                    |
| vuedraggable             | MEDIUM | Drag in large lists     | Known perf issues with 100+ items                                        |
| localStorage             | LOW    | Expand/collapse         | JSON parse/stringify of ID arrays                                        |
| flattenGroupedItems      | LOW    | Any re-render           | O(n) recursive sort on computed                                          |

### Specific Concerns:

1. Collections + Fields Search (highest risk)
   // Called for EVERY collection on EVERY keystroke
   const fields = fieldsStore.getFieldsForCollection(collection.collection);
   if (fields.some((field) => field.field.toLowerCase().includes(searchQuery))) return true;
   With 500 collections × 20 fields avg = 10,000 filter operations per keystroke.

2. No Search Debounce
   Visibility tree recomputes immediately on input. Standard practice is 150-300ms debounce.
3. No List Virtualization
   All 500+ items render to DOM even if off-screen. Libraries like vue-virtual-scroller solve this.
4. Draggable with Large Lists
   vuedraggable performance degrades significantly past ~100 items. Consider disabling drag during search or using virtual scroll.

Recommended Mitigations (future):

| Priority | Fix                                       | Effort |
| -------- | ----------------------------------------- | ------ |
| P1       | Add 200ms debounce to search input        | Low    |
| P1       | Cache/memoize field lookups during search | Medium |
| P2       | Virtual scrolling for 100+ items          | High   |
| P3       | Disable drag-drop during active search    | Low    |
| P3       | Paginate or lazy-load deeply nested items | Medium |


## Tested Scenarios

- [x] Build passes
- [x] 104,435 unit tests pass
- [x] Migration tested on database with 27 flows, 107 collections
- [x] Manual testing: folder creation, drag-drop, search, collapse

## Review Notes / Questions
Manual Flows Sidebar - Hierarchy Decision

The content sidebar (`flow-sidebar-detail.vue`) currently displays manual flows
as a flat list of action buttons. Evaluated adding hierarchy support but
decided against it. The hierarchy addition in the content sidebar is unrelated to the system layout organization implemented with this PR and would be very difficult to implement and handle all the exception cases evaluated.

## Checklist

- [X] Added or updated tests
- [X] Documentation PR created [here](https://github.com/directus/docs/pull/530)

---

Fixes #26431
