### PR TITLE
Update pnpm version

### DIFF
--- a/.changeset/thirty-comics-try.md
+++ b/.changeset/thirty-comics-try.md
@@ -1,0 +1,5 @@
+---
+'directus': patch
+---
+
+Updated pnpm version to 10.27

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 			"glob@11.0.3": "11.1.0"
 		}
 	},
-	"packageManager": "pnpm@10.14.0",
+	"packageManager": "pnpm@10.26.0",
 	"engines": {
 		"node": "22",
 		"pnpm": ">=10 <11"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 			"glob@11.0.3": "11.1.0"
 		}
 	},
-	"packageManager": "pnpm@10.26.0",
+	"packageManager": "pnpm@10.27.0",
 	"engines": {
 		"node": "22",
 		"pnpm": ">=10 <11"


### PR DESCRIPTION
## Scope

What's changed:

Update pnpm version to address:
- https://github.com/advisories/GHSA-379q-355j-w6rj
- https://github.com/advisories/GHSA-7vhp-vf5g-r2fw
- https://github.com/advisories/GHSA-2phv-j68v-wwqx

## Potential Risks / Drawbacks

- A minor version update should be relatively safe

## Tested Scenarios

- Built and ran the repo locally

## Review Notes / Questions

- I would like to lorem ipsum

Fixes #26465
Fixes dependabot#393
Fixes dependabot#394
Fixes dependabot#395
