### PR TITLE
fix(app): normalize decimal separator in float input display

### DIFF
--- a/.changeset/fix-decimal-separator.md
+++ b/.changeset/fix-decimal-separator.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix decimal input fields displaying locale-specific separators (e.g. `,` instead of `.`) when editing existing values.

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -350,7 +350,7 @@ function useInlineWarning() {
 					:max="max"
 					:step="step"
 					:disabled="disabled"
-					:value="modelValue === undefined || modelValue === null ? '' : String(modelValue)"
+					:value="modelValue == null ? '' : float ? String(modelValue).replace(',', '.') : String(modelValue)"
 					v-on="listeners"
 					@keydown.space="$emit('keydown:space', $event)"
 					@keydown.enter="$emit('keydown:enter', $event)"

--- a/contributors.yml
+++ b/contributors.yml
@@ -250,3 +250,4 @@
 - alvarosabu
 - omkarg01
 - wotan-allfather
+- mixelburg


### PR DESCRIPTION
## Scope

What's changed:

- Normalize the rendered value of float/decimal input fields to always use `.` as the decimal separator
- When editing a decimal field, the value could display with a locale-specific separator (e.g. `,` in Belgium) even though the API returns `300.44`. This ensures the input consistently shows `.`

## Potential Risks / Drawbacks

- None — this only affects the display value binding, not the emit/save logic (which already normalizes `,` to `.`)

## Tested Scenarios

- Float input with modelValue containing `,` renders with `.` instead
- Non-float inputs are unaffected
- Null/undefined values still render as empty string

## Review Notes / Questions

- The emit side already had this normalization (`value.replace(',', '.')` in `emitValue`), this adds the same for the display/render side

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #24803