### PR TITLE
Fix issue preventing sidebar details from being fetched when navigating back

### DIFF
--- a/.changeset/slimy-times-count.md
+++ b/.changeset/slimy-times-count.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed issue preventng sidebar details from being fetched when navigating back
+Fixed issue preventing sidebar details from being fetched when navigating back

--- a/.changeset/slimy-times-count.md
+++ b/.changeset/slimy-times-count.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed issue preventng sidebar details from being fetched when navigating back

--- a/app/src/modules/settings/routes/flows/components/logs-sidebar-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/logs-sidebar-detail.vue
@@ -12,6 +12,7 @@ import VPagination from '@/components/v-pagination.vue';
 import VProgressLinear from '@/components/v-progress-linear.vue';
 import { useRevisions } from '@/composables/use-revisions';
 import SidebarDetail from '@/views/private/components/sidebar-detail.vue';
+import { useSidebarStore } from '@/views/private/private-view/stores/sidebar';
 
 const props = defineProps<{
 	flow: FlowRaw;
@@ -27,6 +28,8 @@ const { active: open } = useGroupable({
 	value: title.value,
 	group: 'sidebar-detail',
 });
+
+const sidebarStore = useSidebarStore();
 
 const page = ref<number>(1);
 const selectedRevision = ref();
@@ -61,7 +64,10 @@ function filterRevisions() {
 
 onMounted(() => {
 	getRevisionsCount();
-	if (open.value) getRevisions();
+
+	if (open.value || sidebarStore.activeAccordionItem === 'logs') {
+		getRevisions();
+	}
 });
 
 function onToggle(open: boolean) {

--- a/app/src/views/private/components/comment-input.vue
+++ b/app/src/views/private/components/comment-input.vue
@@ -366,7 +366,7 @@ function pressedEnter() {
 }
 
 .collapsed .v-template-input {
-	block-size: 48px;
+	block-size: var(--input-height-md);
 	padding-block-end: 0;
 }
 

--- a/app/src/views/private/components/comments-sidebar-detail.vue
+++ b/app/src/views/private/components/comments-sidebar-detail.vue
@@ -7,6 +7,7 @@ import dompurify from 'dompurify';
 import { flatten, groupBy, orderBy } from 'lodash';
 import { computed, onMounted, ref, Ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useSidebarStore } from '../private-view/stores/sidebar';
 import CommentInput from './comment-input.vue';
 import CommentItem from './comment-item.vue';
 import SidebarDetail from './sidebar-detail.vue';
@@ -41,12 +42,17 @@ const { active: open } = useGroupable({
 
 const { collection, primaryKey } = toRefs(props);
 
+const sidebarStore = useSidebarStore();
+
 const { comments, getComments, loading, refresh, commentsCount, getCommentsCount, loadingCount, userPreviews } =
 	useComments(collection, primaryKey);
 
 onMounted(() => {
 	getCommentsCount();
-	if (open.value) getComments();
+
+	if (open.value || sidebarStore.activeAccordionItem === 'comments') {
+		getComments();
+	}
 });
 
 function onToggle(open: boolean) {

--- a/app/src/views/private/components/comments-sidebar-detail.vue
+++ b/app/src/views/private/components/comments-sidebar-detail.vue
@@ -238,7 +238,7 @@ async function loadUserPreviews(comments: Comment[], regex: RegExp) {
 		id="comments"
 		:title
 		icon="chat_bubble_outline"
-		:badge="!loadingCount && commentsCount > 0 ? abbreviateNumber(commentsCount) : null"
+		:badge="!loadingCount && commentsCount > 0 ? abbreviateNumber(commentsCount) : undefined"
 		@toggle="onToggle"
 	>
 		<CommentInput :refresh="refresh" :collection="collection" :primary-key="primaryKey" />

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -91,7 +91,7 @@ defineExpose({
 		id="revisions"
 		:title
 		icon="change_history"
-		:badge="!loadingCount && revisionsCount > 0 ? abbreviateNumber(revisionsCount) : null"
+		:badge="!loadingCount && revisionsCount > 0 ? abbreviateNumber(revisionsCount) : undefined"
 		@toggle="onToggle"
 	>
 		<VProgressLinear v-if="!revisions && loading" indeterminate />

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -4,6 +4,7 @@ import { ContentVersion, PrimaryKey } from '@directus/types';
 import { abbreviateNumber } from '@directus/utils';
 import { computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useSidebarStore } from '../private-view/stores/sidebar';
 import RevisionsDateGroup from './revisions-date-group.vue';
 import SidebarDetail from './sidebar-detail.vue';
 import VDivider from '@/components/v-divider.vue';
@@ -32,6 +33,8 @@ const { active: open } = useGroupable({
 
 const { collection, primaryKey, version } = toRefs(props);
 
+const sidebarStore = useSidebarStore();
+
 const comparisonModalActive = ref(false);
 const currentRevision = ref<Revision | null>(null);
 const page = ref<number>(1);
@@ -51,7 +54,10 @@ const {
 
 onMounted(() => {
 	getRevisionsCount();
-	if (open.value) getRevisions();
+
+	if (open.value || sidebarStore.activeAccordionItem === 'revisions') {
+		getRevisions();
+	}
 });
 
 watch(

--- a/app/src/views/private/components/shares-sidebar-detail.vue
+++ b/app/src/views/private/components/shares-sidebar-detail.vue
@@ -94,7 +94,7 @@ function useShares(collection: Ref<string>, primaryKey: Ref<PrimaryKey>) {
 	watch([collection, primaryKey], () => refresh());
 
 	const sendPublicLink = computed(() => {
-		if (!shareToSend.value) return null;
+		if (!shareToSend.value) return undefined;
 		return window.location.origin + getRootPath() + 'admin/shared/' + shareToSend.value.id;
 	});
 
@@ -276,7 +276,7 @@ async function copy(id: string) {
 		id="shares"
 		:title
 		icon="share"
-		:badge="!loadingCount && sharesCount > 0 ? abbreviateNumber(sharesCount) : null"
+		:badge="!loadingCount && sharesCount > 0 ? abbreviateNumber(sharesCount) : undefined"
 		@toggle="onToggle"
 	>
 		<VNotice v-if="error" type="danger">{{ $t('unexpected_error') }}</VNotice>

--- a/app/src/views/private/components/shares-sidebar-detail.vue
+++ b/app/src/views/private/components/shares-sidebar-detail.vue
@@ -4,6 +4,7 @@ import { PrimaryKey, Share } from '@directus/types';
 import { abbreviateNumber } from '@directus/utils';
 import { computed, onMounted, ref, Ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useSidebarStore } from '../private-view/stores/sidebar';
 import ShareItem from './share-item.vue';
 import SidebarDetail from './sidebar-detail.vue';
 import api from '@/api';
@@ -39,6 +40,8 @@ const { active: open } = useGroupable({
 	group: 'sidebar-detail',
 });
 
+const sidebarStore = useSidebarStore();
+
 const { copyToClipboard } = useClipboard();
 
 const {
@@ -65,7 +68,10 @@ const {
 
 onMounted(() => {
 	getSharesCount();
-	if (open.value) getShares();
+
+	if (open.value || sidebarStore.activeAccordionItem === 'shares') {
+		getShares();
+	}
 });
 
 function onToggle(open: boolean) {


### PR DESCRIPTION
## Scope

What's changed:

- Fixed sidebar detail components (comments, revisions, shares) not fetching content when navigating back to a page where the sidebar was already open

- Fixed pre-existing type errors in related files

Files modified:
- `app/src/views/private/components/comments-sidebar-detail.vue`
- `app/src/views/private/components/revisions-sidebar-detail.vue`
- `app/src/views/private/components/shares-sidebar-detail.vue`
- `app/src/views/private/components/logs-sidebar-detail.vue`

## Potential Risks / Drawbacks

- Low risk

## Test Scenarios

- Navigate to an item with sidebar open, navigate away, then navigate back - content should load
- Open sidebar manually after page load - content should still load correctly

## Review Notes / Questions

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26360

