### PR TITLE
Fix non-editable state for relational fields with custom permissions

### DIFF
--- a/.changeset/quick-signs-stand.md
+++ b/.changeset/quick-signs-stand.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed non-editable state for relational fields with custom permissions

--- a/app/src/composables/use-permissions/item/lib/get-fields.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.ts
@@ -28,9 +28,21 @@ export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermi
 			fields = fields.filter((field) => readableFields.includes(field.field));
 		}
 
-		const permission = collectionInfo.value?.meta?.singleton
-			? fetchedItemPermissions.value.update
-			: getPermission(collectionValue, unref(isNew) ? 'create' : 'update');
+		let permission;
+
+		if (collectionInfo.value?.meta?.singleton) {
+			permission = fetchedItemPermissions.value.update;
+		} else if (unref(isNew)) {
+			permission = getPermission(collectionValue, 'create');
+		} else {
+			const storePermission = getPermission(collectionValue, 'update');
+
+			if (storePermission?.access !== 'partial') {
+				permission = storePermission;
+			} else {
+				permission = fetchedItemPermissions.value.update.access ? storePermission : null;
+			}
+		}
 
 		if (!permission?.fields?.includes('*')) {
 			for (const field of fields) {


### PR DESCRIPTION
## Scope

What's changed:

- For existing items in collections with `access: 'partial'` (custom item rules), `getFields()` now checks `fetchedItemPermissions` to determine if the item passes the rule
- When item fails the rule, all fields get `readonly: true` + `non_editable: true` instead of just `disabled: true`
- This allows relational interfaces (M2O, O2M, M2M) to open the drawer in read-only mode instead of being completely inert

## Potential Risks / Drawbacks

- When a field is both readonly from collection settings AND the item fails a custom rule, `non_editable` takes precedence over `disabled` in relational interfaces.  The field becomes interactive (view-only) rather than fully disabled.

## Tested Scenarios

- Existing item with `access: 'partial'` failing custom rule → all fields non-editable
- Existing item with `access: 'partial'` passing custom rule → store fields used
- Existing item with `access: 'full'` → no item-level check, store permission used directly
- New item with `access: 'partial'` → store create permission used, no item-level check
- Singleton behavior unchanged

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26670
