### PR TITLE
Fix system filter no longer displayed on search

### DIFF
--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -2,7 +2,7 @@
 import TransitionExpand from '@/components/transition/expand.vue';
 import VBadge from '@/components/v-badge.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
-import InterfaceSystemFilter from '@/interfaces/_system/system-filter';
+import InterfaceSystemFilter from '@/interfaces/_system/system-filter/system-filter.vue';
 import { useElementSize } from '@directus/composables';
 import { Filter } from '@directus/types';
 import { isObject } from 'lodash';


### PR DESCRIPTION
## Scope

What's changed:

- Adds correct import for system filter component

##### Before

https://github.com/user-attachments/assets/e6d89b37-25a9-4ddf-8b17-6e8060a5ca74


##### After

https://github.com/user-attachments/assets/bf867fae-f51f-402e-9a02-43b4f550bbf4



## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios
- Filter now shows when clicked

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes N/A
Due to unreleased: https://github.com/directus/directus/pull/26390
