### PR TITLE
Fix: Hide AI settings page when MCP and AI features are disabled through ENV

### DIFF
--- a/.changeset/large-deer-enjoy.md
+++ b/.changeset/large-deer-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Hide AI settings page when MCP and AI features are disabled through ENV

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -72,11 +72,13 @@ const links = computed<Link[][]>(() => [
 			name: t('settings_translations'),
 			to: `/settings/translations`,
 		},
-		{
-			icon: 'smart_toy',
-			name: t('settings_ai'),
-			to: `/settings/ai`,
-		},
+		info.value.ai_enabled || info.value.mcp_enabled
+			? {
+					icon: 'smart_toy',
+					name: t('settings_ai'),
+					to: `/settings/ai`,
+				}
+			: undefined,
 	].filter((link) => link) as Link[],
 	[
 		{


### PR DESCRIPTION
 Pretty straightforward -- we just hide the AI settings page from the Settings > Navigation when both AI and MCP are disabled through the ENV vars

AI_ENABLED=false
MCP_ENABLED=false

---

<img width="626" height="1220" alt="ScreenShot 2026-01-20 at 10 15 05@2x" src="https://github.com/user-attachments/assets/7d091709-0d28-4967-89b0-991fad798212" />
