### PR TITLE
Enable “Navigate to Item” button for non-editable relational fields

### DIFF
--- a/.changeset/floppy-ads-say.md
+++ b/.changeset/floppy-ads-say.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Enabled navigation for non-editable relational fields
+Enabled “Navigate to Item” button for non-editable relational fields

--- a/.changeset/floppy-ads-say.md
+++ b/.changeset/floppy-ads-say.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Enabled navigation for non-editable relational fields

--- a/app/src/interfaces/list-m2m/list-m2m.test.ts
+++ b/app/src/interfaces/list-m2m/list-m2m.test.ts
@@ -124,14 +124,13 @@ const global: GlobalMountOptions = {
 	],
 };
 
+const routerLinkStub = {
+	template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+};
+
 const globalWithRouterLink: GlobalMountOptions = {
 	...global,
-	stubs: {
-		...global.stubs,
-		RouterLink: {
-			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
-		},
-	},
+	stubs: { ...global.stubs, RouterLink: routerLinkStub },
 };
 
 const tableGlobal: GlobalMountOptions = {
@@ -147,12 +146,7 @@ const tableGlobal: GlobalMountOptions = {
 
 const tableGlobalWithRouterLink: GlobalMountOptions = {
 	...tableGlobal,
-	stubs: {
-		...tableGlobal.stubs,
-		RouterLink: {
-			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
-		},
-	},
+	stubs: { ...tableGlobal.stubs, RouterLink: routerLinkStub },
 };
 
 const listProps = {
@@ -222,6 +216,18 @@ describe('list-m2m', () => {
 			});
 		});
 
+		describe('disabled state', () => {
+			it('should render action buttons disabled when disabled is true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').attributes('disabled')).toBe('true');
+			});
+		});
+
 		describe('editable state', () => {
 			it('should show remove button when nonEditable is false', () => {
 				const wrapper = mount(ListM2M, {
@@ -272,6 +278,18 @@ describe('list-m2m', () => {
 				});
 
 				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+			});
+		});
+
+		describe('disabled state', () => {
+			it('should render action buttons disabled when disabled is true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, disabled: true },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').attributes('disabled')).toBe('true');
 			});
 		});
 

--- a/app/src/interfaces/list-m2m/list-m2m.test.ts
+++ b/app/src/interfaces/list-m2m/list-m2m.test.ts
@@ -1,0 +1,290 @@
+import { Field, Relation } from '@directus/types';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import ListM2M from './list-m2m.vue';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+import { Collection } from '@/types/collections';
+import { LAYOUTS } from '@/types/interfaces';
+
+vi.mock('@/composables/use-relation-m2m', () => ({
+	useRelationM2M: () => ({
+		relationInfo: computed(() => ({
+			relation: {
+				collection: 'junction-collection',
+				field: 'related_id',
+				related_collection: 'related-collection',
+				schema: null,
+				meta: null,
+			} as Relation,
+			relatedCollection: {
+				collection: 'related-collection',
+			} as Collection,
+			relatedPrimaryKeyField: { field: 'id' } as Field,
+			junctionCollection: {
+				collection: 'junction-collection',
+			} as Collection,
+			junctionPrimaryKeyField: { field: 'id' } as Field,
+			junctionField: { field: 'related_id' } as Field,
+			reverseJunctionField: { field: 'item_id' } as Field,
+			junction: {
+				collection: 'junction-collection',
+				field: 'item_id',
+				related_collection: 'test-collection',
+				schema: null,
+				meta: null,
+			} as Relation,
+			type: 'm2m',
+		})),
+	}),
+}));
+
+vi.mock('@/composables/use-relation-permissions', () => ({
+	useRelationPermissionsM2M: () => ({
+		createAllowed: computed(() => true),
+		selectAllowed: computed(() => true),
+		updateAllowed: computed(() => true),
+		deleteAllowed: computed(() => true),
+	}),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getFieldsForCollection: vi.fn(() => []),
+		getField: vi.fn(() => null),
+		getPrimaryKeyFieldForCollection: vi.fn(() => ({ field: 'id' })),
+	}),
+}));
+
+vi.mock('@/composables/use-relation-multiple', () => ({
+	useRelationMultiple: () => ({
+		create: vi.fn(),
+		update: vi.fn(),
+		remove: vi.fn(),
+		select: vi.fn(),
+		displayItems: ref([{ id: '1', related_id: { id: '10' }, $type: 'existingItem', $index: 0, $edits: 0 }]),
+		totalItemCount: ref(1),
+		loading: ref(false),
+		selected: ref([]),
+		fetchedSelectItems: ref([]),
+		fetchedItems: ref([]),
+		useActions: vi.fn(() => ({
+			cleanItem: vi.fn((item: any) => item),
+			getPage: vi.fn(),
+			isLocalItem: vi.fn(() => false),
+			getItemEdits: vi.fn(() => 0),
+			isEmpty: vi.fn(() => false),
+		})),
+		cleanItem: vi.fn((item: any) => item),
+		isItemSelected: vi.fn(() => false),
+		isLocalItem: vi.fn(() => false),
+		getItemEdits: vi.fn(() => 0),
+	}),
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+const global: GlobalMountOptions = {
+	stubs: {
+		VIcon: true,
+		VListItem: {
+			template: '<div class="v-list-item"><slot /></div>',
+		},
+		VNotice: true,
+		VRemove: true,
+		VSkeletonLoader: true,
+		VButton: true,
+		VPagination: true,
+		VSelect: true,
+		VTable: true,
+		DrawerBatch: true,
+		DrawerCollection: true,
+		DrawerItem: true,
+		RenderTemplate: true,
+		RouterLink: true,
+		SearchInput: true,
+		Draggable: {
+			template: '<div><slot v-for="element in modelValue" name="item" :element="element" /></div>',
+			props: ['modelValue'],
+		},
+	},
+	directives: {
+		tooltip: () => {},
+		'prevent-focusout': () => {},
+	},
+	plugins: [
+		i18n,
+		createTestingPinia({
+			createSpy: vi.fn,
+		}),
+	],
+};
+
+const globalWithRouterLink: GlobalMountOptions = {
+	...global,
+	stubs: {
+		...global.stubs,
+		RouterLink: {
+			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+		},
+	},
+};
+
+const tableGlobal: GlobalMountOptions = {
+	...global,
+	stubs: {
+		...global.stubs,
+		VTable: {
+			template: '<div class="v-table"><slot v-for="item in items" name="item-append" :item="item" /></div>',
+			props: ['items'],
+		},
+	},
+};
+
+const tableGlobalWithRouterLink: GlobalMountOptions = {
+	...tableGlobal,
+	stubs: {
+		...tableGlobal.stubs,
+		RouterLink: {
+			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+		},
+	},
+};
+
+const listProps = {
+	primaryKey: '1',
+	collection: 'test-collection',
+	field: 'test-field',
+	width: 'full',
+	version: null,
+};
+
+describe('list-m2m', () => {
+	it('should mount', () => {
+		const wrapper = mount(ListM2M, {
+			props: listProps,
+			global,
+		});
+
+		expect(wrapper.exists()).toBe(true);
+	});
+
+	describe('list layout', () => {
+		describe('non-editable state', () => {
+			it('should show item-actions with navigate link when nonEditable and enableLink are true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, enableLink: true, nonEditable: true, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions router-link-stub').exists()).toBe(true);
+			});
+
+			it('should hide item-actions when nonEditable is true and enableLink is false', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, enableLink: false, nonEditable: true, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(false);
+			});
+
+			it('should hide remove button when nonEditable is true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, enableLink: true, nonEditable: true, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(false);
+			});
+
+			it('should render clickable navigate link when nonEditable and disabled are both true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, enableLink: true, nonEditable: true, disabled: true },
+					global: globalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
+			});
+
+			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, enableLink: true, nonEditable: false, disabled: true },
+					global: globalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+			});
+		});
+
+		describe('editable state', () => {
+			it('should show remove button when nonEditable is false', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, enableLink: true, nonEditable: false, disabled: false },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+			});
+		});
+	});
+
+	describe('table layout', () => {
+		describe('non-editable state', () => {
+			it('should show item-actions with navigate link when nonEditable and enableLink are true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: true, disabled: true },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions router-link-stub').exists()).toBe(true);
+			});
+
+			it('should hide remove button when nonEditable is true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: true, disabled: true },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(false);
+			});
+
+			it('should render clickable navigate link when nonEditable and disabled are both true', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: true, disabled: true },
+					global: tableGlobalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
+			});
+
+			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: false, disabled: true },
+					global: tableGlobalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+			});
+		});
+
+		describe('editable state', () => {
+			it('should show remove button when nonEditable is false', () => {
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: false, disabled: false },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+			});
+		});
+	});
+});

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -566,10 +566,10 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 					/>
 				</template>
 
-				<template v-if="!nonEditable" #item-append="{ item }">
+				<template v-if="!nonEditable || enableLink" #item-append="{ item }">
 					<div class="item-actions">
 						<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(item)!" custom>
-							<VIcon v-if="disabled || item.$type === 'created'" name="launch" />
+							<VIcon v-if="(disabled && !nonEditable) || item.$type === 'created'" name="launch" />
 
 							<a
 								v-else
@@ -584,7 +584,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 						</RouterLink>
 
 						<VRemove
-							v-if="deleteAllowed || isLocalItem(item)"
+							v-if="!nonEditable && (deleteAllowed || isLocalItem(item))"
 							:disabled
 							:class="{ deleted: item.$type === 'deleted' }"
 							:item-type="item.$type"
@@ -646,9 +646,9 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 
 							<div class="spacer" />
 
-							<div v-if="!nonEditable" class="item-actions">
+							<div v-if="!nonEditable || enableLink" class="item-actions" @click.stop>
 								<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(element)!" custom>
-									<VIcon v-if="disabled || element.$type === 'created'" name="launch" />
+									<VIcon v-if="(disabled && !nonEditable) || element.$type === 'created'" name="launch" />
 
 									<a
 										v-else
@@ -663,7 +663,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 								</RouterLink>
 
 								<VRemove
-									v-if="deleteAllowed || isLocalItem(element)"
+									v-if="!nonEditable && (deleteAllowed || isLocalItem(element))"
 									:disabled
 									:item-type="element.$type"
 									:item-info="relationInfo"

--- a/app/src/interfaces/list-o2m/list-o2m.test.ts
+++ b/app/src/interfaces/list-o2m/list-o2m.test.ts
@@ -111,14 +111,13 @@ const global: GlobalMountOptions = {
 	],
 };
 
+const routerLinkStub = {
+	template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+};
+
 const globalWithRouterLink: GlobalMountOptions = {
 	...global,
-	stubs: {
-		...global.stubs,
-		RouterLink: {
-			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
-		},
-	},
+	stubs: { ...global.stubs, RouterLink: routerLinkStub },
 };
 
 const tableGlobal: GlobalMountOptions = {
@@ -134,12 +133,7 @@ const tableGlobal: GlobalMountOptions = {
 
 const tableGlobalWithRouterLink: GlobalMountOptions = {
 	...tableGlobal,
-	stubs: {
-		...tableGlobal.stubs,
-		RouterLink: {
-			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
-		},
-	},
+	stubs: { ...tableGlobal.stubs, RouterLink: routerLinkStub },
 };
 
 const listProps = {
@@ -209,6 +203,18 @@ describe('list-o2m', () => {
 			});
 		});
 
+		describe('disabled state', () => {
+			it('should render action buttons disabled when disabled is true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').attributes('disabled')).toBe('true');
+			});
+		});
+
 		describe('editable state', () => {
 			it('should show remove button when nonEditable is false', () => {
 				const wrapper = mount(ListO2M, {
@@ -259,6 +265,18 @@ describe('list-o2m', () => {
 				});
 
 				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+			});
+		});
+
+		describe('disabled state', () => {
+			it('should render action buttons disabled when disabled is true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, disabled: true },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').attributes('disabled')).toBe('true');
 			});
 		});
 

--- a/app/src/interfaces/list-o2m/list-o2m.test.ts
+++ b/app/src/interfaces/list-o2m/list-o2m.test.ts
@@ -1,0 +1,277 @@
+import { Field, Relation } from '@directus/types';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import ListO2M from './list-o2m.vue';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+import { Collection } from '@/types/collections';
+import { LAYOUTS } from '@/types/interfaces';
+
+vi.mock('@/composables/use-relation-o2m', () => ({
+	useRelationO2M: () => ({
+		relationInfo: computed(() => ({
+			relation: {
+				collection: 'related-collection',
+				field: 'parent_id',
+				related_collection: 'test-collection',
+				schema: null,
+				meta: null,
+			} as Relation,
+			relatedCollection: {
+				collection: 'related-collection',
+			} as Collection,
+			relatedPrimaryKeyField: { field: 'id' } as Field,
+			reverseJunctionField: { field: 'parent_id' } as Field,
+			type: 'o2m',
+		})),
+	}),
+}));
+
+vi.mock('@/composables/use-relation-permissions', () => ({
+	useRelationPermissionsO2M: () => ({
+		createAllowed: computed(() => true),
+		updateAllowed: computed(() => true),
+		deleteAllowed: computed(() => true),
+	}),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getFieldsForCollection: vi.fn(() => []),
+		getField: vi.fn(() => null),
+		getPrimaryKeyFieldForCollection: vi.fn(() => ({ field: 'id' })),
+	}),
+}));
+
+vi.mock('@/composables/use-relation-multiple', () => ({
+	useRelationMultiple: () => ({
+		create: vi.fn(),
+		update: vi.fn(),
+		remove: vi.fn(),
+		select: vi.fn(),
+		displayItems: ref([{ id: '1', $type: 'existingItem', $index: 0, $edits: 0 }]),
+		totalItemCount: ref(1),
+		loading: ref(false),
+		selected: ref([]),
+		fetchedSelectItems: ref([]),
+		fetchedItems: ref([]),
+		useActions: vi.fn(() => ({
+			cleanItem: vi.fn((item: any) => item),
+			getPage: vi.fn(),
+			isLocalItem: vi.fn(() => false),
+			getItemEdits: vi.fn(() => 0),
+			isEmpty: vi.fn(() => false),
+		})),
+		cleanItem: vi.fn((item: any) => item),
+		isItemSelected: vi.fn(() => false),
+		isLocalItem: vi.fn(() => false),
+		getItemEdits: vi.fn(() => 0),
+	}),
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+const global: GlobalMountOptions = {
+	stubs: {
+		VIcon: true,
+		VListItem: {
+			template: '<div class="v-list-item"><slot /></div>',
+		},
+		VNotice: true,
+		VRemove: true,
+		VSkeletonLoader: true,
+		VButton: true,
+		VPagination: true,
+		VSelect: true,
+		VTable: true,
+		DrawerBatch: true,
+		DrawerCollection: true,
+		DrawerItem: true,
+		RenderTemplate: true,
+		RouterLink: true,
+		SearchInput: true,
+		Draggable: {
+			template: '<div><slot v-for="element in modelValue" name="item" :element="element" /></div>',
+			props: ['modelValue'],
+		},
+	},
+	directives: {
+		tooltip: () => {},
+		'prevent-focusout': () => {},
+	},
+	plugins: [
+		i18n,
+		createTestingPinia({
+			createSpy: vi.fn,
+		}),
+	],
+};
+
+const globalWithRouterLink: GlobalMountOptions = {
+	...global,
+	stubs: {
+		...global.stubs,
+		RouterLink: {
+			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+		},
+	},
+};
+
+const tableGlobal: GlobalMountOptions = {
+	...global,
+	stubs: {
+		...global.stubs,
+		VTable: {
+			template: '<div class="v-table"><slot v-for="item in items" name="item-append" :item="item" /></div>',
+			props: ['items'],
+		},
+	},
+};
+
+const tableGlobalWithRouterLink: GlobalMountOptions = {
+	...tableGlobal,
+	stubs: {
+		...tableGlobal.stubs,
+		RouterLink: {
+			template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+		},
+	},
+};
+
+const listProps = {
+	primaryKey: '1',
+	collection: 'test-collection',
+	field: 'test-field',
+	width: 'full',
+	version: null,
+};
+
+describe('list-o2m', () => {
+	it('should mount', () => {
+		const wrapper = mount(ListO2M, {
+			props: listProps,
+			global,
+		});
+
+		expect(wrapper.exists()).toBe(true);
+	});
+
+	describe('list layout', () => {
+		describe('non-editable state', () => {
+			it('should show item-actions with navigate link when nonEditable and enableLink are true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, enableLink: true, nonEditable: true, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions router-link-stub').exists()).toBe(true);
+			});
+
+			it('should hide item-actions when nonEditable is true and enableLink is false', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, enableLink: false, nonEditable: true, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(false);
+			});
+
+			it('should hide remove button when nonEditable is true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, enableLink: true, nonEditable: true, disabled: true },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(false);
+			});
+
+			it('should render clickable navigate link when nonEditable and disabled are both true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, enableLink: true, nonEditable: true, disabled: true },
+					global: globalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
+			});
+
+			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, enableLink: true, nonEditable: false, disabled: true },
+					global: globalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+			});
+		});
+
+		describe('editable state', () => {
+			it('should show remove button when nonEditable is false', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, enableLink: true, nonEditable: false, disabled: false },
+					global,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+			});
+		});
+	});
+
+	describe('table layout', () => {
+		describe('non-editable state', () => {
+			it('should show item-actions with navigate link when nonEditable and enableLink are true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: true, disabled: true },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions router-link-stub').exists()).toBe(true);
+			});
+
+			it('should hide remove button when nonEditable is true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: true, disabled: true },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(false);
+			});
+
+			it('should render clickable navigate link when nonEditable and disabled are both true', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: true, disabled: true },
+					global: tableGlobalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
+			});
+
+			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: false, disabled: true },
+					global: tableGlobalWithRouterLink,
+				});
+
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+			});
+		});
+
+		describe('editable state', () => {
+			it('should show remove button when nonEditable is false', () => {
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: false, disabled: false },
+					global: tableGlobal,
+				});
+
+				expect(wrapper.find('.item-actions').exists()).toBe(true);
+				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+			});
+		});
+	});
+});

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -527,10 +527,10 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 					/>
 				</template>
 
-				<template v-if="!nonEditable" #item-append="{ item }">
+				<template v-if="!nonEditable || enableLink" #item-append="{ item }">
 					<div class="item-actions">
 						<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(item)!" custom>
-							<VIcon v-if="disabled || item.$type === 'created'" name="launch" />
+							<VIcon v-if="(disabled && !nonEditable) || item.$type === 'created'" name="launch" />
 
 							<a
 								v-else
@@ -545,7 +545,7 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 						</RouterLink>
 
 						<VRemove
-							v-if="deleteAllowed || isLocalItem(item)"
+							v-if="!nonEditable && (deleteAllowed || isLocalItem(item))"
 							:disabled
 							:class="{ deleted: item.$type === 'deleted' }"
 							:item-type="item.$type"
@@ -607,9 +607,9 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 
 							<div class="spacer" />
 
-							<div v-if="!nonEditable" class="item-actions">
+							<div v-if="!nonEditable || enableLink" class="item-actions" @click.stop>
 								<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(element)!" custom>
-									<VIcon v-if="disabled || element.$type === 'created'" name="launch" />
+									<VIcon v-if="(disabled && !nonEditable) || element.$type === 'created'" name="launch" />
 
 									<a
 										v-else
@@ -624,7 +624,7 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 								</RouterLink>
 
 								<VRemove
-									v-if="deleteAllowed || isLocalItem(element)"
+									v-if="!nonEditable && (deleteAllowed || isLocalItem(element))"
 									:disabled
 									:item-type="element.$type"
 									:item-info="relationInfo"

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.test.ts
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.test.ts
@@ -105,20 +105,125 @@ describe('Interface', () => {
 		expect(wrapper.find('.item-actions v-icon-stub.add').attributes('disabled')).toBe('true');
 	});
 
-	it('should hide action buttons when nonEditable is true', () => {
+	it('should hide action buttons when nonEditable is true and enableLink is false', () => {
 		const wrapper = mount(SelectDropdownM2O, {
 			props: {
+				value: '1',
 				collection: 'test-collection',
 				field: 'test-field',
-				enableLink: true,
+				enableLink: false,
 				nonEditable: true,
-				// Note: if nonEditable is true, disabled prop will also be true
 				disabled: true,
 			},
 			global,
 		});
 
 		expect(wrapper.find('.item-actions').exists()).toBe(false);
+	});
+
+	it('should show item-actions with navigate link when nonEditable is true and enableLink is true', () => {
+		const wrapper = mount(SelectDropdownM2O, {
+			props: {
+				value: '1',
+				collection: 'test-collection',
+				field: 'test-field',
+				enableLink: true,
+				nonEditable: true,
+				disabled: true,
+			},
+			global,
+		});
+
+		expect(wrapper.find('.item-actions').exists()).toBe(true);
+		expect(wrapper.find('.item-actions router-link-stub').exists()).toBe(true);
+	});
+
+	it('should hide edit and remove controls when nonEditable is true', () => {
+		const wrapper = mount(SelectDropdownM2O, {
+			props: {
+				value: '1',
+				collection: 'test-collection',
+				field: 'test-field',
+				enableLink: true,
+				nonEditable: true,
+				disabled: true,
+			},
+			global,
+		});
+
+		expect(wrapper.find('.item-actions').exists()).toBe(true);
+		expect(wrapper.find('.item-actions v-icon-stub[name="edit"]').exists()).toBe(false);
+		expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(false);
+	});
+
+	it('should show edit and remove controls when nonEditable is false', () => {
+		const wrapper = mount(SelectDropdownM2O, {
+			props: {
+				value: '1',
+				collection: 'test-collection',
+				field: 'test-field',
+				enableLink: true,
+				nonEditable: false,
+				disabled: false,
+			},
+			global,
+		});
+
+		expect(wrapper.find('.item-actions').exists()).toBe(true);
+		expect(wrapper.find('.item-actions v-icon-stub[name="edit"]').exists()).toBe(true);
+		expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+	});
+
+	it('should render clickable navigate link when nonEditable and disabled are both true', () => {
+		const globalWithRouterLink: GlobalMountOptions = {
+			...global,
+			stubs: {
+				...global.stubs,
+				RouterLink: {
+					template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+				},
+			},
+		};
+
+		const wrapper = mount(SelectDropdownM2O, {
+			props: {
+				value: '1',
+				collection: 'test-collection',
+				field: 'test-field',
+				enableLink: true,
+				nonEditable: true,
+				disabled: true,
+			},
+			global: globalWithRouterLink,
+		});
+
+		expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
+	});
+
+	it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+		const globalWithRouterLink: GlobalMountOptions = {
+			...global,
+			stubs: {
+				...global.stubs,
+				RouterLink: {
+					template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+				},
+			},
+		};
+
+		const wrapper = mount(SelectDropdownM2O, {
+			props: {
+				value: '1',
+				collection: 'test-collection',
+				field: 'test-field',
+				enableLink: true,
+				nonEditable: false,
+				disabled: true,
+			},
+			global: globalWithRouterLink,
+		});
+
+		expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
 	});
 
 	describe('on click', () => {

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.test.ts
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.test.ts
@@ -76,6 +76,15 @@ const global: GlobalMountOptions = {
 	],
 };
 
+const routerLinkStub = {
+	template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
+};
+
+const globalWithRouterLink: GlobalMountOptions = {
+	...global,
+	stubs: { ...global.stubs, RouterLink: routerLinkStub },
+};
+
 describe('Interface', () => {
 	it('should mount', () => {
 		const wrapper = mount(SelectDropdownM2O, {
@@ -112,6 +121,7 @@ describe('Interface', () => {
 				collection: 'test-collection',
 				field: 'test-field',
 				enableLink: false,
+				// Note: if nonEditable is true, disabled prop will also be true
 				nonEditable: true,
 				disabled: true,
 			},
@@ -175,16 +185,6 @@ describe('Interface', () => {
 	});
 
 	it('should render clickable navigate link when nonEditable and disabled are both true', () => {
-		const globalWithRouterLink: GlobalMountOptions = {
-			...global,
-			stubs: {
-				...global.stubs,
-				RouterLink: {
-					template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
-				},
-			},
-		};
-
 		const wrapper = mount(SelectDropdownM2O, {
 			props: {
 				value: '1',
@@ -201,16 +201,6 @@ describe('Interface', () => {
 	});
 
 	it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
-		const globalWithRouterLink: GlobalMountOptions = {
-			...global,
-			stubs: {
-				...global.stubs,
-				RouterLink: {
-					template: '<div class="router-link-stub"><slot v-bind="{ href: \'/test\', navigate: () => {} }" /></div>',
-				},
-			},
-		};
-
 		const wrapper = mount(SelectDropdownM2O, {
 			props: {
 				value: '1',

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -213,10 +213,10 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 
 			<div class="spacer" />
 
-			<div v-if="!nonEditable" class="item-actions">
+			<div v-if="!nonEditable || (enableLink && displayItem)" class="item-actions" @click.stop>
 				<template v-if="displayItem">
 					<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem()" custom>
-						<VIcon v-if="disabled" name="launch" />
+						<VIcon v-if="disabled && !nonEditable" name="launch" />
 
 						<a
 							v-else
@@ -230,9 +230,23 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 						</a>
 					</RouterLink>
 
-					<VIcon v-tooltip="$t('edit_item')" name="edit" clickable :disabled @click="editModalActive = true" />
+					<VIcon
+						v-if="!nonEditable"
+						v-tooltip="$t('edit_item')"
+						name="edit"
+						clickable
+						:disabled
+						@click="editModalActive = true"
+					/>
 
-					<VRemove deselect :disabled :item-info="relationInfo" :item-edits="edits" @action="$emit('input', null)" />
+					<VRemove
+						v-if="!nonEditable"
+						deselect
+						:disabled
+						:item-info="relationInfo"
+						:item-edits="edits"
+						@action="$emit('input', null)"
+					/>
 				</template>
 
 				<template v-else>

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -4,6 +4,7 @@ import { ContentVersion, PrimaryKey } from '@directus/types';
 import { abbreviateNumber } from '@directus/utils';
 import { computed, onMounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 import { useSidebarStore } from '../private-view/stores/sidebar';
 import RevisionsDateGroup from './revisions-date-group.vue';
 import SidebarDetail from './sidebar-detail.vue';
@@ -34,6 +35,7 @@ const { active: open } = useGroupable({
 const { collection, primaryKey, version } = toRefs(props);
 
 const sidebarStore = useSidebarStore();
+const route = useRoute();
 
 const comparisonModalActive = ref(false);
 const currentRevision = ref<Revision | null>(null);
@@ -66,6 +68,8 @@ watch(
 		refresh(newPage);
 	},
 );
+
+watch(() => route.fullPath, closeModal);
 
 function openModal(id: number) {
 	currentRevision.value = (revisions.value as Revision[])?.find((revision) => revision.id === id) ?? null;


### PR DESCRIPTION
## Scope

Allow non-editable relational fields to navigate to related items by keeping the button visible and clickable while hiding edit/delete controls.

<img width="2286" height="970" alt="m2m_disabled_false_nonEditable_true" src="https://github.com/user-attachments/assets/f2b20cdc-3b6b-4f37-9331-6294bc5f81ba" />


What's changed:

- `.item-actions` container now renders when `enableLink` is `true`, even for non-editable fields
- applied to `select-dropdown-m2o`, `list-o2m`, `list-m2m`

## Potential Risks / Drawbacks

- `@click.stop` on `.item-actions` in list layouts prevents any click inside the actions area from reaching the parent `VListItem`

## Tested Scenarios

- M2O non-editable: launch icon clickable, navigates to related item, no edit/deselect icons
- O2M non-editable (list + table): launch icon per item, no remove buttons
- Disabled-only fields: unchanged behavior, icon visible but not clickable
- Editable fields: no behavior change
- `enableLink=false`: `.item-actions` div not rendered

## Review Notes / Questions

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26689
