### PR TITLE
Preserve M2A type info when using named GraphQL fragments

### DIFF
--- a/.changeset/large-geese-teach.md
+++ b/.changeset/large-geese-teach.md
@@ -1,5 +1,6 @@
 ---
 '@directus/api': patch
+'@directus/utils': patch
 ---
 
 Preserved M2A type info when using named GraphQL fragments

--- a/.changeset/large-geese-teach.md
+++ b/.changeset/large-geese-teach.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Preserved M2A type info when using named GraphQL fragments

--- a/api/src/services/graphql/schema/parse-query.test.ts
+++ b/api/src/services/graphql/schema/parse-query.test.ts
@@ -20,9 +20,53 @@ vi.mock('../utils/replace-funcs.js', () => ({
 	replaceFuncs: vi.fn((v) => v),
 }));
 
-const mockSchema = {} as any;
+const mockSchema = { relations: [] } as any;
 const mockAccountability = null;
 const mockVariableValues = {};
+
+// test_collection.parent is A2O → child
+const m2aSchema = {
+	relations: [
+		{
+			collection: 'test_collection',
+			field: 'parent',
+			related_collection: null,
+			meta: {
+				one_collection_field: 'collection',
+				one_allowed_collections: ['child'],
+				one_field: null,
+			},
+		},
+	],
+} as any;
+
+// Page → content (O2M junction) → item (A2O)
+const pageM2ASchema = {
+	relations: [
+		{
+			// O2M: Page.contents → page_content
+			collection: 'page_content',
+			field: 'page_id',
+			related_collection: 'Page',
+			meta: {
+				one_field: 'contents',
+				one_collection_field: null,
+				one_allowed_collections: null,
+			},
+		},
+		{
+			// A2O: page_content.item → ComponentText
+			collection: 'page_content',
+			field: 'item',
+			related_collection: null,
+			meta: {
+				one_collection_field: 'collection',
+				one_allowed_collections: ['ComponentText'],
+				one_field: null,
+			},
+		},
+	],
+} as any;
 
 describe('parseFields', () => {
 	afterEach(() => {
@@ -56,17 +100,88 @@ describe('parseFields', () => {
 		expect(query.alias).toEqual({ writer: 'author' });
 	});
 
-	test('should parse InlineFragment', async () => {
+	test('should parse M2A InlineFragment with schema relations', async () => {
 		const selections = [
 			{
 				kind: 'Field',
 				name: { value: 'parent' },
-				selectionSet: { selections: [{ kind: 'InlineFragment', typeCondition: { name: { value: 'child' } } }] },
+				selectionSet: {
+					selections: [
+						{
+							kind: 'InlineFragment',
+							typeCondition: { name: { value: 'child' } },
+							selectionSet: {
+								selections: [{ kind: 'Field', name: { value: 'id' } }],
+							},
+						},
+					],
+				},
 			},
 		] as unknown as SelectionNode[];
 
-		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability, 'test_collection');
-		expect(query.fields).toContain('parent:child');
+		const query = await getQuery({}, m2aSchema, selections, mockVariableValues, mockAccountability, 'test_collection');
+		expect(query.fields).toEqual(['parent:child.id']);
+	});
+
+	test('should inline non-M2A InlineFragment without type prefix', async () => {
+		// Page { ...PageFragment } at root level, not M2A
+		const selections = [
+			{
+				kind: 'InlineFragment',
+				typeCondition: { name: { value: 'Page' } },
+				selectionSet: {
+					selections: [
+						{ kind: 'Field', name: { value: 'id' } },
+						{ kind: 'Field', name: { value: 'title' } },
+					],
+				},
+			},
+		] as unknown as SelectionNode[];
+
+		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability, 'Page');
+		expect(query.fields).toEqual(['id', 'title']);
+	});
+
+	test('should inline non-M2A InlineFragment on O2M field', async () => {
+		// author { ...AuthorFragment } where author is O2M, not M2A
+		const o2mSchema = {
+			relations: [
+				{
+					collection: 'author',
+					field: 'page_id',
+					related_collection: 'Page',
+					meta: {
+						one_field: 'author',
+						one_collection_field: null,
+						one_allowed_collections: null,
+					},
+				},
+			],
+		} as any;
+
+		const selections = [
+			{
+				kind: 'Field',
+				name: { value: 'author' },
+				selectionSet: {
+					selections: [
+						{
+							kind: 'InlineFragment',
+							typeCondition: { name: { value: 'author' } },
+							selectionSet: {
+								selections: [
+									{ kind: 'Field', name: { value: 'name' } },
+									{ kind: 'Field', name: { value: 'email' } },
+								],
+							},
+						},
+					],
+				},
+			},
+		] as unknown as SelectionNode[];
+
+		const query = await getQuery({}, o2mSchema, selections, mockVariableValues, mockAccountability, 'Page');
+		expect(query.fields).toEqual(['author.name', 'author.email']);
 	});
 
 	test('should parse nested selectionSet', async () => {
@@ -100,7 +215,7 @@ describe('parseFields', () => {
 		expect(query.fields).toEqual(['posts']);
 	});
 
-	test('should parse InlineFragment with arguments', async () => {
+	test('should parse M2A InlineFragment with arguments', async () => {
 		const selections = [
 			{
 				kind: 'Field',
@@ -127,7 +242,7 @@ describe('parseFields', () => {
 
 		vi.mocked(sanitizeQuery).mockResolvedValue({ limit: 10 });
 
-		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
+		const query = await getQuery({}, m2aSchema, selections, mockVariableValues, mockAccountability, 'test_collection');
 		expect(query.fields).toEqual(['parent:child.grandchild']);
 
 		expect(query.deep).toStrictEqual({
@@ -162,6 +277,97 @@ describe('parseFields', () => {
 	test('should handle empty selections', async () => {
 		const query = await getQuery({}, mockSchema, [], mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual([]);
+	});
+
+	test('M2A InlineFragment with full relation chain produces correct paths', async () => {
+		// contents → item → InlineFragment(ComponentText) with translation filter
+		const selections = [
+			{
+				kind: 'Field',
+				name: { value: 'contents' },
+				selectionSet: {
+					selections: [
+						{
+							kind: 'Field',
+							name: { value: 'item' },
+							selectionSet: {
+								selections: [
+									{
+										kind: 'InlineFragment',
+										typeCondition: { name: { value: 'ComponentText' } },
+										selectionSet: {
+											selections: [
+												{ kind: 'Field', name: { value: 'id' } },
+												{
+													kind: 'Field',
+													name: { value: 'translations' },
+													arguments: [
+														{
+															name: { value: 'filter' },
+															value: {
+																kind: 'ObjectValue',
+																fields: [
+																	{
+																		kind: 'ObjectField',
+																		name: { value: 'languages_code' },
+																		value: {
+																			kind: 'ObjectValue',
+																			fields: [
+																				{
+																					kind: 'ObjectField',
+																					name: { value: 'code' },
+																					value: {
+																						kind: 'ObjectValue',
+																						fields: [
+																							{
+																								kind: 'ObjectField',
+																								name: { value: '_eq' },
+																								value: { kind: 'StringValue', value: 'en-EN' },
+																							},
+																						],
+																					},
+																				},
+																			],
+																		},
+																	},
+																],
+															},
+														},
+													],
+													selectionSet: {
+														selections: [{ kind: 'Field', name: { value: 'id' } }],
+													},
+												},
+											],
+										},
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+		] as unknown as SelectionNode[];
+
+		vi.mocked(sanitizeQuery).mockResolvedValue({
+			filter: { languages_code: { code: { _eq: 'en-EN' } } },
+		});
+
+		const query = await getQuery({}, pageM2ASchema, selections, mockVariableValues, mockAccountability, 'Page');
+
+		expect(query.fields).toEqual(['contents.item:ComponentText.id', 'contents.item:ComponentText.translations.id']);
+
+		expect(query.deep).toEqual(
+			expect.objectContaining({
+				contents: expect.objectContaining({
+					item__ComponentText: expect.objectContaining({
+						translations: expect.objectContaining({
+							_filter: { languages_code: { code: { _eq: 'en-EN' } } },
+						}),
+					}),
+				}),
+			}),
+		);
 	});
 
 	test('should handle deeply nested fields', async () => {

--- a/api/src/services/graphql/schema/parse-query.test.ts
+++ b/api/src/services/graphql/schema/parse-query.test.ts
@@ -1,7 +1,37 @@
-import type { FieldNode, SelectionNode } from 'graphql';
+import type { SelectionNode } from 'graphql';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { sanitizeQuery } from '../../../utils/sanitize-query.js';
 import { getQuery } from './parse-query.js';
+
+// AST node helpers
+const field = (name: string, opts?: { alias?: string; args?: any[]; children?: any[] }) =>
+	({
+		kind: 'Field',
+		name: { value: name },
+		...(opts?.alias && { alias: { value: opts.alias } }),
+		...(opts?.args && { arguments: opts.args }),
+		...(opts?.children && { selectionSet: { selections: opts.children } }),
+	}) as unknown as SelectionNode;
+
+const inlineFragment = (type: string, children: any[]) =>
+	({
+		kind: 'InlineFragment',
+		typeCondition: { name: { value: type } },
+		selectionSet: { selections: children },
+	}) as unknown as SelectionNode;
+
+const gqlFilterArg = (filter: Record<string, any>): any => {
+	const toObjectValue = (obj: Record<string, any>): any => ({
+		kind: 'ObjectValue',
+		fields: Object.entries(obj).map(([key, val]) => ({
+			kind: 'ObjectField',
+			name: { value: key },
+			value: typeof val === 'object' ? toObjectValue(val) : { kind: 'StringValue', value: val },
+		})),
+	});
+
+	return { name: { value: 'filter' }, value: toObjectValue(filter) };
+};
 
 vi.mock('../../../utils/sanitize-query.js', () => ({
 	sanitizeQuery: vi.fn(async (q) => q),
@@ -74,50 +104,28 @@ describe('parseFields', () => {
 	});
 
 	test('should parse simple field selection', async () => {
-		const selections = [
-			{ kind: 'Field', name: { value: 'id' } },
-			{ kind: 'Field', name: { value: 'name' } },
-		] as SelectionNode[];
+		const selections = [field('id'), field('name')];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['id', 'name']);
 	});
 
 	test('should ignore __typename fields', async () => {
-		const selections = [
-			{ kind: 'Field', name: { value: '__typename' } },
-			{ kind: 'Field', name: { value: 'title' } },
-		] as SelectionNode[];
+		const selections = [field('__typename'), field('title')];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['title']);
 	});
 
 	test('should parse field with alias', async () => {
-		const selections = [{ kind: 'Field', name: { value: 'author' }, alias: { value: 'writer' } }] as SelectionNode[];
+		const selections = [field('author', { alias: 'writer' })];
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['author']);
 		expect(query.alias).toEqual({ writer: 'author' });
 	});
 
 	test('should parse M2A InlineFragment with schema relations', async () => {
-		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'parent' },
-				selectionSet: {
-					selections: [
-						{
-							kind: 'InlineFragment',
-							typeCondition: { name: { value: 'child' } },
-							selectionSet: {
-								selections: [{ kind: 'Field', name: { value: 'id' } }],
-							},
-						},
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+		const selections = [field('parent', { children: [inlineFragment('child', [field('id')])] })];
 
 		const query = await getQuery({}, m2aSchema, selections, mockVariableValues, mockAccountability, 'test_collection');
 		expect(query.fields).toEqual(['parent:child.id']);
@@ -125,18 +133,7 @@ describe('parseFields', () => {
 
 	test('should inline non-M2A InlineFragment without type prefix', async () => {
 		// Page { ...PageFragment } at root level, not M2A
-		const selections = [
-			{
-				kind: 'InlineFragment',
-				typeCondition: { name: { value: 'Page' } },
-				selectionSet: {
-					selections: [
-						{ kind: 'Field', name: { value: 'id' } },
-						{ kind: 'Field', name: { value: 'title' } },
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+		const selections = [inlineFragment('Page', [field('id'), field('title')])];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability, 'Page');
 		expect(query.fields).toEqual(['id', 'title']);
@@ -150,95 +147,40 @@ describe('parseFields', () => {
 					collection: 'author',
 					field: 'page_id',
 					related_collection: 'Page',
-					meta: {
-						one_field: 'author',
-						one_collection_field: null,
-						one_allowed_collections: null,
-					},
+					meta: { one_field: 'author', one_collection_field: null, one_allowed_collections: null },
 				},
 			],
 		} as any;
 
-		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'author' },
-				selectionSet: {
-					selections: [
-						{
-							kind: 'InlineFragment',
-							typeCondition: { name: { value: 'author' } },
-							selectionSet: {
-								selections: [
-									{ kind: 'Field', name: { value: 'name' } },
-									{ kind: 'Field', name: { value: 'email' } },
-								],
-							},
-						},
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+		const selections = [field('author', { children: [inlineFragment('author', [field('name'), field('email')])] })];
 
 		const query = await getQuery({}, o2mSchema, selections, mockVariableValues, mockAccountability, 'Page');
 		expect(query.fields).toEqual(['author.name', 'author.email']);
 	});
 
 	test('should parse nested selectionSet', async () => {
-		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'user' },
-				selectionSet: {
-					selections: [
-						{ kind: 'Field', name: { value: 'id' } },
-						{ kind: 'Field', name: { value: 'email' } },
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+		const selections = [field('user', { children: [field('id'), field('email')] })];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['user.id', 'user.email']);
 	});
 
 	test('should parse field with arguments', async () => {
-		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'posts' },
-				arguments: [{ name: { value: 'limit' }, value: { kind: 'IntValue', value: '10' } }],
-			},
-		] as unknown as FieldNode[];
+		const limitArg = { name: { value: 'limit' }, value: { kind: 'IntValue', value: '10' } };
+		const selections = [field('posts', { args: [limitArg] })];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['posts']);
 	});
 
 	test('should parse M2A InlineFragment with arguments', async () => {
+		const limitArg = { name: { value: 'limit' }, value: { kind: 'IntValue', value: '10' } };
+
 		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'parent' },
-				selectionSet: {
-					selections: [
-						{
-							kind: 'InlineFragment',
-							typeCondition: { name: { value: 'child' } },
-							selectionSet: {
-								selections: [
-									{
-										kind: 'Field',
-										name: { value: 'grandchild' },
-										arguments: [{ name: { value: 'limit' }, value: { kind: 'IntValue', value: '10' } }],
-									},
-								],
-							},
-						},
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+			field('parent', {
+				children: [inlineFragment('child', [field('grandchild', { args: [limitArg] })])],
+			}),
+		];
 
 		vi.mocked(sanitizeQuery).mockResolvedValue({ limit: 10 });
 
@@ -257,18 +199,7 @@ describe('parseFields', () => {
 	});
 
 	test('should parse _func field with selectionSet', async () => {
-		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'count_func' },
-				selectionSet: {
-					selections: [
-						{ kind: 'Field', name: { value: 'sum' } },
-						{ kind: 'Field', name: { value: 'avg' } },
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+		const selections = [field('count_func', { children: [field('sum'), field('avg')] })];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['sum(count)', 'avg(count)']);
@@ -281,73 +212,22 @@ describe('parseFields', () => {
 
 	test('M2A InlineFragment with full relation chain produces correct paths', async () => {
 		// contents → item → InlineFragment(ComponentText) with translation filter
+		const filterArg = gqlFilterArg({ languages_code: { code: { _eq: 'en-EN' } } });
+
 		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'contents' },
-				selectionSet: {
-					selections: [
-						{
-							kind: 'Field',
-							name: { value: 'item' },
-							selectionSet: {
-								selections: [
-									{
-										kind: 'InlineFragment',
-										typeCondition: { name: { value: 'ComponentText' } },
-										selectionSet: {
-											selections: [
-												{ kind: 'Field', name: { value: 'id' } },
-												{
-													kind: 'Field',
-													name: { value: 'translations' },
-													arguments: [
-														{
-															name: { value: 'filter' },
-															value: {
-																kind: 'ObjectValue',
-																fields: [
-																	{
-																		kind: 'ObjectField',
-																		name: { value: 'languages_code' },
-																		value: {
-																			kind: 'ObjectValue',
-																			fields: [
-																				{
-																					kind: 'ObjectField',
-																					name: { value: 'code' },
-																					value: {
-																						kind: 'ObjectValue',
-																						fields: [
-																							{
-																								kind: 'ObjectField',
-																								name: { value: '_eq' },
-																								value: { kind: 'StringValue', value: 'en-EN' },
-																							},
-																						],
-																					},
-																				},
-																			],
-																		},
-																	},
-																],
-															},
-														},
-													],
-													selectionSet: {
-														selections: [{ kind: 'Field', name: { value: 'id' } }],
-													},
-												},
-											],
-										},
-									},
-								],
-							},
-						},
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+			field('contents', {
+				children: [
+					field('item', {
+						children: [
+							inlineFragment('ComponentText', [
+								field('id'),
+								field('translations', { args: [filterArg], children: [field('id')] }),
+							]),
+						],
+					}),
+				],
+			}),
+		];
 
 		vi.mocked(sanitizeQuery).mockResolvedValue({
 			filter: { languages_code: { code: { _eq: 'en-EN' } } },
@@ -371,23 +251,7 @@ describe('parseFields', () => {
 	});
 
 	test('should handle deeply nested fields', async () => {
-		const selections = [
-			{
-				kind: 'Field',
-				name: { value: 'parent' },
-				selectionSet: {
-					selections: [
-						{
-							kind: 'Field',
-							name: { value: 'child' },
-							selectionSet: {
-								selections: [{ kind: 'Field', name: { value: 'grandchild' } }],
-							},
-						},
-					],
-				},
-			},
-		] as unknown as SelectionNode[];
+		const selections = [field('parent', { children: [field('child', { children: [field('grandchild')] })] })];
 
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['parent.child.grandchild']);

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -1,7 +1,8 @@
 import type { Accountability, Query, SchemaOverview } from '@directus/types';
-import { getRelation, getRelationInfo, getRelationType } from '@directus/utils';
+import { getRelationInfo } from '@directus/utils';
 import type { FieldNode, GraphQLResolveInfo, InlineFragmentNode, SelectionNode } from 'graphql';
 import { get, mapKeys, merge, set, uniq } from 'lodash-es';
+import { getRelatedCollection } from '../../../database/get-ast-from-query/utils/get-related-collection.js';
 import { sanitizeQuery } from '../../../utils/sanitize-query.js';
 import { validateQuery } from '../../../utils/validate-query.js';
 import { filterReplaceM2A, filterReplaceM2ADeep } from '../utils/filter-replace-m2a.js';
@@ -111,21 +112,7 @@ export async function getQuery(
 
 				// Resolve child collection for recursive calls
 				if (currentCollection && selection.selectionSet) {
-					const fieldName = selection.name.value;
-					const relation = getRelation(schema.relations, currentCollection, fieldName);
-
-					if (relation) {
-						const relType = getRelationType({
-							relation,
-							collection: currentCollection,
-							field: fieldName,
-							useA2O: true,
-						});
-
-						if (relType === 'o2m') childCollection = relation.collection;
-						else if (relType === 'm2o') childCollection = relation.related_collection ?? undefined;
-						else if (relType === 'a2o') childCollection = relation.collection;
-					}
+					childCollection = getRelatedCollection(schema, currentCollection, selection.name.value) ?? currentCollection;
 				}
 			}
 

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -1,5 +1,5 @@
 import type { Accountability, Query, SchemaOverview } from '@directus/types';
-import { getRelation, getRelationType } from '@directus/utils';
+import { getRelation, getRelationInfo, getRelationType } from '@directus/utils';
 import type { FieldNode, GraphQLResolveInfo, InlineFragmentNode, SelectionNode } from 'graphql';
 import { get, mapKeys, merge, set, uniq } from 'lodash-es';
 import { sanitizeQuery } from '../../../utils/sanitize-query.js';
@@ -36,13 +36,6 @@ export async function getQuery(
 		return aliases;
 	};
 
-	const isM2AField = (fieldName: string, fieldCollection: string): boolean => {
-		const relation = getRelation(schema.relations, fieldCollection, fieldName);
-		if (!relation) return false;
-
-		return getRelationType({ relation, collection: fieldCollection, field: fieldName, useA2O: true }) === 'a2o';
-	};
-
 	const parseFields = async (
 		selections: readonly SelectionNode[],
 		parent?: string,
@@ -63,7 +56,10 @@ export async function getQuery(
 			if (selection.kind === 'InlineFragment') {
 				if (selection.typeCondition!.name.value.startsWith('__')) continue;
 
-				const isM2A = parentFieldName && currentCollection ? isM2AField(parentFieldName, currentCollection) : false;
+				const isM2A =
+					parentFieldName && currentCollection
+						? getRelationInfo(schema.relations, currentCollection, parentFieldName).relationType === 'a2o'
+						: false;
 
 				if (isM2A) {
 					current = `${parent}:${selection.typeCondition!.name.value}`;

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -1,4 +1,5 @@
 import type { Accountability, Query, SchemaOverview } from '@directus/types';
+import { getRelation, getRelationType } from '@directus/utils';
 import type { FieldNode, GraphQLResolveInfo, InlineFragmentNode, SelectionNode } from 'graphql';
 import { get, mapKeys, merge, set, uniq } from 'lodash-es';
 import { sanitizeQuery } from '../../../utils/sanitize-query.js';
@@ -35,7 +36,19 @@ export async function getQuery(
 		return aliases;
 	};
 
-	const parseFields = async (selections: readonly SelectionNode[], parent?: string): Promise<string[]> => {
+	const isM2AField = (fieldName: string, fieldCollection: string): boolean => {
+		const relation = getRelation(schema.relations, fieldCollection, fieldName);
+		if (!relation) return false;
+
+		return getRelationType({ relation, collection: fieldCollection, field: fieldName, useA2O: true }) === 'a2o';
+	};
+
+	const parseFields = async (
+		selections: readonly SelectionNode[],
+		parent?: string,
+		currentCollection?: string,
+		parentFieldName?: string,
+	): Promise<string[]> => {
 		const fields: string[] = [];
 
 		for (let selection of selections) {
@@ -45,12 +58,28 @@ export async function getQuery(
 
 			let current: string;
 			let currentAlias: string | null = null;
+			let childCollection: string | undefined = currentCollection;
 
-			// Union type (Many-to-Any)
 			if (selection.kind === 'InlineFragment') {
 				if (selection.typeCondition!.name.value.startsWith('__')) continue;
 
-				current = `${parent}:${selection.typeCondition!.name.value}`;
+				const isM2A = parentFieldName && currentCollection ? isM2AField(parentFieldName, currentCollection) : false;
+
+				if (isM2A) {
+					current = `${parent}:${selection.typeCondition!.name.value}`;
+					childCollection = selection.typeCondition!.name.value;
+				} else {
+					// Non-M2A fragment: inline children with same parent
+					const children = await parseFields(
+						selection.selectionSet?.selections ?? [],
+						parent,
+						currentCollection,
+						parentFieldName,
+					);
+
+					fields.push(...children);
+					continue;
+				}
 			}
 			// Any other field type
 			else {
@@ -83,6 +112,25 @@ export async function getQuery(
 						}
 					}
 				}
+
+				// Resolve child collection for recursive calls
+				if (currentCollection && selection.selectionSet) {
+					const fieldName = selection.name.value;
+					const relation = getRelation(schema.relations, currentCollection, fieldName);
+
+					if (relation) {
+						const relType = getRelationType({
+							relation,
+							collection: currentCollection,
+							field: fieldName,
+							useA2O: true,
+						});
+
+						if (relType === 'o2m') childCollection = relation.collection;
+						else if (relType === 'm2o') childCollection = relation.related_collection ?? undefined;
+						else if (relType === 'a2o') childCollection = relation.collection;
+					}
+				}
 			}
 
 			if (selection.selectionSet) {
@@ -99,7 +147,12 @@ export async function getQuery(
 						children.push(`${subSelection.name!.value}(${rootField})`);
 					}
 				} else {
-					children = await parseFields(selection.selectionSet.selections, currentAlias ?? current);
+					children = await parseFields(
+						selection.selectionSet.selections,
+						currentAlias ?? current,
+						childCollection,
+						selection.kind === 'Field' ? selection.name.value : undefined,
+					);
 				}
 
 				fields.push(...children);
@@ -130,7 +183,7 @@ export async function getQuery(
 	};
 
 	query.alias = parseAliases(selections);
-	query.fields = await parseFields(selections);
+	query.fields = await parseFields(selections, undefined, collection);
 
 	if (query.filter) query.filter = replaceFuncs(query.filter);
 

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -57,8 +57,7 @@ export async function getQuery(
 			if (selection.kind === 'InlineFragment') {
 				if (selection.typeCondition!.name.value.startsWith('__')) continue;
 
-				const isM2A =
-					getRelationInfo(schema.relations, currentCollection ?? '', parentFieldName ?? '').relationType === 'a2o';
+				const isM2A = getRelationInfo(schema.relations, currentCollection, parentFieldName).relationType === 'a2o';
 
 				if (isM2A) {
 					current = `${parent}:${selection.typeCondition!.name.value}`;

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -110,6 +110,9 @@ export async function getQuery(
 
 				// Resolve child collection for recursive calls
 				if (currentCollection && selection.selectionSet) {
+					// For A2O, getRelatedCollection returns null. Fallback to currentCollection
+					// keeps the junction in context so the next level can detect M2A via isM2AField.
+					// The actual target collection is then set from the InlineFragment typeCondition.
 					childCollection = getRelatedCollection(schema, currentCollection, selection.name.value) ?? currentCollection;
 				}
 			}

--- a/api/src/services/graphql/schema/parse-query.ts
+++ b/api/src/services/graphql/schema/parse-query.ts
@@ -58,9 +58,7 @@ export async function getQuery(
 				if (selection.typeCondition!.name.value.startsWith('__')) continue;
 
 				const isM2A =
-					parentFieldName && currentCollection
-						? getRelationInfo(schema.relations, currentCollection, parentFieldName).relationType === 'a2o'
-						: false;
+					getRelationInfo(schema.relations, currentCollection ?? '', parentFieldName ?? '').relationType === 'a2o';
 
 				if (isM2A) {
 					current = `${parent}:${selection.typeCondition!.name.value}`;

--- a/api/src/services/graphql/utils/replace-fragments.test.ts
+++ b/api/src/services/graphql/utils/replace-fragments.test.ts
@@ -1,0 +1,157 @@
+import type { FragmentDefinitionNode, SelectionNode } from 'graphql';
+import { describe, expect, test } from 'vitest';
+import { replaceFragmentsInSelections } from './replace-fragments.js';
+
+describe('replaceFragmentsInSelections', () => {
+	test('returns null for undefined selections', () => {
+		expect(replaceFragmentsInSelections(undefined, {})).toBeNull();
+	});
+
+	test('passes through regular fields unchanged', () => {
+		const selections = [
+			{ kind: 'Field', name: { value: 'id' } },
+			{ kind: 'Field', name: { value: 'title' } },
+		] as unknown as SelectionNode[];
+
+		const result = replaceFragmentsInSelections(selections, {});
+		expect(result).toHaveLength(2);
+		expect((result![0] as any).name.value).toBe('id');
+		expect((result![1] as any).name.value).toBe('title');
+	});
+
+	test('wraps FragmentSpread in InlineFragment preserving typeCondition', () => {
+		const selections = [{ kind: 'FragmentSpread', name: { value: 'MyFragment' } }] as unknown as SelectionNode[];
+
+		const fragments = {
+			MyFragment: {
+				kind: 'FragmentDefinition',
+				name: { value: 'MyFragment' },
+				typeCondition: { kind: 'NamedType', name: { value: 'Page' } },
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: [
+						{ kind: 'Field', name: { value: 'id' } },
+						{ kind: 'Field', name: { value: 'title' } },
+					] as unknown as SelectionNode[],
+				},
+			},
+		} as unknown as Record<string, FragmentDefinitionNode>;
+
+		const result = replaceFragmentsInSelections(selections, fragments);
+
+		// Should produce a single InlineFragment
+		expect(result).toHaveLength(1);
+		expect((result![0] as any).kind).toBe('InlineFragment');
+		expect((result![0] as any).typeCondition.name.value).toBe('Page');
+
+		// Should contain the original fields
+		const innerSelections = (result![0] as any).selectionSet.selections;
+		expect(innerSelections).toHaveLength(2);
+		expect(innerSelections[0].name.value).toBe('id');
+		expect(innerSelections[1].name.value).toBe('title');
+	});
+
+	test('passes through InlineFragment with typeCondition (M2A inline)', () => {
+		const selections = [
+			{
+				kind: 'InlineFragment',
+				typeCondition: { kind: 'NamedType', name: { value: 'ComponentText' } },
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: [{ kind: 'Field', name: { value: 'id' } }],
+				},
+			},
+		] as unknown as SelectionNode[];
+
+		const result = replaceFragmentsInSelections(selections, {});
+		expect(result).toHaveLength(1);
+		expect((result![0] as any).kind).toBe('InlineFragment');
+		expect((result![0] as any).typeCondition.name.value).toBe('ComponentText');
+	});
+
+	test('named fragment in M2A context preserves typeCondition as InlineFragment', () => {
+		const itemSelections = [{ kind: 'FragmentSpread', name: { value: 'ComponentText' } }] as unknown as SelectionNode[];
+
+		const fragments = {
+			ComponentText: {
+				kind: 'FragmentDefinition',
+				name: { value: 'ComponentText' },
+				typeCondition: { kind: 'NamedType', name: { value: 'ComponentText' } },
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: [
+						{ kind: 'Field', name: { value: 'id' } },
+						{
+							kind: 'Field',
+							name: { value: 'translations' },
+							arguments: [
+								{
+									kind: 'Argument',
+									name: { value: 'filter' },
+									value: { kind: 'ObjectValue', fields: [] },
+								},
+							],
+							selectionSet: {
+								kind: 'SelectionSet',
+								selections: [{ kind: 'Field', name: { value: 'id' } }] as unknown as SelectionNode[],
+							},
+						},
+					] as unknown as SelectionNode[],
+				},
+			},
+		} as unknown as Record<string, FragmentDefinitionNode>;
+
+		const result = replaceFragmentsInSelections(itemSelections, fragments);
+
+		expect(result).toHaveLength(1);
+		expect((result![0] as any).kind).toBe('InlineFragment');
+		expect((result![0] as any).typeCondition.name.value).toBe('ComponentText');
+
+		// check arguments preserved
+		const innerSelections = (result![0] as any).selectionSet.selections;
+		expect(innerSelections).toHaveLength(2);
+		expect(innerSelections[0].name.value).toBe('id');
+		expect(innerSelections[1].name.value).toBe('translations');
+		expect(innerSelections[1].arguments).toHaveLength(1);
+	});
+
+	test('handles nested fragments (fragment referencing another fragment)', () => {
+		const selections = [{ kind: 'FragmentSpread', name: { value: 'Outer' } }] as unknown as SelectionNode[];
+
+		const fragments = {
+			Outer: {
+				kind: 'FragmentDefinition',
+				name: { value: 'Outer' },
+				typeCondition: { kind: 'NamedType', name: { value: 'Page' } },
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: [
+						{ kind: 'Field', name: { value: 'id' } },
+						{ kind: 'FragmentSpread', name: { value: 'Inner' } },
+					] as unknown as SelectionNode[],
+				},
+			},
+			Inner: {
+				kind: 'FragmentDefinition',
+				name: { value: 'Inner' },
+				typeCondition: { kind: 'NamedType', name: { value: 'Author' } },
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: [{ kind: 'Field', name: { value: 'name' } }] as unknown as SelectionNode[],
+				},
+			},
+		} as unknown as Record<string, FragmentDefinitionNode>;
+
+		const result = replaceFragmentsInSelections(selections, fragments);
+
+		expect(result).toHaveLength(1);
+		expect((result![0] as any).kind).toBe('InlineFragment');
+		expect((result![0] as any).typeCondition.name.value).toBe('Page');
+
+		const innerSelections = (result![0] as any).selectionSet.selections;
+		expect(innerSelections).toHaveLength(2);
+		expect(innerSelections[0].name.value).toBe('id');
+		expect(innerSelections[1].kind).toBe('InlineFragment');
+		expect(innerSelections[1].typeCondition.name.value).toBe('Author');
+	});
+});

--- a/api/src/services/graphql/utils/replace-fragments.ts
+++ b/api/src/services/graphql/utils/replace-fragments.ts
@@ -15,7 +15,21 @@ export function replaceFragmentsInSelections(
 		selections.map((selection) => {
 			// Fragments can contains fragments themselves. This allows for nested fragments
 			if (selection.kind === 'FragmentSpread') {
-				return replaceFragmentsInSelections(fragments[selection.name.value]!.selectionSet.selections, fragments);
+				const fragment = fragments[selection.name.value]!;
+
+				const replacedSelections = replaceFragmentsInSelections(fragment.selectionSet.selections, fragments);
+
+				// Wrap in InlineFragment to preserve typeCondition
+				return [
+					{
+						kind: 'InlineFragment' as const,
+						typeCondition: fragment.typeCondition,
+						selectionSet: {
+							kind: 'SelectionSet' as const,
+							selections: replacedSelections ?? [],
+						},
+					} as SelectionNode,
+				];
 			}
 
 			// Nested relational fields can also contain fragments

--- a/packages/utils/shared/get-relation-info.ts
+++ b/packages/utils/shared/get-relation-info.ts
@@ -15,7 +15,13 @@ function checkImplicitRelation(field: string) {
 	return null;
 }
 
-export function getRelationInfo(relations: Relation[], collection: string, field: string): RelationInfo {
+export function getRelationInfo(
+	relations: Relation[],
+	collection: string | undefined,
+	field: string | undefined,
+): RelationInfo {
+	if (!collection || !field) return { relation: null, relationType: null };
+
 	if (field.startsWith('$FOLLOW') && field.length > 500) {
 		throw new Error(`Implicit $FOLLOW statement is too big to parse. Got: "${field.substring(500)}..."`);
 	}


### PR DESCRIPTION
## Scope

What's changed:

- named fragments (FragmentSpread) are now wrapped in InlineFragment instead of being flattened to bare fields, preserving the typeCondition
- `parseFields` function uses schema relations to distinguish M2A `InlineFragment` from regular ones

## Potential Risks / Drawbacks

- parseFields now does relation lookups per field (via getRelation/getRelationType from @directus/utils), adds minor overhead per GraphQL query
- Subscriptions don't call replaceFragmentsInSelections at all, so they have the same pre-existing bug (separate fix needed)

## Tested Scenarios

- Inline fragment with translation filter returns only filtered locale (still works)
- Named fragment with same filter now returns only filtered locale (was returning all locales)
- Non-M2A fragments at root level (...PageFragment on Page) inline correctly without :Type prefix
- Non-M2A fragments on O2M fields (author { ...AuthorFrag }) inline as dot-notation paths

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [X] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #14276 
