### PR TITLE
fix: skip cache for Cache-Control: no-cache in addition to no-store

### DIFF
--- a/.changeset/shy-tigers-camp.md
+++ b/.changeset/shy-tigers-camp.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed cache skip to also respect Cache-Control: no-cache directive

--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -140,3 +140,29 @@ test.each([
 		expect(shouldSkipCache(req)).toBe(value);
 	},
 );
+
+test.each([
+	{ scenario: 'accept', value: true },
+	{ scenario: 'ignore', value: false },
+])(
+	'should $scenario Cache-Control request header containing "no-cache" when CACHE_SKIP_ALLOWED is $value',
+	({ value }) => {
+		vi.mocked(useEnv).mockReturnValue({
+			PUBLIC_URL: '/',
+			CACHE_SKIP_ALLOWED: value,
+		});
+
+		const req = {
+			get: vi.fn((str) => {
+				switch (str) {
+					case 'cache-control':
+						return 'no-cache';
+					default:
+						return undefined;
+				}
+			}),
+		} as unknown as Request;
+
+		expect(shouldSkipCache(req)).toBe(value);
+	},
+);

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -27,7 +27,11 @@ export function shouldSkipCache(req: Request): boolean {
 		}
 	}
 
-	if (env['CACHE_SKIP_ALLOWED'] && req.get('cache-control')?.includes('no-store')) return true;
+	if (
+		env['CACHE_SKIP_ALLOWED'] &&
+		(req.get('cache-control')?.includes('no-store') || req.get('cache-control')?.includes('no-cache'))
+	)
+		return true;
 
 	return false;
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -251,3 +251,4 @@
 - omkarg01
 - wotan-allfather
 - danielbuechele
+- veeceey


### PR DESCRIPTION
The `shouldSkipCache` utility only checked for `no-store` in the `Cache-Control` request header when deciding whether to bypass the cache. However, browsers (including the Directus admin UI) typically send `Cache-Control: no-cache` rather than `no-store`. This meant that with `CACHE_SKIP_ALLOWED=true`, admin UI requests were still being served stale data from cache.

The fix adds `no-cache` as an additional accepted value in the Cache-Control check, so both `no-store` and `no-cache` will trigger cache bypass when `CACHE_SKIP_ALLOWED` is enabled.

Added corresponding test coverage for the `no-cache` directive.

Fixes #26278