### PR TITLE
feature: allow dropdown display for unknown fields

### DIFF
--- a/app/src/interfaces/select-dropdown/index.ts
+++ b/app/src/interfaces/select-dropdown/index.ts
@@ -8,7 +8,7 @@ export default defineInterface({
 	description: '$t:interfaces.select-dropdown.description',
 	icon: 'arrow_drop_down_circle',
 	component: InterfaceSelectDropdown,
-	types: ['string', 'integer', 'float', 'decimal', 'bigInteger'],
+	types: ['string', 'integer', 'float', 'decimal', 'bigInteger', 'unknown'],
 	group: 'selection',
 	preview: PreviewSVG,
 	options: ({ field }) => [


### PR DESCRIPTION
## Scope

What's changed:

This change allows to select the "dropdown" interface for "unknown" column types. As discussed in #4887 enums from Postgres are unknown fields and therefore only provide a text input field. This change allows to also choose the dropdown type.

## Potential Risks / Drawbacks

Valid enum values still need to be manually entered and potentially kept in sync with the database, as the enum changes. A more sophisticated solution would query the available values from the database, but that creates a larger problem how to support this across different database adapters

## Tested Scenarios

- Created a database with an unsupported type
- Field shows as "unknown" in the UI
- User can choose a dropdown as interface
- Values can be selected from the dropdown when creating/editing a row

<img width="1694" height="678" alt="CleanShot 2026-03-04 at 23 21 54@2x" src="https://github.com/user-attachments/assets/691e306a-170b-4494-b7d6-0922d7895f72" />
<img width="1684" height="836" alt="CleanShot 2026-03-04 at 23 22 01@2x" src="https://github.com/user-attachments/assets/afb94d3f-7172-4f7d-93c7-217c0546527f" />
<img width="1416" height="422" alt="CleanShot 2026-03-04 at 23 22 16@2x" src="https://github.com/user-attachments/assets/5456e23b-091a-4a1c-8fea-94e5ea90c554" />