### PR TITLE
Add duplicate policy action

### DIFF
--- a/.changeset/salty-mugs-help.md
+++ b/.changeset/salty-mugs-help.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Added duplicate policy action
+Added functionality to duplicate access policies

--- a/.changeset/salty-mugs-help.md
+++ b/.changeset/salty-mugs-help.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added duplicate policy action

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2940,6 +2940,7 @@ series_grouping: Series Grouping
 date_precision: Date Precision
 export_dashboard: Export Dashboard
 duplicate_dashboard: Duplicate Dashboard
+duplicate_policy: Duplicate Policy
 search_dashboard: Search Dashboard...
 search_flow: Search Flow...
 percent: Percent

--- a/app/src/modules/settings/routes/policies/collection.vue
+++ b/app/src/modules/settings/routes/policies/collection.vue
@@ -4,10 +4,22 @@ import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { RouterView, useRouter } from 'vue-router';
 import SettingsNavigation from '../../components/navigation.vue';
+import { type PolicyItem, useDuplicate } from './use-duplicate';
 import VBreadcrumb from '@/components/v-breadcrumb.vue';
 import VButton from '@/components/v-button.vue';
+import VCardActions from '@/components/v-card-actions.vue';
+import VCardText from '@/components/v-card-text.vue';
+import VCardTitle from '@/components/v-card-title.vue';
+import VCard from '@/components/v-card.vue';
+import VDialog from '@/components/v-dialog.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VInfo from '@/components/v-info.vue';
+import VInput from '@/components/v-input.vue';
+import VListItemContent from '@/components/v-list-item-content.vue';
+import VListItemIcon from '@/components/v-list-item-icon.vue';
+import VListItem from '@/components/v-list-item.vue';
+import VList from '@/components/v-list.vue';
+import VMenu from '@/components/v-menu.vue';
 import { Header as TableHeader } from '@/components/v-table/types';
 import VTable from '@/components/v-table/v-table.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
@@ -18,16 +30,9 @@ import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import { PrivateView } from '@/views/private';
 import SearchInput from '@/views/private/components/search-input.vue';
 
-type PolicyBaseFields = 'id' | 'name' | 'icon' | 'description';
-
-type PolicyResponse = Pick<Policy, PolicyBaseFields> & {
+type PolicyResponse = PolicyItem & {
 	users: [{ count: { user: number } }];
 	roles: [{ count: { role: number } }];
-};
-
-type PolicyItem = Pick<Policy, PolicyBaseFields> & {
-	userCount?: number;
-	roleCount?: number;
 };
 
 const { t } = useI18n();
@@ -36,6 +41,19 @@ const router = useRouter();
 
 const policies = ref<PolicyItem[]>([]);
 const loading = ref(false);
+
+const duplicateDialogActive = ref(false);
+const duplicateSource = ref<PolicyItem | null>(null);
+const duplicateName = ref('');
+
+const { duplicating, duplicate } = useDuplicate({
+	source: duplicateSource,
+	name: duplicateName,
+	onSuccess: async () => {
+		duplicateDialogActive.value = false;
+		await fetchPolicies();
+	},
+});
 
 const search = ref<string | null>(null);
 
@@ -105,7 +123,18 @@ async function fetchPolicies() {
 		const response = await fetchAll<PolicyResponse>(`/policies`, {
 			params: {
 				limit: -1,
-				fields: ['id', 'name', 'icon', 'description', 'admin_access', 'users', 'roles'],
+				fields: [
+					'id',
+					'name',
+					'icon',
+					'description',
+					'enforce_tfa',
+					'ip_access',
+					'app_access',
+					'admin_access',
+					'users',
+					'roles',
+				],
 				deep: {
 					users: {
 						_aggregate: { count: 'user' },
@@ -144,6 +173,12 @@ async function fetchPolicies() {
 
 function navigateToPolicy({ item }: { item: Policy }) {
 	router.push(`/settings/policies/${item.id}`);
+}
+
+function openDuplicateDialog(item: PolicyItem) {
+	duplicateSource.value = item;
+	duplicateName.value = `${item.name} (copy)`;
+	duplicateDialogActive.value = true;
 }
 </script>
 
@@ -189,6 +224,27 @@ function navigateToPolicy({ item }: { item: Policy }) {
 				<template #[`item.description`]="{ item }">
 					<VTextOverflow v-if="item.description" :text="item.description" class="description" :highlight="search" />
 				</template>
+
+				<template #item-append="{ item }">
+					<VMenu placement="left-start" show-arrow>
+						<template #activator="{ toggle }">
+							<VIcon name="more_vert" class="ctx-toggle" clickable @click.stop="toggle" />
+						</template>
+
+						<VList>
+							<VListItem
+								clickable
+								@click="
+									openDuplicateDialog(item);
+									toggle();
+								"
+							>
+								<VListItemIcon><VIcon name="content_copy" /></VListItemIcon>
+								<VListItemContent>{{ $t('duplicate_policy') }}</VListItemContent>
+							</VListItem>
+						</VList>
+					</VMenu>
+				</template>
 			</VTable>
 		</div>
 
@@ -199,6 +255,21 @@ function navigateToPolicy({ item }: { item: Policy }) {
 				<VButton @click="search = null">{{ $t('clear_filters') }}</VButton>
 			</template>
 		</VInfo>
+
+		<VDialog v-model="duplicateDialogActive" @esc="duplicateDialogActive = false" @apply="duplicate">
+			<VCard>
+				<VCardTitle>{{ $t('duplicate_policy') }}</VCardTitle>
+				<VCardText>
+					<VInput v-model="duplicateName" autofocus />
+				</VCardText>
+				<VCardActions>
+					<VButton secondary @click="duplicateDialogActive = false">{{ $t('cancel') }}</VButton>
+					<VButton :disabled="!duplicateName" :loading="duplicating" @click="duplicate">
+						{{ $t('duplicate') }}
+					</VButton>
+				</VCardActions>
+			</VCard>
+		</VDialog>
 
 		<RouterView name="add" />
 	</PrivateView>

--- a/app/src/modules/settings/routes/policies/collection.vue
+++ b/app/src/modules/settings/routes/policies/collection.vue
@@ -232,13 +232,7 @@ function openDuplicateDialog(item: PolicyItem) {
 						</template>
 
 						<VList>
-							<VListItem
-								clickable
-								@click="
-									openDuplicateDialog(item);
-									toggle();
-								"
-							>
+							<VListItem clickable @click="openDuplicateDialog(item)">
 								<VListItemIcon><VIcon name="content_copy" /></VListItemIcon>
 								<VListItemContent>{{ $t('duplicate_policy') }}</VListItemContent>
 							</VListItem>

--- a/app/src/modules/settings/routes/policies/use-duplicate.test.ts
+++ b/app/src/modules/settings/routes/policies/use-duplicate.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { type PolicyItem, useDuplicate } from './use-duplicate';
+
+vi.mock('@/api', () => ({
+	default: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}));
+
+vi.mock('@/utils/unexpected-error', () => ({
+	unexpectedError: vi.fn(),
+}));
+
+const source: PolicyItem = {
+	id: 'policy-abc',
+	name: 'Editor',
+	icon: 'supervised_user_circle',
+	description: 'Can edit content',
+	enforce_tfa: false,
+	ip_access: null,
+	app_access: true,
+	admin_access: false,
+};
+
+let api: { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> };
+
+beforeEach(async () => {
+	api = (await vi.importMock('@/api')).default as typeof api;
+	vi.clearAllMocks();
+});
+
+describe('useDuplicate', () => {
+	it('POSTs to /policies with the expected shape derived from the source item', async () => {
+		api.get.mockResolvedValue({ data: { data: [] } });
+		api.post.mockResolvedValue({ data: { data: { id: 'new-policy-id' } } });
+
+		const { duplicate } = useDuplicate({
+			source: ref(source),
+			name: ref('Editor (copy)'),
+			onSuccess: vi.fn(),
+		});
+
+		await duplicate();
+
+		expect(api.post).toHaveBeenCalledWith('/policies', {
+			name: 'Editor (copy)',
+			icon: 'supervised_user_circle',
+			description: 'Can edit content',
+			enforce_tfa: false,
+			ip_access: null,
+			app_access: true,
+			admin_access: false,
+		});
+	});
+
+	it('does not copy users or roles onto the new policy', async () => {
+		api.get.mockResolvedValue({ data: { data: [] } });
+		api.post.mockResolvedValue({ data: { data: { id: 'new-policy-id' } } });
+
+		const { duplicate } = useDuplicate({
+			source: ref(source),
+			name: ref('Editor (copy)'),
+			onSuccess: vi.fn(),
+		});
+
+		await duplicate();
+
+		const postedPolicy = api.post.mock.calls[0]![1];
+		expect(postedPolicy).not.toHaveProperty('users');
+		expect(postedPolicy).not.toHaveProperty('roles');
+	});
+
+	it('POSTs permissions with the new policy id and without the original policy id', async () => {
+		api.get.mockResolvedValue({
+			data: {
+				data: [
+					{ collection: 'articles', action: 'read', permissions: null, validation: null, presets: null, fields: ['*'] },
+					{
+						collection: 'articles',
+						action: 'create',
+						permissions: null,
+						validation: null,
+						presets: null,
+						fields: null,
+					},
+				],
+			},
+		});
+
+		api.post.mockResolvedValue({ data: { data: { id: 'new-policy-id' } } });
+
+		const { duplicate } = useDuplicate({
+			source: ref(source),
+			name: ref('Editor (copy)'),
+			onSuccess: vi.fn(),
+		});
+
+		await duplicate();
+
+		expect(api.post).toHaveBeenCalledWith('/permissions', [
+			{
+				collection: 'articles',
+				action: 'read',
+				permissions: null,
+				validation: null,
+				presets: null,
+				fields: ['*'],
+				policy: 'new-policy-id',
+			},
+			{
+				collection: 'articles',
+				action: 'create',
+				permissions: null,
+				validation: null,
+				presets: null,
+				fields: null,
+				policy: 'new-policy-id',
+			},
+		]);
+	});
+
+	it('skips the permissions POST when the source policy has no permissions', async () => {
+		api.get.mockResolvedValue({ data: { data: [] } });
+		api.post.mockResolvedValue({ data: { data: { id: 'new-policy-id' } } });
+
+		const { duplicate } = useDuplicate({
+			source: ref(source),
+			name: ref('Editor (copy)'),
+			onSuccess: vi.fn(),
+		});
+
+		await duplicate();
+
+		// Only the policy POST should have been called
+		expect(api.post).toHaveBeenCalledTimes(1);
+		expect(api.post).toHaveBeenCalledWith('/policies', expect.any(Object));
+	});
+});

--- a/app/src/modules/settings/routes/policies/use-duplicate.test.ts
+++ b/app/src/modules/settings/routes/policies/use-duplicate.test.ts
@@ -22,6 +22,8 @@ const source: PolicyItem = {
 	ip_access: null,
 	app_access: true,
 	admin_access: false,
+	userCount: 3,
+	roleCount: 1,
 };
 
 let api: { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> };
@@ -76,7 +78,15 @@ describe('useDuplicate', () => {
 		api.get.mockResolvedValue({
 			data: {
 				data: [
-					{ collection: 'articles', action: 'read', permissions: null, validation: null, presets: null, fields: ['*'] },
+					{
+						collection: 'articles',
+						action: 'read',
+						permissions: null,
+						validation: null,
+						presets: null,
+						fields: ['*'],
+						policy: source.id,
+					},
 					{
 						collection: 'articles',
 						action: 'create',
@@ -84,6 +94,7 @@ describe('useDuplicate', () => {
 						validation: null,
 						presets: null,
 						fields: null,
+						policy: source.id,
 					},
 				],
 			},

--- a/app/src/modules/settings/routes/policies/use-duplicate.ts
+++ b/app/src/modules/settings/routes/policies/use-duplicate.ts
@@ -1,0 +1,68 @@
+import type { Permission, Policy } from '@directus/types';
+import type { Ref } from 'vue';
+import { ref } from 'vue';
+import api from '@/api';
+import { unexpectedError } from '@/utils/unexpected-error';
+
+type PolicyFields = keyof Policy;
+
+export type PolicyItem = Pick<Policy, PolicyFields> & {
+	userCount?: number;
+	roleCount?: number;
+};
+
+export interface UseDuplicateOptions {
+	source: Ref<PolicyItem | null>;
+	name: Ref<string>;
+	onSuccess: () => void | Promise<void>;
+}
+
+export function useDuplicate({ source, name, onSuccess }: UseDuplicateOptions) {
+	const duplicating = ref(false);
+
+	return { duplicating, duplicate };
+
+	async function duplicate() {
+		if (!source.value || !name.value || duplicating.value) return;
+
+		const item = source.value;
+		duplicating.value = true;
+
+		try {
+			const permissionsResponse = await api.get('/permissions', {
+				params: {
+					filter: { policy: { _eq: item.id } },
+					limit: -1,
+					fields: ['collection', 'action', 'permissions', 'validation', 'presets', 'fields'],
+				},
+			});
+
+			const permissions: Permission[] = permissionsResponse.data.data;
+
+			const newPolicyResponse = await api.post('/policies', {
+				name: name.value,
+				icon: item.icon,
+				description: item.description,
+				enforce_tfa: item.enforce_tfa,
+				ip_access: item.ip_access,
+				app_access: item.app_access,
+				admin_access: item.admin_access,
+			});
+
+			const newPolicyId: string = newPolicyResponse.data.data.id;
+
+			if (permissions.length > 0) {
+				await api.post(
+					'/permissions',
+					permissions.map((p) => ({ ...p, policy: newPolicyId })),
+				);
+			}
+
+			await onSuccess();
+		} catch (error) {
+			unexpectedError(error);
+		} finally {
+			duplicating.value = false;
+		}
+	}
+}

--- a/app/src/modules/settings/routes/policies/use-duplicate.ts
+++ b/app/src/modules/settings/routes/policies/use-duplicate.ts
@@ -4,9 +4,7 @@ import { ref } from 'vue';
 import api from '@/api';
 import { unexpectedError } from '@/utils/unexpected-error';
 
-type PolicyFields = keyof Policy;
-
-export type PolicyItem = Pick<Policy, PolicyFields> & {
+export type PolicyItem = Policy & {
 	userCount?: number;
 	roleCount?: number;
 };
@@ -33,7 +31,7 @@ export function useDuplicate({ source, name, onSuccess }: UseDuplicateOptions) {
 				params: {
 					filter: { policy: { _eq: item.id } },
 					limit: -1,
-					fields: ['collection', 'action', 'permissions', 'validation', 'presets', 'fields'],
+					fields: ['collection', 'action', 'permissions', 'validation', 'presets', 'fields', 'policy'],
 				},
 			});
 


### PR DESCRIPTION
  ## Scope

  What's changed:

  - Added a "Duplicate Policy" action to the policies list via a context menu on each row
  - Created `use-duplicate.ts` composable that handles duplicating a policy and all its permissions to a new policy
  - Added a confirmation dialog with a name input, defaulting to `"<original name> (copy)"`


  ## Potential Risks / Drawbacks

- None

 ## Tested Scenarios

  - Duplicating a policy with multiple permissions correctly creates a new policy and copies all permissions with the new
  policy ID and user-provided name.
 - Duplicating a policy with no permissions skips the permissions call
 - The duplicate payload excludes `users` and `roles`

 ## Review Notes / Questions
  - Right now, just the permissions are copied to the new policy. This made the most sense to me. But there could be a case for also copying the roles. Open to opinions on this. 

 ## Checklist

 - [x] Added or updated tests
 - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
 - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

  ---

  Fixes [CMS-1520](https://linear.app/directus/issue/CMS-1520/duplicate-policies-to-improve-ux)
