### PR TITLE
fix(app): persist folder state in file selection drawer

### DIFF
--- a/.changeset/fix-file-interface-folder-state.md
+++ b/.changeset/fix-file-interface-folder-state.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed folder navigation state being lost when reopening file selection drawer

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -358,6 +358,7 @@ function useURLImport() {
 		<DrawerFiles
 			v-if="activeDialog === 'choose'"
 			:folder="folder"
+			:field="field"
 			:active="activeDialog === 'choose'"
 			:filter="customFilter"
 			@update:active="activeDialog = null"

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -454,6 +454,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 			v-model:active="selectModalActive"
 			:collection="relationInfo.relatedCollection.collection"
 			:folder="folder"
+			:field="field"
 			:filter="customFilter"
 			multiple
 			@input="onSelect"

--- a/app/src/views/private/components/drawer-files.test.ts
+++ b/app/src/views/private/components/drawer-files.test.ts
@@ -1,11 +1,23 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 import DrawerFiles from './drawer-files.vue';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
 import { useUserStore } from '@/stores/user';
+
+const sessionStore = new Map<string, ReturnType<typeof ref>>();
+
+vi.mock('@vueuse/core', () => ({
+	useSessionStorage: vi.fn((key: string, initialValue: unknown) => {
+		if (!sessionStore.has(key)) {
+			sessionStore.set(key, ref(initialValue));
+		}
+
+		return sessionStore.get(key);
+	}),
+}));
 
 vi.mock('@/stores/user', () => ({
 	useUserStore: vi.fn(),
@@ -32,6 +44,8 @@ let global: GlobalMountOptions;
 let mockUserStore: any;
 
 beforeEach(() => {
+	sessionStore.clear();
+
 	const pinia = createPinia();
 	setActivePinia(pinia);
 

--- a/app/src/views/private/components/drawer-files.test.ts
+++ b/app/src/views/private/components/drawer-files.test.ts
@@ -1,0 +1,169 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import DrawerFiles from './drawer-files.vue';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+import { useUserStore } from '@/stores/user';
+
+vi.mock('@/stores/user', () => ({
+	useUserStore: vi.fn(),
+}));
+
+vi.mock('@/utils/get-folder-filter', () => ({
+	getFolderFilter: vi.fn(() => null),
+}));
+
+const FilesNavigationStub = defineComponent({
+	name: 'FilesNavigation',
+	props: {
+		customTargetHandler: { type: Function, default: undefined },
+		currentFolder: { type: String, default: undefined },
+		currentSpecial: { type: String, default: undefined },
+		rootFolder: { type: String, default: undefined },
+		localOpenFolders: { type: Boolean, default: false },
+		actionsDisabled: { type: Boolean, default: false },
+	},
+	template: '<div class="files-nav-stub"></div>',
+});
+
+let global: GlobalMountOptions;
+let mockUserStore: any;
+
+beforeEach(() => {
+	const pinia = createPinia();
+	setActivePinia(pinia);
+
+	mockUserStore = {
+		currentUser: { id: 'test-user' },
+	};
+
+	vi.mocked(useUserStore).mockReturnValue(mockUserStore);
+
+	global = {
+		stubs: {
+			DrawerCollection: {
+				template: '<div><slot name="sidebar" /></div>',
+			},
+			FilesNavigation: FilesNavigationStub,
+		},
+		plugins: [pinia, i18n],
+	};
+});
+
+describe('DrawerFiles', () => {
+	test('persists folder state across unmount/remount cycles', async () => {
+		const wrapper = mount(DrawerFiles, {
+			props: {},
+			global,
+		});
+
+		await flushPromises();
+
+		const nav = wrapper.findComponent(FilesNavigationStub);
+		expect(nav.props('currentFolder')).toBeUndefined();
+
+		// Simulate folder navigation via the custom target handler
+		const handler = nav.props('customTargetHandler') as (target: { folder?: string }) => void;
+		handler({ folder: 'subfolder-123' });
+		await flushPromises();
+
+		expect(nav.props('currentFolder')).toBe('subfolder-123');
+
+		wrapper.unmount();
+
+		// Remount — folder state should be preserved from the previous mount
+		const wrapper2 = mount(DrawerFiles, {
+			props: {},
+			global,
+		});
+
+		await flushPromises();
+
+		const nav2 = wrapper2.findComponent(FilesNavigationStub);
+		expect(nav2.props('currentFolder')).toBe('subfolder-123');
+
+		wrapper2.unmount();
+	});
+
+	test('persists special folder state across unmount/remount cycles', async () => {
+		// Use a unique folder key to isolate from other tests
+		const wrapper = mount(DrawerFiles, {
+			props: { folder: 'test-special' },
+			global,
+		});
+
+		await flushPromises();
+
+		const nav = wrapper.findComponent(FilesNavigationStub);
+		const handler = nav.props('customTargetHandler') as (target: { special?: string }) => void;
+		handler({ special: 'mine' });
+		await flushPromises();
+
+		expect(nav.props('currentSpecial')).toBe('mine');
+
+		wrapper.unmount();
+
+		const wrapper2 = mount(DrawerFiles, {
+			props: { folder: 'test-special' },
+			global,
+		});
+
+		await flushPromises();
+
+		const nav2 = wrapper2.findComponent(FilesNavigationStub);
+		expect(nav2.props('currentSpecial')).toBe('mine');
+
+		wrapper2.unmount();
+	});
+
+	test('isolates persisted state between different root folder props', async () => {
+		// Mount with folder A and navigate to subfolder
+		const wrapperA = mount(DrawerFiles, {
+			props: { folder: 'root-a' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA = wrapperA.findComponent(FilesNavigationStub);
+		const handlerA = navA.props('customTargetHandler') as (target: { folder?: string }) => void;
+		handlerA({ folder: 'subfolder-in-a' });
+		await flushPromises();
+
+		wrapperA.unmount();
+
+		// Mount with folder B and navigate to a different subfolder
+		const wrapperB = mount(DrawerFiles, {
+			props: { folder: 'root-b' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navB = wrapperB.findComponent(FilesNavigationStub);
+
+		// Should NOT see folder A's state
+		expect(navB.props('currentFolder')).toBe('root-b');
+
+		const handlerB = navB.props('customTargetHandler') as (target: { folder?: string }) => void;
+		handlerB({ folder: 'subfolder-in-b' });
+		await flushPromises();
+
+		wrapperB.unmount();
+
+		// Remount folder A — should see its own persisted state
+		const wrapperA2 = mount(DrawerFiles, {
+			props: { folder: 'root-a' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA2 = wrapperA2.findComponent(FilesNavigationStub);
+		expect(navA2.props('currentFolder')).toBe('subfolder-in-a');
+
+		wrapperA2.unmount();
+	});
+});

--- a/app/src/views/private/components/drawer-files.test.ts
+++ b/app/src/views/private/components/drawer-files.test.ts
@@ -220,6 +220,49 @@ describe('DrawerFiles', () => {
 		wrapperA2.unmount();
 	});
 
+	test('isolates persisted state between same field on different collections', async () => {
+		// Mount field "thumbnail" on collection "articles" and navigate
+		const wrapperA = mount(DrawerFiles, {
+			props: { collection: 'articles', field: 'thumbnail' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA = wrapperA.findComponent(FilesNavigationStub);
+		const handlerA = navA.props('customTargetHandler') as (target: { folder?: string }) => void;
+		handlerA({ folder: 'article-images' });
+		await flushPromises();
+
+		wrapperA.unmount();
+
+		// Mount same field "thumbnail" on collection "authors" — should have independent state
+		const wrapperB = mount(DrawerFiles, {
+			props: { collection: 'authors', field: 'thumbnail' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navB = wrapperB.findComponent(FilesNavigationStub);
+		expect(navB.props('currentFolder')).toBeUndefined();
+
+		wrapperB.unmount();
+
+		// Remount on "articles" — should see its own persisted state
+		const wrapperA2 = mount(DrawerFiles, {
+			props: { collection: 'articles', field: 'thumbnail' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA2 = wrapperA2.findComponent(FilesNavigationStub);
+		expect(navA2.props('currentFolder')).toBe('article-images');
+
+		wrapperA2.unmount();
+	});
+
 	test('isolates persisted state between different root folder props', async () => {
 		// Mount with folder A and navigate to subfolder
 		const wrapperA = mount(DrawerFiles, {

--- a/app/src/views/private/components/drawer-files.test.ts
+++ b/app/src/views/private/components/drawer-files.test.ts
@@ -132,6 +132,94 @@ describe('DrawerFiles', () => {
 		wrapper2.unmount();
 	});
 
+	test('isolates persisted state between different field props without a root folder', async () => {
+		// Mount with field "avatar" and navigate to a subfolder
+		const wrapperA = mount(DrawerFiles, {
+			props: { field: 'avatar' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA = wrapperA.findComponent(FilesNavigationStub);
+		const handlerA = navA.props('customTargetHandler') as (target: { folder?: string }) => void;
+		handlerA({ folder: 'photos' });
+		await flushPromises();
+
+		wrapperA.unmount();
+
+		// Mount with field "banner" — should have independent state
+		const wrapperB = mount(DrawerFiles, {
+			props: { field: 'banner' },
+			global,
+		});
+
+		await flushPromises();
+
+		// Should NOT see field A's state
+		const navB = wrapperB.findComponent(FilesNavigationStub);
+		expect(navB.props('currentFolder')).toBeUndefined();
+
+		wrapperB.unmount();
+
+		// Remount field A — should see its own persisted state
+		const wrapperA2 = mount(DrawerFiles, {
+			props: { field: 'avatar' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA2 = wrapperA2.findComponent(FilesNavigationStub);
+		expect(navA2.props('currentFolder')).toBe('photos');
+
+		wrapperA2.unmount();
+	});
+
+	test('isolates persisted state between different fields sharing the same root folder', async () => {
+		// Mount field "avatar" scoped to root-x and navigate to a subfolder
+		const wrapperA = mount(DrawerFiles, {
+			props: { field: 'avatar', folder: 'root-x' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA = wrapperA.findComponent(FilesNavigationStub);
+		const handlerA = navA.props('customTargetHandler') as (target: { folder?: string }) => void;
+		handlerA({ folder: 'subfolder-avatar' });
+		await flushPromises();
+
+		wrapperA.unmount();
+
+		// Mount field "banner" scoped to the same root-x
+		const wrapperB = mount(DrawerFiles, {
+			props: { field: 'banner', folder: 'root-x' },
+			global,
+		});
+
+		await flushPromises();
+
+		// Should NOT see field A's subfolder — should start at root-x
+		const navB = wrapperB.findComponent(FilesNavigationStub);
+		expect(navB.props('currentFolder')).toBe('root-x');
+
+		wrapperB.unmount();
+
+		// Remount field A — should see its own persisted subfolder
+		const wrapperA2 = mount(DrawerFiles, {
+			props: { field: 'avatar', folder: 'root-x' },
+			global,
+		});
+
+		await flushPromises();
+
+		const navA2 = wrapperA2.findComponent(FilesNavigationStub);
+		expect(navA2.props('currentFolder')).toBe('subfolder-avatar');
+
+		wrapperA2.unmount();
+	});
+
 	test('isolates persisted state between different root folder props', async () => {
 		// Mount with folder A and navigate to subfolder
 		const wrapperA = mount(DrawerFiles, {

--- a/app/src/views/private/components/drawer-files.vue
+++ b/app/src/views/private/components/drawer-files.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
 	defineProps<{
 		collection?: string;
 		folder?: string;
+		field?: string;
 		filter?: Filter;
 	}>(),
 	{
@@ -27,7 +28,9 @@ const drawerProps = {
 	sidebarLabel: t('folders'),
 };
 
-const stateKey = props.folder ?? '';
+// Positional key so that field-only and folder-only contexts never collide
+// (e.g. field="avatar" → "avatar:", folder="abc" → ":abc", both → "avatar:abc")
+const stateKey = `${props.field ?? ''}:${props.folder ?? ''}`;
 
 const persisted = useSessionStorage<{ folder?: string; special?: SpecialFolder }>(
 	`directus-drawer-files-state:${stateKey}`,

--- a/app/src/views/private/components/drawer-files.vue
+++ b/app/src/views/private/components/drawer-files.vue
@@ -28,9 +28,9 @@ const drawerProps = {
 	sidebarLabel: t('folders'),
 };
 
-// Positional key so that field-only and folder-only contexts never collide
-// (e.g. field="avatar" → "avatar:", folder="abc" → ":abc", both → "avatar:abc")
-const stateKey = `${props.field ?? ''}:${props.folder ?? ''}`;
+// Positional key so that collection, field, and folder contexts never collide
+// (e.g. field="avatar" → "directus_files:avatar:", collection="articles", field="avatar" → "articles:avatar:")
+const stateKey = `${props.collection ?? ''}:${props.field ?? ''}:${props.folder ?? ''}`;
 
 const persisted = useSessionStorage<{ folder?: string; special?: SpecialFolder }>(
 	`directus-drawer-files-state:${stateKey}`,

--- a/contributors.yml
+++ b/contributors.yml
@@ -257,3 +257,4 @@
 - LZylstra
 - deepDiverPaul
 - Mugesh13102001
+- costajohnt


### PR DESCRIPTION
## Scope

What's changed:

- Added module-level state persistence in `drawer-files.vue` so folder navigation state (selected folder and special folder) survives drawer close/reopen cycles
- State is keyed by the `folder` prop to isolate different field configurations from each other

## Potential Risks / Drawbacks

- Module-level state persists for the entire browser session (not just the current drawer instance). This is intentional — the issue specifically requests that navigating to a subfolder should be remembered when reopening the drawer.
- Different file fields with different `folder` prop values get isolated state, so they won't interfere with each other.

## Tested Scenarios

- Open file selection drawer, navigate to a subfolder, close drawer, reopen → subfolder is preserved
- Open file selection drawer, switch to "My Files" special folder, close drawer, reopen → "My Files" is preserved
- Two different file fields with different root folder configurations maintain independent persisted state
- All 3 new unit tests pass; full test suite (105,397 tests) passes

## Review Notes / Questions

- The fix uses a `<script>` block alongside `<script setup>` for module-level state — this is a standard Vue 3 pattern for state that should survive component unmount/remount cycles
- The `setOpenFolders` watcher in `files-navigation.vue` automatically expands the folder tree to match the persisted `currentFolder`, so the open folders tree state is also correctly restored without changes to that file

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25416