### PR TITLE
fix(app): guard date picker against dynamic variable values

### DIFF
--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -133,29 +133,36 @@ watch(
 		}
 
 		// Parse based on type
-		switch (props.type) {
-			case 'date':
-				calendarValue.value = parseDate(newValue);
-				break;
-			case 'time':
-				internalTimeValue.value = parseTime(newValue);
-				break;
+		// Guard against non-date values like dynamic variables (e.g. $NOW, $CURRENT_USER).
+		// If parsing throws, leave the calendar in its current state instead of crashing.
+		try {
+			switch (props.type) {
+				case 'date':
+					calendarValue.value = parseDate(newValue);
+					break;
+				case 'time':
+					internalTimeValue.value = parseTime(newValue);
+					break;
 
-			case 'dateTime': {
-				// Matches legacy Flatpickr format: "yyyy-MM-dd'T'HH:mm:ss"
-				const dt = parseDateTime(newValue);
-				calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
-				internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
-				break;
-			}
+				case 'dateTime': {
+					// Matches legacy Flatpickr format: "yyyy-MM-dd'T'HH:mm:ss"
+					const dt = parseDateTime(newValue);
+					calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
+					internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
+					break;
+				}
 
-			case 'timestamp': {
-				// Matches legacy Flatpickr format: Date.toISOString() (absolute timestamp)
-				const dt = parseAbsoluteToLocal(newValue);
-				calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
-				internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
-				break;
+				case 'timestamp': {
+					// Matches legacy Flatpickr format: Date.toISOString() (absolute timestamp)
+					const dt = parseAbsoluteToLocal(newValue);
+					calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
+					internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
+					break;
+				}
 			}
+		} catch {
+			// Value is not a parseable date string (e.g. a dynamic variable like $NOW).
+			// Leave calendar state unchanged so the picker can still open without crashing.
 		}
 	},
 	{ immediate: true },

--- a/contributors.yml
+++ b/contributors.yml
@@ -258,4 +258,4 @@
 - deepDiverPaul
 - tysoncung
 - Mugesh13102001
-- costajohnt
+- costajohnt- mibragimov


### PR DESCRIPTION
## Summary

Fixes a crash in the calendar picker when a dynamic variable (e.g. `$NOW`) is used as a date field value in validation rules.

## Root Cause

The `v-date-picker` component watches its `modelValue` prop and calls `@internationalized/date` parsing functions on it. When the value is a dynamic variable string like `$NOW`, parsing throws an uncaught exception which triggers a focus-trap error, breaking the entire UI.

## Fix

Wrapped the date parsing in a `try/catch` block so that non-date string values are handled gracefully instead of crashing.

## Testing

- Open a collection field config → Validation tab
- Add a filter rule with a date field and set the value to `$NOW`
- Click the calendar icon — should no longer crash

Closes #26828