### PR TITLE
Only focus on fields that have a schema

### DIFF
--- a/.changeset/forty-singers-slide.md
+++ b/.changeset/forty-singers-slide.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed only focusing on fields that have a schema

--- a/app/src/composables/use-collab.test.ts
+++ b/app/src/composables/use-collab.test.ts
@@ -46,7 +46,7 @@ const {
 	const mockNotificationsStore = { add: vi.fn(), queue: [] };
 	const mockPermissionsStore = { getPermission: vi.fn().mockReturnValue({ access: 'all' }) };
 	const mockRelationsStore = { getRelationForField: vi.fn() };
-	const mockFieldsStore = { getPrimaryKeyFieldForCollection: vi.fn() };
+	const mockFieldsStore = { getPrimaryKeyFieldForCollection: vi.fn(), getField: vi.fn() };
 	const mockRouter = { push: vi.fn() };
 
 	return {

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -530,6 +530,7 @@ export function useCollab(
 
 	const onFocus = debounce((field: string | null) => {
 		if (field && Object.values(focused.value).includes(field)) return;
+		if (field && !fieldsStore.getField(collection.value, field)?.schema) return;
 
 		sendMessage({
 			action: ACTION.CLIENT.FOCUS,


### PR DESCRIPTION
## Scope

This prevents the client from sending a WebSocket focus message for fields that don't have a database column (presentation-links, presentation-dividers, presentation-notices, etc.).
Without this, the server's checkFieldsAccess in api/src/websocket/collab/collab.ts:563 looks for the field in the DB schema, doesn't find it, and throws a ForbiddenError.

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- Focusing on button presentation interface

## Review Notes / Questions

- Fields that are on in the database won't have a schema so there is no point in focusing them.

## Checklist

---

Fixes #26620
