### PR TITLE
vev ← Add field permission and version access checks to Visual Editor

### DIFF
--- a/.changeset/ready-memes-drum.md
+++ b/.changeset/ready-memes-drum.md
@@ -1,0 +1,11 @@
+---
+'@directus/app': minor
+---
+
+Added field permission and version access checks to Visual Editor
+
+::: notice
+
+The field access checks require an update of the `@directus/visual-editing` library to v2.0.0.
+
+:::

--- a/app/src/modules/content/components/version-menu.test.ts
+++ b/app/src/modules/content/components/version-menu.test.ts
@@ -85,6 +85,7 @@ const mountOptions = {
 				props: ['clickable', 'active', 'disabled'],
 			},
 			VListItemContent: { template: '<div class="v-list-item-content"><slot /></div>' },
+			VListItemIcon: { template: '<div class="v-list-item-icon"><slot /></div>' },
 			VDivider: { template: '<hr class="v-divider" />' },
 			VIcon: { template: '<span class="v-icon" :data-name="$attrs.name"></span>' },
 			VTextOverflow: { template: '<span class="v-text-overflow">{{ $attrs.text }}</span>' },
@@ -134,6 +135,11 @@ describe('VersionMenu', () => {
 			});
 
 			expect(wrapper.find('.edit-dot').exists()).toBe(true);
+
+			const versionItems = wrapper.findAll('.v-list-item');
+			const versionItem = versionItems.find((item) => item.text().includes('Version Name'));
+
+			expect(versionItem!.find('.edit-dot').exists()).toBe(true);
 		});
 
 		it('should not show edit dot for versions without content changes', () => {
@@ -152,7 +158,10 @@ describe('VersionMenu', () => {
 				},
 			});
 
-			expect(wrapper.find('.edit-dot').exists()).toBe(false);
+			const versionItems = wrapper.findAll('.v-list-item');
+			const versionItem = versionItems.find((item) => item.text().includes('Version Name'));
+
+			expect(versionItem!.find('.edit-dot').exists()).toBe(false);
 		});
 	});
 

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -1,0 +1,265 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CheckFieldAccessData } from '../types';
+import EditingLayer from './editing-layer.vue';
+import { Tooltip } from '@/__utils__/tooltip';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+import { useCollectionsStore } from '@/stores/collections';
+import { usePermissionsStore } from '@/stores/permissions';
+import { useUserStore } from '@/stores/user';
+
+vi.mock('@directus/composables', () => ({
+	useCollection: () => ({
+		info: { value: null },
+		primaryKeyField: { value: { field: 'id' } },
+		fields: { value: [] },
+	}),
+}));
+
+vi.mock('@/ai/composables/use-context-staging', () => ({
+	useContextStaging: () => ({ stageVisualElement: vi.fn() }),
+}));
+
+vi.mock('@/ai/stores/use-ai', () => ({
+	useAiStore: () => ({
+		onVisualElementHighlight: vi.fn(() => ({ off: vi.fn() })),
+	}),
+}));
+
+vi.mock('@/ai/stores/use-ai-context', () => ({
+	useAiContextStore: () => ({
+		syncVisualElementContextUrl: vi.fn(),
+		clearVisualElementContext: vi.fn(),
+	}),
+}));
+
+vi.mock('@/ai/stores/use-ai-tools', () => ({
+	useAiToolsStore: () => ({
+		onSystemToolResult: vi.fn(() => ({ off: vi.fn() })),
+	}),
+}));
+
+vi.mock('@/api', () => ({
+	default: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+}));
+
+vi.mock('../utils/same-origin', () => ({
+	sameOrigin: () => true,
+}));
+
+const FRAME_SRC = 'https://example.com';
+
+let postMessageSpy: ReturnType<typeof vi.fn>;
+let mockFrameEl: HTMLIFrameElement;
+let mountOptions: GlobalMountOptions;
+
+function sendCheckFieldAccess(elements: CheckFieldAccessData[]) {
+	window.dispatchEvent(
+		new MessageEvent('message', {
+			origin: FRAME_SRC,
+			data: { action: 'checkFieldAccess', data: elements },
+		}),
+	);
+}
+
+function createElements(...overrides: Partial<CheckFieldAccessData>[]): CheckFieldAccessData[] {
+	if (overrides.length === 0) overrides = [{}];
+
+	return overrides.map((o, i) => ({
+		key: `el-${i}`,
+		collection: 'articles',
+		item: '1',
+		fields: ['title'],
+		...o,
+	}));
+}
+
+beforeEach(() => {
+	postMessageSpy = vi.fn();
+
+	mockFrameEl = {
+		contentWindow: { postMessage: postMessageSpy },
+	} as unknown as HTMLIFrameElement;
+
+	const pinia = createTestingPinia({
+		createSpy: vi.fn,
+		initialState: {
+			settingsStore: { settings: {} },
+			serverStore: { info: { ai_enabled: false } },
+		},
+	});
+
+	setActivePinia(pinia);
+
+	mountOptions = {
+		plugins: [i18n, pinia],
+		directives: { tooltip: Tooltip },
+		stubs: {
+			OverlayItem: true,
+			VButton: true,
+			VIcon: true,
+		},
+	};
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+function mountLayer(version: { key: string; name: string } | null = null) {
+	return mount(EditingLayer, {
+		global: mountOptions,
+		props: { frameSrc: FRAME_SRC, frameEl: mockFrameEl, version },
+	});
+}
+
+function setupCollection(meta: Record<string, unknown> = {}) {
+	vi.mocked(useCollectionsStore().getCollection).mockReturnValue({
+		collection: 'articles',
+		meta: { versioning: false, ...meta },
+	} as any);
+}
+
+function setupPermission(fields: string[] | null = null, access = 'full') {
+	vi.mocked(usePermissionsStore().getPermission).mockReturnValue({ access, fields } as any);
+}
+
+function setupNonAdmin() {
+	(useUserStore() as any).isAdmin = false;
+}
+
+describe('checkFieldAccess', () => {
+	it.each([null, ''])('filters out elements with item=%j', (item) => {
+		mountLayer();
+		sendCheckFieldAccess(createElements({ item }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('filters out elements with unknown collection', () => {
+		mountLayer();
+		vi.mocked(useCollectionsStore().getCollection).mockReturnValue(null);
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('filters out elements when version is set but collection has no versioning', () => {
+		mountLayer({ key: 'draft', name: 'Draft' });
+		setupCollection({ versioning: false });
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('allows elements when version is set and collection has versioning', () => {
+		mountLayer({ key: 'draft', name: 'Draft' });
+		setupCollection({ versioning: true });
+		(useUserStore() as any).isAdmin = true;
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+
+	it('allows all elements for admin users', () => {
+		mountLayer();
+		setupCollection();
+		(useUserStore() as any).isAdmin = true;
+
+		sendCheckFieldAccess(createElements({ key: 'a' }, { key: 'b' }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['a', 'b'] }, FRAME_SRC);
+	});
+
+	it('filters out elements when no permission exists', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('filters out elements when permission access is none', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+		setupPermission(null, 'none');
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('filters out elements when none of the fields are permitted', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+		setupPermission(['body', 'status']);
+
+		sendCheckFieldAccess(createElements({ fields: ['title', 'slug'] }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('allows elements when at least one field is permitted', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+		setupPermission(['title', 'status']);
+
+		sendCheckFieldAccess(createElements({ fields: ['title', 'slug'] }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+
+	it('allows elements when permission has wildcard fields', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+		setupPermission(['*']);
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+
+	it('allows elements when element declares no specific fields', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+		setupPermission(['title']);
+
+		sendCheckFieldAccess(createElements({ fields: [] }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+
+	it('allows elements when permission has no field restrictions', () => {
+		mountLayer();
+		setupCollection();
+		setupNonAdmin();
+		setupPermission(null);
+
+		sendCheckFieldAccess(createElements({ fields: ['title'] }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+
+	it('allows elements when no version is set on a versioned collection', () => {
+		mountLayer();
+		setupCollection({ versioning: true });
+		(useUserStore() as any).isAdmin = true;
+
+		sendCheckFieldAccess(createElements());
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+});

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -238,6 +238,7 @@ function useVisualEditingAi({
 
 function useItemWithEdits() {
 	const edits = ref<Record<string, any>>({});
+	const saving = ref(false);
 	const editOverlayActive = ref(false);
 	const msgKey = ref('');
 	const collection = ref<EditConfig['collection']>('');
@@ -254,9 +255,10 @@ function useItemWithEdits() {
 
 	const editingLayerEl = useTemplateRef<HTMLElement>('editing-layer');
 
-	watch(edits, (newEdits) => {
+	watch([edits, saving], ([newEdits, isSaving]) => {
 		const hasEdits = Object.keys(newEdits)?.length;
-		if (!hasEdits) return;
+		if (!hasEdits || isSaving) return;
+
 		save();
 	});
 
@@ -322,6 +324,8 @@ function useItemWithEdits() {
 	}
 
 	async function save() {
+		saving.value = true;
+
 		try {
 			let response;
 
@@ -351,6 +355,8 @@ function useItemWithEdits() {
 			resetEdits();
 		} catch (error) {
 			unexpectedError(error);
+		} finally {
+			saving.value = false;
 		}
 	}
 

--- a/app/src/modules/visual/types/index.ts
+++ b/app/src/modules/visual/types/index.ts
@@ -17,6 +17,13 @@ export type SavedData = {
 	payload: Record<string, unknown>;
 };
 
+export type CheckFieldAccessData = {
+	key: string;
+	collection: EditConfig['collection'];
+	item: EditConfig['item'];
+	fields: string[];
+};
+
 export type AddToContextData = {
 	key: string;
 	editConfig: EditConfig;
@@ -34,9 +41,9 @@ export type ConfirmData = {
 	aiEnabled: boolean;
 };
 
-export type ReceiveAction = 'connect' | 'edit' | 'navigation' | 'addToContext';
+export type ReceiveAction = 'connect' | 'checkFieldAccess' | 'edit' | 'navigation' | 'addToContext';
 
-export type SendAction = 'confirm' | 'showEditableElements' | 'saved' | 'highlightElement';
+export type SendAction = 'confirm' | 'activateElements' | 'showEditableElements' | 'saved' | 'highlightElement';
 
 /** Not shared with the package */
 
@@ -49,4 +56,5 @@ export type ReceiveData =
 	| { action: 'edit'; data: EditData }
 	| { action: 'navigation'; data: NavigationData }
 	| { action: 'addToContext'; data: AddToContextData }
+	| { action: 'checkFieldAccess'; data: CheckFieldAccessData[] }
 	| { action: null; data: null };


### PR DESCRIPTION
## Scope

What's changed:

- **Field access control in editing layer**: New `checkFieldAccess` message handler receives element data from the iframe, checks user permissions, and responds with `activateElements` containing only the keys the user can actually edit.
- **Permission checks**: Non-admin users only see editable elements for fields they have `update` permission on. When a version is selected, elements are hidden for collections without versioning enabled and for users without `read` + (`create` or `update`) on `directus_versions`.
- **Version selector gated by permissions**: The version dropdown in the Visual Editor header now requires `read` permission on `directus_versions` to appear.
- **Prevent duplicate version creation**: Added a `saving` ref guard so concurrent saves don't race and create duplicate
  versions.

Builds on top of the version support added in `feat/versions-for-visual-editor`.

## Potential Risks / Drawbacks

- Permission checking is client-side only. The backend `VersionsService.save()` bypasses permission checks on `directus_versions` by using `admin: true`, so a user with only read access can still save version deltas via the API. This is tracked in #26748 and out of scope here.
- The `checkFieldAccess` / `activateElements` protocol requires a matching update in the `@directus/visual-editing` library ([directus/visual-editing#34](https://github.com/directus/visual-editing/pull/34)). Breaking change notice added to the changeset.

## Tested Scenarios

- Admin user sees all editable elements
- Non-admin user only sees elements for fields they have update permission on
- Version mode hides elements for collections without versioning enabled
- Version mode hides elements for users without version CRUD permissions
- Version selector hidden when user lacks read permission on `directus_versions`
- Concurrent saves don't create duplicate versions

## Review Notes / Questions

- **Please checkout** the companion library change lives in [directus/visual-editing#34](https://github.com/directus/visual-editing/pull/34). Both PRs needed together for E2E testing (test website in the repo).

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs/pull/547)
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-1625
