### PR TITLE
Fix translation interface disable logic

### DIFF
--- a/.changeset/common-jars-cover.md
+++ b/.changeset/common-jars-cover.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed translation interface being disabled when delete permission not allowed

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -143,7 +143,7 @@ function onToggleDelete(item: DisplayItem, itemInitial?: DisplayItem) {
 			:items="languageOptions"
 			:danger="item?.$type === 'deleted'"
 			:secondary
-			:disabled="activatorDisabled"
+			:disabled="disabled"
 			:non-editable
 		>
 			<template #prepend>

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -70,9 +70,11 @@ const {
 );
 
 const activatorDisabled = computed(() => {
-	return (
-		disabled || (!item.value && !saveAllowed.value) || (item.value && !deleteAllowed.value && !isLocalItem(item.value))
-	);
+	return disabled || (!item.value && !saveAllowed.value);
+});
+
+const removeDisabled = computed(() => {
+	return disabled || (item.value && !deleteAllowed.value && !isLocalItem(item.value));
 });
 
 const { transition, iconName, onEnableTranslation, onMousedown, onMouseup, onTransitionEnd } = useActivatorButton();
@@ -176,8 +178,8 @@ function onToggleDelete(item: DisplayItem, itemInitial?: DisplayItem) {
 			<template #controls="{ active, toggle }">
 				<VRemove
 					v-if="item && !(nonEditable && item.$type !== 'deleted')"
-					:class="{ disabled: activatorDisabled }"
-					:disabled="activatorDisabled"
+					:class="{ disabled: removeDisabled }"
+					:disabled="removeDisabled"
 					:item-type="item.$type"
 					:item-info="relationInfo"
 					:item-is-local="isLocalItem(item)"

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -70,11 +70,9 @@ const {
 );
 
 const activatorDisabled = computed(() => {
-	return disabled || (!item.value && !saveAllowed.value);
-});
-
-const removeDisabled = computed(() => {
-	return disabled || (item.value && !deleteAllowed.value && !isLocalItem(item.value));
+	return (
+		disabled || (!item.value && !saveAllowed.value) || (item.value && !deleteAllowed.value && !isLocalItem(item.value))
+	);
 });
 
 const { transition, iconName, onEnableTranslation, onMousedown, onMouseup, onTransitionEnd } = useActivatorButton();
@@ -178,8 +176,8 @@ function onToggleDelete(item: DisplayItem, itemInitial?: DisplayItem) {
 			<template #controls="{ active, toggle }">
 				<VRemove
 					v-if="item && !(nonEditable && item.$type !== 'deleted')"
-					:class="{ disabled: removeDisabled }"
-					:disabled="removeDisabled"
+					:class="{ disabled: activatorDisabled }"
+					:disabled="activatorDisabled"
 					:item-type="item.$type"
 					:item-info="relationInfo"
 					:item-is-local="isLocalItem(item)"


### PR DESCRIPTION
## Scope

What's changed:

- Fixes a regression from https://github.com/directus/directus/pull/26470 which was fully disabling the translation interface when delete permission was not allowed
- Now the disable logic is seperated out so the entire interface is disabled for `!isSaveAllowed` and the delete button is disabled when `!deleteAllowed`

## Potential Risks / Drawbacks

- Probably very little as this partially backtracks to logic we had before

## Tested Scenarios

- The stated issue is no longer occuring

## Review Notes / Questions

- Is there something I'm not seeing?

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-1818
