### PR TITLE
Persist table column widths to localStorage

### DIFF
--- a/.changeset/cute-ravens-stay.md
+++ b/.changeset/cute-ravens-stay.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Persisted table column widths to localStorage

--- a/app/src/composables/use-column-widths.ts
+++ b/app/src/composables/use-column-widths.ts
@@ -1,0 +1,38 @@
+import { useEventListener, useLocalStorage } from '@vueuse/core';
+import { type MaybeRefOrGetter, ref } from 'vue';
+
+/**
+ * Persists table column widths to localStorage, batching writes so they only
+ * occur on pointerup (end of drag) rather than on every pointermove event.
+ *
+ * During a drag, width updates are held in `pendingColumnWidths` (in-memory)
+ * and flushed to `columnWidths` (localStorage) once the user releases the pointer.
+ */
+export function useColumnWidths(storageKey: MaybeRefOrGetter<string>) {
+	const columnWidths = useLocalStorage<Record<string, number>>(storageKey, {});
+
+	const pendingColumnWidths = ref<Record<string, number>>({});
+
+	useEventListener(window, 'pointerup', () => {
+		if (Object.keys(pendingColumnWidths.value).length > 0) {
+			columnWidths.value = { ...columnWidths.value, ...pendingColumnWidths.value };
+			pendingColumnWidths.value = {};
+		}
+	});
+
+	function getWidth(key: string, defaultWidth: number): number {
+		return pendingColumnWidths.value[key] ?? columnWidths.value[key] ?? defaultWidth;
+	}
+
+	function updateWidths(headers: Array<{ value: string; width?: number }>) {
+		const widths: Record<string, number> = {};
+
+		headers.forEach((h) => {
+			widths[h.value] = h.width ?? 160;
+		});
+
+		pendingColumnWidths.value = { ...pendingColumnWidths.value, ...widths };
+	}
+
+	return { getWidth, updateWidths };
+}

--- a/app/src/interfaces/list-m2m/list-m2m.test.ts
+++ b/app/src/interfaces/list-m2m/list-m2m.test.ts
@@ -1,7 +1,7 @@
 import { Field, Relation } from '@directus/types';
 import { createTestingPinia } from '@pinia/testing';
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import ListM2M from './list-m2m.vue';
 import type { GlobalMountOptions } from '@/__utils__/types';
@@ -50,10 +50,18 @@ vi.mock('@/composables/use-relation-permissions', () => ({
 	}),
 }));
 
+const mockGetField = vi.hoisted(() => vi.fn(() => null as any));
+const mockGetWidth = vi.hoisted(() => vi.fn((_key: string, defaultWidth: number) => defaultWidth));
+const mockUpdateWidths = vi.hoisted(() => vi.fn());
+
+vi.mock('@/composables/use-column-widths', () => ({
+	useColumnWidths: () => ({ getWidth: mockGetWidth, updateWidths: mockUpdateWidths }),
+}));
+
 vi.mock('@/stores/fields', () => ({
 	useFieldsStore: () => ({
 		getFieldsForCollection: vi.fn(() => []),
-		getField: vi.fn(() => null),
+		getField: mockGetField,
 		getPrimaryKeyFieldForCollection: vi.fn(() => ({ field: 'id' })),
 	}),
 }));
@@ -147,6 +155,19 @@ const tableGlobal: GlobalMountOptions = {
 const tableGlobalWithRouterLink: GlobalMountOptions = {
 	...tableGlobal,
 	stubs: { ...tableGlobal.stubs, RouterLink: routerLinkStub },
+};
+
+const tableGlobalWithHeaderEmit: GlobalMountOptions = {
+	...global,
+	stubs: {
+		...global.stubs,
+		VTable: {
+			name: 'VTable',
+			template: '<div class="v-table" />',
+			props: ['modelValue', 'headers', 'items'],
+			emits: ['update:headers'],
+		},
+	},
 };
 
 const listProps = {
@@ -302,6 +323,61 @@ describe('list-m2m', () => {
 
 				expect(wrapper.find('.item-actions').exists()).toBe(true);
 				expect(wrapper.find('.item-actions v-remove-stub').exists()).toBe(true);
+			});
+		});
+
+		describe('column width persistence', () => {
+			beforeEach(() => {
+				mockGetField.mockReset();
+				mockGetWidth.mockImplementation((_key: string, defaultWidth: number) => defaultWidth);
+				mockUpdateWidths.mockReset();
+			});
+
+			it('only calls updateWidths for columns whose width changed', async () => {
+				mockGetField.mockReturnValue({ name: 'Name', type: 'string', field: 'name' } as any);
+				// getWidth returns 160 (default), so any other value counts as a resize
+				mockGetWidth.mockReturnValue(160);
+
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, fields: ['name'] },
+					global: tableGlobalWithHeaderEmit,
+				});
+
+				const vTable = wrapper.findComponent({ name: 'VTable' });
+
+				// Emit a resize: 'name' changes to 250, different from stored 160
+				await vTable.vm.$emit('update:headers', [{ text: 'Name', value: 'name', width: 250 }]);
+				expect(mockUpdateWidths).toHaveBeenCalledWith([{ text: 'Name', value: 'name', width: 250 }]);
+			});
+
+			it('does not call updateWidths when no width changed', async () => {
+				mockGetField.mockReturnValue({ name: 'Name', type: 'string', field: 'name' } as any);
+				mockGetWidth.mockReturnValue(160);
+
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, fields: ['name'] },
+					global: tableGlobalWithHeaderEmit,
+				});
+
+				const vTable = wrapper.findComponent({ name: 'VTable' });
+
+				// Emit same width as currently rendered — no actual resize
+				await vTable.vm.$emit('update:headers', [{ text: 'Name', value: 'name', width: 160 }]);
+				expect(mockUpdateWidths).not.toHaveBeenCalled();
+			});
+
+			it('uses getWidth to restore stored column widths on mount', async () => {
+				mockGetField.mockReturnValue({ name: 'Name', type: 'string', field: 'name' } as any);
+				mockGetWidth.mockReturnValue(300); // simulate a stored width of 300
+
+				const wrapper = mount(ListM2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, fields: ['name'] },
+					global: tableGlobalWithHeaderEmit,
+				});
+
+				const vTable = wrapper.findComponent({ name: 'VTable' });
+				const headers = vTable.props('headers') as Array<{ value: string; width: number }>;
+				expect(headers?.find((h) => h.value === 'name')?.width).toBe(300);
 			});
 		});
 	});

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -251,7 +251,16 @@ const headers = computed({
 			})
 			.filter((h) => h !== null);
 	},
-	set: updateWidths,
+	set: (val: Array<any>) => {
+		const currentHeaders = headers.value;
+
+		const changed = val.filter((h) => {
+			const current = currentHeaders.find((ch: any) => ch.value === h.value);
+			return current && current.width !== h.width;
+		});
+
+		if (changed.length > 0) updateWidths(changed);
+	},
 });
 
 const spacings = {

--- a/app/src/interfaces/list-o2m/list-o2m.test.ts
+++ b/app/src/interfaces/list-o2m/list-o2m.test.ts
@@ -38,6 +38,12 @@ vi.mock('@/composables/use-relation-permissions', () => ({
 }));
 
 const mockGetField = vi.hoisted(() => vi.fn(() => null as any));
+const mockGetWidth = vi.hoisted(() => vi.fn((_key: string, defaultWidth: number) => defaultWidth));
+const mockUpdateWidths = vi.hoisted(() => vi.fn());
+
+vi.mock('@/composables/use-column-widths', () => ({
+	useColumnWidths: () => ({ getWidth: mockGetWidth, updateWidths: mockUpdateWidths }),
+}));
 
 vi.mock('@/stores/fields', () => ({
 	useFieldsStore: () => ({
@@ -309,11 +315,16 @@ describe('list-o2m', () => {
 
 		describe('column width persistence', () => {
 			beforeEach(() => {
-				localStorage.clear();
 				mockGetField.mockReset();
+				mockGetWidth.mockImplementation((_key: string, defaultWidth: number) => defaultWidth);
+				mockUpdateWidths.mockReset();
 			});
 
-			it('persists resized column widths to localStorage', async () => {
+			it('only calls updateWidths for columns whose width changed', async () => {
+				mockGetField.mockReturnValue({ name: 'Name', type: 'string', field: 'name' } as any);
+				// getWidth returns 160 (default), so any other value counts as a resize
+				mockGetWidth.mockReturnValue(160);
+
 				const wrapper = mount(ListO2M, {
 					props: { ...listProps, layout: LAYOUTS.TABLE, fields: ['name'] },
 					global: tableGlobalWithHeaderEmit,
@@ -321,20 +332,30 @@ describe('list-o2m', () => {
 
 				const vTable = wrapper.findComponent({ name: 'VTable' });
 
-				// Simulate column resize: v-table emits update:headers with a new width
+				// Emit a resize: 'name' changes to 250, different from stored 160
 				await vTable.vm.$emit('update:headers', [{ text: 'Name', value: 'name', width: 250 }]);
-
-				const stored = JSON.parse(
-					localStorage.getItem(`directus-o2m-column-widths-test-collection-test-field`) ?? '{}',
-				);
-
-				expect(stored).toEqual({ name: 250 });
+				expect(mockUpdateWidths).toHaveBeenCalledWith([{ text: 'Name', value: 'name', width: 250 }]);
 			});
 
-			it('restores persisted column widths on mount', async () => {
-				localStorage.setItem('directus-o2m-column-widths-test-collection-test-field', JSON.stringify({ name: 300 }));
-
+			it('does not call updateWidths when no width changed', async () => {
 				mockGetField.mockReturnValue({ name: 'Name', type: 'string', field: 'name' } as any);
+				mockGetWidth.mockReturnValue(160);
+
+				const wrapper = mount(ListO2M, {
+					props: { ...listProps, layout: LAYOUTS.TABLE, fields: ['name'] },
+					global: tableGlobalWithHeaderEmit,
+				});
+
+				const vTable = wrapper.findComponent({ name: 'VTable' });
+
+				// Emit same width as currently rendered — no actual resize
+				await vTable.vm.$emit('update:headers', [{ text: 'Name', value: 'name', width: 160 }]);
+				expect(mockUpdateWidths).not.toHaveBeenCalled();
+			});
+
+			it('uses getWidth to restore stored column widths on mount', async () => {
+				mockGetField.mockReturnValue({ name: 'Name', type: 'string', field: 'name' } as any);
+				mockGetWidth.mockReturnValue(300); // simulate a stored width of 300
 
 				const wrapper = mount(ListO2M, {
 					props: { ...listProps, layout: LAYOUTS.TABLE, fields: ['name'] },
@@ -343,8 +364,7 @@ describe('list-o2m', () => {
 
 				const vTable = wrapper.findComponent({ name: 'VTable' });
 				const headers = vTable.props('headers') as Array<{ value: string; width: number }>;
-				const nameHeader = headers?.find((h) => h.value === 'name');
-				expect(nameHeader?.width).toBe(300);
+				expect(headers?.find((h) => h.value === 'name')?.width).toBe(300);
 			});
 		});
 	});

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -222,7 +222,16 @@ const headers = computed({
 			})
 			.filter((h) => h !== null);
 	},
-	set: updateWidths,
+	set: (val: Array<any>) => {
+		const currentHeaders = headers.value;
+
+		const changed = val.filter((h) => {
+			const current = currentHeaders.find((ch: any) => ch.value === h.value);
+			return current && current.width !== h.width;
+		});
+
+		if (changed.length > 0) updateWidths(changed);
+	},
 });
 
 const spacings = {


### PR DESCRIPTION
## Scope

## What's changed

- Persist resized column widths in the O2M/M2M table layout to `localStorage`, keyed by collection and field
- Restore persisted column widths on mount, falling back to content-based defaults
- Refactor `headers` from a `ref` + `watch` to a writable `computed`. Getter builds headers with merged widths, setter persists changes
- Add unit tests covering width persistence and restoration

## Potential Risks / Drawbacks

- localStorage key is `directus-<o2m/m2m>-column-widths-{collection}-{field}` — existing users have no prior data so no migration concern, but the key is not namespaced per-user (shared across users on the same browser)

## Tested Scenarios

- Resize a column and confirm the new width is saved to localStorage under the correct key
- Reload the component with a pre-seeded localStorage entry and confirm the persisted width is applied to the correct header
- Confirm fields with no persisted width fall back to the content-based default

## Review Notes / Questions

- Special attention should be paid to whether scoping the localStorage key per-user is required for this project's use cases @JamesW1 

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-1554](https://linear.app/directus/issue/CMS-1554/persist-custom-column-width-of-columns-in-table-view-in-a-one-to-many)
