### PR TITLE
fix(app): handle dynamic variables in date picker

### DIFF
--- a/.changeset/fix-date-picker-dynamic-variables.md
+++ b/.changeset/fix-date-picker-dynamic-variables.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed calendar picker crashing when a dynamic variable (e.g. `$NOW`) is used as a date field value in validation rules

--- a/.changeset/fix-date-picker-dynamic-variables.md
+++ b/.changeset/fix-date-picker-dynamic-variables.md
@@ -1,5 +1,6 @@
 ---
 '@directus/app': patch
+'@directus/utils': patch
 ---
 
 Fixed calendar picker crashing when a dynamic variable (e.g. `$NOW`) is used as a date field value in validation rules

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -10,8 +10,6 @@ vi.mock('@/utils/format-date-picker-model-value', () => ({
 	formatDatePickerModelValue: vi.fn(),
 }));
 
-// Mock @directus/utils — only the two functions used by v-date-picker are needed.
-// Using importOriginal would require the full monorepo to be built; mock only what's needed instead.
 vi.mock('@directus/utils', () => ({
 	isDynamicVariable: vi.fn((value: unknown) => typeof value === 'string' && value.startsWith('$NOW')),
 	parseDynamicVariable: vi.fn((value: unknown, _accountability: unknown, _context: unknown) => {
@@ -1236,17 +1234,12 @@ describe('v-date-picker', () => {
 
 	describe('dynamic variable handling (isDynamicVariable / parseDynamicVariable)', () => {
 		it('parses the dynamic variable and uses its resolved value for calendar state', async () => {
-			// "$NOW" is a dynamic variable → parseDynamicVariable resolves it to "2024-06-15T00:00:00"
-			// The watcher should update calendarValue based on the resolved date, not discard it.
-			// We use 'dateTime' so we can trigger emission via TimeFieldRoot without overwriting calendarValue.
 			let capturedCalendarValue: unknown;
 
 			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
 				capturedCalendarValue = options.calendarValue;
 				return '2024-06-15T00:00:00';
 			});
-
-			// parseDynamicVariable mock returns "2024-06-15T00:00:00" for $NOW in dateTime context
 
 			const { parseDynamicVariable: mockParseDV } = await import('@directus/utils');
 
@@ -1262,12 +1255,10 @@ describe('v-date-picker', () => {
 
 			await nextTick();
 
-			// Trigger emission via time-field update — this calls emitValue() without overwriting calendarValue.
 			const timeField = wrapper.findComponent(TimeFieldRoot);
 			await timeField.vm.$emit('update:modelValue', new Time(0, 0, 0));
 			await nextTick();
 
-			// calendarValue should reflect the resolved date "2024-06-15" (year=2024, month=6, day=15)
 			expect(capturedCalendarValue).toBeDefined();
 
 			const cv = capturedCalendarValue as { year: number; month: number; day: number };
@@ -1277,9 +1268,6 @@ describe('v-date-picker', () => {
 		});
 
 		it('does not alter internal state for non-dynamic values — passes them through unchanged', async () => {
-			// A plain datetime string is NOT a dynamic variable.
-			// isDynamicVariable returns false → parseDynamicVariable should NOT transform it.
-			// calendarValue should be set directly from the provided date string.
 			let capturedCalendarValue: unknown;
 
 			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
@@ -1294,12 +1282,10 @@ describe('v-date-picker', () => {
 
 			await nextTick();
 
-			// Trigger emission via time-field update — keeps calendarValue intact.
 			const timeField = wrapper.findComponent(TimeFieldRoot);
 			await timeField.vm.$emit('update:modelValue', new Time(0, 0, 0));
 			await nextTick();
 
-			// calendarValue should directly reflect "2024-03-20" without any transformation
 			expect(capturedCalendarValue).toBeDefined();
 
 			const cv = capturedCalendarValue as { year: number; month: number; day: number };

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -1247,7 +1247,9 @@ describe('v-date-picker', () => {
 			});
 
 			// parseDynamicVariable mock returns "2024-06-15T00:00:00" for $NOW in dateTime context
+
 			const { parseDynamicVariable: mockParseDV } = await import('@directus/utils');
+
 			vi.mocked(mockParseDV).mockImplementation((value: unknown) => {
 				if (typeof value === 'string' && value.startsWith('$NOW')) return '2024-06-15T00:00:00';
 				return value;

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -10,6 +10,16 @@ vi.mock('@/utils/format-date-picker-model-value', () => ({
 	formatDatePickerModelValue: vi.fn(),
 }));
 
+// Mock @directus/utils — only the two functions used by v-date-picker are needed.
+// Using importOriginal would require the full monorepo to be built; mock only what's needed instead.
+vi.mock('@directus/utils', () => ({
+	isDynamicVariable: vi.fn((value: unknown) => typeof value === 'string' && value.startsWith('$NOW')),
+	parseDynamicVariable: vi.fn((value: unknown, _accountability: unknown, _context: unknown) => {
+		if (typeof value === 'string' && value.startsWith('$NOW')) return '2024-06-15';
+		return value;
+	}),
+}));
+
 // Mock the user store with configurable values
 const mockUserStore = {
 	language: 'en-US',
@@ -1221,6 +1231,79 @@ describe('v-date-picker', () => {
 			// Component should handle all transitions and emit
 			expect(callCount).toBeGreaterThan(0);
 			expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+		});
+	});
+
+	describe('dynamic variable handling (isDynamicVariable / parseDynamicVariable)', () => {
+		it('parses the dynamic variable and uses its resolved value for calendar state', async () => {
+			// "$NOW" is a dynamic variable → parseDynamicVariable resolves it to "2024-06-15T00:00:00"
+			// The watcher should update calendarValue based on the resolved date, not discard it.
+			// We use 'dateTime' so we can trigger emission via TimeFieldRoot without overwriting calendarValue.
+			let capturedCalendarValue: unknown;
+
+			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
+				capturedCalendarValue = options.calendarValue;
+				return '2024-06-15T00:00:00';
+			});
+
+			// parseDynamicVariable mock returns "2024-06-15T00:00:00" for $NOW in dateTime context
+			const { parseDynamicVariable: mockParseDV } = await import('@directus/utils');
+			vi.mocked(mockParseDV).mockImplementation((value: unknown) => {
+				if (typeof value === 'string' && value.startsWith('$NOW')) return '2024-06-15T00:00:00';
+				return value;
+			});
+
+			const wrapper = createWrapper({
+				type: 'dateTime',
+				modelValue: '$NOW',
+			});
+
+			await nextTick();
+
+			// Trigger emission via time-field update — this calls emitValue() without overwriting calendarValue.
+			const timeField = wrapper.findComponent(TimeFieldRoot);
+			await timeField.vm.$emit('update:modelValue', new Time(0, 0, 0));
+			await nextTick();
+
+			// calendarValue should reflect the resolved date "2024-06-15" (year=2024, month=6, day=15)
+			expect(capturedCalendarValue).toBeDefined();
+
+			const cv = capturedCalendarValue as { year: number; month: number; day: number };
+			expect(cv.year).toBe(2024);
+			expect(cv.month).toBe(6);
+			expect(cv.day).toBe(15);
+		});
+
+		it('does not alter internal state for non-dynamic values — passes them through unchanged', async () => {
+			// A plain datetime string is NOT a dynamic variable.
+			// isDynamicVariable returns false → parseDynamicVariable should NOT transform it.
+			// calendarValue should be set directly from the provided date string.
+			let capturedCalendarValue: unknown;
+
+			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
+				capturedCalendarValue = options.calendarValue;
+				return '2024-03-20T00:00:00';
+			});
+
+			const wrapper = createWrapper({
+				type: 'dateTime',
+				modelValue: '2024-03-20T00:00:00',
+			});
+
+			await nextTick();
+
+			// Trigger emission via time-field update — keeps calendarValue intact.
+			const timeField = wrapper.findComponent(TimeFieldRoot);
+			await timeField.vm.$emit('update:modelValue', new Time(0, 0, 0));
+			await nextTick();
+
+			// calendarValue should directly reflect "2024-03-20" without any transformation
+			expect(capturedCalendarValue).toBeDefined();
+
+			const cv = capturedCalendarValue as { year: number; month: number; day: number };
+			expect(cv.year).toBe(2024);
+			expect(cv.month).toBe(3);
+			expect(cv.day).toBe(20);
 		});
 	});
 });

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { parseDynamicVariable } from '@directus/utils';
+import { isDynamicVariable, parseDynamicVariable } from '@directus/utils';
 import {
 	CalendarDate,
 	CalendarDateTime,
@@ -133,7 +133,9 @@ watch(
 			return;
 		}
 
-		if (parseDynamicVariable(newValue, null, {}) !== newValue) return;
+		if (isDynamicVariable(newValue)) {
+			newValue = parseDynamicVariable(newValue, null, {});
+		}
 
 		// Parse based on type
 		switch (props.type) {

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { parseDynamicVariable } from '@directus/utils';
 import {
 	CalendarDate,
 	CalendarDateTime,
@@ -131,6 +132,8 @@ watch(
 
 			return;
 		}
+
+		if (parseDynamicVariable(newValue, null, {}) !== newValue) return;
 
 		// Parse based on type
 		switch (props.type) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -259,3 +259,4 @@
 - tysoncung
 - Mugesh13102001
 - costajohnt
+- mibragimov

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -8,7 +8,7 @@ import { isObject } from './is-object.js';
 import { parseJSON } from './parse-json.js';
 import { toArray } from './to-array.js';
 
-type ParseFilterContext = {
+export type ParseFilterContext = {
 	// The user can add any custom fields to any of them
 	$CURRENT_USER?: User & Record<string, any>;
 	$CURRENT_ROLE?: Role & Record<string, any>;
@@ -16,7 +16,7 @@ type ParseFilterContext = {
 	$CURRENT_POLICIES?: (Policy & Record<string, any>)[];
 };
 
-type BasicAccountability = Pick<Accountability, 'user' | 'role' | 'roles'>;
+export type BasicAccountability = Pick<Accountability, 'user' | 'role' | 'roles'>;
 
 export function parseFilter(
 	filter: Filter | null,
@@ -139,7 +139,7 @@ function parseFilterEntry(
 	}
 }
 
-function parseDynamicVariable(value: any, accountability: BasicAccountability | null, context: ParseFilterContext) {
+export function parseDynamicVariable(value: any, accountability: BasicAccountability | null, context: ParseFilterContext) {
 	if (typeof value !== 'string') {
 		return value;
 	}

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -139,7 +139,11 @@ function parseFilterEntry(
 	}
 }
 
-export function parseDynamicVariable(value: any, accountability: BasicAccountability | null, context: ParseFilterContext) {
+export function parseDynamicVariable(
+	value: any,
+	accountability: BasicAccountability | null,
+	context: ParseFilterContext,
+) {
 	if (typeof value !== 'string') {
 		return value;
 	}


### PR DESCRIPTION
## Summary

Fixes a crash in the calendar picker when a dynamic variable (e.g. `$NOW`) is used as a date field value in validation rules.

## Root Cause

The `v-date-picker` component parses its `modelValue` using `@internationalized/date`. When the value is a dynamic variable like `$NOW`, parsing fails and triggers a focus-trap error that breaks the UI.

## Fix

Used the existing `isDynamicVariable` utility from `@directus/utils` to detect dynamic variables before attempting date parsing. If the value is a dynamic variable, parsing is skipped entirely.

## Testing

- All existing unit tests pass
- Lint, format, and stylelint checks pass

Closes #26828