### PR TITLE
Fix "License modal is not responsive on mobile screens #26732"

### DIFF
--- a/.changeset/brave-rats-attend.md
+++ b/.changeset/brave-rats-attend.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Adjust css in app\src\routes\setup\form.vue to make the License modal narrower on mobile devices.
+Fixed license modal is not responsive on mobile screens

--- a/.changeset/brave-rats-attend.md
+++ b/.changeset/brave-rats-attend.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Adjust css in app\src\routes\setup\form.vue to make the License modal narrower on mobile devices.

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -134,6 +134,7 @@ const fields = useFormFields(props.register, value, initialValues);
 <style scoped>
 .setup-form {
 	display: grid;
+	grid-template-columns: minmax(0, 1fr);
 
 	&.skipLicense {
 		.v-notice {
@@ -173,10 +174,12 @@ p {
 }
 
 .v-checkbox {
-	block-size: 32px;
+	block-size: auto;
+	align-items: flex-start;
 
 	span {
 		font-weight: 600;
+		white-space: normal;
 	}
 }
 


### PR DESCRIPTION
This is to fix https://github.com/directus/directus/issues/26732

Results:

On Chrome Dev Tool:
<img width="1603" height="1791" alt="Screenshot_1" src="https://github.com/user-attachments/assets/7833e84e-0f4f-42bc-b72d-956600e0cea9" />

On Iphone 12:
![图片_20260226112433_7_2](https://github.com/user-attachments/assets/84e0f22d-11f8-4523-b6ff-fcd90594964d)

![图片_20260226112435_8_2](https://github.com/user-attachments/assets/ecb7f615-0c02-4d47-8cf3-8fb8a2e414bb)