### PR TITLE
fix: return 500 instead of 503 for file write failures

### DIFF
--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -159,10 +159,8 @@ export class FilesService extends ItemsService<File> {
 
 			if (err instanceof ContentTooLargeError) {
 				throw err;
-			} else if (err?.code && ['EROFS', 'EACCES', 'EPERM'].includes(err.code)) {
-				throw new InternalServerError();
 			} else {
-				throw new ServiceUnavailableError({ service: 'files', reason: `Couldn't save file ${payload.filename_disk}` });
+				throw new InternalServerError();
 			}
 		}
 


### PR DESCRIPTION
When Directus fails to write a file (e.g. due to filesystem permission errors), it was returning a 503 Service Unavailable error which implies a temporary condition that the client could retry. File write failures are server-side errors that the client cannot resolve, so a 500 Internal Server Error is more appropriate. This change replaces the ServiceUnavailableError thrown on file write failures with an InternalServerError.

Addresses #26501.