### PR TITLE
Fix reset confirm state after flow error

### DIFF
--- a/.changeset/gentle-bears-mate.md
+++ b/.changeset/gentle-bears-mate.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Reset confirm state after flow error

--- a/.changeset/gentle-bears-mate.md
+++ b/.changeset/gentle-bears-mate.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Reset confirm state after flow error
+Fixed reset confirm state after flow error

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -399,6 +399,43 @@ describe('runManualFlow', () => {
 		expect(mockOnRefresh).toHaveBeenCalledOnce();
 	});
 
+	test('resets confirm state after flow API error, showing dialog again on next trigger', async () => {
+		const flowWithConfirm = {
+			id: 'flow-confirm',
+			name: 'Flow Confirm',
+			trigger: 'manual',
+			status: 'active',
+			options: {
+				collections: ['test_collection'],
+				location: 'collection',
+				requireConfirmation: true,
+				confirmationDescription: 'Are you sure?',
+				fields: [],
+			},
+		};
+
+		const mockFlowsStore = {
+			getManualFlowsForCollection: vi.fn().mockReturnValue([flowWithConfirm]),
+		};
+
+		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
+		vi.mocked(api.post).mockRejectedValue(new Error('Flow step error'));
+
+		const testOptions = { ...useFlowsOptions, hasEdits: ref(false) };
+		const { runManualFlow, flowDialogsContext } = useFlows(testOptions);
+
+		await runManualFlow(flowWithConfirm.id);
+		expect(flowDialogsContext.value.displayCustomConfirmDialog).toBe(true);
+
+		flowDialogsContext.value.confirmCustomDialog(flowWithConfirm.id);
+		await nextTick();
+
+		expect(flowDialogsContext.value.currentFlowId).toBeNull();
+
+		await runManualFlow(flowWithConfirm.id);
+		expect(flowDialogsContext.value.displayCustomConfirmDialog).toBe(true);
+	});
+
 	test('calls runFlow with reactive primaryKey', async () => {
 		const mockFlowsStore = {
 			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),

--- a/app/src/composables/use-flows.ts
+++ b/app/src/composables/use-flows.ts
@@ -248,11 +248,10 @@ export function useFlows(options: UseFlowsOptions) {
 			});
 
 			await notificationStore.refreshUnreadCount();
-
-			resetConfirm();
 		} catch (error) {
 			unexpectedError(error);
 		} finally {
+			resetConfirm();
 			runningFlows.value = runningFlows.value.filter((runningFlow) => runningFlow !== flowId);
 		}
 	}


### PR DESCRIPTION
## Scope

What's changed:

- Move `resetConfirm()` from the `try` block to the `finally` block in `runManualFlow` so confirmation state is always cleared after a flow attempt, regardless of success or failure

## Potential Risks / Drawbacks

## Tested Scenarios

- Trigger a flow with a confirmation dialog, confirm it, have the flow fail (e.g. a step throws an error): the dialog appears again on the next trigger
- Trigger a flow successfully: dialog still resets as before (no regression)

## Review Notes / Questions

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26797