### PR TITLE
Constrain display template images in header bar to text line-height

### DIFF
--- a/.changeset/tough-comics-nail.md
+++ b/.changeset/tough-comics-nail.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Constrained display template images in header bar to text line-height

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1017,12 +1017,6 @@ function useItemNavigation() {
 
 :deep(.type-title) {
 	min-inline-size: 0;
-
-	.render-template {
-		img {
-			block-size: 20px;
-		}
-	}
 }
 
 .headline-wrapper {

--- a/app/src/views/private/private-view/components/private-view-header-bar.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar.vue
@@ -163,6 +163,12 @@ const showSidebarToggle = computed(() => {
 	&:deep(.type-title) {
 		line-height: 1.2em;
 		max-inline-size: 100%;
+
+		.render-template img,
+		.render-template .preview {
+			block-size: 1.2em;
+			vertical-align: middle;
+		}
 	}
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Constrain images and file previews inside header display templates to match text `line-height` (`1.2em`), preventing overflow of the header bar
- Override `vertical-align: -30%` from `display-image` with `middle` to keep images inline with text
- Remove competing (and fragile) image size override from `item.vue` that depended on stylesheet load order

## Potential Risks / Drawbacks

- Images in header titles are now ~22px height, significantly smaller than the previous 64px (`system-small-cover`). Detailed thumbnails may be harder to distinguish at this size
- SVGs that previously rendered at full size will now be constrained (intentional)

## Tested Scenarios

- Collection item with image field in display template (e.g. `{{ logo }} {{ name }}`)
- Collection item with text-only display template: no visual change

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26666
