### PR TITLE
Update `openldap` image to `:latest`

### DIFF
--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   #   Admin Password: secret
   #   Base DN:       dc=my-domain,dc=com
   openldap:
-    image: cleanstart/openldap:2.6.10
+    image: cleanstart/openldap:2.6.12
     ports:
       - 6109:389
     healthcheck:

--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   #   Admin Password: secret
   #   Base DN:       dc=my-domain,dc=com
   openldap:
-    image: cleanstart/openldap:2.6.12
+    image: cleanstart/openldap:latest
     ports:
       - 6109:389
     healthcheck:


### PR DESCRIPTION
## Scope

What's changed:

- Updates `OpenLDAP` image to use `:latest`.

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- On every new version the previous versions tags are deleted breaking the pipeline, using `:latest` here as an exception to prevent this.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
