### PR TITLE
Add revisions activity index

### DIFF
--- a/.changeset/bumpy-books-hug.md
+++ b/.changeset/bumpy-books-hug.md
@@ -1,0 +1,6 @@
+---
+'@directus/system-data': patch
+'@directus/api': patch
+---
+
+Added system index for revisions.activity

--- a/api/src/database/migrations/20260113A-add-revisions-index.ts
+++ b/api/src/database/migrations/20260113A-add-revisions-index.ts
@@ -1,0 +1,49 @@
+import type { Knex } from 'knex';
+import { FieldsService } from '../../services/fields.js';
+import { getSchema } from '../../utils/get-schema.js';
+import { transaction } from '../../utils/transaction.js';
+import { getHelpers } from '../helpers/index.js';
+import { getDatabaseClient } from '../index.js';
+
+const RETENTION_INDEXES = [
+	// MySQL and MariaDB are ignored because they already have an index on revisions.activity
+	{ collection: 'directus_revisions', field: 'activity', ignore: ['mysql', 'mariadb'] },
+];
+
+export async function up(knex: Knex): Promise<void> {
+	const client = getDatabaseClient(knex);
+	const helpers = getHelpers(knex);
+	const schema = await getSchema();
+	const service = new FieldsService({ knex, schema });
+
+	for (const { collection, field, ignore } of RETENTION_INDEXES) {
+		if (ignore.includes(client)) continue;
+
+		const existingColumn = await service.columnInfo(collection, field);
+
+		if (!existingColumn.is_indexed) {
+			await helpers.schema.createIndex(collection, field, { attemptConcurrentIndex: true });
+		}
+	}
+}
+
+export async function down(knex: Knex): Promise<void> {
+	const client = getDatabaseClient(knex);
+	const helpers = getHelpers(knex);
+	const schema = await getSchema();
+	const service = new FieldsService({ knex, schema });
+
+	for (const { collection, field, ignore } of RETENTION_INDEXES) {
+		if (ignore.includes(client)) continue;
+
+		const existingColumn = await service.columnInfo(collection, field);
+
+		if (existingColumn.is_indexed) {
+			await transaction(knex, async (trx) => {
+				await trx.schema.alterTable(collection, async (table) => {
+					table.dropIndex([field], helpers.schema.generateIndexName('index', collection, field));
+				});
+			});
+		}
+	}
+}

--- a/packages/system-data/src/fields/revisions.yaml
+++ b/packages/system-data/src/fields/revisions.yaml
@@ -31,3 +31,4 @@ fields:
 
 indexed:
   - field: parent
+  - field: activity


### PR DESCRIPTION
## Scope

What's changed:

- Added migration to add an index on revisions.activity (ignoring mysql and mariadb that already have it)
- Added the system index to the system-data definition for snapshots

## Potential Risks / Drawbacks

- Snapshots will have to be recreated or they might remove this index accidentally

## Tested Scenarios

- Ran migration against postgres
- Get, diff and applied a snapshot

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests

Fixes #CMS-1659
