### PR TITLE
Fix an issue where custom CSS classes applied to PrivateView were not rendered

### DIFF
--- a/.changeset/puny-breads-bet.md
+++ b/.changeset/puny-breads-bet.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed an issue where custom CSS classes applied to PrivateView were not rendered

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -54,7 +54,7 @@ const showLicenseBanner = computed(
 
 <template>
 	<PrivateViewNoAppAccess v-if="appAccess === false" />
-	<PrivateViewRoot v-else v-bind="$props">
+	<PrivateViewRoot v-else v-bind="$props" :class="$attrs.class">
 		<template #navigation><slot name="navigation" /></template>
 		<template #actions:append><slot name="actions:append" /></template>
 		<template #actions:prepend><slot name="actions:prepend" /></template>


### PR DESCRIPTION
Forwards the classes to the root view in order to maintain styling functionality as it was pre v11.14 

Fixes #26522