### PR TITLE
Fix date picker month select offset

### DIFF
--- a/.changeset/nine-views-sip.md
+++ b/.changeset/nine-views-sip.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed date picker month select offset

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -847,6 +847,27 @@ describe('v-date-picker', () => {
 			const monthOptions = wrapper.findAll('#calendar-month-select option');
 			expect(monthOptions.length).toBe(12);
 		});
+
+		it('month option labels match their value in negative-UTC-offset timezones', () => {
+			const originalTZ = process.env.TZ;
+
+			try {
+				process.env.TZ = 'America/Los_Angeles';
+
+				const wrapper = createWrapper({
+					type: 'date',
+					modelValue: '2024-06-15',
+				});
+
+				const options = wrapper.findAll('#calendar-month-select option');
+
+				expect(options.at(0)?.text()).toBe('January');
+				expect(options.at(5)?.text()).toBe('June');
+				expect(options.at(11)?.text()).toBe('December');
+			} finally {
+				process.env.TZ = originalTZ;
+			}
+		});
 	});
 
 	describe('RTL support', () => {

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -1,6 +1,6 @@
 import { CalendarDate, Time } from '@internationalized/date';
 import { mount } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import VDatePicker from './v-date-picker.vue';
 import { formatDatePickerModelValue } from '@/utils/format-date-picker-model-value';
@@ -848,12 +848,18 @@ describe('v-date-picker', () => {
 			expect(monthOptions.length).toBe(12);
 		});
 
-		it('month option labels match their value in negative-UTC-offset timezones', () => {
+		describe('in negative-UTC-offset timezones', () => {
 			const originalTZ = process.env.TZ;
 
-			try {
+			beforeEach(() => {
 				process.env.TZ = 'America/Los_Angeles';
+			});
 
+			afterEach(() => {
+				process.env.TZ = originalTZ;
+			});
+
+			it('month option labels match their value', () => {
 				const wrapper = createWrapper({
 					type: 'date',
 					modelValue: '2024-06-15',
@@ -864,9 +870,7 @@ describe('v-date-picker', () => {
 				expect(options.at(0)?.text()).toBe('January');
 				expect(options.at(5)?.text()).toBe('June');
 				expect(options.at(11)?.text()).toBe('December');
-			} finally {
-				process.env.TZ = originalTZ;
-			}
+			});
 		});
 	});
 

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -103,7 +103,9 @@ const timeValue = computed<TimeValue | null | undefined>({
 
 const monthFormatter = computed(() => {
 	// Use 'long' for “January”, 'short' for “Jan”, 'narrow' for “J”
-	return new DateFormatter(userStore.language, { month: 'long' });
+	// timeZone: 'UTC' ensures the month name matches the UTC date created by `toDate('UTC')` below,
+	// preventing off-by-one month labels in negative-UTC-offset timezones.
+	return new DateFormatter(userStore.language, { month: 'long', timeZone: 'UTC' });
 });
 
 const monthOptions = computed(() => {
@@ -113,8 +115,6 @@ const monthOptions = computed(() => {
 
 		return {
 			value,
-			// This `DateFormatter` type expects a native `Date`, so we convert using UTC.
-			// (Timezone doesn't matter for month names; this keeps it stable.)
 			text: monthFormatter.value.format(date.toDate('UTC')),
 		};
 	});


### PR DESCRIPTION
## Scope

What's changed:

- Add `timeZone: 'UTC'` to the `DateFormatter` used for month option labels in `v-date-picker`

## Potential Risks / Drawbacks

## Tested Scenarios

- Set system timezone to US Pacific (`UTC-8`), opened date picker with a stored `dateTime` value — month select now matches the calendar grid
- Verified month labels are correct across all 12 months in both positive and negative UTC offsets

## Review Notes / Questions

- The formatter was already receiving UTC dates via `toDate('UTC')`, it just wasn't formatting them in UTC

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26652
