### PR TITLE
Fix AI tool approval flow hanging after approving provider-executed tools

### DIFF
--- a/.changeset/clean-rivers-return.md
+++ b/.changeset/clean-rivers-return.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed AI tool approval flow hanging after approving provider-executed tools.

--- a/app/src/ai/components/parts/ai-message-tool.vue
+++ b/app/src/ai/components/parts/ai-message-tool.vue
@@ -38,7 +38,11 @@ const state = computed(
 			| 'output-error',
 );
 
-const approval = computed(() => props.part.approval);
+const approval = computed(() => props.part.approval as { id: string; approved?: boolean; reason?: string } | undefined);
+const isApprovalRequested = computed(
+	() =>
+		state.value === 'approval-requested' || (approval.value?.id !== undefined && approval.value.approved === undefined),
+);
 
 const isAskUser = computed(() => toolName.value === 'ask_user');
 </script>
@@ -54,13 +58,7 @@ const isAskUser = computed(() => toolName.value === 'ask_user');
 	</AiToolCallCard>
 	<template v-else-if="isAskUser && state !== 'output-error'" />
 
-	<AiToolCallCard
-		v-else
-		:state="state"
-		:approval="approval"
-		:tool-name="toolName"
-		:default-open="state === 'approval-requested'"
-	>
+	<AiToolCallCard v-else :state="state" :approval="approval" :tool-name="toolName" :default-open="isApprovalRequested">
 		<template #title>
 			<VTextOverflow :text="toolDisplayName" />
 		</template>

--- a/app/src/ai/components/parts/ai-message-tool.vue
+++ b/app/src/ai/components/parts/ai-message-tool.vue
@@ -54,13 +54,7 @@ const isAskUser = computed(() => toolName.value === 'ask_user');
 	</AiToolCallCard>
 	<template v-else-if="isAskUser && state !== 'output-error'" />
 
-	<AiToolCallCard
-		v-else
-		:state="state"
-		:approval="approval"
-		:tool-name="toolName"
-		:default-open="state === 'approval-requested'"
-	>
+	<AiToolCallCard v-else :state="state" :approval="approval" :tool-name="toolName">
 		<template #title>
 			<VTextOverflow :text="toolDisplayName" />
 		</template>

--- a/app/src/ai/components/parts/ai-message-tool.vue
+++ b/app/src/ai/components/parts/ai-message-tool.vue
@@ -39,10 +39,6 @@ const state = computed(
 );
 
 const approval = computed(() => props.part.approval as { id: string; approved?: boolean; reason?: string } | undefined);
-const isApprovalRequested = computed(
-	() =>
-		state.value === 'approval-requested' || (approval.value?.id !== undefined && approval.value.approved === undefined),
-);
 
 const isAskUser = computed(() => toolName.value === 'ask_user');
 </script>
@@ -58,7 +54,13 @@ const isAskUser = computed(() => toolName.value === 'ask_user');
 	</AiToolCallCard>
 	<template v-else-if="isAskUser && state !== 'output-error'" />
 
-	<AiToolCallCard v-else :state="state" :approval="approval" :tool-name="toolName" :default-open="isApprovalRequested">
+	<AiToolCallCard
+		v-else
+		:state="state"
+		:approval="approval"
+		:tool-name="toolName"
+		:default-open="state === 'approval-requested'"
+	>
 		<template #title>
 			<VTextOverflow :text="toolDisplayName" />
 		</template>

--- a/app/src/ai/components/parts/ai-tool-call-card.test.ts
+++ b/app/src/ai/components/parts/ai-tool-call-card.test.ts
@@ -1,0 +1,61 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import AiToolCallCard from './ai-tool-call-card.vue';
+
+vi.mock('vue-i18n', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-i18n')>();
+
+	return {
+		...actual,
+		useI18n: () => ({ t: (key: string) => key }),
+	};
+});
+
+vi.mock('@/ai/stores/use-ai', () => ({
+	useAiStore: () => ({
+		approveToolCall: vi.fn(),
+		denyToolCall: vi.fn(),
+	}),
+}));
+
+vi.mock('@/ai/stores/use-ai-tools', () => ({
+	useAiToolsStore: () => ({
+		setToolApprovalMode: vi.fn(),
+	}),
+}));
+
+function mountCard(props: Record<string, unknown> = {}) {
+	return shallowMount(AiToolCallCard, {
+		props: {
+			state: 'output-available',
+			toolName: 'test_tool',
+			...props,
+		},
+	});
+}
+
+describe('ai-tool-call-card open/close behavior', () => {
+	test('starts closed for completed tools', () => {
+		const wrapper = mountCard({ state: 'output-available' });
+		const root = wrapper.findComponent({ name: 'CollapsibleRoot' });
+		expect(root.props('open')).toBe(false);
+	});
+
+	test('opens when state transitions to approval-requested', async () => {
+		const wrapper = mountCard({ state: 'input-streaming' });
+		const root = wrapper.findComponent({ name: 'CollapsibleRoot' });
+		expect(root.props('open')).toBe(false);
+
+		await wrapper.setProps({ state: 'approval-requested' });
+		expect(root.props('open')).toBe(true);
+	});
+
+	test('closes when state transitions from approval-requested to output-available', async () => {
+		const wrapper = mountCard({ state: 'approval-requested' });
+		const root = wrapper.findComponent({ name: 'CollapsibleRoot' });
+		expect(root.props('open')).toBe(true);
+
+		await wrapper.setProps({ state: 'output-available' });
+		expect(root.props('open')).toBe(false);
+	});
+});

--- a/app/src/ai/components/parts/ai-tool-call-card.vue
+++ b/app/src/ai/components/parts/ai-tool-call-card.vue
@@ -15,18 +15,22 @@ const { t } = useI18n();
 
 const props = defineProps<{
 	state: 'input-streaming' | 'input-available' | 'approval-requested' | 'output-available' | 'output-error';
-	approval?: { id: string };
+	approval?: { id: string; approved?: boolean; reason?: string };
 	toolName: string;
 	icon?: string;
 	defaultOpen?: boolean;
 }>();
 
-const isStreaming = computed(() => props.state === 'input-streaming' || props.state === 'input-available');
-const isApprovalRequested = computed(() => props.state === 'approval-requested');
-const shouldBeOpen = computed(() => props.state === 'approval-requested' || props.defaultOpen);
+const hasPendingApproval = computed(() => props.approval?.id !== undefined && props.approval.approved === undefined);
+const effectiveState = computed(() => (hasPendingApproval.value ? 'approval-requested' : props.state));
+const isStreaming = computed(
+	() => effectiveState.value === 'input-streaming' || effectiveState.value === 'input-available',
+);
+const isApprovalRequested = computed(() => effectiveState.value === 'approval-requested');
+const shouldBeOpen = computed(() => isApprovalRequested.value || props.defaultOpen);
 
 const statusConfig = computed(() => {
-	switch (props.state) {
+	switch (effectiveState.value) {
 		case 'input-streaming':
 			return { icon: 'pending', label: t('ai.streaming'), class: 'status-streaming' };
 		case 'input-available':

--- a/app/src/ai/components/parts/ai-tool-call-card.vue
+++ b/app/src/ai/components/parts/ai-tool-call-card.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger } from 'reka-ui';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useAiStore } from '@/ai/stores/use-ai';
 import { useAiToolsStore } from '@/ai/stores/use-ai-tools';
@@ -21,16 +21,21 @@ const props = defineProps<{
 	defaultOpen?: boolean;
 }>();
 
-const hasPendingApproval = computed(() => props.approval?.id !== undefined && props.approval.approved === undefined);
-const effectiveState = computed(() => (hasPendingApproval.value ? 'approval-requested' : props.state));
-const isStreaming = computed(
-	() => effectiveState.value === 'input-streaming' || effectiveState.value === 'input-available',
-);
-const isApprovalRequested = computed(() => effectiveState.value === 'approval-requested');
+const isStreaming = computed(() => props.state === 'input-streaming' || props.state === 'input-available');
+const isApprovalRequested = computed(() => props.state === 'approval-requested');
 const shouldBeOpen = computed(() => isApprovalRequested.value || props.defaultOpen);
+const isOpen = ref(false);
+
+watch(
+	shouldBeOpen,
+	(next) => {
+		isOpen.value = next;
+	},
+	{ immediate: true },
+);
 
 const statusConfig = computed(() => {
-	switch (effectiveState.value) {
+	switch (props.state) {
 		case 'input-streaming':
 			return { icon: 'pending', label: t('ai.streaming'), class: 'status-streaming' };
 		case 'input-available':
@@ -68,7 +73,7 @@ const handleAlwaysAllow = () => {
 </script>
 
 <template>
-	<CollapsibleRoot class="tool-call-card" :default-open="shouldBeOpen" :disabled="isApprovalRequested">
+	<CollapsibleRoot v-model:open="isOpen" class="tool-call-card" :disabled="isApprovalRequested">
 		<CollapsibleTrigger
 			class="card-header"
 			:class="{ 'is-disabled': isApprovalRequested }"

--- a/app/src/ai/stores/use-ai.test.ts
+++ b/app/src/ai/stores/use-ai.test.ts
@@ -1,5 +1,9 @@
 import { createTestingPinia } from '@pinia/testing';
-import type { UIMessage } from 'ai';
+import {
+	lastAssistantMessageIsCompleteWithApprovalResponses,
+	lastAssistantMessageIsCompleteWithToolCalls,
+	type UIMessage,
+} from 'ai';
 import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ref } from 'vue';
@@ -74,7 +78,7 @@ vi.mock('@ai-sdk/vue', () => {
 				regenerate: vi.fn(),
 				stop: vi.fn(),
 				addToolResult: vi.fn(),
-				addToolApprovalResponse: vi.fn(),
+				addToolApprovalResponse: vi.fn(() => Promise.resolve()),
 			};
 		}),
 	};
@@ -164,6 +168,94 @@ describe('useAiStore', () => {
 			expect(aiStore.isAwaitingToolExecution).toBe(false);
 			expect(aiStore.isUiLoading).toBe(false);
 			expect(aiStore.showAssistantLoadingIndicator).toBe(false);
+		});
+	});
+
+	describe('tool approval auto-send', () => {
+		test('normalizes pending approval state before approving', () => {
+			const aiStore = useAiStore();
+
+			aiStore.chat.messages.push({
+				id: '1',
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-schema',
+						toolCallId: 'call-1',
+						state: 'input-available',
+						input: {},
+						approval: { id: 'approval-1' },
+					},
+				],
+			} as any);
+
+			aiStore.approveToolCall('approval-1');
+
+			expect((aiStore.chat.messages[0]!.parts[0] as any).state).toBe('approval-requested');
+			expect(aiStore.chat.addToolApprovalResponse).toHaveBeenCalledWith({ id: 'approval-1', approved: true });
+		});
+
+		test('auto-sends when a provider-executed tool approval is responded', () => {
+			useAiStore();
+
+			vi.mocked(lastAssistantMessageIsCompleteWithApprovalResponses).mockReturnValue(false);
+			vi.mocked(lastAssistantMessageIsCompleteWithToolCalls).mockReturnValue(false);
+
+			const shouldSend = lastChatConfig.sendAutomaticallyWhen({
+				messages: [
+					{
+						id: '1',
+						role: 'assistant',
+						parts: [
+							{
+								type: 'tool-schema',
+								toolCallId: 'call-1',
+								state: 'approval-responded',
+								input: {},
+								providerExecuted: true,
+								approval: { id: 'approval-1', approved: true },
+							},
+						],
+					},
+				],
+			});
+
+			expect(shouldSend).toBe(true);
+		});
+
+		test('does not auto-send if a tool in the same step is still pending', () => {
+			useAiStore();
+
+			vi.mocked(lastAssistantMessageIsCompleteWithApprovalResponses).mockReturnValue(false);
+			vi.mocked(lastAssistantMessageIsCompleteWithToolCalls).mockReturnValue(false);
+
+			const shouldSend = lastChatConfig.sendAutomaticallyWhen({
+				messages: [
+					{
+						id: '1',
+						role: 'assistant',
+						parts: [
+							{
+								type: 'tool-schema',
+								toolCallId: 'call-1',
+								state: 'approval-responded',
+								input: {},
+								providerExecuted: true,
+								approval: { id: 'approval-1', approved: true },
+							},
+							{
+								type: 'tool-items',
+								toolCallId: 'call-2',
+								state: 'input-available',
+								input: {},
+								providerExecuted: false,
+							},
+						],
+					},
+				],
+			});
+
+			expect(shouldSend).toBe(false);
 		});
 	});
 

--- a/app/src/ai/stores/use-ai.test.ts
+++ b/app/src/ai/stores/use-ai.test.ts
@@ -169,6 +169,28 @@ describe('useAiStore', () => {
 			expect(aiStore.isUiLoading).toBe(false);
 			expect(aiStore.showAssistantLoadingIndicator).toBe(false);
 		});
+
+		test('treats pending approvals as approval-requested when state is input-available', () => {
+			const aiStore = useAiStore();
+
+			aiStore.chat.messages.push({
+				id: '1',
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-schema',
+						toolCallId: 'call-1',
+						state: 'input-available',
+						input: {},
+						approval: { id: 'approval-1' },
+					},
+				],
+			} as any);
+
+			expect(aiStore.hasPendingToolCall).toBe(true);
+			expect(aiStore.isAwaitingToolExecution).toBe(false);
+			expect(aiStore.isUiLoading).toBe(false);
+		});
 	});
 
 	describe('tool approval auto-send', () => {

--- a/app/src/ai/stores/use-ai.test.ts
+++ b/app/src/ai/stores/use-ai.test.ts
@@ -1,9 +1,5 @@
 import { createTestingPinia } from '@pinia/testing';
-import {
-	lastAssistantMessageIsCompleteWithApprovalResponses,
-	lastAssistantMessageIsCompleteWithToolCalls,
-	type UIMessage,
-} from 'ai';
+import { lastAssistantMessageIsCompleteWithToolCalls, type UIMessage } from 'ai';
 import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ref } from 'vue';
@@ -89,7 +85,6 @@ vi.mock('ai', () => ({
 		lastTransportConfig = config;
 		return config;
 	}),
-	lastAssistantMessageIsCompleteWithApprovalResponses: vi.fn(),
 	lastAssistantMessageIsCompleteWithToolCalls: vi.fn(),
 }));
 
@@ -220,7 +215,6 @@ describe('useAiStore', () => {
 		test('auto-sends when a provider-executed tool approval is responded', () => {
 			useAiStore();
 
-			vi.mocked(lastAssistantMessageIsCompleteWithApprovalResponses).mockReturnValue(false);
 			vi.mocked(lastAssistantMessageIsCompleteWithToolCalls).mockReturnValue(false);
 
 			const shouldSend = lastChatConfig.sendAutomaticallyWhen({
@@ -248,7 +242,6 @@ describe('useAiStore', () => {
 		test('does not auto-send if a tool in the same step is still pending', () => {
 			useAiStore();
 
-			vi.mocked(lastAssistantMessageIsCompleteWithApprovalResponses).mockReturnValue(false);
 			vi.mocked(lastAssistantMessageIsCompleteWithToolCalls).mockReturnValue(false);
 
 			const shouldSend = lastChatConfig.sendAutomaticallyWhen({

--- a/app/src/ai/stores/use-ai.ts
+++ b/app/src/ai/stores/use-ai.ts
@@ -581,11 +581,11 @@ export const useAiStore = defineStore('ai-store', () => {
 
 		void chat
 			.addToolApprovalResponse({ id: approvalId, approved })
-			.catch(unexpectedError)
-			.finally(() => {
+			.then(() => {
 				applyLocalApprovalResponseFallback(approvalId, approved);
 				maybeContinueAfterApprovalResponse();
-			});
+			})
+			.catch(unexpectedError);
 	};
 
 	const approveToolCall = (approvalId: string) => respondToToolCall(approvalId, true);

--- a/app/src/ai/stores/use-ai.ts
+++ b/app/src/ai/stores/use-ai.ts
@@ -1,13 +1,7 @@
 import { Chat } from '@ai-sdk/vue';
 import { type ContextAttachment, type PrimaryKey, type StandardProviderType, type SystemTool } from '@directus/ai';
 import { createEventHook, useLocalStorage, useSessionStorage } from '@vueuse/core';
-import {
-	DefaultChatTransport,
-	type FileUIPart,
-	lastAssistantMessageIsCompleteWithApprovalResponses,
-	lastAssistantMessageIsCompleteWithToolCalls,
-	type UIMessage,
-} from 'ai';
+import { DefaultChatTransport, type FileUIPart, lastAssistantMessageIsCompleteWithToolCalls, type UIMessage } from 'ai';
 import { defineStore } from 'pinia';
 import { computed, reactive, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
@@ -20,6 +14,32 @@ import { useAiToolsStore } from './use-ai-tools';
 import { useSettingsStore } from '@/stores/settings';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { useSidebarStore } from '@/views/private/private-view/stores/sidebar';
+
+const lastAssistantMessageIsCompleteWithToolApprovalResponses = ({ messages }: { messages: UIMessage[] }) => {
+	const message = messages.at(-1);
+
+	if (!message || message.role !== 'assistant') {
+		return false;
+	}
+
+	const lastStepStartIndex = message.parts.reduce((lastIndex, part, index) => {
+		return part.type === 'step-start' ? index : lastIndex;
+	}, -1);
+
+	const lastStepToolInvocations = message.parts
+		.slice(lastStepStartIndex + 1)
+		.filter((part) => part.type === 'dynamic-tool' || part.type.startsWith('tool-')) as Array<{ state: string }>;
+
+	// Include provider-executed tools here. We still need to trigger a new request
+	// after approval responses so the server can continue execution.
+	return (
+		lastStepToolInvocations.some((part) => part.state === 'approval-responded') &&
+		lastStepToolInvocations.every(
+			(part) =>
+				part.state === 'output-available' || part.state === 'output-error' || part.state === 'approval-responded',
+		)
+	);
+};
 
 export const useAiStore = defineStore('ai-store', () => {
 	const settingsStore = useSettingsStore();
@@ -248,7 +268,7 @@ export const useAiStore = defineStore('ai-store', () => {
 			},
 		}),
 		sendAutomaticallyWhen: ({ messages }) =>
-			lastAssistantMessageIsCompleteWithApprovalResponses({ messages }) ||
+			lastAssistantMessageIsCompleteWithToolApprovalResponses({ messages }) ||
 			lastAssistantMessageIsCompleteWithToolCalls({ messages }),
 		onData: (data) => {
 			if (data.type === 'data-usage') {
@@ -486,12 +506,40 @@ export const useAiStore = defineStore('ai-store', () => {
 		return context;
 	});
 
+	const normalizePendingApprovalState = (approvalId: string) => {
+		const lastMessage = chat.messages.at(-1);
+
+		if (!lastMessage || lastMessage.role !== 'assistant') {
+			return;
+		}
+
+		const matchingPart = lastMessage.parts.find((part) => {
+			if (part.type !== 'dynamic-tool' && !part.type.startsWith('tool-')) {
+				return false;
+			}
+
+			return 'approval' in part && part.approval?.id === approvalId;
+		}) as { state: string } | undefined;
+
+		if (!matchingPart) {
+			return;
+		}
+
+		// Some streams provide approval metadata before state settles to
+		// approval-requested. Normalize so addToolApprovalResponse can always apply.
+		if (matchingPart.state === 'input-streaming' || matchingPart.state === 'input-available') {
+			matchingPart.state = 'approval-requested';
+		}
+	};
+
 	const approveToolCall = (approvalId: string) => {
-		chat.addToolApprovalResponse({ id: approvalId, approved: true });
+		normalizePendingApprovalState(approvalId);
+		void chat.addToolApprovalResponse({ id: approvalId, approved: true }).catch(unexpectedError);
 	};
 
 	const denyToolCall = (approvalId: string) => {
-		chat.addToolApprovalResponse({ id: approvalId, approved: false });
+		normalizePendingApprovalState(approvalId);
+		void chat.addToolApprovalResponse({ id: approvalId, approved: false }).catch(unexpectedError);
 	};
 
 	return {

--- a/app/src/ai/stores/use-ai.ts
+++ b/app/src/ai/stores/use-ai.ts
@@ -41,6 +41,19 @@ const lastAssistantMessageIsCompleteWithToolApprovalResponses = ({ messages }: {
 	);
 };
 
+type ToolPartLike = { state?: string; approval?: { id: string; approved?: boolean; reason?: string } };
+
+const getEffectiveToolPartState = (part: ToolPartLike) => {
+	if (!part.state) return undefined;
+	if (!part.approval?.id || part.approval.approved !== undefined) return part.state;
+
+	if (part.state === 'input-streaming' || part.state === 'input-available') {
+		return 'approval-requested';
+	}
+
+	return part.state;
+};
+
 export const useAiStore = defineStore('ai-store', () => {
 	const settingsStore = useSettingsStore();
 	const sidebarStore = useSidebarStore();
@@ -214,59 +227,61 @@ export const useAiStore = defineStore('ai-store', () => {
 	const pendingContextSnapshot = ref<ContextAttachment[]>([]);
 	const isPreparingSubmission = ref(false);
 
+	const transport = new DefaultChatTransport({
+		api: '/ai/chat',
+		credentials: 'include',
+		body: () => {
+			const tools = [...toolsStore.enabledSystemTools, ...toolsStore.localTools.map(toApiTool)];
+
+			// Filter toolApprovals to only include 'always' and 'ask' (not 'disabled')
+			const approvals: Record<string, 'always' | 'ask'> = {};
+
+			for (const [toolName, mode] of Object.entries(toolsStore.toolApprovals)) {
+				if (mode === 'always' || mode === 'ask') {
+					approvals[toolName] = mode;
+				}
+			}
+
+			// Build context for system prompt
+			const context: {
+				attachments?: ContextAttachment[];
+				page?: { path: string; collection?: string; item?: string | number; module?: string };
+			} = {
+				page: currentPageContext.value,
+			};
+
+			if (pendingContextSnapshot.value.length > 0) {
+				context.attachments = pendingContextSnapshot.value;
+			}
+
+			return {
+				provider: selectedModel.value?.provider,
+				model: selectedModel.value?.model,
+				tools,
+				toolApprovals: approvals,
+				context,
+			};
+		},
+		prepareSendMessagesRequest: (req) => {
+			const limitedMessages =
+				estimatedMaxMessages.value < Infinity ? req.messages.slice(-estimatedMaxMessages.value) : req.messages;
+
+			const messages = sanitizeMessages(limitedMessages);
+
+			return {
+				...req,
+				body: {
+					...req.body,
+					messages,
+				},
+			};
+		},
+	});
+
 	// Chat instance
 	const chat = new Chat<UIMessage>({
 		messages: storedMessages.value,
-		transport: new DefaultChatTransport({
-			api: '/ai/chat',
-			credentials: 'include',
-			body: () => {
-				const tools = [...toolsStore.enabledSystemTools, ...toolsStore.localTools.map(toApiTool)];
-
-				// Filter toolApprovals to only include 'always' and 'ask' (not 'disabled')
-				const approvals: Record<string, 'always' | 'ask'> = {};
-
-				for (const [toolName, mode] of Object.entries(toolsStore.toolApprovals)) {
-					if (mode === 'always' || mode === 'ask') {
-						approvals[toolName] = mode;
-					}
-				}
-
-				// Build context for system prompt
-				const context: {
-					attachments?: ContextAttachment[];
-					page?: { path: string; collection?: string; item?: string | number; module?: string };
-				} = {
-					page: currentPageContext.value,
-				};
-
-				if (pendingContextSnapshot.value.length > 0) {
-					context.attachments = pendingContextSnapshot.value;
-				}
-
-				return {
-					provider: selectedModel.value?.provider,
-					model: selectedModel.value?.model,
-					tools,
-					toolApprovals: approvals,
-					context,
-				};
-			},
-			prepareSendMessagesRequest: (req) => {
-				const limitedMessages =
-					estimatedMaxMessages.value < Infinity ? req.messages.slice(-estimatedMaxMessages.value) : req.messages;
-
-				const messages = sanitizeMessages(limitedMessages);
-
-				return {
-					...req,
-					body: {
-						...req.body,
-						messages,
-					},
-				};
-			},
-		}),
+		transport,
 		sendAutomaticallyWhen: ({ messages }) =>
 			lastAssistantMessageIsCompleteWithToolApprovalResponses({ messages }) ||
 			lastAssistantMessageIsCompleteWithToolCalls({ messages }),
@@ -331,7 +346,21 @@ export const useAiStore = defineStore('ai-store', () => {
 	const messages = computed(() =>
 		chat.messages.map((msg) => ({
 			...msg,
-			parts: [...(msg.parts ?? [])],
+			parts: (msg.parts ?? []).map((part) => {
+				if (part.type !== 'dynamic-tool' && !part.type.startsWith('tool-')) {
+					return part;
+				}
+
+				const toolPart = part as ToolPartLike;
+
+				// Always clone tool parts to force Vue prop updates when the SDK mutates
+				// nested fields (state/approval) in place.
+				return {
+					...part,
+					state: getEffectiveToolPartState(toolPart) ?? toolPart.state,
+					...(toolPart.approval ? { approval: { ...toolPart.approval } } : {}),
+				};
+			}),
 		})),
 	);
 
@@ -506,24 +535,19 @@ export const useAiStore = defineStore('ai-store', () => {
 		return context;
 	});
 
-	const normalizePendingApprovalState = (approvalId: string) => {
+	const findMatchingApprovalPart = (approvalId: string) => {
 		const lastMessage = chat.messages.at(-1);
+		if (!lastMessage || lastMessage.role !== 'assistant') return undefined;
 
-		if (!lastMessage || lastMessage.role !== 'assistant') {
-			return;
-		}
-
-		const matchingPart = lastMessage.parts.find((part) => {
-			if (part.type !== 'dynamic-tool' && !part.type.startsWith('tool-')) {
-				return false;
-			}
-
+		return lastMessage.parts.find((part) => {
+			if (part.type !== 'dynamic-tool' && !part.type.startsWith('tool-')) return false;
 			return 'approval' in part && part.approval?.id === approvalId;
-		}) as { state: string } | undefined;
+		}) as (ToolPartLike & { state: string }) | undefined;
+	};
 
-		if (!matchingPart) {
-			return;
-		}
+	const normalizePendingApprovalState = (approvalId: string) => {
+		const matchingPart = findMatchingApprovalPart(approvalId);
+		if (!matchingPart) return;
 
 		// Some streams provide approval metadata before state settles to
 		// approval-requested. Normalize so addToolApprovalResponse can always apply.
@@ -532,15 +556,40 @@ export const useAiStore = defineStore('ai-store', () => {
 		}
 	};
 
-	const approveToolCall = (approvalId: string) => {
-		normalizePendingApprovalState(approvalId);
-		void chat.addToolApprovalResponse({ id: approvalId, approved: true }).catch(unexpectedError);
+	const applyLocalApprovalResponseFallback = (approvalId: string, approved: boolean) => {
+		const matchingPart = findMatchingApprovalPart(approvalId);
+		if (!matchingPart) return;
+
+		matchingPart.state = 'approval-responded';
+
+		matchingPart.approval = {
+			id: approvalId,
+			approved,
+			...(matchingPart.approval?.reason ? { reason: matchingPart.approval.reason } : {}),
+		};
 	};
 
-	const denyToolCall = (approvalId: string) => {
-		normalizePendingApprovalState(approvalId);
-		void chat.addToolApprovalResponse({ id: approvalId, approved: false }).catch(unexpectedError);
+	const maybeContinueAfterApprovalResponse = () => {
+		if (chat.status === 'streaming' || chat.status === 'submitted') return;
+		if (!lastAssistantMessageIsCompleteWithToolApprovalResponses({ messages: chat.messages })) return;
+
+		void chat.sendMessage().catch(unexpectedError);
 	};
+
+	const respondToToolCall = (approvalId: string, approved: boolean) => {
+		normalizePendingApprovalState(approvalId);
+
+		void chat
+			.addToolApprovalResponse({ id: approvalId, approved })
+			.catch(unexpectedError)
+			.finally(() => {
+				applyLocalApprovalResponseFallback(approvalId, approved);
+				maybeContinueAfterApprovalResponse();
+			});
+	};
+
+	const approveToolCall = (approvalId: string) => respondToToolCall(approvalId, true);
+	const denyToolCall = (approvalId: string) => respondToToolCall(approvalId, false);
 
 	return {
 		// UI State


### PR DESCRIPTION
## Scope

This fixes a bug where the UI hangs on tool approval status which causes users to never see the tool approval buttons.

What's changed:

- Fixed AI tool approval flow hanging after approving provider-executed tools
- Replaced upstream `lastAssistantMessageIsCompleteWithApprovalResponses` with a custom implementation that correctly handles provider-executed tool approvals
- Added state normalization so approval responses work even when tool part state hasn't settled to `approval-requested` yet
- Tool call card now reactively opens/closes based on approval state instead of relying on `defaultOpen`
- Added local fallback that applies approval response state directly when the SDK doesn't update it, then triggers `sendMessage` to continue the flow

## Potential Risks / Drawbacks

- Custom `lastAssistantMessageIsCompleteWithToolApprovalResponses` diverges from upstream SDK — need to track if the SDK fixes this behavior later
- Direct mutation of tool part state in `normalizePendingApprovalState` is a workaround for SDK timing issues

## Tested Scenarios

- Approve a provider-executed tool call → flow continues without hanging
- Deny a provider-executed tool call → flow continues without hanging
- Multiple tool calls in same step where one is approved and another is still pending → doesn't auto-send prematurely
- Tool call card opens when approval is requested and closes after response
- Unit tests added for tool call card open/close behavior and approval auto-send logic

## Review Notes / Questions

- The core issue was that the SDK's built-in `lastAssistantMessageIsCompleteWithApprovalResponses` didn't account for provider-executed tools, so after approving them, `sendAutomaticallyWhen` never fired and the chat just hung
- `getEffectiveToolPartState` also handles the case where tool parts arrive with `input-available` state but already have approval metadata — treats those as `approval-requested` for the UI

## Checklist

- [x] Added or updated tests
- ~~Documentation PR created [here](https://github.com/directus/docs) or not required~~
- ~~OpenAPI package PR created [here](https://github.com/directus/openapi) or not required~~


Fixes #26855