### PR TITLE
Guard nav-bar and sidebar size stores against non-finite values

### DIFF
--- a/.changeset/kind-jeans-laugh.md
+++ b/.changeset/kind-jeans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Guarded nav-bar and sidebar size stores against non-finite values

--- a/app/src/views/private/private-view/stores/nav-bar.test.ts
+++ b/app/src/views/private/private-view/stores/nav-bar.test.ts
@@ -1,0 +1,69 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useNavBarStore } from './nav-bar';
+
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+
+	return {
+		...actual,
+		useLocalStorage: (_key: string, defaultValue: unknown) => ref(defaultValue),
+		useBreakpoints: () => ({
+			lg: ref(true),
+			xl: ref(true),
+		}),
+	};
+});
+
+vi.mock('vue-router', () => ({
+	useRoute: () => ({
+		fullPath: ref('/'),
+	}),
+}));
+
+beforeEach(() => {
+	setActivePinia(createPinia());
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('nav-bar store size guard', () => {
+	it('returns default size on init', () => {
+		const store = useNavBarStore();
+		expect(store.size).toBe(250);
+	});
+
+	it('accepts finite values', () => {
+		const store = useNavBarStore();
+		store.size = 300;
+		expect(store.size).toBe(300);
+	});
+
+	it('rejects NaN and returns default', () => {
+		const store = useNavBarStore();
+		store.size = NaN;
+		expect(store.size).toBe(250);
+	});
+
+	it('rejects Infinity and returns default', () => {
+		const store = useNavBarStore();
+		store.size = Infinity;
+		expect(store.size).toBe(250);
+	});
+
+	it('rejects -Infinity and returns default', () => {
+		const store = useNavBarStore();
+		store.size = -Infinity;
+		expect(store.size).toBe(250);
+	});
+
+	it('preserves last valid value after rejected write', () => {
+		const store = useNavBarStore();
+		store.size = 320;
+		store.size = NaN;
+		expect(store.size).toBe(320);
+	});
+});

--- a/app/src/views/private/private-view/stores/nav-bar.ts
+++ b/app/src/views/private/private-view/stores/nav-bar.ts
@@ -7,7 +7,19 @@ import { useSidebarStore } from '@/views/private/private-view/stores/sidebar';
 
 export const useNavBarStore = defineStore('nav-bar-store', () => {
 	const collapsed = useLocalStorage('nav-bar-collapsed', false);
-	const size = useLocalStorage('nav-bar-size', 250);
+
+	const DEFAULT_SIZE = 250;
+	const storedSize = useLocalStorage('nav-bar-size', DEFAULT_SIZE);
+
+	const size = computed({
+		get() {
+			const val = storedSize.value;
+			return Number.isFinite(val) ? val : DEFAULT_SIZE;
+		},
+		set(val: number) {
+			if (Number.isFinite(val)) storedSize.value = val;
+		},
+	});
 
 	const route = useRoute();
 	const { lg, xl } = useBreakpoints(BREAKPOINTS);

--- a/app/src/views/private/private-view/stores/nav-bar.ts
+++ b/app/src/views/private/private-view/stores/nav-bar.ts
@@ -14,7 +14,13 @@ export const useNavBarStore = defineStore('nav-bar-store', () => {
 	const size = computed({
 		get() {
 			const val = storedSize.value;
-			return Number.isFinite(val) ? val : DEFAULT_SIZE;
+
+			if (!Number.isFinite(val)) {
+				storedSize.value = DEFAULT_SIZE;
+				return DEFAULT_SIZE;
+			}
+
+			return val;
 		},
 		set(val: number) {
 			if (Number.isFinite(val)) storedSize.value = val;

--- a/app/src/views/private/private-view/stores/sidebar.test.ts
+++ b/app/src/views/private/private-view/stores/sidebar.test.ts
@@ -1,0 +1,59 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useSidebarStore } from './sidebar';
+
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+
+	return {
+		...actual,
+		useLocalStorage: (_key: string, defaultValue: unknown) => ref(defaultValue),
+	};
+});
+
+beforeEach(() => {
+	setActivePinia(createPinia());
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('sidebar store size guard', () => {
+	it('returns default size on init', () => {
+		const store = useSidebarStore();
+		expect(store.size).toBe(370);
+	});
+
+	it('accepts finite values', () => {
+		const store = useSidebarStore();
+		store.size = 400;
+		expect(store.size).toBe(400);
+	});
+
+	it('rejects NaN and returns default', () => {
+		const store = useSidebarStore();
+		store.size = NaN;
+		expect(store.size).toBe(370);
+	});
+
+	it('rejects Infinity and returns default', () => {
+		const store = useSidebarStore();
+		store.size = Infinity;
+		expect(store.size).toBe(370);
+	});
+
+	it('rejects -Infinity and returns default', () => {
+		const store = useSidebarStore();
+		store.size = -Infinity;
+		expect(store.size).toBe(370);
+	});
+
+	it('preserves last valid value after rejected write', () => {
+		const store = useSidebarStore();
+		store.size = 500;
+		store.size = NaN;
+		expect(store.size).toBe(500);
+	});
+});

--- a/app/src/views/private/private-view/stores/sidebar.ts
+++ b/app/src/views/private/private-view/stores/sidebar.ts
@@ -11,7 +11,13 @@ export const useSidebarStore = defineStore('sidebar-store', () => {
 	const size = computed({
 		get() {
 			const val = storedSize.value;
-			return Number.isFinite(val) ? val : DEFAULT_SIZE;
+
+			if (!Number.isFinite(val)) {
+				storedSize.value = DEFAULT_SIZE;
+				return DEFAULT_SIZE;
+			}
+
+			return val;
 		},
 		set(val: number) {
 			if (Number.isFinite(val)) storedSize.value = val;

--- a/app/src/views/private/private-view/stores/sidebar.ts
+++ b/app/src/views/private/private-view/stores/sidebar.ts
@@ -1,10 +1,22 @@
 import { createEventHook, useLocalStorage } from '@vueuse/core';
 import { defineStore } from 'pinia';
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 export const useSidebarStore = defineStore('sidebar-store', () => {
 	const collapsed = useLocalStorage('sidebar-collapsed', false);
-	const size = useLocalStorage('sidebar-size', 370);
+
+	const DEFAULT_SIZE = 370;
+	const storedSize = useLocalStorage('sidebar-size', DEFAULT_SIZE);
+
+	const size = computed({
+		get() {
+			const val = storedSize.value;
+			return Number.isFinite(val) ? val : DEFAULT_SIZE;
+		},
+		set(val: number) {
+			if (Number.isFinite(val)) storedSize.value = val;
+		},
+	});
 
 	const activeAccordionItem = ref<string>();
 


### PR DESCRIPTION
## Scope

What's changed:

- Added writable computed wrapper around `useLocalStorage` in both `nav-bar.ts` and `sidebar.ts` stores
- Getter rejects `NaN`/`Infinity`/`-Infinity` and falls back to default (250px / 370px)
- Setter silently drops non-finite writes, preventing corruption from reaching localStorage

## Potential Risks / Drawbacks

- The upstream vulnerability in `@directus/vue-split-panel` (`pixelsToPercentage` divides by zero when `useElementSize` returns `0` during initial render) is not fixed, this is a defensive guard only.

## Tested Scenarios

-Manually setting `localStorage.setItem('nav-bar-size', 'NaN')` and reloading: falls back to default 250px
- Same for sidebar-size: falls back to 370px
- Normal resize via split panel divider: values persist correctly as before

## Review Notes / Questions

- I've been unable to reproduce it manually, only by changing the value in the localStorage.
- An issue on `@directus/vue-split-panel` [has been created](https://github.com/directus/vue-split-panel/issues/69) (https://github.com/directus/vue-split-panel/pull/70)

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-1790](https://linear.app/directus/issue/CMS-1790/flaky-ui-experience-with-sidebars)
