### PR TITLE
Improve system field validation message and set `users.last_access` display mode to absolute

### DIFF
--- a/.changeset/free-apes-bake.md
+++ b/.changeset/free-apes-bake.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved error message for system field updates that are not schema.is_indexed

--- a/.changeset/tiny-pans-allow.md
+++ b/.changeset/tiny-pans-allow.md
@@ -1,0 +1,6 @@
+---
+'@directus/system-data': patch
+'@directus/api': patch
+---
+
+Changed users.last_access display mode to absolute

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -138,7 +138,9 @@ router.patch(
 			if (isSystemField(req.params['collection']!, fieldData['field']!)) {
 				const { error } = systemFieldUpdateSchema.safeParse(fieldData);
 
-				if (error) throw new InvalidPayloadError({ reason: `You can't modify system fields. Only "schema.is_indexed" can be updated` });
+				if (error) {
+					throw new InvalidPayloadError({ reason: 'Only "schema.is_indexed" may be modified for system fields' });
+				}
 			}
 		}
 
@@ -194,7 +196,9 @@ router.patch(
 		if (isSystemField(req.params['collection']!, req.params['field']!)) {
 			const { error } = systemFieldUpdateSchema.safeParse(req.body);
 
-			if (error) throw new InvalidPayloadError({ reason: `You can't modify system fields. Only "schema.is_indexed" can be updated` });
+			if (error) {
+				throw new InvalidPayloadError({ reason: 'Only "schema.is_indexed" may be modified for system fields' });
+			}
 		} else {
 			const { error } = updateSchema.validate(req.body);
 

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -138,7 +138,7 @@ router.patch(
 			if (isSystemField(req.params['collection']!, fieldData['field']!)) {
 				const { error } = systemFieldUpdateSchema.safeParse(fieldData);
 
-				if (error) throw error.issues.map((details) => new InvalidPayloadError({ reason: details.message }));
+				if (error) throw new InvalidPayloadError({ reason: `You can't modify system fields. Only "schema.is_indexed" can be updated` });
 			}
 		}
 
@@ -194,7 +194,7 @@ router.patch(
 		if (isSystemField(req.params['collection']!, req.params['field']!)) {
 			const { error } = systemFieldUpdateSchema.safeParse(req.body);
 
-			if (error) throw error.issues.map((details) => new InvalidPayloadError({ reason: details.message }));
+			if (error) throw new InvalidPayloadError({ reason: `You can't modify system fields. Only "schema.is_indexed" can be updated` });
 		} else {
 			const { error } = updateSchema.validate(req.body);
 

--- a/api/src/services/graphql/resolvers/system-admin.ts
+++ b/api/src/services/graphql/resolvers/system-admin.ts
@@ -3,7 +3,6 @@ import { isSystemField } from '@directus/system-data';
 import type { GraphQLParams } from '@directus/types';
 import { GraphQLBoolean, GraphQLID, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { SchemaComposer, toInputObjectType } from 'graphql-compose';
-import { fromZodError } from 'zod-validation-error';
 import { CollectionsService } from '../../collections.js';
 import { ExtensionsService } from '../../extensions.js';
 import { FieldsService, systemFieldUpdateSchema } from '../../fields.js';
@@ -130,7 +129,7 @@ export function resolveSystemAdmin(
 					const validationResult = systemFieldUpdateSchema.safeParse(args['data']);
 
 					if (!validationResult.success) {
-						throw new InvalidPayloadError({ reason: fromZodError(validationResult.error).message });
+						throw new InvalidPayloadError({ reason: 'Only "schema.is_indexed" may be modified for system fields' });
 					}
 				}
 
@@ -166,7 +165,7 @@ export function resolveSystemAdmin(
 						const validationResult = systemFieldUpdateSchema.safeParse(fieldData);
 
 						if (!validationResult.success) {
-							throw new InvalidPayloadError({ reason: fromZodError(validationResult.error).message });
+							throw new InvalidPayloadError({ reason: 'Only "schema.is_indexed" may be modified for system fields' });
 						}
 					}
 				}

--- a/packages/system-data/src/fields/users.yaml
+++ b/packages/system-data/src/fields/users.yaml
@@ -226,8 +226,6 @@ fields:
     width: half
     display: datetime
     readonly: true
-    display_options:
-      relative: false
 
   - field: provider
     width: half

--- a/packages/system-data/src/fields/users.yaml
+++ b/packages/system-data/src/fields/users.yaml
@@ -227,7 +227,7 @@ fields:
     display: datetime
     readonly: true
     display_options:
-      relative: true
+      relative: false
 
   - field: provider
     width: half


### PR DESCRIPTION
## Scope

What's changed:

- Change the default display mode of last_access to use absolute time instead of relative
- Updated error message when user tries to edit system field that cannot be updated

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- Studio display of absolute time
- `PATCH` request on system field that can't be edited

## Review Notes / Questions

- Reduces ambiguity when reviewing access dates for user management and compliance

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR not required
- [x] OpenAPI package PR not required

---

Fixes CMS-1703
