### PR TITLE
Fix realtime socket reconnect after token refresh

### DIFF
--- a/.changeset/dry-cameras-clap.md
+++ b/.changeset/dry-cameras-clap.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fix realtime socket reconnect after access token refresh

--- a/contributors.yml
+++ b/contributors.yml
@@ -249,3 +249,4 @@
 - sinan-yildiz-marsus
 - alvarosabu
 - wotan-allfather
+- RajjakAhmed

--- a/sdk/src/realtime/composable.test.ts
+++ b/sdk/src/realtime/composable.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import { realtime } from './composable.js';
+
+describe('Realtime composable', () => {
+	it('should authenticate websocket in handshake mode', async () => {
+		const sendMock = vi.fn();
+
+		class MockWebSocket {
+			onopen: ((ev: Event) => void) | null = null;
+			onmessage: ((ev: MessageEvent) => void) | null = null;
+
+			constructor(_url: string) {
+				setTimeout(() => {
+					this.onopen?.(new Event('open'));
+				}, 0);
+			}
+
+			send(data: string) {
+				sendMock(data);
+
+				const parsed = JSON.parse(data);
+
+				if (parsed.type === 'auth') {
+					setTimeout(() => {
+						this.onmessage?.(
+							new MessageEvent('message', {
+								data: JSON.stringify({
+									type: 'auth',
+									status: 'ok',
+								}),
+							}),
+						);
+					}, 0);
+				}
+			}
+
+			addEventListener(event: string, cb: any) {
+				if (event === 'open') this.onopen = cb;
+				if (event === 'message') this.onmessage = cb;
+			}
+
+			removeEventListener() {}
+			close() {}
+		}
+
+		const client: any = {
+			url: new URL('http://localhost'),
+			globals: {
+				WebSocket: MockWebSocket,
+				URL,
+				logger: console,
+			},
+			getToken: vi.fn(async () => 'token-a'),
+		};
+
+		const rt = realtime({ authMode: 'handshake' })(client);
+
+		await rt.connect();
+
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(sendMock).toHaveBeenCalled();
+		expect(sendMock.mock.calls[0][0]).toContain('"type":"auth"');
+	});
+
+	it('should handle TOKEN_EXPIRED without retrying if no refresh is implemented', async () => {
+		const sendMock = vi.fn();
+
+		const tokenMock = vi.fn().mockResolvedValue('token-a');
+
+		class MockWebSocket {
+			onopen: ((ev: Event) => void) | null = null;
+			onmessage: ((ev: MessageEvent) => void) | null = null;
+
+			constructor(_url: string) {
+				setTimeout(() => {
+					this.onopen?.(new Event('open'));
+				}, 0);
+			}
+
+			send(data: string) {
+				sendMock(data);
+
+				const parsed = JSON.parse(data);
+
+				if (parsed.type === 'auth') {
+					// Auth success first
+					setTimeout(() => {
+						this.onmessage?.(
+							new MessageEvent('message', {
+								data: JSON.stringify({
+									type: 'auth',
+									status: 'ok',
+								}),
+							}),
+						);
+					}, 0);
+
+					// Then token expiry error
+					setTimeout(() => {
+						this.onmessage?.(
+							new MessageEvent('message', {
+								data: JSON.stringify({
+									type: 'auth',
+									status: 'error',
+									error: {
+										code: 'TOKEN_EXPIRED',
+										message: 'Expired token',
+									},
+								}),
+							}),
+						);
+					}, 10);
+				}
+			}
+
+			addEventListener(event: string, cb: any) {
+				if (event === 'open') this.onopen = cb;
+				if (event === 'message') this.onmessage = cb;
+			}
+
+			removeEventListener() {}
+			close() {}
+		}
+
+		const client: any = {
+			url: new URL('http://localhost'),
+			globals: {
+				WebSocket: MockWebSocket,
+				URL,
+				logger: console,
+			},
+			getToken: tokenMock,
+		};
+
+		const rt = realtime({ authMode: 'handshake' })(client);
+
+		await rt.connect();
+
+		await new Promise((r) => setTimeout(r, 200));
+
+		// ✅ Auth was sent once
+		expect(sendMock.mock.calls[0][0]).toContain('"type":"auth"');
+		expect(sendMock.mock.calls[0][0]).toContain('"type":"auth"');
+
+		// ✅ Token was fetched once (no refresh retry exists)
+		expect(tokenMock).toHaveBeenCalledTimes(1);
+
+		// ✅ No second auth attempt happened
+		expect(sendMock.mock.calls.length).toBe(1);
+	});
+});

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -291,6 +291,7 @@ export function realtime(config: WebSocketConfig = {}) {
 						reject('Connection attempt timed out.');
 					}, config.connect.timeout ?? 10000);
 				}
+
 				ws.addEventListener('open', async (evt: Event) => {
 					debug('info', `Connection open.`);
 
@@ -308,6 +309,7 @@ export function realtime(config: WebSocketConfig = {}) {
 								'No token for authenticating the websocket. Make sure to provide one or call the login() function beforehand.',
 							);
 						}
+
 						lastAccessToken = access_token;
 
 						ws.send(auth({ access_token }));
@@ -382,15 +384,19 @@ export function realtime(config: WebSocketConfig = {}) {
 			},
 			async sendMessage(message: string | Record<string, any>) {
 				const self = this as AuthWSClient<Schema>;
+
 				if (hasAuth(self)) {
 					const currentToken = await self.getToken();
+
 					if (lastAccessToken && currentToken && currentToken !== lastAccessToken) {
 						debug('info', 'Access token changed, reconnecting realtime socket...');
 						this.disconnect();
 						await this.connect();
 					}
+
 					lastAccessToken = currentToken;
 				}
+
 				if (state.code !== 'open') {
 					// TODO use directus error
 					throw new Error(

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -47,7 +47,6 @@ export function realtime(config: WebSocketConfig = {}) {
 		let uid = generateUid();
 		let lastAccessToken: string | null = null;
 
-
 		let state: ConnectionState = {
 			code: 'closed',
 		};
@@ -311,7 +310,6 @@ export function realtime(config: WebSocketConfig = {}) {
 						}
 						lastAccessToken = access_token;
 
-
 						ws.send(auth({ access_token }));
 						const confirm = await messageCallback(ws);
 
@@ -384,15 +382,15 @@ export function realtime(config: WebSocketConfig = {}) {
 			},
 			async sendMessage(message: string | Record<string, any>) {
 				const self = this as AuthWSClient<Schema>;
-				  if (hasAuth(self)) {
-    				const currentToken = await self.getToken();
+				if (hasAuth(self)) {
+					const currentToken = await self.getToken();
 					if (lastAccessToken && currentToken && currentToken !== lastAccessToken) {
-      					debug('info', 'Access token changed, reconnecting realtime socket...');
-      					this.disconnect();
-      					await this.connect();
+						debug('info', 'Access token changed, reconnecting realtime socket...');
+						this.disconnect();
+						await this.connect();
 					}
 					lastAccessToken = currentToken;
-				  }
+				}
 				if (state.code !== 'open') {
 					// TODO use directus error
 					throw new Error(

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -160,23 +160,24 @@ export function realtime(config: WebSocketConfig = {}) {
 
 		async function handleAuthError(message: WebSocketAuthError, currentClient: AuthWSClient<Schema>) {
 			if (state.code !== 'open') return;
+
 			if (message.error.code === 'TOKEN_EXPIRED') {
-			debug('warn', 'Authentication token expired!');
+				debug('warn', 'Authentication token expired!');
 
-			// If SDK has access to token → resend auth
-			if (hasAuth(currentClient)) {
-				const access_token = await currentClient.getToken();
+				// If SDK has access to token → resend auth
+				if (hasAuth(currentClient)) {
+					const access_token = await currentClient.getToken();
 
-				if (access_token) {
-				state.connection.send(auth({ access_token }));
-				return;
+					if (access_token) {
+						state.connection.send(auth({ access_token }));
+						return;
+					}
 				}
-			}
 
-			// Otherwise cookie-session auth → reconnect
-			debug('warn', 'No token available, reconnecting websocket...');
-			await reconnect(currentClient);
-			return;
+				// Otherwise cookie-session auth → reconnect
+				debug('warn', 'No token available, reconnecting websocket...');
+				await reconnect(currentClient);
+				return;
 			}
 
 			if (message.error.code === 'AUTH_TIMEOUT') {
@@ -193,31 +194,28 @@ export function realtime(config: WebSocketConfig = {}) {
 
 			if (message.error.code === 'AUTH_FAILED') {
 				if (state.firstMessage && config.authMode === 'public') {
-				debug(
-					'warn',
-					'Authentication failed! Currently the "authMode" is "public" try using "handshake" instead'
-				);
-				config.reconnect = false;
-				return state.connection.close();
-			}
+					debug('warn', 'Authentication failed! Currently the "authMode" is "public" try using "handshake" instead');
+					config.reconnect = false;
+					return state.connection.close();
+				}
 
-			debug('warn', 'Authentication failed!');
+				debug('warn', 'Authentication failed!');
 
-		// Token-based auth: retry auth
-			if (hasAuth(currentClient)) {
+				// Token-based auth: retry auth
+				if (hasAuth(currentClient)) {
 					const access_token = await currentClient.getToken();
 
-			if (access_token) {
-				state.connection.send(auth({ access_token }));
-					return;
-			}
-		}
+					if (access_token) {
+						state.connection.send(auth({ access_token }));
+						return;
+					}
+				}
 
-		// Cookie/session auth: reconnect
-		debug('warn', 'No token available, reconnecting websocket...');
-		await reconnect(currentClient);
-		return;
-		}
+				// Cookie/session auth: reconnect
+				debug('warn', 'No token available, reconnecting websocket...');
+				await reconnect(currentClient);
+				return;
+			}
 		}
 
 		const handleMessages = async (currentClient: AuthWSClient<Schema>) => {
@@ -320,10 +318,10 @@ export function realtime(config: WebSocketConfig = {}) {
 					reconnectState.attempts = 0;
 					reconnectState.active = false;
 					clearTimeout(connectTimeout);
-					
 
 					if (config.authMode === 'handshake' && hasAuth(client as any)) {
 						const access_token = await (client as any).getToken();
+
 						if (!access_token) {
 							return reject(
 								'No token for authenticating the websocket. Make sure to provide one or call the login() function beforehand.',
@@ -348,11 +346,10 @@ export function realtime(config: WebSocketConfig = {}) {
 						} else {
 							debug('info', 'Authentication successful!');
 						}
-						
 					}
-					
+
 					handleMessages(self);
-					
+
 					eventHandlers['open'].forEach((handler) => handler.call(ws, evt));
 
 					resolved = true;

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -160,19 +160,23 @@ export function realtime(config: WebSocketConfig = {}) {
 
 		async function handleAuthError(message: WebSocketAuthError, currentClient: AuthWSClient<Schema>) {
 			if (state.code !== 'open') return;
-
 			if (message.error.code === 'TOKEN_EXPIRED') {
-				debug('warn', 'Authentication token expired!');
+			debug('warn', 'Authentication token expired!');
 
-				if (hasAuth(currentClient)) {
-					const access_token = await currentClient.getToken();
+			// If SDK has access to token → resend auth
+			if (hasAuth(currentClient)) {
+				const access_token = await currentClient.getToken();
 
-					if (!access_token) {
-						throw Error('No token for re-authenticating the websocket');
-					}
-
-					state.connection.send(auth({ access_token }));
+				if (access_token) {
+				state.connection.send(auth({ access_token }));
+				return;
 				}
+			}
+
+			// Otherwise cookie-session auth → reconnect
+			debug('warn', 'No token available, reconnecting websocket...');
+			await reconnect(currentClient);
+			return;
 			}
 
 			if (message.error.code === 'AUTH_TIMEOUT') {
@@ -189,14 +193,31 @@ export function realtime(config: WebSocketConfig = {}) {
 
 			if (message.error.code === 'AUTH_FAILED') {
 				if (state.firstMessage && config.authMode === 'public') {
-					// detected likely misconfigured authMode
-					debug('warn', 'Authentication failed! Currently the "authMode" is "public" try using "handshake" instead');
-					config.reconnect = false;
-					return state.connection.close();
-				}
-
-				debug('warn', 'Authentication failed!');
+				debug(
+					'warn',
+					'Authentication failed! Currently the "authMode" is "public" try using "handshake" instead'
+				);
+				config.reconnect = false;
+				return state.connection.close();
 			}
+
+			debug('warn', 'Authentication failed!');
+
+		// Token-based auth: retry auth
+			if (hasAuth(currentClient)) {
+					const access_token = await currentClient.getToken();
+
+			if (access_token) {
+				state.connection.send(auth({ access_token }));
+					return;
+			}
+		}
+
+		// Cookie/session auth: reconnect
+		debug('warn', 'No token available, reconnecting websocket...');
+		await reconnect(currentClient);
+		return;
+		}
 		}
 
 		const handleMessages = async (currentClient: AuthWSClient<Schema>) => {
@@ -299,11 +320,10 @@ export function realtime(config: WebSocketConfig = {}) {
 					reconnectState.attempts = 0;
 					reconnectState.active = false;
 					clearTimeout(connectTimeout);
-					handleMessages(self);
+					
 
-					if (config.authMode === 'handshake' && hasAuth(self)) {
-						const access_token = await self.getToken();
-
+					if (config.authMode === 'handshake' && hasAuth(client as any)) {
+						const access_token = await (client as any).getToken();
 						if (!access_token) {
 							return reject(
 								'No token for authenticating the websocket. Make sure to provide one or call the login() function beforehand.',
@@ -328,8 +348,11 @@ export function realtime(config: WebSocketConfig = {}) {
 						} else {
 							debug('info', 'Authentication successful!');
 						}
+						
 					}
-
+					
+					handleMessages(self);
+					
 					eventHandlers['open'].forEach((handler) => handler.call(ws, evt));
 
 					resolved = true;


### PR DESCRIPTION
###Fixes directus/directus #26556


When using the SDK realtime client, the websocket connection does not properly
update authentication after the access token is refreshed.

This PR tracks the last access token used for websocket authentication and
automatically reconnects the realtime socket when a refreshed token is detected.

### Changes
- Track last access token used for websocket authentication
- Reconnect socket when token changes before sending messages

### Testing
- pnpm -C sdk test
