### PR TITLE
Fix GraphQL groupBy collision when a field is named `group`

### DIFF
--- a/.changeset/fix-graphql-groupby-collision.md
+++ b/.changeset/fix-graphql-groupby-collision.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed GraphQL groupBy collision when a field is literally named `group`
+Fixed GraphQL groupBy collision when a field is named `group`

--- a/.changeset/fix-graphql-groupby-collision.md
+++ b/.changeset/fix-graphql-groupby-collision.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed GraphQL groupBy collision when a field is literally named `group`

--- a/api/src/services/graphql/resolvers/query.test.ts
+++ b/api/src/services/graphql/resolvers/query.test.ts
@@ -207,6 +207,40 @@ describe('resolveQuery', () => {
 		expect(queryArg).toEqual(expect.objectContaining({ fields: ['count(a)', 'b.sum(c)', 'c.d.max(e)'] }));
 	});
 
+	test('inject group field when groupBy field is named "group"', async () => {
+		mockReplaceFragments.mockReturnValue([{}]);
+		mockParseArgs.mockReturnValue({});
+
+		mockGetAggregateQuery.mockResolvedValue({
+			group: ['group'],
+			aggregate: { count: ['id'] },
+		});
+
+		const gql: any = {
+			scope: 'app',
+			schema: { collections: {} },
+			accountability: {},
+			read: vi.fn(() => [
+				{ group: 'admin', count: { id: 3 } },
+				{ group: 'user', count: { id: 7 } },
+			]),
+		};
+
+		const info: any = {
+			fieldName: 'items_aggregated',
+			fieldNodes: [{ selectionSet: { selections: [{}] }, arguments: [] }],
+			fragments: {},
+			variableValues: {},
+		};
+
+		const res = await resolveQuery(gql, info);
+
+		expect(res).toEqual([
+			{ group: { group: 'admin' }, count: { id: 3 } },
+			{ group: { group: 'user' }, count: { id: 7 } },
+		]);
+	});
+
 	test('inject group field for each item when grouping', async () => {
 		mockReplaceFragments.mockReturnValue([{}]);
 		mockParseArgs.mockReturnValue({});

--- a/api/src/services/graphql/resolvers/query.ts
+++ b/api/src/services/graphql/resolvers/query.ts
@@ -1,7 +1,6 @@
 import type { Item, Query } from '@directus/types';
 import { parseFilterFunctionPath } from '@directus/utils';
 import type { GraphQLResolveInfo } from 'graphql';
-import { omit } from 'lodash-es';
 import type { GraphQLService } from '../index.js';
 import { parseArgs } from '../schema/parse-args.js';
 import { getQuery } from '../schema/parse-query.js';
@@ -52,11 +51,14 @@ export async function resolveQuery(gql: GraphQLService, info: GraphQLResolveInfo
 	if (args['id']) return result;
 
 	if (query.group) {
-		// for every entry in result add a group field based on query.group;
-		const aggregateKeys = Object.keys(query.aggregate ?? {});
-
 		result['map']((field: Item) => {
-			field['group'] = omit(field, aggregateKeys);
+			const groupValues: Record<string, any> = {};
+
+			for (const key of query.group!) {
+				groupValues[key] = field[key];
+			}
+
+			field['group'] = groupValues;
 		});
 	}
 

--- a/api/src/services/graphql/utils/aggregate-query.test.ts
+++ b/api/src/services/graphql/utils/aggregate-query.test.ts
@@ -196,6 +196,30 @@ describe('getAggregateQuery', () => {
 			});
 		});
 
+		test('should skip the group field selection', async () => {
+			const selections: SelectionNode[] = [
+				{
+					kind: 'Field',
+					name: { value: 'count' },
+					selectionSet: {
+						selections: [{ kind: 'Field', name: { value: 'id' } } as FieldNode],
+					},
+				} as unknown as FieldNode,
+				{
+					kind: 'Field',
+					name: { value: 'group' },
+				} as FieldNode,
+			];
+
+			const result = await getAggregateQuery({}, selections, schema);
+
+			expect(result.aggregate).toEqual({
+				count: ['id'],
+			});
+
+			expect(result.aggregate).not.toHaveProperty('group');
+		});
+
 		test('should handle field nodes with an empty selectionSet', async () => {
 			const selections: SelectionNode[] = [
 				{

--- a/api/src/services/graphql/utils/aggregate-query.ts
+++ b/api/src/services/graphql/utils/aggregate-query.ts
@@ -27,6 +27,9 @@ export async function getAggregateQuery(
 		// filter out graphql pointers, like __typename
 		if (aggregationGroup.name.value.startsWith('__')) continue;
 
+		// skip the 'group' field — it holds grouped values, not an aggregate function
+		if (aggregationGroup.name.value === 'group') continue;
+
 		const aggregateProperty = aggregationGroup.name.value as keyof Aggregate;
 
 		query.aggregate[aggregateProperty] =

--- a/tests/blackbox/tests/db/routes/items/no-relation.seed.ts
+++ b/tests/blackbox/tests/db/routes/items/no-relation.seed.ts
@@ -40,6 +40,14 @@ export const seedDBStructure = () => {
 						schema: {},
 					});
 
+					await CreateField(vendor, {
+						collection: localCollectionArtists,
+						field: 'group',
+						type: 'string',
+						meta: {},
+						schema: {},
+					});
+
 					expect(true).toBeTruthy();
 				} catch (error) {
 					expect(error).toBeFalsy();


### PR DESCRIPTION
## Scope

- Fixed GraphQL `groupBy` collision when a collection field is literally named `group`
- Replaced `omit`-based approach with explicit construction from `query.group` keys
- Removed unused `omit` import from `lodash-es`

## Potential Risks / Drawbacks

- None — the output structure is identical for non-conflicting field names
- The existing test for normal groupBy passes unchanged

## Tested Scenarios

- Added unit test for `groupBy: ["group"]` — verifies the group response object correctly contains `{ group: 'admin' }` instead of `{}`
- Existing groupBy test (`groupBy: ["category"]`) passes unchanged

## Review Notes / Questions

- Root cause: `omit(field, aggregateKeys)` omits `group` from itself when the field is named `group`, producing `{}`
- Fix constructs the group object explicitly from `query.group` keys instead of using omit

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #17374