### PR TITLE
Add missing label field to ReadProviderOutput interface

### DIFF
--- a/sdk/src/rest/commands/auth/providers.ts
+++ b/sdk/src/rest/commands/auth/providers.ts
@@ -4,6 +4,7 @@ export interface ReadProviderOutput {
 	name: string;
 	driver: string;
 	icon?: string | null;
+	label?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #26644. The `ReadProviderOutput` interface in the SDK is missing the `label` field that the API's `get-auth-providers` endpoint actually returns.

### API response (`api/src/utils/get-auth-providers.ts`)

Returns `{ name, driver, icon, label }` for each provider.

### SDK interface (before this fix)

```ts
interface ReadProviderOutput {
  name: string;
  driver: string;
  icon?: string | null;
  // label was missing!
}
```

### Fix

Added `label?: string | null` to match the API response.

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*