### PR TITLE
Fix back button navigation on related items

### DIFF
--- a/.changeset/four-dolls-bake.md
+++ b/.changeset/four-dolls-bake.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed back button navigation on related items

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -66,7 +66,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { t, te } = useI18n();
 
 const router = useRouter();
-const { collectionRoute } = useCollectionRoute();
+const { collectionRoute, backRoute } = useItemNavigation();
 
 const userStore = useUserStore();
 
@@ -585,7 +585,7 @@ const shouldShowVersioning = computed(
 		!versionsLoading.value,
 );
 
-function useCollectionRoute() {
+function useItemNavigation() {
 	const route = useRoute();
 
 	const collectionRoute = computed(() => {
@@ -594,7 +594,17 @@ function useCollectionRoute() {
 		return collectionPath;
 	});
 
-	return { collectionRoute };
+	// If there's in-app navigation history, use browser back
+	// Otherwise fall back to collection route
+	const backRoute = computed(() => {
+		if (history.state?.back) {
+			return undefined;
+		}
+
+		return collectionRoute.value;
+	});
+
+	return { collectionRoute, backRoute };
 }
 </script>
 
@@ -608,7 +618,7 @@ function useCollectionRoute() {
 		:class="{ 'has-content-versioning': shouldShowVersioning }"
 		:title
 		:show-back="!collectionInfo.meta?.singleton"
-		:back-to="collectionRoute"
+		:back-to="backRoute"
 		:show-header-shadow="showHeaderShadow"
 		:icon="collectionInfo.meta?.singleton ? collectionInfo.icon : undefined"
 	>


### PR DESCRIPTION
## Scope

What's changed:

- When navigating from a related item, the back button now uses browser history (if available) instead of always redirecting to the collection route
- Falls back to collection route when there's no navigation history

## Potential Risks / Drawbacks

- Should be careful this doesn't regress from other fixes applied by [this ](https://github.com/directus/directus/pull/26427)pr

## Tested Scenarios

- Navigated to a related item from a parent item, verified back button returns to parent item
- Directly accessed an item via URL, verified back button navigates to collection

## Review Notes / Questions


## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26540 
