### PR TITLE
Fix keepMounted logic in VDialog

### DIFF
--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -115,10 +115,9 @@ function useOverlayFocusTrap() {
 				<component
 					:is="placement === 'center' ? 'span' : 'div'"
 					v-if="internalActive || keepMounted"
-					v-show="!keepMounted || internalActive"
 					ref="overlayEl"
 					class="container"
-					:class="[className, placement, keepBehind ? 'keep-behind' : null]"
+					:class="[className, placement, keepBehind ? 'keep-behind' : null, { show: !keepMounted || internalActive }]"
 				>
 					<VOverlay active absolute @click="emitToggle" />
 					<slot />
@@ -140,9 +139,13 @@ function useOverlayFocusTrap() {
 	inset-block-start: 0;
 	inset-inline-start: 0;
 	z-index: 500;
-	display: flex;
 	inline-size: 100%;
 	block-size: 100%;
+	display: none;
+
+	&.show {
+		display: flex;
+	}
 
 	&.keep-behind {
 		z-index: 490;


### PR DESCRIPTION
## Scope

What's changed:

- VDialogs recently added keepMounted logic was used in v-show which toggles display none and block. However, instead of block it should be flex.

Follow-up of https://github.com/directus/directus/pull/26731