### PR TITLE
Fixed "create related item with "empty" or default state #26536"

### DIFF
--- a/.changeset/better-lamps-feel.md
+++ b/.changeset/better-lamps-feel.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed "create related item with "empty" or default state #26536"
+Fixed creation of related item with empty or default state

--- a/.changeset/better-lamps-feel.md
+++ b/.changeset/better-lamps-feel.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed "create related item with "empty" or default state #26536"

--- a/app/src/views/private/components/overlay-item.test.ts
+++ b/app/src/views/private/components/overlay-item.test.ts
@@ -9,6 +9,17 @@ import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
 
 const mockCollabConnected = ref<boolean | undefined>(false);
+const mockSaveAllowed = ref(true);
+
+vi.mock('@/composables/use-permissions', () => ({
+	usePermissions: () => ({
+		collectionPermissions: {},
+		itemPermissions: {
+			fields: computed(() => []),
+			saveAllowed: computed(() => mockSaveAllowed.value),
+		},
+	}),
+}));
 
 vi.mock('@/composables/use-collab', () => ({
 	useCollab: () => ({
@@ -81,6 +92,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	mockCollabConnected.value = false;
+	mockSaveAllowed.value = true;
 	vi.clearAllMocks();
 });
 
@@ -113,5 +125,82 @@ describe('unsaved-changes dialog', () => {
 
 		expect(wrapper.text()).toContain(i18n.global.t('unsaved_changes_collab'));
 		expect(wrapper.text()).not.toContain(i18n.global.t('unsaved_changes'));
+	});
+});
+
+describe('isSavable', () => {
+	function mountWithActionSlot(props: Record<string, any>) {
+		return mount(OverlayItem, {
+			props: {
+				collection: 'articles',
+				overlay: 'drawer',
+				...props,
+			},
+			global: {
+				...global,
+				stubs: {
+					...globalStubs.stubs,
+					VDrawer: { template: '<div><slot /><slot name="actions" /></div>' },
+				},
+			},
+		});
+	}
+
+	function getSaveButton(wrapper: ReturnType<typeof mount>) {
+		return wrapper.find('private-view-header-bar-action-button-stub');
+	}
+
+	it('enables save button for a new item without edits', () => {
+		const wrapper = mountWithActionSlot({
+			active: true,
+			primaryKey: '+',
+		});
+
+		const saveButton = getSaveButton(wrapper);
+		expect(saveButton.attributes('disabled')).toBe('false');
+	});
+
+	it('disables save button for an existing item without edits', () => {
+		const wrapper = mountWithActionSlot({
+			active: true,
+			primaryKey: '1',
+		});
+
+		const saveButton = getSaveButton(wrapper);
+		expect(saveButton.attributes('disabled')).toBe('true');
+	});
+
+	it('enables save button for an existing item with edits', () => {
+		const wrapper = mountWithActionSlot({
+			active: true,
+			primaryKey: '1',
+			edits: { title: 'updated' },
+		});
+
+		const saveButton = getSaveButton(wrapper);
+		expect(saveButton.attributes('disabled')).toBe('false');
+	});
+
+	it('disables save button when disabled prop is true even for new items', () => {
+		const wrapper = mountWithActionSlot({
+			active: true,
+			primaryKey: '+',
+			disabled: true,
+		});
+
+		const saveButton = getSaveButton(wrapper);
+		expect(saveButton.attributes('disabled')).toBe('true');
+	});
+
+	it('disables save button when save is not allowed by permissions', () => {
+		mockSaveAllowed.value = false;
+
+		const wrapper = mountWithActionSlot({
+			active: true,
+			primaryKey: '+',
+		});
+
+		const saveButton = getSaveButton(wrapper);
+		expect(saveButton.attributes('disabled')).toBe('true');
 	});
 });

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -263,7 +263,7 @@ const templatePrimaryKey = computed(() =>
 const templateCollection = computed(() => relatedCollectionInfo.value || collectionInfo.value);
 
 const isSavable = computed(() => {
-	if (props.disabled || !hasEdits.value) return false;
+	if (props.disabled || (!hasEdits.value && !isNew.value)) return false;
 	if (!relatedCollection.value) return saveAllowed.value;
 	return saveAllowed.value || saveRelatedCollectionAllowed.value;
 });


### PR DESCRIPTION
To fix: https://github.com/directus/directus/issues/26536

### Reason of bug:
When creating a new item via M2O or M2M relationship in another collection, the code checks whether user has entered inputs, and only allows the operation when the result is yes. 
But it shouldn't, because fields can be empty or have a default value, in which case no user inputs are necessary. 

### Fix: 
Modify the check's logic and allow the operation even if there are no user inputs. 