### PR TITLE
Change permission-blocked fields from disabled to non-editable appearance

### DIFF
--- a/.changeset/solid-ghosts-see.md
+++ b/.changeset/solid-ghosts-see.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added non_editable meta flag for permission blocked fields distinct from user define readonly

--- a/.changeset/solid-ghosts-see.md
+++ b/.changeset/solid-ghosts-see.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Added non_editable meta flag for permission blocked fields distinct from user define readonly
+Added non_editable meta flag for permission blocked fields distinct from user defined readonly

--- a/.changeset/solid-ghosts-see.md
+++ b/.changeset/solid-ghosts-see.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Added non_editable meta flag for permission blocked fields distinct from user defined readonly
+Changed permission-blocked fields from disabled to non-editable appearance

--- a/app/src/components/v-form/components/form-field.test.ts
+++ b/app/src/components/v-form/components/form-field.test.ts
@@ -99,4 +99,55 @@ describe('FormField', () => {
 
 		expect(wrapper.findComponent({ name: 'FormFieldLabel' }).exists()).toBe(false);
 	});
+
+	describe('isNonEditable', () => {
+		it('should pass non-editable=false when neither prop nor meta is set', () => {
+			const wrapper = mount(FormField, {
+				props: {
+					field: baseField,
+				},
+				global,
+			});
+
+			const fieldInterface = wrapper.findComponent({ name: 'FormFieldInterface' });
+			expect(fieldInterface.props('nonEditable')).toBe(false);
+		});
+
+		it('should pass non-editable=true when nonEditable prop is true', () => {
+			const wrapper = mount(FormField, {
+				props: {
+					field: baseField,
+					nonEditable: true,
+				},
+				global,
+			});
+
+			const fieldInterface = wrapper.findComponent({ name: 'FormFieldInterface' });
+			expect(fieldInterface.props('nonEditable')).toBe(true);
+		});
+
+		it('should pass non-editable=true when field.meta.non_editable is true', () => {
+			const wrapper = mount(FormField, {
+				props: {
+					field: { ...baseField, meta: { ...baseField.meta, non_editable: true } },
+				},
+				global,
+			});
+
+			const fieldInterface = wrapper.findComponent({ name: 'FormFieldInterface' });
+			expect(fieldInterface.props('nonEditable')).toBe(true);
+		});
+
+		it('should pass non-editable=false when field.meta.readonly is true but non_editable is not set', () => {
+			const wrapper = mount(FormField, {
+				props: {
+					field: { ...baseField, meta: { ...baseField.meta, readonly: true } },
+				},
+				global,
+			});
+
+			const fieldInterface = wrapper.findComponent({ name: 'FormFieldInterface' });
+			expect(fieldInterface.props('nonEditable')).toBe(false);
+		});
+	});
 });

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -59,7 +59,7 @@ const isDisabled = computed(() => {
 	return false;
 });
 
-const computedNonEditable = computed(() => {
+const isNonEditable = computed(() => {
 	if (props.nonEditable) return true;
 	if (props.field?.meta?.non_editable === true) return true;
 	return false;

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -232,7 +232,7 @@ function useComputedValues() {
 			:batch-mode="batchMode"
 			:batch-active="batchActive"
 			:disabled="isDisabled"
-			:non-editable="computedNonEditable"
+			:non-editable="isNonEditable"
 			:primary-key="primaryKey"
 			:raw-editor-enabled="rawEditorEnabled"
 			:raw-editor-active="rawEditorActive"

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -59,6 +59,12 @@ const isDisabled = computed(() => {
 	return false;
 });
 
+const computedNonEditable = computed(() => {
+	if (props.nonEditable) return true;
+	if (props.field?.meta?.non_editable === true) return true;
+	return false;
+});
+
 const isLabelHidden = computed(() => {
 	if ((props.batchMode || !!props.comparison) && !props.field.meta?.special?.includes('no-data')) return false;
 	return props.field.hideLabel;
@@ -226,7 +232,7 @@ function useComputedValues() {
 			:batch-mode="batchMode"
 			:batch-active="batchActive"
 			:disabled="isDisabled"
-			:non-editable="nonEditable"
+			:non-editable="computedNonEditable"
 			:primary-key="primaryKey"
 			:raw-editor-enabled="rawEditorEnabled"
 			:raw-editor-active="rawEditorActive"

--- a/app/src/components/v-form/types.ts
+++ b/app/src/components/v-form/types.ts
@@ -1,8 +1,11 @@
 import { DeepPartial, Field, InterfaceConfig } from '@directus/types';
 
-export type FormField = DeepPartial<Field> & {
+export type FormField = Omit<DeepPartial<Field>, 'meta'> & {
 	field: string;
 	name: string;
+	meta?: DeepPartial<Field['meta']> & {
+		non_editable?: boolean;
+	};
 } & Pick<InterfaceConfig, 'hideLabel' | 'hideLoader' | 'indicatorStyle'>;
 
 export interface ComparisonContext {

--- a/app/src/composables/use-permissions/item/lib/get-fields.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.ts
@@ -3,6 +3,7 @@ import { Field, ItemPermissions } from '@directus/types';
 import { cloneDeep } from 'lodash';
 import { computed, ref, Ref, unref } from 'vue';
 import { Collection, IsNew } from '../../types';
+import type { FormField } from '@/components/v-form/types';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useUserStore } from '@/stores/user';
 
@@ -34,10 +35,11 @@ export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermi
 		if (!permission?.fields?.includes('*')) {
 			for (const field of fields) {
 				if (!permission?.fields?.includes(field.field)) {
-					field.meta = {
+					(field as FormField).meta = {
 						...(field.meta || {}),
 						readonly: true,
-					} as Field['meta'];
+						non_editable: true,
+					};
 				}
 			}
 		}


### PR DESCRIPTION
## Scope

What's changed:

- Add `non_editable` property to `FormField` meta type
- Set `meta.non_editable: true` in `get-fields.ts` when user lacks create/update permission
- `form-field.vue` uses `computedNonEditable` to show non-editable visual only for permission-blocked fields

## Potential Risks / Drawbacks

- Custom interfaces relying on `readonly` for non-editable styling may need updates

## Tested Scenarios

- Disabled fields show disabled styling
- Permission-blocked fields show non-editable styling

## Review Notes / Questions

- `FormField` type extended with custom meta to include `non_editable` to avoid modifying the shared `Field` type

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #23686
