### PR TITLE
fix(users): show user-friendly error when invite is no longer valid

### DIFF
--- a/.changeset/fix-invite-invalid-error-message.md
+++ b/.changeset/fix-invite-invalid-error-message.md
@@ -1,0 +1,7 @@
+---
+'@directus/errors': minor
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Fixed incorrect error message shown on invite page when invite is no longer valid (user already activated).  Introduced INVITE_INVALID error code and user-friendly translation.

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { InvalidPayloadError, InviteInvalidError, RecordNotUniqueError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -30,6 +30,10 @@ vi.mock('@directus/env', () => ({
 }));
 
 vi.mock('../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js');
+
+vi.mock('../utils/jwt.js', () => ({
+	verifyJWT: vi.fn().mockReturnValue({ email: 'test@example.com', scope: 'invite' }),
+}));
 
 const testRoleId = '4ccdb196-14b3-4ed1-b9da-c1978be07ca2';
 
@@ -391,6 +395,33 @@ describe('Integration Tests', () => {
 
 				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([mockUser.id]);
 				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+			});
+		});
+
+		describe('acceptInvite', () => {
+			it('should throw InviteInvalidError when user is not in invited status', async () => {
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-accept',
+					status: 'active',
+				});
+
+				await expect(service.acceptInvite('valid-token', 'password123')).rejects.toThrow(InviteInvalidError);
+			});
+
+			it('should throw InviteInvalidError when user does not exist', async () => {
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(undefined);
+
+				await expect(service.acceptInvite('valid-token', 'password123')).rejects.toThrow(InviteInvalidError);
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError, InviteInvalidError, RecordNotUniqueError } from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	Item,
@@ -421,8 +421,9 @@ export class UsersService extends ItemsService {
 
 		const user = await this.getUserByEmail(email);
 
+		// Invite no longer valid (user already activated).
 		if (user?.status !== 'invited') {
-			throw new InvalidPayloadError({ reason: `Email address ${email} hasn't been invited` });
+			throw new InviteInvalidError();
 		}
 
 		// Allow unauthenticated update

--- a/app/src/lang/translations/en-GB.yaml
+++ b/app/src/lang/translations/en-GB.yaml
@@ -570,6 +570,7 @@ errors:
   INVALID_CREDENTIALS: Wrong username or password
   INVALID_FOREIGN_KEY: Invalid foreign key
   INVALID_IP: IP Address not allowed
+  INVITE_INVALID: This invitation is no longer valid.  The account may already have been activated.  Please sign in if you have an account.
   INVALID_OTP: Wrong one-time password
   INVALID_PAYLOAD: Invalid payload
   INVALID_PROVIDER: User belongs to a different auth provider

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -821,6 +821,7 @@ errors:
   INVALID_CREDENTIALS: Wrong username or password
   INVALID_FOREIGN_KEY: Invalid foreign key
   INVALID_IP: IP Address not allowed
+  INVITE_INVALID: This invitation is no longer valid.  The account may already have been activated.  Please sign in if you have an account.
   INVALID_OTP: Wrong one-time password
   INVALID_PAYLOAD: Invalid payload
   INVALID_PROVIDER: User belongs to a different auth provider

--- a/contributors.yml
+++ b/contributors.yml
@@ -247,3 +247,4 @@
 - vdr-smartdev-trinh
 - sinan-yildiz-marsus
 - alvarosabu
+- alexander-shaw

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -7,6 +7,7 @@ export enum ErrorCode {
 	Internal = 'INTERNAL_SERVER_ERROR',
 	InvalidCredentials = 'INVALID_CREDENTIALS',
 	InvalidForeignKey = 'INVALID_FOREIGN_KEY',
+	InviteInvalid = 'INVITE_INVALID',
 	InvalidIp = 'INVALID_IP',
 	InvalidOtp = 'INVALID_OTP',
 	InvalidPayload = 'INVALID_PAYLOAD',

--- a/packages/errors/src/errors/index.ts
+++ b/packages/errors/src/errors/index.ts
@@ -8,6 +8,7 @@ export { InternalServerError } from './internal.js';
 export { InvalidCredentialsError } from './invalid-credentials.js';
 export { InvalidForeignKeyError } from './invalid-foreign-key.js';
 export { InvalidIpError } from './invalid-ip.js';
+export { InviteInvalidError } from './invite-invalid.js';
 export { InvalidOtpError } from './invalid-otp.js';
 export { InvalidPayloadError } from './invalid-payload.js';
 export { InvalidPathParameterError } from './invalid-path-parameter.js';

--- a/packages/errors/src/errors/invite-invalid.test.ts
+++ b/packages/errors/src/errors/invite-invalid.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+import { ErrorCode } from '../index.js';
+import { InviteInvalidError } from './invite-invalid.js';
+
+test('has correct code and status', () => {
+	const error = new InviteInvalidError();
+
+	expect(error.code).toBe(ErrorCode.InviteInvalid);
+	expect(error.status).toBe(400);
+	expect(error.message).toBe('This invitation is no longer valid.');
+});

--- a/packages/errors/src/errors/invite-invalid.ts
+++ b/packages/errors/src/errors/invite-invalid.ts
@@ -1,0 +1,7 @@
+import { createError, ErrorCode } from '../index.js';
+
+export const InviteInvalidError = createError(
+	ErrorCode.InviteInvalid,
+	'This invitation is no longer valid.',
+	400,
+);


### PR DESCRIPTION
## Scope

What's changed:

- Introduced `INVITE_INVALID` error code in `@directus/errors` for invite-no-longer-valid cases
- Replaced `InvalidPayloadError` with `InviteInvalidError` in `UsersService.acceptInvite()` when user is not in `invited` status
- Added user-facing translations for `errors.INVITE_INVALID` in en-US and en-GB
- Added unit tests for the new error and for `acceptInvite` when invite is invalid

## Potential Risks / Drawbacks

- Low risk: only affects the invite-accept path when user is not in `invited` status
- API clients that rely on `INVALID_PAYLOAD` for this case will now receive `INVITE_INVALID` instead

## Tested Scenarios

- Unit test for `InviteInvalidError` (code, status, message)
- Unit test for `acceptInvite` when user exists but status is not `invited` (e.g. `active`)
- Unit test for `acceptInvite` when user does not exist
- Ran `@directus/errors` tests and ESLint on modified files

## Review Notes / Questions

- Please confirm the new error is only used for the invite-invalid case
- Please review the translation text for clarity and tone

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26699