### PR TITLE
Update .gitignore to include AI-related personal workflow directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,6 @@ TODO
 /packages/extensions-sdk/temp-extension-*/
 
 # AI
-.claude/issues/
-.claude/reviews/
-.claude/plans/
+.claude/*
+!.claude/CLAUDE.md
+!.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ TODO
 /tests/blackbox/server-log-*
 /tests/blackbox/sequencer-data.json
 /packages/extensions-sdk/temp-extension-*/
+
+# AI
+.claude/issues/
+.claude/reviews/
+.claude/plans/


### PR DESCRIPTION
## Scope

What's changed:

- Add rule to ignore worfklow related subdirectories of `.claude` and temp files related to personal workflows
- Only CLAUDE.md and skills sub directory are whitelisted.

## Potential Risks / Drawbacks

- None


## Review Notes / Questions

- Is there anything you would atually like to persist in the repo?

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
