### PR TITLE
fix : AI assistant Keyboard Navigation jumps #26674

### DIFF
--- a/app/src/ai/components/ai-header.vue
+++ b/app/src/ai/components/ai-header.vue
@@ -13,7 +13,7 @@ const aiStore = useAiStore();
 		<AiModelSelector />
 		<div class="spacer" />
 		<VButton v-tooltip.left="$t('ai.clear_conversation')" x-small icon secondary @click="aiStore.reset">
-			<VIcon clickable name="delete_history" small />
+			<VIcon name="delete_history" small />
 		</VButton>
 		<AiSettingsMenu class="settings-menu" />
 	</div>


### PR DESCRIPTION
Fixes keyboard navigation jump in the AI assistant header.

Previously, the Clear Conversation button contained a focus-able VIcon (clickable enabled), which created an extra tab stop. This caused keyboard navigation to require an additional Tab press before reaching the Settings menu.

The fix removes the clickable prop from VIcon, ensuring only the parent VButton remains focusable. This restores correct and expected tab order behaviour.

Fixes #26674