### PR TITLE
vev ← Add version support for visual editing in live preview

### DIFF
--- a/.changeset/tender-paths-hear.md
+++ b/.changeset/tender-paths-hear.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added version support for visual editing in live preview

--- a/app/src/composables/use-visual-editing.test.ts
+++ b/app/src/composables/use-visual-editing.test.ts
@@ -118,17 +118,6 @@ describe('useVisualEditing', () => {
 		expect(visualModuleEnabled.value).toBe(true);
 	});
 
-	test('visualEditingEnabled is false when visual_editor_urls is empty', () => {
-		mockVisualEditorUrls.value = [];
-
-		const { visualEditingEnabled } = useVisualEditing({
-			previewUrl: 'https://example.com/preview',
-			isNew: false,
-		});
-
-		expect(visualEditingEnabled.value).toBe(false);
-	});
-
 	test('visualEditingEnabled is true when all prerequisites are met', () => {
 		const { visualEditingEnabled } = useVisualEditing({
 			previewUrl: 'https://example.com/preview',
@@ -136,16 +125,6 @@ describe('useVisualEditing', () => {
 		});
 
 		expect(visualEditingEnabled.value).toBe(true);
-	});
-
-	test('visualEditorUrls extracts URLs correctly from settings', () => {
-		mockVisualEditorUrls.value = [{ url: 'https://example.com' }, { url: 'https://another.com' }, { url: '' }];
-
-		const { visualEditorUrls } = useVisualEditing({
-			previewUrl: 'https://example.com/preview',
-		});
-
-		expect(visualEditorUrls.value).toEqual(['https://example.com', 'https://another.com']);
 	});
 
 	test('visualEditingEnabled reacts to isNew ref changes', () => {

--- a/app/src/composables/use-visual-editing.test.ts
+++ b/app/src/composables/use-visual-editing.test.ts
@@ -6,10 +6,6 @@ const mockModuleBar = vi.hoisted(() => ({
 	value: [] as Array<{ type: string; id: string; enabled: boolean }>,
 }));
 
-const mockVisualEditorUrls = vi.hoisted(() => ({
-	value: [] as Array<{ url: string }>,
-}));
-
 vi.mock('@/utils/normalize-url', () => ({
 	normalizeUrl: (url: string | null) => url,
 }));
@@ -19,9 +15,6 @@ vi.mock('@/stores/settings', () => ({
 		settings: {
 			get module_bar() {
 				return mockModuleBar.value;
-			},
-			get visual_editor_urls() {
-				return mockVisualEditorUrls.value;
 			},
 		},
 	}),
@@ -33,7 +26,6 @@ beforeEach(() => {
 		{ type: 'module', id: 'visual', enabled: true },
 	];
 
-	mockVisualEditorUrls.value = [{ url: 'https://example.com' }];
 });
 
 afterEach(() => {

--- a/app/src/composables/use-visual-editing.ts
+++ b/app/src/composables/use-visual-editing.ts
@@ -21,10 +21,6 @@ export function useVisualEditing({ previewUrl, isNew = false }: UseVisualEditing
 	const settingsStore = useSettingsStore();
 	const moduleBar = computed(() => settingsStore.settings?.module_bar ?? MODULE_BAR_DEFAULT);
 
-	const visualEditorUrls = computed(
-		() => settingsStore.settings?.visual_editor_urls?.map(({ url }) => url).filter(Boolean) ?? [],
-	);
-
 	const visualModuleEnabled = computed(() =>
 		moduleBar.value.some((part) => part.type === 'module' && part.id === 'visual' && part.enabled),
 	);
@@ -36,12 +32,7 @@ export function useVisualEditing({ previewUrl, isNew = false }: UseVisualEditing
 	 * This does NOT require the visual module to be enabled - only that VE-URLs are configured.
 	 * The visual module toggle only controls access to the full Visual Editor page.
 	 */
-	const visualEditingEnabled = computed(
-		() =>
-			!!normalizedPreviewUrl.value &&
-			!unref(isNew) &&
-			visualEditorUrls.value.length > 0,
-	);
+	const visualEditingEnabled = computed(() => !!normalizedPreviewUrl.value && !unref(isNew));
 
-	return { visualEditingEnabled, visualEditorUrls, visualModuleEnabled };
+	return { visualEditingEnabled, visualModuleEnabled };
 }

--- a/app/src/composables/use-visual-editing.ts
+++ b/app/src/composables/use-visual-editing.ts
@@ -1,4 +1,3 @@
-import type { ContentVersion } from '@directus/types';
 import { computed, type MaybeRef, unref } from 'vue';
 import { MODULE_BAR_DEFAULT } from '@/constants';
 import { useSettingsStore } from '@/stores/settings';
@@ -9,8 +8,6 @@ interface UseVisualEditingOptions {
 	previewUrl: MaybeRef<string | null>;
 	/** Whether this is a new item - visual editing is disabled for new items. Defaults to false. */
 	isNew?: MaybeRef<boolean>;
-	/** Current content version - visual editing is disabled for non-main versions. Defaults to null (main). */
-	currentVersion?: MaybeRef<ContentVersion | null>;
 }
 
 /**
@@ -20,7 +17,7 @@ interface UseVisualEditingOptions {
  * Note: This checks prerequisites only. The live-preview component does the final
  * sameOrigin validation against the currently displayed URL.
  */
-export function useVisualEditing({ previewUrl, isNew = false, currentVersion = null }: UseVisualEditingOptions) {
+export function useVisualEditing({ previewUrl, isNew = false }: UseVisualEditingOptions) {
 	const settingsStore = useSettingsStore();
 	const moduleBar = computed(() => settingsStore.settings?.module_bar ?? MODULE_BAR_DEFAULT);
 
@@ -43,7 +40,6 @@ export function useVisualEditing({ previewUrl, isNew = false, currentVersion = n
 		() =>
 			!!normalizedPreviewUrl.value &&
 			!unref(isNew) &&
-			unref(currentVersion) === null &&
 			visualEditorUrls.value.length > 0,
 	);
 

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -371,7 +371,7 @@ const livePreviewSize = computed({
 
 provide('live-preview-active', livePreviewActive);
 
-const { visualEditingEnabled, visualEditorUrls, visualModuleEnabled } = useVisualEditing({
+const { visualEditingEnabled, visualModuleEnabled } = useVisualEditing({
 	previewUrl,
 	isNew,
 });
@@ -902,7 +902,6 @@ function useItemNavigation() {
 					:url="previewUrl"
 					:version="currentVersion"
 					:can-enable-visual-editing="visualEditingEnabled"
-					:visual-editor-urls="visualEditorUrls"
 					:show-open-in-visual-editor="visualModuleEnabled"
 					:is-full-width="livePreviewFullWidth"
 					@new-window="livePreviewMode = 'popup'"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -374,7 +374,6 @@ provide('live-preview-active', livePreviewActive);
 const { visualEditingEnabled, visualEditorUrls, visualModuleEnabled } = useVisualEditing({
 	previewUrl,
 	isNew,
-	currentVersion,
 });
 
 watch(previewUrl, (url) => {
@@ -901,6 +900,7 @@ function useItemNavigation() {
 				<LivePreview
 					v-if="livePreviewActive && previewUrl"
 					:url="previewUrl"
+					:version="currentVersion"
 					:can-enable-visual-editing="visualEditingEnabled"
 					:visual-editor-urls="visualEditorUrls"
 					:show-open-in-visual-editor="visualModuleEnabled"

--- a/app/src/modules/content/routes/preview.vue
+++ b/app/src/modules/content/routes/preview.vue
@@ -30,7 +30,7 @@ const previewUrl = computed(() => {
 	return displayValue.value || null;
 });
 
-const { visualEditingEnabled, visualEditorUrls } = useVisualEditing({ previewUrl, currentVersion });
+const { visualEditingEnabled, visualEditorUrls } = useVisualEditing({ previewUrl });
 
 function closePopup() {
 	window.close();
@@ -45,6 +45,7 @@ function onSaved() {
 	<LivePreview
 		v-if="previewUrl"
 		:url="previewUrl"
+		:version="currentVersion"
 		in-popup
 		:can-enable-visual-editing="visualEditingEnabled"
 		:visual-editor-urls="visualEditorUrls"

--- a/app/src/modules/content/routes/preview.vue
+++ b/app/src/modules/content/routes/preview.vue
@@ -30,7 +30,7 @@ const previewUrl = computed(() => {
 	return displayValue.value || null;
 });
 
-const { visualEditingEnabled, visualEditorUrls } = useVisualEditing({ previewUrl });
+const { visualEditingEnabled } = useVisualEditing({ previewUrl });
 
 function closePopup() {
 	window.close();
@@ -48,7 +48,6 @@ function onSaved() {
 		:version="currentVersion"
 		in-popup
 		:can-enable-visual-editing="visualEditingEnabled"
-		:visual-editor-urls="visualEditorUrls"
 		@new-window="closePopup"
 		@saved="onSaved"
 	/>

--- a/app/src/views/private/components/live-preview.test.ts
+++ b/app/src/views/private/components/live-preview.test.ts
@@ -8,6 +8,10 @@ import { Tooltip } from '@/__utils__/tooltip';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
 
+vi.mock('@/modules/visual/composables/use-visual-editor-urls', () => ({
+	useVisualEditorUrls: () => ({ urlTemplates: ref([]), firstResolvedUrl: ref(null), resolveUrls: () => [] }),
+}));
+
 vi.mock('@directus/composables', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('@directus/composables')>();
 	return { ...actual, useElementSize: vi.fn(() => ({ width: ref(0), height: ref(0) })) };

--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -17,6 +17,7 @@ import VProgressCircular from '@/components/v-progress-circular.vue';
 import VSelect from '@/components/v-select/v-select.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
 import EditingLayer from '@/modules/visual/components/editing-layer.vue';
+import { useVisualEditorUrls } from '@/modules/visual/composables/use-visual-editor-urls';
 import { getUrlRoute } from '@/modules/visual/utils/get-url-route';
 import { sameOrigin } from '@/modules/visual/utils/same-origin';
 import PrivateViewResizeHandle from '@/views/private/private-view/components/private-view-resize-handle.vue';
@@ -34,7 +35,6 @@ const {
 	dynamicDisplay,
 	singleUrlSubdued = true,
 	canEnableVisualEditing = false,
-	visualEditorUrls = [],
 	version = null,
 	showOpenInVisualEditor = true,
 	defaultShowEditableElements = false,
@@ -54,7 +54,6 @@ const {
 	inPopup?: boolean;
 	centered?: boolean;
 	canEnableVisualEditing?: boolean;
-	visualEditorUrls?: string[];
 	version?: Pick<ContentVersion, 'key' | 'name'> | null;
 	showOpenInVisualEditor?: boolean;
 	defaultShowEditableElements?: boolean;
@@ -76,6 +75,7 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const router = useRouter();
 const slots = useSlots();
+const { resolveUrls } = useVisualEditorUrls();
 
 useResizeObserver();
 
@@ -137,9 +137,12 @@ const visualEditingEnabled = computed(() => {
 	if (invalidUrl) return false;
 
 	const currentUrl = frameSrc.value;
-	if (!currentUrl || !visualEditorUrls.length) return false;
+	if (!currentUrl) return false;
 
-	return visualEditorUrls.some((allowedUrl) => sameOrigin(allowedUrl, currentUrl));
+	const allowedUrls = resolveUrls(version?.key);
+	if (!allowedUrls.length) return false;
+
+	return allowedUrls.some((allowedUrl) => sameOrigin(allowedUrl, currentUrl));
 });
 
 function toggleFullscreen() {

--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useElementSize } from '@directus/composables';
+import type { ContentVersion } from '@directus/types';
 import { SplitPanel } from '@directus/vue-split-panel';
 import { computed, type CSSProperties, nextTick, onMounted, ref, useSlots, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -34,6 +35,7 @@ const {
 	singleUrlSubdued = true,
 	canEnableVisualEditing = false,
 	visualEditorUrls = [],
+	version = null,
 	showOpenInVisualEditor = true,
 	defaultShowEditableElements = false,
 	isFullWidth = false,
@@ -53,6 +55,7 @@ const {
 	centered?: boolean;
 	canEnableVisualEditing?: boolean;
 	visualEditorUrls?: string[];
+	version?: Pick<ContentVersion, 'key' | 'name'> | null;
 	showOpenInVisualEditor?: boolean;
 	defaultShowEditableElements?: boolean;
 	isFullWidth?: boolean;
@@ -490,6 +493,7 @@ function useUrls() {
 								v-if="visualEditingEnabled && !overlayProvided"
 								:frame-el="frameEl"
 								:frame-src="frameSrc"
+								:version="version"
 								:show-editable-elements="showEditableElements"
 								@saved="(data) => emit('saved', data)"
 							/>
@@ -531,6 +535,7 @@ function useUrls() {
 						v-if="visualEditingEnabled && !overlayProvided"
 						:frame-el="frameEl"
 						:frame-src="frameSrc"
+						:version="version"
 						:show-editable-elements="showEditableElements"
 						@saved="(data) => emit('saved', data)"
 					/>


### PR DESCRIPTION
## Scope

What's changed:

- **Removed `currentVersion` parameter from `useVisualEditing`**: Visual editing is no longer disabled for non-main versions
- **Removed `visualEditorUrls` from `useVisualEditing` return**: URL resolution now handled internally by the live preview component via `useVisualEditorUrls()`
- **Restructured `live-preview.vue`**: Replaced `visualEditorUrls` prop with a `version` prop. The component resolves URLs internally (with version key) and performs the `sameOrigin` check itself. Related logic encapsulated in a local `useVisualEditing()` function
- **Passes `version` to `EditingLayer`** for version-aware saving

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Visual editing in Live Preview pane

## Review Notes / Questions

- Review by commit
- Companion `@directus/visual-editing` PR needed for E2E testing: https://github.com/directus/visual-editing/pull/34
- There is a test website in the repo to test the feature end-to-end

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs/pull/547) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-1872