### PR TITLE
upgrade reka-ui to 2.8.2 to fix time field two-digit hour typing

### DIFF
--- a/.changeset/every-falcons-notice.md
+++ b/.changeset/every-falcons-notice.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Upgraded reka-ui to 2.8.2 for timefield two-digit hour fix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,8 +775,8 @@ catalogs:
       specifier: 7.2.0
       version: 7.2.0
     reka-ui:
-      specifier: 2.8.0
-      version: 2.8.0
+      specifier: 2.8.2
+      version: 2.8.2
     rimraf:
       specifier: 6.1.0
       version: 6.1.0
@@ -1874,7 +1874,7 @@ importers:
         version: 1.5.4
       reka-ui:
         specifier: 'catalog:'
-        version: 2.8.0(vue@3.5.24(typescript@5.9.3))
+        version: 2.8.2(vue@3.5.24(typescript@5.9.3))
       sass-embedded:
         specifier: 'catalog:'
         version: 1.93.3
@@ -7277,11 +7277,6 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  '@vueuse/core@14.2.0':
-    resolution: {integrity: sha512-tpjzVl7KCQNVd/qcaCE9XbejL38V6KJAEq/tVXj7mDPtl6JtzmUdnXelSS+ULRkkrDgzYVK7EerQJvd2jR794Q==}
-    peerDependencies:
-      vue: ^3.5.0
-
   '@vueuse/core@14.2.1':
     resolution: {integrity: sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==}
     peerDependencies:
@@ -7332,9 +7327,6 @@ packages:
   '@vueuse/metadata@14.0.0':
     resolution: {integrity: sha512-6yoGqbJcMldVCevkFiHDBTB1V5Hq+G/haPlGIuaFZHpXC0HADB0EN1ryQAAceiW+ryS3niUwvdFbGiqHqBrfVA==}
 
-  '@vueuse/metadata@14.2.0':
-    resolution: {integrity: sha512-i3axTGjU8b13FtyR4Keeama+43iD+BwX9C2TmzBVKqjSHArF03hjkp2SBZ1m72Jk2UtrX0aYCugBq2R1fhkuAQ==}
-
   '@vueuse/metadata@14.2.1':
     resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
 
@@ -7346,11 +7338,6 @@ packages:
 
   '@vueuse/shared@14.0.0':
     resolution: {integrity: sha512-mTCA0uczBgurRlwVaQHfG0Ja7UdGe4g9mwffiJmvLiTtp1G4AQyIjej6si/k8c8pUwTfVpNufck+23gXptPAkw==}
-    peerDependencies:
-      vue: ^3.5.0
-
-  '@vueuse/shared@14.2.0':
-    resolution: {integrity: sha512-Z0bmluZTlAXgUcJ4uAFaML16JcD8V0QG00Db3quR642I99JXIDRa2MI2LGxiLVhcBjVnL1jOzIvT5TT2lqJlkA==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -12457,8 +12444,8 @@ packages:
   reinterval@1.1.0:
     resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
 
-  reka-ui@2.8.0:
-    resolution: {integrity: sha512-N4JOyIrmDE7w2i06WytqcV2QICubtS2PsK5Uo8FIMAgmO13KhUAgAByP26cXjjm2oF/w7rTyRs8YaqtvaBT+SA==}
+  reka-ui@2.8.2:
+    resolution: {integrity: sha512-8lTKcJhmG+D3UyJxhBnNnW/720sLzm0pbA9AC1MWazmJ5YchJAyTSl+O00xP/kxBmEN0fw5JqWVHguiFmsGjzA==}
     peerDependencies:
       vue: '>= 3.2.0'
 
@@ -19905,13 +19892,6 @@ snapshots:
       '@vueuse/shared': 14.0.0(vue@3.5.24(typescript@5.9.3))
       vue: 3.5.24(typescript@5.9.3)
 
-  '@vueuse/core@14.2.0(vue@3.5.24(typescript@5.9.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.2.0
-      '@vueuse/shared': 14.2.0(vue@3.5.24(typescript@5.9.3))
-      vue: 3.5.24(typescript@5.9.3)
-
   '@vueuse/core@14.2.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
@@ -19933,8 +19913,6 @@ snapshots:
 
   '@vueuse/metadata@14.0.0': {}
 
-  '@vueuse/metadata@14.2.0': {}
-
   '@vueuse/metadata@14.2.1': {}
 
   '@vueuse/router@14.0.0(vue-router@4.6.3(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))':
@@ -19944,10 +19922,6 @@ snapshots:
       vue-router: 4.6.3(vue@3.5.24(typescript@5.9.3))
 
   '@vueuse/shared@14.0.0(vue@3.5.24(typescript@5.9.3))':
-    dependencies:
-      vue: 3.5.24(typescript@5.9.3)
-
-  '@vueuse/shared@14.2.0(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       vue: 3.5.24(typescript@5.9.3)
 
@@ -25558,15 +25532,15 @@ snapshots:
 
   reinterval@1.1.0: {}
 
-  reka-ui@2.8.0(vue@3.5.24(typescript@5.9.3)):
+  reka-ui@2.8.2(vue@3.5.24(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/vue': 1.1.9(vue@3.5.24(typescript@5.9.3))
       '@internationalized/date': 3.10.1
       '@internationalized/number': 3.6.5
       '@tanstack/vue-virtual': 3.13.12(vue@3.5.24(typescript@5.9.3))
-      '@vueuse/core': 14.2.0(vue@3.5.24(typescript@5.9.3))
-      '@vueuse/shared': 14.2.0(vue@3.5.24(typescript@5.9.3))
+      '@vueuse/core': 14.2.1(vue@3.5.24(typescript@5.9.3))
+      '@vueuse/shared': 14.2.1(vue@3.5.24(typescript@5.9.3))
       aria-hidden: 1.2.6
       defu: 6.1.4
       ohash: 2.0.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -270,7 +270,7 @@ catalog:
   qs: 6.14.1
   rate-limiter-flexible: 7.2.0
   redlock: 5.0.0-beta.2
-  reka-ui: 2.8.0
+  reka-ui: 2.8.2
   rimraf: 6.1.0
   rolldown: 1.0.0-beta.31
   rollup: 4.52.5


### PR DESCRIPTION
## Scope

What's changed:

- Bump `reka-ui` from `2.8.0` to `2.8.2` in catalog
- Also upgrades transitive deps `@vueuse/core` and `@vueuse/shared` from `14.2.0` to `14.2.1`

## Potential Risks / Drawbacks

- Minor reka-ui patch bump; no breaking changes expected

## Tested Scenarios

- Typing two-digit hours (e.g., `14`) in a time field within the date picker now works correctly

## Review Notes / Questions

- This is a targeted dependency bump to pick up the upstream timefield fix in reka-ui 2.8.2

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #CMS-1836