### PR TITLE
fix(app): persist custom Vue operation options

### DIFF
--- a/.changeset/curvy-candles-travel.md
+++ b/.changeset/curvy-candles-travel.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed custom Vue operation options to persist edited values in Flow settings.

--- a/app/src/modules/settings/routes/flows/components/operation-detail.test.ts
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.test.ts
@@ -1,0 +1,138 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import OperationDetail from './operation-detail.vue';
+import { i18n } from '@/lang';
+
+const { mockOperation } = vi.hoisted(() => ({
+	mockOperation: {
+		id: 'test-operation',
+		name: 'Test Operation',
+		icon: 'bolt',
+		description: 'Custom operation',
+		options: {},
+	},
+}));
+
+vi.mock('@/composables/use-dialog-route', async () => {
+	const { ref } = await import('vue');
+
+	return {
+		useDialogRoute: () => ref(true),
+	};
+});
+
+vi.mock('@/composables/use-extension', async () => {
+	const { ref } = await import('vue');
+
+	return {
+		useExtension: () => ref(mockOperation),
+	};
+});
+
+vi.mock('@/extensions', async () => {
+	const { ref } = await import('vue');
+
+	return {
+		useExtensions: () => ({
+			operations: ref([mockOperation]),
+		}),
+	};
+});
+
+vi.mock('@/views/private', async () => {
+	const { defineComponent } = await import('vue');
+
+	return {
+		PrivateViewHeaderBarActionButton: defineComponent({
+			name: 'PrivateViewHeaderBarActionButton',
+			emits: ['click'],
+			template: '<button class="header-apply" @click="$emit(\'click\')">save</button>',
+		}),
+	};
+});
+
+const CustomOperationOptions = defineComponent({
+	name: 'OperationOptionsTestOperation',
+	props: {
+		value: {
+			type: Object,
+			default: () => ({}),
+		},
+	},
+	emits: ['input'],
+	template: `
+		<div>
+			<span class="current-endpoint">{{ value?.endpoint ?? '' }}</span>
+			<button
+				class="emit-update"
+				@click="$emit('input', { endpoint: 'deals', action: 'create' })"
+			>
+				update
+			</button>
+		</div>
+	`,
+});
+
+const VDrawerStub = defineComponent({
+	name: 'VDrawer',
+	emits: ['apply', 'cancel'],
+	template: `
+		<div>
+			<slot name="actions" />
+			<slot />
+			<button class="drawer-apply" @click="$emit('apply')">apply</button>
+		</div>
+	`,
+});
+
+describe('OperationDetail', () => {
+	it('persists changes from custom operation options components', async () => {
+		const wrapper = mount(OperationDetail, {
+			props: {
+				primaryKey: 'flow-1',
+				operationId: 'operation-1',
+				flow: { name: 'Test Flow' } as any,
+				operation: {
+					type: 'test-operation',
+					key: 'test_operation',
+					name: 'Test Operation',
+					options: {
+						endpoint: 'contacts',
+						action: 'read',
+					},
+				},
+				existingOperationKeys: [],
+			},
+			global: {
+				plugins: [i18n],
+				components: {
+					'operation-options-test-operation': CustomOperationOptions,
+				},
+				stubs: {
+					ExtensionOptions: true,
+					VDivider: true,
+					VDrawer: VDrawerStub,
+					VFancySelect: true,
+					VIcon: true,
+					VInput: true,
+					VNotice: true,
+				},
+			},
+		});
+
+		expect(wrapper.find('.current-endpoint').text()).toBe('contacts');
+
+		await wrapper.find('.emit-update').trigger('click');
+		await wrapper.find('.drawer-apply').trigger('click');
+
+		expect(wrapper.emitted('save')?.[0]?.[0]).toEqual(
+			expect.objectContaining({
+				options: {
+					endpoint: 'deals',
+					action: 'create',
+				},
+			}),
+		);
+	});
+});

--- a/app/src/modules/settings/routes/flows/components/operation-detail.vue
+++ b/app/src/modules/settings/routes/flows/components/operation-detail.vue
@@ -207,7 +207,8 @@ function saveOperation() {
 			<component
 				:is="`operation-options-${operationType}`"
 				v-else-if="operationType && selectedOperation"
-				:options="operation"
+				:value="options"
+				@input="options = $event"
 			/>
 		</div>
 	</VDrawer>

--- a/contributors.yml
+++ b/contributors.yml
@@ -259,3 +259,4 @@
 - tysoncung
 - Mugesh13102001
 - costajohnt
+- AbdelhamidKhald


### PR DESCRIPTION
Fixes #26499.

## Summary

Custom Vue-based operation option components in Flow settings were not persisting edited values.

## Root cause

The fallback renderer in `operation-detail.vue` used the wrong binding contract for Vue-based custom option components. It passed the wrong prop shape, so emitted updates were not written back into the saved `options` payload.

## Changes

- bind the fallback custom component path to `:value="options"`
- persist updates with `@input="options = $event"`
- add a regression test for a dynamically registered custom operation options component

## Testing

- `pnpm exec eslint app/src/modules/settings/routes/flows/components/operation-detail.vue app/src/modules/settings/routes/flows/components/operation-detail.test.ts`
- `app\node_modules\.bin\vitest.cmd run src/modules/settings/routes/flows/components/operation-detail.test.ts`