### PR TITLE
Update `relationship_not_setup` wording to clarify it may also result from missing permissions

### DIFF
--- a/.changeset/fix-relation-permission-warning.md
+++ b/.changeset/fix-relation-permission-warning.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Updated the `relationship_not_setup` translation to clarify that the warning may also appear when the user lacks permission to access the related collection.

--- a/.changeset/fix-relation-permission-warning.md
+++ b/.changeset/fix-relation-permission-warning.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Updated the `relationship_not_setup` translation to clarify that the warning may also appear when the user lacks permission to access the related collection.
+Updated `relationship_not_setup` wording to clarify it may also result from missing permissions.

--- a/.changeset/fix-relation-permission-warning.md
+++ b/.changeset/fix-relation-permission-warning.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Updated `relationship_not_setup` wording to clarify it may also result from missing permissions.
+Updated `relationship_not_setup` wording to clarify it may also result from missing permissions

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -777,7 +777,7 @@ no_collections: No Collections
 create_collection: Create Collection
 no_collections_copy_admin: You don’t have any Collections yet. Click the button below to get started.
 no_collections_copy: You don’t have any Collections yet. Please contact your system administrator.
-relationship_not_setup: The relationship hasn't been configured correctly
+relationship_not_setup: The relationship is not configured properly or you don't have permission to access it
 no_singleton_relations: Relationships to Singletons are not supported
 display_template_not_setup: The display template option is misconfigured
 collection_field_not_setup: The collection field option is misconfigured

--- a/contributors.yml
+++ b/contributors.yml
@@ -261,3 +261,4 @@
 - costajohnt
 - AbdelhamidKhald
 - HattoriEnzo
+- Ikromjon1998


### PR DESCRIPTION
## Summary

When a user lacks read permission on a related collection, the relational interfaces (M2O, O2M, M2M, M2A, Files) showed "The relationship hasn't been configured correctly" — which is misleading since the relationship is correctly configured, the user simply doesn't have access.

This is a follow-up to #26837 with the **backend fix** requested by reviewers.

### What changed

**Backend (`api/src/services/relations.ts`):**
- Modified `filterForbidden()` to differentiate between two cases:
  1. User can't read the **many-side** (collection/field owning the relation) → relation is still filtered out completely
  2. User can read the many-side but **can't read the related collection** → relation is kept but marked with `related_collection_readable: false`

**Types (`packages/types/src/relations.ts`):**
- Added optional `related_collection_readable?: boolean` field to the `Relation` type

**Frontend composables:**
- Added `relationMissingPermissions` computed property to `use-relation-m2o.ts`, `use-relation-o2m.ts`, `use-relation-m2m.ts`, and `use-relation-m2a.ts` that checks the explicit backend flag
- `relationInfo` returns `undefined` when `related_collection_readable === false` to prevent downstream errors

**Frontend interfaces:**
- Updated 5 relational interface components to show a permission-specific warning when `relationMissingPermissions` is true

**Translation:**
- Added `relationship_missing_permissions` key to `en-US.yaml`

Closes #21337

## Key design decisions

- The fix is in `filterForbidden()` on the backend — the root cause — rather than inferring permission issues from `meta.special` on the frontend
- The `related_collection_readable` field is optional and backwards compatible — existing consumers that don't know about it will just ignore it
- When undefined, the relation is fully accessible (same behavior as before)

## Test plan

- [x] Unit tests for all 4 relation composables (M2O, O2M, M2M, M2A)
- [ ] User with read permission on main collection but no read permission on related collection sees "You don't have permission to view the related collection"
- [ ] User with a genuinely misconfigured relationship still sees "The relationship hasn't been configured correctly"
- [ ] Admin users are unaffected (full access to all relations)