### PR TITLE
Don't allow null in unions

### DIFF
--- a/.changeset/little-clowns-boil.md
+++ b/.changeset/little-clowns-boil.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed AI tool schema to not allow `null` for `trigger` and `accountability` fields in flow input validation.

--- a/api/src/ai/tools/schema.ts
+++ b/api/src/ai/tools/schema.ts
@@ -152,13 +152,13 @@ export const FlowItemInputSchema = z
 		color: z.union([z.string(), z.null()]),
 		description: z.union([z.string(), z.null()]),
 		status: z.enum(['active', 'inactive']),
-		trigger: z.union([z.enum(['event', 'schedule', 'operation', 'webhook', 'manual']), z.null()]),
+		trigger: z.enum(['event', 'schedule', 'operation', 'webhook', 'manual']),
 		options: z.union([z.record(z.string(), z.any()), z.null()]),
 		operation: z.union([z.string(), z.null()]),
 		operations: z.array(OperationItemInputSchema),
 		date_created: z.string(),
 		user_created: z.string(),
-		accountability: z.union([z.enum(['all', 'activity']), z.null()]),
+		accountability: z.enum(['all', 'activity']),
 	})
 	.partial();
 


### PR DESCRIPTION
This should resolve #26682 by making sure we're not using `null` in enums, as Google only accepts STRINGs in enums.

@bryantgillespie could this cause any other shenanigans that I'm not thinking of?

## Scope

- Removed the nullable `z.null()` union wrapper from `trigger` and `accountability` enum fields in `FlowItemInputSchema`. When converted to JSON Schema via `zodSchema()`, `z.union([z.enum([...]), z.null()])` produces `anyOf` patterns that Gemini rejects with `enum: only allowed for STRING type`. Since the entire object is `.partial()`, the AI model can omit these fields instead of sending null.

## Potential Risks / Drawbacks

None significant. The schema is `.partial()` so omitting the field is already the way to express "no value". The AI model would never need to explicitly send `null` for an enum field.

## Tested Scenarios

- Verified the resulting JSON Schema output no longer contains `anyOf` wrappers on enum fields
- Existing test suite for `chat-request-tool-to-ai-sdk-tool` passes

## Review Notes

Estimated review time: ~2m

Fixes #26762