### PR TITLE
Replace INTERNAL_SERVER_ERROR with SERVICE_UNAVAILABLE for marketplace registry errors, and provide user-friendly messages.

### DIFF
--- a/.changeset/ready-ghosts-call.md
+++ b/.changeset/ready-ghosts-call.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Replaced INTERNAL_SERVER_ERROR with SERVICE_UNAVAILABLE for marketplace registry errors and improved error messages.

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -1,7 +1,13 @@
 import type { ReadStream } from 'node:fs';
 import { EXTENSION_TYPES } from '@directus/constants';
 import { useEnv } from '@directus/env';
-import { ErrorCode, ForbiddenError, isDirectusError, RouteNotFoundError } from '@directus/errors';
+import {
+	ErrorCode,
+	ForbiddenError,
+	isDirectusError,
+	RouteNotFoundError,
+	ServiceUnavailableError,
+} from '@directus/errors';
 import {
 	account,
 	type AccountOptions,
@@ -104,7 +110,24 @@ router.get(
 			options.registry = env['MARKETPLACE_REGISTRY'];
 		}
 
-		const payload = await list(query, options);
+		let payload;
+
+		try {
+			payload = await list(query, options);
+		} catch (error: any) {
+			if (error.name === 'TimeoutError') {
+				throw new ServiceUnavailableError({ service: 'marketplace', reason: 'The registry server is not responding' });
+			} else if (error.name === 'TypeError' && error.message.includes('fetch')) {
+				throw new ServiceUnavailableError({
+					service: 'marketplace',
+					reason: 'Unable to connect to the registry server',
+				});
+			} else if (error instanceof Error) {
+				throw new ServiceUnavailableError({ service: 'marketplace', reason: error.message });
+			} else {
+				throw new ServiceUnavailableError({ service: 'marketplace', reason: 'An unknown error occurred' });
+			}
+		}
 
 		res.locals['payload'] = payload;
 		return next();

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -1,13 +1,7 @@
 import type { ReadStream } from 'node:fs';
 import { EXTENSION_TYPES } from '@directus/constants';
 import { useEnv } from '@directus/env';
-import {
-	ErrorCode,
-	ForbiddenError,
-	isDirectusError,
-	RouteNotFoundError,
-	ServiceUnavailableError,
-} from '@directus/errors';
+import { ErrorCode, ForbiddenError, isDirectusError, RouteNotFoundError } from '@directus/errors';
 import {
 	account,
 	type AccountOptions,
@@ -29,6 +23,7 @@ import { ExtensionReadError, ExtensionsService } from '../services/extensions.js
 import asyncHandler from '../utils/async-handler.js';
 import { getCacheControlHeader } from '../utils/get-cache-headers.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
+import { handleRegistryError } from './utils/handle-registry-error.js';
 
 const router = express.Router();
 const env = useEnv();
@@ -114,19 +109,8 @@ router.get(
 
 		try {
 			payload = await list(query, options);
-		} catch (error: any) {
-			if (error.name === 'TimeoutError') {
-				throw new ServiceUnavailableError({ service: 'marketplace', reason: 'The registry server is not responding' });
-			} else if (error.name === 'TypeError' && error.message.includes('fetch')) {
-				throw new ServiceUnavailableError({
-					service: 'marketplace',
-					reason: 'Unable to connect to the registry server',
-				});
-			} else if (error instanceof Error) {
-				throw new ServiceUnavailableError({ service: 'marketplace', reason: error.message });
-			} else {
-				throw new ServiceUnavailableError({ service: 'marketplace', reason: 'An unknown error occurred' });
-			}
+		} catch (error) {
+			handleRegistryError(error);
 		}
 
 		res.locals['payload'] = payload;
@@ -152,7 +136,13 @@ router.get(
 			options.registry = env['MARKETPLACE_REGISTRY'];
 		}
 
-		const payload = await account(req.params['pk'], options);
+		let payload;
+
+		try {
+			payload = await account(req.params['pk'], options);
+		} catch (error) {
+			handleRegistryError(error);
+		}
 
 		res.locals['payload'] = payload;
 		return next();
@@ -177,7 +167,13 @@ router.get(
 			options.registry = env['MARKETPLACE_REGISTRY'];
 		}
 
-		const payload = await describe(req.params['pk'], options);
+		let payload;
+
+		try {
+			payload = await describe(req.params['pk'], options);
+		} catch (error) {
+			handleRegistryError(error);
+		}
 
 		res.locals['payload'] = payload;
 		return next();

--- a/api/src/controllers/utils/handle-registry-error.test.ts
+++ b/api/src/controllers/utils/handle-registry-error.test.ts
@@ -1,0 +1,27 @@
+import { ServiceUnavailableError } from '@directus/errors';
+import { describe, expect, it } from 'vitest';
+import { handleRegistryError } from './handle-registry-error.js';
+
+describe('handleRegistryError', () => {
+	it('should handle TimeoutError', () => {
+		const err = new Error();
+		err.name = 'TimeoutError';
+
+		expect(() => handleRegistryError(err)).toThrow(ServiceUnavailableError);
+	});
+
+	it('should handle fetch TypeError', () => {
+		const err = new Error('fetch failed');
+		err.name = 'TypeError';
+
+		expect(() => handleRegistryError(err)).toThrow(ServiceUnavailableError);
+	});
+
+	it('should handle other error', () => {
+		expect(() => handleRegistryError(new Error('Aborted operation'))).toThrow(ServiceUnavailableError);
+	});
+
+	it('should handle unknown error', () => {
+		expect(() => handleRegistryError('thrown string')).toThrow(ServiceUnavailableError);
+	});
+});

--- a/api/src/controllers/utils/handle-registry-error.ts
+++ b/api/src/controllers/utils/handle-registry-error.ts
@@ -1,0 +1,29 @@
+import { ServiceUnavailableError } from '@directus/errors';
+
+export function handleRegistryError(error: unknown): never {
+	if (error instanceof Error) {
+		if (error.name === 'TimeoutError') {
+			throw new ServiceUnavailableError({
+				service: 'marketplace',
+				reason: 'The registry server is not responding',
+			});
+		}
+
+		if (error.name === 'TypeError' && error.message.includes('fetch')) {
+			throw new ServiceUnavailableError({
+				service: 'marketplace',
+				reason: 'Unable to connect to the registry server',
+			});
+		}
+
+		throw new ServiceUnavailableError({
+			service: 'marketplace',
+			reason: error.message,
+		});
+	}
+
+	throw new ServiceUnavailableError({
+		service: 'marketplace',
+		reason: 'An unknown error occurred',
+	});
+}

--- a/contributors.yml
+++ b/contributors.yml
@@ -264,3 +264,4 @@
 - Ikromjon1998
 - Zhey-on
 - faizkhairi
+- eric-pennecot


### PR DESCRIPTION
## Scope

Replace INTERNAL_SERVER_ERROR with SERVICE_UNAVAILABLE for marketplace registry errors, and provide clearer, user-friendly messages.

## Impacted endpoints:
- GET /registry
- GET /registry/account/:pk
- GET /registry/extension/:pk

## Error mapping

- TimeoutError → The registry server is not responding
- TypeError → Unable to connect to the registry server
- Other Error → error.message
- Unknown → An unknown error occurred

## Tests
- Added unit tests for handleRegistryError
- Manually tested error scenarios (timeout, network failure, other errors, unknown errors) across affected endpoints

## Notes:
- Only covers endpoints directly calling `@directus/extensions-registry`
- Internal services (install, reinstall, etc.) are intentionally unchanged

---

Fixes #22416. Partially addressed by #22379, which fixed error objects being used as the message.