### PR TITLE
Fix ARM64 Docker build using native runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if packages exist on NPM
         uses: directus/npm-package-existence-checker@v1
@@ -97,8 +97,16 @@ jobs:
 
   build-images:
     name: Build Images
-    runs-on: ubuntu-latest
     needs: check-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       actions: write
       attestations: write
@@ -115,15 +123,13 @@ jobs:
       security-events: write
       statuses: write
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_SLUG=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
-        if: env.DOCKERHUB_IMAGE
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -132,9 +138,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.PLATFORM_SLUG }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-${{ env.PLATFORM_SLUG }}-buildx-
 
       - name: Extract metadata for Docker image
         id: meta
@@ -147,11 +153,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ needs.check-version.outputs.prerelease == 'false' }}
             type=raw,value=canary,enable=${{ needs.check-version.outputs.prerelease }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: env.DOCKERHUB_IMAGE
+        if: env.DOCKERHUB_IMAGE != ''
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -159,35 +166,154 @@ jobs:
 
       - name: Login to GHCR
         uses: docker/login-action@v3
-        if: env.GHCR_IMAGE
+        if: env.GHCR_IMAGE != ''
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
         uses: docker/build-push-action@v6
-        id: build-and-push
+        id: build
         with:
           context: .
           file: ./Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          push: true
+          provenance: true
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          # prettier-ignore
+          outputs: type=image,"name=${{ env.DOCKERHUB_IMAGE }},${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
 
-      - name: Sign Docker Hub image with GitHub OIDC Token
-        if: env.DOCKERHUB_IMAGE
-        env:
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        run: cosign sign --yes --recursive ${DOCKERHUB_IMAGE}@${DIGEST}
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
-      # Temp fix:
+      - name: Upload digest
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ env.PLATFORM_SLUG }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # Temp fix for cache growth:
       # https://github.com/docker/build-push-action/issues/252
       # https://github.com/moby/buildkit/issues/1896
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  publish-docker-images:
+    name: Publish Docker Images
+    runs-on: ubuntu-latest
+    needs:
+      - check-version
+      - build-images
+    permissions:
+      actions: write
+      attestations: write
+      checks: write
+      contents: write
+      deployments: write
+      discussions: write
+      id-token: write
+      issues: write
+      models: read
+      packages: write
+      pages: write
+      pull-requests: write
+      security-events: write
+      statuses: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        if: env.DOCKERHUB_IMAGE != ''
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ needs.check-version.outputs.prerelease == 'false' }}
+            type=raw,value=canary,enable=${{ needs.check-version.outputs.prerelease }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: env.DOCKERHUB_IMAGE != ''
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        if: env.GHCR_IMAGE != ''
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push to Docker Hub
+        id: push-dockerhub
+        if: env.DOCKERHUB_IMAGE != ''
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("docker.io"))) | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
+            $(printf '${{ env.DOCKERHUB_IMAGE }}@sha256:%s ' *)
+
+      - name: Create manifest list and push to GHCR
+        if: env.GHCR_IMAGE != ''
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io"))) | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Get Docker Hub manifest digest
+        id: get-digest
+        if: env.DOCKERHUB_IMAGE != ''
+        run: |
+          set -euo pipefail
+          DIGEST=$(docker buildx imagetools inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }} --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [ -z "$DIGEST" ]; then
+            echo "::error::Failed to get manifest digest for ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }}"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Sign Docker Hub image with GitHub OIDC Token
+        if: env.DOCKERHUB_IMAGE != ''
+        run: |
+          cosign sign --yes --recursive ${{ env.DOCKERHUB_IMAGE }}@${{ steps.get-digest.outputs.digest }}
+
+      - name: Inspect Docker Hub image
+        if: env.DOCKERHUB_IMAGE != ''
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }}
+
+      - name: Inspect GHCR image
+        if: env.GHCR_IMAGE != ''
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Scope

What's changed:

- Switched Docker ARM64 builds from QEMU emulation to native GitHub ARM64 runners (`ubuntu-24.04-arm`)
- Restructured `build-images` job to use a matrix strategy with per-platform builds
- Added new `publish-docker-images` job to merge platform digests into multi-arch manifest
- Added explicit `latest` tag for stable releases

## Potential Risks / Drawbacks

- Requires GitHub-hosted ARM64 runners (available on public repos and GitHub Teams/Enterprise)
- Slightly more complex workflow structure (two jobs instead of one)

## Tested Scenarios

- Built and published test image at `docker.io/licitdev/directus:0.0.0` using the new workflow
  - Test PR: https://github.com/licitdev/directus/pull/77
  - Workflow run: https://github.com/licitdev/directus/actions/runs/21028009708
  - Docker images: https://hub.docker.com/r/licitdev/directus/tags
- Verified structural parity and Cosign signatures with `directus/directus:11.14.0`:

```
=== STRUCTURE COMPARISON ===
✅ IDENTICAL STRUCTURE
{
  "schema": 2,
  "media": "application/vnd.oci.image.index.v1+json",
  "platforms": ["linux/amd64", "linux/arm64"],
  "manifest_sizes": [1817, 1817],
  "has_annotations": false,
  "attestation_types": ["attestation-manifest", "attestation-manifest"]
}

=== COSIGN SIGNATURE VERIFICATION ===
✅ Image 1: Signature verified (via docker.io/directus/directus-signatures)
✅ Image 2: Signature verified (via docker.io/licitdev/directus-signatures)
```

<details>
<summary>Comparison script used</summary>

```bash
#!/bin/bash
# Compare Docker image structure and verify signatures between two multi-arch images
# Usage: ./compare-images.sh [image1] [image2]

set -euo pipefail

IMAGE1="${1:-docker.io/directus/directus:11.14.0}"
IMAGE2="${2:-docker.io/licitdev/directus:0.0.0}"

echo "Comparing: $IMAGE1 vs $IMAGE2"
echo ""

# Get normalized structure for comparison
get_structure() {
  docker buildx imagetools inspect "$1" --raw 2>/dev/null | jq -c '{
    schema: .schemaVersion,
    media: .mediaType,
    platforms: [.manifests[] | select(.platform.os != "unknown") | "\(.platform.os)/\(.platform.architecture)"] | sort,
    manifest_sizes: [.manifests[] | select(.platform.os != "unknown") | .size] | sort,
    has_annotations: [.manifests[] | select(.platform.os != "unknown") | .annotations != null] | any,
    attestation_types: [.manifests[] | select(.annotations["vnd.docker.reference.type"]) | .annotations["vnd.docker.reference.type"]] | sort
  }'
}

echo "=== STRUCTURE COMPARISON ==="
STRUCT1=$(get_structure "$IMAGE1")
STRUCT2=$(get_structure "$IMAGE2")

if [ "$STRUCT1" == "$STRUCT2" ]; then
  echo "✅ IDENTICAL STRUCTURE"
  echo "$STRUCT1" | jq '.'
else
  echo "❌ STRUCTURE DIFFERS"
  echo "Image 1:" && echo "$STRUCT1" | jq '.'
  echo "Image 2:" && echo "$STRUCT2" | jq '.'
fi

echo ""
echo "=== COSIGN SIGNATURE VERIFICATION ==="

verify_signature() {
  local image=$1
  local name=$2
  # Derive signature repository from image name (e.g., directus/directus -> directus/directus-signatures)
  local sig_repo=$(echo "$image" | sed 's/:.*$//' | sed 's/$/-signatures/')
  
  if docker run --rm -e COSIGN_REPOSITORY="$sig_repo" gcr.io/projectsigstore/cosign:v2.2.0 verify \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    --certificate-identity-regexp ".*" \
    "$image" >/dev/null 2>&1; then
    echo "✅ $name: Signature verified (via $sig_repo)"
  else
    echo "❌ $name: No valid signature found"
  fi
}

verify_signature "$IMAGE1" "Image 1"
verify_signature "$IMAGE2" "Image 2"

echo ""
echo "=== COMPARISON COMPLETE ==="
```

</details>

## Review Notes / Questions

- The workflow follows [Docker docs for distributing build across multiple runners](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)
- Special attention should be paid to the `imagetools create` commands which merge platform-specific digests

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26492
Fixes CMS-1669