### PR TITLE
fix(app): show permission warning instead of misconfiguration error in relational interfaces

### DIFF
--- a/.changeset/fix-relation-permission-warning.md
+++ b/.changeset/fix-relation-permission-warning.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Show permission-specific warning instead of misconfiguration error in relational interfaces when user lacks read access on related collection

--- a/app/src/composables/use-relation-m2a.test.ts
+++ b/app/src/composables/use-relation-m2a.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useRelationM2A } from './use-relation-m2a';
+
+const mockRelationsStore = {
+	getRelationsForField: vi.fn(),
+};
+
+const mockCollectionsStore = {
+	getCollection: vi.fn(),
+};
+
+const mockFieldsStore = {
+	getPrimaryKeyFieldForCollection: vi.fn(),
+	getField: vi.fn(),
+};
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: vi.fn(() => mockRelationsStore),
+}));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: vi.fn(() => mockCollectionsStore),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: vi.fn(() => mockFieldsStore),
+}));
+
+describe('useRelationM2A', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('relationMissingPermissions is false when relationInfo exists', () => {
+		const junction = {
+			collection: 'page_blocks',
+			field: 'page_id',
+			related_collection: 'pages',
+			meta: { one_field: 'blocks', junction_field: 'item', sort_field: null },
+			schema: null,
+		};
+
+		const relation = {
+			collection: 'page_blocks',
+			field: 'item',
+			related_collection: null,
+			meta: {
+				junction_field: 'page_id',
+				one_allowed_collections: ['headings', 'texts'],
+				one_collection_field: 'collection',
+			},
+			schema: null,
+		};
+
+		mockRelationsStore.getRelationsForField.mockReturnValue([junction, relation]);
+
+		mockCollectionsStore.getCollection.mockImplementation((collection: string) => {
+			if (collection === 'page_blocks') return { collection: 'page_blocks' };
+			if (collection === 'headings') return { collection: 'headings' };
+			if (collection === 'texts') return { collection: 'texts' };
+			return null;
+		});
+
+		mockFieldsStore.getPrimaryKeyFieldForCollection.mockReturnValue({ field: 'id' });
+		mockFieldsStore.getField.mockReturnValue({ field: 'item' });
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2A(ref('pages'), ref('blocks'));
+
+		expect(relationInfo.value).toBeDefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is true when relationInfo is undefined and field has m2a special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'blocks',
+			meta: { special: ['m2a'] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2A(ref('pages'), ref('blocks'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(true);
+	});
+
+	test('relationMissingPermissions is false when relationInfo is undefined and field has no m2a special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'blocks',
+			meta: { special: [] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2A(ref('pages'), ref('blocks'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is false when field has no meta', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+		mockFieldsStore.getField.mockReturnValue(undefined);
+
+		const { relationMissingPermissions } = useRelationM2A(ref('pages'), ref('blocks'));
+
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+});

--- a/app/src/composables/use-relation-m2a.ts
+++ b/app/src/composables/use-relation-m2a.ts
@@ -88,5 +88,12 @@ export function useRelationM2A(collection: Ref<string>, field: Ref<string>) {
 		} as RelationM2A;
 	});
 
-	return { relationInfo };
+	const relationMissingPermissions = computed(() => {
+		if (relationInfo.value) return false;
+
+		const fieldInfo = fieldsStore.getField(collection.value, field.value);
+		return fieldInfo?.meta?.special?.includes('m2a') ?? false;
+	});
+
+	return { relationInfo, relationMissingPermissions };
 }

--- a/app/src/composables/use-relation-m2m.test.ts
+++ b/app/src/composables/use-relation-m2m.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useRelationM2M } from './use-relation-m2m';
+
+const mockRelationsStore = {
+	getRelationsForField: vi.fn(),
+};
+
+const mockCollectionsStore = {
+	getCollection: vi.fn(),
+};
+
+const mockFieldsStore = {
+	getPrimaryKeyFieldForCollection: vi.fn(),
+	getField: vi.fn(),
+};
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: vi.fn(() => mockRelationsStore),
+}));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: vi.fn(() => mockCollectionsStore),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: vi.fn(() => mockFieldsStore),
+}));
+
+describe('useRelationM2M', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('relationMissingPermissions is false when relationInfo exists', () => {
+		const junction = {
+			collection: 'articles_tags',
+			field: 'article_id',
+			related_collection: 'articles',
+			meta: { one_field: 'tags', junction_field: 'tag_id', sort_field: null },
+			schema: null,
+		};
+
+		const relation = {
+			collection: 'articles_tags',
+			field: 'tag_id',
+			related_collection: 'tags',
+			meta: { junction_field: 'article_id' },
+			schema: null,
+		};
+
+		mockRelationsStore.getRelationsForField.mockReturnValue([junction, relation]);
+		mockCollectionsStore.getCollection.mockReturnValue({ collection: 'tags' });
+		mockFieldsStore.getPrimaryKeyFieldForCollection.mockReturnValue({ field: 'id' });
+		mockFieldsStore.getField.mockReturnValue({ field: 'tag_id' });
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2M(ref('articles'), ref('tags'));
+
+		expect(relationInfo.value).toBeDefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is true when relationInfo is undefined and field has m2m special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'tags',
+			meta: { special: ['m2m'] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2M(ref('articles'), ref('tags'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(true);
+	});
+
+	test('relationMissingPermissions is false when relationInfo is undefined and field has no m2m special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'tags',
+			meta: { special: [] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2M(ref('articles'), ref('tags'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is false when field has no meta', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+		mockFieldsStore.getField.mockReturnValue(undefined);
+
+		const { relationMissingPermissions } = useRelationM2M(ref('articles'), ref('tags'));
+
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+});

--- a/app/src/composables/use-relation-m2m.ts
+++ b/app/src/composables/use-relation-m2m.ts
@@ -65,5 +65,12 @@ export function useRelationM2M(collection: Ref<string>, field: Ref<string>) {
 		} as RelationM2M;
 	});
 
-	return { relationInfo };
+	const relationMissingPermissions = computed(() => {
+		if (relationInfo.value) return false;
+
+		const fieldInfo = fieldsStore.getField(collection.value, field.value);
+		return fieldInfo?.meta?.special?.includes('m2m') ?? false;
+	});
+
+	return { relationInfo, relationMissingPermissions };
 }

--- a/app/src/composables/use-relation-m2o.test.ts
+++ b/app/src/composables/use-relation-m2o.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useRelationM2O } from './use-relation-m2o';
+
+const mockRelationsStore = {
+	getRelationsForField: vi.fn(),
+};
+
+const mockCollectionsStore = {
+	getCollection: vi.fn(),
+};
+
+const mockFieldsStore = {
+	getPrimaryKeyFieldForCollection: vi.fn(),
+	getField: vi.fn(),
+};
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: vi.fn(() => mockRelationsStore),
+}));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: vi.fn(() => mockCollectionsStore),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: vi.fn(() => mockFieldsStore),
+}));
+
+describe('useRelationM2O', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('relationMissingPermissions is false when relationInfo exists', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([
+			{ collection: 'articles', field: 'author', related_collection: 'users', meta: null, schema: null },
+		]);
+
+		mockCollectionsStore.getCollection.mockReturnValue({ collection: 'users' });
+		mockFieldsStore.getPrimaryKeyFieldForCollection.mockReturnValue({ field: 'id' });
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2O(ref('articles'), ref('author'));
+
+		expect(relationInfo.value).toBeDefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is true when relationInfo is undefined and field has m2o special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'author',
+			meta: { special: ['m2o'] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2O(ref('articles'), ref('author'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(true);
+	});
+
+	test('relationMissingPermissions is false when relationInfo is undefined and field has no m2o special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'author',
+			meta: { special: [] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationM2O(ref('articles'), ref('author'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is false when field has no meta', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+		mockFieldsStore.getField.mockReturnValue(undefined);
+
+		const { relationMissingPermissions } = useRelationM2O(ref('articles'), ref('author'));
+
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+});

--- a/app/src/composables/use-relation-m2o.ts
+++ b/app/src/composables/use-relation-m2o.ts
@@ -40,5 +40,12 @@ export function useRelationM2O(collection: Ref<string>, field: Ref<string>) {
 		} as RelationM2O;
 	});
 
-	return { relationInfo };
+	const relationMissingPermissions = computed(() => {
+		if (relationInfo.value) return false;
+
+		const fieldInfo = fieldsStore.getField(collection.value, field.value);
+		return fieldInfo?.meta?.special?.includes('m2o') ?? false;
+	});
+
+	return { relationInfo, relationMissingPermissions };
 }

--- a/app/src/composables/use-relation-o2m.test.ts
+++ b/app/src/composables/use-relation-o2m.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useRelationO2M } from './use-relation-o2m';
+
+const mockRelationsStore = {
+	getRelationsForField: vi.fn(),
+};
+
+const mockCollectionsStore = {
+	getCollection: vi.fn(),
+};
+
+const mockFieldsStore = {
+	getPrimaryKeyFieldForCollection: vi.fn(),
+	getField: vi.fn(),
+};
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: vi.fn(() => mockRelationsStore),
+}));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: vi.fn(() => mockCollectionsStore),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: vi.fn(() => mockFieldsStore),
+}));
+
+describe('useRelationO2M', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('relationMissingPermissions is false when relationInfo exists', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([
+			{
+				collection: 'comments',
+				field: 'article',
+				related_collection: 'articles',
+				meta: { many_field: 'article', sort_field: null },
+				schema: null,
+			},
+		]);
+
+		mockCollectionsStore.getCollection.mockReturnValue({ collection: 'comments' });
+		mockFieldsStore.getPrimaryKeyFieldForCollection.mockReturnValue({ field: 'id' });
+		mockFieldsStore.getField.mockReturnValue({ field: 'article' });
+
+		const { relationInfo, relationMissingPermissions } = useRelationO2M(ref('articles'), ref('comments'));
+
+		expect(relationInfo.value).toBeDefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is true when relationInfo is undefined and field has o2m special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'comments',
+			meta: { special: ['o2m'] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationO2M(ref('articles'), ref('comments'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(true);
+	});
+
+	test('relationMissingPermissions is false when relationInfo is undefined and field has no o2m special', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+
+		mockFieldsStore.getField.mockReturnValue({
+			field: 'comments',
+			meta: { special: [] },
+		});
+
+		const { relationInfo, relationMissingPermissions } = useRelationO2M(ref('articles'), ref('comments'));
+
+		expect(relationInfo.value).toBeUndefined();
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+
+	test('relationMissingPermissions is false when field has no meta', () => {
+		mockRelationsStore.getRelationsForField.mockReturnValue([]);
+		mockFieldsStore.getField.mockReturnValue(undefined);
+
+		const { relationMissingPermissions } = useRelationO2M(ref('articles'), ref('comments'));
+
+		expect(relationMissingPermissions.value).toBe(false);
+	});
+});

--- a/app/src/composables/use-relation-o2m.ts
+++ b/app/src/composables/use-relation-o2m.ts
@@ -45,5 +45,12 @@ export function useRelationO2M(collection: Ref<string>, field: Ref<string>) {
 		} as RelationO2M;
 	});
 
-	return { relationInfo };
+	const relationMissingPermissions = computed(() => {
+		if (relationInfo.value) return false;
+
+		const fieldInfo = fieldsStore.getField(collection.value, field.value);
+		return fieldInfo?.meta?.special?.includes('o2m') ?? false;
+	});
+
+	return { relationInfo, relationMissingPermissions };
 }

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -331,8 +331,12 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">{{ $t('relationship_missing_permissions') }}</VNotice>
-	<VNotice v-else-if="!relationInfo" type="warning">{{ $t('relationship_not_setup') }}</VNotice>
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">
+		{{ $t('relationship_missing_permissions') }}
+	</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">
+		{{ $t('relationship_not_setup') }}
+	</VNotice>
 	<div v-else v-prevent-focusout="menuActive" class="many-to-many">
 		<template v-if="loading">
 			<VSkeletonLoader

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -66,7 +66,7 @@ const emit = defineEmits<{
 }>();
 
 const { collection, field, primaryKey, limit, version } = toRefs(props);
-const { relationInfo } = useRelationM2M(collection, field);
+const { relationInfo, relationMissingPermissions } = useRelationM2M(collection, field);
 
 const value = computed({
 	get: () => props.value,
@@ -331,7 +331,8 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo" type="warning">{{ $t('relationship_not_setup') }}</VNotice>
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">{{ $t('relationship_missing_permissions') }}</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">{{ $t('relationship_not_setup') }}</VNotice>
 	<div v-else v-prevent-focusout="menuActive" class="many-to-many">
 		<template v-if="loading">
 			<VSkeletonLoader

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -58,7 +58,7 @@ const props = withDefaults(
 const emit = defineEmits(['input']);
 const { t, te } = useI18n();
 const { collection, field, primaryKey, limit, version } = toRefs(props);
-const { relationInfo } = useRelationM2A(collection, field);
+const { relationInfo, relationMissingPermissions } = useRelationM2A(collection, field);
 
 const value = computed({
 	get: () => props.value,
@@ -355,7 +355,8 @@ const menuActive = computed(
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo" type="warning">{{ $t('relationship_not_setup') }}</VNotice>
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">{{ $t('relationship_missing_permissions') }}</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">{{ $t('relationship_not_setup') }}</VNotice>
 	<VNotice v-else-if="allowedCollections.length === 0" type="warning">{{ $t('no_singleton_relations') }}</VNotice>
 	<div v-else v-prevent-focusout="menuActive" class="m2a-builder">
 		<VNotice v-if="!disabled && canDrag && !allowDrag">{{ $t('interfaces.list-m2a.sorting_disabled') }}</VNotice>

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -355,8 +355,12 @@ const menuActive = computed(
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">{{ $t('relationship_missing_permissions') }}</VNotice>
-	<VNotice v-else-if="!relationInfo" type="warning">{{ $t('relationship_not_setup') }}</VNotice>
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">
+		{{ $t('relationship_missing_permissions') }}
+	</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">
+		{{ $t('relationship_not_setup') }}
+	</VNotice>
 	<VNotice v-else-if="allowedCollections.length === 0" type="warning">{{ $t('no_singleton_relations') }}</VNotice>
 	<div v-else v-prevent-focusout="menuActive" class="m2a-builder">
 		<VNotice v-if="!disabled && canDrag && !allowDrag">{{ $t('interfaces.list-m2a.sorting_disabled') }}</VNotice>

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -80,7 +80,7 @@ const props = withDefaults(
 const emit = defineEmits(['input']);
 const { t, n } = useI18n();
 const { collection, field, primaryKey, version } = toRefs(props);
-const { relationInfo } = useRelationM2M(collection, field);
+const { relationInfo, relationMissingPermissions } = useRelationM2M(collection, field);
 const fieldsStore = useFieldsStore();
 
 const value = computed({
@@ -486,7 +486,10 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo" type="warning">
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">
+		{{ $t('relationship_missing_permissions') }}
+	</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">
 		{{ $t('relationship_not_setup') }}
 	</VNotice>
 	<VNotice v-else-if="relationInfo.relatedCollection.meta?.singleton" type="warning">

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -77,7 +77,7 @@ const props = withDefaults(
 const emit = defineEmits(['input']);
 const { t, n } = useI18n();
 const { collection, field, primaryKey, version } = toRefs(props);
-const { relationInfo } = useRelationO2M(collection, field);
+const { relationInfo, relationMissingPermissions } = useRelationO2M(collection, field);
 const fieldsStore = useFieldsStore();
 
 const { getWidth, updateWidths } = useColumnWidths(
@@ -449,7 +449,10 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo" type="warning">
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">
+		{{ $t('relationship_missing_permissions') }}
+	</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">
 		{{ $t('relationship_not_setup') }}
 	</VNotice>
 	<VNotice v-else-if="relationInfo.relatedCollection.meta?.singleton" type="warning">

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -68,7 +68,7 @@ const customFilter = computed(() => {
 });
 
 const { collection, field } = toRefs(props);
-const { relationInfo } = useRelationM2O(collection, field);
+const { relationInfo, relationMissingPermissions } = useRelationM2O(collection, field);
 
 const value = computed({
 	get: () => props.value ?? null,
@@ -178,7 +178,10 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 </script>
 
 <template>
-	<VNotice v-if="!relationInfo" type="warning">
+	<VNotice v-if="!relationInfo && relationMissingPermissions" type="warning">
+		{{ $t('relationship_missing_permissions') }}
+	</VNotice>
+	<VNotice v-else-if="!relationInfo" type="warning">
 		{{ $t('relationship_not_setup') }}
 	</VNotice>
 	<VNotice v-else-if="relationInfo.relatedCollection.meta?.singleton" type="warning">

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -747,6 +747,7 @@ create_collection: Create Collection
 no_collections_copy_admin: You don’t have any Collections yet. Click the button below to get started.
 no_collections_copy: You don’t have any Collections yet. Please contact your system administrator.
 relationship_not_setup: The relationship hasn't been configured correctly
+relationship_missing_permissions: You don't have permission to view the related collection
 no_singleton_relations: Relationships to Singletons are not supported
 display_template_not_setup: The display template option is misconfigured
 collection_field_not_setup: The collection field option is misconfigured

--- a/contributors.yml
+++ b/contributors.yml
@@ -259,3 +259,4 @@
 - tysoncung
 - Mugesh13102001
 - costajohnt
+- Ikromjon1998


### PR DESCRIPTION
When a user lacks read permission on a related collection, the relational interfaces (M2O, O2M, M2M, M2A, Files) showed "The relationship hasn't been configured correctly" — which is misleading since the relationship is correctly configured, the user simply doesn't have access.

This change adds a `relationMissingPermissions` computed property to each relation composable that checks if the field's metadata indicates a relation should exist (via `meta.special`) while `relationInfo` is undefined. When this is the case, a new "You don't have permission to view the related collection" message is shown instead.

Closes #21337

## Scope

What's changed:

- Added `relationMissingPermissions` computed property to `use-relation-m2o.ts`, `use-relation-o2m.ts`, `use-relation-m2m.ts`, and `use-relation-m2a.ts` composables
- Updated 5 relational interface components (`select-dropdown-m2o`, `list-o2m`, `list-m2m`, `list-m2a`, `files`) to show a permission-specific warning when `relationMissingPermissions` is true
- Added `relationship_missing_permissions` translation key to `en-US.yaml`

## Potential Risks / Drawbacks

- The detection relies on the field's `meta.special` array containing the relation type (e.g. `m2o`, `o2m`). If a field's special metadata is missing or corrupted, it would fall back to the original "not configured" message, which is the safe default.
- Only the `en-US` translation is added. Other locales will fall back to the translation key until translated.

## Tested Scenarios

- User with read permission on main collection but no read permission on related collection sees "You don't have permission to view the related collection" instead of "The relationship hasn't been configured correctly"
- User with a genuinely misconfigured relationship still sees the original "The relationship hasn't been configured correctly" message
- Admin users are unaffected as they have full access to all relations

## Review Notes / Questions

- The fix is frontend-only and does not change the API behavior. The API still filters out forbidden relations via `filterForbidden()` in the relations service.
- An alternative approach would be to have the API return permission metadata alongside relations, but that would be a larger change. This frontend-only approach covers the user-facing issue with minimal risk.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #21337