### PR TITLE
psql compatible fallback condition for case when statements

### DIFF
--- a/.changeset/dry-donkeys-throw.md
+++ b/.changeset/dry-donkeys-throw.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Changed fallback condition for case/when statements to be compatible with PostgresSQL

--- a/api/src/database/run-ast/utils/apply-case-when.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.ts
@@ -45,7 +45,7 @@ export function applyCaseWhen(
 		}
 	}
 
-	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1';
+	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : 'TRUE';
 	const bindings = [...caseQuery.toSQL().bindings, column];
 
 	let rawCase = `(CASE WHEN ${sql} THEN ?? END)`;

--- a/contributors.yml
+++ b/contributors.yml
@@ -247,3 +247,4 @@
 - vdr-smartdev-trinh
 - sinan-yildiz-marsus
 - alvarosabu
+- mgwestwerk


### PR DESCRIPTION
## Scope

What's changed:

- the fallback contition for case when statements is changed from `1` to `TRUE`

## Potential Risks / Drawbacks

- For SQLite Version before 3.23.0 (2018-04-02) `TRUE` is not a valid keyword

## Tested Scenarios

- The error I described in my issue no longer occurs

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26586
