### PR TITLE
Remove `node:assert` usage from shared utils

### DIFF
--- a/.changeset/spotty-rocks-itch.md
+++ b/.changeset/spotty-rocks-itch.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Removed `node:assert` usage from shared utils

--- a/packages/utils/shared/deep-map-filter.ts
+++ b/packages/utils/shared/deep-map-filter.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { InvalidQueryError } from '@directus/errors';
 import type { CollectionOverview, FieldOverview, Filter, Relation, SchemaOverview } from '@directus/types';
 import { isPlainObject } from 'lodash-es';
@@ -33,7 +32,9 @@ export function deepMapFilter(
 	const collection = context.schema.collections[context.collection]!;
 	const path = context.path ?? [];
 
-	assert(isObject(filter), `DeepMapResponse only works on objects, received ${JSON.stringify(filter)}`);
+	if (!isObject(filter)) {
+		throw new Error(`deepMapFilter only works on objects, received ${JSON.stringify(filter)}`);
+	}
 
 	const result = Object.fromEntries(
 		Object.entries(filter)

--- a/packages/utils/shared/deep-map-with-schema.ts
+++ b/packages/utils/shared/deep-map-with-schema.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { InvalidQueryError } from '@directus/errors';
 import type { CollectionOverview, FieldOverview, Relation, SchemaOverview } from '@directus/types';
 import { isPlainObject } from 'lodash-es';
@@ -86,7 +85,9 @@ export function deepMapWithSchema(
 		primaryKeyMapped = true;
 	}
 
-	assert(isObject(object), `DeepMapResponse only works on objects, received ${JSON.stringify(object)}`);
+	if (!isObject(object)) {
+		throw new Error(`deepMapWithSchema only works on objects, received ${JSON.stringify(object)}`);
+	}
 
 	let fields: [string, FieldOverview | undefined][];
 


### PR DESCRIPTION
## Scope

What's changed:

- Remove usage of `node:assert` from deepMapWithSchema and deepMapFilter

## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [x]  Added or updated tests or **not required**
- [x] Documentation PR created [here](https://github.com/directus/docs) or **not required**
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes #26613
