### PR TITLE
Fix unsaved changes dialog showing collaborative variant when not in a collaborative session

### DIFF
--- a/.changeset/calm-ducks-thank.md
+++ b/.changeset/calm-ducks-thank.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed unsaved changes dialog showing collaborative variant when not in a collaborative session

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1356,7 +1356,7 @@ unsaved_changes_copy_collab:
   You’re editing this item with others. Your changes will remain in the collaborative session for now, but may be lost
   if no one saves them.
 leave_page: Leave Page
-close_drawer: Close Drawer
+cancel_anyway: Cancel Anyway
 discard_changes: Discard Changes
 discard_all_changes: Discard All Changes
 discard_changes_copy: Are you sure you want to discard all the changes made?

--- a/app/src/lang/translations/fa-IR.yaml
+++ b/app/src/lang/translations/fa-IR.yaml
@@ -1311,7 +1311,6 @@ unsaved_changes_copy: آيا مطمئن هستيد که می خواهيد این
 unsaved_changes_collab: تغییرات مشارکتی ذخیره نشده
 unsaved_changes_copy_collab: شما در حال ویرایش این مورد با دیگران هستید. تغییرات شما فعلا در نشست مشارکتی باقی می‌ماند؛ ولی ممکن است اگر کسی آن‌ها را ذخیره نکند از دست برود.
 leave_page: ترک صفحه
-close_drawer: بستن کشو
 discard_changes: لغو تغییرات
 discard_all_changes: لغو تمام تغییرات
 discard_changes_copy: آیا مطمئن هستید که می‌خواهید تمام تغییرات خود را لغو کنید؟

--- a/app/src/views/private/components/overlay-item.test.ts
+++ b/app/src/views/private/components/overlay-item.test.ts
@@ -1,0 +1,117 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import OverlayItem from './overlay-item.vue';
+import { ClickOutside } from '@/__utils__/click-outside';
+import { Tooltip } from '@/__utils__/tooltip';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+
+const mockCollabConnected = ref<boolean | undefined>(false);
+
+vi.mock('@/composables/use-collab', () => ({
+	useCollab: () => ({
+		connected: mockCollabConnected,
+		users: ref([]),
+		focused: ref({}),
+		connectionId: ref(null),
+		collabCollision: ref(undefined),
+		collabContext: { focusedFields: [] },
+		update: vi.fn(),
+		clearCollidingChanges: vi.fn(),
+	}),
+}));
+
+vi.mock('@directus/composables', () => ({
+	useCollection: () => ({
+		info: computed(() => ({ name: 'Articles', collection: 'articles', meta: null })),
+		primaryKeyField: computed(() => ({ field: 'id' })),
+		fields: computed(() => []),
+	}),
+	useGroupable: () => ({ active: ref(false), toggle: vi.fn() }),
+	useSizeClass: () => computed(() => ''),
+}));
+
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal<typeof import('vue-router')>()),
+	useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/composables/use-edits-guard', () => ({
+	useEditsGuard: () => ({ confirmLeave: ref(false), leaveTo: ref(null) }),
+}));
+
+vi.mock('@/api', () => ({
+	default: { get: vi.fn() },
+	RequestError: class RequestError extends Error {},
+}));
+
+let global: GlobalMountOptions;
+
+const globalStubs: GlobalMountOptions = {
+	directives: {
+		tooltip: Tooltip,
+		'click-outside': ClickOutside,
+	},
+	stubs: {
+		VDialog: { template: '<div><slot /></div>' },
+		VDrawer: { template: '<div><slot /></div>' },
+		VMenu: { template: '<div><slot /></div>' },
+		VCard: { template: '<div><slot /></div>' },
+		VCardTitle: { template: '<div><slot /></div>' },
+		VCardText: { template: '<div><slot /></div>' },
+		VCardActions: { template: '<div><slot /></div>' },
+		VButton: { template: '<button><slot /></button>' },
+		VIcon: true,
+		VBreadcrumb: true,
+		VSkeletonLoader: true,
+		OverlayItemContent: true,
+		CollabIndicatorHeader: true,
+		ComparisonModal: { template: '<div />' },
+		FlowDialogs: true,
+		RenderTemplate: true,
+		PrivateViewHeaderBarActionButton: true,
+	},
+};
+
+beforeEach(() => {
+	global = { ...globalStubs, plugins: [i18n, createTestingPinia({ createSpy: vi.fn })] };
+});
+
+afterEach(() => {
+	mockCollabConnected.value = false;
+	vi.clearAllMocks();
+});
+
+describe('unsaved-changes dialog', () => {
+	it('shows standard dialog when collab is not connected', () => {
+		const wrapper = mount(OverlayItem, {
+			props: {
+				collection: 'articles',
+				active: true,
+				primaryKey: '+',
+			},
+			global,
+		});
+
+		expect(wrapper.text()).toContain(i18n.global.t('unsaved_changes'));
+		expect(wrapper.text()).not.toContain(i18n.global.t('unsaved_changes_collab'));
+	});
+
+	it('shows collab dialog when collab is connected', () => {
+		mockCollabConnected.value = true;
+
+		const wrapper = mount(OverlayItem, {
+			props: {
+				collection: 'articles',
+				active: true,
+				primaryKey: '+',
+			},
+			global,
+		});
+
+		expect(wrapper.text()).toContain(i18n.global.t('unsaved_changes_collab'));
+		expect(wrapper.text()).not.toContain(i18n.global.t('unsaved_changes'));
+	});
+});

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -753,7 +753,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 	/>
 
 	<VDialog v-model="confirmLeave" @esc="confirmLeave = false" @apply="discardAndLeave">
-		<VCard v-if="!collab?.connected">
+		<VCard v-if="!collab?.connected.value">
 			<VCardTitle>{{ $t('unsaved_changes') }}</VCardTitle>
 			<VCardText>{{ $t('unsaved_changes_copy') }}</VCardText>
 			<VCardActions>
@@ -768,7 +768,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 			<VCardText>{{ $t('unsaved_changes_copy_collab') }}</VCardText>
 			<VCardActions>
 				<VButton secondary @click="discardAndLeave">
-					{{ $t('close_drawer') }}
+					{{ $t('cancel_anyway') }}
 				</VButton>
 				<VButton @click="confirmLeave = false">{{ $t('keep_editing') }}</VButton>
 			</VCardActions>
@@ -776,7 +776,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 	</VDialog>
 
 	<VDialog v-model="confirmCancel" @esc="confirmCancel = false" @apply="discardAndCancel">
-		<VCard v-if="!collab?.connected">
+		<VCard v-if="!collab?.connected.value">
 			<VCardTitle>{{ $t('discard_all_changes') }}</VCardTitle>
 			<VCardText>{{ $t('discard_changes_copy') }}</VCardText>
 			<VCardActions>
@@ -791,7 +791,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 			<VCardText>{{ $t('unsaved_changes_copy_collab') }}</VCardText>
 			<VCardActions>
 				<VButton secondary @click="discardAndCancel">
-					{{ $t('close_drawer') }}
+					{{ $t('cancel_anyway') }}
 				</VButton>
 				<VButton @click="confirmCancel = false">{{ $t('keep_editing') }}</VButton>
 			</VCardActions>


### PR DESCRIPTION
## Scope

What's changed:

- Fix collab?.connected → collab?.connected.value in overlay-item.vue so the correct dialog card renders based on actual collab connection state
- Rename translation key close_drawer → cancel_anyway for the collab dialog's secondary action button, since this could also apply to modals and popovers — not only drawers.

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Open an item drawer in visual editor with no active collaborative session → standard unsaved changes dialog now shows correctly
- Open an item drawer in visual editor with an active collaborative session → collab-specific dialog still shows correctly

## Review Notes / Questions

- The close_drawer translations were removed from all languages

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26712
