### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,29 @@
 			{
 				"matcher": "Edit|Write",
 				"hooks": [
-					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prettier.sh" },
-					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/eslint.sh" },
-					{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stylelint.sh" }
+					{
+						"type": "command",
+						"command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prettier.sh"
+					},
+					{
+						"type": "command",
+						"command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/eslint.sh"
+					},
+					{
+						"type": "command",
+						"command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stylelint.sh"
+					}
+				]
+			}
+		],
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "npx block-no-verify@1.1.2"
+					}
 				]
 			}
 		]


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing `PostToolUse` hooks.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing `PostToolUse` hooks for prettier, eslint, and stylelint are preserved unchanged.

Closes #26923

---

_Disclosure: I am the author and maintainer of `block-no-verify`._