### PR TITLE
fix(app): exclude virtual fields from export default field selection

### DIFF
--- a/.changeset/small-rats-join.md
+++ b/.changeset/small-rats-join.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed virtual fields (like `$thumbnail`) being included in the default export field selection, causing export errors.

--- a/app/src/utils/exclude-virtual-fields.test.ts
+++ b/app/src/utils/exclude-virtual-fields.test.ts
@@ -1,0 +1,91 @@
+import type { Field } from '@directus/types';
+import { expect, test } from 'vitest';
+import { excludeVirtualFieldNames, excludeVirtualFields, isVirtualFieldName } from '@/utils/exclude-virtual-fields';
+
+// ── isVirtualFieldName ────────────────────────────────────────────────────────
+
+test('isVirtualFieldName returns true for fields prefixed with $', () => {
+	expect(isVirtualFieldName('$thumbnail')).toBe(true);
+	expect(isVirtualFieldName('$count')).toBe(true);
+});
+
+test('isVirtualFieldName returns false for regular field names', () => {
+	expect(isVirtualFieldName('id')).toBe(false);
+	expect(isVirtualFieldName('title')).toBe(false);
+	expect(isVirtualFieldName('')).toBe(false);
+});
+
+// ── excludeVirtualFields ──────────────────────────────────────────────────────
+
+test('excludeVirtualFields returns empty array for empty input', () => {
+	expect(excludeVirtualFields([])).toEqual([]);
+});
+
+test('excludeVirtualFields filters out alias-type fields', () => {
+	const fields: Field[] = [
+		makeField('id', 'integer'),
+		makeField('title', 'string'),
+		makeField('o2m', 'alias'),
+		makeField('m2m', 'alias'),
+	];
+
+	expect(excludeVirtualFields(fields)).toEqual(['id', 'title']);
+});
+
+test('excludeVirtualFields filters out fields whose name starts with $', () => {
+	const fields: Field[] = [
+		makeField('id', 'integer'),
+		makeField('$thumbnail', 'string'),
+		makeField('title', 'string'),
+	];
+
+	expect(excludeVirtualFields(fields)).toEqual(['id', 'title']);
+});
+
+test('excludeVirtualFields filters out both alias-type and $-prefixed fields', () => {
+	const fields: Field[] = [
+		makeField('id', 'integer'),
+		makeField('title', 'string'),
+		makeField('o2m', 'alias'),
+		makeField('$thumbnail', 'string'),
+	];
+
+	expect(excludeVirtualFields(fields)).toEqual(['id', 'title']);
+});
+
+test('excludeVirtualFields returns all field names when no virtual fields are present', () => {
+	const fields: Field[] = [makeField('id', 'integer'), makeField('title', 'string'), makeField('status', 'string')];
+
+	expect(excludeVirtualFields(fields)).toEqual(['id', 'title', 'status']);
+});
+
+// ── excludeVirtualFieldNames ──────────────────────────────────────────────────
+
+test('excludeVirtualFieldNames returns empty array for empty input', () => {
+	expect(excludeVirtualFieldNames([])).toEqual([]);
+});
+
+test('excludeVirtualFieldNames filters out field names starting with $', () => {
+	expect(excludeVirtualFieldNames(['id', '$thumbnail', 'title', '$count'])).toEqual(['id', 'title']);
+});
+
+test('excludeVirtualFieldNames keeps all names when none start with $', () => {
+	expect(excludeVirtualFieldNames(['id', 'title', 'status'])).toEqual(['id', 'title', 'status']);
+});
+
+test('excludeVirtualFieldNames removes all names when all start with $', () => {
+	expect(excludeVirtualFieldNames(['$thumbnail', '$count'])).toEqual([]);
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeField(field: string, type: Field['type']): Field {
+	return {
+		collection: 'test_collection',
+		field,
+		type,
+		schema: null,
+		meta: null,
+		name: field,
+	};
+}

--- a/app/src/utils/exclude-virtual-fields.ts
+++ b/app/src/utils/exclude-virtual-fields.ts
@@ -1,0 +1,27 @@
+import type { Field } from '@directus/types';
+
+/**
+ * Determines if a field name represents a virtual field (prefixed with '$').
+ * Virtual fields don't exist as real database columns and cannot be exported.
+ */
+export function isVirtualFieldName(fieldName: string): boolean {
+	return fieldName.startsWith('$');
+}
+
+/**
+ * Filters out virtual fields from a list of Field objects and returns their names as strings.
+ * Excludes fields with type 'alias' or with field names prefixed with '$'.
+ */
+export function excludeVirtualFields(fields: Field[]): string[] {
+	return fields
+		.filter((field) => field.type !== 'alias' && !isVirtualFieldName(field.field))
+		.map((field) => field.field);
+}
+
+/**
+ * Filters out virtual field names from a list of field name strings.
+ * Removes any field names prefixed with '$'.
+ */
+export function excludeVirtualFieldNames(fields: string[]): string[] {
+	return fields.filter((field) => !isVirtualFieldName(field));
+}

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -84,9 +84,7 @@ const exportSettings = reactive({
 	search: props.search,
 	fields:
 		props.layoutQuery?.fields ??
-		fields.value
-			?.filter((field) => field.type !== 'alias' && !field.field.startsWith('$'))
-			.map((field) => field.field),
+		fields.value?.filter((field) => field.type !== 'alias' && !field.field.startsWith('$')).map((field) => field.field),
 	sort: `${primaryKeyField.value?.field ?? ''}`,
 });
 

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -83,7 +83,10 @@ const exportSettings = reactive({
 	filter: props.filter,
 	search: props.search,
 	fields:
-		props.layoutQuery?.fields ?? fields.value?.filter((field) => field.type !== 'alias').map((field) => field.field),
+		props.layoutQuery?.fields ??
+		fields.value
+			?.filter((field) => field.type !== 'alias' && !field.field.startsWith('$'))
+			.map((field) => field.field),
 	sort: `${primaryKeyField.value?.field ?? ''}`,
 });
 
@@ -91,7 +94,10 @@ watch(
 	fields,
 	() => {
 		if (props.layoutQuery?.fields) return;
-		exportSettings.fields = fields.value?.filter((field) => field.type !== 'alias').map((field) => field.field);
+
+		exportSettings.fields = fields.value
+			?.filter((field) => field.type !== 'alias' && !field.field.startsWith('$'))
+			.map((field) => field.field);
 	},
 	{ immediate: true },
 );
@@ -102,7 +108,8 @@ watch(
 		exportSettings.limit = props.layoutQuery?.limit ?? defaultLimit;
 
 		if (props.layoutQuery?.fields) {
-			exportSettings.fields = props.layoutQuery?.fields;
+			// Filter out virtual fields (prefixed with $) that don't exist as real DB columns
+			exportSettings.fields = props.layoutQuery.fields.filter((field) => !field.startsWith('$'));
 		}
 
 		if (props.layoutQuery?.sort) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -250,3 +250,4 @@
 - alvarosabu
 - omkarg01
 - wotan-allfather
+- shtse8


### PR DESCRIPTION
## Description

Virtual fields prefixed with `$` (like `$thumbnail` in `directus_files`) are synthetic/computed fields that don't exist as real database columns. When they're included in the export field list, the API throws a `FORBIDDEN` error because they can't be queried.

## Changes

In `export-sidebar-detail.vue`, added a filter to exclude fields starting with `$` from the default export field selection. This matches the existing behavior already in place in `packages/composables/src/use-items.ts`:

```ts
// Filter out fake internal columns. This is (among other things) for a fake $thumbnail m2o field on directus_files
fieldsToFetch = fieldsToFetch.filter((field) => field.startsWith('$') === false);
```

The fix is applied in three places:
1. Initial `exportSettings.fields` reactive state initialization
2. The `watch(fields, ...)` callback that updates fields when the store changes
3. The `watch(() => props.layoutQuery, ...)` callback that syncs from layout query (handles saved presets that may contain `$thumbnail`)

## Steps to reproduce

1. Upload a file to `directus_files`
2. Open the File Library in the Admin UI
3. Click the Export button in the sidebar
4. `$thumbnail` appears in the default field selection
5. Click Download → **FORBIDDEN error**

After this fix, `$thumbnail` is excluded from the default selection and the export works correctly.

Fixes #25588