### PR TITLE
Make claude hooks windows friendly

### DIFF
--- a/.claude/hooks/eslint.mjs
+++ b/.claude/hooks/eslint.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env nodeimport { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const file = input.tool_input?.file_path ?? '';
+
+if (/\.(js|mjs|ts|vue)$/.test(file)) {
+	spawnSync('pnpm', ['exec', 'eslint', '--fix', file], {
+		cwd: process.env.CLAUDE_PROJECT_DIR,
+		stdio: 'inherit',
+		shell: true,
+	});
+}

--- a/.claude/hooks/eslint.mjs
+++ b/.claude/hooks/eslint.mjs
@@ -1,4 +1,5 @@
-#!/usr/bin/env nodeimport { spawnSync } from 'node:child_process';
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 const input = JSON.parse(readFileSync(0, 'utf8'));

--- a/.claude/hooks/eslint.sh
+++ b/.claude/hooks/eslint.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-FILE=$(jq -r '.tool_input.file_path')
-echo "$FILE" | grep -qE '\.(js|mjs|ts|vue)$' && "$CLAUDE_PROJECT_DIR"/node_modules/.bin/eslint --fix "$FILE" || true

--- a/.claude/hooks/prettier.mjs
+++ b/.claude/hooks/prettier.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const file = input.tool_input?.file_path ?? '';
+
+if (/\.(js|mjs|ts|json|vue|scss|css|md|yaml|yml)$/.test(file)) {
+	spawnSync('pnpm', ['exec', 'prettier', '--write', file], {
+		cwd: process.env.CLAUDE_PROJECT_DIR,
+		stdio: 'inherit',
+		shell: true,
+	});
+}

--- a/.claude/hooks/prettier.sh
+++ b/.claude/hooks/prettier.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-FILE=$(jq -r '.tool_input.file_path')
-echo "$FILE" | grep -qE '\.(js|mjs|ts|json|vue|scss|css|md|yaml|yml)$' && "$CLAUDE_PROJECT_DIR"/node_modules/.bin/prettier --write "$FILE" || true

--- a/.claude/hooks/stylelint.mjs
+++ b/.claude/hooks/stylelint.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const file = input.tool_input?.file_path ?? '';
+
+if (/\.(css|scss|vue)$/.test(file)) {
+	spawnSync('pnpm', ['exec', 'stylelint', '--fix', file], {
+		cwd: process.env.CLAUDE_PROJECT_DIR,
+		stdio: 'inherit',
+		shell: true,
+	});
+}

--- a/.claude/hooks/stylelint.sh
+++ b/.claude/hooks/stylelint.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-FILE=$(jq -r '.tool_input.file_path')
-echo "$FILE" | grep -qE '\.(css|scss|vue)$' && "$CLAUDE_PROJECT_DIR"/node_modules/.bin/stylelint --fix "$FILE" || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,9 @@
 			{
 				"matcher": "Edit|Write",
 				"hooks": [
-					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prettier.sh" },
-					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/eslint.sh" },
-					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stylelint.sh" }
+					{ "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prettier.mjs" },
+					{ "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/eslint.mjs" },
+					{ "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stylelint.mjs" }
 				]
 			}
 		]


### PR DESCRIPTION
## Scope

What's changed:

Converts eslint/prettier/stylelint hooks from bash+jq to .mjs scripts                                                                     
   so they work on Windows (no bash/grep/jq required, pnpm handles binary                                                                    
   resolution cross-platform).

## Potential Risks / Drawbacks

None

## Tested Scenarios

- I didn't test it on windows, only unix

## Review Notes / Questions

- It would be nice if somebody with Windows tests this

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

