### PR TITLE
Restore default export of `PrivateView` component

### DIFF
--- a/app/src/views/private/index.ts
+++ b/app/src/views/private/index.ts
@@ -2,3 +2,4 @@ import PrivateViewHeaderBarActionButton from './private-view/components/private-
 import PrivateView from './private-view/components/private-view.vue';
 
 export { PrivateView, PrivateViewHeaderBarActionButton };
+export default PrivateView;


### PR DESCRIPTION
## Scope

A change in https://github.com/directus/directus/pull/26390 removed the default, barrel export for the `PrivateView` component, which causes issues when it's being used in the [`registerViews`](https://github.com/directus/directus/blob/dbf35a1736f8068a9bbc768cb5645d96c0777285/app/src/views/register.ts) function. See https://github.com/directus/directus/pull/26390#discussion_r2653832068

This surfaces, for example, when installing the global search / command palette module. Navigating to the module does not show anything but a blank page.

What's changed:

- Re-add default export to `app/src/views/private/index.ts`

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- Global Search / Command Palette module shows private view again

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

No issue to fix since nothing was released just yet.
