### PR TITLE
Fix tree view edit opening multiple drawers

### DIFF
--- a/.changeset/wet-ducks-stop.md
+++ b/.changeset/wet-ducks-stop.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed issue with opening multiple drawers when editing tree view item

--- a/app/src/interfaces/list-o2m-tree-view/NestedDraggable.vue
+++ b/app/src/interfaces/list-o2m-tree-view/NestedDraggable.vue
@@ -85,7 +85,6 @@ const { collection, field, primaryKey, relationInfo, root, fields, template, cus
 
 const addNewActive = defineModel<boolean>('addNewOpen');
 const selectDrawer = defineModel<boolean>('selectOpen');
-const editOpen = defineModel<boolean>('editOpen');
 
 const drag = ref(false);
 const open = ref<Record<string, boolean>>({});
@@ -217,7 +216,6 @@ function stageEdits(item: Record<string, any>) {
 				:class="{ draggable: element.$type !== 'deleted' }"
 			>
 				<ItemPreview
-					v-model:edit-open="editOpen"
 					:item="element"
 					:edits="getItemEdits(element)"
 					:template="template"
@@ -234,7 +232,6 @@ function stageEdits(item: Record<string, any>) {
 				/>
 				<NestedDraggable
 					v-if="open[element[relationInfo.relatedPrimaryKeyField.field]]"
-					v-model:edit-open="editOpen"
 					:model-value="element[field]"
 					:template="template"
 					:collection="collection"

--- a/app/src/interfaces/list-o2m-tree-view/item-preview.vue
+++ b/app/src/interfaces/list-o2m-tree-view/item-preview.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VRemove from '@/components/v-remove.vue';
 import { RelationO2M } from '@/composables/use-relation-o2m';
@@ -26,7 +27,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits(['update:open', 'deselect', 'input']);
-const editActive = defineModel<boolean>('editOpen');
+const editActive = ref(false);
 </script>
 
 <template>

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -116,9 +116,8 @@ const fields = computed(() => {
 
 const addNewOpen = ref(false);
 const selectOpen = ref(false);
-const editOpen = ref(false);
 
-const menuActive = computed(() => addNewOpen.value || selectOpen.value || editOpen.value);
+const menuActive = computed(() => addNewOpen.value || selectOpen.value);
 </script>
 
 <template>
@@ -133,7 +132,6 @@ const menuActive = computed(() => addNewOpen.value || selectOpen.value || editOp
 			v-model="_value"
 			v-model:add-new-open="addNewOpen"
 			v-model:select-open="selectOpen"
-			v-model:edit-open="editOpen"
 			:template="template"
 			:collection="collection"
 			:field="field"


### PR DESCRIPTION
## Scope

What's changed:

- Reverts a questionable change from collaborative editing that causes the tree view edit button to open mutliple drawers

## Potential Risks / Drawbacks

- Tree view for collaborative editing is affected

## Tested Scenarios

- Tested in both collaborative and non-collaborative mode, appears to still work

## Review Notes / Questions

- NA

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26654
