### PR TITLE
Add `lower_case_table_names` support for mysql

### DIFF
--- a/.changeset/loud-eyes-search.md
+++ b/.changeset/loud-eyes-search.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': minor
+'@directus/app': patch
+---
+
+Added `lower_case_table_names` support for mysql

--- a/api/src/database/helpers/schema/dialects/mysql.test.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.test.ts
@@ -123,4 +123,30 @@ describe('SchemaHelperMySQL', () => {
 			'my_custom_column',
 		]);
 	});
+
+	describe('parseCollectionName', () => {
+		test('should return collection name in lowercase if lower_case_table_names === 1', async () => {
+			vi.resetModules();
+			const { SchemaHelperMySQL } = await import('./mysql.js');
+			const mockRaw = vi.fn().mockResolvedValue([[{ lctn: 1 }]]);
+			const mockKnex = { raw: mockRaw } as unknown as Knex;
+			const helper = new SchemaHelperMySQL(mockKnex);
+			const result = await helper.parseCollectionName('MyCollection');
+
+			expect(result).toBe('mycollection');
+			expect(mockRaw).toHaveBeenCalledWith('SELECT @@lower_case_table_names AS lctn');
+		});
+
+		test('should return original collection name if lower_case_table_names !== 1', async () => {
+			vi.resetModules();
+			const { SchemaHelperMySQL } = await import('./mysql.js');
+			const mockRaw = vi.fn().mockResolvedValue([[{ lctn: 2 }]]);
+			const mockKnex = { raw: mockRaw } as unknown as Knex;
+			const helper = new SchemaHelperMySQL(mockKnex);
+			const result = await helper.parseCollectionName('MyCollection');
+
+			expect(result).toBe('MyCollection');
+			expect(mockRaw).toHaveBeenCalledWith('SELECT @@lower_case_table_names AS lctn');
+		});
+	});
 });

--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -6,6 +6,7 @@ import { getDefaultIndexName } from '../../../../utils/get-default-index-name.js
 import { type CreateIndexOptions, SchemaHelper, type SortRecord } from '../types.js';
 
 const env = useEnv();
+let lowerCaseTableNames: number | undefined;
 
 export class SchemaHelperMySQL extends SchemaHelper {
 	override generateIndexName(
@@ -118,5 +119,18 @@ export class SchemaHelperMySQL extends SchemaHelper {
 		}
 
 		return blockingQuery;
+	}
+
+	override async parseCollectionName(collection: string): Promise<string> {
+		if (lowerCaseTableNames === undefined) {
+			const result = await this.knex.raw('SELECT @@lower_case_table_names AS lctn');
+			lowerCaseTableNames = Number(result[0]?.[0]?.lctn ?? 0);
+		}
+
+		if (lowerCaseTableNames === 1) {
+			return collection.toLowerCase();
+		}
+
+		return collection;
 	}
 }

--- a/api/src/database/helpers/schema/types.test.ts
+++ b/api/src/database/helpers/schema/types.test.ts
@@ -73,4 +73,13 @@ describe('SchemaHelper', () => {
 			'name',
 		]);
 	});
+
+	describe('parseCollectionName', () => {
+		test('should return exactly the same collection name by default', async () => {
+			const { helper } = createHelper();
+			const result = await helper.parseCollectionName('Original_Name_123');
+
+			expect(result).toBe('Original_Name_123');
+		});
+	});
 });

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -219,4 +219,8 @@ export abstract class SchemaHelper extends DatabaseHelper {
 
 		return this.knex.raw(`CREATE ${isUnique ? 'UNIQUE ' : ''}INDEX ?? ON ?? (??)`, [constraintName, collection, field]);
 	}
+
+	async parseCollectionName(collection: string): Promise<string> {
+		return collection;
+	}
 }

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -149,6 +149,24 @@ describe('Integration Tests', () => {
 				expect(mockSchemaBuilder.createTable).toHaveBeenCalledWith('new_collection', expect.any(Function));
 			});
 
+			test('should parse collection name before creating', async () => {
+				tracker.on.select('directus_collections').response([]);
+				const service = new CollectionsService({ knex: db, schema, accountability: null });
+
+				const parseCollectionNameSpy = vi
+					.spyOn(service.helpers.schema, 'parseCollectionName')
+					.mockResolvedValue('parsed_collection_name');
+
+				const result = await service.createOne({
+					collection: 'ORIGINAL_COLLECTION',
+					schema: {},
+				});
+
+				expect(parseCollectionNameSpy).toHaveBeenCalledWith('ORIGINAL_COLLECTION');
+				expect(result).toBe('parsed_collection_name');
+				expect(mockSchemaBuilder.createTable).toHaveBeenCalledWith('parsed_collection_name', expect.any(Function));
+			});
+
 			test('should create collection with meta only', async () => {
 				tracker.on.select('directus_collections').response([]);
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -75,6 +75,8 @@ export class CollectionsService {
 			throw new InvalidPayloadError({ reason: `Collections can't start with "directus_"` });
 		}
 
+		payload.collection = await this.helpers.schema.parseCollectionName(payload.collection);
+
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		try {

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -107,7 +107,7 @@ async function save() {
 	saving.value = true;
 
 	try {
-		await api.post(`/collections`, {
+		const response = await api.post(`/collections`, {
 			collection: collectionName.value,
 			fields: [getPrimaryKeyField(), ...getSystemFields()],
 			schema: {},
@@ -119,6 +119,8 @@ async function save() {
 				singleton: singleton.value,
 			},
 		});
+
+		const createdCollectionName = response.data.data.collection;
 
 		const storeHydrations: Promise<void>[] = [];
 
@@ -137,7 +139,7 @@ async function save() {
 			title: t('collection_created'),
 		});
 
-		router.replace(`/settings/data-model/${collectionName.value}`);
+		router.replace(`/settings/data-model/${createdCollectionName}`);
 	} catch (error) {
 		unexpectedError(error);
 	} finally {


### PR DESCRIPTION
## Scope

What's changed:

- Added `lower_case_table_names` support for mysql

## Potential Risks / Drawbacks

- 

## Tested Scenarios

- Capitalized collections get created with lowercased names on mysql

## Review Notes / Questions

- Start a new db instance with `--lower_case_table_names=1` to enforce the rule
- Please test it with mariadb

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25922, Fixes CMS-1378
