### PR TITLE
Add translation key for collaborative editing enabled setting

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1575,6 +1575,7 @@ fields:
     report_bug_url: Report Bug URL
     report_error_url: Report Error URL
     collaborative_editing: Collaborative Editing
+    collaborative_editing_enabled: Enable Collaborative Editing
     collaborative_editing_note: WebSockets are required for collaborative editing to work.
     ai_notice:
       'AI Assistant provides an in-app sidebar to converse with an LLM. Once enabled, open the AI sidebar from the


### PR DESCRIPTION
## Scope

What's changed:

- Add `fields.directus_settings.collaborative_editing_enabled` translation key to `en-US.yaml`

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- N/A — translation key addition only

## Review Notes / Questions

- N/A

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---