### PR TITLE
Allow claude-review to comment on PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
Comment from review in https://github.com/directus/directus/actions/runs/21521908317?pr=26550

> Note: I attempted to post the review comment directly to the PR, but encountered a permissions issue with the GitHub token. The `GITHUB_TOKEN` being used doesn't have `pull-requests: write` permissions needed to post comments. This is actually the exact issue that the PR is trying to address - by adding the token parameter to enable GitHub API interactions.
