### PR TITLE
Add $project_url variable support in preview URL templates

### DIFF
--- a/.changeset/bright-doors-walk.md
+++ b/.changeset/bright-doors-walk.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": minor
+"@directus/system-data": patch
+---
+
+Added `$project_url` variable support in collection preview URL templates, allowing dynamic resolution of the project URL from Settings.

--- a/app/src/composables/use-fake-project-url-field.ts
+++ b/app/src/composables/use-fake-project-url-field.ts
@@ -1,0 +1,46 @@
+import type { Field } from '@directus/types';
+import { computed, type ComputedRef, type Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+export function useFakeProjectUrlField(
+	collection: Ref<string | null>,
+	enabled: Ref<boolean>,
+): { fakeProjectUrlField: ComputedRef<Field | null> } {
+	const { t } = useI18n();
+
+	const fakeProjectUrlField = computed<Field | null>(() => {
+		if (!enabled.value || !collection.value) return null;
+
+		return {
+			collection: collection.value,
+			field: '$project_url',
+			schema: null,
+			name: t('fields.directus_settings.project_url'),
+			type: 'string',
+			meta: {
+				field: '$project_url',
+				collection: collection.value,
+				id: -1,
+				conditions: null,
+				display: null,
+				display_options: null,
+				group: null,
+				hidden: false,
+				interface: 'input',
+				note: null,
+				options: null,
+				readonly: true,
+				required: false,
+				searchable: false,
+				sort: null,
+				special: null,
+				translations: null,
+				validation: null,
+				validation_message: null,
+				width: 'full',
+			},
+		};
+	});
+
+	return { fakeProjectUrlField };
+}

--- a/app/src/interfaces/_system/system-display-template/system-display-template.vue
+++ b/app/src/interfaces/_system/system-display-template/system-display-template.vue
@@ -2,6 +2,7 @@
 import { computed, inject, ref } from 'vue';
 import VFieldTemplate from '@/components/v-field-template/v-field-template.vue';
 import VNotice from '@/components/v-notice.vue';
+import { useFakeProjectUrlField } from '@/composables/use-fake-project-url-field';
 import { useFakeVersionField } from '@/composables/use-fake-version-field';
 import { FieldNode, useFieldTree } from '@/composables/use-field-tree';
 import { useCollectionsStore } from '@/stores/collections';
@@ -15,6 +16,7 @@ const props = withDefaults(
 		collectionName?: string;
 		fields?: FieldNode[];
 		injectVersionField?: boolean;
+		injectProjectUrlField?: boolean;
 		includeRelations?: boolean;
 	}>(),
 	{
@@ -49,8 +51,12 @@ const collection = computed(() => {
 const versioningEnabled = computed(() => Boolean(values.value.versioning && props.injectVersionField));
 const { fakeVersionField } = useFakeVersionField(collection, versioningEnabled);
 
+const projectUrlEnabled = computed(() => Boolean(props.injectProjectUrlField));
+const { fakeProjectUrlField } = useFakeProjectUrlField(collection, projectUrlEnabled);
+
 const injectFields = computed(() => {
-	return fakeVersionField.value ? { fields: [fakeVersionField.value] } : null;
+	const fields = [fakeVersionField.value, fakeProjectUrlField.value].filter((field) => field !== null);
+	return fields.length > 0 ? { fields } : null;
 });
 
 const { treeList, loadFieldRelations } = useFieldTree(collection, injectFields, () => true, props.includeRelations);

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -37,6 +37,7 @@ import { useVersions } from '@/composables/use-versions';
 import { useVisualEditing } from '@/composables/use-visual-editing';
 import { BREAKPOINTS } from '@/constants';
 import { sameOrigin } from '@/modules/visual/utils/same-origin';
+import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { renderStringTemplate } from '@/utils/render-string-template';
@@ -69,6 +70,7 @@ const router = useRouter();
 const { collectionRoute } = useCollectionRoute();
 
 const userStore = useUserStore();
+const settingsStore = useSettingsStore();
 
 const form = ref<ComponentPublicInstance>();
 
@@ -281,7 +283,10 @@ const previewTemplate = computed(() => collectionInfo.value?.meta?.preview_url ?
 
 const { templateData: previewData, fetchTemplateValues } = useTemplateData(collectionInfo, primaryKey, {
 	template: previewTemplate,
-	injectData: computed(() => ({ $version: currentVersion.value?.key ?? 'main' })),
+	injectData: computed(() => ({
+		$version: currentVersion.value?.key ?? 'main',
+		$project_url: settingsStore.settings?.project_url ?? '',
+	})),
 });
 
 const previewUrl = computed(() => {

--- a/app/src/modules/content/routes/preview.vue
+++ b/app/src/modules/content/routes/preview.vue
@@ -4,6 +4,7 @@ import { computed, toRefs } from 'vue';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
 import { useVisualEditing } from '@/composables/use-visual-editing';
+import { useSettingsStore } from '@/stores/settings';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import LivePreview from '@/views/private/components/live-preview.vue';
 
@@ -18,11 +19,16 @@ const { info: collectionInfo, isSingleton } = useCollection(collection);
 
 const { currentVersion } = useVersions(collection, isSingleton, primaryKey);
 
+const settingsStore = useSettingsStore();
+
 const previewTemplate = computed(() => collectionInfo.value?.meta?.preview_url ?? '');
 
 const { templateData: previewData } = useTemplateData(collectionInfo, primaryKey, {
 	template: previewTemplate,
-	injectData: computed(() => ({ $version: currentVersion.value?.key ?? 'main' })),
+	injectData: computed(() => ({
+		$version: currentVersion.value?.key ?? 'main',
+		$project_url: settingsStore.settings?.project_url ?? '',
+	})),
 });
 
 const previewUrl = computed(() => {

--- a/packages/system-data/src/fields/collections.yaml
+++ b/packages/system-data/src/fields/collections.yaml
@@ -115,6 +115,7 @@ fields:
     options:
       collectionField: collection
       injectVersionField: true
+      injectProjectUrlField: true
     width: full
 
   - field: content_versioning_divider


### PR DESCRIPTION
## Why is this useful?

When configuring preview URLs for collections, users often need to reference their project's base URL. Currently, this requires hardcoding the URL (e.g., `https://example.com/preview/{{slug}}`), which becomes problematic when:

- Moving between environments (development, staging, production)
- Self-hosting Directus where the URL may change
- Managing multiple projects with different URLs

This feature allows using `{{$project_url}}` in preview URL templates, which dynamically resolves to the Project URL configured in Settings. This makes preview URLs portable and environment-agnostic, similar to how `{{$version}}` already works for content versioning.

**Example usage:**
```
{{$project_url}}/preview/{{slug}}?version={{$version}}
```

<img width="824" height="556" alt="image" src="https://github.com/user-attachments/assets/03705590-357f-4bdb-bbb2-6b027172af8b" />

## Scope

What's changed:

- Added `$project_url` variable support in collection preview URL templates
- Created `use-fake-project-url-field` composable for the template picker
- Updated `system-display-template` interface to inject the project URL field
- Injected `$project_url` from settings in `item.vue` and `preview.vue`

## Potential Risks / Drawbacks

- None identified - follows the same pattern as the existing `$version` variable

## Tested Scenarios

- Verified `$project_url` appears in the preview URL template picker
- Verified preview URL resolves correctly with project URL from Settings
- Tested in both split panel and popup preview modes

## Review Notes / Questions

- This follows the exact same pattern as `$version` injection
- No tests added as there are no existing tests for `use-fake-version-field` or `system-display-template`

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required