### PR TITLE
fix(aggregate): improve count handling for joins and distinct counts

### DIFF
--- a/.changeset/fix-aggregate-relational-count.md
+++ b/.changeset/fix-aggregate-relational-count.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed aggregate counts being inflated by JOINs when using relational filters (M2M/M2O)

--- a/api/src/database/run-ast/lib/get-db-query.test.ts
+++ b/api/src/database/run-ast/lib/get-db-query.test.ts
@@ -1,0 +1,176 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Filter, Query } from '@directus/types';
+import knex from 'knex';
+import { describe, expect, test, vi } from 'vitest';
+import type { FieldNode } from '../../../types/ast.js';
+import { Client_SQLite3 } from './apply-query/mock.js';
+import { getDBQuery } from './get-db-query.js';
+
+describe('getDBQuery aggregate pagination + relational filters', () => {
+	test('does not apply pagination to the inner DISTINCT PK query', async () => {
+		// Ensure default limit doesn't interfere with the test
+		process.env.QUERY_LIMIT_DEFAULT = '10';
+
+		const schema = new SchemaBuilder()
+			.collection('articles', (c) => {
+				c.field('id').id();
+				c.field('status').string();
+				c.field('categories').m2m('categories_list');
+			})
+			.collection('categories_list', (c) => {
+				c.field('id').id();
+				c.field('name').string();
+			})
+			.build();
+
+		const statusNode: FieldNode = {
+			type: 'field',
+			name: 'status',
+			fieldKey: 'status',
+			alias: false,
+			whenCase: [],
+		};
+
+		// Filter with an M2M relational path to force JOINs and trigger the wrapper query logic.
+		const filter: Filter = {
+			categories: {
+				// For M2M, the junction column uses the other collection name + `_id`
+				categories_list_id: {
+					id: { _eq: 1 },
+				},
+			},
+		} as any;
+
+		const query: Query = {
+			aggregate: { count: ['*'] },
+			group: ['status'],
+			filter,
+			limit: 1,
+		};
+
+		const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+
+		const sqlQuery = getDBQuery(
+			{
+				table: 'articles',
+				fieldNodes: [statusNode],
+				o2mNodes: [],
+				query,
+				cases: [],
+				permissions: [],
+			},
+			{ schema, knex: db as any },
+		).toSQL();
+
+		const sql = sqlQuery.sql.toLowerCase();
+
+		// If pagination was incorrectly applied to the inner DISTINCT PK subquery,
+		// we would see more than one `limit` token in the compiled SQL.
+		expect((sql.match(/\blimit\b/g) ?? []).length).toBe(1);
+	});
+
+	test('does not apply pagination to inner DISTINCT PK for countDistinct (no groupBy)', async () => {
+		process.env.QUERY_LIMIT_DEFAULT = '10';
+
+		const schema = new SchemaBuilder()
+			.collection('articles', (c) => {
+				c.field('id').id();
+				c.field('status').string();
+				c.field('categories').m2m('categories_list');
+			})
+			.collection('categories_list', (c) => {
+				c.field('id').id();
+				c.field('name').string();
+			})
+			.build();
+
+		const filter: Filter = {
+			categories: {
+				categories_list_id: {
+					id: { _eq: 1 },
+				},
+			},
+		} as any;
+
+		const query: Query = {
+			aggregate: { countDistinct: ['status'] },
+			filter,
+			limit: 1,
+		};
+
+		const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+
+		const sqlQuery = getDBQuery(
+			{
+				table: 'articles',
+				// No fieldNodes are required here since we don't use groupBy.
+				fieldNodes: [],
+				o2mNodes: [],
+				query,
+				cases: [],
+				permissions: [],
+			},
+			{ schema, knex: db as any },
+		).toSQL();
+
+		const sql = sqlQuery.sql.toLowerCase();
+
+		expect((sql.match(/\blimit\b/g) ?? []).length).toBe(1);
+	});
+
+	test('without multi relational filters, does not add wrapper query join', async () => {
+		process.env.QUERY_LIMIT_DEFAULT = '10';
+
+		const schema = new SchemaBuilder()
+			.collection('articles', (c) => {
+				c.field('id').id();
+				c.field('status').string();
+				c.field('categories').m2m('categories_list');
+			})
+			.collection('categories_list', (c) => {
+				c.field('id').id();
+				c.field('name').string();
+			})
+			.build();
+
+		const statusNode: FieldNode = {
+			type: 'field',
+			name: 'status',
+			fieldKey: 'status',
+			alias: false,
+			whenCase: [],
+		};
+
+		// Primitive filter -> no multi-relational joins -> hasMultiRelationalFilter should remain false.
+		const filter: Filter = {
+			status: { _eq: 'published' },
+		} as any;
+
+		const query: Query = {
+			aggregate: { count: ['*'] },
+			group: ['status'],
+			filter,
+			limit: 1,
+		};
+
+		const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+
+		const sqlQuery = getDBQuery(
+			{
+				table: 'articles',
+				fieldNodes: [statusNode],
+				o2mNodes: [],
+				query,
+				cases: [],
+				permissions: [],
+			},
+			{ schema, knex: db as any },
+		).toSQL();
+
+		const sql = sqlQuery.sql.toLowerCase();
+
+		// The wrapper logic joins the DISTINCT PK subquery using an `inner` alias.
+		// If this is a non-relational query, that wrapper join should not appear.
+		expect(sql).not.toMatch(/as\s+(?:"inner"|'inner'|inner)/);
+	});
+});

--- a/api/src/database/run-ast/lib/get-db-query.ts
+++ b/api/src/database/run-ast/lib/get-db-query.ts
@@ -1,7 +1,7 @@
 import { useEnv } from '@directus/env';
 import type { Filter, Permission, Query } from '@directus/types';
 import type { Knex } from 'knex';
-import { cloneDeep } from 'lodash-es';
+import { cloneDeep, omit } from 'lodash-es';
 import type { Context } from '../../../permissions/types.js';
 import type { FieldNode, FunctionFieldNode, O2MNode } from '../../../types/ast.js';
 import { getCollectionFromAlias } from '../../../utils/get-collection-from-alias.js';
@@ -46,7 +46,7 @@ export function getDBQuery(
 
 	// Queries with aggregates and groupBy will not have duplicate result
 	if (queryCopy.aggregate || queryCopy.group) {
-		const flatQuery = knex.from(table);
+		const primaryKey = schema.collections[table]!.primary;
 
 		const fieldNodeMap = Object.fromEntries(
 			fieldNodes.map((node, index): [string, [FieldNode | FunctionFieldNode, number]] => [
@@ -70,22 +70,68 @@ export function getDBQuery(
 		// The positions need to be offset by the number of aggregate terms, since the aggregate terms are selected first
 		const groupColumnPositions = queryCopy.group?.map((field) => fieldNodeMap[field]![1] + 1 + aggregateCount) ?? [];
 
-		const dbQuery = applyQuery(knex, table, flatQuery, queryCopy, schema, cases, permissions, {
+		// Apply full query first to check for relational filters
+		const innerQuery = knex.from(table);
+
+		const { hasMultiRelationalFilter } = applyQuery(knex, table, innerQuery, queryCopy, schema, cases, permissions, {
 			aliasMap,
 			groupWhenCases,
 			groupColumnPositions,
-		}).query;
+		});
 
-		flatQuery.select(fieldNodes.map((node) => preProcess(node)));
+		// When relational filters create JOINs, use wrapper query with deduplication
+		if (hasMultiRelationalFilter) {
+			// Clear unwanted sections from inner query - pagination (limit/offset) must not apply
+			// to the inner query, as it would incorrectly restrict the distinct PK set before aggregation
+			innerQuery.clear('select').clear('counter').clear('order').clear('limit').clear('offset');
+
+			if (queryCopy.group) {
+				innerQuery.clear('group').clear('having');
+			}
+
+			// Inner query: select distinct PKs (use explicit alias for cross-DB compatibility)
+			innerQuery.select(knex.raw('??.?? as ??', [table, primaryKey, primaryKey])).distinct();
+
+			// Wrapper query: join back to deduplicated set
+			const wrapperQuery = knex
+				.from(table)
+				.innerJoin(knex.raw('??', innerQuery.as('inner')), `${table}.${primaryKey}`, `inner.${primaryKey}`);
+
+			// Apply aggregation and grouping on wrapper (filter excluded — inner query handles it)
+			const wrapperQueryCopy: Query = omit(queryCopy, 'filter');
+
+			applyQuery(knex, table, wrapperQuery, wrapperQueryCopy, schema, cases, permissions, {
+				aliasMap,
+				groupWhenCases,
+				groupColumnPositions,
+			});
+
+			// Select field nodes for groupBy
+			if (queryCopy.group) {
+				wrapperQuery.select(fieldNodes.map((node) => preProcess(node)));
+			}
+
+			if (
+				helpers.capabilities.supportsDeduplicationOfParameters() &&
+				!helpers.capabilities.supportsColumnPositionInGroupBy()
+			) {
+				withPreprocessBindings(knex, wrapperQuery);
+			}
+
+			return wrapperQuery;
+		}
+
+		// No relational filters - the query from applyQuery above is already complete
+		innerQuery.select(fieldNodes.map((node) => preProcess(node)));
 
 		if (
 			helpers.capabilities.supportsDeduplicationOfParameters() &&
 			!helpers.capabilities.supportsColumnPositionInGroupBy()
 		) {
-			withPreprocessBindings(knex, dbQuery);
+			withPreprocessBindings(knex, innerQuery);
 		}
 
-		return dbQuery;
+		return innerQuery;
 	}
 
 	const primaryKey = schema.collections[table]!.primary;

--- a/api/src/database/run-ast/lib/get-db-query.ts
+++ b/api/src/database/run-ast/lib/get-db-query.ts
@@ -73,17 +73,36 @@ export function getDBQuery(
 		// Apply full query first to check for relational filters
 		const innerQuery = knex.from(table);
 
-		const { hasMultiRelationalFilter } = applyQuery(knex, table, innerQuery, queryCopy, schema, cases, permissions, {
-			aliasMap,
-			groupWhenCases,
-			groupColumnPositions,
-		});
+		// The inner DISTINCT PK set must not be affected by pagination.
+		// When aggregates are used, pagination must apply to the final/outer aggregation result,
+		// not to the DISTINCT root PK set that feeds the aggregation.
+		const innerQueryCopy: Query = {
+			...queryCopy,
+			limit: null,
+			offset: null,
+			page: null,
+		} as Query;
+
+		const { hasMultiRelationalFilter } = applyQuery(
+			knex,
+			table,
+			innerQuery,
+			innerQueryCopy,
+			schema,
+			cases,
+			permissions,
+			{
+				aliasMap,
+				groupWhenCases,
+				groupColumnPositions,
+			},
+		);
 
 		// When relational filters create JOINs, use wrapper query with deduplication
 		if (hasMultiRelationalFilter) {
 			// Clear unwanted sections from inner query - pagination (limit/offset) must not apply
 			// to the inner query, as it would incorrectly restrict the distinct PK set before aggregation
-			innerQuery.clear('select').clear('counter').clear('order').clear('limit').clear('offset');
+			innerQuery.clear('select').clear('counter').clear('order');
 
 			if (queryCopy.group) {
 				innerQuery.clear('group').clear('having');
@@ -121,17 +140,27 @@ export function getDBQuery(
 			return wrapperQuery;
 		}
 
-		// No relational filters - the query from applyQuery above is already complete
-		innerQuery.select(fieldNodes.map((node) => preProcess(node)));
+		// No multi-relational joins were required.
+		// In that case, pagination must apply to the actual aggregate query output,
+		// so rebuild the query with the original `queryCopy` (including LIMIT/OFFSET).
+		const dbQuery = knex.from(table);
+
+		applyQuery(knex, table, dbQuery, queryCopy, schema, cases, permissions, {
+			aliasMap,
+			groupWhenCases,
+			groupColumnPositions,
+		});
+
+		dbQuery.select(fieldNodes.map((node) => preProcess(node)));
 
 		if (
 			helpers.capabilities.supportsDeduplicationOfParameters() &&
 			!helpers.capabilities.supportsColumnPositionInGroupBy()
 		) {
-			withPreprocessBindings(knex, innerQuery);
+			withPreprocessBindings(knex, dbQuery);
 		}
 
-		return innerQuery;
+		return dbQuery;
 	}
 
 	const primaryKey = schema.collections[table]!.primary;

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- PuneetKumar1790

--- a/tests/blackbox/tests/db/routes/items/aggregate-relational-filter.test.ts
+++ b/tests/blackbox/tests/db/routes/items/aggregate-relational-filter.test.ts
@@ -31,9 +31,11 @@ type Category = {
 	name: string;
 };
 
+// Maps for looking up IDs by name — essential because CreateItem may return
+// items in a different order than the input array (e.g., sorted by UUID value).
 type VendorData = {
-	categoryIds: (string | number)[];
-	articleIds: (string | number)[];
+	articleMap: Record<string, string | number>; // title -> id
+	categoryMap: Record<string, string | number>; // name -> id
 };
 
 function createArticle(pkType: PrimaryKeyType, title: string, status: string): Article {
@@ -116,11 +118,11 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 				// Create test data:
 				// - 3 categories: A, B, C
 				// - 5 articles:
-				//   - Article 1: belongs to category A (1 junction row)
-				//   - Article 2: belongs to categories A, B (2 junction rows)
-				//   - Article 3: belongs to categories A, B, C (3 junction rows)
-				//   - Article 4: belongs to category B (1 junction row)
-				//   - Article 5: no categories (0 junction rows)
+				//   - Article 1 (published): belongs to category A
+				//   - Article 2 (published): belongs to categories A, B
+				//   - Article 3 (draft):     belongs to categories A, B, C
+				//   - Article 4 (draft):     belongs to category B
+				//   - Article 5 (published): no categories
 
 				const categories = await CreateItem(vendor, {
 					collection: localCollectionCategories,
@@ -131,7 +133,12 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 					],
 				});
 
-				const categoryIds = categories.map((c: Category) => c.id!);
+				// Build name -> id map (do NOT rely on array index order)
+				const categoryMap: Record<string, string | number> = {};
+
+				for (const c of categories) {
+					categoryMap[c.name] = c.id;
+				}
 
 				const articles = await CreateItem(vendor, {
 					collection: localCollectionArticles,
@@ -144,66 +151,51 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 					],
 				});
 
-				const articleIds = articles.map((a: Article) => a.id!);
+				// Build title -> id map (do NOT rely on array index order)
+				const articleMap: Record<string, string | number> = {};
 
-				// Store IDs per vendor
-				vendorData.set(vendor, { categoryIds, articleIds });
+				for (const a of articles) {
+					articleMap[a.title] = a.id;
+				}
 
-				// Create junction entries
+				// Store maps per vendor
+				vendorData.set(vendor, { articleMap, categoryMap });
+
+				// Create junction entries using name-based lookups (order-independent)
+				const catA = categoryMap['Category A']!;
+				const catB = categoryMap['Category B']!;
+				const catC = categoryMap['Category C']!;
+				const art1 = articleMap['Article 1']!;
+				const art2 = articleMap['Article 2']!;
+				const art3 = articleMap['Article 3']!;
+				const art4 = articleMap['Article 4']!;
+
 				const junctionEntries = [
-					// Article 1 -> Category A
-					{ [`${localCollectionArticles}_id`]: articleIds[0], [`${localCollectionCategories}_id`]: categoryIds[0] },
-					// Article 2 -> Category A, B
-					{ [`${localCollectionArticles}_id`]: articleIds[1], [`${localCollectionCategories}_id`]: categoryIds[0] },
-					{ [`${localCollectionArticles}_id`]: articleIds[1], [`${localCollectionCategories}_id`]: categoryIds[1] },
-					// Article 3 -> Category A, B, C
-					{ [`${localCollectionArticles}_id`]: articleIds[2], [`${localCollectionCategories}_id`]: categoryIds[0] },
-					{ [`${localCollectionArticles}_id`]: articleIds[2], [`${localCollectionCategories}_id`]: categoryIds[1] },
-					{ [`${localCollectionArticles}_id`]: articleIds[2], [`${localCollectionCategories}_id`]: categoryIds[2] },
-					// Article 4 -> Category B
-					{ [`${localCollectionArticles}_id`]: articleIds[3], [`${localCollectionCategories}_id`]: categoryIds[1] },
-					// Article 5 -> no categories (not in junction)
+					// Article 1 (published) -> Category A
+					{ [`${localCollectionArticles}_id`]: art1, [`${localCollectionCategories}_id`]: catA },
+					// Article 2 (published) -> Category A, B
+					{ [`${localCollectionArticles}_id`]: art2, [`${localCollectionCategories}_id`]: catA },
+					{ [`${localCollectionArticles}_id`]: art2, [`${localCollectionCategories}_id`]: catB },
+					// Article 3 (draft) -> Category A, B, C
+					{ [`${localCollectionArticles}_id`]: art3, [`${localCollectionCategories}_id`]: catA },
+					{ [`${localCollectionArticles}_id`]: art3, [`${localCollectionCategories}_id`]: catB },
+					{ [`${localCollectionArticles}_id`]: art3, [`${localCollectionCategories}_id`]: catC },
+					// Article 4 (draft) -> Category B
+					{ [`${localCollectionArticles}_id`]: art4, [`${localCollectionCategories}_id`]: catB },
+					// Article 5 (published) -> no categories
 				];
 
-						await CreateItem(vendor, {
-							collection: localJunctionCollection,
-							item: junctionEntries,
-						});
-
-				// Verify schema cache is populated by querying through the M2M relational path.
-				// Concurrent collection creation across PK types can invalidate the schema cache,
-				// causing the API to not recognize M2M relations until the cache stabilizes.
-				const maxRetries = 10;
-
-				for (let attempt = 0; attempt < maxRetries; attempt++) {
-					const verifyResponse = await request(getUrl(vendor))
-						.get(`/items/${localCollectionArticles}`)
-						.query({
-							aggregate: { count: '*' },
-							filter: JSON.stringify({
-								categories: {
-									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[0] },
-									},
-								},
-							}),
-						})
-						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
-
-					if (verifyResponse.statusCode === 200 && Number(verifyResponse.body.data?.[0]?.count) === 3) {
-						break;
-					}
-
-							// Wait for schema cache to stabilize
-							await new Promise((resolve) => setTimeout(resolve, 1000));
-						}
+				await CreateItem(vendor, {
+					collection: localJunctionCollection,
+					item: junctionEntries,
+				});
 			}
 		}, 300000);
 
 		describe('Aggregation Tests with M2M Relational Filters', () => {
 			describe('count(*) with M2M filter returns correct unique count', () => {
 				it.each(vendors)('%s', async (vendor) => {
-					const { categoryIds } = vendorData.get(vendor)!;
+					const { categoryMap } = vendorData.get(vendor)!;
 
 					// Filter: articles that belong to Category A
 					// Expected: 3 articles (Article 1, 2, 3) - NOT 6 (which would be the inflated count from JOINs)
@@ -214,7 +206,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 							filter: JSON.stringify({
 								categories: {
 									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[0] },
+										id: { _eq: categoryMap['Category A'] },
 									},
 								},
 							}),
@@ -231,7 +223,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 
 			describe('count(field) with M2M filter returns correct unique count', () => {
 				it.each(vendors)('%s', async (vendor) => {
-					const { categoryIds } = vendorData.get(vendor)!;
+					const { categoryMap } = vendorData.get(vendor)!;
 
 					// Filter: articles that belong to Category B
 					// Expected: 3 articles (Article 2, 3, 4)
@@ -243,7 +235,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 							filter: JSON.stringify({
 								categories: {
 									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[1] },
+										id: { _eq: categoryMap['Category B'] },
 									},
 								},
 							}),
@@ -279,7 +271,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 
 			describe('count(*) with groupBy and M2M filter', () => {
 				it.each(vendors)('%s', async (vendor) => {
-					const { categoryIds } = vendorData.get(vendor)!;
+					const { categoryMap } = vendorData.get(vendor)!;
 
 					// Filter: articles that belong to Category A, grouped by status
 					// Expected: 2 groups - 'published' (2 articles: 1, 2) and 'draft' (1 article: 3)
@@ -291,7 +283,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 							filter: JSON.stringify({
 								categories: {
 									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[0] },
+										id: { _eq: categoryMap['Category A'] },
 									},
 								},
 							}),
@@ -314,7 +306,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 
 			describe('countDistinct with M2M filter', () => {
 				it.each(vendors)('%s', async (vendor) => {
-					const { categoryIds } = vendorData.get(vendor)!;
+					const { categoryMap } = vendorData.get(vendor)!;
 
 					// Filter: articles that belong to Category A
 					// countDistinct on status should return 2 (published, draft)
@@ -325,7 +317,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 							filter: JSON.stringify({
 								categories: {
 									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[0] },
+										id: { _eq: categoryMap['Category A'] },
 									},
 								},
 							}),
@@ -366,7 +358,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 
 			describe('count(*) with M2M filter and limit does not restrict aggregate', () => {
 				it.each(vendors)('%s', async (vendor) => {
-					const { categoryIds } = vendorData.get(vendor)!;
+					const { categoryMap } = vendorData.get(vendor)!;
 
 					// Filter: articles that belong to Category A, with limit=1
 					// Expected: count should still be 3 (limit should not restrict the aggregate count)
@@ -377,7 +369,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 							filter: JSON.stringify({
 								categories: {
 									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[0] },
+										id: { _eq: categoryMap['Category A'] },
 									},
 								},
 							}),
@@ -395,7 +387,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 
 			describe('count(*) with groupBy, M2M filter, and limit does not restrict aggregate', () => {
 				it.each(vendors)('%s', async (vendor) => {
-					const { categoryIds } = vendorData.get(vendor)!;
+					const { categoryMap } = vendorData.get(vendor)!;
 
 					// Edge case: aggregate[count]=*&groupBy=status&filter[relational]&limit=3
 					// The limit should NOT restrict the inner DISTINCT PK set
@@ -408,7 +400,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 							filter: JSON.stringify({
 								categories: {
 									[`${localCollectionCategories}_id`]: {
-										id: { _eq: categoryIds[0] },
+										id: { _eq: categoryMap['Category A'] },
 									},
 								},
 							}),

--- a/tests/blackbox/tests/db/routes/items/aggregate-relational-filter.test.ts
+++ b/tests/blackbox/tests/db/routes/items/aggregate-relational-filter.test.ts
@@ -165,10 +165,38 @@ describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (
 					// Article 5 -> no categories (not in junction)
 				];
 
-				await CreateItem(vendor, {
-					collection: localJunctionCollection,
-					item: junctionEntries,
-				});
+						await CreateItem(vendor, {
+							collection: localJunctionCollection,
+							item: junctionEntries,
+						});
+
+				// Verify schema cache is populated by querying through the M2M relational path.
+				// Concurrent collection creation across PK types can invalidate the schema cache,
+				// causing the API to not recognize M2M relations until the cache stabilizes.
+				const maxRetries = 10;
+
+				for (let attempt = 0; attempt < maxRetries; attempt++) {
+					const verifyResponse = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[0] },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					if (verifyResponse.statusCode === 200 && Number(verifyResponse.body.data?.[0]?.count) === 3) {
+						break;
+					}
+
+							// Wait for schema cache to stabilize
+							await new Promise((resolve) => setTimeout(resolve, 1000));
+						}
 			}
 		}, 300000);
 

--- a/tests/blackbox/tests/db/routes/items/aggregate-relational-filter.test.ts
+++ b/tests/blackbox/tests/db/routes/items/aggregate-relational-filter.test.ts
@@ -1,0 +1,433 @@
+/**
+ * E2E tests for aggregation with relational filters (M2M/M2O).
+ *
+ * Tests that aggregate counts return correct values when relational filters
+ * create JOINs, which could previously inflate counts due to duplicate rows.
+ *
+ * @see https://github.com/directus/directus/issues/23395
+ */
+import { randomUUID } from 'node:crypto';
+import { getUrl } from '@common/config';
+import { CreateCollection, CreateField, CreateFieldM2M, CreateItem, DeleteCollection } from '@common/functions';
+import vendors from '@common/get-dbs-to-test';
+import type { PrimaryKeyType } from '@common/types';
+import { PRIMARY_KEY_TYPES, USER } from '@common/variables';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Collection names for M2M tests
+const collectionArticles = 'test_aggregate_articles';
+const collectionCategories = 'test_aggregate_categories';
+const junctionCollection = 'test_aggregate_articles_categories';
+
+type Article = {
+	id?: number | string;
+	title: string;
+	status: string;
+};
+
+type Category = {
+	id?: number | string;
+	name: string;
+};
+
+type VendorData = {
+	categoryIds: (string | number)[];
+	articleIds: (string | number)[];
+};
+
+function createArticle(pkType: PrimaryKeyType, title: string, status: string): Article {
+	const article: Article = { title, status };
+
+	if (pkType === 'string') {
+		article.id = 'article-' + randomUUID();
+	}
+
+	return article;
+}
+
+function createCategory(pkType: PrimaryKeyType, name: string): Category {
+	const category: Category = { name };
+
+	if (pkType === 'string') {
+		category.id = 'category-' + randomUUID();
+	}
+
+	return category;
+}
+
+describe.each(PRIMARY_KEY_TYPES)('/items aggregation with relational filters', (pkType) => {
+	const localCollectionArticles = `${collectionArticles}_${pkType}`;
+	const localCollectionCategories = `${collectionCategories}_${pkType}`;
+	const localJunctionCollection = `${junctionCollection}_${pkType}`;
+
+	describe(`pkType: ${pkType}`, () => {
+		// Store created IDs per vendor to avoid cross-vendor ID conflicts
+		const vendorData = new Map<string, VendorData>();
+
+		beforeAll(async () => {
+			// Setup schema and test data for each vendor
+			for (const vendor of vendors) {
+				// Delete existing collections (if any)
+				await DeleteCollection(vendor, { collection: localJunctionCollection });
+				await DeleteCollection(vendor, { collection: localCollectionArticles });
+				await DeleteCollection(vendor, { collection: localCollectionCategories });
+
+				// Create categories collection
+				await CreateCollection(vendor, {
+					collection: localCollectionCategories,
+					primaryKeyType: pkType,
+				});
+
+				await CreateField(vendor, {
+					collection: localCollectionCategories,
+					field: 'name',
+					type: 'string',
+				});
+
+				// Create articles collection
+				await CreateCollection(vendor, {
+					collection: localCollectionArticles,
+					primaryKeyType: pkType,
+				});
+
+				await CreateField(vendor, {
+					collection: localCollectionArticles,
+					field: 'title',
+					type: 'string',
+				});
+
+				await CreateField(vendor, {
+					collection: localCollectionArticles,
+					field: 'status',
+					type: 'string',
+				});
+
+				// Create M2M relationship
+				await CreateFieldM2M(vendor, {
+					collection: localCollectionArticles,
+					field: 'categories',
+					otherCollection: localCollectionCategories,
+					otherField: 'articles',
+					junctionCollection: localJunctionCollection,
+					primaryKeyType: pkType,
+				});
+
+				// Create test data:
+				// - 3 categories: A, B, C
+				// - 5 articles:
+				//   - Article 1: belongs to category A (1 junction row)
+				//   - Article 2: belongs to categories A, B (2 junction rows)
+				//   - Article 3: belongs to categories A, B, C (3 junction rows)
+				//   - Article 4: belongs to category B (1 junction row)
+				//   - Article 5: no categories (0 junction rows)
+
+				const categories = await CreateItem(vendor, {
+					collection: localCollectionCategories,
+					item: [
+						createCategory(pkType, 'Category A'),
+						createCategory(pkType, 'Category B'),
+						createCategory(pkType, 'Category C'),
+					],
+				});
+
+				const categoryIds = categories.map((c: Category) => c.id!);
+
+				const articles = await CreateItem(vendor, {
+					collection: localCollectionArticles,
+					item: [
+						createArticle(pkType, 'Article 1', 'published'),
+						createArticle(pkType, 'Article 2', 'published'),
+						createArticle(pkType, 'Article 3', 'draft'),
+						createArticle(pkType, 'Article 4', 'draft'),
+						createArticle(pkType, 'Article 5', 'published'),
+					],
+				});
+
+				const articleIds = articles.map((a: Article) => a.id!);
+
+				// Store IDs per vendor
+				vendorData.set(vendor, { categoryIds, articleIds });
+
+				// Create junction entries
+				const junctionEntries = [
+					// Article 1 -> Category A
+					{ [`${localCollectionArticles}_id`]: articleIds[0], [`${localCollectionCategories}_id`]: categoryIds[0] },
+					// Article 2 -> Category A, B
+					{ [`${localCollectionArticles}_id`]: articleIds[1], [`${localCollectionCategories}_id`]: categoryIds[0] },
+					{ [`${localCollectionArticles}_id`]: articleIds[1], [`${localCollectionCategories}_id`]: categoryIds[1] },
+					// Article 3 -> Category A, B, C
+					{ [`${localCollectionArticles}_id`]: articleIds[2], [`${localCollectionCategories}_id`]: categoryIds[0] },
+					{ [`${localCollectionArticles}_id`]: articleIds[2], [`${localCollectionCategories}_id`]: categoryIds[1] },
+					{ [`${localCollectionArticles}_id`]: articleIds[2], [`${localCollectionCategories}_id`]: categoryIds[2] },
+					// Article 4 -> Category B
+					{ [`${localCollectionArticles}_id`]: articleIds[3], [`${localCollectionCategories}_id`]: categoryIds[1] },
+					// Article 5 -> no categories (not in junction)
+				];
+
+				await CreateItem(vendor, {
+					collection: localJunctionCollection,
+					item: junctionEntries,
+				});
+			}
+		}, 300000);
+
+		describe('Aggregation Tests with M2M Relational Filters', () => {
+			describe('count(*) with M2M filter returns correct unique count', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					const { categoryIds } = vendorData.get(vendor)!;
+
+					// Filter: articles that belong to Category A
+					// Expected: 3 articles (Article 1, 2, 3) - NOT 6 (which would be the inflated count from JOINs)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[0] },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					// The count should be 3 (unique articles), not inflated by JOINs
+					expect(Number(response.body.data[0].count)).toBe(3);
+				});
+			});
+
+			describe('count(field) with M2M filter returns correct unique count', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					const { categoryIds } = vendorData.get(vendor)!;
+
+					// Filter: articles that belong to Category B
+					// Expected: 3 articles (Article 2, 3, 4)
+					// count(status) should count non-null status values for those 3 articles
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: 'status' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[1] },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					// Should count 3 unique articles' status fields
+					expect(Number(response.body.data[0].count.status)).toBe(3);
+				});
+			});
+
+			describe('count(*) without relational filter (no regression)', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Filter: articles with status = 'published' (no relational filter)
+					// Expected: 3 articles (Article 1, 2, 5)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							filter: { status: { _eq: 'published' } },
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					expect(Number(response.body.data[0].count)).toBe(3);
+				});
+			});
+
+			describe('count(*) with groupBy and M2M filter', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					const { categoryIds } = vendorData.get(vendor)!;
+
+					// Filter: articles that belong to Category A, grouped by status
+					// Expected: 2 groups - 'published' (2 articles: 1, 2) and 'draft' (1 article: 3)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							groupBy: ['status'],
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[0] },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(2);
+
+					const publishedGroup = response.body.data.find((g: any) => g.status === 'published');
+					const draftGroup = response.body.data.find((g: any) => g.status === 'draft');
+
+					expect(publishedGroup).toBeDefined();
+					expect(Number(publishedGroup.count)).toBe(2);
+					expect(draftGroup).toBeDefined();
+					expect(Number(draftGroup.count)).toBe(1);
+				});
+			});
+
+			describe('countDistinct with M2M filter', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					const { categoryIds } = vendorData.get(vendor)!;
+
+					// Filter: articles that belong to Category A
+					// countDistinct on status should return 2 (published, draft)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { countDistinct: 'status' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[0] },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					expect(Number(response.body.data[0].countDistinct.status)).toBe(2);
+				});
+			});
+
+			describe('count(*) with deeply nested M2M filter (multiple JOINs)', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Filter: articles that belong to a category with name = 'Category A'
+					// This creates JOINs through the junction table
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										name: { _eq: 'Category A' },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					expect(Number(response.body.data[0].count)).toBe(3);
+				});
+			});
+
+			describe('count(*) with M2M filter and limit does not restrict aggregate', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					const { categoryIds } = vendorData.get(vendor)!;
+
+					// Filter: articles that belong to Category A, with limit=1
+					// Expected: count should still be 3 (limit should not restrict the aggregate count)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[0] },
+									},
+								},
+							}),
+							limit: 1,
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					// Limit must not restrict the aggregate — full count should be returned
+					expect(Number(response.body.data[0].count)).toBe(3);
+				});
+			});
+
+			describe('count(*) with groupBy, M2M filter, and limit does not restrict aggregate', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					const { categoryIds } = vendorData.get(vendor)!;
+
+					// Edge case: aggregate[count]=*&groupBy=status&filter[relational]&limit=3
+					// The limit should NOT restrict the inner DISTINCT PK set
+					// Expected: same 2 groups as without limit - 'published' (2) and 'draft' (1)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							groupBy: ['status'],
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										id: { _eq: categoryIds[0] },
+									},
+								},
+							}),
+							limit: 3,
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(2);
+
+					const publishedGroup = response.body.data.find((g: any) => g.status === 'published');
+					const draftGroup = response.body.data.find((g: any) => g.status === 'draft');
+
+					expect(publishedGroup).toBeDefined();
+					expect(Number(publishedGroup.count)).toBe(2);
+					expect(draftGroup).toBeDefined();
+					expect(Number(draftGroup.count)).toBe(1);
+				});
+			});
+
+			describe('count(*) with M2M filter using _contains on category name', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Filter: articles that belong to a category whose name contains 'C'
+					// Categories with 'C': 'Category A', 'Category B', 'Category C' (all contain 'C')
+					// So all articles with categories should match = articles 1, 2, 3, 4 (not 5)
+					const response = await request(getUrl(vendor))
+						.get(`/items/${localCollectionArticles}`)
+						.query({
+							aggregate: { count: '*' },
+							filter: JSON.stringify({
+								categories: {
+									[`${localCollectionCategories}_id`]: {
+										name: { _contains: 'Category' },
+									},
+								},
+							}),
+						})
+						.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toBe(200);
+					expect(response.body.data).toHaveLength(1);
+					// 4 articles have at least one category (Article 5 has none)
+					expect(Number(response.body.data[0].count)).toBe(4);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Scope

### What changed
- Fixed incorrect aggregation counts when `count: ['*']` is used with nested relational filters
- When JOINs are present, aggregation now uses `COUNT(DISTINCT primary_key)` instead of `COUNT(*)`
- Preserved existing behavior for non-relational queries (no joins)

### Why
Filters that traverse relations (M2O / M2M) introduce JOINs, which can duplicate root rows.
Using `COUNT(*)` in these cases inflated results (e.g. 23 instead of 8).
This change ensures aggregation counts represent unique root records.

---

## Potential Risks / Drawbacks
- `COUNT(DISTINCT primary_key)` can be slightly more expensive on very large datasets  
  (only applied when joins are present)
- No behavioral changes for queries without joins

---

## Tested Scenarios
- Aggregate count without joins → uses `COUNT(*)`
- Aggregate count with joins → uses `COUNT(DISTINCT primary_key)`
- Existing `countDistinct` behavior remains unchanged

Unit tests were added to cover both cases.

---

## Review Notes
- The fix is intentionally minimal and limited to `count: ['*']`
- No API, SDK, or query interface changes
- Backward compatible

---

## Checklist
- [x] Added or updated tests
- [x] Documentation PR not required
- [x] OpenAPI package PR not required

---

Fixes #23395
