### PR TITLE
[Collab] Add virtual room support for translations interface

### DIFF
--- a/api/src/websocket/collab/is-virtual-room-item.test.ts
+++ b/api/src/websocket/collab/is-virtual-room-item.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { isVirtualRoomItem } from './is-virtual-room-item.js';
+
+describe('isVirtualRoomItem', () => {
+	test('returns true for valid virtual room items', () => {
+		expect(isVirtualRoomItem('++')).toBe(true);
+		expect(isVirtualRoomItem('+virtual+')).toBe(true);
+		expect(isVirtualRoomItem('+articles-123-translations-fr-FR+')).toBe(true);
+	});
+
+	test('returns false for strings missing + wrapper', () => {
+		expect(isVirtualRoomItem('regular-string')).toBe(false);
+		expect(isVirtualRoomItem('+no-trailing')).toBe(false);
+		expect(isVirtualRoomItem('no-leading+')).toBe(false);
+		expect(isVirtualRoomItem('not+virtual+item')).toBe(false);
+		expect(isVirtualRoomItem('')).toBe(false);
+	});
+
+	test('returns false for non-string types', () => {
+		expect(isVirtualRoomItem(null)).toBe(false);
+		expect(isVirtualRoomItem(undefined)).toBe(false);
+		expect(isVirtualRoomItem(123)).toBe(false);
+		expect(isVirtualRoomItem({ id: '+virtual+' })).toBe(false);
+		expect(isVirtualRoomItem(['+virtual+'])).toBe(false);
+	});
+});

--- a/api/src/websocket/collab/is-virtual-room-item.ts
+++ b/api/src/websocket/collab/is-virtual-room-item.ts
@@ -1,0 +1,7 @@
+/**
+ * Check if an item ID represents a virtual room
+ */
+export function isVirtualRoomItem(item: any): boolean {
+	if (typeof item !== 'string') return false;
+	return item.startsWith('+') && item.endsWith('+');
+}

--- a/api/src/websocket/collab/payload-permissions.ts
+++ b/api/src/websocket/collab/payload-permissions.ts
@@ -2,6 +2,7 @@ import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import type { Accountability, PrimaryKey, SchemaOverview } from '@directus/types';
 import { deepMapWithSchema, isDetailedUpdateSyntax } from '@directus/utils';
 import type { Knex } from 'knex';
+import { isVirtualRoomItem } from './is-virtual-room-item.js';
 import { verifyPermissions } from './verify-permissions.js';
 
 type PermissionContext = {
@@ -129,7 +130,7 @@ async function processPermissions(
 			let allowedFields = await getPermissions(currentCollection, effectiveItemId, action);
 
 			// Fallbacks
-			if (!allowedFields) {
+			if (!allowedFields || (allowedFields.length === 0 && isVirtualRoomItem(effectiveItemId))) {
 				if (direction === 'inbound' && action === 'update') {
 					// Toggle to create if update fails due to non-existence
 					action = 'create';

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -6,6 +6,7 @@ import VDivider from '@/components/v-divider.vue';
 import VForm from '@/components/v-form/v-form.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VRemove from '@/components/v-remove.vue';
+import { type CollabContext } from '@/composables/use-collab';
 import { usePermissions } from '@/composables/use-permissions';
 import { type RelationM2M } from '@/composables/use-relation-m2m';
 import { type DisplayItem } from '@/composables/use-relation-multiple';
@@ -38,6 +39,7 @@ const {
 	remove: (...items: DisplayItem[]) => void;
 	updateValue: (item: DisplayItem | undefined, lang: string | undefined) => void;
 	secondary?: boolean;
+	collabContext?: CollabContext;
 }>();
 
 const lang = defineModel<string>('lang');
@@ -203,6 +205,7 @@ function onToggleDelete(item: DisplayItem, itemInitial?: DisplayItem) {
 			:badge="selectedLanguage.text"
 			:direction="selectedLanguage.direction"
 			:autofocus="autofocus"
+			:collab-context="collabContext"
 			inline
 			@update:model-value="updateValue($event, lang)"
 		/>


### PR DESCRIPTION
# WIP POC

## Scope

What's changed:

- Added virtual room support for translations interface in collaborative editing
- Refactored permission checks to handle virtual items by using collection-level permissions


https://github.com/user-attachments/assets/f62be395-95f2-46f8-9919-fc7c76d7b694



## Potential Risks / Drawbacks

- Virtual items use CREATE permissions as fallback when item doesn't exist
- Last write wins possible if users edit different translations and save parent form without sync
- Virtual room pattern `+...+`, changing it would break compatibility

## Tested Scenarios

- Virtual room join with create permissions

## Review Notes / Questions

- 
