### PR TITLE
Add CLAUDE.md documentation for Vue 3 CMS app guidelines

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -8,20 +8,26 @@ Vue 3 CMS app studio built with Vite and Pinia. See [root agents.md](../agents.m
 
 - Always use `<script setup lang="ts">` — no Options API
 - Block order enforced by ESLint: `<script>` → `<template>` → `<style>`
-- Define props with a TypeScript interface + `defineProps<Props>()`, use `withDefaults` for any defaults
+- Define props inline with `defineProps<{}>()` and destructure directly (Vue 3.5+) — defaults go in the destructuring assignment
+- Use `withDefaults` only when the inline type gets unwieldy or you need to reference `props` as an object
 - Add JSDoc comments to every prop
 - Use typed `defineEmits` signatures
 
 ```vue
 <script setup lang="ts">
-interface Props {
+// preferred — destructuring with defaults
+const {
 	/** Description of what this prop does */
-	label?: string;
+	label,
 	/** Whether the component is disabled */
+	disabled = false,
+} = defineProps<{
+	label?: string;
 	disabled?: boolean;
-}
+}>();
 
-const props = withDefaults(defineProps<Props>(), {
+// use withDefaults when you need props as a reactive object
+const props = withDefaults(defineProps<{ label?: string; disabled?: boolean }>(), {
 	disabled: false,
 });
 
@@ -35,14 +41,7 @@ const emit = defineEmits<{
 
 - PascalCase for component names: `<MyComponent />` not `<my-component />` (enforced by ESLint)
 - Shorthand attributes: `:prop`, `@event`, `#slot`
-- **Always check `src/components/` before writing plain HTML or creating a new component.** Components are globally
-  registered via `registerComponents()` — no import needed in templates. Key components:
-  - Buttons/links: `VButton`
-  - Inputs: `VInput`, `VTextarea`, `VCheckbox`, `VRadio`, `VSelect`, `VSlider`, `VDatePicker`
-  - Layout: `VCard` + `VCardTitle`/`VCardText`/`VCardActions`, `VSheet`, `VDivider`, `VList`/`VListItem`/`VListGroup`
-  - Overlay/navigation: `VDialog`, `VDrawer`, `VMenu`, `VOverlay`, `VTabs`/`VTab`
-  - Feedback: `VNotice`, `VProgressLinear`, `VProgressCircular`, `VSkeletonLoader`
-  - Display: `VIcon`, `VAvatar`, `VBadge`, `VChip`, `VHighlight`, `VImage`, `VInfo`, `VPagination`, `VTable`
+- **Always check `src/components/` before writing plain HTML or creating a new component.** Consult `src/components/register.ts` for the full list of globally registered components — no import needed in templates.
 
 ### File naming
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,101 @@
+# App CLAUDE.md
+
+Vue 3 CMS app studio built with Vite and Pinia. See [root agents.md](../agents.md) for general project guidance.
+
+## Vue Components
+
+### Script block
+
+- Always use `<script setup lang="ts">` — no Options API
+- Block order enforced by ESLint: `<script>` → `<template>` → `<style>`
+- Define props with a TypeScript interface + `defineProps<Props>()`, use `withDefaults` for any defaults
+- Add JSDoc comments to every prop
+- Use typed `defineEmits` signatures
+
+```vue
+<script setup lang="ts">
+interface Props {
+	/** Description of what this prop does */
+	label?: string;
+	/** Whether the component is disabled */
+	disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	disabled: false,
+});
+
+const emit = defineEmits<{
+	click: [event: MouseEvent];
+}>();
+</script>
+```
+
+### Template
+
+- PascalCase for component names: `<MyComponent />` not `<my-component />`  (enforced by ESLint)
+- Shorthand attributes: `:prop`, `@event`, `#slot`
+- **Always check `src/components/` before writing plain HTML or creating a new component.** Components are globally registered via `registerComponents()` — no import needed in templates. Key components:
+  - Buttons/links: `VButton`
+  - Inputs: `VInput`, `VTextarea`, `VCheckbox`, `VRadio`, `VSelect`, `VSlider`, `VDatePicker`
+  - Layout: `VCard` + `VCardTitle`/`VCardText`/`VCardActions`, `VSheet`, `VDivider`, `VList`/`VListItem`/`VListGroup`
+  - Overlay/navigation: `VDialog`, `VDrawer`, `VMenu`, `VOverlay`, `VTabs`/`VTab`
+  - Feedback: `VNotice`, `VProgressLinear`, `VProgressCircular`, `VSkeletonLoader`
+  - Display: `VIcon`, `VAvatar`, `VBadge`, `VChip`, `VHighlight`, `VImage`, `VInfo`, `VPagination`, `VTable`
+
+### File naming
+
+- Components: Prefer PascalCase for component file names: `MyComponent.vue` not `my-component.vue`
+- Path alias: `@/` resolves to `src/` — use it for all cross-directory imports
+
+## Styling
+
+- Always use `<style lang="scss">`
+- Use CSS custom properties for theming, following the `--component-name-property` pattern:
+
+```vue
+<style lang="scss">
+.my-component {
+	--my-component-color: var(--theme--foreground);
+
+	color: var(--my-component-color);
+}
+</style>
+```
+
+- **CSS logical properties are required** (enforced by Stylelint `csstools/use-logical`):
+  - `inline-size` / `block-size` instead of `width` / `height`
+  - `inset-inline-start` / `inset-inline-end` instead of `left` / `right`
+  - `inset-block-start` / `inset-block-end` instead of `top` / `bottom`
+  - `padding-inline` / `margin-block` instead of directional shorthands
+- Theme design tokens available via `var(--theme--*)` (e.g. `--theme--primary`, `--theme--foreground`, `--theme--background`)
+
+## Composables
+
+- Named export, `use*` prefix: `export function useMyFeature() {}`
+- File naming: `use-my-feature.ts` in `src/composables/`
+- Return a plain object
+- **A composable must use Vue's reactivity system** — it should own reactive state (`ref`, `reactive`, `computed`) or call another composable/store that does. If a function has no reactive state and no lifecycle hooks, it's a utility function and belongs in `src/utils/` instead.
+
+```ts
+// composable — owns reactive state
+export function useMyFeature() {
+	const state = ref(null);
+	const derived = computed(() => state.value?.name);
+	return { state, derived, doSomething };
+
+	function doSomething() { /* ... */ }
+}
+
+// NOT a composable — pure logic, no reactivity → put in src/utils/
+export function formatMyValue(value: string): string {
+	return value.trim().toLowerCase();
+}
+```
+
+## Stores (Pinia)
+
+- Use Setup Store style (function-based) over Options style
+- Named export: `export const useMyStore = defineStore('myStore', () => { ... })`
+- Store ID in camelCase with `Store` suffix: `'userStore'`
+- File naming: `kebab-case.ts` in `src/stores/`

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -10,7 +10,7 @@ Vue 3 CMS app studio built with Vite and Pinia. See [root agents.md](../agents.m
 - Block order enforced by ESLint: `<script>` → `<template>` → `<style>`
 - Define props inline with `defineProps<{}>()` and destructure directly (Vue 3.5+) — defaults go in the destructuring assignment
 - Use `withDefaults` only when the inline type gets unwieldy or you need to reference `props` as an object
-- Add JSDoc comments to every prop
+- Prefer descriptive naming over JSDocs comments for props
 - Use typed `defineEmits` signatures
 
 ```vue

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -77,7 +77,8 @@ const emit = defineEmits<{
 - Named export, `use*` prefix: `export function useMyFeature() {}`
 - File naming: `use-my-feature.ts` in `src/composables/`
 - Return a plain object
-- **Check VueUse before writing custom reactive logic.** `@vueuse/core`, `@vueuse/integrations`, and `@vueuse/router` are available. Common cases that VueUse already covers:
+- **Check VueUse before writing custom reactive logic.** `@vueuse/core`, `@vueuse/integrations`, and `@vueuse/router`
+  are available. Common cases that VueUse already covers:
   - Event listeners → `useEventListener`
   - `window`/`document` size or scroll → `useWindowSize`, `useScroll`, `useIntersectionObserver`
   - Keyboard shortcuts → `useKeyModifier`, `onKeyStroke`

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -33,9 +33,10 @@ const emit = defineEmits<{
 
 ### Template
 
-- PascalCase for component names: `<MyComponent />` not `<my-component />`  (enforced by ESLint)
+- PascalCase for component names: `<MyComponent />` not `<my-component />` (enforced by ESLint)
 - Shorthand attributes: `:prop`, `@event`, `#slot`
-- **Always check `src/components/` before writing plain HTML or creating a new component.** Components are globally registered via `registerComponents()` — no import needed in templates. Key components:
+- **Always check `src/components/` before writing plain HTML or creating a new component.** Components are globally
+  registered via `registerComponents()` — no import needed in templates. Key components:
   - Buttons/links: `VButton`
   - Inputs: `VInput`, `VTextarea`, `VCheckbox`, `VRadio`, `VSelect`, `VSlider`, `VDatePicker`
   - Layout: `VCard` + `VCardTitle`/`VCardText`/`VCardActions`, `VSheet`, `VDivider`, `VList`/`VListItem`/`VListGroup`
@@ -68,14 +69,17 @@ const emit = defineEmits<{
   - `inset-inline-start` / `inset-inline-end` instead of `left` / `right`
   - `inset-block-start` / `inset-block-end` instead of `top` / `bottom`
   - `padding-inline` / `margin-block` instead of directional shorthands
-- Theme design tokens available via `var(--theme--*)` (e.g. `--theme--primary`, `--theme--foreground`, `--theme--background`)
+- Theme design tokens available via `var(--theme--*)` (e.g. `--theme--primary`, `--theme--foreground`,
+  `--theme--background`)
 
 ## Composables
 
 - Named export, `use*` prefix: `export function useMyFeature() {}`
 - File naming: `use-my-feature.ts` in `src/composables/`
 - Return a plain object
-- **A composable must use Vue's reactivity system** — it should own reactive state (`ref`, `reactive`, `computed`) or call another composable/store that does. If a function has no reactive state and no lifecycle hooks, it's a utility function and belongs in `src/utils/` instead.
+- **A composable must use Vue's reactivity system** — it should own reactive state (`ref`, `reactive`, `computed`) or
+  call another composable/store that does. If a function has no reactive state and no lifecycle hooks, it's a utility
+  function and belongs in `src/utils/` instead.
 
 ```ts
 // composable — owns reactive state
@@ -84,7 +88,9 @@ export function useMyFeature() {
 	const derived = computed(() => state.value?.name);
 	return { state, derived, doSomething };
 
-	function doSomething() { /* ... */ }
+	function doSomething() {
+		/* ... */
+	}
 }
 
 // NOT a composable — pure logic, no reactivity → put in src/utils/

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -77,6 +77,20 @@ const emit = defineEmits<{
 - Named export, `use*` prefix: `export function useMyFeature() {}`
 - File naming: `use-my-feature.ts` in `src/composables/`
 - Return a plain object
+- **Check VueUse before writing custom reactive logic.** `@vueuse/core`, `@vueuse/integrations`, and `@vueuse/router` are available. Common cases that VueUse already covers:
+  - Event listeners → `useEventListener`
+  - `window`/`document` size or scroll → `useWindowSize`, `useScroll`, `useIntersectionObserver`
+  - Keyboard shortcuts → `useKeyModifier`, `onKeyStroke`
+  - Clipboard → `useClipboard`
+  - Local/session storage → `useLocalStorage`, `useSessionStorage`
+  - Debounce / throttle → `useDebounceFn`, `useThrottleFn`
+  - Fetch / async state → `useFetch`, `useAsyncState`
+  - Media queries → `useMediaQuery`
+  - Element visibility → `useElementVisibility`
+  - Mouse position → `useMouse`
+  - `ResizeObserver` → `useResizeObserver`
+  - `MutationObserver` → `useMutationObserver`
+  - Router params/query (typed) → `@vueuse/router`
 - **A composable must use Vue's reactivity system** — it should own reactive state (`ref`, `reactive`, `computed`) or
   call another composable/store that does. If a function has no reactive state and no lifecycle hooks, it's a utility
   function and belongs in `src/utils/` instead.


### PR DESCRIPTION
## Scope

- Added `app/CLAUDE.md` with AI agent coding guidelines scoped to the `@app` package
- Vue component conventions: `<script setup lang="ts">`, props via TypeScript interface + `withDefaults`, JSDoc per prop, typed emits, block ordering
- Template conventions: PascalCase component names, shorthand attributes, and rule to prefer globally registered components from `src/components/` over plain HTML
- Styling rules: CSS custom properties theming pattern (`--component-name-property`), required CSS logical properties, `--theme--*` design tokens
- Composables rule: must own or call reactive state — pure logic belongs in `src/utils/` instead
- Pinia store conventions: Setup Store style, camelCase ID with `Store` suffix

## Potential Risks / Drawbacks

- None — documentation only, no runtime changes

## Tested Scenarios

- Not applicable — documentation only

## Review Notes / Questions

- New component file naming convention is PascalCase going forward; existing `v-*.vue` files are untouched
- The globally registered component list in the template section was cross-checked against `src/components/register.ts`

## Checklist

- [ ] Added or updated tests — not applicable
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required