### PR TITLE
Prevent uncaught exception when v-menu has no tabbable elements

### DIFF
--- a/.changeset/giant-cups-sell.md
+++ b/.changeset/giant-cups-sell.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevented uncaught exception when v-menu has no tabbable elements

--- a/app/src/components/v-menu.test.ts
+++ b/app/src/components/v-menu.test.ts
@@ -347,6 +347,38 @@ test('should place menu arrow right when using placement "top-start" and using r
 	expect(menuArrow.attributes('style')).toContain('transform: translate3d(-6px, 0px, 0)');
 });
 
+test('v-menu-content should have tabindex="-1" to act as focus trap fallback target', async () => {
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			modelValue: true,
+		},
+		slots: {
+			// no tabbable elements
+			default: { template: '<span>non-interactive content</span>' },
+		},
+	});
+
+	const menuContent = wrapper.findComponent(TransitionBounce).find('.v-menu-content');
+
+	expect(menuContent.attributes('tabindex')).toBe('-1');
+});
+
+test('should not throw when menu opens with no tabbable elements', async () => {
+	const wrapper = mount(VMenu, {
+		...mountOptions,
+		props: {
+			trigger: 'click',
+		},
+		slots: {
+			activator: { template: '<button type="button">Open</button>' },
+			default: { template: '<span>non-interactive content</span>' },
+		},
+	});
+
+	await expect(wrapper.find('.v-menu').trigger('click')).resolves.not.toThrow();
+});
+
 test('should place menu arrow right when using placement "bottom-start" and using rtl', async () => {
 	const button = { template: '<button type="button">Content</button>' };
 

--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -152,6 +152,7 @@ function useActiveState() {
 	const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } = useFocusTrap([menuEl, activator], {
 		escapeDeactivates: false,
 		initialFocus: false,
+		fallbackFocus: () => menuEl.value!,
 		returnFocusOnDeactivate: !props.noFocusReturn,
 		allowOutsideClick: true,
 		clickOutsideDeactivates: props.closeOnClick,
@@ -495,6 +496,7 @@ function usePopper(
 					</div>
 					<div
 						ref="menuEl"
+						tabindex="-1"
 						class="v-menu-content"
 						:class="{ seamless }"
 						v-on="{


### PR DESCRIPTION
## Scope

What's changed:

- Added `fallbackFocus` option to the `useFocusTrap` configuration in `v-menu.vue` so the menu container itself is used
  as a fallback focus target when no tabbable elements are present

## Potential Risks / Drawbacks

- No breaking changes

## Tested Scenarios

- Verified no errors thrown in the console when interacting with the collab header avatars

## Review Notes / Questions

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #cms-2014