### PR TITLE
Fix GraphQL countAll aggregate returning null

### DIFF
--- a/api/src/database/run-ast/lib/apply-query/aggregate.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/aggregate.test.ts
@@ -126,6 +126,26 @@ test('aggregate countAll', async () => {
 	expect(rawQuery.bindings).toEqual([]);
 });
 
+test('aggregate countAll with empty fields (GraphQL)', async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applyAggregate(
+		schema,
+		queryBuilder,
+		{
+			countAll: [],
+		},
+		'articles',
+		false,
+	);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toEqual(`select count(*) as "countAll"`);
+	expect(rawQuery.bindings).toEqual([]);
+});
+
 test('aggregate count o2m', async () => {
 	const o2mSchema = new SchemaBuilder()
 		.collection('articles', (c) => {

--- a/api/src/database/run-ast/lib/apply-query/aggregate.ts
+++ b/api/src/database/run-ast/lib/apply-query/aggregate.ts
@@ -11,11 +11,12 @@ export function applyAggregate(
 	for (const [operation, fields] of Object.entries(aggregate)) {
 		if (!fields) continue;
 
+		if (operation === 'countAll') {
+			dbQuery.count('*', { as: 'countAll' });
+			continue;
+		}
+
 		for (const field of fields) {
-			if (operation === 'countAll') {
-				dbQuery.count('*', { as: 'countAll' });
-				continue;
-			}
 
 			if (operation === 'count' && field === '*') {
 				dbQuery.count('*', { as: 'count' });


### PR DESCRIPTION
## Summary

Fixes `countAll` returning `null` when queried via GraphQL (e.g. `{ posts_aggregated { countAll } }`).

## Problem

When GraphQL sends an aggregate query with `countAll`, the aggregate object is `{ countAll: [] }` — an empty fields array. The `countAll` check in `applyAggregate()` was inside the `for (const field of fields)` loop, so when `fields` is empty, the loop never executes and `count(*)` is never applied.

This caused the query to fall through to a plain `SELECT *` with a LIMIT, returning rows instead of a count.

## Fix

Moved the `countAll` handling before the fields iteration loop so it executes regardless of the fields array contents.

Also added a test case that reproduces the exact GraphQL scenario (`countAll: []`).

## References

As noted by @MaSpeng in the issue, the existing test used `countAll: ['*']` which worked because the loop executed once — but this doesn't match the actual GraphQL input.

Fixes #26768