### PR TITLE
Fix block editor deleting/duplicating blocks on "save and stay"

### DIFF
--- a/.changeset/new-signs-sort.md
+++ b/.changeset/new-signs-sort.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed block editor deleting/duplicating blocks on "save and stay"

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -11,6 +11,67 @@ vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock('@/utils/unexpected-error', () => ({ unexpectedError: vi.fn() }));
 
 describe('InputBlockEditor', () => {
+	it('should not re-render after save-and-stay', async () => {
+		const blocksA = [{ type: 'paragraph', data: { text: 'first edit' } }];
+		const blocksB = [{ type: 'paragraph', data: { text: 'second edit' } }];
+		let resolveReady!: () => void;
+		let onChange!: (api: EditorJS.API) => Promise<void>;
+
+		const mockSave = vi
+			.fn()
+			.mockResolvedValueOnce({ blocks: blocksA }) // first emitValue call
+			.mockResolvedValueOnce({ blocks: blocksB }) // second emitValue call
+			.mockResolvedValue({ blocks: blocksB }); // watcher's save() call — editor still has blocksB
+
+		const mockRender = vi.fn().mockResolvedValue(undefined);
+
+		const mockInstance = {
+			isReady: new Promise<void>((r) => (resolveReady = r)),
+			render: mockRender,
+			clear: vi.fn(),
+			destroy: vi.fn(),
+			focus: vi.fn(),
+			on: vi.fn(),
+			saver: { save: mockSave },
+			readOnly: { toggle: vi.fn(), isEnabled: false },
+		};
+
+		vi.mocked(EditorJS).mockImplementation((config) => {
+			if (config && typeof config !== 'string') {
+				onChange = config.onChange as unknown as typeof onChange;
+			}
+
+			return mockInstance as unknown as EditorJS;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: { value: null },
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		resolveReady();
+
+		// First edit: editor content becomes blocksA, haveValuesChanged = true
+		await onChange(mockInstance as unknown as EditorJS.API);
+
+		// Second edit before server responds: editor content becomes blocksB, haveValuesChanged still true
+		await onChange(mockInstance as unknown as EditorJS.API);
+
+		// Server responds to first edit with blocksA — absorbed by haveValuesChanged, resets to false
+		await wrapper.setProps({ value: { blocks: blocksA } });
+
+		// Server responds to second edit with blocksB.
+		await wrapper.setProps({ value: { blocks: blocksB } });
+
+		// render should never have been called
+		expect(mockRender).not.toHaveBeenCalled();
+
+		wrapper.unmount();
+	});
+
 	it('should render content before toggling readOnly on concurrent prop change', async () => {
 		const callOrder: string[] = [];
 		let resolveReady!: () => void;
@@ -32,7 +93,7 @@ describe('InputBlockEditor', () => {
 					readOnly: {
 						toggle: vi.fn((val: boolean) => callOrder.push(`toggle:${val}`)),
 					},
-				}) as any,
+				}) as unknown as EditorJS,
 		);
 
 		const wrapper = mount(InputBlockEditor, {

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -138,12 +138,6 @@ watch(
 
 			if (editorjsRef.value.readOnly.isEnabled) return;
 
-			const currentData = await editorjsRef.value.save();
-			const currentBlocks = currentData.blocks?.length ? currentData.blocks : null;
-			const incomingBlocks = sanitizedValue?.blocks?.length ? sanitizedValue.blocks : null;
-
-			if (isEqual(incomingBlocks, currentBlocks)) return;
-
 			if (sanitizedValue) {
 				await editorjsRef.value.render(sanitizedValue);
 			} else {

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -136,6 +136,14 @@ watch(
 		try {
 			const sanitizedValue = sanitizeValue(newVal);
 
+			if (editorjsRef.value.readOnly.isEnabled) return;
+
+			const currentData = await editorjsRef.value.save();
+			const currentBlocks = currentData.blocks?.length ? currentData.blocks : null;
+			const incomingBlocks = sanitizedValue?.blocks?.length ? sanitizedValue.blocks : null;
+
+			if (isEqual(incomingBlocks, currentBlocks)) return;
+
 			if (sanitizedValue) {
 				await editorjsRef.value.render(sanitizedValue);
 			} else {


### PR DESCRIPTION
 ## Scope                                                                                                          
                  
  What's changed:

  - Fixed block editor re-rendering when a prop update arrives with data identical to what the editor already
  contains
  - Added a test case covering the save-and-stay regression

  ## Potential Risks / Drawbacks

  - None I can think of

  ## Tested Scenarios

  - "Save and stay" on a block editor item no longer deletes or resets blocks
  - Existing read-only toggle test still passes

  ## Review Notes / Questions

  ## Checklist

  - [x] Added or updated tests
  - [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
  
  Fixes #26791
