### PR TITLE
Fix IPTC metadata key casing in getMetadata

### DIFF
--- a/.changeset/fix-iptc-metadata-casing.md
+++ b/.changeset/fix-iptc-metadata-casing.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed IPTC metadata key casing in getMetadata so that description, title, and tags are correctly populated from IPTC data.

--- a/api/src/services/files/utils/get-metadata.test.ts
+++ b/api/src/services/files/utils/get-metadata.test.ts
@@ -27,3 +27,36 @@ test('Resolves empty object on unexpected error in transformation', async () => 
 
 	expect(result).toEqual({});
 });
+
+test('Populates description, title, and tags from IPTC metadata', async () => {
+	const stream = new Readable();
+	stream._read = vi.fn();
+
+	vi.mocked(getSharpInstance).mockImplementation(
+		() =>
+			({
+				metadata: vi.fn().mockImplementation((fn: (err: null, metadata: Record<string, unknown>) => void) => {
+					fn(null, {
+						width: 100,
+						height: 100,
+						iptc: Buffer.from([
+							0x1c, 0x02, 0x00, 0x00, 0x02, 0x00, 0x04, // IPTC record version (skipped by parser)
+							0x1c, 0x02, 0x78, 0x00, 0x0c, ...Buffer.from('Test caption'),
+							0x1c, 0x02, 0x69, 0x00, 0x0d, ...Buffer.from('Test headline'),
+							0x1c, 0x02, 0x19, 0x00, 0x06, ...Buffer.from('nature'),
+							0x1c, 0x02, 0x19, 0x00, 0x06, ...Buffer.from('travel'),
+						]),
+					});
+
+					return new Transform();
+				}),
+			}) as unknown as Sharp,
+	);
+
+	const result = await getMetadata(stream);
+
+	expect(result.description).toBe('Test caption');
+	expect(result.title).toBe('Test headline');
+	expect(result.tags).toEqual(['nature', 'travel']);
+});
+

--- a/api/src/services/files/utils/get-metadata.test.ts
+++ b/api/src/services/files/utils/get-metadata.test.ts
@@ -40,11 +40,37 @@ test('Populates description, title, and tags from IPTC metadata', async () => {
 						width: 100,
 						height: 100,
 						iptc: Buffer.from([
-							0x1c, 0x02, 0x00, 0x00, 0x02, 0x00, 0x04, // IPTC record version (skipped by parser)
-							0x1c, 0x02, 0x78, 0x00, 0x0c, ...Buffer.from('Test caption'),
-							0x1c, 0x02, 0x69, 0x00, 0x0d, ...Buffer.from('Test headline'),
-							0x1c, 0x02, 0x19, 0x00, 0x06, ...Buffer.from('nature'),
-							0x1c, 0x02, 0x19, 0x00, 0x06, ...Buffer.from('travel'),
+							0x1c,
+							0x02,
+							0x00,
+							0x00,
+							0x02,
+							0x00,
+							0x04, // IPTC record version (skipped by parser)
+							0x1c,
+							0x02,
+							0x78,
+							0x00,
+							0x0c,
+							...Buffer.from('Test caption'),
+							0x1c,
+							0x02,
+							0x69,
+							0x00,
+							0x0d,
+							...Buffer.from('Test headline'),
+							0x1c,
+							0x02,
+							0x19,
+							0x00,
+							0x06,
+							...Buffer.from('nature'),
+							0x1c,
+							0x02,
+							0x19,
+							0x00,
+							0x06,
+							...Buffer.from('travel'),
 						]),
 					});
 
@@ -59,4 +85,3 @@ test('Populates description, title, and tags from IPTC metadata', async () => {
 	expect(result.title).toBe('Test headline');
 	expect(result.tags).toEqual(['nature', 'travel']);
 });
-

--- a/api/src/services/files/utils/get-metadata.ts
+++ b/api/src/services/files/utils/get-metadata.ts
@@ -107,16 +107,16 @@ export async function getMetadata(
 					}
 				}
 
-				if (fullMetadata?.iptc?.['Caption'] && typeof fullMetadata.iptc['Caption'] === 'string') {
-					metadata.description = fullMetadata.iptc?.['Caption'];
+				if (fullMetadata?.iptc?.['caption'] && typeof fullMetadata.iptc['caption'] === 'string') {
+					metadata.description = fullMetadata.iptc['caption'];
 				}
 
-				if (fullMetadata?.iptc?.['Headline'] && typeof fullMetadata.iptc['Headline'] === 'string') {
-					metadata.title = fullMetadata.iptc['Headline'];
+				if (fullMetadata?.iptc?.['headline'] && typeof fullMetadata.iptc['headline'] === 'string') {
+					metadata.title = fullMetadata.iptc['headline'];
 				}
 
-				if (fullMetadata?.iptc?.['Keywords']) {
-					metadata.tags = fullMetadata.iptc['Keywords'] as string;
+				if (fullMetadata?.iptc?.['keywords']) {
+					metadata.tags = fullMetadata.iptc['keywords'] as string;
 				}
 
 				if (allowList === '*' || allowList?.[0] === '*') {

--- a/contributors.yml
+++ b/contributors.yml
@@ -250,3 +250,4 @@
 - alvarosabu
 - omkarg01
 - wotan-allfather
+- danielbuechele


### PR DESCRIPTION
`parseIptc` returns lowercase keys (`caption`, `headline`, `keywords`), but `getMetadata` was looking them up with capitalized keys (`Caption`, `Headline`, `Keywords`). As a result, the `description`, `title`, and `tags` fields on `directus_files` were never populated from IPTC metadata.