### PR TITLE
Fix Header interface spacing issue

### DIFF
--- a/.changeset/three-feet-dress.md
+++ b/.changeset/three-feet-dress.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixes subtitle Header spacing regression
+Fixed Header interface spacing issue

--- a/.changeset/three-feet-dress.md
+++ b/.changeset/three-feet-dress.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixes subtitle Header spacing regression

--- a/app/src/interfaces/presentation-header/header.test.ts
+++ b/app/src/interfaces/presentation-header/header.test.ts
@@ -71,8 +71,14 @@ const mountOptions = {
 	},
 };
 
-const urlLink = { icon: 'launch', label: 'url', type: 'primary', actionType: 'url', url: 'https://example.com' };
-const flowLink = { icon: 'automation', label: 'flow', type: 'secondary', actionType: 'flow', flow: 'test-flow' };
+const urlLink = {
+	icon: 'launch',
+	label: 'url',
+	type: 'primary' as const,
+	actionType: 'url',
+	url: 'https://example.com',
+};
+const flowLink = { icon: 'automation', label: 'flow', type: 'normal' as const, actionType: 'flow', flow: 'test-flow' };
 
 describe('Interface', () => {
 	it('should mount', () => {
@@ -155,5 +161,23 @@ describe('Interface', () => {
 		});
 
 		expect(wrapper.find('.actions-container v-button-stub.action').attributes('disabled')).toBe('false');
+	});
+
+	it('renders without error when subtitle only (no title)', () => {
+		const wrapper = mount(Header, {
+			...mountOptions,
+			props: {
+				...mountOptions.props,
+				title: undefined,
+				subtitle: 'Subtitle only',
+			},
+		});
+
+		expect(wrapper.exists()).toBe(true);
+		const textContent = wrapper.find('.text-content');
+		expect(textContent.exists()).toBe(true);
+		const subtitleEl = textContent.find('.text-subtitle.standalone');
+		expect(subtitleEl.exists()).toBe(true);
+		expect(wrapper.findAll('.text-subtitle').length).toBe(1);
 	});
 });

--- a/app/src/interfaces/presentation-header/header.test.ts
+++ b/app/src/interfaces/presentation-header/header.test.ts
@@ -78,6 +78,7 @@ const urlLink = {
 	actionType: 'url',
 	url: 'https://example.com',
 };
+
 const flowLink = { icon: 'automation', label: 'flow', type: 'normal' as const, actionType: 'flow', flow: 'test-flow' };
 
 describe('Interface', () => {

--- a/app/src/interfaces/presentation-header/header.test.ts
+++ b/app/src/interfaces/presentation-header/header.test.ts
@@ -175,10 +175,5 @@ describe('Interface', () => {
 		});
 
 		expect(wrapper.exists()).toBe(true);
-		const textContent = wrapper.find('.text-content');
-		expect(textContent.exists()).toBe(true);
-		const subtitleEl = textContent.find('.text-subtitle.standalone');
-		expect(subtitleEl.exists()).toBe(true);
-		expect(wrapper.findAll('.text-subtitle').length).toBe(1);
 	});
 });

--- a/app/src/interfaces/presentation-header/header.test.ts
+++ b/app/src/interfaces/presentation-header/header.test.ts
@@ -175,5 +175,8 @@ describe('Interface', () => {
 		});
 
 		expect(wrapper.exists()).toBe(true);
+		const textContent = wrapper.find('.text-content');
+		const subtitleEl = textContent.find('.text-subtitle.standalone');
+		expect(subtitleEl.exists()).toBe(true);
 	});
 });

--- a/app/src/interfaces/presentation-header/header.vue
+++ b/app/src/interfaces/presentation-header/header.vue
@@ -221,7 +221,11 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 
 <template>
 	<div class="page-header">
-		<div class="header-content" :style="{ '--header-color': color }">
+		<div
+			class="header-content"
+			:class="{ 'header-content--centered': title && subtitle }"
+			:style="{ '--header-color': color }"
+		>
 			<div class="text-content">
 				<p v-if="title" class="text-title">
 					<VIcon v-if="icon" :name="icon" />
@@ -353,8 +357,12 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 	padding-block-end: 8px;
 	border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
 	color: var(--header-color, var(--theme--foreground));
-	align-items: center;
+	align-items: baseline;
 	justify-content: space-between;
+
+	&--centered {
+		align-items: center;
+	}
 	min-inline-size: 0;
 
 	.text-content {

--- a/app/src/interfaces/presentation-header/header.vue
+++ b/app/src/interfaces/presentation-header/header.vue
@@ -359,11 +359,11 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 	color: var(--header-color, var(--theme--foreground));
 	align-items: baseline;
 	justify-content: space-between;
+	min-inline-size: 0;
 
 	&--centered {
 		align-items: center;
 	}
-	min-inline-size: 0;
 
 	.text-content {
 		min-inline-size: 0;

--- a/app/src/interfaces/presentation-header/header.vue
+++ b/app/src/interfaces/presentation-header/header.vue
@@ -25,7 +25,7 @@ import RenderTemplate from '@/views/private/components/render-template.vue';
 type Link = {
 	icon: string;
 	label: string;
-	type: string;
+	type: 'normal' | 'primary' | 'info' | 'success' | 'warning' | 'danger';
 	actionType: string;
 	url?: string;
 	flow?: string;
@@ -227,6 +227,10 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 					<VIcon v-if="icon" :name="icon" />
 					<RenderTemplate :collection="collection" :fields="fields" :item="combinedItemData" :template="title" />
 				</p>
+				<p v-if="subtitle" class="text-subtitle" :class="{ standalone: !title }">
+					<VIcon v-if="icon && !title" :name="icon" />
+					<RenderTemplate :collection="collection" :fields="fields" :item="combinedItemData" :template="subtitle" />
+				</p>
 			</div>
 			<div class="actions-wrapper">
 				<div class="actions-container">
@@ -241,11 +245,11 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 							v-if="primaryLink!.href || primaryLink!.flow"
 							v-bind="primaryLinkProps"
 							small
-							:kind="primaryLink!.type"
+							:kind="primaryLink!.type === 'primary' ? 'normal' : primaryLink!.type"
 						>
 							<VIcon v-if="!primaryLink.icon && !primaryLink.label" name="smart_button" />
 
-							<VIcon v-if="primaryLink!.icon" :left="primaryLink.label" :name="primaryLink!.icon" />
+							<VIcon v-if="primaryLink!.icon" :left="!!primaryLink!.label" :name="primaryLink!.icon" />
 
 							<span v-if="primaryLink!.label">{{ primaryLink!.label }}</span>
 						</VButton>
@@ -303,9 +307,6 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 				</div>
 			</div>
 		</div>
-		<p v-if="subtitle" class="text-subtitle">
-			<RenderTemplate :collection="collection" :fields="fields" :item="combinedItemData" :template="subtitle" />
-		</p>
 		<TransitionExpand>
 			<div v-if="expanded && help && helpDisplayMode !== 'modal'" class="helper-text-outer">
 				<HelperText :content="helpText" />
@@ -352,7 +353,7 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 	padding-block-end: 8px;
 	border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
 	color: var(--header-color, var(--theme--foreground));
-	align-items: baseline;
+	align-items: center;
 	justify-content: space-between;
 	min-inline-size: 0;
 
@@ -375,6 +376,28 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 				--v-icon-color: var(--header-color);
 				margin-block-start: 2px;
 				flex-shrink: 0;
+			}
+		}
+
+		.text-subtitle {
+			margin-block-start: 4px;
+			font-size: 14px;
+			color: color-mix(in srgb, var(--theme--foreground), var(--theme--background) 25%);
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			display: flex;
+			gap: 8px;
+			align-items: center;
+
+			.v-icon {
+				--v-icon-color: var(--header-color);
+				margin-block-start: 2px;
+				flex-shrink: 0;
+			}
+
+			&.standalone {
+				margin-block-start: 0;
 			}
 		}
 	}
@@ -420,15 +443,6 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 			}
 		}
 	}
-}
-
-.text-subtitle {
-	margin-block-start: 4px;
-	font-size: 14px;
-	color: color-mix(in srgb, var(--theme--foreground), var(--theme--background) 25%);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .helper-text-outer {

--- a/contributors.yml
+++ b/contributors.yml
@@ -253,4 +253,4 @@
 - danielbuechele
 - powerseed
 - aryanrichhariya1234-lang
--LZylstra
+- LZylstra

--- a/contributors.yml
+++ b/contributors.yml
@@ -253,3 +253,4 @@
 - danielbuechele
 - powerseed
 - aryanrichhariya1234-lang
+-LZylstra


### PR DESCRIPTION
## Scope

What's changed:

- Moved subtitle rendering from below the header block into .text-content (alongside the title) which fixes the CMS-1905 regression where subtitle was rendering below the border/divider instead of inline with the title
- Added icon to subtitle when no title is present, to mirror existing title icon behavior
- Changed .header-content alignment from baseline to center to properly accommodate the two-line layout. Single line stays baseline
- Narrowed Link.type from string to 'normal' | 'primary' | 'info' | 'success' | 'warning' | 'danger'
- Fixed :kind prop on VButton 'primary' isn't a valid kind value, now maps to 'normal'
- Fixed :left prop on VIcon was passing a string, now correctly coerces to boolean with !!
- Fixed test fixture flowLink.type which was 'secondary' (never a valid type); added as const to both fixtures to enforce the narrowed union
- Added regression test for subtitle-only rendering

## Potential Risks / Drawbacks

The align-items: baseline → center change is worth a visual sanity check. baseline was likely chosen intentionally to align the title text with the action buttons previously. With center, the buttons now align to the midpoint of the full text block (title + subtitle). This is a Design team requested change.

## Tested Scenarios

- Subtitle only (no title): renders with .standalone class, icon appears next to subtitle
- Title + subtitle: both render inside .text-content, standalone class absent, single subtitle element
- Title only: subtitle element absent
- Existing disabled/nonEditable button tests still pass

<img width="789" height="285" alt="image" src="https://github.com/user-attachments/assets/3d616fa8-50cc-459d-9631-bdbc9344f921" />


## Review Notes / Questions

The 'primary' → 'normal' kind mapping is a workaround for a mismatch between the options list in index.ts (which offers 'primary' as a user choice) and VButton's kind prop (which doesn't accept it). This was silently broken before kind="primary" was just ignored. The fix is correct but the naming is a bit confusing; might want to revisit the option values in a follow-up.

## Checklist

- [x] Added or updated tests
- [NA] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26751 
