### PR TITLE
Fix an invalid filter for M2M interfaces when the item Id is null

### DIFF
--- a/.changeset/cyan-bikes-find.md
+++ b/.changeset/cyan-bikes-find.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed invalid filter being generator for m2m interfaces
+Fixed an invalid filter for M2M interfaces when the item ID is null

--- a/.changeset/cyan-bikes-find.md
+++ b/.changeset/cyan-bikes-find.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed invalid filter being generator for m2m interfaces

--- a/.changeset/cyan-bikes-find.md
+++ b/.changeset/cyan-bikes-find.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed an invalid filter for M2M interfaces when the item ID is null
+Fixed an invalid filter for M2M interfaces when the item Id is null

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -324,8 +324,6 @@ describe('test o2m relation', () => {
 				}),
 			}),
 		);
-
-		expect(sdkSpy.mock.lastCall?.[0]()).toEqual(expect.objectContaining({ body: {} }));
 	});
 
 	test('Initial data should be cleared when itemId changes to new item', async () => {

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -5,6 +5,7 @@ import { computed, defineComponent, h, ref, toRefs } from 'vue';
 import { RelationM2A } from './use-relation-m2a';
 import { RelationO2M } from './use-relation-o2m';
 import { RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
+import sdk from '@/sdk';
 
 vi.mock('@/sdk', async () => {
 	const { mockSdk } = await import('@/test-utils/sdk');
@@ -273,6 +274,58 @@ describe('test o2m relation', () => {
 			$type: 'updated',
 			$index: 0,
 		});
+	});
+
+	test('should use "_null" operator in filter when item id is "null"', async () => {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+
+		mount(TestComponent, {
+			props: { relation: relationO2M, value: [], id: null },
+		});
+
+		await flushPromises();
+
+		expect(sdkSpy.mock.lastCall?.[0]()).toEqual(
+			expect.objectContaining({
+				params: expect.objectContaining({
+					filter: {
+						_and: [
+							{
+								facility: {
+									_null: true,
+								},
+							},
+						],
+					},
+				}),
+			}),
+		);
+	});
+
+	test('should use value directly in filter when item id is defined', async () => {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+
+		mount(TestComponent, {
+			props: { relation: relationO2M, value: [], id: 1 },
+		});
+
+		await flushPromises();
+
+		expect(sdkSpy.mock.lastCall?.[0]()).toEqual(
+			expect.objectContaining({
+				params: expect.objectContaining({
+					filter: {
+						_and: [
+							{
+								facility: 1,
+							},
+						],
+					},
+				}),
+			}),
+		);
+
+		expect(sdkSpy.mock.lastCall?.[0]()).toEqual(expect.objectContaining({ body: {} }));
 	});
 
 	test('Initial data should be cleared when itemId changes to new item', async () => {

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -385,7 +385,9 @@ export function useRelationMultiple(
 			if (itemId.value !== '+') {
 				const currentItemId = itemId.value;
 
-				const filter: Filter = { _and: [{ [reverseJunctionField]: itemId.value } as Filter] };
+				const filter: Filter = {
+					_and: [{ [reverseJunctionField]: itemId.value === null ? { _null: true } : itemId.value } as Filter],
+				};
 
 				if (previewQuery.value.filter) {
 					filter._and.push(previewQuery.value.filter);


### PR DESCRIPTION
## Scope

What's changed:

- Utilize `_null` operator when item id is null

## Potential Risks / Drawbacks

- Should be none

## Tested Scenarios

- [x] Expect item id non null (and not `+`) properly constructs filter
- [x] Expect item id null (and not `+`) property constructs filter

## Review Notes / Questions
- This was an old silent bug that only surfaced after [migrating some calls to the SDK](https://github.com/directus/directus/pull/26605). axios would [silently strip null from the params](https://github.com/axios/axios/issues/1139) before this.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26824
