### PR TITLE
fix(app): exclude alias fields from CSV export Select All

### DIFF
--- a/.changeset/fix-csv-export-alias-fields.md
+++ b/.changeset/fix-csv-export-alias-fields.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed CSV export "Select All" including alias fields (accordions, dividers) that cannot be fetched from the API

--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -104,7 +104,10 @@ const treeList = computed(() => {
 });
 
 const addAll = () => {
-	const allFields = unref(treeList).map((field) => field.field);
+	const allFields = unref(treeList)
+		.filter((field) => !field.group && field.type !== 'alias')
+		.map((field) => field.field);
+
 	emit('add', unref(allFields));
 };
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -253,3 +253,4 @@
 - danielbuechele
 - powerseed
 - aryanrichhariya1234-lang
+- nielskaspers


### PR DESCRIPTION
## Summary

Fixes #26766

When using the export function and clicking "Select All," alias fields (such as accordion groups, dividers, and other presentation fields) were included in the field selection. These fields are virtual and cannot be fetched from the API, causing an error during export.

### Changes

- Filter out group and alias-type fields from the "Select All" action in `v-field-list.vue`
- This is consistent with how these fields are already marked as `disabled` for individual selection (line 94: `let disabled = field.group || false`)

### Root cause

The `addAll` function in `v-field-list.vue` mapped all top-level fields from the tree list without filtering, while the individual field selection already correctly disabled alias/group fields. The fix adds the same filtering to `addAll`.

### How to reproduce (from issue)

1. Create a collection with an accordion group field
2. Go to the collection's item list
3. Open Export sidebar → Export Items
4. In the Fields section, click "Add Field" → "Select All"
5. Observe that the accordion group field is included
6. Attempt to export → error because the alias field cannot be fetched from the API