### PR TITLE
Fix hardcoded "Loading..." text in field tree by using translation key

### DIFF
--- a/.changeset/use-field-tree-i18n.md
+++ b/.changeset/use-field-tree-i18n.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed hardcoded "Loading..." text in field tree by using translation key

--- a/app/src/composables/use-field-tree.test.ts
+++ b/app/src/composables/use-field-tree.test.ts
@@ -324,6 +324,50 @@ test('Returns tree list with group', () => {
 	]);
 });
 
+test('Returns loading placeholder for relational field inside group', () => {
+	const fieldsStore = useFieldsStore();
+
+	fieldsStore.fields = [
+		{
+			collection: 'a',
+			field: 'my_group',
+			type: 'alias',
+			schema: null,
+			meta: { id: 1, collection: 'a', field: 'my_group', special: ['group'], group: null },
+			name: 'My Group',
+		},
+		{
+			collection: 'a',
+			field: 'm2o_field',
+			type: 'integer',
+			schema: {},
+			meta: { id: 2, collection: 'a', field: 'm2o_field', special: ['m2o'], group: 'my_group' },
+			name: 'M2O Field',
+		},
+	] as Field[];
+
+	const relationsStore = useRelationsStore();
+
+	relationsStore.relations = [
+		{
+			collection: 'a',
+			field: 'm2o_field',
+			related_collection: 'b',
+			schema: {},
+			meta: { id: 1, many_collection: 'a', many_field: 'm2o_field', one_collection: 'b', one_field: null },
+		},
+	] as Relation[];
+
+	const { treeList } = useFieldTree(ref('a'));
+
+	const groupNode = unref(treeList).find((node) => node.field === 'my_group');
+	const relationalChild = groupNode?.children?.find((child) => child.field === 'm2o_field');
+
+	expect(relationalChild?.children).toEqual([
+		{ name: 'Loading...', field: '', collection: '', key: '', path: '', type: 'alias', _loading: true },
+	]);
+});
+
 test('Returns tree list for O2M', () => {
 	const fieldsStore = useFieldsStore();
 

--- a/app/src/composables/use-field-tree.test.ts
+++ b/app/src/composables/use-field-tree.test.ts
@@ -10,15 +10,12 @@ import { useRelationsStore } from '@/stores/relations';
 
 vi.stubGlobal('crypto', cryptoStub);
 
-vi.mock('vue-i18n', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('vue-i18n')>();
-	return {
-		...actual,
-		useI18n: () => ({
-			t: (key: string) => (key === 'loading' ? 'Loading...' : key),
-		}),
-	};
-});
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: vi.fn((key: string) => (key === 'loading' ? 'Loading...' : key)),
+	}),
+	createI18n: vi.fn(() => ({})),
+}));
 
 beforeEach(() => {
 	setActivePinia(

--- a/app/src/composables/use-field-tree.test.ts
+++ b/app/src/composables/use-field-tree.test.ts
@@ -10,6 +10,16 @@ import { useRelationsStore } from '@/stores/relations';
 
 vi.stubGlobal('crypto', cryptoStub);
 
+vi.mock('vue-i18n', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-i18n')>();
+	return {
+		...actual,
+		useI18n: () => ({
+			t: (key: string) => (key === 'loading' ? 'Loading...' : key),
+		}),
+	};
+});
+
 beforeEach(() => {
 	setActivePinia(
 		createTestingPinia({

--- a/app/src/composables/use-field-tree.ts
+++ b/app/src/composables/use-field-tree.ts
@@ -2,6 +2,7 @@ import { Field, Relation, Type } from '@directus/types';
 import { getRelationType } from '@directus/utils';
 import { isNil } from 'lodash';
 import { Ref, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 
@@ -31,6 +32,7 @@ export function useFieldTree(
 	includeRelations = true,
 	includeAliasFields = false,
 ): FieldTreeContext {
+	const { t } = useI18n();
 	const fieldsStore = useFieldsStore();
 	const relationsStore = useRelationsStore();
 
@@ -100,7 +102,7 @@ export function useFieldTree(
 				for (const child of children) {
 					if (child.relatedCollection) {
 						child.children = [
-							{ name: 'Loading...', field: '', collection: '', key: '', path: '', type: 'alias', _loading: true },
+							{ name: t('loading'), field: '', collection: '', key: '', path: '', type: 'alias', _loading: true },
 						];
 					}
 				}

--- a/contributors.yml
+++ b/contributors.yml
@@ -244,3 +244,4 @@
 - thanhle98
 - Joey92
 - vdr-smartdev-trinh
+- sinan-yildiz-marsus


### PR DESCRIPTION
## Scope

What's changed:

- Replaced hardcoded "Loading..." text with `t('loading')` translation function in `use-field-tree.ts`
- Added `useI18n` import from `vue-i18n`
- This ensures the loading indicator in field trees is properly localized for all supported languages

## Potential Risks / Drawbacks

- None identified - this is a straightforward i18n fix
- The `loading` translation key already exists in all language files

## Tested Scenarios

- Field tree displays translated "Loading..." text when expanding relational fields
- Composable works correctly with the `useI18n` hook in Vue components

## Review Notes / Questions

- The existing `loading` translation key was used (e.g., `loading: Loading...` in en-US.yaml)
- Follows the same pattern used in other composables like `use-revisions.ts`