### PR TITLE
Optimize client room lookup to check local node only

### DIFF
--- a/api/src/websocket/collab/messenger.ts
+++ b/api/src/websocket/collab/messenger.ts
@@ -10,7 +10,6 @@ import {
 	type ServerError,
 	type ServerMessage,
 } from '@directus/types/collab';
-import { uniq } from 'lodash-es';
 import { useBus } from '../../bus/index.js';
 import { useLogger } from '../../logger/index.js';
 import { useStore } from './store.js';
@@ -167,15 +166,6 @@ export class Messenger {
 			.flat();
 	}
 
-	async getGlobalRooms(): Promise<string[]> {
-		const instances = await this.store(async (store) => await store.get('instances'));
-
-		return uniq(
-			Object.values(instances)
-				.map(({ rooms }) => rooms)
-				.flat(),
-		);
-	}
 
 	async pruneDeadInstances(): Promise<RegistrySnapshot> {
 		const instances = await this.store(async (store) => await store.get('instances'));

--- a/api/src/websocket/collab/messenger.ts
+++ b/api/src/websocket/collab/messenger.ts
@@ -166,7 +166,6 @@ export class Messenger {
 			.flat();
 	}
 
-
 	async pruneDeadInstances(): Promise<RegistrySnapshot> {
 		const instances = await this.store(async (store) => await store.get('instances'));
 

--- a/api/src/websocket/collab/room.test.ts
+++ b/api/src/websocket/collab/room.test.ts
@@ -46,7 +46,6 @@ const mockMessenger = {
 	removeClient: vi.fn(),
 	registerRoom: vi.fn(),
 	unregisterRoom: vi.fn(),
-	getGlobalRooms: vi.fn().mockResolvedValue([]),
 	hasClient: vi.fn(),
 	terminateClient: vi.fn(),
 } as any;
@@ -207,8 +206,6 @@ describe('RoomManager', () => {
 
 		const room = await roomManager.createRoom('a', getTestItem(), null);
 		await room.join(client);
-
-		vi.mocked(mockMessenger.getGlobalRooms).mockResolvedValue([room.uid]);
 
 		const clientRooms = await roomManager.getClientRooms(client.uid);
 

--- a/api/src/websocket/collab/room.test.ts
+++ b/api/src/websocket/collab/room.test.ts
@@ -207,9 +207,16 @@ describe('RoomManager', () => {
 		const room = await roomManager.createRoom('a', getTestItem(), null);
 		await room.join(client);
 
+		const externalRoomUid = getRoomHash('b', '2', null);
+		mockData.set(`${externalRoomUid}:uid`, externalRoomUid);
+		mockData.set(`${externalRoomUid}:collection`, 'b');
+		mockData.set(`${externalRoomUid}:item`, '2');
+
 		const clientRooms = await roomManager.getClientRooms(client.uid);
 
 		expect(clientRooms).toEqual([room]);
+		expect(Object.keys(roomManager.rooms)).toHaveLength(1);
+		expect(roomManager.rooms[room.uid]).toBe(room);
 	});
 
 	test('cleanupRooms', async () => {

--- a/api/src/websocket/collab/room.ts
+++ b/api/src/websocket/collab/room.ts
@@ -99,7 +99,7 @@ export class RoomManager {
 	}
 
 	/**
-	 * Get all rooms a client is currently in
+	 * Get all rooms a client is currently in from local memory
 	 */
 	async getClientRooms(uid: ClientID) {
 		const rooms = [];

--- a/api/src/websocket/collab/room.ts
+++ b/api/src/websocket/collab/room.ts
@@ -99,7 +99,7 @@ export class RoomManager {
 	}
 
 	/**
-	 * Get all rooms a client is currently in from global memory
+	 * Get all rooms a client is currently in
 	 */
 	async getClientRooms(uid: ClientID) {
 		const rooms = [];

--- a/api/src/websocket/collab/room.ts
+++ b/api/src/websocket/collab/room.ts
@@ -103,12 +103,9 @@ export class RoomManager {
 	 */
 	async getClientRooms(uid: ClientID) {
 		const rooms = [];
-		const globalRooms = await this.messenger.getGlobalRooms();
 
-		for (const roomId of Object.values(globalRooms)) {
-			const room = await this.getRoom(roomId);
-
-			if (room && (await room.hasClient(uid))) {
+		for (const room of Object.values(this.rooms)) {
+			if (await room.hasClient(uid)) {
 				rooms.push(room);
 			}
 		}


### PR DESCRIPTION
## Scope

What's changed:

- Search only local memory instead of querying the global cluster registry

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- Existing tests pass

## Review Notes / Questions

- WebSocket connection is fixed to a specific node where the local memory is guaranteed to contain all rooms that the client has joined
- Searching the global registry is inefficient, both memory and processing
- This partially reverts changes in https://github.com/directus/directus/commit/1d87757e97eda8b822b0e4fa06e92a3241452ef5
