### PR TITLE
Fix tags interface not resolving variable strings in raw editor mode

### DIFF
--- a/.changeset/soft-readers-attack.md
+++ b/.changeset/soft-readers-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added variable mode in tags interface

--- a/.changeset/soft-readers-attack.md
+++ b/.changeset/soft-readers-attack.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Added variable mode in tags interface
+Fixed tags interface not resolving variable strings in raw editor mode

--- a/app/src/interfaces/tags/tags.test.ts
+++ b/app/src/interfaces/tags/tags.test.ts
@@ -17,6 +17,64 @@ const global: GlobalMountOptions = {
 	plugins: [i18n],
 };
 
+describe('Variable mode', () => {
+	it('renders variable string as readonly input with clear button, no chips', () => {
+		const wrapper = mount(Tags, {
+			props: { value: '{{$trigger.payload.id}}', rawEditorEnabled: true },
+			global,
+		});
+
+		expect(wrapper.find('input[readonly]').exists()).toBe(true);
+		expect((wrapper.find('input[readonly]').element as HTMLInputElement).value).toBe('{{$trigger.payload.id}}');
+		expect(wrapper.find('v-icon-stub[name="close"]').exists()).toBe(true);
+		expect(wrapper.findAll('.v-chip.tag').length).toBe(0);
+	});
+
+	it('pressing Enter in variable mode does not add a tag', async () => {
+		const wrapper = mount(Tags, {
+			props: { value: '{{$trigger.payload.id}}', rawEditorEnabled: true },
+			global,
+		});
+
+		await wrapper.find('input[readonly]').trigger('keydown', { key: 'Enter' });
+
+		expect(wrapper.emitted('input')).toBeUndefined();
+	});
+
+	it('clicking clear button emits empty value and exits variable mode', async () => {
+		const wrapper = mount(Tags, {
+			props: { value: '{{$trigger.payload.id}}', rawEditorEnabled: true },
+			global,
+		});
+
+		await wrapper.find('v-icon-stub[name="close"]').trigger('click');
+
+		expect(wrapper.emitted('input')).toBeTruthy();
+		expect(wrapper.emitted('input')![0]).toEqual([null]);
+		expect(wrapper.find('input[readonly]').exists()).toBe(false);
+	});
+
+	it('any string value triggers variable mode when rawEditorEnabled', () => {
+		const wrapper = mount(Tags, { props: { value: 'foo', rawEditorEnabled: true }, global });
+
+		expect(wrapper.find('input[readonly]').exists()).toBe(true);
+	});
+
+	it('string value without rawEditorEnabled stays in normal tags mode', () => {
+		const wrapper = mount(Tags, { props: { value: '{{$trigger.payload.id}}' }, global });
+
+		expect(wrapper.find('input[readonly]').exists()).toBe(false);
+	});
+
+	it('null or array value stays in normal tags mode', () => {
+		const wrapper1 = mount(Tags, { props: { value: null }, global });
+		const wrapper2 = mount(Tags, { props: { value: ['a', 'b'] }, global });
+
+		expect(wrapper1.find('input[readonly]').exists()).toBe(false);
+		expect(wrapper2.find('input[readonly]').exists()).toBe(false);
+	});
+});
+
 describe('Interface', () => {
 	const presets = ['Tag 1', 'Tag 2', 'Tag 3'];
 	const value = ['Value 1', 'Value 2'];

--- a/app/src/interfaces/tags/tags.test.ts
+++ b/app/src/interfaces/tags/tags.test.ts
@@ -24,8 +24,8 @@ describe('Variable mode', () => {
 			global,
 		});
 
-		expect(wrapper.find('input[readonly]').exists()).toBe(true);
-		expect((wrapper.find('input[readonly]').element as HTMLInputElement).value).toBe('{{$trigger.payload.id}}');
+		expect(wrapper.find('input[disabled]').exists()).toBe(true);
+		expect((wrapper.find('input[disabled]').element as HTMLInputElement).value).toBe('{{$trigger.payload.id}}');
 		expect(wrapper.find('v-icon-stub[name="close"]').exists()).toBe(true);
 		expect(wrapper.findAll('.v-chip.tag').length).toBe(0);
 	});
@@ -36,7 +36,7 @@ describe('Variable mode', () => {
 			global,
 		});
 
-		await wrapper.find('input[readonly]').trigger('keydown', { key: 'Enter' });
+		await wrapper.find('input[disabled]').trigger('keydown', { key: 'Enter' });
 
 		expect(wrapper.emitted('input')).toBeUndefined();
 	});
@@ -48,30 +48,31 @@ describe('Variable mode', () => {
 		});
 
 		await wrapper.find('v-icon-stub[name="close"]').trigger('click');
+		await wrapper.setProps({ value: null });
 
 		expect(wrapper.emitted('input')).toBeTruthy();
 		expect(wrapper.emitted('input')![0]).toEqual([null]);
-		expect(wrapper.find('input[readonly]').exists()).toBe(false);
+		expect(wrapper.find('input[disabled]').exists()).toBe(false);
 	});
 
 	it('any string value triggers variable mode when rawEditorEnabled', () => {
 		const wrapper = mount(Tags, { props: { value: 'foo', rawEditorEnabled: true }, global });
 
-		expect(wrapper.find('input[readonly]').exists()).toBe(true);
+		expect(wrapper.find('input[disabled]').exists()).toBe(true);
 	});
 
 	it('string value without rawEditorEnabled stays in normal tags mode', () => {
 		const wrapper = mount(Tags, { props: { value: '{{$trigger.payload.id}}' }, global });
 
-		expect(wrapper.find('input[readonly]').exists()).toBe(false);
+		expect(wrapper.find('input[disabled]').exists()).toBe(false);
 	});
 
 	it('null or array value stays in normal tags mode', () => {
 		const wrapper1 = mount(Tags, { props: { value: null }, global });
 		const wrapper2 = mount(Tags, { props: { value: ['a', 'b'] }, global });
 
-		expect(wrapper1.find('input[readonly]').exists()).toBe(false);
-		expect(wrapper2.find('input[readonly]').exists()).toBe(false);
+		expect(wrapper1.find('input[disabled]').exists()).toBe(false);
+		expect(wrapper2.find('input[disabled]').exists()).toBe(false);
 	});
 });
 

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -199,6 +199,7 @@ function clearVariable() {
 <style lang="scss" scoped>
 .remove-variable {
 	display: flex;
+
 	--v-icon-color-hover: var(--v-remove-color, var(--theme--danger));
 }
 

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -135,7 +135,7 @@ function clearVariable() {
 
 <template>
 	<div class="interface-tags">
-		<VInput v-if="isVariableMode" :model-value="(value as string)" readonly>
+		<VInput v-if="isVariableMode" :model-value="value as string" readonly>
 			<template #append>
 				<span class="remove-variable">
 					<VIcon v-tooltip="$t('interfaces.tags.remove_variable')" name="close" clickable @click.stop="clearVariable" />

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -89,6 +89,8 @@ function processArray(array: string[]): string[] {
 }
 
 function onInput(event: KeyboardEvent) {
+	if (isVariableMode.value) return;
+
 	if (event.target && (event.key === 'Enter' || event.key === ',' || (event.type === 'blur' && document.hasFocus()))) {
 		event.preventDefault();
 		addTag((event.target as HTMLInputElement).value);

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -4,7 +4,6 @@ import { computed, ref, watch } from 'vue';
 import VChip from '@/components/v-chip.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VInput from '@/components/v-input.vue';
-import VRemove from '@/components/v-remove.vue';
 
 const props = withDefaults(
 	defineProps<{

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -34,6 +34,9 @@ const presetVals = computed<string[]>(() => {
 	return [];
 });
 
+// Variable mode: when `rawEditorEnabled` is true and the value is a string rather than an array.
+// This happens in contexts like Flows and Insights where the field value can be a dynamic
+// variable expression (e.g. "{{$trigger.body.tags}}") instead of an array of tags.
 const isVariableMode = computed(() => props.rawEditorEnabled === true && typeof props.value === 'string');
 
 const selectedValsLocal = ref<string[]>(Array.isArray(props.value) ? processArray(props.value) : []);
@@ -133,14 +136,14 @@ function clearVariable() {
 		<VInput
 			v-if="isVariableMode || allowCustom"
 			:model-value="isVariableMode ? (value as string) : undefined"
-			:placeholder="isVariableMode ? undefined : placeholder || $t('interfaces.tags.add_tags')"
+			:placeholder="placeholder || $t('interfaces.tags.add_tags')"
 			:disabled="isVariableMode || disabled"
 			:non-editable="isVariableMode || nonEditable"
 			:dir="direction"
 			@keydown="onInput"
 			@blur="onInput"
 		>
-			<template v-if="!isVariableMode && iconLeft" #prepend><VIcon :name="iconLeft" /></template>
+			<template v-if="iconLeft" #prepend><VIcon :name="iconLeft" /></template>
 			<template #append>
 				<VIcon
 					v-if="isVariableMode"
@@ -148,6 +151,7 @@ function clearVariable() {
 					class="remove-variable"
 					name="close"
 					clickable
+					:disabled
 					@click.stop="clearVariable"
 				/>
 				<VIcon v-else :name="iconRight" />
@@ -197,8 +201,6 @@ function clearVariable() {
 
 <style lang="scss" scoped>
 .remove-variable {
-	display: flex;
-
 	--v-icon-color-hover: var(--v-remove-color, var(--theme--danger));
 }
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2303,7 +2303,6 @@ interfaces:
     alphabetize: Alphabetize
     alphabetize_label: Force Alphabetical Order
     add_tags: Add a tag and press Enter...
-    remove_variable: Remove variable
   input:
     input: Input
     description: Manually enter a value

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2303,6 +2303,7 @@ interfaces:
     alphabetize: Alphabetize
     alphabetize_label: Force Alphabetical Order
     add_tags: Add a tag and press Enter...
+    remove_variable: Remove variable
   input:
     input: Input
     description: Manually enter a value


### PR DESCRIPTION
## Scope

What's changed:

- Tags interface now detects string values when `rawEditorEnabled` is enabled and enters "variable mode"
- In variable mode, it shows a readonly `VInput` with the raw value instead of tag editor
- Close icon in the append slot clears the variable and returns to normal mode

## Potential Risks / Drawbacks

- Any string value (not just `{{...}}` templates) triggers variable mode. Intentional, but could surprise if a non-template string somehow ends up as the value

## Tested Scenarios

- String value with `rawEditorEnabled: true` renders readonly input with close icon, no chips
- Pressing Enter in variable mode does not add a tag
- Clicking close emits `null` and exits variable mode
- String value without `rawEditorEnabled` stays in normal tags mode
- `null` and array values stay in normal tags mode

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25732
