### PR TITLE
fix(sdk): add inline DOM types for RequestCredentials and CloseEvent

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- brick-pixel

--- a/sdk/src/auth/types.ts
+++ b/sdk/src/auth/types.ts
@@ -1,3 +1,6 @@
+// Inline DOM type to avoid requiring "DOM" lib in consumer tsconfig
+type RequestCredentials = "include" | "omit" | "same-origin";
+
 export type AuthenticationMode = 'json' | 'cookie' | 'session';
 
 export type LocalLoginPayload = { email: string; password: string };

--- a/sdk/src/graphql/types.ts
+++ b/sdk/src/graphql/types.ts
@@ -1,3 +1,6 @@
+// Inline DOM type to avoid requiring "DOM" lib in consumer tsconfig
+type RequestCredentials = "include" | "omit" | "same-origin";
+
 export interface GraphqlClient<_Schema> {
 	query<Output extends object = Record<string, any>>(
 		query: string,

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -1,3 +1,10 @@
+// Inline DOM type to avoid requiring "DOM" lib in consumer tsconfig
+interface CloseEvent extends Event {
+  readonly code: number;
+  readonly reason: string;
+  readonly wasClean: boolean;
+}
+
 import type { ApplyQueryFields, CollectionType, WebSocketInterface } from '../index.js';
 import type { Query } from '../types/query.js';
 

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -1,3 +1,6 @@
+// Inline DOM type to avoid requiring "DOM" lib in consumer tsconfig
+type RequestCredentials = "include" | "omit" | "same-origin";
+
 import type { RequestOptions, RequestTransformer, ResponseTransformer } from '../types/request.js';
 
 export interface RestCommand<_Output extends object | unknown, _Schema> {


### PR DESCRIPTION
## What

Added inline type declarations for `RequestCredentials` and `CloseEvent` in the SDK source files that reference them.

## Why

Projects using `@directus/sdk` with `skipLibCheck: false` and without `DOM` in their `tsconfig.json` `lib` array get `TS2304` errors:

```
Cannot find name 'RequestCredentials'.
Cannot find name 'CloseEvent'.
```

The SDK's own `tsconfig.json` includes `DOM`, but consumers shouldn't be forced to include it just for these two types.

## Changes

| File | Type Added |
|------|-----------|
| `sdk/src/auth/types.ts` | `RequestCredentials` |
| `sdk/src/rest/types.ts` | `RequestCredentials` |
| `sdk/src/graphql/types.ts` | `RequestCredentials` |
| `sdk/src/realtime/types.ts` | `CloseEvent` |

The types are declared inline to match the DOM spec definitions without requiring the full DOM lib.



Fixes #26850