### PR TITLE
Support `app/` prefix in vitest test file paths

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -79,6 +79,8 @@ export default defineConfig({
 		},
 	}),
 	test: {
+		dir: path.resolve(__dirname, '..'),
+		include: ['app/**/*.test.ts'],
 		environment: 'happy-dom',
 		deps: {
 			optimizer: {


### PR DESCRIPTION
## Scope

What's changed:                                                                                          
                
- Added `dir` and `include` to vitest test config in `app/vite.config.js`
- Tests can now be run with both `app/src/...` and `src/...` path prefixes. For example: `pnpm --filter app test app/src/hydrate.test.ts` previously failed. A problem that AI agents constantly ran into.

## Potential Risks / Drawbacks

- None — `root` is unchanged, so snapshots, coverage, and aliases are unaffected

## Tested Scenarios

- `pnpm --filter app test app/src/hydrate.test.ts` — finds and runs test
- `pnpm --filter app test src/hydrate.test.ts` — still works (backward compat)
- `pnpm --filter app test` — full suite still passes

## Review Notes / Questions

- By setting `dir` to the monorepo root, the relative test path becomes `app/src/...` instead of `src/...`. Both `app/src/foo.test.ts` and `src/foo.test.ts` are substrings of `app/src/foo.test.ts`, so both match.
- `include` is explicitly set to `['app/**/*.test.ts']` to prevent vitest from scanning the entire monorepo.