### PR TITLE
fix(comment): comment input buggy nature fixed

### DIFF
--- a/.changeset/fix-caret-jumping-v-template-input.md
+++ b/.changeset/fix-caret-jumping-v-template-input.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed an issue where the caret would jump to the end of the input in `v-template-input` when typing or updating content.

--- a/app/src/components/v-template-input.vue
+++ b/app/src/components/v-template-input.vue
@@ -260,16 +260,19 @@ function parseHTML(innerText?: string, isDirectInput = false) {
 		}
 	}
 
+	let targetPosition = caretPos;
+
+	if (isDirectInput || !window.getSelection()?.rangeCount) {
+		targetPosition += input.value.innerText.length - previousInnerTextLength;
+	}
+
 	if (input.value.innerHTML !== newHTML.replaceAll(String.fromCharCode(160), '&nbsp;')) {
 		input.value.innerHTML = newHTML;
 
-		const delta = input.value.innerText.length - previousInnerTextLength;
-		const newPosition = caretPos + delta;
-
-		if (newPosition > input.value.innerText.length || newPosition < 0) {
+		if (targetPosition > input.value.innerText.length || targetPosition < 0) {
 			position(input.value, input.value.innerText.length);
 		} else {
-			position(input.value, newPosition);
+			position(input.value, targetPosition);
 		}
 	}
 
@@ -282,7 +285,7 @@ function parseHTML(innerText?: string, isDirectInput = false) {
 	}
 
 	previousInnerTextLength = input.value.innerText.length;
-	previousCaretPos = caretPos;
+	previousCaretPos = targetPosition;
 }
 </script>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -98,6 +98,7 @@
 - weberet
 - u5r0
 - wasimTQ
+- mustafaazad03
 - omahs
 - codeit-ninja
 - mahendraHegde


### PR DESCRIPTION
## Scope

What's changed:

- Introduced `targetPosition` to manually track and offset the cursor position during `contenteditable` updates.
- Added a check to prevent redundant `innerHTML` assignments, which avoids unnecessary cursor resets and improves performance.
- Implemented range checks to ensure the caret is never positioned outside the valid `innerText` length, preventing potential crashes or invisible cursors.

[Screencast from 24-01-26 07:02:44 PM IST.webm](https://github.com/user-attachments/assets/d450944d-8d47-46ca-b714-2491a98db41e)

## Potential Risks / Drawbacks

- None
- 
## Tested Scenarios

- Verified that typing inside or around existing template tags doesn't cause the cursor to jump to the end.
- Tested that backspacing/deleting across template boundaries maintains the correct cursor focus.
- Confirmed that the "preview" conversion (converting text to `<mark>` tags) feels seamless without cursor flickering.

## Review Notes / Questions

- The logic relies on the existing `caret-pos` library but adds a layer of manual delta calculation (`innerText.length - previousInnerTextLength`) to handle the mismatch between raw text and the HTML-augmented view.
- Special attention was paid to the normalization of non-breaking spaces (`&nbsp;` vs char code 160) to ensure the `innerHTML` comparison is accurate.

## Checklist

- [x] Added or updated tests (N/A for this UI component fix)
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required


---

Fixes #25709
