### PR TITLE
fix: resolve {{fieldName}} in validation

### DIFF
--- a/.changeset/fix-data-studio-date-validation-25389.md
+++ b/.changeset/fix-data-studio-date-validation-25389.md
@@ -1,0 +1,7 @@
+---
+'@directus/utils': patch
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Fixed Data Studio date validation error when using field references (`end_date` > `{{start_date}}`).  Validation rules that reference another field via `{{fieldName}}` are now resolved from the current item/payload before validation in both the API and the Data Studio, so item create/update no longer throws "date must have a valid date format or reference".

--- a/api/src/permissions/modules/process-payload/process-payload.test.ts
+++ b/api/src/permissions/modules/process-payload/process-payload.test.ts
@@ -323,3 +323,73 @@ test('Checks validation rules against payload with defaults', async () => {
 		'field-a': 2,
 	});
 });
+
+describe('Resolves {{fieldName}} in field validation from payload (date validation)', () => {
+	const schema = new SchemaBuilder()
+		.collection('services', (c) => {
+			c.field('id').id();
+			c.field('start_date').date();
+			c.field('end_date')
+				.date()
+				.options({
+					validation: {
+						_and: [
+							{
+								_or: [
+									{ end_date: { _null: true } },
+									{ end_date: { _gt: '{{start_date}}' } },
+								],
+							},
+						],
+					},
+				});
+		})
+		.build();
+
+	test('accepts payload when end_date is greater than start_date', async () => {
+		const acc = { admin: true } as unknown as Accountability;
+
+		const result = await processPayload(
+			{
+				accountability: acc,
+				action: 'create',
+				collection: 'services',
+				payload: {
+					start_date: '2024-01-15',
+					end_date: '2024-06-20',
+				},
+				nested: [],
+			},
+			{ schema } as Context,
+		);
+
+		expect(result).toEqual({
+			start_date: '2024-01-15',
+			end_date: '2024-06-20',
+		});
+	});
+
+	test('throws when end_date is less than or equal to start_date', async () => {
+		const acc = { admin: true } as unknown as Accountability;
+
+		try {
+			await processPayload(
+				{
+					accountability: acc,
+					action: 'create',
+					collection: 'services',
+					payload: {
+						start_date: '2024-06-20',
+						end_date: '2024-01-15',
+					},
+					nested: [],
+				},
+				{ schema } as Context,
+			);
+			expect(true).toBe(false);
+		} catch (errors: any) {
+			expect(errors.length).toBeGreaterThanOrEqual(1);
+			expect(errors[0]).toBeInstanceOf(FailedValidationError);
+		}
+	});
+});

--- a/api/src/permissions/modules/process-payload/process-payload.ts
+++ b/api/src/permissions/modules/process-payload/process-payload.ts
@@ -58,6 +58,9 @@ export async function processPayload(options: ProcessPayloadOptions, context: Co
 		permissionValidationRules = permissions.map(({ validation }) => validation);
 	}
 
+	const presets = (permissions ?? []).map((permission) => permission.presets);
+	const payloadWithPresets = assign({}, ...presets, options.payload);
+
 	const fields = Object.values(context.schema.collections[options.collection]?.fields ?? {});
 
 	const fieldValidationRules: (Filter | null)[] = [];
@@ -95,15 +98,14 @@ export async function processPayload(options: ProcessPayloadOptions, context: Co
 					)
 				: undefined;
 
-			const validationFilter = parseFilter(field.validation, options.accountability, filterContext);
+			const validationFilter = parseFilter(field.validation, options.accountability, {
+				...filterContext,
+				$PAYLOAD: payloadWithPresets,
+			} as Parameters<typeof parseFilter>[2]);
 
 			fieldValidationRules.push(validationFilter);
 		}
 	}
-
-	const presets = (permissions ?? []).map((permission) => permission.presets);
-
-	const payloadWithPresets = assign({}, ...presets, options.payload);
 
 	const validationRules = [...fieldValidationRules, ...permissionValidationRules].filter((rule): rule is Filter => {
 		if (rule === null) return false;

--- a/app/src/utils/validate-item.ts
+++ b/app/src/utils/validate-item.ts
@@ -1,5 +1,5 @@
 import { ContentVersion, Field, LogicalFilterAND } from '@directus/types';
-import { validatePayload } from '@directus/utils';
+import { parseFilter, validatePayload } from '@directus/utils';
 import {
 	FailedValidationError,
 	FailedValidationErrorExtensions,
@@ -40,7 +40,10 @@ export function validateItem(
 
 	if (includeCustomValidations) fields.forEach(applyValidationRules);
 
-	const errors = validatePayload(validationRules, updatedItem).map((error) =>
+	const resolvedRules =
+		parseFilter(validationRules, null, { $PAYLOAD: updatedItem } as Parameters<typeof parseFilter>[2]) ??
+		validationRules;
+	const errors = validatePayload(resolvedRules, updatedItem).map((error) =>
 		error.details.map(
 			(details) => new FailedValidationError(joiValidationErrorItemToErrorExtensions(details)).extensions,
 		),

--- a/contributors.yml
+++ b/contributors.yml
@@ -71,6 +71,7 @@
 - Dominic-Marcelino
 - AndreGKruger
 - AxeemHaider
+- alexander-shaw
 - alexvdvalk
 - thame
 - christianrr

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -774,7 +774,7 @@ describe('#parseFilter', () => {
 			],
 		} as Filter;
 
-		const mockAccountability = {};
+		const mockAccountability = null;
 		const mockContext = { $CURRENT_POLICIES: [{ id: 'policy-1' }] as unknown as Policy[] };
 		expect(parseFilter(mockFilter, mockAccountability, mockContext)).toStrictEqual(mockResult);
 	});
@@ -800,8 +800,79 @@ describe('#parseFilter', () => {
 			],
 		} as Filter;
 
-		const mockAccountability = {};
+		const mockAccountability = null;
 		const mockContext = { $CURRENT_POLICIES: [{ key: 'policy-key' }] as unknown as Policy[] };
 		expect(parseFilter(mockFilter, mockAccountability, mockContext)).toStrictEqual(mockResult);
+	});
+
+	it('replaces {{fieldName}} with value from $PAYLOAD when context has $PAYLOAD', () => {
+		const mockFilter = {
+			_and: [
+				{
+					end_date: {
+						_gt: '{{start_date}}',
+					},
+				},
+			],
+		} as Filter;
+
+		const startDate = '2024-01-15';
+		const mockContext = { $PAYLOAD: { start_date: startDate } };
+		const result = parseFilter(mockFilter, null, mockContext);
+
+		expect(result).toStrictEqual({
+			_and: [
+				{
+					end_date: {
+						_gt: startDate,
+					},
+				},
+			],
+		});
+	});
+
+	it('replaces {{fieldName}} with date value from $PAYLOAD for validation rules', () => {
+		const mockFilter = {
+			_or: [
+				{ end_date: { _null: true } },
+				{ end_date: { _gt: '{{start_date}}' } },
+			],
+		} as Filter;
+
+		const startDate = new Date('2024-01-15');
+		const mockContext = { $PAYLOAD: { start_date: startDate } };
+		const result = parseFilter(mockFilter, null, mockContext);
+
+		expect(result).toStrictEqual({
+			_or: [
+				{ end_date: { _null: true } },
+				{ end_date: { _gt: startDate } },
+			],
+		});
+	});
+
+	it('leaves {{fieldName}} unchanged when $PAYLOAD is not provided', () => {
+		const mockFilter = {
+			field: {
+				_gt: '{{start_date}}',
+			},
+		} as Filter;
+
+		const result = parseFilter(mockFilter, null, {});
+
+		expect(result).toStrictEqual(mockFilter);
+	});
+
+	it('leaves {{fieldName}} unchanged when field is not in $PAYLOAD', () => {
+		const mockFilter = {
+			field: {
+				_gt: '{{other_field}}',
+			},
+		} as Filter;
+
+		const mockContext = { $PAYLOAD: { start_date: '2024-01-15' } };
+		const result = parseFilter(mockFilter, null, mockContext);
+
+		expect(result).toStrictEqual(mockFilter);
 	});
 });

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -8,12 +8,14 @@ import { isObject } from './is-object.js';
 import { parseJSON } from './parse-json.js';
 import { toArray } from './to-array.js';
 
-type ParseFilterContext = {
+export type ParseFilterContext = {
 	// The user can add any custom fields to any of them
 	$CURRENT_USER?: User & Record<string, any>;
 	$CURRENT_ROLE?: Role & Record<string, any>;
 	$CURRENT_ROLES?: (Role & Record<string, any>)[];
 	$CURRENT_POLICIES?: (Policy & Record<string, any>)[];
+	/** Current item/payload for resolving {{fieldName}} in validation rules */
+	$PAYLOAD?: Record<string, unknown>;
 };
 
 type BasicAccountability = Pick<Accountability, 'user' | 'role' | 'roles'>;
@@ -173,6 +175,16 @@ function parseDynamicVariable(value: any, accountability: BasicAccountability | 
 		if (value === '$CURRENT_POLICIES')
 			return (get(context, value, null) as Policy[] | null)?.map(({ id }) => id) ?? null;
 		return get(context, value, null);
+	}
+
+	// Resolve {{fieldName}} from current item/payload (for validation: end_date > {{start_date}}).
+	const payloadRefMatch = value.match(/^\{\{\s*(.+?)\s*\}\}$/);
+	const payload = context.$PAYLOAD;
+	if (payloadRefMatch && payloadRefMatch[1] !== undefined && payload !== undefined) {
+		const fieldName = payloadRefMatch[1].trim();
+		if (Object.prototype.hasOwnProperty.call(payload, fieldName)) {
+			return payload[fieldName];
+		}
 	}
 
 	return value;


### PR DESCRIPTION
## Scope

What's changed:

- Extended `parseFilter` in `@directus/utils` to resolve `{{fieldName}}` from an optional `$PAYLOAD` context so validation rules can reference other fields (e.g. `end_date` > `{{start_date}}`).
- API `process-payload`: compute `payloadWithPresets` before the field loop and pass it as `$PAYLOAD` when parsing each field’s validation.
- App `validate-item`: resolve validation rules with `parseFilter(..., { $PAYLOAD: updatedItem })` before `validatePayload` so Data Studio create/update uses resolved values.
- Added unit tests for `$PAYLOAD` / `{{fieldName}}` in parse-filter and for date validation with `{{start_date}}` in process-payload; added changeset and contributor entry.

## Potential Risks / Drawbacks

- Callers that pass a context object without `$PAYLOAD` are unchanged; resolution only runs when `$PAYLOAD` is provided.
- If the payload is very large, passing it into `parseFilter` adds a shallow reference only; no extra copy.

## Tested Scenarios

- Parse-filter: `{{fieldName}}` replaced from `$PAYLOAD` when present; left unchanged when `$PAYLOAD` is absent or field is missing; date value from payload in validation-style rule.
- Process-payload: payload with `end_date` > `start_date` passes; payload with `end_date` ≤ `start_date` throws validation error.
- Existing parse-filter and process-payload tests still pass.

## Review Notes / Questions

- Type assertions `as Parameters<typeof parseFilter>[2]` are used in the API and app so the context with `$PAYLOAD` type-checks when consumers use a cached/older `ParseFilterContext`; `ParseFilterContext` is now exported from utils for future builds.
- `ParseFilterContext` was exported from `packages/utils/shared/parse-filter.ts`; confirm that’s desired as part of the public API.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25389