### PR TITLE
Fix manual flow triggers not working in drawer

### DIFF
--- a/.changeset/plain-guests-build.md
+++ b/.changeset/plain-guests-build.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed manual flow triggers not working in drawer

--- a/app/src/stores/notifications.ts
+++ b/app/src/stores/notifications.ts
@@ -14,6 +14,7 @@ export const useNotificationsStore = defineStore({
 		previous: [] as Snackbar[],
 		notifications: [] as Notification[],
 		unread: 0,
+		overlayIsActive: false,
 	}),
 	actions: {
 		async hydrate() {
@@ -54,6 +55,9 @@ export const useNotificationsStore = defineStore({
 		},
 		setUnreadCount(count: number) {
 			this.unread = count < 0 ? 0 : count;
+		},
+		setOverlayIsActive(active: boolean) {
+			this.overlayIsActive = active;
 		},
 		add(notification: SnackbarRaw) {
 			const id = nanoid();

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import { toRefs } from 'vue';
+import { computed, toRefs } from 'vue';
 import NotificationItem from './notification-item.vue';
 import { useNotificationsStore } from '@/stores/notifications';
 
 const notificationsStore = useNotificationsStore();
 const queue = toRefs(notificationsStore).queue;
+
+const overlayIsActive = computed(() => notificationsStore.overlayIsActive);
 </script>
 
 <template>
-	<TransitionGroup class="notifications-group" name="slide-fade" tag="div">
+	<TransitionGroup class="notifications-group" :class="{ overlay: overlayIsActive }" name="slide-fade" tag="div">
 		<slot />
 		<NotificationItem
 			v-for="notification in queue"
@@ -40,6 +42,11 @@ const queue = toRefs(notificationsStore).queue;
 	flex-direction: column;
 	align-items: end;
 	inline-size: 256px;
+
+	&.overlay {
+		z-index: 700;
+		position: fixed;
+	}
 }
 
 .notification-item {
@@ -63,13 +70,5 @@ const queue = toRefs(notificationsStore).queue;
 	opacity: 0;
 	transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
 	transition-duration: 200ms;
-}
-</style>
-
-<style lang="scss">
-// relocate to fixed position when dialog is open to prevent it from being covered by the dialog
-body:has(#dialog-outlet > .container.right) .notifications-group {
-	position: fixed;
-	z-index: 700;
 }
 </style>

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -65,3 +65,11 @@ const queue = toRefs(notificationsStore).queue;
 	transition-duration: 200ms;
 }
 </style>
+
+<style lang="scss">
+// relocate to fixed position when dialog is open to prevent it from being covered by the dialog
+body:has(#dialog-outlet > .container.right) .notifications-group {
+	position: fixed;
+	z-index: 700;
+}
+</style>

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -38,6 +38,7 @@ import { translateShortcut } from '@/utils/translate-shortcut';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
 import CollabAvatars from '@/views/private/components/CollabAvatars.vue';
+import FlowDialogs from '@/views/private/components/flow-dialogs.vue';
 
 export interface OverlayItemProps {
 	overlay?: 'drawer' | 'modal' | 'popover';
@@ -292,7 +293,7 @@ const overlayItemContentProps = computed(() => {
 	};
 });
 
-const { provideRunManualFlow } = useFlows({
+const { flowDialogsContext, provideRunManualFlow } = useFlows({
 	collection,
 	primaryKey: primaryKey,
 	location: 'item',
@@ -619,6 +620,8 @@ function popoverClickOutsideMiddleware(e: Event) {
 		</template>
 
 		<template #actions>
+			<FlowDialogs v-bind="flowDialogsContext" />
+
 			<CollabAvatars
 				:model-value="uniqBy([...(collab?.users.value ?? []), ...(relatedCollab?.users.value ?? [])], 'connection')"
 				:connected="collab?.connected.value && (!relatedCollab || relatedCollab?.connected.value)"

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -31,6 +31,7 @@ import { usePermissions } from '@/composables/use-permissions';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useFieldsStore } from '@/stores/fields';
+import { useNotificationsStore } from '@/stores/notifications';
 import { useRelationsStore } from '@/stores/relations';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { mergeItemData } from '@/utils/merge-item-data';
@@ -324,9 +325,13 @@ function useItem() {
 	const loading = ref(false);
 	const initialValues = ref<Record<string, any> | null>(null);
 
+	const notificationsStore = useNotificationsStore();
+
 	watch(
 		() => props.active,
 		(isActive) => {
+			notificationsStore.setOverlayIsActive(!!isActive);
+
 			if (isActive) {
 				if (props.primaryKey !== '+') fetchItem();
 				if (props.relatedPrimaryKey !== '+') fetchRelatedItem();


### PR DESCRIPTION
## Scope

What's changed:

- Fix manual flow triggers silently failing when item is opened in a drawer
- Root cause: `overlay-item.vue` called `useFlows()` but never rendered `FlowDialogs`, so confirmation dialogs had no UI and flows aborted silently
- Fix notification toasts appearing behind the drawer by switching to `position: fixed; z-index: 700` when a drawer is open

## Potential Risks / Drawbacks

## Tested Scenarios

- Open an item that has a manual flow trigger button
- Verify flow triggers correctly from the normal item view
- Open the same item via a relational field (in a drawer) and trigger the flow — should work now
- Verify the success notification toast appears above the drawer
- Verify notifications on normal pages (no drawer) still appear correctly

## Review Notes / Questions

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26541
