### PR TITLE
Fix Vue warning by passing required prop to interfaces

### DIFF
--- a/.changeset/soft-donkeys-act.md
+++ b/.changeset/soft-donkeys-act.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed Vue warning by passing required prop to interfaces

--- a/app/src/components/v-form/components/form-field-interface.vue
+++ b/app/src/components/v-form/components/form-field-interface.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ContentVersion } from '@directus/types';
 import { computed } from 'vue';
 import type { ComparisonContext, FormField } from '../types';
 import VErrorBoundary from '@/components/v-error-boundary.vue';
@@ -23,6 +24,7 @@ const props = defineProps<{
 	rawEditorEnabled?: boolean;
 	rawEditorActive?: boolean;
 	direction?: string;
+	version?: ContentVersion | null;
 }>();
 
 defineEmits(['update:modelValue', 'setFieldValue']);
@@ -77,6 +79,7 @@ const value = computed(() =>
 				:length="field.schema && field.schema.max_length"
 				:direction="direction"
 				:raw-editor-enabled="rawEditorEnabled"
+				:version
 				@input="$emit('update:modelValue', $event)"
 				@set-field-value="$emit('setFieldValue', $event)"
 			/>

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ValidationError } from '@directus/types';
+import { ContentVersion } from '@directus/types';
 import { parseJSON } from '@directus/utils';
 import { isEqual } from 'lodash';
 import { computed, ref, watch } from 'vue';
@@ -35,6 +36,7 @@ const props = withDefaults(
 		disabledMenuOptions?: MenuOptions[];
 		disabledMenu?: boolean;
 		direction?: string;
+		version?: ContentVersion | null;
 	}>(),
 	{
 		modelValue: undefined,
@@ -231,6 +233,7 @@ function useComputedValues() {
 			:direction="direction"
 			:comparison="comparison"
 			:comparison-active="comparisonActive"
+			:version
 			@update:model-value="emitValue($event)"
 			@set-field-value="$emit('setFieldValue', $event)"
 		/>

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -473,6 +473,7 @@ function getComparisonIndicatorClasses(field: TFormField, isGroup = false) {
 					:disabled-menu-options="disabledMenuOptions"
 					:disabled-menu="disabledMenu"
 					:direction="direction"
+					:version
 					@update:model-value="setValue(fieldName, $event)"
 					@set-field-value="setValue($event.field, $event.value, { force: true })"
 					@unset="unsetValue(fieldsMap[fieldName]!)"


### PR DESCRIPTION
## Scope

What's changed:

- Prop-drilled the required version prop to all affected interfaces

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Added Files, M2A, M2M, O2M, O2M Tree, and Translations interfaces to a collection
- Verified that the Studio loads without Vue warnings in the browser console

## Review Notes / Questions

- Test the original cases described in this PR https://github.com/directus/directus/pull/25384

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26505