### PR TITLE
Fix WYSIWYG interface not rendering when field is named "tooltip"

### DIFF
--- a/.changeset/quick-planes-dance.md
+++ b/.changeset/quick-planes-dance.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed WYSIWYG interface not rendering when field is named "tooltip"

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -465,7 +465,7 @@ onMounted(() => {
 </script>
 
 <template>
-	<div :id="field" class="wysiwyg" :class="{ disabled }">
+	<div class="wysiwyg" :class="{ disabled }">
 		<Editor
 			v-if="nonEditable"
 			:key="`comparison-${comparisonSide ?? ''}-${comparisonEditorKey}`"

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -67,7 +67,6 @@ type CustomFormat = {
 const props = withDefaults(
 	defineProps<{
 		value: string | null;
-		field?: string;
 		toolbar?: string[];
 		font?: 'sans-serif' | 'serif' | 'monospace';
 		customFormats?: CustomFormat[];


### PR DESCRIPTION
## Scope                                                                                                                                         
                                                                                                                                                   
  What's changed:                                                                                                                                  
   
  - Removed unused `:id="field"` attribute from WYSIWYG interface container in `app/src/interfaces/input-rich-text-html/input-rich-text-html.vue`  
                                 
  ## Potential Risks / Drawbacks

  - Could cause issues for any extensions that might be depending on the id field.
  - Appears to be a safe change for the directus codebase. Looks like a vestige no longer needed.

  ## Tested Scenarios

  - Verified WYSIWYG field named "tooltip" now renders correctly
  - Confirmed no JavaScript code in the component relies on the field-based ID
  - Confirmed no CSS selectors target the field-based ID

  ## Review Notes / Questions

  - when a field was named "tooltip", the container got `id="tooltip"` which matched the global `#tooltip`
  CSS selector in `_tooltip.scss` that applies `display: none` by default

  ## Checklist

  - [ ] Added or updated tests
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

  ---

  Fixes #cms-1710
