### PR TITLE
Add `cache clear` CLI command with `--system` and `--data` flags

### DIFF
--- a/.changeset/gold-rockets-live.md
+++ b/.changeset/gold-rockets-live.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Added cache clear CLI command
+Added `cache clear` CLI command

--- a/.changeset/gold-rockets-live.md
+++ b/.changeset/gold-rockets-live.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added cache clear CLI command

--- a/.changeset/gold-rockets-live.md
+++ b/.changeset/gold-rockets-live.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Added `cache clear` CLI command
+Added `cache clear` CLI command with `--system` and `--data` flags

--- a/api/src/cli/commands/cache/clear.test.ts
+++ b/api/src/cli/commands/cache/clear.test.ts
@@ -1,13 +1,14 @@
 import { useEnv } from '@directus/env';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { flushCaches } from '../../../cache.js';
+import { clearSystemCache, getCache } from '../../../cache.js';
 import { useLogger } from '../../../logger/index.js';
 import cacheClear from './clear.js';
 
 vi.mock('@directus/env');
 
 vi.mock('../../../cache.js', () => ({
-	flushCaches: vi.fn(),
+	clearSystemCache: vi.fn(),
+	getCache: vi.fn().mockReturnValue({ cache: { clear: vi.fn() } }),
 }));
 
 vi.mock('../../../logger/index.js', () => ({
@@ -16,40 +17,59 @@ vi.mock('../../../logger/index.js', () => ({
 
 describe('cache clear command', () => {
 	let mockLogger: any;
+	let mockCacheClear: any;
 
 	beforeEach(() => {
 		mockLogger = {
 			error: vi.fn(),
 		};
 
+		mockCacheClear = vi.fn();
 		vi.mocked(useLogger).mockReturnValue(mockLogger);
 		vi.mocked(useEnv).mockReturnValue({ CACHE_STORE: 'redis' } as any);
+		vi.mocked(getCache).mockReturnValue({ cache: { clear: mockCacheClear } } as any);
+		vi.mocked(clearSystemCache).mockResolvedValue(undefined);
 		vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
 		vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as any);
 	});
 
-	test('should call flushCaches with forced flag', async () => {
-		vi.mocked(flushCaches).mockResolvedValue(undefined);
+	test('should clear all caches by default', async () => {
+		await cacheClear({});
 
-		await cacheClear();
-
-		expect(flushCaches).toHaveBeenCalledWith(true);
+		expect(clearSystemCache).toHaveBeenCalledWith({ forced: true });
+		expect(mockCacheClear).toHaveBeenCalled();
+		expect(process.stdout.write).toHaveBeenCalledWith('Cleared all caches successfully\n');
+		expect(process.exit).toHaveBeenCalledWith(0);
 	});
 
-	test('should output success message and exit with 0', async () => {
-		vi.mocked(flushCaches).mockResolvedValue(undefined);
+	test('should clear only system cache with --system flag', async () => {
+		await cacheClear({ system: true });
 
-		await cacheClear();
+		expect(clearSystemCache).toHaveBeenCalledWith({ forced: true });
+		expect(mockCacheClear).not.toHaveBeenCalled();
+		expect(process.stdout.write).toHaveBeenCalledWith('Cleared system cache successfully\n');
+	});
 
-		expect(process.stdout.write).toHaveBeenCalledWith('Cache cleared successfully\n');
-		expect(process.exit).toHaveBeenCalledWith(0);
+	test('should clear only data cache with --data flag', async () => {
+		await cacheClear({ data: true });
+
+		expect(clearSystemCache).not.toHaveBeenCalled();
+		expect(mockCacheClear).toHaveBeenCalled();
+		expect(process.stdout.write).toHaveBeenCalledWith('Cleared data cache successfully\n');
+	});
+
+	test('should clear both when --system and --data are passed', async () => {
+		await cacheClear({ system: true, data: true });
+
+		expect(clearSystemCache).toHaveBeenCalledWith({ forced: true });
+		expect(mockCacheClear).toHaveBeenCalled();
 	});
 
 	test('should log error and exit with 1 on failure', async () => {
 		const error = new Error('Redis connection failed');
-		vi.mocked(flushCaches).mockRejectedValue(error);
+		vi.mocked(clearSystemCache).mockRejectedValue(error);
 
-		await cacheClear();
+		await cacheClear({});
 
 		expect(mockLogger.error).toHaveBeenCalledWith(error);
 		expect(process.exit).toHaveBeenCalledWith(1);
@@ -58,9 +78,10 @@ describe('cache clear command', () => {
 	test('should warn and exit when CACHE_STORE is not redis', async () => {
 		vi.mocked(useEnv).mockReturnValue({ CACHE_STORE: 'memory' } as any);
 
-		await cacheClear();
+		await cacheClear({});
 
-		expect(flushCaches).not.toHaveBeenCalled();
+		expect(clearSystemCache).not.toHaveBeenCalled();
+		expect(mockCacheClear).not.toHaveBeenCalled();
 
 		expect(process.stdout.write).toHaveBeenCalledWith(
 			expect.stringContaining('In-memory caches are local to each running process'),

--- a/api/src/cli/commands/cache/clear.test.ts
+++ b/api/src/cli/commands/cache/clear.test.ts
@@ -20,6 +20,8 @@ describe('cache clear command', () => {
 	let mockCacheClear: any;
 
 	beforeEach(() => {
+		vi.clearAllMocks();
+
 		mockLogger = {
 			error: vi.fn(),
 		};

--- a/api/src/cli/commands/cache/clear.test.ts
+++ b/api/src/cli/commands/cache/clear.test.ts
@@ -1,8 +1,10 @@
+import { useEnv } from '@directus/env';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { flushCaches } from '../../../cache.js';
 import { useLogger } from '../../../logger/index.js';
 import cacheClear from './clear.js';
 
+vi.mock('@directus/env');
 vi.mock('../../../cache.js');
 vi.mock('../../../logger/index.js');
 
@@ -15,6 +17,7 @@ describe('cache clear command', () => {
 		};
 
 		vi.mocked(useLogger).mockReturnValue(mockLogger);
+		vi.mocked(useEnv).mockReturnValue({ CACHE_STORE: 'redis' } as any);
 		vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
 		vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as any);
 	});
@@ -44,5 +47,19 @@ describe('cache clear command', () => {
 
 		expect(mockLogger.error).toHaveBeenCalledWith(error);
 		expect(process.exit).toHaveBeenCalledWith(1);
+	});
+
+	test('should warn and exit when CACHE_STORE is not redis', async () => {
+		vi.mocked(useEnv).mockReturnValue({ CACHE_STORE: 'memory' } as any);
+
+		await cacheClear();
+
+		expect(flushCaches).not.toHaveBeenCalled();
+
+		expect(process.stdout.write).toHaveBeenCalledWith(
+			expect.stringContaining('In-memory caches are local to each running process'),
+		);
+
+		expect(process.exit).toHaveBeenCalledWith(0);
 	});
 });

--- a/api/src/cli/commands/cache/clear.test.ts
+++ b/api/src/cli/commands/cache/clear.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { flushCaches } from '../../../cache.js';
+import { useLogger } from '../../../logger/index.js';
+import cacheClear from './clear.js';
+
+vi.mock('../../../cache.js');
+vi.mock('../../../logger/index.js');
+
+describe('cache clear command', () => {
+	let mockLogger: any;
+
+	beforeEach(() => {
+		mockLogger = {
+			error: vi.fn(),
+		};
+
+		vi.mocked(useLogger).mockReturnValue(mockLogger);
+		vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+		vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as any);
+	});
+
+	test('should call flushCaches with forced flag', async () => {
+		vi.mocked(flushCaches).mockResolvedValue(undefined);
+
+		await cacheClear();
+
+		expect(flushCaches).toHaveBeenCalledWith(true);
+	});
+
+	test('should output success message and exit with 0', async () => {
+		vi.mocked(flushCaches).mockResolvedValue(undefined);
+
+		await cacheClear();
+
+		expect(process.stdout.write).toHaveBeenCalledWith('Cache cleared successfully\n');
+		expect(process.exit).toHaveBeenCalledWith(0);
+	});
+
+	test('should log error and exit with 1 on failure', async () => {
+		const error = new Error('Redis connection failed');
+		vi.mocked(flushCaches).mockRejectedValue(error);
+
+		await cacheClear();
+
+		expect(mockLogger.error).toHaveBeenCalledWith(error);
+		expect(process.exit).toHaveBeenCalledWith(1);
+	});
+});

--- a/api/src/cli/commands/cache/clear.test.ts
+++ b/api/src/cli/commands/cache/clear.test.ts
@@ -5,8 +5,14 @@ import { useLogger } from '../../../logger/index.js';
 import cacheClear from './clear.js';
 
 vi.mock('@directus/env');
-vi.mock('../../../cache.js');
-vi.mock('../../../logger/index.js');
+
+vi.mock('../../../cache.js', () => ({
+	flushCaches: vi.fn(),
+}));
+
+vi.mock('../../../logger/index.js', () => ({
+	useLogger: vi.fn(),
+}));
 
 describe('cache clear command', () => {
 	let mockLogger: any;

--- a/api/src/cli/commands/cache/clear.ts
+++ b/api/src/cli/commands/cache/clear.ts
@@ -1,0 +1,15 @@
+import { flushCaches } from '../../../cache.js';
+import { useLogger } from '../../../logger/index.js';
+
+export default async function cacheClear(): Promise<void> {
+	const logger = useLogger();
+
+	try {
+		await flushCaches(true);
+		process.stdout.write('Cache cleared successfully\n');
+		process.exit(0);
+	} catch (err: any) {
+		logger.error(err);
+		process.exit(1);
+	}
+}

--- a/api/src/cli/commands/cache/clear.ts
+++ b/api/src/cli/commands/cache/clear.ts
@@ -1,8 +1,18 @@
+import { useEnv } from '@directus/env';
 import { flushCaches } from '../../../cache.js';
 import { useLogger } from '../../../logger/index.js';
 
 export default async function cacheClear(): Promise<void> {
+	const env = useEnv();
 	const logger = useLogger();
+
+	if (env['CACHE_STORE'] !== 'redis') {
+		process.stdout.write(
+			'CACHE_STORE is not set to "redis". In-memory caches are local to each running process and cannot be cleared externally.\n',
+		);
+
+		process.exit(0);
+	}
 
 	try {
 		await flushCaches(true);

--- a/api/src/cli/commands/cache/clear.ts
+++ b/api/src/cli/commands/cache/clear.ts
@@ -1,8 +1,8 @@
 import { useEnv } from '@directus/env';
-import { flushCaches } from '../../../cache.js';
+import { clearSystemCache, getCache } from '../../../cache.js';
 import { useLogger } from '../../../logger/index.js';
 
-export default async function cacheClear(): Promise<void> {
+export default async function cacheClear({ system, data }: { system?: boolean; data?: boolean }): Promise<void> {
 	const env = useEnv();
 	const logger = useLogger();
 
@@ -14,9 +14,23 @@ export default async function cacheClear(): Promise<void> {
 		process.exit(0);
 	}
 
+	const clearAll = !system && !data;
+
 	try {
-		await flushCaches(true);
-		process.stdout.write('Cache cleared successfully\n');
+		if (clearAll || system) {
+			await clearSystemCache({ forced: true });
+		}
+
+		if (clearAll || data) {
+			const { cache } = getCache();
+			await cache?.clear();
+		}
+
+		const target = clearAll
+			? 'all caches'
+			: [system && 'system cache', data && 'data cache'].filter(Boolean).join(' and ');
+
+		process.stdout.write(`Cleared ${target} successfully\n`);
 		process.exit(0);
 	} catch (err: any) {
 		logger.error(err);

--- a/api/src/cli/commands/cache/clear.ts
+++ b/api/src/cli/commands/cache/clear.ts
@@ -12,28 +12,28 @@ export default async function cacheClear({ system, data }: { system?: boolean; d
 		);
 
 		process.exit(0);
-	}
+	} else {
+		const clearAll = !system && !data;
 
-	const clearAll = !system && !data;
+		try {
+			if (clearAll || system) {
+				await clearSystemCache({ forced: true });
+			}
 
-	try {
-		if (clearAll || system) {
-			await clearSystemCache({ forced: true });
+			if (clearAll || data) {
+				const { cache } = getCache();
+				await cache?.clear();
+			}
+
+			const target = clearAll
+				? 'all caches'
+				: [system && 'system cache', data && 'data cache'].filter(Boolean).join(' and ');
+
+			process.stdout.write(`Cleared ${target} successfully\n`);
+			process.exit(0);
+		} catch (err: any) {
+			logger.error(err);
+			process.exit(1);
 		}
-
-		if (clearAll || data) {
-			const { cache } = getCache();
-			await cache?.clear();
-		}
-
-		const target = clearAll
-			? 'all caches'
-			: [system && 'system cache', data && 'data cache'].filter(Boolean).join(' and ');
-
-		process.stdout.write(`Cleared ${target} successfully\n`);
-		process.exit(0);
-	} catch (err: any) {
-		logger.error(err);
-		process.exit(1);
 	}
 }

--- a/api/src/cli/index.test.ts
+++ b/api/src/cli/index.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import emitter from '../emitter.js';
 import { startServer } from '../server.js';
 import bootstrap from './commands/bootstrap/index.js';
+import cacheClear from './commands/cache/clear.js';
 import dbMigrate from './commands/database/migrate.js';
 import init from './commands/init/index.js';
 import { apply } from './commands/schema/apply.js';
@@ -25,6 +26,10 @@ vi.mock('./load-extensions.js', () => ({
 }));
 
 vi.mock('./commands/bootstrap/index.js', () => ({
+	default: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./commands/cache/clear.js', () => ({
 	default: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -90,6 +95,12 @@ describe('createCli', () => {
 			await program.parseAsync(['node', 'directus', 'bootstrap']);
 
 			expect(bootstrap).toHaveBeenCalledTimes(1);
+		});
+
+		test('Should call cacheClear when cache clear command is invoked', async () => {
+			await program.parseAsync(['node', 'directus', 'cache', 'clear']);
+
+			expect(cacheClear).toHaveBeenCalledTimes(1);
 		});
 
 		test.each([

--- a/api/src/cli/index.test.ts
+++ b/api/src/cli/index.test.ts
@@ -103,6 +103,18 @@ describe('createCli', () => {
 			expect(cacheClear).toHaveBeenCalledTimes(1);
 		});
 
+		test('Should pass --system flag to cacheClear', async () => {
+			await program.parseAsync(['node', 'directus', 'cache', 'clear', '--system']);
+
+			expect(cacheClear).toHaveBeenCalledWith(expect.objectContaining({ system: true }), expect.anything());
+		});
+
+		test('Should pass --data flag to cacheClear', async () => {
+			await program.parseAsync(['node', 'directus', 'cache', 'clear', '--data']);
+
+			expect(cacheClear).toHaveBeenCalledWith(expect.objectContaining({ data: true }), expect.anything());
+		});
+
 		test.each([
 			['latest', 'migrate:latest'],
 			['up', 'migrate:up'],

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -81,7 +81,13 @@ export async function createCli(): Promise<Command> {
 		.option('--app', `whether or not the role has app access`)
 		.action(rolesCreate);
 
-	program.command('cache').command('clear').description('Clear the data and system caches').action(cacheClear);
+	program
+		.command('cache')
+		.command('clear')
+		.description('Clear the data and system caches')
+		.option('--system', 'Clear the system cache only (schema, permissions)')
+		.option('--data', 'Clear the data cache only')
+		.action(cacheClear);
 
 	program.command('count <collection>').description('Count the amount of items in a given collection').action(count);
 

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -81,7 +81,6 @@ export async function createCli(): Promise<Command> {
 		.option('--app', `whether or not the role has app access`)
 		.action(rolesCreate);
 
-
 	program.command('cache').command('clear').description('Clear the data and system caches').action(cacheClear);
 
 	program.command('count <collection>').description('Count the amount of items in a given collection').action(count);

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -81,9 +81,8 @@ export async function createCli(): Promise<Command> {
 		.option('--app', `whether or not the role has app access`)
 		.action(rolesCreate);
 
-	const cacheCommand = program.command('cache');
 
-	cacheCommand.command('clear').description('Clear the data and system caches').action(cacheClear);
+	program.command('cache').command('clear').description('Clear the data and system caches').action(cacheClear);
 
 	program.command('count <collection>').description('Count the amount of items in a given collection').action(count);
 

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -3,6 +3,7 @@ import { version } from 'directus/version';
 import emitter from '../emitter.js';
 import { startServer } from '../server.js';
 import bootstrap from './commands/bootstrap/index.js';
+import cacheClear from './commands/cache/clear.js';
 import count from './commands/count/index.js';
 import dbInstall from './commands/database/install.js';
 import dbMigrate from './commands/database/migrate.js';
@@ -79,6 +80,13 @@ export async function createCli(): Promise<Command> {
 		.option('--admin', `whether or not the role has admin access`)
 		.option('--app', `whether or not the role has app access`)
 		.action(rolesCreate);
+
+	const cacheCommand = program.command('cache');
+
+	cacheCommand
+		.command('clear')
+		.description('Clear the data and system caches')
+		.action(cacheClear);
 
 	program.command('count <collection>').description('Count the amount of items in a given collection').action(count);
 

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -83,10 +83,7 @@ export async function createCli(): Promise<Command> {
 
 	const cacheCommand = program.command('cache');
 
-	cacheCommand
-		.command('clear')
-		.description('Clear the data and system caches')
-		.action(cacheClear);
+	cacheCommand.command('clear').description('Clear the data and system caches').action(cacheClear);
 
 	program.command('count <collection>').description('Count the amount of items in a given collection').action(count);
 


### PR DESCRIPTION
## Scope

What's changed:

- Added `npx directus cache clear` command that flushes both data and system caches\
- `--system` and `--data` flags for granular cache clearing, clears both by default

## Potential Risks / Drawbacks

- When using memory as `CACHE_STORE`, the command has no effect on running instances since in-memory caches are local to each process

## Tested Scenarios

- Unit tests for all flag combinations (none, --system, --data, both)

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [X] Added or updated tests
- [X] Documentation PR created [here](https://github.com/directus/docs/pull/590) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
