### PR TITLE
Update OpenLDAP image version in docker-compose

### DIFF
--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -138,13 +138,13 @@ services:
       - 'host.docker.internal:host-gateway'
 
   # OpenLDAP server for LDAP authentication tests
-  # Uses cleanstart/openldap:2.6 with default configuration
+  # Uses cleanstart/openldap with default configuration
   # Credentials:
   #   Admin DN:      cn=Manager,dc=my-domain,dc=com
   #   Admin Password: secret
   #   Base DN:       dc=my-domain,dc=com
   openldap:
-    image: cleanstart/openldap:2.6
+    image: cleanstart/openldap:2.6.10
     ports:
       - 6109:389
     healthcheck:


### PR DESCRIPTION
## Scope

What's changed:

-  OpenLDAP image version in docker-compose

## Review Notes / Questions

- 2.6 image tag was removed

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

