### PR TITLE
Fix item comparison failing when special characters are present in manual primary keys

### DIFF
--- a/.changeset/full-beers-relate.md
+++ b/.changeset/full-beers-relate.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed useComparison fetchMainVersion call to encode URI component to not strip out special characters
+Fixed item comparison failing when special characters are present in manual primary keys

--- a/.changeset/full-beers-relate.md
+++ b/.changeset/full-beers-relate.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed useComparison fetchMainVersion call to encode URI component to not strip out special characters

--- a/app/src/views/private/components/comparison/use-comparison.ts
+++ b/app/src/views/private/components/comparison/use-comparison.ts
@@ -367,7 +367,7 @@ export function useComparison(options: UseComparisonOptions) {
 
 	async function fetchMainVersion(collection: string, item: PrimaryKey): Promise<Record<string, any>> {
 		const endpoint = getEndpoint(collection);
-		const itemEndpoint = `${endpoint}/${item}`;
+		const itemEndpoint = `${endpoint}/${encodeURIComponent(item)}`;
 
 		try {
 			const itemResponse = await api.get(itemEndpoint);


### PR DESCRIPTION
## Scope

What's changed:

- When fetching the main  (original) version from revisions we will now encode the id in the request url so it does not strip out special characters

## Potential Risks / Drawbacks

- None I can think of

## Tested Scenarios

- Tested in the app, does not throw error
- Existing tests still pass

## Review Notes / Questions

- NA

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-1828
