### PR TITLE
Follow-up: move FlowDialogs component to ensure each overlay type renders it correctly

### DIFF
--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -625,8 +625,6 @@ function popoverClickOutsideMiddleware(e: Event) {
 		</template>
 
 		<template #actions>
-			<FlowDialogs v-bind="flowDialogsContext" />
-
 			<CollabAvatars
 				:model-value="uniqBy([...(collab?.users.value ?? []), ...(relatedCollab?.users.value ?? [])], 'connection')"
 				:connected="collab?.connected.value && (!relatedCollab || relatedCollab?.connected.value)"
@@ -725,6 +723,8 @@ function popoverClickOutsideMiddleware(e: Event) {
 			/>
 		</div>
 	</VMenu>
+
+	<FlowDialogs v-bind="flowDialogsContext" />
 
 	<ComparisonModal
 		v-if="collab"


### PR DESCRIPTION
This is a follow-up of https://github.com/directus/directus/pull/26617

Instead of rendering the dialogs in the header bar action slot of the drawer, it will render outside the drawer so every overlay type can display the Flow Dialogs.