### PR TITLE
Fix block editor deleting blocks on save-and-stay

### DIFF
--- a/.changeset/moody-windows-kick.md
+++ b/.changeset/moody-windows-kick.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed block editor deleting blocks on save-and-stay

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -68,4 +68,48 @@ describe('InputBlockEditor', () => {
 		await flushPromises();
 		wrapper.unmount();
 	});
+
+	it('should not clear content when value becomes null while disabled', async () => {
+		// This test should prevent a regression that results in data loss when the value is temporarily null and the field is disabled
+		const clear = vi.fn();
+
+		vi.mocked(EditorJS).mockImplementation(
+			() =>
+				({
+					isReady: Promise.resolve(),
+					render: vi.fn().mockResolvedValue(undefined),
+					clear,
+					destroy: vi.fn(),
+					focus: vi.fn(),
+					on: vi.fn(),
+					saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
+					readOnly: {
+						toggle: vi.fn(),
+					},
+				}) as any,
+		);
+
+		const wrapper = mount(InputBlockEditor, {
+			props: {
+				disabled: false,
+				value: { blocks: [{ type: 'paragraph', data: { text: 'initial' } }] },
+			},
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+
+		await wrapper.setProps({ disabled: true });
+		await flushPromises();
+
+		await wrapper.setProps({ value: null });
+		await flushPromises();
+
+		expect(clear).not.toHaveBeenCalled();
+
+		wrapper.unmount();
+	});
 });

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -126,6 +126,9 @@ watch(
 		// First value will be set in 'onMounted'
 		if (!editorjsRef.value || !editorjsIsReady.value) return;
 
+		// During refresh, item is temporarily null and the field is disabled — skip to avoid clearing the editor
+		if (newVal === null && props.disabled) return;
+
 		if (haveValuesChanged.value) {
 			haveValuesChanged.value = false;
 			return;


### PR DESCRIPTION
## Scope

What's changed:

- Guard against clearing block editor content when value becomes null during a save-and-stay refresh. The item is temporarily set to null while refetching, which the watcher interpreted as "clear the editor", deleting
  blocks.

## Potential Risks / Drawbacks

- The guard checks for null && disabled specifically, so it only skips when the field is disabled (i.e. during refresh). A genuinely null value on an enabled field still clears as before.
- Low risk overall. Narrow condition, no behavior change outside the refresh scenario.

## Tested Scenarios

- Save and stay on item with block editor content: blocks are preserved
- Setting a block editor field to empty on an enabled field still works as expected

## Review Notes / Questions

—

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26791