### PR TITLE
Improve prompts for using Visual Editor elements inside AI Assistant

### DIFF
--- a/.changeset/tangy-poems-relate.md
+++ b/.changeset/tangy-poems-relate.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved prompts for using Visual Editor elements inside AI Assistant

--- a/api/src/ai/chat/utils/format-context.test.ts
+++ b/api/src/ai/chat/utils/format-context.test.ts
@@ -106,7 +106,9 @@ describe('formatContextForSystemPrompt', () => {
 		expect(result).toContain('<visual_editing>');
 		expect(result).toContain('### sections/456 — "Hero Section"');
 		expect(result).toContain('Editable fields: title, subtitle');
+		expect(result).toContain('To update: items tool with collection="sections", keys=["456"], action="update"');
 		expect(result).toContain('&quot;title&quot;: &quot;Welcome&quot;');
+		expect(result).toContain('NEVER use form-values tools for visual editor elements');
 		expect(result).toContain('</visual_editing>');
 	});
 

--- a/api/src/ai/chat/utils/format-context.ts
+++ b/api/src/ai/chat/utils/format-context.ts
@@ -43,6 +43,7 @@ function formatVisualElement(att: ContextAttachment & { type: 'visual-element' }
 
 	return `### ${collection}/${item} — "${display}"
 Editable fields: ${fields}
+To update: items tool with collection="${collection}", keys=["${item}"], action="update"
 \`\`\`json
 ${escapeAngleBrackets(JSON.stringify(att.snapshot, null, 2))}
 \`\`\``;
@@ -141,6 +142,10 @@ ${itemLines}`);
 		parts.push(`<visual_editing>
 ## Selected Elements
 The user selected these elements for editing in the visual editor.
+
+IMPORTANT: For visual editor elements, ALWAYS use the items tool:
+- To UPDATE: items tool with action: 'update', collection, keys, and data
+- NEVER use form-values tools for visual editor elements
 
 ${elementLines}
 </visual_editing>`);


### PR DESCRIPTION
## Scope

What's changed:

- Tweaked some of the prompts to achieve better results when using VE elements inside AI Assistant

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- VE with AI Assistant trying to selectively update single and multiple fields

## Review Notes / Questions

N/A

## Checklist

- [X] Added or updated tests
---
