### PR TITLE
Private view: Constrain title within limits of --header-bar-max-height

### DIFF
--- a/.changeset/private-view-header-bar-title-thumbnail-fix.md
+++ b/.changeset/private-view-header-bar-title-thumbnail-fix.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Private view: Constrain title within limits of --header-bar-max-height

--- a/app/src/views/private/private-view/components/private-view-header-bar.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar.vue
@@ -155,10 +155,14 @@ const showSidebarToggle = computed(() => {
 .title-container {
 	position: relative;
 	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	max-block-size: var(--header-bar-height);
 }
 
 .title {
 	display: flex;
+	min-block-size: 0;
 
 	&:deep(.type-title) {
 		line-height: 1.2em;
@@ -172,6 +176,7 @@ const showSidebarToggle = computed(() => {
 	font-weight: 600;
 	font-size: 12px;
 	line-height: 12px;
+	margin-block: 4px;
 	white-space: nowrap;
 	font-family: var(--theme--header--headline--font-family);
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -249,3 +249,4 @@
 - sinan-yildiz-marsus
 - alvarosabu
 - wotan-allfather
+- barry86m


### PR DESCRIPTION
## Scope

What's changed:

- restricts the size of the title-container to --header-bar-max-height
- adds a suitable margin vertically around the headline (i.e. object type)
- when oversized, ensures the title is scaled appropriately, including any images or thumbnails

## Potential Risks / Drawbacks

- Minimal risk - only changes CSS
- No breaking changes expected
- Affects only visual layout, not functionality

## Tested Scenarios

- Normal usage of data studio
- 'Mobile view' of data studio

## Review Notes / Questions

- May need further work on 'mobile view' (i.e. vw < 400px)
- If this fix works in practice, it may later be transposed to:
-- app/src/components/v-drawer-header.vue
-- app/src/views/private/components/comparison/comparison-header.vue

## Checklist

- [X] Added or updated tests
- ~[ ] Documentation PR created [here](https://github.com/directus/docs) or not required~
- ~[ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required~

---

Fixes: N/A - No issue filed
