### PR TITLE
Updated pnpm audit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
 			"@yarnpkg/shell>cross-spawn": "7.0.6",
 			"jws": "4.0.1",
 			"glob@10.4.5": "10.5.0",
-			"glob@11.0.3": "11.1.0"
+			"glob@11.0.3": "11.1.0",
+			"pnpm": "10.27.0",
+			"pm2-sysmonit>systeminformation": "5.27.14",
+			"tar": "7.5.4",
+			"qs": "6.14.1"
 		}
 	},
 	"packageManager": "pnpm@10.27.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 	"pnpm": {
 		"overrides": {
 			"@yarnpkg/shell>cross-spawn": "7.0.6",
-			"pnpm": "10.27.0",
 			"pm2-sysmonit>systeminformation": "5.27.14",
 			"tar": "7.5.4",
 			"qs": "6.14.1"

--- a/package.json
+++ b/package.json
@@ -34,11 +34,7 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"tar-fs": "2.1.4",
 			"@yarnpkg/shell>cross-spawn": "7.0.6",
-			"jws": "4.0.1",
-			"glob@10.4.5": "10.5.0",
-			"glob@11.0.3": "11.1.0",
 			"pnpm": "10.27.0",
 			"pm2-sysmonit>systeminformation": "5.27.14",
 			"tar": "7.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: 3.0.0
       version: 3.0.0
     '@directus/vue-split-panel':
-      specifier: 0.8.2
-      version: 0.8.2
+      specifier: 0.8.4
+      version: 0.8.4
     '@editorjs/attaches':
       specifier: 1.3.2
       version: 1.3.2
@@ -924,7 +924,6 @@ catalogs:
 
 overrides:
   '@yarnpkg/shell>cross-spawn': 7.0.6
-  pnpm: 10.27.0
   pm2-sysmonit>systeminformation: 5.27.14
   tar: 7.5.4
   qs: 6.14.1
@@ -1573,7 +1572,7 @@ importers:
         version: link:../packages/validation
       '@directus/vue-split-panel':
         specifier: 'catalog:'
-        version: 0.8.2(vue@3.5.24(typescript@5.9.3))
+        version: 0.8.4(vue@3.5.24(typescript@5.9.3))
       '@editorjs/attaches':
         specifier: 'catalog:'
         version: 1.3.2
@@ -3841,8 +3840,8 @@ packages:
     resolution: {integrity: sha512-b0BWboH2W++Zx/I/PsMWBeDmMgXZIEOVP2JUh6gWXh3L/TaLuFF/1LG8gv7ise4WDMnW69Vum5kSroNTQyqlUQ==}
     engines: {pnpm: '9'}
 
-  '@directus/vue-split-panel@0.8.2':
-    resolution: {integrity: sha512-h+odlp1g2J7SE+ZQITeiIkvYvkd2HIZzDI+dLa9YVhvz/yuikOXibUCu2SG1CmuX1/8EyQmC5ugO2k15PsaOEg==}
+  '@directus/vue-split-panel@0.8.4':
+    resolution: {integrity: sha512-epfvBWFoX/jxAnUQWsKUXEDLUqvuaF6z8bCMjdQjf5fCKptr5gJRtu5ntVFLlLropBQsJcGuvN7L6i9I7Cvtcw==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -11835,11 +11834,6 @@ packages:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
 
-  pnpm@10.27.0:
-    resolution: {integrity: sha512-ctaZ2haxF5wUup5k3HHJpAmIy9xlwmTLDkidt96RfyDc9NZNhyNiXylpulLUt+KhFwaC2awqXcrqq3MrfhbwSg==}
-    engines: {node: '>=18.12'}
-    hasBin: true
-
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -15770,10 +15764,9 @@ snapshots:
 
   '@directus/tsconfig@3.0.0': {}
 
-  '@directus/vue-split-panel@0.8.2(vue@3.5.24(typescript@5.9.3))':
+  '@directus/vue-split-panel@0.8.4(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.24(typescript@5.9.3))
-      pnpm: 10.27.0
       test: 3.3.0
       vue: 3.5.24(typescript@5.9.3)
 
@@ -24902,8 +24895,6 @@ snapshots:
       - utf-8-validate
 
   pngjs@5.0.0: {}
-
-  pnpm@10.27.0: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -923,11 +923,7 @@ catalogs:
       version: 4.0.2
 
 overrides:
-  tar-fs: 2.1.4
   '@yarnpkg/shell>cross-spawn': 7.0.6
-  jws: 4.0.1
-  glob@10.4.5: 10.5.0
-  glob@11.0.3: 11.1.0
   pnpm: 10.27.0
   pm2-sysmonit>systeminformation: 5.27.14
   tar: 7.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ catalogs:
       specifier: 5.1.2
       version: 5.1.2
     '@modelcontextprotocol/sdk':
-      specifier: 1.24.0
-      version: 1.24.0
+      specifier: 1.25.2
+      version: 1.25.2
     '@ngneat/falso':
       specifier: 8.0.2
       version: 8.0.2
@@ -745,8 +745,8 @@ catalogs:
       specifier: 13.1.2
       version: 13.1.2
     pm2:
-      specifier: 6.0.13
-      version: 6.0.13
+      specifier: 6.0.14
+      version: 6.0.14
     postcss-html:
       specifier: 1.8.0
       version: 1.8.0
@@ -762,9 +762,6 @@ catalogs:
     qrcode:
       specifier: 1.5.4
       version: 1.5.4
-    qs:
-      specifier: 6.14.0
-      version: 6.14.0
     rate-limiter-flexible:
       specifier: 7.2.0
       version: 7.2.0
@@ -843,9 +840,6 @@ catalogs:
     swagger-ui-watcher:
       specifier: 2.1.14
       version: 2.1.14
-    tar:
-      specifier: 7.5.2
-      version: 7.5.2
     tedious:
       specifier: 18.6.1
       version: 18.6.1
@@ -934,6 +928,10 @@ overrides:
   jws: 4.0.1
   glob@10.4.5: 10.5.0
   glob@11.0.3: 11.1.0
+  pnpm: 10.27.0
+  pm2-sysmonit>systeminformation: 5.27.14
+  tar: 7.5.4
+  qs: 6.14.1
 
 importers:
 
@@ -1091,7 +1089,7 @@ importers:
         version: 4.12.1
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.24.0(zod@4.1.12)
+        version: 1.25.2(hono@4.11.4)(zod@4.1.12)
       '@rollup/plugin-alias':
         specifier: 'catalog:'
         version: 5.1.1(rollup@4.52.5)
@@ -1319,7 +1317,7 @@ importers:
         version: 13.1.2
       pm2:
         specifier: 'catalog:'
-        version: 6.0.13
+        version: 6.0.14
       prom-client:
         specifier: 'catalog:'
         version: 15.1.3
@@ -1327,8 +1325,8 @@ importers:
         specifier: 'catalog:'
         version: 2.0.7
       qs:
-        specifier: 'catalog:'
-        version: 6.14.0
+        specifier: 6.14.1
+        version: 6.14.1
       rate-limiter-flexible:
         specifier: 'catalog:'
         version: 7.2.0
@@ -1357,8 +1355,8 @@ importers:
         specifier: 'catalog:'
         version: 1.9.1
       tar:
-        specifier: 'catalog:'
-        version: 7.5.2
+        specifier: 7.5.4
+        version: 7.5.4
       tsx:
         specifier: 'catalog:'
         version: 4.20.6
@@ -4545,6 +4543,12 @@ packages:
   '@histoire/vendors@0.17.17':
     resolution: {integrity: sha512-QZvmffdoJlLuYftPIkOU5Q2FPAdG2JjMuQ5jF7NmEl0n1XnmbMqtRkdYTZ4eF6CO1KLZ0Zyf6gBQvoT1uWNcjA==}
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -5029,8 +5033,8 @@ packages:
   '@minimistjs/subarg@1.0.0':
     resolution: {integrity: sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==}
 
-  '@modelcontextprotocol/sdk@1.24.0':
-    resolution: {integrity: sha512-D8h5KXY2vHFW8zTuxn2vuZGN0HGrQ5No6LkHwlEA9trVgNdPL3TF1dSqKA7Dny6BbBYKSW/rOBDXdC8KJAjUCg==}
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -9211,6 +9215,10 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
@@ -9824,6 +9832,10 @@ packages:
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
+  hono@4.11.4:
+    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -10355,10 +10367,6 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -10399,6 +10407,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -11015,10 +11026,6 @@ packages:
 
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
   minipass@7.1.2:
@@ -11823,8 +11830,8 @@ packages:
   pm2-sysmonit@1.2.8:
     resolution: {integrity: sha512-ACOhlONEXdCTVwKieBIQLSi2tQZ8eKinhcr9JpZSUAL8Qy0ajIgRtsLxG/lwPOW3JEKqPyw/UaHmTWhUzpP4kA==}
 
-  pm2@6.0.13:
-    resolution: {integrity: sha512-1hS/adMgKoDpX4S1ichJW8SiGpex+oBSZK31dP1FSYOOGtaeuemXzhXPOCefmddgIY4K6v7uu+7xNPnmEnK3ag==}
+  pm2@6.0.14:
+    resolution: {integrity: sha512-wX1FiFkzuT2H/UUEA8QNXDAA9MMHDsK/3UHj6Dkd5U7kxyigKDA5gyDw78ycTQZAuGCLWyUX5FiXEuVQWafukA==}
     engines: {node: '>=16.0.0'}
     hasBin: true
 
@@ -11832,8 +11839,8 @@ packages:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
 
-  pnpm@10.18.3:
-    resolution: {integrity: sha512-u9FubXKG/X4B9rPAs8kyzaKWXAapCDKPdGY/EKmupR8RKe6mFRNL+ZKDGwCeq+Fn7LcAi1l/QP+bx1lGqt+wjQ==}
+  pnpm@10.27.0:
+    resolution: {integrity: sha512-ctaZ2haxF5wUup5k3HHJpAmIy9xlwmTLDkidt96RfyDc9NZNhyNiXylpulLUt+KhFwaC2awqXcrqq3MrfhbwSg==}
     engines: {node: '>=18.12'}
     hasBin: true
 
@@ -12227,12 +12234,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -13406,8 +13409,8 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  systeminformation@5.27.11:
-    resolution: {integrity: sha512-K3Lto/2m3K2twmKHdgx5B+0in9qhXK4YnoT9rIlgwN/4v7OV5c8IjbeAUkuky/6VzCQC7iKCAqi8rZathCdjHg==}
+  systeminformation@5.27.14:
+    resolution: {integrity: sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -13432,12 +13435,8 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-
-  tar@7.5.2:
-    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
+  tar@7.5.4:
+    resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
 
   tarn@3.0.2:
@@ -15778,7 +15777,7 @@ snapshots:
   '@directus/vue-split-panel@0.8.2(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.24(typescript@5.9.3))
-      pnpm: 10.18.3
+      pnpm: 10.27.0
       test: 3.3.0
       vue: 3.5.24(typescript@5.9.3)
 
@@ -16324,6 +16323,10 @@ snapshots:
       vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@histoire/vendors@0.17.17': {}
+
+  '@hono/node-server@1.19.9(hono@4.11.4)':
+    dependencies:
+      hono: 4.11.4
 
   '@humanfs/core@0.19.1': {}
 
@@ -16939,8 +16942,9 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  '@modelcontextprotocol/sdk@1.24.0(zod@4.1.12)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.4)(zod@4.1.12)':
     dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.4)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -16951,11 +16955,13 @@ snapshots:
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
       jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
       zod: 4.1.12
       zod-to-json-schema: 3.25.0(zod@4.1.12)
     transitivePeerDependencies:
+      - hono
       - supports-color
 
   '@napi-rs/snappy-android-arm-eabi@7.3.3':
@@ -20414,7 +20420,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.13.0
+      qs: 6.14.1
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -20429,7 +20435,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 3.0.1
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -20533,7 +20539,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.4
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -20551,7 +20557,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.3
       ssri: 12.0.0
-      tar: 7.5.2
+      tar: 7.5.4
       unique-filename: 4.0.0
 
   cache-parser@1.2.5: {}
@@ -21886,13 +21892,49 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
       serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
@@ -21920,7 +21962,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -22152,7 +22194,7 @@ snapshots:
       '@paralleldrive/cuid2': 2.2.2
       dezalgo: 1.0.4
       once: 1.4.0
-      qs: 6.14.0
+      qs: 6.14.1
 
   formidable@3.5.4:
     dependencies:
@@ -22631,6 +22673,8 @@ snapshots:
       - supports-color
       - terser
       - utf-8-validate
+
+  hono@4.11.4: {}
 
   hookable@5.5.3: {}
 
@@ -23145,10 +23189,6 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -23216,6 +23256,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -23891,9 +23933,6 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  minipass@5.0.0:
-    optional: true
-
   minipass@7.1.2: {}
 
   minizlib@2.1.2:
@@ -24042,7 +24081,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.3
-      tar: 7.5.2
+      tar: 7.5.4
       tinyglobby: 0.2.15
       which: 5.0.0
     transitivePeerDependencies:
@@ -24058,7 +24097,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.3
-      tar: 6.2.1
+      tar: 7.5.4
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -24822,13 +24861,13 @@ snapshots:
       async: 3.2.6
       debug: 4.4.3(supports-color@5.5.0)
       pidusage: 2.0.21
-      systeminformation: 5.27.11
+      systeminformation: 5.27.14
       tx2: 1.0.5
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  pm2@6.0.13:
+  pm2@6.0.14:
     dependencies:
       '@pm2/agent': 2.1.1
       '@pm2/blessed': 0.1.81
@@ -24846,7 +24885,7 @@ snapshots:
       enquirer: 2.3.6
       eventemitter2: 5.0.1
       fclone: 1.0.11
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       mkdirp: 1.0.4
       needle: 2.4.0
       pidusage: 3.0.2
@@ -24868,7 +24907,7 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  pnpm@10.18.3: {}
+  pnpm@10.27.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -25237,11 +25276,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.13.0:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -26273,7 +26308,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.4
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -26616,7 +26651,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
+      qs: 6.14.1
     transitivePeerDependencies:
       - supports-color
 
@@ -26630,7 +26665,7 @@ snapshots:
       formidable: 2.1.5
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
+      qs: 6.14.1
       readable-stream: 3.6.2
       semver: 7.7.3
     transitivePeerDependencies:
@@ -26694,7 +26729,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       commander: 5.1.0
-      express: 4.21.2
+      express: 4.22.1
       js-yaml: 3.14.1
       json-refs: 3.0.15
       open: 7.4.2
@@ -26727,7 +26762,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  systeminformation@5.27.11:
+  systeminformation@5.27.14:
     optional: true
 
   tabbable@4.0.0: {}
@@ -26766,17 +26801,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    optional: true
-
-  tar@7.5.2:
+  tar@7.5.4:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   '@directus/schema-builder': workspace:*
   '@directus/tsconfig': 3.0.0
   '@directus/types': workspace:*
-  '@directus/vue-split-panel': 0.8.2
+  '@directus/vue-split-panel': 0.8.4
   '@editorjs/attaches': 1.3.2
   '@editorjs/checklist': 1.6.0
   '@editorjs/code': 2.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,7 +56,7 @@ catalog:
   '@mapbox/mapbox-gl-draw': 1.5.1
   '@mapbox/mapbox-gl-draw-static-mode': 1.0.1
   '@mapbox/mapbox-gl-geocoder': 5.1.2
-  '@modelcontextprotocol/sdk': 1.24.0
+  '@modelcontextprotocol/sdk': 1.25.2
   '@ngneat/falso': 8.0.2
   '@npm/types': 2.1.0
   '@pinia/testing': 1.0.3
@@ -258,13 +258,13 @@ catalog:
   pino-http: 10.5.0
   pino-http-print: 3.1.0
   pino-pretty: 13.1.2
-  pm2: 6.0.13
+  pm2: 6.0.14
   postcss-html: 1.8.0
   prettier: 3.6.2
   prom-client: 15.1.3
   proxy-addr: 2.0.7
   qrcode: 1.5.4
-  qs: 6.14.0
+  qs: 6.14.1
   rate-limiter-flexible: 7.2.0
   reka-ui: 2.6.0
   rimraf: 6.1.0
@@ -291,7 +291,7 @@ catalog:
   stylelint-use-logical: 2.1.2
   swagger-cli: 4.0.4
   swagger-ui-watcher: 2.1.14
-  tar: 7.5.2
+  tar: 7.5.4
   tedious: 18.6.1
   tinymce: 6.8.6
   tmp: 0.2.5


### PR DESCRIPTION
## Scope

What's changed:

Removed obsolete overrides for `tar-fs`, `jws` and `glob`.

### HIGH SEVERITY

[CVE-2026-23950]
```
tar 7.5.2 -> 7.5.4
overridde any tar to 7.5.4

api>sqlite3>tar   (not updated in 2 years)
packages__release-notes-generator>@pnpm/workspace.find-packages>@pnpm/cli-utils>@pnpm/store-connection-manager>@pnpm/client>@pnpm/git-fetcher>@pnpm/prepare-package>@pnpm/lifecycle>@pnpm/npm-lifecycle>node-gyp>tar 
```
https://github.com/advisories/GHSA-r6q2-hw4h-h46w
https://github.com/advisories/GHSA-8qq5-rm4j-mr97

[CVE-2026-0621] 
```
@modelcontextprotocol/sdk 1.24.0 -> 1.25.2
```
https://github.com/advisories/GHSA-8r9q-7v3j-jr4g

[CVE-2025-15284] 
```
api>qs 6.14.0 -> 6.14.1

api>express>qs 
api>express>body-parser>qs
```
https://github.com/advisories/GHSA-6rw7-vpxm-498p

[CVE-2025-68154]
```
systeminformation 5.27.11 -> 5.27.14
```
https://github.com/advisories/GHSA-wphj-fx3q-84ch

### MODERATE SEVERITY

[CVE-2025-64718]
```
pm2 6.0.13 -> 6.0.14
```
https://github.com/advisories/GHSA-mh29-5h37-fv8m

## Potential Risks / Drawbacks

- Theres always some with dependencies

## Tested Scenarios

- used `pnpm audit` and dependabot for high severity issues

## Review Notes / Questions

- ~We can remove the `pnpm` override when its removed from the @directus/vue-split-panel package and published~ has been updated

## Checklist

- [x] Check if existing overrides are still needed
- [x] https://github.com/directus/vue-split-panel/issues/64
- [x] Test other scanners for high severity reports

