### PR TITLE
fix(api): handle countAll aggregate operation when fields array is empty

### DIFF
--- a/api/src/database/run-ast/lib/apply-query/aggregate.ts
+++ b/api/src/database/run-ast/lib/apply-query/aggregate.ts
@@ -11,12 +11,13 @@ export function applyAggregate(
 	for (const [operation, fields] of Object.entries(aggregate)) {
 		if (!fields) continue;
 
-		for (const field of fields) {
-			if (operation === 'countAll') {
-				dbQuery.count('*', { as: 'countAll' });
-				continue;
-			}
+		// Handle countAll operation separately since it doesn't require fields
+		if (operation === 'countAll') {
+			dbQuery.count('*', { as: 'countAll' });
+			continue;
+		}
 
+		for (const field of fields) {
 			if (operation === 'count' && field === '*') {
 				dbQuery.count('*', { as: 'count' });
 				continue;


### PR DESCRIPTION
## Description

Fixes the GraphQL `_aggregate` `countAll` operation not working when the fields array is empty.

## Problem

When using the GraphQL API to retrieve the total count via `countAll`, the query was generating `SELECT * FROM table LIMIT $1` instead of `SELECT COUNT(*) FROM table`.

The root cause was that `countAll` was checked inside the `for (const field of fields)` loop, but GraphQL sends `countAll` with an empty fields array `[]`, so the loop never executed and `countAll` was never applied.

## Solution

Moved the `countAll` operation check outside the fields iteration loop, since `countAll` does not require any specific fields.

## Changes
- Moved `countAll` check before the `fields` loop
- Added comment explaining why this operation is handled separately

## Related Issues

Fixes #26768