### PR TITLE
Correct field editability for conditional update policies and version items

### DIFF
--- a/.changeset/thin-files-film.md
+++ b/.changeset/thin-files-film.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Corrected field editability for conditional update policies and version items

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -74,7 +74,8 @@ export function useItem<T extends Item>(
 		return item.value?.[collectionInfo.value.meta.archive_field] === collectionInfo.value.meta.archive_value;
 	});
 
-	const permissions = usePermissions(collection, primaryKey, isNew);
+	const isVersion = computed(() => !!unref(query).version);
+	const permissions = usePermissions(collection, primaryKey, isNew, isVersion);
 	const fieldsWithPermissions = permissions.itemPermissions.fields;
 
 	const loading = computed(() => loadingItem.value || permissions.itemPermissions.loading.value);

--- a/app/src/composables/use-permissions/index.ts
+++ b/app/src/composables/use-permissions/index.ts
@@ -9,7 +9,12 @@ export type UsablePermissions = {
 	itemPermissions: UsableItemPermissions & { saveAllowed: ComputedRef<boolean> };
 };
 
-export function usePermissions(collection: Collection, primaryKey: PrimaryKey, isNew: IsNew, isVersion: IsNew = false): UsablePermissions {
+export function usePermissions(
+	collection: Collection,
+	primaryKey: PrimaryKey,
+	isNew: IsNew,
+	isVersion: IsNew = false,
+): UsablePermissions {
 	const collectionPermissions = useCollectionPermissions(collection);
 
 	const itemPermissions = useItemPermissions(collection, primaryKey, isNew, isVersion);

--- a/app/src/composables/use-permissions/index.ts
+++ b/app/src/composables/use-permissions/index.ts
@@ -9,10 +9,10 @@ export type UsablePermissions = {
 	itemPermissions: UsableItemPermissions & { saveAllowed: ComputedRef<boolean> };
 };
 
-export function usePermissions(collection: Collection, primaryKey: PrimaryKey, isNew: IsNew): UsablePermissions {
+export function usePermissions(collection: Collection, primaryKey: PrimaryKey, isNew: IsNew, isVersion: IsNew = false): UsablePermissions {
 	const collectionPermissions = useCollectionPermissions(collection);
 
-	const itemPermissions = useItemPermissions(collection, primaryKey, isNew);
+	const itemPermissions = useItemPermissions(collection, primaryKey, isNew, isVersion);
 
 	const saveAllowed = isSaveAllowed(isNew, collectionPermissions.createAllowed, itemPermissions.updateAllowed);
 

--- a/app/src/composables/use-permissions/item/lib/get-fields.test.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.test.ts
@@ -389,6 +389,51 @@ describe('non-admin users', () => {
 			}
 		});
 
+		it('should use store permission for versions even when main item fails custom rule', () => {
+			const permissionsStore = mockedStore(usePermissionsStore());
+
+			permissionsStore.getPermission.mockImplementation((_, action) => {
+				if (action === 'update') return { access: 'partial', fields: ['*'] };
+				return null;
+			});
+
+			fetchedItemPermissions = computed(() => ({
+				update: { access: false }, // main item fails condition
+				delete: { access: false },
+				share: { access: false },
+			}));
+
+			const fields = getFields(sample.collection, false, fetchedItemPermissions, true);
+
+			for (const field of fields.value) {
+				expect(!!field.meta?.readonly).toBe(false);
+			}
+		});
+
+		it('should apply store field restrictions for versions when main item fails custom rule', () => {
+			const allowedFields = ['id', 'start_date'];
+
+			const permissionsStore = mockedStore(usePermissionsStore());
+
+			permissionsStore.getPermission.mockImplementation((_, action) => {
+				if (action === 'update') return { access: 'partial', fields: allowedFields };
+				return null;
+			});
+
+			fetchedItemPermissions = computed(() => ({
+				update: { access: false }, // main item fails condition
+				delete: { access: false },
+				share: { access: false },
+			}));
+
+			const fields = getFields(sample.collection, false, fetchedItemPermissions, true);
+
+			for (const field of fields.value) {
+				const readonly = allowedFields.includes(field.field) ? undefined : true;
+				expect(field.meta?.readonly).toBe(readonly);
+			}
+		});
+
 		it('should use store create permission for new items regardless of partial access', () => {
 			const permissionsStore = mockedStore(usePermissionsStore());
 

--- a/app/src/composables/use-permissions/item/lib/get-fields.test.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.test.ts
@@ -180,7 +180,7 @@ describe('non-admin users', () => {
 		const permissionActions: PermissionsAction[] = ['create', 'update'];
 
 		describe.each(permissionActions)('%s', (testAction) => {
-			it('should mark all fields as read-only if user has no (fields) permission', () => {
+			it('should mark all fields as read-only if user has no update/create permission', () => {
 				if (collectionType === 'collection') {
 					const permissionsStore = mockedStore(usePermissionsStore());
 
@@ -341,6 +341,27 @@ describe('non-admin users', () => {
 			for (const field of fields.value) {
 				expect(field.meta?.readonly).toBe(true);
 				expect((field as FormField).meta?.non_editable).toBe(true);
+			}
+		});
+
+		it('should not restrict fields when partial access has no field restriction and item passes custom rule', () => {
+			const permissionsStore = mockedStore(usePermissionsStore());
+
+			permissionsStore.getPermission.mockImplementation((_, action) => {
+				if (action === 'update') return { access: 'partial' }; // no fields property
+				return null;
+			});
+
+			fetchedItemPermissions = computed(() => ({
+				update: { access: true }, // item passes condition
+				delete: { access: false },
+				share: { access: false },
+			}));
+
+			const fields = getFields(sample.collection, false, fetchedItemPermissions);
+
+			for (const field of fields.value) {
+				expect(!!field.meta?.readonly).toBe(false);
 			}
 		});
 

--- a/app/src/composables/use-permissions/item/lib/get-fields.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.ts
@@ -7,7 +7,7 @@ import type { FormField } from '@/components/v-form/types';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useUserStore } from '@/stores/user';
 
-export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermissions: Ref<ItemPermissions>) {
+export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermissions: Ref<ItemPermissions>, isVersion: IsNew = false) {
 	const userStore = useUserStore();
 	const { getPermission } = usePermissionsStore();
 	const { fields: rawFields, info: collectionInfo } = useCollection(ref(collection));
@@ -39,14 +39,24 @@ export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermi
 
 			if (storePermission?.access !== 'partial') {
 				permission = storePermission;
+			} else if (unref(isVersion) || fetchedItemPermissions.value.update.access) {
+				permission = storePermission;
 			} else {
-				permission = fetchedItemPermissions.value.update.access ? storePermission : null;
+				permission = null;
 			}
 		}
 
-		if (!permission?.fields?.includes('*')) {
+		if (!permission || permission.access === false) {
 			for (const field of fields) {
-				if (!permission?.fields?.includes(field.field)) {
+				(field as FormField).meta = {
+					...(field.meta || {}),
+					readonly: true,
+					non_editable: true,
+				};
+			}
+		} else if (permission.fields && !permission.fields.includes('*')) {
+			for (const field of fields) {
+				if (!permission.fields.includes(field.field)) {
 					(field as FormField).meta = {
 						...(field.meta || {}),
 						readonly: true,

--- a/app/src/composables/use-permissions/item/lib/get-fields.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.ts
@@ -7,7 +7,12 @@ import type { FormField } from '@/components/v-form/types';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useUserStore } from '@/stores/user';
 
-export function getFields(collection: Collection, isNew: IsNew, fetchedItemPermissions: Ref<ItemPermissions>, isVersion: IsNew = false) {
+export function getFields(
+	collection: Collection,
+	isNew: IsNew,
+	fetchedItemPermissions: Ref<ItemPermissions>,
+	isVersion: IsNew = false,
+) {
 	const userStore = useUserStore();
 	const { getPermission } = usePermissionsStore();
 	const { fields: rawFields, info: collectionInfo } = useCollection(ref(collection));

--- a/app/src/composables/use-permissions/item/use-item-permissions.ts
+++ b/app/src/composables/use-permissions/item/use-item-permissions.ts
@@ -21,6 +21,7 @@ export function useItemPermissions(
 	collection: Collection,
 	primaryKey: PrimaryKey,
 	isNew: IsNew,
+	isVersion: IsNew = false,
 ): UsableItemPermissions {
 	const { loading, fetchedItemPermissions, refresh } = fetchItemPermissions(collection, primaryKey);
 
@@ -30,7 +31,7 @@ export function useItemPermissions(
 
 	const archiveAllowed = isArchiveAllowed(collection, updateAllowed);
 
-	const fields = getFields(collection, isNew, fetchedItemPermissions);
+	const fields = getFields(collection, isNew, fetchedItemPermissions, isVersion);
 
 	return { loading, refresh, updateAllowed, deleteAllowed, shareAllowed, archiveAllowed, fields };
 }


### PR DESCRIPTION
## Scope

What's changed:

- Fix fields being incorrectly marked as `non_editable` for items where the update policy has conditional access but no explicit field restriction (`fields: undefined` was treated as "no fields allowed")
- Fix content version items having all fields locked when the main item fails a permission condition — version editing now uses store permissions directly, bypassing the `fetchedItemPermissions` check that evaluates against the wrong (main) item data
- Introduce `isVersion` flag to `useItem`, `usePermissions`, `useItemPermissions`, `getFields` to identify when a version is being edited

## Potential Risks / Drawbacks

- The version fix is optimistic on the frontend: permission conditions are skipped entirely for version items rather than evaluated against the merged version data. If a version's merged data should fail the condition (e.g. version re-introduces a value that violates the rule), fields will appear editable but the backend will reject the save. The root cause (backend evaluating conditions against the main item row instead of merged version data) remains and would require a separate backend fix.

## Tested Scenarios

- Non-admin user with `update` policy conditioned on `status != published` can edit fields on a draft item
- Non-admin user editing a content version (main item `status=published`, version `status=draft`, condition `status=draft`) can edit fields
- When a non-version item fails its permission condition (partial access, condition not met), all fields remain non-editable

## Review Notes / Questions

- I would like reviewers to confirm the trade-off is acceptable: version items bypass `fetchedItemPermissions` entirely, relying on the backend to enforce condition checks on save. A follow-up issue should track the proper backend fix (`GET /permissions/me/{collection}/{pk}?version={versionId}` evaluating conditions against merged data). Already agreed with @formfcw 

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26721