### PR TITLE
Fix race condition and allow accessing the connected state

### DIFF
--- a/.changeset/blue-houses-retire.md
+++ b/.changeset/blue-houses-retire.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed race condition in sdk and allow accessing the connected state

--- a/.changeset/blue-houses-retire.md
+++ b/.changeset/blue-houses-retire.md
@@ -1,5 +1,5 @@
 ---
-'@directus/sdk': patch
+'@directus/sdk': major
 ---
 
 Fixed race condition in sdk and allow accessing the connected state

--- a/.changeset/blue-houses-retire.md
+++ b/.changeset/blue-houses-retire.md
@@ -1,5 +1,5 @@
 ---
-'@directus/sdk': major
+'@directus/sdk': minor
 ---
 
-Fixed race condition in sdk and allow accessing the connected state
+Fixed race condition and allow accessing the connected state

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -253,7 +253,14 @@ export function realtime(config: WebSocketConfig = {}) {
 					throw new Error(`Cannot connect when state is "${state.code}"`);
 				}
 
-				const { promise: connectPromise, resolve, reject } = Promise.withResolvers<WebSocketInterface>();
+				// Eventually update to Promise.withResolvers()
+				let resolve!: (value: WebSocketInterface | PromiseLike<WebSocketInterface>) => void;
+				let reject!: (reason?: any) => void;
+
+				const connectPromise = new Promise<WebSocketInterface>((res, rej) => {
+					resolve = res;
+					reject = rej;
+				});
 
 				state = {
 					code: 'connecting',

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -258,12 +258,19 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				// we need to use THIS here instead of client to access overridden functions
 				const self = this as AuthWSClient<Schema>;
-				const url = await getSocketUrl(self);
-				debug('info', `Connecting to ${url}...`);
+
+				let ws: WebSocketInterface;
+				try {
+					const url = await getSocketUrl(self);
+					debug('info', `Connecting to ${url}...`);
+
+					ws = new client.globals.WebSocket(url);
+				} catch (e) {
+					state = { code: 'closed' };
+					throw e;
+				}
 
 				let resolved = false;
-				const ws = new client.globals.WebSocket(url);
-
 				let connectTimeout: ReturnType<typeof setTimeout> | undefined;
 
 				if (config.connect) {

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -227,6 +227,10 @@ export function realtime(config: WebSocketConfig = {}) {
 		};
 
 		return {
+			/**
+			 * Checks if a websocket connection has been established.
+			 * Does not check authentication status.
+			 */
 			async isConnected() {
 				if (state.code === 'connecting') {
 					try {

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -229,7 +229,11 @@ export function realtime(config: WebSocketConfig = {}) {
 		return {
 			async isConnected() {
 				if (state.code === 'connecting') {
-					await state.connection;
+					try {
+						await state.connection;
+					} catch {
+						return false;
+					}
 				}
 
 				return state.code === 'open';

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -258,8 +258,8 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				// we need to use THIS here instead of client to access overridden functions
 				const self = this as AuthWSClient<Schema>;
-
 				let ws: WebSocketInterface;
+				
 				try {
 					const url = await getSocketUrl(self);
 					debug('info', `Connecting to ${url}...`);

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -267,6 +267,7 @@ export function realtime(config: WebSocketConfig = {}) {
 					ws = new client.globals.WebSocket(url);
 				} catch (e) {
 					state = { code: 'closed' };
+					reject(e);
 					throw e;
 				}
 

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -259,7 +259,7 @@ export function realtime(config: WebSocketConfig = {}) {
 				// we need to use THIS here instead of client to access overridden functions
 				const self = this as AuthWSClient<Schema>;
 				let ws: WebSocketInterface;
-				
+
 				try {
 					const url = await getSocketUrl(self);
 					debug('info', `Connecting to ${url}...`);

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -32,6 +32,7 @@ export type RemoveEventHandler = () => void;
 export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;
 
 export interface WebSocketClient<Schema> {
+	isConnected(): Promise<boolean>;
 	connect(): Promise<WebSocketInterface>;
 	disconnect(): void;
 	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,19 +1,10 @@
 {
 	"extends": "@directus/tsconfig/node22",
 	"compilerOptions": {
-		"lib": [
-			"ES2024",
-			"DOM"
-		],
+		"lib": ["ES2024", "DOM"]
 	},
-	"include": [
-		"src",
-		"tests"
-	],
+	"include": ["src", "tests"],
 	"typedocOptions": {
-		"entryPoints": [
-			"./src/client.ts",
-			"./src/*/index.ts"
-		]
+		"entryPoints": ["./src/client.ts", "./src/*/index.ts"]
 	}
 }

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,10 +1,19 @@
 {
 	"extends": "@directus/tsconfig/node22",
 	"compilerOptions": {
-		"lib": ["ES2023", "DOM"]
+		"lib": [
+			"ES2024",
+			"DOM"
+		],
 	},
-	"include": ["src", "tests"],
+	"include": [
+		"src",
+		"tests"
+	],
 	"typedocOptions": {
-		"entryPoints": ["./src/client.ts", "./src/*/index.ts"]
+		"entryPoints": [
+			"./src/client.ts",
+			"./src/*/index.ts"
+		]
 	}
 }

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "@directus/tsconfig/node22",
 	"compilerOptions": {
-		"lib": ["ES2024", "DOM"]
+		"lib": ["ES2023", "DOM"]
 	},
 	"include": ["src", "tests"],
 	"typedocOptions": {


### PR DESCRIPTION
## Scope

What's changed:

- Fixed race condition whereby consecutive calls of connect would make the sdk connect multiple times.
- Added `isConnected()` to the sdk

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- `await Promise.all([sdk.connect(), sdk.connect()])`

## Review Notes / Questions

- None

---

Fixes a bug Collab Editing is currently experiencing.
