### PR TITLE
fix: Add proxy support to S3 storage driver

### DIFF
--- a/.changeset/s3-proxy-support.md
+++ b/.changeset/s3-proxy-support.md
@@ -1,0 +1,5 @@
+---
+'@directus/storage-driver-s3': patch
+---
+
+Added proxy support for S3 storage driver using proxy-agent

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- TanayK07

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -34,7 +34,8 @@
 		"@shopify/semaphore": "catalog:",
 		"@smithy/node-http-handler": "catalog:",
 		"@tus/utils": "catalog:",
-		"ms": "catalog:"
+		"ms": "catalog:",
+		"proxy-agent": "catalog:"
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "catalog:",

--- a/packages/storage-driver-s3/src/index.test.ts
+++ b/packages/storage-driver-s3/src/index.test.ts
@@ -30,8 +30,8 @@ import {
 	randWord,
 } from '@ngneat/falso';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ProxyAgent } from 'proxy-agent';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { DriverS3Config } from './index.js';
 import { DriverS3 } from './index.js';
 
@@ -308,7 +308,15 @@ describe('#getClient', () => {
 		vi.mocked(ProxyAgent).mockClear();
 		const maxSockets = randNumber({ min: 1, max: 1000 });
 		const keepAlive = randBoolean();
-		new DriverS3({ key: sample.config.key, secret: sample.config.secret, bucket: sample.config.bucket, maxSockets, keepAlive });
+
+		new DriverS3({
+			key: sample.config.key,
+			secret: sample.config.secret,
+			bucket: sample.config.bucket,
+			maxSockets,
+			keepAlive,
+		});
+
 		expect(ProxyAgent).toHaveBeenCalledWith({ maxSockets, keepAlive });
 	});
 

--- a/packages/storage-driver-s3/src/index.test.ts
+++ b/packages/storage-driver-s3/src/index.test.ts
@@ -31,6 +31,7 @@ import {
 } from '@ngneat/falso';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ProxyAgent } from 'proxy-agent';
 import type { DriverS3Config } from './index.js';
 import { DriverS3 } from './index.js';
 
@@ -39,6 +40,11 @@ vi.mock('@directus/utils');
 vi.mock('@aws-sdk/client-s3');
 vi.mock('@aws-sdk/lib-storage');
 vi.mock('node:path');
+
+vi.mock('proxy-agent', () => {
+	const ProxyAgent = vi.fn();
+	return { ProxyAgent };
+});
 
 let sample: {
 	config: DriverS3Config & Required<Pick<DriverS3Config, 'key' | 'secret' | 'root' | 'region' | 'forcePathStyle'>>;
@@ -290,6 +296,26 @@ describe('#getClient', () => {
 			},
 			requestHandler: expect.any(NodeHttpHandler),
 		});
+	});
+
+	test('Uses ProxyAgent for httpAgent and httpsAgent', () => {
+		vi.mocked(ProxyAgent).mockClear();
+		new DriverS3({ key: sample.config.key, secret: sample.config.secret, bucket: sample.config.bucket });
+		expect(ProxyAgent).toHaveBeenCalledTimes(2);
+	});
+
+	test('Passes maxSockets and keepAlive to ProxyAgent', () => {
+		vi.mocked(ProxyAgent).mockClear();
+		const maxSockets = randNumber({ min: 1, max: 1000 });
+		const keepAlive = randBoolean();
+		new DriverS3({ key: sample.config.key, secret: sample.config.secret, bucket: sample.config.bucket, maxSockets, keepAlive });
+		expect(ProxyAgent).toHaveBeenCalledWith({ maxSockets, keepAlive });
+	});
+
+	test('Uses default maxSockets (500) and keepAlive (true) for ProxyAgent', () => {
+		vi.mocked(ProxyAgent).mockClear();
+		new DriverS3({ key: sample.config.key, secret: sample.config.secret, bucket: sample.config.bucket });
+		expect(ProxyAgent).toHaveBeenCalledWith({ maxSockets: 500, keepAlive: true });
 	});
 });
 

--- a/packages/storage-driver-s3/src/index.ts
+++ b/packages/storage-driver-s3/src/index.ts
@@ -1,6 +1,5 @@
 import fs, { promises as fsProm } from 'node:fs';
-import { Agent as HttpAgent } from 'node:http';
-import { Agent as HttpsAgent } from 'node:https';
+import { ProxyAgent } from 'proxy-agent';
 import os from 'node:os';
 import { join } from 'node:path';
 import stream, { type Readable, promises as streamProm } from 'node:stream';
@@ -101,8 +100,8 @@ export class DriverS3 implements TusDriver {
 			requestHandler: new NodeHttpHandler({
 				connectionTimeout,
 				socketTimeout,
-				httpAgent: new HttpAgent({ maxSockets, keepAlive }),
-				httpsAgent: new HttpsAgent({ maxSockets, keepAlive }),
+				httpAgent: new ProxyAgent({ maxSockets, keepAlive }),
+				httpsAgent: new ProxyAgent({ maxSockets, keepAlive }),
 			}),
 		};
 

--- a/packages/storage-driver-s3/src/index.ts
+++ b/packages/storage-driver-s3/src/index.ts
@@ -1,5 +1,4 @@
 import fs, { promises as fsProm } from 'node:fs';
-import { ProxyAgent } from 'proxy-agent';
 import os from 'node:os';
 import { join } from 'node:path';
 import stream, { type Readable, promises as streamProm } from 'node:stream';
@@ -38,6 +37,7 @@ import { Permit, Semaphore } from '@shopify/semaphore';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { ERRORS, StreamSplitter, TUS_RESUMABLE } from '@tus/utils';
 import ms, { type StringValue } from 'ms';
+import { ProxyAgent } from 'proxy-agent';
 
 export type DriverS3Config = {
 	root?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,6 +774,9 @@ catalogs:
     proxy-addr:
       specifier: 2.0.7
       version: 2.0.7
+    proxy-agent:
+      specifier: ^7.0.0
+      version: 7.0.0
     qrcode:
       specifier: 1.5.4
       version: 1.5.4
@@ -2723,6 +2726,9 @@ importers:
       ms:
         specifier: 'catalog:'
         version: 2.1.3
+      proxy-agent:
+        specifier: 'catalog:'
+        version: 7.0.0
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -7843,6 +7849,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-base@8.0.0:
+    resolution: {integrity: sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -9005,6 +9015,10 @@ packages:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
 
+  data-uri-to-buffer@7.0.0:
+    resolution: {integrity: sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==}
+    engines: {node: '>= 14'}
+
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
@@ -9161,6 +9175,12 @@ packages:
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  degenerator@6.0.0:
+    resolution: {integrity: sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      quickjs-wasi: ^0.0.1
 
   del@6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
@@ -10039,6 +10059,10 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  get-uri@7.0.0:
+    resolution: {integrity: sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==}
+    engines: {node: '>= 14'}
+
   getopts@2.3.0:
     resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
 
@@ -10340,6 +10364,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http-proxy-agent@8.0.0:
+    resolution: {integrity: sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==}
+    engines: {node: '>= 14'}
+
   http-vary@1.0.3:
     resolution: {integrity: sha512-sx7Y8YTqF3o0mFJJvF66n8dbaE8v3liV1RgCz46XP5xK7dnzyZHvwMWRA115q5kjbCPBV65/nOMlgW54WLyiag==}
 
@@ -10353,6 +10381,10 @@ packages:
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@8.0.0:
+    resolution: {integrity: sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==}
     engines: {node: '>= 14'}
 
   human-id@4.1.2:
@@ -12064,9 +12096,19 @@ packages:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
     engines: {node: '>= 14'}
 
+  pac-proxy-agent@8.0.0:
+    resolution: {integrity: sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==}
+    engines: {node: '>= 14'}
+
   pac-resolver@7.0.1:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
+
+  pac-resolver@8.0.0:
+    resolution: {integrity: sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      quickjs-wasi: ^0.0.1
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -12731,6 +12773,10 @@ packages:
     resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
     engines: {node: '>= 14'}
 
+  proxy-agent@7.0.0:
+    resolution: {integrity: sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==}
+    engines: {node: '>= 14'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -12787,6 +12833,9 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quickjs-wasi@0.0.1:
+    resolution: {integrity: sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==}
 
   quickselect@2.0.0:
     resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
@@ -13478,6 +13527,10 @@ packages:
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks-proxy-agent@9.0.0:
+    resolution: {integrity: sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==}
     engines: {node: '>= 14'}
 
   socks@2.8.7:
@@ -20765,6 +20818,8 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-base@8.0.0: {}
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -21918,6 +21973,8 @@ snapshots:
 
   data-uri-to-buffer@6.0.2: {}
 
+  data-uri-to-buffer@7.0.0: {}
+
   data-urls@3.0.2:
     dependencies:
       abab: 2.0.6
@@ -22041,6 +22098,13 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+
+  degenerator@6.0.0(quickjs-wasi@0.0.1):
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+      quickjs-wasi: 0.0.1
 
   del@6.1.1:
     dependencies:
@@ -23214,6 +23278,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  get-uri@7.0.0:
+    dependencies:
+      basic-ftp: 5.2.0
+      data-uri-to-buffer: 7.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   getopts@2.3.0: {}
 
   git-node-fs@1.0.0(js-git@0.7.8):
@@ -23580,6 +23652,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@8.0.0:
+    dependencies:
+      agent-base: 8.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   http-vary@1.0.3: {}
 
   http2-wrapper@1.0.3:
@@ -23597,6 +23676,13 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@8.0.0:
+    dependencies:
+      agent-base: 8.0.0
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -25404,10 +25490,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  pac-proxy-agent@8.0.0:
+    dependencies:
+      agent-base: 8.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      get-uri: 7.0.0
+      http-proxy-agent: 8.0.0
+      https-proxy-agent: 8.0.0
+      pac-resolver: 8.0.0(quickjs-wasi@0.0.1)
+      quickjs-wasi: 0.0.1
+      socks-proxy-agent: 9.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   pac-resolver@7.0.1:
     dependencies:
       degenerator: 5.0.1
       netmask: 2.0.2
+
+  pac-resolver@8.0.0(quickjs-wasi@0.0.1):
+    dependencies:
+      degenerator: 6.0.0(quickjs-wasi@0.0.1)
+      netmask: 2.0.2
+      quickjs-wasi: 0.0.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -26141,6 +26246,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  proxy-agent@7.0.0:
+    dependencies:
+      agent-base: 8.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      http-proxy-agent: 8.0.0
+      https-proxy-agent: 8.0.0
+      lru-cache: 7.18.3
+      pac-proxy-agent: 8.0.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 9.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
@@ -26189,6 +26307,8 @@ snapshots:
   quick-lru@4.0.1: {}
 
   quick-lru@5.1.1: {}
+
+  quickjs-wasi@0.0.1: {}
 
   quickselect@2.0.0: {}
 
@@ -27140,6 +27260,14 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks-proxy-agent@9.0.0:
+    dependencies:
+      agent-base: 8.0.0
       debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -268,6 +268,7 @@ catalog:
   prettier: 3.6.2
   prom-client: 15.1.3
   proxy-addr: 2.0.7
+  proxy-agent: ^7.0.0
   qrcode: 1.5.4
   qs: 6.14.2
   rate-limiter-flexible: 7.2.0


### PR DESCRIPTION
## Scope

What's changed:

- Replaced Node.js built-in `HttpAgent`/`HttpsAgent` with `ProxyAgent` from the `proxy-agent` package in the S3 storage driver
- This enables S3 file uploads to work behind corporate proxies by respecting `HTTP_PROXY`/`HTTPS_PROXY` environment variables
- When no proxy env vars are set, `ProxyAgent` falls through to a direct connection — fully backward-compatible

## Potential Risks / Drawbacks

- New dependency (`proxy-agent`) added to `@directus/storage-driver-s3` — however, `proxy-agent` is maintained by TooTallNate and used by npm itself
- `ProxyAgent` extends `http.Agent`, so it is type-compatible with `NodeHttpHandler`'s `httpAgent`/`httpsAgent` params

## Tested Scenarios

- All 57 existing unit tests pass
- Added 3 new tests verifying `ProxyAgent` is used with correct `maxSockets` and `keepAlive` defaults
- Build compiles successfully

## Review Notes / Questions

- The only source change is swapping two import lines and two constructor calls in `getClient()`
- No other storage drivers (Azure, GCS, Cloudinary, Supabase, Local) are affected — they don't use explicit HTTP agents

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #24381