### PR TITLE
fix(app): preserve empty string defaults for non-nullable string/text fields

### DIFF
--- a/.changeset/polite-lamps-double.md
+++ b/.changeset/polite-lamps-double.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the advanced field schema editor to preserve empty-string defaults for non-nullable string and text fields.

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.test.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.test.ts
@@ -1,0 +1,77 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { useFieldDetailStore } from '../store';
+import FieldDetailAdvancedSchema from './field-detail-advanced-schema.vue';
+
+const i18n = createI18n({ legacy: false });
+
+vi.spyOn(i18n.global, 't').mockImplementation((key: any) => key);
+
+describe('FieldDetailAdvancedSchema', () => {
+	beforeEach(() => {
+		const pinia = createTestingPinia({
+			createSpy: vi.fn,
+			stubActions: false,
+		});
+
+		setActivePinia(pinia);
+	});
+
+	it('keeps null defaults for nullable string fields', async () => {
+		const { wrapper, fieldDetailStore } = mountWithField({ type: 'string', isNullable: true });
+
+		await wrapper.get('input[placeholder="NULL"]').setValue('');
+
+		expect(fieldDetailStore.field.schema?.default_value).toBeNull();
+	});
+
+	it.each(['string', 'text'])('stores empty string defaults for non-nullable %s fields', async (type) => {
+		const { wrapper, fieldDetailStore } = mountWithField({ type, isNullable: false });
+		const selector = type === 'text' ? 'textarea[placeholder="NULL"]' : 'input[placeholder="NULL"]';
+
+		await wrapper.get(selector).setValue('');
+
+		expect(fieldDetailStore.field.schema?.default_value).toBe('');
+	});
+});
+
+function mountWithField({ type, isNullable }: { type: 'string' | 'text'; isNullable: boolean }) {
+	const fieldDetailStore = useFieldDetailStore();
+
+	fieldDetailStore.$patch({
+		localType: 'standard',
+		field: {
+			collection: 'articles',
+			field: 'title',
+			type,
+			schema: {
+				default_value: 'seed',
+				is_nullable: isNullable,
+				is_primary_key: false,
+				is_generated: false,
+			},
+			meta: {},
+		},
+	});
+
+	const wrapper = mount(FieldDetailAdvancedSchema, {
+		global: {
+			plugins: [i18n],
+			directives: {
+				focus: () => undefined,
+				tooltip: () => undefined,
+			},
+			stubs: {
+				InterfaceInputCode: true,
+				VCheckbox: true,
+				VIcon: true,
+				VSelect: true,
+			},
+		},
+	});
+
+	return { wrapper, fieldDetailStore };
+}

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -398,9 +398,21 @@ function useOnUpdate() {
 			<div v-if="!isAlias && !isPrimaryKey && !isGenerated" class="field full">
 				<div class="label type-label">{{ $t('default_value') }}</div>
 
-				<VInput v-if="['string', 'uuid'].includes(type)" v-model="defaultValue" class="monospace" placeholder="NULL" />
+				<VInput
+					v-if="['string', 'uuid'].includes(type)"
+					v-model="defaultValue"
+					class="monospace"
+					:nullable="type === 'string' ? nullable : true"
+					placeholder="NULL"
+				/>
 
-				<VTextarea v-else-if="['text'].includes(type)" v-model="defaultValue" class="monospace" placeholder="NULL" />
+				<VTextarea
+					v-else-if="['text'].includes(type)"
+					v-model="defaultValue"
+					class="monospace"
+					:nullable="nullable"
+					placeholder="NULL"
+				/>
 				<VInput
 					v-else-if="['integer', 'bigInteger', 'float', 'decimal'].includes(type)"
 					v-model="defaultValue"

--- a/contributors.yml
+++ b/contributors.yml
@@ -259,3 +259,4 @@
 - tysoncung
 - Mugesh13102001
 - costajohnt
+- AbdelhamidKhald


### PR DESCRIPTION
## Scope

What's changed:

- made the advanced field schema editor keep `''` when clearing defaults for non-nullable `string` and `text` fields
- kept nullable `string` defaults clearing to `null`
- added a regression test covering both behaviors
- added `AbdelhamidKhald` to `contributors.yml` for the CLA check

## Potential Risks / Drawbacks

- only the advanced schema editor path changed; simple field creation still behaves as before
- the change only affects `string` / `text` default editors and leaves `uuid` plus other types unchanged

## Tested Scenarios

- cleared a nullable `string` default and verified the stored value becomes `null`
- cleared non-nullable `string` and `text` defaults and verified the stored value becomes `''`
- ran targeted ESLint, Prettier, and Vitest checks

## Review Notes / Questions

- I limited the fix to the advanced schema editor because that is where `is_nullable` is explicitly available
- this avoids the regression from the earlier attempt that made `null` unreachable for nullable fields

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #24759
