### PR TITLE
Fix block editor readOnly toggle race condition

### DIFF
--- a/.changeset/thirty-olives-tap.md
+++ b/.changeset/thirty-olives-tap.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed block editor readOnly toggle race condition

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -1,0 +1,71 @@
+import EditorJS from '@editorjs/editorjs';
+import { flushPromises, mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import InputBlockEditor from './input-block-editor.vue';
+
+vi.mock('@editorjs/editorjs', () => ({ default: vi.fn() }));
+vi.mock('./tools', () => ({ default: vi.fn(() => ({})) }));
+vi.mock('@/api', () => ({ default: { defaults: { baseURL: '' } } }));
+vi.mock('@/stores/collections', () => ({ useCollectionsStore: () => ({ getCollection: () => null }) }));
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('@/utils/unexpected-error', () => ({ unexpectedError: vi.fn() }));
+
+describe('InputBlockEditor', () => {
+	it('should render content before toggling readOnly on concurrent prop change', async () => {
+		const callOrder: string[] = [];
+		let resolveReady!: () => void;
+		let resolveRender!: () => void;
+
+		vi.mocked(EditorJS).mockImplementation(
+			() =>
+				({
+					isReady: new Promise<void>((r) => (resolveReady = r)),
+					render: vi.fn(() => {
+						callOrder.push('render');
+						return new Promise<void>((r) => (resolveRender = r));
+					}),
+					clear: vi.fn(),
+					destroy: vi.fn(),
+					focus: vi.fn(),
+					on: vi.fn(),
+					saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
+					readOnly: {
+						toggle: vi.fn((val: boolean) => callOrder.push(`toggle:${val}`)),
+					},
+				}) as any,
+		);
+
+		const wrapper = mount(InputBlockEditor, {
+			props: {
+				disabled: false,
+				value: { blocks: [{ type: 'paragraph', data: { text: 'initial' } }] },
+			},
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		// Complete initial mount
+		resolveReady();
+		await flushPromises();
+		resolveRender();
+		await flushPromises();
+		callOrder.length = 0;
+
+		// Both props change in the same tick — triggers disabled + value watchers
+		await wrapper.setProps({
+			disabled: true,
+			value: { blocks: [{ type: 'paragraph', data: { text: 'updated' } }] },
+		});
+
+		await flushPromises();
+
+		// Without the fix, the sync disabled watcher fires toggle before the value watcher calls render
+		expect(callOrder.indexOf('render')).toBeLessThan(callOrder.indexOf('toggle:true'));
+
+		resolveRender();
+		await flushPromises();
+		wrapper.unmount();
+	});
+});

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import EditorJS from '@editorjs/editorjs';
 import { isEqual } from 'lodash';
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useBus } from './bus';
 import { sanitizeValue } from './sanitize';
@@ -110,10 +110,11 @@ onUnmounted(() => {
 
 watch(
 	[editorjsIsReady, () => props.disabled],
-	([isReady, isDisabled]) => {
+	async ([isReady, isDisabled]) => {
 		if (!isReady) return;
 
 		// Note: EditorJS must be ready before readOnly is toggled; otherwise, the content won’t render, which could result in data loss!
+		await nextTick();
 		editorjsRef.value?.readOnly.toggle(isDisabled);
 	},
 	{ immediate: true },


### PR DESCRIPTION
## Scope

What's changed:

- Defer setting readOnly via await nextTick() so it fires after the value watcher's render() when both props change in the same tick

## Potential Risks / Drawbacks

- If the root cause is a different one than the DOM updates, nextTick might not be the best solution.

## Tested Scenarios

- Opening items with a block editor in the item view and in the relational drawer and verifying the content appears
- Throttled network speed

## Review Notes / Questions

- Without the fix, the disabled watcher sets the editor to disabled before the value watcher starts render(), causing EditorJS to silently drop content

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26635
