### PR TITLE
fix : AI assistant Keyboard Navigation jumps #26674

### DIFF
--- a/.changeset/.changeset/keyboard-navigation-fix.md
+++ b/.changeset/.changeset/keyboard-navigation-fix.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fix extra tab stop in AI assistant header caused by a focusable VIcon inside VButton.

--- a/.changeset/.changeset/keyboard-navigation-fix.md
+++ b/.changeset/.changeset/keyboard-navigation-fix.md
@@ -1,5 +1,0 @@
----
-"@directus/app": patch
----
-
-Fix extra tab stop in AI assistant header caused by a focusable VIcon inside VButton.

--- a/.changeset/keyboard-navigation-fix.md
+++ b/.changeset/keyboard-navigation-fix.md
@@ -1,5 +1,1 @@
----
-"@directus/app": patch
----
-
-Fix extra tab stop in AI assistant header caused by a focusable VIcon inside VButton.
+Fixed extra tab stop in AI assistant header caused by a focusable VIcon inside VButton.

--- a/.changeset/keyboard-navigation-fix.md
+++ b/.changeset/keyboard-navigation-fix.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fix extra tab stop in AI assistant header caused by a focusable VIcon inside VButton.

--- a/.changeset/keyboard-navigation-fix.md
+++ b/.changeset/keyboard-navigation-fix.md
@@ -1,1 +1,4 @@
+---
+"@directus/app": patch
+---
 Fixed extra tab stop in AI assistant header caused by a focusable VIcon inside VButton.

--- a/app/src/ai/components/ai-header.vue
+++ b/app/src/ai/components/ai-header.vue
@@ -13,7 +13,7 @@ const aiStore = useAiStore();
 		<AiModelSelector />
 		<div class="spacer" />
 		<VButton v-tooltip.left="$t('ai.clear_conversation')" x-small icon secondary @click="aiStore.reset">
-			<VIcon clickable name="delete_history" small />
+			<VIcon name="delete_history" small />
 		</VButton>
 		<AiSettingsMenu class="settings-menu" />
 	</div>

--- a/contributors.yml
+++ b/contributors.yml
@@ -255,3 +255,4 @@
 - powerseed
 - aryanrichhariya1234-lang
 - deepDiverPaul
+- Mugesh13102001


### PR DESCRIPTION
Fixes keyboard navigation jump in the AI assistant header.

Previously, the Clear Conversation button contained a focusable VIcon (clickable enabled), which created an extra tab stop. This caused keyboard navigation to require an additional Tab press before reaching the Settings menu.

The fix removes the clickable prop from VIcon, ensuring only the parent VButton remains focusable. This restores correct and expected tab order behavior.

Fixes #26674