### PR TITLE
Add field level MIME type restriction to file-image interface

### DIFF
--- a/.changeset/bumpy-lamps-flash.md
+++ b/.changeset/bumpy-lamps-flash.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added field level MIME type restriction to file-image interface

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -41,6 +41,7 @@ const props = withDefaults(
 		letterbox?: boolean;
 		enableCreate?: boolean;
 		enableSelect?: boolean;
+		allowedMimeTypes?: string[];
 	}>(),
 	{
 		crop: true,
@@ -142,12 +143,9 @@ async function imageErrorHandler() {
 
 const values = inject('values', ref<Record<string, unknown>>({}));
 
-// Image-only filter for file library
-const imageFilter = {
-	type: {
-		_starts_with: 'image/',
-	},
-};
+const { mimeTypeFilter, combinedAcceptString } = useMimeTypeFilter(
+	computed(() => (props.allowedMimeTypes?.length ? props.allowedMimeTypes : ['image/*'])),
+);
 
 const customFilter = computed(() => {
 	const filter = parseFilter(
@@ -160,10 +158,11 @@ const customFilter = computed(() => {
 		}),
 	);
 
-	if (!filter) return imageFilter;
+	if (!mimeTypeFilter.value) return filter;
+	if (!filter) return mimeTypeFilter.value;
 
 	return {
-		_and: [filter, imageFilter],
+		_and: [filter, mimeTypeFilter.value],
 	};
 });
 
@@ -192,8 +191,6 @@ const menuActive = computed(
 );
 
 const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo);
-
-const { combinedAcceptString } = useMimeTypeFilter(computed(() => ['image/*']));
 </script>
 
 <template>

--- a/app/src/interfaces/file-image/index.ts
+++ b/app/src/interfaces/file-image/index.ts
@@ -26,6 +26,7 @@ export default defineInterface({
 					note: '$t:interfaces.system-folder.field_hint',
 				},
 			},
+
 			{
 				field: 'crop',
 				name: '$t:interfaces.file-image.crop',
@@ -93,6 +94,28 @@ export default defineInterface({
 				},
 				schema: {
 					default_value: false,
+				},
+			},
+			{
+				field: 'allowedMimeTypes',
+				name: '$t:interfaces.file.allowed_mime_types',
+				type: 'json',
+				meta: {
+					interface: 'select-multiple-dropdown',
+					options: {
+						placeholder: '$t:interfaces.file.mime_types_placeholder',
+						choices: [
+							{ value: 'image/jpeg', text: 'image/jpeg' },
+							{ value: 'image/png', text: 'image/png' },
+							{ value: 'image/gif', text: 'image/gif' },
+							{ value: 'image/webp', text: 'image/webp' },
+							{ value: 'image/svg+xml', text: 'image/svg+xml' },
+							{ value: 'image/avif', text: 'image/avif' },
+							{ value: 'image/tiff', text: 'image/tiff' },
+						],
+						allowOther: true,
+					},
+					note: '$t:interfaces.file.mime_types_note',
 				},
 			},
 		];


### PR DESCRIPTION
## Scope

What's changed:

- Introduced a new field for allowed MIME types in the file-image interface.
- Updated the image filter logic to respect the specified MIME types.

## Potential Risks / Drawbacks

- Same pattern used across the other file interfaces, so same risk as there (probably none)

## Tested Scenarios

- Validated the new field functionality with various MIME type selections.
- Ensured that the image filter behaves correctly with allowed MIME types.

## Review Notes / Questions

- NA

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes cms-1982

