### PR TITLE
Fix password reset sending emails to external auth provider users

### DIFF
--- a/.changeset/fix-password-reset-external-provider.md
+++ b/.changeset/fix-password-reset-external-provider.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed password reset sending emails to external auth provider users

--- a/.changeset/fix-password-reset-external-provider.md
+++ b/.changeset/fix-password-reset-external-provider.md
@@ -1,5 +1,6 @@
 ---
 '@directus/api': major
+'@directus/specs': patch
 ---
 
 Fixed password reset sending emails to external auth provider users

--- a/.changeset/fix-password-reset-external-provider.md
+++ b/.changeset/fix-password-reset-external-provider.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': patch
+'@directus/api': minor
 ---
 
 Fixed password reset sending emails to external auth provider users

--- a/.changeset/fix-password-reset-external-provider.md
+++ b/.changeset/fix-password-reset-external-provider.md
@@ -1,5 +1,5 @@
 ---
-'@directus/api': minor
+'@directus/api': major
 ---
 
 Fixed password reset sending emails to external auth provider users

--- a/.changeset/fix-password-reset-external-provider.md
+++ b/.changeset/fix-password-reset-external-provider.md
@@ -1,5 +1,6 @@
 ---
 '@directus/api': major
+'@directus/app': patch
 '@directus/specs': patch
 ---
 

--- a/.changeset/fix-password-reset-external-provider.md
+++ b/.changeset/fix-password-reset-external-provider.md
@@ -5,3 +5,7 @@
 ---
 
 Fixed password reset sending emails to external auth provider users
+
+:::notice
+`requestPasswordReset` now throws a `Forbidden` error for external auth provider users.
+:::

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -300,8 +300,8 @@ describe('Integration Tests', () => {
 		});
 
 		describe('requestPasswordReset', () => {
-			it('should silently return for external provider users', async () => {
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+			it('should throw ForbiddenError for external provider users', async () => {
+				tracker.on.select('directus_users').response({
 					id: 'user-id-ext',
 					role: 'role-id',
 					status: 'active',
@@ -317,13 +317,13 @@ describe('Integration Tests', () => {
 					schema,
 				});
 
-				await service.requestPasswordReset('ext@example.com', null);
+				await expect(service.requestPasswordReset('ext@example.com', null)).rejects.toThrow(ForbiddenError);
 
 				expect(mailService.send).not.toHaveBeenCalled();
 			});
 
 			it('should send reset email for default provider users', async () => {
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+				tracker.on.select('directus_users').response({
 					id: 'user-id-def',
 					role: 'role-id',
 					status: 'active',

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -299,6 +299,52 @@ describe('Integration Tests', () => {
 			});
 		});
 
+		describe('requestPasswordReset', () => {
+			it('should silently return for external provider users', async () => {
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-ext',
+					role: 'role-id',
+					status: 'active',
+					password: 'hashed',
+					email: 'ext@example.com',
+					provider: 'google',
+				});
+
+				const mailService = new MailService({ schema });
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.requestPasswordReset('ext@example.com', null);
+
+				expect(mailService.send).not.toHaveBeenCalled();
+			});
+
+			it('should send reset email for default provider users', async () => {
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-def',
+					role: 'role-id',
+					status: 'active',
+					password: 'hashed',
+					email: 'def@example.com',
+					provider: 'default',
+				});
+
+				const mailService = new MailService({ schema });
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.requestPasswordReset('def@example.com', null);
+
+				expect(mailService.send).toHaveBeenCalledTimes(1);
+			});
+		});
+
 		describe('invite', () => {
 			const mailService = new MailService({
 				schema,

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -574,7 +574,7 @@ export class UsersService extends ItemsService {
 
 		if (user.provider !== DEFAULT_AUTH_PROVIDER) {
 			await stall(STALL_TIME, timeStart);
-			return;
+			throw new ForbiddenError();
 		}
 
 		const mailService = new MailService({

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -17,6 +17,7 @@ import jwt from 'jsonwebtoken';
 import { isEmpty } from 'lodash-es';
 import type { StringValue } from 'ms';
 import { clearSystemCache } from '../cache.js';
+import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import getDatabase from '../database/index.js';
 import { useLogger } from '../logger/index.js';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
@@ -136,9 +137,11 @@ export class UsersService extends ItemsService {
 	 */
 	private async getUserByEmail(
 		email: string,
-	): Promise<{ id: string; role: string; status: string; password: string; email: string } | undefined> {
+	): Promise<
+		{ id: string; role: string; status: string; password: string; email: string; provider: string } | undefined
+	> {
 		return this.knex
-			.select('id', 'role', 'status', 'password', 'email')
+			.select('id', 'role', 'status', 'password', 'email', 'provider')
 			.from('directus_users')
 			.whereRaw(`LOWER(??) = ?`, ['email', email.toLowerCase()])
 			.first();
@@ -567,6 +570,11 @@ export class UsersService extends ItemsService {
 		if (user?.status !== 'active') {
 			await stall(STALL_TIME, timeStart);
 			throw new ForbiddenError();
+		}
+
+		if (user.provider !== DEFAULT_AUTH_PROVIDER) {
+			await stall(STALL_TIME, timeStart);
+			return;
 		}
 
 		const mailService = new MailService({

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -866,7 +866,7 @@ unexpected_error_copy: An unexpected error has occurred. Please try again.
 copy_details: Copy Details
 no_app_access: No App Access
 no_app_access_copy: This user isn't allowed to use the admin app.
-password_reset_sent: If you have an account, we've sent you a secure link to reset your password
+password_reset_sent: If you have an account and it supports password reset, we've sent a secure link to your email
 password_reset_successful: Password successfully reset
 back: Back
 filter: Filter

--- a/packages/specs/src/paths/auth/password-request.yaml
+++ b/packages/specs/src/paths/auth/password-request.yaml
@@ -3,7 +3,9 @@ post:
     - Authentication
   operationId: passwordRequest
   summary: Request a Password Reset
-  description: Request a reset password email to be send.
+  description:
+    Request that a password reset email be sent. This does not apply to users authenticated through external providers
+    (OAuth, SAML, LDAP, etc.).
   requestBody:
     content:
       application/json:


### PR DESCRIPTION
## Scope

- Password reset now checks user's auth provider before sending reset email
- External provider users (OAuth, SAML, LDAP, etc.) get silently ignored to prevent confusing reset emails
- Added `provider` to `getUserByEmail` select query
- Uses `DEFAULT_AUTH_PROVIDER` constant for comparison

## Potential Risks / Drawbacks

- Silent return prevents user enumeration (attacker can't distinguish external vs nonexistent users)
- No behavioral change for `default` provider users

## Tested Scenarios

- Added test: external provider user (`provider: 'google'`) — no email sent
- Added test: default provider user (`provider: 'default'`) — email sent as before
- All 34 existing user service tests continue to pass

## Review Notes / Questions

- Root cause: `requestPasswordReset` never checked `provider`, so external auth users received reset emails they couldn't use
- Pattern follows existing stall-and-return approach for ForbiddenError cases to avoid timing attacks

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created - https://github.com/directus/docs/pull/558
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #16133