### PR TITLE
Fix LDAP DN properties casted as arrays

### DIFF
--- a/.changeset/olive-trains-eat.md
+++ b/.changeset/olive-trains-eat.md
@@ -1,0 +1,5 @@
+---
+'@directus/env': patch
+---
+
+Fixed LDAP DN properties casted as arrays

--- a/packages/env/src/constants/type-map.ts
+++ b/packages/env/src/constants/type-map.ts
@@ -37,6 +37,7 @@ export const TYPE_MAP: Record<string, EnvType> = {
 	LOG_HTTP_IGNORE_PATHS: 'array',
 
 	REDIS_ENABLED: 'boolean',
+	REDIS_PASSWORD: 'string',
 
 	METRICS_TOKENS: 'array',
 	METRICS_SERVICES: 'array',
@@ -49,10 +50,15 @@ export const TYPE_MAP: Record<string, EnvType> = {
 	SECRET: 'string',
 
 	EXTENSIONS_ROLLDOWN: 'boolean',
+
 	EMAIL_SMTP_PASSWORD: 'string',
-	REDIS_PASSWORD: 'string',
-	'AUTH_.+_BIND_PASSWORD': 'string',
+
 	'STORAGE_.+_SECRET': 'string',
+
+	'AUTH_.+_BIND_DN': 'string',
+	'AUTH_.+_USER_DN': 'string',
+	'AUTH_.+_GROUP_DN': 'string',
+	'AUTH_.+_BIND_PASSWORD': 'string',
 } as const;
 
 export const TYPE_MAP_REGEX: [RegExp, EnvType][] = Object.entries(TYPE_MAP).map(([name, value]) => [


### PR DESCRIPTION
## Scope

What's changed:

- LDAP DN properties are now auto casted to strings 

## Potential Risks / Drawbacks

- Should be minimal as these are expected to be strings. They can be overridden by our type prefix (e.g. `array:`) if needed.

## Tested Scenarios

- Setting relevant DN properties show up as strings without type prefix required
- Adding a different type prefix (e.g. `array:`) overrides the new auto cast

## Review Notes / Questions

- N/A

## Checklist

- [ ] Added or updated tests - N/A
- [ ] Documentation PR created [here](https://github.com/directus/docs) or **not required**
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes #26576
