### PR TITLE
Fix drawer not scrolling to top when validation errors occur

### DIFF
--- a/.changeset/full-needles-grow.md
+++ b/.changeset/full-needles-grow.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed drawer not scrolling to top when validation errors occur

--- a/app/src/views/private/components/overlay-item-content.vue
+++ b/app/src/views/private/components/overlay-item-content.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Field, PrimaryKey } from '@directus/types';
-import { cloneDeep } from 'lodash';
-import { computed, useTemplateRef } from 'vue';
+import { cloneDeep, isEqual } from 'lodash';
+import { computed, inject, type Ref, useTemplateRef, watch } from 'vue';
 import ValidationErrors from '@/components/v-form/components/validation-errors.vue';
 import VForm from '@/components/v-form/v-form.vue';
 import VInfo from '@/components/v-info.vue';
@@ -15,6 +15,7 @@ const {
 	relatedCollectionFields,
 	initialValues,
 	fields,
+	validationErrors,
 	junctionFieldLocation = 'bottom',
 	relatedPrimaryKeyField,
 } = defineProps<{
@@ -95,6 +96,15 @@ function useFile() {
 function useValidationScrollToField() {
 	const mainFormEl = useTemplateRef<any>('mainForm');
 	const junctionFormEl = useTemplateRef<any>('junctionForm');
+	const mainDrawerElement = inject<Ref<HTMLElement | null>>('main-element');
+
+	watch(
+		() => validationErrors,
+		(newVal, oldVal) => {
+			if (isEqual(newVal, oldVal)) return;
+			if (newVal?.length > 0) mainDrawerElement?.value?.scrollTo({ top: 0, behavior: 'smooth' });
+		},
+	);
 
 	return { scrollToField };
 

--- a/app/src/views/private/components/overlay-item-content.vue
+++ b/app/src/views/private/components/overlay-item-content.vue
@@ -44,7 +44,7 @@ const { mainInitialValues, junctionInitialValues } = useInitialValues();
 const { file } = useFile();
 const { scrollToField } = useValidationScrollToField();
 
-const validationErrorsEl = useTemplateRef<any>('validationErrors');
+const validationErrorsEl = useTemplateRef('validationErrors');
 
 watch(
 	() => validationErrors,


### PR DESCRIPTION
## Scope                                                                                       
                                                                                      
  What's changed:                                                                                
                                                                                                 
  - When validation errors appear in
   a drawer, automatically scroll the drawer to the top so the errors are visible                
                                                            
  ## Potential Risks / Drawbacks

  - None that I can think of

  ## Tested Scenarios

  - Opened a O2M drawer with multiple fields (enough to require scrolling)
  - Scrolled down and submitted without filling in a required field
  - Verified the drawer scrolls to the top and the validation error banner is visible

  ## Review Notes / Questions

  - The fix mirrors the existing pattern in `v-form.vue`, which watches
  `validationErrors` and scrolls the form into view.

  ## Checklist

  - [ ] Added or updated tests ( don't think this is necessary for this small improvement )
  - [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

  ---

  Fixes #26735