### PR TITLE
feat: add non interactive mode to create-directus-extension

### DIFF
--- a/.changeset/goofy-teams-stay.md
+++ b/.changeset/goofy-teams-stay.md
@@ -1,0 +1,5 @@
+---
+'create-directus-extension': minor
+---
+
+Add non interactive mode to create-directus-extension

--- a/contributors.yml
+++ b/contributors.yml
@@ -240,3 +240,4 @@
 - DanielRubianes
 - bruno-costa
 - DamnItAzriel
+- bdg-dev

--- a/packages/create-directus-extension/lib/index.js
+++ b/packages/create-directus-extension/lib/index.js
@@ -10,6 +10,26 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 export async function run() {
+	// Parse CLI arguments for non-interactive mode
+	const args = process.argv.slice(2);
+	const hasType = args.length > 0 && !args[0].startsWith('--');
+	const hasName = args.length > 1 && !args[1].startsWith('--');
+
+	if (hasType && hasName) {
+		// Non-interactive mode
+		const type = args[0];
+		const name = args[1];
+
+		// Parse options (--language, --no-install)
+		const langIndex = args.findIndex((a) => a === '--language' || a === '-l');
+		const language = langIndex !== -1 && args[langIndex + 1] ? args[langIndex + 1] : 'javascript';
+		const install = !args.includes('--no-install');
+
+		await create(type, name, { language, install });
+		return;
+	}
+
+	// Interactive mode
 	// eslint-disable-next-line no-console
 	console.log('This utility will walk you through creating a Directus extension.\n');
 

--- a/packages/create-directus-extension/lib/index.test.js
+++ b/packages/create-directus-extension/lib/index.test.js
@@ -308,6 +308,7 @@ describe('run function', () => {
 				language: 'javascript',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -324,6 +325,7 @@ describe('run function', () => {
 				language: 'typescript',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -340,6 +342,7 @@ describe('run function', () => {
 				language: 'typescript',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -356,6 +359,7 @@ describe('run function', () => {
 				language: 'javascript',
 				install: false,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -372,6 +376,7 @@ describe('run function', () => {
 				language: 'typescript',
 				install: false,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -388,6 +393,7 @@ describe('run function', () => {
 				language: 'typescript',
 				install: false,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -409,6 +415,7 @@ describe('run function', () => {
 
 			// Assert
 			expect(mockInquirerPrompt).toHaveBeenCalledTimes(1);
+
 			expect(mockCreate).toHaveBeenCalledWith('interface', 'test-extension', {
 				language: 'typescript',
 				install: true,
@@ -433,6 +440,7 @@ describe('run function', () => {
 
 			// Assert
 			expect(mockInquirerPrompt).toHaveBeenCalledTimes(1);
+
 			expect(mockCreate).toHaveBeenCalledWith('panel', 'test-panel', {
 				language: 'javascript',
 				install: false,
@@ -502,6 +510,7 @@ describe('run function', () => {
 				language: 'javascript',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -518,6 +527,7 @@ describe('run function', () => {
 				language: 'typescript',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -536,6 +546,7 @@ describe('run function', () => {
 				language: '--no-install',
 				install: false,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -553,6 +564,7 @@ describe('run function', () => {
 				language: 'javascript',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 
@@ -570,6 +582,7 @@ describe('run function', () => {
 				language: 'invalid-lang',
 				install: true,
 			});
+
 			expect(mockInquirerPrompt).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/create-directus-extension/readme.md
+++ b/packages/create-directus-extension/readme.md
@@ -13,3 +13,54 @@ npx create-directus-extension
 ```
 yarn create directus-extension
 ```
+
+## Usage
+
+### Interactive Mode
+
+Run the command without any arguments to launch the interactive wizard:
+
+```
+npx create-directus-extension
+```
+
+You will be prompted to choose:
+- Extension type (interface, display, panel, layout, module, hook, endpoint, operation, bundle)
+- Extension name
+- Language (JavaScript or TypeScript)
+- Whether to auto-install dependencies
+
+### Non-Interactive Mode
+
+For automated workflows, coding agnets or when you know exactly what you want, you can provide all options via command-line arguments:
+
+```
+npx create-directus-extension <type> <name> [options]
+```
+
+#### Arguments
+
+- `<type>` - The extension type (interface, display, panel, layout, module, hook, endpoint, operation, bundle)
+- `<name>` - The name of your extension
+
+#### Options
+
+- `--language <language>` or `-l <language>` - Specify the language (javascript or typescript). Defaults to javascript
+- `--no-install` - Skip automatic dependency installation
+
+#### Examples
+
+Create a TypeScript panel extension:
+```
+npx create-directus-extension panel my-panel --language typescript
+```
+
+Create a JavaScript hook without installing dependencies:
+```
+npx create-directus-extension hook my-hook --no-install
+```
+
+Create a TypeScript interface with all options:
+```
+npx create-directus-extension interface my-interface -l typescript
+```

--- a/packages/create-directus-extension/readme.md
+++ b/packages/create-directus-extension/readme.md
@@ -25,6 +25,7 @@ npx create-directus-extension
 ```
 
 You will be prompted to choose:
+
 - Extension type (interface, display, panel, layout, module, hook, endpoint, operation, bundle)
 - Extension name
 - Language (JavaScript or TypeScript)
@@ -32,7 +33,8 @@ You will be prompted to choose:
 
 ### Non-Interactive Mode
 
-For automated workflows, coding agnets or when you know exactly what you want, you can provide all options via command-line arguments:
+For automated workflows, coding agnets or when you know exactly what you want, you can provide all options via
+command-line arguments:
 
 ```
 npx create-directus-extension <type> <name> [options]
@@ -51,16 +53,19 @@ npx create-directus-extension <type> <name> [options]
 #### Examples
 
 Create a TypeScript panel extension:
+
 ```
 npx create-directus-extension panel my-panel --language typescript
 ```
 
 Create a JavaScript hook without installing dependencies:
+
 ```
 npx create-directus-extension hook my-hook --no-install
 ```
 
 Create a TypeScript interface with all options:
+
 ```
 npx create-directus-extension interface my-interface -l typescript
 ```


### PR DESCRIPTION
## Scope

What's changed:

- Added non-interactive mode to `create-directus-extension` CLI tool, enabling extension creation via command-line arguments
- Implemented support for `--language`/`-l` and `--no-install` flags with sensible defaults (javascript, auto-install)
- Added comprehensive test coverage with 16 new tests covering non-interactive mode scenarios and edge cases
- Updated README with usage documentation for both interactive and non-interactive modes
- Added proper argument parsing with fallback to interactive mode when insufficient arguments are provided

## Potential Risks / Drawbacks

- Edge case: When `--language` is immediately followed by another flag (e.g., `--language --no-install`), the next flag becomes the language value (documented in tests)
- No CLI-level validation for extension type or language values - validation is delegated to the underlying `create()` function
- Minor behavior quirk: Bundle types accept language parameter in non-interactive mode even though it may not be used

## Tested Scenarios

- Non-interactive mode with type and name only (defaults to javascript, auto-install)
- Non-interactive mode with `--language typescript` and `-l typescript` variations
- Non-interactive mode with `--no-install` flag
- Combined options in various orders (`--language typescript --no-install`, `--no-install -l typescript`)
- Fallback to interactive mode when only type provided, no arguments, or first argument starts with `--`
- Default language behavior when `--language` or `-l` has no value
- Bundle type extension creation in non-interactive mode
- Invalid extension type and language pass-through to create() function

## Review Notes / Questions

- The `--language --no-install` edge case behavior is documented but might benefit from improved argument parsing logic
- Should we add CLI-level validation for extension types and languages, or is delegating to `create()` acceptable?
- This enables automation workflows and coding agents to create extensions programmatically

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required (README updated in this PR)
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required (not applicable)

---

Enables automated extension scaffolding for CI/CD pipelines, scripts, and coding agents while maintaining backward compatibility with the interactive wizard. 

## Open question
Do we want to use `commander` package for this? My idea was to keep it simple without any additional packages.