### PR TITLE
Fix CockroachDB Schema Operations Performance Improvements.

### DIFF
--- a/.changeset/forty-ideas-push.md
+++ b/.changeset/forty-ideas-push.md
@@ -1,0 +1,9 @@
+---
+'@directus/api': patch
+---
+
+Fix CockroachDB Schema Operations Performance Improvements #26552, by separate the paths for cockroach DB and
+non-cockroach DB when updating fields. The former no longer calls `addColumnToTable`, because this function creates a
+new column, and uses it to replace the existing one. In non-cockroach DBs, the unchanged parts will be ignored (like the
+column type when you only want to change its default value); but in CockRoach DB, all rows are re-written into the new
+column, therefore the bug.

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -4,6 +4,7 @@ import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, Field, RawField } from '@directus/types';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as cacheModule from '../cache.js';
+import { getDatabaseClient } from '../database/index.js';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import {
 	createMockKnex,
@@ -77,11 +78,13 @@ vi.mock('../utils/should-clear-cache.js', () => ({
 }));
 
 const mockCreateIndexSpy = vi.fn().mockResolvedValue(undefined);
+const mockChangeNullableSpy = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../database/helpers/index.js', () => ({
 	getHelpers: vi.fn(() => ({
 		schema: {
 			createIndex: mockCreateIndexSpy,
+			changeNullable: mockChangeNullableSpy,
 			processFieldType: vi.fn((field) => field.type),
 			preColumnChange: vi.fn().mockResolvedValue(true),
 			postColumnChange: vi.fn().mockResolvedValue(undefined),
@@ -664,6 +667,193 @@ describe('Integration Tests', () => {
 
 				expect(createOneSpy).toHaveBeenCalled();
 			});
+
+			describe('CockroachDB non-type column changes', () => {
+				const existingColumn = {
+					table: 'test_collection',
+					name: 'name',
+					data_type: 'character varying',
+					default_value: null,
+					max_length: 255,
+					numeric_precision: null,
+					numeric_scale: null,
+					is_generated: false,
+					generation_expression: null,
+					is_nullable: true,
+					is_unique: true,
+					is_indexed: false,
+					is_primary_key: false,
+					has_auto_increment: false,
+					foreign_key_column: null,
+					foreign_key_table: null,
+				};
+
+				test('should use raw SQL for default_value change on CockroachDB (bypassing ALTER COLUMN TYPE)', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+					tracker.on.any(/ALTER TABLE/i).response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 'new_default',
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith("ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT 'new_default'", [
+						'test_collection',
+						'name',
+					]);
+
+					// Should NOT have called alterTable (which would trigger ALTER COLUMN TYPE)
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+
+					rawSpy.mockRestore();
+				});
+
+				test('should drop default value on CockroachDB when set to null', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					const existingWithDefault = {
+						...existingColumn,
+						default_value: 'old_default',
+					};
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingWithDefault]);
+
+					tracker.on.select('directus_fields').response([]);
+					tracker.on.any(/ALTER TABLE/i).response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingWithDefault,
+							default_value: null,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? DROP DEFAULT', [
+						'test_collection',
+						'name',
+					]);
+
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+
+					rawSpy.mockRestore();
+				});
+
+				test('should use normal ALTER path on CockroachDB when column type changes', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							max_length: 512, // type-defining property changed
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should use normal ALTER path on non-CockroachDB even for non-type changes', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('postgres');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 'new_default',
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should change nullability on CockroachDB without ALTER COLUMN TYPE', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							is_nullable: false,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(mockChangeNullableSpy).toHaveBeenCalledWith('test_collection', 'name', false);
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
+			});
 		});
 
 		describe('updateFields', () => {
@@ -780,6 +970,29 @@ describe('Integration Tests', () => {
 				await service.deleteField('test_collection', 'name');
 
 				expect(clearSpy).toHaveBeenCalled();
+			});
+
+			test('should bypass outer transaction for CockroachDB', async () => {
+				vi.mocked(getDatabaseClient).mockReturnValueOnce('cockroachdb');
+
+				const service = new FieldsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				// Override default empty response with specific field data
+				tracker.on.select('directus_fields').response([{ collection: 'test_collection', field: 'name' }]);
+				// Mock any DDL queries
+				tracker.on.any(/alter table/i).response([]);
+
+				const deleteByQuerySpy = vi.spyOn(ItemsService.prototype, 'deleteByQuery').mockResolvedValue([]);
+
+				db.schema.table = mockSchemaTable() as any;
+
+				await service.deleteField('test_collection', 'name');
+
+				expect(deleteByQuerySpy).toHaveBeenCalled();
 			});
 		});
 

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -1118,10 +1118,10 @@ describe('Integration Tests', () => {
 
 					await service.updateField('test_collection', field);
 
-					expect(rawSpy).toHaveBeenCalledWith(
-						'ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT gen_random_uuid()',
-						['test_collection', 'name'],
-					);
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT gen_random_uuid()', [
+						'test_collection',
+						'name',
+					]);
 
 					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
 

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -853,6 +853,704 @@ describe('Integration Tests', () => {
 					expect(mockChangeNullableSpy).toHaveBeenCalledWith('test_collection', 'name', false);
 					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
 				});
+
+				test('should use normal ALTER path on CockroachDB when data_type changes', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							data_type: 'text', // type-defining property changed
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should use normal ALTER path on CockroachDB when numeric_precision changes', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const numericColumn = {
+						...existingColumn,
+						data_type: 'numeric',
+						numeric_precision: 10,
+						numeric_scale: 2,
+					};
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([numericColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'decimal',
+						schema: {
+							...numericColumn,
+							numeric_precision: 12,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should use normal ALTER path on CockroachDB when numeric_scale changes', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const numericColumn = {
+						...existingColumn,
+						data_type: 'numeric',
+						numeric_precision: 10,
+						numeric_scale: 2,
+					};
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([numericColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'decimal',
+						schema: {
+							...numericColumn,
+							numeric_scale: 4,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should use normal ALTER path on CockroachDB when has_auto_increment changes', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'integer',
+						schema: {
+							...existingColumn,
+							has_auto_increment: true,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should set default to now() on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 'now()',
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT now()', [
+						'test_collection',
+						'name',
+					]);
+
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+
+					rawSpy.mockRestore();
+				});
+
+				test('should set default to CURRENT_TIMESTAMP on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 'CURRENT_TIMESTAMP',
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT now()', [
+						'test_collection',
+						'name',
+					]);
+
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+
+					rawSpy.mockRestore();
+				});
+
+				test('should set default to CURRENT_TIMESTAMP with precision on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 'CURRENT_TIMESTAMP(3)',
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT CURRENT_TIMESTAMP(3)', [
+						'test_collection',
+						'name',
+					]);
+
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+
+					rawSpy.mockRestore();
+				});
+
+				test('should set default to allowed function (gen_random_uuid) on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 'gen_random_uuid()',
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith(
+						'ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT gen_random_uuid()',
+						['test_collection', 'name'],
+					);
+
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+
+					rawSpy.mockRestore();
+				});
+
+				test('should set numeric default value on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: 42,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT 42', [
+						'test_collection',
+						'name',
+					]);
+
+					rawSpy.mockRestore();
+				});
+
+				test('should set boolean default value on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: true,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT true', [
+						'test_collection',
+						'name',
+					]);
+
+					rawSpy.mockRestore();
+				});
+
+				test('should set false boolean default value on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: false,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT false', [
+						'test_collection',
+						'name',
+					]);
+
+					rawSpy.mockRestore();
+				});
+
+				test('should escape single quotes in string default value on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const rawSpy = vi.spyOn(db, 'raw').mockResolvedValue({} as any);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: "it's a test",
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(rawSpy).toHaveBeenCalledWith("ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT 'it''s a test'", [
+						'test_collection',
+						'name',
+					]);
+
+					rawSpy.mockRestore();
+				});
+
+				test('should throw InvalidPayloadError for non-finite number default on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							default_value: Infinity,
+						},
+					};
+
+					await expect(service.updateField('test_collection', field)).rejects.toThrow(InvalidPayloadError);
+				});
+
+				test('should add unique constraint on CockroachDB without ALTER COLUMN TYPE', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const nonUniqueColumn = {
+						...existingColumn,
+						is_unique: false,
+					};
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([nonUniqueColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...nonUniqueColumn,
+							is_unique: true,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(mockCreateIndexSpy).toHaveBeenCalledWith('test_collection', 'name', { unique: true });
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
+
+				test('should drop unique constraint on CockroachDB without ALTER COLUMN TYPE', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							is_unique: false,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					// alterTable is called for dropUnique, but NOT via the normal addColumnToTable path
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should add index on CockroachDB without ALTER COLUMN TYPE', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							is_indexed: true,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(mockCreateIndexSpy).toHaveBeenCalledWith('test_collection', 'name');
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
+
+				test('should drop index on CockroachDB without ALTER COLUMN TYPE', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const indexedColumn = {
+						...existingColumn,
+						is_indexed: true,
+					};
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([indexedColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					db.schema.alterTable = mockAlterTable() as any;
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...indexedColumn,
+							is_indexed: false,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					// alterTable is called for dropIndex
+					expect(db.schema.alterTable).toHaveBeenCalled();
+				});
+
+				test('should skip unique/index changes for primary key columns on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const primaryKeyColumn = {
+						...existingColumn,
+						is_primary_key: true,
+						is_nullable: false,
+						is_unique: false,
+						is_indexed: false,
+					};
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([primaryKeyColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...primaryKeyColumn,
+							is_unique: true,
+							is_indexed: true,
+						},
+					};
+
+					await service.updateField('test_collection', field);
+
+					expect(mockCreateIndexSpy).not.toHaveBeenCalled();
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
+
+				test('should defer unique creation to addColumnIndex when attemptConcurrentIndex is true on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const nonUniqueColumn = {
+						...existingColumn,
+						is_unique: false,
+					};
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([nonUniqueColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...nonUniqueColumn,
+							is_unique: true,
+						},
+					};
+
+					await service.updateField('test_collection', field, { attemptConcurrentIndex: true });
+
+					// createIndex is called from addColumnIndex (deferred concurrent creation), not inline
+					expect(mockCreateIndexSpy).toHaveBeenCalledWith('test_collection', 'name', {
+						unique: true,
+						attemptConcurrentIndex: true,
+					});
+
+					// Should NOT have used normal ALTER path
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
+
+				test('should defer index creation to addColumnIndex when attemptConcurrentIndex is true on CockroachDB', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+							is_indexed: true,
+						},
+					};
+
+					await service.updateField('test_collection', field, { attemptConcurrentIndex: true });
+
+					// createIndex is called from addColumnIndex (deferred concurrent creation), not inline
+					expect(mockCreateIndexSpy).toHaveBeenCalledWith('test_collection', 'name', {
+						unique: false,
+						attemptConcurrentIndex: true,
+					});
+
+					// Should NOT have used normal ALTER path
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
+
+				test('should use CockroachDB path when no schema changes at all (no-op)', async () => {
+					vi.mocked(getDatabaseClient).mockReturnValue('cockroachdb');
+
+					const service = new FieldsService({
+						knex: db,
+						schema,
+						accountability: null,
+					});
+
+					service.schemaInspector.columnInfo = vi.fn().mockResolvedValue([existingColumn]);
+
+					tracker.on.select('directus_fields').response([]);
+
+					const field: RawField = {
+						field: 'name',
+						type: 'string',
+						schema: {
+							...existingColumn,
+						},
+					};
+
+					// Should not throw and should not call alterTable
+					await service.updateField('test_collection', field);
+
+					expect(mockSchemaBuilder.alterTable).not.toHaveBeenCalled();
+				});
 			});
 		});
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -31,7 +31,7 @@ import { ALIAS_TYPES, ALLOWED_DB_DEFAULT_FUNCTIONS } from '../constants.js';
 import { translateDatabaseError } from '../database/errors/translate.js';
 import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
-import getDatabase, { getSchemaInspector } from '../database/index.js';
+import getDatabase, { getDatabaseClient, getSchemaInspector } from '../database/index.js';
 import emitter from '../emitter.js';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../permissions/lib/fetch-policies.js';
@@ -561,17 +561,27 @@ export class FieldsService {
 				if (!isEqual(columnToCompare, hookAdjustedField.schema)) {
 					try {
 						const attemptConcurrentIndex = Boolean(opts?.attemptConcurrentIndex);
+						const isCockroachDb = getDatabaseClient(this.knex) === 'cockroachdb';
 
-						await transaction(this.knex, async (trx) => {
-							await trx.schema.alterTable(collection, (table) => {
-								if (!hookAdjustedField.schema) return;
+						// On CockroachDB, ALTER COLUMN TYPE fails for columns that are part of an index.
+						// When only non-type properties changed (default_value, is_nullable, etc.),
+						// apply them individually to avoid the unnecessary ALTER COLUMN TYPE.
+						if (isCockroachDb && !this.hasColumnTypeChanged(existingColumn, hookAdjustedField)) {
+							await this.applyNonTypeColumnChanges(collection, hookAdjustedField, existingColumn, {
+								attemptConcurrentIndex,
+							});
+						} else {
+							await transaction(this.knex, async (trx) => {
+								await trx.schema.alterTable(collection, (table) => {
+									if (!hookAdjustedField.schema) return;
 
-								this.addColumnToTable(table, collection, field, {
-									existing: existingColumn,
-									attemptConcurrentIndex,
+									this.addColumnToTable(table, collection, field, {
+										existing: existingColumn,
+										attemptConcurrentIndex,
+									});
 								});
 							});
-						});
+						}
 
 						// concurrent index creation cannot be done inside the transaction
 						if (attemptConcurrentIndex) {
@@ -900,6 +910,138 @@ export class FieldsService {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Checks if the column type-defining properties have changed between the existing column
+	 * and the incoming field schema update. Used on CockroachDB to determine whether we can
+	 * avoid ALTER COLUMN TYPE (which fails for indexed columns).
+	 */
+	private hasColumnTypeChanged(existingColumn: Column, field: RawField): boolean {
+		const schema = field.schema;
+		if (!schema) return false;
+
+		if (schema.data_type !== undefined && schema.data_type !== existingColumn.data_type) return true;
+		if (schema.max_length !== undefined && schema.max_length !== existingColumn.max_length) return true;
+
+		if (schema.numeric_precision !== undefined && schema.numeric_precision !== existingColumn.numeric_precision) {
+			return true;
+		}
+
+		if (schema.numeric_scale !== undefined && schema.numeric_scale !== existingColumn.numeric_scale) return true;
+
+		if (schema.has_auto_increment !== undefined && schema.has_auto_increment !== existingColumn.has_auto_increment) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Applies non-type column changes (default value, nullability, unique, index) individually
+	 * using targeted SQL, avoiding ALTER COLUMN TYPE which CockroachDB doesn't support for
+	 * columns that are part of an index.
+	 */
+	private async applyNonTypeColumnChanges(
+		collection: string,
+		field: RawField,
+		existingColumn: Column,
+		opts?: { attemptConcurrentIndex?: boolean },
+	): Promise<void> {
+		const schema = field.schema;
+		if (!schema) return;
+
+		// Apply default value change
+		if (schema.default_value !== undefined && schema.default_value !== existingColumn.default_value) {
+			if (schema.default_value === null) {
+				await this.knex.raw('ALTER TABLE ?? ALTER COLUMN ?? DROP DEFAULT', [collection, field.field]);
+			} else {
+				const defaultValue = schema.default_value;
+				const isString = typeof defaultValue === 'string';
+				const isNowFunction = isString && defaultValue.toLowerCase() === 'now()';
+				const isCurrentTimestamp = isString && defaultValue === 'CURRENT_TIMESTAMP';
+
+				const isTimestampWithPrecision =
+					isString && defaultValue.includes('CURRENT_TIMESTAMP(') && defaultValue.includes(')');
+
+				const isAllowedFunction = isString && ALLOWED_DB_DEFAULT_FUNCTIONS.includes(defaultValue);
+
+				if (isNowFunction || isCurrentTimestamp) {
+					await this.knex.raw('ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT now()', [collection, field.field]);
+				} else if (isTimestampWithPrecision) {
+					const precision = defaultValue.match(REGEX_BETWEEN_PARENS)![1];
+
+					await this.knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT CURRENT_TIMESTAMP(${Number(precision)})`, [
+						collection,
+						field.field,
+					]);
+				} else if (isAllowedFunction) {
+					// ALLOWED_DB_DEFAULT_FUNCTIONS contains known safe function names (e.g., 'gen_random_uuid()')
+					await this.knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT ${defaultValue}`, [collection, field.field]);
+				} else {
+					// CockroachDB cannot handle parameterized bindings ($1) in DDL SET DEFAULT,
+					// so the value must be embedded as a SQL literal.
+					await this.knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT ${this.toSqlLiteral(defaultValue)}`, [
+						collection,
+						field.field,
+					]);
+				}
+			}
+		}
+
+		// Apply nullability change
+		if (schema.is_nullable !== undefined && schema.is_nullable !== existingColumn.is_nullable) {
+			await this.helpers.schema.changeNullable(collection, field.field, schema.is_nullable);
+		}
+
+		const attemptConcurrentIndex = Boolean(opts?.attemptConcurrentIndex);
+
+		// Apply unique constraint change (concurrent creation is handled by addColumnIndex in the caller)
+		if (schema.is_unique !== undefined && !existingColumn.is_primary_key) {
+			if (schema.is_unique === true && existingColumn.is_unique === false && !attemptConcurrentIndex) {
+				await this.helpers.schema.createIndex(collection, field.field, { unique: true });
+			} else if (schema.is_unique === false && existingColumn.is_unique === true) {
+				const indexName = this.helpers.schema.generateIndexName('unique', collection, field.field);
+
+				await this.knex.schema.alterTable(collection, (table) => {
+					table.dropUnique([field.field], indexName);
+				});
+			}
+		}
+
+		// Apply index change (concurrent creation is handled by addColumnIndex in the caller)
+		if (schema.is_indexed !== undefined && !existingColumn.is_primary_key) {
+			if (schema.is_indexed === true && existingColumn.is_indexed === false && !attemptConcurrentIndex) {
+				await this.helpers.schema.createIndex(collection, field.field);
+			} else if (schema.is_indexed === false && existingColumn.is_indexed === true) {
+				const indexName = this.helpers.schema.generateIndexName('index', collection, field.field);
+
+				await this.knex.schema.alterTable(collection, (table) => {
+					table.dropIndex([field.field], indexName);
+				});
+			}
+		}
+	}
+
+	/**
+	 * Formats a JavaScript value as a safe SQL literal for use in DDL statements
+	 * where parameterized bindings are not supported (e.g., CockroachDB SET DEFAULT).
+	 */
+	private toSqlLiteral(value: unknown): string {
+		if (typeof value === 'number') {
+			if (!Number.isFinite(value)) {
+				throw new InvalidPayloadError({ reason: 'Default value must be a finite number' });
+			}
+
+			return String(value);
+		}
+
+		if (typeof value === 'boolean') {
+			return value ? 'true' : 'false';
+		}
+
+		// For strings and anything else, escape single quotes by doubling them (SQL standard)
+		return `'${String(value).replace(/'/g, "''")}'`;
 	}
 
 	public addColumnToTable(


### PR DESCRIPTION
To fix https://github.com/directus/directus/issues/26552.

The issue mentioned above states two problems:
Issue 1: Transaction Handling Conflicts
Issue 2: Hidden Table Rewrites

Since I cannot reproduce the issues caused by the first, this PR only solves the 2nd. 

Reason for the 2nd issue:
When updating a field, `updateField()` in `api/src/services/fields.ts` calls `addColumnToTable()`, which builds a new column definition, and adds it to the table if a column with the same name doesn't exist, or replaces the existing one. This is because Knex's `alter()` function, which is called inside `addColumnToTable()`, is not incremental. 

When replacing the existing one (which is the case when updating a column), in non-cockroach DBs, the unchanged parts will be ignored (like the column type when you only want to change its default value); but in CockRoach DB, all rows are re-written into the new column, therefore the backfills and slowness. And when the column is indexed, it is not allowed at all, so the transaction fails.

Fix:
In the `updateField()` function stated above, separate the paths for cockroach DB and non-cockroach DB, and apply changes of non-type properties (default_value, is_nullable, etc.) individually instead of calling `addColumnToTable()`. 
This way, there is no using one column to replace another, and therefore no backfills. 

Note:
This is a solution created by AI. I am incapable of understanding the changes as junior dev and new contributor. 
Please review the changes carefully.