### PR TITLE
Address code related feedback on AI ask user tool

### DIFF
--- a/app/src/ai/components/parts/ai-ask-user.vue
+++ b/app/src/ai/components/parts/ai-ask-user.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import formatTitle from '@directus/format-title';
+import { useResizeObserver } from '@vueuse/core';
 import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
@@ -178,10 +179,11 @@ function handleKeydown(event: KeyboardEvent) {
 	}
 }
 
+// Tabs
+
 const tabsContainerRef = useTemplateRef<HTMLElement>('tabs-container');
 const showLeftFade = ref(false);
 const showRightFade = ref(false);
-let resizeObserver: ResizeObserver | null = null;
 
 function updateFades() {
 	const el = tabsContainerRef.value;
@@ -191,6 +193,8 @@ function updateFades() {
 	showLeftFade.value = el.scrollLeft > 0;
 	showRightFade.value = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
 }
+
+useResizeObserver(tabsContainerRef, updateFades);
 
 watch(activeQuestionIndex, (newIndex, oldIndex) => {
 	slideDirection.value = newIndex > oldIndex ? 'forward' : 'backward';
@@ -211,16 +215,9 @@ onMounted(() => {
 		rootEl.value?.focus();
 		updateFades();
 	});
-
-	if (tabsContainerRef.value) {
-		resizeObserver?.disconnect();
-		resizeObserver = new ResizeObserver(updateFades);
-		resizeObserver.observe(tabsContainerRef.value);
-	}
 });
 
 onUnmounted(() => {
-	resizeObserver?.disconnect();
 	// Safety net for non-standard unmount paths (e.g. parent route change)
 	cancelPending();
 });


### PR DESCRIPTION
 ## Scope                                                                 
                                                                           
  What's changed:                                                          
                                   
  - Replace manual `@keydown="handleKeydown"` switch-case with individual  
  `onKeyStroke` composables from VueUse for each key group (arrows, Enter, 
  Escape, 1-4)
  - Replace manual `ResizeObserver` setup/teardown in
  `onMounted`/`onUnmounted` with `useResizeObserver` from VueUse
  - Fix number key `1` not activating text input when it's the only option
  — added `else if` branch for `allow_text` activation at `optionCount + 1`
  - Change `rootEl` from `ref<HTMLElement | null>` to
  `useTemplateRef<HTMLElement>('root-el')` for consistency
  - Change `savedHeight` from `let` to `ref(0)` (reactive, no mutable local
   variable)
  - Remove dead `resizeObserver` variable and manual `disconnect()` calls
  - Remove `@keydown` binding from root template element (handled by
  `onKeyStroke` now)

  ## Potential Risks / Drawbacks

  - `onKeyStroke` listens globally (document-level by default) instead of
  scoped to the component's root element — could intercept keys when other
  elements are focused

  ## Tested Scenarios

  - Number keys 1-4 select options correctly
  - Number key activates text input when it's the next index after options
  - Arrow keys navigate between question tabs
  - Enter submits on last question, advances on others
  - Escape skips to next question
  - Tab fade indicators update on resize

  ## Review Notes / Questions

  - The `onKeyStroke` handlers don't check if the component's root element
  has focus, unlike the previous `@keydown` approach which was scoped to
  the focused element. May want to add a `target` option or guard check

  ## Checklist

  - [ ] Added or updated tests
  - [ ] Documentation PR created [here](https://github.com/directus/docs)
  or not required
  - [ ] OpenAPI package PR created
  [here](https://github.com/directus/openapi) or not required