### PR TITLE
fix: clamp target dimensions when withoutEnlargement is true

### DIFF
--- a/.changeset/fix-withoutenlargement-focal-point.md
+++ b/.changeset/fix-withoutenlargement-focal-point.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Fixed asset transformation error when using `withoutEnlargement` with focal point and dimensions larger than the original image. The target dimensions are now clamped to the original image dimensions when `withoutEnlargement` is enabled, preventing the "bad extract area" error from Sharp.
+Fixed asset transformation error when using `withoutEnlargement` with focal point and dimensions larger than the original image. Target dimensions are now clamped to the original image dimensions.

--- a/.changeset/fix-withoutenlargement-focal-point.md
+++ b/.changeset/fix-withoutenlargement-focal-point.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed asset transformation error when using `withoutEnlargement` with focal point and dimensions larger than the original image. The target dimensions are now clamped to the original image dimensions when `withoutEnlargement` is enabled, preventing the "bad extract area" error from Sharp.

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -251,12 +251,7 @@ describe('resolvePreset', () => {
 		]);
 	});
 
-	test('Add resize transformation: withoutEnlargement clamps dimensions larger than original #22391', () => {
-		// Test case from issue #22391:
-		// Image is 1920x1080, but we request 2000x1200 with withoutEnlargement=true and a focal point
-		// Without the fix, this would cause "bad extract area" error in Sharp
-		// because the extraction region is calculated based on target dimensions (2000x1200)
-		// but the resize step can't enlarge beyond the original (1920x1080)
+	test('Resize transformation with withoutEnlargement clamps dimensions larger than original', () => {
 		const transformationParams: TransformationParams = {
 			key: 'test-larger-than-original',
 			width: 2000, // larger than original width (1920)

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -295,10 +295,7 @@ describe('resolvePreset', () => {
 		);
 
 		// Width should be clamped to 1920, height stays at 500
-		// With 1920x500 target and centered focal point on 1920x1080 image:
-		// hRatio = 1080/500 = 2.16, wRatio = 1920/1920 = 1
-		// wRatio < hRatio, so factor = 1, width = 1920, height = 1080/1 = 1080
-		// Extract region: left = 0, top = (1080/2 - 500/2) = 290
+		// With 1920x500 target and centered focal point on 1920x1080 image
 		expect(output).toStrictEqual([
 			[
 				'resize',

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -324,10 +324,6 @@ describe('resolvePreset', () => {
 			{ ...inputFile, focal_point_x: inputFile.width / 2, focal_point_y: inputFile.height / 2 },
 		);
 
-		// 1920x1080 -> 800x600
-		// hRatio = 1080/600 = 1.8, wRatio = 1920/800 = 2.4
-		// hRatio < wRatio, so factor = 1.8, height = 600, width = Math.round(1920/1.8) = 1067
-		// Extract region: newXCenter = 960/1.8 = 533.33, left = Math.round(533.33 - 400) = 133, top = 0
 		expect(output).toStrictEqual([
 			[
 				'resize',

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -310,8 +310,7 @@ describe('resolvePreset', () => {
 		]);
 	});
 
-	test('Add resize transformation: withoutEnlargement with smaller dimensions unchanged', () => {
-		// Both dimensions are smaller than original - should work normally
+	test('Resize transformation with withoutEnlargement with smaller dimensions is unchanged', () => {
 		const transformationParams: TransformationParams = {
 			key: 'test-smaller',
 			width: 800,

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -266,8 +266,6 @@ describe('resolvePreset', () => {
 		);
 
 		// Dimensions should be clamped to original (1920x1080)
-		// Since we're requesting 1920x1080 with a centered focal point on a 1920x1080 image,
-		// the intermediate dimensions will be 1920x1080, and the extract will be the full image
 		expect(output).toStrictEqual([
 			[
 				'resize',

--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -280,8 +280,7 @@ describe('resolvePreset', () => {
 		]);
 	});
 
-	test('Add resize transformation: withoutEnlargement clamps only width when height is smaller #22391', () => {
-		// Width is larger, height is smaller - only width should be clamped
+	test('Resize transformation with withoutEnlargement clamps only width when height is smaller', () => {
 		const transformationParams: TransformationParams = {
 			key: 'test-width-larger',
 			width: 2000, // larger than original width (1920)

--- a/api/src/utils/transformations.ts
+++ b/api/src/utils/transformations.ts
@@ -16,8 +16,26 @@ export function resolvePreset({ transformationParams, acceptFormat }: Transforma
 	}
 
 	if ((transformationParams.width || transformationParams.height) && file.width && file.height) {
-		const toWidth = transformationParams.width ? Number(transformationParams.width) : undefined;
-		const toHeight = transformationParams.height ? Number(transformationParams.height) : undefined;
+		let toWidth = transformationParams.width ? Number(transformationParams.width) : undefined;
+		let toHeight = transformationParams.height ? Number(transformationParams.height) : undefined;
+
+		/*
+		 * When withoutEnlargement is true, clamp target dimensions to original dimensions.
+		 * This prevents "bad extract area" errors when using focal points with requested
+		 * dimensions larger than the original image. Without this, the extraction region
+		 * would be calculated based on the larger target dimensions, but the resize step
+		 * can't enlarge the image, resulting in an attempt to extract from non-existent area.
+		 * See: https://github.com/directus/directus/issues/22391
+		 */
+		if (transformationParams.withoutEnlargement) {
+			if (toWidth !== undefined) {
+				toWidth = Math.min(toWidth, file.width);
+			}
+
+			if (toHeight !== undefined) {
+				toHeight = Math.min(toHeight, file.height);
+			}
+		}
 
 		const toFocalPointX = transformationParams.focal_point_x
 			? Number(transformationParams.focal_point_x)

--- a/api/src/utils/transformations.ts
+++ b/api/src/utils/transformations.ts
@@ -20,12 +20,7 @@ export function resolvePreset({ transformationParams, acceptFormat }: Transforma
 		let toHeight = transformationParams.height ? Number(transformationParams.height) : undefined;
 
 		/*
-		 * When withoutEnlargement is true, clamp target dimensions to original dimensions.
-		 * This prevents "bad extract area" errors when using focal points with requested
-		 * dimensions larger than the original image. Without this, the extraction region
-		 * would be calculated based on the larger target dimensions, but the resize step
-		 * can't enlarge the image, resulting in an attempt to extract from non-existent area.
-		 * See: https://github.com/directus/directus/issues/22391
+		 * When withoutEnlargement is true, clamp target dimensions to original dimensions to prevent "bad extract area" errors when using focal points.
 		 */
 		if (transformationParams.withoutEnlargement) {
 			if (toWidth !== undefined) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -247,3 +247,4 @@
 - vdr-smartdev-trinh
 - sinan-yildiz-marsus
 - alvarosabu
+- wotan-allfather


### PR DESCRIPTION
When using `withoutEnlargement=true` with a focal point and requesting dimensions larger than the original image, Sharp throws a "bad extract area" error. This is because the extraction region is calculated based on the larger target dimensions, but the resize step cannot enlarge the image beyond its original size.

This fix clamps the target dimensions (width and height) to the original image dimensions when `withoutEnlargement` is enabled, ensuring the extraction region stays within valid bounds.

Closes #22391

## Scope

What's changed:
- Added dimension clamping logic when `withoutEnlargement` is `true`
- Target width is clamped to `Math.min(toWidth, file.width)`
- Target height is clamped to `Math.min(toHeight, file.height)`
- Added comprehensive tests for the fix

## Potential Risks / Drawbacks

- This changes the effective dimensions when `withoutEnlargement=true` and requested dimensions exceed the original. The previous behavior was to error; now it silently clamps. This is consistent with Sharp's behavior for non-focal-point resizes.

## Tested Scenarios

- [x] Both dimensions larger than original → clamped to original dimensions
- [x] Only width larger than original → width clamped, height unchanged
- [x] Both dimensions smaller than original → no change (existing behavior)
- All 16 transformation tests pass

## Review Notes / Questions

- The solution follows the approach suggested by @MauriceArikoglu in the issue thread
- The clamping is applied early in the transformation flow, before focal point calculations

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required