### PR TITLE
fix(app): normalize decimal separator in v-input display value

### DIFF
--- a/.changeset/fix-decimal-separator.md
+++ b/.changeset/fix-decimal-separator.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed decimal input field displaying wrong separator (comma instead of dot) for locales that use comma as decimal separator

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -350,7 +350,7 @@ function useInlineWarning() {
 					:max="max"
 					:step="step"
 					:disabled="disabled"
-					:value="modelValue === undefined || modelValue === null ? '' : String(modelValue)"
+					:value="modelValue == null ? '' : props.float ? String(modelValue).replace(',', '.') : String(modelValue)"
 					v-on="listeners"
 					@keydown.space="$emit('keydown:space', $event)"
 					@keydown.enter="$emit('keydown:enter', $event)"


### PR DESCRIPTION
## Summary
- Fixed decimal input field displaying wrong decimal separator for locales using comma separators (e.g., `nl-BE`)
- The `v-input` component's value binding now normalizes commas to dots when `float` mode is active, matching the existing emit-side normalization

## Details
When a user's OS locale uses commas as decimal separators, `String(modelValue)` renders `300,44` instead of `300.44`. The emit path (line 248) already normalizes `,` → `.` during typing, but the display/render path did not apply the same normalization.

This is a minimal 1-line fix that adds `.replace(',', '.')` to the value binding when `props.float === true`.

## Changeset
Included a patch changeset for `@directus/app`.

## Fixes
Fixes #24803

🤖 Generated with [Claude Code](https://claude.com/claude-code)