### PR TITLE
Add Claude Code hooks for auto-formatting and linting 

### DIFF
--- a/.claude/hooks/eslint.sh
+++ b/.claude/hooks/eslint.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 FILE=$(jq -r '.tool_input.file_path')
-echo "$FILE" | grep -qE '\.(js|mjs|ts|vue)$' && ./node_modules/.bin/eslint --fix "$FILE" || true
+echo "$FILE" | grep -qE '\.(js|mjs|ts|vue)$' && "$CLAUDE_PROJECT_DIR"/node_modules/.bin/eslint --fix "$FILE" || true

--- a/.claude/hooks/eslint.sh
+++ b/.claude/hooks/eslint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+FILE=$(jq -r '.tool_input.file_path')
+echo "$FILE" | grep -qE '\.(js|mjs|ts|vue)$' && ./node_modules/.bin/eslint --fix "$FILE" || true

--- a/.claude/hooks/prettier.sh
+++ b/.claude/hooks/prettier.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 FILE=$(jq -r '.tool_input.file_path')
-echo "$FILE" | grep -qE '\.(js|mjs|ts|json|vue|scss|css|md|yaml|yml)$' && ./node_modules/.bin/prettier --write "$FILE" || true
+echo "$FILE" | grep -qE '\.(js|mjs|ts|json|vue|scss|css|md|yaml|yml)$' && "$CLAUDE_PROJECT_DIR"/node_modules/.bin/prettier --write "$FILE" || true

--- a/.claude/hooks/prettier.sh
+++ b/.claude/hooks/prettier.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+FILE=$(jq -r '.tool_input.file_path')
+echo "$FILE" | grep -qE '\.(js|mjs|ts|json|vue|scss|css|md|yaml|yml)$' && ./node_modules/.bin/prettier --write "$FILE" || true

--- a/.claude/hooks/stylelint.sh
+++ b/.claude/hooks/stylelint.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 FILE=$(jq -r '.tool_input.file_path')
-echo "$FILE" | grep -qE '\.(css|scss|vue)$' && ./node_modules/.bin/stylelint --fix "$FILE" || true
+echo "$FILE" | grep -qE '\.(css|scss|vue)$' && "$CLAUDE_PROJECT_DIR"/node_modules/.bin/stylelint --fix "$FILE" || true

--- a/.claude/hooks/stylelint.sh
+++ b/.claude/hooks/stylelint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+FILE=$(jq -r '.tool_input.file_path')
+echo "$FILE" | grep -qE '\.(css|scss|vue)$' && ./node_modules/.bin/stylelint --fix "$FILE" || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "jq -r '.tool_input.file_path' | xargs npx prettier --write"
+					},
+					{
+						"type": "command",
+						"command": "jq -r '.tool_input.file_path' | xargs npx eslint --fix"
+					},
+					{
+						"type": "command",
+						"command": "FILE=$(jq -r '.tool_input.file_path'); echo $FILE | grep -qE '\\.(css|scss|vue)$' && npx stylelint --fix $FILE || true"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,18 +4,9 @@
 			{
 				"matcher": "Edit|Write",
 				"hooks": [
-					{
-						"type": "command",
-						"command": "jq -r '.tool_input.file_path' | xargs npx prettier --write"
-					},
-					{
-						"type": "command",
-						"command": "jq -r '.tool_input.file_path' | xargs npx eslint --fix"
-					},
-					{
-						"type": "command",
-						"command": "FILE=$(jq -r '.tool_input.file_path'); echo $FILE | grep -qE '\\.(css|scss|vue)$' && npx stylelint --fix $FILE || true"
-					}
+					{ "type": "command", "command": "bash .claude/hooks/prettier.sh" },
+					{ "type": "command", "command": "bash .claude/hooks/eslint.sh" },
+					{ "type": "command", "command": "bash .claude/hooks/stylelint.sh" }
 				]
 			}
 		]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,9 @@
 			{
 				"matcher": "Edit|Write",
 				"hooks": [
-					{ "type": "command", "command": "bash .claude/hooks/prettier.sh" },
-					{ "type": "command", "command": "bash .claude/hooks/eslint.sh" },
-					{ "type": "command", "command": "bash .claude/hooks/stylelint.sh" }
+					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prettier.sh" },
+					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/eslint.sh" },
+					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stylelint.sh" }
 				]
 			}
 		]

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ TODO
 # AI
 .claude/*
 !.claude/CLAUDE.md
+!.claude/settings.json
 !.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ TODO
 .claude/*
 !.claude/CLAUDE.md
 !.claude/settings.json
+!.claude/hooks/
 !.claude/skills/


### PR DESCRIPTION
## Scope                                                                                                                                                                                                                              
                                                                                                                                                                                                                                      
What's changed:                                                                                                                                                                                                                       
                                                                                                                                                                                                                                      
- Add `.claude/settings.json` with `PostToolUse` hooks that automatically run **Prettier**, **ESLint**, and **Stylelint** on files after Claude Code edits or writes them
- Extract hook logic into .claude/hooks/ scripts, filter by file extension, use ./node_modules/.bin/ over npx
- Update `.gitignore` to track `.claude/settings.json` and `.claude/hooks/`                                                                                                                                                          

This ensures Claude Code output always conforms to the project's existing formatting and linting rules without manual intervention.

Reference: [Claude Code Hooks – Auto-format code after edits](https://code.claude.com/docs/en/hooks-guide#auto-format-code-after-edits)

## Potential Risks / Drawbacks

- If prettier/eslint/stylelint configs are broken or missing, hooks will silently fail without affecting Claude's workflow

## Tested Scenarios

- Verified Prettier formats files on Edit/Write
- Verified ESLint auto-fixes on Edit/Write
- Verified Stylelint runs only on `.css`/`.scss`/`.vue` files and is a no-op for others

## Review Notes / Questions

- The hooks apply to all contributors using Claude Code in this repo since `settings.json` is checked in
