### PR TITLE
fix(app): exclude alias fields from export Select All

### DIFF
--- a/.changeset/exclude-alias-fields-export.md
+++ b/.changeset/exclude-alias-fields-export.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Exclude alias fields from "Select All" in export field picker

--- a/app/src/components/v-field-list/v-field-list.vue
+++ b/app/src/components/v-field-list/v-field-list.vue
@@ -104,7 +104,10 @@ const treeList = computed(() => {
 });
 
 const addAll = () => {
-	const allFields = unref(treeList).map((field) => field.field);
+	const allFields = unref(treeList)
+		.filter((field) => !field.disabled && field.type !== 'alias')
+		.map((field) => field.field);
+
 	emit('add', unref(allFields));
 };
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- howwohmm


### PR DESCRIPTION
## Scope

What's changed:

- Filter out alias-type fields (which don't hold actual data) from the "Select All" action in the export field picker
- Also skip already-disabled fields (e.g. group headers) when selecting all

## Potential Risks / Drawbacks

- None — alias fields were never valid export targets. The initial field list in the export dialog already excluded them (see `export-sidebar-detail.vue` lines 86, 94), this just applies the same logic to the "Select All" button.

## Tested Scenarios

- Clicking "Select All" in the export drawer no longer includes alias fields (e.g. accordion/group presentation fields)
- Manually adding individual alias fields via the field picker still works as before
- Fields that are already selected (disabled in the list) are also excluded from the "Select All" action

## Review Notes / Questions

- Aware of #26775 which addresses the same issue but has been inactive for ~2 weeks. Happy to close this if that PR is still being worked on.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26766