### PR TITLE
fix(api): improve error message for already active invited users

### DIFF
--- a/.changeset/fix-invite-error-message.md
+++ b/.changeset/fix-invite-error-message.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed misleading error message when accepting an invite for an already active user

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -424,8 +424,10 @@ export class UsersService extends ItemsService {
 
 		const user = await this.getUserByEmail(email);
 
-		if (user?.status !== 'invited') {
-			throw new InvalidPayloadError({ reason: `Email address ${email} hasn't been invited` });
+		if (!user || user.status !== 'invited') {
+			throw new InvalidPayloadError({
+				reason: `Email address ${email} hasn't been invited or is already active`,
+			});
 		}
 
 		// Allow unauthenticated update

--- a/contributors.yml
+++ b/contributors.yml
@@ -252,3 +252,4 @@
 - wotan-allfather
 - danielbuechele
 - powerseed
+- AbdelhamidKhald


### PR DESCRIPTION
## Summary

Fixes #26699

When a user is invited to Directus but an admin manually activates them before they click the invite link, the `acceptInvite()` endpoint returns:

> `"Email address test@test.com hasn't been invited."`

This is misleading — the user **was** invited, they're just already active.

## Changes

Updated the error message in `api/src/services/users.ts` to:

> `"Email address test@test.com hasn't been invited or is already active"`

Also made the null check explicit (`!user || user.status !== 'invited'`) instead of relying on optional chaining for clarity.

This follows the approach suggested by @AlexGaillard in #26708:

> *"A better approach would be to update the returned error to something like \"*

## Scope

- **1 file changed**: `api/src/services/users.ts` (line 427)
- **No logic changes** — only the error message text
- **No security implications** — the behavior is identical; only the user-facing message is improved
- Includes changeset for `@directus/api` patch