### PR TITLE
fix(api): validate numeric filter values before sending to database

### DIFF
--- a/.changeset/fix-filter-type-mismatch.md
+++ b/.changeset/fix-filter-type-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed filter rule type mismatch causing database error instead of returning INVALID_QUERY

--- a/api/src/database/run-ast/lib/apply-query/filter/operator.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/operator.test.ts
@@ -113,9 +113,9 @@ test('applyOperator throws InvalidQueryError for non-numeric value on integer fi
 	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 	const queryBuilder = db.queryBuilder();
 
-	expect(() =>
-		applyOperator(db, queryBuilder, schema, 'articles.likes', '_eq', 'not-a-number'),
-	).toThrow(InvalidQueryError);
+	expect(() => applyOperator(db, queryBuilder, schema, 'articles.likes', '_eq', 'not-a-number')).toThrow(
+		InvalidQueryError,
+	);
 });
 
 test('applyOperator throws InvalidQueryError for non-numeric array value on integer field', async () => {
@@ -131,7 +131,7 @@ test('applyOperator throws InvalidQueryError for non-numeric array value on inte
 	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 	const queryBuilder = db.queryBuilder();
 
-	expect(() =>
-		applyOperator(db, queryBuilder, schema, 'articles.likes', '_eq', ['abc', '123']),
-	).toThrow(InvalidQueryError);
+	expect(() => applyOperator(db, queryBuilder, schema, 'articles.likes', '_eq', ['abc', '123'])).toThrow(
+		InvalidQueryError,
+	);
 });

--- a/api/src/database/run-ast/lib/apply-query/filter/operator.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/operator.test.ts
@@ -6,6 +6,15 @@ import { Client_SQLite3 } from '../mock.js';
 
 const { applyOperator } = await import('./operator.js');
 
+const schema = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('title').string();
+		c.field('likes').integer();
+		c.field('links').o2m('links', 'article_id');
+	})
+	.build();
+
 for (const { field, operator, value, sql, bindings } of [
 	{
 		field: 'articles.title',
@@ -86,15 +95,6 @@ for (const { field, operator, value, sql, bindings } of [
 	},
 ]) {
 	test(`applyOperator on ${field} ${operator} ${value}`, async () => {
-		const schema = new SchemaBuilder()
-			.collection('articles', (c) => {
-				c.field('id').id();
-				c.field('title').string();
-				c.field('likes').integer();
-				c.field('links').o2m('links', 'article_id');
-			})
-			.build();
-
 		const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 		const queryBuilder = db.queryBuilder();
 
@@ -108,15 +108,6 @@ for (const { field, operator, value, sql, bindings } of [
 }
 
 test('applyOperator throws InvalidQueryError for non-numeric value on function-based numeric field', async () => {
-	const schema = new SchemaBuilder()
-		.collection('articles', (c) => {
-			c.field('id').id();
-			c.field('title').string();
-			c.field('likes').integer();
-			c.field('links').o2m('links', 'article_id');
-		})
-		.build();
-
 	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 	const queryBuilder = db.queryBuilder();
 
@@ -126,15 +117,6 @@ test('applyOperator throws InvalidQueryError for non-numeric value on function-b
 });
 
 test('applyOperator throws InvalidQueryError for non-numeric array value on function-based numeric field', async () => {
-	const schema = new SchemaBuilder()
-		.collection('articles', (c) => {
-			c.field('id').id();
-			c.field('title').string();
-			c.field('likes').integer();
-			c.field('links').o2m('links', 'article_id');
-		})
-		.build();
-
 	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 	const queryBuilder = db.queryBuilder();
 
@@ -144,15 +126,6 @@ test('applyOperator throws InvalidQueryError for non-numeric array value on func
 });
 
 test('applyOperator throws InvalidQueryError for non-numeric value on integer field', async () => {
-	const schema = new SchemaBuilder()
-		.collection('articles', (c) => {
-			c.field('id').id();
-			c.field('title').string();
-			c.field('likes').integer();
-			c.field('links').o2m('links', 'article_id');
-		})
-		.build();
-
 	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 	const queryBuilder = db.queryBuilder();
 
@@ -162,15 +135,6 @@ test('applyOperator throws InvalidQueryError for non-numeric value on integer fi
 });
 
 test('applyOperator throws InvalidQueryError for non-numeric array value on integer field', async () => {
-	const schema = new SchemaBuilder()
-		.collection('articles', (c) => {
-			c.field('id').id();
-			c.field('title').string();
-			c.field('likes').integer();
-			c.field('links').o2m('links', 'article_id');
-		})
-		.build();
-
 	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
 	const queryBuilder = db.queryBuilder();
 

--- a/api/src/database/run-ast/lib/apply-query/filter/operator.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/operator.ts
@@ -1,3 +1,4 @@
+import { InvalidQueryError } from '@directus/errors';
 import type { FieldFunction, SchemaOverview } from '@directus/types';
 import { getOutputTypeForFunction } from '@directus/utils';
 import type { Knex } from 'knex';
@@ -72,7 +73,16 @@ export function applyOperator(
 		const type = getOutputTypeForFunction(functionName);
 
 		if (['integer', 'float', 'decimal'].includes(type)) {
-			compareValue = Array.isArray(compareValue) ? compareValue.map(Number) : Number(compareValue);
+			if (Array.isArray(compareValue)) {
+				compareValue = compareValue.map((val) => {
+					const num = Number(val);
+					if (Number.isNaN(num)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
+					return num;
+				});
+			} else {
+				compareValue = Number(compareValue);
+				if (Number.isNaN(compareValue)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
+			}
 		}
 	}
 
@@ -93,9 +103,14 @@ export function applyOperator(
 
 		if (['integer', 'float', 'decimal'].includes(type)) {
 			if (Array.isArray(compareValue)) {
-				compareValue = compareValue.map((val) => Number(val));
+				compareValue = compareValue.map((val) => {
+					const num = Number(val);
+					if (Number.isNaN(num)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
+					return num;
+				});
 			} else {
 				compareValue = Number(compareValue);
+				if (Number.isNaN(compareValue)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
 			}
 		}
 	}

--- a/api/src/database/run-ast/lib/apply-query/filter/operator.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/operator.ts
@@ -5,6 +5,20 @@ import type { Knex } from 'knex';
 import { getHelpers } from '../../../../helpers/index.js';
 import { getColumn } from '../../../utils/get-column.js';
 
+function castToNumber(value: any): any {
+	if (Array.isArray(value)) {
+		return value.map((val) => {
+			const num = Number(val);
+			if (Number.isNaN(num)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
+			return num;
+		});
+	}
+
+	const num = Number(value);
+	if (Number.isNaN(num)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
+	return num;
+}
+
 export function applyOperator(
 	knex: Knex,
 	dbQuery: Knex.QueryBuilder,
@@ -73,16 +87,7 @@ export function applyOperator(
 		const type = getOutputTypeForFunction(functionName);
 
 		if (['integer', 'float', 'decimal'].includes(type)) {
-			if (Array.isArray(compareValue)) {
-				compareValue = compareValue.map((val) => {
-					const num = Number(val);
-					if (Number.isNaN(num)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
-					return num;
-				});
-			} else {
-				compareValue = Number(compareValue);
-				if (Number.isNaN(compareValue)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
-			}
+			compareValue = castToNumber(compareValue);
 		}
 	}
 
@@ -102,16 +107,7 @@ export function applyOperator(
 		}
 
 		if (['integer', 'float', 'decimal'].includes(type)) {
-			if (Array.isArray(compareValue)) {
-				compareValue = compareValue.map((val) => {
-					const num = Number(val);
-					if (Number.isNaN(num)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
-					return num;
-				});
-			} else {
-				compareValue = Number(compareValue);
-				if (Number.isNaN(compareValue)) throw new InvalidQueryError({ reason: `Invalid numeric value` });
-			}
+			compareValue = castToNumber(compareValue);
 		}
 	}
 

--- a/tests/blackbox/tests/db/routes/items/no-relation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/no-relation.test.ts
@@ -98,9 +98,6 @@ describe.each(PRIMARY_KEY_TYPES)('/items', (pkType) => {
 						expect(gqlResponse.statusCode).toBe(200);
 
 						switch (vendor) {
-							case 'sqlite3':
-								expect(gqlResponse.body.data[localCollectionArtists].length).toEqual(0);
-								break;
 							case 'postgres':
 							case 'postgres10':
 							case 'mssql':


### PR DESCRIPTION
## Scope

- Added NaN validation after `Number()` cast in filter operator processing
- Both function-based casts (e.g. `count()`) and field-type-based casts now validate
- Throws `INVALID_QUERY` error with clear message instead of database-level parse errors

## Potential Risks / Drawbacks

- Filters that previously crashed the database now return a 400 error — this is strictly better behavior
- No behavioral change for valid numeric filter values

## Tested Scenarios

- Added test: non-numeric string value (`'not-a-number'`) on integer field — throws `InvalidQueryError`
- Added test: array with non-numeric value (`['abc', '123']`) on integer field — throws `InvalidQueryError`
- All 10 existing operator tests continue to pass

## Review Notes / Questions

- Root cause: `Number('uuid-string')` returns `NaN`, which gets sent to the database and causes "invalid input syntax for type integer"
- Fix validates immediately after the `Number()` cast at both cast sites in the function

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #15910