### PR TITLE
Update CLA bot to version 0.0.3

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: check
-        uses: directus/cla-bot@v0.0.2
+        uses: directus/cla-bot@v0.0.3
 
       - if: failure() && steps.check.outputs.missing
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
v0.0.3 ignores the `claude` bot user. Previous bots (identified with `[bot]`) were already ignored. Claude uses the @claude user handle instead