### PR TITLE
Release 11.15.2

### DIFF
--- a/.changeset/dry-deer-kneel.md
+++ b/.changeset/dry-deer-kneel.md
@@ -1,7 +1,0 @@
----
-'@directus/types': minor
-'@directus/api': minor
-'@directus/app': minor
----
-
-Added Netlify as a deployment provider

--- a/.changeset/fix-withoutenlargement-focal-point.md
+++ b/.changeset/fix-withoutenlargement-focal-point.md
@@ -1,5 +1,0 @@
----
-"@directus/api": patch
----
-
-Fixed asset transformation error when using `withoutEnlargement` with focal point and dimensions larger than the original image. Target dimensions are now clamped to the original image dimensions.

--- a/.changeset/forty-singers-slide.md
+++ b/.changeset/forty-singers-slide.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed only focusing on fields that have a schema

--- a/.changeset/gold-friends-stare.md
+++ b/.changeset/gold-friends-stare.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed nested group fields losing values when a condition toggles the group's readonly property

--- a/.changeset/goofy-fans-bow.md
+++ b/.changeset/goofy-fans-bow.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed useStores, useApi, and useSdk not working inside Pinia stores in extensions

--- a/.changeset/lovely-needles-feel.md
+++ b/.changeset/lovely-needles-feel.md
@@ -1,5 +1,0 @@
----
-'@directus/extensions-sdk': patch
----
-
-Fixed linking scoped extensions created nested folders

--- a/.changeset/plain-guests-build.md
+++ b/.changeset/plain-guests-build.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed manual flow triggers not working in drawer

--- a/.changeset/safe-pens-draw.md
+++ b/.changeset/safe-pens-draw.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Preserved SQL parameterization in relational count subquery and used content-disposition library for folder zip download header

--- a/.changeset/spotty-rocks-itch.md
+++ b/.changeset/spotty-rocks-itch.md
@@ -1,5 +1,0 @@
----
-'@directus/utils': patch
----
-
-Removed `node:assert` usage from shared utils

--- a/.changeset/tangy-dingos-drive.md
+++ b/.changeset/tangy-dingos-drive.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Replaced flatpickr with reka ui primitives

--- a/.changeset/thirty-olives-tap.md
+++ b/.changeset/thirty-olives-tap.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed block editor readOnly toggle race condition

--- a/.changeset/twenty-pots-bake.md
+++ b/.changeset/twenty-pots-bake.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Updated editorjs to fix inline link tool bug

--- a/.changeset/wacky-stamps-brake.md
+++ b/.changeset/wacky-stamps-brake.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed metric list labels to no longer be cut off by bar value labels

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/api",
-	"version": "33.1.1",
+	"version": "33.2.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/app",
-	"version": "15.1.1",
+	"version": "15.2.0",
 	"description": "App dashboard for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "directus",
-	"version": "11.15.1",
+	"version": "11.15.2",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/composables",
-	"version": "11.2.11",
+	"version": "11.2.12",
 	"description": "Shared Vue composables for Directus use",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-directus-extension",
-	"version": "11.0.27",
+	"version": "11.0.28",
 	"description": "A small util that will scaffold a Directus extension",
 	"keywords": [
 		"directus",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/env",
-	"version": "5.5.1",
+	"version": "5.5.2",
 	"description": "Utilities around using global env configuration",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/extensions-registry/package.json
+++ b/packages/extensions-registry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-registry",
-	"version": "3.0.17",
+	"version": "3.0.18",
 	"description": "Abstraction for exploring Directus extensions on a package registry",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-sdk",
-	"version": "17.0.7",
+	"version": "17.0.8",
 	"description": "A toolkit to develop extensions to extend Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions",
-	"version": "3.0.17",
+	"version": "3.0.18",
 	"description": "Utilities and types for Directus extensions",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/memory",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "Memory / Redis abstraction for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/pressure",
-	"version": "3.0.15",
+	"version": "3.0.16",
 	"description": "Pressure based rate limiter",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/schema-builder/package.json
+++ b/packages/schema-builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/schema-builder",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"description": "Directus SchemaBuilder for mocking/constructing a database schema based on code.",
 	"keywords": [
 		"sql",

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-azure",
-	"version": "12.0.15",
+	"version": "12.0.16",
 	"description": "Azure file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-cloudinary",
-	"version": "12.0.15",
+	"version": "12.0.16",
 	"description": "Cloudinary file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-gcs",
-	"version": "12.0.15",
+	"version": "12.0.16",
 	"description": "GCS file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-s3",
-	"version": "12.1.1",
+	"version": "12.1.2",
 	"description": "S3 file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-supabase",
-	"version": "3.0.15",
+	"version": "3.0.16",
 	"description": "Supabase file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/themes",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "Themes for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/types",
-	"version": "14.1.0",
+	"version": "14.2.0",
 	"description": "Shared types for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/utils",
-	"version": "13.2.0",
+	"version": "13.2.1",
 	"description": "Utilities shared between the Directus packages",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/validation",
-	"version": "2.0.15",
+	"version": "2.0.16",
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {


### PR DESCRIPTION
### ✅ Release Checklist
- [x] Changesets processed and cleared
- [x] Package versions updated
- [x] Release notes generated
- [x] Merge Crowdin PR: https://github.com/directus/directus/pull/26624
- [x] PR reviewed and approved
- [ ] Blackbox tests passed

### 🚀 Release Notes
```md
### ✨ New Features & Improvements

- **@directus/app**
  - Added Netlify as a deployment provider ([#26594](https://github.com/directus/directus/pull/26594) by @yassilah)
- **@directus/api**
  - Added Netlify as a deployment provider ([#26594](https://github.com/directus/directus/pull/26594) by @yassilah)
- **@directus/types**
  - Added Netlify as a deployment provider ([#26594](https://github.com/directus/directus/pull/26594) by @yassilah)

### 🐛 Bug Fixes & Optimizations

- **@directus/app**
  - Fixed only focusing on fields that have a schema ([#26622](https://github.com/directus/directus/pull/26622) by @Nitwel)
  - Fixed nested group fields losing values when a condition toggles the group's readonly property ([#26563](https://github.com/directus/directus/pull/26563) by @HZooly)
  - Fixed useStores, useApi, and useSdk not working inside Pinia stores in extensions ([#26438](https://github.com/directus/directus/pull/26438) by @kekekuli)
  - Fixed manual flow triggers not working in drawer ([#26617](https://github.com/directus/directus/pull/26617) by @HZooly)
  - Replaced flatpickr with reka ui primitives ([#26502](https://github.com/directus/directus/pull/26502) by @alvarosabu)
  - Fixed block editor readOnly toggle race condition ([#26640](https://github.com/directus/directus/pull/26640) by @formfcw)
  - Updated editorjs to fix inline link tool bug ([#26639](https://github.com/directus/directus/pull/26639) by @AlexGaillard)
  - Fixed metric list labels to no longer be cut off by bar value labels ([#26527](https://github.com/directus/directus/pull/26527) by @Prasad7007)
- **@directus/api**
  - Fixed asset transformation error when using `withoutEnlargement` with focal point and dimensions larger than the original image. Target dimensions are now clamped to the original image dimensions. ([#26608](https://github.com/directus/directus/pull/26608) by @wotan-allfather)
  - Preserved SQL parameterization in relational count subquery and used content-disposition library for folder zip download header ([#26592](https://github.com/directus/directus/pull/26592) by @dstockton)
- **@directus/extensions-sdk**
  - Fixed linking scoped extensions created nested folders ([#25957](https://github.com/directus/directus/pull/25957) by @Nitwel)
- **@directus/utils**
  - Removed `node:assert` usage from shared utils ([#26614](https://github.com/directus/directus/pull/26614) by @ComfortablyCoding)

### 📦 Published Versions

- `@directus/app@15.2.0`
- `@directus/api@33.2.0`
- `@directus/composables@11.2.12`
- `create-directus-extension@11.0.28`
- `@directus/env@5.5.2`
- `@directus/extensions@3.0.18`
- `@directus/extensions-registry@3.0.18`
- `@directus/extensions-sdk@17.0.8`
- `@directus/memory@3.1.1`
- `@directus/pressure@3.0.16`
- `@directus/schema-builder@0.0.13`
- `@directus/storage-driver-azure@12.0.16`
- `@directus/storage-driver-cloudinary@12.0.16`
- `@directus/storage-driver-gcs@12.0.16`
- `@directus/storage-driver-s3@12.1.2`
- `@directus/storage-driver-supabase@3.0.16`
- `@directus/themes@1.2.3`
- `@directus/types@14.2.0`
- `@directus/utils@13.2.1`
- `@directus/validation@2.0.16`
```