### PR TITLE
fix(composables): eliminate redundant count API requests in useItems

### DIFF
--- a/.changeset/fix-use-items-redundant-count-requests.md
+++ b/.changeset/fix-use-items-redundant-count-requests.md
@@ -1,0 +1,16 @@
+---
+'@directus/composables': patch
+---
+
+fix(composables): eliminate redundant API count requests in `useItems`
+
+Merged the two separate `watch` blocks in `useItems` into a single one that
+also watches `filterSystem`. A new `shouldUpdateTotal` flag is derived from
+collection or `filterSystem` changes, and `getTotalCount` is now called
+inside the throttled `fetchItems` alongside `getItems` and `getItemCount`.
+
+This removes the duplicate `aggregate[countDistinct]` requests that occurred
+on page init, route navigation, and bookmark switching — reducing up to 3
+redundant count calls down to 1 per trigger.
+
+Fixes #25194

--- a/contributors.yml
+++ b/contributors.yml
@@ -258,3 +258,4 @@
 - deepDiverPaul
 - tysoncung
 - Mugesh13102001
+- vharsh43

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -73,17 +73,21 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
 	// Throttle is used to ensure we send the first trigger instantly, debounce will not.
-	const fetchItems = throttle((shouldUpdateCount: boolean) => {
-		Promise.all([getItems(), shouldUpdateCount ? getItemCount() : Promise.resolve()]);
-	}, 500);
+	const fetchItems = throttle((shouldUpdateCount: boolean, shouldUpdateTotal: boolean = false) => {
+Promise.all([
+getItems(),
+shouldUpdateCount ? getItemCount() : Promise.resolve(),
+shouldUpdateTotal ? getTotalCount() : Promise.resolve(),
+]);
+}, 500);
 
 	watch(
-		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep)],
+		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep), toRef(filterSystem)],
 		async (after, before) => {
 			if (isEqual(after, before)) return;
 
-			const [newCollection, newLimit, newSort, newSearch, newFilter] = after;
-			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter] = before;
+			const [newCollection, newLimit, newSort, newSearch, newFilter, , , , , newFilterSystem] = after;
+			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter, , , , , oldFilterSystem] = before;
 
 			if (!newCollection || !query) return;
 
@@ -106,20 +110,16 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 			const shouldUpdateCount =
 				newCollection !== oldCollection || !isEqual(newFilter, oldFilter) || newSearch !== oldSearch;
 
-			fetchItems(shouldUpdateCount);
+			// determine if the total count needs to be updated based on changes to collection or filterSystem
+			const shouldUpdateTotal =
+				newCollection !== oldCollection || !isEqual(newFilterSystem, oldFilterSystem);
+
+			fetchItems(shouldUpdateCount, shouldUpdateTotal);
 		},
 		{ deep: true, immediate: true },
 	);
 
-	watch(
-		[collection, toRef(filterSystem)],
-		async (after, before) => {
-			if (isEqual(after, before)) return;
 
-			getTotalCount();
-		},
-		{ deep: true, immediate: true },
-	);
 
 	return {
 		itemCount,

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -74,12 +74,12 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 	// Throttle is used to ensure we send the first trigger instantly, debounce will not.
 	const fetchItems = throttle((shouldUpdateCount: boolean, shouldUpdateTotal: boolean = false) => {
-Promise.all([
-getItems(),
-shouldUpdateCount ? getItemCount() : Promise.resolve(),
-shouldUpdateTotal ? getTotalCount() : Promise.resolve(),
-]);
-}, 500);
+		Promise.all([
+			getItems(),
+			shouldUpdateCount ? getItemCount() : Promise.resolve(),
+			shouldUpdateTotal ? getTotalCount() : Promise.resolve(),
+		]);
+	}, 500);
 
 	watch(
 		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep), toRef(filterSystem)],
@@ -111,15 +111,12 @@ shouldUpdateTotal ? getTotalCount() : Promise.resolve(),
 				newCollection !== oldCollection || !isEqual(newFilter, oldFilter) || newSearch !== oldSearch;
 
 			// determine if the total count needs to be updated based on changes to collection or filterSystem
-			const shouldUpdateTotal =
-				newCollection !== oldCollection || !isEqual(newFilterSystem, oldFilterSystem);
+			const shouldUpdateTotal = newCollection !== oldCollection || !isEqual(newFilterSystem, oldFilterSystem);
 
 			fetchItems(shouldUpdateCount, shouldUpdateTotal);
 		},
 		{ deep: true, immediate: true },
 	);
-
-
 
 	return {
 		itemCount,


### PR DESCRIPTION
## Description

Fixes #25194

The `useItems` composable had two separate `watch` blocks both with `immediate: true`:

1. **Watch 1** — watched `[collection, limit, sort, search, filter, fields, page, alias, deep]` and called `fetchItems()` (throttled), which called `getItems()` + conditionally `getItemCount()`
2. 2. **Watch 2** — watched `[collection, filterSystem]` and called `getTotalCount()` directly (unthrottled)
On initialization, navigation, and bookmark switching, both watchers fired simultaneously, producing **2–3 redundant `aggregate[countDistinct]` API calls** per navigation event.

## Changes

- Merged the two `watch` blocks into a **single watch** that also includes `filterSystem` in its dependency array
- - Added a `shouldUpdateTotal` flag (derived from collection or `filterSystem` changes) alongside the existing `shouldUpdateCount` flag
- - Updated `fetchItems` to accept `shouldUpdateTotal` and conditionally call `getTotalCount()` inside the existing throttled `Promise.all`
- - Removed the second standalone watch entirely
## Result

All three count/data calls (`getItems`, `getItemCount`, `getTotalCount`) are now coordinated within a single throttled batch, eliminating duplicate requests.

| Scenario | Before | After |
|---|---|---|
| Refresh `/content/:collection` | 3 requests (2× countDistinct + 1× items) | 2 requests (1× countDistinct + 1× items) |
| Navigate to `/content/:collection` | 4 requests (3× countDistinct + 1× items) | 2 requests (1× countDistinct + 1× items) |
| Navigate with `?bookmark=xxx` | 3 requests (2× countDistinct + 1× items) | 2 requests (1× countDistinct + 1× items) |

## Testing

All 7 existing `use-items.test.ts` tests pass with no changes to the test file.