### PR TITLE
Fix unable to click on m2o fields arrow icon to open drawer

### DIFF
--- a/.changeset/wild-yaks-post.md
+++ b/.changeset/wild-yaks-post.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fix unable to click on m2o fields arrow icon to open drawer
+Fixed unable to click on m2o fields arrow icon to open drawer

--- a/.changeset/wild-yaks-post.md
+++ b/.changeset/wild-yaks-post.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix unable to click on m2o fields arrow icon to open drawer

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -261,7 +261,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 						@click="editModalActive = true"
 					/>
 
-					<VIcon v-if="enableSelect" class="expand" name="expand_more" />
+					<VIcon v-if="enableSelect" class="expand" name="expand_more" clickable @click="selectModalActive = true" />
 				</template>
 			</div>
 		</VListItem>


### PR DESCRIPTION
                                                                                                                
##Scope                                                                                                                                                                                                   
                  
  What's changed:

  - Gave select-m2o its own click handler instead of delegating to the parent container

  ## Potential Risks / Drawbacks

  - Low risk

  ## Tested Scenarios

  - Clicking the expand arrow icon on an M2O field opens the select drawer

  ## Review Notes / Questions

  - The root cause was that the arrow icon had no click handler of its own and depended on bubbling, but the bubbling is now prevented on the parent after this PR #26711

  ## Checklist

  - [ ] Added or updated tests
  - [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

 ---

Fixes #26820
