### PR TITLE
Fix file title handling for TUS uploads and URL imports

### DIFF
--- a/.changeset/fix-file-title-extension-stripping.md
+++ b/.changeset/fix-file-title-extension-stripping.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed file title including extension for TUS uploads and URL imports by stripping the file extension before generating the title.

--- a/.changeset/fix-file-title-extension-stripping.md
+++ b/.changeset/fix-file-title-extension-stripping.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed file title including extension for TUS uploads and URL imports by stripping the file extension before generating the title.
+Fixed file title including extension for TUS uploads and URL imports

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -255,7 +255,7 @@ export class FilesService extends ItemsService<File> {
 			filename_download: filename,
 			storage: toArray(env['STORAGE_LOCATIONS'] as string)[0]!,
 			type: fileResponse.headers['content-type'],
-			title: formatTitle(filename),
+			title: formatTitle(path.parse(filename).name),
 			...(body || {}),
 		};
 

--- a/api/src/services/tus/data-store.ts
+++ b/api/src/services/tus/data-store.ts
@@ -1,4 +1,4 @@
-import { extname } from 'node:path';
+import { extname, parse } from 'node:path';
 import stream from 'node:stream';
 import formatTitle from '@directus/format-title';
 import type { TusDriver } from '@directus/storage';
@@ -66,7 +66,7 @@ export class TusDataStore extends DataStore {
 		}
 
 		if (!upload.metadata['title']) {
-			upload.metadata['title'] = formatTitle(upload.metadata['filename_download']);
+			upload.metadata['title'] = formatTitle(parse(upload.metadata['filename_download']).name);
 		}
 
 		let existingFile: Record<string, any> | null = null;

--- a/contributors.yml
+++ b/contributors.yml
@@ -252,3 +252,4 @@
 - wotan-allfather
 - danielbuechele
 - powerseed
+- Michael-Nussbaumer


### PR DESCRIPTION
## Scope
This pull request addresses an issue where file titles included their extensions for TUS uploads and URL imports. The changes ensure that the file extension is stripped before generating the title, resulting in cleaner and more consistent file titles.

Improvements to file title generation:

* Updated the logic in `FilesService` (`api/src/services/files.ts`) to generate the `title` by stripping the file extension from the filename using `path.parse(filename).name`.
* Modified the TUS upload handling in `TusDataStore` (`api/src/services/tus/data-store.ts`) to set the `title` by removing the file extension from `filename_download` using `parse(upload.metadata['filename_download']).name`.
* Added `parse` import from `node:path` in `api/src/services/tus/data-store.ts` to enable extension stripping.

Documentation:

* Added a changeset file describing the fix for file title extension stripping for TUS uploads and URL imports.
