### PR TITLE
Resolve conflict with VSCode organize imports functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
 	"scssFormatter.singleQuote": true,
-	"stylelint.validate": ["css", "scss", "vue"]
+	"stylelint.validate": ["css", "scss", "vue"],
+	"editor.codeActionsOnSave": {
+		"source.organizeImports": "never",
+		"source.fixAll.eslint": "explicit"
+	}
 }


### PR DESCRIPTION
## Scope

What's changed:

- Use ESLint as the single source of truth for import sorting within the codebase. 
- By configuring VS Code to use ESLint over its built-in organizeImports to eliminate the persistent conflicts between differing sort logic.

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- Messed imports up, saved, and they are re-organized

## Review Notes / Questions

- 

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required