### PR TITLE
Refactor "Clear value(s) on save when hidden" to run in a drawer

### DIFF
--- a/.changeset/plenty-beans-relax.md
+++ b/.changeset/plenty-beans-relax.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Ensure clear field on hidden condition is applied in a drawer
+Refactored "Clear value(s) on save when hidden" condition so it's applied inside a drawer

--- a/.changeset/plenty-beans-relax.md
+++ b/.changeset/plenty-beans-relax.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensure clear field on hidden condition is applied in a drawer

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -15,9 +15,8 @@ import sdk, { requestEndpoint } from '@/sdk';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { APIError } from '@/types/error';
-import { applyConditions } from '@/utils/apply-conditions';
+import { clearHiddenFieldsByCondition } from '@/utils/clear-hidden-fields-by-condition';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
-import { getFieldsInGroup } from '@/utils/get-fields-in-group';
 import { mergeItemData } from '@/utils/merge-item-data';
 import { notify } from '@/utils/notify';
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
@@ -133,52 +132,6 @@ export function useItem<T extends Item>(
 		} finally {
 			loadingItem.value = false;
 		}
-	}
-
-	function shouldClearField(field: Field, currentValues: Record<string, any>): boolean {
-		if (!field.meta?.conditions) return false;
-
-		const fieldWithConditions = applyConditions(currentValues, field);
-		return !!fieldWithConditions.meta?.hidden && !!fieldWithConditions.meta?.clear_hidden_value_on_save;
-	}
-
-	function clearHiddenFieldsByCondition(edits: Item, fields: Field[], defaultValues: any, item: any): Item {
-		const currentValues = mergeItemData(defaultValues, item, edits);
-
-		const fieldsToClearMap: Map<string, any> = new Map();
-
-		function addFieldToClear(field: Field) {
-			const defaultValue = field.schema?.default_value;
-			fieldsToClearMap.set(field.field, defaultValue !== undefined ? defaultValue : null);
-		}
-
-		for (const field of fields) {
-			if (shouldClearField(field, currentValues)) {
-				// If this is a group field that should be cleared, clear all fields within the group
-				if (field.meta?.special?.includes('group')) {
-					const fieldsInGroup = getFieldsInGroup(field.field, fields);
-
-					for (const groupField of fieldsInGroup) {
-						addFieldToClear(groupField);
-					}
-				} else {
-					// For non-group fields, add the field itself to be cleared
-					addFieldToClear(field);
-				}
-			}
-		}
-
-		if (fieldsToClearMap.size === 0) {
-			return edits;
-		}
-
-		const editsWithClearedValues = cloneDeep(edits);
-
-		for (const [field, defaultValue] of fieldsToClearMap) {
-			editsWithClearedValues[field] = defaultValue;
-		}
-
-		return editsWithClearedValues;
 	}
 
 	async function save() {

--- a/app/src/utils/clear-hidden-fields-by-condition.test.ts
+++ b/app/src/utils/clear-hidden-fields-by-condition.test.ts
@@ -1,0 +1,320 @@
+import { Field } from '@directus/types';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearHiddenFieldsByCondition, shouldClearField } from './clear-hidden-fields-by-condition.js';
+
+function makeField(fieldName: string, overrides: Partial<Field> = {}): Field {
+	return {
+		collection: 'test',
+		field: fieldName,
+		name: fieldName,
+		type: 'string',
+		schema: null,
+		meta: {
+			id: 1,
+			collection: 'test',
+			field: fieldName,
+			special: null,
+			interface: 'input',
+			options: null,
+			display: null,
+			display_options: null,
+			readonly: false,
+			hidden: false,
+			sort: 1,
+			width: 'full',
+			translations: null,
+			note: null,
+			conditions: null,
+			required: false,
+			group: null,
+			validation: null,
+			validation_message: null,
+		},
+		...overrides,
+	} as Field;
+}
+
+beforeEach(() => {
+	setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+});
+
+describe('shouldClearField', () => {
+	it('returns false when field has no conditions', () => {
+		const field = makeField('title');
+		expect(shouldClearField(field, {})).toBe(false);
+	});
+
+	it('returns false when no condition matches', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'hide when published',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		expect(shouldClearField(field, { status: 'draft' })).toBe(false);
+	});
+
+	it('returns false when condition matches but hidden is false', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'not hidden when published',
+						rule: { status: { _eq: 'published' } },
+						hidden: false,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		expect(shouldClearField(field, { status: 'published' })).toBe(false);
+	});
+
+	it('returns false when condition matches, hidden is true, but clear_hidden_value_on_save is false', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'hide but keep value',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: false,
+					},
+				],
+			},
+		});
+
+		expect(shouldClearField(field, { status: 'published' })).toBe(false);
+	});
+
+	it('returns true when condition matches and both hidden and clear_hidden_value_on_save are true', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'hide and clear when published',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		expect(shouldClearField(field, { status: 'published' })).toBe(true);
+	});
+});
+
+describe('clearHiddenFieldsByCondition', () => {
+	it('returns original edits reference when no fields need clearing', () => {
+		const field = makeField('title');
+		const edits = { title: 'hello' };
+		const result = clearHiddenFieldsByCondition(edits, [field], {}, {});
+		expect(result).toBe(edits);
+	});
+
+	it('clears a field to null when schema has no default_value', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'clear title',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		const edits = { title: 'some value', status: 'published' };
+		const result = clearHiddenFieldsByCondition(edits, [field], {}, {});
+		expect(result.title).toBeNull();
+	});
+
+	it('clears a field to its schema default_value', () => {
+		const field = makeField('score', {
+			schema: {
+				name: 'score',
+				table: 'test',
+				data_type: 'integer',
+				default_value: 0,
+				max_length: null,
+				numeric_precision: null,
+				numeric_scale: null,
+				is_generated: false,
+				generation_expression: null,
+				is_nullable: true,
+				is_unique: false,
+				is_indexed: false,
+				is_primary_key: false,
+				has_auto_increment: false,
+				foreign_key_column: null,
+				foreign_key_table: null,
+			},
+			meta: {
+				...makeField('score').meta!,
+				conditions: [
+					{
+						name: 'clear score',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		const edits = { score: 42, status: 'published' };
+		const result = clearHiddenFieldsByCondition(edits, [field], {}, {});
+		expect(result.score).toBe(0);
+	});
+
+	it('does not mutate the original edits', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'clear title',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		const edits = { title: 'original', status: 'published' };
+		const result = clearHiddenFieldsByCondition(edits, [field], {}, {});
+		expect(edits.title).toBe('original');
+		expect(result.title).toBeNull();
+	});
+
+	it('evaluates conditions against merged values from defaults, item, and edits', () => {
+		const field = makeField('title', {
+			meta: {
+				...makeField('title').meta!,
+				conditions: [
+					{
+						name: 'clear when archived',
+						rule: { status: { _eq: 'archived' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		// status comes from existing item, not edits
+		const edits = { title: 'some value' };
+		const defaults = {};
+		const item = { status: 'archived' };
+		const result = clearHiddenFieldsByCondition(edits, [field], defaults, item);
+		expect(result.title).toBeNull();
+	});
+
+	it('clears all fields within a hidden group', () => {
+		const groupField = makeField('my_group', {
+			type: 'alias',
+			schema: null,
+			meta: {
+				...makeField('my_group').meta!,
+				special: ['alias', 'no-data', 'group'],
+				conditions: [
+					{
+						name: 'hide group',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		const childField1 = makeField('child_one', {
+			meta: { ...makeField('child_one').meta!, group: 'my_group' },
+		});
+
+		const childField2 = makeField('child_two', {
+			meta: { ...makeField('child_two').meta!, group: 'my_group' },
+		});
+
+		const edits = { child_one: 'value1', child_two: 'value2', status: 'published' };
+		const result = clearHiddenFieldsByCondition(edits, [groupField, childField1, childField2], {}, {});
+		expect(result.child_one).toBeNull();
+		expect(result.child_two).toBeNull();
+	});
+
+	it('does not clear fields in a group when its condition does not match', () => {
+		const groupField = makeField('my_group', {
+			type: 'alias',
+			schema: null,
+			meta: {
+				...makeField('my_group').meta!,
+				special: ['alias', 'no-data', 'group'],
+				conditions: [
+					{
+						name: 'hide group',
+						rule: { status: { _eq: 'published' } },
+						hidden: true,
+						readonly: false,
+						options: null,
+						required: false,
+						clear_hidden_value_on_save: true,
+					},
+				],
+			},
+		});
+
+		const childField = makeField('child_one', {
+			meta: { ...makeField('child_one').meta!, group: 'my_group' },
+		});
+
+		const edits = { child_one: 'value1', status: 'draft' };
+		const result = clearHiddenFieldsByCondition(edits, [groupField, childField], {}, {});
+		expect(result).toBe(edits);
+	});
+});

--- a/app/src/utils/clear-hidden-fields-by-condition.test.ts
+++ b/app/src/utils/clear-hidden-fields-by-condition.test.ts
@@ -237,7 +237,7 @@ describe('clearHiddenFieldsByCondition', () => {
 						rule: { status: { _eq: 'archived' } },
 						hidden: true,
 						readonly: false,
-						options: null,
+						options: undefined,
 						required: false,
 						clear_hidden_value_on_save: true,
 					},

--- a/app/src/utils/clear-hidden-fields-by-condition.ts
+++ b/app/src/utils/clear-hidden-fields-by-condition.ts
@@ -7,7 +7,7 @@ import { mergeItemData } from './merge-item-data';
 export function shouldClearField(field: Field, currentValues: Record<string, any>): boolean {
 	if (!field.meta?.conditions) return false;
 
-	const fieldWithConditions = applyConditions(currentValues, field, null);
+	const fieldWithConditions = applyConditions(currentValues, field);
 	return !!fieldWithConditions.meta?.hidden && !!fieldWithConditions.meta?.clear_hidden_value_on_save;
 }
 

--- a/app/src/utils/clear-hidden-fields-by-condition.ts
+++ b/app/src/utils/clear-hidden-fields-by-condition.ts
@@ -1,0 +1,49 @@
+import { Field, Item } from '@directus/types';
+import { cloneDeep } from 'lodash';
+import { applyConditions } from './apply-conditions';
+import { getFieldsInGroup } from './get-fields-in-group';
+import { mergeItemData } from './merge-item-data';
+
+export function shouldClearField(field: Field, currentValues: Record<string, any>): boolean {
+	if (!field.meta?.conditions) return false;
+
+	const fieldWithConditions = applyConditions(currentValues, field, null);
+	return !!fieldWithConditions.meta?.hidden && !!fieldWithConditions.meta?.clear_hidden_value_on_save;
+}
+
+export function clearHiddenFieldsByCondition(edits: Item, fields: Field[], defaultValues: any, item: any): Item {
+	const currentValues = mergeItemData(defaultValues, item, edits);
+
+	const fieldsToClearMap: Map<string, any> = new Map();
+
+	function addFieldToClear(field: Field) {
+		const defaultValue = field.schema?.default_value;
+		fieldsToClearMap.set(field.field, defaultValue !== undefined ? defaultValue : null);
+	}
+
+	for (const field of fields) {
+		if (shouldClearField(field, currentValues)) {
+			if (field.meta?.special?.includes('group')) {
+				const fieldsInGroup = getFieldsInGroup(field.field, fields);
+
+				for (const groupField of fieldsInGroup) {
+					addFieldToClear(groupField);
+				}
+			} else {
+				addFieldToClear(field);
+			}
+		}
+	}
+
+	if (fieldsToClearMap.size === 0) {
+		return edits;
+	}
+
+	const editsWithClearedValues = cloneDeep(edits);
+
+	for (const [field, defaultValue] of fieldsToClearMap) {
+		editsWithClearedValues[field] = defaultValue;
+	}
+
+	return editsWithClearedValues;
+}

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -33,6 +33,7 @@ import { useTemplateData } from '@/composables/use-template-data';
 import { useFieldsStore } from '@/stores/fields';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useRelationsStore } from '@/stores/relations';
+import { clearHiddenFieldsByCondition } from '@/utils/clear-hidden-fields-by-condition';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { mergeItemData } from '@/utils/merge-item-data';
 import { translateShortcut } from '@/utils/translate-shortcut';
@@ -558,6 +559,26 @@ function useActions() {
 
 		if (props.primaryKey && props.primaryKey !== '+' && primaryKeyField.value) {
 			internalEdits.value[primaryKeyField.value.field] = props.primaryKey;
+		}
+
+		const mainDefaults = unref(getDefaultValuesFromFields(fieldsWithoutCircular.value));
+
+		internalEdits.value = clearHiddenFieldsByCondition(
+			internalEdits.value,
+			fieldsWithoutCircular.value,
+			mainDefaults,
+			initialValues.value,
+		);
+
+		if (props.junctionField && internalEdits.value[props.junctionField]) {
+			const junctionDefaults = unref(getDefaultValuesFromFields(relatedCollectionFields.value));
+
+			internalEdits.value[props.junctionField] = clearHiddenFieldsByCondition(
+				internalEdits.value[props.junctionField],
+				relatedCollectionFields.value,
+				junctionDefaults,
+				initialValues.value?.[props.junctionField],
+			);
 		}
 
 		emit('input', internalEdits.value);


### PR DESCRIPTION
## Scope

What's changed:

- Refactored the logic for clearing hidden fields into a dedicated utility function.
- Improved field handling by implementing the `clearHiddenFieldsByCondition` utility in the `useActions` hook.

## Potential Risks / Drawbacks

- Application of conditions in a drawer are affected

## Tested Scenarios

- Verified that hidden fields are cleared correctly in the drawer

## Review Notes / Questions

- Nothing I can think of

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes cms-2036

