### PR TITLE
fix(app): render M2A related values with collection templates

### DIFF
--- a/.changeset/fix-m2a-related-values-display.md
+++ b/.changeset/fix-m2a-related-values-display.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed default M2A related-values displays to use each related collection's display template

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -5,6 +5,7 @@ import { getFieldsFromTemplate } from '@directus/utils';
 import { get, set } from 'lodash';
 import DisplayRelatedValues from './related-values.vue';
 import { useExtension } from '@/composables/use-extension';
+import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
@@ -104,6 +105,7 @@ export default defineDisplay({
 
 		if (!relatedCollectionData) return [];
 
+		const collectionsStore = useCollectionsStore();
 		const fieldsStore = useFieldsStore();
 
 		const { junctionCollection, relatedCollection, path } = relatedCollectionData;
@@ -128,11 +130,39 @@ export default defineDisplay({
 			const relationsStore = useRelationsStore();
 			const relations = relationsStore.getRelationsForField(collection, field);
 
-			const collectionField = relations.find((relation) => relation.meta?.one_collection_field)?.meta
-				?.one_collection_field;
+			const relation = relations.find((relation) => relation.meta?.one_collection_field);
+			const collectionField = relation?.meta?.one_collection_field;
 
 			if (collectionField && !fields.find((field) => field === collectionField)) {
 				fields.push(collectionField);
+			}
+
+			if (!options?.template && relation?.field) {
+				for (const allowedCollection of relation.meta?.one_allowed_collections ?? []) {
+					const relationPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(allowedCollection);
+
+					if (!relationPrimaryKeyField) continue;
+
+					const displayTemplate =
+						collectionsStore.getCollection(allowedCollection)?.meta?.display_template ||
+						`{{ ${relationPrimaryKeyField.field} }}`;
+
+					const displayFields = adjustFieldsForDisplays(
+						getFieldsFromTemplate(displayTemplate),
+						allowedCollection,
+					).map((displayField) => `${relation.field}:${allowedCollection}.${displayField}`);
+
+					const m2aFields = [
+						...displayFields,
+						`${relation.field}:${allowedCollection}.${relationPrimaryKeyField.field}`,
+					];
+
+					for (const displayField of m2aFields) {
+						if (!fields.includes(displayField)) {
+							fields.push(displayField);
+						}
+					}
+				}
 			}
 		}
 

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -147,10 +147,9 @@ export default defineDisplay({
 						collectionsStore.getCollection(allowedCollection)?.meta?.display_template ||
 						`{{ ${relationPrimaryKeyField.field} }}`;
 
-					const displayFields = adjustFieldsForDisplays(
-						getFieldsFromTemplate(displayTemplate),
-						allowedCollection,
-					).map((displayField) => `${relation.field}:${allowedCollection}.${displayField}`);
+					const displayFields = adjustFieldsForDisplays(getFieldsFromTemplate(displayTemplate), allowedCollection).map(
+						(displayField) => `${relation.field}:${allowedCollection}.${displayField}`,
+					);
 
 					const m2aFields = [
 						...displayFields,

--- a/app/src/displays/related-values/related-values.test.ts
+++ b/app/src/displays/related-values/related-values.test.ts
@@ -1,0 +1,348 @@
+import type { Field, Relation } from '@directus/types';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, defineComponent, unref } from 'vue';
+import { createI18n } from 'vue-i18n';
+import RelatedValues from './related-values.vue';
+import relatedValuesDisplay from './index';
+
+vi.mock('@directus/utils', () => ({
+	getFieldsFromTemplate: (template: string) =>
+		Array.from(template.matchAll(/{{\s*([^}]+?)\s*}}/g)).map(([, field]) => field.trim()),
+}));
+
+vi.mock('@/composables/use-extension', () => ({
+	useExtension: () => computed(() => null),
+}));
+
+vi.mock('@/views/private/components/render-template.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			props: {
+				collection: {
+					type: String,
+					default: '',
+				},
+				template: {
+					type: String,
+					required: true,
+				},
+				item: {
+					type: Object,
+					default: () => ({}),
+				},
+			},
+			setup(props) {
+				return () => {
+					const displayValue = Object.values(props.item).find((value) => typeof value === 'string') ?? '';
+					return h('span', `${props.collection}|${props.template}|${displayValue}`);
+				};
+			},
+		}),
+	};
+});
+
+vi.mock('@/components/v-icon/v-icon.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup() {
+				return () => h('span');
+			},
+		}),
+	};
+});
+
+vi.mock('@/components/v-list-item-content.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup(_, { slots }) {
+				return () => h('div', slots.default?.());
+			},
+		}),
+	};
+});
+
+vi.mock('@/components/v-list-item-icon.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup(_, { slots }) {
+				return () => h('div', slots.default?.());
+			},
+		}),
+	};
+});
+
+vi.mock('@/components/v-list-item.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup(_, { slots }) {
+				return () => h('div', slots.default?.());
+			},
+		}),
+	};
+});
+
+vi.mock('@/components/v-list.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup(_, { slots }) {
+				return () => h('div', slots.default?.());
+			},
+		}),
+	};
+});
+
+vi.mock('@/components/v-menu.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup(_, { slots }) {
+				return () =>
+					h('div', [
+						slots.activator?.({ toggle: () => undefined }),
+						slots.default?.(),
+					]);
+			},
+		}),
+	};
+});
+
+vi.mock('@/views/private/components/value-null.vue', async () => {
+	const { defineComponent, h } = await import('vue');
+
+	return {
+		default: defineComponent({
+			setup() {
+				return () => h('span', 'null');
+			},
+		}),
+	};
+});
+
+const collections = {
+	collection_one: {
+		collection: 'collection_one',
+		name: 'Collection One',
+		meta: { display_template: '{{ name }}' },
+	},
+	collection_two: {
+		collection: 'collection_two',
+		name: 'Collection Two',
+		meta: { display_template: '{{ title }}' },
+	},
+	collection_three_blocks: {
+		collection: 'collection_three_blocks',
+		name: 'Collection Three Blocks',
+		meta: null,
+	},
+};
+
+const fieldsByCollection: Record<string, Record<string, Field>> = {
+	collection_three: {
+		blocks: {
+			collection: 'collection_three',
+			field: 'blocks',
+			type: 'alias',
+			name: 'Blocks',
+			schema: null,
+			meta: {
+				id: 1,
+				collection: 'collection_three',
+				field: 'blocks',
+				special: ['m2a'],
+				interface: 'list-m2a',
+			},
+		} as Field,
+	},
+	collection_three_blocks: {
+		id: { collection: 'collection_three_blocks', field: 'id', type: 'integer', name: 'ID', schema: null, meta: null } as Field,
+		collection: {
+			collection: 'collection_three_blocks',
+			field: 'collection',
+			type: 'string',
+			name: 'Collection',
+			schema: null,
+			meta: null,
+		} as Field,
+		item: { collection: 'collection_three_blocks', field: 'item', type: 'json', name: 'Item', schema: null, meta: null } as Field,
+	},
+	collection_one: {
+		id: { collection: 'collection_one', field: 'id', type: 'integer', name: 'ID', schema: null, meta: null } as Field,
+		name: { collection: 'collection_one', field: 'name', type: 'string', name: 'Name', schema: null, meta: null } as Field,
+	},
+	collection_two: {
+		id: { collection: 'collection_two', field: 'id', type: 'integer', name: 'ID', schema: null, meta: null } as Field,
+		title: {
+			collection: 'collection_two',
+			field: 'title',
+			type: 'string',
+			name: 'Title',
+			schema: null,
+			meta: null,
+		} as Field,
+	},
+};
+
+const relations: Relation[] = [
+	{
+		collection: 'collection_three_blocks',
+		field: 'collection_three_id',
+		related_collection: 'collection_three',
+		schema: null,
+		meta: {
+			id: 1,
+			many_collection: 'collection_three_blocks',
+			many_field: 'collection_three_id',
+			one_collection: 'collection_three',
+			one_field: 'blocks',
+			one_collection_field: null,
+			one_allowed_collections: null,
+			junction_field: 'item',
+			sort_field: null,
+			one_deselect_action: 'nullify',
+		},
+	} as Relation,
+	{
+		collection: 'collection_three_blocks',
+		field: 'item',
+		related_collection: null,
+		schema: null,
+		meta: {
+			id: 2,
+			many_collection: 'collection_three_blocks',
+			many_field: 'item',
+			one_collection: null,
+			one_field: null,
+			one_collection_field: 'collection',
+			one_allowed_collections: ['collection_one', 'collection_two'],
+			junction_field: 'collection_three_id',
+			sort_field: null,
+			one_deselect_action: 'nullify',
+		},
+	} as Relation,
+];
+
+const getCollection = vi.fn((collection: string) => collections[collection as keyof typeof collections] ?? null);
+const getField = vi.fn((collection: string, field: string) => fieldsByCollection[collection]?.[field] ?? null);
+const getPrimaryKeyFieldForCollection = vi.fn((collection: string) => fieldsByCollection[collection]?.id ?? null);
+
+const getRelationsForField = vi.fn((collection: string, field: string) => {
+	if (collection === 'collection_three' && field === 'blocks') return relations;
+	return [];
+});
+
+vi.mock('@directus/composables', () => ({
+	useCollection: (collection: string) => ({
+		primaryKeyField: computed(() => getPrimaryKeyFieldForCollection(unref(collection))),
+	}),
+}));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: () => ({
+		getCollection,
+	}),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getField,
+		getPrimaryKeyFieldForCollection,
+	}),
+}));
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: () => ({
+		getRelationsForField,
+	}),
+}));
+
+vi.mock('@/utils/get-local-type', () => ({
+	getLocalTypeForField: () => 'm2a',
+}));
+
+vi.mock('@/utils/get-related-collection', () => ({
+	getRelatedCollection: () => ({
+		relatedCollection: 'collection_three_blocks',
+	}),
+}));
+
+const i18n = createI18n({
+	legacy: false,
+	locale: 'en-US',
+	missingWarn: false,
+	messages: {
+		'en-US': {
+			item: 'item',
+			items: 'items',
+		},
+	},
+});
+
+const RouterLinkStub = defineComponent({
+	props: {
+		to: {
+			type: String,
+			required: true,
+		},
+	},
+	template: '<a :href="to"><slot /></a>',
+});
+
+describe('related-values m2a display', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders default M2A entries with each related collection display template and fetches the needed fields', () => {
+		const wrapper = mount(RelatedValues, {
+			props: {
+				collection: 'collection_three',
+				field: 'blocks',
+				value: [
+					{ id: 1, collection: 'collection_one', item: { id: 11, name: 'Ahmed' } },
+					{ id: 2, collection: 'collection_two', item: { id: 22, title: 'Admin' } },
+				],
+			},
+			global: {
+				plugins: [i18n],
+				stubs: {
+					RouterLink: RouterLinkStub,
+				},
+			},
+		});
+
+		expect(wrapper.text()).toContain('Collection One:');
+		expect(wrapper.text()).toContain('collection_one|{{ name }}|Ahmed');
+		expect(wrapper.text()).toContain('Collection Two:');
+		expect(wrapper.text()).toContain('collection_two|{{ title }}|Admin');
+
+		expect(wrapper.findAll('a').map((link) => link.attributes('href'))).toEqual([
+			'/content/collection_one/11',
+			'/content/collection_two/22',
+		]);
+
+		expect(relatedValuesDisplay.fields(null, { collection: 'collection_three', field: 'blocks' })).toEqual(
+			expect.arrayContaining([
+				'id',
+				'collection',
+				'item:collection_one.id',
+				'item:collection_one.name',
+				'item:collection_two.id',
+				'item:collection_two.title',
+			]),
+		);
+	});
+});

--- a/app/src/displays/related-values/related-values.test.ts
+++ b/app/src/displays/related-values/related-values.test.ts
@@ -110,11 +110,7 @@ vi.mock('@/components/v-menu.vue', async () => {
 	return {
 		default: defineComponent({
 			setup(_, { slots }) {
-				return () =>
-					h('div', [
-						slots.activator?.({ toggle: () => undefined }),
-						slots.default?.(),
-					]);
+				return () => h('div', [slots.activator?.({ toggle: () => undefined }), slots.default?.()]);
 			},
 		}),
 	};
@@ -168,7 +164,14 @@ const fieldsByCollection: Record<string, Record<string, Field>> = {
 		} as Field,
 	},
 	collection_three_blocks: {
-		id: { collection: 'collection_three_blocks', field: 'id', type: 'integer', name: 'ID', schema: null, meta: null } as Field,
+		id: {
+			collection: 'collection_three_blocks',
+			field: 'id',
+			type: 'integer',
+			name: 'ID',
+			schema: null,
+			meta: null,
+		} as Field,
 		collection: {
 			collection: 'collection_three_blocks',
 			field: 'collection',
@@ -177,11 +180,25 @@ const fieldsByCollection: Record<string, Record<string, Field>> = {
 			schema: null,
 			meta: null,
 		} as Field,
-		item: { collection: 'collection_three_blocks', field: 'item', type: 'json', name: 'Item', schema: null, meta: null } as Field,
+		item: {
+			collection: 'collection_three_blocks',
+			field: 'item',
+			type: 'json',
+			name: 'Item',
+			schema: null,
+			meta: null,
+		} as Field,
 	},
 	collection_one: {
 		id: { collection: 'collection_one', field: 'id', type: 'integer', name: 'ID', schema: null, meta: null } as Field,
-		name: { collection: 'collection_one', field: 'name', type: 'string', name: 'Name', schema: null, meta: null } as Field,
+		name: {
+			collection: 'collection_one',
+			field: 'name',
+			type: 'string',
+			name: 'Name',
+			schema: null,
+			meta: null,
+		} as Field,
 	},
 	collection_two: {
 		id: { collection: 'collection_two', field: 'id', type: 'integer', name: 'ID', schema: null, meta: null } as Field,

--- a/app/src/displays/related-values/related-values.test.ts
+++ b/app/src/displays/related-values/related-values.test.ts
@@ -61,8 +61,9 @@ vi.mock('@/components/v-list-item-content.vue', async () => {
 
 	return {
 		default: defineComponent({
-			setup(_, { slots }) {
-				return () => h('div', slots.default?.());
+			inheritAttrs: false,
+			setup(_, { attrs, slots }) {
+				return () => h('div', { class: ['v-list-item-content', attrs.class] }, slots.default?.());
 			},
 		}),
 	};
@@ -345,6 +346,8 @@ describe('related-values m2a display', () => {
 		expect(wrapper.text()).toContain('collection_one|{{ name }}|Ahmed');
 		expect(wrapper.text()).toContain('Collection Two:');
 		expect(wrapper.text()).toContain('collection_two|{{ title }}|Admin');
+		expect(wrapper.findAll('.v-list-item-content.m2a-item')).toHaveLength(0);
+		expect(wrapper.findAll('.v-list-item-content .m2a-item')).toHaveLength(2);
 
 		expect(wrapper.findAll('a').map((link) => link.attributes('href'))).toEqual([
 			'/content/collection_one/11',

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -61,7 +61,9 @@ const m2aRelationInfo = computed(() => {
 
 	if (!junction) return null;
 
-	const relation = relations.find((relation) => relation.collection === junction.collection && relation.field === junction.meta?.junction_field);
+	const relation = relations.find(
+		(relation) => relation.collection === junction.collection && relation.field === junction.meta?.junction_field,
+	);
 
 	if (!relation?.meta?.one_collection_field || !junction.meta?.junction_field) return null;
 
@@ -142,7 +144,7 @@ function getLinkForItem(item: any) {
 }
 
 function getM2ACollection(item: any) {
-	return m2aRelationInfo.value ? item?.[m2aRelationInfo.value.collectionField] ?? null : null;
+	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.collectionField] ?? null) : null;
 }
 
 function getM2ATemplate(item: any) {
@@ -154,7 +156,7 @@ function getM2ATemplate(item: any) {
 }
 
 function getM2AValue(item: any) {
-	return m2aRelationInfo.value ? item?.[m2aRelationInfo.value.junctionField] ?? null : null;
+	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.junctionField] ?? null) : null;
 }
 
 function getM2APrefix(item: any) {
@@ -199,7 +201,9 @@ function getM2APrefix(item: any) {
 						/>
 					</VListItemContent>
 					<VListItemIcon>
-						<RouterLink v-if="getLinkForItem(item)" :to="getLinkForItem(item)!"><VIcon name="launch" small /></RouterLink>
+						<RouterLink v-if="getLinkForItem(item)" :to="getLinkForItem(item)!">
+							<VIcon name="launch" small />
+						</RouterLink>
 					</VListItemIcon>
 				</VListItem>
 			</template>

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -10,6 +10,9 @@ import VListItemIcon from '@/components/v-list-item-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
+import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
 import { getLocalTypeForField } from '@/utils/get-local-type';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { getItemRoute } from '@/utils/get-route';
@@ -24,6 +27,9 @@ const props = defineProps<{
 }>();
 
 const { t, te } = useI18n();
+const collectionsStore = useCollectionsStore();
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
 
 const relatedCollectionData = computed(() => {
 	return getRelatedCollection(props.collection, props.field);
@@ -41,6 +47,45 @@ const localType = computed(() => {
 	return getLocalTypeForField(props.collection, props.field);
 });
 
+const m2aRelationInfo = computed(() => {
+	if (localType.value !== 'm2a') return null;
+
+	const relations = relationsStore.getRelationsForField(props.collection, props.field);
+
+	const junction = relations.find(
+		(relation) =>
+			relation.related_collection === props.collection &&
+			relation.meta?.one_field === props.field &&
+			relation.meta?.junction_field,
+	);
+
+	if (!junction) return null;
+
+	const relation = relations.find((relation) => relation.collection === junction.collection && relation.field === junction.meta?.junction_field);
+
+	if (!relation?.meta?.one_collection_field || !junction.meta?.junction_field) return null;
+
+	const primaryKeyFields = Object.fromEntries(
+		(relation.meta.one_allowed_collections ?? [])
+			.map((collection) => [collection, fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field ?? null])
+			.filter(([, field]) => field !== null),
+	) as Record<string, string>;
+
+	const templates = Object.fromEntries(
+		Object.entries(primaryKeyFields).map(([collection, primaryKeyField]) => [
+			collection,
+			collectionsStore.getCollection(collection)?.meta?.display_template || `{{ ${primaryKeyField} }}`,
+		]),
+	);
+
+	return {
+		collectionField: relation.meta.one_collection_field,
+		junctionField: junction.meta.junction_field,
+		primaryKeyFields,
+		templates,
+	};
+});
+
 const { primaryKeyField } = useCollection(relatedCollection);
 
 const primaryKeyFieldPath = computed(() => {
@@ -55,6 +100,10 @@ const internalTemplate = computed(() => {
 
 const unit = computed(() => {
 	if (Array.isArray(props.value)) {
+		if (localType.value === 'm2a') {
+			return props.value.length === 1 ? t('item') : t('items');
+		}
+
 		if (props.value.length === 1) {
 			if (te(`collection_names_singular.${relatedCollection.value}`)) {
 				return t(`collection_names_singular.${relatedCollection.value}`);
@@ -74,10 +123,50 @@ const unit = computed(() => {
 });
 
 function getLinkForItem(item: any) {
+	if (m2aRelationInfo.value) {
+		const itemCollection = item?.[m2aRelationInfo.value.collectionField];
+		const primaryKeyField = itemCollection ? m2aRelationInfo.value.primaryKeyFields[itemCollection] : null;
+
+		const primaryKey =
+			itemCollection && primaryKeyField ? item?.[m2aRelationInfo.value.junctionField]?.[primaryKeyField] : null;
+
+		if (!itemCollection || primaryKey === null || primaryKey === undefined) return null;
+
+		return getItemRoute(itemCollection, primaryKey);
+	}
+
 	if (!relatedCollectionData.value || !primaryKeyFieldPath.value) return null;
 	const primaryKey = get(item, primaryKeyFieldPath.value);
 
 	return getItemRoute(relatedCollection.value, primaryKey);
+}
+
+function getM2ACollection(item: any) {
+	return m2aRelationInfo.value ? item?.[m2aRelationInfo.value.collectionField] ?? null : null;
+}
+
+function getM2ATemplate(item: any) {
+	const itemCollection = getM2ACollection(item);
+
+	if (!itemCollection || !m2aRelationInfo.value) return '';
+
+	return m2aRelationInfo.value.templates[itemCollection] ?? '';
+}
+
+function getM2AValue(item: any) {
+	return m2aRelationInfo.value ? item?.[m2aRelationInfo.value.junctionField] ?? null : null;
+}
+
+function getM2APrefix(item: any) {
+	const itemCollection = getM2ACollection(item);
+
+	if (!itemCollection) return t('item');
+
+	if (te(`collection_names_singular.${itemCollection}`)) {
+		return t(`collection_names_singular.${itemCollection}`);
+	}
+
+	return collectionsStore.getCollection(itemCollection)?.name ?? itemCollection;
 }
 </script>
 
@@ -99,18 +188,36 @@ function getLinkForItem(item: any) {
 		</template>
 
 		<VList class="links">
-			<VListItem v-for="item in value" :key="item[primaryKeyFieldPath!]">
-				<VListItemContent>
-					<RenderTemplate
-						:template="internalTemplate"
-						:item="item"
-						:collection="junctionCollection ?? relatedCollection"
-					/>
-				</VListItemContent>
-				<VListItemIcon>
-					<RouterLink :to="getLinkForItem(item)!"><VIcon name="launch" small /></RouterLink>
-				</VListItemIcon>
-			</VListItem>
+			<template v-if="localType === 'm2a' && !template">
+				<VListItem v-for="item in value" :key="item[primaryKeyFieldPath!]">
+					<VListItemContent class="m2a-item">
+						<span class="collection">{{ getM2APrefix(item) }}:</span>
+						<RenderTemplate
+							:template="getM2ATemplate(item)"
+							:item="getM2AValue(item)"
+							:collection="getM2ACollection(item) || undefined"
+						/>
+					</VListItemContent>
+					<VListItemIcon>
+						<RouterLink v-if="getLinkForItem(item)" :to="getLinkForItem(item)!"><VIcon name="launch" small /></RouterLink>
+					</VListItemIcon>
+				</VListItem>
+			</template>
+
+			<template v-else>
+				<VListItem v-for="item in value" :key="item[primaryKeyFieldPath!]">
+					<VListItemContent>
+						<RenderTemplate
+							:template="internalTemplate"
+							:item="item"
+							:collection="junctionCollection ?? relatedCollection"
+						/>
+					</VListItemContent>
+					<VListItemIcon>
+						<RouterLink :to="getLinkForItem(item)!"><VIcon name="launch" small /></RouterLink>
+					</VListItemIcon>
+				</VListItem>
+			</template>
 		</VList>
 	</VMenu>
 	<RenderTemplate v-else :template="internalTemplate" :item="value" :collection="relatedCollection" />
@@ -167,6 +274,15 @@ function getLinkForItem(item: any) {
 .links {
 	.v-list-item-content {
 		block-size: var(--v-list-item-min-height, 32px);
+	}
+}
+
+.m2a-item {
+	display: flex;
+	gap: 4px;
+
+	.collection {
+		font-weight: 600;
 	}
 }
 </style>

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
 import { get } from 'lodash';
-import { computed } from 'vue';
+import { computed, toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 import VIcon from '@/components/v-icon/v-icon.vue';
@@ -10,9 +10,8 @@ import VListItemIcon from '@/components/v-list-item-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
+import { useRelationM2A } from '@/composables/use-relation-m2a';
 import { useCollectionsStore } from '@/stores/collections';
-import { useFieldsStore } from '@/stores/fields';
-import { useRelationsStore } from '@/stores/relations';
 import { getLocalTypeForField } from '@/utils/get-local-type';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { getItemRoute } from '@/utils/get-route';
@@ -28,8 +27,7 @@ const props = defineProps<{
 
 const { t, te } = useI18n();
 const collectionsStore = useCollectionsStore();
-const fieldsStore = useFieldsStore();
-const relationsStore = useRelationsStore();
+const { relationInfo } = useRelationM2A(toRef(props, 'collection'), toRef(props, 'field'));
 
 const relatedCollectionData = computed(() => {
 	return getRelatedCollection(props.collection, props.field);
@@ -50,27 +48,10 @@ const localType = computed(() => {
 const m2aRelationInfo = computed(() => {
 	if (localType.value !== 'm2a') return null;
 
-	const relations = relationsStore.getRelationsForField(props.collection, props.field);
-
-	const junction = relations.find(
-		(relation) =>
-			relation.related_collection === props.collection &&
-			relation.meta?.one_field === props.field &&
-			relation.meta?.junction_field,
-	);
-
-	if (!junction) return null;
-
-	const relation = relations.find(
-		(relation) => relation.collection === junction.collection && relation.field === junction.meta?.junction_field,
-	);
-
-	if (!relation?.meta?.one_collection_field || !junction.meta?.junction_field) return null;
+	if (!relationInfo.value) return null;
 
 	const primaryKeyFields = Object.fromEntries(
-		(relation.meta.one_allowed_collections ?? [])
-			.map((collection) => [collection, fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field ?? null])
-			.filter(([, field]) => field !== null),
+		Object.entries(relationInfo.value.relationPrimaryKeyFields).map(([collection, field]) => [collection, field.field]),
 	) as Record<string, string>;
 
 	const templates = Object.fromEntries(
@@ -81,8 +62,8 @@ const m2aRelationInfo = computed(() => {
 	);
 
 	return {
-		collectionField: relation.meta.one_collection_field,
-		junctionField: junction.meta.junction_field,
+		collectionField: relationInfo.value.collectionField.field,
+		junctionField: relationInfo.value.junctionField.field,
 		primaryKeyFields,
 		templates,
 	};
@@ -124,7 +105,7 @@ const unit = computed(() => {
 	return null;
 });
 
-function getLinkForItem(item: any) {
+function getLinkForItem(item: Record<string, any>) {
 	if (m2aRelationInfo.value) {
 		const itemCollection = item?.[m2aRelationInfo.value.collectionField];
 		const primaryKeyField = itemCollection ? m2aRelationInfo.value.primaryKeyFields[itemCollection] : null;
@@ -143,11 +124,11 @@ function getLinkForItem(item: any) {
 	return getItemRoute(relatedCollection.value, primaryKey);
 }
 
-function getM2ACollection(item: any) {
+function getM2ACollection(item: Record<string, any>) {
 	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.collectionField] ?? null) : null;
 }
 
-function getM2ATemplate(item: any) {
+function getM2ATemplate(item: Record<string, any>) {
 	const itemCollection = getM2ACollection(item);
 
 	if (!itemCollection || !m2aRelationInfo.value) return '';
@@ -155,11 +136,11 @@ function getM2ATemplate(item: any) {
 	return m2aRelationInfo.value.templates[itemCollection] ?? '';
 }
 
-function getM2AValue(item: any) {
+function getM2AValue(item: Record<string, any>) {
 	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.junctionField] ?? null) : null;
 }
 
-function getM2APrefix(item: any) {
+function getM2APrefix(item: Record<string, any>) {
 	const itemCollection = getM2ACollection(item);
 
 	if (!itemCollection) return t('item');
@@ -192,13 +173,15 @@ function getM2APrefix(item: any) {
 		<VList class="links">
 			<template v-if="localType === 'm2a' && !template">
 				<VListItem v-for="item in value" :key="item[primaryKeyFieldPath!]">
-					<VListItemContent class="m2a-item">
-						<span class="collection">{{ getM2APrefix(item) }}:</span>
-						<RenderTemplate
-							:template="getM2ATemplate(item)"
-							:item="getM2AValue(item)"
-							:collection="getM2ACollection(item) || undefined"
-						/>
+					<VListItemContent>
+						<div class="m2a-item">
+							<span class="collection">{{ getM2APrefix(item) }}:</span>
+							<RenderTemplate
+								:template="getM2ATemplate(item)"
+								:item="getM2AValue(item)"
+								:collection="getM2ACollection(item) || undefined"
+							/>
+						</div>
 					</VListItemContent>
 					<VListItemIcon>
 						<RouterLink v-if="getLinkForItem(item)" :to="getLinkForItem(item)!">

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -11,7 +11,6 @@ import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
 import { useRelationM2A } from '@/composables/use-relation-m2a';
-import { useCollectionsStore } from '@/stores/collections';
 import { getLocalTypeForField } from '@/utils/get-local-type';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { getItemRoute } from '@/utils/get-route';
@@ -26,8 +25,10 @@ const props = defineProps<{
 }>();
 
 const { t, te } = useI18n();
-const collectionsStore = useCollectionsStore();
-const { relationInfo } = useRelationM2A(toRef(props, 'collection'), toRef(props, 'field'));
+const { relationInfo } = useRelationM2A(
+	computed(() => props.collection),
+	computed(() => props.field),
+);
 
 const relatedCollectionData = computed(() => {
 	return getRelatedCollection(props.collection, props.field);
@@ -46,27 +47,7 @@ const localType = computed(() => {
 });
 
 const m2aRelationInfo = computed(() => {
-	if (localType.value !== 'm2a') return null;
-
-	if (!relationInfo.value) return null;
-
-	const primaryKeyFields = Object.fromEntries(
-		Object.entries(relationInfo.value.relationPrimaryKeyFields).map(([collection, field]) => [collection, field.field]),
-	) as Record<string, string>;
-
-	const templates = Object.fromEntries(
-		Object.entries(primaryKeyFields).map(([collection, primaryKeyField]) => [
-			collection,
-			collectionsStore.getCollection(collection)?.meta?.display_template || `{{ ${primaryKeyField} }}`,
-		]),
-	);
-
-	return {
-		collectionField: relationInfo.value.collectionField.field,
-		junctionField: relationInfo.value.junctionField.field,
-		primaryKeyFields,
-		templates,
-	};
+	return localType.value === 'm2a' ? relationInfo.value : null;
 });
 
 const { primaryKeyField } = useCollection(relatedCollection);
@@ -107,11 +88,13 @@ const unit = computed(() => {
 
 function getLinkForItem(item: Record<string, any>) {
 	if (m2aRelationInfo.value) {
-		const itemCollection = item?.[m2aRelationInfo.value.collectionField];
-		const primaryKeyField = itemCollection ? m2aRelationInfo.value.primaryKeyFields[itemCollection] : null;
+		const itemCollection = item?.[m2aRelationInfo.value.collectionField.field];
+		const primaryKeyField = itemCollection ? m2aRelationInfo.value.relationPrimaryKeyFields[itemCollection] : null;
 
 		const primaryKey =
-			itemCollection && primaryKeyField ? item?.[m2aRelationInfo.value.junctionField]?.[primaryKeyField] : null;
+			itemCollection && primaryKeyField
+				? item?.[m2aRelationInfo.value.junctionField.field]?.[primaryKeyField.field]
+				: null;
 
 		if (!itemCollection || primaryKey === null || primaryKey === undefined) return null;
 
@@ -125,7 +108,7 @@ function getLinkForItem(item: Record<string, any>) {
 }
 
 function getM2ACollection(item: Record<string, any>) {
-	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.collectionField] ?? null) : null;
+	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.collectionField.field] ?? null) : null;
 }
 
 function getM2ATemplate(item: Record<string, any>) {
@@ -133,11 +116,17 @@ function getM2ATemplate(item: Record<string, any>) {
 
 	if (!itemCollection || !m2aRelationInfo.value) return '';
 
-	return m2aRelationInfo.value.templates[itemCollection] ?? '';
+	const allowedCollection = m2aRelationInfo.value.allowedCollections.find(
+		(collection) => collection.collection === itemCollection,
+	);
+
+	const primaryKeyField = m2aRelationInfo.value.relationPrimaryKeyFields[itemCollection];
+
+	return allowedCollection?.meta?.display_template || (primaryKeyField ? `{{ ${primaryKeyField.field} }}` : '');
 }
 
 function getM2AValue(item: Record<string, any>) {
-	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.junctionField] ?? null) : null;
+	return m2aRelationInfo.value ? (item?.[m2aRelationInfo.value.junctionField.field] ?? null) : null;
 }
 
 function getM2APrefix(item: Record<string, any>) {
@@ -149,7 +138,10 @@ function getM2APrefix(item: Record<string, any>) {
 		return t(`collection_names_singular.${itemCollection}`);
 	}
 
-	return collectionsStore.getCollection(itemCollection)?.name ?? itemCollection;
+	return (
+		m2aRelationInfo.value?.allowedCollections.find((collection) => collection.collection === itemCollection)?.name ??
+		itemCollection
+	);
 }
 </script>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -259,3 +259,4 @@
 - tysoncung
 - Mugesh13102001
 - costajohnt
+- AbdelhamidKhald


### PR DESCRIPTION
Fixes #25348.

## Summary

The `related-values` display resolved default M2A values against the junction collection, so M2A entries showed junction-level defaults instead of each related collection's display template.

## Changes

- render default M2A related-values entries with each item's actual related collection and display template
- link M2A related-values entries to the actual related item instead of the junction row
- fetch the per-collection fields and primary keys needed for default M2A related-values rendering
- add a focused regression test for the default M2A display path

## Testing

- `pnpm exec eslint app/src/displays/related-values/related-values.vue app/src/displays/related-values/index.ts app/src/displays/related-values/related-values.test.ts`
- `vitest run src/displays/related-values/related-values.test.ts`