### PR TITLE
Fix type safety in ai-ask-user-summary component

### DIFF
--- a/app/src/ai/components/parts/ai-ask-user-summary.vue
+++ b/app/src/ai/components/parts/ai-ask-user-summary.vue
@@ -1,14 +1,23 @@
 <script setup lang="ts">
 import type { DynamicToolUIPart } from 'ai';
 import { computed } from 'vue';
-import type { AskUserAnswers, AskUserInput } from '../../composables/use-ask-user-tool';
+import type { AskUserAnswers } from '../../composables/use-ask-user-tool';
+import { inputSchema } from '../../composables/use-ask-user-tool';
 
 const props = defineProps<{
 	part: DynamicToolUIPart;
 }>();
 
-const questions = computed(() => (props.part.input as AskUserInput | undefined)?.questions ?? []);
-const output = computed(() => (props.part.output as AskUserAnswers) ?? {});
+const questions = computed(() => {
+	const parsed = inputSchema.safeParse(props.part.input);
+	return parsed.success ? parsed.data.questions : [];
+});
+
+function isAskUserAnswers(val: unknown): val is AskUserAnswers {
+	return typeof val === 'object' && val !== null;
+}
+
+const output = computed(() => (isAskUserAnswers(props.part.output) ? props.part.output : {}));
 
 function getAnswer(questionId: string): string | undefined {
 	const val = output.value[questionId];

--- a/app/src/ai/components/parts/ai-ask-user.vue
+++ b/app/src/ai/components/parts/ai-ask-user.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import formatTitle from '@directus/format-title';
+import { useResizeObserver } from '@vueuse/core';
 import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
@@ -178,10 +179,11 @@ function handleKeydown(event: KeyboardEvent) {
 	}
 }
 
+// Tabs
+
 const tabsContainerRef = useTemplateRef<HTMLElement>('tabs-container');
 const showLeftFade = ref(false);
 const showRightFade = ref(false);
-let resizeObserver: ResizeObserver | null = null;
 
 function updateFades() {
 	const el = tabsContainerRef.value;
@@ -191,6 +193,8 @@ function updateFades() {
 	showLeftFade.value = el.scrollLeft > 0;
 	showRightFade.value = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
 }
+
+useResizeObserver(tabsContainerRef, updateFades);
 
 watch(activeQuestionIndex, (newIndex, oldIndex) => {
 	slideDirection.value = newIndex > oldIndex ? 'forward' : 'backward';
@@ -211,16 +215,9 @@ onMounted(() => {
 		rootEl.value?.focus();
 		updateFades();
 	});
-
-	if (tabsContainerRef.value) {
-		resizeObserver?.disconnect();
-		resizeObserver = new ResizeObserver(updateFades);
-		resizeObserver.observe(tabsContainerRef.value);
-	}
 });
 
 onUnmounted(() => {
-	resizeObserver?.disconnect();
 	// Safety net for non-standard unmount paths (e.g. parent route change)
 	cancelPending();
 });

--- a/app/src/ai/components/parts/ai-ask-user.vue
+++ b/app/src/ai/components/parts/ai-ask-user.vue
@@ -51,6 +51,7 @@ const slideDirection = ref<'forward' | 'backward'>('forward');
 const rootEl = useTemplateRef<HTMLElement>('root-el');
 const questionWrapperRef = useTemplateRef<HTMLElement>('question-wrapper');
 const savedHeight = ref(0);
+let rafId: number | null = null;
 
 function onBeforeLeave() {
 	const wrapper = questionWrapperRef.value;
@@ -65,7 +66,7 @@ function onEnter() {
 	const newHeight = wrapper.offsetHeight;
 	wrapper.style.height = `${savedHeight.value}px`;
 
-	requestAnimationFrame(() => {
+	rafId = requestAnimationFrame(() => {
 		wrapper.style.height = `${newHeight}px`;
 	});
 }
@@ -224,6 +225,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+	if (rafId !== null) cancelAnimationFrame(rafId);
 	// Safety net for non-standard unmount paths (e.g. parent route change)
 	cancelPending();
 });

--- a/app/src/ai/composables/use-ask-user-tool.ts
+++ b/app/src/ai/composables/use-ask-user-tool.ts
@@ -23,6 +23,7 @@ const inputSchema = z.object({
 	questions: z.array(questionSchema).min(1),
 });
 
+export { inputSchema };
 export type AskUserInput = z.infer<typeof inputSchema>;
 export type AskUserQuestion = z.infer<typeof questionSchema>;
 export type AskUserAnswers = Record<string, string | string[]>;
@@ -82,9 +83,10 @@ export function useAskUserTool() {
 		inputSchema,
 		execute: (args) => {
 			cancelPending();
+			const input = inputSchema.parse(args);
 
 			return new Promise<AskUserAnswers>((resolve) => {
-				pendingAskUser.value = { input: args, resolve };
+				pendingAskUser.value = { input, resolve };
 			});
 		},
 	});


### PR DESCRIPTION

#26687 should be merged first

## Scope

What's changed:

- Replace unsafe `as` casts in `ai-ask-user-summary.vue` with proper runtime validation: `inputSchema.safeParse()` for questions and an `isAskUserAnswers()` type guard for output
- Export `inputSchema` from `use-ask-user-tool.ts` so the summary component can validate against it
- Fix pre-existing type error in `use-ask-user-tool.ts`: explicitly parse `args` through `inputSchema` in `execute` to correctly convert `z.input<T>` (optional defaults) to `z.output<T>` (defaults applied), aligning with `PendingAskUser.input: AskUserInput`

## Potential Risks / Drawbacks

- None — runtime behavior is unchanged; `inputSchema.parse(args)` is a no-op since the AI SDK already validates and applies defaults before calling execute

## Tested Scenarios

- Summary component renders correctly after an ask_user interaction

## Review Notes / Questions

- Addresses review comment https://github.com/directus/directus/pull/26633#discussion_r2813544301

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>