### PR TITLE
fix(app): prevent M2M fields from being misclassified as M2O

### DIFF
--- a/.changeset/fix-m2m-local-type.md
+++ b/.changeset/fix-m2m-local-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed M2M fields being misclassified as M2O when relation data includes a matching collection/field pair with junction metadata. This resolves the "Interface 'list-m2m' not found" error that could occur after modifying field types.

--- a/app/src/utils/get-local-type.test.ts
+++ b/app/src/utils/get-local-type.test.ts
@@ -322,7 +322,7 @@ test('Returns M2A', () => {
 	expect(getLocalTypeForField('test_collection', 'test_field')).toBe('m2a');
 });
 
-test('Returns M2O for searched relation', () => {
+test('Returns M2M when junction relation has matching collection and field', () => {
 	const fieldsStore = useFieldsStore();
 
 	(fieldsStore.getField as Mock).mockReturnValue({
@@ -376,7 +376,7 @@ test('Returns M2O for searched relation', () => {
 		},
 	]);
 
-	expect(getLocalTypeForField('collection_a', 'test_field')).toBe('m2o');
+	expect(getLocalTypeForField('collection_a', 'test_field')).toBe('m2m');
 });
 
 test('Returns FILES for M2M relations to directus_files', () => {

--- a/app/src/utils/get-local-type.ts
+++ b/app/src/utils/get-local-type.ts
@@ -1,5 +1,4 @@
 import { LocalType, Relation } from '@directus/types';
-import { getRelation } from '@directus/utils';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 
@@ -40,9 +39,15 @@ export function getLocalTypeForField(collection: string, field: string): LocalTy
 			return 'm2a';
 		}
 
-		const relationForCurrent = getRelation(relations, collection, field);
+		const directRelation = relations.find(
+			(relation) =>
+				relation.collection === collection &&
+				relation.field === field &&
+				relation.meta !== null &&
+				!relation.meta.junction_field,
+		);
 
-		if (relationForCurrent?.collection === collection && relationForCurrent?.field === field) {
+		if (directRelation) {
 			return 'm2o';
 		}
 


### PR DESCRIPTION
## Summary

Fixes #26893 — "Interface 'list-m2m' not found" error after modifying field types.

**Root cause:** In `getLocalTypeForField`, when a field has 2 relations, the M2O check used `getRelation()` which matches relations in both directions. For M2M fields, this could match a junction-table relation via its `collection`/`field` properties, incorrectly classifying the field as M2O instead of M2M.

**Fix:** Replace `getRelation()` with a direct `relations.find()` that:
- Only matches relations where `collection === collection && field === field` (direct match, not reverse)
- Excludes junction relations (where `meta.junction_field` is set)
- Requires `meta !== null` to confirm M2O status (schema-only FKs without metadata should not be assumed to be direct M2O)

This extends the partial fix from #25602 (which only addressed `directus_files`) to handle all collections.

## Changes

- `app/src/utils/get-local-type.ts` — Replace `getRelation()` with filtered `relations.find()`
- `app/src/utils/get-local-type.test.ts` — Fix test that was encoding the bug (expected M2O for a junction relation)

## Test plan

- [x] Existing test suite passes (13/13 tests)
- [x] Updated test now correctly expects M2M when a junction relation has matching collection/field
- [ ] Manual verification: create M2M field between two regular collections, verify interface renders correctly