### PR TITLE
fix: use collab typescript

### DIFF
--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -319,7 +319,7 @@ export function useCollab(
 					},
 					//  Object syntax for nested fields - SDK types require schema definition for full support
 					// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-					fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
+					fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
 				}),
 			);
 
@@ -409,7 +409,7 @@ export function useCollab(
 					.request<CollabUser>(
 						readUser(message.user, {
 							// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-							fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
+							fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
 						}),
 					)
 					.catch(() => ({}));

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -1,5 +1,5 @@
 import { ErrorCode } from '@directus/errors';
-import { readUser, readUsers, realtime, RemoveEventHandler, WebSocketClient } from '@directus/sdk';
+import { DirectusUser, readUser, readUsers, realtime, RemoveEventHandler, WebSocketClient } from '@directus/sdk';
 import { Avatar, ContentVersion, Item, PrimaryKey, WS_TYPE } from '@directus/types';
 import { ACTION, ClientID, ClientMessage, Color, ServerError, ServerMessage } from '@directus/types/collab';
 import { isDetailedUpdateSyntax, isObject } from '@directus/utils';
@@ -319,7 +319,7 @@ export function useCollab(
 					},
 					//  Object syntax for nested fields - SDK types require schema definition for full support
 					// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-					fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
+					fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as (keyof DirectusUser)[],
 				}),
 			);
 
@@ -409,7 +409,7 @@ export function useCollab(
 					.request<CollabUser>(
 						readUser(message.user, {
 							// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-							fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
+							fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as (keyof DirectusUser)[],
 						}),
 					)
 					.catch(() => ({}));

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -318,7 +318,7 @@ export function useCollab(
 						},
 					},
 					//  Object syntax for nested fields - SDK types require schema definition for full support
-					// TODO: Update this once https://linear.app/directus/issue/CMS-1702/improve-sdk-type-safety-by-using-coreschema-instead-of-unknown is Done
+					// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
 					fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
 				}),
 			);
@@ -408,7 +408,7 @@ export function useCollab(
 			: await sdk
 					.request<CollabUser>(
 						readUser(message.user, {
-							// TODO: Update this once https://linear.app/directus/issue/CMS-1702/improve-sdk-type-safety-by-using-coreschema-instead-of-unknown is Done
+							// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
 							fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
 						}),
 					)

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -306,7 +306,9 @@ export function useCollab(
 							_in: Array.from(new Set(message.users.map((user) => user.user))),
 						},
 					},
-					fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as any,
+					//  Object syntax for nested fields - SDK types require schema definition for full support
+					// TODO: Update this once https://linear.app/directus/issue/CMS-1702/improve-sdk-type-safety-by-using-coreschema-instead-of-unknown is Done
+					fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
 				}),
 			);
 
@@ -395,7 +397,8 @@ export function useCollab(
 			: await sdk
 					.request<CollabUser>(
 						readUser(message.user, {
-							fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as any,
+							// TODO: Update this once https://linear.app/directus/issue/CMS-1702/improve-sdk-type-safety-by-using-coreschema-instead-of-unknown is Done
+							fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as ('id' | 'first_name' | 'last_name' | 'avatar')[],
 						}),
 					)
 					.catch(() => ({}));

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -319,7 +319,7 @@ export function useCollab(
 					},
 					//  Object syntax for nested fields - SDK types require schema definition for full support
 					// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-					fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as (keyof DirectusUser)[],
+					fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on']}] as (keyof DirectusUser)[],
 				}),
 			);
 
@@ -406,10 +406,10 @@ export function useCollab(
 		const user = existingInfo
 			? existingInfo
 			: await sdk
-					.request<CollabUser>(
+					.request(
 						readUser(message.user, {
 							// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-							fields: ['id', 'first_name', 'last_name', 'avatar.id', 'avatar.modified_on'] as (keyof DirectusUser)[],
+							fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on']}] as (keyof DirectusUser)[],
 						}),
 					)
 					.catch(() => ({}));

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -23,6 +23,17 @@ type UpdateMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.UPDAT
 type FocusMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.FOCUS }>;
 type DiscardMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.DISCARD }>;
 
+/**
+ * User info returned from SDK queries.
+ * TODO: Remove once https://linear.app/directus/issue/CMS-1702 is done
+ */
+type CollabUserInfo = {
+	id: string;
+	first_name?: string | null;
+	last_name?: string | null;
+	avatar?: { id: string; modified_on: string } | null;
+};
+
 type NonInitServerAction = Exclude<ServerMessage['action'], typeof ACTION.SERVER.INIT>;
 
 type ServerMessageHandler<A extends ServerMessage['action']> = (
@@ -314,7 +325,7 @@ export function useCollab(
 
 			users.value = message.users
 				.map(({ user, color, connection }) => {
-					const info = usersInfo.find((u) => u.id === user) as any;
+					const info = usersInfo.find((u) => u.id === user) as CollabUserInfo | undefined;
 
 					if (message.connection === connection) {
 						sessionStorage.setItem(SESSION_COLOR_KEY, color);
@@ -330,7 +341,7 @@ export function useCollab(
 					if (a.connection === message.connection) return -1;
 					if (b.connection === message.connection) return 1;
 					return 0;
-				});
+				}) as CollabUser[];
 		}
 
 		focused.value = message.focuses;


### PR DESCRIPTION
## Scope                                                                                                                              
                                                                                                                                        
  What's changed:                                                                                                                       
                                                                                                                                        
  - Replaced `as any` type assertions with explicit types in `use-collab.ts`                                                            
  - Added `CollabUserInfo` type for SDK user query results                                                                              
  - Used object syntax for nested fields in SDK queries (`{ avatar: ['id', 'modified_on'] }`)                                           
  - Added TODO comments linking to https://github.com/directus/directus/issues/26558 for future SDK type improvements                                                            
                                                                                                                                        
  ## Potential Risks / Drawbacks                                                                                                        
                                                                                                                                        
  - Type assertions (`as CollabUserInfo`, `as CollabUser[]`) still needed due to SDK schema generic limitations                         
  - No runtime behavior changes, purely type-level improvements                                                                         
                                                                                                                                        
  ## Tested Scenarios                                                                                                                   
                                                                                                                                        
  - TypeScript compilation passes with no errors                                                                                        
  - No `as any` remaining in the file                                                                                                   
                                                                                                                                        
  ## Review Notes / Questions                                                                                                           
                                                                                                                                        
  - The SDK uses `unknown` as schema generic, preventing proper type inference for relational fields                                    
  - CMS-1702 tracks the long-term fix: passing `CoreSchema` to the SDK client                                                           
  - Type assertions maintain exact runtime behavior while improving type documentation                                                  
                                                                                                                                        
  ## Checklist                                                                                                                          
                                                                                                                                        
  - [ ] Added or updated tests                                                                                                          
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required                                               
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required    
