### PR TITLE
Enforce MIME type allow list on remaining v-uploads not previously covered

### DIFF
--- a/.changeset/khaki-buses-joke.md
+++ b/.changeset/khaki-buses-joke.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Enforced MIME type allow list on remaining v-uploads missed in first round

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -13,6 +13,7 @@ import VNotice from '@/components/v-notice.vue';
 import VRemove from '@/components/v-remove.vue';
 import VSkeletonLoader from '@/components/v-skeleton-loader.vue';
 import VUpload from '@/components/v-upload.vue';
+import { useMimeTypeFilter } from '@/composables/use-mime-type-filter';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
 import { useRelationPermissionsM2O } from '@/composables/use-relation-permissions';
 import { RelationQuerySingle, useRelationSingle } from '@/composables/use-relation-single';
@@ -191,6 +192,8 @@ const menuActive = computed(
 );
 
 const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo);
+
+const { combinedAcceptString } = useMimeTypeFilter(computed(() => ['image/*']));
 </script>
 
 <template>
@@ -298,7 +301,7 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 			:folder="folder"
 			:filter="customFilter"
 			:disabled="internalDisabled"
-			accept="image/*"
+			:accept="combinedAcceptString"
 			@input="onUpload"
 		/>
 	</div>

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -7,6 +7,7 @@ vi.mock('@editorjs/editorjs', () => ({ default: vi.fn() }));
 vi.mock('./tools', () => ({ default: vi.fn(() => ({})) }));
 vi.mock('@/api', () => ({ default: { defaults: { baseURL: '' } } }));
 vi.mock('@/stores/collections', () => ({ useCollectionsStore: () => ({ getCollection: () => null }) }));
+vi.mock('@/stores/server', () => ({ useServerStore: () => ({ info: { files: { mimeTypeAllowList: null } } }) }));
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock('@/utils/unexpected-error', () => ({ unexpectedError: vi.fn() }));
 

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -10,7 +10,9 @@ import { useFileHandler } from './use-file-handler';
 import api from '@/api';
 import VDrawer from '@/components/v-drawer.vue';
 import VUpload from '@/components/v-upload.vue';
+import { parseGlobalMimeTypeAllowList } from '@/composables/use-mime-type-filter';
 import { useCollectionsStore } from '@/stores/collections';
+import { useServerStore } from '@/stores/server';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 import './editorjs-overrides.css';
@@ -43,6 +45,8 @@ const bus = useBus();
 const emit = defineEmits<{ input: [value: EditorJS.OutputData | null] }>();
 
 const collectionStore = useCollectionsStore();
+const { info } = useServerStore();
+const allowedMimeTypes = computed(() => parseGlobalMimeTypeAllowList(info.files?.mimeTypeAllowList)?.join(','));
 
 const { currentPreview, setCurrentPreview, fileHandler, setFileHandler, unsetFileHandler, handleFile } =
 	useFileHandler();
@@ -201,6 +205,7 @@ const menuActive = computed(() => fileHandler.value !== null);
 					:folder="folder"
 					from-library
 					from-url
+					:accept="allowedMimeTypes"
 					@input="handleFile"
 				/>
 			</div>

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -31,8 +31,10 @@ import VTextarea from '@/components/v-textarea.vue';
 import VUpload from '@/components/v-upload.vue';
 import { useInjectFocusTrapManager } from '@/composables/use-focus-trap-manager';
 import { useFocusin } from '@/composables/use-focusin';
+import { parseGlobalMimeTypeAllowList } from '@/composables/use-mime-type-filter';
 import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
 import { i18n } from '@/lang';
+import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -99,6 +101,8 @@ const comparisonEditorKey = ref(0);
 
 const { imageToken } = toRefs(props);
 const settingsStore = useSettingsStore();
+const { info } = useServerStore();
+const allowedMimeTypes = computed(() => parseGlobalMimeTypeAllowList(info.files?.mimeTypeAllowList)?.join(','));
 
 const storageAssetTransform = ref('all');
 const storageAssetPresets = ref<SettingsStorageAssetPreset[]>([]);
@@ -597,7 +601,15 @@ const menuActive = computed(
 						</div>
 					</div>
 				</template>
-				<VUpload v-else :multiple="false" from-library from-url :folder="folder" @input="onImageSelect" />
+				<VUpload
+					v-else
+					:multiple="false"
+					from-library
+					from-url
+					:folder="folder"
+					:accept="allowedMimeTypes"
+					@input="onImageSelect"
+				/>
 			</div>
 
 			<template #actions>
@@ -647,7 +659,15 @@ const menuActive = computed(
 								</div>
 							</div>
 						</template>
-						<VUpload v-else :multiple="false" from-library from-url :folder="folder" @input="onMediaSelect" />
+						<VUpload
+							v-else
+							:multiple="false"
+							from-library
+							from-url
+							:folder="folder"
+							:accept="allowedMimeTypes"
+							@input="onMediaSelect"
+						/>
 					</VTabItem>
 					<VTabItem value="embed">
 						<div class="grid">

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -18,8 +18,10 @@ import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
 import VUpload from '@/components/v-upload.vue';
+import { parseGlobalMimeTypeAllowList } from '@/composables/use-mime-type-filter';
 import { useShortcut } from '@/composables/use-shortcut';
 import { useWindowSize } from '@/composables/use-window-size';
+import { useServerStore } from '@/stores/server';
 import { getAssetUrl } from '@/utils/get-asset-url';
 import { percentage } from '@/utils/percentage';
 import { translateShortcut } from '@/utils/translate-shortcut';
@@ -68,6 +70,9 @@ const props = withDefaults(
 );
 
 const emit = defineEmits(['input']);
+
+const { info } = useServerStore();
+const allowedMimeTypes = computed(() => parseGlobalMimeTypeAllowList(info.files?.mimeTypeAllowList)?.join(','));
 
 const { width } = useWindowSize();
 
@@ -426,7 +431,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 			<VCard>
 				<VCardTitle>{{ $t('upload_from_device') }}</VCardTitle>
 				<VCardText>
-					<VUpload from-url from-library :folder="folder" @input="onImageUpload" />
+					<VUpload from-url from-library :folder="folder" :accept="allowedMimeTypes" @input="onImageUpload" />
 				</VCardText>
 				<VCardActions>
 					<VButton secondary @click="imageDialogOpen = false">{{ $t('cancel') }}</VButton>

--- a/app/src/views/private/components/file-preview-replace.test.ts
+++ b/app/src/views/private/components/file-preview-replace.test.ts
@@ -1,9 +1,11 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import FilePreviewReplace from './file-preview-replace.vue';
 import { Tooltip } from '@/__utils__/tooltip';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
+
+vi.mock('@/stores/server', () => ({ useServerStore: () => ({ info: { files: { mimeTypeAllowList: null } } }) }));
 
 beforeEach(() => {
 	for (const id of ['menu-outlet', 'dialog-outlet']) {

--- a/app/src/views/private/components/file-preview-replace.vue
+++ b/app/src/views/private/components/file-preview-replace.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
 import VCardText from '@/components/v-card-text.vue';
@@ -7,9 +7,15 @@ import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VUpload from '@/components/v-upload.vue';
+import { parseGlobalMimeTypeAllowList } from '@/composables/use-mime-type-filter';
+import { useServerStore } from '@/stores/server';
 import FilePreview, { type Props as FilePreviewProps } from '@/views/private/components/file-preview.vue';
 
 defineProps<FilePreviewProps>();
+
+const { info } = useServerStore();
+
+const allowedMimeTypes = computed(() => parseGlobalMimeTypeAllowList(info.files?.mimeTypeAllowList)?.join(','));
 
 const emit = defineEmits<{
 	click: [];
@@ -40,7 +46,7 @@ function close() {
 			<VCard>
 				<VCardTitle>{{ $t('replace_file') }}</VCardTitle>
 				<VCardText>
-					<VUpload :file-id="file.id" from-url @input="onInput" />
+					<VUpload :file-id="file.id" from-url :accept="allowedMimeTypes" @input="onInput" />
 				</VCardText>
 				<VCardActions>
 					<VButton secondary @click="close">{{ $t('done') }}</VButton>


### PR DESCRIPTION
 ## Scope    
                                                                             
  What's changed:
                                                                                                                                                         
  - Enforced global MIME type allow list on all remaining `v-upload` usages not covered by #26647

 ## Potential Risks / Drawbacks

  - None I can think of

 ## Tested Scenarios

  - Verified the replace file dialog, block editor, and both rich text editors all respect the global allow list

 ## Review Notes / Questions
Existing tests should suffice since it covers the composable that provides the functionality.

 ## Checklist

  - [x] Added or updated tests (tests already exist)
  - [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

  ---

  Fixes [#prod-2006](https://linear.app/directus/issue/PROD-2006/enforce-mime-types-everywhere-v-upload-is-used)