### PR TITLE
fix(sdk): add missing label property to ReadProviderOutput interface

### DIFF
--- a/sdk/src/rest/commands/auth/providers.ts
+++ b/sdk/src/rest/commands/auth/providers.ts
@@ -4,6 +4,7 @@ export interface ReadProviderOutput {
 	name: string;
 	driver: string;
 	icon?: string | null;
+	label?: string | null;
 }
 
 /**


### PR DESCRIPTION
Fixes #26644

## Problem

The `ReadProviderOutput` interface in the SDK is missing the `label` property that the API's `get-auth-providers.ts` returns.

**API interface** (`api/src/utils/get-auth-providers.ts`):
```ts
interface AuthProvider {
  name: string;
  driver: string;
  icon?: string;
  label?: string;  // ← present
}
```

**SDK interface** (`sdk/src/rest/commands/auth/providers.ts`):
```ts
export interface ReadProviderOutput {
  name: string;
  driver: string;
  icon?: string | null;
  // label is missing!
}
```

## Fix

Added `label?: string | null` to `ReadProviderOutput` to match the API response.