### PR TITLE
Add fallback to undefined in v-upload file import

### DIFF
--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -344,7 +344,7 @@ function useURLImport() {
 			const response = await api.post(`/files/import`, {
 				url: url.value,
 				data,
-				options: { filterMimeType: props.accept ? props.accept.split(',') : '' },
+				options: { filterMimeType: props.accept?.split(',') },
 			});
 
 			newUpload.progress.value = 100;


### PR DESCRIPTION
## Scope

What's changed:

- Implemented a fallback to `undefined` for the `filterMimeType` option in the file import call.
  
## Potential Risks / Drawbacks

- None identified.

## Tested Scenarios

- Verified that file imports function correctly with and without the `accept` prop.

## Review Notes / Questions

- I would like to confirm if additional edge cases need testing.
- Special attention should be paid to the behavior when `accept` is not provided.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes NA

