### PR TITLE
add default border width variable to avatar component to match the design

### DIFF
--- a/app/src/components/v-avatar.vue
+++ b/app/src/components/v-avatar.vue
@@ -44,6 +44,7 @@ const sizeClass = useSizeClass(props);
 
 	Available Variables:
 
+	--v-avatar-border-width [2px]
 	--v-avatar-border-color [var(--theme--border-color)]
 	--v-avatar-color  [var(--theme--background-normal)]
 	--v-avatar-size   [48px]
@@ -69,7 +70,7 @@ const sizeClass = useSizeClass(props);
 }
 
 .border {
-	border: var(--theme--border-width) solid var(--v-avatar-border-color, var(--theme--border-color));
+	border: var(--v-avatar-border-width, 2px) solid var(--v-avatar-border-color, var(--theme--border-color));
 }
 
 .x-small {


### PR DESCRIPTION
Follow-up of https://github.com/directus/directus/pull/26574

Tiny change requested by the design team:
- avatars border width should be 2px
- added a new css variable `--v-avatar-border-width`