### PR TITLE
Tweak workflow to use label on PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,48 +1,72 @@
 name: Claude Code Review
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [labeled]
 
 jobs:
-  claude-review:
-    # Only maintainers can trigger on PRs by commenting /review
-    if: |
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/review') &&
-      (
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
-      )
-
+  review-with-tracking:
+    if: github.event.label.name == 'claude'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: read
       id-token: write
-
     steps:
-      # CodeQL: Checkout is safe as no PR code is executed, only read for analysis.
-      # Re-evaluate if adding steps that run scripts from the checkout.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          ref: refs/pull/${{ github.event.issue.number }}/head
 
-      - name: Run Claude Code Review
-        id: claude-review
+      - name: PR Review with Progress Tracking
         uses: anthropics/claude-code-action@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Post a comment about the status of the review
           track_progress: true
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
+
+          # Your custom review instructions
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Perform a comprehensive code review with the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use top-level comments for general observations or praise.
+
+          # Tools for comprehensive PR review
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Remove claude label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label claude --repo ${{ github.repository }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:


### PR DESCRIPTION

* Changed the workflow trigger from `issue_comment` to `pull_request` events, specifically when the `claude` label is added, allowing reviews to be initiated via labeling instead of comment commands.
* Removed the previous conditional logic that restricted review triggering to maintainers commenting `/review`, simplifying the workflow initiation.
* Enhanced the review step to include detailed instructions covering code quality, security, performance, testing, and documentation, making reviews more thorough and standardized.
* Enabled progress tracking for the review step and updated the action version for `actions/checkout` to v6 for improved reliability.
* Added a step to automatically remove the `claude` label after the review is completed, ensuring labels are managed and the workflow is ready for future reviews.