### PR TITLE
Add new entries into `app\src\lang\translations\en-US.yaml` to translate some texts.

### DIFF
--- a/.changeset/dry-gifts-take.md
+++ b/.changeset/dry-gifts-take.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Add new entries into app\src\lang\translations\en-US.yaml to translate some texts.

--- a/.changeset/dry-gifts-take.md
+++ b/.changeset/dry-gifts-take.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Add new entries into app\src\lang\translations\en-US.yaml to translate some texts.
+Added some missing translation keys for directus_settings and directus_roles.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1535,6 +1535,7 @@ fields:
     project_color: Project Color
     project_logo: Project Logo
     default_language: Default Language
+    project_owner: Project Owner
     branding: Branding
     public_foreground: Public Foreground
     public_background: Public Background
@@ -1570,6 +1571,9 @@ fields:
     public_registration_verify_email_note:
       Sends an email to the registering user asking them to click on a verification link before they can sign in.
     visual_editor_urls: Visual Editor URLs
+    report_feature_url: Report Feature URL
+    report_bug_url: Report Bug URL
+    report_error_url: Report Error URL
     collaborative_editing: Collaborative Editing
     collaborative_editing_note: WebSockets are required for collaborative editing to work.
     ai_notice:
@@ -1649,6 +1653,7 @@ fields:
     users: Users in Role
     parent: Parent Role
     children: Child Roles
+    policies: Policies
   directus_policies:
     name: Policy Name
     description: Description

--- a/contributors.yml
+++ b/contributors.yml
@@ -251,3 +251,4 @@
 - omkarg01
 - wotan-allfather
 - danielbuechele
+- powerseed


### PR DESCRIPTION
To fix https://github.com/directus/directus/issues/26714.

Some of the mentioned texts don't have entries in `app\src\lang\translations\en-US.yaml`, therefore have been added.

The rest already have entries in the file, but miss translations (or the translations are problematic therefore cannot be displayed) in CrowdIn, like `Settings -> Collaborative Editing -> Collaborative Editing Enabled` and `Settings -> AI -> Allow Deletes (Helping has no translation)`. They need to be fixed in CrowdIn.