### PR TITLE
fix: add missing label property to ReadProviderOutput interface

### DIFF
--- a/sdk/src/rest/commands/auth/providers.ts
+++ b/sdk/src/rest/commands/auth/providers.ts
@@ -4,6 +4,7 @@ export interface ReadProviderOutput {
 	name: string;
 	driver: string;
 	icon?: string | null;
+	label?: string | null;
 }
 
 /**


### PR DESCRIPTION
Fixes #26644

## Problem
The `ReadProviderOutput` interface in the SDK is missing the `label` property that the API's `getAuthProviders` utility actually returns.

The API (`api/src/utils/get-auth-providers.ts`) returns:
```ts
{ name, driver, icon, label }
```

But the SDK type (`sdk/src/rest/commands/auth/providers.ts`) only declared:
```ts
{ name, driver, icon }
```

This means SDK users can't access the `label` field without type assertions.

## Fix
Added `label?: string | null` to `ReadProviderOutput`, matching the API's return type.